### PR TITLE
auth lmdb random-ids: stop generating negative numbers

### DIFF
--- a/ext/lmdb-safe/lmdb-typed.cc
+++ b/ext/lmdb-safe/lmdb-typed.cc
@@ -19,9 +19,9 @@ unsigned int MDBGetRandomID(MDBRWTransaction& txn, MDBDbi& dbi)
   for(int attempts=0; attempts<20; attempts++) {
     MDBOutVal key, content;
 
-    // dns_random generates a random number in [0..type_max-1]. We add 1 to avoid 0 and allow type_max.
+    // dns_random generates a random number in [0..signed_int_max-1]. We add 1 to avoid 0 and allow type_max.
     // 0 is avoided because the put() interface uses it to mean "please allocate a number for me"
-    id = dns_random(std::numeric_limits<decltype(id)>::max()) + 1;
+    id = dns_random(std::numeric_limits<signed int>::max()) + 1;
     if(cursor.find(MDBInVal(id), key, content)) {
       return id;
     }

--- a/regression-tests/backends/lmdb-master
+++ b/regression-tests/backends/lmdb-master
@@ -4,6 +4,7 @@ case $context in
 module-dir=./modules
 launch=lmdb
 lmdb-filename=./pdns.lmdb
+lmdb-random-ids=yes
 __EOF__
 
         rm -f pdns.lmdb*


### PR DESCRIPTION
### Short description
regression testing now happens with random IDs, except for HTTP API testing

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master