### PR TITLE
auth-4.6.x: LMDB backports

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -84,6 +84,16 @@ PowerDNS Version  LMDB Schema version
 4.4.x and up      3
 ================  ===================
 
+.. _settings-lmdb-random-ids:
+
+``lmdb-random-ids``
+^^^^^^^^^^^^^^^^^^^
+
+  .. versionadded:: 4.7.0
+
+Numeric IDs inside the database are generated randomly instead of sequentially.
+If some external process is synchronising databases between systems, this will avoid conflicts when objects (domains, keys, etc.) get added.
+
 LMDB Structure
 --------------
 

--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -94,6 +94,17 @@ PowerDNS Version  LMDB Schema version
 Numeric IDs inside the database are generated randomly instead of sequentially.
 If some external process is synchronising databases between systems, this will avoid conflicts when objects (domains, keys, etc.) get added.
 
+.. _settings-lmdb-map-size:
+
+``lmdb-random-ids``
+^^^^^^^^^^^^^^^^^^^
+
+  .. versionadded:: 4.7.0
+
+Size, in megabytes, of each LMDB database.
+This number can be increased later, but never decreased.
+Defaults to 100 on 32 bit systems, and 16000 on 64 bit systems.
+
 LMDB Structure
 --------------
 

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -27,11 +27,9 @@ MDBDbi::MDBDbi(MDB_env* env, MDB_txn* txn, const string_view dbname, int flags)
   // Database names are keys in the unnamed database, and may be read but not written.
 }
 
-MDBEnv::MDBEnv(const char* fname, int flags, int mode)
+MDBEnv::MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB)
 {
   mdb_env_create(&d_env);
-  uint64_t mapsizeMB = (sizeof(long)==4) ? 100 : 16000;
-  // on 32 bit platforms, there is just no room for more
   if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576))
     throw std::runtime_error("setting map size");
     /*
@@ -90,7 +88,7 @@ int MDBEnv::getROTX()
 }
 
 
-std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode)
+std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB)
 {
   struct Value
   {
@@ -107,7 +105,7 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode)
       throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
     else {
       std::lock_guard<std::mutex> l(mut);
-      auto fresh = std::make_shared<MDBEnv>(fname, flags, mode);
+      auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
       if(stat(fname, &statbuf))
         throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
       auto key = std::tie(statbuf.st_dev, statbuf.st_ino);
@@ -132,7 +130,7 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode)
     }
   }
 
-  auto fresh = std::make_shared<MDBEnv>(fname, flags, mode);
+  auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
   s_envs[key] = {fresh, flags};
   
   return fresh;

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -54,7 +54,7 @@ using MDBRWTransaction = std::unique_ptr<MDBRWTransactionImpl>;
 class MDBEnv
 {
 public:
-  MDBEnv(const char* fname, int flags, int mode);
+  MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB);
 
   ~MDBEnv()
   {
@@ -87,7 +87,7 @@ private:
   std::map<std::thread::id, int> d_ROtransactionsOut;
 };
 
-std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode);
+std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB=(sizeof(void *)==4) ? 100 : 16000);
 
 
 

--- a/ext/lmdb-safe/lmdb-typed.cc
+++ b/ext/lmdb-safe/lmdb-typed.cc
@@ -19,9 +19,9 @@ unsigned int MDBGetRandomID(MDBRWTransaction& txn, MDBDbi& dbi)
   for(int attempts=0; attempts<20; attempts++) {
     MDBOutVal key, content;
 
-    // dns_random generates a random number in [0..type_max-1]. We add 1 to avoid 0 and allow type_max.
+    // dns_random generates a random number in [0..signed_int_max-1]. We add 1 to avoid 0 and allow type_max.
     // 0 is avoided because the put() interface uses it to mean "please allocate a number for me"
-    id = dns_random(std::numeric_limits<decltype(id)>::max()) + 1;
+    id = dns_random(std::numeric_limits<signed int>::max()) + 1;
     if(cursor.find(MDBInVal(id), key, content)) {
       return id;
     }

--- a/ext/lmdb-safe/lmdb-typed.cc
+++ b/ext/lmdb-safe/lmdb-typed.cc
@@ -1,4 +1,5 @@
 #include "lmdb-typed.hh"
+#include "pdns/dns_random.hh"
 
 unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi)
 {
@@ -9,6 +10,23 @@ unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi)
     maxid = maxidval.get<unsigned int>();
   }
   return maxid;
+}
+
+unsigned int MDBGetRandomID(MDBRWTransaction& txn, MDBDbi& dbi)
+{
+  auto cursor = txn->getRWCursor(dbi);
+  unsigned int id;
+  for(int attempts=0; attempts<20; attempts++) {
+    MDBOutVal key, content;
+
+    // dns_random generates a random number in [0..type_max-1]. We add 1 to avoid 0 and allow type_max.
+    // 0 is avoided because the put() interface uses it to mean "please allocate a number for me"
+    id = dns_random(std::numeric_limits<decltype(id)>::max()) + 1;
+    if(cursor.find(MDBInVal(id), key, content)) {
+      return id;
+    }
+  }
+  throw std::runtime_error("MDBGetRandomID() could not assign an unused random ID");
 }
 
 

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -35,6 +35,12 @@
 */
 unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi);
 
