### PR TITLE
dnsdist: Set TCP_NODELAY on the TCP connection to backends

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -76,6 +76,12 @@ bool ConnectionToBackend::reconnect()
       auto socket = std::make_unique<Socket>(d_ds->d_config.remote.sin4.sin_family, SOCK_STREAM, 0);
       DEBUGLOG("result of socket() is "<<socket->getHandle());
 
+      /* disable NAGLE, which does not play nicely with delayed ACKs.
+         In theory we could be wasting up to 500 milliseconds waiting for
+         the other end to acknowledge our initial packet before we could
+         send the rest. */
+      setTCPNoDelay(socket->getHandle());
+
 #ifdef SO_BINDTODEVICE
       if (!d_ds->d_config.sourceItfName.empty()) {
         int res = setsockopt(socket->getHandle(), SOL_SOCKET, SO_BINDTODEVICE, d_ds->d_config.sourceItfName.c_str(), d_ds->d_config.sourceItfName.length());


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Setting `TCP_NODELAY` disables Nagle's algorithm, which is unfortunately not always playing nice with TCP delayed ACKs. This is especially true when the backend supports out-of-order processing, allowing dnsdist to send several queries at once without waiting for an answer. In that case dnsdist often has to wait several milliseconds (20ms is common) before
the remote end decides to send the delayed ACK which allows us to send the next query.
Note that this could lead to more TCP segments being sent by dnsdist instead of being aggregated, but in practice we already take care of sending a DNS query as a single `send()` syscall whenever possible.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
