### PR TITLE
Refactor signers tests

### DIFF
--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -421,7 +421,7 @@ bool DecafED448DNSCryptoKeyEngine::verify(const std::string& msg, const std::str
 
 namespace
 {
-struct LoaderDecafStruct
+const struct LoaderDecafStruct
 {
   LoaderDecafStruct()
   {

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -6,6 +6,7 @@
 #include <decaf.hxx>
 #include <decaf/eddsa.hxx>
 #include <decaf/spongerng.hxx>
+#include "dnsseckeeper.hh"
 
 #include "dnssecinfra.hh"
 
@@ -425,8 +426,8 @@ const struct LoaderDecafStruct
 {
   LoaderDecafStruct()
   {
-    DNSCryptoKeyEngine::report(15, &DecafED25519DNSCryptoKeyEngine::maker, true);
-    DNSCryptoKeyEngine::report(16, &DecafED448DNSCryptoKeyEngine::maker);
+    DNSCryptoKeyEngine::report(DNSSECKeeper::ED25519, &DecafED25519DNSCryptoKeyEngine::maker, true);
+    DNSCryptoKeyEngine::report(DNSSECKeeper::ED448, &DecafED448DNSCryptoKeyEngine::maker);
   }
 } loaderdecaf;
 }

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -225,7 +225,7 @@ vector<pair<uint8_t, string>> DNSCryptoKeyEngine::listAllAlgosWithBackend()
 void DNSCryptoKeyEngine::report(unsigned int algo, maker_t* maker, bool fallback)
 {
   getAllMakers()[algo].push_back(maker);
-  if (getMakers().count(algo) && fallback) {
+  if (getMakers().count(algo) != 0 && fallback) {
     return;
   }
   getMakers()[algo] = maker;

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -225,10 +225,10 @@ vector<pair<uint8_t, string>> DNSCryptoKeyEngine::listAllAlgosWithBackend()
 void DNSCryptoKeyEngine::report(unsigned int algo, maker_t* maker, bool fallback)
 {
   getAllMakers()[algo].push_back(maker);
-  if(getMakers().count(algo) && fallback) {
+  if (getMakers().count(algo) && fallback) {
     return;
   }
-  getMakers()[algo]=maker;
+  getMakers()[algo] = maker;
 }
 
 bool DNSCryptoKeyEngine::testAll()

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -1178,19 +1178,19 @@ namespace {
   {
     LoaderStruct()
     {
-      DNSCryptoKeyEngine::report(5, &OpenSSLRSADNSCryptoKeyEngine::maker);
-      DNSCryptoKeyEngine::report(7, &OpenSSLRSADNSCryptoKeyEngine::maker);
-      DNSCryptoKeyEngine::report(8, &OpenSSLRSADNSCryptoKeyEngine::maker);
-      DNSCryptoKeyEngine::report(10, &OpenSSLRSADNSCryptoKeyEngine::maker);
+      DNSCryptoKeyEngine::report(DNSSECKeeper::RSASHA1, &OpenSSLRSADNSCryptoKeyEngine::maker);
+      DNSCryptoKeyEngine::report(DNSSECKeeper::RSASHA1NSEC3SHA1, &OpenSSLRSADNSCryptoKeyEngine::maker);
+      DNSCryptoKeyEngine::report(DNSSECKeeper::RSASHA256, &OpenSSLRSADNSCryptoKeyEngine::maker);
+      DNSCryptoKeyEngine::report(DNSSECKeeper::RSASHA512, &OpenSSLRSADNSCryptoKeyEngine::maker);
 #ifdef HAVE_LIBCRYPTO_ECDSA
-      DNSCryptoKeyEngine::report(13, &OpenSSLECDSADNSCryptoKeyEngine::maker);
-      DNSCryptoKeyEngine::report(14, &OpenSSLECDSADNSCryptoKeyEngine::maker);
+      DNSCryptoKeyEngine::report(DNSSECKeeper::ECDSA256, &OpenSSLECDSADNSCryptoKeyEngine::maker);
+      DNSCryptoKeyEngine::report(DNSSECKeeper::ECDSA384, &OpenSSLECDSADNSCryptoKeyEngine::maker);
 #endif
 #ifdef HAVE_LIBCRYPTO_ED25519
-      DNSCryptoKeyEngine::report(15, &OpenSSLEDDSADNSCryptoKeyEngine::maker);
+      DNSCryptoKeyEngine::report(DNSSECKeeper::ED25519, &OpenSSLEDDSADNSCryptoKeyEngine::maker);
 #endif
 #ifdef HAVE_LIBCRYPTO_ED448
-      DNSCryptoKeyEngine::report(16, &OpenSSLEDDSADNSCryptoKeyEngine::maker);
+      DNSCryptoKeyEngine::report(DNSSECKeeper::ED448, &OpenSSLEDDSADNSCryptoKeyEngine::maker);
 #endif
     }
   } loaderOpenSSL;

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -1174,7 +1174,7 @@ void OpenSSLEDDSADNSCryptoKeyEngine::fromPublicKeyString(const std::string& cont
 #endif // HAVE_LIBCRYPTO_EDDSA
 
 namespace {
-  struct LoaderStruct
+  const struct LoaderStruct
   {
     LoaderStruct()
     {

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -7,6 +7,7 @@ extern "C" {
 #include <sodium.h>
 }
 #include "dnssecinfra.hh"
+#include "dnsseckeeper.hh"
 
 class SodiumED25519DNSCryptoKeyEngine : public DNSCryptoKeyEngine
 {
@@ -204,7 +205,7 @@ const struct LoaderSodiumStruct
 {
   LoaderSodiumStruct()
   {
-    DNSCryptoKeyEngine::report(15, &SodiumED25519DNSCryptoKeyEngine::maker);
+    DNSCryptoKeyEngine::report(DNSSECKeeper::ED25519, &SodiumED25519DNSCryptoKeyEngine::maker);
   }
 } loadersodium;
 }

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -200,7 +200,7 @@ bool SodiumED25519DNSCryptoKeyEngine::verify(const std::string& msg, const std::
 }
 
 namespace {
-struct LoaderSodiumStruct
+const struct LoaderSodiumStruct
 {
   LoaderSodiumStruct()
   {

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -167,8 +167,8 @@ static const SignerParams ed25519 = SignerParams{
 
   .name = "ed25519.",
 
-  // vector extracted from https://gitlab.labs.nic.cz/labs/ietf/blob/master/dnskey.py
-  // (rev 476d6ded) by printing signature_data
+  // vector extracted from https://gitlab.labs.nic.cz/labs/ietf/blob/master/dnskey.py (rev
+  // 476d6ded) by printing signature_data
   .rfcMsgDump = "00 0f 0f 02 00 00 0e 10 55 d4 fc 60 55 b9 4c e0 0e 1d 07 65 78 "
                 "61 6d 70 6c 65 03 63 6f 6d 00 07 65 78 61 6d 70 6c 65 03 63 6f "
                 "6d 00 00 0f 00 01 00 00 0e 10 00 14 00 0a 04 6d 61 69 6c 07 65 "
@@ -188,6 +188,64 @@ static const SignerParams ed25519 = SignerParams{
 
   .pem = "-----BEGIN PRIVATE KEY-----\n"
          "MC4CAQAwBQYDK2VwBCIEIDgyMjYwMzg0NjI4MDgwMTIyNjQ1MTkwMjA0MTQyMjYy\n"
+         "-----END PRIVATE KEY-----\n"};
+
+/* Ed448.
+ */
+static const SignerParams ed448 = SignerParams{
+  .iscMap = "Private-key-format: v1.2\n"
+            "Algorithm: 16 (ED448)\n"
+            "PrivateKey: xZ+5Cgm463xugtkY5B0Jx6erFTXp13rYegst0qRtNsOYnaVpMx0Z/c5EiA9x8wWbDDct/U3FhYWA\n",
+
+  .dsSHA1 = "9712 16 1 2873e800eb2d784cdd1802f884b3c540b573eaa0",
+
+  .dsSHA256 = "9712 16 2 9aa27306f8a04a0a6fae8affd65d6f35875dcb134c05bd7c7b61bd0dc44009cd",
+
+  .dsSHA384 = "9712 16 4 3876e5d892d3f31725f9964a332f9b9afd791171833480f2e71af78efb985cde9900ba95315287123a5908ca8f334369",
+
+  // clang-format off
+  .signature = {
+    0xb5, 0xcc, 0x21, 0x5a, 0x52, 0x21, 0x60, 0xa3, 0xb8, 0xd9, 0x3a, 0xd7, 0x05,
+    0xdd, 0x4a, 0x32, 0x96, 0xce, 0x08, 0xde, 0x74, 0x5f, 0xdb, 0xde, 0x54, 0x95,
+    0x97, 0x93, 0x6f, 0x3a, 0x4a, 0x34, 0x41, 0x14, 0xba, 0x99, 0x86, 0x0d, 0xe2,
+    0x99, 0xf1, 0x14, 0x6a, 0x1b, 0x7a, 0xfa, 0xef, 0xab, 0x62, 0xd2, 0x71, 0x85,
+    0xae, 0xd1, 0x84, 0x80, 0x00, 0x50, 0x03, 0x9e, 0x73, 0x53, 0xe8, 0x9e, 0x19,
+    0xb8, 0xc0, 0xdb, 0xd4, 0xf0, 0x1e, 0x44, 0x4c, 0xb7, 0x32, 0x07, 0xda, 0x0b,
+    0x64, 0x22, 0xa8, 0x63, 0xaa, 0x7a, 0x12, 0x73, 0xc9, 0x29, 0xfd, 0x50, 0x85,
+    0x0f, 0x43, 0x72, 0x77, 0x86, 0xec, 0x88, 0x1a, 0x96, 0x95, 0x4a, 0x01, 0xfe,
+    0xf2, 0xe6, 0x77, 0x4a, 0x2e, 0x43, 0xdd, 0x60, 0x29, 0x00,
+  },
+  // clang-format on
+
+  .zoneRepresentation = "256 3 16 "
+                        "3kgROaDjrh0H2iuixWBrc8g2EpBBLCdGzHmn+"
+                        "G2MpTPhpj/OiBVHHSfPodx1FYYUcJKm1MDpJtIA",
+
+  .name = "ed448.",
+
+  // vector extracted from https://gitlab.labs.nic.cz/labs/ietf/blob/master/dnskey.py (rev
+  // 476d6ded) by printing signature_data
+  .rfcMsgDump = "00 0f 10 02 00 00 0e 10 55 d4 fc 60 55 b9 4c e0 25 f1 07 65 78 "
+                "61 6d 70 6c 65 03 63 6f 6d 00 07 65 78 61 6d 70 6c 65 03 63 6f "
+                "6d 00 00 0f 00 01 00 00 0e 10 00 14 00 0a 04 6d 61 69 6c 07 65 "
+                "78 61 6d 70 6c 65 03 63 6f 6d 00 ",
+
+  // vector verified from dnskey.py as above, and confirmed with
+  // https://www.rfc-editor.org/errata_search.php?rfc=8080&eid=4935
+  .rfcB64Signature = "3cPAHkmlnxcDHMyg7vFC34l0blBhuG1qpwLmjInI8w1CMB29FkEA"
+                     "IJUA0amxWndkmnBZ6SKiwZSAxGILn/NBtOXft0+Gj7FSvOKxE/07"
+                     "+4RQvE581N3Aj/JtIyaiYVdnYtyMWbSNyGEY2213WKsJlwEA",
+
+  .bits = 456,
+  .flags = 256,
+  .rfcFlags = 257,
+
+  .algorithm = DNSSECKeeper::ED448,
+  .isDeterministic = true,
+
+  .pem = "-----BEGIN PRIVATE KEY-----\n"
+         "MEcCAQAwBQYDK2VxBDsEOcWfuQoJuOt8boLZGOQdCcenqxU16dd62HoLLdKkbTbD\n"
+         "mJ2laTMdGf3ORIgPcfMFmww3Lf1NxYWFgA==\n"
          "-----END PRIVATE KEY-----\n"};
 
 struct Fixture
@@ -210,6 +268,10 @@ struct Fixture
 
     #if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED25519)
     addSignerParams(DNSSECKeeper::ED25519, "ED25519", ed25519);
+    #endif
+
+    #if defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED448)
+    addSignerParams(DNSSECKeeper::ED448, "ED448", ed448);
     #endif
   }
 
@@ -372,49 +434,6 @@ BOOST_FIXTURE_TEST_CASE(test_generic_signers, Fixture)
     }
   }
 }
-
-#if defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED448)
-BOOST_AUTO_TEST_CASE(test_ed448_signer) {
-    sortedRecords_t rrs;
-    DNSName qname("example.com.");
-    DNSKEYRecordContent drc;
-
-    // TODO: make this a collection of inputs and resulting sigs for various algos
-    shared_ptr<DNSCryptoKeyEngine> engine = DNSCryptoKeyEngine::makeFromISCString(drc,
-"Private-key-format: v1.2\n"
-"Algorithm: 16 (ED448)\n"
-"PrivateKey: xZ+5Cgm463xugtkY5B0Jx6erFTXp13rYegst0qRtNsOYnaVpMx0Z/c5EiA9x8wWbDDct/U3FhYWA\n");
-
-    DNSSECPrivateKey dpk;
-    dpk.setKey(engine);
-
-    reportBasicTypes();
-
-    rrs.insert(DNSRecordContent::mastermake(QType::MX, 1, "10 mail.example.com."));
-
-    RRSIGRecordContent rrc;
-    rrc.d_originalttl = 3600;
-    rrc.d_sigexpire = 1440021600;
-    rrc.d_siginception = 1438207200;
-    rrc.d_signer = qname;
-    rrc.d_type = QType::MX;
-    rrc.d_labels = 2;
-    // TODO: derive the next two from the key
-    rrc.d_tag = 9713;
-    rrc.d_algorithm = 16;
-
-    string msg = getMessageForRRSET(qname, rrc, rrs, false);
-
-    // vector extracted from https://gitlab.labs.nic.cz/labs/ietf/blob/master/dnskey.py (rev 476d6ded) by printing signature_data
-    BOOST_CHECK_EQUAL(makeHexDump(msg), "00 0f 10 02 00 00 0e 10 55 d4 fc 60 55 b9 4c e0 25 f1 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 00 0f 00 01 00 00 0e 10 00 14 00 0a 04 6d 61 69 6c 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ");
-
-    string signature = engine->sign(msg);
-    string b64 = Base64Encode(signature);
-
-    // vector verified from dnskey.py as above, and confirmed with https://www.rfc-editor.org/errata_search.php?rfc=8080&eid=4935
-    BOOST_CHECK_EQUAL(b64, "3cPAHkmlnxcDHMyg7vFC34l0blBhuG1qpwLmjInI8w1CMB29FkEAIJUA0amxWndkmnBZ6SKiwZSAxGILn/NBtOXft0+Gj7FSvOKxE/07+4RQvE581N3Aj/JtIyaiYVdnYtyMWbSNyGEY2213WKsJlwEA");
-}
-#endif /* defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED448) */
 
 BOOST_AUTO_TEST_CASE(test_hash_qname_with_salt) {
   {

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -16,8 +16,6 @@
 
 BOOST_AUTO_TEST_SUITE(test_signers)
 
-static const std::string message = "Very good, young padawan.";
-
 struct SignerParams
 {
   std::string iscMap;
@@ -37,127 +35,151 @@ struct SignerParams
   std::optional<std::string> pem;
 };
 
-static const std::array<struct SignerParams, 3> signers
+static const SignerParams rsaSha256SignerParams = SignerParams{
+  "Algorithm: 8\n"
+  "Modulus: qtunSiHnYq4XRLBehKAw1Glxb+48oIpAC7w3Jhpj570bb2uHt6orWGqnuyRtK8oqUi2ABoV0PFm8+IPgDMEdCQ==\n"
+  "PublicExponent: AQAB\n"
+  "PrivateExponent: MiItniUAngXzMeaGdWgDq/AcpvlCtOCcFlVt4TJRKkfp8DNRSxIxG53NNlOFkp1W00iLHqYC2GrH1qkKgT9l+Q==\n"
+  "Prime1: 3sZmM+5FKFy5xaRt0n2ZQOZ2C+CoKzVil6/al9LmYVs=\n"
+  "Prime2: xFcNWSIW6v8dDL2JQ1kxFDm/8RVeUSs1BNXXnvCjBGs=\n"
+  "Exponent1: WuUwhjfN1+4djlrMxHmisixWNfpwI1Eg7Ss/UXsnrMk=\n"
+  "Exponent2: vfMqas1cNsXRqP3Fym6D2Pl2BRuTQBv5E1B/ZrmQPTk=\n"
+  "Coefficient: Q10z43cA3hkwOkKsj5T0W5jrX97LBwZoY5lIjDCa4+M=\n",
+
+  "1506 8 1 172a500b374158d1a64ba3073cdbbc319b2fdf2c",
+  "1506 8 2 253b099ff47b02c6ffa52695a30a94c6681c56befe0e71a5077d6f79514972f9",
+  "1506 8 4 22ea940600dc2d9a98b1126c26ac0dc5c91b31eb50fe784b36ad675e9eecfe6573c1f85c53b6bc94580f3ac443d13c4c",
+
+  // clang-format off
+  /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
+  { 0x93, 0x93, 0x5f, 0xd8, 0xa1, 0x2b, 0x4c, 0x0b, 0xf3, 0x67, 0x42, 0x13, 0x52, 0x00, 0x35, 0xdc,
+    0x09, 0xe0, 0xdf, 0xe0, 0x3e, 0xc2, 0xcf, 0x64, 0xab, 0x9f, 0x9f, 0x51, 0x5f, 0x5c, 0x27, 0xbe,
+    0x13, 0xd6, 0x17, 0x07, 0xa6, 0xe4, 0x3b, 0x63, 0x44, 0x85, 0x06, 0x13, 0xaa, 0x01, 0x3c, 0x58,
+    0x52, 0xa3, 0x98, 0x20, 0x65, 0x03, 0xd0, 0x40, 0xc8, 0xa0, 0xe9, 0xd2, 0xc0, 0x03, 0x5a, 0xab },
+  // clang-format on
+
+  "256 3 8 AwEAAarbp0oh52KuF0SwXoSgMNRpcW/uPKCKQAu8NyYaY+e9G29rh7eqK1hqp7skbSvKKlItgAaFdDxZvPiD4AzBHQk=",
+  "rsa.",
+  "",
+  "",
+  512,
+  256,
+  0,
+  DNSSECKeeper::RSASHA256,
+  true,
+
+  std::nullopt};
+
+/* ECDSA-P256-SHA256 from
+ * https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h
+ */
+static const SignerParams ecdsaSha256 = SignerParams{
+  "Algorithm: 13\n"
+  "PrivateKey: iyLIPdk3DOIxVmmSYlmTstbtUPiVlEyDX46psyCwNVQ=\n",
+
+  "5345 13 1 954103ac7c43810ce9f414e80f30ab1cbe49b236",
+  "5345 13 2 bac2107036e735b50f85006ce409a19a3438cab272e70769ebda032239a3d0ca",
+  "5345 13 4 a0ac6790483872be72a258314200a88ab75cdd70f66a18a09f0f414c074df0989fdb1df0e67d82d4312cda67b93a76c1",
+
+  // clang-format off
+  /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
+  { 0xa2, 0x95, 0x76, 0xb5, 0xf5, 0x7e, 0xbd, 0xdd, 0xf5, 0x62, 0xa2, 0xc3, 0xa4, 0x8d, 0xd4, 0x53,
+    0x5c, 0xba, 0x29, 0x71, 0x8c, 0xcc, 0x28, 0x7b, 0x58, 0xf3, 0x1e, 0x4e, 0x58, 0xe2, 0x36, 0x7e,
+    0xa0, 0x1a, 0xb6, 0xe6, 0x29, 0x71, 0x1b, 0xd3, 0x8c, 0x88, 0xc3, 0xee, 0x12, 0x0e, 0x69, 0x70,
+    0x55, 0x99, 0xec, 0xd5, 0xf6, 0x4f, 0x4b, 0xe2, 0x41, 0xd9, 0x10, 0x7e, 0x67, 0xe5, 0xad, 0x2f },
+  // clang-format on
+
+  "256 3 13 8uD7C4THTM/w7uhryRSToeE/jKT78/p853RX0L5EwrZrSLBubLPiBw7gbvUP6SsIga5ZQ4CSAxNmYA/gZsuXzA==",
+  "ecdsa.",
+  "",
+  "",
+  256,
+  256,
+  0,
+  DNSSECKeeper::ECDSA256,
+  false,
+
+  std::make_optional(std::string{
+    "-----BEGIN EC PRIVATE KEY-----\n"
+    "MHcCAQEEIIsiyD3ZNwziMVZpkmJZk7LW7VD4lZRMg1+OqbMgsDVUoAoGCCqGSM49\n"
+    "AwEHoUQDQgAE8uD7C4THTM/w7uhryRSToeE/jKT78/p853RX0L5EwrZrSLBubLPi\n"
+    "Bw7gbvUP6SsIga5ZQ4CSAxNmYA/gZsuXzA==\n"
+    "-----END EC PRIVATE KEY-----\n"})};
+
+/* Ed25519 from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h,
+ * also from rfc8080 section 6.1
+ */
+static const SignerParams ed25519 = SignerParams{
+  "Algorithm: 15\n"
+  "PrivateKey: ODIyNjAzODQ2MjgwODAxMjI2NDUxOTAyMDQxNDIyNjI=\n",
+
+  "3612 15 1 501249721e1f09a79d30d5c6c4dca1dc1da4ed5d",
+  "3612 15 2 1b1c8766b2a96566ff196f77c0c4194af86aaa109c5346ff60231a27d2b07ac0",
+  "3612 15 4 d11831153af4985efbd0ae792c967eb4aff3c35488db95f7e2f85dcec74ae8f59f9a72641798c91c67c675db1d710c18",
+
+  // clang-format off
+  /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
+  { 0x0a, 0x9e, 0x51, 0x5f, 0x16, 0x89, 0x49, 0x27, 0x0e, 0x98, 0x34, 0xd3, 0x48, 0xef, 0x5a, 0x6e,
+    0x85, 0x2f, 0x7c, 0xd6, 0xd7, 0xc8, 0xd0, 0xf4, 0x2c, 0x68, 0x8c, 0x1f, 0xf7, 0xdf, 0xeb, 0x7c,
+    0x25, 0xd6, 0x1a, 0x76, 0x3e, 0xaf, 0x28, 0x1f, 0x1d, 0x08, 0x10, 0x20, 0x1c, 0x01, 0x77, 0x1b,
+    0x5a, 0x48, 0xd6, 0xe5, 0x1c, 0xf9, 0xe3, 0xe0, 0x70, 0x34, 0x5e, 0x02, 0x49, 0xfb, 0x9e, 0x05 },
+  // clang-format on
+
+  "256 3 15 l02Woi0iS8Aa25FQkUd9RMzZHJpBoRQwAQEX1SxZJA4=",
+  "ed25519.",
+
+  // vector extracted from https://gitlab.labs.nic.cz/labs/ietf/blob/master/dnskey.py
+  // (rev 476d6ded) by printing signature_data
+  "00 0f 0f 02 00 00 0e 10 55 d4 fc 60 55 b9 4c e0 0e 1d 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 "
+  "07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 00 0f 00 01 00 00 0e 10 00 14 00 0a 04 6d 61 69 6c 07 "
+  "65 78 61 6d 70 6c 65 03 63 6f 6d 00 ",
+
+  // vector verified from dnskey.py as above, and confirmed with
+  // https://www.rfc-editor.org/errata_search.php?rfc=8080&eid=4935
+  "oL9krJun7xfBOIWcGHi7mag5/hdZrKWw15jPGrHpjQeRAvTdszaPD+QLs3fx8A4M3e23mRZ9VrbpMngwcrqNAg==",
+
+  256,
+  256,
+  257,
+  DNSSECKeeper::ED25519,
+  true,
+
+  std::make_optional(std::string{
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MC4CAQAwBQYDK2VwBCIEIDgyMjYwMzg0NjI4MDgwMTIyNjQ1MTkwMjA0MTQyMjYy\n"
+    "-----END PRIVATE KEY-----\n"})};
+
+struct Fixture
 {
-  /* RSA from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h */
-  SignerParams{
-    "Algorithm: 8\n"
-    "Modulus: qtunSiHnYq4XRLBehKAw1Glxb+48oIpAC7w3Jhpj570bb2uHt6orWGqnuyRtK8oqUi2ABoV0PFm8+IPgDMEdCQ==\n"
-    "PublicExponent: AQAB\n"
-    "PrivateExponent: MiItniUAngXzMeaGdWgDq/AcpvlCtOCcFlVt4TJRKkfp8DNRSxIxG53NNlOFkp1W00iLHqYC2GrH1qkKgT9l+Q==\n"
-    "Prime1: 3sZmM+5FKFy5xaRt0n2ZQOZ2C+CoKzVil6/al9LmYVs=\n"
-    "Prime2: xFcNWSIW6v8dDL2JQ1kxFDm/8RVeUSs1BNXXnvCjBGs=\n"
-    "Exponent1: WuUwhjfN1+4djlrMxHmisixWNfpwI1Eg7Ss/UXsnrMk=\n"
-    "Exponent2: vfMqas1cNsXRqP3Fym6D2Pl2BRuTQBv5E1B/ZrmQPTk=\n"
-    "Coefficient: Q10z43cA3hkwOkKsj5T0W5jrX97LBwZoY5lIjDCa4+M=\n",
+  Fixture()
+  {
+    BOOST_TEST_MESSAGE("All available/supported algorithms:");
+    auto pairs = DNSCryptoKeyEngine::listAllAlgosWithBackend();
+    for (auto const& pair : pairs) {
+      BOOST_TEST_MESSAGE("  " + std::to_string(pair.first) + ": " + pair.second);
+    }
 
-    "1506 8 1 172a500b374158d1a64ba3073cdbbc319b2fdf2c",
-    "1506 8 2 253b099ff47b02c6ffa52695a30a94c6681c56befe0e71a5077d6f79514972f9",
-    "1506 8 4 22ea940600dc2d9a98b1126c26ac0dc5c91b31eb50fe784b36ad675e9eecfe6573c1f85c53b6bc94580f3ac443d13c4c",
+    BOOST_TEST_MESSAGE("Setting up signer params:");
 
-    // clang-format off
-    /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
-    { 0x93, 0x93, 0x5f, 0xd8, 0xa1, 0x2b, 0x4c, 0x0b, 0xf3, 0x67, 0x42, 0x13, 0x52, 0x00, 0x35, 0xdc,
-      0x09, 0xe0, 0xdf, 0xe0, 0x3e, 0xc2, 0xcf, 0x64, 0xab, 0x9f, 0x9f, 0x51, 0x5f, 0x5c, 0x27, 0xbe,
-      0x13, 0xd6, 0x17, 0x07, 0xa6, 0xe4, 0x3b, 0x63, 0x44, 0x85, 0x06, 0x13, 0xaa, 0x01, 0x3c, 0x58,
-      0x52, 0xa3, 0x98, 0x20, 0x65, 0x03, 0xd0, 0x40, 0xc8, 0xa0, 0xe9, 0xd2, 0xc0, 0x03, 0x5a, 0xab },
-    // clang-format on
+    addSignerParams(DNSSECKeeper::RSASHA256, "RSA SHA256", rsaSha256SignerParams);
 
-    "256 3 8 AwEAAarbp0oh52KuF0SwXoSgMNRpcW/uPKCKQAu8NyYaY+e9G29rh7eqK1hqp7skbSvKKlItgAaFdDxZvPiD4AzBHQk=",
-    "rsa.",
-    "",
-    "",
-    512,
-    256,
-    0,
-    DNSSECKeeper::RSASHA256,
-    true,
+    #ifdef HAVE_LIBCRYPTO_ECDSA
+    addSignerParams(DNSSECKeeper::ECDSA256, "ECDSA SHA256", ecdsaSha256);
+    #endif
 
-    std::nullopt},
+    #if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED25519)
+    addSignerParams(DNSSECKeeper::ED25519, "ED25519", ed25519);
+    #endif
+  }
 
-#ifdef HAVE_LIBCRYPTO_ECDSA
-    /* ECDSA-P256-SHA256 from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h */
-    SignerParams{
-      "Algorithm: 13\n"
-      "PrivateKey: iyLIPdk3DOIxVmmSYlmTstbtUPiVlEyDX46psyCwNVQ=\n",
+  void addSignerParams(const uint8_t algorithm, const std::string& name, const SignerParams& params)
+  {
+    BOOST_TEST_MESSAGE("  " + std::to_string(algorithm) + ": " + name + " (" + params.name + ")");
+    signerParams.insert_or_assign(algorithm, params);
+  }
 
-      "5345 13 1 954103ac7c43810ce9f414e80f30ab1cbe49b236",
-      "5345 13 2 bac2107036e735b50f85006ce409a19a3438cab272e70769ebda032239a3d0ca",
-      "5345 13 4 a0ac6790483872be72a258314200a88ab75cdd70f66a18a09f0f414c074df0989fdb1df0e67d82d4312cda67b93a76c1",
-
-      // clang-format off
-      /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
-      { 0xa2, 0x95, 0x76, 0xb5, 0xf5, 0x7e, 0xbd, 0xdd, 0xf5, 0x62, 0xa2, 0xc3, 0xa4, 0x8d, 0xd4, 0x53,
-        0x5c, 0xba, 0x29, 0x71, 0x8c, 0xcc, 0x28, 0x7b, 0x58, 0xf3, 0x1e, 0x4e, 0x58, 0xe2, 0x36, 0x7e,
-        0xa0, 0x1a, 0xb6, 0xe6, 0x29, 0x71, 0x1b, 0xd3, 0x8c, 0x88, 0xc3, 0xee, 0x12, 0x0e, 0x69, 0x70,
-        0x55, 0x99, 0xec, 0xd5, 0xf6, 0x4f, 0x4b, 0xe2, 0x41, 0xd9, 0x10, 0x7e, 0x67, 0xe5, 0xad, 0x2f },
-      // clang-format on
-
-      "256 3 13 8uD7C4THTM/w7uhryRSToeE/jKT78/p853RX0L5EwrZrSLBubLPiBw7gbvUP6SsIga5ZQ4CSAxNmYA/gZsuXzA==",
-      "ecdsa.",
-      "",
-      "",
-      256,
-      256,
-      0,
-      DNSSECKeeper::ECDSA256,
-      false,
-
-      std::make_optional(std::string{
-        "-----BEGIN EC PRIVATE KEY-----\n"
-        "MHcCAQEEIIsiyD3ZNwziMVZpkmJZk7LW7VD4lZRMg1+OqbMgsDVUoAoGCCqGSM49\n"
-        "AwEHoUQDQgAE8uD7C4THTM/w7uhryRSToeE/jKT78/p853RX0L5EwrZrSLBubLPi\n"
-        "Bw7gbvUP6SsIga5ZQ4CSAxNmYA/gZsuXzA==\n"
-        "-----END EC PRIVATE KEY-----\n"})},
-#endif /* HAVE_LIBCRYPTO_ECDSA */
-
-#if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED25519)
-    /* ed25519 from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h,
-       also from rfc8080 section 6.1 */
-    SignerParams{
-      "Algorithm: 15\n"
-      "PrivateKey: ODIyNjAzODQ2MjgwODAxMjI2NDUxOTAyMDQxNDIyNjI=\n",
-
-      "3612 15 1 501249721e1f09a79d30d5c6c4dca1dc1da4ed5d",
-      "3612 15 2 1b1c8766b2a96566ff196f77c0c4194af86aaa109c5346ff60231a27d2b07ac0",
-      "3612 15 4 d11831153af4985efbd0ae792c967eb4aff3c35488db95f7e2f85dcec74ae8f59f9a72641798c91c67c675db1d710c18",
-
-      // clang-format off
-      /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
-      { 0x0a, 0x9e, 0x51, 0x5f, 0x16, 0x89, 0x49, 0x27, 0x0e, 0x98, 0x34, 0xd3, 0x48, 0xef, 0x5a, 0x6e,
-        0x85, 0x2f, 0x7c, 0xd6, 0xd7, 0xc8, 0xd0, 0xf4, 0x2c, 0x68, 0x8c, 0x1f, 0xf7, 0xdf, 0xeb, 0x7c,
-        0x25, 0xd6, 0x1a, 0x76, 0x3e, 0xaf, 0x28, 0x1f, 0x1d, 0x08, 0x10, 0x20, 0x1c, 0x01, 0x77, 0x1b,
-        0x5a, 0x48, 0xd6, 0xe5, 0x1c, 0xf9, 0xe3, 0xe0, 0x70, 0x34, 0x5e, 0x02, 0x49, 0xfb, 0x9e, 0x05 },
-      // clang-format on
-
-      "256 3 15 l02Woi0iS8Aa25FQkUd9RMzZHJpBoRQwAQEX1SxZJA4=",
-      "ed25519.",
-
-      // vector extracted from https://gitlab.labs.nic.cz/labs/ietf/blob/master/dnskey.py
-      // (rev 476d6ded) by printing signature_data
-      "00 0f 0f 02 00 00 0e 10 55 d4 fc 60 55 b9 4c e0 0e 1d 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 "
-      "07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 00 0f 00 01 00 00 0e 10 00 14 00 0a 04 6d 61 69 6c 07 "
-      "65 78 61 6d 70 6c 65 03 63 6f 6d 00 ",
-
-      // vector verified from dnskey.py as above, and confirmed with
-      // https://www.rfc-editor.org/errata_search.php?rfc=8080&eid=4935
-      "oL9krJun7xfBOIWcGHi7mag5/hdZrKWw15jPGrHpjQeRAvTdszaPD+QLs3fx8A4M3e23mRZ9VrbpMngwcrqNAg==",
-
-      256,
-      256,
-      257,
-      DNSSECKeeper::ED25519,
-      true,
-
-#if defined(HAVE_LIBCRYPTO_ED25519)
-      std::make_optional(std::string{
-        "-----BEGIN PRIVATE KEY-----\n"
-        "MC4CAQAwBQYDK2VwBCIEIDgyMjYwMzg0NjI4MDgwMTIyNjQ1MTkwMjA0MTQyMjYy\n"
-        "-----END PRIVATE KEY-----\n"})},
-#else
-      std::nullopt},
-#endif /* defined(HAVE_LIBCRYPTO_ED25519) */
-#endif /* defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED25519) */
+  const std::string message{"Very good, young padawan."};
+  std::unordered_map<uint8_t, struct SignerParams> signerParams;
 };
 
 static void checkRR(const SignerParams& signer)
@@ -216,7 +238,7 @@ static void checkRR(const SignerParams& signer)
   }
 }
 
-static auto test_generic_signer(std::shared_ptr<DNSCryptoKeyEngine> dcke, DNSKEYRecordContent& drc, const SignerParams& signer)
+static void test_generic_signer(std::shared_ptr<DNSCryptoKeyEngine> dcke, DNSKEYRecordContent& drc, const SignerParams& signer, const std::string& message)
 {
   BOOST_CHECK_EQUAL(dcke->getAlgorithm(), signer.algorithm);
   BOOST_CHECK_EQUAL(dcke->getBits(), signer.bits);
@@ -267,12 +289,14 @@ static auto test_generic_signer(std::shared_ptr<DNSCryptoKeyEngine> dcke, DNSKEY
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_generic_signers)
+BOOST_FIXTURE_TEST_CASE(test_generic_signers, Fixture)
 {
-  for (const auto& signer : signers) {
+  for (const auto& algoSignerPair : signerParams) {
+    auto signer = algoSignerPair.second;
+
     DNSKEYRecordContent drc;
     auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(drc, signer.iscMap));
-    test_generic_signer(dcke, drc, signer);
+    test_generic_signer(dcke, drc, signer, message);
 
     if (signer.pem.has_value()) {
       unique_ptr<std::FILE, decltype(&std::fclose)> fp{fmemopen((void*)signer.pem->c_str(), signer.pem->length(), "r"), &std::fclose};
@@ -283,7 +307,7 @@ BOOST_AUTO_TEST_CASE(test_generic_signers)
 
       BOOST_CHECK_EQUAL(pemKey->convertToISC(), dcke->convertToISC());
 
-      test_generic_signer(pemKey, pemDRC, signer);
+      test_generic_signer(pemKey, pemDRC, signer, message);
 
       const size_t buflen = 4096;
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -266,7 +266,8 @@ struct Fixture
     addSignerParams(DNSSECKeeper::ECDSA256, "ECDSA SHA256", ecdsaSha256);
     #endif
 
-    #if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED25519)
+    // We need to have HAVE_LIBCRYPTO_ED25519 for the PEM reader/writer.
+    #if defined(HAVE_LIBCRYPTO_ED25519)
     addSignerParams(DNSSECKeeper::ED25519, "ED25519", ed25519);
     #endif
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -13,6 +13,7 @@
 #include "misc.hh"
 
 #include <cstdio>
+#include <unordered_map>
 
 BOOST_AUTO_TEST_SUITE(test_signers)
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -233,7 +233,7 @@ static void checkRR(const SignerParams& signer)
 
   sortedRecords_t rrs;
   /* values taken from rfc8080 for ed25519 and ed448, rfc5933 for gost */
-  DNSName qname(dpk.d_algorithm == 12 ? "www.example.net." : "example.com.");
+  DNSName qname(dpk.d_algorithm == DNSSECKeeper::ECCGOST ? "www.example.net." : "example.com.");
 
   reportBasicTypes();
 
@@ -241,7 +241,7 @@ static void checkRR(const SignerParams& signer)
   uint32_t expire = 1440021600;
   uint32_t inception = 1438207200;
 
-  if (dpk.d_algorithm == 12) {
+  if (dpk.d_algorithm == DNSSECKeeper::ECCGOST) {
     rrc.d_signer = DNSName("example.net.");
     inception = 946684800;
     expire = 1893456000;

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -36,118 +36,159 @@ struct SignerParams
 };
 
 static const SignerParams rsaSha256SignerParams = SignerParams{
-  "Algorithm: 8\n"
-  "Modulus: qtunSiHnYq4XRLBehKAw1Glxb+48oIpAC7w3Jhpj570bb2uHt6orWGqnuyRtK8oqUi2ABoV0PFm8+IPgDMEdCQ==\n"
-  "PublicExponent: AQAB\n"
-  "PrivateExponent: MiItniUAngXzMeaGdWgDq/AcpvlCtOCcFlVt4TJRKkfp8DNRSxIxG53NNlOFkp1W00iLHqYC2GrH1qkKgT9l+Q==\n"
-  "Prime1: 3sZmM+5FKFy5xaRt0n2ZQOZ2C+CoKzVil6/al9LmYVs=\n"
-  "Prime2: xFcNWSIW6v8dDL2JQ1kxFDm/8RVeUSs1BNXXnvCjBGs=\n"
-  "Exponent1: WuUwhjfN1+4djlrMxHmisixWNfpwI1Eg7Ss/UXsnrMk=\n"
-  "Exponent2: vfMqas1cNsXRqP3Fym6D2Pl2BRuTQBv5E1B/ZrmQPTk=\n"
-  "Coefficient: Q10z43cA3hkwOkKsj5T0W5jrX97LBwZoY5lIjDCa4+M=\n",
+  .iscMap = "Algorithm: 8\n"
+            "Modulus: qtunSiHnYq4XRLBehKAw1Glxb+48oIpAC7w3Jhpj570bb2uHt6orWGqnuyRtK8oqUi2ABoV0PFm8+IPgDMEdCQ==\n"
+            "PublicExponent: AQAB\n"
+            "PrivateExponent: MiItniUAngXzMeaGdWgDq/AcpvlCtOCcFlVt4TJRKkfp8DNRSxIxG53NNlOFkp1W00iLHqYC2GrH1qkKgT9l+Q==\n"
+            "Prime1: 3sZmM+5FKFy5xaRt0n2ZQOZ2C+CoKzVil6/al9LmYVs=\n"
+            "Prime2: xFcNWSIW6v8dDL2JQ1kxFDm/8RVeUSs1BNXXnvCjBGs=\n"
+            "Exponent1: WuUwhjfN1+4djlrMxHmisixWNfpwI1Eg7Ss/UXsnrMk=\n"
+            "Exponent2: vfMqas1cNsXRqP3Fym6D2Pl2BRuTQBv5E1B/ZrmQPTk=\n"
+            "Coefficient: Q10z43cA3hkwOkKsj5T0W5jrX97LBwZoY5lIjDCa4+M=\n",
 
-  "1506 8 1 172a500b374158d1a64ba3073cdbbc319b2fdf2c",
-  "1506 8 2 253b099ff47b02c6ffa52695a30a94c6681c56befe0e71a5077d6f79514972f9",
-  "1506 8 4 22ea940600dc2d9a98b1126c26ac0dc5c91b31eb50fe784b36ad675e9eecfe6573c1f85c53b6bc94580f3ac443d13c4c",
+  .dsSHA1 = "1506 8 1 "
+            "172a500b374158d1a64ba3073cdbbc319b2fdf2c",
+
+  .dsSHA256 = "1506 8 2 "
+              "253b099ff47b02c6ffa52695a30a94c6681c56befe0e71a5077d6f79514972f9",
+
+  .dsSHA384 = "1506 8 4 "
+              "22ea940600dc2d9a98b1126c26ac0dc5c91b31eb50fe784b"
+              "36ad675e9eecfe6573c1f85c53b6bc94580f3ac443d13c4c",
 
   // clang-format off
   /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
-  { 0x93, 0x93, 0x5f, 0xd8, 0xa1, 0x2b, 0x4c, 0x0b, 0xf3, 0x67, 0x42, 0x13, 0x52, 0x00, 0x35, 0xdc,
-    0x09, 0xe0, 0xdf, 0xe0, 0x3e, 0xc2, 0xcf, 0x64, 0xab, 0x9f, 0x9f, 0x51, 0x5f, 0x5c, 0x27, 0xbe,
-    0x13, 0xd6, 0x17, 0x07, 0xa6, 0xe4, 0x3b, 0x63, 0x44, 0x85, 0x06, 0x13, 0xaa, 0x01, 0x3c, 0x58,
-    0x52, 0xa3, 0x98, 0x20, 0x65, 0x03, 0xd0, 0x40, 0xc8, 0xa0, 0xe9, 0xd2, 0xc0, 0x03, 0x5a, 0xab },
+  .signature = {
+    0x93, 0x93, 0x5f, 0xd8, 0xa1, 0x2b, 0x4c, 0x0b, 0xf3, 0x67, 0x42, 0x13, 0x52,
+    0x00, 0x35, 0xdc, 0x09, 0xe0, 0xdf, 0xe0, 0x3e, 0xc2, 0xcf, 0x64, 0xab, 0x9f,
+    0x9f, 0x51, 0x5f, 0x5c, 0x27, 0xbe, 0x13, 0xd6, 0x17, 0x07, 0xa6, 0xe4, 0x3b,
+    0x63, 0x44, 0x85, 0x06, 0x13, 0xaa, 0x01, 0x3c, 0x58, 0x52, 0xa3, 0x98, 0x20,
+    0x65, 0x03, 0xd0, 0x40, 0xc8, 0xa0, 0xe9, 0xd2, 0xc0, 0x03, 0x5a, 0xab
+  },
   // clang-format on
 
-  "256 3 8 AwEAAarbp0oh52KuF0SwXoSgMNRpcW/uPKCKQAu8NyYaY+e9G29rh7eqK1hqp7skbSvKKlItgAaFdDxZvPiD4AzBHQk=",
-  "rsa.",
-  "",
-  "",
-  512,
-  256,
-  0,
-  DNSSECKeeper::RSASHA256,
-  true,
+  .zoneRepresentation = "256 3 8 "
+                        "AwEAAarbp0oh52KuF0SwXoSgMNRpcW/uPKCKQAu8NyYaY+"
+                        "e9G29rh7eqK1hqp7skbSvKKlItgAaFdDxZvPiD4AzBHQk=",
 
-  std::nullopt};
+  .name = "rsa.",
+
+  .rfcMsgDump = "",
+  .rfcB64Signature = "",
+
+  .bits = 512,
+  .flags = 256,
+  .rfcFlags = 0,
+
+  .algorithm = DNSSECKeeper::RSASHA256,
+  .isDeterministic = true,
+
+  .pem = std::nullopt};
 
 /* ECDSA-P256-SHA256 from
  * https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h
  */
 static const SignerParams ecdsaSha256 = SignerParams{
-  "Algorithm: 13\n"
-  "PrivateKey: iyLIPdk3DOIxVmmSYlmTstbtUPiVlEyDX46psyCwNVQ=\n",
+  .iscMap = "Algorithm: 13\n"
+            "PrivateKey: iyLIPdk3DOIxVmmSYlmTstbtUPiVlEyDX46psyCwNVQ=\n",
 
-  "5345 13 1 954103ac7c43810ce9f414e80f30ab1cbe49b236",
-  "5345 13 2 bac2107036e735b50f85006ce409a19a3438cab272e70769ebda032239a3d0ca",
-  "5345 13 4 a0ac6790483872be72a258314200a88ab75cdd70f66a18a09f0f414c074df0989fdb1df0e67d82d4312cda67b93a76c1",
+  .dsSHA1 = "5345 13 1 "
+            "954103ac7c43810ce9f414e80f30ab1cbe49b236",
+
+  .dsSHA256 = "5345 13 2 "
+              "bac2107036e735b50f85006ce409a19a3438cab272e70769ebda032239a3d0ca",
+
+  .dsSHA384 = "5345 13 4 "
+              "a0ac6790483872be72a258314200a88ab75cdd70f66a18a0"
+              "9f0f414c074df0989fdb1df0e67d82d4312cda67b93a76c1",
 
   // clang-format off
   /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
-  { 0xa2, 0x95, 0x76, 0xb5, 0xf5, 0x7e, 0xbd, 0xdd, 0xf5, 0x62, 0xa2, 0xc3, 0xa4, 0x8d, 0xd4, 0x53,
-    0x5c, 0xba, 0x29, 0x71, 0x8c, 0xcc, 0x28, 0x7b, 0x58, 0xf3, 0x1e, 0x4e, 0x58, 0xe2, 0x36, 0x7e,
-    0xa0, 0x1a, 0xb6, 0xe6, 0x29, 0x71, 0x1b, 0xd3, 0x8c, 0x88, 0xc3, 0xee, 0x12, 0x0e, 0x69, 0x70,
-    0x55, 0x99, 0xec, 0xd5, 0xf6, 0x4f, 0x4b, 0xe2, 0x41, 0xd9, 0x10, 0x7e, 0x67, 0xe5, 0xad, 0x2f },
+  .signature = {
+    0xa2, 0x95, 0x76, 0xb5, 0xf5, 0x7e, 0xbd, 0xdd, 0xf5, 0x62, 0xa2, 0xc3, 0xa4,
+    0x8d, 0xd4, 0x53, 0x5c, 0xba, 0x29, 0x71, 0x8c, 0xcc, 0x28, 0x7b, 0x58, 0xf3,
+    0x1e, 0x4e, 0x58, 0xe2, 0x36, 0x7e, 0xa0, 0x1a, 0xb6, 0xe6, 0x29, 0x71, 0x1b,
+    0xd3, 0x8c, 0x88, 0xc3, 0xee, 0x12, 0x0e, 0x69, 0x70, 0x55, 0x99, 0xec, 0xd5,
+    0xf6, 0x4f, 0x4b, 0xe2, 0x41, 0xd9, 0x10, 0x7e, 0x67, 0xe5, 0xad, 0x2f
+  },
   // clang-format on
 
-  "256 3 13 8uD7C4THTM/w7uhryRSToeE/jKT78/p853RX0L5EwrZrSLBubLPiBw7gbvUP6SsIga5ZQ4CSAxNmYA/gZsuXzA==",
-  "ecdsa.",
-  "",
-  "",
-  256,
-  256,
-  0,
-  DNSSECKeeper::ECDSA256,
-  false,
+  .zoneRepresentation = "256 3 13 "
+                        "8uD7C4THTM/w7uhryRSToeE/jKT78/p853RX0L5EwrZ"
+                        "rSLBubLPiBw7gbvUP6SsIga5ZQ4CSAxNmYA/gZsuXzA==",
 
-  std::make_optional(std::string{
-    "-----BEGIN EC PRIVATE KEY-----\n"
-    "MHcCAQEEIIsiyD3ZNwziMVZpkmJZk7LW7VD4lZRMg1+OqbMgsDVUoAoGCCqGSM49\n"
-    "AwEHoUQDQgAE8uD7C4THTM/w7uhryRSToeE/jKT78/p853RX0L5EwrZrSLBubLPi\n"
-    "Bw7gbvUP6SsIga5ZQ4CSAxNmYA/gZsuXzA==\n"
-    "-----END EC PRIVATE KEY-----\n"})};
+  .name = "ecdsa.",
+
+  .rfcMsgDump = "",
+  .rfcB64Signature = "",
+
+  .bits = 256,
+  .flags = 256,
+  .rfcFlags = 0,
+
+  .algorithm = DNSSECKeeper::ECDSA256,
+  .isDeterministic = false,
+
+  .pem = "-----BEGIN EC PRIVATE KEY-----\n"
+         "MHcCAQEEIIsiyD3ZNwziMVZpkmJZk7LW7VD4lZRMg1+OqbMgsDVUoAoGCCqGSM49\n"
+         "AwEHoUQDQgAE8uD7C4THTM/w7uhryRSToeE/jKT78/p853RX0L5EwrZrSLBubLPi\n"
+         "Bw7gbvUP6SsIga5ZQ4CSAxNmYA/gZsuXzA==\n"
+         "-----END EC PRIVATE KEY-----\n"};
 
 /* Ed25519 from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h,
  * also from rfc8080 section 6.1
  */
 static const SignerParams ed25519 = SignerParams{
-  "Algorithm: 15\n"
-  "PrivateKey: ODIyNjAzODQ2MjgwODAxMjI2NDUxOTAyMDQxNDIyNjI=\n",
+  .iscMap = "Algorithm: 15\n"
+            "PrivateKey: ODIyNjAzODQ2MjgwODAxMjI2NDUxOTAyMDQxNDIyNjI=\n",
 
-  "3612 15 1 501249721e1f09a79d30d5c6c4dca1dc1da4ed5d",
-  "3612 15 2 1b1c8766b2a96566ff196f77c0c4194af86aaa109c5346ff60231a27d2b07ac0",
-  "3612 15 4 d11831153af4985efbd0ae792c967eb4aff3c35488db95f7e2f85dcec74ae8f59f9a72641798c91c67c675db1d710c18",
+  .dsSHA1 = "3612 15 1 "
+            "501249721e1f09a79d30d5c6c4dca1dc1da4ed5d",
+
+  .dsSHA256 = "3612 15 2 "
+              "1b1c8766b2a96566ff196f77c0c4194af86aaa109c5346ff60231a27d2b07ac0",
+
+  .dsSHA384 = "3612 15 4 "
+              "d11831153af4985efbd0ae792c967eb4aff3c35488db95f7"
+              "e2f85dcec74ae8f59f9a72641798c91c67c675db1d710c18",
 
   // clang-format off
   /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
-  { 0x0a, 0x9e, 0x51, 0x5f, 0x16, 0x89, 0x49, 0x27, 0x0e, 0x98, 0x34, 0xd3, 0x48, 0xef, 0x5a, 0x6e,
-    0x85, 0x2f, 0x7c, 0xd6, 0xd7, 0xc8, 0xd0, 0xf4, 0x2c, 0x68, 0x8c, 0x1f, 0xf7, 0xdf, 0xeb, 0x7c,
-    0x25, 0xd6, 0x1a, 0x76, 0x3e, 0xaf, 0x28, 0x1f, 0x1d, 0x08, 0x10, 0x20, 0x1c, 0x01, 0x77, 0x1b,
-    0x5a, 0x48, 0xd6, 0xe5, 0x1c, 0xf9, 0xe3, 0xe0, 0x70, 0x34, 0x5e, 0x02, 0x49, 0xfb, 0x9e, 0x05 },
+  .signature = {
+    0x0a, 0x9e, 0x51, 0x5f, 0x16, 0x89, 0x49, 0x27, 0x0e, 0x98, 0x34, 0xd3, 0x48,
+    0xef, 0x5a, 0x6e, 0x85, 0x2f, 0x7c, 0xd6, 0xd7, 0xc8, 0xd0, 0xf4, 0x2c, 0x68,
+    0x8c, 0x1f, 0xf7, 0xdf, 0xeb, 0x7c, 0x25, 0xd6, 0x1a, 0x76, 0x3e, 0xaf, 0x28,
+    0x1f, 0x1d, 0x08, 0x10, 0x20, 0x1c, 0x01, 0x77, 0x1b, 0x5a, 0x48, 0xd6, 0xe5,
+    0x1c, 0xf9, 0xe3, 0xe0, 0x70, 0x34, 0x5e, 0x02, 0x49, 0xfb, 0x9e, 0x05
+  },
   // clang-format on
 
-  "256 3 15 l02Woi0iS8Aa25FQkUd9RMzZHJpBoRQwAQEX1SxZJA4=",
-  "ed25519.",
+  .zoneRepresentation = "256 3 15 l02Woi0iS8Aa25FQkUd9RMzZHJpBoRQwAQEX1SxZJA4=",
+
+  .name = "ed25519.",
 
   // vector extracted from https://gitlab.labs.nic.cz/labs/ietf/blob/master/dnskey.py
   // (rev 476d6ded) by printing signature_data
-  "00 0f 0f 02 00 00 0e 10 55 d4 fc 60 55 b9 4c e0 0e 1d 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 "
-  "07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 00 0f 00 01 00 00 0e 10 00 14 00 0a 04 6d 61 69 6c 07 "
-  "65 78 61 6d 70 6c 65 03 63 6f 6d 00 ",
+  .rfcMsgDump = "00 0f 0f 02 00 00 0e 10 55 d4 fc 60 55 b9 4c e0 0e 1d 07 65 78 "
+                "61 6d 70 6c 65 03 63 6f 6d 00 07 65 78 61 6d 70 6c 65 03 63 6f "
+                "6d 00 00 0f 00 01 00 00 0e 10 00 14 00 0a 04 6d 61 69 6c 07 65 "
+                "78 61 6d 70 6c 65 03 63 6f 6d 00 ",
 
   // vector verified from dnskey.py as above, and confirmed with
   // https://www.rfc-editor.org/errata_search.php?rfc=8080&eid=4935
-  "oL9krJun7xfBOIWcGHi7mag5/hdZrKWw15jPGrHpjQeRAvTdszaPD+QLs3fx8A4M3e23mRZ9VrbpMngwcrqNAg==",
+  .rfcB64Signature = "oL9krJun7xfBOIWcGHi7mag5/hdZrKWw15jPGrHpjQeR"
+                     "AvTdszaPD+QLs3fx8A4M3e23mRZ9VrbpMngwcrqNAg==",
 
-  256,
-  256,
-  257,
-  DNSSECKeeper::ED25519,
-  true,
+  .bits = 256,
+  .flags = 256,
+  .rfcFlags = 257,
 
-  std::make_optional(std::string{
-    "-----BEGIN PRIVATE KEY-----\n"
-    "MC4CAQAwBQYDK2VwBCIEIDgyMjYwMzg0NjI4MDgwMTIyNjQ1MTkwMjA0MTQyMjYy\n"
-    "-----END PRIVATE KEY-----\n"})};
+  .algorithm = DNSSECKeeper::ED25519,
+  .isDeterministic = true,
+
+  .pem = "-----BEGIN PRIVATE KEY-----\n"
+         "MC4CAQAwBQYDK2VwBCIEIDgyMjYwMzg0NjI4MDgwMTIyNjQ1MTkwMjA0MTQyMjYy\n"
+         "-----END PRIVATE KEY-----\n"};
 
 struct Fixture
 {


### PR DESCRIPTION
### Short description
This cleans up and refactors signers tests (`test-signers.cc`):
- Uses the boost test fixtures, and avoids a bit of duplication with `#ifdef`s.
- Adds some logging (using `--log_level=message`) to print which algorithms and their implementations are available.
- Integrates the testing of `ed448` into the generic signer testing mechanism.
- Adds the PEM import/export tests for `ed448`.

### Checklist

I have:

- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)