### PR TITLE
rec: Introduce dnsheader_aligned: a helper class to access dnsheader data

### DIFF
--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -207,6 +207,30 @@ struct dnsheader {
 
 static_assert(sizeof(dnsheader) == 12, "dnsheader size must be 12");
 
+class dnsheader_aligned
+{
+public:
+  dnsheader_aligned(const void* mem)
+  {
+    if (reinterpret_cast<uintptr_t>(mem) % sizeof(uint32_t) == 0) {
+      d_p = reinterpret_cast<const dnsheader*>(mem);
+    }
+    else {
+      memcpy(&d_h, mem, sizeof(dnsheader));
+      d_p = &d_h;
+    }
+  }
+
+  const dnsheader* get() const
+  {
+    return d_p;
+  }
+
+private:
+  dnsheader d_h;
+  const dnsheader *d_p;
+};
+
 inline uint16_t * getFlagsFromDNSHeader(struct dnsheader * dh)
 {
   return (uint16_t*) (((char *) dh) + sizeof(uint16_t));

--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -44,7 +44,8 @@ public:
        + the OPT RR rdlen (2)
        = 15
     */
-    const struct dnsheader* dh = reinterpret_cast<const struct dnsheader*>(packet.data());
+    const dnsheader_aligned dnsheaderdata(packet.data());
+    const struct dnsheader *dh = dnsheaderdata.get();
     if (ntohs(dh->qdcount) != 1 || ntohs(dh->ancount) != 0 || ntohs(dh->nscount) != 0 || ntohs(dh->arcount) != 1 || (pos + 15) >= packetSize) {
       if (packetSize > pos) {
         currentHash = burtle(reinterpret_cast<const unsigned char*>(&packet.at(pos)), packetSize - pos, currentHash);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1639,7 +1639,8 @@ void getQNameAndSubnet(const std::string& question, DNSName* dnsname, uint16_t* 
 {
   const bool lookForXPF = xpfSource != nullptr && g_xpfRRCode != 0;
   const bool lookForECS = ednssubnet != nullptr;
-  const struct dnsheader* dh = reinterpret_cast<const struct dnsheader*>(question.c_str());
+  const dnsheader_aligned dnshead(question.data());
+  const dnsheader* dh = dnshead.get();
   size_t questionLen = question.length();
   unsigned int consumed = 0;
   *dnsname = DNSName(question.c_str(), questionLen, sizeof(dnsheader), false, qtype, qclass, &consumed);
@@ -1795,7 +1796,8 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
     g_stats.ipv6qcounter++;
 
   string response;
-  const struct dnsheader* dh = (struct dnsheader*)question.c_str();
+  const dnsheader_aligned headerdata(question.data());
+  const dnsheader* dh = headerdata.get();
   unsigned int ctag = 0;
   uint32_t qhash = 0;
   bool needECS = false;
@@ -2149,7 +2151,8 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       }
 
       try {
-        dnsheader* dh = (dnsheader*)&data[0];
+        const dnsheader_aligned headerdata(data.data());
+        const dnsheader* dh = headerdata.get();
 
         if (dh->qr) {
           g_stats.ignoredCount++;

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -433,7 +433,8 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
         dc->d_tag = g_paddingTag;
       }
 
-      const struct dnsheader* dh = reinterpret_cast<const struct dnsheader*>(&conn->data[0]);
+      const dnsheader_aligned headerdata(conn->data.data());
+      const struct dnsheader* dh = headerdata.get();
 
       if (t_protobufServers || t_outgoingProtobufServers) {
         dc->d_requestorId = requestorId;


### PR DESCRIPTION
As the string holding the packet may be potentially unaligned wrt to int access.

I'm using a copy of the header, but the copy is only made if the passed in pointer is pointing to unaligned data.

Some day we should switch to `PacketBuffer` instead of `std::string` for packet data. The first is naturally aligned (it allocates using `new()` instead of the more complex way a `std::string` works) and has the nice feature of not initializing its buffer when (re)sizing.

I am not doing that now as it has tentacles all over the place including the packet cache code that is shared with auth. Also `PacketBuffer` is missing a few methods that the current code uses (e.g. `compare()`. This is all solvable, but now for now.

This was caught by using `-fsanitize=undefined -fsanitize-minimal-runtime` that was included in OpenBSD recently. I don't know why the regular ubsan we use on CI does not catch this. On common archs this is likely not an actual problem, as they allow unaligned access, but it might be on some ARM, MIPS and certainly Sparc64 archs.

This only handles rec. The other products should also be checked for this.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
