### PR TITLE
auth: Speed up ECDSA and RSA signatures

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -110,8 +110,7 @@ bool DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, in
     throw runtime_error("The algorithm does not support the given bit size.");
   }
   DNSSECPrivateKey dspk;
-  dspk.setKey(dpk, setSEPBit ? 257 : 256);
-  dspk.setAlgorithm(algorithm);
+  dspk.setKey(dpk, setSEPBit ? 257 : 256, algorithm);
   return addKey(name, dspk, id, active, published) && clearKeyCache(name);
 }
 
@@ -170,8 +169,7 @@ DNSSECPrivateKey DNSSECKeeper::getKeyById(const DNSName& zname, unsigned int id)
     DNSKEYRecordContent dkrc;
     auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
     DNSSECPrivateKey dpk;
-    dpk.setKey(key, kd.flags);
-    dpk.setAlgorithm(dkrc.d_algorithm);
+    dpk.setKey(key, kd.flags, dkrc.d_algorithm);
     
     return dpk;    
   }
@@ -583,8 +581,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
     DNSKEYRecordContent dkrc;
     auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
     DNSSECPrivateKey dpk;
-    dpk.setKey(key, kd.flags);
-    dpk.setAlgorithm(dkrc.d_algorithm);
+    dpk.setKey(key, kd.flags, dkrc.d_algorithm);
 
     KeyMetaData kmd;
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -103,16 +103,15 @@ bool DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, in
       }
     }
   }
-  DNSSECPrivateKey dspk;
   shared_ptr<DNSCryptoKeyEngine> dpk(DNSCryptoKeyEngine::make(algorithm));
   try{
     dpk->create(bits);
   } catch (const std::runtime_error& error){
     throw runtime_error("The algorithm does not support the given bit size.");
   }
-  dspk.d_algorithm = algorithm;
-  dspk.d_flags = setSEPBit ? 257 : 256;
-  dspk.setKey(dpk);
+  DNSSECPrivateKey dspk;
+  dspk.setKey(dpk, setSEPBit ? 257 : 256);
+  dspk.setAlgorithm(algorithm);
   return addKey(name, dspk, id, active, published) && clearKeyCache(name);
 }
 
@@ -145,7 +144,7 @@ void DNSSECKeeper::clearCaches(const DNSName& name)
 bool DNSSECKeeper::addKey(const DNSName& name, const DNSSECPrivateKey& dpk, int64_t& id, bool active, bool published)
 {
   DNSBackend::KeyData kd;
-  kd.flags = dpk.d_flags; // the dpk doesn't get stored, only they key part
+  kd.flags = dpk.getFlags(); // the dpk doesn't get stored, only they key part
   kd.active = active;
   kd.published = published;
   kd.content = dpk.getKey()->convertToISC();
@@ -168,12 +167,11 @@ DNSSECPrivateKey DNSSECKeeper::getKeyById(const DNSName& zname, unsigned int id)
     if(kd.id != id) 
       continue;
     
-    DNSSECPrivateKey dpk;
     DNSKEYRecordContent dkrc;
     auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
-    dpk.d_flags = kd.flags;
-    dpk.d_algorithm = dkrc.d_algorithm;
-    dpk.setKey(key);
+    DNSSECPrivateKey dpk;
+    dpk.setKey(key, kd.flags);
+    dpk.setAlgorithm(dkrc.d_algorithm);
     
     return dpk;    
   }
@@ -565,10 +563,10 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
   set<uint8_t> algoSEP, algoNoSEP;
   vector<uint8_t> algoHasSeparateKSK;
   for(const DNSBackend::KeyData &keydata : dbkeyset) {
-    DNSSECPrivateKey dpk;
     DNSKEYRecordContent dkrc;
     auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, keydata.content));
-    dpk.setKey(key);
+    DNSSECPrivateKey dpk;
+    dpk.setKey(key, dkrc.d_algorithm);
 
     if(keydata.active) {
       if(keydata.flags == 257)
@@ -582,12 +580,11 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
 
   for(DNSBackend::KeyData& kd : dbkeyset)
   {
-    DNSSECPrivateKey dpk;
     DNSKEYRecordContent dkrc;
     auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
-    dpk.d_flags = kd.flags;
-    dpk.d_algorithm = dkrc.d_algorithm;
-    dpk.setKey(key);
+    DNSSECPrivateKey dpk;
+    dpk.setKey(key, kd.flags);
+    dpk.setAlgorithm(dkrc.d_algorithm);
 
     KeyMetaData kmd;
 
@@ -596,7 +593,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
     kmd.hasSEPBit = (kd.flags == 257);
     kmd.id = kd.id;
 
-    if (find(algoHasSeparateKSK.begin(), algoHasSeparateKSK.end(), dpk.d_algorithm) == algoHasSeparateKSK.end())
+    if (find(algoHasSeparateKSK.begin(), algoHasSeparateKSK.end(), dpk.getAlgorithm()) == algoHasSeparateKSK.end())
       kmd.keyType = CSK;
     else if(kmd.hasSEPBit)
       kmd.keyType = KSK;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -110,9 +110,9 @@ bool DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, in
   } catch (const std::runtime_error& error){
     throw runtime_error("The algorithm does not support the given bit size.");
   }
-  dspk.setKey(dpk);
   dspk.d_algorithm = algorithm;
   dspk.d_flags = setSEPBit ? 257 : 256;
+  dspk.setKey(dpk);
   return addKey(name, dspk, id, active, published) && clearKeyCache(name);
 }
 
