### PR TITLE
circleci: revert docs build to specific debian image, instead of the debian:testing underlying the texlive image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -759,7 +759,7 @@ jobs:
     resource_class: small
 
     docker:
-      - image: texlive/texlive
+      - image: debian:bullseye
         auth:
           username: powerdnsreadonly
           password: $DOCKERHUB_PASSWORD
@@ -772,7 +772,7 @@ jobs:
     resource_class: small
 
     docker:
-      - image: texlive/texlive
+      - image: debian:bullseye
         auth:
           username: powerdnsreadonly
           password: $DOCKERHUB_PASSWORD
@@ -787,7 +787,7 @@ jobs:
     resource_class: small
 
     docker:
-      - image: texlive/texlive
+      - image: debian:bullseye
         auth:
           username: powerdnsreadonly
           password: $DOCKERHUB_PASSWORD
@@ -800,7 +800,7 @@ jobs:
     resource_class: small
 
     docker:
-      - image: texlive/texlive
+      - image: debian:bullseye
         auth:
           username: powerdnsreadonly
           password: $DOCKERHUB_PASSWORD
@@ -815,7 +815,7 @@ jobs:
     resource_class: small
 
     docker:
-      - image: texlive/texlive
+      - image: debian:bullseye
         auth:
           username: powerdnsreadonly
           password: $DOCKERHUB_PASSWORD
@@ -828,7 +828,7 @@ jobs:
     resource_class: small
 
     docker:
-      - image: texlive/texlive
+      - image: debian:bullseye
         auth:
           username: powerdnsreadonly
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
### Short description
This should unbreak docs building in CircleCI.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master