### PR TITLE
Rec: consider dns64 processing in more cases than Rcode == NoError

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -629,7 +629,7 @@ static bool udrCheckUniqueDNSRecord(Logr::log_t nodlogger, const DNSName& dname,
 }
 #endif /* NOD_ENABLED */
 
-static bool answerIsNOData(uint16_t requestedType, int rcode, const std::vector<DNSRecord>& records);
+static bool dns64Candidate(uint16_t requestedType, int rcode, const std::vector<DNSRecord>& records);
 
 int followCNAMERecords(vector<DNSRecord>& ret, const QType qtype, int rcode)
 {
@@ -652,7 +652,7 @@ int followCNAMERecords(vector<DNSRecord>& ret, const QType qtype, int rcode)
   auto log = g_slog->withName("lua")->withValues("method", Logging::Loggable("followCNAMERecords"));
   rcode = directResolve(target, qtype, QClass::IN, resolved, t_pdl, log);
 
-  if (g_dns64Prefix && qtype == QType::AAAA && answerIsNOData(qtype, rcode, resolved)) {
+  if (g_dns64Prefix && qtype == QType::AAAA && dns64Candidate(qtype, rcode, resolved)) {
     rcode = getFakeAAAARecords(target, *g_dns64Prefix, resolved);
   }
 
@@ -774,6 +774,16 @@ static bool answerIsNOData(uint16_t requestedType, int rcode, const std::vector<
     }
   }
   return true;
+}
+
+// RFC 6147 section 5.1 all rcodes except NXDomain should be candidate for dns64
+// for NoError, check if it is NoData
+static bool dns64Candidate(uint16_t requestedType, int rcode, const std::vector<DNSRecord>& records)
+{
+  if (rcode == RCode::NoError) {
+    return answerIsNOData(requestedType, rcode, records);
+  }
+  return rcode != RCode::NXDomain;
 }
 
 bool isAllowNotifyForZone(DNSName qname)
@@ -1096,7 +1106,7 @@ void startDoResolve(void* p)
         else {
           auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw, tcpGuard);
           if (policyResult == PolicyResult::HaveAnswer) {
-            if (g_dns64Prefix && dq.qtype == QType::AAAA && answerIsNOData(dc->d_mdp.d_qtype, res, ret)) {
+            if (g_dns64Prefix && dq.qtype == QType::AAAA && dns64Candidate(dc->d_mdp.d_qtype, res, ret)) {
               res = getFakeAAAARecords(dq.qname, *g_dns64Prefix, ret);
               shouldNotValidate = true;
             }
@@ -1166,7 +1176,7 @@ void startDoResolve(void* p)
         }
       }
 
