### PR TITLE
auth: Small performance improvement for the LMDB backend

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -853,7 +853,7 @@ bool LMDBBackend::get(DNSZoneRecord& zr)
         continue;
       }
 
-      serFromString(d_currentVal.get<string>(), d_currentrrset);
+      serFromString(d_currentVal.get<string_view>(), d_currentrrset);
       d_currentrrsetpos = 0;
     }
     else {

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -200,7 +200,8 @@ public:
   virtual std::string getZoneRepresentation(bool noDot=false) const = 0;
   virtual ~DNSRecordContent() {}
   virtual void toPacket(DNSPacketWriter& pw)=0;
-  virtual string serialize(const DNSName& qname, bool canonic=false, bool lowerCase=false) // it would rock if this were const, but it is too hard
+  // returns the wire format of the content, possibly including compressed pointers pointing to the owner name (unless canonic or lowerCase are set)
+  virtual string serialize(const DNSName& qname, bool canonic=false, bool lowerCase=false) // it would rock if this were const, but it is too hard because we use the same method (xfrPacket) for both kinds of conversion (fromPacket, toPacket)
   {
     vector<uint8_t> packet;
     DNSPacketWriter pw(packet, g_rootdnsname, 1);
@@ -223,6 +224,7 @@ public:
     return typeid(*this)==typeid(rhs) && this->getZoneRepresentation() == rhs.getZoneRepresentation();
   }
 
+  // parse the content in wire format, possibly including compressed pointers pointing to the owner name
   static shared_ptr<DNSRecordContent> deserialize(const DNSName& qname, uint16_t qtype, const string& serialized);
 
   void doRecordCheck(const struct DNSRecord&){}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This two commits improve the performance of the LMDB backend a bit (I remember seeing up to 10% reduction in CPU usage in an unrealistic benchmark):
- avoid the allocation of a string in `LMDBBackend::get()`
- reduce allocations and copies in `DNSRecordContent::deserialize()`: the move from a vector to a PacketBuffer prevents the memory from being zeroed while we are going to overwrite it right away. The change from MOADNSParser to PacketReader avoids the need to copy the header and the whole packet (allocation + copy), parse the qname again, as well as the allocation of a vector of records while we know we have only one of these.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
