### PR TITLE
rec: Add setting to prefer a matching forward over a NS entry found in the cache.

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1562,6 +1562,20 @@ The dnsdist docs have `more information about the PROXY protocol <https://dnsdis
 
 The maximum size, in bytes, of a Proxy Protocol payload (header, addresses and ports, and TLV values). Queries with a larger payload will be dropped.
 
+.. _setting-prefer-forward-over-cached-ns:
+
+``prefer-forward-over-cached-ns``
+---------------------------------
+.. versionadded:: 4.6.1
+
+- Boolean
+- Default: no
+
+Prefer to forward a query to a matching forwarder, even if a more specific ``NS`` record is found in the cache,
+making the behavior of forwarding match what was done prior to 4.4.0.
+If this option is set, qname minimization wil also be disabled for forwarded names.
+Note that to be able to use a locally cached (root) zone, this option must *not* be enabled.
+
 .. _setting-public-suffix-list-file:
 
 ``public-suffix-list-file``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1573,7 +1573,7 @@ The maximum size, in bytes, of a Proxy Protocol payload (header, addresses and p
 
 Prefer to forward a query to a matching forwarder, even if a more specific ``NS`` record is found in the cache,
 making the behavior of forwarding match what was done prior to 4.4.0.
-If this option is set, qname minimization wil also be disabled for forwarded names.
+If this option is set, qname minimization will also be disabled for forwarded names.
 Note that to be able to use a locally cached (root) zone, this option must *not* be enabled.
 
 .. _setting-public-suffix-list-file:

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -4,8 +4,8 @@ Upgrade Guide
 Before upgrading, it is advised to read the :doc:`changelog/index`.
 When upgrading several versions, please read **all** notes applying to the upgrade.
 
-4.6.x to master
----------------
+4.6.1 to master branch
+----------------------
 
 Zone to Cache Changes
 ^^^^^^^^^^^^^^^^^^^^^
@@ -17,6 +17,14 @@ Asynchronous retrieval of ``AAAA`` records for nameservers
 If IPv6 is enabled for outgoing queries using :ref:`setting-query-local-address`, the Recursor will schedule an asynchronous task to resolve IPv6 addresses of nameservers it did not otherwise learn.
 These addresses will then be used for future queries to authoritative nameservers.
 This has the consequence that authoritative nameservers will be contacted over IPv6 in more case than before.
+
+4.6.0 to 4.6.1
+--------------
+
+New Settings
+^^^^^^^^^^^^
+- The :ref:`setting-prefer-forward-over-cached-ns` has been introduced, to indicate a matching forwarder should be used even
+  if a more specific ``NS`` record is present in the cache.
 
 Deprecated and changed settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1307,6 +1307,7 @@ static int serviceMain(int argc, char* argv[])
 
   SyncRes::s_dot_to_port_853 = ::arg().mustDo("dot-to-port-853");
   SyncRes::s_event_trace_enabled = ::arg().asNum("event-trace-enabled");
+  SyncRes::s_prefer_forward_over_cached_ns = ::arg().mustDo("prefer-forward-over-cached-ns");
 
   if (SyncRes::s_tcp_fast_open_connect) {
     checkFastOpenSysctl(true);
@@ -2488,6 +2489,7 @@ int main(int argc, char** argv)
     ::arg().set("tcp-out-max-queries", "Maximum total number of queries per TCP/DoT connection, 0 means no limit") = "0";
     ::arg().set("tcp-out-max-idle-per-thread", "Maximum number of idle TCP/DoT connections per thread") = "100";
     ::arg().setSwitch("structured-logging", "Prefer structured logging") = "yes";
+    ::arg().setSwitch("prefer-forward-over-cached-ns", "Prefer matching forwarder over NS record in cache") = "no";
 
     ::arg().setCmd("help", "Provide a helpful message");
     ::arg().setCmd("version", "Print version string");

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -181,6 +181,7 @@ void initSR(bool debug)
   SyncRes::s_nonresolvingnsmaxfails = 0;
   SyncRes::s_nonresolvingnsthrottletime = 0;
   SyncRes::s_refresh_ttlperc = 0;
+  SyncRes::s_prefer_forward_over_cached_ns = false;
 
   SyncRes::clearNSSpeeds();
   BOOST_CHECK_EQUAL(SyncRes::getNSSpeedsSize(), 0U);

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -807,6 +807,7 @@ public:
   static const int event_trace_to_pb = 1;
   static const int event_trace_to_log = 2;
   static int s_event_trace_enabled;
+  static bool s_prefer_forward_over_cached_ns;
 
   std::unordered_map<std::string,bool> d_discardedPolicies;
   DNSFilterEngine::Policy d_appliedPolicy;
@@ -867,6 +868,7 @@ private:
   bool doOOBResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, int &res);
   bool isRecursiveForwardOrAuth(const DNSName &qname) const;
   bool isForwardOrAuth(const DNSName &qname) const;
+  bool isAnyForwardOrAuth(const DNSName &qname) const;
   domainmap_t::const_iterator getBestAuthZone(DNSName* qname) const;
   bool doCNAMECacheCheck(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state, bool wasAuthZone, bool wasForwardRecurse);
   bool doCacheCheck(const DNSName &qname, const DNSName& authname, bool wasForwardedOrAuthZone, bool wasAuthZone, bool wasForwardRecurse, QType qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state);


### PR DESCRIPTION
This (conditionally) reverts to the pre-4.4 behavior for forwarded domains.

The change to prefer cached NS records was introduced in #9351 to allow e.g. a local root auth zone, but we have reports that in specific (complex) setups this is not desired.

The setting is called `prefer-forward-over-cached-ns` Default remains `no`: prefer cached NS records.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
