### PR TITLE
Prevent segfault with empty allow-from-file and allow-from options

### DIFF
--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -958,8 +958,6 @@ static std::shared_ptr<NetmaskGroup> parseACL(const std::string& aclFile, const 
       result->addMask(line);
     }
     g_log << Logger::Info << "Done parsing " << result->size() << " " << aclSetting << " ranges from file '" << ::arg()[aclFile] << "' - overriding '" << aclSetting << "' setting" << endl;
-
-    return result;
   }
   else if (!::arg()[aclSetting].empty()) {
     vector<string> ips;
@@ -973,11 +971,9 @@ static std::shared_ptr<NetmaskGroup> parseACL(const std::string& aclFile, const 
       g_log << Logger::Info << *i;
     }
     g_log << Logger::Info << endl;
-
-    return result;
   }
 
-  return nullptr;
+  return result;
 }
 
 static void* pleaseSupplantAllowFrom(std::shared_ptr<NetmaskGroup> ng)


### PR DESCRIPTION
### Short description
parseACL() returns a nullptr when both options are set empty.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)