### PR TITLE
Support PEM import and export of EdDSA keys

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -942,8 +942,8 @@ speedtest_SOURCES = \
 	speedtest.cc \
 	statbag.cc \
 	svc-records.cc svc-records.hh \
-        unix_utility.cc \
-        uuid-utils.cc
+	unix_utility.cc \
+	uuid-utils.cc
 
 speedtest_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
 speedtest_LDADD = $(LIBCRYPTO_LIBS) \
@@ -964,8 +964,8 @@ dnswasher_SOURCES = \
 	statbag.cc \
 	unix_utility.cc
 
-dnswasher_LDFLAGS = 	$(AM_LDFLAGS) $(BOOST_PROGRAM_OPTIONS_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
-dnswasher_LDADD = 	$(BOOST_PROGRAM_OPTIONS_LIBS) $(LIBCRYPTO_LIBS) $(IPCRYPT_LIBS)
+dnswasher_LDFLAGS =	$(AM_LDFLAGS) $(BOOST_PROGRAM_OPTIONS_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
+dnswasher_LDADD =	$(BOOST_PROGRAM_OPTIONS_LIBS) $(LIBCRYPTO_LIBS) $(IPCRYPT_LIBS)
 
 dnsbulktest_SOURCES = \
 	arguments.cc arguments.hh \
@@ -1421,7 +1421,7 @@ testrunner_SOURCES = \
 testrunner_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	$(LIBCRYPTO_LDFLAGS) \
-	$(BOOST_UNIT_TEST_FRAMEWORK_LDFLAGS) 
+	$(BOOST_UNIT_TEST_FRAMEWORK_LDFLAGS)
 
 testrunner_LDADD = \
 	$(LIBCRYPTO_LIBS) \

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -224,6 +224,40 @@ public:
   }
   string getName() const override { return "Decaf ED448"; }
   void create(unsigned int bits) override;
+
+#if defined(HAVE_LIBCRYPTO_ED448)
+  /**
+   * \brief Creates an ED448 key engine from a PEM file.
+   *
+   * Receives an open file handle with PEM contents and creates an ED448
+   * key engine.
+   *
+   * \param[in] drc Key record contents to be populated.
+   *
+   * \param[in] filename Only used for providing filename information in
+   * error messages.
+   *
+   * \param[in] fp An open file handle to a file containing ED448 PEM
+   * contents.
+   *
+   * \return An ED448 key engine populated with the contents of the PEM
+   * file.
+   */
+  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& fp) override;
+
+  /**
+   * \brief Writes this key's contents to a file.
+   *
+   * Receives an open file handle and writes this key's contents to the
+   * file.
+   *
+   * \param[in] fp An open file handle for writing.
+   *
+   * \exception std::runtime_error In case of OpenSSL errors.
+   */
+  void convertToPEM(std::FILE& fp) const override;
+#endif
+
   storvector_t convertToISCVector() const override;
   std::string getPubKeyHash() const override;
   std::string sign(const std::string& msg) const override;
@@ -257,6 +291,42 @@ void DecafED448DNSCryptoKeyEngine::create(unsigned int bits)
   priv.serialize_into(d_seckey);
   pub.serialize_into(d_pubkey);
 }
