### PR TITLE
rec: Use boost::mult-index for nsspeed table and make it shared.

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -973,16 +973,6 @@ static uint64_t getNegCacheSize()
   return g_negCache->size();
 }
 
-uint64_t* pleaseGetNsSpeedsSize()
-{
-  return new uint64_t(SyncRes::getNSSpeedsSize());
-}
-
-static uint64_t getNsSpeedsSize()
-{
-  return broadcastAccFunction<uint64_t>(pleaseGetNsSpeedsSize);
-}
-
 uint64_t* pleaseGetEDNSStatusesSize()
 {
   return new uint64_t(SyncRes::getEDNSStatusesSize());
@@ -1244,7 +1234,7 @@ static void registerAllStats1()
   addGetStat("negcache-entries", getNegCacheSize);
   addGetStat("throttle-entries", getThrottleSize);
 
-  addGetStat("nsspeeds-entries", getNsSpeedsSize);
+  addGetStat("nsspeeds-entries", SyncRes::getNSSpeedsSize);
   addGetStat("failed-host-entries", SyncRes::getFailedServersSize);
   addGetStat("non-resolving-nameserver-entries", SyncRes::getNonResolvingNSSize);
 
@@ -1988,7 +1978,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
     return doDumpToFile(s, pleaseDumpEDNSMap, cmd);
   }
   if (cmd == "dump-nsspeeds") {
-    return doDumpToFile(s, pleaseDumpNSSpeeds, cmd);
+    return doDumpToFile(s, pleaseDumpNSSpeeds, cmd, false);
   }
   if (cmd == "dump-failedservers") {
     return doDumpToFile(s, pleaseDumpFailedServers, cmd, false);

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -151,47 +151,6 @@ private:
   cont_t d_cont;
 };
 
-
-/** Class that implements a decaying EWMA.
-    This class keeps an exponentially weighted moving average which, additionally, decays over time.
-    The decaying is only done on get.
-*/
-class DecayingEwma
-{
-public:
-  DecayingEwma() {}
-  DecayingEwma(const DecayingEwma& orig) = delete;
-  DecayingEwma & operator=(const DecayingEwma& orig) = delete;
-  
-  void submit(int val, const struct timeval& now)
-  {
-    if (d_last.tv_sec == 0 && d_last.tv_usec == 0) {
-      d_last = now;
-      d_val = val;
-    }
-    else {
-      float diff = makeFloat(d_last - now);
-      d_last = now;
-      float factor = expf(diff)/2.0f; // might be '0.5', or 0.0001
-      d_val = (1-factor)*val + factor*d_val;
-    }
-  }
-
-  float get(float factor)
-  {
-    return d_val *= factor;
-  }
-
-  float peek(void) const
-  {
-    return d_val;
-  }
-
-private:
-  struct timeval d_last{0, 0};          // stores time
-  float d_val{0};
-};
-
 extern std::unique_ptr<NegCache> g_negCache;
 
 class SyncRes : public boost::noncopyable
@@ -201,65 +160,6 @@ public:
   typedef std::function<LWResult::Result(const ComboAddress& ip, const DNSName& qdomain, int qtype, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult *lwr, bool* chained)> asyncresolve_t;
 
   enum class HardenNXD { No, DNSSEC, Yes };
