### PR TITLE
Stop using the boost version of tie and tuple by default

### DIFF
--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -29,8 +29,6 @@
 #include <mutex>
 #include <boost/utility.hpp>
 
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -69,7 +67,7 @@ struct Bind2DNSRecord
       return false;
     if (qtype == QType::SOA && rhs.qtype != QType::SOA)
       return true;
-    return tie(qtype, content, ttl) < tie(rhs.qtype, rhs.content, rhs.ttl);
+    return std::tie(qtype, content, ttl) < std::tie(rhs.qtype, rhs.content, rhs.ttl);
   }
 };
 

--- a/pdns/anadns.hh
+++ b/pdns/anadns.hh
@@ -37,8 +37,8 @@ struct QuestionIdentifier
   bool operator<(const QuestionIdentifier& rhs) const
   {
     return 
-      tie(d_id,         d_qtype,     d_source,     d_dest,     d_qname) < 
-      tie(rhs.d_id, rhs.d_qtype, rhs.d_source, rhs.d_dest, rhs.d_qname);
+      std::tie(d_id,         d_qtype,     d_source,     d_dest,     d_qname) <
+      std::tie(rhs.d_id, rhs.d_qtype, rhs.d_source, rhs.d_dest, rhs.d_qname);
   }
 
 

--- a/pdns/anadns.hh
+++ b/pdns/anadns.hh
@@ -20,8 +20,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <string>
 #include <netinet/ip.h>
 #include <netinet/udp.h>

--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -25,9 +25,13 @@
 #include "dns.hh"
 #include <boost/version.hpp>
 #include "namespaces.hh"
