### PR TITLE
dnsdist: Optionally send 'verbose' messages to a file, and log them at 'DEBUG' level otherwise

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -709,6 +709,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "setUDPTimeout", true, "n", "set the maximum time dnsdist will wait for a response from a backend over UDP, in seconds" },
   { "setVerbose", true, "bool", "set whether log messages at the verbose level will be logged" },
   { "setVerboseHealthChecks", true, "bool", "set whether health check errors will be logged" },
+  { "setVerboseLogDestination", true, "destination file", "Set a destination file to write the 'verbose' log messages to, instead of sending them to syslog and/or the standard output" },
   { "setWebserverConfig", true, "[{password=string, apiKey=string, customHeaders, statsRequireAuthentication}]", "Updates webserver configuration" },
   { "setWeightedBalancingFactor", true, "factor", "Set the balancing factor for bounded-load weighted policies (whashed, wrandom)" },
   { "setWHashedPertubation", true, "value", "Set the hash perturbation value to be used in the whashed policy instead of a random one, allowing to have consistent whashed results on different instance" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1720,6 +1720,19 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.writeFunction("setVerbose", [](bool verbose) { g_verbose = verbose; });
   luaCtx.writeFunction("getVerbose", []() { return g_verbose; });
   luaCtx.writeFunction("setVerboseHealthChecks", [](bool verbose) { g_verboseHealthChecks = verbose; });
+  luaCtx.writeFunction("setVerboseLogDestination", [](const std::string& dest) {
+    if (g_configurationDone) {
+      g_outputBuffer = "setVerboseLogDestination() cannot be used at runtime!\n";
+      return;
+    }
+    try {
+      auto stream = std::ofstream(dest.c_str());
+      g_verboseStream = std::move(stream);
+    }
+    catch (const std::exception& e) {
+      errlog("Error while opening the verbose logging destination file %s: %s", dest, e.what());
+    }
+  });
 
   luaCtx.writeFunction("setStaleCacheEntriesTTL", [](uint64_t ttl) {
     checkParameterBound("setStaleCacheEntriesTTL", ttl, std::numeric_limits<uint32_t>::max());

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -91,6 +91,7 @@
 
 using std::thread;
 bool g_verbose;
+std::optional<std::ofstream> g_verboseStream{std::nullopt};
 
 struct DNSDistStats g_stats;
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1095,6 +1095,8 @@ Status, Statistics and More
 
   Set a destination file to write the 'verbose' log messages to, instead of sending them to syslog and/or the standard output which is the default.
   Note that these messages will no longer be sent to syslog or the standard output once this option has been set.
+  There is no rotation or file size limit.
+  Only use this feature for debugging under active operator control.
 
   :param str dest: The destination file
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1094,7 +1094,7 @@ Status, Statistics and More
   .. versionadded:: 1.8.0
 
   Set a destination file to write the 'verbose' log messages to, instead of sending them to syslog and/or the standard output which is the default.
-  Note that these messages will no longer be sent to syslog or the standard output once that option has been set.
+  Note that these messages will no longer be sent to syslog or the standard output once this option has been set.
 
   :param str dest: The destination file
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1089,6 +1089,15 @@ Status, Statistics and More
 
   :param bool verbose: Set to true if you want to enable health check errors logging
 
+.. function:: setVerboseLogDestination(dest)
+
+  .. versionadded:: 1.8.0
+
+  Set a destination file to write the 'verbose' log messages to, instead of sending them to syslog and/or the standard output which is the default.
+  Note that these messages will no longer be sent to syslog or the standard output once that option has been set.
+
+  :param str dest: The destination file
+
 .. function:: showBinds()
 
   Print a list of all the current addresses and ports dnsdist is listening on, also called ``frontends``

--- a/pdns/dolog.hh
+++ b/pdns/dolog.hh
@@ -122,12 +122,16 @@ void genlog(std::ostream& stream, int level, bool doSyslog, const char* s, Args.
 template<typename... Args>
 void verboselog(const char* s, Args... args)
 {
+#ifdef DNSDIST
   if (g_verboseStream) {
     genlog(*g_verboseStream, LOG_DEBUG, false, s, args...);
   }
   else {
+#endif /* DNSDIST */
     genlog(std::cout, LOG_DEBUG, g_syslog, s, args...);
+#ifdef DNSDIST
   }
+#endif /* DNSDIST */
 }
 
 #define vinfolog if (g_verbose) verboselog

--- a/pdns/dolog.hh
+++ b/pdns/dolog.hh
@@ -20,7 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
+#include <fstream>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include "config.h"
 #if !defined(RECURSOR)
@@ -78,6 +80,7 @@ extern bool g_verbose;
 extern bool g_syslog;
 #ifdef DNSDIST
 extern bool g_logtimestamps;
+extern std::optional<std::ofstream> g_verboseStream;
 #endif
 
 inline void setSyslogFacility(int facility)
@@ -88,14 +91,14 @@ inline void setSyslogFacility(int facility)
 }
 
 template<typename... Args>
-void genlog(int level, const char* s, Args... args)
+void genlog(std::ostream& stream, int level, bool doSyslog, const char* s, Args... args)
 {
   std::ostringstream str;
   dolog(str, s, args...);
 
   auto output = str.str();
 
-  if (g_syslog) {
+  if (doSyslog) {
     syslog(level, "%s", output.c_str());
   }
 
@@ -109,17 +112,22 @@ void genlog(int level, const char* s, Args... args)
     if (strftime(buffer, sizeof(buffer), "%b %d %H:%M:%S ", &tm) == 0) {
       buffer[0] = '\0';
     }
-    std::cout<<buffer;
+    stream<<buffer;
   }
 #endif
 
-  std::cout<<output<<std::endl;
+  stream<<output<<std::endl;
 }
 
 template<typename... Args>
 void verboselog(const char* s, Args... args)
 {
-  genlog(LOG_DEBUG, s, args...);
+  if (g_verboseStream) {
+    genlog(*g_verboseStream, LOG_DEBUG, false, s, args...);
+  }
+  else {
+    genlog(std::cout, LOG_DEBUG, g_syslog, s, args...);
+  }
 }
 
 #define vinfolog if (g_verbose) verboselog
@@ -127,21 +135,20 @@ void verboselog(const char* s, Args... args)
 template<typename... Args>
 void infolog(const char* s, Args... args)
 {
-  genlog(LOG_INFO, s, args...);
+  genlog(std::cout, LOG_INFO, g_syslog, s, args...);
 }
 
 template<typename... Args>
 void warnlog(const char* s, Args... args)
 {
-  genlog(LOG_WARNING, s, args...);
+  genlog(std::cout, LOG_WARNING, g_syslog, s, args...);
 }
 
 template<typename... Args>
 void errlog(const char* s, Args... args)
 {
-  genlog(LOG_ERR, s, args...);
+  genlog(std::cout, LOG_ERR, g_syslog, s, args...);
 }
-
 
 #else // RECURSOR
 

--- a/pdns/dolog.hh
+++ b/pdns/dolog.hh
@@ -116,8 +116,13 @@ void genlog(int level, const char* s, Args... args)
   std::cout<<output<<std::endl;
 }
 
+template<typename... Args>
+void verboselog(const char* s, Args... args)
+{
+  genlog(LOG_DEBUG, s, args...);
+}
 
-#define vinfolog if(g_verbose)infolog
+#define vinfolog if (g_verbose) verboselog
 
 template<typename... Args>
 void infolog(const char* s, Args... args)

--- a/pdns/test-dnscrypt_cc.cc
+++ b/pdns/test-dnscrypt_cc.cc
@@ -28,11 +28,13 @@
 #include "dnsname.hh"
 #include "dnsparser.hh"
 #include "dnswriter.hh"
+#include "dolog.hh"
 #include <unistd.h>
 
 bool g_verbose{false};
 bool g_syslog{true};
 bool g_logtimestamps{false};
+std::optional<std::ofstream> g_verboseStream{std::nullopt};
 
 BOOST_AUTO_TEST_SUITE(test_dnscrypt_cc)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This pull request:
- sends 'verbose' message at syslog's 'debug' level instead of 'info'
- adds a new configuration option, `setVerboseLogDestination(dest)` which, when used at configuration time, redirects these messages to a file instead of sending to the standard output and/or syslog.

This is useful to be able to log these messages separately when investigating an issue, without flooding the system logs.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
