### PR TITLE
Rec: add Additonal records to query results if appropriate

### DIFF
--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -51,6 +51,14 @@ public:
 
   includeboilerplate(NAPTR)
   template<class Convertor> void xfrRecordContent(Convertor& conv);
+  string getFlags() const
+  {
+    return d_flags;
+  }
+  DNSName getReplacement() const
+  {
+    return d_replacement;
+  }
 private:
   uint16_t d_order, d_preference;
   string d_flags, d_services, d_regexp;

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -51,11 +51,11 @@ public:
 
   includeboilerplate(NAPTR)
   template<class Convertor> void xfrRecordContent(Convertor& conv);
-  string getFlags() const
+  const string& getFlags() const
   {
     return d_flags;
   }
-  DNSName getReplacement() const
+  const DNSName& getReplacement() const
   {
     return d_replacement;
   }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1268,7 +1268,7 @@ void startDoResolve(void* p)
 
       bool needCommit = false;
       for (auto i = ret.cbegin(); i != ret.cend(); ++i) {
-        if (!DNSSECOK && (i->d_type == QType::NSEC3 || ((i->d_type == QType::RRSIG || i->d_type == QType::NSEC) && ((dc->d_mdp.d_qtype != i->d_type && dc->d_mdp.d_qtype != QType::ANY) || i->d_place != DNSResourceRecord::ANSWER)))) {
+        if (!DNSSECOK && (i->d_type == QType::NSEC3 || ((i->d_type == QType::RRSIG || i->d_type == QType::NSEC) && ((dc->d_mdp.d_qtype != i->d_type && dc->d_mdp.d_qtype != QType::ANY) || (i->d_place != DNSResourceRecord::ANSWER && i->d_place != DNSResourceRecord::ADDITIONAL))))) {
           continue;
         }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1259,7 +1259,7 @@ void startDoResolve(void* p)
       }
 
       if (ret.size()) {
-        pdns::orderAndShuffle(ret);
+        pdns::orderAndShuffle(ret, false);
         if (auto sl = luaconfsLocal->sortlist.getOrderCmp(dc->d_source)) {
           stable_sort(ret.begin(), ret.end(), *sl);
           variableAnswer = true;

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -332,6 +332,14 @@ public:
   }
   void postPrepareContext() override
   {
+    // clang-format off
+    d_pd.push_back({"AdditionalMode", in_t{
+          {"Ignore", static_cast<int>(AdditionalMode::Ignore)},
+          {"CacheOnly", static_cast<int>(AdditionalMode::CacheOnly)},
+          {"CacheOnlyRequireAuth", static_cast<int>(AdditionalMode::CacheOnlyRequireAuth)},
+          {"ResolveImmediately", static_cast<int>(AdditionalMode::ResolveImmediately)},
+          {"ResolveDeferred", static_cast<int>(AdditionalMode::ResolveDeferred)}
+        }});
   }
   void postLoad() override
   {
@@ -682,7 +690,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
   });
 #endif /* HAVE_FSTRM */
 
-  Lua->writeFunction("addAllowedAdditionalQType", [&lci](int qtype, std::unordered_map<int, int> targetqtypes, boost::optional<std::map<std::string, std::string>> options) {
+  Lua->writeFunction("addAllowedAdditionalQType", [&lci](int qtype, std::unordered_map<int, int> targetqtypes, boost::optional<std::map<std::string, int>> options) {
     switch (qtype) {
     case QType::MX:
     case QType::SRV:
@@ -704,17 +712,10 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
 
     if (options) {
       if (const auto it = options->find("mode"); it != options->end()) {
-        const map<string, AdditionalMode> modeMap = {
-          {"Ignore", AdditionalMode::Ignore},
-          {"CacheOnly", AdditionalMode::CacheOnly},
-          {"CacheOnlyRequireAuth", AdditionalMode::CacheOnlyRequireAuth},
-          {"ResolveImmediately", AdditionalMode::ResolveImmediately},
-          {"ResolveDeferred", AdditionalMode::ResolveDeferred}};
-        if (modeMap.find(it->second) == modeMap.end()) {
+        mode = static_cast<AdditionalMode>(it->second);
+        if (mode > AdditionalMode::ResolveDeferred) {
           g_log << Logger::Error << "addAllowedAdditionalQType: unknown mode " << it->second << endl;
-          return;
         }
-        mode = modeMap.at(it->second);
       }
     }
     lci.allowAdditionalQTypes.insert_or_assign(qtype, pair(targets, mode));

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -709,8 +709,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
           {"CacheOnly", AdditionalMode::CacheOnly},
           {"CacheOnlyRequireAuth", AdditionalMode::CacheOnlyRequireAuth},
           {"ResolveImmediately", AdditionalMode::ResolveImmediately},
-          {"ResolveDeferred", AdditionalMode::ResolveDeferred}
-        };
+          {"ResolveDeferred", AdditionalMode::ResolveDeferred}};
         if (modeMap.find(it->second) == modeMap.end()) {
           g_log << Logger::Error << "addAllowedAdditionalQType: unknown mode " << it->second << endl;
           return;

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -62,7 +62,8 @@ struct TrustAnchorFileInfo
   std::string fname;
 };
 
-enum class AdditionalMode : uint8_t {
+enum class AdditionalMode : uint8_t
+{
   Ignore,
   CacheOnly,
   CacheOnlyRequireAuth,

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -62,6 +62,14 @@ struct TrustAnchorFileInfo
   std::string fname;
 };
 
+enum class AdditionalMode : uint8_t {
+  Ignore,
+  CacheOnly,
+  CacheOnlyRequireAuth,
+  ResolveImmediately,
+  ResolveDeferred
+};
+
 class LuaConfigItems
 {
 public:
@@ -72,6 +80,7 @@ public:
   map<DNSName, dsmap_t> dsAnchors;
   map<DNSName, std::string> negAnchors;
   map<DNSName, RecZoneToCache::Config> ztcConfigs;
+  std::map<QType, std::pair<std::set<QType>, AdditionalMode>> allowAdditionalQTypes;
   ProtobufExportConfig protobufExportConfig;
   ProtobufExportConfig outgoingProtobufExportConfig;
   FrameStreamExportConfig frameStreamExportConfig;

--- a/pdns/recursordist/docs/lua-config/additionals.rst
+++ b/pdns/recursordist/docs/lua-config/additionals.rst
@@ -27,27 +27,33 @@ An example of a configuration:
 .. code-block:: Lua
 
   addAllowedAdditionalQType(pdns.MX, {pdns.A, pdns.AAAA})
-  addAllowedAdditionalQType(pdns.NAPTR, {pdns.A, pdns.AAAA, pdns.SRV}, {mode="ResolveImmediately"})
+  addAllowedAdditionalQType(pdns.NAPTR, {pdns.A, pdns.AAAA, pdns.SRV}, {mode=pdns.AdditionalMode.ResolveImmediately})
 
 The first line specifies that additional records should be added to the results of ``MX`` queries using the default mode.
 The qtype of the records to be added are ``A`` and ``AAAA``.
-The default mode is ``CacheOnlyRequireAuth``, this mode will only look in the record cache.
+The default mode is ``pdns.AdditionalMode.CacheOnlyRequireAuth``, this mode will only look in the record cache.
 
 The second line specifies that three record types should be added to ``NAPTR`` answers.
 If needed, the Recursor will do an active resolve to retrieve these records.
 
 The modes available are:
-  * ``Ignore`` Do not do any additional processing for this qtype. This is equivalent to not calling :func:`addAllowedAdditionalQType` for the qtype.
-  * ``CacheOnly`` Look in the record cache for available records. Allow non-authoritative (learned from additional sections received from authoritative servers) records to be added.
-  * ``CacheOnlyRequireAuth`` Look in the record cache for available records. Only authoritative records will be added. These are records received from the nameservers for the specific domain.
-  * ``ResolveImmediately`` Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache, actively try to resolve the target name/qtype. This will delay the answer to the client.
-  * ``ResolveDeferred`` Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache and the negative cache also has no entry, schedule a background task to resolve the target name/qtype. The next time the query is processed, the cache might hold the relevant information. This mode is not implemented yet.
 
-If an additional record is not available at that time the query is stored into the packet cache the answer packet stored in the packer cache will not contain the additional record.
+``pdns.AdditionalMode.Ignore``
+  Do not do any additional processing for this qtype. This is equivalent to not calling :func:`addAllowedAdditionalQType` for the qtype.
+``pdns.AdditionalMode.CacheOnly``
+  Look in the record cache for available records. Allow non-authoritative (learned from additional sections received from authoritative servers) records to be added.
+``pdns.AdditionalMode.CacheOnlyRequireAuth``
+  Look in the record cache for available records. Only authoritative records will be added. These are records received from the nameservers for the specific domain.
+``pdns.AdditionalMode.ResolveImmediately``
+  Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache, actively try to resolve the target name/qtype. This will delay the answer to the client.
+``pdns.AdditionalMode.ResolveDeferred``
+  Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache and the negative cache also has no entry, schedule a background task to resolve the target name/qtype. The next time the query is processed, the cache might hold the relevant information. This mode is not implemented yet.
+
+If an additional record is not available at that time the query is stored into the packet cache the answer packet stored in the packet cache will not contain the additional record.
 Clients repeating the same question will get an answer from the packet cache if the question is still in the packet cache.
-These answers do not have the additional record, even if in the meantime the record cache has learned it.
-Clients wil only see the additional record once the packet cache entry expires and the record cache is consulted again.
-The ``ResolveImmediately`` will not have this issue, at the cost of delaying the first query to resolve the additional records needed.
+These answers do not have the additional record, even if the record cache has learned it in the meantime .
+Clients will only see the additional record once the packet cache entry expires and the record cache is consulted again.
+The ``pdns.AdditionalMode.ResolveImmediately`` mode will not have this issue, at the cost of delaying the first query to resolve the additional records needed.
 
 Configuring additional record processing
 ----------------------------------------
@@ -65,6 +71,6 @@ Calling  :func:`addAllowedAdditionalQType` multiple times with a specific qtype 
   :param int qtype:  the qtype number to enable additional record processing for. Supported are: ``pdns.MX``, ``pdns.SRV``, ``pdns.SVCB``, ``pdns.HTTPS`` and ``pdns.NAPTR``.
   :param targets: the target qtypes to look for when adding the additionals. For example ``{pdns.A, pdns.AAAA}``.
   :type targets: list of qtype numbers
-  :param table options: a table of options. Currently the only option is ``mode`` having a string value. For the available modes, see above. If no mode is specified, the default ``"CacheOnlyRequireAuth"`` mode is used.
+  :param table options: a table of options. Currently the only option is ``mode`` having an integer value. For the available modes, see above. If no mode is specified, the default ``pdns.AdditionalMode.CacheOnlyRequireAuth`` mode is used.
 
 

--- a/pdns/recursordist/docs/lua-config/additionals.rst
+++ b/pdns/recursordist/docs/lua-config/additionals.rst
@@ -1,0 +1,70 @@
+Adding Additional Records to Results
+====================================
+Starting with version 4.7.0, the PowerDNS Recursor has the ability to add additional records to query results.
+
+This allows clients to learn useful information without having to do an extra query.
+Examples of useful information are the related ``A`` and ``AAAA`` records to a query for an ``MX`` record:
+
+::
+
+  ;; ANSWER SECTION:
+  example.net.              86362   IN      MX      20 mx2.example.net.
+  example.net.              86362   IN      MX      10 mx1.example.net.
+
+  ;; ADDITIONAL SECTION:
+  mx1.example.net.          86368   IN      A       192.168.1.2
+  mx2.example.net.          86400   IN      A       192.168.1.3
+  mx1.example.net.          86372   IN      AAAA    2001:db8::1
+  mx2.example.net.          86374   IN      AAAA    2001:db8::2
+
+The default is that the Recursor never adds additional records to an answer it sends to the client.
+The default behavior can be changed by using the :func:`addAllowedAdditionalQType` function in the :ref:`setting-lua-config-file`.
+For each query type allowing additional record processing the Recursor has code to determine the target name to add.
+The target qtypes to add are configurable as is the mode, specifying how to retrieve the records to add.
+
+An example of a configuration:
+
+.. code-block:: Lua
+
+  addAllowedAdditionalQType(pdns.MX, {pdns.A, pdns.AAAA})
+  addAllowedAdditionalQType(pdns.NAPTR, {pdns.A, pdns.AAAA, pdns.SRV}, {mode="ResolveImmediately"})
+
+The first line specifies that additional records should be added to the results of ``MX`` queries using the default mode.
+The qtype of the records to be added are ``A`` and ``AAAA``.
+The default mode is ``CacheOnlyRequireAuth``, this mode will only look in the record cache.
+
+The second line specifies that three record types should be added to ``NAPTR`` answers.
+If needed, the Recursor will do an active resolve to retrieve these records.
+
+The modes available are:
+  * ``Ignore`` Do not do any additional processing for this qtype. This is equivalent to not calling :func:`addAllowedAdditionalQType` for the qtype.
+  * ``CacheOnly`` Look in the record cache for available records. Allow non-authoritative (learned from additional sections received from authoritative servers) records to be added.
+  * ``CacheOnlyRequireAuth`` Look in the record cache for available records. Only authoritative records will be added. These are records received from the nameservers for the specific domain.
+  * ``ResolveImmediately`` Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache, actively try to resolve the target name/qtype. This will delay the answer to the client.
+  * ``ResolveDeferred`` Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache and the negative cache also has no entry, schedule a background task to resolve the target name/qtype. The next time the query is processed, the cache might hold the relevant information. This mode is not implemented yet.
+
+If an additional record is not available at that time the query is stored into the packet cache the answer packet stored in the packer cache will not contain the additional record.
+Clients repeating the same question will get an answer from the packet cache if the question is still in the packet cache.
+These answers do not have the additional record, even if in the meantime the record cache has learned it.
+Clients wil only see the additional record once the packet cache entry expires and the record cache is consulted again.
+The ``ResolveImmediately`` will not have this issue, at the cost of delaying the first query to resolve the additional records needed.
+
+Configuring additional record processing
+----------------------------------------
+
+The following function is available to configure additional record processing.
+Reloading the Lua configuration will replace the current configuration with the new one.
+Calling  :func:`addAllowedAdditionalQType` multiple times with a specific qtype will replace previous calls with the same qtype.
+
+.. function:: addAllowedAdditionalQType(qtype, targets [, options ]))
+
+  .. versionadded:: 4.7.0
+
+  Allow additional processing for ``qtype``.
+
+  :param int qtype:  the qtype number to enable additional record processing for. Supported are: ``pdns.MX``, ``pdns.SRV``, ``pdns.SVCB``, ``pdns.HTTPS`` and ``pdns.NAPTR``.
+  :param targets: the target qtypes to look for when adding the additionals. For example ``{pdns.A, pdns.AAAA}``.
+  :type targets: list of qtype numbers
+  :param table options: a table of options. Currently the only option is ``mode`` having a string value. For the available modes, see above. If no mode is specified, the default ``"CacheOnlyRequireAuth"`` mode is used.
+
+

--- a/pdns/recursordist/docs/lua-config/index.rst
+++ b/pdns/recursordist/docs/lua-config/index.rst
@@ -1,4 +1,4 @@
-Lua Configuration: Trustanchors, Query Logging, RPZs, Sortlist and Zone to Cache
+Advanced Configuration Using Lua
 ================================================================================
 
 Since version 4.0.0, the PowerDNS Recursor supports additional configuration options that have to be loaded through :ref:`setting-lua-config-file`.

--- a/pdns/recursordist/docs/lua-config/index.rst
+++ b/pdns/recursordist/docs/lua-config/index.rst
@@ -10,5 +10,6 @@ Since version 4.0.0, the PowerDNS Recursor supports additional configuration opt
     rpz
     sortlist
     ztc
+    additionals
 
 In addition, :func:`pdnslog` together with ``pdns.loglevels`` is also supported in the Lua configuration file.

--- a/pdns/shuffle.cc
+++ b/pdns/shuffle.cc
@@ -73,7 +73,7 @@ void pdns::shuffle(std::vector<DNSZoneRecord>& rrs)
 }
 
 // shuffle, maintaining some semblance of order
-static void shuffle(std::vector<DNSRecord>& rrs)
+static void shuffle(std::vector<DNSRecord>& rrs, bool includingAdditionals)
 {
   // This shuffles in the same style as the above method, keeping CNAME in the front and RRSIGs at the end
   std::vector<DNSRecord>::iterator first, second;
@@ -91,6 +91,10 @@ static void shuffle(std::vector<DNSRecord>& rrs)
   pdns::dns_random_engine r;
   if (second - first > 1) {
     shuffle(first, second, r);
+  }
+
+  if (!includingAdditionals) {
+    return;
   }
 
   // now shuffle the additional records
@@ -123,10 +127,10 @@ static uint16_t mapTypesToOrder(uint16_t type)
 
 // make sure rrs is sorted in d_place order to avoid surprises later
 // then shuffle the parts that desire shuffling
-void pdns::orderAndShuffle(vector<DNSRecord>& rrs)
+void pdns::orderAndShuffle(vector<DNSRecord>& rrs, bool includingAdditionals)
 {
   std::stable_sort(rrs.begin(), rrs.end(), [](const DNSRecord& a, const DNSRecord& b) {
     return std::make_tuple(a.d_place, mapTypesToOrder(a.d_type)) < std::make_tuple(b.d_place, mapTypesToOrder(b.d_type));
   });
-  shuffle(rrs);
+  shuffle(rrs, includingAdditionals);
 }

--- a/pdns/shuffle.hh
+++ b/pdns/shuffle.hh
@@ -28,5 +28,5 @@ struct DNSZoneRecord;
 namespace pdns
 {
 void shuffle(std::vector<DNSZoneRecord>& rrs);
-void orderAndShuffle(std::vector<DNSRecord>& rrs);
+void orderAndShuffle(std::vector<DNSRecord>& rrs, bool includingAdditionals);
 }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -598,7 +598,15 @@ public:
 
   explicit SyncRes(const struct timeval& now);
 
-  void getAdditionals(const DNSName& qname, QType qtype, bool requireAuth, std::set<DNSRecord>& additionals, unsigned int depth);
+  enum class AddtionalMode : uint8_t {
+    Ignore,
+    CacheOnly,
+    CacheOnlyRequireAuth,
+    ResolveImmediately,
+    ResolveDeferred
+  };
+
+  void getAdditionals(const DNSName& qname, QType qtype, AddtionalMode, std::set<DNSRecord>& additionals, unsigned int depth);
   int beginResolve(const DNSName &qname, QType qtype, QClass qclass, vector<DNSRecord>&ret, unsigned int depth = 0);
 
   void setId(int id)

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -68,6 +68,8 @@ extern GlobalStateHolder<SuffixMatchNode> g_dontThrottleNames;
 extern GlobalStateHolder<NetmaskGroup> g_dontThrottleNetmasks;
 extern GlobalStateHolder<SuffixMatchNode> g_DoTToAuthNames;
 
+enum class AdditionalMode : uint8_t; // defined in rec-lua-conf.hh
+
 class RecursorLua4;
 
 typedef std::unordered_map<
@@ -268,14 +270,6 @@ public:
   typedef std::function<LWResult::Result(const ComboAddress& ip, const DNSName& qdomain, int qtype, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult *lwr, bool* chained)> asyncresolve_t;
 
   enum class HardenNXD { No, DNSSEC, Yes };
-
-  enum class AddtionalMode : uint8_t {
-    Ignore,
-    CacheOnly,
-    CacheOnlyRequireAuth,
-    ResolveImmediately,
-    ResolveDeferred
-  };
 
   //! This represents a number of decaying Ewmas, used to store performance per nameserver-name.
   /** Modelled to work mostly like the underlying DecayingEwma */
@@ -846,7 +840,7 @@ private:
   typedef std::map<DNSName,vState> zonesStates_t;
   enum StopAtDelegation { DontStop, Stop, Stopped };
 
-  void resolveAdditionals(const DNSName& qname, QType qtype, AddtionalMode, std::vector<DNSRecord>& additionals, unsigned int depth);
+  void resolveAdditionals(const DNSName& qname, QType qtype, AdditionalMode, std::vector<DNSRecord>& additionals, unsigned int depth);
   void addAdditionals(QType qtype, const vector<DNSRecord>&start, vector<DNSRecord>&addditionals, std::set<std::pair<DNSName, QType>>& uniqueCalls, std::set<std::pair<DNSName, QType>>& uniqueResults, unsigned int depth, unsigned int adddepth);
   void addAdditionals(QType qtype, vector<DNSRecord>&ret, unsigned int depth);
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -598,6 +598,7 @@ public:
 
   explicit SyncRes(const struct timeval& now);
 
+  void getAdditionals(const DNSName& qname, QType qtype, bool requireAuth, std::set<DNSRecord>& additionals, unsigned int depth);
   int beginResolve(const DNSName &qname, QType qtype, QClass qclass, vector<DNSRecord>&ret, unsigned int depth = 0);
 
   void setId(int id)

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -841,7 +841,7 @@ private:
   enum StopAtDelegation { DontStop, Stop, Stopped };
 
   void resolveAdditionals(const DNSName& qname, QType qtype, AdditionalMode, std::vector<DNSRecord>& additionals, unsigned int depth);
-  void addAdditionals(QType qtype, const vector<DNSRecord>&start, vector<DNSRecord>&addditionals, std::set<std::pair<DNSName, QType>>& uniqueCalls, std::set<std::pair<DNSName, QType>>& uniqueResults, unsigned int depth, unsigned int adddepth);
+  void addAdditionals(QType qtype, const vector<DNSRecord>&start, vector<DNSRecord>&addditionals, std::set<std::pair<DNSName, QType>>& uniqueCalls, std::set<std::tuple<DNSName, QType, QType>>& uniqueResults, unsigned int depth, unsigned int adddepth);
   void addAdditionals(QType qtype, vector<DNSRecord>&ret, unsigned int depth);
 
   bool doDoTtoAuth(const DNSName& ns) const;

--- a/regression-tests.recursor-dnssec/test_Additionals.py
+++ b/regression-tests.recursor-dnssec/test_Additionals.py
@@ -1,0 +1,130 @@
+import dns
+import os
+from recursortests import RecursorTest
+
+class testAdditionalsDefault(RecursorTest):
+    _confdir = 'AdditionalsDefault'
+
+    _config_template = """
+    dnssec=validate
+    disable-packetcache
+    """
+    _lua_config_file = """
+    addAllowedAdditionalQType(pdns.MX, {pdns.A, pdns.AAAA})
+    """
+
+    def testMX(self):
+        expected = dns.rrset.from_text('secure.example.', 0, dns.rdataclass.IN, 'MX', '10 mx1.secure.example.', '20 mx2.secure.example.')
+        adds1 = dns.rrset.from_text('mx1.secure.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.18')
+        adds2 = dns.rrset.from_text('mx2.secure.example.', 0, dns.rdataclass.IN, 'AAAA', '1::2')
+        query1 = dns.message.make_query('secure.example', 'MX', want_dnssec=True)
+        query1.flags |= dns.flags.AD
+        query2 = dns.message.make_query('mx1.secure.example', 'A', want_dnssec=True)
+        query2.flags |= dns.flags.AD
+        query3 = dns.message.make_query('mx2.secure.example', 'AAAA', want_dnssec=True)
+        query3.flags |= dns.flags.AD
+
+        res = self.sendUDPQuery(query1)
+        self.assertMessageIsAuthenticated(res)
+        self.assertRRsetInAnswer(res, expected)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+        self.assertAdditionalEmpty(res)
+        # fill the cache
+        res = self.sendUDPQuery(query2)
+        res = self.sendUDPQuery(query3)
+        # query 1 again
+        res = self.sendUDPQuery(query1)
+        self.assertMessageIsAuthenticated(res)
+        self.assertRRsetInAnswer(res, expected)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+        self.assertRRsetInAdditional(res, adds1)
+        self.assertRRsetInAdditional(res, adds2)
+
+class testAdditionalsResolveImmediately(RecursorTest):
+    _confdir = 'AdditionalsResolveImmediately'
+    _config_template = """
+    dnssec=validate
+    disable-packetcache
+    """
+    _lua_config_file = """
+    addAllowedAdditionalQType(pdns.MX, {pdns.A, pdns.AAAA}, { mode = "ResolveImmediately"})
+    addAllowedAdditionalQType(pdns.NAPTR, {pdns.A, pdns.AAAA, pdns.SRV}, { mode = "ResolveImmediately"})
+    addAllowedAdditionalQType(pdns.SRV, {pdns.A, pdns.AAAA}, { mode = "ResolveImmediately"})
+    """
+
+    def testMX(self):
+        expected = dns.rrset.from_text('secure.example.', 0, dns.rdataclass.IN, 'MX', '10 mx1.secure.example.', '20 mx2.secure.example.')
+        adds1 = dns.rrset.from_text('mx1.secure.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.18')
+        adds2 = dns.rrset.from_text('mx2.secure.example.', 0, dns.rdataclass.IN, 'AAAA', '1::2')
+        query1 = dns.message.make_query('secure.example', 'MX', want_dnssec=True)
+        query1.flags |= dns.flags.AD
+
+        res = self.sendUDPQuery(query1)
+        self.assertMessageIsAuthenticated(res)
+        self.assertRRsetInAnswer(res, expected)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+        self.assertRRsetInAdditional(res, adds1)
+        self.assertRRsetInAdditional(res, adds2)
+        self.assertMatchingRRSIGInAdditional(res, adds1)
+        self.assertMatchingRRSIGInAdditional(res, adds2)
+
+    def testNAPTR(self):
+        exp = dns.rrset.from_text('naptr.secure.example.', 0, dns.rdataclass.IN, 'NAPTR',
+                                   '10 10 "s" "Z" "C" service2.secure.example.',
+                                   '10 10 "s" "Y" "B" service1.secure.example.',
+                                   '10 10 "a" "X" "A" s1.secure.example.');
+        adds1 = dns.rrset.from_text('s1.secure.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.19')
+        adds2 = dns.rrset.from_text('service1.secure.example.', 0, dns.rdataclass.IN, 'SRV', '20 100 8080 a.secure.example.')
+        adds3 = dns.rrset.from_text('service2.secure.example.', 0, dns.rdataclass.IN, 'SRV', '20 100 8080 b.secure.example.')
+        adds4 = dns.rrset.from_text('a.secure.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.20', '192.0.2.22')
+        adds5 = dns.rrset.from_text('b.secure.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.21')
+        adds6 = dns.rrset.from_text('b.secure.example.', 0, dns.rdataclass.IN, 'AAAA', '1::3')
+        adds7 = dns.rrset.from_text('s1.secure.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.19')
+
+        query1 = dns.message.make_query('naptr.secure.example', 'NAPTR', want_dnssec=True)
+        query1.flags |= dns.flags.AD
+        res = self.sendUDPQuery(query1)
+        self.assertMessageIsAuthenticated(res)
+        self.assertRRsetInAnswer(res, exp)
+        self.assertMatchingRRSIGInAnswer(res, exp)
+        self.assertRRsetInAdditional(res, adds1)
+        self.assertMatchingRRSIGInAdditional(res, adds1)
+        self.assertRRsetInAdditional(res, adds2)
+        self.assertMatchingRRSIGInAdditional(res, adds2)
+        self.assertRRsetInAdditional(res, adds3)
+        self.assertMatchingRRSIGInAdditional(res, adds3)
+        self.assertRRsetInAdditional(res, adds4)
+        self.assertMatchingRRSIGInAdditional(res, adds4)
+        self.assertRRsetInAdditional(res, adds5)
+        self.assertMatchingRRSIGInAdditional(res, adds5)
+        self.assertRRsetInAdditional(res, adds6)
+        self.assertMatchingRRSIGInAdditional(res, adds6)
+        self.assertRRsetInAdditional(res, adds7)
+        self.assertMatchingRRSIGInAdditional(res, adds7)
+
+class testAdditionalsResolveCacheOnly(RecursorTest):
+    _confdir = 'AdditionalsResolveCacheOnly'
+    _config_template = """
+    dnssec=validate
+    disable-packetcache
+    """
+    _lua_config_file = """
+    addAllowedAdditionalQType(pdns.MX, {pdns.A, pdns.AAAA}, { mode = "ResolveImmediately"})
+    """
+
+    def testMX(self):
+        expected = dns.rrset.from_text('secure.example.', 0, dns.rdataclass.IN, 'MX', '10 mx1.secure.example.', '20 mx2.secure.example.')
+        adds1 = dns.rrset.from_text('mx1.secure.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.18')
+        adds2 = dns.rrset.from_text('mx2.secure.example.', 0, dns.rdataclass.IN, 'AAAA', '1::2')
+        query1 = dns.message.make_query('secure.example', 'MX', want_dnssec=True)
+        query1.flags |= dns.flags.AD
+
+        res = self.sendUDPQuery(query1)
+        self.assertMessageIsAuthenticated(res)
+        self.assertRRsetInAnswer(res, expected)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+        self.assertRRsetInAdditional(res, adds1)
+        self.assertRRsetInAdditional(res, adds2)
+        self.assertMatchingRRSIGInAdditional(res, adds1)
+        self.assertMatchingRRSIGInAdditional(res, adds2)
+

--- a/regression-tests.recursor-dnssec/test_Additionals.py
+++ b/regression-tests.recursor-dnssec/test_Additionals.py
@@ -47,9 +47,9 @@ class testAdditionalsResolveImmediately(RecursorTest):
     disable-packetcache
     """
     _lua_config_file = """
-    addAllowedAdditionalQType(pdns.MX, {pdns.A, pdns.AAAA}, { mode = "ResolveImmediately"})
-    addAllowedAdditionalQType(pdns.NAPTR, {pdns.A, pdns.AAAA, pdns.SRV}, { mode = "ResolveImmediately"})
-    addAllowedAdditionalQType(pdns.SRV, {pdns.A, pdns.AAAA}, { mode = "ResolveImmediately"})
+    addAllowedAdditionalQType(pdns.MX, {pdns.A, pdns.AAAA}, { mode = pdns.AdditionalMode.ResolveImmediately})
+    addAllowedAdditionalQType(pdns.NAPTR, {pdns.A, pdns.AAAA, pdns.SRV}, { mode = pdns.AdditionalMode.ResolveImmediately})
+    addAllowedAdditionalQType(pdns.SRV, {pdns.A, pdns.AAAA}, { mode = pdns.AdditionalMode.ResolveImmediately})
     """
 
     def testMX(self):
@@ -109,7 +109,7 @@ class testAdditionalsResolveCacheOnly(RecursorTest):
     disable-packetcache
     """
     _lua_config_file = """
-    addAllowedAdditionalQType(pdns.MX, {pdns.A, pdns.AAAA}, { mode = "ResolveImmediately"})
+    addAllowedAdditionalQType(pdns.MX, {pdns.A, pdns.AAAA}, { mode = pdns.AdditionalMode.ResolveImmediately})
     """
 
     def testMX(self):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This PR is a PoC of adding additional records to a result if wanted and relevant.

TODO

- [ ] Decide if it is OK to add non-authoritative answers to the additional section
- [ ] See if other types would be needed
- [ ] Potentially be smarter about AliasMode wrt SVCB records
- [x] Tests
- [x] Docs

### Long Description
Currently we consume some Additional record types (name dependent on the corresponding Answer record) from auths and store them as non-auth in the record cache, but we never send any Additional record to the client.

With this PR, we can add Additionals for MX, NS, SRV, NAPTR, SVCB and HTTPS records. We have code per record type to determined the target name.

Additionally, there is a table that defines which qtypes to add for which answer records. The table also defines how to resolve the additional records.
The options are
- `Ignore` (do not add)
- `CacheOnly` look into the record cache add add if availabe
- `CacheOnlyRequireAuth` look into the record cache add add if availabe and authoritative
- `ResolveImmediately` do an active resolve immediately, this does use the record cache.
- `ResolveDeferred` add if in the cache, if not (and also not in negache) start an async task to retrieve them and insert into the cache. Not yet implemented, dependent on #11294

ATM Only `ResolveImmediately` will add RRSIGs to the Additionals, if available and indicated by the `dnssec` setting and query flags.

To configure the table add lines like this to the Lua config:
```
addAllowedAdditionalQType(
   pdns.MX, {pdns.A, pdns.AAAA}, {mode="CacheOnlyRequireAuth"})
addAllowedAdditionalQType(
   pdns.SRV, {pdns.A}, {mode="ResolveImmediately"})
addAllowedAdditionalQType(
   pdns.SVCB, {pdns.A, pdns.AAAA}, {mode="CacheOnly"})
addAllowedAdditionalQType(
   pdns.HTTPS, {pdns.A, pdns.AAAA}, {mode="CacheOnly"})
addAllowedAdditionalQType(
   pdns.NAPTR, {pdns.A, pdns.AAAA, pdns.SRV}, {mode="ResolveImmediately"})
```
(This example table uses the various methods mainly for testing, not because it makes a lot of sense)
So an MX answer will get A and AAAA Additionals if present in the cache authoritatively.

Third argument is optional, default mode is `CacheOnlyRequireAuth` as it is cheap and we have to decide if it's OK to add non-authoritative answers to Additional data.

Note that this is recursive, if an `NAPTR` answer includes an`SVR` record, we also will try to add Additionals for that `SRV` record. e.g.
```
$ dig -p 5301 naptr.m6k.nl naptr 

; <<>> dig 9.10.8-P1 <<>> -p 5301 naptr.m6k.nl naptr
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 49413
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 5

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;naptr.m6k.nl.                  IN      NAPTR

;; ANSWER SECTION:
naptr.m6k.nl.           53      IN      NAPTR   10 10 "s" "X" "" service1.m6k.nl.
naptr.m6k.nl.           53      IN      NAPTR   10 10 "s" "Y" "" service2.m6k.nl.
naptr.m6k.nl.           53      IN      NAPTR   10 10 "a" "Z" "" ttl20.m6k.nl.

;; ADDITIONAL SECTION:
service2.m6k.nl.        53      IN      SRV     20 100 8080 ttl9.m6k.nl.
service1.m6k.nl.        53      IN      SRV     20 100 8080 ttl9.m6k.nl.
ttl9.m6k.nl.            2       IN      A       1.2.3.9
ttl20.m6k.nl.           13      IN      A       1.2.3.20

;; Query time: 0 msec
;; SERVER: 127.0.0.1#5301(127.0.0.1)
;; WHEN: Tue Feb 08 17:10:43 CET 2022
;; MSG SIZE  rcvd: 246
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [x] included documentation (including possible behaviour changes)
- [X] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
