### PR TITLE
rec: Add coverity annotations for a leak false positives

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1803,6 +1803,7 @@ void requestWipeCaches(const DNSName& canon)
 
     unixDie("write to thread pipe returned wrong size or error");
   }
+  // coverity[leaked_storage]
 }
 
 bool expectProxyProtocol(const ComboAddress& from)
@@ -2489,6 +2490,7 @@ void distributeAsyncFunction(const string& packet, const pipefunc_t& func)
       delete tmsg;
     }
   }
+  // coverity[leaked_storage]
 }
 
 // resend event to everybody chained onto it

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1089,6 +1089,7 @@ void broadcastFunction(const pipefunc_t& func)
       delete resp;
       resp = nullptr;
     }
+    // coverity[leaked_storage]
   }
 }
 
@@ -1149,6 +1150,7 @@ T broadcastAccFunction(const std::function<T*()>& func)
       delete resp;
       resp = nullptr;
     }
+    // coverity[leaked_storage]
   }
   return ret;
 }


### PR DESCRIPTION
Writing a pointer though a pipe and freeing it in the pipe reader is not something that Coverity understands.

Writing a model seems much more work, so lets see if these annotation reduce the false positives wrt these leaks.
But even if they don't work as expected, they provide valuable information to a reader of the code IMO.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
