### PR TITLE
dnsdist: Stop background threads and close file descriptors in regression tests

### DIFF
--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -150,6 +150,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls._sock.close()
         if 'DNSDIST_FAST_TESTS' in os.environ:
             delay = 0.1
         else:
@@ -712,6 +713,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         (responseLen,) = struct.unpack("!I", data)
         data = sock.recv(responseLen)
         response = cls._decryptConsole(data, readingNonce)
+        sock.close()
         return response
 
     def compareOptions(self, a, b):

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -68,6 +68,9 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     _checkConfigExpectedOutput = None
     _verboseMode = False
     _skipListeningOnCL = False
+    _backgroundThreads = {}
+    _UDPResponder = None
+    _TCPResponder = None
 
     @classmethod
     def startResponders(cls):
@@ -163,6 +166,10 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                     cls._dnsdist.kill()
                 cls._dnsdist.wait()
 
+        # tell the background threads to stop, if any
+        for backgroundThread in cls._backgroundThreads:
+          cls._backgroundThreads[backgroundThread] = False
+
     @classmethod
     def _ResponderIncrementCounter(cls):
         if threading.currentThread().name in cls._responsesCounter:
@@ -202,6 +209,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
     @classmethod
     def UDPResponder(cls, port, fromQueue, toQueue, trailingDataResponse=False, callback=None):
+        cls._backgroundThreads[threading.get_native_id()] = True
         # trailingDataResponse=True means "ignore trailing data".
         # Other values are either False (meaning "raise an exception")
         # or are interpreted as a response RCODE for queries with trailing data.
@@ -211,8 +219,17 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         sock.bind(("127.0.0.1", port))
+        sock.settimeout(1.0)
         while True:
-            data, addr = sock.recvfrom(4096)
+            try:
+              data, addr = sock.recvfrom(4096)
+            except socket.timeout:
+              if cls._backgroundThreads.get(threading.get_native_id(), False) == False:
+                del cls._backgroundThreads[threading.get_native_id()]
+                break
+              else:
+                continue
+
             forceRcode = None
             try:
                 request = dns.message.from_wire(data, ignore_trailing=ignoreTrailing)
@@ -235,9 +252,8 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             if not wire:
               continue
 
-            sock.settimeout(2.0)
             sock.sendto(wire, addr)
-            sock.settimeout(None)
+
         sock.close()
 
     @classmethod
@@ -299,6 +315,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
     @classmethod
     def TCPResponder(cls, port, fromQueue, toQueue, trailingDataResponse=False, multipleResponses=False, callback=None, tlsContext=None, multipleConnections=False, listeningAddr='127.0.0.1'):
+        cls._backgroundThreads[threading.get_native_id()] = True
         # trailingDataResponse=True means "ignore trailing data".
         # Other values are either False (meaning "raise an exception")
         # or are interpreted as a response RCODE for queries with trailing data.
@@ -314,6 +331,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             sys.exit(1)
 
         sock.listen(100)
+        sock.settimeout(1.0)
         if tlsContext:
           sock = tlsContext.wrap_socket(sock, server_side=True)
 
@@ -324,6 +342,12 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
               continue
             except ConnectionResetError:
               continue
+            except socket.timeout:
+              if cls._backgroundThreads.get(threading.get_native_id(), False) == False:
+                 del cls._backgroundThreads[threading.get_native_id()]
+                 break
+              else:
+                continue
 
             conn.settimeout(5.0)
             if multipleConnections:
@@ -434,6 +458,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
     @classmethod
     def DOHResponder(cls, port, fromQueue, toQueue, trailingDataResponse=False, multipleResponses=False, callback=None, tlsContext=None, useProxyProtocol=False):
+        cls._backgroundThreads[threading.get_native_id()] = True
         # trailingDataResponse=True means "ignore trailing data".
         # Other values are either False (meaning "raise an exception")
         # or are interpreted as a response RCODE for queries with trailing data.
@@ -449,6 +474,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             sys.exit(1)
 
         sock.listen(100)
+        sock.settimeout(1.0)
         if tlsContext:
             sock = tlsContext.wrap_socket(sock, server_side=True)
 
@@ -461,6 +487,12 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                 continue
             except ConnectionResetError:
               continue
