### PR TITLE
Rec: proxymapping stats

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -693,11 +693,27 @@ public:
     return d_network.getBit(bit);
   }
 
+  struct Hash {
+    size_t operator()(const Netmask& nm) const
+    {
+      return burtle(&nm.d_bits, 1, ComboAddress::addressOnlyHash()(nm.d_network));
+    }
+  };
+
 private:
   ComboAddress d_network;
   uint32_t d_mask;
   uint8_t d_bits;
 };
+
+namespace std {
+  template<>
+  struct hash<Netmask> {
+    auto operator()(const Netmask& nm) const {
+      return Netmask::Hash{}(nm);
+    }
+  };
+}
 
 /** Binary tree map implementation with <Netmask,T> pair.
  *

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1843,10 +1843,10 @@ bool checkForCacheHit(bool qnameParsed, unsigned int tag, const string& data,
 
     // This is only to get the proxyMapping suffixMatch stats right i the case of a PC hit
     if (t_proxyMapping && source != mappedSource) {
-      if (auto it = t_proxyMapping->lookup(source)) {
-        if (it->second.suffixMatchNode) {
-          if (it->second.suffixMatchNode->check(qname)) {
-            ++it->second.stats.suffixMatches;
+      if (const auto* found = t_proxyMapping->lookup(source)) {
+        if (found->second.suffixMatchNode) {
+          if (found->second.suffixMatchNode->check(qname)) {
+            ++found->second.stats.suffixMatches;
           }
         }
       }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -963,6 +963,9 @@ void startDoResolve(void* p)
             // No match in domains, use original source
             useMapped = false;
           }
+          else {
+            ++it->second.stats.suffixMatches;
+          }
         }
         // No suffix match node defined, use mapped address
       }
@@ -1812,7 +1815,7 @@ bool checkForCacheHit(bool qnameParsed, unsigned int tag, const string& data,
                       DNSName& qname, uint16_t& qtype, uint16_t& qclass,
                       const struct timeval& now,
                       string& response, uint32_t& qhash,
-                      RecursorPacketCache::OptPBData& pbData, bool tcp, const ComboAddress& source)
+                      RecursorPacketCache::OptPBData& pbData, bool tcp, const ComboAddress& source, const ComboAddress& mappedSource)
 {
   if (!t_packetCache) {
     return false;
@@ -1835,6 +1838,17 @@ bool checkForCacheHit(bool qnameParsed, unsigned int tag, const string& data,
       }
       if (t_bogusqueryring) {
         t_bogusqueryring->push_back({qname, qtype});
+      }
+    }
+
+    // This is only to get the proxyMapping suffixMatch stats right i the case of a PC hit
+    if (t_proxyMapping && source != mappedSource) {
+      if (auto it = t_proxyMapping->lookup(source)) {
+        if (it->second.suffixMatchNode) {
+          if (it->second.suffixMatchNode->check(qname)) {
+            ++it->second.stats.suffixMatches;
+          }
+        }
       }
     }
 
@@ -2028,7 +2042,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
          but it means that the hash would not be computed. If some script decides at a later time to mark back the answer
          as cacheable we would cache it with a wrong tag, so better safe than sorry. */
       eventTrace.add(RecEventTrace::PCacheCheck);
