### PR TITLE
rec: Backport of 11338 to rec-4.6.x: QType ADDR is supposed to be used internally only

### DIFF
--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -248,7 +248,13 @@ time_t MemRecursorCache::fakeTTD(MemRecursorCache::OrderedTagIterator_t& entry, 
       }
       else {
         if (!entry->d_submitted) {
-          pushAlmostExpiredTask(qname, qtype, entry->d_ttd);
+          if (qtype == QType::ADDR) {
+            pushAlmostExpiredTask(qname, QType::A, entry->d_ttd);
+            pushAlmostExpiredTask(qname, QType::AAAA, entry->d_ttd);
+          }
+          else {
+            pushAlmostExpiredTask(qname, qtype, entry->d_ttd);
+          }
           entry->d_submitted = true;
         }
       }

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -76,6 +76,14 @@ void runTaskOnce(bool logErrors)
 void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline)
 {
   ++s_almost_expired_tasks_pushed;
+  switch (qtype) {
+    // Internal types
+  case QType::ENT:
+  case QType::ADDR:
+  case QType::ALIAS:
+  case QType::LUA:
+    return;
+  }
   pdns::ResolveTask task{qname, qtype, deadline, true, resolve};
   t_taskQueue.push(std::move(task));
 }


### PR DESCRIPTION
Minimal backport of #11338 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
