### PR TITLE
Rec: probe auth for DoT support

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -387,6 +387,11 @@ static uint64_t* pleaseDumpNonResolvingNS(int fd)
   return new uint64_t(SyncRes::doDumpNonResolvingNS(fd));
 }
 
+static uint64_t* pleaseDumpDoTProbeMap(int fd)
+{
+  return new uint64_t(SyncRes::doDumpDoTProbeMap(fd));
+}
+
 // Generic dump to file command
 static RecursorControlChannel::Answer doDumpToFile(int s, uint64_t* (*function)(int s), const string& name, bool threads = true)
 {
@@ -1904,6 +1909,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
             "clear-nta [DOMAIN]...            Clear the Negative Trust Anchor for DOMAINs, if no DOMAIN is specified, remove all\n"
             "clear-ta [DOMAIN]...             Clear the Trust Anchor for DOMAINs\n"
             "dump-cache <filename>            dump cache contents to the named file\n"
+            "dump-dot-probe-map <filename>    dump the contents of the DoT probe map to the named file\n"
             "dump-edns [status] <filename>    dump EDNS status to the named file\n"
             "dump-failedservers <filename>    dump the failed servers to the named file\n"
             "dump-non-resolving <filename>    dump non-resolving nameservers addresses to the named file\n"
@@ -1976,6 +1982,9 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
   }
   if (cmd == "dump-cache") {
     return doDumpCache(s);
+  }
+  if (cmd == "dump-dot-probe-map") {
+    return doDumpToFile(s, pleaseDumpDoTProbeMap, cmd, false);
   }
   if (cmd == "dump-ednsstatus" || cmd == "dump-edns") {
     return doDumpToFile(s, pleaseDumpEDNSMap, cmd);

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -96,7 +96,8 @@ int main(int argc, char** argv)
     "dump-rpz",
     "dump-throttlemap",
     "dump-non-resolving",
-    "dump-saved-parent-ns-sets"};
+    "dump-saved-parent-ns-sets",
+    "dump-dot-probe-map"};
   try {
     initArguments(argc, argv);
     string sockname = "pdns_recursor";

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -97,7 +97,8 @@ int main(int argc, char** argv)
     "dump-throttlemap",
     "dump-non-resolving",
     "dump-saved-parent-ns-sets",
-    "dump-dot-probe-map"};
+    "dump-dot-probe-map",
+  };
   try {
     initArguments(argc, argv);
     string sockname = "pdns_recursor";

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -92,6 +92,9 @@ dump-cache *FILENAME*
     also dumped to the same file. The per-thread positive and negative cache
     dumps are separated with an appropriate comment.
 
+dump-dot-probe-map *FILENAME*
+    Dump the contents of the DoT probe map to the *FILENAME* mentioned.
+
 dump-edns *FILENAME*
     Dumps the EDNS status to the filename mentioned. This file should not exist
     already, PowerDNS will refuse to overwrite it. While dumping, the recursor

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1066,6 +1066,30 @@ Path to a lua file to manipulate the Recursor's answers. See :doc:`lua-scripting
 The interval between calls to the Lua user defined `maintenance()` function in seconds.
 See :ref:`hooks-maintenance-callback`
 
+.. _setting-max-busy-dot-probes:
+
+``max-busy-dot-probes``
+-----------------------
+.. versionadded:: 4.7.0
+
+- Integer
+- Default: 0
+
+Limit the maxmium number of simultaneous DoT probes the Recursor will schedule.
+The default value 0 means no DoT probes are scheduled.
+
+DoT probes are used to check if an authoritative server's IP address supports DoT.
+If the probe determines an IP address supports DoT, the Recursor will use DoT to contact it for subsequent queries.
+The results of probes are remembered and can be viewed by the ``rec_control dump-dot-probe-map`` command.
+If the maximum number of pending probes is reached, no probe wil be scheduled, even if no DoT status is known for an address.
+If the result of a probe is not yet available, the Recursor will contact the authoritative server in the regular way,
+unless an authoritative server is configured to be contacted over DoT always using :ref:`setting-dot-to-auth-names`.
+In that case no probe will be scheduled.
+
+Note::
+  DoT probing is an experimental feature.
+  Please test thoroughly if it is suitable in your specific production environment before enabling.
+
 .. _setting-max-cache-bogus-ttl:
 
 ``max-cache-bogus-ttl``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1081,7 +1081,7 @@ The default value 0 means no DoT probes are scheduled.
 DoT probes are used to check if an authoritative server's IP address supports DoT.
 If the probe determines an IP address supports DoT, the Recursor will use DoT to contact it for subsequent queries.
 The results of probes are remembered and can be viewed by the ``rec_control dump-dot-probe-map`` command.
-If the maximum number of pending probes is reached, no probe wil be scheduled, even if no DoT status is known for an address.
+If the maximum number of pending probes is reached, no probes will be scheduled, even if no DoT status is known for an address.
 If the result of a probe is not yet available, the Recursor will contact the authoritative server in the regular way,
 unless an authoritative server is configured to be contacted over DoT always using :ref:`setting-dot-to-auth-names`.
 In that case no probe will be scheduled.

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1089,7 +1089,7 @@ In that case no probe will be scheduled.
 
 Note::
   DoT probing is an experimental feature.
-  Please test thoroughly if it is suitable in your specific production environment before enabling.
+  Please test thoroughly to determine if it is suitable in your specific production environment before enabling.
 
 .. _setting-max-cache-bogus-ttl:
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1079,11 +1079,13 @@ Limit the maximum number of simultaneous DoT probes the Recursor will schedule.
 The default value 0 means no DoT probes are scheduled.
 
 DoT probes are used to check if an authoritative server's IP address supports DoT.
-If the probe determines an IP address supports DoT, the Recursor will use DoT to contact it for subsequent queries.
+If the probe determines an IP address supports DoT, the Recursor will use DoT to contact it for subsequent queries until a failure occurs.
+After a failure, the Recursor will stop using DoT for that specific IP address for a while.
 The results of probes are remembered and can be viewed by the ``rec_control dump-dot-probe-map`` command.
 If the maximum number of pending probes is reached, no probes will be scheduled, even if no DoT status is known for an address.
 If the result of a probe is not yet available, the Recursor will contact the authoritative server in the regular way, unless an authoritative server is configured to be contacted over DoT always using :ref:`setting-dot-to-auth-names`.
 In that case no probe will be scheduled.
+
 
 Note::
   DoT probing is an experimental feature.

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1075,7 +1075,7 @@ See :ref:`hooks-maintenance-callback`
 - Integer
 - Default: 0
 
-Limit the maxmium number of simultaneous DoT probes the Recursor will schedule.
+Limit the maximum number of simultaneous DoT probes the Recursor will schedule.
 The default value 0 means no DoT probes are scheduled.
 
 DoT probes are used to check if an authoritative server's IP address supports DoT.

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1082,8 +1082,7 @@ DoT probes are used to check if an authoritative server's IP address supports Do
 If the probe determines an IP address supports DoT, the Recursor will use DoT to contact it for subsequent queries.
 The results of probes are remembered and can be viewed by the ``rec_control dump-dot-probe-map`` command.
 If the maximum number of pending probes is reached, no probes will be scheduled, even if no DoT status is known for an address.
-If the result of a probe is not yet available, the Recursor will contact the authoritative server in the regular way,
-unless an authoritative server is configured to be contacted over DoT always using :ref:`setting-dot-to-auth-names`.
+If the result of a probe is not yet available, the Recursor will contact the authoritative server in the regular way, unless an authoritative server is configured to be contacted over DoT always using :ref:`setting-dot-to-auth-names`.
 In that case no probe will be scheduled.
 
 Note::

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1319,6 +1319,7 @@ static int serviceMain(int argc, char* argv[])
   SyncRes::s_dot_to_port_853 = ::arg().mustDo("dot-to-port-853");
   SyncRes::s_event_trace_enabled = ::arg().asNum("event-trace-enabled");
   SyncRes::s_save_parent_ns_set = ::arg().mustDo("save-parent-ns-set");
+  SyncRes::s_max_busy_dot_probes = ::arg().asNum("max-busy-dot-probes");
 
   if (SyncRes::s_tcp_fast_open_connect) {
     checkFastOpenSysctl(true);
@@ -2521,6 +2522,7 @@ int main(int argc, char** argv)
     ::arg().set("tcp-out-max-idle-per-thread", "Maximum number of idle TCP/DoT connections per thread") = "100";
     ::arg().setSwitch("structured-logging", "Prefer structured logging") = "yes";
     ::arg().setSwitch("save-parent-ns-set", "Save parent NS set to be used if child NS set fails") = "yes";
+    ::arg().set("max-busy-dot-probes", "Maximum number of concurrent DoT probes") = "0";
 
     ::arg().setCmd("help", "Provide a helpful message");
     ::arg().setCmd("version", "Print version string");

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1894,7 +1894,7 @@ static void houseKeeping(void*)
     // Likley a few handler tasks could be moved to the taskThread
     if (info.isTaskThread()) {
       // TaskQueue is run always
-      runTaskOnce(g_logCommonErrors);
+      runTasks(g_logCommonErrors, 10);
 
       static PeriodicTask ztcTask{"ZTC", 60};
       static map<DNSName, RecZoneToCache::State> ztcStates;

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1930,6 +1930,13 @@ static void houseKeeping(void*)
         SyncRes::pruneNSSpeeds(now.tv_sec - 300);
       });
 
+      if (SyncRes::s_max_busy_dot_probes > 0) {
+        static PeriodicTask pruneDoTProbeMap{"pruneDoTProbeMapTask", 60};
+        pruneDoTProbeMap.runIfDue(now, [now]() {
+          SyncRes::pruneDoTProbeMap(now.tv_sec);
+        });
+      }
+
       static PeriodicTask pruneFailedServersTask{"pruneFailedServerTask", 5};
       pruneFailedServersTask.runIfDue(now, [now]() {
         SyncRes::pruneFailedServers(now.tv_sec - SyncRes::s_serverdownthrottletime * 10);

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -194,7 +194,7 @@ static void tryDoT(const struct timeval& now, bool logErrors, const pdns::Resolv
     }
   }
   catch (...) {
-    log->error(Logr::Error, msg, "Unexpectec exception");
+    log->error(Logr::Error, msg, "Unexpected exception");
   }
   if (ex) {
     ++s_resolve_tasks.exceptions;

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -163,6 +163,65 @@ static void resolve(const struct timeval& now, bool logErrors, const pdns::Resol
   }
 }
 
+static void tryDoT(const struct timeval& now, bool logErrors, const pdns::ResolveTask& task) noexcept
+{
+  auto log = g_slog->withName("taskq")->withValues("method", Logging::Loggable("tryDoT"), "name", Logging::Loggable(task.d_qname), "qtype", Logging::Loggable(QType(task.d_qtype).toString()), "ip", Logging::Loggable(task.d_ip));
+  const string msg = "Exception while running a background tryDoT task";
+  SyncRes sr(now);
+  vector<DNSRecord> ret;
+  sr.setRefreshAlmostExpired(false);
+  bool ex = true;
+  try {
+    log->info(Logr::Warning, "trying DoT");
+    bool ok = sr.tryDoT(task.d_qname, QType(task.d_qtype), DNSName("auth"), DNSName("ns"), task.d_ip, now.tv_sec);
+    ex = false;
+    log->info(Logr::Warning, "done", "ok", Logging::Loggable(ok));
+  }
+  catch (const std::exception& e) {
+    log->error(Logr::Error, msg, e.what());
+  }
+  catch (const PDNSException& e) {
+    log->error(Logr::Error, msg, e.reason);
+  }
+  catch (const ImmediateServFailException& e) {
+    if (logErrors) {
+      log->error(Logr::Error, msg, e.reason);
+    }
+  }
+  catch (const PolicyHitException& e) {
+    if (logErrors) {
+      log->error(Logr::Notice, msg, "PolicyHit");
+    }
+  }
+  catch (...) {
+    log->error(Logr::Error, msg, "Unexpectec exception");
+  }
+  if (ex) {
+    ++s_resolve_tasks.exceptions;
+  }
+  else {
+    ++s_resolve_tasks.run;
+  }
+}
+
+void runTasks(size_t max, bool logErrors)
+{
+  for (size_t count = 0; count < max; count++) {
+    pdns::ResolveTask task;
+    {
+      auto lock = s_taskQueue.lock();
+      if (lock->queue.empty()) {
+        return;
+      }
+      task = lock->queue.pop();
+    }
+    bool expired = task.run(logErrors);
+    if (expired) {
+      s_taskQueue.lock()->queue.incExpired();
+    }
+  }
+}
+
 void runTaskOnce(bool logErrors)
 {
   pdns::ResolveTask task;
@@ -186,9 +245,10 @@ void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline
     log->error(Logr::Error, "Cannot push task", "qtype unsupported");
     return;
   }
-  pdns::ResolveTask task{qname, qtype, deadline, true, resolve};
-  s_taskQueue.lock()->queue.push(std::move(task));
-  ++s_almost_expired_tasks.pushed;
+  pdns::ResolveTask task{qname, qtype, deadline, true, resolve, {}};
+  if (s_taskQueue.lock()->queue.push(std::move(task))) {
+    ++s_almost_expired_tasks.pushed;
+  }
 }
 
 void pushResolveTask(const DNSName& qname, uint16_t qtype, time_t now, time_t deadline)
@@ -198,13 +258,30 @@ void pushResolveTask(const DNSName& qname, uint16_t qtype, time_t now, time_t de
     log->error(Logr::Error, "Cannot push task", "qtype unsupported");
     return;
   }
-  pdns::ResolveTask task{qname, qtype, deadline, false, resolve};
+  pdns::ResolveTask task{qname, qtype, deadline, false, resolve, {}};
   auto lock = s_taskQueue.lock();
   bool inserted = lock->rateLimitSet.insert(now, task);
   if (inserted) {
-    lock->queue.push(std::move(task));
-    ++s_resolve_tasks.pushed;
+    if (lock->queue.push(std::move(task))) {
+      ++s_resolve_tasks.pushed;
+    }
   }
+}
+
+bool pushTryDoTTask(const DNSName& qname, uint16_t qtype, const ComboAddress& ip, time_t deadline)
+{
+  if (SyncRes::isUnsupported(qtype)) {
+    auto log = g_slog->withName("taskq")->withValues("name", Logging::Loggable(qname), "qtype", Logging::Loggable(QType(qtype).toString()));
+    log->error(Logr::Error, "Cannot push task", "qtype unsupported");
+    return false;
+  }
+
+  pdns::ResolveTask task{qname, qtype, deadline, false, tryDoT, ip};
+  bool pushed = s_taskQueue.lock()->queue.push(std::move(task));
+  if (pushed) {
+    ++s_almost_expired_tasks.pushed;
+  }
+  return pushed;
 }
 
 uint64_t getTaskPushes()

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -32,7 +32,7 @@ namespace pdns
 struct ResolveTask;
 }
 void runTasks(size_t max, bool logErrors);
