### PR TITLE
Reject BPFFilter::attachToAllBinds() at configuration time

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -547,6 +547,10 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
 
   luaCtx.registerFunction<void(std::shared_ptr<BPFFilter>::*)()>("attachToAllBinds", [](std::shared_ptr<BPFFilter> bpf) {
       std::string res;
+      if (!g_configurationDone) {
+        throw std::runtime_error("attachToAllBinds() cannot be used at configuration time!");
+        return;
+      }
       if (bpf) {
         for (const auto& frontend : g_frontends) {
           frontend->attachFilter(bpf);

--- a/pdns/dnsdistdist/docs/advanced/ebpf.rst
+++ b/pdns/dnsdistdist/docs/advanced/ebpf.rst
@@ -30,7 +30,9 @@ Contrary to source address filtering, qname filtering only works over UDP. TCP q
 
   addAction(AndRule({TCPRule(true), makeRule("evildomain.com")}), DropAction())
 
-The :meth:`BPFFilter:attachToAllBinds` method attaches the filter to every existing bind at runtime, but it's also possible to define a default BPF filter at configuration time, so it's automatically attached to every bind::
+The :meth:`BPFFilter:attachToAllBinds` method attaches the filter to every existing bind at runtime. It cannot use at configuration time. The :func:`setDefaultBPFFilter()` should be used at configuration time.
+
+The :meth:`BPFFilter:attachToAllBinds` automatically attached to every bind::
 
   bpf = newBPFFilter(1024, 1024, 1024)
   setDefaultBPFFilter(bpf)

--- a/pdns/dnsdistdist/docs/reference/ebpf.rst
+++ b/pdns/dnsdistdist/docs/reference/ebpf.rst
@@ -67,7 +67,7 @@ These are all the functions, objects and methods related to the :doc:`../advance
 
     Attach this filter to every bind already defined.
     This is the run-time equivalent of :func:`setDefaultBPFFilter`.
-    This only can be use at run-time.
+    This method can be used at run-time only.
 
 
   .. method:: BPFFilter:block(address)

--- a/pdns/dnsdistdist/docs/reference/ebpf.rst
+++ b/pdns/dnsdistdist/docs/reference/ebpf.rst
@@ -66,7 +66,9 @@ These are all the functions, objects and methods related to the :doc:`../advance
   .. method:: BPFFilter:attachToAllBinds()
 
     Attach this filter to every bind already defined.
-    This is the run-time equivalent of :func:`setDefaultBPFFilter`
+    This is the run-time equivalent of :func:`setDefaultBPFFilter`.
+    This only can be use at run-time.
+
 
   .. method:: BPFFilter:block(address)
 


### PR DESCRIPTION
Signed-off-by: Y7n05h <Y7n05h@protonmail.com>

### Short description

Allowing the use of `BPFFilter::attachToAllBinds()` at configuration time will result in ambiguous semantics.
In fact, using `BPFFilter::attachToAllBinds()` at configuration may not take effect.
Reject the use of `BPFFilter::attachToAllBinds()` at configuration time will prevent misuse.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
