### PR TITLE
dnsdist newThread(): mask SIGTERM

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -270,6 +270,15 @@ void checkParameterBound(const std::string& parameter, uint64_t value, size_t ma
 static void LuaThread(const std::string code)
 {
   LuaContext l;
+
+  // mask SIGTERM on threads so the signal always comes to dnsdist itself
+  sigset_t blockSignals;
+
+  sigemptyset(&blockSignals);
+  sigaddset(&blockSignals, SIGTERM);
+
+  pthread_sigmask(SIG_BLOCK, &blockSignals, nullptr);
+
   // submitToMainThread is camelcased, threadmessage is not.
   // This follows our tradition of hooks we call being lowercased but functions the user can call being camelcased.
   l.writeFunction("submitToMainThread", [](std::string cmd, LuaAssociativeTable<std::string> data) {
@@ -2873,6 +2882,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       return;
     }
     std::thread newThread(LuaThread, code);
+
     newThread.detach();
   });
 


### PR DESCRIPTION
### Short description
This should make sure that our signal handler wins over any signal handlers installed by threads.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
