### PR TITLE
dnsdist: Raise RLIMIT_MEMLOCK automatically when eBPF is requested

### DIFF
--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -22,7 +22,7 @@ StartLimitInterval=0
 TasksMax=8192
 LimitNOFILE=16384
 # Note: increasing the amount of lockable memory is required to use eBPF support
-# LimitMEMLOCK=infinity
+LimitMEMLOCK=infinity
 
 # Sandboxing
 # Note: adding CAP_SYS_ADMIN (or CAP_BPF for Linux >= 5.8) is required to use eBPF support,

--- a/pdns/dnsdistdist/docs/advanced/ebpf.rst
+++ b/pdns/dnsdistdist/docs/advanced/ebpf.rst
@@ -73,3 +73,6 @@ Since 1.6.0, the default BPF filter set via :func:`setDefaultBPFFilter` will aut
 That feature might require an increase of the memory limit associated to a socket, via the sysctl setting ``net.core.optmem_max``.
 When attaching an eBPF program to a socket, the size of the program is checked against this limit, and the default value might not be enough.
 Large map sizes might also require an increase of ``RLIMIT_MEMLOCK``, which can be done by adding ``LimitMEMLOCK=infinity`` in the systemd unit file.
+
+To change the default hard limit on ``RLIMIT_MEMLOCK`` add the following line to ``/etc/security/limits.conf`` for the user
+  > $USER   hard    memlock   1073741824


### PR DESCRIPTION
### Short Description:
Raise RLIMIT_MEMLOCK automatically when eBPF is requested.

This PR adds changes to eBPF filter constructor which when invoked automatically raises the RLIMIT_MEMLOCK from 64k to 1024k.
The hard limit for the user needs to be set in `/etc/security/limits.conf`.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