-void runTaskOnce(bool logErrors);
+bool runTaskOnce(bool logErrors);
 void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline);
 void pushResolveTask(const DNSName& qname, uint16_t qtype, time_t now, time_t deadline);
 bool pushTryDoTTask(const DNSName& qname, uint16_t qtype, const ComboAddress& ip, time_t deadline, const DNSName& nsname);

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -25,13 +25,17 @@
 #include <time.h>
 
 class DNSName;
+union ComboAddress;
+
 namespace pdns
 {
 struct ResolveTask;
 }
+void runTasks(size_t max, bool logErrors);
 void runTaskOnce(bool logErrors);
 void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline);
 void pushResolveTask(const DNSName& qname, uint16_t qtype, time_t now, time_t deadline);
+bool pushTryDoTTask(const DNSName& qname, uint16_t qtype, const ComboAddress& ip, time_t deadline);
 void taskQueueClear();
 pdns::ResolveTask taskQueuePop();
 

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -35,7 +35,7 @@ void runTasks(size_t max, bool logErrors);
 void runTaskOnce(bool logErrors);
 void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline);
 void pushResolveTask(const DNSName& qname, uint16_t qtype, time_t now, time_t deadline);
-bool pushTryDoTTask(const DNSName& qname, uint16_t qtype, const ComboAddress& ip, time_t deadline);
+bool pushTryDoTTask(const DNSName& qname, uint16_t qtype, const ComboAddress& ip, time_t deadline, const DNSName& nsname);
 void taskQueueClear();
 pdns::ResolveTask taskQueuePop();
 