@@ -171,9 +171,9 @@ DNSSECPrivateKey DNSSECKeeper::getKeyById(const DNSName& zname, unsigned int id)
     DNSSECPrivateKey dpk;
     DNSKEYRecordContent dkrc;
     auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
-    dpk.setKey(key);
     dpk.d_flags = kd.flags;
     dpk.d_algorithm = dkrc.d_algorithm;
+    dpk.setKey(key);
     
     return dpk;    
   }
@@ -585,10 +585,9 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
     DNSSECPrivateKey dpk;
     DNSKEYRecordContent dkrc;
     auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
-    dpk.setKey(key);
-
     dpk.d_flags = kd.flags;
     dpk.d_algorithm = dkrc.d_algorithm;
+    dpk.setKey(key);
 
     KeyMetaData kmd;
 

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -56,7 +56,6 @@ public:
 #endif
 
   storvector_t convertToISCVector() const override;
-  std::string getPubKeyHash() const override;
   std::string sign(const std::string& msg) const override;
   bool verify(const std::string& msg, const std::string& signature) const override;
   std::string getPublicKeyString() const override;
@@ -167,11 +166,6 @@ void DecafED25519DNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, std::m
   pub.serialize_into(d_pubkey);
 }
 
-std::string DecafED25519DNSCryptoKeyEngine::getPubKeyHash() const
-{
-  return this->getPublicKeyString();
-}
-
 std::string DecafED25519DNSCryptoKeyEngine::getPublicKeyString() const
 {
   return string((char*)d_pubkey, DECAF_EDDSA_25519_PUBLIC_BYTES);
@@ -260,7 +254,6 @@ public:
 #endif
 
   storvector_t convertToISCVector() const override;
-  std::string getPubKeyHash() const override;
   std::string sign(const std::string& msg) const override;
   bool verify(const std::string& msg, const std::string& signature) const override;
   std::string getPublicKeyString() const override;
@@ -369,11 +362,6 @@ void DecafED448DNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, std::map
 
   priv.serialize_into(d_seckey);
   pub.serialize_into(d_pubkey);
-}
-
-std::string DecafED448DNSCryptoKeyEngine::getPubKeyHash() const
-{
-  return this->getPublicKeyString();
 }
 
 std::string DecafED448DNSCryptoKeyEngine::getPublicKeyString() const

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -595,9 +595,14 @@ void decrementHash(std::string& raw) // I wonder if this is correct, cmouse? ;-)
   }
 }
 
-DNSKEYRecordContent DNSSECPrivateKey::getDNSKEY() const
+const DNSKEYRecordContent& DNSSECPrivateKey::getDNSKEY() const
 {
-  return makeDNSKEYFromDNSCryptoKeyEngine(getKey(), d_algorithm, d_flags);
+  return d_dnskey;
+}
+
+void DNSSECPrivateKey::computeDNSKEY()
+{
+  d_dnskey = makeDNSKEYFromDNSCryptoKeyEngine(getKey(), d_algorithm, d_flags);
 }
 
 static string calculateHMAC(const std::string& key, const std::string& text, TSIGHashEnum hasher) {

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -148,30 +148,48 @@ struct DNSSECPrivateKey
     return d_key;
   }
 
-  void setKey(std::shared_ptr<DNSCryptoKeyEngine>& key)
+  // be aware that calling setKey() will also set the algorithm
+  void setKey(std::shared_ptr<DNSCryptoKeyEngine>& key, uint16_t flags)
   {
     d_key = key;
+    d_flags = flags;
     d_algorithm = d_key->getAlgorithm();
     computeDNSKEY();
   }
 
-  void setKey(std::unique_ptr<DNSCryptoKeyEngine>&& key)
+  // be aware that calling setKey() will also set the algorithm
+  void setKey(std::unique_ptr<DNSCryptoKeyEngine>&& key, uint16_t flags)
   {
     d_key = std::move(key);
+    d_flags = flags;
     d_algorithm = d_key->getAlgorithm();
     computeDNSKEY();
   }
 
   const DNSKEYRecordContent& getDNSKEY() const;
 
