### PR TITLE
Use RSA-2048 instead of RSA-1024 for crypto benchmark

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -279,7 +279,7 @@ void DNSCryptoKeyEngine::testMakers(unsigned int algo, maker_t* creator, maker_t
   cout<<"Testing algorithm "<<algo<<"("<<DNSSECKeeper::algorithm2name(algo)<<"): '"<<dckeCreate->getName()<<"' ->'"<<dckeSign->getName()<<"' -> '"<<dckeVerify->getName()<<"' ";
   unsigned int bits;
   if(algo <= 10)
-    bits=1024;
+    bits=2048;
   else if(algo == DNSSECKeeper::ECCGOST || algo == DNSSECKeeper::ECDSA256 || algo == DNSSECKeeper::ED25519)
     bits = 256;
   else if(algo == DNSSECKeeper::ECDSA384)


### PR DESCRIPTION
### Short description
This changes the crypto algorithm benchmark used by `pdnsutil test-algorithm` and `pdnsutil test-algorithms` to use RSA keys of 2048 bits instead of 1024 bits.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
