### PR TITLE
dnsdist: Compute backend latency earlier, to avoid internal latency 

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -238,11 +238,6 @@ static IOState sendQueuedResponses(std::shared_ptr<IncomingTCPConnectionState>& 
   return IOState::Done;
 }
 
-static void updateTCPLatency(const std::shared_ptr<DownstreamState>& ds, double udiff)
-{
-  ds->latencyUsecTCP = (127.0 * ds->latencyUsecTCP / 128.0) + udiff/128.0;
-}
-
 static void handleResponseSent(std::shared_ptr<IncomingTCPConnectionState>& state, const TCPResponse& currentResponse)
 {
   if (currentResponse.d_idstate.qtype == QType::AXFR || currentResponse.d_idstate.qtype == QType::IXFR) {
@@ -262,8 +257,6 @@ static void handleResponseSent(std::shared_ptr<IncomingTCPConnectionState>& stat
       backendProtocol = dnsdist::Protocol::DoTCP;
     }
     ::handleResponseSent(ids, udiff, state->d_ci.remote, ds->d_config.remote, static_cast<unsigned int>(currentResponse.d_buffer.size()), currentResponse.d_cleartextDH, backendProtocol);
-
-    updateTCPLatency(ds, udiff);
   }
 }
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -654,6 +654,11 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
         dh->id = ids->origID;
         ++dss->responses;
 
+        double udiff = ids->sentTime.udiff();
+        // do that _before_ the processing, otherwise it's not fair to the backend
+        cerr<<"udiff is "<<(udiff/1000.0)<<endl;
+        dss->latencyUsec = (127.0 * dss->latencyUsec / 128.0) + udiff / 128.0;
+
         /* don't call processResponse for DOH */
         if (du) {
 #ifdef HAVE_DNS_OVER_HTTPS
@@ -686,13 +691,11 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
           sendUDPResponse(origFD, response, dr.delayMsec, ids->hopLocal, ids->hopRemote);
         }
 
-        double udiff = ids->sentTime.udiff();
+        udiff = ids->sentTime.udiff();
         vinfolog("Got answer from %s, relayed to %s, took %f usec", dss->d_config.remote.toStringWithPort(), ids->origRemote.toStringWithPort(), udiff);
 
         handleResponseSent(*ids, udiff, *dr.remote, dss->d_config.remote, static_cast<unsigned int>(got), cleartextDH, dss->getProtocol());
         dss->releaseState(queryId);
-
-        dss->latencyUsec = (127.0 * dss->latencyUsec / 128.0) + udiff/128.0;
 
         doLatencyStats(udiff);
       }
@@ -1383,8 +1386,6 @@ public:
     vinfolog("Got answer from %s, relayed to %s (UDP), took %f usec", d_ds->d_config.remote.toStringWithPort(), ids.origRemote.toStringWithPort(), udiff);
 
     handleResponseSent(ids, udiff, *dr.remote, d_ds->d_config.remote, response.d_buffer.size(), cleartextDH, d_ds->getProtocol());
-
-    d_ds->latencyUsec = (127.0 * d_ds->latencyUsec / 128.0) + udiff/128.0;
 
     doLatencyStats(udiff);
   }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -656,7 +656,6 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
 
         double udiff = ids->sentTime.udiff();
         // do that _before_ the processing, otherwise it's not fair to the backend
-        cerr<<"udiff is "<<(udiff/1000.0)<<endl;
         dss->latencyUsec = (127.0 * dss->latencyUsec / 128.0) + udiff / 128.0;
 
         /* don't call processResponse for DOH */

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -135,6 +135,11 @@ void DoHConnectionToBackend::handleResponse(PendingRequest&& request)
   struct timeval now;
   gettimeofday(&now, nullptr);
   try {
+    if (!d_healthCheckQuery) {
+      const double udiff = request.d_query.d_idstate.sentTime.udiff();
+      d_ds->latencyUsecTCP = (127.0 * d_ds->latencyUsecTCP / 128.0) + udiff / 128.0;
+    }
+
     request.d_sender->handleResponse(now, TCPResponse(std::move(request.d_buffer), std::move(request.d_query.d_idstate), shared_from_this()));
   }
   catch (const std::exception& e) {

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -659,6 +659,9 @@ IOState TCPConnectionToBackend::handleResponse(std::shared_ptr<TCPConnectionToBa
 
   --conn->d_ds->outstanding;
   auto ids = std::move(it->second.d_query.d_idstate);
+  const double udiff = ids.sentTime.udiff();
+  conn->d_ds->latencyUsecTCP = (127.0 * conn->d_ds->latencyUsecTCP / 128.0) + udiff / 128.0;
+
   d_pendingResponses.erase(it);
   /* marking as idle for now, so we can accept new queries if our queues are empty */
   if (d_pendingQueries.empty() && d_pendingResponses.empty()) {

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -132,11 +132,11 @@ class TestAPIBasics(APITestsBase):
                         'dropRate', 'responses', 'tcpDiedSendingQuery', 'tcpDiedReadingResponse',
                         'tcpGaveUp', 'tcpReadTimeouts', 'tcpWriteTimeouts', 'tcpCurrentConnections',
                         'tcpNewConnections', 'tcpReusedConnections', 'tlsResumptions', 'tcpAvgQueriesPerConnection',
-                        'tcpAvgConnectionDuration', 'protocol']:
+                        'tcpAvgConnectionDuration', 'tcpLatency', 'protocol']:
                 self.assertIn(key, server)
 
             for key in ['id', 'latency', 'weight', 'outstanding', 'qpsLimit', 'reuseds',
-                        'qps', 'queries', 'order']:
+                        'qps', 'queries', 'order', 'tcpLatency']:
                 self.assertTrue(server[key] >= 0)
 
             self.assertTrue(server['state'] in ['up', 'down', 'UP', 'DOWN'])
@@ -189,11 +189,11 @@ class TestAPIBasics(APITestsBase):
                         'dropRate', 'responses', 'tcpDiedSendingQuery', 'tcpDiedReadingResponse',
                         'tcpGaveUp', 'tcpReadTimeouts', 'tcpWriteTimeouts', 'tcpCurrentConnections',
                         'tcpNewConnections', 'tcpReusedConnections', 'tcpAvgQueriesPerConnection',
-                        'tcpAvgConnectionDuration', 'protocol']:
+                        'tcpAvgConnectionDuration', 'tcpLatency', 'protocol']:
                 self.assertIn(key, server)
 
             for key in ['id', 'latency', 'weight', 'outstanding', 'qpsLimit', 'reuseds',
-                        'qps', 'queries', 'order']:
+                        'qps', 'queries', 'order', 'tcpLatency']:
                 self.assertTrue(server[key] >= 0)
 
             self.assertTrue(server['state'] in ['up', 'down', 'UP', 'DOWN'])
@@ -361,6 +361,7 @@ class TestAPIServerDown(APITestsBase):
         content = r.json()
 
         self.assertEqual(content['servers'][0]['latency'], None)
+        self.assertEqual(content['servers'][0]['tcpLatency'], None)
 
 class TestAPIWritable(APITestsBase):
     __test__ = True


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Also properly report the latency as TCP when forwaring a query received over UDP to TCP-only, DoT and DoH backends.
And export the TCP latency in the prometheus and API metrics.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
