### PR TITLE
dnsdist: Keep retained capabilities even when switching user/group

### DIFF
--- a/pdns/capabilities.hh
+++ b/pdns/capabilities.hh
@@ -23,4 +23,12 @@
 
 #include <set>
 
-void dropCapabilities(std::set<std::string> capabilitiesToKeep = {});
+/* return true on success, false if support is not available or we don't
+   have enough capabilities to drop our capabilities (I know),
+   and throw on more unexpected errors.
+*/
+bool dropCapabilities(std::set<std::string> capabilitiesToKeep = {});
+/* drop capabilities on setuid()/setgid() */
+bool dropCapabilitiesAfterSwitchingIDs();
+/* retain capabilities on setuid()/setgid() */
+bool keepCapabilitiesAfterSwitchingIDs();

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2617,11 +2617,19 @@ int main(int argc, char** argv)
     uid_t newgid=getegid();
     gid_t newuid=geteuid();
 
-    if(!g_cmdLine.gid.empty())
+    if (!g_cmdLine.gid.empty()) {
       newgid = strToGID(g_cmdLine.gid.c_str());
+    }
 
-    if(!g_cmdLine.uid.empty())
+    if (!g_cmdLine.uid.empty()) {
       newuid = strToUID(g_cmdLine.uid.c_str());
+    }
+
+    bool retainedCapabilities = true;
+    if (!g_capabilitiesToRetain.empty() &&
+        (getegid() != newgid || geteuid() != newuid)) {
+      retainedCapabilities = keepCapabilitiesAfterSwitchingIDs();
+    }
 
     if (getegid() != newgid) {
       if (running_in_service_mgr()) {
@@ -2637,6 +2645,10 @@ int main(int argc, char** argv)
         _exit(EXIT_FAILURE);
       }
       dropUserPrivs(newuid);
+    }
+
+    if (retainedCapabilities) {
+      dropCapabilitiesAfterSwitchingIDs();
     }
 
     try {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
On Linux, we support retaining some capabilities if we are running as root (eeew) or as an unprivileged user with ambient capabilities, but we did not yet support keeping these if we were started as root but then switched to a different user ID and/or group ID.
This commit uses `PR_SET_KEEPCAPS`, when available, to do just that, to be able to retain the capabilities we need without running as a fully privileged users even when we cannot easily use ambient capabilities.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
