### PR TITLE
Switch from boost::function to std::function everywhere

### DIFF
--- a/pdns/mtasker.hh
+++ b/pdns/mtasker.hh
@@ -32,7 +32,7 @@
 #include "misc.hh"
 #include "mtasker_context.hh"
 #include <memory>
-#include <boost/function.hpp>
+
 using namespace ::boost::multi_index;
 
 // #define MTASKERTIMING 1
@@ -56,7 +56,7 @@ private:
   struct ThreadInfo
   {
 	std::shared_ptr<pdns_ucontext_t> context;
-	boost::function<void(void)> start;
+	std::function<void(void)> start;
 	char* startOfStack;
 	char* highestStackSeen;
 #ifdef MTASKERTIMING

--- a/pdns/mtasker_context.hh
+++ b/pdns/mtasker_context.hh
@@ -21,7 +21,6 @@
  */
 #pragma once
 #include "lazy_allocator.hh"
-#include <boost/function.hpp>
 #include <vector>
 #include <exception>
 
@@ -46,7 +45,7 @@ pdns_swapcontext
 
 void
 pdns_makecontext
-(pdns_ucontext_t& ctx, boost::function<void(void)>& start);
+(pdns_ucontext_t& ctx, std::function<void(void)>& start);
 
 #ifdef HAVE_FIBER_SANITIZER
 #include <sanitizer/common_interface_defs.h>

--- a/pdns/mtasker_context.hh
+++ b/pdns/mtasker_context.hh
@@ -23,6 +23,7 @@
 #include "lazy_allocator.hh"
 #include <vector>
 #include <exception>
+#include <functional>
 
 struct pdns_ucontext_t {
     pdns_ucontext_t ();

--- a/pdns/mtasker_fcontext.cc
+++ b/pdns/mtasker_fcontext.cc
@@ -92,7 +92,7 @@ struct args_t {
     fcontext_t prev_ctx = nullptr;
 #endif
     pdns_ucontext_t* self = nullptr;
-    boost::function<void(void)>* work = nullptr;
+    std::function<void(void)>* work = nullptr;
 };
 
 extern "C" {
@@ -212,7 +212,7 @@ pdns_swapcontext
 
 void
 pdns_makecontext
-(pdns_ucontext_t& ctx, boost::function<void(void)>& start) {
+(pdns_ucontext_t& ctx, std::function<void(void)>& start) {
     assert (ctx.uc_link);
     assert (ctx.uc_stack.size() >= 8192);
     assert (!ctx.uc_mcontext);

--- a/pdns/mtasker_ucontext.cc
+++ b/pdns/mtasker_ucontext.cc
@@ -83,7 +83,7 @@ threadWrapper (int const ctx0, int const ctx1, int const fun0, int const fun1) {
     notifyStackSwitchDone();
     auto ctx = joinPtr<pdns_ucontext_t>(ctx0, ctx1);
     try {
-        auto start = std::move(*joinPtr<boost::function<void()>>(fun0, fun1));
+        auto start = std::move(*joinPtr<std::function<void()>>(fun0, fun1));
         start();
     } catch (...) {
         ctx->exception = std::current_exception();
@@ -123,7 +123,7 @@ pdns_swapcontext
 
 void
 pdns_makecontext
-(pdns_ucontext_t& ctx, boost::function<void(void)>& start) {
+(pdns_ucontext_t& ctx, std::function<void(void)>& start) {
     assert (ctx.uc_link);
     assert (ctx.uc_stack.size());
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1105,7 +1105,7 @@ void broadcastFunction(const pipefunc_t& func)
 }
 
 template <class T>
-void* voider(const boost::function<T*()>& func)
+void* voider(const std::function<T*()>& func)
 {
   return func();
 }

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1128,7 +1128,7 @@ static vector<pair<DNSName, uint16_t>>& operator+=(vector<pair<DNSName, uint16_t
 // metrics.
 // Note that this currently skips the handler, but includes the taskThread(s).
 template <class T>
-T broadcastAccFunction(const boost::function<T*()>& func)
+T broadcastAccFunction(const std::function<T*()>& func)
 {
   if (!RecThreadInfo::self().isHandler()) {
     g_log << Logger::Error << "broadcastAccFunction has been called by a worker (" << RecThreadInfo::id() << ")" << endl;
@@ -1165,12 +1165,12 @@ T broadcastAccFunction(const boost::function<T*()>& func)
   return ret;
 }
 
-template string broadcastAccFunction(const boost::function<string*()>& fun); // explicit instantiation
-template RecursorControlChannel::Answer broadcastAccFunction(const boost::function<RecursorControlChannel::Answer*()>& fun); // explicit instantiation
-template uint64_t broadcastAccFunction(const boost::function<uint64_t*()>& fun); // explicit instantiation
-template vector<ComboAddress> broadcastAccFunction(const boost::function<vector<ComboAddress>*()>& fun); // explicit instantiation
-template vector<pair<DNSName, uint16_t>> broadcastAccFunction(const boost::function<vector<pair<DNSName, uint16_t>>*()>& fun); // explicit instantiation
-template ThreadTimes broadcastAccFunction(const boost::function<ThreadTimes*()>& fun);
+template string broadcastAccFunction(const std::function<string*()>& fun); // explicit instantiation
+template RecursorControlChannel::Answer broadcastAccFunction(const std::function<RecursorControlChannel::Answer*()>& fun); // explicit instantiation
+template uint64_t broadcastAccFunction(const std::function<uint64_t*()>& fun); // explicit instantiation
+template vector<ComboAddress> broadcastAccFunction(const std::function<vector<ComboAddress>*()>& fun); // explicit instantiation
+template vector<pair<DNSName, uint16_t>> broadcastAccFunction(const std::function<vector<pair<DNSName, uint16_t>>*()>& fun); // explicit instantiation
+template ThreadTimes broadcastAccFunction(const std::function<ThreadTimes*()>& fun);
 
 static int serviceMain(int argc, char* argv[])
 {

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -254,7 +254,7 @@ extern std::set<uint16_t> g_avoidUdpSourcePorts;
 #endif
 
 /* without reuseport, all listeners share the same sockets */
-typedef vector<pair<int, boost::function<void(int, boost::any&)>>> deferredAdd_t;
+typedef vector<pair<int, std::function<void(int, boost::any&)>>> deferredAdd_t;
 extern deferredAdd_t g_deferredAdds;
 
 typedef map<ComboAddress, uint32_t, ComboAddress::addressOnlyLessThan> tcpClientCounts_t;

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -73,7 +73,7 @@ class StatBag
   map<string, LockGuarded<StatRing<string, CIStringCompare> > > d_rings;
   map<string, LockGuarded<StatRing<SComboAddress> > > d_comboRings;
   map<string, LockGuarded<StatRing<std::tuple<DNSName, QType> > > > d_dnsnameqtyperings;
-  typedef boost::function<uint64_t(const std::string&)> func_t;
+  typedef std::function<uint64_t(const std::string&)> func_t;
   typedef map<string, func_t> funcstats_t;
   funcstats_t d_funcstats;
   bool d_doRings;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1112,7 +1112,7 @@ extern bool g_lowercaseOutgoing;
 
 
 std::string reloadZoneConfiguration();
-typedef boost::function<void*(void)> pipefunc_t;
+typedef std::function<void*(void)> pipefunc_t;
 void broadcastFunction(const pipefunc_t& func);
 void distributeAsyncFunction(const std::string& question, const pipefunc_t& func);
 
@@ -1122,7 +1122,7 @@ int followCNAMERecords(std::vector<DNSRecord>& ret, const QType qtype, int oldre
 int getFakeAAAARecords(const DNSName& qname, ComboAddress prefix, vector<DNSRecord>& ret);
 int getFakePTRRecords(const DNSName& qname, vector<DNSRecord>& ret);
 
-template<class T> T broadcastAccFunction(const boost::function<T*()>& func);
+template<class T> T broadcastAccFunction(const std::function<T*()>& func);
 
 typedef std::unordered_set<DNSName> notifyset_t;
 std::tuple<std::shared_ptr<SyncRes::domainmap_t>, std::shared_ptr<notifyset_t>> parseZoneConfiguration();

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -195,7 +195,7 @@ public:
   void serveConnection(const std::shared_ptr<Socket>& client) const;
   void handleRequest(HttpRequest& request, HttpResponse& resp) const;
 
-  typedef boost::function<void(HttpRequest* req, HttpResponse* resp)> HandlerFunction;
+  typedef std::function<void(HttpRequest* req, HttpResponse* resp)> HandlerFunction;
   void registerApiHandler(const string& url, const HandlerFunction& handler, bool allowPassword=false);
   void registerWebHandler(const string& url, const HandlerFunction& handler);
 

--- a/pdns/ws-auth.hh
+++ b/pdns/ws-auth.hh
@@ -78,7 +78,7 @@ private:
   void indexfunction(HttpRequest* req, HttpResponse* resp);
   void cssfunction(HttpRequest* req, HttpResponse* resp);
   void jsonstat(HttpRequest* req, HttpResponse* resp);
-  void registerApiHandler(const string& url, boost::function<void(HttpRequest*, HttpResponse*)> handler);
+  void registerApiHandler(const string& url, std::function<void(HttpRequest*, HttpResponse*)> handler);
   void printvars(ostringstream &ret);
   void printargs(ostringstream &ret);
   void webThread();

--- a/pdns/ws-recursor.hh
+++ b/pdns/ws-recursor.hh
@@ -39,7 +39,7 @@ public:
 
   friend void AsyncServerNewConnectionMT(void* p);
 
-  typedef boost::function<void(std::shared_ptr<Socket>)> newconnectioncb_t;
+  typedef std::function<void(std::shared_ptr<Socket>)> newconnectioncb_t;
   void asyncWaitForConnections(FDMultiplexer* fdm, const newconnectioncb_t& callback);
 
 private:

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -33,7 +33,6 @@
 #include "arguments.hh"
 #include "bindparserclasses.hh"
 #include "statbag.hh"
-#include <boost/function.hpp>
 #include "dnsrecords.hh"
 #include "misc.hh"
 #include "dns.hh"
@@ -274,7 +273,7 @@ int main( int argc, char* argv[] )
 
                 g_basedn = args["basedn"];
                 g_dnsttl = args.mustDo( "dnsttl" );
-                typedef boost::function<void(unsigned int, const DNSName &, const string &, const string &, int)> callback_t;
+                typedef std::function<void(unsigned int, const DNSName &, const string &, const string &, int)> callback_t;
                 callback_t callback = callback_simple;
                 if( args["layout"] == "tree" )
                 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
One more step in the general rule: if a facility is available in `std`, stop using the `boost` equivalent.
The only remaining ref to `boost::function` is now in `yahttp`, but that is conditional on C++11, so we're clean.

As a side effect this fixes a memory leak reported by scanbuild when using a function object in `rec-main.cc`.
The memory leak itself seems to be deep inside the boost code.

This touches `mtasker`, so it is a bit scary. I did not test the `ucontext` case (and I wonder if we should keep on supporting it).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
