### PR TITLE
dnsdist: Bunch of small cleanups

### DIFF
--- a/pdns/dnsdist-rings.hh
+++ b/pdns/dnsdist-rings.hh
@@ -213,7 +213,7 @@ private:
       d_nbQueryEntries++;
     }
 #if defined(DNSDIST_RINGS_WITH_MACADDRESS)
-    Rings::Query query({requestor, name, when, dh, size, qtype, protocol, "", hasmac});
+    Rings::Query query{requestor, name, when, dh, size, qtype, protocol, "", hasmac};
     if (hasmac) {
       memcpy(query.macaddress, macaddress, maclen);
     }

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -565,7 +565,7 @@ struct TCPCrossProtocolResponse
 class TCPCrossProtocolQuerySender : public TCPQuerySender
 {
 public:
-  TCPCrossProtocolQuerySender(std::shared_ptr<IncomingTCPConnectionState>& state, int responseDescriptor): d_state(state), d_responseDesc(responseDescriptor)
+  TCPCrossProtocolQuerySender(std::shared_ptr<IncomingTCPConnectionState>& state): d_state(state)
   {
   }
 
@@ -581,13 +581,13 @@ public:
 
   void handleResponse(const struct timeval& now, TCPResponse&& response) override
   {
-    if (d_responseDesc == -1) {
+    if (d_state->d_threadData.crossProtocolResponsesPipe == -1) {
       throw std::runtime_error("Invalid pipe descriptor in TCP Cross Protocol Query Sender");
     }
 
     auto ptr = new TCPCrossProtocolResponse(std::move(response), d_state, now);
     static_assert(sizeof(ptr) <= PIPE_BUF, "Writes up to PIPE_BUF are guaranteed not to be interleaved and to either fully succeed or fail");
-    ssize_t sent = write(d_responseDesc, &ptr, sizeof(ptr));
+    ssize_t sent = write(d_state->d_threadData.crossProtocolResponsesPipe, &ptr, sizeof(ptr));
     if (sent != sizeof(ptr)) {
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
         ++g_stats.tcpCrossProtocolResponsePipeFull;
@@ -613,7 +613,6 @@ public:
 
 private:
   std::shared_ptr<IncomingTCPConnectionState> d_state;
-  int d_responseDesc{-1};
 };
 
 class TCPCrossProtocolQuery : public CrossProtocolQuery
@@ -774,7 +773,7 @@ static void handleQuery(std::shared_ptr<IncomingTCPConnectionState>& state, cons
       proxyProtocolPayload = getProxyProtocolPayload(dq);
     }
 
-    auto incoming = std::make_shared<TCPCrossProtocolQuerySender>(state, state->d_threadData.crossProtocolResponsesPipe);
+    auto incoming = std::make_shared<TCPCrossProtocolQuerySender>(state);
     auto cpq = std::make_unique<TCPCrossProtocolQuery>(std::move(state->d_buffer), std::move(ids), ds, incoming);
     cpq->query.d_proxyProtocolPayload = std::move(proxyProtocolPayload);
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1063,6 +1063,8 @@ static bool isUDPQueryAcceptable(ClientState& cs, LocalHolders& holders, const s
        the address is set to 0.0.0.0:0 which makes our sendfromto() use
        the wrong address. In that case it's better to let the kernel
        do the work by itself and use sendto() instead.
+       This is indicated by setting the family to 0 which is acted upon
+       in sendUDPResponse() and DelayedPacket::().
     */
     const ComboAddress bogusV4("0.0.0.0:0");
     const ComboAddress bogusV6("[::]:0");

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -64,6 +64,7 @@
 #include "dnsdist-xpf.hh"
 
 #include "base64.hh"
+#include "capabilities.hh"
 #include "delaypipe.hh"
 #include "dolog.hh"
 #include "dnsname.hh"

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "ext/luawrapper/include/LuaContext.hpp"
 
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -32,8 +33,6 @@
 
 #include <boost/variant.hpp>
 
-#include "capabilities.hh"
-#include "circular_buffer.hh"
 #include "dnscrypt.hh"
 #include "dnsdist-cache.hh"
 #include "dnsdist-dynbpf.hh"

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -9,8 +9,6 @@ AC_PROG_CC
 AC_PROG_CXX
 AC_LANG([C++])
 
-PDNS_CHECK_TIME_T
-
 AC_DEFINE([DNSDIST], [1],
   [This is dnsdist]
 )

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -150,4 +150,4 @@ typedef struct dnsdist_ffi_proxy_protocol_value {
 } dnsdist_ffi_proxy_protocol_value_t;
 
 size_t dnsdist_ffi_generate_proxy_protocol_payload(size_t addrSize, const void* srcAddr, const void* dstAddr, uint16_t srcPort, uint16_t dstPort, bool tcp, size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, size_t outSize) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi_dnsquestion_t* dq, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, const size_t outSize);
+size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi_dnsquestion_t* dq, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, const size_t outSize) __attribute__ ((visibility ("default")));

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -618,21 +618,21 @@ void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dr, u
   }
 }
 
