### PR TITLE
EL9 builds

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -18,6 +18,7 @@ jobs:
           - ubuntu-bionic
           - el-8
           - centos-8-stream
+          - centos-9-stream
           - debian-bullseye
           - ubuntu-jammy
       fail-fast: false

--- a/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -38,6 +38,12 @@ RUN touch /var/lib/rpm/* &&  if $(grep -q 'release 7' /etc/redhat-release); then
 @ENDIF
 
 @IF [ -n "$M_dnsdist$M_all" ]
+
+# remove --enablerepo=epel-testing when new re2 lands
+RUN touch /var/lib/rpm/* && if $(grep -q 'release 9' /etc/redhat-release); then \
+      dnf install -y re2 re2-devel --enablerepo=epel-testing; \
+    fi
+
 RUN touch /var/lib/rpm/* && mkdir /libh2o && cd /libh2o && \
       yum install -y curl openssl-devel cmake && \
       curl -L https://github.com/h2o/h2o/archive/v2.2.6.tar.gz | tar xz && \

--- a/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -44,8 +44,10 @@ RUN touch /var/lib/rpm/* && if $(grep -q 'release 9' /etc/redhat-release); then 
       dnf install -y re2 re2-devel --enablerepo=epel-testing; \
     fi
 
+# --allowerasing does not exist on el7, so we fall back to just installing
+# this is fine because --allowerasing is only there to deal with libcurl conflicting with libcurl-minimal on some el9 images
 RUN touch /var/lib/rpm/* && mkdir /libh2o && cd /libh2o && \
-      yum install -y curl openssl-devel cmake && \
+      yum install -y --allowerasing curl libcurl openssl-devel cmake || yum install -y curl libcurl openssl-devel cmake && \
       curl -L https://github.com/h2o/h2o/archive/v2.2.6.tar.gz | tar xz && \
       CFLAGS='-fPIC' cmake -DWITH_PICOTLS=off -DWITH_BUNDLED_SSL=off -DWITH_MRUBY=off -DCMAKE_INSTALL_PREFIX=/opt ./h2o-2.2.6 && \
       make install

--- a/builder-support/dockerfiles/Dockerfile.target.centos-9-stream
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-9-stream
@@ -1,0 +1,19 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+# This defines the distribution base layer
+# Put only the bare minimum of common commands here, without dev tools
+FROM quay.io/centos/centos:stream9 as dist-base
+
+ARG BUILDER_CACHE_BUSTER=
+
+RUN touch /var/lib/rpm/* && dnf install -y epel-release && \
+    dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled crb
+
+# Do the actual rpm build
+@INCLUDE Dockerfile.rpmbuild
+
+# Do a test install and verify
+# Can be skipped with skiptests=1 in the environment
+# @EXEC [ "$skiptests" = "" ] && include Dockerfile.rpmtest

--- a/builder-support/dockerfiles/Dockerfile.target.el-9
+++ b/builder-support/dockerfiles/Dockerfile.target.el-9
@@ -1,0 +1,26 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+# This defines the distribution base layer
+# Put only the bare minimum of common commands here, without dev tools
+@IF [ ${BUILDER_TARGET} = oraclelinux-9 -o ${BUILDER_TARGET} = el-9 ]
+FROM oraclelinux:9 as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = oraclelinux-9-amd64 -o ${BUILDER_TARGET} = el-9-amd64 ]
+FROM amd64/oraclelinux:9 as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = oraclelinux-9-arm64 -o ${BUILDER_TARGET} = el-9-arm64 ]
+FROM arm64v8/oraclelinux:9 as dist-base
+@ENDIF
+
+ARG BUILDER_CACHE_BUSTER=
+RUN touch /var/lib/rpm/* && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf install -y 'dnf-command(config-manager)' yum && \
+    dnf config-manager --set-enabled ol9_codeready_builder
+
+# Do the actual rpm build
+@INCLUDE Dockerfile.rpmbuild
+
+# Do a test install and verify
+# Can be skipped with skiptests=1 in the environment
+# @EXEC [ "$skiptests" = "" ] && include Dockerfile.rpmtest

--- a/builder-support/dockerfiles/Dockerfile.target.el-9-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.el-9-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.el-9

--- a/builder-support/dockerfiles/Dockerfile.target.el-9-arm64
+++ b/builder-support/dockerfiles/Dockerfile.target.el-9-arm64
@@ -1,0 +1,1 @@
+Dockerfile.target.el-9

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -18,6 +18,7 @@ BuildRequires: systemd
 BuildRequires: systemd-units
 BuildRequires: systemd-devel
 
+BuildRequires: krb5-devel
 BuildRequires: p11-kit-devel
 BuildRequires: libcurl-devel
 %if 0%{?rhel} < 8
@@ -141,7 +142,9 @@ Summary: Geo backend for %{name}
 Group: System Environment/Daemons
 Requires: %{name}%{?_isa} = %{version}-%{release}
 BuildRequires: yaml-cpp-devel
+%if 0%{?rhel} < 9
 BuildRequires: geoip-devel
+%endif
 BuildRequires: libmaxminddb-devel
 %global backends %{backends} geoip
 


### PR DESCRIPTION
This branch successfully builds EL9 packages, but there is some work left:

* [x] see if we can use libmaxminddb to re-enable geoipbackend in auth
* [x] make the changes conditional on el9 (in the specfile, mostly, I think). The krb5-devel addition might be harmless on 7/8, need to check
* [x] check if the re2 fix in epel9 has landed and remove that hack (the hack is now acceptable for merging)

Fixes #11753 