### PR TITLE
dnsdist: Support link-level address retrieval for IPv6 as well

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -510,6 +510,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "getDOHFrontendCount", true, "", "returns the number of DoH listeners" },
   { "getListOfAddressesOfNetworkInterface", true, "itf", "returns the list of addresses configured on a given network interface, as strings" },
   { "getListOfNetworkInterfaces", true, "", "returns the list of network interfaces present on the system, as strings" },
+  { "getMACAddress", true, "IP addr", "return the link-level address (MAC) corresponding to the supplied remote IP address, if known by the kernel" },
   { "getOutgoingTLSSessionCacheSize", true, "", "returns the number of TLS sessions (for outgoing connections) currently cached" },
   { "getPool", true, "name", "return the pool named `name`, or \"\" for the default pool" },
   { "getPoolServers", true, "pool", "return servers part of this pool" },

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -510,7 +510,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "getDOHFrontendCount", true, "", "returns the number of DoH listeners" },
   { "getListOfAddressesOfNetworkInterface", true, "itf", "returns the list of addresses configured on a given network interface, as strings" },
   { "getListOfNetworkInterfaces", true, "", "returns the list of network interfaces present on the system, as strings" },
-  { "getMACAddress", true, "IP addr", "return the link-level address (MAC) corresponding to the supplied remote IP address, if known by the kernel" },
+  { "getMACAddress", true, "IP addr", "return the link-level address (MAC) corresponding to the supplied neighbour  IP address, if known by the kernel" },
   { "getOutgoingTLSSessionCacheSize", true, "", "returns the number of TLS sessions (for outgoing connections) currently cached" },
   { "getPool", true, "name", "return the pool named `name`, or \"\" for the default pool" },
   { "getPoolServers", true, "pool", "return servers part of this pool" },

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -682,4 +682,8 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
     }
     return result;
   });
+
+  luaCtx.writeFunction("getMACAddress", [](const std::string& ip) {
+    return getMACAddress(ComboAddress(ip));
+  });
 }

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -990,7 +990,7 @@ Status, Statistics and More
 
   .. versionadded:: 1.8.0
 
-  Return the link-level address (MAC) corresponding to the supplied remote IP address, if known by the kernel.
+  Return the link-level address (MAC) corresponding to the supplied neighbour IP address, if known by the kernel.
   This function is only implemented on Linux.
 
   :param str ip: The IP address, IPv4 or IPv6, to look up the corresponding link-level address for.

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -983,8 +983,17 @@ Status, Statistics and More
 
   .. versionadded:: 1.8.0
 
-  Return the list of network interfaces configured on the system, as strings
+  Return the list of network interfaces configured on the system, as strings.
   This function requires support for ``getifaddrs``, which is known to be present on FreeBSD, Linux, and OpenBSD at least.
+
+.. function:: getMacAddress(ip)
+
+  .. versionadded:: 1.8.0
+
+  Return the link-level address (MAC) corresponding to the supplied remote IP address, if known by the kernel.
+  This function is only implemented on Linux.
+
+  :param str ip: The IP address, IPv4 or IPv6, to look up the corresponding link-level address for.
 
 .. function:: getOutgoingTLSSessionCacheSize()
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -986,7 +986,7 @@ Status, Statistics and More
   Return the list of network interfaces configured on the system, as strings.
   This function requires support for ``getifaddrs``, which is known to be present on FreeBSD, Linux, and OpenBSD at least.
 
-.. function:: getMacAddress(ip)
+.. function:: getMACAddress(ip)
 
   .. versionadded:: 1.8.0
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -986,11 +986,12 @@ Status, Statistics and More
   Return the list of network interfaces configured on the system, as strings.
   This function requires support for ``getifaddrs``, which is known to be present on FreeBSD, Linux, and OpenBSD at least.
 
-.. function:: getMACAddress(ip)
+.. function:: getMACAddress(ip) -> str
 
   .. versionadded:: 1.8.0
 
   Return the link-level address (MAC) corresponding to the supplied neighbour IP address, if known by the kernel.
+  The link-level address is returned as a raw binary string. An empty string is returned if no matching entry has been found.
   This function is only implemented on Linux.
 
   :param str ip: The IP address, IPv4 or IPv6, to look up the corresponding link-level address for.

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1211,6 +1211,10 @@ int getMACAddress(const ComboAddress& ca, char* dest, size_t destLen)
         continue;
       }
 
