### PR TITLE
New setting compare-signatures-on-zone-freshness-check to disable DO flag for SOA checks

### DIFF
--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -108,12 +108,12 @@ This is useful if the Primary is also PowerDNS as the serial may not be
 increased although signatures are updated. To compare also the RRSIGs,
 PowerDNS sets the DO flag when querying the SOA on the Primary. Setting
 the DO flag may trigger truncated responses and the SOA check should
-fall-back to TCP. As this fall-back is currently not supported in
+fall back to TCP. As this fallback is not currently supported in
 PowerDNS, freshness checks may fail. If it is known that the Primary
 always increases the serial on signature changes, signature comparison
 can be turned off by disabling
 :ref:`setting-compare-signatures-on-zone-freshness-check`. This will disable
-the DO flag and should work around the truncate issue.
+the DO flag and should work around the issue with truncate.
 
 When the freshness of a domain cannot be checked, e.g. because the
 master is offline, PowerDNS will retry the domain after

--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -109,7 +109,7 @@ increased although signatures are updated. To compare also the RRSIGs,
 PowerDNS sets the DO flag when querying the SOA on the Primary. Setting
 the DO flag may trigger truncated responses and the SOA check should
 fall-back to TCP. As this fall-back is currently not supported in
-PowerDNS, freshnes checks may fail. If it is known that the Primary
+PowerDNS, freshness checks may fail. If it is known that the Primary
 always increases the serial on signature changes, signature comparison
 can be turned off by disabling
 :ref:`setting-compare-signatures-on-zone-freshness-check`. This will disable

--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -112,7 +112,7 @@ the primary server. In some conditions, some primary servers answer with
 a truncated SOA response (indicating TCP is required), and the freshness
 check will fail. As a workaround, the signature check and DO flag can be
 turned off by disabling
-:ref:`setting-compare-signatures-on-zone-freshness-check`.
+:ref:`setting-secondary-check-signature-freshness`.
 
 When the freshness of a domain cannot be checked, e.g. because the
 master is offline, PowerDNS will retry the domain after

--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -101,6 +101,20 @@ retrieved and inserted into the database. In any case, after the check,
 the domain is declared 'fresh', and will only be checked again after
 '**refresh**' seconds have passed.
 
+If the serial on the Primary is equal to the serial on the Secondary,
+but the zone is presigned, the Secondary will also compare the RRSIG
+of the SOA and queue a zone transfer if the signatures are different.
+This is useful if the Primary is also PowerDNS as the serial may not be
+increased although signatures are updated. To compare also the RRSIGs,
+PowerDNS sets the DO flag when querying the SOA on the Primary. Setting
+the DO flag may trigger truncated responses and the SOA check should
+fall-back to TCP. As this fall-back is currently not supported in
+PowerDNS, freshnes checks may fail. If it is known that the Primary
+always increases the serial on signature changes, signature comparison
+can be turned off by disabling
+:ref:`setting-compare-signatures-on-zone-freshness-check`. This will disable
+the DO flag and should work around the truncate issue.
+
 When the freshness of a domain cannot be checked, e.g. because the
 master is offline, PowerDNS will retry the domain after
 :ref:`setting-xfr-cycle-interval` seconds.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -273,6 +273,21 @@ Either don't ``chroot`` on these systems or set the 'Type' of the
 service to 'simple' instead of 'notify' (refer to the systemd
 documentation on how to modify unit-files).
 
+.. _setting-compare-signatures-on-zone-freshness-check:
+
+``compare-signatures-on-zone-freshness-check``
+----------------------------------------------
+
+.. versionadded:: 4.7.0
+
+-  Boolean
+-  Default: yes
+
+Turning this off will disable the DO flag for SOA queries during zone freshness checks of secondary zones
+to workaround truncated SOA responses. It will also disable signature comparison which are used to detect
+signature changes even when the serial was not increased. Hence, disable this setting only if the Primary
+name server always increases the serial on signature changes.
+
 .. _setting-config-dir:
 
 ``config-dir``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -289,7 +289,7 @@ signatures in the SOA response.
 
 In some problematic scenarios, primary servers send truncated SOA responses. As a workaround, this setting
 can be turned off, and the DO flag as well as the signature checking will be disabled. To avoid additional
-drift, primary servers then must always increase the zone serial on signature changes.
+drift, primary servers must then always increase the zone serial when it updates signatures.
 
 It is strongly recommended to keep this setting enabled (`yes`).
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -273,10 +273,10 @@ Either don't ``chroot`` on these systems or set the 'Type' of the
 service to 'simple' instead of 'notify' (refer to the systemd
 documentation on how to modify unit-files).
 
-.. _setting-compare-signatures-on-zone-freshness-check:
+.. _setting-secondary-check-signature-freshness:
 
-``compare-signatures-on-zone-freshness-check``
-----------------------------------------------
+``secondary-check-signature-freshness``
+---------------------------------------
 
 .. versionadded:: 4.7.0
 
@@ -284,12 +284,14 @@ documentation on how to modify unit-files).
 -  Default: yes
 
 Enabled by default, freshness checks for secondary zones will set the DO flag on SOA queries. PowerDNS
-uses the DNSSEC signatures in the SOA response to detect (signature) changes on the primary server, when
-the serial number was not increased.
+can detect (signature) changes on the primary server without serial number bumps using the DNSSEC
+signatures in the SOA response.
 
-In some scenarios, primary servers send truncated SOA responses. As a workaround, this setting can be
-turned off, and the DO flag as well as the signature checking will be disabled. To avoid additional
+In some problematic scenarios, primary servers send truncated SOA responses. As a workaround, this setting
+can be turned off, and the DO flag as well as the signature checking will be disabled. To avoid additional
 drift, primary servers then must always increase the zone serial on signature changes.
