### PR TITLE
auth-4.6.x: fix deleteDomain() in lmdb backend

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -673,6 +673,28 @@ bool LMDBBackend::deleteDomain(const DNSName& domain)
 
   doms.commit();
 
+  {
+    auto md_txn = d_tmeta->getRWTransaction();
+    auto range = md_txn.equal_range<0>(domain);
+
+    for (auto& iter = range.first; iter != range.second; ++iter) {
+      iter.del();
+    }
+
+    md_txn.commit();
+  }
+
+  {
+    auto ck_txn = d_tkdb->getRWTransaction();
+    auto range = ck_txn.equal_range<0>(domain);
+
+    for (auto& iter = range.first; iter != range.second; ++iter) {
+      iter.del();
+    }
+
+    ck_txn.commit();
+  }
+
   return true;
 }
 


### PR DESCRIPTION
### Short description
backport the relevant parts of #11764

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] checked that this code was merged to master