+
+#if defined(HAVE_LIBCRYPTO_ED448)
+void DecafED448DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& fp)
+{
+  drc.d_algorithm = d_algorithm;
+  auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&fp, nullptr, nullptr, nullptr), &EVP_PKEY_free);
+  if (key == nullptr) {
+    throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename + "`");
+  }
+
+  std::size_t keylen = DECAF_EDDSA_448_PRIVATE_BYTES;
+  int ret = EVP_PKEY_get_raw_private_key(key.get(), d_seckey, &keylen);
+  if (ret == 0) {
+    throw runtime_error(getName() + ": Failed to get private key from PEM file contents `" + filename + "`");
+  }
+
+  keylen = DECAF_EDDSA_448_PUBLIC_BYTES;
+  ret = EVP_PKEY_get_raw_public_key(key.get(), d_pubkey, &keylen);
+  if (ret == 0) {
+    throw runtime_error(getName() + ": Failed to get public key from PEM file contents `" + filename + "`");
+  }
+}
+
+void DecafED448DNSCryptoKeyEngine::convertToPEM(std::FILE& fp) const
+{
+  auto key = std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>(EVP_PKEY_new_raw_private_key(EVP_PKEY_ED448, nullptr, d_seckey, DECAF_EDDSA_448_PRIVATE_BYTES), EVP_PKEY_free);
+  if (key == nullptr) {
+    throw runtime_error(getName() + ": Could not create private key from buffer");
+  }
+
+  auto ret = PEM_write_PrivateKey(&fp, key.get(), nullptr, nullptr, 0, nullptr, nullptr);
+  if (ret == 0) {
+    throw runtime_error(getName() + ": Could not convert private key to PEM");
+  }
+}
+#endif
 
 int DecafED448DNSCryptoKeyEngine::getBits() const
 {

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -194,13 +194,13 @@ std::string DNSCryptoKeyEngine::convertToISC() const
 std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::make(unsigned int algo)
 {
   const makers_t& makers = getMakers();
-  makers_t::const_iterator iter = makers.find(algo);
+
+  auto iter = makers.find(algo);
   if (iter != makers.cend()) {
     return (iter->second)(algo);
   }
-  else {
-    throw runtime_error("Request to create key object for unknown algorithm number " + std::to_string(algo));
-  }
+
+  throw runtime_error("Request to create key object for unknown algorithm number " + std::to_string(algo));
 }
 
 /**

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -179,14 +179,18 @@ std::string DNSCryptoKeyEngine::convertToISC() const
 {
   storvector_t storvector = this->convertToISCVector();
   ostringstream ret;
-  ret<<"Private-key-format: v1.2\n";
-  for(const storvector_t::value_type& value :  storvector) {
+  ret << "Private-key-format: v1.2\n";
+  for (const storvector_t::value_type& value : storvector) {
+    // clang-format off
     if(value.first != "Algorithm" && value.first != "PIN" &&
        value.first != "Slot" && value.first != "Engine" &&
-       value.first != "Label" && value.first != "PubLabel")
-      ret<<value.first<<": "<<Base64Encode(value.second)<<"\n";
-    else
-      ret<<value.first<<": "<<value.second<<"\n";
+       value.first != "Label" && value.first != "PubLabel") {
+      ret << value.first << ": " << Base64Encode(value.second) << "\n";
+    }
+    else {
+      ret << value.first << ": " << value.second << "\n";
+    }
+    // clang-format on
   }
   return ret.str();
 }

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -962,6 +962,25 @@ public:
   void create(unsigned int bits) override;
 
   /**
+   * \brief Creates an EDDSA key engine from a PEM file.
+   *
+   * Receives an open file handle with PEM contents and creates an EDDSA
+   * key engine.
+   *
+   * \param[in] drc Key record contents to be populated.
+   *
+   * \param[in] filename Only used for providing filename information in
+   * error messages.
+   *
+   * \param[in] fp An open file handle to a file containing EDDSA PEM
+   * contents.
+   *
+   * \return An EDDSA key engine populated with the contents of the PEM
+   * file.
+   */
+  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& fp) override;
+
+  /**
    * \brief Writes this key's contents to a file.
    *
    * Receives an open file handle and writes this key's contents to the
@@ -1013,6 +1032,15 @@ void OpenSSLEDDSADNSCryptoKeyEngine::create(unsigned int bits)
     throw runtime_error(getName()+" key generation failed");
   }
   d_edkey = std::unique_ptr<EVP_PKEY, void(*)(EVP_PKEY*)>(newKey, EVP_PKEY_free);
+}
+
+void OpenSSLEDDSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& fp)
+{
+  drc.d_algorithm = d_algorithm;
+  d_edkey = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&fp, nullptr, nullptr, nullptr), &EVP_PKEY_free);
+  if (d_edkey == nullptr) {
+    throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename + "`");
+  }
 }
 
 void OpenSSLEDDSADNSCryptoKeyEngine::convertToPEM(std::FILE& fp) const

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -960,6 +960,19 @@ public:
   int getBits() const override { return d_len << 3; }
 
   void create(unsigned int bits) override;
+
+  /**
+   * \brief Writes this key's contents to a file.
+   *
+   * Receives an open file handle and writes this key's contents to the
+   * file.
+   *
+   * \param[in] fp An open file handle for writing.
+   *
+   * \exception std::runtime_error In case of OpenSSL errors.
+   */
+  void convertToPEM(std::FILE& fp) const override;
+
   storvector_t convertToISCVector() const override;
   std::string sign(const std::string& msg) const override;
   bool verify(const std::string& msg, const std::string& signature) const override;
@@ -1000,6 +1013,14 @@ void OpenSSLEDDSADNSCryptoKeyEngine::create(unsigned int bits)
     throw runtime_error(getName()+" key generation failed");
   }
   d_edkey = std::unique_ptr<EVP_PKEY, void(*)(EVP_PKEY*)>(newKey, EVP_PKEY_free);
