### PR TITLE
Added Lua custom headers

### DIFF
--- a/pdns/minicurl.cc
+++ b/pdns/minicurl.cc
@@ -122,9 +122,10 @@ void MiniCurl::setupURL(const std::string& str, const ComboAddress* rem, const C
   d_data.clear();
 }
 
-std::string MiniCurl::getURL(const std::string& str, const ComboAddress* rem, const ComboAddress* src, int timeout, bool fastopen, bool verify)
+std::string MiniCurl::getURL(const std::string& str, const MiniCurlHeaders& headers, const ComboAddress* rem, const ComboAddress* src, int timeout, bool fastopen, bool verify)
 {
   setupURL(str, rem, src, timeout, fastopen, verify);
+  setHeaders(headers);
   auto res = curl_easy_perform(d_curl);
   long http_code = 0;
   curl_easy_getinfo(d_curl, CURLINFO_RESPONSE_CODE, &http_code);

--- a/pdns/minicurl.hh
+++ b/pdns/minicurl.hh
@@ -38,7 +38,7 @@ public:
   MiniCurl(const string& useragent="MiniCurl/0.0");
   ~MiniCurl();
   MiniCurl& operator=(const MiniCurl&) = delete;
-  std::string getURL(const std::string& str, const ComboAddress* rem=nullptr, const ComboAddress* src=nullptr, int timeout = 2, bool fastopen = false, bool verify = false);
+  std::string getURL(const std::string& str, const MiniCurlHeaders& headers, const ComboAddress* rem=nullptr, const ComboAddress* src=nullptr, int timeout = 2, bool fastopen = false, bool verify = false);
   std::string postURL(const std::string& str, const std::string& postdata, MiniCurlHeaders& headers, int timeout = 2, bool fastopen = false, bool verify = false);
 private:
   CURL *d_curl;


### PR DESCRIPTION
### Short description
Added an option to add arbitrary http headers to Lua functions
#8295

```
header-demo      IN      LUA     A       "ifurlup('http://demo.example.com', {'192.168.10.71', '192.0.2.2'} , { headers='header-key: header-value'})"
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)