-  uint16_t d_flags;
-  uint8_t d_algorithm;
+  uint16_t getFlags() const
+  {
+    return d_flags;
+  }
+
+  uint8_t getAlgorithm() const
+  {
+    return d_algorithm;
+  }
+
+  void setAlgorithm(uint8_t algo)
+  {
+    d_algorithm = algo;
+  }
 
 private:
   void computeDNSKEY();
 
   DNSKEYRecordContent d_dnskey;
   std::shared_ptr<DNSCryptoKeyEngine> d_key;
+  uint16_t d_flags;
+  uint8_t d_algorithm;
 };
 
 

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -65,7 +65,6 @@ class DNSCryptoKeyEngine
 
     [[nodiscard]] virtual bool verify(const std::string& msg, const std::string& signature) const =0;
 
-    [[nodiscard]] virtual std::string getPubKeyHash()const =0;
     [[nodiscard]] virtual std::string getPublicKeyString()const =0;
     [[nodiscard]] virtual int getBits() const =0;
     [[nodiscard]] virtual unsigned int getAlgorithm() const

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -152,20 +152,25 @@ struct DNSSECPrivateKey
   {
     d_key = key;
     d_algorithm = d_key->getAlgorithm();
+    computeDNSKEY();
   }
 
   void setKey(std::unique_ptr<DNSCryptoKeyEngine>&& key)
   {
     d_key = std::move(key);
     d_algorithm = d_key->getAlgorithm();
+    computeDNSKEY();
   }
 
-  DNSKEYRecordContent getDNSKEY() const;
+  const DNSKEYRecordContent& getDNSKEY() const;
 
   uint16_t d_flags;
   uint8_t d_algorithm;
 
 private:
+  void computeDNSKEY();
+
+  DNSKEYRecordContent d_dnskey;
   std::shared_ptr<DNSCryptoKeyEngine> d_key;
 };
 

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -149,20 +149,20 @@ struct DNSSECPrivateKey
   }
 
   // be aware that calling setKey() will also set the algorithm
-  void setKey(std::shared_ptr<DNSCryptoKeyEngine>& key, uint16_t flags)
+  void setKey(std::shared_ptr<DNSCryptoKeyEngine>& key, uint16_t flags, std::optional<uint8_t> algorithm = std::nullopt)
   {
     d_key = key;
     d_flags = flags;
-    d_algorithm = d_key->getAlgorithm();
+    d_algorithm = algorithm ? *algorithm : d_key->getAlgorithm();
     computeDNSKEY();
   }
 
   // be aware that calling setKey() will also set the algorithm
-  void setKey(std::unique_ptr<DNSCryptoKeyEngine>&& key, uint16_t flags)
+  void setKey(std::unique_ptr<DNSCryptoKeyEngine>&& key, uint16_t flags, std::optional<uint8_t> algorithm = std::nullopt)
   {
     d_key = std::move(key);
     d_flags = flags;
-    d_algorithm = d_key->getAlgorithm();
+    d_algorithm = algorithm ? *algorithm : d_key->getAlgorithm();
     computeDNSKEY();
   }
 
@@ -176,11 +176,6 @@ struct DNSSECPrivateKey
   uint8_t getAlgorithm() const
   {
     return d_algorithm;
-  }
-
-  void setAlgorithm(uint8_t algo)
-  {
-    d_algorithm = algo;
   }
 
 private:

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3488,7 +3488,6 @@ try
     }
 
     DNSSECPrivateKey dpk;
-    dpk.setKey(key);
 
     pdns::checked_stoi_into(dpk.d_algorithm, cmds.at(3));
     if (dpk.d_algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1) {
@@ -3512,6 +3511,7 @@ try
     else {
       dpk.d_flags = 257; // ksk
     }
+    dpk.setKey(key);
 
     int64_t id;
     if (!dk.addKey(DNSName(zone), dpk, id)) {
@@ -3539,7 +3539,6 @@ try
     DNSSECPrivateKey dpk;
     DNSKEYRecordContent drc;
     shared_ptr<DNSCryptoKeyEngine> key(DNSCryptoKeyEngine::makeFromISCFile(drc, fname.c_str()));
-    dpk.setKey(key);
     dpk.d_algorithm = drc.d_algorithm;
 
     if(dpk.d_algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1)
@@ -3567,6 +3566,7 @@ try
         return 1;
       }
     }
+    dpk.setKey(key);
     int64_t id;
     if (!dk.addKey(DNSName(zone), dpk, id, active, published)) {
       cerr<<"Adding key failed, perhaps DNSSEC not enabled in configuration?"<<endl;
@@ -3645,9 +3645,9 @@ try
       }
     }
     dpk->create(bits);
-    dspk.setKey(dpk);
     dspk.d_algorithm = algorithm;
     dspk.d_flags = keyOrZone ? 257 : 256;
