### PR TITLE
Fix recursor not responsive after Lua config reload

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -940,7 +940,7 @@ void startDoResolve(void* p)
     sr.setInitialRequestId(dc->d_uuid);
     sr.setOutgoingProtobufServers(t_outgoingProtobufServers);
 #ifdef HAVE_FSTRM
-    sr.setFrameStreamServers(t_frameStreamServers);
+    sr.setFrameStreamServers(t_frameStreamServersInfo.servers);
 #endif
 
     bool useMapped = true;

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -43,6 +43,27 @@ LuaConfigItems::LuaConfigItems()
 
 /* DID YOU READ THE STORY ABOVE? */
 
+bool operator==(const FrameStreamExportConfig& configA, const FrameStreamExportConfig& configB)
+{
+  // clang-format off
+  return configA.enabled              == configB.enabled              &&
+         configA.logQueries           == configB.logQueries           &&
+         configA.logResponses         == configB.logResponses         &&
+         configA.bufferHint           == configB.bufferHint           &&
+         configA.flushTimeout         == configB.flushTimeout         &&
+         configA.inputQueueSize       == configB.inputQueueSize       &&
+         configA.outputQueueSize      == configB.outputQueueSize      &&
+         configA.queueNotifyThreshold == configB.queueNotifyThreshold &&
+         configA.reopenInterval       == configB.reopenInterval       &&
+         configA.servers              == configB.servers;
+  // clang-format on
+}
+
+bool operator!=(const FrameStreamExportConfig& configA, const FrameStreamExportConfig& configB)
+{
+  return !(configA == configB);
+}
+
 template <typename C>
 typename C::value_type::second_type constGet(const C& c, const std::string& name)
 {

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -62,13 +62,6 @@ struct FrameStreamExportConfig
 bool operator==(const FrameStreamExportConfig& configA, const FrameStreamExportConfig& configB);
 bool operator!=(const FrameStreamExportConfig& configA, const FrameStreamExportConfig& configB);
 
-struct FrameStreamServersInfo
-{
-  std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> servers;
-  uint64_t generation;
-  FrameStreamExportConfig config;
-};
-
 struct TrustAnchorFileInfo
 {
   uint32_t interval{24};

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -28,6 +28,7 @@
 #include "validate.hh"
 #include "rec-zonetocache.hh"
 #include "logging.hh"
+#include "fstrm_logger.hh"
 
 struct ProtobufExportConfig
 {
@@ -56,6 +57,16 @@ struct FrameStreamExportConfig
   unsigned outputQueueSize{0};
   unsigned queueNotifyThreshold{0};
   unsigned reopenInterval{0};
+};
+
+bool operator==(const FrameStreamExportConfig& configA, const FrameStreamExportConfig& configB);
+bool operator!=(const FrameStreamExportConfig& configA, const FrameStreamExportConfig& configB);
+
+struct FrameStreamServersInfo
+{
+  std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> servers;
+  uint64_t generation;
+  FrameStreamExportConfig config;
 };
 
 struct TrustAnchorFileInfo

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -58,8 +58,7 @@ static thread_local uint64_t t_protobufServersGeneration;
 static thread_local uint64_t t_outgoingProtobufServersGeneration;
 
 #ifdef HAVE_FSTRM
-thread_local std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> t_frameStreamServers{nullptr};
-thread_local uint64_t t_frameStreamServersGeneration;
+thread_local FrameStreamServersInfo t_frameStreamServersInfo;
 #endif /* HAVE_FSTRM */
 
 string g_programname = "pdns_recursor";
@@ -629,26 +628,28 @@ static std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> startFra
 bool checkFrameStreamExport(LocalStateHolder<LuaConfigItems>& luaconfsLocal)
 {
   if (!luaconfsLocal->frameStreamExportConfig.enabled) {
-    if (t_frameStreamServers) {
+    if (t_frameStreamServersInfo.servers) {
       // dt's take care of cleanup
-      t_frameStreamServers.reset();
+      t_frameStreamServersInfo.servers.reset();
+      t_frameStreamServersInfo.config = luaconfsLocal->frameStreamExportConfig;
     }
 
     return false;
   }
 
-  /* if the server was not running, or if it was running according to a
-     previous configuration */
-  if (!t_frameStreamServers || t_frameStreamServersGeneration < luaconfsLocal->generation) {
-
-    if (t_frameStreamServers) {
+  /* if the server was not running, or if it was running according to a previous
+   * configuration
+   */
+  if (t_frameStreamServersInfo.generation < luaconfsLocal->generation && t_frameStreamServersInfo.config != luaconfsLocal->frameStreamExportConfig) {
+    if (t_frameStreamServersInfo.servers) {
       // dt's take care of cleanup
-      t_frameStreamServers.reset();
+      t_frameStreamServersInfo.servers.reset();
     }
 
-    auto log = g_slog->withName("dnstap");
-    t_frameStreamServers = startFrameStreamServers(luaconfsLocal->frameStreamExportConfig, log);
-    t_frameStreamServersGeneration = luaconfsLocal->generation;
+    auto dnsTapLog = g_slog->withName("dnstap");
+    t_frameStreamServersInfo.servers = startFrameStreamServers(luaconfsLocal->frameStreamExportConfig, dnsTapLog);
+    t_frameStreamServersInfo.config = luaconfsLocal->frameStreamExportConfig;
+    t_frameStreamServersInfo.generation = luaconfsLocal->generation;
   }
 
   return true;

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -625,12 +625,20 @@ static std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> startFra
   return result;
 }
 
+static void asyncFrameStreamLoggersCleanup(std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>&& servers)
+{
+  auto thread = std::thread([&] {
+    servers.reset();
+  });
+  thread.detach();
+}
+
 bool checkFrameStreamExport(LocalStateHolder<LuaConfigItems>& luaconfsLocal)
 {
   if (!luaconfsLocal->frameStreamExportConfig.enabled) {
     if (t_frameStreamServersInfo.servers) {
       // dt's take care of cleanup
-      t_frameStreamServersInfo.servers.reset();
+      asyncFrameStreamLoggersCleanup(std::move(t_frameStreamServersInfo.servers));
       t_frameStreamServersInfo.config = luaconfsLocal->frameStreamExportConfig;
     }
 
@@ -643,7 +651,7 @@ bool checkFrameStreamExport(LocalStateHolder<LuaConfigItems>& luaconfsLocal)
   if (t_frameStreamServersInfo.generation < luaconfsLocal->generation && t_frameStreamServersInfo.config != luaconfsLocal->frameStreamExportConfig) {
     if (t_frameStreamServersInfo.servers) {
       // dt's take care of cleanup
-      t_frameStreamServersInfo.servers.reset();
+      asyncFrameStreamLoggersCleanup(std::move(t_frameStreamServersInfo.servers));
     }
 
     auto dnsTapLog = g_slog->withName("dnstap");

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -249,6 +249,13 @@ extern thread_local std::shared_ptr<nod::UniqueResponseDB> t_udrDBp;
 #endif
 
 #ifdef HAVE_FSTRM
+struct FrameStreamServersInfo
+{
+  std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> servers;
+  uint64_t generation;
+  FrameStreamExportConfig config;
+};
+
 extern thread_local FrameStreamServersInfo t_frameStreamServersInfo;
 #endif /* HAVE_FSTRM */
 

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -249,8 +249,7 @@ extern thread_local std::shared_ptr<nod::UniqueResponseDB> t_udrDBp;
 #endif
 
 #ifdef HAVE_FSTRM
-extern thread_local std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> t_frameStreamServers;
-extern thread_local uint64_t t_frameStreamServersGeneration;
+extern thread_local FrameStreamServersInfo t_frameStreamServersInfo;
 #endif /* HAVE_FSTRM */
 
 #ifdef HAVE_BOOST_CONTAINER_FLAT_SET_HPP


### PR DESCRIPTION
### Short description
- Avoid reloading Lua config if it hasn't changed
- Asynchronously destroys dnstap connections from the old config in case of reload

Fixes #11795

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)