### PR TITLE
Also reconnect on ENETUNREACH.

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1091,7 +1091,7 @@ ssize_t udpClientSendRequestToBackend(const std::shared_ptr<DownstreamState>& ss
 
   if (result == -1) {
     int savederrno = errno;
-    vinfolog("Error sending request to backend %s: %s", ss->d_config.remote.toStringWithPort(), strerror(savederrno));
+    vinfolog("Error sending request to backend %s: %s", ss->d_config.remote.toStringWithPort(), stringerror(savederrno));
 
     /* This might sound silly, but on Linux send() might fail with EINVAL
        if the interface the socket was bound to doesn't exist anymore.

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1091,14 +1091,14 @@ ssize_t udpClientSendRequestToBackend(const std::shared_ptr<DownstreamState>& ss
 
   if (result == -1) {
     int savederrno = errno;
-    vinfolog("Error sending request to backend %s: %d", ss->d_config.remote.toStringWithPort(), savederrno);
+    vinfolog("Error sending request to backend %s: %s", ss->d_config.remote.toStringWithPort(), strerror(savederrno));
 
     /* This might sound silly, but on Linux send() might fail with EINVAL
        if the interface the socket was bound to doesn't exist anymore.
        We don't want to reconnect the real socket if the healthcheck failed,
        because it's not using the same socket.
     */
-    if (!healthCheck && (savederrno == EINVAL || savederrno == ENODEV)) {
+    if (!healthCheck && (savederrno == EINVAL || savederrno == ENODEV || savederrno == ENETUNREACH)) {
       ss->reconnect();
     }
   }


### PR DESCRIPTION
Ref. #4155

### Short description
Also reconnect on ENETUNREACH.

On Ubuntu 22.04/dnsdist 1.6.1 I get `ENETUNREACH` errno for backend servers only accessible through VPN.

I hid these backends in a `PoolAvalilableRule`, and this works, but when VPN is up again, all DNS packets to the backends are dropped.

After adding the check for `ENETUNREACH` dnsdist is able to resume using these backends.

I've added a `strerror()` wrap around the errno for good measure, as I found the numeric errno less than helpful.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