+            except socket.timeout:
+                if cls._backgroundThreads.get(threading.get_native_id(), False) == False:
+                    del cls._backgroundThreads[threading.get_native_id()]
+                    break
+                else:
+                    continue
 
             conn.settimeout(5.0)
             thread = threading.Thread(name='DoH Connection Handler',

--- a/regression-tests.dnsdist/test_CDB.py
+++ b/regression-tests.dnsdist/test_CDB.py
@@ -15,6 +15,7 @@ def writeCDB(fname, variant=1):
     cdb.add(b'this is the value of the qname tag', b'this is the value of the second tag')
     cdb.commit().close()
     os.rename(fname+'.tmp', fname)
+    cdb.close()
 
 @unittest.skipIf('SKIP_CDB_TESTS' in os.environ, 'CDB tests are disabled')
 class CDBTest(DNSDistTest):

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -17,6 +17,7 @@ class DNSDistProtobufTest(DNSDistTest):
 
     @classmethod
     def ProtobufListener(cls, port):
+        cls._backgroundThreads[threading.get_native_id()] = True
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         try:
@@ -26,8 +27,17 @@ class DNSDistProtobufTest(DNSDistTest):
             sys.exit(1)
 
         sock.listen(100)
+        sock.settimeout(1.0)
         while True:
-            (conn, _) = sock.accept()
+            try:
+                (conn, _) = sock.accept()
+            except socket.timeout:
+                if cls._backgroundThreads.get(threading.get_native_id(), False) == False:
+                    del cls._backgroundThreads[threading.get_native_id()]
+                    break
+                else:
+                    continue
+
             data = None
             while True:
                 data = conn.recv(2)

--- a/regression-tests.dnsdist/test_TCPFastOpen.py
+++ b/regression-tests.dnsdist/test_TCPFastOpen.py
@@ -30,6 +30,7 @@ class TestBrokenTCPFastOpen(DNSDistTest):
 
     @classmethod
     def BrokenTCPResponder(cls, port):
+        cls._backgroundThreads[threading.get_native_id()] = True
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
@@ -40,8 +41,17 @@ class TestBrokenTCPFastOpen(DNSDistTest):
             sys.exit(1)
 
         sock.listen(100)
+        sock.settimeout(1.0)
         while True:
-            (conn, _) = sock.accept()
+            try:
+                (conn, _) = sock.accept()
+            except socket.timeout:
+                if cls._backgroundThreads.get(threading.get_native_id(), False) == False:
+                    del cls._backgroundThreads[threading.get_native_id()]
+                    break
+                else:
+                    continue
+
             conn.settimeout(5.0)
             data = conn.recv(2)
             if not data:

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -12,7 +12,9 @@ class TLSTests(object):
 
     def getServerCertificate(self):
         conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
-        return conn.getpeercert()
+        cert = conn.getpeercert()
+        conn.close()
+        return cert
 
     def getTLSProvider(self):
         return self.sendConsoleCommand("getBind(0):getEffectiveTLSProvider()").rstrip()
@@ -59,6 +61,7 @@ class TLSTests(object):
         self.generateNewCertificateAndKey()
         self.sendConsoleCommand("reloadAllCertificates()")
 
+        conn.close()
         # open a new connection
         conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
 
@@ -86,6 +89,7 @@ class TLSTests(object):
 
         # and that the serial is different
         self.assertNotEqual(serialNumber, cert['serialNumber'])
+        conn.close()
 
     def testTLKA(self):
         """
@@ -111,6 +115,8 @@ class TLSTests(object):
             receivedQuery.id = query.id
             self.assertEqual(query, receivedQuery)
             self.assertEqual(response, receivedResponse)
+
+        conn.close()
 
     def testTLSPipelining(self):
         """
@@ -138,6 +144,8 @@ class TLSTests(object):
             receivedQuery.id = query.id
             self.assertEqual(query, receivedQuery)
             self.assertEqual(response, receivedResponse)
+
+        conn.close()
 
     def testTLSSNIRouting(self):
         """
@@ -169,6 +177,7 @@ class TLSTests(object):
         self.assertTrue(receivedResponse)
         self.assertEqual(expectedResponse, receivedResponse)
 
+        conn.close()
         # this one should not
         conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
 
@@ -179,6 +188,7 @@ class TLSTests(object):
         receivedQuery.id = query.id
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
+        conn.close()
 
     def testTLSSNIRoutingAfterResumption(self):
         # we have more complicated tests about session resumption itself,
@@ -352,12 +362,14 @@ class TestDOTWithCache(DNSDistTest):
         self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryNoEDNS(expectedQuery, receivedQuery)
         self.assertEqual(response, receivedResponse)
+        conn.close()
 
         for _ in range(numberOfQueries):
             conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
             self.sendTCPQueryOverConnection(conn, query, response=None)
             receivedResponse = self.recvTCPResponseOverConnection(conn, useQueue=False)
             self.assertEqual(receivedResponse, response)
+            conn.close()
 
 class TestTLSFrontendLimits(DNSDistTest):
 
@@ -461,6 +473,7 @@ class TestProtocols(DNSDistTest):
         receivedQuery.id = query.id
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
+        conn.close()
 
 class TestPKCSTLSCertificate(DNSDistTest, TLSTests):
     _consoleKey = DNSDistTest.generateConsoleKey()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We now have enough regression tests that nosetests runs out of file descriptors without this change. We should have been more careful about not leaving so much state around between tests anyway.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
