### PR TITLE
Rec: shared ednsmap

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -971,11 +971,6 @@ static uint64_t getNegCacheSize()
   return g_negCache->size();
 }
 
-uint64_t* pleaseGetEDNSStatusesSize()
-{
-  return new uint64_t(SyncRes::getEDNSStatusesSize());
-}
-
 uint64_t* pleaseGetConcurrentQueries()
 {
   return new uint64_t(getMT() ? getMT()->numProcesses() : 0);
@@ -1977,7 +1972,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
     return doDumpToFile(s, pleaseDumpDoTProbeMap, cmd, false);
   }
   if (cmd == "dump-ednsstatus" || cmd == "dump-edns") {
-    return doDumpToFile(s, pleaseDumpEDNSMap, cmd);
+    return doDumpToFile(s, pleaseDumpEDNSMap, cmd, false);
   }
   if (cmd == "dump-nsspeeds") {
     return doDumpToFile(s, pleaseDumpNSSpeeds, cmd, false);

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -984,7 +984,7 @@ static void doStats(void)
             << SyncRes::getThrottledServersSize() << ", ns speeds: "
             << SyncRes::getNSSpeedsSize() << ", failed ns: "
             << SyncRes::getFailedServersSize() << ", ednsmap: "
-            << broadcastAccFunction<uint64_t>(pleaseGetEDNSStatusesSize) << ", non-resolving: "
+            << SyncRes::getEDNSStatusesSize() << ", non-resolving: "
             << SyncRes::getNonResolvingNSSize() << ", saved-parentsets: "
             << SyncRes::getSaveParentsNSSetsSize()
             << endl;
@@ -1010,7 +1010,7 @@ static void doStats(void)
                 "throttle-entries", Logging::Loggable(SyncRes::getThrottledServersSize()),
                 "nsspeed-entries", Logging::Loggable(SyncRes::getNSSpeedsSize()),
                 "failed-host-entries", Logging::Loggable(SyncRes::getFailedServersSize()),
-                "edns-entries", Logging::Loggable(broadcastAccFunction<uint64_t>(pleaseGetEDNSStatusesSize)),
+                "edns-entries", Logging::Loggable(SyncRes::getEDNSStatusesSize()),
                 "non-resolving-nameserver-entries", Logging::Loggable(SyncRes::getNonResolvingNSSize()),
                 "saved-parent-ns-sets-entries", Logging::Loggable(SyncRes::getSaveParentsNSSetsSize()),
                 "outqueries-per-query", Logging::Loggable(ratePercentage(SyncRes::s_outqueries, SyncRes::s_queries)));
@@ -2069,11 +2069,6 @@ static void houseKeeping(void*)
       });
     }
 
