### PR TITLE
dnsdist: Better handling of the different types of metrics

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -73,14 +73,18 @@ void carbonDumpThread()
           time_t now=time(0);
           for(const auto& e : g_stats.entries) {
             str<<namespace_name<<"."<<hostname<<"."<<instance_name<<"."<<e.first<<' ';
-            if(const auto& val = boost::get<pdns::stat_t*>(&e.second))
+            if (const auto& val = boost::get<pdns::stat_t*>(&e.second)) {
               str<<(*val)->load();
-            else if(const auto& adval = boost::get<pdns::stat_t_trait<double>*>(&e.second))
+            }
+            else if(const auto& adval = boost::get<pdns::stat_t_trait<double>*>(&e.second)) {
               str<<(*adval)->load();
-            else if (const auto& dval = boost::get<double*>(&e.second))
+            }
+            else if (const auto& dval = boost::get<double*>(&e.second)) {
               str<<**dval;
-            else
-              str<<(*boost::get<DNSDistStats::statfunction_t>(&e.second))(e.first);
+            }
+            else if (const auto& func = boost::get<DNSDistStats::statfunction_t>(&e.second)) {
+              str<<(*func)(e.first);
+            }
             str<<' '<<now<<"\r\n";
           }
           auto states = g_dstates.getLocal();

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -701,14 +701,14 @@ void setupLuaInspection(LuaContext& luaCtx)
         if (const auto& val = boost::get<pdns::stat_t*>(&e.second)) {
           second = std::to_string((*val)->load());
         }
-        else if(const auto& adval = boost::get<pdns::stat_t_trait<double>*>(&e.second)) {
+        else if (const auto& adval = boost::get<pdns::stat_t_trait<double>*>(&e.second)) {
           second = (flt % (*adval)->load()).str();
         }
         else if (const auto& dval = boost::get<double*>(&e.second)) {
           second = (flt % (**dval)).str();
         }
-        else {
-          second = std::to_string((*boost::get<DNSDistStats::statfunction_t>(&e.second))(e.first));
+        else if (const auto& func = boost::get<DNSDistStats::statfunction_t>(&e.second)) {
+          second = std::to_string((*func)(e.first));
         }
 
         if (leftcolumn.size() < g_stats.entries.size()/2) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This commit ensures that we don't crash if we forget to update a part of code if we ever add a new type of metrics, as happened in 9f4fa5ae01efa878d2aa27e4398740d7ed6ef01f.
I would prefer to refactor all the places in one single function, but the output formats differ too much.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
