### PR TITLE
Add linguist-language tag for dns zones

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# https://github.com/github/linguist/blob/master/docs/overrides.md
+*/zones/* linguist-language=DNS-Zone


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

On the right-hand side of:
https://github.com/powerdns/pdns/
you can see a chart like this:
<img width="321" alt="Language statistics listing: DIGITAL Command Language 5.1%" src="https://user-images.githubusercontent.com/2119212/160045792-8be62427-ca9f-4cc3-a2aa-c24adc9ea982.png">

This can be tuned with:
https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes

With this change, the matching files will be treated as `DNS Zone`, by default the are not [detectable](https://github.com/github/linguist/blob/master/docs/overrides.md#detectable) and thus will fall out of the Languages chart:

This change is currently live on https://github.com/jsoref/pdns:
<img width="312" alt="image" src="https://user-images.githubusercontent.com/2119212/160046078-7dfc1e31-08d4-4d20-8efc-8c6bbf4051d6.png">

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
