### PR TITLE
rec: Set TCP_NODELAY on in and outgoing TCP

### DIFF
--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -261,6 +261,7 @@ static bool tcpconnect(const struct timeval& now, const ComboAddress& ip, TCPOut
   const struct timeval timeout{ g_networkTimeoutMsec / 1000, static_cast<suseconds_t>(g_networkTimeoutMsec) % 1000 * 1000};
   Socket s(ip.sin4.sin_family, SOCK_STREAM);
   s.setNonBlocking();
+  setTCPNoDelay(s.getHandle());
   ComboAddress localip = pdns::getQueryLocalAddress(ip.sin4.sin_family, 0);
   s.bind(localip);
 

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -654,6 +654,7 @@ void handleNewTCPQuestion(int fd, FDMultiplexer::funcparam_t&)
     }
 
     setNonBlocking(newsock);
+    setTCPNoDelay(newsock);
     std::shared_ptr<TCPConnection> tc = std::make_shared<TCPConnection>(newsock, addr);
     tc->d_source = addr;
     tc->d_destination.reset();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

No earth-shattering speed differences in my limited testing, but the nature of DNS message exchange is such that they should benefit from TCP_NODELAY.

In response to #11734 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
