### PR TITLE
rec: Backport 11644 to rec-4.7.x: Deprecation warning for XPF settings.

### DIFF
--- a/pdns/arguments.cc
+++ b/pdns/arguments.cc
@@ -355,7 +355,9 @@ static const map<string,string> deprecateList = {
   { "stats-snmp-blacklist", "stats-snmp-disabled-list" },
   { "edns-subnet-whitelist", "edns-subnet-allow-list" },
   { "new-domain-whitelist", "new-domain-ignore-list" },
-  { "snmp-master-socket", "snmp-daemon-socket" }
+  { "snmp-master-socket", "snmp-daemon-socket" },
+  { "xpf-allow-from", "Proxy Protocol" },
+  { "xpf-rr-code", "Proxy Protocol" },
 };
 
 static void warnIfDeprecated(const string& var)


### PR DESCRIPTION
(cherry picked from commit 7e32a0b96df460abd8fb98fbb63f4d336b9c3d03)

Backport of #11644

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
