### PR TITLE
dnsdist: Fix a possible race in the CDB reload regression tests

### DIFF
--- a/regression-tests.dnsdist/test_CDB.py
+++ b/regression-tests.dnsdist/test_CDB.py
@@ -184,6 +184,9 @@ class TestCDBReload(CDBTest):
             self.assertEqual(expectedResponse, receivedResponse)
 
         # write a new CDB which has no entry for 127.0.0.1
+        # first ensure that the mtime will change after writing
+        # the new version
+        time.sleep(1)
         writeCDB(self._cdbFileName, 2)
         # wait long enough for the CDB database to be reloaded
         time.sleep(self._cdbRefreshDelay + 1)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
dnsdist will only automatically reload the CDB file if the mtime changed, but the mtime might not change if the update to the file happens at the exact same second than the first write.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
