### PR TITLE
dnsdist: Scan the UDP buckets only when we have outstanding queries

### DIFF
--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -357,16 +357,18 @@ void DownstreamState::handleTimeouts()
     }
   }
   else {
-    for (IDState& ids : idStates) {
-      int64_t usageIndicator = ids.usageIndicator;
-      if (IDState::isInUse(usageIndicator) && isIDSExpired(ids)) {
-        if (!ids.tryMarkUnused(usageIndicator)) {
-          /* this state has been altered in the meantime,
-             don't go anywhere near it */
-          continue;
-        }
+    if (outstanding.load() > 0) {
+      for (IDState& ids : idStates) {
+        int64_t usageIndicator = ids.usageIndicator;
+        if (IDState::isInUse(usageIndicator) && isIDSExpired(ids)) {
+          if (!ids.tryMarkUnused(usageIndicator)) {
+            /* this state has been altered in the meantime,
+               don't go anywhere near it */
+            continue;
+          }
 
-        handleTimeout(ids);
+          handleTimeout(ids);
+        }
       }
     }
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
As suggested by @hhoffstaette in #11576, this should significantly reduce the load on dnsdist setups that are mostly idle.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
