### PR TITLE
dnsdist: Accept large buffers in getMACAddress()

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1232,10 +1232,11 @@ int getMACAddress(const ComboAddress& ca, char* dest, size_t destLen)
         }
         else if (rtatp->rta_type == NDA_LLADDR) {
           if (foundIP) {
-            if ((rtatp->rta_len - sizeof(struct rtattr)) != destLen) {
-              return EINVAL;
+            size_t addrLen = rtatp->rta_len - sizeof(struct rtattr);
+            if (addrLen > destLen) {
+              return ENOBUFS;
             }
-            memcpy(dest, reinterpret_cast<const char*>(rtatp) + sizeof(struct rtattr), destLen);
+            memcpy(dest, reinterpret_cast<const char*>(rtatp) + sizeof(struct rtattr), addrLen);
             foundMAC = true;
             done = true;
             break;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It is perfectly valid to pass a buffer larger than a link-level address, and we should not fail when that happens.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
