### PR TITLE
dnsdist: add support for user defined metrics

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -303,6 +303,7 @@ csync
 ctime
 ctor
 ctx
+custommetrics
 cve
 cvename
 cvs

--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -75,6 +75,8 @@ void carbonDumpThread()
             str<<namespace_name<<"."<<hostname<<"."<<instance_name<<"."<<e.first<<' ';
             if(const auto& val = boost::get<pdns::stat_t*>(&e.second))
               str<<(*val)->load();
+            else if(const auto& adval = boost::get<pdns::stat_t_trait<double>*>(&e.second))
+              str<<(*adval)->load();
             else if (const auto& dval = boost::get<double*>(&e.second))
               str<<**dval;
             else

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2869,6 +2869,8 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       return false;
     }
     if (!std::regex_match(name, std::regex("^[a-z0-9-]+$"))) {
+      g_outputBuffer = "Unable to declare metric '" + name + "': invalid name\n";
+      errlog("Unable to declare metric '%s': invalid name", name);
       return false;
     }
     if (type == "counter") {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2863,7 +2863,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     newThread.detach();
   });
 
-  luaCtx.writeFunction("declareMetric", [](const std::string& name, const std::string& type) {
+  luaCtx.writeFunction("declareMetric", [](const std::string& name, const std::string& type, const std::string& description) {
     if (g_configurationDone) {
       g_outputBuffer = "declareMetric cannot be used at runtime!\n";
       return false;
@@ -2877,11 +2877,13 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       auto itp = g_stats.customCounters.emplace(name, 0);
       if (itp.second) {
         g_stats.entries.emplace_back(name, &g_stats.customCounters[name]);
+        addMetricDefinition(name, "counter", description);
       }
     } else if (type == "gauge") {
       auto itp = g_stats.customGauges.emplace(name, 0.);
       if (itp.second) {
         g_stats.entries.emplace_back(name, &g_stats.customGauges[name]);
+        addMetricDefinition(name, "gauge", description);
       }
     } else {
       g_outputBuffer = "declareMetric unknown type '" + type + "'\n";

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2879,13 +2879,15 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         g_stats.entries.emplace_back(name, &g_stats.customCounters[name]);
         addMetricDefinition(name, "counter", description);
       }
-    } else if (type == "gauge") {
+    }
+    else if (type == "gauge") {
       auto itp = g_stats.customGauges.emplace(name, 0.);
       if (itp.second) {
         g_stats.entries.emplace_back(name, &g_stats.customGauges[name]);
         addMetricDefinition(name, "gauge", description);
       }
-    } else {
+    }
+    else {
       g_outputBuffer = "declareMetric unknown type '" + type + "'\n";
       errlog("Unable to declareMetric '%s': no such type '%s'", name, type);
       return false;
@@ -2924,7 +2926,8 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     auto counter = g_stats.customCounters.find(name);
     if (counter != g_stats.customCounters.end()) {
       return (double)counter->second.load();
-    } else {
+    }
+    else {
       auto gauge = g_stats.customGauges.find(name);
       if (gauge != g_stats.customGauges.end()) {
         return gauge->second.load();

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -131,9 +131,9 @@ private:
 };
 
 #ifndef DISABLE_PROMETHEUS
-static const MetricDefinitionStorage s_metricDefinitions;
+static MetricDefinitionStorage s_metricDefinitions;
 
-const std::map<std::string, MetricDefinition> MetricDefinitionStorage::metrics{
+std::map<std::string, MetricDefinition> MetricDefinitionStorage::metrics{
   { "responses",                             MetricDefinition(PrometheusMetricType::counter, "Number of responses received from backends") },
   { "servfail-responses",                    MetricDefinition(PrometheusMetricType::counter, "Number of SERVFAIL answers received from backends") },
   { "queries",                               MetricDefinition(PrometheusMetricType::counter, "Number of received queries")},
@@ -197,6 +197,14 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::metrics{
   { "proxy-protocol-invalid",                MetricDefinition(PrometheusMetricType::counter, "Number of queries dropped because of an invalid Proxy Protocol header") },
 };
 #endif /* DISABLE_PROMETHEUS */
+
+bool addMetricDefinition(const std::string& name, const std::string type, const std::string& description) {
+#ifndef DISABLE_PROMETHEUS
+  return MetricDefinitionStorage::addMetricDefinition(name, type, description);
+#else
+  return true;
+#endif /* DISABLE_PROMETHEUS */
+}
 
 #ifndef DISABLE_WEB_CONFIG
 static bool apiWriteConfigFile(const string& filebasename, const string& content)

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -365,10 +365,10 @@ struct DNSDistStats
   stat_t tcpQueryPipeFull{0};
   stat_t tcpCrossProtocolQueryPipeFull{0};
   stat_t tcpCrossProtocolResponsePipeFull{0};
-
   double latencyAvg100{0}, latencyAvg1000{0}, latencyAvg10000{0}, latencyAvg1000000{0};
   typedef std::function<uint64_t(const std::string&)> statfunction_t;
-  typedef boost::variant<stat_t*, double*, statfunction_t> entry_t;
+  typedef boost::variant<stat_t*, pdns::stat_t_trait<double>*, double*, statfunction_t> entry_t;
+
   std::vector<std::pair<std::string, entry_t>> entries{
     {"responses", &responses},
     {"servfail-responses", &servfailResponses},
@@ -436,6 +436,8 @@ struct DNSDistStats
     {"latency-sum", &latencySum},
     {"latency-count", &latencyCount},
   };
+  std::map<std::string, stat_t> customCounters;
+  std::map<std::string, pdns::stat_t_trait<double> > customGauges;
 };
 
 extern struct DNSDistStats g_stats;

--- a/pdns/dnsdistdist/dnsdist-prometheus.hh
+++ b/pdns/dnsdistdist/dnsdist-prometheus.hh
@@ -54,6 +54,19 @@ struct MetricDefinitionStorage {
     return true;
   };
 
+  static bool addMetricDefinition(const std::string& name, const std::string type, const std::string& description) {
+    static const std::map<std::string, PrometheusMetricType> namesToTypes = {
+      {"counter", PrometheusMetricType::counter},
+      {"gauge",   PrometheusMetricType::gauge},
+    };
+    auto realtype = namesToTypes.find(type);
+    if (realtype == namesToTypes.end()) {
+      return false;
+    }
+    metrics.emplace(name, MetricDefinition{realtype->second, description});
+    return true;
+  }
+
   // Return string representation of Prometheus metric type
   std::string getPrometheusStringMetricType(PrometheusMetricType metricType) const {
     switch (metricType) {
@@ -69,6 +82,6 @@ struct MetricDefinitionStorage {
     }
   };
 
-  static const std::map<std::string, MetricDefinition> metrics;
+  static std::map<std::string, MetricDefinition> metrics;
 };
 #endif /* DISABLE_PROMETHEUS */

--- a/pdns/dnsdistdist/dnsdist-web.hh
+++ b/pdns/dnsdistdist/dnsdist-web.hh
@@ -15,4 +15,6 @@ void dnsdistWebserverThread(int sock, const ComboAddress& local);
 void registerBuiltInWebHandlers();
 void clearWebHandlers();
 
+bool addMetricDefinition(const std::string& name, const std::string type, const std::string& description);
+
 std::string getWebserverConfig();

--- a/pdns/dnsdistdist/docs/reference/custommetrics.rst
+++ b/pdns/dnsdistdist/docs/reference/custommetrics.rst
@@ -1,0 +1,58 @@
+Custom Metrics
+=====================================
+
+You can define at configuration time your own metrics that can be updated using lua.
+
+The first step is to declare a new metric using :func:`declareMetric`.
+
+Then you can update those at runtime using the following functions, depending on the metric type:
+
+ * manipulate counters using :func:`incMetric` and  :func:`decMetric`
+ * update a gauge using :func:`setMetric`
+
+.. function:: declareMetric(name, type) -> bool
+
+  .. versionadded:: 1.x
+
+  Return true if declaration was successful
+
+  :param str name: The name of the metric, lowercase alnum characters only
+  :param str type: The desired type in ``gauge`` or ``counter``
+
+.. function:: incMetric(name) -> int
+
+  .. versionadded:: 1.x
+
+  Increment counter by one, will issue an error if the metric is not declared or not a ``counter``
+  Return the new value
+
+  :param str name: The name of the metric
+
+.. function:: decMetric(name) -> int
+
+  .. versionadded:: 1.x
+
+  Decrement counter by one, will issue an error if the metric is not declared or not a ``counter``
+  Return the new value
+
+  :param str name: The name of the metric
+
+.. function:: getMetric(name) -> double
+
+  .. versionadded:: 1.x
+
+  Get metric value
+
+  :param str name: The name of the metric
+
+.. function:: setMetric(name, value) -> double
+
+  .. versionadded:: 1.x
+
+  Decrement counter by one, will issue an error if the metric is not declared or not a ``counter``
+  Return the new value
+
+  :param str name: The name of the metric
+
+
+                   

--- a/pdns/dnsdistdist/docs/reference/custommetrics.rst
+++ b/pdns/dnsdistdist/docs/reference/custommetrics.rst
@@ -10,7 +10,7 @@ Then you can update those at runtime using the following functions, depending on
  * manipulate counters using :func:`incMetric` and  :func:`decMetric`
  * update a gauge using :func:`setMetric`
 
-.. function:: declareMetric(name, type) -> bool
+.. function:: declareMetric(name, type, description) -> bool
 
   .. versionadded:: 1.8.0
 
@@ -18,6 +18,7 @@ Then you can update those at runtime using the following functions, depending on
 
   :param str name: The name of the metric, lowercase alphanumerical characters and dashes (-) only
   :param str type: The desired type in ``gauge`` or ``counter``
+  :param str name: The description of the metric
 
 .. function:: incMetric(name) -> int
 

--- a/pdns/dnsdistdist/docs/reference/custommetrics.rst
+++ b/pdns/dnsdistdist/docs/reference/custommetrics.rst
@@ -1,7 +1,7 @@
 Custom Metrics
 =====================================
 
-You can define at configuration time your own metrics that can be updated using lua.
+You can define at configuration time your own metrics that can be updated using Lua.
 
 The first step is to declare a new metric using :func:`declareMetric`.
 
@@ -12,16 +12,16 @@ Then you can update those at runtime using the following functions, depending on
 
 .. function:: declareMetric(name, type) -> bool
 
-  .. versionadded:: 1.x
+  .. versionadded:: 1.8.0
 
   Return true if declaration was successful
 
-  :param str name: The name of the metric, lowercase alnum characters only
+  :param str name: The name of the metric, lowercase alphanumerical characters and dashes (-) only
   :param str type: The desired type in ``gauge`` or ``counter``
 
 .. function:: incMetric(name) -> int
 
-  .. versionadded:: 1.x
+  .. versionadded:: 1.8.0
 
   Increment counter by one, will issue an error if the metric is not declared or not a ``counter``
   Return the new value
@@ -30,7 +30,7 @@ Then you can update those at runtime using the following functions, depending on
 
 .. function:: decMetric(name) -> int
 
-  .. versionadded:: 1.x
+  .. versionadded:: 1.8.0
 
   Decrement counter by one, will issue an error if the metric is not declared or not a ``counter``
   Return the new value
@@ -39,7 +39,7 @@ Then you can update those at runtime using the following functions, depending on
 
 .. function:: getMetric(name) -> double
 
-  .. versionadded:: 1.x
+  .. versionadded:: 1.8.0
 
   Get metric value
 
@@ -47,12 +47,9 @@ Then you can update those at runtime using the following functions, depending on
 
 .. function:: setMetric(name, value) -> double
 
-  .. versionadded:: 1.x
+  .. versionadded:: 1.8.0
 
-  Decrement counter by one, will issue an error if the metric is not declared or not a ``counter``
+  Set the new value, will issue an error if the metric is not declared or not a ``gauge``
   Return the new value
 
   :param str name: The name of the metric
-
-
-                   

--- a/pdns/dnsdistdist/docs/reference/index.rst
+++ b/pdns/dnsdistdist/docs/reference/index.rst
@@ -25,3 +25,4 @@ These chapters contain extensive information on all functions and object availab
   logging
   web
   svc
+  custommetrics

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -780,9 +780,9 @@ class TestAPICustomStatistics(APITestsBase):
     _config_template = """
     newServer{address="127.0.0.1:%s"}
     webserver("127.0.0.1:%s")
-    declareMetric("my-custom-metric", "counter")
-    declareMetric("my-other-metric", "counter")
-    declareMetric("my-gauge", "gauge")
+    declareMetric("my-custom-metric", "counter", "Number of statistics")
+    declareMetric("my-other-metric", "counter", "Another number of statistics")
+    declareMetric("my-gauge", "gauge", "Current memory usage")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -454,3 +454,66 @@ class TestProtocols(DNSDistTest):
         receivedQuery.id = query.id
         self.assertEqual(receivedQuery, query)
         self.assertEqual(receivedResponse, response)
+
+class TestCustomMetrics(DNSDistTest):
+    _config_template = """
+    function custommetrics(dq)
+      initialCounter = getMetric("my-custom-counter")
+      initialGauge = getMetric("my-custom-counter")
+      incMetric("my-custom-counter")
+      setMetric("my-custom-gauge", initialGauge + 1.3)
+      if getMetric("my-custom-counter") ~= (initialCounter + 1) or getMetric("my-custom-gauge") ~= (initialGauge + 1.3) then
+        return DNSAction.Spoof, '1.2.3.5'
+      end
+      return DNSAction.Spoof, '4.3.2.1'
+    end
+
+    function declareNewMetric(dq)
+      if declareMetric("new-runtime-metric", "counter") then
+        return DNSAction.Spoof, '1.2.3.4'
+      end
+      return DNSAction.None
+    end
+
+    declareMetric("my-custom-counter", "counter")
+    declareMetric("my-custom-gauge", "gauge")
+    addAction("declare.metric.advanced.tests.powerdns.com.", LuaAction(declareNewMetric))
+    addAction("operations.metric.advanced.tests.powerdns.com.", LuaAction(custommetrics))
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testDeclareAfterConfig(self):
+        """
+        Advanced: Test custom metric declaration after config done
+        """
+        name = 'declare.metric.advanced.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            receivedQuery.id = query.id
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
+
+    def testMetricOperations(self):
+        """
+        Advanced: Test basic operations on custom metrics
+        """
+        name = 'operations.metric.advanced.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '4.3.2.1')
+        response.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (_, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertEqual(receivedResponse, response)

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -469,14 +469,14 @@ class TestCustomMetrics(DNSDistTest):
     end
 
     function declareNewMetric(dq)
-      if declareMetric("new-runtime-metric", "counter") then
+      if declareMetric("new-runtime-metric", "counter", "Metric declaration at runtime should fail") then
         return DNSAction.Spoof, '1.2.3.4'
       end
       return DNSAction.None
     end
 
-    declareMetric("my-custom-counter", "counter")
-    declareMetric("my-custom-gauge", "gauge")
+    declareMetric("my-custom-counter", "counter", "Number of tests run")
+    declareMetric("my-custom-gauge", "gauge", "Temperature of the tests")
     addAction("declare.metric.advanced.tests.powerdns.com.", LuaAction(declareNewMetric))
     addAction("operations.metric.advanced.tests.powerdns.com.", LuaAction(custommetrics))
     newServer{address="127.0.0.1:%s"}


### PR DESCRIPTION
### Short description

This PR adds a few functions to declare and manipulate user-defined metrics. Currently supports `gauge` and `counter` types with set, increment and decrement operations.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
