### PR TITLE
dnsdist: Define types for Lua arrays and associative arrays

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -377,7 +377,7 @@ private:
 class SpoofSVCAction : public DNSAction
 {
 public:
-  SpoofSVCAction(const std::vector<std::pair<int, SVCRecordParameters>>& parameters)
+  SpoofSVCAction(const LuaArray<SVCRecordParameters>& parameters)
   {
     d_payloads.reserve(parameters.size());
 
@@ -2171,12 +2171,12 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new QPSPoolAction(limit, a, stopProcessing.get_value_or(true)));
     });
 
-  luaCtx.writeFunction("SpoofAction", [](boost::variant<std::string,vector<pair<int, std::string>>> inp, boost::optional<responseParams_t> vars) {
+  luaCtx.writeFunction("SpoofAction", [](LuaTypeOrArrayOf<std::string> inp, boost::optional<responseParams_t> vars) {
       vector<ComboAddress> addrs;
       if(auto s = boost::get<std::string>(&inp)) {
         addrs.push_back(ComboAddress(*s));
       } else {
-        const auto& v = boost::get<vector<pair<int,std::string>>>(inp);
+        const auto& v = boost::get<LuaArray<std::string>>(inp);
         for(const auto& a: v) {
           addrs.push_back(ComboAddress(a.second));
         }
@@ -2188,7 +2188,7 @@ void setupLuaActions(LuaContext& luaCtx)
       return ret;
     });
 
-  luaCtx.writeFunction("SpoofSVCAction", [](const std::vector<std::pair<int, SVCRecordParameters>>& parameters, boost::optional<responseParams_t> vars) {
+  luaCtx.writeFunction("SpoofSVCAction", [](const LuaArray<SVCRecordParameters>& parameters, boost::optional<responseParams_t> vars) {
       auto ret = std::shared_ptr<DNSAction>(new SpoofSVCAction(parameters));
       auto sa = std::dynamic_pointer_cast<SpoofSVCAction>(ret);
       parseResponseConfig(vars, sa->d_responseConfig);
@@ -2202,12 +2202,12 @@ void setupLuaActions(LuaContext& luaCtx)
       return ret;
     });
 
-  luaCtx.writeFunction("SpoofRawAction", [](boost::variant<std::string,vector<pair<int, std::string>>> inp, boost::optional<responseParams_t> vars) {
+  luaCtx.writeFunction("SpoofRawAction", [](LuaTypeOrArrayOf<std::string> inp, boost::optional<responseParams_t> vars) {
       vector<string> raws;
       if(auto s = boost::get<std::string>(&inp)) {
         raws.push_back(*s);
       } else {
-        const auto& v = boost::get<vector<pair<int,std::string>>>(inp);
+        const auto& v = boost::get<LuaArray<std::string>>(inp);
         for(const auto& raw: v) {
           raws.push_back(raw.second);
         }
@@ -2271,12 +2271,12 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSResponseAction>(new LimitTTLResponseAction(0, max));
     });
 
-  luaCtx.writeFunction("ClearRecordTypesResponseAction", [](boost::variant<int, vector<pair<int, int>>> types) {
+  luaCtx.writeFunction("ClearRecordTypesResponseAction", [](LuaTypeOrArrayOf<int> types) {
       std::set<QType> qtypes{};
       if (types.type() == typeid(int)) {
         qtypes.insert(boost::get<int>(types));
-      } else if (types.type() == typeid(vector<pair<int, int>>)) {
-        const auto& v = boost::get<vector<pair<int, int>>>(types);
+      } else if (types.type() == typeid(LuaArray<int>)) {
+        const auto& v = boost::get<LuaArray<int>>(types);
         for (const auto& tpair: v) {
           qtypes.insert(tpair.second);
         }
@@ -2338,7 +2338,7 @@ void setupLuaActions(LuaContext& luaCtx)
     });
 
 #ifndef DISABLE_PROTOBUF
-  luaCtx.writeFunction("RemoteLogAction", [](std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(DNSQuestion*, DNSDistProtoBufMessage*)> > alterFunc, boost::optional<std::unordered_map<std::string, std::string>> vars) {
+  luaCtx.writeFunction("RemoteLogAction", [](std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(DNSQuestion*, DNSDistProtoBufMessage*)> > alterFunc, boost::optional<LuaAssociativeTable<std::string>> vars) {
       if (logger) {
         // avoids potentially-evaluated-expression warning with clang.
         RemoteLoggerInterface& rl = *logger.get();
@@ -2362,7 +2362,7 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new RemoteLogAction(logger, alterFunc, serverID, ipEncryptKey));
     });
 
-  luaCtx.writeFunction("RemoteLogResponseAction", [](std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(DNSResponse*, DNSDistProtoBufMessage*)> > alterFunc, boost::optional<bool> includeCNAME, boost::optional<std::unordered_map<std::string, std::string>> vars) {
+  luaCtx.writeFunction("RemoteLogResponseAction", [](std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(DNSResponse*, DNSDistProtoBufMessage*)> > alterFunc, boost::optional<bool> includeCNAME, boost::optional<LuaAssociativeTable<std::string>> vars) {
       if (logger) {
         // avoids potentially-evaluated-expression warning with clang.
         RemoteLoggerInterface& rl = *logger.get();

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -89,7 +89,7 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
   luaCtx.registerFunction<void(DNSQuestion::*)(std::string, std::string)>("setTag", [](DNSQuestion& dq, const std::string& strLabel, const std::string& strValue) {
       dq.setTag(strLabel, strValue);
     });
-  luaCtx.registerFunction<void(DNSQuestion::*)(vector<pair<string, string>>)>("setTagArray", [](DNSQuestion& dq, const vector<pair<string, string>>&tags) {
+  luaCtx.registerFunction<void(DNSQuestion::*)(LuaAssociativeTable<std::string>)>("setTagArray", [](DNSQuestion& dq, const LuaAssociativeTable<std::string>&tags) {
       for (const auto& tag : tags) {
         dq.setTag(tag.first, tag.second);
       }
@@ -115,7 +115,7 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
       return *dq.qTag;
     });
 
-  luaCtx.registerFunction<void(DNSQuestion::*)(std::vector<std::pair<int, std::string>>)>("setProxyProtocolValues", [](DNSQuestion& dq, const std::vector<std::pair<int, std::string>>& values) {
+  luaCtx.registerFunction<void(DNSQuestion::*)(LuaArray<std::string>)>("setProxyProtocolValues", [](DNSQuestion& dq, const LuaArray<std::string>& values) {
     if (!dq.proxyProtocolValues) {
       dq.proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>();
     }
@@ -137,12 +137,12 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
     dq.proxyProtocolValues->push_back({value, static_cast<uint8_t>(type)});
   });
 
-  luaCtx.registerFunction<std::vector<std::pair<int, std::string>>(DNSQuestion::*)()>("getProxyProtocolValues", [](const DNSQuestion& dq) {
+  luaCtx.registerFunction<LuaArray<std::string>(DNSQuestion::*)()>("getProxyProtocolValues", [](const DNSQuestion& dq) {
+    LuaArray<std::string> result;
     if (!dq.proxyProtocolValues) {
-      return std::vector<std::pair<int, std::string>>();
+      return result;
     }
 
-    std::vector<std::pair<int, std::string>> result;
     result.resize(dq.proxyProtocolValues->size());
     for (const auto& value : *dq.proxyProtocolValues) {
       result.push_back({ value.type, value.content });
@@ -151,10 +151,10 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
     return result;
   });
 
-  luaCtx.registerFunction<void(DNSQuestion::*)(const boost::variant<std::vector<std::pair<int, ComboAddress>>, std::vector<std::pair<int, std::string>>>& response)>("spoof", [](DNSQuestion& dq, const boost::variant<std::vector<std::pair<int, ComboAddress>>, std::vector<std::pair<int, std::string>>>& response) {
-      if (response.type() == typeid(vector<pair<int, ComboAddress>>)) {
+  luaCtx.registerFunction<void(DNSQuestion::*)(const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>& response)>("spoof", [](DNSQuestion& dq, const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>& response) {
+      if (response.type() == typeid(LuaArray<ComboAddress>)) {
           std::vector<ComboAddress> data;
-          auto responses = boost::get<vector<pair<int, ComboAddress>>>(response);
+          auto responses = boost::get<LuaArray<ComboAddress>>(response);
           data.reserve(responses.size());
           for (const auto& resp : responses) {
             data.push_back(resp.second);
@@ -164,9 +164,9 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
           sa(&dq, &result);
 	  return;
       }
-      if (response.type() == typeid(vector<pair<int, string>>)) {
+      if (response.type() == typeid(LuaArray<std::string>)) {
           std::vector<std::string> data;
-          auto responses = boost::get<vector<pair<int, string>>>(response);
+          auto responses = boost::get<LuaArray<std::string>>(response);
           data.reserve(responses.size());
           for (const auto& resp : responses) {
             data.push_back(resp.second);
@@ -214,7 +214,7 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
       dr.setTag(strLabel, strValue);
     });
 
-  luaCtx.registerFunction<void(DNSResponse::*)(vector<pair<string, string>>)>("setTagArray", [](DNSResponse& dr, const vector<pair<string, string>>&tags) {
+  luaCtx.registerFunction<void(DNSResponse::*)(LuaAssociativeTable<std::string>)>("setTagArray", [](DNSResponse& dr, const LuaAssociativeTable<string>&tags) {
       for (const auto& tag : tags) {
         dr.setTag(tag.first, tag.second);
       }
@@ -281,9 +281,9 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
       return dq.du->getHTTPScheme();
     });
 
-    luaCtx.registerFunction<std::unordered_map<std::string, std::string>(DNSQuestion::*)(void)const>("getHTTPHeaders", [](const DNSQuestion& dq) {
+    luaCtx.registerFunction<LuaAssociativeTable<std::string>(DNSQuestion::*)(void)const>("getHTTPHeaders", [](const DNSQuestion& dq) {
       if (dq.du == nullptr) {
-        return std::unordered_map<std::string, std::string>();
+        return LuaAssociativeTable<std::string>();
       }
       return dq.du->getHTTPHeaders();
     });

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -41,15 +41,15 @@ std::shared_ptr<DNSRule> makeRule(const luadnsrule_t& var)
   if (var.type() == typeid(string))
     add(*boost::get<string>(&var));
 
-  else if (var.type() == typeid(vector<pair<int, string>>))
-    for(const auto& a : *boost::get<vector<pair<int, string>>>(&var))
+  else if (var.type() == typeid(LuaArray<std::string>))
+    for(const auto& a : *boost::get<LuaArray<std::string>>(&var))
       add(a.second);
 
   else if (var.type() == typeid(DNSName))
     smn.add(*boost::get<DNSName>(&var));
 
-  else if (var.type() == typeid(vector<pair<int, DNSName>>))
-    for(const auto& a : *boost::get<vector<pair<int, DNSName>>>(&var))
+  else if (var.type() == typeid(LuaArray<DNSName>))
+    for(const auto& a : *boost::get<LuaArray<DNSName>>(&var))
       smn.add(a.second);
 
   if(nmg.empty())
@@ -86,7 +86,7 @@ void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid
   creationOrder = s_creationOrder++;
 }
 
-typedef std::unordered_map<std::string, boost::variant<bool, int, std::string, std::vector<std::pair<int,int> > > > ruleparams_t;
+typedef LuaAssociativeTable<boost::variant<bool, int, std::string, LuaArray<int> > > ruleparams_t;
 
 template<typename T>
 static std::string rulesToString(const std::vector<T>& rules, boost::optional<ruleparams_t> vars)
@@ -307,7 +307,7 @@ void setupLuaRules(LuaContext& luaCtx)
         });
     });
 
-  luaCtx.writeFunction("setRules", [](const std::vector<std::pair<int, std::shared_ptr<DNSDistRuleAction>>>& newruleactions) {
+  luaCtx.writeFunction("setRules", [](const LuaArray<std::shared_ptr<DNSDistRuleAction>>& newruleactions) {
       setLuaSideEffect();
       g_ruleactions.modify([newruleactions](decltype(g_ruleactions)::value_type& gruleactions) {
           gruleactions.clear();
@@ -491,11 +491,11 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new OpcodeRule(code));
     });
 
-  luaCtx.writeFunction("AndRule", [](vector<pair<int, std::shared_ptr<DNSRule> > >a) {
+  luaCtx.writeFunction("AndRule", [](LuaArray<std::shared_ptr<DNSRule>> a) {
       return std::shared_ptr<DNSRule>(new AndRule(a));
     });
 
-  luaCtx.writeFunction("OrRule", [](vector<pair<int, std::shared_ptr<DNSRule> > >a) {
+  luaCtx.writeFunction("OrRule", [](LuaArray<std::shared_ptr<DNSRule>>a) {
       return std::shared_ptr<DNSRule>(new OrRule(a));
     });
 

--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -27,7 +27,7 @@
 
 void setupLuaVars(LuaContext& luaCtx)
 {
-  luaCtx.writeVariable("DNSAction", std::unordered_map<string,int>{
+  luaCtx.writeVariable("DNSAction", LuaAssociativeTable<int>{
       {"Drop", (int)DNSAction::Action::Drop},
       {"Nxdomain", (int)DNSAction::Action::Nxdomain},
       {"Refused", (int)DNSAction::Action::Refused},
@@ -45,7 +45,7 @@ void setupLuaVars(LuaContext& luaCtx)
       {"NoRecurse", (int)DNSAction::Action::NoRecurse}
     });
 
-  luaCtx.writeVariable("DNSResponseAction", std::unordered_map<string,int>{
+  luaCtx.writeVariable("DNSResponseAction", LuaAssociativeTable<int>{
       {"Allow",        (int)DNSResponseAction::Action::Allow        },
       {"Delay",        (int)DNSResponseAction::Action::Delay        },
       {"Drop",         (int)DNSResponseAction::Action::Drop         },
@@ -54,14 +54,14 @@ void setupLuaVars(LuaContext& luaCtx)
       {"None",         (int)DNSResponseAction::Action::None         }
     });
 
-  luaCtx.writeVariable("DNSClass", std::unordered_map<string,int>{
+  luaCtx.writeVariable("DNSClass", LuaAssociativeTable<int>{
       {"IN",    QClass::IN    },
       {"CHAOS", QClass::CHAOS },
       {"NONE",  QClass::NONE  },
       {"ANY",   QClass::ANY   }
     });
 
-  luaCtx.writeVariable("DNSOpcode", std::unordered_map<string,int>{
+  luaCtx.writeVariable("DNSOpcode", LuaAssociativeTable<int>{
       {"Query",  Opcode::Query  },
       {"IQuery", Opcode::IQuery },
       {"Status", Opcode::Status },
@@ -69,14 +69,14 @@ void setupLuaVars(LuaContext& luaCtx)
       {"Update", Opcode::Update }
     });
 
-  luaCtx.writeVariable("DNSSection", std::unordered_map<string,int>{
+  luaCtx.writeVariable("DNSSection", LuaAssociativeTable<int>{
       {"Question",  0 },
       {"Answer",    1 },
       {"Authority", 2 },
       {"Additional",3 }
     });
 
-  luaCtx.writeVariable("EDNSOptionCode", std::unordered_map<string,int>{
+  luaCtx.writeVariable("EDNSOptionCode", LuaAssociativeTable<int>{
       {"NSID",         EDNSOptionCode::NSID },
       {"DAU",          EDNSOptionCode::DAU },
       {"DHU",          EDNSOptionCode::DHU },
@@ -90,7 +90,7 @@ void setupLuaVars(LuaContext& luaCtx)
       {"KEYTAG",       EDNSOptionCode::KEYTAG }
     });
 
-  luaCtx.writeVariable("DNSRCode", std::unordered_map<string, int>{
+  luaCtx.writeVariable("DNSRCode", LuaAssociativeTable<int>{
       {"NOERROR",  RCode::NoError  },
       {"FORMERR",  RCode::FormErr  },
       {"SERVFAIL", RCode::ServFail },
@@ -113,13 +113,14 @@ void setupLuaVars(LuaContext& luaCtx)
       {"BADCOOKIE",ERCode::BADCOOKIE }
   });
 
-  vector<pair<string, int> > dd;
-  for(const auto& n : QType::names)
-    dd.push_back({n.first, n.second});
+  LuaAssociativeTable<int> dd;
+  for (const auto& n : QType::names) {
+    dd[n.first] = n.second;
+  }
   luaCtx.writeVariable("DNSQType", dd);
 
 #ifdef HAVE_DNSCRYPT
-    luaCtx.writeVariable("DNSCryptExchangeVersion", std::unordered_map<string,int>{
+    luaCtx.writeVariable("DNSCryptExchangeVersion", LuaAssociativeTable<int>{
         { "VERSION1", DNSCryptExchangeVersion::VERSION1 },
         { "VERSION2", DNSCryptExchangeVersion::VERSION2 },
     });

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -129,13 +129,17 @@ private:
   uint32_t d_max{std::numeric_limits<uint32_t>::max()};
 };
 
-typedef boost::variant<string, vector<pair<int, string>>, std::shared_ptr<DNSRule>, DNSName, vector<pair<int, DNSName> > > luadnsrule_t;
+template <class T> using LuaArray = std::vector<std::pair<int, T>>;
+template <class T> using LuaAssociativeTable = std::unordered_map<std::string, T>;
+template <class T> using LuaTypeOrArrayOf = boost::variant<T, LuaArray<T>>;
+
+using luadnsrule_t = boost::variant<string, LuaArray<std::string>, std::shared_ptr<DNSRule>, DNSName, LuaArray<DNSName>>;
+using luaruleparams_t = LuaAssociativeTable<std::string>;
+using nmts_t = NetmaskTree<DynBlock, AddressAndPortRange>;
+
 std::shared_ptr<DNSRule> makeRule(const luadnsrule_t& var);
-typedef std::unordered_map<std::string, std::string> luaruleparams_t;
 void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid& uuid, std::string& name, uint64_t& creationOrder);
 void checkParameterBound(const std::string& parameter, uint64_t value, size_t max = std::numeric_limits<uint16_t>::max());
-
-typedef NetmaskTree<DynBlock, AddressAndPortRange> nmts_t;
 
 vector<std::function<void(void)>> setupLua(LuaContext& luaCtx, bool client, bool configCheck, const std::string& config);
 void setupLuaActions(LuaContext& luaCtx);

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
@@ -51,13 +51,13 @@ void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client)
 
       ctx->addNewCertificate(newCert, newKey, active ? *active : true);
     });
-    luaCtx.registerFunction<std::map<int, std::shared_ptr<DNSCryptCertificatePair>>(std::shared_ptr<DNSCryptContext>::*)()>("getCertificatePairs", [](std::shared_ptr<DNSCryptContext> ctx) {
-      std::map<int, std::shared_ptr<DNSCryptCertificatePair>> result;
+    luaCtx.registerFunction<LuaArray<std::shared_ptr<DNSCryptCertificatePair>>(std::shared_ptr<DNSCryptContext>::*)()>("getCertificatePairs", [](std::shared_ptr<DNSCryptContext> ctx) {
+      LuaArray<std::shared_ptr<DNSCryptCertificatePair>> result;
 
       if (ctx != nullptr) {
         size_t idx = 1;
         for (auto pair : ctx->getCertificates()) {
-          result[idx++] = pair;
+          result.push_back({idx++, pair});
         }
       }
 

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -33,7 +33,7 @@
 void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
 {
   /* PacketCache */
-  luaCtx.writeFunction("newPacketCache", [client](size_t maxEntries, boost::optional<std::unordered_map<std::string, boost::variant<bool, size_t, std::vector<std::pair<int, uint16_t>>>>> vars) {
+  luaCtx.writeFunction("newPacketCache", [client](size_t maxEntries, boost::optional<LuaAssociativeTable<boost::variant<bool, size_t, LuaArray<uint16_t>>>> vars) {
 
       bool keepStaleData = false;
       size_t maxTTL = 86400;
@@ -95,7 +95,7 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
           }
         }
         if (vars->count("skipOptions")) {
-          for (auto option: boost::get<std::vector<std::pair<int, uint16_t>>>(vars->at("skipOptions"))) {
+          for (auto option: boost::get<LuaArray<uint16_t>>(vars->at("skipOptions"))) {
             optionsToSkip.insert(option.second);
           }
         }
@@ -175,8 +175,8 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
         g_outputBuffer+="TTL Too Shorts: " + std::to_string(cache->getTTLTooShorts()) + "\n";
       }
     });
-  luaCtx.registerFunction<std::unordered_map<std::string, uint64_t>(std::shared_ptr<DNSDistPacketCache>::*)()const>("getStats", [](const std::shared_ptr<DNSDistPacketCache>& cache) {
-      std::unordered_map<std::string, uint64_t> stats;
+  luaCtx.registerFunction<LuaAssociativeTable<uint64_t>(std::shared_ptr<DNSDistPacketCache>::*)()const>("getStats", [](const std::shared_ptr<DNSDistPacketCache>& cache) {
+      LuaAssociativeTable<uint64_t> stats;
       if (cache) {
         stats["entries"] = cache->getEntriesCount();
         stats["maxEntries"] = cache->getMaxEntries();

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -32,7 +32,7 @@
 #include "remote_logger.hh"
 
 #ifdef HAVE_FSTRM
-static void parseFSTRMOptions(const boost::optional<std::unordered_map<std::string, unsigned int>>& params, std::unordered_map<string, unsigned int>& options)
+static void parseFSTRMOptions(const boost::optional<LuaAssociativeTable<unsigned int>>& params, LuaAssociativeTable<unsigned int>& options)
 {
   if (!params) {
     return;
@@ -67,7 +67,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(std::string)>("setTag", [](DNSDistProtoBufMessage& message, const std::string& strValue) {
       message.addTag(strValue);
     });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(vector<pair<int, string>>)>("setTagArray", [](DNSDistProtoBufMessage& message, const vector<pair<int, string>>&tags) {
+  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(LuaArray<std::string>)>("setTagArray", [](DNSDistProtoBufMessage& message, const LuaArray<std::string>& tags) {
       for (const auto& tag : tags) {
         message.addTag(tag.second);
       }
@@ -130,13 +130,13 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
       return std::shared_ptr<RemoteLoggerInterface>(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries*100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client));
     });
 
-  luaCtx.writeFunction("newFrameStreamUnixLogger", [client,configCheck](const std::string& address, boost::optional<std::unordered_map<std::string, unsigned int>> params) {
+  luaCtx.writeFunction("newFrameStreamUnixLogger", [client,configCheck](const std::string& address, boost::optional<LuaAssociativeTable<unsigned int>> params) {
 #ifdef HAVE_FSTRM
       if (client || configCheck) {
         return std::shared_ptr<RemoteLoggerInterface>(nullptr);
       }
 
-      std::unordered_map<string, unsigned int> options;
+      LuaAssociativeTable<unsigned int> options;
       parseFSTRMOptions(params, options);
       return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_UNIX, address, !client, options));
 #else
@@ -144,13 +144,13 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
 #endif /* HAVE_FSTRM */
     });
 
-  luaCtx.writeFunction("newFrameStreamTcpLogger", [client,configCheck](const std::string& address, boost::optional<std::unordered_map<std::string, unsigned int>> params) {
+  luaCtx.writeFunction("newFrameStreamTcpLogger", [client,configCheck](const std::string& address, boost::optional<LuaAssociativeTable<unsigned int>> params) {
 #if defined(HAVE_FSTRM) && defined(HAVE_FSTRM_TCP_WRITER_INIT)
       if (client || configCheck) {
         return std::shared_ptr<RemoteLoggerInterface>(nullptr);
       }
 
-      std::unordered_map<string, unsigned int> options;
+      LuaAssociativeTable<unsigned int> options;
       parseFSTRMOptions(params, options);
       return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_INET, address, !client, options));
 #else

--- a/pdns/dnsdistdist/dnsdist-lua-web.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-web.cc
@@ -39,38 +39,38 @@ void setupLuaWeb(LuaContext& luaCtx)
   luaCtx.registerMember<int(YaHTTP::Request::*)>("version", [](const YaHTTP::Request& req) -> int { return req.version; }, [](YaHTTP::Request& req, int version) { (void) version; });
   luaCtx.registerMember<std::string(YaHTTP::Request::*)>("method", [](const YaHTTP::Request& req) -> std::string { return req.method; }, [](YaHTTP::Request& req, const std::string& method) { (void) method; });
   luaCtx.registerMember<std::string(YaHTTP::Request::*)>("body", [](const YaHTTP::Request& req) -> const std::string { return req.body; }, [](YaHTTP::Request& req, const std::string& body) { (void) body; });
-  luaCtx.registerMember<std::unordered_map<std::string, std::string>(YaHTTP::Request::*)>("getvars", [](const YaHTTP::Request& req) {
-    std::unordered_map<std::string, std::string> values;
+  luaCtx.registerMember<LuaAssociativeTable<std::string>(YaHTTP::Request::*)>("getvars", [](const YaHTTP::Request& req) {
+    LuaAssociativeTable<std::string> values;
     for (const auto& entry : req.getvars) {
       values.insert({entry.first, entry.second});
     }
     return values;
-  }, [](YaHTTP::Request& req, const std::unordered_map<std::string, std::string>& values) { (void) values; });
-  luaCtx.registerMember<std::unordered_map<std::string, std::string>(YaHTTP::Request::*)>("postvars", [](const YaHTTP::Request& req) {
-    std::unordered_map<std::string, std::string> values;
+  }, [](YaHTTP::Request& req, const LuaAssociativeTable<std::string>& values) { (void) values; });
+  luaCtx.registerMember<LuaAssociativeTable<std::string>(YaHTTP::Request::*)>("postvars", [](const YaHTTP::Request& req) {
+    LuaAssociativeTable<std::string> values;
     for (const auto& entry : req.postvars) {
       values.insert({entry.first, entry.second});
     }
     return values;
-  }, [](YaHTTP::Request& req, const std::unordered_map<std::string, std::string>& values) { (void) values; });
-  luaCtx.registerMember<std::unordered_map<std::string, std::string>(YaHTTP::Request::*)>("headers", [](const YaHTTP::Request& req) {
-    std::unordered_map<std::string, std::string> values;
+  }, [](YaHTTP::Request& req, const LuaAssociativeTable<std::string>& values) { (void) values; });
+  luaCtx.registerMember<LuaAssociativeTable<std::string>(YaHTTP::Request::*)>("headers", [](const YaHTTP::Request& req) {
+    LuaAssociativeTable<std::string> values;
     for (const auto& entry : req.headers) {
       values.insert({entry.first, entry.second});
     }
     return values;
-  }, [](YaHTTP::Request& req, const std::unordered_map<std::string, std::string>& values) { (void) values; });
+  }, [](YaHTTP::Request& req, const LuaAssociativeTable<std::string>& values) { (void) values; });
 
   /* Response */
   luaCtx.registerMember<std::string(YaHTTP::Response::*)>("body", [](const YaHTTP::Response& resp) -> const std::string { return resp.body; }, [](YaHTTP::Response& resp, const std::string& body) { resp.body = body; });
   luaCtx.registerMember<int(YaHTTP::Response::*)>("status", [](const YaHTTP::Response& resp) -> int { return resp.status; }, [](YaHTTP::Response& resp, int status) { resp.status = status; });
-  luaCtx.registerMember<std::unordered_map<std::string, std::string>(YaHTTP::Response::*)>("headers", [](const YaHTTP::Response& resp) {
-    std::unordered_map<std::string, std::string> values;
+  luaCtx.registerMember<LuaAssociativeTable<std::string>(YaHTTP::Response::*)>("headers", [](const YaHTTP::Response& resp) {
+    LuaAssociativeTable<std::string> values;
     for (const auto& entry : resp.headers) {
       values.insert({entry.first, entry.second});
     }
     return values;
-  }, [](YaHTTP::Response& resp, const std::unordered_map<std::string, std::string>& values) {
+  }, [](YaHTTP::Response& resp, const LuaAssociativeTable<std::string>& values) {
     resp.headers.clear();
     for (const auto& entry : values) {
       resp.headers.insert({entry.first, entry.second});

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -295,7 +295,7 @@ private:
   };
 
   PacketBuffer d_responseBuffer;
-  std::deque<PendingRequest> d_pendingQueries;
+  std::list<PendingRequest> d_pendingQueries;
   std::unordered_map<uint16_t, PendingRequest> d_pendingResponses;
   std::unique_ptr<std::vector<ProxyProtocolValue>> d_proxyProtocolValuesSent{nullptr};
   PendingRequest d_currentQuery;

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -351,7 +351,7 @@ static const std::string& getReasonFromStatusCode(uint16_t statusCode)
 }
 
 /* Always called from the main DoH thread */
-static void handleResponse(DOHFrontend& df, st_h2o_req_t* req, uint16_t statusCode, const PacketBuffer& response, const std::vector<std::pair<std::string, std::string>>& customResponseHeaders, const std::string& contentType, bool addContentType)
+static void handleResponse(DOHFrontend& df, st_h2o_req_t* req, uint16_t statusCode, const PacketBuffer& response, const std::unordered_map<std::string, std::string>& customResponseHeaders, const std::string& contentType, bool addContentType)
 {
   constexpr int overwrite_if_exists = 1;
   constexpr int maybe_token = 1;
@@ -825,8 +825,7 @@ static void doh_dispatch_query(DOHServerConfig* dsc, h2o_handler_t* self, h2o_re
     du->query_at = req->query_at;
     du->headers.reserve(req->headers.size);
     for (size_t i = 0; i < req->headers.size; ++i) {
-      du->headers.emplace_back(std::string(req->headers.entries[i].name->base, req->headers.entries[i].name->len),
-                               std::string(req->headers.entries[i].value.base, req->headers.entries[i].value.len));
+      du->headers[std::string(req->headers.entries[i].name->base, req->headers.entries[i].name->len)] = std::string(req->headers.entries[i].value.base, req->headers.entries[i].value.len);
     }
 
 #ifdef HAVE_H2O_SOCKET_GET_SSL_SERVER_NAME

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -30,7 +30,7 @@ struct DOHServerConfig;
 class DOHResponseMapEntry
 {
 public:
-  DOHResponseMapEntry(const std::string& regex, uint16_t status, const PacketBuffer& content, const boost::optional<std::vector<std::pair<std::string, std::string>>>& headers): d_regex(regex), d_customHeaders(headers), d_content(content), d_status(status)
+  DOHResponseMapEntry(const std::string& regex, uint16_t status, const PacketBuffer& content, const boost::optional<std::unordered_map<std::string, std::string>>& headers): d_regex(regex), d_customHeaders(headers), d_content(content), d_status(status)
   {
     if (status >= 400 && !d_content.empty() && d_content.at(d_content.size() -1) != 0) {
       // we need to make sure it's null-terminated
@@ -53,14 +53,14 @@ public:
     return d_content;
   }
 
-  const boost::optional<std::vector<std::pair<std::string, std::string>>>& getHeaders() const
+  const boost::optional<std::unordered_map<std::string, std::string>>& getHeaders() const
   {
     return d_customHeaders;
   }
 
 private:
   Regex d_regex;
-  boost::optional<std::vector<std::pair<std::string, std::string>>> d_customHeaders;
+  boost::optional<std::unordered_map<std::string, std::string>> d_customHeaders;
   PacketBuffer d_content;
   uint16_t d_status;
 };
@@ -76,7 +76,7 @@ struct DOHFrontend
   TLSConfig d_tlsConfig;
   TLSErrorCounters d_tlsCounters;
   std::string d_serverTokens{"h2o/dnsdist"};
-  std::vector<std::pair<std::string, std::string>> d_customResponseHeaders;
+  std::unordered_map<std::string, std::string> d_customResponseHeaders;
   ComboAddress d_local;
 
   uint32_t d_idleTimeout{30};             // HTTP idle timeout in seconds
@@ -224,7 +224,7 @@ struct DOHUnit
   std::string scheme;
   std::string host;
   std::string contentType;
-  std::vector<std::pair<std::string, std::string>> headers;
+  std::unordered_map<std::string, std::string> headers;
   PacketBuffer query;
   PacketBuffer response;
   std::shared_ptr<DownstreamState> downstream{nullptr};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
That PR defines types for the mapping of Lua arrays and associative arrays to C++, improving readability and consistency:
```c++
template <class T> using LuaArray = std::vector<std::pair<int, T>>;
template <class T> using LuaAssociativeTable = std::unordered_map<std::string, T>;
template <class T> using LuaTypeOrArrayOf = boost::variant<T, LuaArray<T>>;
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

