### PR TITLE
rec: responsestats on packet cache hits

### DIFF
--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -40,8 +40,6 @@
 #include "ueberbackend.hh"
 #include "common_startup.hh"
 
-extern ResponseStats g_rs;
-
 static bool s_pleasequit;
 static string d_status;
 
@@ -182,13 +180,13 @@ string DLCCHandler(const vector<string>&parts, Utility::pid_t ppid)
 
 string DLQTypesHandler(const vector<string>&parts, Utility::pid_t ppid)
 {
-  return g_rs.getQTypeReport();
+  return g_responseStats.getQTypeReport();
 }
 
 string DLRSizesHandler(const vector<string>&parts, Utility::pid_t ppid)
 {
   typedef map<uint16_t, uint64_t> respsizes_t;
-  respsizes_t respsizes = g_rs.getSizeResponseCounts();
+  respsizes_t respsizes = g_responseStats.getSizeResponseCounts();
   ostringstream os;
   boost::format fmt("%d\t%d\n");
   for(const respsizes_t::value_type& val :  respsizes) {

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -217,7 +217,7 @@ UDPNameserver::UDPNameserver( bool additional_socket )
 void UDPNameserver::send(DNSPacket& p)
 {
   const string& buffer=p.getString();
-  g_rs.submitResponse(p, true);
+  g_responseStats.submitResponse(p, true);
 
   struct msghdr msgh;
   struct iovec iov;

--- a/pdns/nameserver.hh
+++ b/pdns/nameserver.hh
@@ -95,4 +95,3 @@ private:
 
 bool AddressIsUs(const ComboAddress& remote);
 
-extern ResponseStats g_rs;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1447,7 +1447,7 @@ void startDoResolve(void* p)
       pw.commit();
     }
 
-    g_rs.submitResponse(dc->d_mdp.d_qtype, packet.size(), pw.getHeader()->rcode);
+    g_responseStats.submitResponse(dc->d_mdp.d_qtype, packet.size(), pw.getHeader()->rcode);
     updateResponseStats(res, dc->d_source, packet.size(), &dc->d_mdp.d_qname, dc->d_mdp.d_qtype);
 #ifdef NOD_ENABLED
     bool nod = false;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1447,7 +1447,7 @@ void startDoResolve(void* p)
       pw.commit();
     }
 
-    g_rs.submitResponse(dc->d_mdp.d_qtype, packet.size(), pw.getHeader()->rcode, !dc->d_tcp);
+    g_rs.submitResponse(dc->d_mdp.d_qtype, packet.size(), pw.getHeader()->rcode);
     updateResponseStats(res, dc->d_source, packet.size(), &dc->d_mdp.d_qname, dc->d_mdp.d_qtype);
 #ifdef NOD_ENABLED
     bool nod = false;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1771,6 +1771,7 @@ bool checkForCacheHit(bool qnameParsed, unsigned int tag, const string& data,
     if (response.length() >= sizeof(struct dnsheader)) {
       const struct dnsheader* dh = reinterpret_cast<const dnsheader*>(response.data());
       updateResponseStats(dh->rcode, source, response.length(), 0, 0);
+      g_responseStats.submitResponse(qtype, response.length(), dh->rcode);
     }
     g_stats.avgLatencyUsec = (1.0 - 1.0 / g_latencyStatSize) * g_stats.avgLatencyUsec + 0.0; // we assume 0 usec
     g_stats.avgLatencyOursUsec = (1.0 - 1.0 / g_latencyStatSize) * g_stats.avgLatencyOursUsec + 0.0; // we assume 0 usec

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -2134,7 +2134,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
     return {0, setMinimumTTL(begin, end)};
   }
   if (cmd == "get-qtypelist") {
-    return {0, g_rs.getQTypeReport()};
+    return {0, g_responseStats.getQTypeReport()};
   }
   if (cmd == "add-nta") {
     return {0, doAddNTA(begin, end)};

--- a/pdns/responsestats-auth.cc
+++ b/pdns/responsestats-auth.cc
@@ -63,5 +63,5 @@ void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP, bool last) const
     }
   }
 
-  submitResponse(p.qtype.getCode(), buf.length(), p.d.rcode, udpOrTCP);
+  submitResponse(p.qtype.getCode(), buf.length(), p.d.rcode);
 }

--- a/pdns/responsestats.cc
+++ b/pdns/responsestats.cc
@@ -5,7 +5,6 @@
 #include "responsestats.hh"
 
 #include <limits>
-#include <boost/format.hpp>
 
 #include "namespaces.hh"
 #include "logger.hh"
@@ -40,18 +39,6 @@ ResponseStats::ResponseStats() :
 }
 
 ResponseStats g_rs;
