### PR TITLE
Try harder to find libdecaf headers

### DIFF
--- a/m4/pdns_with_libdecaf.m4
+++ b/m4/pdns_with_libdecaf.m4
@@ -19,5 +19,40 @@ AC_DEFUN([PDNS_WITH_LIBDECAF],[
         AC_MSG_ERROR([Could not find libdecaf])
     ])
     LIBS="$save_LIBS"
+
+    AS_IF([test "x$LIBDECAF_CFLAGS" = "x"],[
+      AC_MSG_CHECKING([for libdecaf headers])
+      libdecaf_header_dir=""
+
+      header_dirs="/usr /usr/local"
+      for header_dir in $header_dirs; do
+        if test -f "$header_dir/include/decaf.hxx"; then
+          libdecaf_header_dir="$header_dir/include"
+          break
+        fi
+
+        if test -f "$header_dir/include/decaf/decaf.hxx"; then
+          libdecaf_header_dir="$header_dir/include/decaf"
+          break
+        fi
+      done
+
+      AS_IF([test "x$libdecaf_header_dir" != "x"],[
+          AC_MSG_RESULT([$libdecaf_header_dir])
+          LIBDECAF_CFLAGS="-I$libdecaf_header_dir"
+        ],
+        [AC_MSG_RESULT([not found])])
+    ])
+
+    AC_SUBST([LIBDECAF_CFLAGS])
+
+    save_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $LIBDECAF_CFLAGS"
+    AC_CHECK_HEADERS(
+      [decaf.hxx],
+      [],
+      [AC_MSG_ERROR([cannot find libdecaf headers])]
+    )
+    CXXFLAGS="$save_CXXFLAGS"
   ])
 ])

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -942,8 +942,8 @@ speedtest_SOURCES = \
 	speedtest.cc \
 	statbag.cc \
 	svc-records.cc svc-records.hh \
-        unix_utility.cc \
-        uuid-utils.cc
+	unix_utility.cc \
+	uuid-utils.cc
 
 speedtest_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
 speedtest_LDADD = $(LIBCRYPTO_LIBS) \
@@ -964,8 +964,8 @@ dnswasher_SOURCES = \
 	statbag.cc \
 	unix_utility.cc
 
-dnswasher_LDFLAGS = 	$(AM_LDFLAGS) $(BOOST_PROGRAM_OPTIONS_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
-dnswasher_LDADD = 	$(BOOST_PROGRAM_OPTIONS_LIBS) $(LIBCRYPTO_LIBS) $(IPCRYPT_LIBS)
+dnswasher_LDFLAGS =	$(AM_LDFLAGS) $(BOOST_PROGRAM_OPTIONS_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
+dnswasher_LDADD =	$(BOOST_PROGRAM_OPTIONS_LIBS) $(LIBCRYPTO_LIBS) $(IPCRYPT_LIBS)
 
 dnsbulktest_SOURCES = \
 	arguments.cc arguments.hh \
@@ -1421,7 +1421,7 @@ testrunner_SOURCES = \
 testrunner_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	$(LIBCRYPTO_LDFLAGS) \
-	$(BOOST_UNIT_TEST_FRAMEWORK_LDFLAGS) 
+	$(BOOST_UNIT_TEST_FRAMEWORK_LDFLAGS)
 
 testrunner_LDADD = \
 	$(LIBCRYPTO_LIBS) \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -39,6 +39,10 @@ if LIBSODIUM
 AM_CPPFLAGS +=$(LIBSODIUM_CFLAGS)
 endif
 
+if LIBDECAF
+AM_CPPFLAGS += $(LIBDECAF_CFLAGS)
+endif
+
 EXTRA_DIST = \
 	dnslabeltext.rl \
 	dnslabeltext.cc \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -315,7 +315,7 @@ testrunner_SOURCES = \
 dnsdist_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	$(PROGRAM_LDFLAGS) \
-	-pthread 
+	-pthread
 
 dnsdist_LDADD = \
 	$(LUA_LIBS) \
@@ -414,11 +414,11 @@ endif
 
 if HAVE_SOLARIS
 dnsdist_SOURCES += \
-        devpollmplexer.cc \
-        portsmplexer.cc
+	devpollmplexer.cc \
+	portsmplexer.cc
 testrunner_SOURCES += \
-        devpollmplexer.cc \
-        portsmplexer.cc
+	devpollmplexer.cc \
+	portsmplexer.cc
 endif
 
 MANPAGES=dnsdist.1

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -166,8 +166,8 @@ pdns_recursor_SOURCES = \
 	rec-snmp.hh rec-snmp.cc \
 	rec-taskqueue.cc rec-taskqueue.hh \
 	rec-tcp.cc \
-        rec-tcpout.cc rec-tcpout.hh \
-        rec-zonetocache.cc rec-zonetocache.hh \
+	rec-tcpout.cc rec-tcpout.hh \
+	rec-zonetocache.cc rec-zonetocache.hh \
 	rec_channel.cc rec_channel.hh rec_metrics.hh \
 	rec_channel_rec.cc \
 	recpacketcache.cc recpacketcache.hh \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -3,6 +3,10 @@ PROBDS_LIBS = $(top_srcdir)/ext/probds/libprobds.la
 
 AM_CPPFLAGS = $(LUA_CFLAGS) $(YAHTTP_CFLAGS) $(BOOST_CPPFLAGS) $(LIBSODIUM_CFLAGS) $(NET_SNMP_CFLAGS) $(LIBCAP_CFLAGS) $(SANITIZER_FLAGS) -O3 -Wall -pthread -DSYSCONFDIR=\"${sysconfdir}\" $(SYSTEMD_CFLAGS)
 
+if LIBDECAF
+AM_CPPFLAGS += $(LIBDECAF_CFLAGS)
+endif
+
 AM_CPPFLAGS += \
 	-I$(top_srcdir)/ext/json11 \
 	-I$(top_srcdir)/ext/protozero/include \

--- a/tasks.py
+++ b/tasks.py
@@ -258,7 +258,6 @@ def ci_auth_configure(c):
                    ./configure \
                       CC='clang-12' \
                       CXX='clang++-12' \
-                      CPPFLAGS='-I/usr/local/include/decaf' \
                       LDFLAGS='-L/usr/local/lib -Wl,-rpath,/usr/local/lib' \
                       --enable-option-checking=fatal \
                       --with-modules='bind geoip gmysql godbc gpgsql gsqlite3 ldap lmdb lua2 pipe remote tinydns' \


### PR DESCRIPTION
### Short description
This adds a few things:
- Passing a user-defined header location through LIBDECAF_CFLAGS=-I...
- Otherwise, check the following directories for decaf.hxx:
  - /usr/include
  - /usr/include/decaf
  - Add whichever one is picked to LIBDECAF_CFLAGS
- Then AC_CHECK_HEADER decaf.hxx using CXXFLAGS with LIBDECAF_CFLAGS

The reason for this change is that some package systems have decaf.hxx under /usr/include and others have it under /usr/include/decaf.

### Checklist

I have:

- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)