### PR TITLE
Multiplexer: Take the maximum number of events as a hint

### DIFF
--- a/pdns/devpollmplexer.cc
+++ b/pdns/devpollmplexer.cc
@@ -62,7 +62,7 @@ private:
   int d_devpollfd;
 };
 
-static FDMultiplexer* makeDevPoll()
+static FDMultiplexer* makeDevPoll(unsigned int)
 {
   return new DevPollFDMultiplexer();
 }

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -38,7 +38,7 @@
 class KqueueFDMultiplexer : public FDMultiplexer
 {
 public:
-  KqueueFDMultiplexer();
+  KqueueFDMultiplexer(unsigned int maxEventsHint);
   ~KqueueFDMultiplexer()
   {
     if (d_kqueuefd >= 0) {
@@ -60,14 +60,11 @@ public:
 private:
   int d_kqueuefd;
   std::vector<struct kevent> d_kevents;
-  static unsigned int s_maxevents; // not a hard maximum
 };
 
-unsigned int KqueueFDMultiplexer::s_maxevents = 1024;
-
-static FDMultiplexer* make()
+static FDMultiplexer* make(unsigned int maxEventsHint)
 {
-  return new KqueueFDMultiplexer();
+  return new KqueueFDMultiplexer(maxEventsHint);
 }
 
 static struct KqueueRegisterOurselves
@@ -78,8 +75,8 @@ static struct KqueueRegisterOurselves
   }
 } kQueueDoIt;
 
-KqueueFDMultiplexer::KqueueFDMultiplexer() :
-  d_kevents(s_maxevents)
+KqueueFDMultiplexer::KqueueFDMultiplexer(unsigned int maxEventsHint) :
+  d_kevents(maxEventsHint)
 {
   d_kqueuefd = kqueue();
   if (d_kqueuefd < 0) {
@@ -148,7 +145,7 @@ void KqueueFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
   ts.tv_sec = timeout / 1000;
   ts.tv_nsec = (timeout % 1000) * 1000000;
 
-  int ret = kevent(d_kqueuefd, 0, 0, d_kevents.data(), s_maxevents, &ts);
+  int ret = kevent(d_kqueuefd, 0, 0, d_kevents.data(), d_kevents.size(), &ts);
 
   if (ret < 0 && errno != EINTR) {
     throw FDMultiplexerException("kqueue returned error: " + stringerror());
@@ -177,7 +174,7 @@ int KqueueFDMultiplexer::run(struct timeval* now, int timeout)
   ts.tv_sec = timeout / 1000;
   ts.tv_nsec = (timeout % 1000) * 1000000;
 
-  int ret = kevent(d_kqueuefd, 0, 0, d_kevents.data(), s_maxevents, &ts);
+  int ret = kevent(d_kqueuefd, 0, 0, d_kevents.data(), d_kevents.size(), &ts);
   gettimeofday(now, nullptr); // MANDATORY!
 
   if (ret < 0 && errno != EINTR) {

--- a/pdns/mplexer.hh
+++ b/pdns/mplexer.hh
@@ -76,7 +76,11 @@ public:
   virtual ~FDMultiplexer()
   {}
 
-  static FDMultiplexer* getMultiplexerSilent();
+  // The maximum number of events processed in a single run, not the maximum of watched descriptors
+  static constexpr unsigned int s_maxevents = 1024;
+  /* The maximum number of events processed in a single run will be capped to the
+     minimum value of maxEventsHint and s_maxevents, to reduce memory usage. */
+  static FDMultiplexer* getMultiplexerSilent(unsigned int maxEventsHint = s_maxevents);
 
   /* tv will be updated to 'now' before run returns */
   /* timeout is in ms */
@@ -206,7 +210,7 @@ public:
     return ret;
   }
 
-  typedef FDMultiplexer* getMultiplexer_t();
+  typedef FDMultiplexer* getMultiplexer_t(unsigned int);
   typedef std::multimap<int, getMultiplexer_t*> FDMultiplexermap_t;
 
   static FDMultiplexermap_t& getMultiplexerMap()

--- a/pdns/pollmplexer.cc
+++ b/pdns/pollmplexer.cc
@@ -9,12 +9,12 @@
 #include "misc.hh"
 #include "namespaces.hh"
 
-FDMultiplexer* FDMultiplexer::getMultiplexerSilent()
+FDMultiplexer* FDMultiplexer::getMultiplexerSilent(unsigned int maxEventsHint)
 {
   FDMultiplexer* ret = nullptr;
   for (const auto& i : FDMultiplexer::getMultiplexerMap()) {
     try {
-      ret = i.second();
+      ret = i.second(std::min(maxEventsHint, FDMultiplexer::s_maxevents));
       return ret;
     }
     catch (const FDMultiplexerException& fe) {
@@ -28,7 +28,7 @@ FDMultiplexer* FDMultiplexer::getMultiplexerSilent()
 class PollFDMultiplexer : public FDMultiplexer
 {
 public:
-  PollFDMultiplexer()
+  PollFDMultiplexer(unsigned int maxEventsHint)
   {}
   ~PollFDMultiplexer()
   {
@@ -50,9 +50,9 @@ private:
   vector<struct pollfd> preparePollFD() const;
 };
 
-static FDMultiplexer* make()
+static FDMultiplexer* make(unsigned int maxEventsHint)
 {
-  return new PollFDMultiplexer();
+  return new PollFDMultiplexer(maxEventsHint);
 }
 
 static struct RegisterOurselves

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -340,7 +340,7 @@ static FDMultiplexer* getMultiplexer()
   FDMultiplexer* ret;
   for (const auto& i : FDMultiplexer::getMultiplexerMap()) {
     try {
-      ret = i.second();
+      ret = i.second(FDMultiplexer::s_maxevents);
       return ret;
     }
     catch (FDMultiplexerException& fe) {

--- a/pdns/test-mplexer.cc
+++ b/pdns/test-mplexer.cc
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(test_getMultiplexerSilent)
 BOOST_AUTO_TEST_CASE(test_MPlexer)
 {
   for (const auto& entry : FDMultiplexer::getMultiplexerMap()) {
-    auto mplexer = std::unique_ptr<FDMultiplexer>(entry.second());
+    auto mplexer = std::unique_ptr<FDMultiplexer>(entry.second(FDMultiplexer::s_maxevents));
     BOOST_REQUIRE(mplexer != nullptr);
     //cerr<<"Testing multiplexer "<<mplexer->getName()<<endl;
 
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(test_MPlexer)
 BOOST_AUTO_TEST_CASE(test_MPlexer_ReadAndWrite)
 {
   for (const auto& entry : FDMultiplexer::getMultiplexerMap()) {
-    auto mplexer = std::unique_ptr<FDMultiplexer>(entry.second());
+    auto mplexer = std::unique_ptr<FDMultiplexer>(entry.second(FDMultiplexer::s_maxevents));
     BOOST_REQUIRE(mplexer != nullptr);
     //cerr<<"Testing multiplexer "<<mplexer->getName()<<" for read AND write"<<endl;
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This allows indicating the maximum number of events we want to process in a single run, which is usually bounded by the number of file descriptors we are planning on watching.
The default is still 1024 events, but this change makes it possible to allocate a smaller vector of events to reduce the memory usage when we know we are going to need to process so many events in a single run.

As usual for code that touches to our multiplexer, I unfortunately do not have the platforms needed to test /dev/poll, kqueue and ports at hand, so I would appreciate any feedback, as well as a good review :)
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
