### PR TITLE
Implement `SuffixMatchTree::getBestMatch()` to get the name that matched

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -242,8 +242,10 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
   luaCtx.registerFunction<size_t(DNSName::*)()const>("wirelength", [](const DNSName& name) { return name.wirelength(); });
   luaCtx.registerFunction<string(DNSName::*)()const>("tostring", [](const DNSName&dn ) { return dn.toString(); });
   luaCtx.registerFunction<string(DNSName::*)()const>("toString", [](const DNSName&dn ) { return dn.toString(); });
+  luaCtx.registerFunction<string(DNSName::*)()const>("toStringNoDot", [](const DNSName&dn ) { return dn.toStringNoDot(); });
   luaCtx.registerFunction<string(DNSName::*)()const>("__tostring", [](const DNSName&dn ) { return dn.toString(); });
   luaCtx.registerFunction<string(DNSName::*)()const>("toDNSString", [](const DNSName&dn ) { return dn.toDNSString(); });
+  luaCtx.registerFunction<DNSName(DNSName::*)(const DNSName&)const>("makeRelative", [](const DNSName& dn, const DNSName& to) { return dn.makeRelative(to); });
   luaCtx.writeFunction("newDNSName", [](const std::string& name) { return DNSName(name); });
   luaCtx.writeFunction("newDNSNameFromRaw", [](const std::string& name) { return DNSName(name.c_str(), name.size(), 0, false); });
   luaCtx.writeFunction("newSuffixMatchNode", []() { return SuffixMatchNode(); });
@@ -317,7 +319,15 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
       }
   });
 
-  luaCtx.registerFunction("check",(bool (SuffixMatchNode::*)(const DNSName&) const) &SuffixMatchNode::check);
+  luaCtx.registerFunction("check", (bool (SuffixMatchNode::*)(const DNSName&) const) &SuffixMatchNode::check);
+  luaCtx.registerFunction<boost::optional<DNSName> (SuffixMatchNode::*)(const DNSName&) const>("getBestMatch", [](const SuffixMatchNode& smn, const DNSName& needle) {
+    boost::optional<DNSName> result{boost::none};
+    auto res = smn.getBestMatch(needle);
+    if (res) {
+      result = *res;
+    }
+    return result;
+  });
 #endif /* DISABLE_SUFFIX_MATCH_BINDINGS */
 
 #ifndef DISABLE_NETMASK_BINDINGS

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1590,6 +1590,20 @@ If you are looking for exact name matching, your might want to consider using a 
     :param string name: The suffix to add to the set.
     :param table name: The suffixes to add to the set. Elements of the table should be of the same type, either DNSName or string.
 
+  .. method:: SuffixMatchNode:check(name) -> bool
+
+    Return true if the given name is a sub-domain of one of those in the set, and false otherwise.
+
+    :param DNSName name: The name to test against the set.
+
+  .. method:: SuffixMatchNode:getBestMatch(name) -> DNSName
+
+    .. versionadded:: 1.8.0
+
+    Returns the best match for the supplied name, or nil if there was no match.
+
+    :param DNSName name: The name to look up.
+
   .. method:: SuffixMatchNode:remove(name)
 
     .. versionadded:: 1.5.0
@@ -1599,12 +1613,6 @@ If you are looking for exact name matching, your might want to consider using a 
     :param DNSName name: The suffix to remove from the set.
     :param string name: The suffix to remove from the set.
     :param table name: The suffixes to remove from the set. Elements of the table should be of the same type, either DNSName or string.
-
-  .. method:: SuffixMatchNode:check(name) -> bool
-
-    Return true if the given name is a sub-domain of one of those in the set, and false otherwise.
-
-    :param DNSName name: The name to test against the set.
 
 Outgoing TLS tickets cache management
 -------------------------------------

--- a/pdns/dnsdistdist/docs/reference/dnsname.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsname.rst
@@ -50,6 +50,17 @@ Functions and methods of a ``DNSName``
 
     :param DNSName name: The name to check against
 
+  .. method:: DNSName:makeRelative(name) -> DNSName
+
+    .. versionadded:: 1.8.0
+
+    Provided that the current name is part of the supplied name, returns a new DNSName
+    composed only of the labels that are below the supplied name (ie making www.powerdns.com
+    relative to powerdns.com would return only wwww)
+    Otherwise an empty (unset) DNSName is returned.
+
+    :param DNSName name: The name to make us relative against
+
   .. method:: DNSName:toDNSString() -> string
 
     Returns a wire format form of the DNSName, suitable for usage in :func:`SpoofRawAction`.
@@ -58,6 +69,12 @@ Functions and methods of a ``DNSName``
               DNSName:tostring() -> string
 
     Returns a human-readable form of the DNSName.
+
+  .. method:: DNSName:toStringNoDot() -> string
+
+    .. versionadded:: 1.8.0
+
+    Returns a human-readable form of the DNSName, without the trailing dot.
 
   .. method:: DNSName:wirelength() -> int
 

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -523,14 +523,19 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch) {
 
   smn.add(DNSName("news.bbc.co.uk."));
   BOOST_CHECK(smn.check(DNSName("news.bbc.co.uk.")));
+  BOOST_CHECK(smn.getBestMatch(DNSName("news.bbc.co.uk")) == DNSName("news.bbc.co.uk."));
   BOOST_CHECK(smn.check(DNSName("www.news.bbc.co.uk.")));
+  BOOST_CHECK(smn.getBestMatch(DNSName("www.news.bbc.co.uk")) == DNSName("news.bbc.co.uk."));
   BOOST_CHECK(smn.check(DNSName("www.www.www.www.www.news.bbc.co.uk.")));
   BOOST_CHECK(!smn.check(DNSName("images.bbc.co.uk.")));
+  BOOST_CHECK(smn.getBestMatch(DNSName("images.bbc.co.uk")) == std::nullopt);
 
   BOOST_CHECK(!smn.check(DNSName("www.news.gov.uk.")));
+  BOOST_CHECK(smn.getBestMatch(DNSName("www.news.gov.uk")) == std::nullopt);
 
   smn.add(g_rootdnsname); // block the root
   BOOST_CHECK(smn.check(DNSName("a.root-servers.net.")));
+  BOOST_CHECK(smn.getBestMatch(DNSName("a.root-servers.net.")) == g_rootdnsname);
 
   DNSName examplenet("example.net.");
   DNSName net("net.");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds a new method, `SuffixMatchTree::getBestMatch()` making it possible to know against which name from a `SuffixMatchTree` we matched.
It also adds lua bindings for that method in dnsdist, as well as bindings for a few more `DNSName` methods.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