-
-void ResponseStats::submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rcode, bool udpOrTCP) const
-{
-  d_rcodecounters.at(rcode).value++;
-  submitResponse(qtype, respsize, udpOrTCP);
-}
-
-void ResponseStats::submitResponse(uint16_t qtype, uint16_t respsize, bool udpOrTCP) const
-{
-  d_qtypecounters.at(qtype).value++;
-  d_sizecounters(respsize);
-}
 
 map<uint16_t, uint64_t> ResponseStats::getQTypeResponseCounts() const
 {
@@ -94,9 +81,8 @@ string ResponseStats::getQTypeReport() const
 {
   auto qtypenums = getQTypeResponseCounts();
   ostringstream os;
-  boost::format fmt("%s\t%d\n");
   for (const auto& val : qtypenums) {
-    os << (fmt % DNSRecordContent::NumberToType(val.first) % val.second).str();
+    os << DNSRecordContent::NumberToType(val.first) << '\t' << std::to_string(val.second) << endl;
   }
   return os.str();
 }

--- a/pdns/responsestats.cc
+++ b/pdns/responsestats.cc
@@ -38,7 +38,7 @@ ResponseStats::ResponseStats() :
   }
 }
 
-ResponseStats g_rs;
+ResponseStats g_responseStats;
 
 map<uint16_t, uint64_t> ResponseStats::getQTypeResponseCounts() const
 {

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -32,19 +32,14 @@ class ResponseStats
 public:
   ResponseStats();
 
-  void submitResponse(uint16_t qtype, uint16_t respsize) const
+  void submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rcode) const
   {
+    d_rcodecounters.at(rcode).value++;
     d_qtypecounters.at(qtype).value++;
     d_sizecounters(respsize);
   }
 
-  void submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rcode) const
-  {
-    d_rcodecounters.at(rcode).value++;
-    submitResponse(qtype, respsize);
-  }
-
-  void submitResponse(DNSPacket& p, bool udpOrTCP, bool last = true) const; // only implemneted by auth
+  void submitResponse(DNSPacket& p, bool udpOrTCP, bool last = true) const; // only implemented by auth
   map<uint16_t, uint64_t> getQTypeResponseCounts() const;
   map<uint16_t, uint64_t> getSizeResponseCounts() const;
   map<uint8_t, uint64_t> getRCodeResponseCounts() const;

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -32,9 +32,19 @@ class ResponseStats
 public:
   ResponseStats();
 
-  void submitResponse(DNSPacket& p, bool udpOrTCP, bool last = true) const;
-  void submitResponse(uint16_t qtype, uint16_t respsize, bool udpOrTCP) const;
-  void submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rcode, bool udpOrTCP) const;
+  void submitResponse(uint16_t qtype, uint16_t respsize) const
+  {
+    d_qtypecounters.at(qtype).value++;
+    d_sizecounters(respsize);
+  }
+
+  void submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rcode) const
+  {
+    d_rcodecounters.at(rcode).value++;
+    submitResponse(qtype, respsize);
+  }
+
+  void submitResponse(DNSPacket& p, bool udpOrTCP, bool last = true) const; // only implemneted by auth
   map<uint16_t, uint64_t> getQTypeResponseCounts() const;
   map<uint16_t, uint64_t> getSizeResponseCounts() const;
   map<uint8_t, uint64_t> getRCodeResponseCounts() const;

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -61,4 +61,4 @@ private:
   pdns::AtomicHistogram d_sizecounters;
 };
 
-extern ResponseStats g_rs;
+extern ResponseStats g_responseStats;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -171,7 +171,7 @@ static void writenWithTimeout(int fd, const void *buffer, unsigned int n, unsign
 
 void TCPNameserver::sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last)
 {
-  g_rs.submitResponse(*p, false, last);
+  g_responseStats.submitResponse(*p, false, last);
 
   uint16_t len=htons(p->getString().length());
   string buffer((const char*)&len, 2);

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -45,7 +45,6 @@
 using json11::Json;
 
 extern string s_programname;
-extern ResponseStats g_rs;
 #ifndef RECURSOR
 extern StatBag S;
 #endif
@@ -208,9 +207,9 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp) {
     });
   }
 
-  auto resp_qtype_stats = g_rs.getQTypeResponseCounts();
-  auto resp_size_stats = g_rs.getSizeResponseCounts();
-  auto resp_rcode_stats = g_rs.getRCodeResponseCounts();
+  auto resp_qtype_stats = g_responseStats.getQTypeResponseCounts();
+  auto resp_size_stats = g_responseStats.getSizeResponseCounts();
+  auto resp_rcode_stats = g_responseStats.getRCodeResponseCounts();
   {
     Json::array values;
     for(const auto& item : resp_qtype_stats) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This fixes #11534 

This has to be evaluated for performance impact. If the impact is relatively high, we could change the size
histogram to be raw counts (like qtype) and do the transformation to buckets on reading the data. This would avoid the finding of the right bucket in the histogram code for each packet processed (although the implementation does use a binary search, so it should be quick)

If the performance hit is still too high after that, we should  at least document that packet count hits are not accounted in the response histograms.

If we do merge this, we should make it very clear (both in upgrade guide and other docs) the semantics have changed. Also, we should probably add these stats to `/metrics` in a Prometheus friendly way (as Prometheus histograms).

Note this also impacts auth, but only in a minor way.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