-      bool cacheHit = checkForCacheHit(qnameParsed, ctag, question, qname, qtype, qclass, g_now, response, qhash, pbData, false, source);
+      bool cacheHit = checkForCacheHit(qnameParsed, ctag, question, qname, qtype, qclass, g_now, response, qhash, pbData, false, source, mappedSource);
       eventTrace.add(RecEventTrace::PCacheCheck, cacheHit, false);
       if (cacheHit) {
         if (!g_quiet) {
@@ -2265,6 +2279,7 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       if (t_proxyMapping) {
         if (auto it = t_proxyMapping->lookup(source)) {
           mappedSource = it->second.address;
+          ++it->second.stats.netmaskMatches;
         }
       }
       if (t_remotes) {

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -77,10 +77,17 @@ enum class AdditionalMode : uint8_t
   ResolveDeferred
 };
 
+struct ProxyMappingCounts
+{
+  uint64_t netmaskMatches{};
+  uint64_t suffixMatches{};
+};
+
 struct ProxyByTableValue
 {
   ComboAddress address;
   boost::optional<SuffixMatchNode> suffixMatchNode;
+  mutable ProxyMappingCounts stats{};
 };
 
 using ProxyMapping = NetmaskTree<ProxyByTableValue, Netmask>;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -942,8 +942,9 @@ static ProxyMappingStats_t* pleaseGetProxyMappingStats()
 static string doGetProxyMappingStats()
 {
   ostringstream ret;
-  auto m = broadcastAccFunction<ProxyMappingStats_t>(pleaseGetProxyMappingStats);
-  for (const auto& [key, entry] : m) {
+  ret << "subnet\t\t\tmatches\tsuffixmatches" << endl;
+  auto proxyMappingStats = broadcastAccFunction<ProxyMappingStats_t>(pleaseGetProxyMappingStats);
+  for (const auto& [key, entry] : proxyMappingStats) {
     ret << key.toString() << '\t' << entry.netmaskMatches << '\t' << entry.suffixMatches << endl;
   }
   return ret.str();
@@ -1164,9 +1165,9 @@ static StatsMap toProxyMappingStatsMap(const string& name)
   const string pbasename = getPrometheusName(name);
   StatsMap entries;
 
-  auto m = broadcastAccFunction<ProxyMappingStats_t>(pleaseGetProxyMappingStats);
+  auto proxyMappingStats = broadcastAccFunction<ProxyMappingStats_t>(pleaseGetProxyMappingStats);
   size_t count = 0;
-  for (const auto& [key, entry] : m) {
+  for (const auto& [key, entry] : proxyMappingStats) {
     auto keyname = pbasename + "{netmask=\"" + key.toString() + "\",count=\"";
     auto sname1 = name + "-n-" + std::to_string(count);
     auto pname1 = keyname + "netmaskmatches\"}";
@@ -1920,7 +1921,7 @@ static void* pleaseSupplantProxyMapping(const ProxyMapping& pm)
       auto& newentry = newmapping->insert(nm);
       newentry.second = entry;
       if (t_proxyMapping) {
-        if (auto existing = t_proxyMapping->lookup(nm); existing != nullptr) {
+        if (const auto* existing = t_proxyMapping->lookup(nm); existing != nullptr) {
           newentry.second.stats = existing->second.stats;
         }
       }

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -161,6 +161,9 @@ get-tas
 get-parameter *KEY* [*KEY*]...
     Retrieves the specified configuration parameter(s).
 
+get-proxymapping-stats
+    Get the list of proxy-mapped subnets and associated counters.
+
 get-qtypelist
     Retrieves QType statistics. Queries from cache aren't being counted yet.
 

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -233,7 +233,8 @@ extern string g_programname;
 extern string g_pidfname;
 extern RecursorControlChannel g_rcc; // only active in the handler thread
 
-extern thread_local std::shared_ptr<ProxyMapping> t_proxyMapping;
+extern thread_local std::unique_ptr<ProxyMapping> t_proxyMapping;
+using ProxyMappingStats_t = std::unordered_map<Netmask, ProxyMappingCounts>;
 
 #ifdef NOD_ENABLED
 extern bool g_nodEnabled;
@@ -519,7 +520,7 @@ bool checkForCacheHit(bool qnameParsed, unsigned int tag, const string& data,
                       DNSName& qname, uint16_t& qtype, uint16_t& qclass,
                       const struct timeval& now,
                       string& response, uint32_t& qhash,
-                      RecursorPacketCache::OptPBData& pbData, bool tcp, const ComboAddress& source);
+                      RecursorPacketCache::OptPBData& pbData, bool tcp, const ComboAddress& source, const ComboAddress& mappedSource);
 void protobufLogResponse(pdns::ProtoZero::RecMessage& message);
 void protobufLogResponse(const struct dnsheader* dh, LocalStateHolder<LuaConfigItems>& luaconfsLocal,
                          const RecursorPacketCache::OptPBData& pbData, const struct timeval& tv,

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -269,6 +269,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       if (t_proxyMapping) {
         if (auto it = t_proxyMapping->lookup(conn->d_source)) {
           conn->d_mappedSource = it->second.address;
+          ++it->second.stats.netmaskMatches;
         }
       }
       if (t_allowFrom && !t_allowFrom->match(&conn->d_mappedSource)) {
@@ -553,7 +554,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
              but it means that the hash would not be computed. If some script decides at a later time to mark back the answer
              as cacheable we would cache it with a wrong tag, so better safe than sorry. */
           dc->d_eventTrace.add(RecEventTrace::PCacheCheck);
-          bool cacheHit = checkForCacheHit(qnameParsed, dc->d_tag, conn->data, qname, qtype, qclass, g_now, response, dc->d_qhash, pbData, true, dc->d_source);
+          bool cacheHit = checkForCacheHit(qnameParsed, dc->d_tag, conn->data, qname, qtype, qclass, g_now, response, dc->d_qhash, pbData, true, dc->d_source, dc->d_mappedSource);
           dc->d_eventTrace.add(RecEventTrace::PCacheCheck, cacheHit, false);
 
           if (cacheHit) {
@@ -652,6 +653,7 @@ void handleNewTCPQuestion(int fd, FDMultiplexer::funcparam_t&)
     if (!fromProxyProtocolSource && t_proxyMapping) {
       if (auto it = t_proxyMapping->lookup(addr)) {
         mappedSource = it->second.address;
+        ++it->second.stats.netmaskMatches;
       }
     }
     if (!fromProxyProtocolSource && t_allowFrom && !t_allowFrom->match(&mappedSource)) {

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -1149,6 +1149,11 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::d_metrics
   {"maintenance-calls",
    MetricDefinition(PrometheusMetricType::counter,
                     "Number of times internal maintenance has been called, including Lua maintenance")},
+
+  // For multicounters, state the first
+  {"proxy-mapping-total-n-0",
+   MetricDefinition(PrometheusMetricType::multicounter,
+                    "Number of queries matching proxyMappings")},
 };
 
 #define CHECK_PROMETHEUS_METRICS 0
@@ -1171,7 +1176,7 @@ static void validatePrometheusMetrics()
 
     if (!s_metricDefinitions.getMetricDetails(metricName, metricDetails)) {
       SLOG(g_log << Logger::Debug << "{ \"" << metricName << "\", MetricDefinition(PrometheusMetricType::counter, \"\")}," << endl,
-           g_slog->info(Logr::Debug, "{ \"" << metricName << "\", MetricDefinition(PrometheusMetricType::counter, \"\")},"));
+           g_slog->info(Logr::Debug, "{ \"" + metricName + "\", MetricDefinition(PrometheusMetricType::counter, \"\")},"));
     }
   }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This implements two counters per ProxyMapping subnet. First counter (netmaskMatches) counts the number of hits based on netmask. The second counter counts the hits of domain (if relevant for the mapping).

I did not want to introduce another atomic count, as one day we will be moving to an mcounter like approach.

Actually this PR contains two approaches avoiding atomic counters:
 - The first part (commit 1-3)). Creates a per-thread map of netmask->counts.
This has the drawback that for each ProxyMapping match, we also need to do a lookup in the counts map to find the counters to increment.
- The second approach (last commit) changes the ProxyMapping config to be per-thread (in master it is a shared pointer per thread, all these pointers point to a common config object). That way we can keep the counts in the config object and we do not need the extra lookup. Does need a bit of changing types. We do make sure old counts are not lost on reload.

Example Prometheus output:
```
# TYPE pdns_recursor_proxy_mapping_total counter
# HELP pdns_recursor_proxy_mapping_total Number of queries matching proxyMappings
pdns_recursor_proxy_mapping_total{netmask="127.0.0.0/24",count="netmaskmatches"} 1
pdns_recursor_proxy_mapping_total{netmask="192.168.178.0/24",count="netmaskmatches"} 0
pdns_recursor_proxy_mapping_total{netmask="192.168.178.6/32",count="netmaskmatches"} 0
pdns_recursor_proxy_mapping_total{netmask="192.168.178.99/32",count="netmaskmatches"} 0
pdns_recursor_proxy_mapping_total{netmask="127.0.0.0/24",count="suffixmatches"} 1
pdns_recursor_proxy_mapping_total{netmask="192.168.178.0/24",count="suffixmatches"} 0
pdns_recursor_proxy_mapping_total{netmask="192.168.178.6/32",count="suffixmatches"} 0
pdns_recursor_proxy_mapping_total{netmask="192.168.178.99/32",count="suffixmatches"} 0
```
There is also
```
$ ./rec_control get-proxymapping-stats
127.0.0.0/24	1	1
192.168.178.0/24	0	0
192.168.178.6/32	0	0
192.168.178.99/32	0	0
```
<strike>One potential issue is that the suffixmatches are only incremented on non-PC hits. This has to do with where the suffix the matching is done: after the PC check. I have to see if that is fixable in an easy way.</strike>

Fixes  #11648

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