+}
+
+void OpenSSLEDDSADNSCryptoKeyEngine::convertToPEM(std::FILE& fp) const
+{
+  auto ret = PEM_write_PrivateKey(&fp, d_edkey.get(), nullptr, nullptr, 0, nullptr, nullptr);
+  if (ret == 0) {
+    throw runtime_error(getName() + ": Could not convert private key to PEM");
+  }
 }
 
 DNSCryptoKeyEngine::storvector_t OpenSSLEDDSADNSCryptoKeyEngine::convertToISCVector() const

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -58,7 +58,6 @@ DNSCryptoKeyEngine::storvector_t SodiumED25519DNSCryptoKeyEngine::convertToISCVe
 
   storvector.emplace_back("Algorithm", algorithm);
 
-  vector<unsigned char> buffer;
   storvector.emplace_back("PrivateKey", string((char*)d_seckey, crypto_sign_ed25519_SEEDBYTES));
   return storvector;
 }

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -16,6 +16,7 @@ public:
   string getName() const override { return "Sodium ED25519"; }
   void create(unsigned int bits) override;
 
+#if defined(HAVE_LIBCRYPTO_ED25519)
   /**
    * \brief Creates an ED25519 key engine from a PEM file.
    *
@@ -46,6 +47,7 @@ public:
    * \exception std::runtime_error In case of OpenSSL errors.
    */
   void convertToPEM(std::FILE& fp) const override;
+#endif
 
   storvector_t convertToISCVector() const override;
   std::string getPubKeyHash() const override;
@@ -74,6 +76,7 @@ void SodiumED25519DNSCryptoKeyEngine::create(unsigned int bits)
   crypto_sign_ed25519_keypair(d_pubkey, d_seckey);
 }
 
+#if defined(HAVE_LIBCRYPTO_ED25519)
 void SodiumED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& fp)
 {
   drc.d_algorithm = d_algorithm;
@@ -107,6 +110,7 @@ void SodiumED25519DNSCryptoKeyEngine::convertToPEM(std::FILE& fp) const
     throw runtime_error(getName() + ": Could not convert private key to PEM");
   }
 }
+#endif
 
 int SodiumED25519DNSCryptoKeyEngine::getBits() const
 {

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -184,8 +184,9 @@ std::string SodiumED25519DNSCryptoKeyEngine::sign(const std::string& msg) const
 
 bool SodiumED25519DNSCryptoKeyEngine::verify(const std::string& msg, const std::string& signature) const
 {
-  if (signature.length() != crypto_sign_ed25519_BYTES)
+  if (signature.length() != crypto_sign_ed25519_BYTES) {
     return false;
+  }
 
   unsigned long long smlen = msg.length() + crypto_sign_ed25519_BYTES;
   auto sm = std::make_unique<unsigned char[]>(smlen);

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -253,7 +253,8 @@ static auto test_generic_signer(std::shared_ptr<DNSCryptoKeyEngine> dcke, DNSKEY
   BOOST_CHECK(dcke->verify(message, signature));
 
   if (signer.isDeterministic) {
-    BOOST_CHECK_EQUAL(signature, std::string(signer.signature.begin(), signer.signature.end()));
+    string b64 = Base64Encode(signature);
+    BOOST_CHECK_EQUAL(b64, Base64Encode(std::string(signer.signature.begin(), signer.signature.end())));
   }
   else {
     /* since the signing process is not deterministic, we can't directly compare our signature

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -149,7 +149,14 @@ static const std::array<struct SignerParams, 3> signers
       DNSSECKeeper::ED25519,
       true,
 
+#if defined(HAVE_LIBCRYPTO_ED25519)
+      std::make_optional(std::string{
+        "-----BEGIN PRIVATE KEY-----\n"
+        "MC4CAQAwBQYDK2VwBCIEIDgyMjYwMzg0NjI4MDgwMTIyNjQ1MTkwMjA0MTQyMjYy\n"
+        "-----END PRIVATE KEY-----\n"})},
+#else
       std::nullopt},
+#endif /* defined(HAVE_LIBCRYPTO_ED25519) */
 #endif /* defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED25519) */
 };
 


### PR DESCRIPTION
### Short description
Support PEM import and export of EdDSA keys. There are two implementations:
- OpenSSL, which supports both Ed25519 and Ed448.
- Sodium, which only supports Ed25519 and depends on OpenSSL for PEM de/serialization.
- Libdecaf, which supports both Ed25519 and Ed448 and depends on OpenSSL for PEM de/serialization.

### Checklist

I have:

- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
