### PR TITLE
dnsdist: fill ringbuffers with responses served from the cache

### DIFF
--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -527,11 +527,17 @@ void setupLuaInspection(LuaContext& luaCtx)
 	    extra.clear();
           }
 
+          std::string server = c.ds.toStringWithPort();
+          std::string protocol = dnsdist::Protocol(c.protocol).toString();
+          if (server == "0.0.0.0:0") {
+            server = "Cache";
+            protocol = "-";
+          }
           if (c.usec != std::numeric_limits<decltype(c.usec)>::max()) {
-            out.emplace(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % dnsdist::Protocol(c.protocol).toString() % c.ds.toStringWithPort() % htons(c.dh.id) % c.name.toString() % qt.toString() % (c.usec / 1000.0) % (c.dh.tc ? "TC" : "") % (c.dh.rd ? "RD" : "") % (c.dh.aa ? "AA" : "") % (RCode::to_s(c.dh.rcode) + extra)).str());
+            out.emplace(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % protocol % server % htons(c.dh.id) % c.name.toString() % qt.toString() % (c.usec / 1000.0) % (c.dh.tc ? "TC" : "") % (c.dh.rd ? "RD" : "") % (c.dh.aa ? "AA" : "") % (RCode::to_s(c.dh.rcode) + extra)).str());
           }
           else {
-            out.emplace(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % dnsdist::Protocol(c.protocol).toString() % c.ds.toStringWithPort() % htons(c.dh.id) % c.name.toString() % qt.toString() % "T.O" % (c.dh.tc ? "TC" : "") % (c.dh.rd ? "RD" : "") % (c.dh.aa ? "AA" : "") % (RCode::to_s(c.dh.rcode) + extra)).str());
+            out.emplace(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % protocol % server % htons(c.dh.id) % c.name.toString() % qt.toString() % "T.O" % (c.dh.tc ? "TC" : "") % (c.dh.rd ? "RD" : "") % (c.dh.aa ? "AA" : "") % (RCode::to_s(c.dh.rcode) + extra)).str());
           }
 
           if (limit && *limit == ++num) {

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1128,5 +1128,6 @@ DNSResponse makeDNSResponseFromIDState(IDState& ids, PacketBuffer& data);
 void setIDStateFromDNSQuestion(IDState& ids, DNSQuestion& dq, DNSName&& qname);
 
 ssize_t udpClientSendRequestToBackend(const std::shared_ptr<DownstreamState>& ss, const int sd, const PacketBuffer& request, bool healthCheck = false);
+void handleResponseSent(const DNSName& qname, const QType& qtype, double udiff, const ComboAddress& client, const ComboAddress& backend, unsigned int size, const dnsheader& cleartextDH, dnsdist::Protocol protocol);
 void handleResponseSent(const IDState& ids, double udiff, const ComboAddress& client, const ComboAddress& backend, unsigned int size, const dnsheader& cleartextDH, dnsdist::Protocol protocol);
 

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -620,9 +620,11 @@ static void processDOHQuery(DOHUnitUniquePtr&& du)
       if (du->response.empty()) {
         du->response = std::move(du->query);
       }
-      auto dh = const_cast<struct dnsheader*>(reinterpret_cast<const struct dnsheader*>(du->response.data()));
+      if (du->response.size() >= sizeof(dnsheader) && du->contentType.empty()) {
+        auto dh = reinterpret_cast<const struct dnsheader*>(du->response.data());
 
-      handleResponseSent(qname, QType(qtype), 0., du->ids.origDest, ComboAddress(), du->response.size(), *dh, dnsdist::Protocol::DoH);
+        handleResponseSent(qname, QType(qtype), 0., du->ids.origDest, ComboAddress(), du->response.size(), *dh, dnsdist::Protocol::DoH);
+      }
       sendDoHUnitToTheMainThread(std::move(du), "DoH self-answered response");
       return;
     }

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -622,7 +622,7 @@ static void processDOHQuery(DOHUnitUniquePtr&& du)
       }
       auto dh = const_cast<struct dnsheader*>(reinterpret_cast<const struct dnsheader*>(du->response.data()));
 
-      handleResponseSent(qname, QType(qtype), 0., du->downstream->d_config.remote, ComboAddress(), du->response.size(), *dh, du->downstream->getProtocol());
+      handleResponseSent(qname, QType(qtype), 0., du->ids.origDest, ComboAddress(), du->response.size(), *dh, dnsdist::Protocol::DoH);
       sendDoHUnitToTheMainThread(std::move(du), "DoH self-answered response");
       return;
     }

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -620,6 +620,9 @@ static void processDOHQuery(DOHUnitUniquePtr&& du)
       if (du->response.empty()) {
         du->response = std::move(du->query);
       }
+      auto dh = const_cast<struct dnsheader*>(reinterpret_cast<const struct dnsheader*>(du->response.data()));
+
+      handleResponseSent(qname, QType(qtype), 0., du->downstream->d_config.remote, ComboAddress(), du->response.size(), *dh, du->downstream->getProtocol());
       sendDoHUnitToTheMainThread(std::move(du), "DoH self-answered response");
       return;
     }


### PR DESCRIPTION
### Short description
This tries to make sure we call `handleResponseSent()` when returning directly a self generated answer (like when serving from the packet cache).

`grepq()` display is now:

```
-2.3    127.0.0.1:60976                                 DoUDP                     11991 www.example.com.          A               RD    Question
-2.2    127.0.0.1:60976                                 DoUDP        9.9.9.9:53   11991 www.example.com.          A     102.7     RD    No Error. 1 answers
-1.7    127.0.0.1:52311                                 DoUDP                     25359 www.example.com.          A               RD    Question
-1.7    127.0.0.1:52311                                 -            Cache        25359 www.example.com.          A     0.0       RD    No Error. 1 answers
```

I was a bit unsure about what to do with latencies as it seems  to be initialized or not depending on the context (UDP/TCP/Do{TH}). Maybe zero it everywhere ? Also I may simply have missed something ?

Fix #11585 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
