### PR TITLE
dnsbulktest: initialise struct member; use correct type when setting it

### DIFF
--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -57,7 +57,7 @@ struct DNSResult
 {
   vector<ComboAddress> ips;
   int rcode;
-  bool seenauthsoa;
+  bool seenauthsoa{false};
 };
 
 struct TypedQuery
@@ -159,7 +159,7 @@ struct SendReceive
         if(i->first.d_place == 1 && i->first.d_type == mdp.d_qtype)
           dr.ips.push_back(ComboAddress(i->first.d_content->getZoneRepresentation()));
         if(i->first.d_place == 2 && i->first.d_type == QType::SOA) {
-          dr.seenauthsoa = 1;
+          dr.seenauthsoa = true;
         }
         if(!g_quiet)
         {


### PR DESCRIPTION
### Short description
ubsan spotted the unitialised value

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master