### PR TITLE
auth 2136: in recently added TXT tests, hide SOA details

### DIFF
--- a/regression-tests.nobackend/tinydns-data-check/expected_result
+++ b/regression-tests.nobackend/tinydns-data-check/expected_result
@@ -1,6 +1,6 @@
 229dad9ea0464a429685d3dda8a8e9ef  ../regression-tests/zones/example.com
 fe49d2784b1bcc3b91ddd5619f0b6cc1  ../regression-tests/zones/test.com
-f0df67fa656d33fd85098cbe43893395  ../regression-tests/zones/test.dyndns
+e5e3ee998d151fe194b98997eaa36c53  ../regression-tests/zones/test.dyndns
 dee3e8b568549d9450134b555ca73990  ../regression-tests/zones/sub.test.dyndns
 e7c0fd528e8aaedb1ea3b6daaead4de2  ../regression-tests/zones/wtest.com
 42b442de632686e94bde75acf66cf524  ../regression-tests/zones/nztest.com
@@ -15,4 +15,4 @@ a98864b315f16bcf49ce577426063c42  ../regression-tests/zones/cdnskey-cds-test.com
 9aeed2c26d0c3ba3baf22dfa9568c451  ../regression-tests/zones/2.0.192.in-addr.arpa
 99c73e8b5db5781fec1ac3fa6a2662a9  ../regression-tests/zones/cryptokeys.org
 1f9e19be0cff67330f3a0a5347654f91  ../regression-tests/zones/hiddencryptokeys.org
-31595b9c5e078fa22dd1716a34ca1323  ../modules/tinydnsbackend/data.cdb
+ea497141c22e13c145cf7d7b93787186  ../modules/tinydnsbackend/data.cdb

--- a/regression-tests/tests/1dyndns-update-add-delete-txt/command
+++ b/regression-tests/tests/1dyndns-update-add-delete-txt/command
@@ -3,7 +3,7 @@
 ## add + delete with explicit data
 
 # check all MX records
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 # add mx record
 cleannsupdate <<!
@@ -15,7 +15,7 @@ answer
 !
 
 # check if record was really added
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 # delete the just added record
 cleannsupdate <<!
@@ -27,7 +27,7 @@ answer
 !
 
 # check if the record was deleted.
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 
 ## add with explicit data (single string), remove whole RRset
@@ -42,7 +42,7 @@ answer
 !
 
 # check if record was really added
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 # delete the just added record
 cleannsupdate <<!
@@ -53,7 +53,7 @@ send
 answer
 !
 # check if the record was deleted.
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 ## add with explicit data (single string), remove whole RRset
 
@@ -67,7 +67,7 @@ answer
 !
 
 # check if record was really added
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 # delete the just added record
 cleannsupdate <<!
@@ -78,7 +78,7 @@ send
 answer
 !
 # check if the record was deleted.
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 ## add with explicit data (multiple strings, total over 255), remove whole RRset
 
@@ -92,7 +92,7 @@ answer
 !
 
 # check if record was really added
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 # delete the just added record
 cleannsupdate <<!
@@ -103,7 +103,7 @@ send
 answer
 !
 # check if the record was deleted.
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 ## add with explicit data (multiple strings, total over 255), remove whole RRset by content
 
@@ -117,7 +117,7 @@ answer
 !
 
 # check if record was really added
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 # delete the just added record
 cleannsupdate <<!
@@ -128,12 +128,12 @@ send
 answer
 !
 # check if the record was deleted.
-cleandig test.dyndns TXT
+cleandig test.dyndns TXT hidesoadetails
 
 ## now remove the overly long entry that was autosplit
 
 # check that it exists now
-cleandig xautosplit.test.dyndns TXT
+cleandig xautosplit.test.dyndns TXT hidesoadetails
 
 # delete it
 cleannsupdate <<!
@@ -145,4 +145,4 @@ answer
 !
 
 # check that it is gone
-cleandig xautosplit.test.dyndns TXT
+cleandig xautosplit.test.dyndns TXT hidesoadetails

--- a/regression-tests/tests/1dyndns-update-add-delete-txt/expected_result
+++ b/regression-tests/tests/1dyndns-update-add-delete-txt/expected_result
@@ -1,4 +1,4 @@
-1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2022070126 28800 7200 604800 86400
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='test.dyndns.', qtype=TXT
 Answer:
@@ -16,7 +16,7 @@ Answer:
 ;; ZONE SECTION:
 ;test.dyndns.			IN	SOA
 
-1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2022070128 28800 7200 604800 86400
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='test.dyndns.', qtype=TXT
 Answer:
@@ -34,7 +34,7 @@ Answer:
 ;; ZONE SECTION:
 ;test.dyndns.			IN	SOA
 
-1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2022070130 28800 7200 604800 86400
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='test.dyndns.', qtype=TXT
 Answer:
@@ -52,7 +52,7 @@ Answer:
 ;; ZONE SECTION:
 ;test.dyndns.			IN	SOA
 
-1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2022070132 28800 7200 604800 86400
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='test.dyndns.', qtype=TXT
 Answer:
@@ -70,7 +70,7 @@ Answer:
 ;; ZONE SECTION:
 ;test.dyndns.			IN	SOA
 
-1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2022070134 28800 7200 604800 86400
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='test.dyndns.', qtype=TXT
 Answer:
@@ -88,7 +88,7 @@ Answer:
 ;; ZONE SECTION:
 ;test.dyndns.			IN	SOA
 
-1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2022070136 28800 7200 604800 86400
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='test.dyndns.', qtype=TXT
 0	xautosplit.test.dyndns.	IN	TXT	3600	"They fixed up the corner store like it was a nightclub - It's permanently disco - Everyone is dressed so oddly I can't recognize them - I can't tell the staff from the customers - Baby check this out, I've got something to say - Man, it's so loud in here " "- When they stop the drum machine and I can think again - I'll remember what it was"
@@ -100,6 +100,6 @@ Answer:
 ;; ZONE SECTION:
 ;test.dyndns.			IN	SOA
 
-1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2022070137 28800 7200 604800 86400
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
 Rcode: 3 (Non-Existent domain), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='xautosplit.test.dyndns.', qtype=TXT


### PR DESCRIPTION
### Short description
This should unbreak CI.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master