--- a/pdns/recursordist/taskqueue.cc
+++ b/pdns/recursordist/taskqueue.cc
@@ -28,13 +28,14 @@
 namespace pdns
 {
 
-void TaskQueue::push(ResolveTask&& task)
+bool TaskQueue::push(ResolveTask&& task)
 {
   // Insertion fails if it's already there, no problem since we're already scheduled
-  auto result = d_queue.insert(std::move(task));
-  if (result.second) {
+  auto result = d_queue.insert(std::move(task)).second;
+  if (result) {
     d_pushes++;
   }
+  return result;
 }
 
 ResolveTask TaskQueue::pop()
@@ -66,3 +67,11 @@ bool ResolveTask::run(bool logErrors)
 }
 
 } /* namespace pdns */
+
+namespace boost
+{
+size_t hash_value(const ComboAddress& a)
+{
+  return ComboAddress::addressOnlyHash()(a);
+}
+}

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -59,6 +59,8 @@ struct ResolveTask
   TaskFunction d_func;
   // IP used by DoT probe tasks
   ComboAddress d_ip;
+  // NS name used by DoT probe task
+  DNSName d_nsname;
 
   bool operator<(const ResolveTask& a) const
   {

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -50,10 +50,14 @@ struct ResolveTask
 {
   DNSName d_qname;
   uint16_t d_qtype;
+  // Deadline is not part of index and <
   time_t d_deadline;
-  bool d_refreshMode; // Whether to run this task in regular mode (false) or in the mode that refreshes almost expired tasks
+  // Whether to run this task in regular mode (false) or in the mode that refreshes almost expired tasks
+  bool d_refreshMode;
   // Use a function pointer as comparing std::functions is a nuisance
-  void (*d_func)(const struct timeval& now, bool logErrors, const ResolveTask& task);
+  using TaskFunction  = void (*)(const struct timeval& now, bool logErrors, const ResolveTask& task);
+  TaskFunction d_func;
+  // IP used by DoT probe tasks
   ComboAddress d_ip;
 
   bool operator<(const ResolveTask& a) const
@@ -117,7 +121,7 @@ private:
                                   member<ResolveTask, DNSName, &ResolveTask::d_qname>,
                                   member<ResolveTask, uint16_t, &ResolveTask::d_qtype>,
                                   member<ResolveTask, bool, &ResolveTask::d_refreshMode>,
-                                  member<ResolveTask, void (*)(const struct timeval& now, bool logErrors, const ResolveTask& task), &ResolveTask::d_func>,
+                                  member<ResolveTask, ResolveTask::TaskFunction, &ResolveTask::d_func>,
                                   member<ResolveTask, ComboAddress, &ResolveTask::d_ip>>>,
       sequenced<tag<SequencedTag>>>>
     queue_t;

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -27,7 +27,7 @@
 union ComboAddress;
 namespace boost
 {
-  size_t hash_value(const ComboAddress&);
+size_t hash_value(const ComboAddress&);
 }
 
 #include <boost/multi_index_container.hpp>
@@ -40,7 +40,6 @@ namespace boost
 #include "dnsname.hh"
 #include "iputils.hh"
 #include "qtype.hh"
-
 
 namespace pdns
 {
@@ -129,4 +128,3 @@ private:
 };
 
 }
-

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -50,7 +50,7 @@ struct ResolveTask
 {
   DNSName d_qname;
   uint16_t d_qtype;
-  // Deadline is not part of index and <
+  // Deadline is not part of index and not used by operator<()
   time_t d_deadline;
   // Whether to run this task in regular mode (false) or in the mode that refreshes almost expired tasks
   bool d_refreshMode;
@@ -59,7 +59,7 @@ struct ResolveTask
   TaskFunction d_func;
   // IP used by DoT probe tasks
   ComboAddress d_ip;
-  // NS name used by DoT probe task
+  // NS name used by DoT probe task, not part of index and not used by operator<()
   DNSName d_nsname;
 
   bool operator<(const ResolveTask& a) const

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -55,7 +55,7 @@ struct ResolveTask
   // Whether to run this task in regular mode (false) or in the mode that refreshes almost expired tasks
   bool d_refreshMode;
   // Use a function pointer as comparing std::functions is a nuisance
-  using TaskFunction  = void (*)(const struct timeval& now, bool logErrors, const ResolveTask& task);
+  using TaskFunction = void (*)(const struct timeval& now, bool logErrors, const ResolveTask& task);
   TaskFunction d_func;
   // IP used by DoT probe tasks
   ComboAddress d_ip;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -365,6 +365,8 @@ public:
   static size_t getSaveParentsNSSetsSize();
   static void pruneSaveParentsNSSets(time_t now);
 
+  static void pruneDoTProbeMap(time_t cutoff);
+
   static void setDomainMap(std::shared_ptr<domainmap_t> newMap)
   {
     t_sstorage.domainmap = newMap;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -598,6 +598,7 @@ public:
   static int s_tcp_fast_open;
   static bool s_tcp_fast_open_connect;
   static bool s_dot_to_port_853;
+  static unsigned int s_max_busy_dot_probes;
 
   static const int event_trace_to_pb = 1;
   static const int event_trace_to_log = 2;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -658,7 +658,7 @@ private:
   int doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, QType qtype, vector<DNSRecord>&ret,
                   unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation,
                   std::map<DNSName, std::vector<ComboAddress>>* fallback);
-  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool doDoT, bool& truncated, bool& spoofed);
+  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool doDoT, bool& truncated, bool& spoofed, bool dontThrottle = false);
   bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state, const ComboAddress& remoteIP);
 
   int doResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state);

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -253,6 +253,7 @@ public:
   static uint64_t doDumpFailedServers(int fd);
   static uint64_t doDumpNonResolvingNS(int fd);
   static uint64_t doDumpSavedParentNSSets(int fd);
