### PR TITLE
Reorganize protobuf queueData() with respect to logging

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -1433,7 +1433,7 @@ static DnstapMessage::ProtocolType ProtocolToDNSTap(dnsdist::Protocol protocol)
   throw std::runtime_error("Unhandled protocol for dnstap: " + protocol.toPrettyString());
 }
 
-void remoteLoggerQueueData(RemoteLoggerInterface& r, const std::string& data)
+static void remoteLoggerQueueData(RemoteLoggerInterface& r, const std::string& data)
 {
   auto ret = r.queueData(data);
 
@@ -1441,15 +1441,15 @@ void remoteLoggerQueueData(RemoteLoggerInterface& r, const std::string& data)
   case RemoteLoggerInterface::Result::Queued:
     break;
   case RemoteLoggerInterface::Result::PipeFull: {
-    vinfolog("%s: queue full, dropping.", r.name().c_str());
+    vinfolog("%s: %s", r.name(), RemoteLoggerInterface::toErrorString(ret));
     break;
   }
   case RemoteLoggerInterface::Result::TooLarge: {
-    warnlog("%s: Not sending too large protobuf message", r.name().c_str());
+    warnlog("%s: %s", r.name(), RemoteLoggerInterface::toErrorString(ret));
     break;
   }
   case RemoteLoggerInterface::Result::OtherError:
-    warnlog("%s: submitting to queue failed", r.name().c_str());
+    warnlog("%s: %s", r.name(), RemoteLoggerInterface::toErrorString(ret));
   }
 }
 

--- a/pdns/fstrm_logger.hh
+++ b/pdns/fstrm_logger.hh
@@ -38,7 +38,11 @@ class FrameStreamLogger : public RemoteLoggerInterface, boost::noncopyable
 public:
   FrameStreamLogger(int family, const std::string& address, bool connect, const std::unordered_map<string,unsigned>& options = std::unordered_map<string,unsigned>());
   ~FrameStreamLogger();
-  void queueData(const std::string& data) override;
+  [[nodiscard]] RemoteLoggerInterface::Result queueData(const std::string& data) override;
+  std::string name() const override
+  {
+    return "framestream";
+  }
   std::string toString() const override
   {
     return "FrameStreamLogger to " + d_address + " (" + std::to_string(d_framesSent) + " frames sent, " + std::to_string(d_queueFullDrops) + " dropped, " + std::to_string(d_permanentFailures) + " permanent failures)";

--- a/pdns/fstrm_logger.hh
+++ b/pdns/fstrm_logger.hh
@@ -39,7 +39,7 @@ public:
   FrameStreamLogger(int family, const std::string& address, bool connect, const std::unordered_map<string,unsigned>& options = std::unordered_map<string,unsigned>());
   ~FrameStreamLogger();
   [[nodiscard]] RemoteLoggerInterface::Result queueData(const std::string& data) override;
-  std::string name() const override
+  const std::string name() const override
   {
     return "framestream";
   }

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -72,22 +72,22 @@ void remoteLoggerQueueData(RemoteLoggerInterface& r, const std::string& data)
   case RemoteLoggerInterface::Result::Queued:
     break;
   case RemoteLoggerInterface::Result::PipeFull: {
+    const auto msg = RemoteLoggerInterface::toErrorString(ret);
     const auto name = r.name();
-    const auto msg = "queue full, dropping";
     SLOG(g_log << Logger::Debug << name << ": " << msg <<std::endl,
          g_slog->withName(name)->info(Logr::Debug, msg));
     break;
   }
   case RemoteLoggerInterface::Result::TooLarge: {
+    const auto msg = RemoteLoggerInterface::toErrorString(ret);
     const auto name = r.name();
-    const auto msg = "Not sending too large protobuf message";
     SLOG(g_log << Logger::Notice << name << ": " << msg <<endl,
          g_slog->withName(name)->info(Logr::Debug, msg));
     break;
   }
   case RemoteLoggerInterface::Result::OtherError: {
+    const auto msg = RemoteLoggerInterface::toErrorString(ret);
     const auto name = r.name();
-    const auto msg = "submitting to queue failed";
     SLOG(g_log << Logger::Warning << name << ": " << msg << std::endl,
          g_slog->withName(name)->info(Logr::Warning, msg));
     break;

--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -46,6 +46,9 @@
 
 #include "logging.hh"
 
+// Helper to be defined by main program: queue data and log based on return value of queueData()
+void remoteLoggerQueueData(RemoteLoggerInterface&, const std::string&);
+
 extern std::shared_ptr<Logr::Logger> g_slogout;
 
 class LWResException : public PDNSException

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -506,7 +506,7 @@ void protobufLogQuery(LocalStateHolder<LuaConfigItems>& luaconfsLocal, const boo
 
   std::string msg(m.finishAndMoveBuf());
   for (auto& server : *t_protobufServers) {
-    server->queueData(msg);
+    remoteLoggerQueueData(*server, msg);
   }
 }
 
@@ -518,7 +518,7 @@ void protobufLogResponse(pdns::ProtoZero::RecMessage& message)
 
   std::string msg(message.finishAndMoveBuf());
   for (auto& server : *t_protobufServers) {
-    server->queueData(msg);
+    remoteLoggerQueueData(*server, msg);
   }
 }
 

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -131,17 +131,10 @@ bool RemoteLogger::reconnect()
   return true;
 }
 