+      if (ca.sin4.sin_family == AF_INET6 && ca.sin6.sin6_scope_id != 0 && static_cast<int32_t>(ca.sin6.sin6_scope_id) != nd->ndm_ifindex) {
+        continue;
+      }
+
       for (; done == false && RTA_OK(rtatp, rtattrlen); rtatp = RTA_NEXT(rtatp, rtattrlen)) {
         if (rtatp->rta_type == NDA_DST){
           if (nd->ndm_family == AF_INET) {

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1143,33 +1143,114 @@ bool setCloseOnExec(int sock)
   return true;
 }
 
-int getMACAddress(const ComboAddress& ca, char* dest, size_t len)
-{
 #ifdef __linux__
-  ifstream ifs("/proc/net/arp");
-  if (len < 6) {
-    return EINVAL;
+#include <linux/rtnetlink.h>
+
+int getMACAddress(const ComboAddress& ca, char* dest, size_t destLen)
+{
+  struct {
+    struct nlmsghdr headermsg;
+    struct ndmsg neighbormsg;
+  } request;
+
+  std::array<char, 8192> buffer;
+
+  auto sock = FDWrapper(socket(AF_NETLINK, SOCK_RAW|SOCK_CLOEXEC, NETLINK_ROUTE));
+  if (sock.getHandle() == -1) {
+    return errno;
   }
-  if (!ifs) {
-    return EIO;
-  }
-  string line;
-  string match = ca.toString() + ' ';
-  while(getline(ifs, line)) {
-    if(boost::starts_with(line, match)) {
-      vector<string> parts;
-      stringtok(parts, line, " \n\t\r");
-      if (parts.size() < 4)
-        return ENOENT;
-      if (sscanf(parts[3].c_str(), "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", dest, dest+1, dest+2, dest+3, dest+4, dest+5) != 6) {
-        return ENOENT;
+
+  memset(&request, 0, sizeof(request));
+  request.headermsg.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
+  request.headermsg.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+  request.headermsg.nlmsg_type = RTM_GETNEIGH;
+  request.neighbormsg.ndm_family = ca.sin4.sin_family;
+
+  while (true) {
+    ssize_t sent = send(sock.getHandle(), &request, sizeof(request), 0);
+    if (sent == -1) {
+      if (errno == EINTR) {
+        continue;
       }
-      return 0;
+      return errno;
+    }
+    else if (static_cast<size_t>(sent) != sizeof(request)) {
+      return EIO;
+    }
+    break;
+  }
+
+  bool done = false;
+  bool foundIP = false;
+  bool foundMAC = false;
+  do {
+    ssize_t got = recv(sock.getHandle(), buffer.data(), buffer.size(), 0);
+
+    if (got < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return errno;
+    }
+
+    size_t remaining = static_cast<size_t>(got);
+    for (struct nlmsghdr* nlmsgheader = reinterpret_cast<struct nlmsghdr*>(buffer.data());
+         done == false && NLMSG_OK (nlmsgheader, remaining);
+         nlmsgheader = reinterpret_cast<struct nlmsghdr*>(NLMSG_NEXT(nlmsgheader, remaining))) {
+
+      if (nlmsgheader->nlmsg_type == NLMSG_DONE) {
+        done = true;
+        break;
+      }
+
+      auto nd = reinterpret_cast<struct ndmsg*>(NLMSG_DATA(nlmsgheader));
+      auto rtatp = reinterpret_cast<struct rtattr*>(((char*)(nd)) + NLMSG_ALIGN(sizeof(struct ndmsg)));
+      int rtattrlen = nlmsgheader->nlmsg_len - NLMSG_LENGTH(sizeof(struct ndmsg));
+
+      if (nd->ndm_family != ca.sin4.sin_family) {
+        continue;
+      }
+
+      for (; done == false && RTA_OK(rtatp, rtattrlen); rtatp = RTA_NEXT(rtatp, rtattrlen)) {
+        if (rtatp->rta_type == NDA_DST){
+          if (nd->ndm_family == AF_INET) {
+            auto inp = reinterpret_cast<struct in_addr*>(RTA_DATA(rtatp));
+            if (inp->s_addr == ca.sin4.sin_addr.s_addr) {
+              foundIP = true;
+            }
+          }
+          else if (nd->ndm_family == AF_INET6) {
+            auto inp = reinterpret_cast<struct in6_addr *>(RTA_DATA(rtatp));
+            if (memcmp(inp->s6_addr, ca.sin6.sin6_addr.s6_addr, sizeof(ca.sin6.sin6_addr.s6_addr)) == 0) {
+              foundIP = true;
+            }
+          }
+        }
+        else if (rtatp->rta_type == NDA_LLADDR) {
+          if (foundIP) {
+            if ((rtatp->rta_len - sizeof(struct rtattr)) != destLen) {
+              return EINVAL;
+            }
+            memcpy(dest, (rtatp+1), destLen);
+            foundMAC = true;
+            done = true;
+            break;
+          }
+        }
+      }
     }
   }
-#endif
+  while (done == false);
+
+  return foundMAC ? 0 : ENOENT;
+}
+#else
+int getMACAddress(const ComboAddress& ca, char* dest, size_t len)
+{
   return ENOENT;
 }
+#endif /* __linux__ */
+
 string getMACAddress(const ComboAddress& ca)
 {
   string ret;

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1204,7 +1204,7 @@ int getMACAddress(const ComboAddress& ca, char* dest, size_t destLen)
       }
 
       auto nd = reinterpret_cast<struct ndmsg*>(NLMSG_DATA(nlmsgheader));
-      auto rtatp = reinterpret_cast<struct rtattr*>(((char*)(nd)) + NLMSG_ALIGN(sizeof(struct ndmsg)));
+      auto rtatp = reinterpret_cast<struct rtattr*>(reinterpret_cast<char*>(nd) + NLMSG_ALIGN(sizeof(struct ndmsg)));
       int rtattrlen = nlmsgheader->nlmsg_len - NLMSG_LENGTH(sizeof(struct ndmsg));
 
       if (nd->ndm_family != ca.sin4.sin_family) {
@@ -1231,7 +1231,7 @@ int getMACAddress(const ComboAddress& ca, char* dest, size_t destLen)
             if ((rtatp->rta_len - sizeof(struct rtattr)) != destLen) {
               return EINVAL;
             }
-            memcpy(dest, (rtatp+1), destLen);
+            memcpy(dest, reinterpret_cast<const char*>(rtatp) + sizeof(struct rtattr), destLen);
             foundMAC = true;
             done = true;
             break;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The existing implementation used /proc/net/arp which only contains MAC addresses for IPv4 addresses. Switching to netlink provides support for IPv6 addresses as well, and roughly the same performance (it seems a tiny bit faster but the difference is in the error margin).

<strike>This is just a draft as the code could be prettier, don't merge this just yet!</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
