### PR TITLE
auth: Fix getTSIGKeys() return value in GSQL and LMDB backends

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1745,7 +1745,7 @@ bool LMDBBackend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
   for (auto iter = txn.begin(); iter != txn.end(); ++iter) {
     keys.push_back(*iter);
   }
-  return false;
+  return !keys.empty();
 }
 
 class LMDBFactory : public BackendFactory

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -976,7 +976,7 @@ bool GSQLBackend::getTSIGKeys(std::vector< struct TSIGKey > &keys)
     throw PDNSException("GSQLBackend unable to retrieve TSIG keys: "+e.txtReason());
   }
 
-  return keys.empty();
+  return !keys.empty();
 }
 
 bool GSQLBackend::getDomainKeys(const DNSName& name, std::vector<KeyData>& keys)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
These Bind and remote backends return true when at least a TSIG key is returned, as expected by the API and pdnsutil code, but the GSQL backend returned false if at least a key was returned and true otherwise. The LMDB backend always returned false.
This caused `pdnsutil b2b-migrate` not to migrate TSIG keys from a GSQL or LMDB backend, amongst other things.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
