### PR TITLE
dnsdist: Fix a use-after-free in case of a network error in the middle of a XFR query

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -355,7 +355,10 @@ void TCPConnectionToBackend::handleIO(std::shared_ptr<TCPConnectionToBackend>& c
               conn->d_currentQuery = std::move(query);
             }
 
-            for (auto& pending : conn->d_pendingResponses) {
+            /* if we notify the sender it might terminate us so we need to move these first */
+            auto pendingResponses = std::move(conn->d_pendingResponses);
+            conn->d_pendingResponses.clear();
+            for (auto& pending : pendingResponses) {
               --conn->d_ds->outstanding;
 
               if (pending.second.d_query.isXFR() && pending.second.d_query.d_xfrStarted) {
@@ -375,7 +378,6 @@ void TCPConnectionToBackend::handleIO(std::shared_ptr<TCPConnectionToBackend>& c
                 conn->d_pendingQueries.push_back(std::move(pending.second));
               }
             }
-            conn->d_pendingResponses.clear();
             conn->d_currentPos = 0;
 
             if (conn->d_state == State::sendingQueryToBackend) {

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -2852,6 +2852,180 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
   }
 
   {
+    TEST_INIT("=> Interrupted AXFR");
+
+    PacketBuffer axfrQuery;
+    PacketBuffer secondQuery;
+    std::vector<PacketBuffer> axfrResponses(3);
+    PacketBuffer secondResponse;
+
+    auto proxyPayload = makeProxyHeader(true, getBackendAddress("84", 4242), local, {});
+    BOOST_REQUIRE_GT(proxyPayload.size(), s_proxyProtocolMinimumHeaderSize);
+
+    auto proxyEnabledBackend = std::make_shared<DownstreamState>(getBackendAddress("42", 53));
+    proxyEnabledBackend->d_tlsCtx = tlsCtx;
+    proxyEnabledBackend->useProxyProtocol = true;
+
+    GenericDNSPacketWriter<PacketBuffer> pwAXFRQuery(axfrQuery, DNSName("powerdns.com."), QType::AXFR, QClass::IN, 0);
+    pwAXFRQuery.getHeader()->rd = 0;
+    pwAXFRQuery.getHeader()->id = 42;
+    uint16_t axfrQuerySize = static_cast<uint16_t>(axfrQuery.size());
+    const uint8_t axfrQuerySizeBytes[] = { static_cast<uint8_t>(axfrQuerySize / 256), static_cast<uint8_t>(axfrQuerySize % 256) };
+    axfrQuery.insert(axfrQuery.begin(), axfrQuerySizeBytes, axfrQuerySizeBytes + 2);
+
+    const DNSName name("powerdns.com.");
+    {
+      /* first message */
+      auto& response = axfrResponses.at(0);
+      GenericDNSPacketWriter<PacketBuffer> pwR(response, name, QType::A, QClass::IN, 0);
+      pwR.getHeader()->qr = 1;
+      pwR.getHeader()->id = 42;
+
+      /* insert SOA */
+      pwR.startRecord(name, QType::SOA, 3600, QClass::IN, DNSResourceRecord::ANSWER);
+      pwR.xfrName(g_rootdnsname, true);
+      pwR.xfrName(g_rootdnsname, true);
+      pwR.xfr32BitInt(1 /* serial */);
+      pwR.xfr32BitInt(0);
+      pwR.xfr32BitInt(0);
+      pwR.xfr32BitInt(0);
+      pwR.xfr32BitInt(0);
+      pwR.commit();
+
+      /* A record */
+      pwR.startRecord(name, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+      pwR.xfr32BitInt(0x01020304);
+      pwR.commit();
+
+      uint16_t responseSize = static_cast<uint16_t>(response.size());
+      const uint8_t sizeBytes[] = { static_cast<uint8_t>(responseSize / 256), static_cast<uint8_t>(responseSize % 256) };
+      response.insert(response.begin(), sizeBytes, sizeBytes + 2);
+    }
+    {
+      /* second message */
+      auto& response = axfrResponses.at(1);
+      GenericDNSPacketWriter<PacketBuffer> pwR(response, name, QType::A, QClass::IN, 0);
+      pwR.getHeader()->qr = 1;
+      pwR.getHeader()->id = 42;
+
+      /* A record */
+      pwR.startRecord(name, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+      pwR.xfr32BitInt(0x01020304);
+      pwR.commit();
+
+      uint16_t responseSize = static_cast<uint16_t>(response.size());
+      const uint8_t sizeBytes[] = { static_cast<uint8_t>(responseSize / 256), static_cast<uint8_t>(responseSize % 256) };
+      response.insert(response.begin(), sizeBytes, sizeBytes + 2);
+    }
+    {
+      /* third message */
+      auto& response = axfrResponses.at(2);
+      GenericDNSPacketWriter<PacketBuffer> pwR(response, name, QType::A, QClass::IN, 0);
+      pwR.getHeader()->qr = 1;
+      pwR.getHeader()->id = 42;
+
+      /* A record */
+      pwR.startRecord(name, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+      pwR.xfr32BitInt(0x01020304);
+      pwR.commit();
+
+      /* final SOA */
+      pwR.startRecord(name, QType::SOA, 3600, QClass::IN, DNSResourceRecord::ANSWER);
+      pwR.xfrName(g_rootdnsname, true);
+      pwR.xfrName(g_rootdnsname, true);
+      pwR.xfr32BitInt(1 /* serial */);
+      pwR.xfr32BitInt(0);
+      pwR.xfr32BitInt(0);
+      pwR.xfr32BitInt(0);
+      pwR.xfr32BitInt(0);
+      pwR.commit();
+
+      uint16_t responseSize = static_cast<uint16_t>(response.size());
+      const uint8_t sizeBytes[] = { static_cast<uint8_t>(responseSize / 256), static_cast<uint8_t>(responseSize % 256) };
+      response.insert(response.begin(), sizeBytes, sizeBytes + 2);
+    }
+
+    PacketBuffer expectedWriteBuffer;
+    PacketBuffer expectedBackendWriteBuffer;
+
+    s_readBuffer = axfrQuery;
+
+    uint16_t backendCounter = 0;
+    expectedBackendWriteBuffer.insert(expectedBackendWriteBuffer.end(), proxyPayload.begin(), proxyPayload.end());
+    appendPayloadEditingID(expectedBackendWriteBuffer, axfrQuery, backendCounter++);
+
+    for (const auto& response : axfrResponses) {
+      appendPayloadEditingID(s_backendReadBuffer, response, 0);
+    }
+    expectedWriteBuffer.insert(expectedWriteBuffer.end(), axfrResponses.at(0).begin(), axfrResponses.at(0).end());
+    expectedWriteBuffer.insert(expectedWriteBuffer.end(), axfrResponses.at(1).begin(), axfrResponses.at(1).end());
+
+    bool timeout = false;
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      /* reading a query from the client (1) */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, axfrQuery.size() - 2 },
+      /* opening a connection to the backend */
+      { ExpectedStep::ExpectedRequest::connectToBackend, IOState::Done },
+      /* sending query (1) to the backend */
+      { ExpectedStep::ExpectedRequest::writeToBackend, IOState::Done, proxyPayload.size() + axfrQuery.size() },
+      /* no response ready yet, but setting the backend descriptor readable */
+      { ExpectedStep::ExpectedRequest::readFromBackend, IOState::NeedRead, 0, [&threadData](int desc) {
+        /* the backend descriptor becomes ready */
+        dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(desc);
+      } },
+      /* no more query from the client for now */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead, 0 , [&threadData](int desc) {
+        /* the client descriptor becomes NOT ready */
+        dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setNotReady(-1);
+      } },
+      /* read the response (1) from the backend  */
+      { ExpectedStep::ExpectedRequest::readFromBackend, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::readFromBackend, IOState::Done, axfrResponses.at(0).size() - 2 },
+      /* sending response (1) to the client */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, axfrResponses.at(0).size() },
+      /* reading the response (2) from the backend */
+      { ExpectedStep::ExpectedRequest::readFromBackend, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::readFromBackend, IOState::Done, axfrResponses.at(1).size() - 2 },
+      /* sending response (2) to the client */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, axfrResponses.at(1).size() },
+      /* reading the response (3) from the backend, get EOF!! */
+      { ExpectedStep::ExpectedRequest::readFromBackend, IOState::Done, 0 },
+      /* closing the backend connection */
+      { ExpectedStep::ExpectedRequest::closeBackend, IOState::Done },
+      /* opening a connection to the backend */
+      { ExpectedStep::ExpectedRequest::connectToBackend, IOState::Done },
+      /* closing the client connection */
+      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+      /* closing the backend connection */
+      { ExpectedStep::ExpectedRequest::closeBackend, IOState::Done },
+    };
+
+    s_processQuery = [proxyEnabledBackend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      selectedBackend = proxyEnabledBackend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRuleActions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
+      threadData.mplexer->run(&now);
+    }
+
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), expectedWriteBuffer.size());
+    BOOST_CHECK(s_writeBuffer == expectedWriteBuffer);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), expectedBackendWriteBuffer.size());
+    BOOST_CHECK(s_backendWriteBuffer == expectedBackendWriteBuffer);
+
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
     TEST_INIT("=> IXFR");
 
     PacketBuffer firstQuery;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If an I/O error occurs while we are processing a XFR response whose first message has already been processed, and the proxy protocol is used between dnsdist and the backend, there is a use-after-free in the loop looking at the queries pending for that connection because the frontend might decide to terminate the connection to the backend, clearing the queries container, while we are the middle of loop.

