### PR TITLE
DNSName constructor use memchr instead of strchr and cleanup with string_view

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -53,7 +53,7 @@ void DNSName::throwSafeRangeError(const std::string& msg, const char* buf, size_
   throw std::range_error(msg + label + dots);
 }
 
-DNSName::DNSName(const std::string_view& sw)
+DNSName::DNSName(const std::string_view sw)
 {
   const char* p = sw.data();
   size_t length = sw.length();

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -55,7 +55,7 @@ void DNSName::throwSafeRangeError(const std::string& msg, const char* buf, size_
 
 DNSName::DNSName(const char* p, size_t length)
 {
-  if(length == 0 || p[0]==0 || (p[0]=='.' && p[1]==0)) {
+  if(length == 0 || (length == 1 && p[0]=='.')) {
     d_storage.assign(1, (char)0);
   } else {
     if(!std::memchr(p, '\\', length)) {

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -55,10 +55,10 @@ void DNSName::throwSafeRangeError(const std::string& msg, const char* buf, size_
 
 DNSName::DNSName(const char* p, size_t length)
 {
-  if(p[0]==0 || (p[0]=='.' && p[1]==0)) {
+  if(length == 0 || p[0]==0 || (p[0]=='.' && p[1]==0)) {
     d_storage.assign(1, (char)0);
   } else {
-    if(!strchr(p, '\\')) {
+    if(!std::memchr(p, '\\', length)) {
       unsigned char lenpos=0;
       unsigned char labellen=0;
       size_t plen=length;

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -53,13 +53,13 @@ void DNSName::throwSafeRangeError(const std::string& msg, const char* buf, size_
   throw std::range_error(msg + label + dots);
 }
 
-DNSName::DNSName(const std::string_view sw)
+DNSName::DNSName(const std::string_view& sw)
 {
   const char* p = sw.data();
   size_t length = sw.length();
 
   if(length == 0 || (length == 1 && p[0]=='.')) {
-    d_storage.assign(1, (char)0);
+    d_storage.assign(1, '\0');
   } else {
     if(!std::memchr(p, '\\', length)) {
       unsigned char lenpos=0;
@@ -71,7 +71,7 @@ DNSName::DNSName(const std::string_view sw)
         lenpos = d_storage.size();
         if(*iter=='.')
           throwSafeRangeError("Found . in wrong position in DNSName: ", p, length);
-        d_storage.append(1, (char)0);
+        d_storage.append(1, '\0');
         labellen=0;
         auto begiter=iter;
         for(; iter != pend && *iter!='.'; ++iter) {
@@ -88,7 +88,7 @@ DNSName::DNSName(const std::string_view sw)
 
         d_storage[lenpos]=labellen;
       }
-      d_storage.append(1, (char)0);
+      d_storage.append(1, '\0');
     }
     else {
       d_storage=segmentDNSNameRaw(p, length);

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -64,9 +64,9 @@ DNSName::DNSName(const std::string_view sw)
     if(!std::memchr(p, '\\', length)) {
       unsigned char lenpos=0;
       unsigned char labellen=0;
-      size_t plen=length;
-      const char* const pbegin=p, *pend=p+plen;
-      d_storage.reserve(plen+1);
+      const char* const pbegin=p, *pend=p+length;
+
+      d_storage.reserve(length+1);
       for(auto iter = pbegin; iter != pend; ) {
         lenpos = d_storage.size();
         if(*iter=='.')

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -53,8 +53,11 @@ void DNSName::throwSafeRangeError(const std::string& msg, const char* buf, size_
   throw std::range_error(msg + label + dots);
 }
 
-DNSName::DNSName(const char* p, size_t length)
+DNSName::DNSName(const std::string_view sw)
 {
+  const char* p = sw.data();
+  size_t length = sw.length();
+
   if(length == 0 || (length == 1 && p[0]=='.')) {
     d_storage.assign(1, (char)0);
   } else {

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -99,7 +99,7 @@ public:
   DNSName(const DNSName& a) = default;
   DNSName(DNSName&& a) = default;
 
-  explicit DNSName(const std::string_view& sw); //!< Constructs from a human formatted, escaped presentation
+  explicit DNSName(std::string_view sw); //!< Constructs from a human formatted, escaped presentation
   DNSName(const char* p, int len, int offset, bool uncompress, uint16_t* qtype=nullptr, uint16_t* qclass=nullptr, unsigned int* consumed=nullptr, uint16_t minOffset=0); //!< Construct from a DNS Packet, taking the first question if offset=12. If supplied, consumed is set to the number of bytes consumed from the packet, which will not be equal to the wire length of the resulting name in case of compression.
 
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name? Note that name.isPartOf(name).

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -99,7 +99,7 @@ public:
   DNSName(const DNSName& a) = default;
   DNSName(DNSName&& a) = default;
 
-  explicit DNSName(const std::string_view sw); //!< Constructs from a human formatted, escaped presentation
+  explicit DNSName(const std::string_view& sw); //!< Constructs from a human formatted, escaped presentation
   DNSName(const char* p, int len, int offset, bool uncompress, uint16_t* qtype=nullptr, uint16_t* qclass=nullptr, unsigned int* consumed=nullptr, uint16_t minOffset=0); //!< Construct from a DNS Packet, taking the first question if offset=12. If supplied, consumed is set to the number of bytes consumed from the packet, which will not be equal to the wire length of the resulting name in case of compression.
 
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name? Note that name.isPartOf(name).

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <iterator>
 #include <unordered_set>
+#include <string_view>
 
 #include <boost/version.hpp>
 
@@ -97,9 +98,8 @@ public:
   }
   DNSName(const DNSName& a) = default;
   DNSName(DNSName&& a) = default;
-  explicit DNSName(const char* p): DNSName(p, std::strlen(p)) {} //!< Constructs from a human formatted, escaped presentation
-  explicit DNSName(const char* p, size_t len);      //!< Constructs from a human formatted, escaped presentation
-  explicit DNSName(const std::string& str) : DNSName(str.c_str(), str.length()) {}; //!< Constructs from a human formatted, escaped presentation
+
+  explicit DNSName(const std::string_view sw); //!< Constructs from a human formatted, escaped presentation
   DNSName(const char* p, int len, int offset, bool uncompress, uint16_t* qtype=nullptr, uint16_t* qclass=nullptr, unsigned int* consumed=nullptr, uint16_t minOffset=0); //!< Construct from a DNS Packet, taking the first question if offset=12. If supplied, consumed is set to the number of bytes consumed from the packet, which will not be equal to the wire length of the resulting name in case of compression.
 
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name? Note that name.isPartOf(name).


### PR DESCRIPTION
Also check length before de-referencing.

## Direct rational for this change:

- Why using `strchr` if we have a length?
- Accepting `char * p` that doesn't contains `\0`

## Is it safe?

- In case of calling from `DNSName` `string` constructor yes `string::length` exclude `\0`
- In case of calling directly it's callee responsibility to provide a valid `length` but it's not less safe than just doing `strchr` IMHO

## Is it still fast?

Not slower in our dev environment.

## Deep rationale: Accepting `char * p` without terminating `\0` 

At work we use https://github.com/PowerDNS/pdns/pull/5160 from @baloo, I work on upstreaming + rebasing this contribution to master (will open an issue to discuss design about it soon).

In a lot of languages `string`s don't terminate with a `\0` like in Rust, so I got some over-read of one with `valgrind` on `strchr` when I wanted to get rid of `string` temporaries just for zeroes.

https://github.com/PowerDNS/pdns/pull/5160/files#diff-8c7f7456f404944349f62aab6fe3444ab12ce90e88d32e3a1a4a93892dd0785aR139-R140

EDIT: small change for clarity English is not my native language