### PR TITLE
fix doc of SVCParams alpn description

### DIFF
--- a/pdns/dnsdistdist/docs/reference/svc.rst
+++ b/pdns/dnsdistdist/docs/reference/svc.rst
@@ -26,7 +26,7 @@ SVCRecordParameters
 
     {
       mandatory={STRING},   -- The mandatory keys. the table of strings must be the key names (like "port" and "key998").
-      alpn={STRING},        -- alpns for this record, like "doh" or "h2".
+      alpn={STRING},        -- alpns for this record, like "dot" or "h2".
       noDefaultAlpn=BOOL,   -- When true, the no-default-alpn key is included in the record, false or absent means it does not exist in the record.
       port=NUM,             -- Port parameter to include.
       ipv4hint={STRING},    -- IPv4 hints to include into the record.


### PR DESCRIPTION
### Short description
fixes documentation of SVCParams alpn description.
"doh" is not a valid alpn value. it's likely a typo and meant to say "dot"

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