-      if (dc->d_luaContext || (g_dns64Prefix && dq.qtype == QType::AAAA && !vStateIsBogus(dq.validationState))) {
+      if (dc->d_luaContext) {
         if (res == RCode::NoError) {
           if (answerIsNOData(dc->d_mdp.d_qtype, res, ret)) {
             if (dc->d_luaContext && dc->d_luaContext->nodata(dq, res, sr.d_eventTrace)) {
@@ -1179,13 +1189,9 @@ void startDoResolve(void* p)
                 return;
               }
             }
-            else if (g_dns64Prefix && dq.qtype == QType::AAAA && !vStateIsBogus(dq.validationState)) {
-              res = getFakeAAAARecords(dq.qname, *g_dns64Prefix, ret);
-              shouldNotValidate = true;
-            }
           }
         }
-        else if (res == RCode::NXDomain && dc->d_luaContext && dc->d_luaContext->nxdomain(dq, res, sr.d_eventTrace)) {
+        else if (res == RCode::NXDomain && dc->d_luaContext->nxdomain(dq, res, sr.d_eventTrace)) {
           shouldNotValidate = true;
           auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw, tcpGuard);
           if (policyResult == PolicyResult::HaveAnswer) {
@@ -1196,22 +1202,12 @@ void startDoResolve(void* p)
           }
         }
 
-        if (dc->d_luaContext) {
-          if (dc->d_luaContext->d_postresolve_ffi) {
-            RecursorLua4::PostResolveFFIHandle handle(dq);
-            sr.d_eventTrace.add(RecEventTrace::LuaPostResolveFFI);
-            bool pr = dc->d_luaContext->postresolve_ffi(handle);
-            sr.d_eventTrace.add(RecEventTrace::LuaPostResolveFFI, pr, false);
-            if (pr) {
-              shouldNotValidate = true;
-              auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw, tcpGuard);
-              // haveAnswer case redundant
-              if (policyResult == PolicyResult::Drop) {
-                return;
-              }
-            }
-          }
-          else if (dc->d_luaContext->postresolve(dq, res, sr.d_eventTrace)) {
+        if (dc->d_luaContext->d_postresolve_ffi) {
+          RecursorLua4::PostResolveFFIHandle handle(dq);
+          sr.d_eventTrace.add(RecEventTrace::LuaPostResolveFFI);
+          bool pr = dc->d_luaContext->postresolve_ffi(handle);
+          sr.d_eventTrace.add(RecEventTrace::LuaPostResolveFFI, pr, false);
+          if (pr) {
             shouldNotValidate = true;
             auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw, tcpGuard);
             // haveAnswer case redundant
@@ -1220,6 +1216,21 @@ void startDoResolve(void* p)
             }
           }
         }
+        else if (dc->d_luaContext->postresolve(dq, res, sr.d_eventTrace)) {
+          shouldNotValidate = true;
+          auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw, tcpGuard);
+          if (policyResult == PolicyResult::HaveAnswer) {
+            goto haveAnswer;
+          }
+          else if (policyResult == PolicyResult::Drop) {
+            return;
+          }
+        }
+      }
+
+      if (g_dns64Prefix && dc->d_mdp.d_qtype == QType::AAAA && !vStateIsBogus(dq.validationState) && dns64Candidate(dc->d_mdp.d_qtype, res, ret)) {
+        res = getFakeAAAARecords(dq.qname, *g_dns64Prefix, ret);
+        shouldNotValidate = true;
       }
     }
     else if (dc->d_luaContext) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1199,7 +1199,7 @@ void startDoResolve(void* p)
         }
       } // dc->d_luaContext
 
