### PR TITLE
Rec: add deferred mode for additional records

### DIFF
--- a/pdns/recursordist/docs/lua-config/additionals.rst
+++ b/pdns/recursordist/docs/lua-config/additionals.rst
@@ -49,13 +49,16 @@ The modes available are:
 ``pdns.AdditionalMode.ResolveImmediately``
   Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache, actively try to resolve the target name/qtype. This will delay the answer to the client.
 ``pdns.AdditionalMode.ResolveDeferred``
-  Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache and the negative cache also has no entry, schedule a background task to resolve the target name/qtype. The next time the query is processed, the cache might hold the relevant information. This mode is not implemented yet.
+  Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache and the negative cache also has no entry, schedule a background task to resolve the target name/qtype. The next time the query is processed, the cache might hold the relevant information.
+  If a task is pushed, the answer that triggered it will be marked as variable and consequently not stored into the packet cache.
+
 
 If an additional record is not available at that time the query is stored into the packet cache the answer packet stored in the packet cache will not contain the additional record.
 Clients repeating the same question will get an answer from the packet cache if the question is still in the packet cache.
 These answers do not have the additional record, even if the record cache has learned it in the meantime .
 Clients will only see the additional record once the packet cache entry expires and the record cache is consulted again.
 The ``pdns.AdditionalMode.ResolveImmediately`` mode will not have this issue, at the cost of delaying the first query to resolve the additional records needed.
+The ``pdns.AdditionalMode.ResolveDeferred`` mode will only store answers in the packet cache if it determines that no deferred tasks are needed, i.e. either a positive or negative answer for potential additional records is available.
 
 Configuring additional record processing
 ----------------------------------------

--- a/pdns/recursordist/docs/lua-config/additionals.rst
+++ b/pdns/recursordist/docs/lua-config/additionals.rst
@@ -41,17 +41,23 @@ If needed, the Recursor will do an active resolve to retrieve these records.
 The modes available are:
 
 ``pdns.AdditionalMode.Ignore``
-  Do not do any additional processing for this qtype. This is equivalent to not calling :func:`addAllowedAdditionalQType` for the qtype.
+  Do not do any additional processing for this qtype.
+  This is equivalent to not calling :func:`addAllowedAdditionalQType` for the qtype.
 ``pdns.AdditionalMode.CacheOnly``
-  Look in the record cache for available records. Allow non-authoritative (learned from additional sections received from authoritative servers) records to be added.
+  Look in the record cache for available records.
+  Allow non-authoritative (learned from additional sections received from authoritative servers) records to be added.
 ``pdns.AdditionalMode.CacheOnlyRequireAuth``
-  Look in the record cache for available records. Only authoritative records will be added. These are records received from the nameservers for the specific domain.
+  Look in the record cache for available records.
+  Only authoritative records will be added. These are records received from the nameservers for the specific domain.
 ``pdns.AdditionalMode.ResolveImmediately``
-  Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache, actively try to resolve the target name/qtype. This will delay the answer to the client.
+  Add records from the record cache (including DNSSEC records if relevant).
+  If no record is found in the record cache, actively try to resolve the target name/qtype.
+  This will delay the answer to the client.
 ``pdns.AdditionalMode.ResolveDeferred``
-  Add records from the record cache (including DNSSEC records if relevant). If no record is found in the record cache and the negative cache also has no entry, schedule a background task to resolve the target name/qtype. The next time the query is processed, the cache might hold the relevant information.
+  Add records from the record cache (including DNSSEC records if relevant).
+  If no record is found in the record cache and the negative cache also has no entry, schedule a task to resolve the target name/qtype.
+  The next time the query is processed, the cache might hold the relevant information.
   If a task is pushed, the answer that triggered it will be marked as variable and consequently not stored into the packet cache.
-
 
 If an additional record is not available at that time the query is stored into the packet cache the answer packet stored in the packet cache will not contain the additional record.
 Clients repeating the same question will get an answer from the packet cache if the question is still in the packet cache.
