### PR TITLE
[tsan] add data race suppression for avg_latency and send_latencyres …

### DIFF
--- a/auth-tsan.supp
+++ b/auth-tsan.supp
@@ -1,0 +1,6 @@
+# Statistic data-race not relevant right now
+# Due to performance issue of atomics
+# Discussion:
+# https://github.com/PowerDNS/pdns/issues/11814
+race:avg_latency
+race:send_latency


### PR DESCRIPTION
Attempt to add suppression for data races on `send_latency` and `avg_latency` globals.
see discussion here #11814