-      if (!luaHookHandled && g_dns64Prefix && dc->d_mdp.d_qtype == QType::AAAA && (!shouldNotValidate || !sr.isDNSSECValidationRequested() || !vStateIsBogus(dq.validationState)) && dns64Candidate(dc->d_mdp.d_qtype, res, ret)) {
+      if (!luaHookHandled && g_dns64Prefix && dc->d_mdp.d_qtype == QType::AAAA && (shouldNotValidate || !sr.isDNSSECValidationRequested() || !vStateIsBogus(dq.validationState)) && dns64Candidate(dc->d_mdp.d_qtype, res, ret)) {
         res = getFakeAAAARecords(dq.qname, *g_dns64Prefix, ret);
         shouldNotValidate = true;
       }

--- a/pdns/recursordist/docs/dns64.rst
+++ b/pdns/recursordist/docs/dns64.rst
@@ -10,6 +10,24 @@ We do this by retrieving the A records for ``www.example.com``, and translating 
 Elsewhere, a NAT64 device listens on these IPv6 addresses, and extracts the IPv4 address from each packet, and proxies it on.
 
 As of 4.4.0, an efficient implementation is built the recursor and can be enabled via the using the :ref:`dns64-prefix setting <setting-dns64-prefix>`.
+
+Native DNS64 support
+--------------------
+Native DNS64 processing will happen after calling a ``nodata`` or ``nxdomain`` Lua hook (if defined), but before calling a ``postresolve`` or ``postresolve_ffi`` Lua hook (if defined).
+
+To consider native DNS64 processing the following conditions must be met:
+
+- The :ref:`setting-dns64-prefix` is defined.
+- A ``nodata`` or ``nxdomain`` Lua hook did not return ``true``.
+- The original query type was ``AAAA``.
+- The result code of the ``AAAA`` query was not ``NXDomain``.
+- No relevant answer was received: the result code was ``NoError`` with no relevant answer records, or an error unequal to ``NXDomain`` occurred.
+- If DNSSEC processing is requested the validation result was not ``Bogus``.
+
+Before version 4.8.0, only ``NoError`` results were considers candidates for DNS64 processing.
+
+Scripted DNS64 Support
+----------------------
 On earlier versions or for maximum flexibility, DNS64 support is included in the :doc:`lua-scripting/index`.
 This allows for example to hand out custom IPv6 gateway ranges depending on the location of the requestor, enabling the use of NAT64 services close to the user.
 

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -299,7 +299,9 @@ node1.undelegated.insecure.example.  3600 IN A    192.0.2.22
 delay1.example.                       3600 IN SOA  {soa}
 delay1.example.                       3600 IN NS n1.delay1.example.
 ns1.delay1.example.                   3600 IN A    {prefix}.16
+8.delay1.example.                     3600 IN A    192.0.2.100
 *.delay1.example.                     0    LUA TXT ";" "local socket=require('socket')" "socket.sleep(tonumber(qname:getRawLabels()[1])/10)" "return 'a'"
+*.delay1.example.                     0    LUA AAAA ";" "local socket=require('socket')" "socket.sleep(tonumber(qname:getRawLabels()[1])/10)" "return '1::2'"
         """,
         
         'delay2.example': """

--- a/regression-tests.recursor-dnssec/test_DNS64.py
+++ b/regression-tests.recursor-dnssec/test_DNS64.py
@@ -19,6 +19,16 @@ class DNS64RecursorTest(RecursorTest):
     dns64-prefix=64:ff9b::/96
     """ % (_confdir, _confdir, _confdir)
 
+    _lua_dns_script_file = """
+      function nodata(dq)
+        if dq.qtype == pdns.AAAA and dq.qname:equal("formerr.example.dns64") then
+          dq.rcode = pdns.FORMERR
+          return true
+        end
+        return false
+       end
+    """
+
     @classmethod
     def generateRecursorConfig(cls, confdir):
         authzonepath = os.path.join(confdir, 'example.dns64.zone')
@@ -30,6 +40,7 @@ www 3600 IN TXT "does exist"
 aaaa 3600 IN AAAA 2001:db8::1
 cname 3600 IN CNAME cname2.example.dns64.
 cname2 3600 IN CNAME www.example.dns64.
+formerr 3600 IN A 192.0.2.43
 """.format(soa=cls._SOA))
 
         authzonepath = os.path.join(confdir, 'in-addr.arpa.zone')
@@ -115,6 +126,18 @@ cname2 3600 IN CNAME www.example.dns64.
     def testExistingAAAA(self):
         qname = 'aaaa.example.dns64.'
         expected = dns.rrset.from_text(qname, 0, dns.rdataclass.IN, 'AAAA', '2001:db8::1')
+
+        query = dns.message.make_query(qname, 'AAAA', want_dnssec=True)
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+            self.assertRcodeEqual(res, dns.rcode.NOERROR)
+            self.assertRRsetInAnswer(res, expected)
+
+    # If the AAAA FormFails, we still should get a dns64 result
+    def testFormErrAAAA(self):
+        qname = 'formerr.example.dns64.'
+        expected = dns.rrset.from_text(qname, 0, dns.rdataclass.IN, 'AAAA', '64:ff9b::c000:22b')
 
         query = dns.message.make_query(qname, 'AAAA', want_dnssec=True)
         for method in ("sendUDPQuery", "sendTCPQuery"):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

RFC 6147 section 5.1 says: all RCodes except NXDomain should be candidate for dns64.
The current code only considers dns64 if RCode == NoError

We also restructure things a bit to get rid of most of the repeated lines handling `policyResult`.

To be added: tests

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

