### PR TITLE
Recursor: Load IPv6 entries from `etc-hosts` file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,4 +30,3 @@ dvi: # do nothing to build dvi
 
 format-code:
 	./build-scripts/format-code `find . -type f -name '*.[ch][ch]' | LANG=C sort | LANG=C comm -23 - .not-formatted`
-

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include <string_view>
 #include <iostream>
 #include "lmdb-safe.hh"
 #include <boost/archive/binary_oarchive.hpp>
@@ -14,7 +15,7 @@
 // using std::endl;
 
 
-/* 
+/*
    Open issues:
 
    Everything should go into a namespace
@@ -30,7 +31,7 @@
 
 
 /** Return the highest ID used in a database. Returns 0 for an empty DB.
-    This makes us start everything at ID=1, which might make it possible to 
+    This makes us start everything at ID=1, which might make it possible to
     treat id 0 as special
 */
 unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi);
@@ -51,7 +52,7 @@ std::string serToString(const T& t)
   boost::iostreams::back_insert_device<std::string> inserter(serial_str);
   boost::iostreams::stream<boost::iostreams::back_insert_device<std::string> > s(inserter);
   boost::archive::binary_oarchive oa(s, boost::archive::no_header | boost::archive::no_codecvt);
-  
+
   oa << t;
   return serial_str;
 }
@@ -83,7 +84,7 @@ inline std::string keyConv(const T& t)
   return std::string((char*)&t, sizeof(t));
 }
 
-// this is how to override specific types.. it is ugly 
+// this is how to override specific types.. it is ugly
 template<class T, typename std::enable_if<std::is_same<T, std::string>::value,T>::type* = nullptr>
 inline std::string keyConv(const T& t)
 {
@@ -91,7 +92,7 @@ inline std::string keyConv(const T& t)
 }
 
 
-/** This is a struct that implements index operations, but 
+/** This is a struct that implements index operations, but
     only the operations that are broadcast to all indexes.
     Specifically, to deal with databases with less than the maximum
     number of interfaces, this only includes calls that should be
@@ -136,7 +137,7 @@ struct index_on : LMDBIndexOps<Class, Type, index_on<Class, Type, PtrToMember>>
   {
     return c.*PtrToMember;
   }
-  
+
   typedef Type type;
 };
 
@@ -152,7 +153,7 @@ struct index_on_function : LMDBIndexOps<Class, Type, index_on_function<Class, Ty
     return f(c);
   }
 
-  typedef Type type;           
+  typedef Type type;
 };
 
 /** nop index, so we can fill our N indexes, even if you don't use them all */
@@ -164,10 +165,10 @@ struct nullindex_t
   template<typename Class>
   void del(MDBRWTransaction& txn, const Class& t, uint32_t id)
   {}
-  
+
   void openDB(std::shared_ptr<MDBEnv>& env, string_view str, int flags)
   {
-    
+
   }
   typedef uint32_t type; // dummy
 };
@@ -194,9 +195,9 @@ public:
 #undef openMacro
   }
 
-  
+
   // we get a lot of our smarts from this tuple, it enables get<0> etc
-  typedef std::tuple<I1, I2, I3, I4> tuple_t; 
+  typedef std::tuple<I1, I2, I3, I4> tuple_t;
   tuple_t d_tuple;
 
   // We support readonly and rw transactions. Here we put the Readonly operations
@@ -230,7 +231,7 @@ public:
       MDBOutVal data;
       if((*d_parent.d_txn)->get(d_parent.d_parent->d_main, id, data))
         return false;
-      
+
       serFromString(data.get<std::string>(), t);
       return true;
     }
@@ -283,7 +284,7 @@ public:
         if(d_end)
           return;
         d_prefix.clear();
-        
+
         if(d_cursor.get(d_key, d_id,  MDB_GET_CURRENT)) {
           d_end = true;
           return;
@@ -303,7 +304,7 @@ public:
         d_cursor(std::move(cursor)),
         d_on_index(true), // is this an iterator on main database or on index?
         d_one_key(false),
-        d_prefix(prefix),  
+        d_prefix(prefix),
         d_end(false)
       {
         if(d_end)
@@ -323,28 +324,28 @@ public:
           serFromString(d_id.get<std::string>(), d_t);
       }
 
-      
+
       std::function<bool(const MDBOutVal&)> filter;
       void del()
       {
         d_cursor.del();
       }
-      
+
       bool operator!=(const eiter_t& rhs) const
       {
         return !d_end;
       }
-      
+
       bool operator==(const eiter_t& rhs) const
       {
         return d_end;
       }
-      
+
       const T& operator*()
       {
         return d_t;
       }
-      
+
       const T* operator->()
       {
         return &d_t;
@@ -372,13 +373,13 @@ public:
               throw std::runtime_error("Missing id field");
             if(filter && !filter(data))
               goto next;
-            
+
             serFromString(data.get<std::string>(), d_t);
           }
           else {
             if(filter && !filter(data))
               goto next;
-                        
+
             serFromString(d_id.get<std::string>(), d_t);
           }
         }
@@ -407,8 +408,8 @@ public:
       {
         return d_key;
       }
-      
-      
+
+
       // transaction we are part of
       Parent* d_parent;
       typename Parent::cursor_t d_cursor;
@@ -426,9 +427,9 @@ public:
     iter_t genbegin(MDB_cursor_op op)
     {
       typename Parent::cursor_t cursor = (*d_parent.d_txn)->getCursor(std::get<N>(d_parent.d_parent->d_tuple).d_idx);
-      
+
       MDBOutVal out, id;
-      
+
       if(cursor.get(out, id,  op)) {
                                              // on_index, one_key, end
         return iter_t{&d_parent, std::move(cursor), true, false, true};
@@ -452,11 +453,11 @@ public:
     iter_t begin()
     {
       typename Parent::cursor_t cursor = (*d_parent.d_txn)->getCursor(d_parent.d_parent->d_main);
-      
+
       MDBOutVal out, id;
-      
+
       if(cursor.get(out, id,  MDB_FIRST)) {
-                                              // on_index, one_key, end        
+                                              // on_index, one_key, end
         return iter_t{&d_parent, std::move(cursor), false, false, true};
       }
 
@@ -478,9 +479,9 @@ public:
       MDBInVal in(keystr);
       MDBOutVal out, id;
       out.d_mdbval = in.d_mdbval;
-      
+
       if(cursor.get(out, id,  op)) {
-                                              // on_index, one_key, end        
+                                              // on_index, one_key, end
         return iter_t{&d_parent, std::move(cursor), true, false, true};
       }
 
@@ -510,9 +511,9 @@ public:
       MDBInVal in(keyString);
       MDBOutVal out, id;
       out.d_mdbval = in.d_mdbval;
-      
+
       if(cursor.get(out, id,  MDB_SET)) {
-                                              // on_index, one_key, end        
+                                              // on_index, one_key, end
         return {iter_t{&d_parent, std::move(cursor), true, true, true}, eiter_t()};
       }
 
@@ -529,34 +530,34 @@ public:
       MDBInVal in(keyString);
       MDBOutVal out, id;
       out.d_mdbval = in.d_mdbval;
-      
+
       if(cursor.get(out, id,  MDB_SET_RANGE)) {
-                                              // on_index, one_key, end        
+                                              // on_index, one_key, end
         return {iter_t{&d_parent, std::move(cursor), true, true, true}, eiter_t()};
       }
 
       return {iter_t(&d_parent, std::move(cursor), keyString), eiter_t()};
     };
 
-    
+
     Parent& d_parent;
   };
-  
+
   class ROTransaction : public ReadonlyOperations<ROTransaction>
   {
   public:
-    explicit ROTransaction(TypedDBI* parent) : ReadonlyOperations<ROTransaction>(*this), d_parent(parent), d_txn(std::make_shared<MDBROTransaction>(d_parent->d_env->getROTransaction())) 
+    explicit ROTransaction(TypedDBI* parent) : ReadonlyOperations<ROTransaction>(*this), d_parent(parent), d_txn(std::make_shared<MDBROTransaction>(d_parent->d_env->getROTransaction()))
     {
     }
 
-    explicit ROTransaction(TypedDBI* parent, std::shared_ptr<MDBROTransaction> txn) : ReadonlyOperations<ROTransaction>(*this), d_parent(parent), d_txn(txn) 
+    explicit ROTransaction(TypedDBI* parent, std::shared_ptr<MDBROTransaction> txn) : ReadonlyOperations<ROTransaction>(*this), d_parent(parent), d_txn(txn)
     {
     }
 
-    
+
     ROTransaction(ROTransaction&& rhs) :
       ReadonlyOperations<ROTransaction>(*this), d_parent(rhs.d_parent),d_txn(std::move(rhs.d_txn))
-      
+
     {
       rhs.d_parent = 0;
     }
@@ -565,14 +566,14 @@ public:
     {
       return d_txn;
     }
-    
+
     typedef MDBROCursor cursor_t;
 
     TypedDBI* d_parent;
-    std::shared_ptr<MDBROTransaction> d_txn;    
-  };    
+    std::shared_ptr<MDBROTransaction> d_txn;
+  };
 
-  
+
   class RWTransaction :  public ReadonlyOperations<RWTransaction>
   {
   public:
@@ -585,7 +586,7 @@ public:
     {
     }
 
-    
+
     RWTransaction(RWTransaction&& rhs) :
       ReadonlyOperations<RWTransaction>(*this),
       d_parent(rhs.d_parent), d_txn(std::move(rhs.d_txn))
@@ -622,10 +623,10 @@ public:
     void modify(uint32_t id, std::function<void(T&)> func)
     {
       T t;
-      if(!this->get(id, t)) 
+      if(!this->get(id, t))
         throw std::runtime_error("Could not modify id "+std::to_string(id));
       func(t);
-      
+
       del(id);  // this is the lazy way. We could test for changed index fields
       put(t, id);
     }
@@ -634,9 +635,9 @@ public:
     void del(uint32_t id)
     {
       T t;
-      if(!this->get(id, t)) 
+      if(!this->get(id, t))
         return;
-      
+
       (*d_txn)->del(d_parent->d_main, id);
       clearIndex(id, t);
     }
@@ -675,7 +676,7 @@ public:
       return d_txn;
     }
 
-    
+
   private:
     // clear this ID from all indexes
     void clearIndex(uint32_t id, const T& t)
@@ -685,7 +686,7 @@ public:
       clearMacro(1);
       clearMacro(2);
       clearMacro(3);
-#undef clearMacro      
+#undef clearMacro
     }
 
   public:
@@ -721,14 +722,9 @@ public:
   {
     return d_env;
   }
-  
+
 private:
   std::shared_ptr<MDBEnv> d_env;
   MDBDbi d_main;
   std::string d_name;
 };
-
-
-
-
-

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -61,14 +61,14 @@ uint32_t burtleCI(const unsigned char* k, uint32_t length, uint32_t init);
 
 //#include <ext/vstring.h>
 
-/* Quest in life: 
+/* Quest in life:
      accept escaped ascii presentations of DNS names and store them "natively"
      accept a DNS packet with an offset, and extract a DNS name from it
      build up DNSNames with prepend and append of 'raw' unescaped labels
 
    Be able to turn them into ASCII and "DNS name in a packet" again on request
 
-   Provide some common operators for comparison, detection of being part of another domain 
+   Provide some common operators for comparison, detection of being part of another domain
 
    NOTE: For now, everything MUST be . terminated, otherwise it is an error
 */
@@ -98,7 +98,7 @@ public:
   explicit DNSName(const char* p, size_t len);      //!< Constructs from a human formatted, escaped presentation
   explicit DNSName(const std::string& str) : DNSName(str.c_str(), str.length()) {}; //!< Constructs from a human formatted, escaped presentation
   DNSName(const char* p, int len, int offset, bool uncompress, uint16_t* qtype=nullptr, uint16_t* qclass=nullptr, unsigned int* consumed=nullptr, uint16_t minOffset=0); //!< Construct from a DNS Packet, taking the first question if offset=12. If supplied, consumed is set to the number of bytes consumed from the packet, which will not be equal to the wire length of the resulting name in case of compression.
