### PR TITLE
rec: Backport 11327 to rec 4.6.x: If we get NODATA on an AAAA in followCNAMERecords, try dns64

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1469,6 +1469,8 @@ static bool udrCheckUniqueDNSRecord(const shared_ptr<Logr::Logger>& nodlogger, c
 }
 #endif /* NOD_ENABLED */
 
+static bool answerIsNOData(uint16_t requestedType, int rcode, const std::vector<DNSRecord>& records);
+
 int followCNAMERecords(vector<DNSRecord>& ret, const QType qtype, int rcode)
 {
   vector<DNSRecord> resolved;
@@ -1489,8 +1491,14 @@ int followCNAMERecords(vector<DNSRecord>& ret, const QType qtype, int rcode)
 
   rcode = directResolve(target, qtype, QClass::IN, resolved, t_pdl);
 
-  for(DNSRecord& rr :  resolved) {
-    ret.push_back(std::move(rr));
+  if (g_dns64Prefix && qtype == QType::AAAA && answerIsNOData(qtype, rcode, resolved)) {
+    rcode = getFakeAAAARecords(target, *g_dns64Prefix, resolved);
+  }
+
+  for (DNSRecord& rr : resolved) {
+    if (rr.d_place == DNSResourceRecord::ANSWER) {
+      ret.push_back(std::move(rr));
+    }
   }
   return rcode;
 }

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -714,7 +714,7 @@ log-common-errors=yes
         self.assertEqual(len(res.authority), 0)
 
 class PolicyEventFilterOnFollowUpTest(RecursorTest):
-    """Tests the interaction between RPZ and followup queries (dns64, folliwCNAME)
+    """Tests the interaction between RPZ and followup queries (dns64, followCNAME)
     """
 
     _confdir = 'policyeventfilter-followup'
@@ -763,3 +763,41 @@ secure.example.zone.rpz. 60 IN A 192.0.2.42
             self.assertEqual(len(res.answer), 2)
             self.assertEqual(len(res.authority), 0)
             self.assertResponseMatches(query, expected, res)
+
+class PolicyEventFilterOnFollowUpWithNativeDNS64Test(RecursorTest):
+    """Tests the interaction between followup queries and native dns64
+    """
+
+    _confdir = 'policyeventfilter-followup-dns64'
+    _config_template = """
+    dns64-prefix=1234::/96
+    """
+    _lua_config_file = """
+    """
+    _lua_dns_script_file = """
+    function preresolve(dq)
+      dq:addAnswer(pdns.CNAME, "cname.secure.example.")
+      dq.followupFunction="followCNAMERecords"
+      dq.rcode = pdns.NOERROR
+      return true
+    end
+
+    """
+
+    def testAAAA(self):
+        expected = [
+            dns.rrset.from_text('mx1.secure.example.', 15, dns.rdataclass.IN, 'CNAME', 'cname.secure.example.'),
+            dns.rrset.from_text('cname.secure.example.', 15, dns.rdataclass.IN, 'CNAME', ' host1.secure.example.'),
+            dns.rrset.from_text('host1.secure.example.', 15, dns.rdataclass.IN, 'AAAA', '1234::c000:202')
+        ]
+        query = dns.message.make_query('mx1.secure.example', 'AAAA')
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+            print(res)
+            self.assertRcodeEqual(res, dns.rcode.NOERROR)
+            self.assertEqual(len(res.answer), 3)
+            self.assertEqual(len(res.authority), 0)
+            self.assertResponseMatches(query, expected, res)
+


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #11327

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
