### PR TITLE
dnsdist: fix building without libedit

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -447,7 +447,7 @@ void doConsole()
   }
 }
 
-#if defined(HAVE_LIBEDIT) and not defined(DISABLE_COMPLETION)
+#ifndef DISABLE_COMPLETION
 /**** CARGO CULT CODE AHEAD ****/
 const std::vector<ConsoleKeyword> g_consoleKeywords{
   /* keyword, function, parameters, description */
@@ -769,6 +769,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "wrandom", false, "", "Weighted random over available servers, based on the server 'weight' parameter" },
 };
 
+#if defined(HAVE_LIBEDIT)
 extern "C" {
 static char* my_generator(const char* text, int state)
 {
@@ -808,6 +809,7 @@ char** my_completion( const char * text , int start,  int end)
   return matches;
 }
 }
+#endif /* HAVE_LIBEDIT */
 #endif /* DISABLE_COMPLETION */
 
 static void controlClientThread(ConsoleConnection&& conn)

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -447,7 +447,7 @@ void doConsole()
   }
 }
 
-#ifndef DISABLE_COMPLETION
+#if defined(HAVE_LIBEDIT) and not defined(DISABLE_COMPLETION)
 /**** CARGO CULT CODE AHEAD ****/
 const std::vector<ConsoleKeyword> g_consoleKeywords{
   /* keyword, function, parameters, description */


### PR DESCRIPTION
### Short description
I tested:

* `./configure --without-libedit CXXFLAGS='-DDISABLE_COMPLETION'`
* `./configure --without-libedit`
* `./configure`

all 3 built, and the third one had working completions.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master