### PR TITLE
Read the base Lua definitions into the Lua context for reading the Lua config

### DIFF
--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -322,8 +322,7 @@ static void rpzPrimary(LuaConfigItems& lci, luaConfigDelayedThreads& delayedThre
   delayedThreads.rpzPrimaryThreads.push_back(std::make_tuple(primaries, defpol, defpolOverrideLocal, maxTTL, zoneIdx, tt, maxReceivedXFRMBytes, localAddress, axfrTimeout, refresh, sr, dumpFile));
 }
 
-// A wrapper clas that load the snadrad Lua defintions into the conext, so that we can use things
-// like pdns.A
+// A wrapper class that loads the standard Lua defintions into the context, so that we can use things like pdns.A
 class RecLuaConfigContext : public BaseLua4
 {
 public:
@@ -331,15 +330,15 @@ public:
   {
     prepareContext();
   }
-  virtual void postPrepareContext() override
+  void postPrepareContext() override
   {
   }
   void postLoad() override
   {
   }
-  std::unique_ptr<LuaContext>& operator()()
+  LuaContext* operator->()
   {
-    return d_lw;
+    return d_lw.get();
   }
 };
 
@@ -358,7 +357,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
   auto luaconfsLocal = g_luaconfs.getLocal();
   lci.generation = luaconfsLocal->generation + 1;
 
