### PR TITLE
Max body size for Lua records

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -97,6 +97,11 @@ private:
       if (cd.opts.count("useragent")) {
         useragent = cd.opts.at("useragent");
       }
+      long maxbody_size = 1048576; // Default to 1 MegaBytes
+       if(cd.opts.count("bodySize")) {
+         maxbody_size = std::atoi(cd.opts.at("bodySize").c_str());
+       }
+
       MiniCurl mc(useragent);
 
       string content;
@@ -110,10 +115,10 @@ private:
 
       if (cd.opts.count("source")) {
         ComboAddress src(cd.opts.at("source"));
-        content=mc.getURL(cd.url, rem, &src, timeout);
+        content=mc.getURL(cd.url, maxbody_size, rem, &src, timeout);
       }
       else {
-        content=mc.getURL(cd.url, rem, nullptr, timeout);
+        content=mc.getURL(cd.url, maxbody_size, rem, nullptr, timeout);
       }
       if (cd.opts.count("stringmatch") && content.find(cd.opts.at("stringmatch")) == string::npos) {
         throw std::runtime_error(boost::str(boost::format("unable to match content with `%s`") % cd.opts.at("stringmatch")));

--- a/pdns/minicurl.cc
+++ b/pdns/minicurl.cc
@@ -122,9 +122,10 @@ void MiniCurl::setupURL(const std::string& str, const ComboAddress* rem, const C
   d_data.clear();
 }
 
-std::string MiniCurl::getURL(const std::string& str, const ComboAddress* rem, const ComboAddress* src, int timeout, bool fastopen, bool verify)
+std::string MiniCurl::getURL(const std::string& str, const long size, const ComboAddress* rem, const ComboAddress* src, int timeout, bool fastopen, bool verify)
 {
   setupURL(str, rem, src, timeout, fastopen, verify);
+  curl_easy_setopt(d_curl, CURLOPT_MAXFILESIZE, size);
   auto res = curl_easy_perform(d_curl);
   long http_code = 0;
   curl_easy_getinfo(d_curl, CURLINFO_RESPONSE_CODE, &http_code);

--- a/pdns/minicurl.hh
+++ b/pdns/minicurl.hh
@@ -38,7 +38,7 @@ public:
   MiniCurl(const string& useragent="MiniCurl/0.0");
   ~MiniCurl();
   MiniCurl& operator=(const MiniCurl&) = delete;
-  std::string getURL(const std::string& str, const ComboAddress* rem=nullptr, const ComboAddress* src=nullptr, int timeout = 2, bool fastopen = false, bool verify = false);
+  std::string getURL(const std::string& str, const long size, const ComboAddress* rem=nullptr, const ComboAddress* src=nullptr, int timeout = 2, bool fastopen = false, bool verify = false);
   std::string postURL(const std::string& str, const std::string& postdata, MiniCurlHeaders& headers, int timeout = 2, bool fastopen = false, bool verify = false);
 private:
   CURL *d_curl;


### PR DESCRIPTION
### Short description
Lua records can be used to monitor webservers and change the result of DNS queries according to the web server availability.
One issue with the current Lua functions is that it is not possible to limit the downloaded body size, and those risking the PowerDNS server availability by monitoring large file.

This PR limit the default body size to 1mb and allow to change it on record basis.
`recrord     IN      LUA     A       "ifurlup('http://record.example.com/file', {'ip', 'ip'} ,{ useragent='test', bodysize='15728640'  })"`
Note, the body size is in bytes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)