### PR TITLE
rec: Backport 11288 to rec 4.6.x: Log an error if pdns.DROP is used as rcode in Lua callbacks 

### DIFF
--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -244,7 +244,8 @@ void BaseLua4::prepareContext() {
                                        {"YXRRSET",  RCode::YXRRSet  },
                                        {"NXRRSET",  RCode::NXRRSet  },
                                        {"NOTAUTH",  RCode::NotAuth  },
-                                       {"NOTZONE",  RCode::NotZone  }};
+                                       {"NOTZONE",  RCode::NotZone  },
+                                       {"DROP",    -2               }}; // To give backport-incompatibilityy warning
   for(const auto& rcode : rcodes)
     d_pd.push_back({rcode.first, rcode.second});
 

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -245,7 +245,7 @@ void BaseLua4::prepareContext() {
                                        {"NXRRSET",  RCode::NXRRSet  },
                                        {"NOTAUTH",  RCode::NotAuth  },
                                        {"NOTZONE",  RCode::NotZone  },
-                                       {"DROP",    -2               }}; // To give backport-incompatibilityy warning
+                                       {"DROP",    -2               }}; // To give backport-incompatibility warning
   for(const auto& rcode : rcodes)
     d_pd.push_back({rcode.first, rcode.second});
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -495,6 +495,15 @@ void RecursorLua4::getFeatures(Features& features)
   features.emplace_back("PR8001_devicename", true);
 }
 
+static void warnDrop(const RecursorLua4::DNSQuestion& dq)
+{
+  if (dq.rcode == -2) {
+    g_log << Logger::Error << "Returing -2 (pdns.DROP) is not supported anymore, see https://docs.powerdns.com/recursor/lua-scripting/hooks.html#hooksemantics" << endl;
+    // We *could* set policy here, but that would also mean interfering with rcode and the return code of the hook.
+    // So leave it at the error message.
+  }
+}
+
 void RecursorLua4::maintenance() const
 {
   if (d_maintenance) {
@@ -510,6 +519,7 @@ bool RecursorLua4::prerpz(DNSQuestion& dq, int& ret, RecEventTrace& et) const
   et.add(RecEventTrace::LuaPreRPZ);
   bool ok = genhook(d_prerpz, dq, ret);
   et.add(RecEventTrace::LuaPreRPZ, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -521,6 +531,7 @@ bool RecursorLua4::preresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) cons
   et.add(RecEventTrace::LuaPreResolve);
   bool ok = genhook(d_preresolve, dq, ret);
   et.add(RecEventTrace::LuaPreResolve, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -532,6 +543,7 @@ bool RecursorLua4::nxdomain(DNSQuestion& dq, int& ret, RecEventTrace& et) const
   et.add(RecEventTrace::LuaNXDomain);
   bool ok = genhook(d_nxdomain, dq, ret);
   et.add(RecEventTrace::LuaNXDomain, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -543,6 +555,7 @@ bool RecursorLua4::nodata(DNSQuestion& dq, int& ret, RecEventTrace& et) const
   et.add(RecEventTrace::LuaNoData);
   bool ok = genhook(d_nodata, dq, ret);
   et.add(RecEventTrace::LuaNoData, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -554,6 +567,7 @@ bool RecursorLua4::postresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) con
   et.add(RecEventTrace::LuaPostResolve);
   bool ok = genhook(d_postresolve, dq, ret);
   et.add(RecEventTrace::LuaPostResolve, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -571,6 +585,7 @@ bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& reque
   et.add(RecEventTrace::LuaPreOutQuery);
   bool ok = genhook(d_preoutquery, dq, ret);
   et.add(RecEventTrace::LuaPreOutQuery, ok, false);
+  warnDrop(dq);
   return ok;
 }
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -498,7 +498,7 @@ void RecursorLua4::getFeatures(Features& features)
 static void warnDrop(const RecursorLua4::DNSQuestion& dq)
 {
   if (dq.rcode == -2) {
-    g_log << Logger::Error << "Returing -2 (pdns.DROP) is not supported anymore, see https://docs.powerdns.com/recursor/lua-scripting/hooks.html#hooksemantics" << endl;
+    g_log << Logger::Error << "Returning -2 (pdns.DROP) is not supported anymore, see https://docs.powerdns.com/recursor/lua-scripting/hooks.html#hooksemantics" << endl;
     // We *could* set policy here, but that would also mean interfering with rcode and the return code of the hook.
     // So leave it at the error message.
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #11288

Once this is is, we have to adapt the docs in the main branch (settings and upgarde guide) to refer to the right version.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
