### PR TITLE
rec: Adaptive root refresh interval, normally at 80% of max-cache-ttl

### DIFF
--- a/pdns/recursordist/docs/appendices/FAQ.rst
+++ b/pdns/recursordist/docs/appendices/FAQ.rst
@@ -57,6 +57,9 @@ Or, in a diagram::
       client bufsize (stub => recursor)
      bufsize reported to client (recursor => stub [always 512])
 
+.. _handling-of-root-hints:
+
+
 Handling of root hints
 ----------------------
 
@@ -75,7 +78,7 @@ If that does not succeed, it wil fall back to using the root hints to fill the c
 Prior to version 4.7.0, the period for re-fetching root data was :ref:`setting-max-cache-ttl` divided by 12, with a minimum of 10 seconds.
 Starting with version 4.7.0, the period is adaptive, starting at 80% of :ref:`setting-max-cache-ttl`, reducing the interval on failure.
 
-There is another detail: after refreshing rhe root records, the :program:`Recursor` will resolve the ``NS`` records for the top level domain of the root servers.
+There is another detail: after refreshing the root records, the :program:`Recursor` will resolve the ``NS`` records for the top level domain of the root servers.
 For example, in the default setup the root name servers are called ``[a-m].root-servers.net``, so the :program:`Recursor` will resolve the name servers of the ``.net`` domain.
 This is needed to correctly determine zone cuts to be able to decide if the ``.root-servers.net`` domain is DNSSEC protected.
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -893,6 +893,7 @@ If set, the root-hints are read from this file. If empty, the default built-in r
 
 In some special cases, processing the root hints is not needed, for example when forwarding all queries to another recursor.
 For these special cases, it is possible to disable the processing of root hints by setting the value to ``no``.
+See :ref:`handling-of-root-hints` for more information on root hints handling.
 
 .. _setting-ignore-unknown-settings:
 
@@ -1121,6 +1122,8 @@ The size of the negative cache is 10% of this number.
 -  Default: 86400
 
 Maximum number of seconds to cache an item in the DNS cache, no matter what the original TTL specified.
+This value also controls the refresh period of cached root data.
+See :ref:`handling-of-root-hints` for more information on this.
 
 .. versionchanged:: 4.1.0
 


### PR DESCRIPTION
and shortening he interval on failure.

The original  code has a fixed 2 hours interval. That was changed to be `max-cache-ttl/12`. But now that we have an easy way to do an adaptive interval that is much preferable.
 
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
