### PR TITLE
auth: getTSIGKey(s) cleanup

### DIFF
--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -218,7 +218,7 @@ public:
   bool deactivateDomainKey(const DNSName& name, unsigned int id) override;
   bool publishDomainKey(const DNSName& name, unsigned int id) override;
   bool unpublishDomainKey(const DNSName& name, unsigned int id) override;
-  bool getTSIGKey(const DNSName& name, DNSName* algorithm, string* content) override;
+  bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content) override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
   bool deleteTSIGKey(const DNSName& name) override;
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys) override;

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -100,7 +100,7 @@ bool Bind2Backend::unpublishDomainKey(const DNSName& name, unsigned int id)
   return false;
 }
 
-bool Bind2Backend::getTSIGKey(const DNSName& name, DNSName* algorithm, string* content)
+bool Bind2Backend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& content)
 {
   return false;
 }
@@ -440,7 +440,7 @@ bool Bind2Backend::unpublishDomainKey(const DNSName& name, unsigned int id)
   return true;
 }
 
-bool Bind2Backend::getTSIGKey(const DNSName& name, DNSName* algorithm, string* content)
+bool Bind2Backend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& content)
 {
   if (!d_dnssecdb || d_hybrid)
     return false;
@@ -449,12 +449,11 @@ bool Bind2Backend::getTSIGKey(const DNSName& name, DNSName* algorithm, string* c
     d_getTSIGKeyQuery_stmt->bind("key_name", name)->execute();
 
     SSqlStatement::row_t row;
-    content->clear();
     while (d_getTSIGKeyQuery_stmt->hasNextRow()) {
       d_getTSIGKeyQuery_stmt->nextRow(row);
-      if (row.size() >= 2 && (algorithm->empty() || *algorithm == DNSName(row[0]))) {
-        *algorithm = DNSName(row[0]);
-        *content = row[1];
+      if (row.size() >= 2 && (algorithm.empty() || algorithm == DNSName(row[0]))) {
+        algorithm = DNSName(row[0]);
+        content = row[1];
       }
     }
 
@@ -463,7 +462,7 @@ bool Bind2Backend::getTSIGKey(const DNSName& name, DNSName* algorithm, string* c
   catch (SSqlException& e) {
     throw PDNSException("Error accessing DNSSEC database in BIND backend, getTSIGKey(): " + e.txtReason());
   }
-  return !content->empty();
+  return true;
 }
 
 bool Bind2Backend::setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content)
@@ -517,7 +516,7 @@ bool Bind2Backend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
   catch (SSqlException& e) {
     throw PDNSException("Error accessing DNSSEC database in BIND backend, getTSIGKeys(): " + e.txtReason());
   }
-  return !keys.empty();
+  return true;
 }
 
 #endif

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -118,7 +118,7 @@ public:
   bool unpublishDomainKey(const DNSName& name, unsigned int id) override;
 
   // TSIG
-  bool getTSIGKey(const DNSName& name, DNSName* algorithm, string* content) override;
+  bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content) override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
   bool deleteTSIGKey(const DNSName& name) override;
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys) override;

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -496,7 +496,7 @@ bool RemoteBackend::doesDNSSEC()
   return d_dnssec;
 }
 
-bool RemoteBackend::getTSIGKey(const DNSName& name, DNSName* algorithm, std::string* content)
+bool RemoteBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, std::string& content)
 {
   // no point doing dnssec if it's not supported
   if (d_dnssec == false)
@@ -510,8 +510,8 @@ bool RemoteBackend::getTSIGKey(const DNSName& name, DNSName* algorithm, std::str
   if (this->send(query) == false || this->recv(answer) == false)
     return false;
 
-  (*algorithm) = DNSName(stringFromJson(answer["result"], "algorithm"));
-  (*content) = stringFromJson(answer["result"], "content");
+  algorithm = DNSName(stringFromJson(answer["result"], "algorithm"));
+  content = stringFromJson(answer["result"], "content");
 
   return true;
 }

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -171,7 +171,7 @@ public:
   bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string>>& meta) override;
   bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta) override;
   bool getDomainKeys(const DNSName& name, std::vector<DNSBackend::KeyData>& keys) override;
