### PR TITLE
dnsdist: Slightly reduce contention around a pool's servers

### DIFF
--- a/pdns/dnsdist-lbpolicies.hh
+++ b/pdns/dnsdist-lbpolicies.hh
@@ -96,7 +96,7 @@ void setPoolPolicy(pools_t& pools, const string& poolName, std::shared_ptr<Serve
 void addServerToPool(pools_t& pools, const string& poolName, std::shared_ptr<DownstreamState> server);
 void removeServerFromPool(pools_t& pools, const string& poolName, std::shared_ptr<DownstreamState> server);
 
-const std::shared_ptr<ServerPolicy::NumberedServerVector> getDownstreamCandidates(const map<std::string,std::shared_ptr<ServerPool>>& pools, const std::string& poolName);
+const std::shared_ptr<const ServerPolicy::NumberedServerVector> getDownstreamCandidates(const map<std::string,std::shared_ptr<ServerPool>>& pools, const std::string& poolName);
 
 std::shared_ptr<DownstreamState> firstAvailable(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1011,7 +1011,7 @@ public:
 
 struct ServerPool
 {
-  ServerPool(): d_servers(std::make_shared<ServerPolicy::NumberedServerVector>())
+  ServerPool(): d_servers(std::make_shared<const ServerPolicy::NumberedServerVector>())
   {
   }
 
@@ -1036,12 +1036,12 @@ struct ServerPool
 
   size_t poolLoad();
   size_t countServers(bool upOnly);
-  const std::shared_ptr<ServerPolicy::NumberedServerVector> getServers();
+  const std::shared_ptr<const ServerPolicy::NumberedServerVector> getServers();
   void addServer(shared_ptr<DownstreamState>& server);
   void removeServer(shared_ptr<DownstreamState>& server);
 
 private:
-  SharedLockGuarded<std::shared_ptr<ServerPolicy::NumberedServerVector>> d_servers;
+  SharedLockGuarded<std::shared_ptr<const ServerPolicy::NumberedServerVector>> d_servers;
   bool d_useECS{false};
 };
 

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -475,21 +475,32 @@ IDState* DownstreamState::getIDState(unsigned int& selectedID, int64_t& generati
 
 size_t ServerPool::countServers(bool upOnly)
 {
+  std::shared_ptr<ServerPolicy::NumberedServerVector> servers = nullptr;
+  {
+    auto lock = d_servers.read_lock();
+    servers = *lock;
+  }
+
   size_t count = 0;
-  auto servers = d_servers.read_lock();
-  for (const auto& server : **servers) {
+  for (const auto& server : *servers) {
     if (!upOnly || std::get<1>(server)->isUp() ) {
       count++;
     }
   }
+
   return count;
 }
 
 size_t ServerPool::poolLoad()
 {
+  std::shared_ptr<ServerPolicy::NumberedServerVector> servers = nullptr;
+  {
+    auto lock = d_servers.read_lock();
+    servers = *lock;
+  }
+
   size_t load = 0;
-  auto servers = d_servers.read_lock();
-  for (const auto& server : **servers) {
+  for (const auto& server : *servers) {
     size_t serverOutstanding = std::get<1>(server)->outstanding.load();
     load += serverOutstanding;
   }

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -475,7 +475,7 @@ IDState* DownstreamState::getIDState(unsigned int& selectedID, int64_t& generati
 
 size_t ServerPool::countServers(bool upOnly)
 {
-  std::shared_ptr<ServerPolicy::NumberedServerVector> servers = nullptr;
+  std::shared_ptr<const ServerPolicy::NumberedServerVector> servers = nullptr;
   {
     auto lock = d_servers.read_lock();
     servers = *lock;
@@ -493,7 +493,7 @@ size_t ServerPool::countServers(bool upOnly)
 
 size_t ServerPool::poolLoad()
 {
-  std::shared_ptr<ServerPolicy::NumberedServerVector> servers = nullptr;
+  std::shared_ptr<const ServerPolicy::NumberedServerVector> servers = nullptr;
   {
     auto lock = d_servers.read_lock();
     servers = *lock;
@@ -507,9 +507,9 @@ size_t ServerPool::poolLoad()
   return load;
 }
 
-const std::shared_ptr<ServerPolicy::NumberedServerVector> ServerPool::getServers()
+const std::shared_ptr<const ServerPolicy::NumberedServerVector> ServerPool::getServers()
 {
-  std::shared_ptr<ServerPolicy::NumberedServerVector> result;
+  std::shared_ptr<const ServerPolicy::NumberedServerVector> result;
   {
     result = *(d_servers.read_lock());
   }
@@ -522,18 +522,18 @@ void ServerPool::addServer(shared_ptr<DownstreamState>& server)
   /* we can't update the content of the shared pointer directly even when holding the lock,
      as other threads might hold a copy. We can however update the pointer as long as we hold the lock. */
   unsigned int count = static_cast<unsigned int>((*servers)->size());
-  auto newServers = std::make_shared<ServerPolicy::NumberedServerVector>(*(*servers));
-  newServers->emplace_back(++count, server);
+  auto newServers = ServerPolicy::NumberedServerVector(*(*servers));
+  newServers.emplace_back(++count, server);
   /* we need to reorder based on the server 'order' */
-  std::stable_sort(newServers->begin(), newServers->end(), [](const std::pair<unsigned int,std::shared_ptr<DownstreamState> >& a, const std::pair<unsigned int,std::shared_ptr<DownstreamState> >& b) {
+  std::stable_sort(newServers.begin(), newServers.end(), [](const std::pair<unsigned int,std::shared_ptr<DownstreamState> >& a, const std::pair<unsigned int,std::shared_ptr<DownstreamState> >& b) {
       return a.second->d_config.order < b.second->d_config.order;
     });
   /* and now we need to renumber for Lua (custom policies) */
   size_t idx = 1;
-  for (auto& serv : *newServers) {
+  for (auto& serv : newServers) {
     serv.first = idx++;
   }
-  *servers = std::move(newServers);
+  *servers = std::make_shared<const ServerPolicy::NumberedServerVector>(std::move(newServers));
 }
 
 void ServerPool::removeServer(shared_ptr<DownstreamState>& server)

--- a/pdns/dnsdistdist/dnsdist-lbpolicies.cc
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.cc
@@ -259,7 +259,7 @@ shared_ptr<DownstreamState> roundrobin(const ServerPolicy::NumberedServerVector&
   return servers.at(candidates.at((counter++) % candidates.size()) - 1).second;
 }
 
-const std::shared_ptr<ServerPolicy::NumberedServerVector> getDownstreamCandidates(const pools_t& pools, const std::string& poolName)
+const std::shared_ptr<const ServerPolicy::NumberedServerVector> getDownstreamCandidates(const pools_t& pools, const std::string& poolName)
 {
   std::shared_ptr<ServerPool> pool = getPool(pools, poolName);
   return pool->getServers();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We only need to take the lock to get the shared pointer, as the actual content is guaranteed not to change, so we do not need to hold the lock while we iterate over the servers list to check whether they are up, or what their current outstanding count is.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
