### PR TITLE
rec: remove > 5 check on ttl of glue from the cache.

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2220,7 +2220,7 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType qtype, vector
           const DNSRecord& dr=*k;
 	  auto nrr = getRR<NSRecordContent>(dr);
           if(nrr && (!nrr->getNS().isPartOf(subdomain) || g_recCache->get(d_now.tv_sec, nrr->getNS(), nsqt,
-                                                                          false, doLog() ? &aset : 0, d_cacheRemote, false, d_routingTag) > 5)) {
+                                                                          false, doLog() ? &aset : 0, d_cacheRemote, false, d_routingTag) > 0)) {
             bestns.push_back(dr);
             LOG(prefix<<qname<<": NS (with ip, or non-glue) in cache for '"<<subdomain<<"' -> '"<<nrr->getNS()<<"'"<<endl);
             LOG(prefix<<qname<<": within bailiwick: "<< nrr->getNS().isPartOf(subdomain));


### PR DESCRIPTION
This makes the view of the record cache consistent with what syncres thinks. This will become important in the near future.

This `> 5` has been there since
https://github.com/PowerDNS/pdns/commit/7bf2638379826e89d655194bf5834bd7deda450a
I *suppose* it was to prevent accessing data from the cache while it could be cleaned by another thread.
But these days we copy data from the cache, so no need for that this "safeguard". Apart from that I wonder what would happen if we encounter glue records with ttl < 5 (not that those would make any practical sense).

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