-  bool getTSIGKey(const DNSName& name, DNSName* algorithm, std::string* content) override;
+  bool getTSIGKey(const DNSName& name, DNSName& algorithm, std::string& content) override;
   bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
   bool setDomainMetadata(const DNSName& name, const string& kind, const std::vector<std::basic_string<char>>& meta) override;
   bool removeDomainKey(const DNSName& name, unsigned int id) override;

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(test_method_getTSIGKey)
   DNSName algorithm;
   std::string content;
   BOOST_TEST_MESSAGE("Testing getTSIGKey method");
-  be->getTSIGKey(DNSName("unit.test."), &algorithm, &content);
+  be->getTSIGKey(DNSName("unit.test."), algorithm, content);
   BOOST_CHECK_EQUAL(algorithm.toString(), "hmac-md5.");
   BOOST_CHECK_EQUAL(content, "kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys=");
 }

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -880,7 +880,7 @@ bool GSQLBackend::removeDomainKey(const DNSName& name, unsigned int id)
   return true;
 }
 
-bool GSQLBackend::getTSIGKey(const DNSName& name, DNSName* algorithm, string* content)
+bool GSQLBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& content)
 {
   try {
     reconnectIfNeeded();
@@ -891,14 +891,13 @@ bool GSQLBackend::getTSIGKey(const DNSName& name, DNSName* algorithm, string* co
 
     SSqlStatement::row_t row;
 
-    content->clear();
     while(d_getTSIGKeyQuery_stmt->hasNextRow()) {
       d_getTSIGKeyQuery_stmt->nextRow(row);
       ASSERT_ROW_COLUMNS("get-tsig-key-query", row, 2);
       try{
-        if(algorithm->empty() || *algorithm==DNSName(row[0])) {
-          *algorithm = DNSName(row[0]);
-          *content = row[1];
+        if (algorithm.empty() || algorithm == DNSName(row[0])) {
+          algorithm = DNSName(row[0]);
+          content = row[1];
         }
       } catch (...) {}
     }
@@ -909,7 +908,7 @@ bool GSQLBackend::getTSIGKey(const DNSName& name, DNSName* algorithm, string* co
     throw PDNSException("GSQLBackend unable to retrieve TSIG key with name '" + name.toLogString() + "': "+e.txtReason());
   }
 
-  return !content->empty();
+  return true;
 }
 
 bool GSQLBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content)
@@ -976,7 +975,7 @@ bool GSQLBackend::getTSIGKeys(std::vector< struct TSIGKey > &keys)
     throw PDNSException("GSQLBackend unable to retrieve TSIG keys: "+e.txtReason());
   }
 
-  return !keys.empty();
+  return true;
 }
 
 bool GSQLBackend::getDomainKeys(const DNSName& name, std::vector<KeyData>& keys)

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -233,8 +233,8 @@ public:
   bool deactivateDomainKey(const DNSName& name, unsigned int id) override;
   bool publishDomainKey(const DNSName& name, unsigned int id) override;
   bool unpublishDomainKey(const DNSName& name, unsigned int id) override;
-  
-  bool getTSIGKey(const DNSName& name, DNSName* algorithm, string* content) override;
+
+  bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content) override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
   bool deleteTSIGKey(const DNSName& name) override;
   bool getTSIGKeys(std::vector< struct TSIGKey > &keys) override;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -205,10 +205,10 @@ public:
   virtual bool publishDomainKey(const DNSName& name, unsigned int id) { return false; }
   virtual bool unpublishDomainKey(const DNSName& name, unsigned int id) { return false; }
 
-  virtual bool getTSIGKey(const DNSName& name, DNSName* algorithm, string* content) { return false; }
   virtual bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) { return false; }
+  virtual bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content) { return false; }
+  virtual bool getTSIGKeys(std::vector<struct TSIGKey>& keys) { return false; }
   virtual bool deleteTSIGKey(const DNSName& name) { return false; }
