### PR TITLE
 rec: rec_control trace-regex: trace to a file or stdout instead of the general log

### DIFF
--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -203,7 +203,6 @@ Logger& Logger::operator<<(const ComboAddress& ca)
   return *this;
 }
 
-#ifdef RECURSOR
 void addTraceTS(const timeval& start, ostringstream& str)
 {
   const auto& content = str.str();
@@ -215,4 +214,3 @@ void addTraceTS(const timeval& start, ostringstream& str)
     str << diff << ' ';
   }
 }
-#endif

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -206,7 +206,7 @@ Logger& Logger::operator<<(const ComboAddress& ca)
 void addTraceTS(const timeval& start, ostringstream& str)
 {
   const auto& content = str.str();
-  if (content.empty() || content.at(content.size() - 1) == '\n') {
+  if (content.empty() || content.back() == '\n') {
     timeval time{};
     gettimeofday(&time, nullptr);
     auto elapsed = time - start;

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -206,7 +206,7 @@ Logger& Logger::operator<<(const ComboAddress& ca)
 #ifdef RECURSOR
 void addTraceTS(const timeval& start, ostringstream& str)
 {
-  const auto & content = str.str();
+  const auto& content = str.str();
   if (content.empty() || content.at(content.size() - 1) == '\n') {
     timeval time{};
     gettimeofday(&time, nullptr);

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -202,3 +202,17 @@ Logger& Logger::operator<<(const ComboAddress& ca)
   *this << ca.toLogString();
   return *this;
 }
+
+#ifdef RECURSOR
+void addTraceTS(const timeval& start, ostringstream& str)
+{
+  const auto & content = str.str();
+  if (content.empty() || content.at(content.size() - 1) == '\n') {
+    timeval time{};
+    gettimeofday(&time, nullptr);
+    auto elapsed = time - start;
+    auto diff = elapsed.tv_sec * 1000000 + static_cast<time_t>(elapsed.tv_usec);
+    str << diff << ' ';
+  }
+}
+#endif

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -183,7 +183,6 @@ struct LogVariant
 
 using OptLog = std::optional<LogVariant>;
 
-
 #ifndef RECURSOR
 // Originally there was a flag but it was never set from !RECURSOR
 #define VLOG(log, x) VLOG only works in recursor
@@ -191,26 +190,26 @@ using OptLog = std::optional<LogVariant>;
 
 void addTraceTS(const timeval& start, ostringstream& str);
 
-#define VLOG(log, x)                                                    \
-  if (log) {                                                            \
-    if (std::holds_alternative<Logger*>((log)->v)) {                    \
+#define VLOG(log, x)                                                       \
+  if (log) {                                                               \
+    if (std::holds_alternative<Logger*>((log)->v)) {                       \
       *std::get<Logger*>(log->v) << Logger::Warning << (log)->prefix << x; \
-    }                                                                   \
-    else if (std::holds_alternative<ostringstream*>((log)->v)) {        \
-      addTraceTS((log)->start, *std::get<ostringstream*>((log)->v));    \
-      *std::get<ostringstream*>((log)->v) << (log)->prefix << x;        \
-    }                                                                   \
+    }                                                                      \
+    else if (std::holds_alternative<ostringstream*>((log)->v)) {           \
+      addTraceTS((log)->start, *std::get<ostringstream*>((log)->v));       \
+      *std::get<ostringstream*>((log)->v) << (log)->prefix << x;           \
+    }                                                                      \
   }
 
-#define VLOG_NO_PREFIX(log, x)                                          \
-  if (log) {                                                            \
-      if (std::holds_alternative<Logger*>((log)->v)) {                  \
-      *std::get<Logger*>(log->v) << Logger::Warning << x;               \
-    }                                                                   \
-    else if (std::holds_alternative<ostringstream*>((log)->v)) {        \
-      addTraceTS((log)->start, *std::get<ostringstream*>((log)->v));    \
-      *std::get<ostringstream*>((log)->v) << x;                         \
-    }                                                                   \
+#define VLOG_NO_PREFIX(log, x)                                       \
+  if (log) {                                                         \
+    if (std::holds_alternative<Logger*>((log)->v)) {                 \
+      *std::get<Logger*>(log->v) << Logger::Warning << x;            \
+    }                                                                \
+    else if (std::holds_alternative<ostringstream*>((log)->v)) {     \
+      addTraceTS((log)->start, *std::get<ostringstream*>((log)->v)); \
+      *std::get<ostringstream*>((log)->v) << x;                      \
+    }                                                                \
   }
 
 #endif

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -176,23 +176,29 @@ Logger& getLogger();
 struct LogVariant
 {
   string prefix;
+  timeval start;
   // variant cannot hold references
   std::variant<Logger*, ostringstream*> v;
 };
 
 using OptLog = std::optional<LogVariant>;
 
+
 #ifndef RECURSOR
 // Originally there was a flag but it was never set from !RECURSOR
 #define VLOG(log, x) VLOG only works in recursor
 #else
-#define VLOG(log, x)                                                       \
-  if (log) {                                                               \
-    if (std::holds_alternative<Logger*>((log)->v)) {                       \
+
+void addTraceTS(const timeval& start, ostringstream& str);
+
+#define VLOG(log, x)                                                    \
+  if (log) {                                                            \
+    if (std::holds_alternative<Logger*>((log)->v)) {                      \
       *std::get<Logger*>(log->v) << Logger::Warning << (log)->prefix << x; \
-    }                                                                      \
-    else if (std::holds_alternative<ostringstream*>((log)->v)) {           \
-      *std::get<ostringstream*>((log)->v) << (log)->prefix << x;           \
-    }                                                                      \
+    }                                                                   \
+    else if (std::holds_alternative<ostringstream*>((log)->v)) {        \
+      addTraceTS((log)->start, *std::get<ostringstream*>((log)->v));    \
+      *std::get<ostringstream*>((log)->v) << (log)->prefix << x;        \
+    }                                                                   \
   }
 #endif

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -183,11 +183,6 @@ struct LogVariant
 
 using OptLog = std::optional<LogVariant>;
 
-#ifndef RECURSOR
-// Originally there was a flag but it was never set from !RECURSOR
-#define VLOG(log, x) VLOG only works in recursor
-#else
-
 void addTraceTS(const timeval& start, ostringstream& str);
 
 #define VLOG(log, x)                                                       \
@@ -211,5 +206,3 @@ void addTraceTS(const timeval& start, ostringstream& str);
       *std::get<ostringstream*>((log)->v) << x;                      \
     }                                                                \
   }
-
-#endif

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -193,7 +193,7 @@ void addTraceTS(const timeval& start, ostringstream& str);
 
 #define VLOG(log, x)                                                    \
   if (log) {                                                            \
-    if (std::holds_alternative<Logger*>((log)->v)) {                      \
+    if (std::holds_alternative<Logger*>((log)->v)) {                    \
       *std::get<Logger*>(log->v) << Logger::Warning << (log)->prefix << x; \
     }                                                                   \
     else if (std::holds_alternative<ostringstream*>((log)->v)) {        \
@@ -201,4 +201,16 @@ void addTraceTS(const timeval& start, ostringstream& str);
       *std::get<ostringstream*>((log)->v) << (log)->prefix << x;        \
     }                                                                   \
   }
+
+#define VLOG_NO_PREFIX(log, x)                                          \
+  if (log) {                                                            \
+      if (std::holds_alternative<Logger*>((log)->v)) {                  \
+      *std::get<Logger*>(log->v) << Logger::Warning << x;               \
+    }                                                                   \
+    else if (std::holds_alternative<ostringstream*>((log)->v)) {        \
+      addTraceTS((log)->start, *std::get<ostringstream*>((log)->v));    \
+      *std::get<ostringstream*>((log)->v) << x;                         \
+    }                                                                   \
+  }
+
 #endif

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -468,7 +468,7 @@ bool AggressiveNSECCache::synthesizeFromNSEC3Wildcard(time_t now, const DNSName&
   std::vector<std::shared_ptr<RRSIGRecordContent>> wcSignatures;
 
   if (g_recCache->get(now, wildcardName, type, MemRecursorCache::RequireAuth, &wcSet, ComboAddress("127.0.0.1"), boost::none, doDNSSEC ? &wcSignatures : nullptr, nullptr, nullptr, &cachedState) <= 0 || cachedState != vState::Secure) {
-    VLOG(log, "Unfortunately we don't have a valid entry for " << wildcardName << ", so we cannot synthesize from that wildcard" << endl);
+    VLOG(log, name << ": Unfortunately we don't have a valid entry for " << wildcardName << ", so we cannot synthesize from that wildcard" << endl);
     return false;
   }
 
@@ -477,7 +477,7 @@ bool AggressiveNSECCache::synthesizeFromNSEC3Wildcard(time_t now, const DNSName&
   addRecordToRRSet(now, nextCloser.d_owner, QType::NSEC3, nextCloser.d_ttd - now, nextCloser.d_record, nextCloser.d_signatures, doDNSSEC, ret);
   /* and of course we won't deny the wildcard either */
 
-  VLOG(log, "Synthesized valid answer from NSEC3s and wildcard!" << endl);
+  VLOG(log, name << ": Synthesized valid answer from NSEC3s and wildcard!" << endl);
   ++d_nsec3WildcardHits;
   return true;
 }
@@ -490,14 +490,14 @@ bool AggressiveNSECCache::synthesizeFromNSECWildcard(time_t now, const DNSName& 
   std::vector<std::shared_ptr<RRSIGRecordContent>> wcSignatures;
 
   if (g_recCache->get(now, wildcardName, type, MemRecursorCache::RequireAuth, &wcSet, ComboAddress("127.0.0.1"), boost::none, doDNSSEC ? &wcSignatures : nullptr, nullptr, nullptr, &cachedState) <= 0 || cachedState != vState::Secure) {
-    VLOG(log, "Unfortunately we don't have a valid entry for " << wildcardName << ", so we cannot synthesize from that wildcard" << endl);
+    VLOG(log, name << ": Unfortunately we don't have a valid entry for " << wildcardName << ", so we cannot synthesize from that wildcard" << endl);
     return false;
   }
 
   addToRRSet(now, wcSet, wcSignatures, name, doDNSSEC, ret, DNSResourceRecord::ANSWER);
   addRecordToRRSet(now, nsec.d_owner, QType::NSEC, nsec.d_ttd - now, nsec.d_record, nsec.d_signatures, doDNSSEC, ret);
 
-  VLOG(log, "Synthesized valid answer from NSECs and wildcard!" << endl);
+  VLOG(log, name << ": Synthesized valid answer from NSECs and wildcard!" << endl);
   ++d_nsecWildcardHits;
   return true;
 }
@@ -522,15 +522,15 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
 
   ZoneEntry::CacheEntry exactNSEC3;
   if (getNSEC3(now, zoneEntry, nameHash, exactNSEC3)) {
-    VLOG(log, "Found a direct NSEC3 match for " << nameHash);
+    VLOG(log, name << ": Found a direct NSEC3 match for " << nameHash);
     auto nsec3 = std::dynamic_pointer_cast<NSEC3RecordContent>(exactNSEC3.d_record);
     if (!nsec3 || nsec3->d_iterations != iterations || nsec3->d_salt != salt) {
-      VLOG(log, " but the content is not valid, or has a different salt or iterations count" << endl);
+      VLOG_NO_PREFIX(log, " but the content is not valid, or has a different salt or iterations count" << endl);
       return false;
     }
 
     if (!isTypeDenied(nsec3, type)) {
-      VLOG(log, " but the requested type (" << type.toString() << ") does exist" << endl);
+      VLOG_NO_PREFIX(log, " but the requested type (" << type.toString() << ") does exist" << endl);
       return false;
     }
 
@@ -544,12 +544,12 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
          that (original) owner name other than DS RRs, and all RRs below that
          owner name regardless of type.
       */
-      VLOG(log, " but this is an ancestor delegation NSEC3" << endl);
+      VLOG_NO_PREFIX(log, " but this is an ancestor delegation NSEC3" << endl);
       return false;
     }
 
     if (type == QType::DS && !name.isRoot() && signer == name) {
-      VLOG(log, " but this NSEC3 comes from the child zone and cannot be used to deny a DS");
+      VLOG_NO_PREFIX(log, " but this NSEC3 comes from the child zone and cannot be used to deny a DS");
       return false;
     }
 
@@ -561,7 +561,7 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
     return true;
   }
 
-  VLOG(log, "No direct NSEC3 match found for " << nameHash << ", looking for closest encloser" << endl);
+  VLOG(log, name << ": No direct NSEC3 match found for " << nameHash << ", looking for closest encloser" << endl);
   DNSName closestEncloser(name);
   bool found = false;
   ZoneEntry::CacheEntry closestNSEC3;
@@ -569,11 +569,11 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
     auto closestHash = DNSName(toBase32Hex(hashQNameWithSalt(salt, iterations, closestEncloser))) + zone;
 
     if (getNSEC3(now, zoneEntry, closestHash, closestNSEC3)) {
-      VLOG(log, "Found closest encloser at " << closestEncloser << " (" << closestHash << ")" << endl);
+      VLOG(log, name << ": Found closest encloser at " << closestEncloser << " (" << closestHash << ")" << endl);
 
       auto nsec3 = std::dynamic_pointer_cast<NSEC3RecordContent>(closestNSEC3.d_record);
       if (!nsec3 || nsec3->d_iterations != iterations || nsec3->d_salt != salt) {
-        VLOG(log, " but the content is not valid, or has a different salt or iterations count" << endl);
+        VLOG_NO_PREFIX(log, " but the content is not valid, or has a different salt or iterations count" << endl);
         break;
       }
 
@@ -587,12 +587,12 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
            that (original) owner name other than DS RRs, and all RRs below that
            owner name regardless of type.
         */
-        VLOG(log, " but this is an ancestor delegation NSEC3" << endl);
+        VLOG_NO_PREFIX(log, " but this is an ancestor delegation NSEC3" << endl);
         break;
       }
 
       if (type == QType::DS && !name.isRoot() && signer == name) {
-        VLOG(log, " but this NSEC3 comes from the child zone and cannot be used to deny a DS");
+        VLOG_NO_PREFIX(log, " but this NSEC3 comes from the child zone and cannot be used to deny a DS");
         return false;
       }
 
@@ -602,7 +602,7 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
   }
 
   if (!found) {
-    VLOG(log, "Nothing found for the closest encloser in NSEC3 aggressive cache either" << endl);
+    VLOG(log, name << ": Nothing found for the closest encloser in NSEC3 aggressive cache either" << endl);
     return false;
   }
 
@@ -615,22 +615,22 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
   DNSName nextCloser(closestEncloser);
   nextCloser.prependRawLabel(name.getRawLabel(labelIdx - 1));
   auto nextCloserHash = toBase32Hex(hashQNameWithSalt(salt, iterations, nextCloser));
-  VLOG(log, "Looking for a NSEC3 covering the next closer " << nextCloser << " (" << nextCloserHash << ")" << endl);
+  VLOG(log, name << ": Looking for a NSEC3 covering the next closer " << nextCloser << " (" << nextCloserHash << ")" << endl);
 
   ZoneEntry::CacheEntry nextCloserEntry;
   if (!getNSECBefore(now, zoneEntry, DNSName(nextCloserHash) + zone, nextCloserEntry)) {
-    VLOG(log, "Nothing found for the next closer in NSEC3 aggressive cache" << endl);
+    VLOG(log, name << ": Nothing found for the next closer in NSEC3 aggressive cache" << endl);
     return false;
   }
 
   if (!isCoveredByNSEC3Hash(DNSName(nextCloserHash) + zone, nextCloserEntry.d_owner, nextCloserEntry.d_next)) {
-    VLOG(log, "No covering record found for the next closer in NSEC3 aggressive cache" << endl);
+    VLOG(log, name << ": No covering record found for the next closer in NSEC3 aggressive cache" << endl);
     return false;
   }
 
   auto nextCloserNsec3 = std::dynamic_pointer_cast<NSEC3RecordContent>(nextCloserEntry.d_record);
   if (!nextCloserNsec3 || nextCloserNsec3->d_iterations != iterations || nextCloserNsec3->d_salt != salt) {
-    VLOG(log, "The NSEC3 covering the next closer is not valid, or has a different salt or iterations count, bailing out" << endl);
+    VLOG(log, name << ": The NSEC3 covering the next closer is not valid, or has a different salt or iterations count, bailing out" << endl);
     return false;
   }
 
@@ -644,20 +644,20 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
      name (we don't insert opt-out NSEC3s into the cache). */
   DNSName wildcard(g_wildcarddnsname + closestEncloser);
   auto wcHash = toBase32Hex(hashQNameWithSalt(salt, iterations, wildcard));
-  VLOG(log, "Looking for a NSEC3 covering the wildcard " << wildcard << " (" << wcHash << ")" << endl);
+  VLOG(log, name << ": Looking for a NSEC3 covering the wildcard " << wildcard << " (" << wcHash << ")" << endl);
 
   ZoneEntry::CacheEntry wcEntry;
   if (!getNSECBefore(now, zoneEntry, DNSName(wcHash) + zone, wcEntry)) {
-    VLOG(log, "Nothing found for the wildcard in NSEC3 aggressive cache" << endl);
+    VLOG(log, name << ": Nothing found for the wildcard in NSEC3 aggressive cache" << endl);
     return false;
   }
 
   if ((DNSName(wcHash) + zone) == wcEntry.d_owner) {
-    VLOG(log, "Found an exact match for the wildcard");
+    VLOG(log, name << ": Found an exact match for the wildcard");
 
     auto nsec3 = std::dynamic_pointer_cast<NSEC3RecordContent>(wcEntry.d_record);
     if (!nsec3 || nsec3->d_iterations != iterations || nsec3->d_salt != salt) {
-      VLOG(log, " but the content is not valid, or has a different salt or iterations count" << endl);
+      VLOG_NO_PREFIX(log, " but the content is not valid, or has a different salt or iterations count" << endl);
       return false;
     }
 
@@ -671,17 +671,17 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
          that (original) owner name other than DS RRs, and all RRs below that
          owner name regardless of type.
       */
-      VLOG(log, " but the NSEC3 covering the wildcard is an ancestor delegation NSEC3, bailing out" << endl);
+      VLOG_NO_PREFIX(log, " but the NSEC3 covering the wildcard is an ancestor delegation NSEC3, bailing out" << endl);
       return false;
     }
 
     if (type == QType::DS && !name.isRoot() && wcSigner == name) {
-      VLOG(log, " but this wildcard NSEC3 comes from the child zone and cannot be used to deny a DS");
+      VLOG_NO_PREFIX(log, " but this wildcard NSEC3 comes from the child zone and cannot be used to deny a DS");
       return false;
     }
 
     if (!isTypeDenied(nsec3, type)) {
-      VLOG(log, " but the requested type (" << type.toString() << ") does exist" << endl);
+      VLOG_NO_PREFIX(log, " but the requested type (" << type.toString() << ") does exist" << endl);
       return synthesizeFromNSEC3Wildcard(now, name, type, ret, res, doDNSSEC, nextCloserEntry, wildcard, log);
     }
 
@@ -690,19 +690,19 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
   }
   else {
     if (!isCoveredByNSEC3Hash(DNSName(wcHash) + zone, wcEntry.d_owner, wcEntry.d_next)) {
-      VLOG(log, "No covering record found for the wildcard in aggressive cache" << endl);
+      VLOG(log, name << ": No covering record found for the wildcard in aggressive cache" << endl);
       return false;
     }
 
     auto nsec3 = std::dynamic_pointer_cast<NSEC3RecordContent>(wcEntry.d_record);
     if (!nsec3 || nsec3->d_iterations != iterations || nsec3->d_salt != salt) {
-      VLOG(log, "The content of the NSEC3 covering the wildcard is not valid, or has a different salt or iterations count" << endl);
+      VLOG(log, name << ": The content of the NSEC3 covering the wildcard is not valid, or has a different salt or iterations count" << endl);
       return false;
     }
 
     const DNSName wcSigner = getSigner(wcEntry.d_signatures);
     if (type == QType::DS && !name.isRoot() && wcSigner == name) {
-      VLOG(log, " but this wildcard NSEC3 comes from the child zone and cannot be used to deny a DS");
+      VLOG_NO_PREFIX(log, " but this wildcard NSEC3 comes from the child zone and cannot be used to deny a DS");
       return false;
     }
 
@@ -722,7 +722,7 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
     addRecordToRRSet(now, wcEntry.d_owner, QType::NSEC3, wcEntry.d_ttd - now, wcEntry.d_record, wcEntry.d_signatures, doDNSSEC, ret);
   }
 
-  VLOG(log, "Found valid NSEC3s covering the requested name and type!" << endl);
+  VLOG(log, name << ": Found valid NSEC3s covering the requested name and type!" << endl);
   ++d_nsec3Hits;
   return true;
 }
@@ -762,7 +762,7 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
   std::vector<std::shared_ptr<RRSIGRecordContent>> soaSignatures;
   /* we might not actually need the SOA if we find a matching wildcard, but let's not bother for now */
   if (g_recCache->get(now, zone, QType::SOA, MemRecursorCache::RequireAuth, &soaSet, who, routingTag, doDNSSEC ? &soaSignatures : nullptr, nullptr, nullptr, &cachedState) <= 0 || cachedState != vState::Secure) {
-    VLOG(log, "No valid SOA found for " << zone << ", which is the best match for " << name << endl);
+    VLOG(log, name << ": No valid SOA found for " << zone << ", which is the best match for " << name << endl);
     return false;
   }
 
@@ -775,9 +775,9 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
   bool covered = false;
   bool needWildcard = false;
 
-  VLOG(log, "Looking for a NSEC before " << name);
+  VLOG(log, name << ": Looking for a NSEC before " << name);
   if (!getNSECBefore(now, zoneEntry, name, entry)) {
-    VLOG(log, ": nothing found in the aggressive cache" << endl);
+    VLOG_NO_PREFIX(log, ": nothing found in the aggressive cache" << endl);
     return false;
   }
 
@@ -786,30 +786,30 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
     return false;
   }
 
-  VLOG(log, ": found a possible NSEC at " << entry.d_owner << " ");
+  VLOG_NO_PREFIX(log, ": found a possible NSEC at " << entry.d_owner << " ");
   // note that matchesNSEC() takes care of ruling out ancestor NSECs for us
   auto denial = matchesNSEC(name, type.getCode(), entry.d_owner, content, entry.d_signatures, log);
   if (denial == dState::NODENIAL || denial == dState::INCONCLUSIVE) {
-    VLOG(log, " but it does no cover us" << endl);
+    VLOG_NO_PREFIX(log, " but it does no cover us" << endl);
     return false;
   }
   else if (denial == dState::NXQTYPE) {
     covered = true;
-    VLOG(log, " and it proves that the type does not exist" << endl);
+    VLOG_NO_PREFIX(log, " and it proves that the type does not exist" << endl);
     res = RCode::NoError;
   }
   else if (denial == dState::NXDOMAIN) {
-    VLOG(log, " and it proves that the name does not exist" << endl);
+    VLOG_NO_PREFIX(log, " and it proves that the name does not exist" << endl);
     DNSName closestEncloser = getClosestEncloserFromNSEC(name, entry.d_owner, entry.d_next);
     DNSName wc = g_wildcarddnsname + closestEncloser;
 
-    VLOG(log, "Now looking for a NSEC before the wildcard " << wc);
+    VLOG(log, name << ": Now looking for a NSEC before the wildcard " << wc);
     if (!getNSECBefore(now, zoneEntry, wc, wcEntry)) {
-      VLOG(log, ": nothing found in the aggressive cache" << endl);
+      VLOG_NO_PREFIX(log, ": nothing found in the aggressive cache" << endl);
       return false;
     }
 
-    VLOG(log, ": found a possible NSEC at " << wcEntry.d_owner << " ");
+    VLOG_NO_PREFIX(log, ": found a possible NSEC at " << wcEntry.d_owner << " ");
 
     auto nsecContent = std::dynamic_pointer_cast<NSECRecordContent>(wcEntry.d_record);
 
@@ -817,21 +817,21 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
     if (denial == dState::NODENIAL || denial == dState::INCONCLUSIVE) {
 
       if (wcEntry.d_owner == wc) {
-        VLOG(log, " proving that the wildcard does exist" << endl);
+        VLOG_NO_PREFIX(log, " proving that the wildcard does exist" << endl);
         return synthesizeFromNSECWildcard(now, name, type, ret, res, doDNSSEC, entry, wc, log);
       }
 
-      VLOG(log, " but it does no cover us" << endl);
+      VLOG_NO_PREFIX(log, " but it does no cover us" << endl);
 
       return false;
     }
     else if (denial == dState::NXQTYPE) {
-      VLOG(log, " and it proves that there is a matching wildcard, but the type does not exist" << endl);
+      VLOG_NO_PREFIX(log, " and it proves that there is a matching wildcard, but the type does not exist" << endl);
       covered = true;
       res = RCode::NoError;
     }
     else if (denial == dState::NXDOMAIN) {
-      VLOG(log, " and it proves that there is no matching wildcard" << endl);
+      VLOG_NO_PREFIX(log, " and it proves that there is no matching wildcard" << endl);
       covered = true;
       res = RCode::NXDomain;
     }
@@ -854,7 +854,7 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
     addRecordToRRSet(now, wcEntry.d_owner, QType::NSEC, wcEntry.d_ttd - now, wcEntry.d_record, wcEntry.d_signatures, doDNSSEC, ret);
   }
 
-  VLOG(log, "Found valid NSECs covering the requested name and type!" << endl);
+  VLOG(log, name << ": Found valid NSECs covering the requested name and type!" << endl);
   ++d_nsecHits;
   return true;
 }

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -790,7 +790,7 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
   // note that matchesNSEC() takes care of ruling out ancestor NSECs for us
   auto denial = matchesNSEC(name, type.getCode(), entry.d_owner, content, entry.d_signatures, log);
   if (denial == dState::NODENIAL || denial == dState::INCONCLUSIVE) {
-    VLOG_NO_PREFIX(log, " but it does no cover us" << endl);
+    VLOG_NO_PREFIX(log, " but it does not cover us" << endl);
     return false;
   }
   else if (denial == dState::NXQTYPE) {

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -286,8 +286,12 @@ top-timeouts
     Shows the top-20 most active downstream timeout destinations.
     Statistics are over the last 'stats-ringbuffer-entries' queries.
 
-trace-regex *REGEX*
-    Emit resolution trace for matching queries. Empty regex to disable trace.
+trace-regex *REGEX* *FILE*
+    Emit resolution trace for matching queries. No arguments disables tracing.
+    Before version 4.9.0, there was no *FILE* argument, traces were always
+    written to the log. Starting with version 4.9.0, trace information is
+    written to the file specified, which may be ``-`` for the standard out
+    stream.
 
     Queries matching this regular expression will generate voluminous tracing
     output. Be aware that matches from the packet cache will still not generate

--- a/pdns/recursordist/docs/running.rst
+++ b/pdns/recursordist/docs/running.rst
@@ -84,7 +84,7 @@ To investigate failures with resolving certain domain names, the PowerDNS :progr
 This infrastructure will log every step the :program:`Recursor` takes to resolve a name and will log all DNSSEC related information as well.
 
 To enable tracing for all queries, enable the :ref:`setting-trace` setting.
-Trace infomration will be written to the log.
+Trace information will be written to the log.
 
 .. warning::
 

--- a/pdns/recursordist/docs/running.rst
+++ b/pdns/recursordist/docs/running.rst
@@ -76,21 +76,39 @@ When debugging resolving issues, it can be advantageous to have a dump of all th
 
   rec_control dump-cache /tmp/cache
 
+.. _tracing:
+
 Tracing Queries
 ---------------
-To investigate failures with resolving certain domain names, the PowerDNS Recursor features a "tracing" infrastructure.
-This infrastructure will log every step the Recursor takes to resolve a name and will log all DNSSEC related information as well.
+To investigate failures with resolving certain domain names, the PowerDNS :program:`Recursor` features a tracing infrastructure.
+This infrastructure will log every step the :program:`Recursor` takes to resolve a name and will log all DNSSEC related information as well.
 
 To enable tracing for all queries, enable the :ref:`setting-trace` setting.
+Trace infomration will be written to the log.
 
 .. warning::
 
   Enabling tracing for all queries on a system with a high query rate can severely impact performance.
 
-Tracing can also be enabled at runtime, without restarting the Recursor, for specific domains.
+Tracing can also be enabled at runtime, without restarting the :program:`Recursor`, for specific domains.
 These specific domains can be specified as a regular expression.
 This can be done using :doc:`rec_control trace-regex <manpages/rec_control.1>`::
 
-    rec_control trace-regex '.*\.example.com\.$'
+  rec_control trace-regex '.*\.example.com\.$'
 
 Will enable tracing for any query *in* the example.com domain (but not example.com itself).
+
+Since version 4.9.0 ``trace_regex`` takes an extra file argument.
+Trace information will be written to the file and not to the log.
+If the file argument is a hyphen (``-``), trace information will be written to the standard output stream.
+For example::
+
+  rec_control trace-regex 'example\.com\.$' - | grep asking
+
+will show which authoritative servers were consulted.
+
+Do not forget to disable tracing after diagnosis is done::
+
+  rec_control trace-regex
+
+

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -15,6 +15,10 @@ This is now resolved, but has the consequence that some metrics (in particular r
 This affects the results shown by ``rec_control get-qtypelist`` and the ``response-by-qtype``, ``response-sizes`` and ``response-by-rcode`` items returned by the ``/api/v1/servers/localhost/statistics`` API endpoint.
 Additionally, most ``RCodes`` and ``QTypes`` that are marked ``Unassigned``, ``Reserved`` or ``Obsolete`` by IANA are not accounted, to reduce the memory consumed by these metrics.
 
+:program:`rec_control`
+^^^^^^^^^^^^^^^^^^^^^^
+The ``trace_regex`` subcommand has been changed to take a file argument.
+Refer to :doc:`rec_control trace-regex <manpages/rec_control.1>` and :ref:`tracing` for details and example use.
 
 4.8.1 to 4.8.2
 --------------

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -838,8 +838,6 @@ static bool isEnabledForUDRs(const std::shared_ptr<std::vector<std::unique_ptr<F
 }
 #endif // HAVE_FSTRM
 
-const char* timestamp(const struct timeval& tv, char* buf, size_t sz);
-
 static void dumpTrace(const string& trace, const timeval& timev)
 {
   if (trace.empty()) {

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -42,7 +42,7 @@
 
 thread_local std::shared_ptr<RecursorLua4> t_pdl;
 thread_local std::shared_ptr<Regex> t_traceRegex;
-thread_local int t_tracefd = -1;
+thread_local FDWrapper t_tracefd = -1;
 thread_local ProtobufServersInfo t_protobufServers;
 thread_local ProtobufServersInfo t_outgoingProtobufServers;
 
@@ -861,10 +861,10 @@ static void dumpTrace(const string& trace, const timeval& timev)
     return;
   }
   std::array<char, 64> timebuf;
-  timestamp(timev, timebuf.data(), timebuf.size());
+  isoDateTimeMillis(timev, timebuf.data(), timebuf.size());
   fprintf(filep.get(), " us === START OF TRACE %s ===\n", timebuf.data());
   fprintf(filep.get(), "%s", trace.c_str());
-  timestamp(now, timebuf.data(), timebuf.size());
+  isoDateTimeMillis(now, timebuf.data(), timebuf.size());
   fprintf(filep.get(), "=== END OF TRACE %s ===\n", timebuf.data());
   // fclose by unique_ptr does implicit flush
 }

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -3096,21 +3096,17 @@ static string* pleaseUseNewTraceRegex(const std::string& newRegex, int file)
   try {
     if (newRegex.empty()) {
       t_traceRegex.reset();
-      close(t_tracefd);
-      t_tracefd = -1;
+      t_tracefd = FDWrapper();
       return new string("unset\n");
     }
     if (file == -1) {
       return new string("could not dup file\n");
     }
-    if (t_tracefd != -1) {
-      close(t_tracefd);
-    }
     t_traceRegex = std::make_shared<Regex>(newRegex);
     t_tracefd = file;
     return new string("ok\n");
   }
-  catch (PDNSException& ae) {
+  catch (const PDNSException& ae) {
     return new string(ae.reason + "\n");
   }
 }

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -3091,24 +3091,35 @@ RecursorControlChannel::Answer doQueueReloadLuaScript(vector<string>::const_iter
   return broadcastAccFunction<RecursorControlChannel::Answer>(doReloadLuaScript);
 }
 
-static string* pleaseUseNewTraceRegex(const std::string& newRegex)
-try {
-  if (newRegex.empty()) {
-    t_traceRegex.reset();
-    return new string("unset\n");
-  }
-  else {
+static string* pleaseUseNewTraceRegex(const std::string& newRegex, int file)
+{
+  try {
+    if (newRegex.empty()) {
+      t_traceRegex.reset();
+      close(t_tracefd);
+      t_tracefd = -1;
+      return new string("unset\n");
+    }
+    if (file == -1) {
+      return new string("could not dup file\n");
+    }
+    if (t_tracefd != -1) {
+      close(t_tracefd);
+    }
     t_traceRegex = std::make_shared<Regex>(newRegex);
+    t_tracefd = file;
     return new string("ok\n");
   }
-}
-catch (PDNSException& ae) {
-  return new string(ae.reason + "\n");
+  catch (PDNSException& ae) {
+    return new string(ae.reason + "\n");
+  }
 }
 
-string doTraceRegex(vector<string>::const_iterator begin, vector<string>::const_iterator end)
+string doTraceRegex(FDWrapper file, vector<string>::const_iterator begin, vector<string>::const_iterator end)
 {
-  return broadcastAccFunction<string>([=] { return pleaseUseNewTraceRegex(begin != end ? *begin : ""); });
+  int fileno = dup(file);
+  // Potential dup failure handled in pleaseUseNewTraceRegex()
+  return broadcastAccFunction<string>([=] { return pleaseUseNewTraceRegex(begin != end ? *begin : "", fileno); });
 }
 
 static uint64_t* pleaseWipePacketCache(const DNSName& canon, bool subtree, uint16_t qtype)

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -227,6 +227,7 @@ extern std::shared_ptr<NetmaskGroup> g_initialAllowFrom; // new thread needs to 
 extern std::shared_ptr<NetmaskGroup> g_initialAllowNotifyFrom; // new threads need this to be setup
 extern std::shared_ptr<notifyset_t> g_initialAllowNotifyFor; // new threads need this to be setup
 extern thread_local std::shared_ptr<Regex> t_traceRegex;
+extern thread_local int t_tracefd;
 extern string g_programname;
 extern string g_pidfname;
 extern RecursorControlChannel g_rcc; // only active in the handler thread
@@ -548,6 +549,7 @@ void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcpSockets
 void handleNewTCPQuestion(int fd, FDMultiplexer::funcparam_t&);
 
 void makeUDPServerSockets(deferredAdd_t& deferredAdds, Logr::log_t);
+string doTraceRegex(FDWrapper file, vector<string>::const_iterator begin, vector<string>::const_iterator end);
 
 #define LOCAL_NETS "127.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 169.254.0.0/16, 192.168.0.0/16, 172.16.0.0/12, ::1/128, fc00::/7, fe80::/10"
 #define LOCAL_NETS_INVERSE "!127.0.0.0/8, !10.0.0.0/8, !100.64.0.0/10, !169.254.0.0/16, !192.168.0.0/16, !172.16.0.0/12, !::1/128, !fc00::/7, !fe80::/10"

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -227,7 +227,7 @@ extern std::shared_ptr<NetmaskGroup> g_initialAllowFrom; // new thread needs to 
 extern std::shared_ptr<NetmaskGroup> g_initialAllowNotifyFrom; // new threads need this to be setup
 extern std::shared_ptr<notifyset_t> g_initialAllowNotifyFor; // new threads need this to be setup
 extern thread_local std::shared_ptr<Regex> t_traceRegex;
-extern thread_local int t_tracefd;
+extern thread_local FDWrapper t_tracefd;
 extern string g_programname;
 extern string g_pidfname;
 extern RecursorControlChannel g_rcc; // only active in the handler thread

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2110,7 +2110,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
             "set-carbon-server                set a carbon server for telemetry\n"
             "set-dnssec-log-bogus SETTING     enable (SETTING=yes) or disable (SETTING=no) logging of DNSSEC validation failures\n"
             "set-event-trace-enabled SETTING  set logging of event trace messages, 0 = disabled, 1 = protobuf, 2 = log file, 3 = both\n"
-            "trace-regex [regex]              emit resolution trace for matching queries (empty regex to clear trace)\n"
+            "trace-regex [regex file]         emit resolution trace for matching queries (no arguments clears tracing)\n"
             "top-largeanswer-remotes          show top remotes receiving large answers\n"
             "top-queries                      show top queries\n"
             "top-pub-queries                  show top queries grouped by public suffix list\n"

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2215,7 +2215,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
     return {0, doSetCarbonServer(begin, end)};
   }
   if (cmd == "trace-regex") {
-    return {0, doTraceRegex(begin, end)};
+    return {0, doTraceRegex(begin == end ? FDWrapper(-1) : getfd(s), begin, end)};
   }
   if (cmd == "unload-lua-script") {
     vector<string> empty;

--- a/pdns/recursordist/rec_control.cc
+++ b/pdns/recursordist/rec_control.cc
@@ -98,6 +98,7 @@ int main(int argc, char** argv)
     "dump-non-resolving",
     "dump-saved-parent-ns-sets",
     "dump-dot-probe-map",
+    "trace-regex",
   };
   try {
     initArguments(argc, argv);
@@ -145,16 +146,22 @@ int main(int argc, char** argv)
         command += " ";
       }
       command += commands[i];
-      if (fileCommands.count(commands[i]) > 0) {
+
+      // special case: trace-regex with no arguments is clear regex
+      auto traceregexClear = command == "trace-regex" && commands.size() == 1;
+
+      if (fileCommands.count(commands[i]) > 0 && !traceregexClear) {
         if (i + 1 < commands.size()) {
           // dump-rpz is different, it also has a zonename as argument
-          if (commands[i] == "dump-rpz") {
+          // trace-regex is different, it also has a regexp as argument
+          if (commands[i] == "dump-rpz" || commands[i] == "trace-regex") {
             if (i + 2 < commands.size()) {
               ++i;
-              command += " " + commands[i]; // add rpzname and continue with filename
+              command += " ";
+              command += commands[i]; // add rpzname/regex and continue with filename
             }
             else {
-              throw PDNSException("Command needs a zone and file argument");
+              throw PDNSException("Command needs two arguments");
             }
           }
           ++i;

--- a/pdns/recursordist/secpoll-recursor.cc
+++ b/pdns/recursordist/secpoll-recursor.cc
@@ -35,6 +35,7 @@ void doSecPoll(time_t* last_secpoll, Logr::log_t log)
     sr.setDoDNSSEC(true);
     sr.setDNSSECValidationRequested(true);
   }
+  sr.setId("SecPoll");
 
   vector<DNSRecord> ret;
 

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -469,13 +469,13 @@ bool SyncRes::s_save_parent_ns_set;
 unsigned int SyncRes::s_max_busy_dot_probes;
 bool SyncRes::s_addExtendedResolutionDNSErrors;
 
-#define LOG(x)                                  \
-  if (d_lm == Log) {                            \
-    g_log << Logger::Warning << x;              \
-  }                                             \
-  else if (d_lm == Store) {                     \
-    addTraceTS(d_fixednow, d_trace);            \
-    d_trace << x;                               \
+#define LOG(x)                       \
+  if (d_lm == Log) {                 \
+    g_log << Logger::Warning << x;   \
+  }                                  \
+  else if (d_lm == Store) {          \
+    addTraceTS(d_fixednow, d_trace); \
+    d_trace << x;                    \
   }
 
 OptLog SyncRes::LogObject(const string& prefix)
@@ -485,7 +485,7 @@ OptLog SyncRes::LogObject(const string& prefix)
     ret = {prefix, d_fixednow, &g_log};
   }
   else if (d_lm == Store) {
-    ret = {prefix, d_now, &d_trace};
+    ret = {prefix, d_fixednow, &d_trace};
   }
   return ret;
 }
@@ -3010,7 +3010,7 @@ std::vector<std::pair<DNSName, float>> SyncRes::shuffleInSpeedOrder(const DNSNam
   return rnameservers;
 }
 
-vector<ComboAddress> SyncRes::shuffleForwardSpeed(const DNSName &qname, const vector<ComboAddress>& rnameservers, const string& prefix, const bool wasRd)
+vector<ComboAddress> SyncRes::shuffleForwardSpeed(const DNSName& qname, const vector<ComboAddress>& rnameservers, const string& prefix, const bool wasRd)
 {
   vector<ComboAddress> nameservers = rnameservers;
   map<ComboAddress, float> speeds;

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -882,9 +882,6 @@ void SyncRes::AuthDomain::addSOA(std::vector<DNSRecord>& records) const
     dr.d_place = DNSResourceRecord::AUTHORITY;
     records.push_back(dr);
   }
-  else {
-    // cerr<<qname<<": can't find SOA record '"<<getName()<<"' in our zone!"<<endl;
-  }
 }
 
 bool SyncRes::AuthDomain::operator==(const AuthDomain& rhs) const
@@ -947,22 +944,18 @@ int SyncRes::AuthDomain::getRecords(const DNSName& qname, const QType qtype, std
 
   if (!records.empty()) {
     /* We have found an exact match, we're done */
-    // cerr<<qname<<": exact match in zone '"<<getName()<<"'"<<endl;
     return result;
   }
 
   if (somedata) {
     /* We have records for that name, but not of the wanted qtype */
-    // cerr<<qname<<": found record in '"<<getName()<<"', but nothing of the right type, sending SOA"<<endl;
     addSOA(records);
 
     return result;
   }
 
-  // cerr<<qname<<": nothing found so far in '"<<getName()<<"', trying wildcards"<<endl;
   DNSName wcarddomain(qname);
   while (wcarddomain != getName() && wcarddomain.chopOff()) {
-    // cerr<<qname<<": trying '*."<<wcarddomain<<"' in "<<getName()<<endl;
     range = d_records.equal_range(std::make_tuple(g_wildcarddnsname + wcarddomain));
     if (range.first == range.second)
       continue;
@@ -981,7 +974,6 @@ int SyncRes::AuthDomain::getRecords(const DNSName& qname, const QType qtype, std
       addSOA(records);
     }
 
-    // cerr<<qname<<": in '"<<getName()<<"', had wildcard match on '*."<<wcarddomain<<"'"<<endl;
     return result;
   }
 
@@ -1000,7 +992,6 @@ int SyncRes::AuthDomain::getRecords(const DNSName& qname, const QType qtype, std
   }
 
   if (records.empty()) {
-    // cerr<<qname<<": no NS match in zone '"<<getName()<<"' either, handing out SOA"<<endl;
     addSOA(records);
     result = RCode::NXDomain;
   }
@@ -1022,11 +1013,11 @@ bool SyncRes::doOOBResolve(const DNSName& qname, const QType qtype, vector<DNSRe
   DNSName authdomain(qname);
   domainmap_t::const_iterator iter = getBestAuthZone(&authdomain);
   if (iter == t_sstorage.domainmap->end() || !iter->second.isAuth()) {
-    LOG(prefix << qname << ": auth storage has no zone for this query!" << endl);
+    LOG(prefix << qname << ": Auth storage has no zone for this query!" << endl);
     return false;
   }
 
-  LOG(prefix << qname << ": auth storage has data, zone='" << authdomain << "'" << endl);
+  LOG(prefix << qname << ": Auth storage has data, zone='" << authdomain << "'" << endl);
   return doOOBResolve(iter->second, qname, qtype, ret, res);
 }
 
@@ -1814,7 +1805,7 @@ int SyncRes::doResolveNoQNameMinimization(const DNSName& qname, const QType qtyp
 {
   auto prefix = getPrefix(depth);
 
-  LOG(prefix << qname << ": Wants " << (d_doDNSSEC ? "" : "NO ") << "DNSSEC processing, " << (d_requireAuthData ? "" : "NO ") << "auth data in query for " << qtype << endl);
+  LOG(prefix << qname << ": Wants " << (d_doDNSSEC ? "" : "NO ") << "DNSSEC processing, " << (d_requireAuthData ? "" : "NO ") << "auth data required by query for " << qtype << endl);
 
   if (s_maxdepth > 0 && depth > s_maxdepth) {
     string msg = "More than " + std::to_string(s_maxdepth) + " (max-recursion-depth) levels of recursion needed while resolving " + qname.toLogString();
@@ -1842,7 +1833,7 @@ int SyncRes::doResolveNoQNameMinimization(const DNSName& qname, const QType qtyp
         if (d_cacheonly) {
           if (iter != t_sstorage.domainmap->end()) {
             if (iter->second.isAuth()) {
-              LOG(prefix << qname << ": cache only lookup for '" << qname << "|" << qtype << "', in auth zone" << endl);
+              LOG(prefix << qname << ": Cache only lookup for '" << qname << "|" << qtype << "', in auth zone" << endl);
               ret.clear();
               d_wasOutOfBand = doOOBResolve(qname, qtype, ret, depth, prefix, res);
               if (fromCache != nullptr) {
@@ -2011,7 +2002,7 @@ int SyncRes::doResolveNoQNameMinimization(const DNSName& qname, const QType qtyp
         return 0;
       }
 
-      LOG(prefix << qname << ": failed (res=" << res << ")" << endl);
+      LOG(prefix << qname << ": Failed (res=" << res << ")" << endl);
       if (res >= 0) {
         break;
       }
@@ -2180,7 +2171,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName& qname, unsigned int depth,
   }
 
   if (doLog()) {
-    LOG(prefix << "Nameserver " << qname << " IPs: ");
+    LOG(prefix << qname << ": Nameserver " << qname << " IPs: ");
     bool first = true;
     for (const auto& addr : ret) {
       if (first) {
@@ -2239,10 +2230,10 @@ void SyncRes::getBestNSFromCache(const DNSName& qname, const QType qtype, vector
           auto nrr = getRR<NSRecordContent>(dr);
           if (nrr && (!nrr->getNS().isPartOf(subdomain) || g_recCache->get(d_now.tv_sec, nrr->getNS(), nsqt, flags, doLog() ? &aset : 0, d_cacheRemote, d_routingTag) > 0)) {
             bestns.push_back(dr);
-            LOG(prefix << qname << ": NS (with ip, or non-glue) in cache for '" << subdomain << "' -> '" << nrr->getNS() << "'" << endl);
-            LOG(prefix << qname << ": within bailiwick: " << nrr->getNS().isPartOf(subdomain));
+            LOG(prefix << qname << ": NS (with ip, or non-glue) in cache for '" << subdomain << "' -> '" << nrr->getNS() << "'");
+            LOG(", within bailiwick: " << nrr->getNS().isPartOf(subdomain));
             if (!aset.empty()) {
-              LOG(",  in cache, ttl=" << (unsigned int)(((time_t)aset.begin()->d_ttl - d_now.tv_sec)) << endl);
+              LOG(", in cache, ttl=" << (unsigned int)(((time_t)aset.begin()->d_ttl - d_now.tv_sec)) << endl);
             }
             else {
               LOG(", not in cache / did not look at cache" << endl);
@@ -2273,7 +2264,7 @@ void SyncRes::getBestNSFromCache(const DNSName& qname, const QType qtype, vector
           if (doLog())
             for (set<GetBestNSAnswer>::const_iterator j = beenthere.begin(); j != beenthere.end(); ++j) {
               bool neo = (j == insertionPair.first);
-              LOG(prefix << qname << ": beenthere" << (neo ? "*" : "") << ": " << j->qname << "|" << DNSRecordContent::NumberToType(j->qtype) << " (" << (unsigned int)j->bestns.size() << ")" << endl);
+              LOG(prefix << qname << ": Beenthere" << (neo ? "*" : "") << ": " << j->qname << "|" << DNSRecordContent::NumberToType(j->qtype) << " (" << (unsigned int)j->bestns.size() << ")" << endl);
             }
           bestns.clear();
         }
@@ -2283,12 +2274,12 @@ void SyncRes::getBestNSFromCache(const DNSName& qname, const QType qtype, vector
         }
       }
     }
-    LOG(prefix << qname << ": no valid/useful NS in cache for '" << subdomain << "'" << endl);
+    LOG(prefix << qname << ": No valid/useful NS in cache for '" << subdomain << "'" << endl);
 
     if (subdomain.isRoot() && !brokeloop) {
       // We lost the root NS records
       primeHints();
-      LOG(prefix << qname << ": reprimed the root" << endl);
+      LOG(prefix << qname << ": Reprimed the root" << endl);
       /* let's prevent an infinite loop */
       if (!d_updatingRootNS) {
         auto log = g_slog->withName("housekeeping");
@@ -2362,14 +2353,14 @@ DNSName SyncRes::getBestNSNamesFromCache(const DNSName& qname, const QType qtype
     // So queries that get NS for authOrForwDomain itself go to the forwarder
     if (authOrForwDomain.isPartOf(nsFromCacheDomain)) {
       if (doLog()) {
-        LOG(prefix << qname << ": using forwarder as NS" << endl);
+        LOG(prefix << qname << ": Using forwarder as NS" << endl);
       }
       nsset.insert({DNSName(), {iter->second.d_servers, false}});
       return authOrForwDomain;
     }
     else {
       if (doLog()) {
-        LOG(prefix << qname << ": using NS from cache" << endl);
+        LOG(prefix << qname << ": Using NS from cache" << endl);
       }
     }
   }
@@ -2413,7 +2404,7 @@ static bool scanForCNAMELoop(const DNSName& name, const vector<DNSRecord>& recor
 bool SyncRes::doCNAMECacheCheck(const DNSName& qname, const QType qtype, vector<DNSRecord>& ret, unsigned int depth, const string& prefix, int& res, Context& context, bool wasAuthZone, bool wasForwardRecurse)
 {
   if ((depth > 9 && d_outqueries > 10 && d_throttledqueries > 5) || depth > 15) {
-    LOG(prefix << qname << ": recursing (CNAME or other indirection) too deep, depth=" << depth << endl);
+    LOG(prefix << qname << ": Recursing (CNAME or other indirection) too deep, depth=" << depth << endl);
     res = RCode::ServFail;
     return true;
   }
@@ -2485,10 +2476,10 @@ bool SyncRes::doCNAMECacheCheck(const DNSName& qname, const QType qtype, vector<
 
         vState recordState = getValidationStatus(foundName, !signatures.empty(), qtype == QType::DS, depth, prefix);
         if (recordState == vState::Secure) {
-          LOG(prefix << qname << ": got vState::Indeterminate state from the " << foundQT.toString() << " cache, validating.." << endl);
+          LOG(prefix << qname << ": Got vState::Indeterminate state from the " << foundQT.toString() << " cache, validating.." << endl);
           context.state = SyncRes::validateRecordsWithSigs(depth, prefix, qname, qtype, foundName, foundQT, cset, signatures);
           if (context.state != vState::Indeterminate) {
-            LOG(prefix << qname << ": got vState::Indeterminate state from the " << foundQT.toString() << " cache, new validation result is " << context.state << endl);
+            LOG(prefix << qname << ": Got vState::Indeterminate state from the " << foundQT.toString() << " cache, new validation result is " << context.state << endl);
             if (vStateIsBogus(context.state)) {
               capTTL = s_maxbogusttl;
             }
@@ -2573,14 +2564,14 @@ bool SyncRes::doCNAMECacheCheck(const DNSName& qname, const QType qtype, vector<
       }
 
       if (qname == newTarget) {
-        string msg = "got a CNAME referral (from cache) to self";
+        string msg = "Got a CNAME referral (from cache) to self";
         LOG(prefix << qname << ": " << msg << endl);
         throw ImmediateServFailException(msg);
       }
 
       if (newTarget.isPartOf(qname)) {
         // a.b.c. CNAME x.a.b.c will go to great depths with QM on
-        string msg = "got a CNAME referral (from cache) to child, disabling QM";
+        string msg = "Got a CNAME referral (from cache) to child, disabling QM";
         LOG(prefix << qname << ": " << msg << endl);
         setQNameMinimization(false);
       }
@@ -2593,7 +2584,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName& qname, const QType qtype, vector<
       // Check to see if we already have seen the new target as a previous target
       if (scanForCNAMELoop(newTarget, ret)) {
         string msg = "got a CNAME referral (from cache) that causes a loop";
-        LOG(prefix << qname << ": status=" << msg << endl);
+        LOG(prefix << qname << ": Status=" << msg << endl);
         throw ImmediateServFailException(msg);
       }
 
@@ -2602,8 +2593,8 @@ bool SyncRes::doCNAMECacheCheck(const DNSName& qname, const QType qtype, vector<
       // Be aware that going out on the network might be disabled (cache-only), for example because we are in QM Step0,
       // so you can't trust that a real lookup will have been made.
       res = doResolve(newTarget, qtype, ret, depth + 1, beenthere, cnameContext);
-      LOG(prefix << qname << ": updating validation state for response to " << qname << " from " << context.state << " with the state from the DNAME/CNAME quest: " << cnameContext.state << endl);
-      updateValidationState(context.state, cnameContext.state, prefix);
+      LOG(prefix << qname << ": Updating validation state for response to " << qname << " from " << context.state << " with the state from the DNAME/CNAME quest: " << cnameContext.state << endl);
+      updateValidationState(qname, context.state, cnameContext.state, prefix);
 
       return true;
     }
@@ -2707,7 +2698,7 @@ void SyncRes::computeNegCacheValidationStatus(const NegCache::NegCacheEntry& ne,
     }
 
     if (recordState != vState::Indeterminate && recordState != state) {
-      updateValidationState(state, recordState, prefix);
+      updateValidationState(qname, state, recordState, prefix);
       if (state != vState::Secure) {
         break;
       }
@@ -2718,7 +2709,7 @@ void SyncRes::computeNegCacheValidationStatus(const NegCache::NegCacheEntry& ne,
     vState neValidationState = ne.d_validationState;
     dState expectedState = res == RCode::NXDomain ? dState::NXDOMAIN : dState::NXQTYPE;
     dState denialState = getDenialValidationState(ne, expectedState, false, prefix);
-    updateDenialValidationState(neValidationState, ne.d_name, state, denialState, expectedState, qtype == QType::DS, depth, prefix);
+    updateDenialValidationState(qname, neValidationState, ne.d_name, state, denialState, expectedState, qtype == QType::DS, depth, prefix);
   }
   if (state != vState::Indeterminate) {
     /* validation succeeded, let's update the cache entry so we don't have to validate again */
@@ -2768,7 +2759,7 @@ bool SyncRes::doCacheCheck(const DNSName& qname, const DNSName& authname, bool w
         giveNegative = true;
         cachedState = ne.d_validationState;
         if (ne.d_qtype.getCode()) {
-          LOG(prefix << qname << ": " << qtype << " is negatively cached via '" << ne.d_auth << "' for another " << sttl << " seconds" << endl);
+          LOG(prefix << qname << "|" << qtype << ": Is negatively cached via '" << ne.d_auth << "' for another " << sttl << " seconds" << endl);
           res = RCode::NoError;
           if (s_addExtendedResolutionDNSErrors) {
             context.extendedError = EDNSExtendedError{0, "Result from negative cache"};
@@ -2818,7 +2809,7 @@ bool SyncRes::doCacheCheck(const DNSName& qname, const DNSName& authname, bool w
     context.state = cachedState;
 
     if (!wasAuthZone && shouldValidate() && context.state == vState::Indeterminate) {
-      LOG(prefix << qname << ": got vState::Indeterminate state for records retrieved from the negative cache, validating.." << endl);
+      LOG(prefix << qname << ": Got vState::Indeterminate state for records retrieved from the negative cache, validating.." << endl);
       computeNegCacheValidationStatus(ne, qname, qtype, res, context.state, depth, prefix);
 
       if (context.state != cachedState && vStateIsBogus(context.state)) {
@@ -2834,7 +2825,7 @@ bool SyncRes::doCacheCheck(const DNSName& qname, const DNSName& authname, bool w
       addTTLModifiedRecords(ne.DNSSECRecords.signatures, sttl, ret);
     }
 
-    LOG(prefix << qname << ": updating validation state with negative cache content for " << qname << " to " << context.state << endl);
+    LOG(prefix << qname << ": Updating validation state with negative cache content for " << qname << " to " << context.state << endl);
     return true;
   }
 
@@ -2865,7 +2856,7 @@ bool SyncRes::doCacheCheck(const DNSName& qname, const DNSName& authname, bool w
       vState recordState = getValidationStatus(qname, !signatures.empty(), qtype == QType::DS, depth, prefix);
 
       if (recordState == vState::Secure) {
-        LOG(prefix << sqname << ": got vState::Indeterminate state from the cache, validating.." << endl);
+        LOG(prefix << sqname << ": Got vState::Indeterminate state from the cache, validating.." << endl);
         if (sqt == QType::DNSKEY && sqname == getSigner(signatures)) {
           cachedState = validateDNSKeys(sqname, cset, signatures, depth, prefix);
         }
@@ -2896,7 +2887,7 @@ bool SyncRes::doCacheCheck(const DNSName& qname, const DNSName& authname, bool w
       }
 
       if (cachedState != vState::Indeterminate) {
-        LOG(prefix << qname << ": got vState::Indeterminate state from the cache, validation result is " << cachedState << endl);
+        LOG(prefix << qname << ": Got vState::Indeterminate state from the cache, validation result is " << cachedState << endl);
         if (vStateIsBogus(cachedState)) {
           capTTL = s_maxbogusttl;
         }
@@ -2952,12 +2943,12 @@ bool SyncRes::doCacheCheck(const DNSName& qname, const DNSName& authname, bool w
     if (found && !expired) {
       if (!giveNegative)
         res = 0;
-      LOG(prefix << qname << ": updating validation state with cache content for " << qname << " to " << cachedState << endl);
+      LOG(prefix << qname << ": Updating validation state with cache content for " << qname << " to " << cachedState << endl);
       context.state = cachedState;
       return true;
     }
     else
-      LOG(prefix << qname << ": cache had only stale entries" << endl);
+      LOG(prefix << qname << ": Cache had only stale entries" << endl);
   }
 
   /* let's check if we have a NSEC covering that record */
@@ -2987,7 +2978,7 @@ struct speedOrder
   }
 };
 
-inline std::vector<std::pair<DNSName, float>> SyncRes::shuffleInSpeedOrder(NsSet& tnameservers, const string& prefix)
+std::vector<std::pair<DNSName, float>> SyncRes::shuffleInSpeedOrder(const DNSName& qname, NsSet& tnameservers, const string& prefix)
 {
   std::vector<std::pair<DNSName, float>> rnameservers;
   rnameservers.reserve(tnameservers.size());
@@ -3003,7 +2994,7 @@ inline std::vector<std::pair<DNSName, float>> SyncRes::shuffleInSpeedOrder(NsSet
   stable_sort(rnameservers.begin(), rnameservers.end(), so);
 
   if (doLog()) {
-    LOG(prefix << "Nameservers: ");
+    LOG(prefix << qname << ": Nameservers: ");
     for (auto i = rnameservers.begin(); i != rnameservers.end(); ++i) {
       if (i != rnameservers.begin()) {
         LOG(", ");
@@ -3019,7 +3010,7 @@ inline std::vector<std::pair<DNSName, float>> SyncRes::shuffleInSpeedOrder(NsSet
   return rnameservers;
 }
 
-inline vector<ComboAddress> SyncRes::shuffleForwardSpeed(const vector<ComboAddress>& rnameservers, const string& prefix, const bool wasRd)
+vector<ComboAddress> SyncRes::shuffleForwardSpeed(const DNSName &qname, const vector<ComboAddress>& rnameservers, const string& prefix, const bool wasRd)
 {
   vector<ComboAddress> nameservers = rnameservers;
   map<ComboAddress, float> speeds;
@@ -3034,7 +3025,7 @@ inline vector<ComboAddress> SyncRes::shuffleForwardSpeed(const vector<ComboAddre
   stable_sort(nameservers.begin(), nameservers.end(), so);
 
   if (doLog()) {
-    LOG(prefix << "Nameservers: ");
+    LOG(prefix << qname << ": Nameservers: ");
     for (vector<ComboAddress>::const_iterator i = nameservers.cbegin(); i != nameservers.cend(); ++i) {
       if (i != nameservers.cbegin()) {
         LOG(", ");
@@ -3206,7 +3197,7 @@ void SyncRes::handlePolicyHit(const std::string& prefix, const DNSName& qname, c
   }
 
   if (d_appliedPolicy.d_type != DNSFilterEngine::PolicyType::None) {
-    LOG(prefix << qname << "|" << qtype << d_appliedPolicy.getLogString() << endl);
+    LOG(prefix << qname << "|" << qtype << ':' << d_appliedPolicy.getLogString() << endl);
   }
 
   switch (d_appliedPolicy.d_kind) {
@@ -3372,7 +3363,7 @@ vector<ComboAddress> SyncRes::retrieveAddressesForNS(const std::string& prefix, 
     LOG(endl);
 
     sendRDQuery = nameservers[tns->first].second;
-    result = shuffleForwardSpeed(nameservers[tns->first].first, doLog() ? (prefix + qname.toString() + ": ") : string(), sendRDQuery);
+    result = shuffleForwardSpeed(qname, nameservers[tns->first].first, prefix, sendRDQuery);
     pierceDontQuery = true;
   }
   return result;
@@ -3388,13 +3379,13 @@ void SyncRes::checkMaxQperQ(const DNSName& qname) const
 bool SyncRes::throttledOrBlocked(const std::string& prefix, const ComboAddress& remoteIP, const DNSName& qname, const QType qtype, bool pierceDontQuery)
 {
   if (isThrottled(d_now.tv_sec, remoteIP)) {
-    LOG(prefix << qname << ": server throttled " << endl);
+    LOG(prefix << qname << ": Server throttled " << endl);
     t_Counters.at(rec::Counter::throttledqueries)++;
     d_throttledqueries++;
     return true;
   }
   else if (isThrottled(d_now.tv_sec, remoteIP, qname, qtype)) {
-    LOG(prefix << qname << ": query throttled " << remoteIP.toString() << ", " << qname << "; " << qtype << endl);
+    LOG(prefix << qname << ": Query throttled " << remoteIP.toString() << ", " << qname << "; " << qtype << endl);
     t_Counters.at(rec::Counter::throttledqueries)++;
     d_throttledqueries++;
     return true;
@@ -3405,7 +3396,7 @@ bool SyncRes::throttledOrBlocked(const std::string& prefix, const ComboAddress& 
     DNSName forwardCandidate(qname);
     auto it = getBestAuthZone(&forwardCandidate);
     if (it == t_sstorage.domainmap->end()) {
-      LOG(prefix << qname << ": not sending query to " << remoteIP.toString() << ", blocked by 'dont-query' setting" << endl);
+      LOG(prefix << qname << ": Not sending query to " << remoteIP.toString() << ", blocked by 'dont-query' setting" << endl);
       t_Counters.at(rec::Counter::dontqueries)++;
       return true;
     }
@@ -3413,12 +3404,12 @@ bool SyncRes::throttledOrBlocked(const std::string& prefix, const ComboAddress& 
       // The name (from the cache) is forwarded, but is it forwarded to an IP in known forwarders?
       const auto& ips = it->second.d_servers;
       if (std::find(ips.cbegin(), ips.cend(), remoteIP) == ips.cend()) {
-        LOG(prefix << qname << ": not sending query to " << remoteIP.toString() << ", blocked by 'dont-query' setting" << endl);
+        LOG(prefix << qname << ": Not sending query to " << remoteIP.toString() << ", blocked by 'dont-query' setting" << endl);
         t_Counters.at(rec::Counter::dontqueries)++;
         return true;
       }
       else {
-        LOG(prefix << qname << ": sending query to " << remoteIP.toString() << ", blocked by 'dont-query' but a forwarding/auth case" << endl);
+        LOG(prefix << qname << ": Sending query to " << remoteIP.toString() << ", blocked by 'dont-query' but a forwarding/auth case" << endl);
       }
     }
   }
@@ -3470,9 +3461,9 @@ uint32_t SyncRes::computeLowestTTD(const std::vector<DNSRecord>& records, const 
   return lowestTTD;
 }
 
-void SyncRes::updateValidationState(vState& state, const vState stateUpdate, const string& prefix)
+void SyncRes::updateValidationState(const DNSName& qname, vState& state, const vState stateUpdate, const string& prefix)
 {
-  LOG(prefix << "validation state was " << state << ", state update is " << stateUpdate);
+  LOG(prefix << qname << ": Validation state was " << state << ", state update is " << stateUpdate);
   updateDNSSECValidationState(state, stateUpdate);
   LOG(", validation state is now " << state << endl);
 }
@@ -3482,23 +3473,22 @@ vState SyncRes::getTA(const DNSName& zone, dsmap_t& ds, const string& prefix)
   auto luaLocal = g_luaconfs.getLocal();
 
   if (luaLocal->dsAnchors.empty()) {
-    LOG(prefix << ": No trust anchors configured, everything is Insecure" << endl);
+    LOG(prefix << zone << ": No trust anchors configured, everything is Insecure" << endl);
     /* We have no TA, everything is insecure */
     return vState::Insecure;
   }
 
   std::string reason;
   if (haveNegativeTrustAnchor(luaLocal->negAnchors, zone, reason)) {
-    LOG(prefix << ": got NTA for '" << zone << "'" << endl);
+    LOG(prefix << zone << ": Got NTA" << endl);
     return vState::NTA;
   }
 
   if (getTrustAnchor(luaLocal->dsAnchors, zone, ds)) {
-    LOG(prefix << ": got TA for '" << zone << "'" << endl);
+    if (!zone.isRoot()) {
+      LOG(prefix << zone << ": Got TA" << endl);
+    }
     return vState::TA;
-  }
-  else {
-    LOG(prefix << ": no TA found for '" << zone << "' among " << luaLocal->dsAnchors.size() << endl);
   }
 
   if (zone.isRoot()) {
@@ -3662,7 +3652,7 @@ vState SyncRes::getDSRecords(const DNSName& zone, dsmap_t& ds, bool taOnly, unsi
     return context.state;
   }
 
-  LOG(prefix << ": returning Bogus state from " << __func__ << "(" << zone << ")" << endl);
+  LOG(prefix << zone << ": Returning Bogus state from " << __func__ << "(" << zone << ")" << endl);
   return vState::BogusUnableToGetDSs;
 }
 
@@ -3682,7 +3672,7 @@ vState SyncRes::getValidationStatus(const DNSName& name, bool wouldBeValid, bool
   {
     const auto& it = d_cutStates.find(subdomain);
     if (it != d_cutStates.cend()) {
-      LOG(prefix << ": got status " << it->second << " for name " << subdomain << endl);
+      LOG(prefix << name << ": Got status " << it->second << " for name " << subdomain << endl);
       return it->second;
     }
   }
@@ -3694,7 +3684,7 @@ vState SyncRes::getValidationStatus(const DNSName& name, bool wouldBeValid, bool
     if (it != d_cutStates.cend()) {
       result = it->second;
       if (vStateIsBogus(result) || result == vState::Insecure) {
-        LOG(prefix << ": got status " << result << " for name " << best << endl);
+        LOG(prefix << name << ": Got status " << result << " for name " << best << endl);
         return result;
       }
       break;
@@ -3707,7 +3697,7 @@ vState SyncRes::getValidationStatus(const DNSName& name, bool wouldBeValid, bool
      we will if we don't have a signature, or if the signer doesn't match what we expect */
   if (!wouldBeValid && best != subdomain) {
     /* no signatures or Bogus, we likely missed a cut, let's try to find it */
-    LOG(prefix << ": no or invalid signature/proof for " << name << ", we likely missed a cut between " << best << " and " << subdomain << ", looking for it" << endl);
+    LOG(prefix << name << ": No or invalid signature/proof for " << name << ", we likely missed a cut between " << best << " and " << subdomain << ", looking for it" << endl);
     DNSName ds(best);
     std::vector<string> labelsToAdd = subdomain.makeRelative(ds).getRawLabels();
 
@@ -3715,15 +3705,15 @@ vState SyncRes::getValidationStatus(const DNSName& name, bool wouldBeValid, bool
 
       ds.prependRawLabel(labelsToAdd.back());
       labelsToAdd.pop_back();
-      LOG(prefix << ": - Looking for a DS at " << ds << endl);
+      LOG(prefix << name << ": - Looking for a DS at " << ds << endl);
 
       bool foundCut = false;
       dsmap_t results;
       vState dsState = getDSRecords(ds, results, false, depth, prefix, false, &foundCut);
 
       if (foundCut) {
-        LOG(prefix << ": - Found cut at " << ds << endl);
-        LOG(prefix << ": New state for " << ds << " is " << dsState << endl);
+        LOG(prefix << name << ": - Found cut at " << ds << endl);
+        LOG(prefix << name << ": New state for " << ds << " is " << dsState << endl);
         d_cutStates[ds] = dsState;
 
         if (dsState != vState::Secure) {
@@ -3760,7 +3750,7 @@ vState SyncRes::validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord
 {
   dsmap_t ds;
   if (signatures.empty()) {
-    LOG(prefix << ": we have " << std::to_string(dnskeys.size()) << " DNSKEYs but no signature, going Bogus!" << endl);
+    LOG(prefix << zone << ": We have " << std::to_string(dnskeys.size()) << " DNSKEYs but no signature, going Bogus!" << endl);
     return vState::BogusNoRRSIG;
   }
 
@@ -3774,12 +3764,12 @@ vState SyncRes::validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord
     }
   }
   else {
-    LOG(prefix << ": we have " << std::to_string(dnskeys.size()) << " DNSKEYs but the zone (" << zone << ") is not part of the signer (" << signer << "), check that we did not miss a zone cut" << endl);
+    LOG(prefix << zone << ": We have " << std::to_string(dnskeys.size()) << " DNSKEYs but the zone (" << zone << ") is not part of the signer (" << signer << "), check that we did not miss a zone cut" << endl);
     /* try again to get the missed cuts, harder this time */
     auto zState = getValidationStatus(zone, false, false, depth, prefix);
     if (zState == vState::Secure) {
       /* too bad */
-      LOG(prefix << ": after checking the zone cuts again, we still have " << std::to_string(dnskeys.size()) << " DNSKEYs and the zone (" << zone << ") is still not part of the signer (" << signer << "), going Bogus!" << endl);
+      LOG(prefix << zone << ": After checking the zone cuts again, we still have " << std::to_string(dnskeys.size()) << " DNSKEYs and the zone (" << zone << ") is still not part of the signer (" << signer << "), going Bogus!" << endl);
       return vState::BogusNoValidRRSIG;
     }
     else {
@@ -3800,23 +3790,23 @@ vState SyncRes::validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord
     }
   }
 
-  LOG(prefix << ": trying to validate " << std::to_string(tentativeKeys.size()) << " DNSKEYs with " << std::to_string(ds.size()) << " DS" << endl);
+  LOG(prefix << zone << ": Trying to validate " << std::to_string(tentativeKeys.size()) << " DNSKEYs with " << std::to_string(ds.size()) << " DS" << endl);
   skeyset_t validatedKeys;
   auto state = validateDNSKeysAgainstDS(d_now.tv_sec, zone, ds, tentativeKeys, toSign, signatures, validatedKeys, LogObject(prefix));
 
-  LOG(prefix << ": we now have " << std::to_string(validatedKeys.size()) << " DNSKEYs" << endl);
+  LOG(prefix << zone << ": We now have " << std::to_string(validatedKeys.size()) << " DNSKEYs" << endl);
 
   /* if we found at least one valid RRSIG covering the set,
      all tentative keys are validated keys. Otherwise it means
      we haven't found at least one DNSKEY and a matching RRSIG
      covering this set, this looks Bogus. */
   if (validatedKeys.size() != tentativeKeys.size()) {
-    LOG(prefix << ": let's check whether we missed a zone cut before returning a Bogus state from " << __func__ << "(" << zone << ")" << endl);
+    LOG(prefix << zone << ": Let's check whether we missed a zone cut before returning a Bogus state from " << __func__ << "(" << zone << ")" << endl);
     /* try again to get the missed cuts, harder this time */
     auto zState = getValidationStatus(zone, false, false, depth, prefix);
     if (zState == vState::Secure) {
       /* too bad */
-      LOG(prefix << ": after checking the zone cuts we are still in a Secure zone, returning Bogus state from " << __func__ << "(" << zone << ")" << endl);
+      LOG(prefix << zone << ": After checking the zone cuts we are still in a Secure zone, returning Bogus state from " << __func__ << "(" << zone << ")" << endl);
       return state;
     }
     else {
@@ -3831,7 +3821,7 @@ vState SyncRes::getDNSKeys(const DNSName& signer, skeyset_t& keys, bool& servFai
 {
   std::vector<DNSRecord> records;
   std::set<GetBestNSAnswer> beenthere;
-  LOG(prefix << "Retrieving DNSKeys for " << signer << endl);
+  LOG(prefix << signer << ": Retrieving DNSKeys" << endl);
 
   Context context;
 
@@ -3855,7 +3845,7 @@ vState SyncRes::getDNSKeys(const DNSName& signer, skeyset_t& keys, bool& servFai
         }
       }
     }
-    LOG(prefix << "Retrieved " << keys.size() << " DNSKeys for " << signer << ", state is " << context.state << endl);
+    LOG(prefix << signer << ": Retrieved " << keys.size() << " DNSKeys, state is " << context.state << endl);
     return context.state;
   }
 
@@ -3863,7 +3853,7 @@ vState SyncRes::getDNSKeys(const DNSName& signer, skeyset_t& keys, bool& servFai
     return context.state;
   }
 
-  LOG(prefix << "Returning Bogus state from " << __func__ << "(" << signer << ")" << endl);
+  LOG(prefix << signer << ": Returning Bogus state from " << __func__ << "(" << signer << ")" << endl);
   return vState::BogusUnableToGetDNSKEYs;
 }
 
@@ -3871,7 +3861,7 @@ vState SyncRes::validateRecordsWithSigs(unsigned int depth, const string& prefix
 {
   skeyset_t keys;
   if (signatures.empty()) {
-    LOG(prefix << "Bogus!" << endl);
+    LOG(prefix << qname << ": Bogus!" << endl);
     return vState::BogusNoRRSIG;
   }
 
@@ -3886,7 +3876,7 @@ vState SyncRes::validateRecordsWithSigs(unsigned int depth, const string& prefix
         /* Unless we are getting the DS of the root zone, we should never see a
            DS (or a denial of a DS) signed by the DS itself, since we should be
            requesting it from the parent zone. Something is very wrong */
-        LOG(prefix << "The DS for " << qname << " is signed by itself" << endl);
+        LOG(prefix << qname << ": The DS for " << qname << " is signed by itself" << endl);
         state = vState::BogusSelfSignedDS;
         dsFailed = true;
       }
@@ -3921,7 +3911,7 @@ vState SyncRes::validateRecordsWithSigs(unsigned int depth, const string& prefix
             }
           }
           else {
-            LOG(prefix << "Unable to get the DS for " << signer << endl);
+            LOG(prefix << qname << ": Unable to get the DS for " << signer << endl);
             state = vState::BogusUnableToGetDNSKEYs;
             dsFailed = true;
           }
@@ -3930,14 +3920,14 @@ vState SyncRes::validateRecordsWithSigs(unsigned int depth, const string& prefix
           /* return immediately since looking at the cuts is not going to change the
              fact that we are looking at a signature done with the key we are trying to
              obtain */
-          LOG(prefix << "we are looking at a signature done with the key we are trying to obtain " << signer << endl);
+          LOG(prefix << qname << ": We are looking at a signature done with the key we are trying to obtain " << signer << endl);
           return vState::Indeterminate;
         }
       }
     }
     bool servFailOccurred = false;
     if (state == vState::Secure) {
-      LOG(prefix << "retrieving the DNSKEYs for " << signer << endl);
+      LOG(prefix << signer << ": Retrieving the DNSKEYs" << endl);
       state = getDNSKeys(signer, keys, servFailOccurred, depth, prefix);
     }
 
@@ -3946,14 +3936,14 @@ vState SyncRes::validateRecordsWithSigs(unsigned int depth, const string& prefix
         return state;
       }
       /* try again to get the missed cuts, harder this time */
-      LOG(prefix << "checking whether we missed a zone cut for " << signer << " before returning a Bogus state for " << name << "|" << type.toString() << endl);
+      LOG(prefix << signer << ": Checking whether we missed a zone cut for " << signer << " before returning a Bogus state for " << name << "|" << type.toString() << endl);
       auto zState = getValidationStatus(signer, false, dsFailed, depth, prefix);
       if (zState == vState::Secure) {
         if (state == vState::BogusUnableToGetDNSKEYs && servFailOccurred) {
           throw ImmediateServFailException("Server Failure while retrieving DNSKEY records for " + signer.toLogString());
         }
         /* too bad */
-        LOG(prefix << "we are still in a Secure zone, returning " << vStateToString(state) << endl);
+        LOG(prefix << signer << ": We are still in a Secure zone, returning " << vStateToString(state) << endl);
         return state;
       }
       else {
@@ -3967,20 +3957,20 @@ vState SyncRes::validateRecordsWithSigs(unsigned int depth, const string& prefix
     recordcontents.insert(record.d_content);
   }
 
-  LOG(prefix << "Going to validate " << recordcontents.size() << " record contents with " << signatures.size() << " sigs and " << keys.size() << " keys for " << name << "|" << type.toString() << endl);
+  LOG(prefix << name << ": Going to validate " << recordcontents.size() << " record contents with " << signatures.size() << " sigs and " << keys.size() << " keys for " << name << "|" << type.toString() << endl);
   vState state = validateWithKeySet(d_now.tv_sec, name, recordcontents, signatures, keys, LogObject(prefix), false);
   if (state == vState::Secure) {
-    LOG(prefix << "Secure!" << endl);
+    LOG(prefix << name << ": Secure!" << endl);
     return vState::Secure;
   }
 
   LOG(prefix << vStateToString(state) << "!" << endl);
   /* try again to get the missed cuts, harder this time */
   auto zState = getValidationStatus(name, false, type == QType::DS, depth, prefix);
-  LOG(prefix << "checking whether we missed a zone cut before returning a Bogus state" << endl);
+  LOG(prefix << name << ": Checking whether we missed a zone cut before returning a Bogus state" << endl);
   if (zState == vState::Secure) {
     /* too bad */
-    LOG(prefix << "we are still in a Secure zone, returning " << vStateToString(state) << endl);
+    LOG(prefix << name << ": We are still in a Secure zone, returning " << vStateToString(state) << endl);
     return state;
   }
   else {
@@ -4016,7 +4006,7 @@ void SyncRes::fixupAnswer(const std::string& prefix, LWResult& lwr, const DNSNam
     if (rec.d_place == DNSResourceRecord::ANSWER && (rec.d_type == qtype || rec.d_type == QType::CNAME || qtype == QType::ANY) && rec.d_name == qname && rec.d_name.isPartOf(auth)) {
       /* This is clearly an answer to the question we were asking, from an authoritative server that is allowed to send it.
          We are going to assume this server is broken and does not know it should set the AA bit, even though it is DNS 101 */
-      LOG(prefix << "Received a record for " << rec.d_name << "|" << DNSRecordContent::NumberToType(rec.d_type) << " in the answer section from " << auth << ", without the AA bit set. Assuming this server is clueless and setting the AA bit." << endl);
+      LOG(prefix << qname << ": Received a record for " << rec.d_name << "|" << DNSRecordContent::NumberToType(rec.d_type) << " in the answer section from " << auth << ", without the AA bit set. Assuming this server is clueless and setting the AA bit." << endl);
       lwr.d_aabit = true;
       return;
     }
@@ -4093,19 +4083,19 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
     }
 
     if (rec->d_class != QClass::IN) {
-      LOG(prefix << "Removing non internet-classed data received from " << auth << endl);
+      LOG(prefix << qname << ": Removing non internet-classed data received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
 
     if (rec->d_type == QType::ANY) {
-      LOG(prefix << "Removing 'ANY'-typed data received from " << auth << endl);
+      LOG(prefix << qname << ": Removing 'ANY'-typed data received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
 
     if (!rec->d_name.isPartOf(auth)) {
-      LOG(prefix << "Removing record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the " << (int)rec->d_place << " section received from " << auth << endl);
+      LOG(prefix << qname << ": Removing record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the " << (int)rec->d_place << " section received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
@@ -4115,20 +4105,20 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
       /* for now we allow a CNAME for the exact qname in ANSWER with AA=0, because Amazon DNS servers
          are sending such responses */
       if (!(rec->d_type == QType::CNAME && qname == rec->d_name)) {
-        LOG(prefix << "Removing record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the answer section without the AA bit set received from " << auth << endl);
+        LOG(prefix << qname << ": Removing record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the answer section without the AA bit set received from " << auth << endl);
         rec = lwr.d_records.erase(rec);
         continue;
       }
     }
 
     if (rec->d_type == QType::DNAME && (rec->d_place != DNSResourceRecord::ANSWER || !qname.isPartOf(rec->d_name))) {
-      LOG(prefix << "Removing invalid DNAME record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the " << (int)rec->d_place << " section received from " << auth << endl);
+      LOG(prefix << qname << ": Removing invalid DNAME record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the " << (int)rec->d_place << " section received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
 
     if (rec->d_place == DNSResourceRecord::ANSWER && (qtype != QType::ANY && rec->d_type != qtype.getCode() && s_redirectionQTypes.count(rec->d_type) == 0 && rec->d_type != QType::SOA && rec->d_type != QType::RRSIG)) {
-      LOG(prefix << "Removing irrelevant record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the ANSWER section received from " << auth << endl);
+      LOG(prefix << qname << ": Removing irrelevant record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the ANSWER section received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
@@ -4143,20 +4133,20 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
 
     /* dealing with the records in authority */
     if (rec->d_place == DNSResourceRecord::AUTHORITY && rec->d_type != QType::NS && rec->d_type != QType::DS && rec->d_type != QType::SOA && rec->d_type != QType::RRSIG && rec->d_type != QType::NSEC && rec->d_type != QType::NSEC3) {
-      LOG(prefix << "Removing irrelevant record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the AUTHORITY section received from " << auth << endl);
+      LOG(prefix << qname << ": Removing irrelevant record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the AUTHORITY section received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
 
     if (rec->d_place == DNSResourceRecord::AUTHORITY && rec->d_type == QType::SOA) {
       if (!qname.isPartOf(rec->d_name)) {
-        LOG(prefix << "Removing irrelevant SOA record '" << rec->d_name << "|" << rec->d_content->getZoneRepresentation() << "' in the AUTHORITY section received from " << auth << endl);
+        LOG(prefix << qname << ": Removing irrelevant SOA record '" << rec->d_name << "|" << rec->d_content->getZoneRepresentation() << "' in the AUTHORITY section received from " << auth << endl);
         rec = lwr.d_records.erase(rec);
         continue;
       }
 
       if (!(lwr.d_aabit || wasForwardRecurse)) {
-        LOG(prefix << "Removing irrelevant record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the AUTHORITY section received from " << auth << endl);
+        LOG(prefix << qname << ": Removing irrelevant record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the AUTHORITY section received from " << auth << endl);
         rec = lwr.d_records.erase(rec);
         continue;
       }
@@ -4177,7 +4167,7 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
        * because they are somewhat easy to insert into a large, fragmented UDP response
        * for an off-path attacker by injecting spoofed UDP fragments. So do not add these to allowedAdditionals.
        */
-      LOG(prefix << "Removing NS record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the " << (int)rec->d_place << " section of a " << (isNXDomain ? "NXD" : "NXQTYPE") << " response received from " << auth << endl);
+      LOG(prefix << qname << ": Removing NS record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the " << (int)rec->d_place << " section of a " << (isNXDomain ? "NXD" : "NXQTYPE") << " response received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
@@ -4187,7 +4177,7 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
        * We don't want to pick up root NS records in AUTHORITY and their associated ADDITIONAL sections of random queries.
        * So don't add them to allowedAdditionals.
        */
-      LOG(prefix << "Removing NS record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the " << (int)rec->d_place << " section of a response received from " << auth << endl);
+      LOG(prefix << qname << ": Removing NS record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the " << (int)rec->d_place << " section of a response received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
@@ -4198,13 +4188,13 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
 
     /* dealing with the records in additional */
     if (rec->d_place == DNSResourceRecord::ADDITIONAL && rec->d_type != QType::A && rec->d_type != QType::AAAA && rec->d_type != QType::RRSIG) {
-      LOG(prefix << "Removing irrelevant record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the ADDITIONAL section received from " << auth << endl);
+      LOG(prefix << qname << ": Removing irrelevant record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the ADDITIONAL section received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
 
     if (rec->d_place == DNSResourceRecord::ADDITIONAL && allowedAdditionals.count(rec->d_name) == 0) {
-      LOG(prefix << "Removing irrelevant additional record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the ADDITIONAL section received from " << auth << endl);
+      LOG(prefix << qname << ": Removing irrelevant additional record '" << rec->d_name << "|" << DNSRecordContent::NumberToType(rec->d_type) << "|" << rec->d_content->getZoneRepresentation() << "' in the ADDITIONAL section received from " << auth << endl);
       rec = lwr.d_records.erase(rec);
       continue;
     }
@@ -4241,7 +4231,7 @@ void SyncRes::rememberParentSetIfNeeded(const DNSName& domain, const vector<DNSR
   for (const auto& ns : existing) {
     auto content = getRR<NSRecordContent>(ns);
     if (authSet.count(content->getNS()) == 0) {
-      LOG(prefix << domain << ": at least one parent-side NS was not in the child-side NS set, remembering parent NS set and cached IPs" << endl);
+      LOG(prefix << domain << ": At least one parent-side NS was not in the child-side NS set, remembering parent NS set and cached IPs" << endl);
       shouldSave = true;
       break;
     }
@@ -4353,7 +4343,7 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, const string&
       continue;
     }
 
-    LOG(prefix << qname << ": accept answer '" << rec.d_name << "|" << DNSRecordContent::NumberToType(rec.d_type) << "|" << rec.d_content->getZoneRepresentation() << "' from '" << auth << "' nameservers? ttl=" << rec.d_ttl << ", place=" << (int)rec.d_place << " ");
+    LOG(prefix << qname << ": Accept answer '" << rec.d_name << "|" << DNSRecordContent::NumberToType(rec.d_type) << "|" << rec.d_content->getZoneRepresentation() << "' from '" << auth << "' nameservers? ttl=" << rec.d_ttl << ", place=" << (int)rec.d_place << " ");
 
     // We called sanitizeRecords before, so all ANY, non-IN and non-aa/non-forwardrecurse answer records are already removed
 
@@ -4421,9 +4411,6 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, const string&
         record.d_ttl = lowestTTD; // boom
       }
     }
-
-    //		cout<<"Have "<<i->second.records.size()<<" records and "<<i->second.signatures.size()<<" signatures for "<<i->first.name;
-    //		cout<<'|'<<DNSRecordContent::NumberToType(i->first.type)<<endl;
   }
 
   for (tcache_t::iterator i = tcache.begin(); i != tcache.end(); ++i) {
@@ -4481,7 +4468,7 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, const string&
          even after the delegation is gone from the parent.
          So let's just do nothing with them, we can fetch them directly if we need them.
       */
-      LOG(prefix << ": skipping authority NS from '" << auth << "' nameservers in CNAME/DNAME answer " << i->first.name << "|" << DNSRecordContent::NumberToType(i->first.type) << endl);
+      LOG(prefix << qname << ": Skipping authority NS from '" << auth << "' nameservers in CNAME/DNAME answer " << i->first.name << "|" << DNSRecordContent::NumberToType(i->first.type) << endl);
       continue;
     }
 
@@ -4505,26 +4492,26 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, const string&
 
     if (expectSignature && shouldValidate()) {
       vState initialState = getValidationStatus(i->first.name, !i->second.signatures.empty(), i->first.type == QType::DS, depth, prefix);
-      LOG(prefix << ": got initial zone status " << initialState << " for record " << i->first.name << "|" << DNSRecordContent::NumberToType(i->first.type) << endl);
+      LOG(prefix << qname << ": Got initial zone status " << initialState << " for record " << i->first.name << "|" << DNSRecordContent::NumberToType(i->first.type) << endl);
 
       if (initialState == vState::Secure) {
         if (i->first.type == QType::DNSKEY && i->first.place == DNSResourceRecord::ANSWER && i->first.name == getSigner(i->second.signatures)) {
-          LOG(prefix << "Validating DNSKEY for " << i->first.name << endl);
+          LOG(prefix << qname << ": Validating DNSKEY for " << i->first.name << endl);
           recordState = validateDNSKeys(i->first.name, i->second.records, i->second.signatures, depth, prefix);
         }
         else {
-          LOG(prefix << "Validating non-additional " << QType(i->first.type).toString() << " record for " << i->first.name << endl);
+          LOG(prefix << qname << ": Validating non-additional " << QType(i->first.type).toString() << " record for " << i->first.name << endl);
           recordState = validateRecordsWithSigs(depth, prefix, qname, qtype, i->first.name, QType(i->first.type), i->second.records, i->second.signatures);
         }
       }
       else {
         recordState = initialState;
-        LOG(prefix << "Skipping validation because the current state is " << recordState << endl);
+        LOG(prefix << qname << ": Skipping validation because the current state is " << recordState << endl);
       }
 
-      LOG(prefix << "Validation result is " << recordState << ", current state is " << state << endl);
+      LOG(prefix << qname << ": Validation result is " << recordState << ", current state is " << state << endl);
       if (state != recordState) {
-        updateValidationState(state, recordState, prefix);
+        updateValidationState(qname, state, recordState, prefix);
       }
     }
 
@@ -4625,14 +4612,14 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, const string&
   return RCode::NoError;
 }
 
-void SyncRes::updateDenialValidationState(vState& neValidationState, const DNSName& neName, vState& state, const dState denialState, const dState expectedState, bool isDS, unsigned int depth, const string& prefix)
+void SyncRes::updateDenialValidationState(const DNSName& qname, vState& neValidationState, const DNSName& neName, vState& state, const dState denialState, const dState expectedState, bool isDS, unsigned int depth, const string& prefix)
 {
   if (denialState == expectedState) {
     neValidationState = vState::Secure;
   }
   else {
     if (denialState == dState::OPTOUT) {
-      LOG(prefix << "OPT-out denial found for " << neName << endl);
+      LOG(prefix << qname << ": OPT-out denial found for " << neName << endl);
       /* rfc5155 states:
          "The AD bit, as defined by [RFC4035], MUST NOT be set when returning a
          response containing a closest (provable) encloser proof in which the
@@ -4650,23 +4637,23 @@ void SyncRes::updateDenialValidationState(vState& neValidationState, const DNSNa
       neValidationState = vState::Insecure;
     }
     else if (denialState == dState::INSECURE) {
-      LOG(prefix << "Insecure denial found for " << neName << ", returning Insecure" << endl);
+      LOG(prefix << qname << ": Insecure denial found for " << neName << ", returning Insecure" << endl);
       neValidationState = vState::Insecure;
     }
     else {
-      LOG(prefix << "Invalid denial found for " << neName << ", res=" << denialState << ", expectedState=" << expectedState << ", checking whether we have missed a zone cut before returning a Bogus state" << endl);
+      LOG(prefix << qname << ": Invalid denial found for " << neName << ", res=" << denialState << ", expectedState=" << expectedState << ", checking whether we have missed a zone cut before returning a Bogus state" << endl);
       /* try again to get the missed cuts, harder this time */
       auto zState = getValidationStatus(neName, false, isDS, depth, prefix);
       if (zState != vState::Secure) {
         neValidationState = zState;
       }
       else {
-        LOG(prefix << "Still in a secure zone with an invalid denial for " << neName << ", returning " << vStateToString(vState::BogusInvalidDenial) << endl);
+        LOG(prefix << qname << ": Still in a secure zone with an invalid denial for " << neName << ", returning " << vStateToString(vState::BogusInvalidDenial) << endl);
         neValidationState = vState::BogusInvalidDenial;
       }
     }
   }
-  updateValidationState(state, neValidationState, prefix);
+  updateValidationState(qname, state, neValidationState, prefix);
 }
 
 dState SyncRes::getDenialValidationState(const NegCache::NegCacheEntry& ne, const dState expectedState, bool referralToUnsigned, const string& prefix)
@@ -4703,7 +4690,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
     }
 
     if (negCacheIndication) {
-      LOG(prefix << qname << ": got negative caching indication for name '" << qname << "' (accept=" << rec.d_name.isPartOf(auth) << "), newtarget='" << newtarget << "'" << endl);
+      LOG(prefix << qname << ": Got negative caching indication for name '" << qname << "' (accept=" << rec.d_name.isPartOf(auth) << "), newtarget='" << newtarget << "'" << endl);
 
       rec.d_ttl = min(rec.d_ttl, s_maxnegttl);
       // only add a SOA if we're not going anywhere after this
@@ -4730,11 +4717,11 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
         auto recordState = getValidationStatus(rec.d_name, !ne.authoritySOA.signatures.empty() || !ne.DNSSECRecords.signatures.empty(), false, depth, prefix);
         if (recordState == vState::Secure) {
           dState denialState = getDenialValidationState(ne, dState::NXDOMAIN, false, prefix);
-          updateDenialValidationState(ne.d_validationState, ne.d_name, state, denialState, dState::NXDOMAIN, false, depth, prefix);
+          updateDenialValidationState(qname, ne.d_validationState, ne.d_name, state, denialState, dState::NXDOMAIN, false, depth, prefix);
         }
         else {
           ne.d_validationState = recordState;
-          updateValidationState(state, ne.d_validationState, prefix);
+          updateValidationState(qname, state, ne.d_validationState, prefix);
         }
       }
 
@@ -4811,7 +4798,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
     }
     // for ANY answers we *must* have an authoritative answer, unless we are forwarding recursively
     else if (rec.d_place == DNSResourceRecord::ANSWER && rec.d_name == qname && (rec.d_type == qtype.getCode() || ((lwr.d_aabit || sendRDQuery) && qtype == QType::ANY))) {
-      LOG(prefix << qname << ": answer is in: resolved to '" << rec.d_content->getZoneRepresentation() << "|" << DNSRecordContent::NumberToType(rec.d_type) << "'" << endl);
+      LOG(prefix << qname << ": Answer is in: resolved to '" << rec.d_content->getZoneRepresentation() << "|" << DNSRecordContent::NumberToType(rec.d_type) << "'" << endl);
 
       done = true;
       rcode = RCode::NoError;
@@ -4843,14 +4830,14 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
                 /* Some part could not be validated, for example a NSEC3 record with a too large number of iterations,
                    this is not enough to warrant a Bogus, but go Insecure. */
                 st = vState::Insecure;
-                LOG(prefix << "Unable to validate denial in wildcard expanded positive response found for " << qname << ", returning Insecure, res=" << res << endl);
+                LOG(prefix << qname << ": Unable to validate denial in wildcard expanded positive response found for " << qname << ", returning Insecure, res=" << res << endl);
               }
               else {
-                LOG(prefix << "Invalid denial in wildcard expanded positive response found for " << qname << ", returning Bogus, res=" << res << endl);
+                LOG(prefix << qname << ": Invalid denial in wildcard expanded positive response found for " << qname << ", returning Bogus, res=" << res << endl);
                 rec.d_ttl = std::min(rec.d_ttl, s_maxbogusttl);
               }
 
-              updateValidationState(state, st, prefix);
+              updateValidationState(qname, state, st, prefix);
               /* we already stored the record with a different validation status, let's fix it */
               updateValidationStatusInCache(qname, qtype, lwr.d_aabit, st);
             }
@@ -4874,7 +4861,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
     else if (rec.d_place == DNSResourceRecord::AUTHORITY && rec.d_type == QType::NS && qname.isPartOf(rec.d_name)) {
       if (moreSpecificThan(rec.d_name, auth)) {
         newauth = rec.d_name;
-        LOG(prefix << qname << ": got NS record '" << rec.d_name << "' -> '" << rec.d_content->getZoneRepresentation() << "'" << endl);
+        LOG(prefix << qname << ": Got NS record '" << rec.d_name << "' -> '" << rec.d_content->getZoneRepresentation() << "'" << endl);
 
         /* check if we have a referral from the parent zone to a child zone for a DS query, which is not right */
         if (qtype == QType::DS && (newauth.isPartOf(qname) || qname == newauth)) {
@@ -4889,14 +4876,14 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
         }
       }
       else {
-        LOG(prefix << qname << ": got upwards/level NS record '" << rec.d_name << "' -> '" << rec.d_content->getZoneRepresentation() << "', had '" << auth << "'" << endl);
+        LOG(prefix << qname << ": Got upwards/level NS record '" << rec.d_name << "' -> '" << rec.d_content->getZoneRepresentation() << "', had '" << auth << "'" << endl);
         if (auto content = getRR<NSRecordContent>(rec)) {
           nsset.insert(content->getNS());
         }
       }
     }
     else if (rec.d_place == DNSResourceRecord::AUTHORITY && rec.d_type == QType::DS && qname.isPartOf(rec.d_name)) {
-      LOG(prefix << qname << ": got DS record '" << rec.d_name << "' -> '" << rec.d_content->getZoneRepresentation() << "'" << endl);
+      LOG(prefix << qname << ": Got DS record '" << rec.d_name << "' -> '" << rec.d_content->getZoneRepresentation() << "'" << endl);
     }
     else if (realreferral && rec.d_place == DNSResourceRecord::AUTHORITY && (rec.d_type == QType::NSEC || rec.d_type == QType::NSEC3) && newauth.isPartOf(auth)) {
       /* we might have received a denial of the DS, let's check */
@@ -4922,7 +4909,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
             if (denialState == dState::OPTOUT) {
               ne.d_validationState = vState::Insecure;
             }
-            LOG(prefix << qname << ": got negative indication of DS record for '" << newauth << "'" << endl);
+            LOG(prefix << qname << ": Got negative indication of DS record for '" << newauth << "'" << endl);
 
             g_negCache->add(ne);
 
@@ -4940,7 +4927,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
       }
     }
     else if (!done && rec.d_place == DNSResourceRecord::AUTHORITY && rec.d_type == QType::SOA && lwr.d_rcode == RCode::NoError && qname.isPartOf(rec.d_name)) {
-      LOG(prefix << qname << ": got negative caching indication for '" << qname << "|" << qtype << "'" << endl);
+      LOG(prefix << qname << ": Got negative caching indication for '" << qname << "|" << qtype << "'" << endl);
 
       if (!newtarget.empty()) {
         LOG(prefix << qname << ": Hang on! Got a redirect to '" << newtarget << "' already" << endl);
@@ -4962,11 +4949,11 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
           auto recordState = getValidationStatus(qname, !ne.authoritySOA.signatures.empty() || !ne.DNSSECRecords.signatures.empty(), qtype == QType::DS, depth, prefix);
           if (recordState == vState::Secure) {
             dState denialState = getDenialValidationState(ne, dState::NXQTYPE, false, prefix);
-            updateDenialValidationState(ne.d_validationState, ne.d_name, state, denialState, dState::NXQTYPE, qtype == QType::DS, depth, prefix);
+            updateDenialValidationState(qname, ne.d_validationState, ne.d_name, state, denialState, dState::NXQTYPE, qtype == QType::DS, depth, prefix);
           }
           else {
             ne.d_validationState = recordState;
-            updateValidationState(state, ne.d_validationState, prefix);
+            updateValidationState(qname, state, ne.d_validationState, prefix);
           }
         }
 
@@ -5000,13 +4987,13 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
   /* If we have seen a proper denial, let's forget that we also had a referral for a DS query.
      Otherwise we need to deal with it. */
   if (referralOnDS && !negindic) {
-    LOG(prefix << qname << ": got a referral to the child zone for a DS query without a negative indication (missing SOA in authority), treating that as a NODATA" << endl);
+    LOG(prefix << qname << ": Got a referral to the child zone for a DS query without a negative indication (missing SOA in authority), treating that as a NODATA" << endl);
     if (!vStateIsBogus(state)) {
       auto recordState = getValidationStatus(qname, false, true, depth, prefix);
       if (recordState == vState::Secure) {
         /* we are in a secure zone, got a referral to the child zone on a DS query, no denial, that's wrong */
         LOG(prefix << qname << ": NODATA without a negative indication (missing SOA in authority) in a DNSSEC secure zone, going Bogus" << endl);
-        updateValidationState(state, vState::BogusMissingNegativeIndication, prefix);
+        updateValidationState(qname, state, vState::BogusMissingNegativeIndication, prefix);
       }
     }
     negindic = true;
@@ -5137,12 +5124,12 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
 
   if (doTCP) {
     if (doDoT) {
-      LOG(prefix << qname << ": using DoT with " << remoteIP.toStringWithPort() << endl);
+      LOG(prefix << qname << ": Using DoT with " << remoteIP.toStringWithPort() << endl);
       t_Counters.at(rec::Counter::dotoutqueries)++;
       d_dotoutqueries++;
     }
     else {
-      LOG(prefix << qname << ": using TCP with " << remoteIP.toStringWithPort() << endl);
+      LOG(prefix << qname << ": Using TCP with " << remoteIP.toStringWithPort() << endl);
       t_Counters.at(rec::Counter::tcpoutqueries)++;
       d_tcpoutqueries++;
     }
@@ -5150,7 +5137,7 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
 
   int preOutQueryRet = RCode::NoError;
   if (d_pdl && d_pdl->preoutquery(remoteIP, d_requestor, qname, qtype, doTCP, lwr.d_records, preOutQueryRet, d_eventTrace, timeval{0, 0})) {
-    LOG(prefix << qname << ": query handled by Lua" << endl);
+    LOG(prefix << qname << ": Query handled by Lua" << endl);
   }
   else {
     ednsmask = getEDNSSubnetMask(qname, remoteIP);
@@ -5194,7 +5181,7 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
     if (resolveret == LWResult::Result::Timeout) {
       /* Time out */
 
-      LOG(prefix << qname << ": timeout resolving after " << lwr.d_usec / 1000.0 << "msec " << (doTCP ? "over TCP" : "") << endl);
+      LOG(prefix << qname << ": Timeout resolving after " << lwr.d_usec / 1000.0 << "msec " << (doTCP ? "over TCP" : "") << endl);
       d_timeouts++;
       t_Counters.at(rec::Counter::outgoingtimeouts)++;
 
@@ -5208,7 +5195,7 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
     }
     else if (resolveret == LWResult::Result::OSLimitError) {
       /* OS resource limit reached */
-      LOG(prefix << qname << ": hit a local resource limit resolving" << (doTCP ? " over TCP" : "") << ", probable error: " << stringerror() << endl);
+      LOG(prefix << qname << ": Hit a local resource limit resolving" << (doTCP ? " over TCP" : "") << ", probable error: " << stringerror() << endl);
       t_Counters.at(rec::Counter::resourceLimits)++;
     }
     else if (resolveret == LWResult::Result::Spoofed) {
@@ -5219,7 +5206,7 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
       t_Counters.at(rec::Counter::unreachables)++;
       d_unreachables++;
       // XXX questionable use of errno
-      LOG(prefix << qname << ": error resolving from " << remoteIP.toString() << (doTCP ? " over TCP" : "") << ", possible error: " << stringerror() << endl);
+      LOG(prefix << qname << ": Error resolving from " << remoteIP.toString() << (doTCP ? " over TCP" : "") << ", possible error: " << stringerror() << endl);
     }
 
     if (resolveret != LWResult::Result::OSLimitError && !chained && !dontThrottle) {
@@ -5291,14 +5278,14 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
     truncated = true;
 
     if (doTCP) {
-      LOG(prefix << qname << ": truncated bit set, over TCP?" << endl);
+      LOG(prefix << qname << ": Truncated bit set, over TCP?" << endl);
       if (!dontThrottle) {
         /* let's treat that as a ServFail answer from this server */
         doThrottle(d_now.tv_sec, remoteIP, qname, qtype, 60, 3);
       }
       return false;
     }
-    LOG(prefix << qname << ": truncated bit set, over UDP" << endl);
+    LOG(prefix << qname << ": Truncated bit set, over UDP" << endl);
 
     return true;
   }
@@ -5309,19 +5296,19 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
 void SyncRes::handleNewTarget(const std::string& prefix, const DNSName& qname, const DNSName& newtarget, const QType qtype, std::vector<DNSRecord>& ret, int& rcode, int depth, const std::vector<DNSRecord>& recordsFromAnswer, vState& state)
 {
   if (newtarget == qname) {
-    LOG(prefix << qname << ": status=got a CNAME referral to self, returning SERVFAIL" << endl);
+    LOG(prefix << qname << ": Status=got a CNAME referral to self, returning SERVFAIL" << endl);
     ret.clear();
     rcode = RCode::ServFail;
     return;
   }
   if (newtarget.isPartOf(qname)) {
     // a.b.c. CNAME x.a.b.c will go to great depths with QM on
-    LOG(prefix << qname << ": status=got a CNAME referral to child, disabling QM" << endl);
+    LOG(prefix << qname << ": Status=got a CNAME referral to child, disabling QM" << endl);
     setQNameMinimization(false);
   }
 
   if (depth > 10) {
-    LOG(prefix << qname << ": status=got a CNAME referral, but recursing too deep, returning SERVFAIL" << endl);
+    LOG(prefix << qname << ": Status=got a CNAME referral, but recursing too deep, returning SERVFAIL" << endl);
     rcode = RCode::ServFail;
     return;
   }
@@ -5333,14 +5320,14 @@ void SyncRes::handleNewTarget(const std::string& prefix, const DNSName& qname, c
 
   // Check to see if we already have seen the new target as a previous target
   if (scanForCNAMELoop(newtarget, ret)) {
-    LOG(prefix << qname << ": status=got a CNAME referral that causes a loop, returning SERVFAIL" << endl);
+    LOG(prefix << qname << ": Status=got a CNAME referral that causes a loop, returning SERVFAIL" << endl);
     ret.clear();
     rcode = RCode::ServFail;
     return;
   }
 
   if (qtype == QType::DS || qtype == QType::DNSKEY) {
-    LOG(prefix << qname << ": status=got a CNAME referral, but we are looking for a DS or DNSKEY" << endl);
+    LOG(prefix << qname << ": Status=got a CNAME referral, but we are looking for a DS or DNSKEY" << endl);
 
     if (d_doDNSSEC) {
       addNXNSECS(ret, recordsFromAnswer);
@@ -5350,13 +5337,13 @@ void SyncRes::handleNewTarget(const std::string& prefix, const DNSName& qname, c
     return;
   }
 
-  LOG(prefix << qname << ": status=got a CNAME referral, starting over with " << newtarget << endl);
+  LOG(prefix << qname << ": Status=got a CNAME referral, starting over with " << newtarget << endl);
 
   set<GetBestNSAnswer> beenthere;
   Context cnameContext;
   rcode = doResolve(newtarget, qtype, ret, depth + 1, beenthere, cnameContext);
-  LOG(prefix << qname << ": updating validation state for response to " << qname << " from " << state << " with the state from the CNAME quest: " << cnameContext.state << endl);
-  updateValidationState(state, cnameContext.state, prefix);
+  LOG(prefix << qname << ": Updating validation state for response to " << qname << " from " << state << " with the state from the CNAME quest: " << cnameContext.state << endl);
+  updateValidationState(qname, state, cnameContext.state, prefix);
 }
 
 bool SyncRes::processAnswer(unsigned int depth, const string& prefix, LWResult& lwr, const DNSName& qname, const QType qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet& nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state, const ComboAddress& remoteIP)
@@ -5385,7 +5372,7 @@ bool SyncRes::processAnswer(unsigned int depth, const string& prefix, LWResult& 
     return true;
   }
 
-  LOG(prefix << qname << ": determining status after receiving this packet" << endl);
+  LOG(prefix << qname << ": Determining status after receiving this packet" << endl);
 
   set<DNSName> nsset;
   bool realreferral = false;
@@ -5397,8 +5384,8 @@ bool SyncRes::processAnswer(unsigned int depth, const string& prefix, LWResult& 
   bool done = processRecords(prefix, qname, qtype, auth, lwr, sendRDQuery, ret, nsset, newtarget, newauth, realreferral, negindic, state, needWildcardProof, gatherWildcardProof, wildcardLabelsCount, *rcode, negIndicHasSignatures, depth);
 
   if (done) {
-    LOG(prefix << qname << ": status=got results, this level of recursion done" << endl);
-    LOG(prefix << qname << ": validation status is " << state << endl);
+    LOG(prefix << qname << ": Status=got results, this level of recursion done" << endl);
+    LOG(prefix << qname << ": Validation status is " << state << endl);
     return true;
   }
 
@@ -5408,17 +5395,17 @@ bool SyncRes::processAnswer(unsigned int depth, const string& prefix, LWResult& 
   }
 
   if (lwr.d_rcode == RCode::NXDomain) {
-    LOG(prefix << qname << ": status=NXDOMAIN, we are done " << (negindic ? "(have negative SOA)" : "") << endl);
+    LOG(prefix << qname << ": Status=NXDOMAIN, we are done " << (negindic ? "(have negative SOA)" : "") << endl);
 
     auto tempState = getValidationStatus(qname, negIndicHasSignatures, qtype == QType::DS, depth, prefix);
     if (tempState == vState::Secure && (lwr.d_aabit || sendRDQuery) && !negindic) {
       LOG(prefix << qname << ": NXDOMAIN without a negative indication (missing SOA in authority) in a DNSSEC secure zone, going Bogus" << endl);
-      updateValidationState(state, vState::BogusMissingNegativeIndication, prefix);
+      updateValidationState(qname, state, vState::BogusMissingNegativeIndication, prefix);
     }
     else if (state == vState::Indeterminate) {
       /* we might not have validated any record, because we did get a NXDOMAIN without any SOA
          from an insecure zone, for example */
-      updateValidationState(state, tempState, prefix);
+      updateValidationState(qname, state, tempState, prefix);
     }
 
     if (d_doDNSSEC) {
@@ -5430,17 +5417,17 @@ bool SyncRes::processAnswer(unsigned int depth, const string& prefix, LWResult& 
   }
 
   if (nsset.empty() && !lwr.d_rcode && (negindic || lwr.d_aabit || sendRDQuery)) {
-    LOG(prefix << qname << ": status=noerror, other types may exist, but we are done " << (negindic ? "(have negative SOA) " : "") << (lwr.d_aabit ? "(have aa bit) " : "") << endl);
+    LOG(prefix << qname << ": Status=noerror, other types may exist, but we are done " << (negindic ? "(have negative SOA) " : "") << (lwr.d_aabit ? "(have aa bit) " : "") << endl);
 
     auto tempState = getValidationStatus(qname, negIndicHasSignatures, qtype == QType::DS, depth, prefix);
     if (tempState == vState::Secure && (lwr.d_aabit || sendRDQuery) && !negindic) {
       LOG(prefix << qname << ": NODATA without a negative indication (missing SOA in authority) in a DNSSEC secure zone, going Bogus" << endl);
-      updateValidationState(state, vState::BogusMissingNegativeIndication, prefix);
+      updateValidationState(qname, state, vState::BogusMissingNegativeIndication, prefix);
     }
     else if (state == vState::Indeterminate) {
       /* we might not have validated any record, because we did get a NODATA without any SOA
          from an insecure zone, for example */
-      updateValidationState(state, tempState, prefix);
+      updateValidationState(qname, state, tempState, prefix);
     }
 
     if (d_doDNSSEC) {
@@ -5452,7 +5439,7 @@ bool SyncRes::processAnswer(unsigned int depth, const string& prefix, LWResult& 
   }
 
   if (realreferral) {
-    LOG(prefix << qname << ": status=did not resolve, got " << (unsigned int)nsset.size() << " NS, ");
+    LOG(prefix << qname << ": Status=did not resolve, got " << (unsigned int)nsset.size() << " NS, ");
 
     nameservers.clear();
     for (auto const& nameserver : nsset) {
@@ -5517,7 +5504,7 @@ int SyncRes::doResolveAt(NsSet& nameservers, DNSName auth, bool flawedNSSet, con
 
   unsigned int addressQueriesForNS = 0;
   for (;;) { // we may get more specific nameservers
-    auto rnameservers = shuffleInSpeedOrder(nameservers, doLog() ? (prefix + qname.toString() + ": ") : string());
+    auto rnameservers = shuffleInSpeedOrder(qname, nameservers, prefix);
 
     // We allow s_maxnsaddressqperq (default 10) queries with empty responses when resolving NS names.
     // If a zone publishes many (more than s_maxnsaddressqperq) NS records, we allow less.

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -1035,7 +1035,7 @@ bool SyncRes::isForwardOrAuth(const DNSName& qname) const
   return iter != t_sstorage.domainmap->end();
 }
 
-const char* timestamp(const struct timeval& tv, char* buf, size_t sz)
+const char* isoDateTimeMillis(const struct timeval& tv, char* buf, size_t sz)
 {
   const std::string s_timestampFormat = "%Y-%m-%dT%T";
   struct tm tm;
@@ -1200,7 +1200,7 @@ uint64_t SyncRes::doDumpNSSpeeds(int fd)
 
     // an <empty> can appear hear in case of authoritative (hosted) zones
     char tmp[26];
-    fprintf(fp.get(), "%s\t%s\t", i.d_name.toLogString().c_str(), timestamp(i.d_lastget, tmp, sizeof(tmp)));
+    fprintf(fp.get(), "%s\t%s\t", i.d_name.toLogString().c_str(), isoDateTimeMillis(i.d_lastget, tmp, sizeof(tmp)));
     bool first = true;
     for (const auto& j : i.d_collection) {
       fprintf(fp.get(), "%s%s/%.3f/%.3f", first ? "" : "\t", j.first.toStringWithPortExcept(53).c_str(), j.second.peek() / 1000.0f, j.second.last() / 1000.0f);

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -568,6 +568,7 @@ public:
   unsigned int d_timeouts;
   unsigned int d_unreachables;
   unsigned int d_totUsec;
+  const struct timeval d_fixednow;
 
 private:
   ComboAddress d_requestor;

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -624,8 +624,8 @@ private:
   void getBestNSFromCache(const DNSName& qname, QType qtype, vector<DNSRecord>& bestns, bool* flawedNSSet, unsigned int depth, const string& prefix, set<GetBestNSAnswer>& beenthere, const boost::optional<DNSName>& cutOffDomain = boost::none);
   DNSName getBestNSNamesFromCache(const DNSName& qname, QType qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, const string& prefix, set<GetBestNSAnswer>& beenthere);
 
-  inline vector<std::pair<DNSName, float>> shuffleInSpeedOrder(NsSet& nameservers, const string& prefix);
-  inline vector<ComboAddress> shuffleForwardSpeed(const vector<ComboAddress>& rnameservers, const string& prefix, const bool wasRd);
+  vector<std::pair<DNSName, float>> shuffleInSpeedOrder(const DNSName& qname, NsSet& nameservers, const string& prefix);
+  vector<ComboAddress> shuffleForwardSpeed(const DNSName& qname, const vector<ComboAddress>& rnameservers, const string& prefix, const bool wasRd);
   bool moreSpecificThan(const DNSName& a, const DNSName& b) const;
   vector<ComboAddress> getAddrs(const DNSName& qname, unsigned int depth, const string& prefix, set<GetBestNSAnswer>& beenthere, bool cacheOnly, unsigned int& addressQueriesForNS);
 
@@ -652,12 +652,12 @@ private:
 
   bool validationEnabled() const;
   uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures, uint32_t signaturesTTL, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs) const;
-  void updateValidationState(vState& state, const vState stateUpdate, const string& prefix);
+  void updateValidationState(const DNSName& qname, vState& state, const vState stateUpdate, const string& prefix);
   vState validateRecordsWithSigs(unsigned int depth, const string& prefix, const DNSName& qname, const QType qtype, const DNSName& name, const QType type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures);
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures, unsigned int depth, const string& prefix);
   vState getDNSKeys(const DNSName& signer, skeyset_t& keys, bool& servFailOccurred, unsigned int depth, const string& prefix);
   dState getDenialValidationState(const NegCache::NegCacheEntry& ne, const dState expectedState, bool referralToUnsigned, const string& prefix);
-  void updateDenialValidationState(vState& neValidationState, const DNSName& neName, vState& state, const dState denialState, const dState expectedState, bool isDS, unsigned int depth, const string& prefix);
+  void updateDenialValidationState(const DNSName& qname, vState& neValidationState, const DNSName& neName, vState& state, const dState denialState, const dState expectedState, bool isDS, unsigned int depth, const string& prefix);
   void computeNegCacheValidationStatus(const NegCache::NegCacheEntry& ne, const DNSName& qname, QType qtype, const int res, vState& state, unsigned int depth, const string& prefix);
   vState getTA(const DNSName& zone, dsmap_t& ds, const string& prefix);
   vState getValidationStatus(const DNSName& subdomain, bool wouldBeValid, bool typeIsDS, unsigned int depth, const string& prefix);

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -922,6 +922,7 @@ uint64_t* pleaseGetPacketCacheHits();
 uint64_t* pleaseGetPacketCacheSize();
 void doCarbonDump(void*);
 bool primeHints(time_t now = time(nullptr));
+const char* timestamp(const struct timeval& tv, char* buf, size_t sz);
 
 struct WipeCacheResult
 {

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -890,7 +890,6 @@ extern thread_local std::unique_ptr<addrringbuf_t> t_servfailremotes, t_largeans
 extern thread_local std::unique_ptr<boost::circular_buffer<pair<DNSName, uint16_t>>> t_queryring, t_servfailqueryring, t_bogusqueryring;
 extern thread_local std::shared_ptr<NetmaskGroup> t_allowFrom;
 extern thread_local std::shared_ptr<NetmaskGroup> t_allowNotifyFrom;
-string doTraceRegex(vector<string>::const_iterator begin, vector<string>::const_iterator end);
 extern unsigned int g_networkTimeoutMsec;
 extern uint16_t g_outgoingEDNSBufsize;
 extern std::atomic<uint32_t> g_maxCacheEntries, g_maxPacketCacheEntries;

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -568,6 +568,7 @@ public:
   unsigned int d_timeouts;
   unsigned int d_unreachables;
   unsigned int d_totUsec;
+  // Initialized ony once, as opposed to d_now which gets updated after outgoing requests
   const struct timeval d_fixednow;
 
 private:
@@ -692,6 +693,7 @@ private:
   std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> d_frameStreamServers;
   boost::optional<const boost::uuids::uuid&> d_initialRequestId;
   asyncresolve_t d_asyncResolve{nullptr};
+  // d_now is initialized in the constructor and updates after outgoing requests in lwres.cc:asyncresolve
   struct timeval d_now;
   /* if the client is asking for a DS that does not exist, we need to provide the SOA along with the NSEC(3) proof
      and we might not have it if we picked up the proof from a delegation */
@@ -922,7 +924,7 @@ uint64_t* pleaseGetPacketCacheHits();
 uint64_t* pleaseGetPacketCacheSize();
 void doCarbonDump(void*);
 bool primeHints(time_t now = time(nullptr));
-const char* timestamp(const struct timeval& tv, char* buf, size_t sz);
+const char* isoDateTimeMillis(const struct timeval& tv, char* buf, size_t sz);
 
 struct WipeCacheResult
 {

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -427,12 +427,12 @@ dState matchesNSEC(const DNSName& name, uint16_t qtype, const DNSName& nsecOwner
   /* check if the type is denied */
   if (name == owner) {
     if (!isTypeDenied(nsec, QType(qtype))) {
-      VLOG_NO_PREFIX(log, "Does _not_ deny existence of type "<<QType(qtype)<<endl);
+      VLOG_NO_PREFIX(log, "does _not_ deny existence of type "<<QType(qtype)<<endl);
       return dState::NODENIAL;
     }
 
     if (qtype == QType::DS && signer == name) {
-      VLOG_NO_PREFIX(log, "The NSEC comes from the child zone and cannot be used to deny a DS"<<endl);
+      VLOG_NO_PREFIX(log, "the NSEC comes from the child zone and cannot be used to deny a DS"<<endl);
       return dState::NODENIAL;
     }
 
@@ -450,7 +450,7 @@ dState matchesNSEC(const DNSName& name, uint16_t qtype, const DNSName& nsecOwner
        asserted, then DNAME substitution should have been done, but the
        substitution has not been done as specified.
     */
-    VLOG(log, "The DNAME bit is set and the query name is a subdomain of that NSEC");
+    VLOG(log, "the DNAME bit is set and the query name is a subdomain of that NSEC");
     return dState::NODENIAL;
   }
 
@@ -458,7 +458,7 @@ dState matchesNSEC(const DNSName& name, uint16_t qtype, const DNSName& nsecOwner
     VLOG_NO_PREFIX(log, name << ": is covered by ("<<owner<<" to "<<nsec->d_next<<")");
 
     if (nsecProvesENT(name, owner, nsec->d_next)) {
-      VLOG_NO_PREFIX(log, " Denies existence of type "<<name<<"/"<<QType(qtype)<<" by proving that "<<name<<" is an ENT"<<endl);
+      VLOG_NO_PREFIX(log, " denies existence of type "<<name<<"/"<<QType(qtype)<<" by proving that "<<name<<" is an ENT"<<endl);
       return dState::NXQTYPE;
     }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

The (open) fd is passed to the recursor. The recursor will then dump its trace info to that fd. It will also add microsecond timestamps.

An example:
```
 us === START OF TRACE 2023-01-31T09:07:58.425 ===
94 QM www.powerdns.com: doResolve
98 www.powerdns.com: Wants DNSSEC processing, auth data required by query for A
112 QM www.powerdns.com: Step0 Not cached
115 QM www.powerdns.com: Checking if we have NS in cache for 'www.powerdns.com'
117 QM www.powerdns.com: No valid/useful NS in cache for 'www.powerdns.com'
119 QM www.powerdns.com: Checking if we have NS in cache for 'powerdns.com'
124 QM www.powerdns.com: NS (with ip, or non-glue) in cache for 'powerdns.com' -> 'pdns-public-ns1.powerdns.com', within bailiwick: 1, in cache, ttl=86387
130 QM www.powerdns.com: NS (with ip, or non-glue) in cache for 'powerdns.com' -> 'pdns-public-ns2.powerdns.com', within bailiwick: 1, in cache, ttl=86387
136 QM www.powerdns.com: We have NS in cache for 'powerdns.com' (flawedNSSet=0)
139 QM www.powerdns.com: Step1 Ancestor from cache is powerdns.com
142 QM www.powerdns.com: Step2 New child www.powerdns.com
143 QM www.powerdns.com: Step3 Going to do final resolve
145 www.powerdns.com: Wants DNSSEC processing, auth data required by query for A
150 www.powerdns.com: No cache hit for 'www.powerdns.com|A', trying to find an appropriate NS record
153 www.powerdns.com: Checking if we have NS in cache for 'www.powerdns.com'
155 www.powerdns.com: No valid/useful NS in cache for 'www.powerdns.com'
157 www.powerdns.com: Checking if we have NS in cache for 'powerdns.com'
160 www.powerdns.com: NS (with ip, or non-glue) in cache for 'powerdns.com' -> 'pdns-public-ns1.powerdns.com', within bailiwick: 1, in cache, ttl=86387
165 www.powerdns.com: NS (with ip, or non-glue) in cache for 'powerdns.com' -> 'pdns-public-ns2.powerdns.com', within bailiwick: 1, in cache, ttl=86387
173 www.powerdns.com: We have NS in cache for 'powerdns.com' (flawedNSSet=0)
177 www.powerdns.com: Cache consultations done, have 2 NS to contact
186 www.powerdns.com: Nameservers: pdns-public-ns1.powerdns.com(6.47ms), pdns-public-ns2.powerdns.com(121.61ms)
198 www.powerdns.com: Trying to resolve NS 'pdns-public-ns1.powerdns.com' (1/2)
204 pdns-public-ns1.powerdns.com: Nameserver pdns-public-ns1.powerdns.com IPs: 188.166.104.87(6.47ms)
213 www.powerdns.com: Resolved 'powerdns.com' NS pdns-public-ns1.powerdns.com to: 188.166.104.87
220 www.powerdns.com: Trying IP 188.166.104.87:53, asking 'www.powerdns.com|A'
6052 www.powerdns.com: Got 3 answers from pdns-public-ns1.powerdns.com (188.166.104.87), rcode=0 (No Error), aa=1, in 5ms
6064 www.powerdns.com: Accept answer 'www.powerdns.com|RRSIG|A 8 3 3600 20230209000000 20230119000000 36021 powerdns.com. PzP5fh9eAmG23/6ySgys/UrROeAf6VsopmKet+qGjitCvzeUtzGNC7JeGGGzaPvx2ZmMdGq/tAzWVzjsDWDnDsEzM1t73MhMkyrcIK+2B+GscDr4bKeXL3EvwAFypN8jPkrx5amthxZ4fYjalh9nkvVvG7cbzJF0c8ylwKFeZSE=' from 'powerdns.com' nameservers? ttl=3600, place=1 RRSIG - separate
6084 www.powerdns.com: Accept answer 'www.powerdns.com|A|188.166.104.92' from 'powerdns.com' nameservers? ttl=3600, place=1 YES!
6089 www.powerdns.com: OPT answer '.' from 'powerdns.com' nameservers
6093 www.powerdns.com: Got initial zone status Secure for record www.powerdns.com|A
6095 www.powerdns.com: Validating non-additional A record for www.powerdns.com
6099 powerdns.com: Retrieving DNSKEYs
6103  QM powerdns.com: doResolve
6105  powerdns.com: Wants DNSSEC processing, auth data required by query for DNSKEY
6111  powerdns.com: Found cache hit for DNSKEY: 256 3 8 AwEAAbQOlJUPNWM8DQown5y/wFgDVt7jskfEQcd4pbLV/1osuBfBNDZXv9ru7wDC/PbpvysEZgFXTPJ9QrdwSsd8KAZVO5mjeDNL0RnlhjHWuXKCqnLI+iLb3OMLQTizjdscdHPoW98wk5931pJkyf2qMDRjRB4c5d81sfoZOd6D7Rrx[ttl=3587] 257 3 8 AwEAAb/+pXOZWYQ8mv9WM5dFva8WU9jcIUdDuEjldbyfnkQ/xlrJC5zAEfhYhrea3SmIPmMTDimLqbh3/4SMTNPTUF+9+U1vpNfIRTFadqsmuU9Fddz3JqCcYwEpWbReg6DJOeyu+9oBoIQkPxFyLtIXEPGlQzrynKubn04Cx83I6NfzDTraJT3jLHKeW5PVc1ifqKzHz5TXdHHTA7NkJAa0sPcZCoNE1LpnJI/wcUpRUiuQhoLFeT1E432GuPuZ7y+agElGj0NnBxEgnHrhrnZWUbULpRa/il+Cr5Taj988HqX9Xdm6FjcP4Lbuds/44U7U8du224Q8jTrZ57Yvj4VDQKc=[ttl=3587] 256 3 8 AwEAAcWHAxSmWGfWvNrHukGubDOYJk72J10MjHARhkqEPmaYTKyFs7gTWGg72hU13PHq88MTmW2tV3fEIWS/NC92gP4GwaDhtQH46DkTfLPS/hdwtieOEzVOD7+5McHubU5uSIBGXnc53N8wwbyEJJLvyperd3mxOY/DRIpOBNfMDDn/[ttl=3587] 
6133  powerdns.com: Updating validation state with cache content for powerdns.com to Secure
6136  QM powerdns.com: Step0 Found in cache
6140 powerdns.com: Retrieved 3 DNSKeys, state is Secure
6143 www.powerdns.com: Going to validate 1 record contents with 1 sigs and 3 keys for www.powerdns.com|A
6177 www.powerdns.com: Signature by key with tag 36021 and algorithm RSASHA256 was valid
6181 www.powerdns.com: Validated www.powerdns.com/A
6184 www.powerdns.com: Secure!
6187 www.powerdns.com: Validation result is Secure, current state is Indeterminate
6190 www.powerdns.com: Validation state was Indeterminate, state update is Secure, validation state is now Secure
6200 www.powerdns.com: Determining status after receiving this packet
6204 www.powerdns.com: Answer is in: resolved to '188.166.104.92|A'
6207 www.powerdns.com: Status=got results, this level of recursion done
6210 www.powerdns.com: Validation status is Secure
6215 QM www.powerdns.com: Step3 Final resolve: No Error/2
=== END OF TRACE 2023-01-31T09:07:58.431 ===
```

You can also do tricks with `-`, eg, `rec_control trace-regex mydomain.com - | grep asking`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