-    static thread_local PeriodicTask pruneEDNSTask{"pruneEDNSTask", 5}; // period could likely be longer
-    pruneEDNSTask.runIfDue(now, [now]() {
-      SyncRes::pruneEDNSStatuses(now.tv_sec - 2 * 3600);
-    });
-
     static thread_local PeriodicTask pruneTCPTask{"pruneTCPTask", 5};
     pruneTCPTask.runIfDue(now, [now]() {
       t_tcp_manager.cleanup(now);
@@ -2118,6 +2113,11 @@ static void houseKeeping(void*)
       static PeriodicTask pruneNSpeedTask{"pruneNSSpeedTask", 30};
       pruneNSpeedTask.runIfDue(now, [now]() {
         SyncRes::pruneNSSpeeds(now.tv_sec - 300);
+      });
+
+      static PeriodicTask pruneEDNSTask{"pruneEDNSTask", 5}; // period could likely be longer
+      pruneEDNSTask.runIfDue(now, [now]() {
+        SyncRes::pruneEDNSStatuses(now.tv_sec - 2 * 3600);
       });
 
       if (SyncRes::s_max_busy_dot_probes > 0) {

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2115,7 +2115,7 @@ static void houseKeeping(void*)
         SyncRes::pruneNSSpeeds(now.tv_sec - 300);
       });
 
-      static PeriodicTask pruneEDNSTask{"pruneEDNSTask", 5}; // period could likely be longer
+      static PeriodicTask pruneEDNSTask{"pruneEDNSTask", 60};
       pruneEDNSTask.runIfDue(now, [now]() {
         SyncRes::pruneEDNSStatuses(now.tv_sec - 2 * 3600);
       });

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1488,8 +1488,8 @@ LWResult::Result SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsM
   {
     auto lock = s_ednsstatus.lock();
     auto ednsstatus = lock->insert(ip).first; // does this include port? YES
-    auto &ind = lock->get<ComboAddress>();
     if (ednsstatus->modeSetAt && ednsstatus->modeSetAt + 3600 < d_now.tv_sec) {
+      auto &ind = lock->get<ComboAddress>();
       lock->reset(ind, ednsstatus);
     }
     mode = ednsstatus->mode;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -216,11 +216,11 @@ public:
     EDNSStatus(const ComboAddress &arg) : address(arg) {}
     ComboAddress address;
     time_t modeSetAt{0};
-    mutable enum EDNSMode : uint8_t { UNKNOWN = 0, EDNSOK = 1, EDNSIGNORANT = 2, NOEDNS = 3 } mode{UNKNOWN};
+    enum EDNSMode : uint8_t { UNKNOWN = 0, EDNSOK = 1, EDNSIGNORANT = 2, NOEDNS = 3 } mode{UNKNOWN};
 
     std::string toString() const
     {
-      const std::array<std::string,4> modes = { "Unknown", "OK", "Ignorant", "NoEDNS" };
+      const std::array<std::string,4> modes = { "Unknown", "OK", "Ignorant", "No" };
       unsigned int m = static_cast<unsigned int>(mode);
       if (m >= modes.size()) {
         return "?";

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -144,37 +144,7 @@ public:
 
   typedef std::unordered_map<DNSName, AuthDomain> domainmap_t;
 
-  struct EDNSStatus {
-    EDNSStatus(const ComboAddress &arg) : address(arg) {}
-    ComboAddress address;
-    time_t modeSetAt{0};
-    mutable enum EDNSMode { UNKNOWN=0, EDNSOK=1, EDNSIGNORANT=2, NOEDNS=3 } mode{UNKNOWN};
-  };
-
-  struct ednsstatus_t : public multi_index_container<EDNSStatus,
-                                                     indexed_by<
-                                                       ordered_unique<tag<ComboAddress>, member<EDNSStatus, ComboAddress, &EDNSStatus::address>>,
-                                                       ordered_non_unique<tag<time_t>, member<EDNSStatus, time_t, &EDNSStatus::modeSetAt>>
-                                  >> {
-    void reset(index<ComboAddress>::type &ind, iterator it) {
-      ind.modify(it, [](EDNSStatus &s) { s.mode = EDNSStatus::EDNSMode::UNKNOWN; s.modeSetAt = 0; });
-    }
-    void setMode(index<ComboAddress>::type &ind, iterator it, EDNSStatus::EDNSMode mode) {
-      it->mode = mode;
-    }
-    void setTS(index<ComboAddress>::type &ind, iterator it, time_t ts) {
-      ind.modify(it, [ts](EDNSStatus &s) { s.modeSetAt = ts; });
-    }
-
-    void prune(time_t cutoff) {
-      auto &ind = get<time_t>();
-      ind.erase(ind.begin(), ind.upper_bound(cutoff));
-    }
-
-  };
-
   struct ThreadLocalStorage {
-    ednsstatus_t ednsstatus;
     std::shared_ptr<domainmap_t> domainmap;
   };
 
@@ -242,26 +212,27 @@ public:
   static void clearNSSpeeds();
   static float getNSSpeed(const DNSName& server, const ComboAddress& ca);
 
-  static EDNSStatus::EDNSMode getEDNSStatus(const ComboAddress& server)
-  {
-    const auto& it = t_sstorage.ednsstatus.find(server);
-    if (it == t_sstorage.ednsstatus.end())
-      return EDNSStatus::UNKNOWN;
+  struct EDNSStatus {
+    EDNSStatus(const ComboAddress &arg) : address(arg) {}
+    ComboAddress address;
+    time_t modeSetAt{0};
+    mutable enum EDNSMode : uint8_t { UNKNOWN = 0, EDNSOK = 1, EDNSIGNORANT = 2, NOEDNS = 3 } mode{UNKNOWN};
 
-    return it->mode;
-  }
-  static uint64_t getEDNSStatusesSize()
-  {
-    return t_sstorage.ednsstatus.size();
-  }
-  static void clearEDNSStatuses()
-  {
-    t_sstorage.ednsstatus.clear();
-  }
-  static void pruneEDNSStatuses(time_t cutoff)
-  {
-    t_sstorage.ednsstatus.prune(cutoff);
-  }
+    std::string toString() const
+    {
+      const std::array<std::string,4> modes = { "Unknown", "OK", "Ignorant", "NoEDNS" };
+      unsigned int m = static_cast<unsigned int>(mode);
+      if (m >= modes.size()) {
+        return "?";
+      }
+      return modes.at(m);
+    }
+  };
+
+  static EDNSStatus::EDNSMode getEDNSStatus(const ComboAddress& server);
+  static uint64_t getEDNSStatusesSize();
+  static void clearEDNSStatuses();
+  static void pruneEDNSStatuses(time_t cutoff);
 
   static uint64_t getThrottledServersSize();
   static void pruneThrottledServers(time_t now);
@@ -929,7 +900,6 @@ void* pleaseSupplantAllowNotifyFor(std::shared_ptr<notifyset_t> ns);
 
 uint64_t* pleaseGetNsSpeedsSize();
 uint64_t* pleaseGetFailedServersSize();
-uint64_t* pleaseGetEDNSStatusesSize();
 uint64_t* pleaseGetConcurrentQueries();
 uint64_t* pleaseGetThrottleSize();
 uint64_t* pleaseGetPacketCacheHits();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This case is bit more tricky compared to the other maps as we context switch and another request/thread might update the status.

The original code refers back to  `mode` to compute the new state, but I think that should be  `EDNSLevel`, to handle the case of mandatory EDNS correctly: in that case we send with EDNS even if mode is `No`.

Also, the original code is a little complex:  it saves the old mode and it uses a pointer to the current mode, It uses those to only change the record if needed. I decide to move that logic to the actual modifier method.

Lastly, the loop is executed at most 3 times according to the original code. I think that should be 2, as we only case we continue is when we set the mode to `NOEDNS`. I did tests on master with 1M names and `assert(tries < 2)` and never hit the assert.

All in all, this need careful review.

We could improve this code a bit more ad only store mode if it's != OK. But that's for another time.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
