### PR TITLE
dnsdist: skip DoT/DoH frontend when a tls configuration error occurs

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2501,6 +2501,19 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       }
 
       parseTLSConfig(frontend->d_tlsConfig, "addDOHLocal", vars);
+      if (vars->count("ignoreTLSConfigurationErrors")) {
+        if (boost::get<bool>((*vars)["ignoreTLSConfigurationErrors"])) {
+          // we are asked to try to load the certificates so we can return a potential error
+          // and properly ignore the frontend before actually launching it
+          try {
+            std::map<int, std::string> ocspResponses = {};
+            auto ctx = libssl_init_server_context(frontend->d_tlsConfig, ocspResponses);
+          } catch (const std::runtime_error& e) {
+            errlog("Ignoring DoH frontend: '%s'", e.what());
+            return ;
+          }
+        }
+      }
     }
     g_dohlocals.push_back(frontend);
     auto cs = std::make_unique<ClientState>(frontend->d_local, true, reusePort, tcpFastOpenQueueSize, interface, cpus);
@@ -2703,6 +2716,19 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       }
 
       parseTLSConfig(frontend->d_tlsConfig, "addTLSLocal", vars);
+      if (vars->count("ignoreTLSConfigurationErrors")) {
+        if (boost::get<bool>((*vars)["ignoreTLSConfigurationErrors"])) {
+          // we are asked to try to load the certificates so we can return a potential error
+          // and properly ignore the frontend before actually launching it
+          try {
+            std::map<int, std::string> ocspResponses = {};
+            auto ctx = libssl_init_server_context(frontend->d_tlsConfig, ocspResponses);
+          } catch (const std::runtime_error& e) {
+            errlog("Ignoring TLS frontend: '%s'", e.what());
+            return ;
+          }
+        }
+      }
     }
 
     try {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2508,9 +2508,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
           try {
             std::map<int, std::string> ocspResponses = {};
             auto ctx = libssl_init_server_context(frontend->d_tlsConfig, ocspResponses);
-          } catch (const std::runtime_error& e) {
+          }
+          catch (const std::runtime_error& e) {
             errlog("Ignoring DoH frontend: '%s'", e.what());
-            return ;
+            return;
           }
         }
       }
@@ -2723,9 +2724,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
           try {
             std::map<int, std::string> ocspResponses = {};
             auto ctx = libssl_init_server_context(frontend->d_tlsConfig, ocspResponses);
-          } catch (const std::runtime_error& e) {
+          }
+          catch (const std::runtime_error& e) {
             errlog("Ignoring TLS frontend: '%s'", e.what());
-            return ;
+            return;
           }
         }
       }

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -120,7 +120,7 @@ Listen Sockets
 
   .. versionchanged:: 1.8.0
      ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`)
-     ``additionalAddresses`` and ``keepIncomingHeaders`` options added.
+     ``additionalAddresses``, ``ignoreTLSConfigurationErrors`` and ``keepIncomingHeaders`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over HTTPS connections, presenting the specified X.509 certificate.
   If no certificate (or key) files are specified, listen for incoming DNS over HTTP connections instead.
@@ -163,6 +163,7 @@ Listen Sockets
   * ``enableRenegotiation=false``: bool - Whether secure TLS renegotiation should be enabled. Disabled by default since it increases the attack surface and is seldom used for DNS.
   * ``keepIncomingHeaders``: bool - Whether to retain the incoming headers in memory, to be able to use :func:`HTTPHeaderRule` or :meth:`DNSQuestion.getHTTPHeaders`. Default is false. Before 1.8.0 the headers were always kept in-memory.
   * ``additionalAddresses``: list - List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses.
+  * ``ignoreTLSConfigurationErrors=false``: bool - Ignore TLS configuration errors (such as invalid certificate path) and just issue a warning instead of aborting the whole process
 
 .. function:: addTLSLocal(address, certFile(s), keyFile(s) [, options])
 
@@ -176,7 +177,7 @@ Listen Sockets
     ``tlsAsyncMode`` option added.
   .. versionchanged:: 1.8.0
      ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`).
-     ``additionalAddresses`` option added.
+     ``additionalAddresses`` and ``ignoreTLSConfigurationErrors`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
@@ -212,6 +213,7 @@ Listen Sockets
   * ``enableRenegotiation=false``: bool - Whether secure TLS renegotiation should be enabled (OpenSSL only, the GnuTLS provider does not support it). Disabled by default since it increases the attack surface and is seldom used for DNS.
   * ``tlsAsyncMode=false``: bool - Whether to enable experimental asynchronous TLS I/O operations if OpenSSL is used as the TLS provider and an asynchronous capable SSL engine is loaded. See also :func:`loadTLSEngine` to load the engine.
   * ``additionalAddresses``: list - List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses.
+  * ``ignoreTLSConfigurationErrors=false``: bool - Ignore TLS configuration errors (such as invalid certificate path) and just issue a warning instead of aborting the whole process
 
 .. function:: setLocal(address[, options])
 


### PR DESCRIPTION
### Short description
Currently, `dnsdist` exits when encountering an error in the DoT/DoH configuration (such as files for keys are not found or readable).

This PR is a proposal to skip the DoT/DoH frontend configuration and to continue launching anyway.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
