### PR TITLE
rec: Backport 11609 to rec 4.7.x: Fix API issue when asking config values for allow-from or allow-notiy-from

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -42,6 +42,7 @@ To use this, DNSSEC processing or validation must be enabled by setting `dnssec`
 
 Netmasks (both IPv4 and IPv6) that are allowed to use the server.
 The default allows access only from :rfc:`1918` private IP addresses.
+An empty value means no checking is done, all clients are allowed.
 Due to the aggressive nature of the internet these days, it is highly recommended to not open up the recursor for the entire internet.
 Questions from IP addresses not listed here are ignored and do not get an answer.
 

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -119,10 +119,10 @@ static void apiServerConfigACL(const std::string& aclType, HttpRequest* req, Htt
 
   // Return currently configured ACLs
   vector<string> entries;
-  if (aclType == "allow-from") {
+  if (t_allowFrom && aclType == "allow-from") {
     t_allowFrom->toStringVector(&entries);
   }
-  else if (aclType == "allow-notify-from") {
+  else if (t_allowNotifyFrom && aclType == "allow-notify-from") {
     t_allowNotifyFrom->toStringVector(&entries);
   }
 

--- a/regression-tests.api/test_RecursorConfig.py
+++ b/regression-tests.api/test_RecursorConfig.py
@@ -22,6 +22,17 @@ class RecursorAllowFromConfig(ApiTestCase):
         self.assertEqual(len(data["value"]), 1)
         self.assertEqual("127.0.0.1/32", data["value"][0])
 
+    def test_config_allow_from_replace_empty(self):
+        payload = {'value': []}
+        r = self.session.put(
+            self.url("/api/v1/servers/localhost/config/allow-from"),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assert_success_json(r)
+        data = r.json()
+        self.assertIn("value", data)
+        self.assertEqual(len(data["value"]), 0)
+
     def test_config_allow_from_replace_error(self):
         """Test the error case, should return 422."""
         payload = {'value': ["abcdefgh"]}
@@ -52,6 +63,17 @@ class RecursorAllowNotifyFromConfig(ApiTestCase):
         self.assertIn("value", data)
         self.assertEqual(len(data["value"]), 1)
         self.assertEqual("127.0.0.1/32", data["value"][0])
+
+    def test_config_allow_notify_from_replace_empty(self):
+        payload = {'value': []}
+        r = self.session.put(
+            self.url("/api/v1/servers/localhost/config/allow-notify-from"),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assert_success_json(r)
+        data = r.json()
+        self.assertIn("value", data)
+        self.assertEqual(len(data["value"]), 0)
 
     def test_config_allow_notify_from_replace_error(self):
         """Test the error case, should return 422."""


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #11609 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