-void RemoteLogger::queueData(const std::string& data)
+RemoteLoggerInterface::Result RemoteLogger::queueData(const std::string& data)
 {
   if (data.size() > std::numeric_limits<uint16_t>::max()) {
-    const auto msg = "Not sending too large protobuf message";
-#ifdef WE_ARE_RECURSOR
-    SLOG(g_log<<Logger::Info<<msg<<endl,
-         g_slog->withName("protobuf")->info(Logr::Info, msg));
-#else
-    warnlog(msg);
-#endif
-    return;
+    return Result::TooLarge;
   }
 
   auto runtime = d_runtime.lock();
@@ -150,33 +143,34 @@ void RemoteLogger::queueData(const std::string& data)
     /* not connected, queue is full, just drop */
     if (!runtime->d_socket) {
       ++d_drops;
-      return;
+      return Result::PipeFull;
     }
     try {
       /* we try to flush some data */
       if (!runtime->d_writer.flush(runtime->d_socket->getHandle())) {
         /* but failed, let's just drop */
         ++d_drops;
-        return;
+        return Result::PipeFull;
       }
 
       /* see if we freed enough data */
       if (!runtime->d_writer.hasRoomFor(data)) {
         /* we didn't */
         ++d_drops;
-        return;
+        return Result::PipeFull;
       }
     }
     catch(const std::exception& e) {
       //      cout << "Got exception writing: "<<e.what()<<endl;
       ++d_drops;
       runtime->d_socket.reset();
-      return;
+      return Result::PipeFull;
     }
   }
 
   runtime->d_writer.write(data);
   ++d_processed;
+  return Result::Queued;
 }
 
 void RemoteLogger::maintenanceThread() 

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -95,6 +95,19 @@ bool CircularWriteBuffer::flush(int fd)
   return true;
 }
 
+const std::string& RemoteLoggerInterface::toErrorString(Result r)
+{
+  static const std::array<std::string,5> str = {
+    "Queued",
+    "Queue full, dropping",
+    "Not sending too large protobuf message",
+    "Submiting to queue failed",
+    "?"
+  };
+  auto i = static_cast<unsigned int>(r);
+  return str[std::min(i, 4U)];
+}
+
 RemoteLogger::RemoteLogger(const ComboAddress& remote, uint16_t timeout, uint64_t maxQueuedBytes, uint8_t reconnectWaitTime, bool asyncConnect): d_remote(remote), d_timeout(timeout), d_reconnectWaitTime(reconnectWaitTime), d_asyncConnect(asyncConnect), d_runtime({CircularWriteBuffer(maxQueuedBytes), nullptr})
 {
   if (!d_asyncConnect) {
@@ -240,3 +253,4 @@ RemoteLogger::~RemoteLogger()
 
   d_thread.join();
 }
+

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -61,11 +61,12 @@ class RemoteLoggerInterface
 {
 public:
   enum class Result : uint8_t { Queued, PipeFull, TooLarge, OtherError };
+  static const std::string& toErrorString(Result r);
 
   virtual ~RemoteLoggerInterface() {};
   virtual Result queueData(const std::string& data) = 0;
   virtual std::string toString() const = 0;
-  virtual std::string name() const = 0;
+  virtual const std::string name() const = 0;
   bool logQueries(void) const { return d_logQueries; }
   bool logResponses(void) const { return d_logResponses; }
   void setLogQueries(bool flag) { d_logQueries = flag; }
@@ -91,7 +92,7 @@ public:
   ~RemoteLogger();
 
   [[nodiscard]] Result queueData(const std::string& data) override;
-  std::string name() const override
+  const std::string name() const override
   {
     return "protobuf";
   }
@@ -126,5 +127,3 @@ private:
   std::thread d_thread;
 };
 
-// Helper to be defined by main program: queue data and log based on return value of queueData()
-void remoteLoggerQueueData(RemoteLoggerInterface&, const std::string&);

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -60,10 +60,12 @@ private:
 class RemoteLoggerInterface
 {
 public:
-  virtual ~RemoteLoggerInterface() {};
-  virtual void queueData(const std::string& data) = 0;
-  virtual std::string toString() const = 0;
+  enum class Result : uint8_t { Queued, PipeFull, TooLarge, OtherError };
 
+  virtual ~RemoteLoggerInterface() {};
+  virtual Result queueData(const std::string& data) = 0;
+  virtual std::string toString() const = 0;
+  virtual std::string name() const = 0;
   bool logQueries(void) const { return d_logQueries; }
   bool logResponses(void) const { return d_logResponses; }
   void setLogQueries(bool flag) { d_logQueries = flag; }
@@ -87,7 +89,12 @@ public:
                uint8_t reconnectWaitTime=1,
                bool asyncConnect=false);
   ~RemoteLogger();
-  void queueData(const std::string& data) override;
+
+  [[nodiscard]] Result queueData(const std::string& data) override;
+  std::string name() const override
+  {
+    return "protobuf";
+  }
   std::string toString() const override
   {
     return d_remote.toStringWithPort() + " (" + std::to_string(d_processed) + " processed, " + std::to_string(d_drops) + " dropped)";
@@ -118,3 +125,6 @@ private:
   LockGuarded<RuntimeData> d_runtime;
   std::thread d_thread;
 };
+
+// Helper to be defined by main program: queue data and log based on return value of queueData()
+void remoteLoggerQueueData(RemoteLoggerInterface&, const std::string&);


### PR DESCRIPTION
Let `queueData()` return a status and log that via a program supplied helper.
This way, the program specific (`recursor`, `dnsdist`) logging isn't polluting the common code.
I'm not 100% happy with this helper, but I lack inspiration to come up with something better atm.

There are a few other cases that need to be dealt with some day.

`dnsdist` log levels should be reviewed (I copied the existing), they might be too verbose.

One observable change in `dnsdist`:
```
"FrameStreamLogger: queue full, dropping."
```
now turned into
```
"dnstap: queue full, dropping."
```
If that is considered a problem, the name of the subsystem should not come the class via a virtual method, but from the caller of the helper.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
