### PR TITLE
rec: Uninited vars, seen by compiling on jammy

### DIFF
--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -291,6 +291,7 @@ static LWResult::Result tcpsendrecv(const ComboAddress& ip, TCPOutConnectionMana
   uint16_t tlen = htons(vpacket.size());
   const char *lenP = reinterpret_cast<const char*>(&tlen);
 
+  len = 0; // in case of error
   localip.sin4.sin_family = ip.sin4.sin_family;
   if (getsockname(connection.d_handler->getDescriptor(), reinterpret_cast<sockaddr*>(&localip), &slen) != 0) {
     return LWResult::Result::PermanentError;

--- a/pdns/recursordist/test-mtasker.cc
+++ b/pdns/recursordist/test-mtasker.cc
@@ -51,6 +51,7 @@ BOOST_AUTO_TEST_CASE(test_MtaskerException)
     MTasker<> mt;
     mt.makeThread(willThrow, 0);
     struct timeval now;
+    now.tv_sec = now.tv_usec = 0;
 
     for (;;) {
       mt.schedule(&now);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -5331,7 +5331,7 @@ bool SyncRes::processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qn
 
   bool needWildcardProof = false;
   bool gatherWildcardProof = false;
-  unsigned int wildcardLabelsCount;
+  unsigned int wildcardLabelsCount = 0;
   *rcode = updateCacheFromRecords(depth, lwr, qname, qtype, auth, wasForwarded, ednsmask, state, needWildcardProof, gatherWildcardProof, wildcardLabelsCount, sendRDQuery, remoteIP);
   if (*rcode != RCode::NoError) {
     return true;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

All considered harmless by code inspection, but the compiler on jammy does not realise that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
