### PR TITLE
dnsdist-1.7.x: Fix a use-after-free in case of a network error in the middle of a XFR query

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -355,7 +355,10 @@ void TCPConnectionToBackend::handleIO(std::shared_ptr<TCPConnectionToBackend>& c
               conn->d_currentQuery = std::move(query);
             }
 
-            for (auto& pending : conn->d_pendingResponses) {
+            /* if we notify the sender it might terminate us so we need to move these first */
+            auto pendingResponses = std::move(conn->d_pendingResponses);
+            conn->d_pendingResponses.clear();
+            for (auto& pending : pendingResponses) {
               --conn->d_ds->outstanding;
 
               if (pending.second.d_query.isXFR() && pending.second.d_query.d_xfrStarted) {
@@ -375,7 +378,6 @@ void TCPConnectionToBackend::handleIO(std::shared_ptr<TCPConnectionToBackend>& c
                 conn->d_pendingQueries.push_back(std::move(pending.second));
               }
             }
-            conn->d_pendingResponses.clear();
             conn->d_currentPos = 0;
 
             if (conn->d_state == State::sendingQueryToBackend) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #11334 to rel/dnsdist-1.7.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