@@ -59,6 +65,8 @@ These answers do not have the additional record, even if the record cache has le
 Clients will only see the additional record once the packet cache entry expires and the record cache is consulted again.
 The ``pdns.AdditionalMode.ResolveImmediately`` mode will not have this issue, at the cost of delaying the first query to resolve the additional records needed.
 The ``pdns.AdditionalMode.ResolveDeferred`` mode will only store answers in the packet cache if it determines that no deferred tasks are needed, i.e. either a positive or negative answer for potential additional records is available.
+If the additional records for an answer have low TTLs compared to the records in the answer section, tasks will be pushed often.
+Until all tasks for the answer have completed the packet cache will not contain the answer, making the packet cache less effective for this specific answer.
 
 Configuring additional record processing
 ----------------------------------------

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -254,7 +254,7 @@ SyncRes::SyncRes(const struct timeval& now) :  d_authzonequeries(0), d_outquerie
 
 static void allowAdditionalEntry(std::unordered_set<DNSName>& allowedAdditionals, const DNSRecord& rec);
 
-void SyncRes::resolveAdditionals(const DNSName& qname, QType qtype, AdditionalMode mode, std::vector<DNSRecord>& additionals, unsigned int depth, bool& taskPushed)
+void SyncRes::resolveAdditionals(const DNSName& qname, QType qtype, AdditionalMode mode, std::vector<DNSRecord>& additionals, unsigned int depth, bool& additionalsNotInCache)
 {
   vector<DNSRecord> addRecords;
 
@@ -335,7 +335,7 @@ void SyncRes::resolveAdditionals(const DNSName& qname, QType qtype, AdditionalMo
       // An example is a SOA-less NODATA response. Rate limiting will kick in if those tasks are pushed too often.
       // We might want to fix these cases (and always either store positive or negative) some day.
       pushResolveTask(qname, qtype, d_now.tv_sec, d_now.tv_sec + 60);
-      taskPushed = true;
+      additionalsNotInCache = true;
     }
     break;
   }
