### PR TITLE
rec: rec-4.4.x has no waitForTCPSocket in test code

### DIFF
--- a/regression-tests.recursor-dnssec/test_RPZIncomplete.py
+++ b/regression-tests.recursor-dnssec/test_RPZIncomplete.py
@@ -226,16 +226,15 @@ e 3600 IN A 192.0.2.42
         raise AssertionError("Waited %d seconds for the serial to be updated to %d but the serial is still %d" % (timeout, serial, currentSerial))
 
     def testRPZ(self):
-        self.waitForTCPSocket("127.0.0.1", self._wsPort)
         # First zone
         self.waitUntilCorrectSerialIsLoaded(1)
-        self.checkRPZStats(1, 1, 1, 1, 1) # failure count includes a port 9999 attempt
+        self.checkRPZStats(1, 1, 1, 1, 3) # failure count includes a port 9999 attempt
 
         # second zone, should fail, incomplete IXFR
         self.waitUntilCorrectSerialIsLoaded(2)
-        self.checkRPZStats(1, 1, 1, 1, 3)
+        self.checkRPZStats(1, 1, 1, 1, 5)
 
         # third zone, should fail, incomplete AXFR
         self.waitUntilCorrectSerialIsLoaded(3)
-        self.checkRPZStats(1, 1, 1, 1, 5)
+        self.checkRPZStats(1, 1, 1, 1, 7)
 


### PR DESCRIPTION
Plus counts are different due to rpz loading changes in master.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
