### PR TITLE
Rec: packet cache improvements

### DIFF
--- a/.not-formatted
+++ b/.not-formatted
@@ -24,7 +24,6 @@
 ./pdns/bindparserclasses.hh
 ./pdns/bpf-filter.cc
 ./pdns/bpf-filter.hh
-./pdns/cachecleaner.hh
 ./pdns/calidns.cc
 ./pdns/capabilities.cc
 ./pdns/cdb.cc

--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -28,10 +28,10 @@
 
 // this function can clean any cache that has a getTTD() method on its entries, a preRemoval() method and a 'sequence' index as its second index
 // the ritual is that the oldest entries are in *front* of the sequence collection, so on a hit, move an item to the end
-// on a miss, move it to the beginning
+// and optionally, on a miss, move it to the beginning
 template <typename S, typename C, typename T> void pruneCollection(C& container, T& collection, size_t maxCached, size_t scanFraction = 1000)
 {
-  const time_t now = time(0);
+  const time_t now = time(nullptr);
   size_t toTrim = 0;
   const size_t cacheSize = collection.size();
 

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -49,6 +49,7 @@
 #include "ednssubnet.hh"
 #include "query-local-address.hh"
 #include "tcpiohandler.hh"
+#include "ednsoptions.hh"
 
 #include "rec-protozero.hh"
 #include "uuid-utils.hh"

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1470,7 +1470,7 @@ void startDoResolve(void* p)
 #endif
     }
 