+
+It is strongly recommended to keep this setting enabled (`yes`).
 
 .. _setting-config-dir:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -283,10 +283,13 @@ documentation on how to modify unit-files).
 -  Boolean
 -  Default: yes
 
-Turning this off will disable the DO flag for SOA queries during zone freshness checks of secondary zones
-to work around truncated SOA responses. It will also disable signature comparison which is used to detect
-signature changes even when the serial was not increased. Hence, disable this setting only if the Primary
-name server always increases the serial on signature changes.
+Enabled by default, freshness checks for secondary zones will set the DO flag on SOA queries. PowerDNS
+uses the DNSSEC signatures in the SOA response to detect (signature) changes on the primary server, when
+the serial number was not increased.
+
+In some scenarios, primary servers send truncated SOA responses. As a workaround, this setting can be
+turned off, and the DO flag as well as the signature checking will be disabled. To avoid additional
+drift, primary servers then must always increase the zone serial on signature changes.
 
 .. _setting-config-dir:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -284,7 +284,7 @@ documentation on how to modify unit-files).
 -  Default: yes
 
 Turning this off will disable the DO flag for SOA queries during zone freshness checks of secondary zones
-to workaround truncated SOA responses. It will also disable signature comparison which are used to detect
+to work around truncated SOA responses. It will also disable signature comparison which is used to detect
 signature changes even when the serial was not increased. Hence, disable this setting only if the Primary
 name server always increases the serial on signature changes.
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -211,7 +211,7 @@ void declareArguments()
   ::arg().set("allow-notify-from", "Allow AXFR NOTIFY from these IP ranges. If empty, drop all incoming notifies.") = "0.0.0.0/0,::/0";
   ::arg().set("slave-cycle-interval", "Schedule slave freshness checks once every .. seconds") = "60";
   ::arg().set("xfr-cycle-interval", "Schedule primary/secondary SOA freshness checks once every .. seconds") = "60";
-  ::arg().set("compare-signatures-on-zone-freshness-check", "Set DO flag on SOA queries to receive signatures for signature comparison") = "yes";
+  ::arg().set("secondary-check-signature-freshness", "Check signatures in SOA freshness check. Sets DO flag on SOA queries. Outside some very problematic scenarios, say yes here.") = "yes";
 
   ::arg().set("tcp-control-address", "If set, PowerDNS can be controlled over TCP on this address") = "";
   ::arg().set("tcp-control-port", "If set, PowerDNS can be controlled over TCP on this address") = "53000";

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -211,6 +211,7 @@ void declareArguments()
   ::arg().set("allow-notify-from", "Allow AXFR NOTIFY from these IP ranges. If empty, drop all incoming notifies.") = "0.0.0.0/0,::/0";
   ::arg().set("slave-cycle-interval", "Schedule slave freshness checks once every .. seconds") = "60";
   ::arg().set("xfr-cycle-interval", "Schedule primary/secondary SOA freshness checks once every .. seconds") = "60";
+  ::arg().set("compare-signatures-on-zone-freshness-check", "Set DO flag on SOA queries to receive signatures for signature comparison") = "yes";
 
   ::arg().set("tcp-control-address", "If set, PowerDNS can be controlled over TCP on this address") = "";
   ::arg().set("tcp-control-port", "If set, PowerDNS can be controlled over TCP on this address") = "53000";

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -1182,7 +1182,7 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
 
       DomainNotificationInfo dni;
       dni.di=di;
-      if (::arg().mustDo("compare-signatures-on-zone-freshness-check")) {
+      if (::arg().mustDo("secondary-check-signature-freshness")) {
         dni.dnssecOk = dk.doesDNSSEC();
       } else {
         dni.dnssecOk = false;
@@ -1331,7 +1331,7 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
     }
     else if(hasSOA && theirserial == ourserial) {
       uint32_t maxExpire=0, maxInception=0;
-      if(dk.isPresigned(di.zone) && ::arg().mustDo("compare-signatures-on-zone-freshness-check")) {
+      if(dk.isPresigned(di.zone) && ::arg().mustDo("secondary-check-signature-freshness")) {
         B->lookup(QType(QType::RRSIG), di.zone, di.id); // can't use DK before we are done with this lookup!
         DNSZoneRecord zr;
         while(B->get(zr)) {

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -1182,7 +1182,11 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
 
       DomainNotificationInfo dni;
       dni.di=di;
-      dni.dnssecOk = dk.doesDNSSEC();
+      if (::arg().mustDo("compare-signatures-on-zone-freshness-check")) {
+        dni.dnssecOk = dk.doesDNSSEC();
+      } else {
+        dni.dnssecOk = false;
+      }
 
       if(dk.getTSIGForAccess(di.zone, sr.master, &dni.tsigkeyname)) {
         string secret64;
@@ -1327,7 +1331,7 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
     }
     else if(hasSOA && theirserial == ourserial) {
       uint32_t maxExpire=0, maxInception=0;
-      if(dk.isPresigned(di.zone)) {
+      if(dk.isPresigned(di.zone) && ::arg().mustDo("compare-signatures-on-zone-freshness-check")) {
         B->lookup(QType(QType::RRSIG), di.zone, di.id); // can't use DK before we are done with this lookup!
         DNSZoneRecord zr;
         while(B->get(zr)) {


### PR DESCRIPTION
This is a workaround for #10447 until SOA Checks over TCP are supported.

Turning this off will disable the DO flag for SOA queries during zone freshness checks of secondary zones
to workaround truncated SOA responses. It will also disable signature comparison which are used to detect
signature changes even when the serial was not increased. Hence, disable this setting only if the Primary
name server always increases the serial on signature changes.
Default: yes (= old behavior)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
