### PR TITLE
libssl: Properly load ciphers and digests with OpenSSL 3.0

### DIFF
--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -83,11 +83,19 @@ void registerOpenSSLUser()
 #ifdef HAVE_OPENSSL_INIT_CRYPTO
     /* load the default configuration file (or one specified via OPENSSL_CONF),
        which can then be used to load engines.
-       Do not load all ciphers and digests, we only need a few of them and these
+    */
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    /* Since 661595ca0933fe631faeadd14a189acd5d4185e0 we can no longer rely on the ciphers and digests
+       required for TLS to be loaded by OPENSSL_init_ssl(), so let's give up and load everything */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, nullptr);
+#else /* OPENSSL_VERSION_MAJOR >= 3 */
+    /* Do not load all ciphers and digests, we only need a few of them and these
        will be loaded by OPENSSL_init_ssl(). */
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG|OPENSSL_INIT_NO_ADD_ALL_CIPHERS|OPENSSL_INIT_NO_ADD_ALL_DIGESTS, nullptr);
+#endif /* OPENSSL_VERSION_MAJOR >= 3 */
+
     OPENSSL_init_ssl(0, nullptr);
-#endif
+#endif /* HAVE_OPENSSL_INIT_CRYPTO */
 
 #if (OPENSSL_VERSION_NUMBER < 0x1010000fL || (defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER < 0x2090100fL))
     /* load error strings for both libcrypto and libssl */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since https://github.com/openssl/openssl/commit/661595ca0933fe631faeadd14a189acd5d4185e0
we can no longer rely on the ciphers and digests required for TLS to be loaded by `OPENSSL_init_ssl()`, so let's give up and load everything.
I hope you have a lot of RAM.

Hopefully fixes #11853 (I don't have the exact same certificate to be 100% sure).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
