### PR TITLE
Add auth-46 and rec-47 for Ubunty Jammy to repo test script.

### DIFF
--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -166,7 +166,9 @@ def write_release_files (release):
         write_dockerfile('debian', 'bullseye', release)
         write_list_file('debian', 'bullseye', release)
 
-    if release in ['auth-master', 'rec-master', 'dnsdist-master']:
+    if release in ['auth-46', 'auth-master',
+                   'rec-47', 'rec-master',
+                   'dnsdist-master']:
         write_dockerfile('ubuntu', 'jammy', release)
         write_list_file('ubuntu', 'jammy', release)
 


### PR DESCRIPTION
### Checklist

I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