+  static uint64_t doDumpDoTProbeMap(int fd);
 
   static int getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigned int depth);
   static void addDontQuery(const std::string& mask)
@@ -395,6 +396,7 @@ public:
   explicit SyncRes(const struct timeval& now);
 
   int beginResolve(const DNSName &qname, QType qtype, QClass qclass, vector<DNSRecord>&ret, unsigned int depth = 0);
+  bool tryDoT(const DNSName& qname, QType qtype, const DNSName& auth, const DNSName& nsName, ComboAddress address, time_t);
 
   void setId(int id)
   {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -398,7 +398,7 @@ public:
   explicit SyncRes(const struct timeval& now);
 
   int beginResolve(const DNSName &qname, QType qtype, QClass qclass, vector<DNSRecord>&ret, unsigned int depth = 0);
-  bool tryDoT(const DNSName& qname, QType qtype, const DNSName& auth, const DNSName& nsName, ComboAddress address, time_t);
+  bool tryDoT(const DNSName& qname, QType qtype, const DNSName& nsName, ComboAddress address, time_t);
 
   void setId(int id)
   {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Creating this PR so other can play wit this. I don't think this is production ready!

This implements an experimental approach to probe nameservers for DoT support and start using DoT to those if it works. Probing is done by a separate task. Until that task comes with a conclusion, the IP will be contacted in the regular way.

Enable by setting `max-busy-dot-probes` to a value > 0. Default is 0.

The `max-busy-dot-probes` number says how many async tasks can be scheduled doing DoT probes concurrently.
The tasks have to compete with other tasks to be done, so it may take a while for it to be executed. Until then the map entry is in state `Busy`. If the task sees it supports DoT, the entry becomes `Good`, otherwise `Bad`.
If there are too may Busy tasks, no new task will be scheduled. This is a crude mechanism, but it should have the effect that the most popular IPs will have a higher chance of getting a probe scheduled. After a while the status table will be filled and a new probe will only be scheduled if a unknown IP is encountered.

Check status by doing `rec-control dump-dot-probe-map - ` e.g.:
```
$ rec-control dump-dot-probe-map - | grep Good
188.166.104.87  powerdns.com.   Good    2022-04-02T15:48:00
185.89.218.12   instagram.com.  Good    2022-04-02T15:48:30
66.111.48.12    whatsapp.com.   Good    2022-04-02T15:51:20
66.111.49.12    whatsapp.com.   Good    2022-04-02T15:52:14
129.134.30.12   instagram.com.  Good    2022-04-02T15:53:00
185.89.219.12   facebook.com.   Good    2022-04-02T15:53:01
```
Note that key is IP and the name printed is the auth domain that triggered the probe. The IP can be authoritative for multiple (other) auth domains. The timestamp is the ttd (time to die) of the entry. Good entries will be kept for three days after last successful use. Bad entries live for 1 day.

This uses some ideas and timeout values from https://datatracker.ietf.org/doc/draft-dkgjsal-dprive-unilateral-probing/ but also leaves many things out. e.g. persistence of the knowledge gained.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