-  Lua()->writeFunction("clearSortlist", [&lci]() { lci.sortlist.clear(); });
+  Lua->writeFunction("clearSortlist", [&lci]() { lci.sortlist.clear(); });
 
   /* we can get: "1.2.3.4"
                  {"1.2.3.4", "4.5.6.7"}
@@ -372,9 +371,9 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
     {"NODATA", DNSFilterEngine::PolicyKind::NODATA},
     {"Truncate", DNSFilterEngine::PolicyKind::Truncate},
     {"Custom", DNSFilterEngine::PolicyKind::Custom}};
-  Lua()->writeVariable("Policy", pmap);
+  Lua->writeVariable("Policy", pmap);
 
-  Lua()->writeFunction("rpzFile", [&lci](const string& filename, boost::optional<rpzOptions_t> options) {
+  Lua->writeFunction("rpzFile", [&lci](const string& filename, boost::optional<rpzOptions_t> options) {
     try {
       boost::optional<DNSFilterEngine::Policy> defpol;
       bool defpolOverrideLocal = true;
@@ -396,17 +395,17 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
     }
   });
 
-  Lua()->writeFunction("rpzMaster", [&lci, &delayedThreads](const boost::variant<string, std::vector<std::pair<int, string>>>& primaries_, const string& zoneName, boost::optional<rpzOptions_t> options) {
+  Lua->writeFunction("rpzMaster", [&lci, &delayedThreads](const boost::variant<string, std::vector<std::pair<int, string>>>& primaries_, const string& zoneName, boost::optional<rpzOptions_t> options) {
     g_log << Logger::Warning << "'rpzMaster' is deprecated and will be removed in a future release, use 'rpzPrimary' instead" << endl;
     rpzPrimary(lci, delayedThreads, primaries_, zoneName, options);
   });
-  Lua()->writeFunction("rpzPrimary", [&lci, &delayedThreads](const boost::variant<string, std::vector<std::pair<int, string>>>& primaries_, const string& zoneName, boost::optional<rpzOptions_t> options) {
+  Lua->writeFunction("rpzPrimary", [&lci, &delayedThreads](const boost::variant<string, std::vector<std::pair<int, string>>>& primaries_, const string& zoneName, boost::optional<rpzOptions_t> options) {
     rpzPrimary(lci, delayedThreads, primaries_, zoneName, options);
   });
 
   typedef std::unordered_map<std::string, boost::variant<uint32_t, std::string>> zoneToCacheOptions_t;
 
-  Lua()->writeFunction("zoneToCache", [&lci](const string& zoneName, const string& method, const boost::variant<string, std::vector<std::pair<int, string>>>& srcs, boost::optional<zoneToCacheOptions_t> options) {
+  Lua->writeFunction("zoneToCache", [&lci](const string& zoneName, const string& method, const boost::variant<string, std::vector<std::pair<int, string>>>& srcs, boost::optional<zoneToCacheOptions_t> options) {
     try {
       RecZoneToCache::Config conf;
       DNSName validZoneName(zoneName);
@@ -487,44 +486,44 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
   });
 
   typedef vector<pair<int, boost::variant<string, vector<pair<int, string>>>>> argvec_t;
-  Lua()->writeFunction("addSortList",
-                    [&lci](const std::string& formask_,
-                           const boost::variant<string, argvec_t>& masks,
-                           boost::optional<int> order_) {
-                      try {
-                        Netmask formask(formask_);
-                        int order = order_ ? (*order_) : lci.sortlist.getMaxOrder(formask) + 1;
-                        if (auto str = boost::get<string>(&masks))
-                          lci.sortlist.addEntry(formask, Netmask(*str), order);
-                        else {
+  Lua->writeFunction("addSortList",
+                     [&lci](const std::string& formask_,
+                            const boost::variant<string, argvec_t>& masks,
+                            boost::optional<int> order_) {
+                       try {
+                         Netmask formask(formask_);
+                         int order = order_ ? (*order_) : lci.sortlist.getMaxOrder(formask) + 1;
+                         if (auto str = boost::get<string>(&masks))
+                           lci.sortlist.addEntry(formask, Netmask(*str), order);
+                         else {
 
-                          auto vec = boost::get<argvec_t>(&masks);
-                          for (const auto& e : *vec) {
-                            if (auto s = boost::get<string>(&e.second)) {
-                              lci.sortlist.addEntry(formask, Netmask(*s), order);
-                            }
-                            else {
-                              const auto& v = boost::get<vector<pair<int, string>>>(e.second);
-                              for (const auto& entry : v)
-                                lci.sortlist.addEntry(formask, Netmask(entry.second), order);
-                            }
-                            ++order;
-                          }
-                        }
-                      }
-                      catch (std::exception& e) {
-                        g_log << Logger::Error << "Error in addSortList: " << e.what() << endl;
-                      }
-                    });
+                           auto vec = boost::get<argvec_t>(&masks);
+                           for (const auto& e : *vec) {
+                             if (auto s = boost::get<string>(&e.second)) {
+                               lci.sortlist.addEntry(formask, Netmask(*s), order);
+                             }
+                             else {
+                               const auto& v = boost::get<vector<pair<int, string>>>(e.second);
+                               for (const auto& entry : v)
+                                 lci.sortlist.addEntry(formask, Netmask(entry.second), order);
+                             }
+                             ++order;
+                           }
+                         }
+                       }
+                       catch (std::exception& e) {
+                         g_log << Logger::Error << "Error in addSortList: " << e.what() << endl;
+                       }
+                     });
 
-  Lua()->writeFunction("addTA", [&lci](const std::string& who, const std::string& what) {
+  Lua->writeFunction("addTA", [&lci](const std::string& who, const std::string& what) {
     warnIfDNSSECDisabled("Warning: adding Trust Anchor for DNSSEC (addTA), but dnssec is set to 'off'!");
     DNSName zone(who);
     auto ds = std::dynamic_pointer_cast<DSRecordContent>(DSRecordContent::make(what));
     lci.dsAnchors[zone].insert(*ds);
   });
 
-  Lua()->writeFunction("clearTA", [&lci](boost::optional<string> who) {
+  Lua->writeFunction("clearTA", [&lci](boost::optional<string> who) {
     warnIfDNSSECDisabled("Warning: removing Trust Anchor for DNSSEC (clearTA), but dnssec is set to 'off'!");
     if (who)
       lci.dsAnchors.erase(DNSName(*who));
@@ -533,7 +532,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
   });
 
   /* Remove in 4.3 */
