### PR TITLE
dnsdist: Fix compilation by adding a missing <optional> include in misc.cc

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -45,6 +45,7 @@
 #include <poll.h>
 #include <iomanip>
 #include <netinet/tcp.h>
+#include <optional>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Otherwise g++ 11.2.0 complains here:
```
misc.cc: In function ‘int makeIPv6sockaddr(const string&, sockaddr_in6*)’:
misc.cc:711:8: error: ‘optional’ is not a member of ‘std’
  711 |   std::optional<uint16_t> port = std::nullopt;
      |        ^~~~~~~~
misc.cc:61:1: note: ‘std::optional’ is defined in header ‘<optional>’; did you forget to ‘#include <optional>’?
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
