### PR TITLE
dnsdist: Fix a crash on a invalid protocol in DoH forwarded-for header

### DIFF
--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -697,21 +697,34 @@ static void processDOHQuery(DOHUnitUniquePtr&& du)
       ids->destHarvested = false;
     }
 
+    bool failed = false;
     if (du->downstream->d_config.useProxyProtocol) {
-      size_t payloadSize = 0;
-      if (addProxyProtocol(dq, &payloadSize)) {
-        du->proxyProtocolPayloadSize = payloadSize;
+      try {
+        size_t payloadSize = 0;
+        if (addProxyProtocol(dq, &payloadSize)) {
+          du->proxyProtocolPayloadSize = payloadSize;
+        }
+      }
+      catch (const std::exception& e) {
+        vinfolog("Adding proxy protocol payload to DoH query from %s failed: %s", ids->origDest.toStringWithPort(), e.what());
+        failed = true;
       }
     }
 
-    int fd = du->downstream->pickSocketForSending();
-    ids->backendFD = fd;
     try {
-      /* you can't touch du after this line, unless the call returned a non-negative value,
-         because it might already have been freed */
-      ssize_t ret = udpClientSendRequestToBackend(du->downstream, fd, du->query);
+      if (!failed) {
+        int fd = du->downstream->pickSocketForSending();
+        ids->backendFD = fd;
+        /* you can't touch du after this line, unless the call returned a non-negative value,
+           because it might already have been freed */
+        ssize_t ret = udpClientSendRequestToBackend(du->downstream, fd, du->query);
 
-      if (ret < 0) {
+        if (ret < 0) {
+          failed = true;
+        }
+      }
+
+      if (failed) {
         /* we are about to handle the error, make sure that
            this pointer is not accessed when the state is cleaned,
            but first check that it still belongs to us */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Passing an IPv6 address in the X-Forwarded-For header of an DoH frontend listening on a IPv4 address, with a proxy-protocol-enabled backend, results in dnsdist trying to mix IPv4 and IPv6 in the same proxy protocol payload which is not possible. The resulting exception was not properly handled and left a dangling UDP state, whose DOHUnit pointer was no longer valid, causing a use-after-free when dnsdist processed the dangling UDP state while checking for timeouts.

<strike>This PR is based on #11604 as it reused the same mechanism for the regression test, so it will have to be rebased after the base PR has been merged.</strike>
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
