### PR TITLE
rec: Remember parent NS set, to be able to fallback to it if needed

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -377,6 +377,11 @@ static uint64_t* pleaseDumpFailedServers(int fd)
   return new uint64_t(SyncRes::doDumpFailedServers(fd));
 }
 
+static uint64_t* pleaseDumpSavedParentNSSets(int fd)
+{
+  return new uint64_t(SyncRes::doDumpSavedParentNSSets(fd));
+}
+
 static uint64_t* pleaseDumpNonResolvingNS(int fd)
 {
   return new uint64_t(SyncRes::doDumpNonResolvingNS(fd));
@@ -1904,6 +1909,8 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
             "dump-failedservers <filename>    dump the failed servers to the named file\n"
             "dump-non-resolving <filename>    dump non-resolving nameservers addresses to the named file\n"
             "dump-nsspeeds <filename>         dump nsspeeds statistics to the named file\n"
+            "dump-saved-parent-ns-sets <filename>\n"
+            "                                 dump saved parent ns sets that were used successfully as fallback\n"
             "dump-rpz <zone name> <filename>  dump the content of a RPZ zone to the named file\n"
             "dump-throttlemap <filename>      dump the contents of the throttle map to the named file\n"
             "get [key1] [key2] ..             get specific statistics\n"
@@ -1979,6 +1986,9 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
   }
   if (cmd == "dump-failedservers") {
     return doDumpToFile(s, pleaseDumpFailedServers, cmd, false);
+  }
+  if (cmd == "dump-saved-parent-ns-sets") {
+    return doDumpToFile(s, pleaseDumpSavedParentNSSets, cmd, false);
   }
   if (cmd == "dump-rpz") {
     return doDumpRPZ(s, begin, end);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1910,7 +1910,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
             "dump-non-resolving <filename>    dump non-resolving nameservers addresses to the named file\n"
             "dump-nsspeeds <filename>         dump nsspeeds statistics to the named file\n"
             "dump-saved-parent-ns-sets <filename>\n"
-            "                                 dump saved parent ns sets that were used successfully as fallback\n"
+            "                                 dump saved parent ns sets that were successfully used as fallback\n"
             "dump-rpz <zone name> <filename>  dump the content of a RPZ zone to the named file\n"
             "dump-throttlemap <filename>      dump the contents of the throttle map to the named file\n"
             "get [key1] [key2] ..             get specific statistics\n"

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -95,7 +95,8 @@ int main(int argc, char** argv)
     "dump-failedservers",
     "dump-rpz",
     "dump-throttlemap",
-    "dump-non-resolving"};
+    "dump-non-resolving",
+    "dump-saved-parent-ns-sets"};
   try {
     initArguments(argc, argv);
     string sockname = "pdns_recursor";

--- a/pdns/recursordist/docs/appendices/internals.rst
+++ b/pdns/recursordist/docs/appendices/internals.rst
@@ -445,6 +445,15 @@ new data should overwrite old data.
 Note that PowerDNS deviates from RFC 2181 (section 5.4.1) in this
 respect.
 
+Starting with version 4.7.0, there is a mechanism to save the
+parent NS set if it contains *more* names than the child NS set.
+This allows fallback to the saved parent NS set on resolution errors
+using the child specified NS set.
+As experience shows, this configuration error is encountered in the
+wild often enough to warrant this workaround.
+See :ref:`setting-save-parent-ns-set`.
+
+
  Some small things
 ------------------
 

--- a/pdns/recursordist/docs/appendices/internals.rst
+++ b/pdns/recursordist/docs/appendices/internals.rst
@@ -447,7 +447,7 @@ respect.
 
 Starting with version 4.7.0, there is a mechanism to save the
 parent NS set if it contains *more* names than the child NS set.
-This allows fallback to the saved parent NS set on resolution errors
+This allows falling back to the saved parent NS set on resolution errors
 using the child specified NS set.
 As experience shows, this configuration error is encountered in the
 wild often enough to warrant this workaround.

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -123,9 +123,9 @@ dump-rpz *ZONE NAME* *FILE NAME*
 
 dump-saved-parent-ns-sets *FILE NAME*
     Dump the entries of the map containing saved parent NS sets
-    that were used successfully in resolving.
+    that were successfully used in resolving.
     The total number of entries is also printed in the header.
-    An entry is saved if the recursor sees that parent set includes
+    An entry is saved if the recursor sees that the parent set includes
     names not in the child set. This is an indication of a
     misconfigured domain.
 

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -121,6 +121,14 @@ dump-rpz *ZONE NAME* *FILE NAME*
     overwrite it otherwise. While dumping, the recursor will not answer
     questions.
 
+dump-saved-parent-ns-sets *FILE NAME*
+    Dump the entries of the map containing saved parent NS sets
+    that were used successfully in resolving.
+    The total number of entries is also printed in the header.
+    An entry is saved if the recursor sees that parent set includes
+    names not in the child set. This is an indication of a
+    misconfigured domain.
+
 dump-throttlemap *FILENAME*
     Dump the contents of the throttle map to the *FILENAME* mentioned.
     This file should not exist already, PowerDNS will refuse to

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1698,6 +1698,18 @@ The effect of this is far fewer queries to the root-servers.
 
     Default is 'yes' now, was 'no' before 4.0.0
 
+.. _setting-save-parent-ns-set:
+
+``save-parent-ns-set``
+----------------------
+.. versionadded:: 4.7.0
+
+- Boolean
+- Default: yes
+
+If set, a parent (non-authoritative) ``NS`` set is saved if it contains more entries than a newly encountered child (authoritative) ``NS`` set for the same domain.
+The saved parent ``NS`` set is tried if resolution using the child ``NS`` set fails.
+
 .. _setting-security-poll-suffix:
 
 ``security-poll-suffix``

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -18,6 +18,10 @@ If IPv6 is enabled for outgoing queries using :ref:`setting-query-local-address`
 These addresses will then be used for future queries to authoritative nameservers.
 This has the consequence that authoritative nameservers will be contacted over IPv6 in more case than before.
 
+New settings
+^^^^^^^^^^^^
+- The :ref:`settings-save-parent-ns-set` setting has been introduced, enabling fall-back cases if the parent ``NS`` set contains names not in the child ``NS`` set.
+
 Deprecated and changed settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 -  The :ref:`setting-hint-file` gained a special value ``no`` to indicate that no hint file should not processed. The hint processing code is also made less verbose.

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -20,7 +20,7 @@ This has the consequence that authoritative nameservers will be contacted over I
 
 New settings
 ^^^^^^^^^^^^
-- The :ref:`settings-save-parent-ns-set` setting has been introduced, enabling fall-back cases if the parent ``NS`` set contains names not in the child ``NS`` set.
+- The :ref:`settings-save-parent-ns-set` setting has been introduced, enabling fallback cases if the parent ``NS`` set contains names not in the child ``NS`` set.
 
 Deprecated and changed settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1310,6 +1310,7 @@ static int serviceMain(int argc, char* argv[])
 
   SyncRes::s_dot_to_port_853 = ::arg().mustDo("dot-to-port-853");
   SyncRes::s_event_trace_enabled = ::arg().asNum("event-trace-enabled");
+  SyncRes::s_save_parent_ns_set = ::arg().mustDo("save-parent-ns-set");
 
   if (SyncRes::s_tcp_fast_open_connect) {
     checkFastOpenSysctl(true);
@@ -2496,6 +2497,7 @@ int main(int argc, char** argv)
     ::arg().set("tcp-out-max-queries", "Maximum total number of queries per TCP/DoT connection, 0 means no limit") = "0";
     ::arg().set("tcp-out-max-idle-per-thread", "Maximum number of idle TCP/DoT connections per thread") = "100";
     ::arg().setSwitch("structured-logging", "Prefer structured logging") = "yes";
+    ::arg().setSwitch("save-parent-ns-set", "Save parent NS set to be used if child NS set fails") = "yes";
 
     ::arg().setCmd("help", "Provide a helpful message");
     ::arg().setCmd("version", "Print version string");

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -192,6 +192,8 @@ void initSR(bool debug)
   BOOST_CHECK_EQUAL(SyncRes::getFailedServersSize(), 0U);
   SyncRes::clearNonResolvingNS();
   BOOST_CHECK_EQUAL(SyncRes::getNonResolvingNSSize(), 0U);
+  SyncRes::clearSaveParentsNSSets();
+  BOOST_CHECK_EQUAL(SyncRes::getSaveParentsNSSetsSize(), 0U);
 
   SyncRes::clearECSStats();
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -181,6 +181,7 @@ void initSR(bool debug)
   SyncRes::s_nonresolvingnsmaxfails = 0;
   SyncRes::s_nonresolvingnsthrottletime = 0;
   SyncRes::s_refresh_ttlperc = 0;
+  SyncRes::s_save_parent_ns_set = true;
 
   SyncRes::clearNSSpeeds();
   BOOST_CHECK_EQUAL(SyncRes::getNSSpeedsSize(), 0U);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -3487,7 +3487,7 @@ void SyncRes::rememberParentSetIfNeeded(const DNSName& domain, const vector<DNSR
   for (const auto& ns : existing) {
     auto content = getRR<NSRecordContent>(ns);
     if (authSet.count(content->getNS()) == 0) {
-      LOG(d_prefix << domain << ": at least one child NS was not in the parent NS set, remembering parent NS set and cached IPs" << endl);
+      LOG(d_prefix << domain << ": at least one parent-side NS was not in the child-side NS set, remembering parent NS set and cached IPs" << endl);
       shouldSave = true;
       break;
     }
@@ -4743,7 +4743,7 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
           /* if tns is empty, retrieveAddressesForNS() knows we have hardcoded servers (i.e. "forwards") */
           remoteIPs = retrieveAddressesForNS(prefix, qname, tns, depth, beenthere, rnameservers, nameservers, sendRDQuery, pierceDontQuery, flawedNSSet, cacheOnly, addressQueriesForNS);
         } else {
-          // should be save, caller makes sure nameservers and fallback contain the same names
+          // should be safe, caller makes sure nameservers and fallback contain the same names
           remoteIPs = fallBack->at(tns->first);
         }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -51,6 +51,7 @@ SyncRes::LogMode SyncRes::s_lm;
 const std::unordered_set<QType> SyncRes::s_redirectionQTypes = {QType::CNAME, QType::DNAME};
 LockGuarded<fails_t<ComboAddress>> SyncRes::s_fails;
 LockGuarded<fails_t<DNSName>> SyncRes::s_nonresolving;
+LockGuarded <SyncRes::SavedParentNSSet> SyncRes::s_savedParentNSSet;
 
 unsigned int SyncRes::s_maxnegttl;
 unsigned int SyncRes::s_maxbogusttl;
@@ -735,6 +736,37 @@ uint64_t SyncRes::doDumpNonResolvingNS(int fd)
   return count;
 }
 
+uint64_t SyncRes::doDumpSavedParentNSSets(int fd)
+{
+  int newfd = dup(fd);
+  if (newfd == -1) {
+    return 0;
+  }
+  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  if (!fp) {
+    close(newfd);
+    return 0;
+  }
+  fprintf(fp.get(), "; dump of saved parent nameserver sets succesfully used follows\n");
+  fprintf(fp.get(), "; total entries: %zu\n", s_savedParentNSSet.lock()->size());
+  fprintf(fp.get(), "; domain\tsuccess\tttd\n");
+  uint64_t count=0;
+
+  // We get a copy, so the I/O does not need to happen while holding the lock
+  for (const auto& i : s_savedParentNSSet.lock()->getMapCopy())
+  {
+    if (i.d_count == 0) {
+      continue;
+    }
+    count++;
+    char tmp[26];
+    ctime_r(&i.d_ttd, tmp);
+    fprintf(fp.get(), "%s\t%llu\t%s", i.d_domain.toString().c_str(), static_cast<unsigned long long>(i.d_count), tmp);
+  }
+
+  return count;
+}
+
 /* so here is the story. First we complete the full resolution process for a domain name. And only THEN do we decide
    to also do DNSSEC validation, which leads to new queries. To make this simple, we *always* ask for DNSSEC records
    so that if there are RRSIGs for a name, we'll have them.
@@ -1244,8 +1276,33 @@ int SyncRes::doResolveNoQNameMinimization(const DNSName &qname, const QType qtyp
     subdomain=getBestNSNamesFromCache(subdomain, qtype, nsset, &flawedNSSet, depth, beenthere); //  pass beenthere to both occasions
   }
 
-  res = doResolveAt(nsset, subdomain, flawedNSSet, qname, qtype, ret, depth, beenthere, state, stopAtDelegation);
+  res = doResolveAt(nsset, subdomain, flawedNSSet, qname, qtype, ret, depth, beenthere, state, stopAtDelegation, nullptr);
 
+  if (res == -1) {
+    // It did not work out, lets check if we have a saved parent NS set
+    map<DNSName, vector<ComboAddress>> fallBack;
+    {
+      auto lock = s_savedParentNSSet.lock();
+      auto domainData= lock->find(subdomain);
+      if (domainData != lock->end() && domainData->d_nsAddresses.size() > 0) {
+        nsset.clear();
+        // Build the nsset arg and fallBack data for the fallback doResolveAt() attempt
+        // Take a copy to be able to release the lock, NsSet is actually a map, go figure
+        for (const auto& ns : domainData->d_nsAddresses) {
+          nsset.emplace(ns.first, pair(std::vector<ComboAddress>(), false));
+          fallBack.emplace(ns.first, ns.second);
+        }
+      }
+    }
+    if (fallBack.size() > 0) {
+      LOG(prefix<<qname<<": Failure, but we have a saved parent NS set, trying that one"<< endl)
+      res = doResolveAt(nsset, subdomain, flawedNSSet, qname, qtype, ret, depth, beenthere, state, stopAtDelegation, &fallBack);
+      if (res == 0) {
+        // It did work out
+        s_savedParentNSSet.lock()->inc(subdomain);
+      }
+    }
+  }
   /* Apply Post filtering policies */
   if (d_wantsRPZ && !d_appliedPolicy.wasHit()) {
     auto luaLocal = g_luaconfs.getLocal();
@@ -3401,6 +3458,55 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
   }
 }
 
+
+void SyncRes::rememberParentSetIfNeeded(const DNSName& domain, const vector<DNSRecord>& newRecords, unsigned int depth)
+{
+  vector<DNSRecord> existing;
+  bool wasAuth = false;
+  auto ttl = g_recCache->get(d_now.tv_sec, domain, QType::NS, false, &existing, d_cacheRemote, false, d_routingTag, nullptr, nullptr, nullptr, nullptr, &wasAuth);
+
+  if (ttl <= 0 || wasAuth) {
+    return;
+  }
+  {
+    auto lock = s_savedParentNSSet.lock();
+    if (lock->find(domain) != lock->end()) {
+      // no relevant data, or we already stored the parent data
+      return;
+    }
+  }
+
+  set<DNSName> authSet;
+  for (const auto& ns : newRecords) {
+    auto content = getRR<NSRecordContent>(ns);
+    authSet.insert(content->getNS());
+  }
+  // The glue IPs could also differ, but we're not checking that yet, we're only looking for child NS records not
+  // in the parent set
+  bool shouldSave = false;
+  for (const auto& ns : existing) {
+    auto content = getRR<NSRecordContent>(ns);
+    if (authSet.count(content->getNS()) == 0) {
+      LOG(d_prefix << domain << ": at least one child NS was not in the parent NS set, remembering parent NS set and cached IPs" << endl);
+      shouldSave = true;
+      break;
+    }
+  }
+
+  if (shouldSave) {
+    map<DNSName, vector<ComboAddress>> entries;
+    for (const auto& ns : existing) {
+      auto content = getRR<NSRecordContent>(ns);
+      const DNSName& name = content->getNS();
+      set<GetBestNSAnswer> beenthereIgnored;
+      unsigned int nretrieveAddressesForNSIgnored;
+      auto addresses = getAddrs(name, depth, beenthereIgnored, true, nretrieveAddressesForNSIgnored);
+      entries.emplace(name, addresses);
+    }
+    s_savedParentNSSet.lock()->emplace(domain, std::move(entries), d_now.tv_sec + ttl);
+  }
+}
+
 RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType qtype, const DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, vState& state, bool& needWildcardProof, bool& gatherWildcardProof, unsigned int& wildcardLabelsCount, bool rdQuery, const ComboAddress& remoteIP)
 {
   bool wasForwardRecurse = wasForwarded && rdQuery;
@@ -3720,6 +3826,10 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr
       d_fromAuthIP = remoteIP;
 
       if (doCache) {
+        // Check if we are going to replace a non-auth (parent) NS recordset
+        if (isAA && i->first.type == QType::NS) {
+          rememberParentSetIfNeeded(i->first.name, i->second.records, depth);
+        }
         g_recCache->replace(d_now.tv_sec, i->first.name, i->first.type, i->second.records, i->second.signatures, authorityRecs, i->first.type == QType::DS ? true : isAA, auth, i->first.place == DNSResourceRecord::ANSWER ? ednsmask : boost::none, d_routingTag, recordState, remoteIP);
 
         if (g_aggressiveNSECCache && needWildcardProof && recordState == vState::Secure && i->first.place == DNSResourceRecord::ANSWER && i->first.name == qname && !i->second.signatures.empty() && !d_routingTag && !ednsmask) {
@@ -4531,7 +4641,8 @@ bool SyncRes::doDoTtoAuth(const DNSName& ns) const
  */
 int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, const QType qtype,
                          vector<DNSRecord>&ret,
-                         unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation)
+                         unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation,
+                         map<DNSName, vector<ComboAddress>>* fallBack)
 {
   auto luaconfsLocal = g_luaconfs.getLocal();
   string prefix;
@@ -4628,8 +4739,13 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
         }
       }
       else {
-        /* if tns is empty, retrieveAddressesForNS() knows we have hardcoded servers (i.e. "forwards") */
-        remoteIPs = retrieveAddressesForNS(prefix, qname, tns, depth, beenthere, rnameservers, nameservers, sendRDQuery, pierceDontQuery, flawedNSSet, cacheOnly, addressQueriesForNS);
+        if (fallBack == nullptr) {
+          /* if tns is empty, retrieveAddressesForNS() knows we have hardcoded servers (i.e. "forwards") */
+          remoteIPs = retrieveAddressesForNS(prefix, qname, tns, depth, beenthere, rnameservers, nameservers, sendRDQuery, pierceDontQuery, flawedNSSet, cacheOnly, addressQueriesForNS);
+        } else {
+          // should be save, caller makes sure nameservers and fallback contain the same names
+          remoteIPs = fallBack->at(tns->first);
+        }
 
         if(remoteIPs.empty()) {
           LOG(prefix<<qname<<": Failed to get IP for NS "<<tns->first<<", trying next if available"<<endl);

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -815,7 +815,8 @@ public:
   static const int event_trace_to_pb = 1;
   static const int event_trace_to_log = 2;
   static int s_event_trace_enabled;
-
+  static bool s_save_parent_ns_set;
+  
   std::unordered_map<std::string,bool> d_discardedPolicies;
   DNSFilterEngine::Policy d_appliedPolicy;
   std::unordered_set<std::string> d_policyTags;


### PR DESCRIPTION
When a non-auth NS set is replaced by an auth one, remember the non-auth one if it contains NS not in the auth set.

Use that NS set later as a fallback if resolving fails.

TODO:
 
- [x] general validation of method
- [x] pruning the new table (based on TTL of child and parent NS set?)
- [x] tests
- [x] config switch? Ir can this be alwasy-on?
- [x] docs
- [x] move the implementation of the data structure out of syncres.hh, it's already way too big

Should fix #10594

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
