### PR TITLE
Compile yahttp with C++11 support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,9 @@ AC_CONFIG_HEADERS([config.h])
 
 AC_CANONICAL_HOST
 # Add some default CFLAGS and CXXFLAGS, can be appended to using the environment variables
-CFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CFLAGS"
-CXXFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CXXFLAGS"
+# -DHAVE_CXX11 is for compilling YAHTTP with cpp11 support.
+CFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -DHAVE_CXX11 $CFLAGS"
+CXXFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -DHAVE_CXX11 $CXXFLAGS"
 
 AC_SUBST([pdns_configure_args], ["$ac_configure_args"])
 AC_DEFINE_UNQUOTED([PDNS_CONFIG_ARGS],


### PR DESCRIPTION
### Short description

Reduce compiler noise related to boost yahttp compilation by trying to compile yahttp with Cpp11 support. This noise also renders impossible a run with `-fanalyzer` because it goes crazy with memory allocation due to boost warning.

Addition: It's compiling under gcc12 before and after the change.
### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code (will do it monday)
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)


My version of gcc:
```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/12.1.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++ --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror --with-build-config=bootstrap-lto --enable-link-serialization=1
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.1.0 (GCC)
```

And the configure build I would run: (with or without `-O3` or with or without `-fanalyzer`)
```
./configure --with-modules="" --disable-lua-records CFLAGS="-fsanitize=address" LDDFLAGS="-fsanitize=address" CXXFLAGS="-O3 -Wextra -Wall -W -Wall -std=c++17 -fsanitize=address" --enable-ubsan --enable-malloc-trace --enable-lsan --enable-asan --enable-coverage
```
Exemple of the compiler noise I get with GCC12:
```
make[4]: Entering directory '/home/darnuria/programmation/pdns/ext/yahttp/yahttp'
  CXX      reqresp.lo
  CXX      router.lo
In file included from /usr/include/string.h:535,
                 from /usr/include/c++/12.1.0/cstring:42,
                 from /usr/include/boost/assert/source_location.hpp:17,
                 from /usr/include/boost/exception/exception.hpp:9,
                 from /usr/include/boost/throw_exception.hpp:21,
                 from /usr/include/boost/function/detail/prologue.hpp:15,
                 from /usr/include/boost/function.hpp:30,
                 from reqresp.hpp:7,
                 from yahttp.hpp:19,
                 from reqresp.cpp:1:
In function 'void* memcpy(void*, const void*, size_t)',
    inlined from 'void boost::function3<R, T1, T2, T3>::move_assign(boost::function3<R, T1, T2, T3>&) [with R = long unsigned int; T0 = const YaHTTP::HTTPBase*; T1 = std::basic_ostream<char>&; T2 = bool]' at /usr/include/boost/function/function_template.hpp:1008:24,
    inlined from 'void boost::function3<R, T1, T2, T3>::swap(boost::function3<R, T1, T2, T3>&) [with R = long unsigned int; T0 = const YaHTTP::HTTPBase*; T1 = std::basic_ostream<char>&; T2 = bool]' at /usr/include/boost/function/function_template.hpp:862:22,
    inlined from 'typename boost::enable_if_<(! boost::is_integral<Functor>::value), boost::function<R(T0, T1, T2)>&>::type boost::function<R(T0, T1, T2)>::operator=(Functor) [with Functor = YaHTTP::HTTPBase::SendBodyRender; R = long unsigned int; T0 = const YaHTTP::HTTPBase*; T1 = std::basic_ostream<char>&; T2 = bool]' at /usr/include/boost/function/function_template.hpp:1147:22,
    inlined from 'virtual void YaHTTP::HTTPBase::initialize()' at reqresp.hpp:106:33:
/usr/include/bits/string_fortified.h:29:33: warning: '*(unsigned char (*)[24])((char*)&<unnamed> + offsetof(boost::self_type, boost::function<long unsigned int(const YaHTTP::HTTPBase*, std::basic_ostream<char, std::char_traits<char> >&, bool)>::<unnamed>.boost::function3<long unsigned int, const YaHTTP::HTTPBase*, std::basic_ostream<char, std::char_traits<char> >&, bool>::<unnamed>.boost::function_base::functor))' is used uninitialized [-Wuninitialized]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/boost/function/detail/maybe_include.hpp:36,
                 from /usr/include/boost/function/detail/function_iterate.hpp:14,
                 from /usr/include/boost/preprocessor/iteration/detail/iter/limits/forward1_256.hpp:29,
                 from /usr/include/boost/preprocessor/iteration/detail/iter/forward1.hpp:1343,
                 from /usr/include/boost/function.hpp:70:
```

With the changes I only get:

```
make[4]: Entering directory '/home/darnuria/programmation/pdns/ext/yahttp/yahttp'
  CXX      reqresp.lo
  CXX      router.lo
  CXXLD    libyahttp.la
make[4]: Leaving directory '/home/darnuria/programmation/pdns/ext/yahttp/yahttp'
```