+/** Return a randomly generated ID that is unique and not zero.
+    May throw if the database is very full.
+*/
+unsigned int MDBGetRandomID(MDBRWTransaction& txn, MDBDbi& dbi);
+
+
 /** This is our serialization interface.
     You can define your own serToString for your type if you know better
 */
@@ -588,12 +594,17 @@ public:
     }
 
     // insert something, with possibly a specific id
-    uint32_t put(const T& t, uint32_t id=0)
+    uint32_t put(const T& t, uint32_t id, bool random_ids=false)
     {
       int flags = 0;
       if(!id) {
-        id = MDBGetMaxID(*d_txn, d_parent->d_main) + 1;
-        flags = MDB_APPEND;
+        if(random_ids) {
+          id = MDBGetRandomID(*d_txn, d_parent->d_main);
+        }
+        else {
+          id = MDBGetMaxID(*d_txn, d_parent->d_main) + 1;
+          flags = MDB_APPEND;
+        }
       }
       (*d_txn)->put(d_parent->d_main, id, serToString(t), flags);
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -34,11 +34,13 @@
 #include "pdns/version.hh"
 #include "pdns/arguments.hh"
 #include "pdns/lock.hh"
+#include "pdns/uuid-utils.hh"
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/string.hpp>
 #include <boost/serialization/utility.hpp>
+#include <boost/uuid/uuid_serialize.hpp>
 
 #include <boost/iostreams/device/back_inserter.hpp>
 
@@ -113,6 +115,13 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
       else {
         s_shards = atoi(getArg("shards").c_str());
         txn->put(pdnsdbi, "shards", s_shards);
+      }
+
+      MDBOutVal gotuuid;
+      if (txn->get(pdnsdbi, "uuid", gotuuid)) {
+        const auto uuid = getUniqueID();
+        const string uuids(uuid.begin(), uuid.end());
+        txn->put(pdnsdbi, "uuid", uuids);
       }
 
       txn->commit();

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -219,9 +219,9 @@ public:
   {
     DNSName domain;
     std::string content;
-    unsigned int flags;
-    bool active;
-    bool published;
+    unsigned int flags{0};
+    bool active{true};
+    bool published{true};
   };
   class LMDBResourceRecord : public DNSResourceRecord
   {

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -311,5 +311,6 @@ private:
   DNSName d_transactiondomain;
   uint32_t d_transactiondomainid;
   bool d_dolog;
+  bool d_random_ids;
   DTime d_dtime; // used only for logging
 };

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -378,6 +378,7 @@ pdnsutil_SOURCES = \
 	tsigutils.hh tsigutils.cc \
 	ueberbackend.cc \
 	unix_utility.cc \
+	uuid-utils.hh uuid-utils.cc \
 	zoneparser-tng.cc
 
 pdnsutil_LDFLAGS = \

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -175,7 +175,7 @@ public:
 class LMDBKVStore: public KeyValueStore
 {
 public:
-  LMDBKVStore(const std::string& fname, const std::string& dbName, bool noLock=false): d_env(fname.c_str(), noLock ? MDB_NOSUBDIR|MDB_RDONLY|MDB_NOLOCK : MDB_NOSUBDIR|MDB_RDONLY, 0600), d_dbi(d_env.openDB(dbName, 0)), d_fname(fname), d_dbName(dbName)
+  LMDBKVStore(const std::string& fname, const std::string& dbName, bool noLock=false): d_env(fname.c_str(), noLock ? MDB_NOSUBDIR|MDB_RDONLY|MDB_NOLOCK : MDB_NOSUBDIR|MDB_RDONLY, 0600, 0), d_dbi(d_env.openDB(dbName, 0)), d_fname(fname), d_dbName(dbName)
   {
   }
 

--- a/pdns/dnsdistdist/test-dnsdistkvs_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistkvs_cc.cc
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(test_LMDB) {
 
   const string dbPath("/tmp/test_lmdb.XXXXXX");
   {
-    MDBEnv env(dbPath.c_str(), MDB_NOSUBDIR, 0600);
+    MDBEnv env(dbPath.c_str(), MDB_NOSUBDIR, 0600, 50);
     auto transaction = env.getRWTransaction();
     auto dbi = transaction->openDB("db-name", MDB_CREATE);
     transaction->put(dbi, MDBInVal(std::string(reinterpret_cast<const char*>(&rem.sin4.sin_addr.s_addr), sizeof(rem.sin4.sin_addr.s_addr))), MDBInVal("this is the value for the remote addr"));
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(test_LMDB) {
   }
 
   {
-    MDBEnv env(dbPath.c_str(), MDB_NOSUBDIR, 0600);
+    MDBEnv env(dbPath.c_str(), MDB_NOSUBDIR, 0600, 50);
     auto transaction = env.getRWTransaction();
     auto dbi = transaction->openDB("range-db-name", MDB_CREATE);
     /* range-based lookups */

--- a/regression-tests.nobackend/lmdb-id-generation/command
+++ b/regression-tests.nobackend/lmdb-id-generation/command
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+if [ "${PDNS_DEBUG}" = "YES" ]; then
+  set -x
+fi
+
+rootPath=$(readlink -f $(dirname $0))
+
+for random in no yes
+do
+  workdir=$(mktemp -d)
+
+  cat << EOF > "${workdir}/pdns-lmdb.conf"
+  module-dir=../regression-tests/modules
+  launch=lmdb
+  lmdb-filename=${workdir}/pdns.lmdb
+  lmdb-shards=2
+  lmdb-random-ids=${random}
+EOF
+
+  $PDNSUTIL --config-dir="${workdir}" --config-name=lmdb create-zone example.com
+  ids=$( for i in a b c ; do $PDNSUTIL --config-dir="${workdir}" --config-name=lmdb add-zone-key example.com ksk ; done | xargs )
+  if [ $random = no ]
+  then
+    if [ "$ids" = "1 2 3" ]
+    then
+      echo "sequential generator generated 1 2 3 correctly"
+    else
+      echo "sequential generator: expected 1 2 3, but got $ids"
+    fi
+  else
+    if [ "$ids" = "1 2 3" ]
+    then
+      echo "random generator generated 1 2 3, this is unlikely"
+    else
+      echo "random generator generated something other than 1 2 3, good"
+    fi
+  fi
+done

--- a/regression-tests.nobackend/lmdb-id-generation/description
+++ b/regression-tests.nobackend/lmdb-id-generation/description
@@ -1,0 +1,1 @@
+This test verifies that LMDB ID generation is sequential, unless configured with lmdb-random-ids=yes

--- a/regression-tests.nobackend/lmdb-id-generation/expected_result
+++ b/regression-tests.nobackend/lmdb-id-generation/expected_result
@@ -1,0 +1,2 @@
+sequential generator generated 1 2 3 correctly
+random generator generated something other than 1 2 3, good

--- a/regression-tests/backends/lmdb-master
+++ b/regression-tests/backends/lmdb-master
@@ -4,6 +4,7 @@ case $context in
 module-dir=./modules
 launch=lmdb
 lmdb-filename=./pdns.lmdb
+lmdb-random-ids=yes
 __EOF__
 
         rm -f pdns.lmdb*


### PR DESCRIPTION
### Short description
* UUID for LMDB database: #11241
* LMDB random ids: #11309, #11354
* configurable LMDB map size: #11328
* auth lmdb: default values for KeyDataDB members, thanks ubsan #11306 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master