### PR TITLE
auth-4.5.x docs: Pin jinja2 to < 3.1.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ git+https://github.com/pieterlexis/sphinx-changelog@render-tags
 sphinxcontrib-fulltoc
 guzzle_sphinx_theme
 docutils!=0.15,<0.18
+jinja2<3.1.0

--- a/pdns/dnsdistdist/docs/requirements.txt
+++ b/pdns/dnsdistdist/docs/requirements.txt
@@ -5,3 +5,4 @@ git+https://github.com/pieterlexis/sphinx-changelog@render-tags
 sphinxcontrib-httpdomain
 sphinxcontrib-fulltoc
 docutils!=0.15,<0.18
+jinja2<3.1.0

--- a/pdns/recursordist/docs/requirements.txt
+++ b/pdns/recursordist/docs/requirements.txt
@@ -6,3 +6,4 @@ guzzle_sphinx_theme
 sphinxcontrib.httpdomain
 sphinxcontrib-fulltoc
 docutils!=0.15,<0.18
+jinja2<3.1.0


### PR DESCRIPTION
backport of #11449

Jinja2 3.1.0 removed deprecated code that is still used by sphinx
1.8.x, and it looks like our custom sphinx extensions are not working
with more recent versions of sphinx..

See:
- https://github.com/pallets/jinja/issues/1631
- https://github.com/readthedocs/readthedocs.org/issues/9037

and

- https://github.com/PowerDNS/pdns/pull/7712

The exact error is:
```
Extension error:
Could not import extension sphinx.builders.latex (exception: cannot import name 'contextfunction' from 'jinja2' (/dnsdist/pdns/dnsdistdist/.venv/lib/python3.7/site-packages/jinja2/__init__.py))
```

(cherry picked from commit 92ad29702011ac7cbd0d7d118ba612e7e07cedbe)


### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master