-  
+
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name? Note that name.isPartOf(name).
   inline bool operator==(const DNSName& rhs) const; //!< DNS-native comparison (case insensitive) - empty compares to empty
   bool operator!=(const DNSName& other) const { return !(*this == other); }
@@ -162,7 +162,7 @@ public:
 
   bool operator<(const DNSName& rhs)  const // this delivers _some_ kind of ordering, but not one useful in a DNS context. Really fast though.
   {
-    return std::lexicographical_compare(d_storage.rbegin(), d_storage.rend(), 
+    return std::lexicographical_compare(d_storage.rbegin(), d_storage.rend(),
 				 rhs.d_storage.rbegin(), rhs.d_storage.rend(),
 				 [](const unsigned char& a, const unsigned char& b) {
 					  return dns_tolower(a) < dns_tolower(b);
@@ -170,7 +170,7 @@ public:
   }
 
   inline bool canonCompare(const DNSName& rhs) const;
-  bool slowCanonCompare(const DNSName& rhs) const;  
+  bool slowCanonCompare(const DNSName& rhs) const;
 
 #if BOOST_VERSION >= 105300
   typedef boost::container::string string_t;
@@ -230,7 +230,7 @@ inline bool DNSName::canonCompare(const DNSName& rhs) const
   //
   // 0,2,6,a
   // 0,4,a
-  
+
   uint8_t ourpos[64], rhspos[64];
   uint8_t ourcount=0, rhscount=0;
   //cout<<"Asked to compare "<<toString()<<" to "<<rhs.toString()<<endl;
@@ -242,7 +242,7 @@ inline bool DNSName::canonCompare(const DNSName& rhs) const
   if(ourcount == sizeof(ourpos) || rhscount==sizeof(rhspos)) {
     return slowCanonCompare(rhs);
   }
-  
+
   for(;;) {
     if(ourcount == 0 && rhscount != 0)
       return true;
@@ -252,21 +252,21 @@ inline bool DNSName::canonCompare(const DNSName& rhs) const
     rhscount--;
 
     bool res=std::lexicographical_compare(
-					  d_storage.c_str() + ourpos[ourcount] + 1, 
+					  d_storage.c_str() + ourpos[ourcount] + 1,
 					  d_storage.c_str() + ourpos[ourcount] + 1 + *(d_storage.c_str() + ourpos[ourcount]),
-					  rhs.d_storage.c_str() + rhspos[rhscount] + 1, 
+					  rhs.d_storage.c_str() + rhspos[rhscount] + 1,
 					  rhs.d_storage.c_str() + rhspos[rhscount] + 1 + *(rhs.d_storage.c_str() + rhspos[rhscount]),
 					  [](const unsigned char& a, const unsigned char& b) {
 					    return dns_tolower(a) < dns_tolower(b);
 					  });
-    
+
     //    cout<<"Forward: "<<res<<endl;
     if(res)
       return true;
 
-    res=std::lexicographical_compare(	  rhs.d_storage.c_str() + rhspos[rhscount] + 1, 
+    res=std::lexicographical_compare(	  rhs.d_storage.c_str() + rhspos[rhscount] + 1,
 					  rhs.d_storage.c_str() + rhspos[rhscount] + 1 + *(rhs.d_storage.c_str() + rhspos[rhscount]),
-					  d_storage.c_str() + ourpos[ourcount] + 1, 
+					  d_storage.c_str() + ourpos[ourcount] + 1,
 					  d_storage.c_str() + ourpos[ourcount] + 1 + *(d_storage.c_str() + ourpos[ourcount]),
 					  [](const unsigned char& a, const unsigned char& b) {
 					    return dns_tolower(a) < dns_tolower(b);
@@ -320,7 +320,7 @@ struct SuffixMatchTree
   {
     return strcasecmp(d_name.c_str(), rhs.d_name.c_str()) < 0;
   }
-  
+
   std::string d_name;
   mutable std::set<SuffixMatchTree, std::less<>> children;
   mutable bool endNode;
@@ -582,16 +582,19 @@ namespace std {
 }
 
 DNSName::string_t segmentDNSNameRaw(const char* input, size_t inputlen); // from ragel
+
 bool DNSName::operator==(const DNSName& rhs) const
 {
-  if(rhs.empty() != empty() || rhs.d_storage.size() != d_storage.size())
+  if (rhs.empty() != empty() || rhs.d_storage.size() != d_storage.size()) {
     return false;
+  }
 
-  auto us = d_storage.cbegin();
-  auto p = rhs.d_storage.cbegin();
-  for(; us != d_storage.cend() && p != rhs.d_storage.cend(); ++us, ++p) { 
-    if(dns_tolower(*p) != dns_tolower(*us))
+  const auto* us = d_storage.cbegin();
+  const auto* p = rhs.d_storage.cbegin();
+  for (; us != d_storage.cend() && p != rhs.d_storage.cend(); ++us, ++p) {
+    if (dns_tolower(*p) != dns_tolower(*us)) {
       return false;
+    }
   }
   return true;
 }

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -293,6 +293,9 @@ struct DNSRecord
     d_type(0), d_class(QClass::IN), d_place(DNSResourceRecord::ANSWER)
   {}
   explicit DNSRecord(const DNSResourceRecord& rr);
+  DNSRecord(const std::string& name, std::shared_ptr<DNSRecordContent> content, const uint16_t type, const uint16_t qclass = QClass::IN, const uint32_t ttl = 86400, const uint16_t clen = 0, const DNSResourceRecord::Place place = DNSResourceRecord::ANSWER) :
+    d_name(DNSName(name)), d_content(std::move(content)), d_type(type), d_class(qclass), d_ttl(ttl), d_clen(clen), d_place(place) {}
+
   DNSName d_name;
   std::shared_ptr<DNSRecordContent> d_content;
   uint16_t d_type;

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -294,8 +294,20 @@ struct DNSRecord
     d_class(QClass::IN)
   {}
   explicit DNSRecord(const DNSResourceRecord& rr);
-  DNSRecord(const std::string& name, std::shared_ptr<DNSRecordContent> content, const uint16_t type, const uint16_t qclass = QClass::IN, const uint32_t ttl = 86400, const uint16_t clen = 0, const DNSResourceRecord::Place place = DNSResourceRecord::ANSWER) :
-    d_name(DNSName(name)), d_content(std::move(content)), d_type(type), d_class(qclass), d_ttl(ttl), d_clen(clen), d_place(place) {}
+  DNSRecord(const std::string& name,
+            std::shared_ptr<DNSRecordContent> content,
+            const uint16_t type,
+            const uint16_t qclass = QClass::IN,
+            const uint32_t ttl = 86400,
+            const uint16_t clen = 0,
+            const DNSResourceRecord::Place place = DNSResourceRecord::ANSWER) :
+    d_name(DNSName(name)),
+    d_content(std::move(content)),
+    d_type(type),
+    d_class(qclass),
+    d_ttl(ttl),
+    d_clen(clen),
+    d_place(place) {}
 
   DNSName d_name;
   std::shared_ptr<DNSRecordContent> d_content;

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -289,15 +289,16 @@ protected:
 
 struct DNSRecord
 {
-  DNSRecord() : d_type(0), d_class(QClass::IN), d_ttl(0), d_clen(0), d_place(DNSResourceRecord::ANSWER)
+  DNSRecord() :
+    d_type(0), d_class(QClass::IN), d_place(DNSResourceRecord::ANSWER)
   {}
   explicit DNSRecord(const DNSResourceRecord& rr);
   DNSName d_name;
   std::shared_ptr<DNSRecordContent> d_content;
   uint16_t d_type;
-  uint16_t d_class;
-  uint32_t d_ttl;
-  uint16_t d_clen;
+  uint16_t d_class{};
+  uint32_t d_ttl{};
+  uint16_t d_clen{};
   DNSResourceRecord::Place d_place;
 
   bool operator<(const DNSRecord& rhs) const

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <iostream>
+#include <utility>
 #include <vector>
 #include <cerrno>
 // #include <netinet/in.h>
@@ -303,6 +304,18 @@ struct DNSRecord
   uint32_t d_ttl{};
   uint16_t d_clen{};
   DNSResourceRecord::Place d_place;
+
+  [[nodiscard]] std::string print(const std::string& indent = "") const
+  {
+    std::stringstream s;
+    s << indent << "Content = " << d_content->getZoneRepresentation() << std::endl;
+    s << indent << "Type = " << d_type << std::endl;
+    s << indent << "Class = " << d_class << std::endl;
+    s << indent << "TTL = " << d_ttl << std::endl;
+    s << indent << "clen = " << d_clen << std::endl;
+    s << indent << "Place = " << std::to_string(d_place) << std::endl;
+    return s.str();
+  }
 
   bool operator<(const DNSRecord& rhs) const
   {

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -291,7 +291,7 @@ protected:
 struct DNSRecord
 {
   DNSRecord() :
-    d_type(0), d_class(QClass::IN), d_place(DNSResourceRecord::ANSWER)
+    d_class(QClass::IN)
   {}
   explicit DNSRecord(const DNSResourceRecord& rr);
   DNSRecord(const std::string& name, std::shared_ptr<DNSRecordContent> content, const uint16_t type, const uint16_t qclass = QClass::IN, const uint32_t ttl = 86400, const uint16_t clen = 0, const DNSResourceRecord::Place place = DNSResourceRecord::ANSWER) :
@@ -299,11 +299,11 @@ struct DNSRecord
 
   DNSName d_name;
   std::shared_ptr<DNSRecordContent> d_content;
-  uint16_t d_type;
+  uint16_t d_type{};
   uint16_t d_class{};
   uint32_t d_ttl{};
   uint16_t d_clen{};
-  DNSResourceRecord::Place d_place;
+  DNSResourceRecord::Place d_place{DNSResourceRecord::ANSWER};
 
   [[nodiscard]] std::string print(const std::string& indent = "") const
   {

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -25,7 +25,7 @@
 #include <stdexcept>
 #include <iostream>
 #include <vector>
-#include <errno.h>
+#include <cerrno>
 // #include <netinet/in.h>
 #include "misc.hh"
 
@@ -343,11 +343,11 @@ struct DNSRecord
     return lzrp < rzrp;
   }
 
-
   bool operator==(const DNSRecord& rhs) const
   {
-    if(d_type != rhs.d_type || d_class != rhs.d_class || d_name != rhs.d_name)
+    if (d_type != rhs.d_type || d_class != rhs.d_class || d_name != rhs.d_name) {
       return false;
+    }
 
     return *d_content == *rhs.d_content;
   }

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -91,17 +91,17 @@ bool DNSResourceRecord::operator==(const DNSResourceRecord& rhs)
 
 boilerplate_conv(A, conv.xfrIP(d_ip));
 
-ARecordContent::ARecordContent(uint32_t ip) 
+ARecordContent::ARecordContent(uint32_t ip)
 {
   d_ip = ip;
 }
 
-ARecordContent::ARecordContent(const ComboAddress& ca) 
+ARecordContent::ARecordContent(const ComboAddress& ca)
 {
   d_ip = ca.sin4.sin_addr.s_addr;
 }
 
-AAAARecordContent::AAAARecordContent(const ComboAddress& ca) 
+AAAARecordContent::AAAARecordContent(const ComboAddress& ca)
 {
   d_ip6.assign((const char*)ca.sin6.sin6_addr.s6_addr, 16);
 }
@@ -130,7 +130,7 @@ ComboAddress AAAARecordContent::getCA(int port) const
 
 
 void ARecordContent::doRecordCheck(const DNSRecord& dr)
-{  
+{
   if(dr.d_clen!=4)
     throw MOADNSException("Wrong size for A record ("+std::to_string(dr.d_clen)+")");
 }
@@ -157,7 +157,7 @@ boilerplate_conv(SPF, conv.xfrText(d_text, true));
 boilerplate_conv(HINFO, conv.xfrText(d_cpu);   conv.xfrText(d_host));
 
 boilerplate_conv(RP,
-                 conv.xfrName(d_mbox);   
+                 conv.xfrName(d_mbox);
                  conv.xfrName(d_info)
                  );
 
@@ -209,7 +209,7 @@ boilerplate_conv(TSIG,
                  conv.xfr16BitInt(d_origID);
                  conv.xfr16BitInt(d_eRcode);
                  size=d_otherData.size();
-                 conv.xfr16BitInt(size); 
+                 conv.xfr16BitInt(size);
                  if (size>0) conv.xfrBlobNoSpaces(d_otherData, size);
                  );
 
@@ -231,7 +231,7 @@ boilerplate_conv(IPSECKEY,
    conv.xfr8BitInt(d_preference);
    conv.xfr8BitInt(d_gatewaytype);
    conv.xfr8BitInt(d_algorithm);
- 
+
    // now we need to determine values
    switch(d_gatewaytype) {
    case 0: // NO KEY
@@ -243,7 +243,7 @@ boilerplate_conv(IPSECKEY,
      conv.xfrIP6(d_ip6);
      break;
    case 3: // DNS label
-     conv.xfrName(d_gateway, false); 
+     conv.xfrName(d_gateway, false);
      break;
    default:
      throw MOADNSException("Parsing record content: invalid gateway type");
@@ -259,7 +259,7 @@ boilerplate_conv(IPSECKEY,
    default:
      throw MOADNSException("Parsing record content: invalid algorithm type");
    }
-) 
+)
 
 boilerplate_conv(DHCID,
                  conv.xfrBlob(d_content);
@@ -279,16 +279,16 @@ boilerplate_conv(NAPTR,
                  )
 
 
-SRVRecordContent::SRVRecordContent(uint16_t preference, uint16_t weight, uint16_t port, DNSName  target) 
+SRVRecordContent::SRVRecordContent(uint16_t preference, uint16_t weight, uint16_t port, DNSName  target)
 : d_weight(weight), d_port(port), d_target(std::move(target)), d_preference(preference)
 {}
 
 boilerplate_conv(SRV,
                  conv.xfr16BitInt(d_preference);   conv.xfr16BitInt(d_weight);   conv.xfr16BitInt(d_port);
-                 conv.xfrName(d_target); 
+                 conv.xfrName(d_target);
                  )
 
-SOARecordContent::SOARecordContent(DNSName  mname, DNSName  rname, const struct soatimes& st) 
+SOARecordContent::SOARecordContent(DNSName  mname, DNSName  rname, const struct soatimes& st)
 : d_mname(std::move(mname)), d_rname(std::move(rname)), d_st(st)
 {
 }
@@ -304,9 +304,9 @@ boilerplate_conv(SOA,
                  );
 #undef KEY
 boilerplate_conv(KEY,
-                 conv.xfr16BitInt(d_flags); 
-                 conv.xfr8BitInt(d_protocol); 
-                 conv.xfr8BitInt(d_algorithm); 
+                 conv.xfr16BitInt(d_flags);
+                 conv.xfr8BitInt(d_protocol);
+                 conv.xfr8BitInt(d_algorithm);
                  conv.xfrBlob(d_certificate);
                  );
 
@@ -318,21 +318,21 @@ boilerplate_conv(ZONEMD,
                  );
 
 boilerplate_conv(CERT,
-                 conv.xfr16BitInt(d_type); 
+                 conv.xfr16BitInt(d_type);
                  if (d_type == 0) throw MOADNSException("CERT type 0 is reserved");
 
-                 conv.xfr16BitInt(d_tag); 
-                 conv.xfr8BitInt(d_algorithm); 
+                 conv.xfr16BitInt(d_tag);
+                 conv.xfr8BitInt(d_algorithm);
                  conv.xfrBlob(d_certificate);
                  )
 
 boilerplate_conv(TLSA,
-                 conv.xfr8BitInt(d_certusage); 
-                 conv.xfr8BitInt(d_selector); 
-                 conv.xfr8BitInt(d_matchtype); 
+                 conv.xfr8BitInt(d_certusage);
+                 conv.xfr8BitInt(d_selector);
+                 conv.xfr8BitInt(d_matchtype);
                  conv.xfrHexBlob(d_cert, true);
-                 )                 
-                 
+                 )
+
 boilerplate_conv(OPENPGPKEY,
                  conv.xfrBlob(d_keyring);
                  )
@@ -362,69 +362,69 @@ boilerplate_conv(SMIMEA,
 
 DSRecordContent::DSRecordContent() {}
 boilerplate_conv(DS,
-                 conv.xfr16BitInt(d_tag); 
-                 conv.xfr8BitInt(d_algorithm); 
-                 conv.xfr8BitInt(d_digesttype); 
+                 conv.xfr16BitInt(d_tag);
+                 conv.xfr8BitInt(d_algorithm);
+                 conv.xfr8BitInt(d_digesttype);
                  conv.xfrHexBlob(d_digest, true); // keep reading across spaces
                  )
 
 CDSRecordContent::CDSRecordContent() {}
 boilerplate_conv(CDS,
-                 conv.xfr16BitInt(d_tag); 
-                 conv.xfr8BitInt(d_algorithm); 
-                 conv.xfr8BitInt(d_digesttype); 
+                 conv.xfr16BitInt(d_tag);
+                 conv.xfr8BitInt(d_algorithm);
+                 conv.xfr8BitInt(d_digesttype);
                  conv.xfrHexBlob(d_digest, true); // keep reading across spaces
                  )
 
 DLVRecordContent::DLVRecordContent() {}
 boilerplate_conv(DLV,
-                 conv.xfr16BitInt(d_tag); 
-                 conv.xfr8BitInt(d_algorithm); 
-                 conv.xfr8BitInt(d_digesttype); 
+                 conv.xfr16BitInt(d_tag);
+                 conv.xfr8BitInt(d_algorithm);
+                 conv.xfr8BitInt(d_digesttype);
                  conv.xfrHexBlob(d_digest, true); // keep reading across spaces
                  )
 
 
 boilerplate_conv(SSHFP,
-                 conv.xfr8BitInt(d_algorithm); 
-                 conv.xfr8BitInt(d_fptype); 
+                 conv.xfr8BitInt(d_algorithm);
+                 conv.xfr8BitInt(d_fptype);
                  conv.xfrHexBlob(d_fingerprint, true);
                  )
 
 boilerplate_conv(RRSIG,
-                 conv.xfrType(d_type); 
-                   conv.xfr8BitInt(d_algorithm); 
-                   conv.xfr8BitInt(d_labels); 
-                   conv.xfr32BitInt(d_originalttl); 
-                   conv.xfrTime(d_sigexpire); 
-                   conv.xfrTime(d_siginception); 
-                 conv.xfr16BitInt(d_tag); 
+                 conv.xfrType(d_type);
+                   conv.xfr8BitInt(d_algorithm);
+                   conv.xfr8BitInt(d_labels);
+                   conv.xfr32BitInt(d_originalttl);
+                   conv.xfrTime(d_sigexpire);
+                   conv.xfrTime(d_siginception);
+                 conv.xfr16BitInt(d_tag);
                  conv.xfrName(d_signer);
                  conv.xfrBlob(d_signature);
                  )
-                 
+
 RRSIGRecordContent::RRSIGRecordContent() {}
 
 boilerplate_conv(DNSKEY,
-                 conv.xfr16BitInt(d_flags); 
-                 conv.xfr8BitInt(d_protocol); 
-                 conv.xfr8BitInt(d_algorithm); 
+                 conv.xfr16BitInt(d_flags);
+                 conv.xfr8BitInt(d_protocol);
+                 conv.xfr8BitInt(d_algorithm);
                  conv.xfrBlob(d_key);
                  )
 DNSKEYRecordContent::DNSKEYRecordContent() {}
 
 boilerplate_conv(CDNSKEY,
-                 conv.xfr16BitInt(d_flags); 
-                 conv.xfr8BitInt(d_protocol); 
-                 conv.xfr8BitInt(d_algorithm); 
+                 conv.xfr16BitInt(d_flags);
+                 conv.xfr8BitInt(d_protocol);
+                 conv.xfr8BitInt(d_algorithm);
                  conv.xfrBlob(d_key);
                  )
 CDNSKEYRecordContent::CDNSKEYRecordContent() {}
 
 boilerplate_conv(RKEY,
-                 conv.xfr16BitInt(d_flags); 
-                 conv.xfr8BitInt(d_protocol); 
-                 conv.xfr8BitInt(d_algorithm); 
+                 conv.xfr16BitInt(d_flags);
+                 conv.xfr8BitInt(d_protocol);
+                 conv.xfr8BitInt(d_algorithm);
                  conv.xfrBlob(d_key);
                  )
 RKEYRecordContent::RKEYRecordContent() {}
@@ -463,9 +463,9 @@ std::shared_ptr<DNSRecordContent> EUI48RecordContent::make(const string& zone)
 {
     // try to parse
     auto ret=std::make_shared<EUI48RecordContent>();
-    // format is 6 hex bytes and dashes    
-    if (sscanf(zone.c_str(), "%2hhx-%2hhx-%2hhx-%2hhx-%2hhx-%2hhx", 
-           ret->d_eui48, ret->d_eui48+1, ret->d_eui48+2, 
+    // format is 6 hex bytes and dashes
+    if (sscanf(zone.c_str(), "%2hhx-%2hhx-%2hhx-%2hhx-%2hhx-%2hhx",
+           ret->d_eui48, ret->d_eui48+1, ret->d_eui48+2,
            ret->d_eui48+3, ret->d_eui48+4, ret->d_eui48+5) != 6) {
        throw MOADNSException("Asked to encode '"+zone+"' as an EUI48 address, but does not parse");
     }
@@ -474,13 +474,13 @@ std::shared_ptr<DNSRecordContent> EUI48RecordContent::make(const string& zone)
 void EUI48RecordContent::toPacket(DNSPacketWriter& pw)
 {
     string blob(d_eui48, d_eui48+6);
-    pw.xfrBlob(blob); 
+    pw.xfrBlob(blob);
 }
 string EUI48RecordContent::getZoneRepresentation(bool noDot) const
 {
-    char tmp[18]; 
+    char tmp[18];
     snprintf(tmp,sizeof(tmp),"%02x-%02x-%02x-%02x-%02x-%02x",
-           d_eui48[0], d_eui48[1], d_eui48[2], 
+           d_eui48[0], d_eui48[1], d_eui48[2],
            d_eui48[3], d_eui48[4], d_eui48[5]);
     return tmp;
 }
@@ -507,7 +507,7 @@ std::shared_ptr<DNSRecordContent> EUI64RecordContent::make(const string& zone)
     // try to parse
     auto ret=std::make_shared<EUI64RecordContent>();
     // format is 8 hex bytes and dashes
-    if (sscanf(zone.c_str(), "%2hhx-%2hhx-%2hhx-%2hhx-%2hhx-%2hhx-%2hhx-%2hhx", 
+    if (sscanf(zone.c_str(), "%2hhx-%2hhx-%2hhx-%2hhx-%2hhx-%2hhx-%2hhx-%2hhx",
            ret->d_eui64, ret->d_eui64+1, ret->d_eui64+2,
            ret->d_eui64+3, ret->d_eui64+4, ret->d_eui64+5,
            ret->d_eui64+6, ret->d_eui64+7) != 8) {
@@ -522,7 +522,7 @@ void EUI64RecordContent::toPacket(DNSPacketWriter& pw)
 }
 string EUI64RecordContent::getZoneRepresentation(bool noDot) const
 {
-    char tmp[24]; 
+    char tmp[24];
     snprintf(tmp,sizeof(tmp),"%02x-%02x-%02x-%02x-%02x-%02x-%02x-%02x",
            d_eui64[0], d_eui64[1], d_eui64[2],
            d_eui64[3], d_eui64[4], d_eui64[5],
@@ -837,7 +837,7 @@ static uint16_t makeTag(const std::string& data)
 
   unsigned long ac;     /* assumed to be 32 bits or larger */
   unsigned int i;                /* loop index */
-  
+
   for ( ac = 0, i = 0; i < keysize; ++i )
     ac += (i & 1) ? key[i] : key[i] << 8;
   ac += (ac >> 16) & 0xFFFF;
@@ -850,7 +850,7 @@ uint16_t DNSKEYRecordContent::getTag() const
   return makeTag(tmp.serialize(DNSName()));  // this can't be const for some reason
 }
 
-uint16_t DNSKEYRecordContent::getTag() 
+uint16_t DNSKEYRecordContent::getTag()
 {
   return makeTag(this->serialize(DNSName()));
 }

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -368,7 +368,7 @@ public:
   string d_key;
   bool operator<(const DNSKEYRecordContent& rhs) const
   {
-    return std::tie(d_flags, d_protocol, d_algorithm, d_key) < 
+    return std::tie(d_flags, d_protocol, d_algorithm, d_key) <
       std::tie(rhs.d_flags, rhs.d_protocol, rhs.d_algorithm, rhs.d_key);
   }
 };
@@ -552,7 +552,7 @@ public:
 class RRSIGRecordContent : public DNSRecordContent
 {
 public:
-  RRSIGRecordContent(); 
+  RRSIGRecordContent();
   includeboilerplate(RRSIG)
 
   uint16_t d_type{0};
@@ -564,7 +564,7 @@ public:
 };
 
 //namespace {
-  struct soatimes 
+  struct soatimes
   {
     uint32_t serial;
     uint32_t refresh;
@@ -891,7 +891,7 @@ private:
   DNSName d_fqdn;
 };
 
-class EUI48RecordContent : public DNSRecordContent 
+class EUI48RecordContent : public DNSRecordContent
 {
 public:
   EUI48RecordContent() {};
@@ -903,7 +903,7 @@ public:
   uint16_t getType() const override { return QType::EUI48; }
 private:
  // storage for the bytes
- uint8_t d_eui48[6]; 
+ uint8_t d_eui48[6];
 };
 
 class EUI64RecordContent : public DNSRecordContent
@@ -1031,8 +1031,8 @@ string RNAME##RecordContent::getZoneRepresentation(bool noDot) const            
   RecordTextWriter rtw(ret, noDot);                                                                       \
   const_cast<RNAME##RecordContent*>(this)->xfrPacket(rtw);                                         \
   return ret;                                                                                      \
-}                                                                                                  
-                                                                                           
+}
+
 
 #define boilerplate_conv(RNAME, CONV)                             \
 boilerplate(RNAME)                                                \

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -283,6 +283,32 @@ union ComboAddress {
       return "invalid "+stringerror();
   }
 
+  [[nodiscard]] string toStringReversed() const
+  {
+    if (isIPv4()) {
+      const auto ip = ntohl(sin4.sin_addr.s_addr);
+      auto a = (ip >> 0) & 0xFF;
+      auto b = (ip >> 8) & 0xFF;
+      auto c = (ip >> 16) & 0xFF;
+      auto d = (ip >> 24) & 0xFF;
+      return std::to_string(a) + "." + std::to_string(b) + "." + std::to_string(c) + "." + std::to_string(d);
+    }
+    else {
+      const auto* addr = &sin6.sin6_addr;
+      std::stringstream res{};
+      res << std::hex;
+      for (int i = 15; i >= 0; i--) {
+        auto byte = addr->s6_addr[i];
+        res << ((byte >> 0) & 0xF) << ".";
+        res << ((byte >> 4) & 0xF);
+        if (i != 0) {
+          res << ".";
+        }
+      }
+      return res.str();
+    }
+  }
+
   string toStringWithPort() const
   {
     if(sin4.sin_family==AF_INET)

--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -175,7 +175,7 @@ public:
        = 15
     */
     const dnsheader_aligned dnsheaderdata(query.data());
-    const struct dnsheader* dh = dnsheaderdata.get();    
+    const struct dnsheader* dh = dnsheaderdata.get();
     if (ntohs(dh->qdcount) != 1 || ntohs(dh->ancount) != 0 || ntohs(dh->nscount) != 0 || ntohs(dh->arcount) != 1 || (pos + 15) >= querySize || optionsToIgnore.empty()) {
       return cachedQuery.compare(pos, cachedQuerySize - pos, query, pos, querySize - pos) == 0;
     }

--- a/pdns/recursordist/.gitignore
+++ b/pdns/recursordist/.gitignore
@@ -55,3 +55,4 @@ PowerDNS-Recursor.pdf
 /*.pb.cc
 /*.pb.h
 /.cache
+/.clang-tidy

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -175,6 +175,7 @@ pdns_recursor_SOURCES = \
 	rec_channel_rec.cc \
 	recpacketcache.cc recpacketcache.hh \
 	recursor_cache.cc recursor_cache.hh \
+	reczones-helpers.cc reczones-helpers.hh \
 	reczones.cc \
 	remote_logger.cc remote_logger.hh \
 	resolve-context.hh \
@@ -290,6 +291,7 @@ testrunner_SOURCES = \
 	rec-zonetocache.cc rec-zonetocache.hh \
 	recpacketcache.cc recpacketcache.hh \
 	recursor_cache.cc recursor_cache.hh \
+	reczones-helpers.cc reczones-helpers.hh \
 	resolver.hh resolver.cc \
 	responsestats.cc \
 	root-dnssec.hh \
@@ -329,6 +331,7 @@ testrunner_SOURCES = \
 	test-rec-zonetocache.cc \
 	test-recpacketcache_cc.cc \
 	test-recursorcache_cc.cc \
+	test-reczones-helpers.cc \
 	test-rpzloader_cc.cc \
 	test-secpoll_cc.cc \
 	test-signers.cc \

--- a/pdns/recursordist/reczones-helpers.cc
+++ b/pdns/recursordist/reczones-helpers.cc
@@ -1,0 +1,1 @@
+../reczones-helpers.cc

--- a/pdns/recursordist/reczones-helpers.hh
+++ b/pdns/recursordist/reczones-helpers.hh
@@ -1,0 +1,1 @@
+../reczones-helpers.hh

--- a/pdns/recursordist/test-reczones-helpers.cc
+++ b/pdns/recursordist/test-reczones-helpers.cc
@@ -72,7 +72,6 @@ struct Fixture
         DNSRecord("1.0.168.192.in-addr.arpa", makeLocalhostDRC(), QType::NS),
         DNSRecord("1.0.168.192.in-addr.arpa", makeLocalhostRootDRC(), QType::SOA),
         DNSRecord("1.0.168.192.in-addr.arpa", makePtrDRC("foo."), QType::PTR),
-        DNSRecord("1.0.168.192.in-addr.arpa", makePtrDRC("bar."), QType::PTR),
       });
     addDomainMapFixtureEntry("baz", QType::A, "192.168.0.2");
     addDomainMapFixtureEntry(
@@ -108,7 +107,6 @@ struct Fixture
         DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostDRC(), QType::NS),
         DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostRootDRC(), QType::SOA),
         DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("foo6."), QType::PTR),
-        DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("bar6."), QType::PTR),
       });
 
     addDomainMapFixtureEntry("localhost", QType::AAAA, "::1");
@@ -119,7 +117,6 @@ struct Fixture
         DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makeLocalhostDRC(), QType::NS),
         DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makeLocalhostRootDRC(), QType::SOA),
         DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makePtrDRC("localhost."), QType::PTR),
-        DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makePtrDRC("self."), QType::PTR),
       });
 
     addDomainMapFixtureEntry("some", QType::AAAA, "2001:db8::567:89ac");
@@ -131,8 +128,6 @@ struct Fixture
         DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostDRC(), QType::NS),
         DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostRootDRC(), QType::SOA),
         DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("some.address.somewhere."), QType::PTR),
-        DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("some."), QType::PTR),
-        DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("some.address."), QType::PTR),
       });
   }
 

--- a/pdns/recursordist/test-reczones-helpers.cc
+++ b/pdns/recursordist/test-reczones-helpers.cc
@@ -37,9 +37,11 @@ struct Fixture
     return DNSRecordContent::mastermake(QType::PTR, QClass::IN, name);
   }
 
-  void addDomainMapFixtureEntry(const std::string& name, const SyncRes::AuthDomain::records_t& records)
+  static void addDomainMapFixtureEntry(SyncRes::domainmap_t& domainMap,
+                                       const std::string& name,
+                                       const SyncRes::AuthDomain::records_t& records)
   {
-    domainMapFixture[DNSName{name}] = SyncRes::AuthDomain{
+    domainMap[DNSName{name}] = SyncRes::AuthDomain{
       .d_records = records,
       .d_servers = {},
       .d_name = DNSName{name},
@@ -47,9 +49,12 @@ struct Fixture
     };
   }
 
-  void addDomainMapFixtureEntry(const std::string& name, const QType type, const std::string& address)
+  static void addDomainMapFixtureEntry(SyncRes::domainmap_t& domainMap,
+                                       const std::string& name,
+                                       const QType type,
+                                       const std::string& address)
   {
-    domainMapFixture[DNSName{name}] = SyncRes::AuthDomain{
+    domainMap[DNSName{name}] = SyncRes::AuthDomain{
       .d_records = {
         DNSRecord(name, DNSRecordContent::mastermake(type, QClass::IN, address), type),
         DNSRecord(name, makeLocalhostDRC(), QType::NS),
@@ -61,36 +66,43 @@ struct Fixture
     };
   }
 
-  Fixture()
+  static void populateDomainMapFixture(SyncRes::domainmap_t& domainMap,
+                                       const std::string& searchSuffix = "")
   {
-    addDomainMapFixtureEntry("foo", QType::A, "192.168.0.1");
-    addDomainMapFixtureEntry("bar", QType::A, "192.168.0.1");
-    addDomainMapFixtureEntry("dupfoo", QType::A, "192.168.0.1");
+    const auto actualSearchSuffix = searchSuffix.empty() ? "" : "." + searchSuffix;
+
+    addDomainMapFixtureEntry(domainMap, "foo" + actualSearchSuffix, QType::A, "192.168.0.1");
+    addDomainMapFixtureEntry(domainMap, "bar" + actualSearchSuffix, QType::A, "192.168.0.1");
+    addDomainMapFixtureEntry(domainMap, "dupfoo" + actualSearchSuffix, QType::A, "192.168.0.1");
     addDomainMapFixtureEntry(
+      domainMap,
       "1.0.168.192.in-addr.arpa",
       {
         DNSRecord("1.0.168.192.in-addr.arpa", makeLocalhostDRC(), QType::NS),
         DNSRecord("1.0.168.192.in-addr.arpa", makeLocalhostRootDRC(), QType::SOA),
         DNSRecord("1.0.168.192.in-addr.arpa", makePtrDRC("foo."), QType::PTR),
       });
-    addDomainMapFixtureEntry("baz", QType::A, "192.168.0.2");
+    addDomainMapFixtureEntry(domainMap, "baz" + actualSearchSuffix, QType::A, "192.168.0.2");
     addDomainMapFixtureEntry(
+      domainMap,
       "2.0.168.192.in-addr.arpa",
       {
         DNSRecord("2.0.168.192.in-addr.arpa", makeLocalhostDRC(), QType::NS),
         DNSRecord("2.0.168.192.in-addr.arpa", makeLocalhostRootDRC(), QType::SOA),
         DNSRecord("2.0.168.192.in-addr.arpa", makePtrDRC("baz."), QType::PTR),
       });
-    addDomainMapFixtureEntry("fancy", QType::A, "1.1.1.1");
+    addDomainMapFixtureEntry(domainMap, "fancy" + actualSearchSuffix, QType::A, "1.1.1.1");
     addDomainMapFixtureEntry(
+      domainMap,
       "1.1.1.1.in-addr.arpa",
       {
         DNSRecord("1.1.1.1.in-addr.arpa", makeLocalhostDRC(), QType::NS),
         DNSRecord("1.1.1.1.in-addr.arpa", makeLocalhostRootDRC(), QType::SOA),
         DNSRecord("1.1.1.1.in-addr.arpa", makePtrDRC("fancy."), QType::PTR),
       });
-    addDomainMapFixtureEntry("more.fancy", QType::A, "2.2.2.2");
+    addDomainMapFixtureEntry(domainMap, "more.fancy", QType::A, "2.2.2.2");
     addDomainMapFixtureEntry(
+      domainMap,
       "2.2.2.2.in-addr.arpa",
       {
         DNSRecord("2.2.2.2.in-addr.arpa", makeLocalhostDRC(), QType::NS),
@@ -98,10 +110,11 @@ struct Fixture
         DNSRecord("2.2.2.2.in-addr.arpa", makePtrDRC("more.fancy."), QType::PTR),
       });
 
-    addDomainMapFixtureEntry("foo6", QType::AAAA, "2001:db8::567:89ab");
-    addDomainMapFixtureEntry("bar6", QType::AAAA, "2001:db8::567:89ab");
-    addDomainMapFixtureEntry("dupfoo6", QType::AAAA, "2001:db8::567:89ab");
+    addDomainMapFixtureEntry(domainMap, "foo6" + actualSearchSuffix, QType::AAAA, "2001:db8::567:89ab");
+    addDomainMapFixtureEntry(domainMap, "bar6" + actualSearchSuffix, QType::AAAA, "2001:db8::567:89ab");
+    addDomainMapFixtureEntry(domainMap, "dupfoo6" + actualSearchSuffix, QType::AAAA, "2001:db8::567:89ab");
     addDomainMapFixtureEntry(
+      domainMap,
       "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
       {
         DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostDRC(), QType::NS),
@@ -109,9 +122,10 @@ struct Fixture
         DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("foo6."), QType::PTR),
       });
 
-    addDomainMapFixtureEntry("localhost", QType::AAAA, "::1");
-    addDomainMapFixtureEntry("self", QType::AAAA, "::1");
+    addDomainMapFixtureEntry(domainMap, "localhost" + actualSearchSuffix, QType::AAAA, "::1");
+    addDomainMapFixtureEntry(domainMap, "self" + actualSearchSuffix, QType::AAAA, "::1");
     addDomainMapFixtureEntry(
+      domainMap,
       "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa",
       {
         DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makeLocalhostDRC(), QType::NS),
@@ -119,16 +133,23 @@ struct Fixture
         DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makePtrDRC("localhost."), QType::PTR),
       });
 
-    addDomainMapFixtureEntry("some", QType::AAAA, "2001:db8::567:89ac");
-    addDomainMapFixtureEntry("some.address.somewhere", QType::AAAA, "2001:db8::567:89ac");
-    addDomainMapFixtureEntry("some.address", QType::AAAA, "2001:db8::567:89ac");
+    addDomainMapFixtureEntry(domainMap, "some" + actualSearchSuffix, QType::AAAA, "2001:db8::567:89ac");
+    addDomainMapFixtureEntry(domainMap, "some.address.somewhere", QType::AAAA, "2001:db8::567:89ac");
+    addDomainMapFixtureEntry(domainMap, "some.address", QType::AAAA, "2001:db8::567:89ac");
     addDomainMapFixtureEntry(
+      domainMap,
       "c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
       {
         DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostDRC(), QType::NS),
         DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostRootDRC(), QType::SOA),
         DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("some.address.somewhere."), QType::PTR),
       });
+  }
+
+  Fixture()
+  {
+    populateDomainMapFixture(domainMapFixture);
+    populateDomainMapFixture(domainMapFixtureWithSearchSuffix, "search.suffix");
   }
 
   using DomainMapEntry = std::pair<DNSName, SyncRes::AuthDomain>;
@@ -162,8 +183,14 @@ struct Fixture
     return sortDomainMap(domainMapFixture);
   }
 
+  std::vector<DomainMapEntry> getDomainMapFixtureWithSearchSuffix() const
+  {
+    return sortDomainMap(domainMapFixtureWithSearchSuffix);
+  }
+
 private:
   SyncRes::domainmap_t domainMapFixture{};
+  SyncRes::domainmap_t domainMapFixtureWithSearchSuffix{};
 };
 
 BOOST_FIXTURE_TEST_CASE(test_loading_etc_hosts, Fixture)
@@ -171,11 +198,15 @@ BOOST_FIXTURE_TEST_CASE(test_loading_etc_hosts, Fixture)
   auto log = g_slog->withName("config");
 
   auto domainMap = std::make_shared<SyncRes::domainmap_t>();
+  auto domainMapWithSearchSuffix = std::make_shared<SyncRes::domainmap_t>();
   std::vector<std::string> parts{};
   for (auto line : hostLines) {
     BOOST_REQUIRE(parseEtcHostsLine(parts, line));
     addForwardAndReverseLookupEntries(*domainMap, "", parts, log);
+    addForwardAndReverseLookupEntries(*domainMapWithSearchSuffix, "search.suffix", parts, log);
   }
+
+  BOOST_TEST_MESSAGE("Actual and expected outputs without search suffixes:");
 
   auto actual = sortDomainMap(*domainMap);
   BOOST_TEST_MESSAGE("Actual:");
@@ -190,6 +221,26 @@ BOOST_FIXTURE_TEST_CASE(test_loading_etc_hosts, Fixture)
     BOOST_CHECK(actual[i].first == expected[i].first);
     BOOST_CHECK(actual[i].second == expected[i].second);
   }
+
+  BOOST_TEST_MESSAGE("-----------------------------------------------------");
+
+  BOOST_TEST_MESSAGE("Actual and expected outputs with search suffixes:");
+
+  auto actualSearchSuffix = sortDomainMap(*domainMapWithSearchSuffix);
+  BOOST_TEST_MESSAGE("Actual (with search suffix):");
+  BOOST_TEST_MESSAGE(printDomainMap(actualSearchSuffix));
+
+  auto expectedSearchSuffix = getDomainMapFixtureWithSearchSuffix();
+  BOOST_TEST_MESSAGE("Expected (with search suffix):");
+  BOOST_TEST_MESSAGE(printDomainMap(expectedSearchSuffix));
+
+  BOOST_CHECK_EQUAL(actualSearchSuffix.size(), expectedSearchSuffix.size());
+  for (std::vector<DomainMapEntry>::size_type i = 0; i < actualSearchSuffix.size(); i++) {
+    BOOST_CHECK(actualSearchSuffix[i].first == expectedSearchSuffix[i].first);
+    BOOST_CHECK(actualSearchSuffix[i].second == expectedSearchSuffix[i].second);
+  }
+
+  BOOST_TEST_MESSAGE("-----------------------------------------------------");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-reczones-helpers.cc
+++ b/pdns/recursordist/test-reczones-helpers.cc
@@ -8,12 +8,16 @@
 
 BOOST_AUTO_TEST_SUITE(reczones_helpers)
 
-static const std::array<std::string, 5> hostLines = {
+static const std::array<std::string, 9> hostLines = {
   "192.168.0.1             foo bar\n",
   "192.168.0.1             dupfoo\n",
   "192.168.0.2             baz\n",
   "1.1.1.1                 fancy\n",
   "2.2.2.2                 more.fancy\n",
+  "2001:db8::567:89ab      foo6 bar6\n",
+  "2001:db8::567:89ab      dupfoo6\n",
+  "::1                     localhost self\n",
+  "2001:db8::567:89ac      some.address.somewhere some some.address\n",
 };
 
 struct Fixture
@@ -94,6 +98,42 @@ struct Fixture
         DNSRecord("2.2.2.2.in-addr.arpa", makeLocalhostRootDRC(), QType::SOA),
         DNSRecord("2.2.2.2.in-addr.arpa", makePtrDRC("more.fancy."), QType::PTR),
       });
+
+    addDomainMapFixtureEntry("foo6", QType::AAAA, "2001:db8::567:89ab");
+    addDomainMapFixtureEntry("bar6", QType::AAAA, "2001:db8::567:89ab");
+    addDomainMapFixtureEntry("dupfoo6", QType::AAAA, "2001:db8::567:89ab");
+    addDomainMapFixtureEntry(
+      "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
+      {
+        DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostDRC(), QType::NS),
+        DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostRootDRC(), QType::SOA),
+        DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("foo6."), QType::PTR),
+        DNSRecord("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("bar6."), QType::PTR),
+      });
+
+    addDomainMapFixtureEntry("localhost", QType::AAAA, "::1");
+    addDomainMapFixtureEntry("self", QType::AAAA, "::1");
+    addDomainMapFixtureEntry(
+      "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa",
+      {
+        DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makeLocalhostDRC(), QType::NS),
+        DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makeLocalhostRootDRC(), QType::SOA),
+        DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makePtrDRC("localhost."), QType::PTR),
+        DNSRecord("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa", makePtrDRC("self."), QType::PTR),
+      });
+
+    addDomainMapFixtureEntry("some", QType::AAAA, "2001:db8::567:89ac");
+    addDomainMapFixtureEntry("some.address.somewhere", QType::AAAA, "2001:db8::567:89ac");
+    addDomainMapFixtureEntry("some.address", QType::AAAA, "2001:db8::567:89ac");
+    addDomainMapFixtureEntry(
+      "c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
+      {
+        DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostDRC(), QType::NS),
+        DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makeLocalhostRootDRC(), QType::SOA),
+        DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("some.address.somewhere."), QType::PTR),
+        DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("some."), QType::PTR),
+        DNSRecord("c.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", makePtrDRC("some.address."), QType::PTR),
+      });
   }
 
   using DomainMapEntry = std::pair<DNSName, SyncRes::AuthDomain>;
@@ -139,7 +179,7 @@ BOOST_FIXTURE_TEST_CASE(test_loading_etc_hosts, Fixture)
   std::vector<std::string> parts{};
   for (auto line : hostLines) {
     BOOST_REQUIRE(parseEtcHostsLine(parts, line));
-    addForwardAndReverseLookupEntries(domainMap, "", parts, log);
+    addForwardAndReverseLookupEntries(*domainMap, "", parts, log);
   }
 
   auto actual = sortDomainMap(*domainMap);
@@ -155,9 +195,6 @@ BOOST_FIXTURE_TEST_CASE(test_loading_etc_hosts, Fixture)
     BOOST_CHECK(actual[i].first == expected[i].first);
     BOOST_CHECK(actual[i].second == expected[i].second);
   }
-
-  // BOOST_CHECK_EQUAL(actual, expected);
-  // BOOST_CHECK(actualSorted == expectedSorted);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-reczones-helpers.cc
+++ b/pdns/recursordist/test-reczones-helpers.cc
@@ -1,0 +1,163 @@
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <stdio.h>
+
+#include "test-syncres_cc.hh"
+#include "reczones-helpers.hh"
+
+BOOST_AUTO_TEST_SUITE(reczones_helpers)
+
+static const std::array<std::string, 5> hostLines = {
+  "192.168.0.1             foo bar\n",
+  "192.168.0.1             dupfoo\n",
+  "192.168.0.2             baz\n",
+  "1.1.1.1                 fancy\n",
+  "2.2.2.2                 more.fancy\n",
+};
+
+struct Fixture
+{
+  static std::shared_ptr<DNSRecordContent> makeLocalhostRootDRC()
+  {
+    return DNSRecordContent::mastermake(QType::SOA, QClass::IN, "localhost. root 1 604800 86400 2419200 604800");
+  }
+
+  static std::shared_ptr<DNSRecordContent> makeLocalhostDRC()
+  {
+    return DNSRecordContent::mastermake(QType::NS, QClass::IN, "localhost.");
+  }
+
+  static std::shared_ptr<DNSRecordContent> makePtrDRC(const std::string& name)
+  {
+    return DNSRecordContent::mastermake(QType::PTR, QClass::IN, name);
+  }
+
+  void addDomainMapFixtureEntry(const std::string& name, const SyncRes::AuthDomain::records_t& records)
+  {
+    domainMapFixture[DNSName{name}] = SyncRes::AuthDomain{
+      .d_records = records,
+      .d_servers = {},
+      .d_name = DNSName{name},
+      .d_rdForward = false,
+    };
+  }
+
+  void addDomainMapFixtureEntry(const std::string& name, const QType type, const std::string& address)
+  {
+    domainMapFixture[DNSName{name}] = SyncRes::AuthDomain{
+      .d_records = {
+        DNSRecord(name, DNSRecordContent::mastermake(type, QClass::IN, address), type),
+        DNSRecord(name, makeLocalhostDRC(), QType::NS),
+        DNSRecord(name, makeLocalhostRootDRC(), QType::SOA),
+      },
+      .d_servers = {},
+      .d_name = DNSName{name},
+      .d_rdForward = false,
+    };
+  }
+
+  Fixture()
+  {
+    addDomainMapFixtureEntry("foo", QType::A, "192.168.0.1");
+    addDomainMapFixtureEntry("bar", QType::A, "192.168.0.1");
+    addDomainMapFixtureEntry("dupfoo", QType::A, "192.168.0.1");
+    addDomainMapFixtureEntry(
+      "1.0.168.192.in-addr.arpa",
+      {
+        DNSRecord("1.0.168.192.in-addr.arpa", makeLocalhostDRC(), QType::NS),
+        DNSRecord("1.0.168.192.in-addr.arpa", makeLocalhostRootDRC(), QType::SOA),
+        DNSRecord("1.0.168.192.in-addr.arpa", makePtrDRC("foo."), QType::PTR),
+        DNSRecord("1.0.168.192.in-addr.arpa", makePtrDRC("bar."), QType::PTR),
+      });
+    addDomainMapFixtureEntry("baz", QType::A, "192.168.0.2");
+    addDomainMapFixtureEntry(
+      "2.0.168.192.in-addr.arpa",
+      {
+        DNSRecord("2.0.168.192.in-addr.arpa", makeLocalhostDRC(), QType::NS),
+        DNSRecord("2.0.168.192.in-addr.arpa", makeLocalhostRootDRC(), QType::SOA),
+        DNSRecord("2.0.168.192.in-addr.arpa", makePtrDRC("baz."), QType::PTR),
+      });
+    addDomainMapFixtureEntry("fancy", QType::A, "1.1.1.1");
+    addDomainMapFixtureEntry(
+      "1.1.1.1.in-addr.arpa",
+      {
+        DNSRecord("1.1.1.1.in-addr.arpa", makeLocalhostDRC(), QType::NS),
+        DNSRecord("1.1.1.1.in-addr.arpa", makeLocalhostRootDRC(), QType::SOA),
+        DNSRecord("1.1.1.1.in-addr.arpa", makePtrDRC("fancy."), QType::PTR),
+      });
+    addDomainMapFixtureEntry("more.fancy", QType::A, "2.2.2.2");
+    addDomainMapFixtureEntry(
+      "2.2.2.2.in-addr.arpa",
+      {
+        DNSRecord("2.2.2.2.in-addr.arpa", makeLocalhostDRC(), QType::NS),
+        DNSRecord("2.2.2.2.in-addr.arpa", makeLocalhostRootDRC(), QType::SOA),
+        DNSRecord("2.2.2.2.in-addr.arpa", makePtrDRC("more.fancy."), QType::PTR),
+      });
+  }
+
+  using DomainMapEntry = std::pair<DNSName, SyncRes::AuthDomain>;
+
+  static std::vector<DomainMapEntry> sortDomainMap(const SyncRes::domainmap_t& domainMap)
+  {
+    std::vector<DomainMapEntry> sorted{};
+    sorted.reserve(domainMap.size());
+    for (const auto& pair : domainMap) {
+      sorted.emplace_back(pair.first, pair.second);
+    }
+    std::stable_sort(std::begin(sorted), std::end(sorted), [](const DomainMapEntry& a, const DomainMapEntry& b) {
+      return a.first < b.first && a.second.d_name < b.second.d_name;
+    });
+    return sorted;
+  }
+
+  static std::string printDomainMap(const std::vector<DomainMapEntry>& domainMap)
+  {
+    std::stringstream s{};
+    for (const auto& entry : domainMap) {
+      s << "Entry `" << entry.first << "` {" << std::endl;
+      s << entry.second.print("  ");
+      s << "}" << std::endl;
+    }
+    return s.str();
+  }
+
+  std::vector<DomainMapEntry> getDomainMapFixture() const
+  {
+    return sortDomainMap(domainMapFixture);
+  }
+
+private:
+  SyncRes::domainmap_t domainMapFixture{};
+};
+
+BOOST_FIXTURE_TEST_CASE(test_loading_etc_hosts, Fixture)
+{
+  auto log = g_slog->withName("config");
+
+  auto domainMap = std::make_shared<SyncRes::domainmap_t>();
+  std::vector<std::string> parts{};
+  for (auto line : hostLines) {
+    BOOST_REQUIRE(parseEtcHostsLine(parts, line));
+    addForwardAndReverseLookupEntries(domainMap, "", parts, log);
+  }
+
+  auto actual = sortDomainMap(*domainMap);
+  BOOST_TEST_MESSAGE("Actual:");
+  BOOST_TEST_MESSAGE(printDomainMap(actual));
+
+  auto expected = getDomainMapFixture();
+  BOOST_TEST_MESSAGE("Expected:");
+  BOOST_TEST_MESSAGE(printDomainMap(expected));
+
+  BOOST_CHECK_EQUAL(actual.size(), expected.size());
+  for (std::vector<DomainMapEntry>::size_type i = 0; i < actual.size(); i++) {
+    BOOST_CHECK(actual[i].first == expected[i].first);
+    BOOST_CHECK(actual[i].second == expected[i].second);
+  }
+
+  // BOOST_CHECK_EQUAL(actual, expected);
+  // BOOST_CHECK(actualSorted == expectedSorted);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/reczones-helpers.cc
+++ b/pdns/reczones-helpers.cc
@@ -1,0 +1,157 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "syncres.hh"
+#include "reczones-helpers.hh"
+
+static void makeNameToIPZone(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
+                             const DNSName& hostname,
+                             const string& ip,
+                             Logr::log_t log)
+{
+  SyncRes::AuthDomain ad;
+  ad.d_rdForward = false;
+
+  DNSRecord dr;
+  dr.d_name = hostname;
+  dr.d_place = DNSResourceRecord::ANSWER;
+  dr.d_ttl = 86400;
+  dr.d_type = QType::SOA;
+  dr.d_class = 1;
+  dr.d_content = DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800");
+
+  ad.d_records.insert(dr);
+
+  dr.d_type = QType::NS;
+  dr.d_content = std::make_shared<NSRecordContent>("localhost.");
+
+  ad.d_records.insert(dr);
+
+  dr.d_type = QType::A;
+  dr.d_content = DNSRecordContent::mastermake(QType::A, 1, ip);
+  ad.d_records.insert(dr);
+
+  if (newMap->count(dr.d_name) != 0) {
+    SLOG(g_log << Logger::Warning << "Hosts file will not overwrite zone '" << dr.d_name << "' already loaded" << endl,
+         log->info(Logr::Warning, "Hosts file will not overwrite already loaded zone", "zone", Logging::Loggable(dr.d_name)));
+  }
+  else {
+    SLOG(g_log << Logger::Warning << "Inserting forward zone '" << dr.d_name << "' based on hosts file" << endl,
+         log->info(Logr::Notice, "Inserting forward zone based on hosts file", "zone", Logging::Loggable(dr.d_name)));
+    ad.d_name = dr.d_name;
+    (*newMap)[ad.d_name] = ad;
+  }
+}
+
+//! parts[0] must be an IP address, the rest must be host names
+void makeIPToNamesZone(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
+                       const vector<string>& parts,
+                       Logr::log_t log)
+{
+  string address = parts[0];
+  vector<string> ipParts;
+  stringtok(ipParts, address, ".");
+
+  SyncRes::AuthDomain ad;
+  ad.d_rdForward = false;
+
+  DNSRecord dr;
+  for (auto part = ipParts.rbegin(); part != ipParts.rend(); ++part) {
+    dr.d_name.appendRawLabel(*part);
+  }
+  dr.d_name.appendRawLabel("in-addr");
+  dr.d_name.appendRawLabel("arpa");
+  dr.d_class = 1;
+  dr.d_place = DNSResourceRecord::ANSWER;
+  dr.d_ttl = 86400;
+  dr.d_type = QType::SOA;
+  dr.d_content = DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800");
+
+  ad.d_records.insert(dr);
+
+  dr.d_type = QType::NS;
+  dr.d_content = std::make_shared<NSRecordContent>(DNSName("localhost."));
+
+  ad.d_records.insert(dr);
+  dr.d_type = QType::PTR;
+
+  if (ipParts.size() == 4) { // otherwise this is a partial zone
+    for (unsigned int n = 1; n < parts.size(); ++n) {
+      dr.d_content = DNSRecordContent::mastermake(QType::PTR, 1, DNSName(parts[n]).toString()); // XXX FIXME DNSNAME PAIN CAN THIS BE RIGHT?
+      ad.d_records.insert(dr);
+    }
+  }
+
+  if (newMap->count(dr.d_name) != 0) {
+    SLOG(g_log << Logger::Warning << "Will not overwrite zone '" << dr.d_name << "' already loaded" << endl,
+         log->info(Logr::Warning, "Will not overwrite already loaded zone", "zone", Logging::Loggable(dr.d_name)));
+  }
+  else {
+    if (ipParts.size() == 4) {
+      SLOG(g_log << Logger::Warning << "Inserting reverse zone '" << dr.d_name << "' based on hosts file" << endl,
+           log->info(Logr::Notice, "Inserting reverse zone based on hosts file", "zone", Logging::Loggable(dr.d_name)));
+    }
+    ad.d_name = dr.d_name;
+    (*newMap)[ad.d_name] = ad;
+  }
+}
+
+void addForwardAndReverseLookupEntries(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
+                                       const std::string& searchSuffix,
+                                       const std::vector<std::string>& parts,
+                                       Logr::log_t log)
+{
+  for (unsigned int n = 1; n < parts.size(); ++n) {
+    if (searchSuffix.empty() || parts[n].find('.') != string::npos) {
+      makeNameToIPZone(newMap, DNSName(parts[n]), parts[0], log);
+    }
+    else {
+      DNSName canonic = toCanonic(DNSName(searchSuffix), parts[n]); /// XXXX DNSName pain
+      if (canonic != DNSName(parts[n])) { // XXX further DNSName pain
+        makeNameToIPZone(newMap, canonic, parts[0], log);
+      }
+    }
+  }
+  makeIPToNamesZone(newMap, parts, log);
+}
+
+bool parseEtcHostsLine(std::vector<std::string>& parts, std::string& line)
+{
+  const string::size_type pos = line.find('#');
+  if (pos != string::npos) {
+    line.resize(pos);
+  }
+  boost::trim(line);
+  if (line.empty()) {
+    return false;
+  }
+  parts.clear();
+  stringtok(parts, line, "\t\r\n ");
+  if (parts[0].find(':') != string::npos) {
+    return false;
+  }
+  return parts.size() >= 2;
+}

--- a/pdns/reczones-helpers.cc
+++ b/pdns/reczones-helpers.cc
@@ -27,115 +27,129 @@
 #include "syncres.hh"
 #include "reczones-helpers.hh"
 
-static void makeNameToIPZone(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
-                             const DNSName& hostname,
-                             const string& ip,
-                             Logr::log_t log)
+template <typename T>
+static SyncRes::AuthDomain makeSOAAndNSNodes(DNSRecord& dr, T content)
 {
-  SyncRes::AuthDomain ad;
-  ad.d_rdForward = false;
-
-  DNSRecord dr;
-  dr.d_name = hostname;
+  dr.d_class = 1;
   dr.d_place = DNSResourceRecord::ANSWER;
   dr.d_ttl = 86400;
   dr.d_type = QType::SOA;
-  dr.d_class = 1;
   dr.d_content = DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800");
-
-  ad.d_records.insert(dr);
-
-  dr.d_type = QType::NS;
-  dr.d_content = std::make_shared<NSRecordContent>("localhost.");
-
-  ad.d_records.insert(dr);
-
-  dr.d_type = QType::A;
-  dr.d_content = DNSRecordContent::mastermake(QType::A, 1, ip);
-  ad.d_records.insert(dr);
-
-  if (newMap->count(dr.d_name) != 0) {
-    SLOG(g_log << Logger::Warning << "Hosts file will not overwrite zone '" << dr.d_name << "' already loaded" << endl,
-         log->info(Logr::Warning, "Hosts file will not overwrite already loaded zone", "zone", Logging::Loggable(dr.d_name)));
-  }
-  else {
-    SLOG(g_log << Logger::Warning << "Inserting forward zone '" << dr.d_name << "' based on hosts file" << endl,
-         log->info(Logr::Notice, "Inserting forward zone based on hosts file", "zone", Logging::Loggable(dr.d_name)));
-    ad.d_name = dr.d_name;
-    (*newMap)[ad.d_name] = ad;
-  }
-}
-
-//! parts[0] must be an IP address, the rest must be host names
-void makeIPToNamesZone(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
-                       const vector<string>& parts,
-                       Logr::log_t log)
-{
-  string address = parts[0];
-  vector<string> ipParts;
-  stringtok(ipParts, address, ".");
 
   SyncRes::AuthDomain ad;
   ad.d_rdForward = false;
+  ad.d_records.insert(dr);
 
+  dr.d_type = QType::NS;
+  dr.d_content = std::make_shared<NSRecordContent>(content);
+  ad.d_records.insert(dr);
+
+  return ad;
+}
+
+static void addToDomainMap(SyncRes::domainmap_t& newMap,
+                           SyncRes::AuthDomain ad,
+                           DNSName& name,
+                           Logr::log_t log,
+                           const bool partial = false,
+                           const bool reverse = false)
+{
+  if (newMap.count(name) != 0) {
+    SLOG(g_log << Logger::Warning << "Will not overwrite zone '" << name << "' already loaded" << endl,
+         log->info(Logr::Warning, "Will not overwrite already loaded zone", "zone",
+                   Logging::Loggable(name)));
+  }
+  else {
+    if (!partial) {
+      const auto direction = reverse ? std::string{"reverse"} : std::string{"forward"};
+      SLOG(g_log << Logger::Warning << "Inserting " << direction << " zone '" << name << "' based on hosts file" << endl,
+           log->info(Logr::Notice, "Inserting " + direction + " zone based on hosts file", "zone", Logging::Loggable(name)));
+    }
+    ad.d_name = name;
+    newMap[ad.d_name] = ad;
+  }
+}
+
+static void makeNameToIPZone(SyncRes::domainmap_t& newMap,
+                             const DNSName& hostname,
+                             const ComboAddress& addr,
+                             Logr::log_t log)
+{
   DNSRecord dr;
-  for (auto part = ipParts.rbegin(); part != ipParts.rend(); ++part) {
-    dr.d_name.appendRawLabel(*part);
+  dr.d_name = hostname;
+
+  SyncRes::AuthDomain ad = makeSOAAndNSNodes(dr, "localhost.");
+
+  auto recType = addr.isIPv6() ? QType::AAAA : QType::A;
+  dr.d_type = recType;
+  dr.d_content = DNSRecordContent::mastermake(recType, 1, addr.toStringNoInterface());
+  ad.d_records.insert(dr);
+
+  addToDomainMap(newMap, ad, dr.d_name, log);
+}
+
+static void makeIPToNamesZone(SyncRes::domainmap_t& newMap,
+                              const ComboAddress& addr,
+                              const std::vector<std::string>& parts,
+                              Logr::log_t log)
+{
+  DNSRecord dr;
+  dr.d_name = DNSName(addr.toStringReversed());
+  dr.d_name.appendRawLabel(addr.isIPv4() ? "in-addr" : "ip6");
+  dr.d_name.appendRawLabel("arpa");
+
+  SyncRes::AuthDomain ad = makeSOAAndNSNodes(dr, DNSName("localhost."));
+
+  // Go over the hostname and aliases (parts[1], parts[2], etc...) and add PTR entries for
+  // reverse lookups.
+  dr.d_type = QType::PTR;
+  for (auto name = parts.cbegin() + 1; name != parts.cend(); ++name) {
+    dr.d_content = DNSRecordContent::mastermake(QType::PTR, 1, DNSName(*name).toString());
+    ad.d_records.insert(dr);
+  }
+
+  addToDomainMap(newMap, ad, dr.d_name, log, false, true);
+}
+
+void makePartialIPZone(SyncRes::domainmap_t& newMap,
+                       std::initializer_list<const char*> labels,
+                       Logr::log_t log)
+{
+  DNSRecord dr;
+  for (auto label = std::rbegin(labels); label != std::rend(labels); ++label) {
+    dr.d_name.appendRawLabel(*label);
   }
   dr.d_name.appendRawLabel("in-addr");
   dr.d_name.appendRawLabel("arpa");
-  dr.d_class = 1;
-  dr.d_place = DNSResourceRecord::ANSWER;
-  dr.d_ttl = 86400;
-  dr.d_type = QType::SOA;
-  dr.d_content = DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800");
 
-  ad.d_records.insert(dr);
+  SyncRes::AuthDomain ad = makeSOAAndNSNodes(dr, DNSName("localhost."));
 
-  dr.d_type = QType::NS;
-  dr.d_content = std::make_shared<NSRecordContent>(DNSName("localhost."));
-
-  ad.d_records.insert(dr);
-  dr.d_type = QType::PTR;
-
-  if (ipParts.size() == 4) { // otherwise this is a partial zone
-    for (unsigned int n = 1; n < parts.size(); ++n) {
-      dr.d_content = DNSRecordContent::mastermake(QType::PTR, 1, DNSName(parts[n]).toString()); // XXX FIXME DNSNAME PAIN CAN THIS BE RIGHT?
-      ad.d_records.insert(dr);
-    }
-  }
-
-  if (newMap->count(dr.d_name) != 0) {
-    SLOG(g_log << Logger::Warning << "Will not overwrite zone '" << dr.d_name << "' already loaded" << endl,
-         log->info(Logr::Warning, "Will not overwrite already loaded zone", "zone", Logging::Loggable(dr.d_name)));
-  }
-  else {
-    if (ipParts.size() == 4) {
-      SLOG(g_log << Logger::Warning << "Inserting reverse zone '" << dr.d_name << "' based on hosts file" << endl,
-           log->info(Logr::Notice, "Inserting reverse zone based on hosts file", "zone", Logging::Loggable(dr.d_name)));
-    }
-    ad.d_name = dr.d_name;
-    (*newMap)[ad.d_name] = ad;
-  }
+  addToDomainMap(newMap, ad, dr.d_name, log, true, true);
 }
 
-void addForwardAndReverseLookupEntries(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
+void addForwardAndReverseLookupEntries(SyncRes::domainmap_t& newMap,
                                        const std::string& searchSuffix,
                                        const std::vector<std::string>& parts,
                                        Logr::log_t log)
 {
-  for (unsigned int n = 1; n < parts.size(); ++n) {
-    if (searchSuffix.empty() || parts[n].find('.') != string::npos) {
-      makeNameToIPZone(newMap, DNSName(parts[n]), parts[0], log);
+  const ComboAddress address{parts[0]};
+
+  // Go over the hostname and aliases (parts[1], parts[2], etc...) and add entries
+  // for forward lookups.
+  for (auto name = parts.cbegin() + 1; name != parts.cend(); ++name) {
+    if (searchSuffix.empty() || name->find('.') != string::npos) {
+      makeNameToIPZone(newMap, DNSName(*name), address, log);
     }
     else {
-      DNSName canonic = toCanonic(DNSName(searchSuffix), parts[n]); /// XXXX DNSName pain
-      if (canonic != DNSName(parts[n])) { // XXX further DNSName pain
-        makeNameToIPZone(newMap, canonic, parts[0], log);
+      DNSName canonical = toCanonic(DNSName(searchSuffix), *name);
+      if (canonical != DNSName(*name)) {
+        makeNameToIPZone(newMap, canonical, address, log);
       }
     }
   }
-  makeIPToNamesZone(newMap, parts, log);
+
+  // Add entries for reverse lookups.
+  makeIPToNamesZone(newMap, address, parts, log);
 }
 
 bool parseEtcHostsLine(std::vector<std::string>& parts, std::string& line)
@@ -150,8 +164,5 @@ bool parseEtcHostsLine(std::vector<std::string>& parts, std::string& line)
   }
   parts.clear();
   stringtok(parts, line, "\t\r\n ");
-  if (parts[0].find(':') != string::npos) {
-    return false;
-  }
   return parts.size() >= 2;
 }

--- a/pdns/reczones-helpers.hh
+++ b/pdns/reczones-helpers.hh
@@ -39,7 +39,11 @@ void makeIPToNamesZone(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
 //! A return value `false` means that the line cannot be parsed (e.g. unsupported IPv6).
 bool parseEtcHostsLine(std::vector<std::string>& parts, std::string& line);
 
-void addForwardAndReverseLookupEntries(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
+void makePartialIPZone(SyncRes::domainmap_t& newMap,
+                       std::initializer_list<const char*> labels,
+                       Logr::log_t log);
+
+void addForwardAndReverseLookupEntries(SyncRes::domainmap_t& newMap,
                                        const std::string& searchSuffix,
                                        const std::vector<std::string>& parts,
                                        Logr::log_t log);

--- a/pdns/reczones-helpers.hh
+++ b/pdns/reczones-helpers.hh
@@ -1,0 +1,45 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string>
+#include <vector>
+#include <memory>
+#include "syncres.hh"
+#include "logger.hh"
+
+void makeIPToNamesZone(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
+                       const vector<string>& parts,
+                       Logr::log_t log);
+
+//! A return value `false` means that the line cannot be parsed (e.g. unsupported IPv6).
+bool parseEtcHostsLine(std::vector<std::string>& parts, std::string& line);
+
+void addForwardAndReverseLookupEntries(const std::shared_ptr<SyncRes::domainmap_t>& newMap,
+                                       const std::string& searchSuffix,
+                                       const std::vector<std::string>& parts,
+                                       Logr::log_t log);

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -19,9 +19,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "syncres.hh"
 #include "arguments.hh"
 #include "zoneparser-tng.hh"
@@ -291,8 +293,8 @@ static void convertServersForAD(const std::string& zone, const std::string& inpu
   ad.d_servers.clear();
 
   vector<string> addresses;
-  for (vector<string>::const_iterator iter = servers.begin(); iter != servers.end(); ++iter) {
-    ComboAddress addr = parseIPAndPort(*iter, 53);
+  for (auto server = servers.begin(); server != servers.end(); ++server) {
+    ComboAddress addr = parseIPAndPort(*server, 53);
     ad.d_servers.push_back(addr);
     if (verbose) {
       addresses.push_back(addr.toStringWithPort());
@@ -540,8 +542,12 @@ std::tuple<std::shared_ptr<SyncRes::domainmap_t>, std::shared_ptr<notifyset_t>> 
         newSet->insert(ad.d_name);
       }
     }
-    SLOG(g_log << Logger::Warning << "Done parsing " << newMap->size() - before << " forwarding instructions from file '" << ::arg()["forward-zones-file"] << "'" << endl,
-         log->info(Logr::Notice, "Done parsing forwarding instructions from file", "file", Logging::Loggable(::arg()["forward-zones-file"]), "count", Logging::Loggable(newMap->size() - before)));
+    SLOG(g_log << Logger::Warning << "Done parsing " << newMap->size() - before
+               << " forwarding instructions from file '"
+               << ::arg()["forward-zones-file"] << "'" << endl,
+         log->info(Logr::Notice, "Done parsing forwarding instructions from file", "file",
+                   Logging::Loggable(::arg()["forward-zones-file"]), "count",
+                   Logging::Loggable(newMap->size() - before)));
   }
 
   if (::arg().mustDo("export-etc-hosts")) {
@@ -605,8 +611,8 @@ std::tuple<std::shared_ptr<SyncRes::domainmap_t>, std::shared_ptr<notifyset_t>> 
 
   parts.clear();
   stringtok(parts, ::arg()["allow-notify-for"], " ,\t\n\r");
-  for (parts_t::const_iterator iter = parts.begin(); iter != parts.end(); ++iter) {
-    newSet->insert(DNSName(*iter));
+  for (auto& part : parts) {
+    newSet->insert(DNSName(part));
   }
 
   if (auto anff = ::arg()["allow-notify-for-file"]; !anff.empty()) {

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -237,15 +237,15 @@ static void makeNameToIPZone(const std::shared_ptr<SyncRes::domainmap_t>& newMap
 static void makeIPToNamesZone(const std::shared_ptr<SyncRes::domainmap_t>& newMap, const vector<string>& parts, Logr::log_t log)
 {
   string address = parts[0];
-  vector<string> ipparts;
-  stringtok(ipparts, address, ".");
+  vector<string> ipParts;
+  stringtok(ipParts, address, ".");
 
   SyncRes::AuthDomain ad;
   ad.d_rdForward = false;
 
   DNSRecord dr;
-  for (int n = ipparts.size() - 1; n >= 0; --n) {
-    dr.d_name.appendRawLabel(ipparts[n]);
+  for (auto part = ipParts.rbegin(); part != ipParts.rend(); ++part) {
+    dr.d_name.appendRawLabel(*part);
   }
   dr.d_name.appendRawLabel("in-addr");
   dr.d_name.appendRawLabel("arpa");
@@ -263,7 +263,7 @@ static void makeIPToNamesZone(const std::shared_ptr<SyncRes::domainmap_t>& newMa
   ad.d_records.insert(dr);
   dr.d_type = QType::PTR;
 
-  if (ipparts.size() == 4) { // otherwise this is a partial zone
+  if (ipParts.size() == 4) { // otherwise this is a partial zone
     for (unsigned int n = 1; n < parts.size(); ++n) {
       dr.d_content = DNSRecordContent::mastermake(QType::PTR, 1, DNSName(parts[n]).toString()); // XXX FIXME DNSNAME PAIN CAN THIS BE RIGHT?
       ad.d_records.insert(dr);
@@ -275,7 +275,7 @@ static void makeIPToNamesZone(const std::shared_ptr<SyncRes::domainmap_t>& newMa
          log->info(Logr::Warning, "Will not overwrite already loaded zone", "zone", Logging::Loggable(dr.d_name)));
   }
   else {
-    if (ipparts.size() == 4) {
+    if (ipParts.size() == 4) {
       SLOG(g_log << Logger::Warning << "Inserting reverse zone '" << dr.d_name << "' based on hosts file" << endl,
            log->info(Logr::Notice, "Inserting reverse zone based on hosts file", "zone", Logging::Loggable(dr.d_name)));
     }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -860,6 +860,14 @@ void SyncRes::AuthDomain::addSOA(std::vector<DNSRecord>& records) const
   }
 }
 
+bool SyncRes::AuthDomain::operator==(const AuthDomain& rhs) const
+{
+  return d_records == rhs.d_records
+    && d_servers == rhs.d_servers
+    && d_name == rhs.d_name
+    && d_rdForward == rhs.d_rdForward;
+}
+
 int SyncRes::AuthDomain::getRecords(const DNSName& qname, const QType qtype, std::vector<DNSRecord>& records) const
 {
   int result = RCode::NoError;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -868,6 +868,30 @@ bool SyncRes::AuthDomain::operator==(const AuthDomain& rhs) const
     && d_rdForward == rhs.d_rdForward;
 }
 
+[[nodiscard]] std::string SyncRes::AuthDomain::print(const std::string& indent,
+                                                     const std::string& indentLevel) const
+{
+  std::stringstream s;
+  s << indent << "DNSName = " << d_name << std::endl;
+  s << indent << "rdForward = " << d_rdForward << std::endl;
+  s << indent << "Records {" << std::endl;
+  auto recordContentIndentation = indent;
+  recordContentIndentation += indentLevel;
+  recordContentIndentation += indentLevel;
+  for (const auto& record : d_records) {
+    s << indent << indentLevel << "Record `" << record.d_name << "` {" << std::endl;
+    s << record.print(recordContentIndentation);
+    s << indent << indentLevel << "}" << std::endl;
+  }
+  s << indent << "}" << std::endl;
+  s << indent << "Servers {" << std::endl;
+  for (const auto& server : d_servers) {
+    s << indent << indentLevel << server.toString() << std::endl;
+  }
+  s << indent << "}" << std::endl;
+  return s.str();
+}
+
 int SyncRes::AuthDomain::getRecords(const DNSName& qname, const QType qtype, std::vector<DNSRecord>& records) const
 {
   int result = RCode::NoError;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -114,6 +114,8 @@ public:
     DNSName d_name;
     bool d_rdForward{false};
 
+    bool operator==(const AuthDomain& rhs) const;
+
     int getRecords(const DNSName& qname, QType qtype, std::vector<DNSRecord>& records) const;
     bool isAuth() const
     {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -151,7 +151,7 @@ public:
                                                        ordered_non_unique<tag<time_t>, member<EDNSStatus, time_t, &EDNSStatus::modeSetAt>>
                                   >> {
     void reset(index<ComboAddress>::type &ind, iterator it) {
-      ind.modify(it, [](EDNSStatus &s) { s.mode = EDNSStatus::EDNSMode::UNKNOWN; s.modeSetAt = 0; }); 
+      ind.modify(it, [](EDNSStatus &s) { s.mode = EDNSStatus::EDNSMode::UNKNOWN; s.modeSetAt = 0; });
     }
     void setMode(index<ComboAddress>::type &ind, iterator it, EDNSStatus::EDNSMode mode) {
       it->mode = mode;
@@ -519,7 +519,7 @@ public:
   static const int event_trace_to_log = 2;
   static int s_event_trace_enabled;
   static bool s_save_parent_ns_set;
-  
+
   std::unordered_map<std::string,bool> d_discardedPolicies;
   DNSFilterEngine::Policy d_appliedPolicy;
   std::unordered_set<std::string> d_policyTags;
@@ -953,4 +953,3 @@ struct ThreadTimes
     return *this;
   }
 };
-

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -116,6 +116,10 @@ public:
 
     bool operator==(const AuthDomain& rhs) const;
 
+    [[nodiscard]]
+    std::string print(const std::string& indent = "",
+                      const std::string& indentLevel = "  ") const;
+
     int getRecords(const DNSName& qname, QType qtype, std::vector<DNSRecord>& records) const;
     bool isAuth() const
     {

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -21,16 +21,16 @@ BOOST_AUTO_TEST_CASE(test_ComboAddress) {
   ComboAddress remote("130.161.33.15", 53);
   BOOST_CHECK(!(local == remote));
   BOOST_CHECK_EQUAL(remote.sin4.sin_port, htons(53));
-  
+
   ComboAddress withport("213.244.168.210:53");
   BOOST_CHECK_EQUAL(withport.sin4.sin_port, htons(53));
-  
+
   ComboAddress withportO("213.244.168.210:53", 5300);
   BOOST_CHECK_EQUAL(withportO.sin4.sin_port, htons(53));
- 
+
   withport = ComboAddress("[::]:53");
   BOOST_CHECK_EQUAL(withport.sin4.sin_port, htons(53));
-  
+
   withport = ComboAddress("[::]:5300", 53);
   BOOST_CHECK_EQUAL(withport.sin4.sin_port, htons(5300));
 
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(test_ComboAddressTruncate) {
 
   ca4.truncate(29);
   BOOST_CHECK_EQUAL(ca4.toString(), "130.161.252.24");
-  
+
   ca4.truncate(23);
   BOOST_CHECK_EQUAL(ca4.toString(), "130.161.252.0");
 
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(test_ComboAddressTruncate) {
   BOOST_CHECK_EQUAL(ca6.toString(), "2001::");
   ca6.truncate(8);
   BOOST_CHECK_EQUAL(ca6.toString(), "2000::");
-  
+
 
   orig=ca6=ComboAddress("2001:888:2000:1d::2");
   for(int n=128; n; --n) {
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(test_Mapping)
 BOOST_AUTO_TEST_CASE(test_Netmask) {
   ComboAddress local("127.0.0.1", 53);
   ComboAddress remote("130.161.252.29", 53);
-  
+
   Netmask nm("127.0.0.1/24");
   BOOST_CHECK(nm.getBits() == 24);
   BOOST_CHECK(nm.match(local));

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -162,6 +162,27 @@ BOOST_AUTO_TEST_CASE(test_ComboAddressTruncate) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_ComboAddressReverse)
+{
+  ComboAddress a{"1.2.3.4"};
+  BOOST_CHECK_EQUAL(a.toStringReversed(), "4.3.2.1");
+
+  ComboAddress b{"192.168.0.1"};
+  BOOST_CHECK_EQUAL(b.toStringReversed(), "1.0.168.192");
+
+  ComboAddress c{"2001:db8::567:89ab"};
+  BOOST_CHECK_EQUAL(c.toStringReversed(), "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2");
+
+  ComboAddress d{"::1"};
+  BOOST_CHECK_EQUAL(d.toStringReversed(), "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0");
+
+  ComboAddress e{"ab:cd::10"};
+  BOOST_CHECK_EQUAL(e.toStringReversed(), "0.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.0.0.b.a.0.0");
+
+  ComboAddress f{"4321:0:1:2:3:4:567:89ab"};
+  BOOST_CHECK_EQUAL(f.toStringReversed(), "b.a.9.8.7.6.5.0.4.0.0.0.3.0.0.0.2.0.0.0.1.0.0.0.0.0.0.0.1.2.3.4");
+}
+
 BOOST_AUTO_TEST_CASE(test_Mapping)
 {
   ComboAddress lh("::1");


### PR DESCRIPTION
### Short description
This adds the missing parts to load IPv6 entries from a provided `etc-hosts` file:
* Adds support for reversing IPv4 and IPv6 addresses to `ComboAddress`. Also adds tests for that.
* Replaces the usage of strings for IP addresses with `ComboAddress`.
* Moves a few things around for testability (in a separate commit).
* Also breaks down some parts into smaller functions (also in a separate commit).
* Fixes a pre-existing issue where `PTR` entries were being added for aliases (i.e. "non canonical hostname(s)").
* Adds tests for the pre-existing IPv4-only functionality in `test-reczones-helpers.cc`.
* Also adds tests for loading IPv6 entries as well.
* Adds the ability to print domain maps and their corresponding record entries to a `std::stringstream`.
* The usual misc cleanups & clang-tidy fixes.

Closes #2248 

PS: To run the tests with print output use `./testrunner --run_test=... --log_level=message`

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [X] added or modified unit test(s)