### PR TITLE
dnsdist: Prevent allocations in two corner cases 

### DIFF
--- a/pdns/dolog.hh
+++ b/pdns/dolog.hh
@@ -93,8 +93,11 @@ void genlog(int level, const char* s, Args... args)
   std::ostringstream str;
   dolog(str, s, args...);
 
-  if(g_syslog)
-    syslog(level, "%s", str.str().c_str());
+  auto output = str.str();
+
+  if (g_syslog) {
+    syslog(level, "%s", output.c_str());
+  }
 
 #ifdef DNSDIST
   if (g_logtimestamps) {
@@ -110,7 +113,7 @@ void genlog(int level, const char* s, Args... args)
   }
 #endif
 
-  std::cout<<str.str()<<std::endl;
+  std::cout<<output<<std::endl;
 }
 
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Avoid a reallocation if the initial allocation of the proxy header is too small to host the remaining content
- When syslog logging is enabled, we do not need to allocate two strings with the same content to log to syslog and stdout

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
