### PR TITLE
rec: fix unaligned access is murmur hash code used by NOD

### DIFF
--- a/pdns/recursordist/stable-bloom.hh
+++ b/pdns/recursordist/stable-bloom.hh
@@ -168,7 +168,7 @@ private:
     // MurmurHash3 assumes the data is uint32_t aligned, so fixup if needed
     // It does handle string lengths that are not a multiple of sizeof(uint32_t) correctly
     if (reinterpret_cast<uintptr_t>(data.data()) % sizeof(uint32_t) != 0) {
-      NoInitVector<uint32_t> x((data.length() / sizeof(int32_t)) + 1);
+      NoInitVector<uint32_t> x((data.length() / sizeof(uint32_t)) + 1);
       memcpy(x.data(), data.data(), data.length());
       MurmurHash3_x86_32(x.data(), data.length(), 1, &h1);
       MurmurHash3_x86_32(x.data(), data.length(), 2, &h2);

--- a/pdns/recursordist/stable-bloom.hh
+++ b/pdns/recursordist/stable-bloom.hh
@@ -28,6 +28,7 @@
 #include <arpa/inet.h>
 #include <boost/dynamic_bitset.hpp>
 #include "misc.hh"
+#include "noinitvector.hh"
 #include "ext/probds/murmur3.h"
 
 namespace bf
@@ -164,8 +165,18 @@ private:
   std::vector<uint32_t> hash(const std::string& data) const
   {
     uint32_t h1, h2;
-    MurmurHash3_x86_32(data.c_str(), data.length(), 1, (void*)&h1);
-    MurmurHash3_x86_32(data.c_str(), data.length(), 2, (void*)&h2);
+    // MurmurHash3 assumes the data is uint32_t aligned, so fixup if needed
+    // It does handle string lengths that are not a multiple of sizeof(uint32_t) correctly
+    if (reinterpret_cast<uintptr_t>(data.data()) % sizeof(uint32_t) != 0) {
+      NoInitVector<uint32_t> x((data.length() / sizeof(int32_t)) + 1);
+      memcpy(x.data(), data.data(), data.length());
+      MurmurHash3_x86_32(x.data(), data.length(), 1, &h1);
+      MurmurHash3_x86_32(x.data(), data.length(), 2, &h2);
+    }
+    else {
+      MurmurHash3_x86_32(data.data(), data.length(), 1, &h1);
+      MurmurHash3_x86_32(data.data(), data.length(), 2, &h2);
+    }
     std::vector<uint32_t> ret_hashes(d_k);
     for (size_t i = 0; i < d_k; ++i) {
       ret_hashes[i] = h1 + i * h2;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Detected by `-fsanitize=undefined -fsanitize-minimal-runtime` on OpenBSD; no idea why the regular ubsan run we do on CI does not catch this.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