-  Lua()->writeFunction("addDS", [&lci](const std::string& who, const std::string& what) {
+  Lua->writeFunction("addDS", [&lci](const std::string& who, const std::string& what) {
     warnIfDNSSECDisabled("Warning: adding Trust Anchor for DNSSEC (addDS), but dnssec is set to 'off'!");
     g_log << Logger::Warning << "addDS is deprecated and will be removed in the future, switch to addTA" << endl;
     DNSName zone(who);
@@ -542,7 +541,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
   });
 
   /* Remove in 4.3 */
-  Lua()->writeFunction("clearDS", [&lci](boost::optional<string> who) {
+  Lua->writeFunction("clearDS", [&lci](boost::optional<string> who) {
     g_log << Logger::Warning << "clearDS is deprecated and will be removed in the future, switch to clearTA" << endl;
     warnIfDNSSECDisabled("Warning: removing Trust Anchor for DNSSEC (clearDS), but dnssec is set to 'off'!");
     if (who)
@@ -551,7 +550,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
       lci.dsAnchors.clear();
   });
 
-  Lua()->writeFunction("addNTA", [&lci](const std::string& who, const boost::optional<std::string> why) {
+  Lua->writeFunction("addNTA", [&lci](const std::string& who, const boost::optional<std::string> why) {
     warnIfDNSSECDisabled("Warning: adding Negative Trust Anchor for DNSSEC (addNTA), but dnssec is set to 'off'!");
     if (why)
       lci.negAnchors[DNSName(who)] = static_cast<string>(*why);
@@ -559,7 +558,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
       lci.negAnchors[DNSName(who)] = "";
   });
 
-  Lua()->writeFunction("clearNTA", [&lci](boost::optional<string> who) {
+  Lua->writeFunction("clearNTA", [&lci](boost::optional<string> who) {
     warnIfDNSSECDisabled("Warning: removing Negative Trust Anchor for DNSSEC (clearNTA), but dnssec is set to 'off'!");
     if (who)
       lci.negAnchors.erase(DNSName(*who));
@@ -567,7 +566,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
       lci.negAnchors.clear();
   });
 
-  Lua()->writeFunction("readTrustAnchorsFromFile", [&lci](const std::string& fnamearg, const boost::optional<uint32_t> interval) {
+  Lua->writeFunction("readTrustAnchorsFromFile", [&lci](const std::string& fnamearg, const boost::optional<uint32_t> interval) {
     uint32_t realInterval = 24;
     if (interval) {
       realInterval = static_cast<uint32_t>(*interval);
@@ -578,12 +577,12 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
     updateTrustAnchorsFromFile(fnamearg, lci.dsAnchors);
   });
 
-  Lua()->writeFunction("setProtobufMasks", [&lci](const uint8_t maskV4, uint8_t maskV6) {
+  Lua->writeFunction("setProtobufMasks", [&lci](const uint8_t maskV4, uint8_t maskV6) {
     lci.protobufMaskV4 = maskV4;
     lci.protobufMaskV6 = maskV6;
   });
 
-  Lua()->writeFunction("protobufServer", [&lci](boost::variant<const std::string, const std::unordered_map<int, std::string>> servers, boost::optional<protobufOptions_t> vars) {
+  Lua->writeFunction("protobufServer", [&lci](boost::variant<const std::string, const std::unordered_map<int, std::string>> servers, boost::optional<protobufOptions_t> vars) {
     if (!lci.protobufExportConfig.enabled) {
 
       lci.protobufExportConfig.enabled = true;
@@ -615,7 +614,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
     }
   });
 
-  Lua()->writeFunction("outgoingProtobufServer", [&lci](boost::variant<const std::string, const std::unordered_map<int, std::string>> servers, boost::optional<protobufOptions_t> vars) {
+  Lua->writeFunction("outgoingProtobufServer", [&lci](boost::variant<const std::string, const std::unordered_map<int, std::string>> servers, boost::optional<protobufOptions_t> vars) {
     if (!lci.outgoingProtobufExportConfig.enabled) {
 
       lci.outgoingProtobufExportConfig.enabled = true;
@@ -648,7 +647,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
   });
 
 #ifdef HAVE_FSTRM
-  Lua()->writeFunction("dnstapFrameStreamServer", [&lci](boost::variant<const std::string, const std::unordered_map<int, std::string>> servers, boost::optional<frameStreamOptions_t> vars) {
+  Lua->writeFunction("dnstapFrameStreamServer", [&lci](boost::variant<const std::string, const std::unordered_map<int, std::string>> servers, boost::optional<frameStreamOptions_t> vars) {
     if (!lci.frameStreamExportConfig.enabled) {
 
       lci.frameStreamExportConfig.enabled = true;
@@ -684,7 +683,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
 #endif /* HAVE_FSTRM */
 
   try {
-    Lua()->executeCode(ifs);
+    Lua->executeCode(ifs);
     g_luaconfs.setState(std::move(lci));
   }
   catch (const LuaContext::ExecutionErrorException& e) {

--- a/pdns/recursordist/docs/lua-config/protobuf.rst
+++ b/pdns/recursordist/docs/lua-config/protobuf.rst
@@ -33,6 +33,10 @@ Protobuf export to a server is enabled using the ``protobufServer()`` directive:
   * ``logResponses=true``: bool - Whether to export responses
   * ``exportTypes={'A', 'AAAA', 'CNAME'}``: list of strings - The list of record types found in the answer section to export. Only A, AAAA, CNAME, MX, NS, PTR, SPF, SRV and TXT are currently supported
 
+  .. versionchanged:: 4.7.0
+
+  The values in ``exportTypes`` can be numeric as well as strings. Symbolic names from ``pdns`` can be used, e.g.  ``exportTypes = { pdns.A, pdns.AAAA, pdns.CNAME }``
+
 .. function:: protobufServer(server [[[[[[[, timeout=2], maxQueuedEntries=100], reconnectWaitTime=1], maskV4=32], maskV6=128], asyncConnect=false], taggedOnly=false])
 
   .. deprecated:: 4.2.0
@@ -77,7 +81,11 @@ While :func:`protobufServer` only exports the queries sent to the recursor from 
   * ``asyncConnect``: bool - When set to false (default) the first connection to the server during startup will block up to ``timeout`` seconds, otherwise the connection is done in a separate thread, after the first message has been queued
   * ``logQueries=true``: bool - Whether to export queries
   * ``logResponses=true``: bool - Whether to export responses
-  * ``exportTypes={'A', 'AAAA', 'CNAME'}``: list of strings - The list of record types found in the answer section to export. Only A, AAAA, CNAME, MX, NS, PTR, SPF, SRV and TXT are currently supported
+  * ``exportTypes={'A', 'AAAA', 'CNAME'}``: list of strings or qtypes - The list of record types found in the answer section to export. Only A, AAAA, CNAME, MX, NS, PTR, SPF, SRV and TXT are currently supported
+
+  .. versionchanged:: 4.7.0
+
+  The values in ``exportTypes`` can be numeric as well as strings. Symbolic names from ``pdns`` can be used, e.g.  ``exportTypes = { pdns.A, pdns.AAAA, pdns.CNAME }``
 
 .. function:: outgoingProtobufServer(server [[[[, timeout=2], maxQueuedEntries=100], reconnectWaitTime=1], asyncConnect=false])
 


### PR DESCRIPTION

This allows symbolic names for e.g. QTypes. Use that in protobufServer() and
outgoingProtobufServer(). Will also be used for the upcoming additional records code.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
