### PR TITLE
rec: Keep time and count metrics when maintenance is called.

### DIFF
--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -387,6 +387,6 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   registerCounter64Stat("almost-expired-exceptions", almostExpiredExceptions, OID_LENGTH(almostExpiredExceptions));
   registerCounter64Stat("non-resolving-nameserver-entries", nonResolvingNameserverEntriesOID, OID_LENGTH(nonResolvingNameserverEntriesOID));
   registerCounter64Stat("maintenance-usec", maintenanceUSecOID, OID_LENGTH(maintenanceUSecOID));
-  registerCounter64Stat("maintenance-calls", maintenanceCountOID, OID_LENGTH(maintenanceCallsOID));
+  registerCounter64Stat("maintenance-calls", maintenanceCallsOID, OID_LENGTH(maintenanceCallsOID));
 #endif /* HAVE_NET_SNMP */
 }

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -147,6 +147,8 @@ static const oid udp6InCsumErrorsOID[] = {RECURSOR_STATS_OID, 123};
 static const oid sourceDisallowedNotifyOID[] = {RECURSOR_STATS_OID, 124};
 static const oid zoneDisallowedNotifyOID[] = {RECURSOR_STATS_OID, 125};
 static const oid nonResolvingNameserverEntriesOID[] = {RECURSOR_STATS_OID, 126};
+static const oid maintenanceUSecOID[] = {RECURSOR_STATS_OID, 127};
+static const oid maintenanceCallsOID[] = {RECURSOR_STATS_OID, 128};
 
 static std::unordered_map<oid, std::string> s_statsMap;
 
@@ -384,5 +386,7 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   registerCounter64Stat("almost-expired-run", almostExpiredRun, OID_LENGTH(almostExpiredRun));
   registerCounter64Stat("almost-expired-exceptions", almostExpiredExceptions, OID_LENGTH(almostExpiredExceptions));
   registerCounter64Stat("non-resolving-nameserver-entries", nonResolvingNameserverEntriesOID, OID_LENGTH(nonResolvingNameserverEntriesOID));
+  registerCounter64Stat("maintenance-usec", maintenanceUSecOID, OID_LENGTH(maintenanceUSecOID));
+  registerCounter64Stat("maintenance-calls", maintenanceCountOID, OID_LENGTH(maintenanceCallsOID));
 #endif /* HAVE_NET_SNMP */
 }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1383,6 +1383,9 @@ static void registerAllStats1()
 
   addGetStat("idle-tcpout-connections", getCurrentIdleTCPConnections);
 
+  addGetStat("maintenance-usec", &g_stats.maintenanceUsec);
+  addGetStat("maintenance-calls", &g_stats.maintenanceCalls);
+
   /* make sure that the ECS stats are properly initialized */
   SyncRes::clearECSStats();
   for (size_t idx = 0; idx < SyncRes::s_ecsResponsesBySubnetSize4.size(); idx++) {

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -1066,7 +1066,7 @@ nonResolvingNameserverEntries OBJECT-TYPE
     ::= { stats 126 }
 
 maintenanceUSec OBJECT-TYPE
-    SYNTAX CounterBasedGauge64
+    SYNTAX Counter64
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
@@ -1074,7 +1074,7 @@ maintenanceUSec OBJECT-TYPE
     ::= { stats 127 }
 
 maintenanceCount OBJECT-TYPE
-    SYNTAX CounterBasedGauge64
+    SYNTAX Counter64
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -48,6 +48,9 @@ rec MODULE-IDENTITY
     REVISION "202201310000Z"
     DESCRIPTION "Added non-resolving NS name metric."
 
+    REVISION "202208220000Z"
+    DESCRIPTION "Added internal maintenance metrics."
+
     ::= { powerdns 2 }
 
 powerdns		OBJECT IDENTIFIER ::= { enterprises 43315 }
@@ -1235,7 +1238,9 @@ recGroup OBJECT-GROUP
         udp6InCsumErrors,
         sourceDisallowedNotify,
         zoneDisallowedNotify,
-        nonResolvingNameserverEntries
+        nonResolvingNameserverEntries,
+        maintenanceUSec,
+        maintenanceCalls
     }
     STATUS current
     DESCRIPTION "Objects conformance group for PowerDNS Recursor"

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -1065,6 +1065,22 @@ nonResolvingNameserverEntries OBJECT-TYPE
         "Number of entries in the non-resolving NS name cache"
     ::= { stats 126 }
 
+maintenanceUSec OBJECT-TYPE
+    SYNTAX CounterBasedGauge64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Time spent doing internal maintenance, including Lua maintenance"
+    ::= { stats 127 }
+
+maintenanceCount OBJECT-TYPE
+    SYNTAX CounterBasedGauge64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of times internal maintenance has been called, including Lua maintenance"
+    ::= { stats 128 }
+
 ---
 --- Traps / Notifications
 ---

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -512,6 +512,14 @@ ipv6-questions
 ^^^^^^^^^^^^^^
 counts all end-user initiated queries with the RD   bit set, received over IPv6 UDP
 
+maintenance-usec
+^^^^^^^^^^^^^^^^
+time spent doing internal maintenance, including Lua maintenance
+
+maintenance-calls
+^^^^^^^^^^^^^^^^^
+number of times internal maintenance has been called, including Lua maintenance
+
 malloc-bytes
 ^^^^^^^^^^^^
 returns the number of bytes allocated by the process (broken, always returns 0)

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -794,6 +794,8 @@ struct RecursorStats
   pdns::stat_t proxyProtocolInvalidCount{0};
   pdns::stat_t nodLookupsDroppedOversize{0};
   pdns::stat_t dns64prefixanswers{0};
+  pdns::stat_t maintenanceUsec{0};
+  pdns::stat_t maintenanceCalls{0};
 
   RecursorStats() :
     answers("answers", { 1000, 10000, 100000, 1000000 }),

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -1142,6 +1142,13 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::d_metrics
    MetricDefinition(PrometheusMetricType::gauge,
                     "Number of connections in the TCP idle outgoing connections pool")},
 
+  {"maintenance-usec",
+   MetricDefinition(PrometheusMetricType::counter,
+                    "Time spent doing internal maintenance, including Lua maintenance")},
+
+  {"maintenance-calls",
+   MetricDefinition(PrometheusMetricType::counter,
+                    "Number of times internal maintenance has been called, including Lua maintenance")},
 };
 
 #define CHECK_PROMETHEUS_METRICS 0


### PR DESCRIPTION
Fixes #6981

If we think it will provide useful numbers, we could split the metrics in a general maintenance and Lua maintenance.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
