### PR TITLE
Zap binary function, not needed and deprecated in c++11, removed in c++17

### DIFF
--- a/pdns/zonemd.hh
+++ b/pdns/zonemd.hh
@@ -107,7 +107,7 @@ private:
   typedef std::pair<DNSName, QType> RRSetKey_t;
   typedef std::vector<std::shared_ptr<DNSRecordContent>> RRVector_t;
 
-  struct CanonRRSetKeyCompare : public std::binary_function<RRSetKey_t, RRSetKey_t, bool>
+  struct CanonRRSetKeyCompare
   {
     bool operator()(const RRSetKey_t& a, const RRSetKey_t& b) const
     {


### PR DESCRIPTION
Fixes #11625

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