-
-  //! This represents a number of decaying Ewmas, used to store performance per nameserver-name.
-  /** Modelled to work mostly like the underlying DecayingEwma */
-  struct DecayingEwmaCollection
-  {
-    void submit(const ComboAddress& remote, int usecs, const struct timeval& now)
-    {
-      d_collection[remote].submit(usecs, now);
-    }
-
-    float getFactor(const struct timeval &now) {
-      float diff = makeFloat(d_lastget - now);
-      return expf(diff / 60.0f); // is 1.0 or less
-    }
-    
-    float get(const struct timeval& now)
-    {
-      if (d_collection.empty()) {
-        return 0;
-      }
-      if (d_lastget.tv_sec == 0 && d_lastget.tv_usec == 0) {
-        d_lastget = now;
-      }
-
-      float ret = std::numeric_limits<float>::max();
-      float factor = getFactor(now);
-      float tmp;
-      for (auto& entry : d_collection) {
-        if ((tmp = entry.second.get(factor)) < ret) {
-          ret = tmp;
-        }
-      }
-      d_lastget = now;
-      return ret;
-    }
-
-    bool stale(time_t limit) const
-    {
-      return limit > d_lastget.tv_sec;
-    }
-
-    void purge(const std::map<ComboAddress, float>& keep)
-    {
-      for (auto iter = d_collection.begin(); iter != d_collection.end(); ) {
-        if (keep.find(iter->first) != keep.end()) {
-          ++iter;
-        }
-        else {
-          iter = d_collection.erase(iter);
-        }
-      }
-    }
-
-    typedef std::map<ComboAddress, DecayingEwma> collection_t;
-    collection_t d_collection;
-    struct timeval d_lastget{0, 0};       // stores time
-  };
-
-  typedef std::unordered_map<DNSName, DecayingEwmaCollection> nsspeeds_t;
 
   vState getDSRecords(const DNSName& zone, dsmap_t& ds, bool onlyTA, unsigned int depth, bool bogusOnNXD=true, bool* foundCut=nullptr);
 
@@ -339,7 +239,6 @@ public:
   };
 
   struct ThreadLocalStorage {
-    nsspeeds_t nsSpeeds;
     throttle_t throttle;
     ednsstatus_t ednsstatus;
     std::shared_ptr<domainmap_t> domainmap;
@@ -401,33 +300,13 @@ public:
   {
     s_ednsdomains = SuffixMatchNode();
   }
-  static void pruneNSSpeeds(time_t limit)
-  {
-    for(auto i = t_sstorage.nsSpeeds.begin(), end = t_sstorage.nsSpeeds.end(); i != end; ) {
-      if(i->second.stale(limit)) {
-        i = t_sstorage.nsSpeeds.erase(i);
-      }
-      else {
-        ++i;
-      }
-    }
-  }
-  static uint64_t getNSSpeedsSize()
-  {
-    return t_sstorage.nsSpeeds.size();
-  }
-  static void submitNSSpeed(const DNSName& server, const ComboAddress& ca, uint32_t usec, const struct timeval& now)
-  {
-    t_sstorage.nsSpeeds[server].submit(ca, usec, now);
-  }
-  static void clearNSSpeeds()
-  {
-    t_sstorage.nsSpeeds.clear();
-  }
-  static float getNSSpeed(const DNSName& server, const ComboAddress& ca)
-  {
-    return t_sstorage.nsSpeeds[server].d_collection[ca].peek();
-  }
+
+  static void pruneNSSpeeds(time_t limit);
+  static uint64_t getNSSpeedsSize();
+  static void submitNSSpeed(const DNSName& server, const ComboAddress& ca, uint32_t usec, const struct timeval& now);
+  static void clearNSSpeeds();
+  static float getNSSpeed(const DNSName& server, const ComboAddress& ca);
+
   static EDNSStatus::EDNSMode getEDNSStatus(const ComboAddress& server)
   {
     const auto& it = t_sstorage.ednsstatus.find(server);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This moves the nsspeeds table to use a multi-index and become shared between threads. The multi-index is used to be able to purge without needing a full scan. Shared has the big advantage that all threads can use and update the speed info, which should make the mechanism more effective and avoid a lot of duplicate information.

But: this is a draft request, it needs tests with many thread to

- check if lock contention is an issue
- check if heap fragmentation with multiple threads doing allocations and de-allocations is an issue

The two points above might outweigh the benefits. If they do, we still can keep the multi-index part (and cheap pruning) and not use the shared part.

This also changes the format of the dump-nsspeeds command: the 2nd column now has the timestamp and the columns are tab separated:
```
c.gtld-servers.net      2022-03-30T13:23:35.580 192.26.92.30/24298.744141       2001:503:83eb::30/18006.664062
```

Internally, I also no longer store a timestamp per collection entry, but one single timestamp for the whole collection. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