@@ -350,7 +350,7 @@ void SyncRes::resolveAdditionals(const DNSName& qname, QType qtype, AdditionalMo
 // This function uses to state sets to avoid infinite recursion and allow depulication
 // depth is the main recursion depth
 // additionaldepth is the depth for addAdditionals itself
-void SyncRes::addAdditionals(QType qtype, const vector<DNSRecord>&start, vector<DNSRecord>&additionals, std::set<std::pair<DNSName, QType>>& uniqueCalls, std::set<std::tuple<DNSName, QType, QType>>& uniqueResults, unsigned int depth, unsigned additionaldepth, bool& taskPushed)
+void SyncRes::addAdditionals(QType qtype, const vector<DNSRecord>&start, vector<DNSRecord>&additionals, std::set<std::pair<DNSName, QType>>& uniqueCalls, std::set<std::tuple<DNSName, QType, QType>>& uniqueResults, unsigned int depth, unsigned additionaldepth, bool& additionalsNotInCache)
 {
   if (additionaldepth >= 5 || start.empty()) {
     return;
@@ -382,7 +382,7 @@ void SyncRes::addAdditionals(QType qtype, const vector<DNSRecord>&start, vector<
       std::vector<DNSRecord> records;
       bool inserted = uniqueCalls.emplace(addname, targettype).second;
       if (inserted) {
-        resolveAdditionals(addname, targettype, mode, records, depth, taskPushed);
+        resolveAdditionals(addname, targettype, mode, records, depth, additionalsNotInCache);
       }
       if (!records.empty()) {
         for (auto r = records.begin(); r != records.end(); ) {
@@ -409,7 +409,7 @@ void SyncRes::addAdditionals(QType qtype, const vector<DNSRecord>&start, vector<
           }
           uniqueResults.emplace(r.d_name, r.d_type, covered);
         }
-        addAdditionals(targettype, records, additionals, uniqueCalls, uniqueResults, depth, additionaldepth + 1, taskPushed);
+        addAdditionals(targettype, records, additionals, uniqueCalls, uniqueResults, depth, additionaldepth + 1, additionalsNotInCache);
       }
     }
   }
@@ -428,14 +428,14 @@ bool SyncRes::addAdditionals(QType qtype, vector<DNSRecord>&ret, unsigned int de
   // For RRSIGs, the type covered is stored in the second Qtype
   std::set<std::tuple<DNSName, QType, QType>> uniqueResults;
 
-  bool pushed = false;
-  addAdditionals(qtype, ret, additionals, uniqueCalls, uniqueResults, depth, 0, pushed);
+  bool additionalsNotInCache = false;
+  addAdditionals(qtype, ret, additionals, uniqueCalls, uniqueResults, depth, 0, additionalsNotInCache);
 
   for (auto& rec : additionals) {
     rec.d_place = DNSResourceRecord::ADDITIONAL;
     ret.push_back(std::move(rec));
   }
-  return pushed;
+  return additionalsNotInCache;
 }
 
 /** everything begins here - this is the entry point just after receiving a packet */
@@ -490,8 +490,8 @@ int SyncRes::beginResolve(const DNSName &qname, const QType qtype, QClass qclass
   // Avoid calling addAdditionals() if we know we won't find anything
   auto luaLocal = g_luaconfs.getLocal();
   if (res == 0 && qclass == QClass::IN && luaLocal->allowAdditionalQTypes.find(qtype) != luaLocal->allowAdditionalQTypes.end()) {
-    bool taskPushed = addAdditionals(qtype, ret, depth);
-    if (taskPushed) {
+    bool additionalsNotInCache = addAdditionals(qtype, ret, depth);
+    if (additionalsNotInCache) {
       d_wasVariable = true;
     }
   }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -768,9 +768,9 @@ private:
   typedef std::map<DNSName,vState> zonesStates_t;
   enum StopAtDelegation { DontStop, Stop, Stopped };
 
-  void resolveAdditionals(const DNSName& qname, QType qtype, AdditionalMode, std::vector<DNSRecord>& additionals, unsigned int depth);
-  void addAdditionals(QType qtype, const vector<DNSRecord>&start, vector<DNSRecord>&addditionals, std::set<std::pair<DNSName, QType>>& uniqueCalls, std::set<std::tuple<DNSName, QType, QType>>& uniqueResults, unsigned int depth, unsigned int adddepth);
-  void addAdditionals(QType qtype, vector<DNSRecord>&ret, unsigned int depth);
+  void resolveAdditionals(const DNSName& qname, QType qtype, AdditionalMode, std::vector<DNSRecord>& additionals, unsigned int depth, bool& pushed);
+  void addAdditionals(QType qtype, const vector<DNSRecord>&start, vector<DNSRecord>&addditionals, std::set<std::pair<DNSName, QType>>& uniqueCalls, std::set<std::tuple<DNSName, QType, QType>>& uniqueResults, unsigned int depth, unsigned int adddepth, bool& pushed);
+  bool addAdditionals(QType qtype, vector<DNSRecord>&ret, unsigned int depth);
 
   bool doDoTtoAuth(const DNSName& ns) const;
   int doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, QType qtype, vector<DNSRecord>&ret,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This was left unimplemented in the initial PR.

If a task is pushed, I mark the triggering question as variable, so the result is not inserted into the packet cache. Once the additional records are retrieved (or absence is determined) no tasks are pushed and answer will be inserted into the PC. 

This mechanism has to be evaluated critically, as a additional records with low TTLs now often prevent caching the main answer in the PC as those low TTL record cause new tasks to be pushed often. So I'm actually not sure if this mechanism is effective, especially given the trend of lower and lower TTLs (e.g. check microsoft.com or any domain that hosts their mail with MS)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
