### PR TITLE
Rec: systemd-journal structured logging followup

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -2016,6 +2016,22 @@ A list of comma-separated statistic names, that are prevented from being exporte
 
 Prefer structured logging when both an old style and a structured log messages is available.
 
+.. _setting-structured-logging-backend:
+
+``structured-logging-backend``
+------------------------------
+.. versionadded:: 4.8.0
+
+- String
+- Default: "default"
+
+The backend used for structured logging output.
+Available backends are:
+
+- ``default``: use the traditional logging system to output structured logging information.
+- ``systemd-journal``: use systemd-journal.
+  When using this backend, provide ``-o verbose`` or simular output option to ``journalctl`` to view the full information.
+
 .. _setting-tcp-fast-open:
 
 ``tcp-fast-open``

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -887,8 +887,11 @@ static const char* toTimestampStringMilli(const struct timeval& tv, char* buf, s
 #ifdef HAVE_SYSTEMD
 static void loggerSDBackend(const Logging::Entry& entry)
 {
+  // First map SL priority to syslog's Urgency
   Logger::Urgency u = entry.d_priority ? Logger::Urgency(entry.d_priority) : Logger::Info;
   if (u > s_logUrgency) {
+    // We do not log anything if the Urgency of the message is lower than the requested loglevel.
+    // Not that lower Urgency means higher number.
     return;
   }
   // We need to keep the string in mem until sd_journal_sendv has ben called
@@ -928,8 +931,11 @@ static void loggerBackend(const Logging::Entry& entry)
 {
   static thread_local std::stringstream buf;
 
+  // First map SL priority to syslog's Urgency
   Logger::Urgency u = entry.d_priority ? Logger::Urgency(entry.d_priority) : Logger::Info;
   if (u > s_logUrgency) {
+    // We do not log anything if the Urgency of the message is lower than the requested loglevel.
+    // Not that lower Urgency means higher number.
     return;
   }
   buf.str("");
@@ -2797,8 +2803,9 @@ int main(int argc, char** argv)
     g_slogStructured = ::arg().mustDo("structured-logging");
     s_structured_logger_backend = ::arg()["structured-logging-backend"];
 
-    if (s_logUrgency < Logger::Error)
+    if (s_logUrgency < Logger::Error) {
       s_logUrgency = Logger::Error;
+    }
     if (!g_quiet && s_logUrgency < Logger::Info) { // Logger::Info=6, Logger::Debug=7
       s_logUrgency = Logger::Info; // if you do --quiet=no, you need Info to also see the query log
     }
@@ -2866,8 +2873,9 @@ int main(int argc, char** argv)
     s_logUrgency = (Logger::Urgency)::arg().asNum("loglevel");
     g_slogStructured = ::arg().mustDo("structured-logging");
 
-    if (s_logUrgency < Logger::Error)
+    if (s_logUrgency < Logger::Error) {
       s_logUrgency = Logger::Error;
+    }
     if (!g_quiet && s_logUrgency < Logger::Info) { // Logger::Info=6, Logger::Debug=7
       s_logUrgency = Logger::Info; // if you do --quiet=no, you need Info to also see the query log
     }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
As @mnordhoff noted, the new systemd-journal backend isn't nice for human consumption. So switch back to the row of `k=v` pairs output by default and introduce a setting to use the systemd-journal backend. This setting also allows for other backends to be used (in the future).

Also: respect loglevel. The traditional output was filtered, but for structured logging, that was not done. While there, shortcut the traditional way as well, to avoid unnecessary churn.

Should fix #11705 and #11706

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
