### PR TITLE
Check return value of DNSCryptoKeyEngine::makeFromPEMString()

### DIFF
--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -26,8 +26,6 @@ public:
   int getBits() const override;
   void fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& stormap) override;
   void fromPublicKeyString(const std::string& content) override;
-  void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) override
-  {}
 
   static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3296,6 +3296,10 @@ try
     DNSSECPrivateKey dpk;
     DNSKEYRecordContent drc;
     shared_ptr<DNSCryptoKeyEngine> key(DNSCryptoKeyEngine::makeFromPEMString(drc, raw));
+    if (!key) {
+      cerr << "Could not convert key from PEM to internal format" << endl;
+      return 1;
+    }
     dpk.setKey(key);
 
     dpk.d_algorithm = pdns_stou(cmds.at(3));

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -21,8 +21,6 @@ public:
   int getBits() const override;
   void fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& stormap) override;
   void fromPublicKeyString(const std::string& content) override;
-  void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) override
-  {}
 
   static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {


### PR DESCRIPTION
And do not implement non-implemented features with an empty body.

At least avoids the crash of #11325

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