-using namespace ::boost::multi_index;
 
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/hashed_index.hpp> 
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+using namespace ::boost::multi_index;
 
 #include "dnspacket.hh"
 #include "lock.hh"

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -97,7 +97,7 @@ void AuthQueryCache::insert(const DNSName &qname, const QType& qtype, vector<DNS
 
     bool inserted;
     cmap_t::iterator place;
-    tie(place, inserted) = map->insert(val);
+    std::tie(place, inserted) = map->insert(val);
 
     if (!inserted) {
       map->replace(place, std::move(val));
@@ -119,7 +119,7 @@ void AuthQueryCache::insert(const DNSName &qname, const QType& qtype, vector<DNS
 bool AuthQueryCache::getEntryLocked(const cmap_t& map, const DNSName &qname, uint16_t qtype, vector<DNSZoneRecord>& value, int zoneID, time_t now)
 {
   auto& idx = boost::multi_index::get<HashTag>(map);
-  auto iter = idx.find(tie(qname, qtype, zoneID));
+  auto iter = idx.find(std::tie(qname, qtype, zoneID));
 
   if (iter == idx.end()) {
     (*d_statnummiss)++;

--- a/pdns/auth-querycache.hh
+++ b/pdns/auth-querycache.hh
@@ -25,9 +25,13 @@
 #include "dns.hh"
 #include <boost/version.hpp>
 #include "namespaces.hh"
-using namespace ::boost::multi_index;
 
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/hashed_index.hpp> 
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+using namespace ::boost::multi_index;
 
 #include "dns.hh"
 #include "dnspacket.hh"

--- a/pdns/auth-zonecache.cc
+++ b/pdns/auth-zonecache.cc
@@ -74,7 +74,7 @@ void AuthZoneCache::clear()
   purgeLockedCollectionsVector(d_maps);
 }
 
-void AuthZoneCache::replace(const vector<tuple<DNSName, int>>& zone_indices)
+void AuthZoneCache::replace(const vector<std::tuple<DNSName, int>>& zone_indices)
 {
   if (!d_refreshinterval)
     return;
@@ -83,10 +83,10 @@ void AuthZoneCache::replace(const vector<tuple<DNSName, int>>& zone_indices)
   vector<cmap_t> newMaps(d_maps.size());
 
   // build new maps
-  for (const tuple<DNSName, int>& tup : zone_indices) {
-    const DNSName& zone = tup.get<0>();
+  for (const std::tuple<DNSName, int>& tup : zone_indices) {
+    const DNSName& zone = std::get<0>(tup);
     CacheValue val;
-    val.zoneId = tup.get<1>();
+    val.zoneId = std::get<1>(tup);
     auto& mc = newMaps[getMapIndex(zone)];
     auto iter = mc.find(zone);
     if (iter != mc.end()) {
@@ -101,11 +101,11 @@ void AuthZoneCache::replace(const vector<tuple<DNSName, int>>& zone_indices)
     // process zone updates done while data collection for replace() was already in progress.
     auto pending = d_pending.lock();
     assert(pending->d_replacePending); // make sure we never forget to call setReplacePending()
-    for (const tuple<DNSName, int, bool>& tup : pending->d_pendingUpdates) {
-      const DNSName& zone = tup.get<0>();
+    for (const std::tuple<DNSName, int, bool>& tup : pending->d_pendingUpdates) {
+      const DNSName& zone = std::get<0>(tup);
       CacheValue val;
-      val.zoneId = tup.get<1>();
-      bool insert = tup.get<2>();
+      val.zoneId = std::get<1>(tup);
+      bool insert = std::get<2>(tup);
       auto& mc = newMaps[getMapIndex(zone)];
       auto iter = mc.find(zone);
       if (iter != mc.end()) {

--- a/pdns/auth-zonecache.hh
+++ b/pdns/auth-zonecache.hh
@@ -32,7 +32,7 @@ class AuthZoneCache : public boost::noncopyable
 public:
   AuthZoneCache(size_t mapsCount = 1024);
 
-  void replace(const vector<tuple<DNSName, int>>& zone);
+  void replace(const vector<std::tuple<DNSName, int>>& zone);
   void add(const DNSName& zone, const int zoneId);
   void remove(const DNSName& zone);
   void setReplacePending(); //!< call this when data collection for the subsequent replace() call starts.
@@ -91,7 +91,7 @@ private:
 
   struct PendingData
   {
-    std::vector<tuple<DNSName, int, bool>> d_pendingUpdates;
+    std::vector<std::tuple<DNSName, int, bool>> d_pendingUpdates;
     bool d_replacePending{false};
   };
   LockGuarded<PendingData> d_pending;

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -50,7 +50,7 @@ struct SuckRequest
   std::pair<RequestPriority, uint64_t> priorityAndOrder;
   bool operator<(const SuckRequest& b) const
   {
-    return tie(domain, master) < tie(b.domain, b.master);
+    return std::tie(domain, master) < std::tie(b.domain, b.master);
   }
 };
 

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -20,11 +20,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
-#include <boost/multi_index/key_extractors.hpp>
-#include <boost/multi_index/sequenced_index.hpp>
 #include "qtype.hh"
 #include "dnsname.hh"
 #include <time.h>

--- a/pdns/dnsdemog.cc
+++ b/pdns/dnsdemog.cc
@@ -44,7 +44,7 @@ struct Entry
 
   bool operator<(const struct Entry& rhs) const 
   {
-    return tie(ip, port, id) < tie(rhs.ip, rhs.port, rhs.id);
+    return std::tie(ip, port, id) < std::tie(rhs.ip, rhs.port, rhs.id);
   }
 };
 

--- a/pdns/dnsdemog.cc
+++ b/pdns/dnsdemog.cc
@@ -26,8 +26,6 @@
 #include "statbag.hh"
 #include "dnspcap.hh"
 #include "dnsparser.hh"
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <map>
 #include <set>
 #include <fstream>

--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -88,7 +88,7 @@ void DNSDistPacketCache::insertLocked(CacheShard& shard, std::unordered_map<uint
 
   std::unordered_map<uint32_t,CacheValue>::iterator it;
   bool result;
-  tie(it, result) = map.insert({key, newValue});
+  std::tie(it, result) = map.insert({key, newValue});
 
   if (result) {
     ++shard.d_entriesCount;

--- a/pdns/dnsdist-dynbpf.cc
+++ b/pdns/dnsdist-dynbpf.cc
@@ -49,8 +49,8 @@ void DynBPFFilter::purgeExpired(const struct timespec& now)
 {
   auto data = d_data.lock();
 
-  typedef nth_index<container_t,1>::type ordered_until;
-  ordered_until& ou = get<1>(data->d_entries);
+  typedef boost::multi_index::nth_index<container_t,1>::type ordered_until;
+  ordered_until& ou = boost::multi_index::get<1>(data->d_entries);
 
   for (ordered_until::iterator it = ou.begin(); it != ou.end(); ) {
     if (it->d_until < now) {

--- a/pdns/dnsdist-dynbpf.hh
+++ b/pdns/dnsdist-dynbpf.hh
@@ -27,6 +27,7 @@
 
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/member.hpp>
 
 class DynBPFFilter
 {
@@ -59,12 +60,12 @@ private:
     ComboAddress d_addr;
     struct timespec d_until;
   };
-  typedef multi_index_container<BlockEntry,
-                                indexed_by <
-                                  ordered_unique< member<BlockEntry,ComboAddress,&BlockEntry::d_addr>, ComboAddress::addressOnlyLessThan >,
-                                  ordered_non_unique< member<BlockEntry,struct timespec,&BlockEntry::d_until> >
-                                  >
-                                > container_t;
+  typedef boost::multi_index_container<BlockEntry,
+                                       boost::multi_index::indexed_by <
+                                         boost::multi_index::ordered_unique< boost::multi_index::member<BlockEntry,ComboAddress,&BlockEntry::d_addr>, ComboAddress::addressOnlyLessThan >,
+                                         boost::multi_index::ordered_non_unique< boost::multi_index::member<BlockEntry,struct timespec,&BlockEntry::d_until> >
+                                         >
+                                       > container_t;
   struct Data {
     container_t d_entries;
     std::shared_ptr<BPFFilter> d_bpf{nullptr};

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -480,7 +480,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
                          }
 
                          if (vars.count("id")) {
-                           ret->setId(boost::uuids::string_generator()((boost::get<string>(vars["id"]))));
+                           ret->setId(boost::uuids::string_generator()(boost::get<string>(vars["id"])));
                          }
 
                          if (vars.count("checkName")) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -50,9 +50,7 @@
 #include "dnsdist-web.hh"
 
 #include "base64.hh"
-#include "dnswriter.hh"
 #include "dolog.hh"
-#include "lock.hh"
 #include "sodcrypto.hh"
 
 #ifdef HAVE_LIBSSL
@@ -60,7 +58,7 @@
 #endif
 
 #include <boost/logic/tribool.hpp>
-#include <boost/lexical_cast.hpp>
+#include <boost/uuid/string_generator.hpp>
 
 #ifdef HAVE_SYSTEMD
 #include <systemd/sd-daemon.h>
@@ -482,7 +480,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
                          }
 
                          if (vars.count("id")) {
-                           ret->setId(boost::lexical_cast<boost::uuids::uuid>(boost::get<string>(vars["id"])));
+                           ret->setId(boost::uuids::string_generator()((boost::get<string>(vars["id"]))));
                          }
 
                          if (vars.count("checkName")) {
@@ -2287,6 +2285,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #endif
     return result;
   });
+
   luaCtx.writeFunction("addDOHLocal", [client](const std::string& addr, boost::optional<boost::variant<std::string, std::shared_ptr<TLSCertKeyPair>, std::vector<std::pair<int, std::string>>, std::vector<std::pair<int, std::shared_ptr<TLSCertKeyPair>>>>> certFiles, boost::optional<boost::variant<std::string, std::vector<std::pair<int, std::string>>>> keyFiles, boost::optional<boost::variant<std::string, vector<pair<int, std::string>>>> urls, boost::optional<localbind_t> vars) {
     if (client) {
       return;

--- a/pdns/dnsdistdist/dnsdist-lbpolicies.cc
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.cc
@@ -36,14 +36,14 @@ shared_ptr<DownstreamState> leastOutstanding(const ServerPolicy::NumberedServerV
     return servers[0].second;
   }
 
-  vector<pair<tuple<int,int,double>, size_t>> poss;
+  vector<pair<std::tuple<int,int,double>, size_t>> poss;
   /* so you might wonder, why do we go through this trouble? The data on which we sort could change during the sort,
      which would suck royally and could even lead to crashes. So first we snapshot on what we sort, and then we sort */
   poss.reserve(servers.size());
   size_t position = 0;
   for(const auto& d : servers) {
     if(d.second->isUp()) {
-      poss.emplace_back(make_tuple(d.second->outstanding.load(), d.second->order, d.second->latencyUsec), position);
+      poss.emplace_back(std::make_tuple(d.second->outstanding.load(), d.second->order, d.second->latencyUsec), position);
     }
     ++position;
   }

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -21,6 +21,11 @@
  */
 #pragma once
 
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+
 #include "cachecleaner.hh"
 #include "dnsdist.hh"
 #include "dnsdist-ecs.hh"

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+
 #include <queue>
 
 #include "sstuff.hh"

--- a/pdns/dnsgram.cc
+++ b/pdns/dnsgram.cc
@@ -27,8 +27,6 @@
 #include "dnspcap.hh"
 #include "dnsrecords.hh"
 #include "dnsparser.hh"
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <map>
 #include <set>
 #include <fstream>

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -29,8 +29,6 @@
 // #include <netinet/in.h>
 #include "misc.hh"
 
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include "dns.hh"
 #include "dnswriter.hh"
 #include "dnsname.hh"
@@ -303,10 +301,10 @@ struct DNSRecord
 
   bool operator<(const DNSRecord& rhs) const
   {
-    if(tie(d_name, d_type, d_class, d_ttl) < tie(rhs.d_name, rhs.d_type, rhs.d_class, rhs.d_ttl))
+    if(std::tie(d_name, d_type, d_class, d_ttl) < std::tie(rhs.d_name, rhs.d_type, rhs.d_class, rhs.d_ttl))
       return true;
     
-    if(tie(d_name, d_type, d_class, d_ttl) != tie(rhs.d_name, rhs.d_type, rhs.d_class, rhs.d_ttl))
+    if(std::tie(d_name, d_type, d_class, d_ttl) != std::tie(rhs.d_name, rhs.d_type, rhs.d_class, rhs.d_ttl))
       return false;
     
     string lzrp, rzrp;
@@ -329,10 +327,10 @@ struct DNSRecord
     if(b.d_name.canonCompare(a.d_name))
       return false;
 
-    if(tie(aType, a.d_class, a.d_ttl) < tie(bType, b.d_class, b.d_ttl))
+    if(std::tie(aType, a.d_class, a.d_ttl) < std::tie(bType, b.d_class, b.d_ttl))
       return true;
     
-    if(tie(aType, a.d_class, a.d_ttl) != tie(bType, b.d_class, b.d_ttl))
+    if(std::tie(aType, a.d_class, a.d_ttl) != std::tie(bType, b.d_class, b.d_ttl))
       return false;
     
     string lzrp, rzrp;

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -82,8 +82,8 @@ bool DNSResourceRecord::operator==(const DNSResourceRecord& rhs)
   string rcontent=toLower(rhs.content);
 
   return
-    tie(qname, qtype, lcontent, ttl) ==
-    tie(rhs.qname, rhs.qtype, rcontent, rhs.ttl);
+    std::tie(qname, qtype, lcontent, ttl) ==
+    std::tie(rhs.qname, rhs.qtype, rcontent, rhs.ttl);
 }
 
 boilerplate_conv(A, conv.xfrIP(d_ip));

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -359,8 +359,8 @@ public:
   string d_key;
   bool operator<(const DNSKEYRecordContent& rhs) const
   {
-    return tie(d_flags, d_protocol, d_algorithm, d_key) < 
-      tie(rhs.d_flags, rhs.d_protocol, rhs.d_algorithm, rhs.d_key);
+    return std::tie(d_flags, d_protocol, d_algorithm, d_key) < 
+      std::tie(rhs.d_flags, rhs.d_protocol, rhs.d_algorithm, rhs.d_key);
   }
 };
 
@@ -386,13 +386,13 @@ public:
     if(typeid(*this) != typeid(rhs))
       return false;
     auto rrhs =dynamic_cast<const decltype(this)>(&rhs);
-    return tie(d_tag, d_algorithm, d_digesttype, d_digest) ==
-      tie(rrhs->d_tag, rrhs->d_algorithm, rrhs->d_digesttype, rrhs->d_digest);
+    return std::tie(d_tag, d_algorithm, d_digesttype, d_digest) ==
+      std::tie(rrhs->d_tag, rrhs->d_algorithm, rrhs->d_digesttype, rrhs->d_digest);
   }
   bool operator<(const DSRecordContent& rhs) const
   {
-    return tie(d_tag, d_algorithm, d_digesttype, d_digest) <
-      tie(rhs.d_tag, rhs.d_algorithm, rhs.d_digesttype, rhs.d_digest);
+    return std::tie(d_tag, d_algorithm, d_digesttype, d_digest) <
+      std::tie(rhs.d_tag, rhs.d_algorithm, rhs.d_digesttype, rhs.d_digest);
   }
 
   includeboilerplate(DS)

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -31,8 +31,6 @@
 #include "dnspcap.hh"
 #include "dnsparser.hh"
 #include "dnsname.hh"
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <map>
 #include <set>
 #include <fstream>

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -102,7 +102,7 @@ std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCString(DNSKEY
   map<string, string> stormap;
 
   while (std::getline(str, sline)) {
-    tie(key,value) = splitField(sline, ':');
+    std::tie(key,value) = splitField(sline, ':');
     boost::trim(value);
 
     toLowerInPlace(key);
@@ -303,7 +303,7 @@ void DNSCryptoKeyEngine::testMakers(unsigned int algo, maker_t* creator, maker_t
     map<string, string> stormap;
 
     while(std::getline(str, sline)) {
-      tie(key,value)=splitField(sline, ':');
+      std::tie(key,value)=splitField(sline, ':');
       boost::trim(value);
       if(pdns_iequals(key,"algorithm")) {
         algorithm = pdns_stou(value);

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -27,7 +27,6 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/ordered_index.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index/key_extractors.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include "dnssecinfra.hh"

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -173,7 +173,7 @@ uint64_t signatureCacheSize(const std::string& str)
 
 static bool rrsigncomp(const DNSZoneRecord& a, const DNSZoneRecord& b)
 {
-  return tie(a.dr.d_place, a.dr.d_type) < tie(b.dr.d_place, b.dr.d_type);
+  return std::tie(a.dr.d_place, a.dr.d_type) < std::tie(b.dr.d_place, b.dr.d_type);
 }
 
 static bool getBestAuthFromSet(const set<DNSName>& authSet, const DNSName& name, DNSName& auth)

--- a/pdns/inflighter.cc
+++ b/pdns/inflighter.cc
@@ -23,10 +23,12 @@
 #include "config.h"
 #endif
 #include <vector>
-#include <deque>
 #include <iostream>
 
 #include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+
 #include <boost/format.hpp>
 #include <sys/time.h>
 #include <time.h>

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -32,8 +32,6 @@
 #include "misc.hh"
 #include <netdb.h>
 #include <sstream>
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 
 #include "namespaces.hh"
 
@@ -91,7 +89,7 @@ union ComboAddress {
 
   bool operator==(const ComboAddress& rhs) const
   {
-    if(boost::tie(sin4.sin_family, sin4.sin_port) != boost::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
+    if(std::tie(sin4.sin_family, sin4.sin_port) != std::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
       return false;
     if(sin4.sin_family == AF_INET)
       return sin4.sin_addr.s_addr == rhs.sin4.sin_addr.s_addr;
@@ -109,9 +107,9 @@ union ComboAddress {
     if(sin4.sin_family == 0) {
       return false;
     }
-    if(boost::tie(sin4.sin_family, sin4.sin_port) < boost::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
+    if(std::tie(sin4.sin_family, sin4.sin_port) < std::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
       return true;
-    if(boost::tie(sin4.sin_family, sin4.sin_port) > boost::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
+    if(std::tie(sin4.sin_family, sin4.sin_port) > std::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
       return false;
 
     if(sin4.sin_family == AF_INET)
@@ -614,7 +612,7 @@ public:
 
   bool operator==(const Netmask& rhs) const
   {
-    return tie(d_network, d_bits) == tie(rhs.d_network, rhs.d_bits);
+    return std::tie(d_network, d_bits) == std::tie(rhs.d_network, rhs.d_bits);
   }
 
   bool empty() const
@@ -1552,7 +1550,7 @@ public:
 
   bool operator==(const AddressAndPortRange& rhs) const
   {
-    return tie(d_addr, d_addrMask, d_portMask) == tie(rhs.d_addr, rhs.d_addrMask, rhs.d_portMask);
+    return std::tie(d_addr, d_addrMask, d_portMask) == std::tie(rhs.d_addr, rhs.d_addrMask, rhs.d_portMask);
   }
 
   bool operator<(const AddressAndPortRange& rhs) const

--- a/pdns/ixfrutils.cc
+++ b/pdns/ixfrutils.cc
@@ -94,7 +94,7 @@ uint32_t getSerialFromRecords(const records_t& records, DNSRecord& soaret)
 {
   uint16_t t=QType::SOA;
 
-  auto found = records.equal_range(boost::tie(g_rootdnsname, t));
+  auto found = records.equal_range(std::tie(g_rootdnsname, t));
 
   for(auto iter = found.first; iter != found.second; ++iter) {
     auto soa = std::dynamic_pointer_cast<SOARecordContent>(iter->d_content);

--- a/pdns/ixfrutils.hh
+++ b/pdns/ixfrutils.hh
@@ -22,7 +22,11 @@
 #pragma once
 
 #include <sys/types.h>
+
 #include <boost/multi_index_container.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+
 #include "dnsparser.hh"
 #include "dnsrecords.hh"
 

--- a/pdns/ixplore.cc
+++ b/pdns/ixplore.cc
@@ -213,7 +213,7 @@ int main(int argc, char** argv) {
 
         for(const auto& rr : remove) {
           report<<'-'<< (rr.d_name+zone) <<" IN "<<DNSRecordContent::NumberToType(rr.d_type)<<" "<<rr.d_content->getZoneRepresentation()<<endl;
-          auto range = records.equal_range(tie(rr.d_name, rr.d_type, rr.d_class, rr.d_content));
+          auto range = records.equal_range(std::tie(rr.d_name, rr.d_type, rr.d_class, rr.d_content));
           if(range.first == range.second) {
             cout<<endl<<" !! Could not find record "<<rr.d_name<<" to remove!!"<<endl;
             //	  stop=true;

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -414,7 +414,7 @@ void RecursorLua4::postPrepareContext()
 
   d_lw->writeFunction("getStat", [](const std::string& str) {
       uint64_t result = 0;
-      boost::optional<uint64_t> value = getStatByName(str);
+      auto value = getStatByName(str);
       if (value) {
         result = *value;
       }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -26,14 +26,8 @@
 #include <regex.h>
 #include <limits.h>
 #include <type_traits>
-#include <boost/algorithm/string.hpp>
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
-#include <boost/multi_index/key_extractors.hpp>
-#include <boost/multi_index/sequenced_index.hpp>
 
-using namespace ::boost::multi_index;
+#include <boost/algorithm/string.hpp>
 
 #include "dns.hh"
 #include <atomic>
@@ -321,16 +315,16 @@ inline uint64_t uSec(const struct timeval& tv)
 
 inline bool operator<(const struct timeval& lhs, const struct timeval& rhs)
 {
-  return tie(lhs.tv_sec, lhs.tv_usec) < tie(rhs.tv_sec, rhs.tv_usec);
+  return std::tie(lhs.tv_sec, lhs.tv_usec) < std::tie(rhs.tv_sec, rhs.tv_usec);
 }
 inline bool operator<=(const struct timeval& lhs, const struct timeval& rhs)
 {
-  return tie(lhs.tv_sec, lhs.tv_usec) <= tie(rhs.tv_sec, rhs.tv_usec);
+  return std::tie(lhs.tv_sec, lhs.tv_usec) <= std::tie(rhs.tv_sec, rhs.tv_usec);
 }
 
 inline bool operator<(const struct timespec& lhs, const struct timespec& rhs)
 {
-  return tie(lhs.tv_sec, lhs.tv_nsec) < tie(rhs.tv_sec, rhs.tv_nsec);
+  return std::tie(lhs.tv_sec, lhs.tv_nsec) < std::tie(rhs.tv_sec, rhs.tv_nsec);
 }
 
 

--- a/pdns/mplexer.hh
+++ b/pdns/mplexer.hh
@@ -20,10 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include <boost/function.hpp>
 #include <boost/any.hpp>
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/hashed_index.hpp>
@@ -55,7 +52,7 @@ class FDMultiplexer
 {
 public:
   typedef boost::any funcparam_t;
-  typedef boost::function<void(int, funcparam_t&)> callbackfunc_t;
+  typedef std::function<void(int, funcparam_t&)> callbackfunc_t;
   enum class EventKind : uint8_t
   {
     Read,
@@ -196,11 +193,11 @@ public:
   std::vector<std::pair<int, funcparam_t>> getTimeouts(const struct timeval& tv, bool writes = false)
   {
     std::vector<std::pair<int, funcparam_t>> ret;
-    const auto tied = boost::tie(tv.tv_sec, tv.tv_usec);
+    const auto tied = std::tie(tv.tv_sec, tv.tv_usec);
     auto& idx = writes ? d_writeCallbacks.get<TTDOrderedTag>() : d_readCallbacks.get<TTDOrderedTag>();
 
     for (auto it = idx.begin(); it != idx.end(); ++it) {
-      if (it->d_ttd.tv_sec == 0 || tied <= boost::tie(it->d_ttd.tv_sec, it->d_ttd.tv_usec)) {
+      if (it->d_ttd.tv_sec == 0 || tied <= std::tie(it->d_ttd.tv_sec, it->d_ttd.tv_usec)) {
         break;
       }
       ret.emplace_back(it->d_fd, it->d_parameter);

--- a/pdns/namespaces.hh
+++ b/pdns/namespaces.hh
@@ -21,7 +21,6 @@
  */
 #pragma once
 
-#include <boost/tuple/tuple.hpp>
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <iostream>
@@ -30,12 +29,6 @@
 #include <set>
 #include <string>
 #include <vector>
-
-// We have a few paces where boost::tuple is used, and other places where an unscoped tuple is used
-// prefer the boost one for now. We might want to switch to std::tuple one day. Same for tie.
-using boost::make_tuple;
-using boost::tuple;
-using boost::tie;
 
 using std::cerr;
 using std::clog;

--- a/pdns/pdns_hw.cc
+++ b/pdns/pdns_hw.cc
@@ -24,7 +24,6 @@
 #endif
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index/key_extractors.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -172,7 +172,7 @@ static int handleCounter64Stats(netsnmp_mib_handler* handler,
     return SNMP_ERR_GENERR;
   }
 
-  boost::optional<uint64_t> value = getStatByName(it->second);
+  auto value = getStatByName(it->second);
   if (value) {
     return RecursorSNMPAgent::setCounter64Value(requests, *value);
   }

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <map>
+#include <optional>
 #include <vector>
 #include <inttypes.h>
 #include <sys/un.h>
@@ -33,7 +34,6 @@
 #include "dnsname.hh"
 #include "sholder.hh"
 #include <atomic>
-#include <boost/optional.hpp>
 
 extern GlobalStateHolder<SuffixMatchNode> g_dontThrottleNames;
 extern GlobalStateHolder<NetmaskGroup> g_dontThrottleNetmasks;
@@ -134,7 +134,7 @@ std::vector<ComboAddress>* pleaseGetLargeAnswerRemotes();
 std::vector<ComboAddress>* pleaseGetTimeouts();
 DNSName getRegisteredName(const DNSName& dom);
 std::atomic<unsigned long>* getDynMetric(const std::string& str, const std::string& prometheusName);
-boost::optional<uint64_t> getStatByName(const std::string& name);
+std::optional<uint64_t> getStatByName(const std::string& name);
 bool isStatDisabled(StatComponent component, const std::string& name);
 void disableStat(StatComponent component, const string& name);
 void disableStats(StatComponent component, const string& stats);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -12,9 +12,6 @@
 #include "recursor_cache.hh"
 #include "syncres.hh"
 #include "negcache.hh"
-#include <boost/function.hpp>
-#include <boost/optional.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -158,9 +155,9 @@ std::atomic<unsigned long>* getDynMetric(const std::string& str, const std::stri
   return ret.d_ptr;
 }
 
-static boost::optional<uint64_t> get(const string& name)
+static std::optional<uint64_t> get(const string& name)
 {
-  boost::optional<uint64_t> ret;
+  std::optional<uint64_t> ret;
 
   if (d_get32bitpointers.count(name))
     return *d_get32bitpointers.find(name)->second;
@@ -188,7 +185,7 @@ static boost::optional<uint64_t> get(const string& name)
   return ret;
 }
 
-boost::optional<uint64_t> getStatByName(const std::string& name)
+std::optional<uint64_t> getStatByName(const std::string& name)
 {
   return get(name);
 }
@@ -248,7 +245,7 @@ static string doGet(T begin, T end)
   string ret;
 
   for (T i = begin; i != end; ++i) {
-    boost::optional<uint64_t> num = get(*i);
+    std::optional<uint64_t> num = get(*i);
     if (num)
       ret += std::to_string(*num) + "\n";
     else
@@ -1497,8 +1494,8 @@ vector<pair<DNSName, uint16_t>>* pleaseGetBogusQueryRing()
   return ret;
 }
 
-typedef boost::function<vector<ComboAddress>*()> pleaseremotefunc_t;
-typedef boost::function<vector<pair<DNSName, uint16_t>>*()> pleasequeryfunc_t;
+typedef std::function<vector<ComboAddress>*()> pleaseremotefunc_t;
+typedef std::function<vector<pair<DNSName, uint16_t>>*()> pleasequeryfunc_t;
 
 vector<ComboAddress>* pleaseGetRemotes()
 {
@@ -1632,7 +1629,7 @@ static DNSName nopFilter(const DNSName& name)
   return name;
 }
 
-static string doGenericTopQueries(pleasequeryfunc_t func, boost::function<DNSName(const DNSName&)> filter = nopFilter)
+static string doGenericTopQueries(pleasequeryfunc_t func, std::function<DNSName(const DNSName&)> filter = nopFilter)
 {
   typedef pair<DNSName, uint16_t> query_t;
   typedef map<query_t, int> counts_t;

--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -129,7 +129,7 @@ bool RecursorPacketCache::getResponsePacket(unsigned int tag, const std::string&
 {
   *qhash = canHashPacket(queryPacket, s_skipOptions);
   const auto& idx = d_packetCache.get<HashTag>();
-  auto range = idx.equal_range(tie(tag, *qhash, tcp));
+  auto range = idx.equal_range(std::tie(tag, *qhash, tcp));
 
   if (range.first == range.second) {
     d_misses++;
@@ -144,7 +144,7 @@ bool RecursorPacketCache::getResponsePacket(unsigned int tag, const std::string&
 {
   *qhash = canHashPacket(queryPacket, s_skipOptions);
   const auto& idx = d_packetCache.get<HashTag>();
-  auto range = idx.equal_range(tie(tag, *qhash, tcp));
+  auto range = idx.equal_range(std::tie(tag, *qhash, tcp));
 
   if (range.first == range.second) {
     d_misses++;
@@ -159,7 +159,7 @@ bool RecursorPacketCache::getResponsePacket(unsigned int tag, const std::string&
 void RecursorPacketCache::insertResponsePacket(unsigned int tag, uint32_t qhash, std::string&& query, const DNSName& qname, uint16_t qtype, uint16_t qclass, std::string&& responsePacket, time_t now, uint32_t ttl, const vState& valState, OptPBData&& pbdata, bool tcp)
 {
   auto& idx = d_packetCache.get<HashTag>();
-  auto range = idx.equal_range(tie(tag, qhash, tcp));
+  auto range = idx.equal_range(std::tie(tag, qhash, tcp));
   auto iter = range.first;
 
   for (; iter != range.second; ++iter) {

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -28,7 +28,6 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/hashed_index.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index/key_extractors.hpp>
 #include <boost/optional.hpp>

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -30,6 +30,7 @@
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
 #include <boost/optional.hpp>
 
 #include "packetcache.hh"

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -165,7 +165,7 @@ MemRecursorCache::cache_t::const_iterator MemRecursorCache::getEntryUsingECSInde
         /* we have nothing more specific for you */
         break;
       }
-      auto key = boost::make_tuple(qname, qtype, boost::none, best);
+      auto key = std::make_tuple(qname, qtype, boost::none, best);
       auto entry = map.d_map.find(key);
       if (entry == map.d_map.end()) {
         /* ecsIndex is not up-to-date */
@@ -197,7 +197,7 @@ MemRecursorCache::cache_t::const_iterator MemRecursorCache::getEntryUsingECSInde
   }
 
   /* we have nothing specific, let's see if we have a generic one */
-  auto key = boost::make_tuple(qname, qtype, boost::none, Netmask());
+  auto key = std::make_tuple(qname, qtype, boost::none, Netmask());
   auto entry = map.d_map.find(key);
   if (entry != map.d_map.end()) {
     if (entry->d_ttd > now) {
@@ -404,7 +404,7 @@ void MemRecursorCache::replace(time_t now, const DNSName& qname, const QType qt,
 
   // We only store with a tag if we have an ednsmask and the tag is available
   // We only store an ednsmask if we do not have a tag and we do have a mask.
-  auto key = boost::make_tuple(qname, qt.getCode(), ednsmask ? routingTag : boost::none, (ednsmask && !routingTag) ? *ednsmask : Netmask());
+  auto key = std::make_tuple(qname, qt.getCode(), ednsmask ? routingTag : boost::none, (ednsmask && !routingTag) ? *ednsmask : Netmask());
   bool isNew = false;
   cache_t::iterator stored = map->d_map.find(key);
   if (stored == map->d_map.end()) {
@@ -421,7 +421,7 @@ void MemRecursorCache::replace(time_t now, const DNSName& qname, const QType qt,
   if (isNew || stored->d_ttd <= now) {
     /* don't bother building an ecsIndex if we don't have any netmask-specific entries */
     if (!routingTag && ednsmask && !ednsmask->empty()) {
-      auto ecsIndexKey = boost::make_tuple(qname, qt.getCode());
+      auto ecsIndexKey = std::make_tuple(qname, qt.getCode());
       auto ecsIndex = map->d_ecsIndex.find(ecsIndexKey);
       if (ecsIndex == map->d_ecsIndex.end()) {
         ecsIndex = map->d_ecsIndex.insert(ECSIndexEntry(qname, qt.getCode())).first;

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -155,7 +155,7 @@ time_t MemRecursorCache::handleHit(MapCombo::LockedContent& content, MemRecursor
 MemRecursorCache::cache_t::const_iterator MemRecursorCache::getEntryUsingECSIndex(MapCombo::LockedContent& map, time_t now, const DNSName& qname, const QType qtype, bool requireAuth, const ComboAddress& who)
 {
   // MUTEX SHOULD BE ACQUIRED (as indicated by the reference to the content which is protected by a lock)
-  auto ecsIndexKey = tie(qname, qtype);
+  auto ecsIndexKey = std::tie(qname, qtype);
   auto ecsIndex = map.d_ecsIndex.find(ecsIndexKey);
   if (ecsIndex != map.d_ecsIndex.end() && !ecsIndex->isEmpty()) {
     /* we have netmask-specific entries, let's see if we match one */
@@ -221,7 +221,7 @@ MemRecursorCache::Entries MemRecursorCache::getEntries(MapCombo::LockedContent& 
     map.d_cachedqname = qname;
     map.d_cachedrtag = rtag;
     const auto& idx = map.d_map.get<NameAndRTagOnlyHashedTag>();
-    map.d_cachecache = idx.equal_range(tie(qname, rtag));
+    map.d_cachecache = idx.equal_range(std::tie(qname, rtag));
     map.d_cachecachevalid = true;
   }
   return map.d_cachecache;
@@ -522,7 +522,7 @@ size_t MemRecursorCache::doWipeCache(const DNSName& name, bool sub, const QType 
     }
     else {
       auto& ecsIdx = map->d_ecsIndex.get<HashedTag>();
-      auto ecsIndexRange = ecsIdx.equal_range(tie(name, qtype));
+      auto ecsIndexRange = ecsIdx.equal_range(std::tie(name, qtype));
       ecsIdx.erase(ecsIndexRange.first, ecsIndexRange.second);
     }
   }
@@ -564,7 +564,7 @@ bool MemRecursorCache::doAgeCache(time_t now, const DNSName& name, const QType q
 {
   auto& mc = getMap(name);
   auto map = mc.lock();
-  cache_t::iterator iter = map->d_map.find(tie(name, qtype));
+  cache_t::iterator iter = map->d_map.find(std::tie(name, qtype));
   if (iter == map->d_map.end()) {
     return false;
   }

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -261,7 +261,7 @@ public:
       return;
     }
 
-    auto key = tie(entry.d_qname, entry.d_qtype);
+    auto key = std::tie(entry.d_qname, entry.d_qtype);
     auto ecsIndexEntry = map.d_ecsIndex.find(key);
     if (ecsIndexEntry != map.d_ecsIndex.end()) {
       ecsIndexEntry->removeNetmask(entry.d_netmask);

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -32,7 +32,6 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/hashed_index.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index/key_extractors.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/version.hpp>
@@ -73,8 +72,8 @@ public:
 private:
   struct CacheEntry
   {
-    CacheEntry(const boost::tuple<DNSName, QType, OptTag, Netmask>& key, bool auth) :
-      d_qname(key.get<0>()), d_netmask(key.get<3>().getNormalized()), d_rtag(key.get<2>()), d_state(vState::Indeterminate), d_ttd(0), d_qtype(key.get<1>()), d_auth(auth), d_submitted(false)
+    CacheEntry(const std::tuple<DNSName, QType, OptTag, Netmask>& key, bool auth) :
+      d_qname(std::get<0>(key)), d_netmask(std::get<3>(key).getNormalized()), d_rtag(std::get<2>(key)), d_state(vState::Indeterminate), d_ttd(0), d_qtype(std::get<1>(key)), d_auth(auth), d_submitted(false)
     {
     }
 

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -28,6 +28,8 @@
 #include <boost/multi_index/key_extractors.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 
+using namespace ::boost::multi_index;
+
 #include "base32.hh"
 #include "dnsname.hh"
 #include "dnsrecords.hh"

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -62,7 +62,7 @@ bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, N
   auto& map = getMap(lastLabel);
   auto content = map.lock();
 
-  negcache_t::const_iterator ni = content->d_map.find(tie(lastLabel, qtnull));
+  negcache_t::const_iterator ni = content->d_map.find(std::tie(lastLabel, qtnull));
 
   while (ni != content->d_map.end() && ni->d_name == lastLabel && ni->d_auth.isRoot() && ni->d_qtype == qtnull) {
     // We have something
@@ -142,7 +142,7 @@ void NegCache::updateValidationStatus(const DNSName& qname, const QType& qtype, 
 {
   auto& mc = getMap(qname);
   auto map = mc.lock();
-  auto range = map->d_map.equal_range(tie(qname, qtype));
+  auto range = map->d_map.equal_range(std::tie(qname, qtype));
 
   if (range.first != range.second) {
     range.first->d_validationState = newState;
@@ -161,7 +161,7 @@ size_t NegCache::count(const DNSName& qname)
 {
   auto& map = getMap(qname);
   auto content = map.lock();
-  return content->d_map.count(tie(qname));
+  return content->d_map.count(std::tie(qname));
 }
 
 /*!
@@ -174,7 +174,7 @@ size_t NegCache::count(const DNSName& qname, const QType qtype)
 {
   auto& map = getMap(qname);
   auto content = map.lock();
-  return content->d_map.count(tie(qname, qtype));
+  return content->d_map.count(std::tie(qname, qtype));
 }
 
 /*!
@@ -190,7 +190,7 @@ size_t NegCache::wipe(const DNSName& name, bool subtree)
   if (subtree) {
     for (auto& map : d_maps) {
       auto m = map.lock();
-      for (auto i = m->d_map.lower_bound(tie(name)); i != m->d_map.end();) {
+      for (auto i = m->d_map.lower_bound(std::tie(name)); i != m->d_map.end();) {
         if (!i->d_name.isPartOf(name))
           break;
         i = m->d_map.erase(i);
@@ -203,7 +203,7 @@ size_t NegCache::wipe(const DNSName& name, bool subtree)
 
   auto& map = getMap(name);
   auto content = map.lock();
-  auto range = content->d_map.equal_range(tie(name));
+  auto range = content->d_map.equal_range(std::tie(name));
   auto i = range.first;
   while (i != range.second) {
     i = content->d_map.erase(i);

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -23,7 +23,10 @@
 
 #include <vector>
 #include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
 #include <boost/optional.hpp>
 #include "dnsparser.hh"
 #include "dnsname.hh"

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -30,7 +30,6 @@
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index/tag.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 
 #include "dnsname.hh"
 #include "qtype.hh"

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -467,7 +467,7 @@ std::tuple<std::shared_ptr<SyncRes::domainmap_t>, std::shared_ptr<notifyset_t>> 
       if (line[0] == '#') // Comment line, skip to the next line
         continue;
       string domain, instructions;
-      tie(domain, instructions) = splitField(line, '=');
+      std::tie(domain, instructions) = splitField(line, '=');
       instructions = splitField(instructions, '#').first; // Remove EOL comments
       boost::trim(domain);
       boost::trim(instructions);

--- a/pdns/signingpipe.cc
+++ b/pdns/signingpipe.cc
@@ -100,12 +100,12 @@ namespace {
 bool
 dedupLessThan(const DNSZoneRecord& a, const DNSZoneRecord &b)
 {
-  return make_tuple(a.dr.d_content->getZoneRepresentation(), a.dr.d_ttl) < make_tuple(b.dr.d_content->getZoneRepresentation(), b.dr.d_ttl);  // XXX SLOW SLOW SLOW
+  return std::make_tuple(a.dr.d_content->getZoneRepresentation(), a.dr.d_ttl) < std::make_tuple(b.dr.d_content->getZoneRepresentation(), b.dr.d_ttl);  // XXX SLOW SLOW SLOW
 }
 
 bool dedupEqual(const DNSZoneRecord& a, const DNSZoneRecord &b)
 {
-  return make_tuple(a.dr.d_content->getZoneRepresentation(), a.dr.d_ttl) == make_tuple(b.dr.d_content->getZoneRepresentation(), b.dr.d_ttl);  // XXX SLOW SLOW SLOW
+  return std::make_tuple(a.dr.d_content->getZoneRepresentation(), a.dr.d_ttl) == std::make_tuple(b.dr.d_content->getZoneRepresentation(), b.dr.d_ttl);  // XXX SLOW SLOW SLOW
 }
 }
 

--- a/pdns/statnode.hh
+++ b/pdns/statnode.hh
@@ -60,7 +60,7 @@ public:
   void submit(const DNSName& domain, int rcode, unsigned int bytes, boost::optional<const ComboAddress&> remote);
 
   Stat print(unsigned int depth=0, Stat newstat=Stat(), bool silent=false) const;
-  typedef boost::function<void(const StatNode*, const Stat& selfstat, const Stat& childstat)> visitor_t;
+  typedef std::function<void(const StatNode*, const Stat& selfstat, const Stat& childstat)> visitor_t;
   void visit(visitor_t visitor, Stat& newstat, unsigned int depth=0) const;
   bool empty() const
   {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -320,7 +320,7 @@ int SyncRes::AuthDomain::getRecords(const DNSName& qname, const QType qtype, std
   records.clear();
 
   // partial lookup
-  std::pair<records_t::const_iterator,records_t::const_iterator> range = d_records.equal_range(tie(qname));
+  std::pair<records_t::const_iterator,records_t::const_iterator> range = d_records.equal_range(std::tie(qname));
 
   SyncRes::AuthDomain::records_t::const_iterator ziter;
   bool somedata = false;
@@ -1675,7 +1675,7 @@ struct CacheKey
   QType type;
   DNSResourceRecord::Place place;
   bool operator<(const CacheKey& rhs) const {
-    return tie(type, place, name) < tie(rhs.type, rhs.place, rhs.name);
+    return std::tie(type, place, name) < std::tie(rhs.type, rhs.place, rhs.name);
   }
 };
 typedef map<CacheKey, CacheEntry> tcache_t;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -832,8 +832,8 @@ private:
     uint8_t qtype;
     bool operator<(const GetBestNSAnswer &b) const
     {
-      return boost::tie(qtype, qname, bestns) <
-	boost::tie(b.qtype, b.qname, b.bestns);
+      return std::tie(qtype, qname, bestns) <
+	std::tie(b.qtype, b.qname, b.bestns);
     }
   };
 
@@ -1002,14 +1002,14 @@ struct PacketIDCompare
 {
   bool operator()(const std::shared_ptr<PacketID>& a, const std::shared_ptr<PacketID>& b) const
   {
-    if (tie(a->remote, a->tcpsock, a->type) < tie(b->remote, b->tcpsock, b->type)) {
+    if (std::tie(a->remote, a->tcpsock, a->type) < std::tie(b->remote, b->tcpsock, b->type)) {
       return true;
     }
-    if (tie(a->remote, a->tcpsock, a->type) > tie(b->remote, b->tcpsock, b->type)) {
+    if (std::tie(a->remote, a->tcpsock, a->type) > std::tie(b->remote, b->tcpsock, b->type)) {
       return false;
     }
 
-    return tie(a->domain, a->fd, a->id) < tie(b->domain, b->fd, b->id);
+    return std::tie(a->domain, a->fd, a->id) < std::tie(b->domain, b->fd, b->id);
   }
 };
 
@@ -1017,10 +1017,10 @@ struct PacketIDBirthdayCompare
 {
   bool operator()(const std::shared_ptr<PacketID>& a, const std::shared_ptr<PacketID>& b) const
   {
-    if (tie(a->remote, a->tcpsock, a->type) < tie(b->remote, b->tcpsock, b->type)) {
+    if (std::tie(a->remote, a->tcpsock, a->type) < std::tie(b->remote, b->tcpsock, b->type)) {
       return true;
     }
-    if (tie(a->remote, a->tcpsock, a->type) > tie(b->remote, b->tcpsock, b->type)) {
+    if (std::tie(a->remote, a->tcpsock, a->type) > std::tie(b->remote, b->tcpsock, b->type)) {
       return false;
     }
     return a->domain < b->domain;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -40,9 +40,7 @@
 #include "sstuff.hh"
 #include "recursor_cache.hh"
 #include "recpacketcache.hh"
-#include <boost/tuple/tuple.hpp>
 #include <boost/optional.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include "mtasker.hh"
 #include "iputils.hh"
 #include "validate-recursor.hh"
@@ -376,7 +374,7 @@ public:
   };
 
   typedef std::unordered_map<DNSName, AuthDomain> domainmap_t;
-  typedef Throttle<boost::tuple<ComboAddress,DNSName,uint16_t> > throttle_t;
+  typedef Throttle<std::tuple<ComboAddress,DNSName,uint16_t> > throttle_t;
 
   struct EDNSStatus {
     EDNSStatus(const ComboAddress &arg) : address(arg) {}
@@ -532,15 +530,15 @@ public:
   }
   static bool isThrottled(time_t now, const ComboAddress& server, const DNSName& target, uint16_t qtype)
   {
-    return t_sstorage.throttle.shouldThrottle(now, boost::make_tuple(server, target, qtype));
+    return t_sstorage.throttle.shouldThrottle(now, std::make_tuple(server, target, qtype));
   }
   static bool isThrottled(time_t now, const ComboAddress& server)
   {
-    return t_sstorage.throttle.shouldThrottle(now, boost::make_tuple(server, "", 0));
+    return t_sstorage.throttle.shouldThrottle(now, std::make_tuple(server, g_rootdnsname, 0));
   }
   static void doThrottle(time_t now, const ComboAddress& server, time_t duration, unsigned int tries)
   {
-    t_sstorage.throttle.throttle(now, boost::make_tuple(server, "", 0), duration, tries);
+    t_sstorage.throttle.throttle(now, std::make_tuple(server, g_rootdnsname, 0), duration, tries);
   }
   static uint64_t getFailedServersSize()
   {

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -828,7 +828,7 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
   // Group records by name and type, signpipe stumbles over interrupted rrsets
   if(securedZone && !presignedZone) {
     sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
-      return tie(a.dr.d_name, a.dr.d_type) < tie(b.dr.d_name, b.dr.d_type);
+      return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
     });
   }
 

--- a/pdns/test-auth-zonecache_cc.cc
+++ b/pdns/test-auth-zonecache_cc.cc
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(test_replace)
   AuthZoneCache cache;
   cache.setRefreshInterval(3600);
 
-  vector<tuple<DNSName, int>> zone_indices{
+  vector<std::tuple<DNSName, int>> zone_indices{
     {DNSName("example.org."), 1},
   };
   cache.setReplacePending();
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(test_add_while_pending_replace)
   AuthZoneCache cache;
   cache.setRefreshInterval(3600);
 
-  vector<tuple<DNSName, int>> zone_indices{
+  vector<std::tuple<DNSName, int>> zone_indices{
     {DNSName("powerdns.org."), 1}};
   cache.setReplacePending();
   cache.add(DNSName("example.org."), 2);
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(test_remove_while_pending_replace)
   AuthZoneCache cache;
   cache.setRefreshInterval(3600);
 
-  vector<tuple<DNSName, int>> zone_indices{
+  vector<std::tuple<DNSName, int>> zone_indices{
     {DNSName("powerdns.org."), 1}};
   cache.setReplacePending();
   cache.remove(DNSName("powerdns.org."));
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(test_add_while_pending_replace_duplicate)
   AuthZoneCache cache;
   cache.setRefreshInterval(3600);
 
-  vector<tuple<DNSName, int>> zone_indices{
+  vector<std::tuple<DNSName, int>> zone_indices{
     {DNSName("powerdns.org."), 1},
     {DNSName("example.org."), 2},
   };

--- a/pdns/test-base32_cc.cc
+++ b/pdns/test-base32_cc.cc
@@ -6,13 +6,12 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/assign/list_of.hpp>
 
-#include <boost/tuple/tuple.hpp>
 #include "base32.hh"
 
 BOOST_AUTO_TEST_SUITE(test_base32_cc)
 
 BOOST_AUTO_TEST_CASE(test_base32_basic) {
-  typedef boost::tuple<const std::string, const std::string> case_t;
+  typedef std::tuple<const std::string, const std::string> case_t;
   typedef std::list<case_t> cases_t;
 
   // RFC test vectors
@@ -28,10 +27,10 @@ BOOST_AUTO_TEST_CASE(test_base32_basic) {
 
   for(const case_t& val :  cases) {
      std::string res;
-     res = toBase32Hex(val.get<0>());
-     BOOST_CHECK_EQUAL(res, val.get<1>());
-     res = fromBase32Hex(val.get<1>());
-     BOOST_CHECK_EQUAL(res, val.get<0>());
+     res = toBase32Hex(std::get<0>(val));
+     BOOST_CHECK_EQUAL(res, std::get<1>(val));
+     res = fromBase32Hex(std::get<1>(val));
+     BOOST_CHECK_EQUAL(res, std::get<0>(val));
   }
 };
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -6,8 +6,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/assign/list_of.hpp>
 
-#include <boost/tuple/tuple.hpp>
-
 #include "base32.hh"
 #include "base64.hh"
 #include "dnsseckeeper.hh"

--- a/pdns/test-statbag_cc.cc
+++ b/pdns/test-statbag_cc.cc
@@ -7,7 +7,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/assign/list_of.hpp>
 
-#include <boost/tuple/tuple.hpp>
 #include <stdint.h>
 #include <thread>
 #include "misc.hh"

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -12,7 +12,6 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/hashed_index.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index/key_extractors.hpp>
 
 #include "arguments.hh"
@@ -153,7 +152,7 @@ public:
         d_end = range.second;
       }
       else {
-        auto range = idx.equal_range(boost::make_tuple(qdomain, qtype.getCode()));
+        auto range = idx.equal_range(std::make_tuple(qdomain, qtype.getCode()));
         d_iter = range.first;
         d_end = range.second;
       }
@@ -200,7 +199,7 @@ public:
   bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta) override
   {
     const auto& idx = boost::multi_index::get<OrderedNameKindTag>(s_metadata.at(d_backendId));
-    auto it = idx.find(boost::make_tuple(name, kind));
+    auto it = idx.find(std::make_tuple(name, kind));
     if (it == idx.end()) {
       /* funnily enough, we are expected to return true even though we might not know that zone */
       return true;
@@ -213,7 +212,7 @@ public:
   bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta) override
   {
     auto& idx = boost::multi_index::get<OrderedNameKindTag>(s_metadata.at(d_backendId));
-    auto it = idx.find(boost::make_tuple(name, kind));
+    auto it = idx.find(std::make_tuple(name, kind));
     if (it == idx.end()) {
       s_metadata.at(d_backendId).insert(SimpleMetaData(name, kind, meta));
       return true;
@@ -258,7 +257,7 @@ public:
       }
 
       auto& idx = records->get<OrderedNameTypeTag>();
-      auto range = idx.equal_range(boost::make_tuple(best, QType::SOA));
+      auto range = idx.equal_range(std::make_tuple(best, QType::SOA));
       if (range.first == range.second) {
         return false;
       }
@@ -1155,7 +1154,7 @@ BOOST_AUTO_TEST_CASE(test_multi_backends_metadata) {
 
     {
       // check that it has not been updated in the second backend
-      const auto& it = SimpleBackend::s_metadata[2].find(boost::make_tuple(DNSName("powerdns.org."), "test-data-b"));
+      const auto& it = SimpleBackend::s_metadata[2].find(std::make_tuple(DNSName("powerdns.org."), "test-data-b"));
       BOOST_REQUIRE(it != SimpleBackend::s_metadata[2].end());
       BOOST_REQUIRE_EQUAL(it->d_values.size(), 2U);
       BOOST_CHECK_EQUAL(it->d_values.at(0), "value1");

--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -6,7 +6,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/assign/list_of.hpp>
 
-#include <boost/tuple/tuple.hpp>
 #include <boost/iostreams/device/file.hpp>
 #include "dns.hh"
 #include "zoneparser-tng.hh"

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -278,7 +278,7 @@ void UeberBackend::updateZoneCache() {
     return;
   }
 
-  vector<tuple<DNSName, int>> zone_indices;
+  vector<std::tuple<DNSName, int>> zone_indices;
   g_zoneCache.setReplacePending();
 
   for (vector<DNSBackend*>::iterator i = backends.begin(); i != backends.end(); ++i )

--- a/pdns/ws-api.hh
+++ b/pdns/ws-api.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 #include <map>
+#include <optional>
 #include "webserver.hh"
 
 void apiDiscovery(HttpRequest* req, HttpResponse* resp);
@@ -39,4 +40,4 @@ DNSName apiNameToDNSName(const string& name);
 
 // To be provided by product code.
 void productServerStatisticsFetch(std::map<string,string>& out);
-boost::optional<uint64_t> productServerStatisticsFetch(const std::string& name);
+std::optional<uint64_t> productServerStatisticsFetch(const std::string& name);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -504,14 +504,14 @@ void productServerStatisticsFetch(map<string,string>& out)
   out["uptime"] = std::to_string(time(nullptr) - s_starttime);
 }
 
-boost::optional<uint64_t> productServerStatisticsFetch(const std::string& name)
+std::optional<uint64_t> productServerStatisticsFetch(const std::string& name)
 {
   try {
     // ::read() calls ::exists() which throws a PDNSException when the key does not exist
     return S.read(name);
   }
-  catch(...) {
-    return boost::none;
+  catch (...) {
+    return std::nullopt;
   }
 }
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2048,7 +2048,7 @@ static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp) {
     di.backend->getDomainMetadataOne(zonename, "SOA-EDIT", soa_edit_kind);
     bool soa_edit_done = false;
 
-    set<tuple<DNSName, QType, string>> seen;
+    set<std::tuple<DNSName, QType, string>> seen;
 
     for (const auto& rrset : rrsets.array_items()) {
       string changetype = toUpper(stringFromJson(rrset, "changetype"));

--- a/pdns/ws-auth.hh
+++ b/pdns/ws-auth.hh
@@ -21,7 +21,6 @@
  */
 #pragma once
 #include <string>
-#include <tuple>
 #include <map>
 #include <time.h>
 #include <pthread.h>

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -57,7 +57,7 @@ void productServerStatisticsFetch(map<string, string>& out)
   out.swap(ret);
 }
 
-boost::optional<uint64_t> productServerStatisticsFetch(const std::string& name)
+std::optional<uint64_t> productServerStatisticsFetch(const std::string& name)
 {
   return getStatByName(name);
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Also try to pull a bit less of boost headers everywhere in our code base. Hopefully it will make compilation a bit faster but I mostly hope to avoid using the boost version instead of the `std` one by default without knowing it.

This PR needs a good review, as the changes should not break anything but it might some subtle differences between the boost and `std` versions that I missed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
