### PR TITLE
rec: Fix typo in stats log message

### DIFF
--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -971,7 +971,7 @@ static void doStats(void)
                 "dot-outqueries", Logging::Loggable(SyncRes::s_dotoutqueries),
                 "idle-tcpout-connections", Logging::Loggable(getCurrentIdleTCPConnections()),
                 "concurrent-queries", Logging::Loggable(broadcastAccFunction<uint64_t>(pleaseGetConcurrentQueries)),
-                "outgoing-timesouts", Logging::Loggable(SyncRes::s_outgoingtimeouts));
+                "outgoing-timeouts", Logging::Loggable(SyncRes::s_outgoingtimeouts));
       log->info(Logr::Info, m,
                 "packetcache-entries", Logging::Loggable(pcSize),
                 "packetcache-hitratio-perc", Logging::Loggable(ratePercentage(pcHits, g_stats.qcounter)),


### PR DESCRIPTION
### Short description
"time**s**outs" typo. Introduced in #11654.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)