```
==22972== Thread 3 dnsdist/tcpClie:
==22972== Invalid read of size 8
==22972==    at 0x6A725A: _M_next (hashtable_policy.h:282)
==22972==    by 0x6A725A: _M_incr (hashtable_policy.h:299)
==22972==    by 0x6A725A: operator++ (hashtable_policy.h:351)
==22972==    by 0x6A725A: TCPConnectionToBackend::handleIO(std::shared_ptr<TCPConnectionToBackend>&, timeval const&) (dnsdist-tcp-downstream.cc:363)
==22972==    by 0x6A76B1: TCPConnectionToBackend::handleIOCallback(int, boost::any&) (dnsdist-tcp-downstream.cc:452)
==22972==    by 0x772E29: operator() (function_template.hpp:763)
==22972==    by 0x772E29: EpollFDMultiplexer::run(timeval*, int) (epollmplexer.cc:193)
==22972==    by 0x6B52D3: tcpClientThread(int, int, int, int) (dnsdist-tcp.cc:1210)
==22972==    by 0x55384D3: execute_native_thread_routine (thread.cc:82)
==22972==    by 0x581B5C1: start_thread (in /usr/lib/libc.so.6)
==22972==    by 0x58A0583: clone (in /usr/lib/libc.so.6)
==22972==  Address 0x7f896b0 is 0 bytes inside a block of size 432 free'd
==22972==    at 0x4848B6F: operator delete(void*, unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22972==    by 0x6AAE29: deallocate (new_allocator.h:145)
==22972==    by 0x6AAE29: deallocate (alloc_traits.h:492)
==22972==    by 0x6AAE29: _M_deallocate_node_ptr (hashtable_policy.h:1902)
==22972==    by 0x6AAE29: _M_deallocate_node (hashtable_policy.h:1892)
==22972==    by 0x6AAE29: _M_deallocate_nodes (hashtable_policy.h:1913)
==22972==    by 0x6AAE29: std::_Hashtable<unsigned short, std::pair<unsigned short const, TCPConnectionToBackend::PendingRequest>, std::allocator<std::pair<unsigned short const, TCPConnectionToBackend::PendingRequest> >, std::__detail::_Select1st, std::equal_to<unsigned short>, std::hash<unsigned short>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::clear() (hashtable.h:2299)
==22972==    by 0x6A466C: clear (unordered_map.h:791)
==22972==    by 0x6A466C: TCPConnectionToBackend::release() (dnsdist-tcp-downstream.cc:136)
==22972==    by 0x6B32C8: IncomingTCPConnectionState::terminateClientConnection() (dnsdist-tcp.cc:382)
==22972==    by 0x6B75D4: IncomingTCPConnectionState::notifyIOError(IDState&&, timeval const&) (dnsdist-tcp.cc:1040)
==22972==    by 0x6A7259: TCPConnectionToBackend::handleIO(std::shared_ptr<TCPConnectionToBackend>&, timeval const&) (dnsdist-tcp-downstream.cc:371)
==22972==    by 0x6A76B1: TCPConnectionToBackend::handleIOCallback(int, boost::any&) (dnsdist-tcp-downstream.cc:452)
==22972==    by 0x772E29: operator() (function_template.hpp:763)
==22972==    by 0x772E29: EpollFDMultiplexer::run(timeval*, int) (epollmplexer.cc:193)
==22972==    by 0x6B52D3: tcpClientThread(int, int, int, int) (dnsdist-tcp.cc:1210)
==22972==    by 0x55384D3: execute_native_thread_routine (thread.cc:82)
==22972==    by 0x581B5C1: start_thread (in /usr/lib/libc.so.6)
==22972==    by 0x58A0583: clone (in /usr/lib/libc.so.6)
==22972==  Block was alloc'd at
==22972==    at 0x4846013: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22972==    by 0x6A362B: allocate (new_allocator.h:127)
==22972==    by 0x6A362B: allocate (alloc_traits.h:460)
==22972==    by 0x6A362B: _M_allocate_node<std::pair<short unsigned int const, TCPConnectionToBackend::PendingRequest> > (hashtable_policy.h:1870)
==22972==    by 0x6A362B: _Scoped_node<std::pair<short unsigned int const, TCPConnectionToBackend::PendingRequest> > (hashtable.h:289)
==22972==    by 0x6A362B: _M_emplace<std::pair<short unsigned int const, TCPConnectionToBackend::PendingRequest> > (hashtable.h:1945)
==22972==    by 0x6A362B: insert<std::pair<short unsigned int const, TCPConnectionToBackend::PendingRequest> > (hashtable_policy.h:1035)
==22972==    by 0x6A362B: insert (unordered_map.h:558)
==22972==    by 0x6A362B: TCPConnectionToBackend::sendQuery(std::shared_ptr<TCPConnectionToBackend>&, timeval const&) (dnsdist-tcp-downstream.cc:220)
==22972==    by 0x6A6D66: TCPConnectionToBackend::handleIO(std::shared_ptr<TCPConnectionToBackend>&, timeval const&) (dnsdist-tcp-downstream.cc:253)
==22972==    by 0x6A76B1: TCPConnectionToBackend::handleIOCallback(int, boost::any&) (dnsdist-tcp-downstream.cc:452)
==22972==    by 0x772E29: operator() (function_template.hpp:763)
==22972==    by 0x772E29: EpollFDMultiplexer::run(timeval*, int) (epollmplexer.cc:193)
==22972==    by 0x6B52D3: tcpClientThread(int, int, int, int) (dnsdist-tcp.cc:1210)
==22972==    by 0x55384D3: execute_native_thread_routine (thread.cc:82)
==22972==    by 0x581B5C1: start_thread (in /usr/lib/libc.so.6)
==22972==    by 0x58A0583: clone (in /usr/lib/libc.so.6)
```

Hopefully fixes #11330.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