+    dspk.setKey(dpk);
 
     // print key to stdout
     cout << "Flags: " << dspk.d_flags << endl <<

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3513,8 +3513,7 @@ try
     else {
       flags = 257; // ksk
     }
-    dpk.setKey(key, flags);
-    dpk.setAlgorithm(algo);
+    dpk.setKey(key, flags, algo);
 
     int64_t id;
     if (!dk.addKey(DNSName(zone), dpk, id)) {
@@ -3566,11 +3565,11 @@ try
     }
 
     DNSSECPrivateKey dpk;
-    dpk.setKey(key, flags);
-
-    if (dpk.getAlgorithm() == DNSSECKeeper::RSASHA1NSEC3SHA1) {
-      dpk.setAlgorithm(DNSSECKeeper::RSASHA1);
+    uint8_t algo = key->getAlgorithm();
+    if (algo == DNSSECKeeper::RSASHA1NSEC3SHA1) {
+      algo = DNSSECKeeper::RSASHA1;
     }
+    dpk.setKey(key, flags, algo);
 
     int64_t id;
     if (!dk.addKey(DNSName(zone), dpk, id, active, published)) {
@@ -3650,8 +3649,7 @@ try
     }
     dpk->create(bits);
     DNSSECPrivateKey dspk;
-    dspk.setKey(dpk, keyOrZone ? 257 : 256);
-    dspk.setAlgorithm(algorithm);
+    dspk.setKey(dpk, keyOrZone ? 257 : 256, algorithm);
 
     // print key to stdout
     cout << "Flags: " << dspk.getFlags() << endl <<

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1013,7 +1013,7 @@ static void listKey(DomainInfo const &di, DNSSECKeeper& dk, bool printHeader = t
       cout<<key.first.getKey()->getBits()<<string(spacelen, ' ');
     }
 
-    string algname = DNSSECKeeper::algorithm2name(key.first.d_algorithm);
+    string algname = DNSSECKeeper::algorithm2name(key.first.getAlgorithm());
     spacelen = (algname.length() >= 16) ? 1 : 16 - algname.length();
     cout<<algname<<string(spacelen, ' ');
 
@@ -2161,7 +2161,7 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
     }
 
     for(const DNSSECKeeper::keyset_t::value_type& value :  keyset) {
-      string algname = DNSSECKeeper::algorithm2name(value.first.d_algorithm);
+      string algname = DNSSECKeeper::algorithm2name(value.first.getAlgorithm());
       if (!exportDS) {
         cout<<"ID = "<<value.second.id<<" ("<<DNSSECKeeper::keyTypeToString(value.second.keyType)<<")";
       }
@@ -2170,9 +2170,9 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
         continue;
       }
       if (!exportDS) {
-        cout<<", flags = "<<std::to_string(value.first.d_flags);
+        cout<<", flags = "<<std::to_string(value.first.getFlags());
         cout<<", tag = "<<value.first.getDNSKEY().getTag();
-        cout<<", algo = "<<(int)value.first.d_algorithm<<", bits = "<<value.first.getKey()->getBits()<<"\t"<<((int)value.second.active == 1 ? "  A" : "Ina")<<"ctive\t"<<(value.second.published ? " Published" : " Unpublished")<<"  ( " + algname + " ) "<<endl;
+        cout<<", algo = "<<(int)value.first.getAlgorithm()<<", bits = "<<value.first.getKey()->getBits()<<"\t"<<((int)value.second.active == 1 ? "  A" : "Ina")<<"ctive\t"<<(value.second.published ? " Published" : " Unpublished")<<"  ( " + algname + " ) "<<endl;
       }
 
       if (!exportDS) {
@@ -3489,19 +3489,21 @@ try
 
     DNSSECPrivateKey dpk;
 
-    pdns::checked_stoi_into(dpk.d_algorithm, cmds.at(3));
-    if (dpk.d_algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1) {
-      dpk.d_algorithm = DNSSECKeeper::RSASHA1;
+    uint8_t algo = 0;
+    pdns::checked_stoi_into(algo, cmds.at(3));
+    if (algo == DNSSECKeeper::RSASHA1NSEC3SHA1) {
+      algo = DNSSECKeeper::RSASHA1;
     }
 
-    cerr << (int)dpk.d_algorithm << endl;
+    cerr << std::to_string(algo) << endl;
 
+    uint16_t flags = 0;
     if (cmds.size() > 4) {
       if (pdns_iequals(cmds.at(4), "ZSK")) {
-        dpk.d_flags = 256;
+        flags = 256;
       }
       else if (pdns_iequals(cmds.at(4), "KSK")) {
-        dpk.d_flags = 257;
+        flags = 257;
       }
       else {
         cerr << "Unknown key flag '" << cmds.at(4) << "'" << endl;
@@ -3509,9 +3511,10 @@ try
       }
     }
     else {
-      dpk.d_flags = 257; // ksk
+      flags = 257; // ksk
     }
-    dpk.setKey(key);
+    dpk.setKey(key, flags);
+    dpk.setAlgorithm(algo);
 
     int64_t id;
     if (!dk.addKey(DNSName(zone), dpk, id)) {
@@ -3536,23 +3539,18 @@ try
     }
     string zone = cmds.at(1);
     string fname = cmds.at(2);
-    DNSSECPrivateKey dpk;
     DNSKEYRecordContent drc;
     shared_ptr<DNSCryptoKeyEngine> key(DNSCryptoKeyEngine::makeFromISCFile(drc, fname.c_str()));
-    dpk.d_algorithm = drc.d_algorithm;
 
-    if(dpk.d_algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1)
-      dpk.d_algorithm = DNSSECKeeper::RSASHA1;
-
-    dpk.d_flags = 257;
+    uint16_t flags = 257;
     bool active=true;
     bool published=true;
 
     for(unsigned int n = 3; n < cmds.size(); ++n) {
       if (pdns_iequals(cmds.at(n), "ZSK"))
-        dpk.d_flags = 256;
+        flags = 256;
       else if (pdns_iequals(cmds.at(n), "KSK"))
-        dpk.d_flags = 257;
+        flags = 257;
       else if (pdns_iequals(cmds.at(n), "active"))
         active = true;
       else if (pdns_iequals(cmds.at(n), "passive") || pdns_iequals(cmds.at(n), "inactive")) // passive eventually needs to be removed
@@ -3566,7 +3564,14 @@ try
         return 1;
       }
     }
-    dpk.setKey(key);
+
+    DNSSECPrivateKey dpk;
+    dpk.setKey(key, flags);
+
+    if (dpk.getAlgorithm() == DNSSECKeeper::RSASHA1NSEC3SHA1) {
+      dpk.setAlgorithm(DNSSECKeeper::RSASHA1);
+    }
+
     int64_t id;
     if (!dk.addKey(DNSName(zone), dpk, id, active, published)) {
       cerr<<"Adding key failed, perhaps DNSSEC not enabled in configuration?"<<endl;
@@ -3627,7 +3632,6 @@ try
     if(bits)
       cerr<<"Requesting specific key size of "<<bits<<" bits"<<endl;
 
-    DNSSECPrivateKey dspk;
     shared_ptr<DNSCryptoKeyEngine> dpk(DNSCryptoKeyEngine::make(algorithm));
     if(!bits) {
       if(algorithm <= 10)
@@ -3645,12 +3649,12 @@ try
       }
     }
     dpk->create(bits);
-    dspk.d_algorithm = algorithm;
-    dspk.d_flags = keyOrZone ? 257 : 256;
-    dspk.setKey(dpk);
+    DNSSECPrivateKey dspk;
+    dspk.setKey(dpk, keyOrZone ? 257 : 256);
+    dspk.setAlgorithm(algorithm);
 
     // print key to stdout
-    cout << "Flags: " << dspk.d_flags << endl <<
+    cout << "Flags: " << dspk.getFlags() << endl <<
              dspk.getKey()->convertToISC() << endl;
   }
   else if (cmds.at(0) == "generate-tsig-key") {
@@ -3921,15 +3925,14 @@ try
         "PubLabel: " << pub_label << std::endl;
 
       DNSKEYRecordContent drc;
-      DNSSECPrivateKey dpk;
-      dpk.d_flags = (keyOrZone ? 257 : 256);
 
       shared_ptr<DNSCryptoKeyEngine> dke(DNSCryptoKeyEngine::makeFromISCString(drc, iscString.str()));
       if(!dke->checkKey()) {
         cerr << "Invalid DNS Private Key in engine " << module << " slot " << slot << std::endl;
         return 1;
       }
-      dpk.setKey(dke);
+      DNSSECPrivateKey dpk;
+      dpk.setKey(dke, keyOrZone ? 257 : 256);
 
       // make sure this key isn't being reused.
       B.getDomainKeys(zone, keys);

--- a/pdns/pkcs11signers.hh
+++ b/pdns/pkcs11signers.hh
@@ -52,8 +52,6 @@ class PKCS11DNSCryptoKeyEngine : public DNSCryptoKeyEngine
 
     bool verify(const std::string& msg, const std::string& signature) const override;
 
-    std::string getPubKeyHash() const override;
-
     std::string getPublicKeyString() const override;
     int getBits() const override;
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -463,8 +463,7 @@ void generateKeyMaterial(const DNSName& name, unsigned int algo, uint8_t digest,
   auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(algo));
   dcke->create((algo <= 10) ? 2048 : dcke->getBits());
   DNSSECPrivateKey dpk;
-  dpk.d_flags = 256;
-  dpk.setKey(dcke);
+  dpk.setKey(dcke, 256);
   DSRecordContent ds = makeDSFromDNSKey(name, dpk.getDNSKEY(), digest);
   keys[name] = std::pair<DNSSECPrivateKey, DSRecordContent>(dpk, ds);
 }

