### PR TITLE
Fix warnings found by compiler on MacOS, where char is unsigned

### DIFF
--- a/pdns/dnslabeltext.rl
+++ b/pdns/dnslabeltext.rl
@@ -108,11 +108,11 @@ DNSName::string_t segmentDNSNameRaw(const char* realinput, size_t inputlen)
         const char* eof = pe;
         int cs;
         char val = 0;
-        char labellen=0;
+        unsigned char labellen=0;
         unsigned int lenpos=0;
         %%{
                 action labelEnd { 
-                        if (labellen < 0 || labellen > 63) {
+                        if (labellen > 63) {
                           throw runtime_error("Unable to parse DNS name '"+string(realinput)+"': invalid label length "+std::to_string(labellen));
                         }
                         ret[lenpos]=labellen;

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -255,8 +255,8 @@ bool DNSName::isPartOf(const DNSName& parent) const
       }
       return true;
     }
-    if (*us < 0) {
-      throw std::out_of_range("negative label length in dnsname");
+    if (static_cast<uint8_t>(*us) > 63) {
+      throw std::out_of_range("illegal label length in dnsname");
     }
   }
   return false;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

The test in `dnslabeltext.rl` should be exactly equivalent, but not cause a compiler warning on platforms where `char` is unsigned.

The test in `dnsname.cc` gets more strict, it will now detect illegal label lengths on all platforms, not just > 127 only on platforms where `char` is signed, as it does before this PR.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