-const std::string& getLuaFFIWrappers()
-{
-  static const std::string interface =
-#include "dnsdist-lua-ffi-interface.inc"
-    ;
-  static const std::string code = R"FFICodeContent(
+static constexpr char s_lua_ffi_code[] = R"FFICodeContent(
   local ffi = require("ffi")
   local C = ffi.C
 
   ffi.cdef[[
-)FFICodeContent" + interface + R"FFICodeContent(
+)FFICodeContent"
+#include "dnsdist-lua-ffi-interface.inc"
+R"FFICodeContent(
   ]]
 
 )FFICodeContent";
-  return code;
+
+const char* getLuaFFIWrappers()
+{
+  return s_lua_ffi_code;
 }
 
 void setupLuaLoadBalancingContext(LuaContext& luaCtx)

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.hh
@@ -128,5 +128,5 @@ struct dnsdist_ffi_servers_list_t
   const ServerPolicy::NumberedServerVector& servers;
 };
 
-const std::string& getLuaFFIWrappers();
+const char* getLuaFFIWrappers();
 void setupLuaFFIPerThreadContext(LuaContext& luaCtx);

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -68,7 +68,7 @@ bool ConnectionToBackend::reconnect()
   d_proxyProtocolPayloadSent = false;
 
   do {
-    vinfolog("TCP connecting to downstream %s (%d)", d_ds->getNameWithAddr(), d_downstreamFailures);
+    DEBUGLOG("TCP connecting to downstream "<<d_ds->getNameWithAddr()<<" ("<<d_downstreamFailures<<")");
     DEBUGLOG("Opening TCP connection to backend "<<d_ds->getNameWithAddr());
     ++d_ds->tcpNewConnections;
     try {

--- a/pdns/dnsdistdist/test-connectionmanagement_hh.cc
+++ b/pdns/dnsdistdist/test-connectionmanagement_hh.cc
@@ -29,6 +29,7 @@ BOOST_AUTO_TEST_CASE(test_ConnectionManagementEnabled) {
   /* raise the number of slots */
   maxConns = 12;
   manager.setMaxConcurrentConnections(maxConns);
+  BOOST_CHECK_EQUAL(manager.getMaxConcurrentConnections(), maxConns);
   BOOST_CHECK_EQUAL(manager.registerConnection(), true);
   BOOST_CHECK_EQUAL(manager.registerConnection(), true);
   BOOST_CHECK_EQUAL(manager.registerConnection(), false);

--- a/pdns/test-credentials_cc.cc
+++ b/pdns/test-credentials_cc.cc
@@ -25,6 +25,7 @@ BOOST_AUTO_TEST_CASE(test_CredentialsUtils)
 
   BOOST_CHECK(!verifyPassword(hashed, "not test"));
   BOOST_CHECK(!verifyPassword(sampleHash, "not test"));
+  BOOST_CHECK(!verifyPassword("test", "test"));
 
   BOOST_CHECK(isPasswordHashed(hashed));
   BOOST_CHECK(isPasswordHashed(sampleHash));
@@ -43,6 +44,8 @@ BOOST_AUTO_TEST_CASE(test_CredentialsUtils)
   BOOST_CHECK(!isPasswordHashed(""));
   // missing leading $
   BOOST_CHECK(!isPasswordHashed("scrypt$ln=10,p=1,r=8$1GZ10YdmSGtTmKK9jTH85Q==$JHeICW1mUCnTC+nnULDr7QFQ3kRrZ7u12djruJdrPhI="));
+  // prefix-only
+  BOOST_CHECK(!isPasswordHashed("$scrypt$"));
   // unknown algo
   BOOST_CHECK(!isPasswordHashed("$tcrypt$ln=10,p=1,r=8$1GZ10YdmSGtTmKK9jTH85Q==$JHeICW1mUCnTC+nnULDr7QFQ3kRrZ7u12djruJdrPhI="));
   // missing parameters


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR contains a bunch of small cleanups for dnsdist, most of these straightforward ones.
The only controversial one being the decision to revert the `time_t` check for dnsdist, which I believe makes sense because:
- dnsdist does not deal with signatures, and therefore is less sensitive to time issues than the auth or the rec
- it is more and more often deployed on embedded devices were this will still be an issue for some time, until a 64-bit `time_t` becomes available, and it seems silly to just prevent using dnsdist there. In fact we are seeing downstream maintainers removing that check, which is probably a good indication that it is more a hindrance than anything else. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