-    if (!SyncRes::s_nopacketcache && !variableAnswer && !sr.wasVariable()) {
+    if (t_packetCache && !variableAnswer && !sr.wasVariable()) {
       const auto& hdr = pw.getHeader();
       if ((hdr->rcode != RCode::NoError && hdr->rcode != RCode::NXDomain) || (hdr->ancount == 0 && hdr->nscount == 0)) {
         minTTL = min(minTTL, SyncRes::s_packetcacheservfailttl);
@@ -1724,15 +1724,18 @@ bool checkForCacheHit(bool qnameParsed, unsigned int tag, const string& data,
                       string& response, uint32_t& qhash,
                       RecursorPacketCache::OptPBData& pbData, bool tcp, const ComboAddress& source)
 {
+  if (!t_packetCache) {
+    return false;
+  }
   bool cacheHit = false;
   uint32_t age;
   vState valState;
 
   if (qnameParsed) {
-    cacheHit = !SyncRes::s_nopacketcache && t_packetCache->getResponsePacket(tag, data, qname, qtype, qclass, now.tv_sec, &response, &age, &valState, &qhash, &pbData, tcp);
+    cacheHit = t_packetCache->getResponsePacket(tag, data, qname, qtype, qclass, now.tv_sec, &response, &age, &valState, &qhash, &pbData, tcp);
   }
   else {
-    cacheHit = !SyncRes::s_nopacketcache && t_packetCache->getResponsePacket(tag, data, qname, &qtype, &qclass, now.tv_sec, &response, &age, &valState, &qhash, &pbData, tcp);
+    cacheHit = t_packetCache->getResponsePacket(tag, data, qname, &qtype, &qclass, now.tv_sec, &response, &age, &valState, &qhash, &pbData, tcp);
   }
 
   if (cacheHit) {

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -354,7 +354,7 @@ static uint64_t dumpAggressiveNSECCache(int fd)
 
 static uint64_t* pleaseDump(int fd)
 {
-  return new uint64_t(t_packetCache->doDump(fd));
+  return new uint64_t(t_packetCache ? t_packetCache->doDump(fd) : 0);
 }
 
 static uint64_t* pleaseDumpEDNSMap(int fd)
@@ -855,6 +855,9 @@ static string setMaxPacketCacheEntries(T begin, T end)
 {
   if (end - begin != 1)
     return "Need to supply new packet cache size\n";
+  if (::arg().mustDo("disable-packetcache")) {
+    return "Packet cache is disabled\n";
+  }
   try {
     g_maxPacketCacheEntries = pdns::checked_stoi<uint32_t>(*begin);
     return "New max packetcache entries: " + std::to_string(g_maxPacketCacheEntries) + "\n";

--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -92,8 +92,8 @@ bool RecursorPacketCache::checkResponseMatches(std::pair<packetCache_t::index<Ha
       return true;
     }
     else {
-      // We used to move the item to the fron ot the to be deleted sequence,
-      // but we're very likely will update the entry very soon, so leave it
+      // We used to move the item to the front of "the to be deleted" sequence,
+      // but we very likely will update the entry very soon, so leave it
       d_misses++;
       break;
     }

--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -192,10 +192,9 @@ void RecursorPacketCache::insertResponsePacket(unsigned int tag, uint32_t qhash,
   d_packetCache.insert(e);
 
   if (d_packetCache.size() > d_maxSize) {
-    auto it = d_packetCache.begin();
-    d_packetCache.erase(it);
+    auto& seq_idx = d_packetCache.get<SequencedTag>();
+    seq_idx.erase(seq_idx.begin());
   }
-
 }
 
 uint64_t RecursorPacketCache::bytes() const

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -59,8 +59,8 @@ public:
   };
   typedef boost::optional<PBData> OptPBData;
 
-  RecursorPacketCache(size_t maxsize)
-    : d_maxSize(maxsize)
+  RecursorPacketCache(size_t maxsize) :
+    d_maxSize(maxsize)
   {
   }
 

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -59,7 +59,11 @@ public:
   };
   typedef boost::optional<PBData> OptPBData;
 
-  RecursorPacketCache();
+  RecursorPacketCache(size_t maxsize)
+    : d_maxSize(maxsize)
+  {
+  }
+
   bool getResponsePacket(unsigned int tag, const std::string& queryPacket, time_t now, std::string* responsePacket, uint32_t* age, uint32_t* qhash);
   bool getResponsePacket(unsigned int tag, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, uint32_t* qhash);
   bool getResponsePacket(unsigned int tag, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, uint32_t* qhash, OptPBData* pbdata, bool tcp);
@@ -70,10 +74,19 @@ public:
   uint64_t doDump(int fd);
   int doWipePacketCache(const DNSName& name, uint16_t qtype = 0xffff, bool subtree = false);
 
-  void prune();
-  uint64_t d_hits, d_misses;
-  uint64_t size();
-  uint64_t bytes();
+  void setMaxSize(size_t sz)
+  {
+    d_maxSize = sz;
+  }
+
+  uint64_t size() const
+  {
+    return d_packetCache.size();
+  }
+  uint64_t bytes() const;
+
+  uint64_t d_hits{0};
+  uint64_t d_misses{0};
 
 private:
   struct HashTag
@@ -131,6 +144,7 @@ private:
     packetCache_t;
 
   packetCache_t d_packetCache;
+  size_t d_maxSize;
 
   static bool qrMatch(const packetCache_t::index<HashTag>::type::iterator& iter, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass);
   bool checkResponseMatches(std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2707,7 +2707,7 @@ string doTraceRegex(vector<string>::const_iterator begin, vector<string>::const_
 
 static uint64_t* pleaseWipePacketCache(const DNSName& canon, bool subtree, uint16_t qtype)
 {
-  return new uint64_t(t_packetCache ? 0 : t_packetCache->doWipePacketCache(canon, qtype, subtree));
+  return new uint64_t(t_packetCache ? t_packetCache->doWipePacketCache(canon, qtype, subtree) : 0);
 }
 
 struct WipeCacheResult wipeCaches(const DNSName& canon, bool subtree, uint16_t qtype)

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -36,6 +36,7 @@
 #include "rec-snmp.hh"
 #include "rec_channel.hh"
 #include "threadname.hh"
+#include "recpacketcache.hh"
 
 #ifdef NOD_ENABLED
 #include "nod.hh"
@@ -181,6 +182,7 @@ enum class PaddingMode
 
 typedef MTasker<std::shared_ptr<PacketID>, PacketBuffer, PacketIDCompare> MT_t;
 extern thread_local std::unique_ptr<MT_t> MT; // the big MTasker
+extern thread_local std::unique_ptr<RecursorPacketCache> t_packetCache;
 
 extern bool g_logCommonErrors;
 extern size_t g_proxyProtocolMaximumSize;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -204,7 +204,6 @@ bool SyncRes::s_ecsipv6nevercache;
 
 bool SyncRes::s_doIPv4;
 bool SyncRes::s_doIPv6;
-bool SyncRes::s_nopacketcache;
 bool SyncRes::s_rootNXTrust;
 bool SyncRes::s_noEDNS;
 bool SyncRes::s_qnameminimization;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -39,7 +39,6 @@
 #include "circular_buffer.hh"
 #include "sstuff.hh"
 #include "recursor_cache.hh"
-#include "recpacketcache.hh"
 #include <boost/optional.hpp>
 #include "mtasker.hh"
 #include "iputils.hh"
@@ -712,7 +711,6 @@ public:
   static bool s_noEDNSPing;
   static bool s_noEDNS;
   static bool s_rootNXTrust;
-  static bool s_nopacketcache;
   static bool s_qnameminimization;
   static HardenNXD s_hardenNXD;
   static unsigned int s_refresh_ttlperc;
@@ -961,7 +959,6 @@ struct PacketIDBirthdayCompare
   }
 };
 extern std::unique_ptr<MemRecursorCache> g_recCache;
-extern thread_local std::unique_ptr<RecursorPacketCache> t_packetCache;
 
 struct RecursorStats
 {

--- a/pdns/test-recpacketcache_cc.cc
+++ b/pdns/test-recpacketcache_cc.cc
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_SUITE(test_recpacketcache_cc)
 
 BOOST_AUTO_TEST_CASE(test_recPacketCacheSimple)
 {
-  RecursorPacketCache rpc;
+  RecursorPacketCache rpc(1000);
   string fpacket;
   unsigned int tag = 0;
   uint32_t age = 0;
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimple)
 
 BOOST_AUTO_TEST_CASE(test_recPacketCacheSimplePost2038)
 {
-  RecursorPacketCache rpc;
+  RecursorPacketCache rpc(1000);
   string fpacket;
   unsigned int tag = 0;
   uint32_t age = 0;
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCache_Tags)
      should not override the first one, and we should get a hit for the
      query with either tags, with the response matching the tag.
   */
-  RecursorPacketCache rpc;
+  RecursorPacketCache rpc(1000);
   string fpacket;
   const unsigned int tag1 = 0;
   const unsigned int tag2 = 42;
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCache_TCP)
   /* Insert a response with UDP, the exact same query with a TCP flag
      should lead to a miss. 
   */
-  RecursorPacketCache rpc;
+  RecursorPacketCache rpc(1000);
   string fpacket;
   uint32_t age = 0;
   uint32_t qhash = 0;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This PR changes the eviction policy for the packet cache. It requires less operations in the LRU list and spreads the cost of pruning the full cache by removing an item when an item is added to a full cache.

This makes the order of the PC cache now strictly LRU, with the reasoning that if a cache item is found to be expired, we are going to update it very soon as we only look for entry we are looking up for a client. If it is expired, a resolve will follow immediately. (no recursion desired is really an exception). So the existing method of moving it to the front will be followed by an move to the back very soon. We do keep moving it to the back of it is not expired.

So what this PR does is:

- Tell the PC its size, so that it can evict an item when an item is added to a full cache
- If we get a PC miss, do not move the item to the front the of "to be deleted" list. We will *very likely* update the item soon and move it to the back of the "to be deleted queue". So leave it.
- only create and prune the packetcache for threads that need it
- If the packet cache is disabled, warn that setting the size using rec_control is a no-op

Test setup: a recursor with a `pre_resolve` Lua function that sets an answer and returns true. This way mostly the PC cache performance is measured.

Wit master and using `dnsperf` with a large test file I see the memory usage and PC entries grow beyond the limit. Only when the cleanup action is done, the number of PC cache entries it reduced again.

With this PR, the PC entries never grow beyond the limit and the RES size is lower, as expected.

The QPS I'm seeing vary, but in general the PR code is a bit faster.

If I use a smaller test file that fits in the PC, I'm seeing a speedup as well since the cache lookup has a little bit less work to do.

Additionally fix the PC hit ratio and qps printed by stats.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
