### PR TITLE
dnsdist: Add a 'getAddressAndPort()' method to DOHFrontend and TLSFrontend objects

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2544,6 +2544,13 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
+  luaCtx.registerFunction<std::string (std::shared_ptr<DOHFrontend>::*)()const>("getAddressAndPort", [](const std::shared_ptr<DOHFrontend>& frontend) {
+    if (frontend == nullptr) {
+      return std::string();
+    }
+    return frontend->d_local.toStringWithPort();
+  });
+
   luaCtx.writeFunction("addTLSLocal", [client](const std::string& addr, boost::variant<std::string, std::shared_ptr<TLSCertKeyPair>, LuaArray<std::string>, LuaArray<std::shared_ptr<TLSCertKeyPair>>> certFiles, LuaTypeOrArrayOf<std::string> keyFiles, boost::optional<localbind_t> vars) {
     if (client) {
       return;
@@ -2700,6 +2707,13 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     if (ctx != nullptr) {
       ctx->loadTicketsKeys(file);
     }
+  });
+
+  luaCtx.registerFunction<std::string (std::shared_ptr<TLSFrontend>::*)()const>("getAddressAndPort", [](const std::shared_ptr<TLSFrontend>& frontend) {
+    if (frontend == nullptr) {
+      return std::string();
+    }
+    return frontend->d_addr.toStringWithPort();
   });
 
   luaCtx.registerFunction<void (std::shared_ptr<TLSFrontend>::*)()>("rotateTicketsKey", [](std::shared_ptr<TLSFrontend>& frontend) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2544,7 +2544,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
-  luaCtx.registerFunction<std::string (std::shared_ptr<DOHFrontend>::*)()const>("getAddressAndPort", [](const std::shared_ptr<DOHFrontend>& frontend) {
+  luaCtx.registerFunction<std::string (std::shared_ptr<DOHFrontend>::*)() const>("getAddressAndPort", [](const std::shared_ptr<DOHFrontend>& frontend) {
     if (frontend == nullptr) {
       return std::string();
     }
@@ -2709,7 +2709,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
-  luaCtx.registerFunction<std::string (std::shared_ptr<TLSFrontend>::*)()const>("getAddressAndPort", [](const std::shared_ptr<TLSFrontend>& frontend) {
+  luaCtx.registerFunction<std::string (std::shared_ptr<TLSFrontend>::*)() const>("getAddressAndPort", [](const std::shared_ptr<TLSFrontend>& frontend) {
     if (frontend == nullptr) {
       return std::string();
     }

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1720,6 +1720,12 @@ DOHFrontend
 
   This object represents an address and port dnsdist is listening on for DNS over HTTPS queries.
 
+  .. method:: DOHFrontend:getAddressAndPort() -> string
+
+     .. versionadded:: 1.7.1
+
+     Return the address and port this frontend is listening on.
+
   .. method:: DOHFrontend:loadNewCertificatesAndKeys(certFile(s), keyFile(s))
 
      .. versionadded:: 1.6.1
@@ -1788,6 +1794,12 @@ TLSFrontend
 .. class:: TLSFrontend
 
   This object represents the configuration of a listening frontend for DNS over TLS queries. To each frontend is associated a TLSContext.
+
+  .. method:: TLSFrontend:getAddressAndPort() -> string
+
+     .. versionadded:: 1.7.1
+
+     Return the address and port this frontend is listening on.
 
   .. method:: TLSFrontend:loadNewCertificatesAndKeys(certFile(s), keyFile(s))
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Closes #11434

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
