### PR TITLE
Upgrade check-spelling to v0.0.20

### DIFF
--- a/.github/actions/spell-check/README.md
+++ b/.github/actions/spell-check/README.md
@@ -1,0 +1,15 @@
+# check-spelling/check-spelling configuration
+
+File | Purpose | Format | Info
+-|-|-|-
+[allow.txt](allow.txt) | Add words to the dictionary | one word per line (only letters and `'`s allowed) | [allow](https://github.com/check-spelling/check-spelling/wiki/Configuration#allow)
+[reject.txt](reject.txt) | Remove words from the dictionary (after allow) | grep pattern matching whole dictionary words | [reject](https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples%3A-reject)
+[excludes.txt](excludes.txt) | Files to ignore entirely | perl regular expression | [excludes](https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples%3A-excludes)
+[only.txt](only.txt) | Only check matching files (applied after excludes) | perl regular expression | [only](https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples%3A-only)
+[patterns.txt](patterns.txt) | Patterns to ignore from checked lines | perl regular expression (order matters, first match wins) | [patterns](https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples%3A-patterns)
+[line_forbidden.patterns](line_forbidden.patterns) | Patterns to flag in checked lines | perl regular expression (order matters, first match wins) | [patterns](https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples%3A-patterns)
+[expect.txt](expect.txt) | Expected words that aren't in the dictionary | one word per line (sorted, alphabetically) | [expect](https://github.com/check-spelling/check-spelling/wiki/Configuration#expect)
+[advice.md](advice.md) | Supplement for GitHub comment when unrecognized words are found | GitHub Markdown | [advice](https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples%3A-advice)
+
+Note: you can replace any of these files with a directory by the same name (minus the suffix)
+and then include multiple files inside that directory (with that suffix) to merge multiple files together.

--- a/.github/actions/spell-check/advice.md
+++ b/.github/actions/spell-check/advice.md
@@ -1,7 +1,17 @@
 <!-- See https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples%3A-advice --> <!-- markdownlint-disable MD033 MD041 -->
-<details><summary>If the flagged items do not appear to be text</summary>
+<details><summary>If the flagged items are false positives</summary>
 
 If items relate to a ...
+* binary file (or some other file you wouldn't want to check at all).
+
+  Please add a file path to the `excludes.txt` file matching the containing file.
+
+  File paths are Perl 5 Regular Expressions - you can [test](
+https://www.regexplanet.com/advanced/perl/) yours before committing to verify it will match your files.
+
+  `^` refers to the file's path from the root of the repository, so `^README\.md$` would exclude [README.md](
+../tree/HEAD/README.md) (on whichever branch you're using).
+
 * well-formed pattern.
 
   If you can write a [pattern](https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-patterns) that would match it,
@@ -11,15 +21,5 @@ If items relate to a ...
 https://www.regexplanet.com/advanced/perl/) yours before committing to verify it will match your lines.
 
   Note that patterns can't match multiline strings.
-
-* binary file.
-
-  Please add a file path to the `excludes.txt` file matching the containing file.
-
-  File paths are Perl 5 Regular Expressions - you can [test](
-https://www.regexplanet.com/advanced/perl/) yours before committing to verify it will match your files.
-
-  `^` refers to the file's path from the root of the repository, so `^README\.md$` would exclude [README.md](
-../tree/HEAD/README.md) (on whichever branch you're using).
 
 </details>

--- a/.github/actions/spell-check/allow.txt
+++ b/.github/actions/spell-check/allow.txt
@@ -175,6 +175,7 @@ authconfdir
 authdir
 authdirs
 authdomain
+authip
 authlog
 authname
 authoritatives
@@ -428,6 +429,7 @@ childstat
 chkconfig
 chr
 chrono
+cidr
 cin
 cinttypes
 ciphersuites
@@ -750,6 +752,7 @@ dnsdistrules
 dnsdisttcp
 dnsdisttests
 dnserrors
+DNSHEADER
 DNSID
 DNSIP
 dnskeyr
@@ -3387,7 +3390,6 @@ SSLRSADNS
 sslsock
 SSLTLS
 SSLTLSIO
-SSLv
 SSocket
 ssql
 ssqlite

--- a/.github/actions/spell-check/excludes.txt
+++ b/.github/actions/spell-check/excludes.txt
@@ -19,6 +19,7 @@ SUMS$
 \.asc$
 \.avi$
 \.bmp$
+\.bz2$
 \.cer$
 \.class$
 \.crl$
@@ -30,13 +31,13 @@ SUMS$
 \.eps$
 \.exe$
 \.gif$
+\.gitattributes$
 \.graffle$
 \.gz$
 \.icns$
 \.ico$
 \.jar$
-\.jpeg$
-\.jpg$
+\.jpe?g$
 \.keys?$
 \.lib$
 \.lock$
@@ -48,6 +49,7 @@ SUMS$
 \.mp4$
 \.mp[34]$
 \.nsec3(?:-optout|)$
+\.ocf$
 \.otf$
 \.pdf$
 \.pem$
@@ -63,6 +65,7 @@ SUMS$
 \.ttf$
 \.wav$
 \.woff
+\.woff2?$
 \.xcf$
 \.xls
 \.xpm$
@@ -78,3 +81,4 @@ SUMS$
 ^pdns/recursordist/html/js/
 ^regression-tests\.recursor-dnssec/test_ReadTrustAnchorsFromFile\.py$
 ^\.github/actions/spell-check/
+^\.github/workflows/spelling\.yml$

--- a/.github/actions/spell-check/line_forbidden.patterns
+++ b/.github/actions/spell-check/line_forbidden.patterns
@@ -1,0 +1,39 @@
+# reject `m_data` as there's a certain OS which has evil defines that break things if it's used elsewhere
+# \bm_data\b
+
+# s.b. GitHub
+\bGithub\b
+
+# s.b. GitLab
+\bGitlab\b
+
+# s.b. JavaScript
+\bJavascript\b
+
+# s.b. Microsoft
+\bMicroSoft\b
+
+# s.b. another
+\ban[- ]other\b
+
+# s.b. greater than
+\bgreater then\b
+
+# s.b. less than
+\bless then\b
+
+# s.b. otherwise
+\bother[- ]wise\b
+
+# s.b. nonexistent
+\bnon existing\b
+\b[Nn]o[nt][- ]existent\b
+
+# s.b. preexisting
+[Pp]re-existing
+
+# s.b. preemptively
+[Pp]re-emptively
+
+# Reject duplicate words
+\s([A-Z]{3,}|[A-Z][a-z]{2,}|[a-z]{3,})\s\g{-1}\s

--- a/.github/actions/spell-check/patterns.txt
+++ b/.github/actions/spell-check/patterns.txt
@@ -26,6 +26,14 @@ addNSECRecordToLW.*DNSName.*powerdnt.com.*QType::NS.*res->d_records
 data:[a-zA-Z=;,/0-9+]+
 BOOST_CHECK_EQUAL\(b64, "[a-zA-Z=;,/0-9+]+"
 
+# acceptable duplicates
+# ls directory listings
+[-bcdlpsw](?:[-r][-w][-sx]){3}\s+\d+\s+(\S+)\s+\g{-1}\s+\d+\s+
+# C types
+\s(long|LONG) \g{-1}\s
+# javadoc / .net
+(?:[\\@](?:groupname|param)|(?:public|private)(?:\s+static|\s+readonly)*)\s+(\w+)\s+\g{-1}\s
+
 # ignore long runs of a single character:
 \b([A-Za-z])\g{-1}{3,}\b
 

--- a/.github/actions/spell-check/reject.txt
+++ b/.github/actions/spell-check/reject.txt
@@ -1,7 +1,10 @@
 ^attache$
 benefitting
-occurence
+occurences?
+^dependan.*
+^oer$
 Sorce
-^[Ss]pae
-^untill
-^wether
+^[Ss]pae.*
+^untill$
+^untilling$
+^wether.*

--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -16,17 +16,41 @@ on:
 jobs:
   spelling:
     name: Spell checking
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+    outputs:
+      followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
+    if: "contains(github.event_name, 'pull_request') || github.event_name == 'push'"
+    concurrency:
+      group: spelling-${{ github.event.pull_request.number || github.ref }}
+      # note: If you use only_check_changed_files, you do not want cancel-in-progress
+      cancel-in-progress: true
     steps:
-    - name: checkout-merge
-      if: "contains(github.event_name, 'pull_request')"
-      uses: actions/checkout@v2
-      with:
-        ref: refs/pull/${{github.event.pull_request.number}}/merge
-    - name: checkout
-      if: ${{ github.event_name == 'push' }}
-      uses: actions/checkout@v2
-    - uses: check-spelling/check-spelling@v0.0.19
+    - name: check-spelling
       id: spelling
+      uses: check-spelling/check-spelling@v0.0.20
       with:
         config: .github/actions/spell-check
+        suppress_push_for_open_pull_request: 1
+        checkout: true
+        post_comment: 0
+        check_extra_dictionaries: ''
+
+  comment:
+    name: Report
+    runs-on: ubuntu-latest
+    needs: spelling
+    permissions:
+      contents: write
+      pull-requests: write
+    if: (success() || failure()) && needs.spelling.outputs.followup
+    steps:
+    - name: comment
+      uses: check-spelling/check-spelling@v0.0.20
+      with:
+        config: .github/actions/spell-check
+        checkout: true
+        task: ${{ needs.spelling.outputs.followup }}

--- a/docs/backends/generic-postgresql.rst
+++ b/docs/backends/generic-postgresql.rst
@@ -176,4 +176,4 @@ taken from the generic MySQL backend, and modified for syntax:
 References
 ^^^^^^^^^^
 
-See `this Github issue <https://github.com/PowerDNS/pdns/issues/5375#issuecomment-644771800>`__ for the original tests and a full working schema.
+See `this GitHub issue <https://github.com/PowerDNS/pdns/issues/5375#issuecomment-644771800>`__ for the original tests and a full working schema.

--- a/docs/changelog/4.1.rst
+++ b/docs/changelog/4.1.rst
@@ -671,7 +671,7 @@ Changelogs for 4.1.x
     :tags: Internals, Bug Fixes
     :pullreq: 5917
 
-    Use ``_exit()`` when we really really want to exit, for example
+    Use ``_exit()`` when we *really* want to exit, for example
     after a fatal error. This stops us dying while we die. A call to
     ``exit()`` will trigger destructors, which may paradoxically stop
     the process from exiting, taking down only one thread, but harming

--- a/docs/changelog/4.4.rst
+++ b/docs/changelog/4.4.rst
@@ -324,7 +324,7 @@ Changelogs for 4.4.x
     :tags: New Features
     :pullreq: 9239
 
-    Add pdns_control command to the the list of XFR domains in queue
+    Add pdns_control command to the list of XFR domains in queue
 
 .. changelog::
   :version: 4.4.0-alpha3

--- a/docs/changelog/pre-4.0.rst
+++ b/docs/changelog/pre-4.0.rst
@@ -5246,7 +5246,7 @@ Changes
 ^^^^^^^
 
 -  The monitor command **set** no longer allows the changing of
-   non-existent variables.
+   nonexistent variables.
 -  IBM Universal Database DB2 backend now included in source
    distribution (untested!)
 -  Oracle backend now included in source distribution (slightly tested!)

--- a/docs/changelog/pre-4.0.rst
+++ b/docs/changelog/pre-4.0.rst
@@ -5916,7 +5916,7 @@ Bugs fixed
 -  PostgreSQL backend was case sensitive and returned only answers in
    case an exact match was found. The Generic PostgreSQL backend is now
    officially all lower case and zone2sql in PostgreSQL mode enforces
-   this. Documentation has been been updated to reflect the case change.
+   this. Documentation has been updated to reflect the case change.
    Thanks to Maikel Verheijen of Ladot for spotting this!
 -  Documentation bug - postgresql create/index statements created a
    duplicate index. If you've previously copy pasted the commands and

--- a/docs/changelog/pre-4.0.rst
+++ b/docs/changelog/pre-4.0.rst
@@ -3288,7 +3288,7 @@ New features
 -  Added support for DHCID, IPSECKEY and KX records, thanks Norbert
    Sendetzky for the hint. Implemented in `commit
    1144 <http://wiki.powerdns.com/projects/trac/changeset/1144>`__.
--  Norbert Sendetzky has has added support for all record types
+-  Norbert Sendetzky has added support for all record types
    supported by PowerDNS to the LDAPBackend. Furthermore, the detection
    of OpenLDAP in autoconf has been improved. Finally, debian has
    supplied some fixes to PowerLDAP. Implemented in `commit

--- a/docs/domainmetadata.rst
+++ b/docs/domainmetadata.rst
@@ -73,7 +73,7 @@ This metadata item controls whether or not a zone is fully rectified on changes
 to the contents of a zone made through the :doc:`API <http-api/index>`.
 
 When the ``API-RECTIFY`` value is "1", the zone will be rectified on changes.
-Any other other value means that it will not be rectified. If this is not set
+Any other value means that it will not be rectified. If this is not set
 at all, rectifying of the zone depends on the config variable
 :ref:`setting-default-api-rectify`.
 

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -99,7 +99,7 @@ remove-zone-key *ZONE* *KEY-ID*
     Remove a key with id *KEY-ID* from a zone called *ZONE*.
 set-nsec3 *ZONE* ['*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*'] [**narrow**]
     Sets NSEC3 parameters for this zone. The quoted parameters are 4
-    values that are used for the the NSEC3PARAM record and decide how
+    values that are used for the NSEC3PARAM record and decide how
     NSEC3 records are created. The NSEC3 parameters must be quoted on
     the command line. *HASH-ALGORITHM* must be 1 (SHA-1). Setting
     *FLAGS* to 1 enables NSEC3 opt-out operation. Only do this if you

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -31,7 +31,7 @@ inner process as well.
 Logging to syslog on systemd-based operating systems
 ----------------------------------------------------
 
-By default, logging to syslog is disabled in the the systemd unit file
+By default, logging to syslog is disabled in the systemd unit file
 to prevent the service logging twice, as the systemd journal picks up
 the output from the process itself.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -687,7 +687,7 @@ If this is enabled, ALIAS records are expanded (synthesized to their
 A/AAAA).
 
 If this is disabled (the default), ALIAS records will not be expanded and
-the server will will return NODATA for A/AAAA queries for such names.
+the server will return NODATA for A/AAAA queries for such names.
 
 .. note::
   :ref:`setting-resolver` must also be set for ALIAS expansion to work!

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -484,7 +484,7 @@ void declareStats()
   S.declare(
     "xfr-queue", "Size of the queue of zones to be XFRd", [](const string&) { return Communicator.getSuckRequestsWaiting(); }, StatType::gauge);
   S.declareDNSNameQTypeRing("queries", "UDP Queries Received");
-  S.declareDNSNameQTypeRing("nxdomain-queries", "Queries for non-existent records within existent zones");
+  S.declareDNSNameQTypeRing("nxdomain-queries", "Queries for nonexistent records within existent zones");
   S.declareDNSNameQTypeRing("noerror-queries", "Queries for existing records, but for type we don't have");
   S.declareDNSNameQTypeRing("servfail-queries", "Queries that could not be answered due to backend errors");
   S.declareDNSNameQTypeRing("unauth-queries", "Queries for zones that we are not authoritative for");

--- a/pdns/dnsdistdist/docs/advanced/passing-source-address.rst
+++ b/pdns/dnsdistdist/docs/advanced/passing-source-address.rst
@@ -94,7 +94,7 @@ For that feature to work, dnsdist will look up twice into the packet cache when 
 That feature is enabled by setting ``disableZeroScope=false`` on :func:`newServer` (default) and ``parseECS=true`` on :func:`newPacketCache` (not the default).
 
 
-Things are different for XPF and the proxy protocol, because dnsdist then does the cache lookup **before** adding the payload. It means that caching can still be enabled as long as the response is not source-dependant, but should be disabled otherwise.
+Things are different for XPF and the proxy protocol, because dnsdist then does the cache lookup **before** adding the payload. It means that caching can still be enabled as long as the response is not source-dependent, but should be disabled otherwise.
 
 +------------------+----------+---------------------+----------------+------------------------+
 | Protocol         | Standard | Require DNS parsing | Contains ports | Caching                |

--- a/pdns/dnsdistdist/docs/advanced/tls-sessions-management.rst
+++ b/pdns/dnsdistdist/docs/advanced/tls-sessions-management.rst
@@ -69,7 +69,7 @@ For GnuTLS:
 Sessions management for outgoing connections
 --------------------------------------------
 
-Since 1.7, dnsdist supports securing the connection toward backends using DNS over TLS. For these connections, it keeps a cache of TLS tickets to be able to resume a TLS session quickly. By default that cache contains up to 20 TLS tickets per-backend, is cleaned up every every 60s, and TLS tickets expire if they have not been used after 600 seconds.
+Since 1.7, dnsdist supports securing the connection toward backends using DNS over TLS. For these connections, it keeps a cache of TLS tickets to be able to resume a TLS session quickly. By default that cache contains up to 20 TLS tickets per-backend, is cleaned up every 60s, and TLS tickets expire if they have not been used after 600 seconds.
 These values can be set at configuration time via:
 
  * :func:`setOutgoingTLSSessionsCacheMaxTicketsPerBackend`

--- a/pdns/dnsdistdist/docs/guides/downstreams.rst
+++ b/pdns/dnsdistdist/docs/guides/downstreams.rst
@@ -97,7 +97,7 @@ channel.
 
 The TCP-only mode for a backend can be enabled by using the ``tcpOnly`` parameter of the :func:`newServer` command.
 
-The DNS over TLS mode via the the ``tls`` parameter of the :func:`newServer` command. Additional parameters control the
+The DNS over TLS mode via the ``tls`` parameter of the :func:`newServer` command. Additional parameters control the
 validation of the certificate presented by the backend (``caStore``, ``validateCertificates``), the actual TLS ciphers
 used (``ciphers``, ``ciphersTLS13``) and the SNI value sent (``subjectName``).
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1618,7 +1618,7 @@ If you are looking for exact name matching, your might want to consider using a 
 Outgoing TLS tickets cache management
 -------------------------------------
 
-Since 1.7, dnsdist supports securing the connection toward backends using DNS over TLS. For these connections, it keeps a cache of TLS tickets to be able to resume a TLS session quickly. By default that cache contains up to 20 TLS tickets per-backend, is cleaned up every every 60s, and TLS tickets expire if they have not been used after 600 seconds.
+Since 1.7, dnsdist supports securing the connection toward backends using DNS over TLS. For these connections, it keeps a cache of TLS tickets to be able to resume a TLS session quickly. By default that cache contains up to 20 TLS tickets per-backend, is cleaned up every 60s, and TLS tickets expire if they have not been used after 600 seconds.
 These values can be set at configuration time via:
 
 .. function:: setOutgoingTLSSessionsCacheMaxTicketsPerBackend(num)

--- a/pdns/dnsdistdist/docs/reference/dnscrypt.rst
+++ b/pdns/dnsdistdist/docs/reference/dnscrypt.rst
@@ -139,7 +139,7 @@ Context
 
   .. method:: DNSCryptContext:addNewCertificate(cert, key[, active])
 
-    Add a new certificate to the the given context. Active certificates are advertised to
+    Add a new certificate to the given context. Active certificates are advertised to
     clients, inactive ones are not.
 
     :param DNSCryptCert cert: The certificate to add to the context

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -796,7 +796,7 @@ Combining Rules
 
 .. function:: OrRule(selectors)
 
-  Matches the traffic if one or more of the the ``selectors`` Rules does match.
+  Matches the traffic if one or more of the ``selectors`` Rules does match.
 
   :param {Rule} selector: A table of Rules
 
@@ -909,7 +909,7 @@ The following actions exist.
 
 .. function:: DnstapLogAction(identity, logger[, alterFunction])
 
-  Send the the current query to a remote logger as a :doc:`dnstap <reference/dnstap>` message.
+  Send the current query to a remote logger as a :doc:`dnstap <reference/dnstap>` message.
   ``alterFunction`` is a callback, receiving a :class:`DNSQuestion` and a :class:`DnstapMessage`, that can be used to modify the message.
   Subsequent rules are processed after this action.
 
@@ -919,7 +919,7 @@ The following actions exist.
 
 .. function:: DnstapLogResponseAction(identity, logger[, alterFunction])
 
-  Send the the current response to a remote logger as a :doc:`dnstap <reference/dnstap>` message.
+  Send the current response to a remote logger as a :doc:`dnstap <reference/dnstap>` message.
   ``alterFunction`` is a callback, receiving a :class:`DNSQuestion` and a :class:`DnstapMessage`, that can be used to modify the message.
   Subsequent rules are processed after this action.
 

--- a/pdns/nod.cc
+++ b/pdns/nod.cc
@@ -122,7 +122,7 @@ void PersistentSBF::setCacheDir(const std::string& cachedir)
   if (!d_init) {
     filesystem::path p(cachedir);
     if (!exists(p))
-      throw PDNSException("NODDB setCacheDir specified non-existent directory: " + cachedir);
+      throw PDNSException("NODDB setCacheDir specified nonexistent directory: " + cachedir);
     else if (!is_directory(p))
       throw PDNSException("NODDB setCacheDir specified a file not a directory: " + cachedir);
     d_cachedir = cachedir;

--- a/pdns/recursordist/docs/changelog/4.1.rst
+++ b/pdns/recursordist/docs/changelog/4.1.rst
@@ -832,7 +832,7 @@ See :doc:`EOL Statements <../appendices/EOL>`.
     :tags: Internals, Bug Fixes
     :pullreq: 5917
 
-    Use ``_exit()`` when we really really want to exit, for example
+    Use ``_exit()`` when we *really* want to exit, for example
     after a fatal error. This stops us dying while we die. A call to
     ``exit()`` will trigger destructors, which may paradoxically stop
     the process from exiting, taking down only one thread, but harming

--- a/pdns/recursordist/docs/changelog/pre-4.0.rst
+++ b/pdns/recursordist/docs/changelog/pre-4.0.rst
@@ -1018,7 +1018,7 @@ Changes between RC2 and -release
 -  'Make install' when an existing configuration file contained a 'fork'
    statement has been fixed. Spotted by Darren Gamble, code in `commit
    1534 <http://wiki.powerdns.com/projects/trac/changeset/1534>`__.
--  Reloading a non-existent allow-from-file caused the control thread to
+-  Reloading a nonexistent allow-from-file caused the control thread to
    stop working. Spotted by Imre Gergely, code in `commit
    1532 <http://wiki.powerdns.com/projects/trac/changeset/1532>`__.
 -  Parser got confused by reading en empty line in auth-forward-zones.

--- a/pdns/recursordist/docs/dnssec.rst
+++ b/pdns/recursordist/docs/dnssec.rst
@@ -36,7 +36,7 @@ Responses to client queries are the same as with `process`_.
 ``validate``
 ^^^^^^^^^^^^
 The highest mode of DNSSEC processing.
-In this mode, all responses will be be validated and and queries will be answered with a SERVFAIL in case of bogus data, even if the client did not request validation by setting the AD or DO bit.
+In this mode, all responses will be be validated and queries will be answered with a SERVFAIL in case of bogus data, even if the client did not request validation by setting the AD or DO bit.
 
 **Note**: the CD-bit is honored for ``process``, ``log-fail`` and
 ``validate``. This mean that even if validation fails, results are

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -157,7 +157,7 @@ The DNSQuestion object contains at least the following fields:
 
   .. attribute:: DNSQuestion.udpAnswer
 
-      Answer to the :attr:`udpQuery <DNSQuestion.udpQuery>` when when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>`.
+      Answer to the :attr:`udpQuery <DNSQuestion.udpQuery>` when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>`.
       Only filled when the call-back function is invoked.
 
   .. attribute:: DNSQuestion.udpQueryDest

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -33,7 +33,7 @@ This ratio can be greater than 100% since additional queries could be needed to 
 217 outgoing tcp connections were done, there were 0 queries running at the moment and 9155 queries to authoritative servers saw timeouts.
 
 The packets cache had 4536 entries and 82% of queries were served from it.
-The workload of the the worker queries was 175728 and 169484 respectively.
+The workload of the worker queries was 175728 and 169484 respectively.
 Finally, measured in the last half hour, an average of 1 qps was performed.
 
 Multi-threading and metrics

--- a/pdns/recursordist/docs/security-advisories/powerdns-advisory-2017-05.rst
+++ b/pdns/recursordist/docs/security-advisories/powerdns-advisory-2017-05.rst
@@ -15,7 +15,7 @@ PowerDNS Security Advisory 2017-05: Cross-Site Scripting in the web interface
 
 An issue has been found in the web interface of PowerDNS Recursor, where the
 qname of DNS queries was displayed without any escaping, allowing a remote
-attacker to inject HTML and Javascript code into the web interface, altering
+attacker to inject HTML and JavaScript code into the web interface, altering
 the content. This issue has been assigned CVE-2017-15092.
 
 PowerDNS Recursor from 4.0.0 up to and including 4.0.6 are affected.

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -98,7 +98,7 @@ public:
     if (d_doRings)  {
       auto it = d_rings.find(name);
       if (it == d_rings.end()) {
-	throw runtime_error("Attempting to account to non-existent ring '"+std::string(name)+"'");
+	throw runtime_error("Attempting to account to nonexistent ring '"+std::string(name)+"'");
       }
 
       it->second.lock()->account(item);
@@ -109,7 +109,7 @@ public:
     if (d_doRings) {
       auto it = d_comboRings.find(name);
       if (it == d_comboRings.end()) {
-	throw runtime_error("Attempting to account to non-existent comboRing '"+std::string(name)+"'");
+	throw runtime_error("Attempting to account to nonexistent comboRing '"+std::string(name)+"'");
       }
       it->second.lock()->account(item);
     }
@@ -119,7 +119,7 @@ public:
     if (d_doRings) {
       auto it = d_dnsnameqtyperings.find(name);
       if (it == d_dnsnameqtyperings.end()) {
-	throw runtime_error("Attempting to account to non-existent dnsname+qtype ring '"+std::string(name)+"'");
+	throw runtime_error("Attempting to account to nonexistent dnsname+qtype ring '"+std::string(name)+"'");
       }
       it->second.lock()->account(std::make_tuple(dnsname, qtype));
     }

--- a/regression-tests.recursor-dnssec/test_AggressiveNSECCache.py
+++ b/regression-tests.recursor-dnssec/test_AggressiveNSECCache.py
@@ -42,7 +42,7 @@ class AggressiveNSECCacheBase(RecursorTest):
 
     def testNoData(self):
 
-        # first we query a non-existent type, to get the NSEC in our cache
+        # first we query a nonexistent type, to get the NSEC in our cache
         entries = self.getMetric('aggressive-nsec-cache-entries')
         res = self.sendQuery('host1.secure.example.', 'TXT')
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
@@ -71,7 +71,7 @@ class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
     # do not deny the same names than the non-hashed NSECs do
     def testNXD(self):
 
-        # first we query a non-existent name, to get the needed NSECs (name + widcard) in our cache
+        # first we query a nonexistent name, to get the needed NSECs (name + widcard) in our cache
         entries = self.getMetric('aggressive-nsec-cache-entries')
         hits = self.getMetric('aggressive-nsec-cache-nsec-hits')
         res = self.sendQuery('host2.secure.example.', 'TXT')
@@ -98,7 +98,7 @@ class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
 
     def testWildcard(self):
 
-        # first we query a non-existent name, but for which a wildcard matches,
+        # first we query a nonexistent name, but for which a wildcard matches,
         # to get the NSEC in our cache
         res = self.sendQuery('test1.wildcard.secure.example.', 'A')
         expected = dns.rrset.from_text('test1.wildcard.secure.example.', 0, dns.rdataclass.IN, 'A', '{prefix}.10'.format(prefix=self._PREFIX))
@@ -220,7 +220,7 @@ class AggressiveNSECCacheNSEC3(AggressiveNSECCacheBase):
 
     def testNXD(self):
 
-        # first we query a non-existent name, to get the needed NSEC3s in our cache
+        # first we query a nonexistent name, to get the needed NSEC3s in our cache
         res = self.sendQuery('host2.secure.example.', 'TXT')
         self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
         self.assertAnswerEmpty(res)
@@ -247,7 +247,7 @@ class AggressiveNSECCacheNSEC3(AggressiveNSECCacheBase):
         self.assertAuthorityHasSOA(res)
         self.assertMessageIsAuthenticated(res)
 
-        # we query a non-existent name, but for which a wildcard matches,
+        # we query a nonexistent name, but for which a wildcard matches,
         # to get the NSEC3 in our cache
         res = self.sendQuery('test5.wildcard.secure.example.', 'A')
         expected = dns.rrset.from_text('test5.wildcard.secure.example.', 0, dns.rdataclass.IN, 'A', '{prefix}.10'.format(prefix=self._PREFIX))

--- a/regression-tests/tests/ds-at-apex-noerror/description
+++ b/regression-tests/tests/ds-at-apex-noerror/description
@@ -1,1 +1,1 @@
-This test tries to resolve a non-existent DS at apex
+This test tries to resolve a nonexistent DS at apex

--- a/regression-tests/tests/minimal-nxdomain/description
+++ b/regression-tests/tests/minimal-nxdomain/description
@@ -1,2 +1,2 @@
-Minimal zone (only NS records) Make sure non-existent hosts generates a correct
+Minimal zone (only NS records) Make sure nonexistent hosts generates a correct
 NSEC(3) denial.


### PR DESCRIPTION
### Short description
This upgrades check-spelling to [v0.0.20](https://github.com/check-spelling/check-spelling/releases/tag/v0.0.20)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master


### Testing
https://github.com/check-spelling/pdns/pull/1

### Notable changes
* comments are collapsed as new runs are performed. A passing run should even collapse the last comment leaving none expanded.
* you can forbid patterns, e.g. `Github`
* duplicate word detection, e.g. `the the` -- note that there can be false positives, it's quite likely that I shouldn't have changed `really really` to `really` -- this can be masked by adjusting `patterns.txt`
* advice refresh -- small tweaks based on feedback
* permissions -- the v0.0.19 workflow relies on default permissions. It's possible for an organization or a repository to set read-only default permissions which results in the action not being able to post comments (and a really ugly error message in v0.0.19) -- the workflow now only requests the permissions it needs (instead of either getting nearly all possible write permissions, or getting only readonly), and it now runs in two phases -- the first phase where it's considering untrusted user input doesn't have write permissions, the second phase where it produces comments has write permissions (to post a comment to a PR or to a commit)
* updating pull request head branches by talking to the bot is enabled for forks (but not for this repository) 
 
