### PR TITLE
rec: Save the last nsspeed recorded plus output it in rec_control dump-nsspeeds

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -123,13 +123,13 @@ private:
     void submit(int arg, const struct timeval& last, const struct timeval& now)
     {
       d_last = arg;
-      float val = static_cast<float>(arg);
+      auto val = static_cast<float>(arg);
       if (d_val == 0) {
         d_val = val;
       }
       else {
-        float diff = makeFloat(last - now);
-        float factor = expf(diff) / 2.0f; // might be '0.5', or 0.0001
+        auto diff = makeFloat(last - now);
+        auto factor = expf(diff) / 2.0f; // might be '0.5', or 0.0001
         d_val = (1.0f - factor) * val + factor * d_val;
       }
     }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -120,15 +120,17 @@ private:
   struct DecayingEwma
   {
   public:
-    void submit(int val, const struct timeval& last, const struct timeval& now)
+    void submit(int arg, const struct timeval& last, const struct timeval& now)
     {
+      d_last = arg;
+      float val = static_cast<float>(arg);
       if (d_val == 0) {
-        d_val = static_cast<float>(val);
+        d_val = val;
       }
       else {
         float diff = makeFloat(last - now);
         float factor = expf(diff) / 2.0f; // might be '0.5', or 0.0001
-        d_val = (1.0f - factor) * static_cast<float>(val) + factor * d_val;
+        d_val = (1.0f - factor) * val + factor * d_val;
       }
     }
 
@@ -142,7 +144,13 @@ private:
       return d_val;
     }
 
+    int last(void) const
+    {
+      return d_last;
+    }
+
     float d_val{0};
+    int d_last{0};
   };
 
 public:
@@ -1179,7 +1187,7 @@ uint64_t SyncRes::doDumpNSSpeeds(int fd)
     return 0;
   }
 
-  fprintf(fp.get(), "; nsspeed dump follows\n;\n");
+  fprintf(fp.get(), "; nsspeed dump follows\n; nsname\ttimestamp\t[ip/decaying-ms/last-ms...]\n");
   uint64_t count = 0;
 
   // Create a copy to avoid holding the lock while doing I/O
@@ -1189,9 +1197,10 @@ uint64_t SyncRes::doDumpNSSpeeds(int fd)
     // an <empty> can appear hear in case of authoritative (hosted) zones
     char tmp[26];
     fprintf(fp.get(), "%s\t%s\t", i.d_name.toLogString().c_str(), timestamp(i.d_lastget, tmp, sizeof(tmp)));
+    bool first = true;
     for (const auto& j : i.d_collection) {
-      // typedef vector<pair<ComboAddress, DecayingEwma> > collection_t;
-      fprintf(fp.get(), "%s/%f\t", j.first.toStringWithPortExcept(53).c_str(), j.second.peek());
+      fprintf(fp.get(), "%s%s/%.3f/%.3f", first ? "" : "\t", j.first.toStringWithPortExcept(53).c_str(), j.second.peek() / 1000.0f, j.second.last() / 1000.0f);
+      first = false;
     }
     fprintf(fp.get(), "\n");
   }


### PR DESCRIPTION
Fixes #11736 in the most basic way. There are some plans to unify
the various NS state tables into a single elaborate data structure,
that would be the moment to store a moving average or similar.

Also modify the output a bit: show times in ms instead of us and
without all the decimals.
Example output:
```
; nsspeed dump follows
; nsname        timestamp       [ip/decaying-ms/last-ms...]
a6-192.akamaiedge.net   2022-07-12T13:59:29.585 23.211.133.192/4.440/8.837
usw6.akam.net   2022-07-12T13:59:25.472 23.61.199.64/423.307/1000.000
ns6-194.akamaiedge.net  2022-07-12T13:59:29.585 95.100.168.194/5.835/14.186
ns5-194.akamaiedge.net  2022-07-12T13:59:29.585 184.85.248.194/11.788/28.661
a11-192.akamaiedge.net  2022-07-12T13:59:29.585 84.53.139.192/6.843/10.938      2600:1480:1::c0/14.585/18.466
a12-192.akamaiedge.net  2022-07-12T13:59:29.585 184.26.160.192/47.739/116.072
...
```
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
