### PR TITLE
Log "NULL" for nullptr-bound properties instead of dereferencing

### DIFF
--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -85,7 +85,13 @@ public:
           if (i != 0) {
             log_message << ", ";
           }
-          log_message << "$" << (i + 1) << " = '" << paramValues[i] << "'";
+          log_message << "$" << (i + 1) << " = ";
+          if (paramValues[i] == nullptr) {
+            log_message << "NULL";
+          }
+          else {
+            log_message << "'" << paramValues[i] << "'";
+          }
         }
         g_log << Logger::Warning << log_message.str() << endl;
       }


### PR DESCRIPTION
### Short description

Fixes the issue where pdnsutil would segfault when query logging is enabled, and would leave the db unmodified. Surprisingly, the segfault only happened on FreeBSD.

Fixes #11731

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)