--- a/pdns/recursordist/test-syncres_cc10.cc
+++ b/pdns/recursordist/test-syncres_cc10.cc
@@ -928,16 +928,14 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_loop)
   auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey key;
-  key.d_flags = 257;
-  key.setKey(std::move(dcke));
+  key.setKey(std::move(dcke), 257);
   DSRecordContent drc = makeDSFromDNSKey(DNSName("powerdns.com."), key.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   testkeysset_t wrongKeys;
   auto wrongDcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   wrongDcke->create(wrongDcke->getBits());
   DNSSECPrivateKey wrongKey;
-  wrongKey.d_flags = 256;
-  wrongKey.setKey(std::move(wrongDcke));
+  wrongKey.setKey(std::move(wrongDcke), 256);
   DSRecordContent uselessdrc = makeDSFromDNSKey(DNSName("powerdns.com."), wrongKey.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   wrongKeys[DNSName("powerdns.com.")] = std::pair<DNSSECPrivateKey, DSRecordContent>(wrongKey, uselessdrc);

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -441,8 +441,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig)
   dcke->create(dcke->getBits());
   // cerr<<dcke->convertToISC()<<endl;
   DNSSECPrivateKey dpk;
-  dpk.d_flags = 256;
-  dpk.setKey(std::move(dcke));
+  dpk.setKey(std::move(dcke), 256);
 
   sortedRecords_t recordcontents;
   recordcontents.insert(getRecordContent(QType::A, "192.0.2.1"));
@@ -546,15 +545,13 @@ BOOST_AUTO_TEST_CASE(test_dnssec_root_validation_ksk_zsk)
   auto dckeZ = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dckeZ->create(dckeZ->getBits());
   DNSSECPrivateKey ksk;
-  ksk.d_flags = 257;
-  ksk.setKey(std::move(dckeZ));
+  ksk.setKey(std::move(dckeZ), 257);
   DSRecordContent kskds = makeDSFromDNSKey(target, ksk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   auto dckeK = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dckeK->create(dckeK->getBits());
   DNSSECPrivateKey zsk;
-  zsk.d_flags = 256;
-  zsk.setKey(std::move(dckeK));
+  zsk.setKey(std::move(dckeK), 256);
   DSRecordContent zskds = makeDSFromDNSKey(target, zsk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   kskeys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(ksk, kskds);
@@ -699,8 +696,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_without_zone_flag)
   auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey csk;
-  csk.d_flags = 0;
-  csk.setKey(std::move(dcke));
+  csk.setKey(std::move(dcke), 0);
   DSRecordContent ds = makeDSFromDNSKey(target, csk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   keys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(csk, ds);
@@ -776,8 +772,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_revoked)
   auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey csk;
-  csk.d_flags = 257 | 128;
-  csk.setKey(std::move(dcke));
+  csk.setKey(std::move(dcke), 257 | 128);
   DSRecordContent ds = makeDSFromDNSKey(target, csk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   keys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(csk, ds);
@@ -853,15 +848,13 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_doesnt_match_ds)
   auto dckeDS = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dckeDS->create(dckeDS->getBits());
   DNSSECPrivateKey dskey;
-  dskey.d_flags = 257;
-  dskey.setKey(std::move(dckeDS));
+  dskey.setKey(std::move(dckeDS), 257);
   DSRecordContent drc = makeDSFromDNSKey(target, dskey.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey dpk;
-  dpk.d_flags = 256;
-  dpk.setKey(std::move(dcke));
+  dpk.setKey(std::move(dcke), 256);
   DSRecordContent uselessdrc = makeDSFromDNSKey(target, dpk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   dskeys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(dskey, drc);
@@ -979,8 +972,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_rrsig_signed_with_unknown_dnskey)
   auto dckeRRSIG = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dckeRRSIG->create(dckeRRSIG->getBits());
   DNSSECPrivateKey rrsigkey;
-  rrsigkey.d_flags = 257;
-  rrsigkey.setKey(std::move(dckeRRSIG));
+  rrsigkey.setKey(std::move(dckeRRSIG), 257);
   DSRecordContent rrsigds = makeDSFromDNSKey(target, rrsigkey.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   rrsigkeys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(rrsigkey, rrsigds);
@@ -1202,10 +1194,9 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_algorithm)
   auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey dpk;
-  dpk.d_flags = 256;
+  dpk.setKey(std::move(dcke), 256);
   /* Fake algorithm number (private) */
-  dpk.d_algorithm = 253;
-  dpk.setKey(std::move(dcke));
+  dpk.setAlgorithm(253);
 
   DSRecordContent drc = makeDSFromDNSKey(target, dpk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
   keys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(dpk, drc);
@@ -1285,8 +1276,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_digest)
   auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey dpk;
-  dpk.d_flags = 256;
-  dpk.setKey(std::move(dcke));
+  dpk.setKey(std::move(dcke), 256);
   DSRecordContent drc = makeDSFromDNSKey(target, dpk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
   /* Fake digest number (reserved) */
   drc.d_digesttype = 0;

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -1203,9 +1203,9 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_algorithm)
   dcke->create(dcke->getBits());
   DNSSECPrivateKey dpk;
   dpk.d_flags = 256;
-  dpk.setKey(std::move(dcke));
   /* Fake algorithm number (private) */
   dpk.d_algorithm = 253;
+  dpk.setKey(std::move(dcke));
 
   DSRecordContent drc = makeDSFromDNSKey(target, dpk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
   keys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(dpk, drc);

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -1194,9 +1194,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_algorithm)
   auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey dpk;
-  dpk.setKey(std::move(dcke), 256);
   /* Fake algorithm number (private) */
-  dpk.setAlgorithm(253);
+  dpk.setKey(std::move(dcke), 256, 253);
 
   DSRecordContent drc = makeDSFromDNSKey(target, dpk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
   keys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(dpk, drc);

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -51,7 +51,6 @@ public:
 #endif
 
   storvector_t convertToISCVector() const override;
-  std::string getPubKeyHash() const override;
   std::string sign(const std::string& msg) const override;
   bool verify(const std::string& msg, const std::string& signature) const override;
   std::string getPublicKeyString() const override;
@@ -159,11 +158,6 @@ void SodiumED25519DNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, std::
 
   memcpy(seed.get(), privateKey.c_str(), crypto_sign_ed25519_SEEDBYTES);
   crypto_sign_ed25519_seed_keypair(d_pubkey, d_seckey, seed.get());
-}
-
-std::string SodiumED25519DNSCryptoKeyEngine::getPubKeyHash() const
-{
-  return this->getPublicKeyString();
 }
 
 std::string SodiumED25519DNSCryptoKeyEngine::getPublicKeyString() const

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -305,8 +305,8 @@ static void checkRR(const SignerParams& signer)
   DNSKEYRecordContent drc;
   auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(drc, signer.iscMap));
   DNSSECPrivateKey dpk;
-  dpk.setKey(dcke);
   dpk.d_flags = signer.rfcFlags;
+  dpk.setKey(dcke);
 
   sortedRecords_t rrs;
   /* values taken from rfc8080 for ed25519 and ed448, rfc5933 for gost */
@@ -375,8 +375,8 @@ static void test_generic_signer(std::shared_ptr<DNSCryptoKeyEngine> dcke, DNSKEY
   BOOST_CHECK_EQUAL(drc.d_algorithm, signer.algorithm);
 
   DNSSECPrivateKey dpk;
-  dpk.setKey(dcke);
   dpk.d_flags = signer.flags;
+  dpk.setKey(dcke);
   drc = dpk.getDNSKEY();
 
   BOOST_CHECK_EQUAL(drc.d_algorithm, signer.algorithm);

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -305,12 +305,11 @@ static void checkRR(const SignerParams& signer)
   DNSKEYRecordContent drc;
   auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(drc, signer.iscMap));
   DNSSECPrivateKey dpk;
-  dpk.d_flags = signer.rfcFlags;
-  dpk.setKey(dcke);
+  dpk.setKey(dcke, signer.rfcFlags);
 
   sortedRecords_t rrs;
   /* values taken from rfc8080 for ed25519 and ed448, rfc5933 for gost */
-  DNSName qname(dpk.d_algorithm == DNSSECKeeper::ECCGOST ? "www.example.net." : "example.com.");
+  DNSName qname(dpk.getAlgorithm() == DNSSECKeeper::ECCGOST ? "www.example.net." : "example.com.");
 
   reportBasicTypes();
 
@@ -318,7 +317,7 @@ static void checkRR(const SignerParams& signer)
   uint32_t expire = 1440021600;
   uint32_t inception = 1438207200;
 
-  if (dpk.d_algorithm == DNSSECKeeper::ECCGOST) {
+  if (dpk.getAlgorithm() == DNSSECKeeper::ECCGOST) {
     rrc.d_signer = DNSName("example.net.");
     inception = 946684800;
     expire = 1893456000;
@@ -335,7 +334,7 @@ static void checkRR(const SignerParams& signer)
   rrc.d_type = (*rrs.cbegin())->getType();
   rrc.d_labels = qname.countLabels();
   rrc.d_tag = dpk.getTag();
-  rrc.d_algorithm = dpk.d_algorithm;
+  rrc.d_algorithm = dpk.getAlgorithm();
 
   string msg = getMessageForRRSET(qname, rrc, rrs, false);
 
@@ -375,8 +374,7 @@ static void test_generic_signer(std::shared_ptr<DNSCryptoKeyEngine> dcke, DNSKEY
   BOOST_CHECK_EQUAL(drc.d_algorithm, signer.algorithm);
 
   DNSSECPrivateKey dpk;
-  dpk.d_flags = signer.flags;
-  dpk.setKey(dcke);
+  dpk.setKey(dcke, signer.flags);
   drc = dpk.getDNSKEY();
 
   BOOST_CHECK_EQUAL(drc.d_algorithm, signer.algorithm);

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -29,7 +29,6 @@ struct SignerParams
   std::string name;
   std::string rfcMsgDump;
   std::string rfcB64Signature;
-  std::string pubKeyHash;
   int bits;
   uint16_t flags;
   uint16_t rfcFlags;
@@ -78,7 +77,6 @@ static const SignerParams rsaSha256SignerParams = SignerParams{
 
   .rfcMsgDump = "",
   .rfcB64Signature = "",
-  .pubKeyHash = "QH+uURzTHkYZ5MrwNvOrn+BtnL4=",
 
   .bits = 512,
   .flags = 256,
@@ -133,7 +131,6 @@ static const SignerParams ecdsaSha256 = SignerParams{
 
   .rfcMsgDump = "",
   .rfcB64Signature = "",
-  .pubKeyHash = "aIQTEsTXwMDIOXPY9e6W1G1AnAk=",
 
   .bits = 256,
   .flags = 256,
@@ -191,7 +188,6 @@ static const SignerParams ed25519 = SignerParams{
   // https://www.rfc-editor.org/errata_search.php?rfc=8080&eid=4935
   .rfcB64Signature = "oL9krJun7xfBOIWcGHi7mag5/hdZrKWw15jPGrHpjQeR"
                      "AvTdszaPD+QLs3fx8A4M3e23mRZ9VrbpMngwcrqNAg==",
-  .pubKeyHash = "l02Woi0iS8Aa25FQkUd9RMzZHJpBoRQwAQEX1SxZJA4=",
 
   .bits = 256,
   .flags = 256,
@@ -253,8 +249,6 @@ static const SignerParams ed448 = SignerParams{
   .rfcB64Signature = "3cPAHkmlnxcDHMyg7vFC34l0blBhuG1qpwLmjInI8w1CMB29FkEA"
                      "IJUA0amxWndkmnBZ6SKiwZSAxGILn/NBtOXft0+Gj7FSvOKxE/07"
                      "+4RQvE581N3Aj/JtIyaiYVdnYtyMWbSNyGEY2213WKsJlwEA",
-  .pubKeyHash = "3kgROaDjrh0H2iuixWBrc8g2EpBBLCdGzHmn+G2MpTPhpj/"
-                "OiBVHHSfPodx1FYYUcJKm1MDpJtIA",
 
   .bits = 456,
   .flags = 256,
@@ -425,8 +419,6 @@ static void test_generic_signer(std::shared_ptr<DNSCryptoKeyEngine> dcke, DNSKEY
   if (!signer.rfcMsgDump.empty() && !signer.rfcB64Signature.empty()) {
     checkRR(signer);
   }
-
-  BOOST_CHECK_EQUAL(Base64Encode(dcke->getPubKeyHash()), signer.pubKeyHash);
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,readability-identifier-length): Boost stuff.

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1307,11 +1307,11 @@ static void apiZoneCryptokeysPOST(const DNSName& zonename, HttpRequest *req, Htt
       }
 
       uint8_t algorithm = dkrc.d_algorithm;
-      dpk.setKey(dke, flags);
       // TODO remove in 4.2.0
       if (algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1) {
-        dpk.setAlgorithm(DNSSECKeeper::RSASHA1);
+        algorithm = DNSSECKeeper::RSASHA1;
       }
+      dpk.setKey(dke, flags, algorithm);
     }
     catch (std::runtime_error& error) {
       throw ApiException("Key could not be parsed. Make sure your key format is correct.");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
For `ECDSA`, and likely for `RSA`, computing the public key is not a cheap operation. So instead of computing it twice to get the lookup key for our signatures cache, reuse the computed public key and only compute its digest.
In addition, since ed* algorithms were already using the whole key instead of a digest, place the cut off at public keys larger than 64 bytes, meaning that only `RSA` ones (128+ bytes) will be hashed.
This provides an additional speedup for `ECDSA` keys (32 or 48 bytes) since they no longer need to be hashed, and simplifies the signers code as the hashing can be moved to signature key cache now that it only depends on they key size.
For reference the size of a `SHA-1` digest is 20 bytes.

In my tests this reduces by 30% the cost of calling `addRRSigs()` for `ECDSA` signatures when the signature is already present in the cache.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