-  virtual bool getTSIGKeys(std::vector< struct TSIGKey > &keys) { return false; }
 
   virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after)
   {

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -733,8 +733,8 @@ bool DNSPacket::checkForCorrectTSIG(UeberBackend* B, DNSName* keyname, string* s
     tt.algo = DNSName("hmac-md5");
 
   string secret64;
-  if(!B->getTSIGKey(*keyname, &tt.algo, &secret64)) {
-    g_log<<Logger::Error<<"Packet for domain '"<<this->qdomain<<"' denied: can't find TSIG key with name '"<<*keyname<<"' and algorithm '"<<tt.algo<<"'"<<endl;
+  if (!B->getTSIGKey(*keyname, tt.algo, secret64)) {
+    g_log << Logger::Error << "Packet for domain '" << this->qdomain << "' denied: can't find TSIG key with name '" << *keyname << "' and algorithm '" << tt.algo << "'" << endl;
     return false;
   }
   B64Decode(secret64, *secret);

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -254,8 +254,8 @@ void CommunicatorClass::sendNotification(int sock, const DNSName& domain, const 
   pw.getHeader()->aa = true; 
 
   if (tsigkeyname.empty() == false) {
-    if (!B->getTSIGKey(tsigkeyname, &tsigalgorithm, &tsigsecret64)) {
-      g_log<<Logger::Warning<<"TSIG key '"<<tsigkeyname<<"' for domain '"<<domain<<"' not found"<<endl;
+    if (!B->getTSIGKey(tsigkeyname, tsigalgorithm, tsigsecret64)) {
+      g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << domain << "' not found" << endl;
       return;
     }
     TSIGRecordContent trc;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -340,12 +340,13 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
     TSIGTriplet tt;
     if(dk.getTSIGForAccess(domain, remote, &tt.name)) {
       string tsigsecret64;
-      if(B.getTSIGKey(tt.name, &tt.algo, &tsigsecret64)) {
+      if (B.getTSIGKey(tt.name, tt.algo, tsigsecret64)) {
         if(B64Decode(tsigsecret64, tt.secret)) {
           g_log<<Logger::Error<<logPrefix<<"unable to Base-64 decode TSIG key '"<<tt.name<<"' or zone not found"<<endl;
           return;
         }
-      } else {
+      }
+      else {
         g_log<<Logger::Warning<<logPrefix<<"TSIG key '"<<tt.name<<"' for zone not found"<<endl;
         return;
       }
@@ -851,7 +852,7 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
 
       if(dk.getTSIGForAccess(di.zone, sr.master, &dni.tsigkeyname)) {
         string secret64;
-        if(!B->getTSIGKey(dni.tsigkeyname, &dni.tsigalgname, &secret64)) {
+        if (!B->getTSIGKey(dni.tsigkeyname, dni.tsigalgname, secret64)) {
           g_log<<Logger::Warning<<"TSIG key '"<<dni.tsigkeyname<<"' for domain '"<<di.zone<<"' not found, can not AXFR."<<endl;
           continue;
         }

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -624,8 +624,7 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
     DNSName algorithm=trc.d_algoName; // FIXME400: check
     if (algorithm == DNSName("hmac-md5.sig-alg.reg.int"))
       algorithm = DNSName("hmac-md5");
-
-    if(!db.getTSIGKey(tsigkeyname, &algorithm, &tsig64)) {
+    if (!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
       g_log<<Logger::Warning<<logPrefix<<"TSIG key not found"<<endl;
       return 0;
     }
@@ -1176,8 +1175,8 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock)
       DNSName algorithm=trc.d_algoName; // FIXME400: was toLowerCanonic, compare output
       if (algorithm == DNSName("hmac-md5.sig-alg.reg.int"))
         algorithm = DNSName("hmac-md5");
-      if(!db.getTSIGKey(tsigkeyname, &algorithm, &tsig64)) {
-        g_log<<Logger::Error<<logPrefix<<"TSIG key '"<<tsigkeyname<<"' not found"<<endl;
+      if (!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
+        g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << target << "' not found" << endl;
         return 0;
       }
       if (B64Decode(tsig64, tsigsecret) == -1) {

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -229,41 +229,6 @@ bool UeberBackend::removeDomainKey(const DNSName& name, unsigned int id)
 }
 
 
-bool UeberBackend::getTSIGKey(const DNSName& name, DNSName* algorithm, string* content)
-{
-  for(DNSBackend* db :  backends) {
-    if(db->getTSIGKey(name, algorithm, content))
-      return true;
-  }
-  return false;
-}
-
-
-bool UeberBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content)
-{
-  for(DNSBackend* db :  backends) {
-    if(db->setTSIGKey(name, algorithm, content))
-      return true;
-  }
-  return false;
-}
-
-bool UeberBackend::deleteTSIGKey(const DNSName& name)
-{
-  for(DNSBackend* db :  backends) {
-    if(db->deleteTSIGKey(name))
-      return true;
-  }
-  return false;
-}
-
-bool UeberBackend::getTSIGKeys(std::vector< struct TSIGKey > &keys)
-{
-  for(DNSBackend* db :  backends) {
-    db->getTSIGKeys(keys);
-  }
-  return true;
-}
 
 void UeberBackend::reload()
 {
@@ -739,6 +704,55 @@ bool UeberBackend::get(DNSZoneRecord &rr)
   return false;
 }
 
+// TSIG
+//
+bool UeberBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content)
+{
+  for (auto* b : backends) {
+    if (b->setTSIGKey(name, algorithm, content)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool UeberBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& content)
+{
+  algorithm.clear();
+  content.clear();
+
+  for (auto* b : backends) {
+    if (b->getTSIGKey(name, algorithm, content)) {
+      break;
+    }
+  }
+  return (!algorithm.empty() && !content.empty());
+}
+
+bool UeberBackend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
+{
+  keys.clear();
+
+  for (auto* b : backends) {
+    if (b->getTSIGKeys(keys)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool UeberBackend::deleteTSIGKey(const DNSName& name)
+{
+  for (auto* b : backends) {
+    if (b->deleteTSIGKey(name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// API Search
+//
 bool UeberBackend::searchRecords(const string& pattern, int maxResults, vector<DNSResourceRecord>& result)
 {
   bool rc = false;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -123,20 +123,22 @@ public:
   bool publishDomainKey(const DNSName& name, unsigned int id);
   bool unpublishDomainKey(const DNSName& name, unsigned int id);
 
-  bool getTSIGKey(const DNSName& name, DNSName* algorithm, string* content);
-  bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content);
-  bool deleteTSIGKey(const DNSName& name);
-  bool getTSIGKeys(std::vector< struct TSIGKey > &keys);
-
   void alsoNotifies(const DNSName &domain, set<string> *ips); 
   void rediscover(string* status=0);
   void reload();
+
+  bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content);
+  bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content);
+  bool getTSIGKeys(std::vector<struct TSIGKey>& keys);
+  bool deleteTSIGKey(const DNSName& name);
+
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result);
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result);
 
   void updateZoneCache();
 
   bool inTransaction();
+
 private:
   handle d_handle;
   vector<DNSZoneRecord> d_answers;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -814,8 +814,7 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
       auto keyname(apiZoneIdToName(value.string_value()));
       DNSName keyAlgo;
       string keyContent;
-      B.getTSIGKey(keyname, &keyAlgo, &keyContent);
-      if (keyAlgo.empty() || keyContent.empty()) {
+      if (!B.getTSIGKey(keyname, keyAlgo, keyContent)) {
         throw ApiException("A TSIG key with the name '"+keyname.toLogString()+"' does not exist");
       }
       metadata.push_back(keyname.toString());
@@ -830,8 +829,7 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
       auto keyname(apiZoneIdToName(value.string_value()));
       DNSName keyAlgo;
       string keyContent;
-      B.getTSIGKey(keyname, &keyAlgo, &keyContent);
-      if (keyAlgo.empty() || keyContent.empty()) {
+      if (!B.getTSIGKey(keyname, keyAlgo, keyContent)) {
         throw ApiException("A TSIG key with the name '"+keyname.toLogString()+"' does not exist");
       }
       metadata.push_back(keyname.toString());
@@ -1476,8 +1474,7 @@ static void checkNewRecords(vector<DNSResourceRecord>& records, const DNSName& z
 static void checkTSIGKey(UeberBackend& B, const DNSName& keyname, const DNSName& algo, const string& content) {
   DNSName algoFromDB;
   string contentFromDB;
-  B.getTSIGKey(keyname, &algoFromDB, &contentFromDB);
-  if (!contentFromDB.empty() || !algoFromDB.empty()) {
+  if (B.getTSIGKey(keyname, algoFromDB, contentFromDB)) {
     throw HttpConflictException("A TSIG key with the name '"+keyname.toLogString()+"' already exists");
   }
 
@@ -1556,7 +1553,7 @@ static void apiServerTSIGKeyDetail(HttpRequest* req, HttpResponse* resp) {
   DNSName algo;
   string content;
 
-  if (!B.getTSIGKey(keyname, &algo, &content)) {
+  if (!B.getTSIGKey(keyname, algo, content)) {
     throw HttpNotFoundException("TSIG key with name '"+keyname.toLogString()+"' not found");
   }
 


### PR DESCRIPTION
### Short description
Stop after the first backend with TSIG support (like we do with metadata and cryptokeys)

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
