### PR TITLE
dnsdist: Do not keep the mplexer created for the initial health-check around

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2712,17 +2712,20 @@ int main(int argc, char** argv)
 
     checkFileDescriptorsLimits(udpBindsCount, tcpBindsCount);
 
-    auto mplexer = std::unique_ptr<FDMultiplexer>(FDMultiplexer::getMultiplexerSilent());
-    for (auto& dss : g_dstates.getCopy()) { // it is a copy, but the internal shared_ptrs are the real deal
-      if (dss->d_config.availability == DownstreamState::Availability::Auto) {
-        dss->d_nextCheck = dss->d_config.checkInterval;
-        if (!queueHealthCheck(mplexer, dss, true)) {
-          dss->setUpStatus(false);
-          warnlog("Marking downstream %s as 'down'", dss->getNameWithAddr());
+    {
+      auto states = g_dstates.getCopy(); // it is a copy, but the internal shared_ptrs are the real deal
+      auto mplexer = std::unique_ptr<FDMultiplexer>(FDMultiplexer::getMultiplexerSilent(states.size()));
+      for (auto& dss : states) {
+        if (dss->d_config.availability == DownstreamState::Availability::Auto) {
+          dss->d_nextCheck = dss->d_config.checkInterval;
+          if (!queueHealthCheck(mplexer, dss, true)) {
+            dss->setUpStatus(false);
+            warnlog("Marking downstream %s as 'down'", dss->getNameWithAddr());
+          }
         }
       }
+      handleQueuedHealthChecks(*mplexer, true);
     }
-    handleQueuedHealthChecks(*mplexer, true);
 
     for(auto& cs : g_frontends) {
       if (cs->dohFrontend != nullptr) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We no longer need it after that initial health-check round so it is only wasting (a very small amount of) memory and one file descriptor at that point.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
