### PR TITLE
Update `also-notify` docs for non-standard ports

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -106,6 +106,10 @@ When notifying a zone, also notify these nameservers. Example:
 ``also-notify`` always receive a notification. Even if they do not match
 the list in :ref:`setting-only-notify`.
 
+You may specify an alternate port by appending :port. Example:
+``also-notify=192.0.2.1:5300``. If no port is specified, port 53
+is used.
+
 .. _setting-any-to-tcp:
 
 ``any-to-tcp``


### PR DESCRIPTION
### Short description
This patch documents sending NOTIFY on non-standard ports for `also-notify`.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
