### PR TITLE
auth: Tweak for Coverity 1488422

### DIFF
--- a/pdns/signingpipe.cc
+++ b/pdns/signingpipe.cc
@@ -201,13 +201,13 @@ void ChunkedSigningPipe::sendRRSetToWorker() // it sounds so socialist!
     shuffle(rwVect.second.begin(), rwVect.second.end(), pdns::dns_random_engine()); // pick random available worker
     auto ptr = d_rrsetToSign.get();
     writen2(*rwVect.second.begin(), &ptr, sizeof(ptr));
-    d_rrsetToSign.release();
+    // coverity[leaked_storage]
+    static_cast<void>(d_rrsetToSign.release());
     d_rrsetToSign = make_unique<rrset_t>();
     d_outstandings[*rwVect.second.begin()]++;
     d_outstanding++;
     d_queued++;
     wantWrite=false;
-    // coverity[leaked_storage]
   } 
   
   if(wantRead) {
@@ -252,12 +252,12 @@ void ChunkedSigningPipe::sendRRSetToWorker() // it sounds so socialist!
     shuffle(rwVect.second.begin(), rwVect.second.end(), pdns::dns_random_engine()); // pick random available worker
     auto ptr = d_rrsetToSign.get();
     writen2(*rwVect.second.begin(), &ptr, sizeof(ptr));
-    d_rrsetToSign.release();
+    // coverity[leaked_storage]
+    static_cast<void>(d_rrsetToSign.release());
     d_rrsetToSign = make_unique<rrset_t>();
     d_outstandings[*rwVect.second.begin()]++;
     d_outstanding++;
     d_queued++;
-    // coverity[leaked_storage]
   }
   
 }


### PR DESCRIPTION
The spot where the warning happens changed, plus appease clang-tidy.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
