### PR TITLE
dnsdist: Add local ComboAddress parameter for SBind() at TeeAction()

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -765,7 +765,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "TagRule", true, "name [, value]", "matches if the tag named 'name' is present, with the given 'value' matching if any" },
   { "TCAction", true, "", "create answer to query with TC and RD bits set, to move to TCP" },
   { "TCPRule", true, "[tcp]", "Matches question received over TCP if tcp is true, over UDP otherwise" },
-  { "TeeAction", true, "remote [, addECS]", "send copy of query to remote, optionally adding ECS info" },
+  { "TeeAction", true, "remote [, addECS [, local]]", "send copy of query to remote, optionally adding ECS info, optionally set local address" },
   { "testCrypto", true, "", "test of the crypto all works" },
   { "TimedIPSetRule", true, "", "Create a rule which matches a set of IP addresses which expire"}, 
   { "topBandwidth", true, "top", "show top-`top` clients that consume the most bandwidth over length of ringbuffer" },

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -135,7 +135,6 @@ public:
 
 private:
   ComboAddress d_remote;
-  boost::optional<ComboAddress> d_local;
   std::thread d_worker;
   void worker();
 
@@ -157,12 +156,12 @@ private:
 };
 
 TeeAction::TeeAction(const ComboAddress& rca, const boost::optional<ComboAddress>& lca, bool addECS) 
-  : d_remote(rca), d_local(lca), d_addECS(addECS)
+  : d_remote(rca), d_addECS(addECS)
 {
   d_fd=SSocket(d_remote.sin4.sin_family, SOCK_DGRAM, 0);
   try {
-    if (d_local) {
-      SBind(d_fd, *d_local);
+    if (lca) {
+      SBind(d_fd, *lca);
     }
     SConnect(d_fd, d_remote);
     setNonBlocking(d_fd);

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -127,7 +127,7 @@ class TeeAction : public DNSAction
 {
 public:
   // this action does not stop the processing
-  TeeAction(const ComboAddress& ca, bool addECS=false);
+  TeeAction(const ComboAddress& rca, const ComboAddress& lca, bool setLocalBindAddress=false, bool addECS=false);
   ~TeeAction() override;
   DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override;
   std::string toString() const override;
@@ -135,6 +135,7 @@ public:
 
 private:
   ComboAddress d_remote;
+  ComboAddress d_local;
   std::thread d_worker;
   void worker();
 
@@ -152,13 +153,18 @@ private:
   mutable stat_t d_tcpdrops{0};
   stat_t d_otherrcode{0};
   std::atomic<bool> d_pleaseQuit{false};
+  bool d_setLocalBindAddress{false};
   bool d_addECS{false};
 };
 
-TeeAction::TeeAction(const ComboAddress& ca, bool addECS) : d_remote(ca), d_addECS(addECS)
+TeeAction::TeeAction(const ComboAddress& rca, const ComboAddress& lca, bool setLocalBindAddress, bool addECS) 
+  : d_remote(rca), d_local(lca), d_setLocalBindAddress(setLocalBindAddress), d_addECS(addECS)
 {
   d_fd=SSocket(d_remote.sin4.sin_family, SOCK_DGRAM, 0);
   try {
+    if (d_setLocalBindAddress) {
+      SBind(d_fd, d_local);
+    }
     SConnect(d_fd, d_remote);
     setNonBlocking(d_fd);
     d_worker=std::thread([this](){worker();});
@@ -2416,8 +2422,8 @@ void setupLuaActions(LuaContext& luaCtx)
     });
 #endif /* DISABLE_PROTOBUF */
 
-  luaCtx.writeFunction("TeeAction", [](const std::string& remote, boost::optional<bool> addECS) {
-      return std::shared_ptr<DNSAction>(new TeeAction(ComboAddress(remote, 53), addECS ? *addECS : false));
+  luaCtx.writeFunction("TeeAction", [](const std::string& remote, boost::optional<bool> addECS, boost::optional<std::string> local) {
+      return std::shared_ptr<DNSAction>(new TeeAction(ComboAddress(remote, 53), ComboAddress(local ? *local : "0.0.0.0", 0), local ? true : false, addECS ? *addECS : false));
     });
 
   luaCtx.writeFunction("SetECSPrefixLengthAction", [](uint16_t v4PrefixLength, uint16_t v6PrefixLength) {

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -127,7 +127,7 @@ class TeeAction : public DNSAction
 {
 public:
   // this action does not stop the processing
-  TeeAction(const ComboAddress& rca, const ComboAddress& lca, bool setLocalBindAddress=false, bool addECS=false);
+  TeeAction(const ComboAddress& rca, const boost::optional<ComboAddress>& lca, bool addECS=false);
   ~TeeAction() override;
   DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override;
   std::string toString() const override;
@@ -135,7 +135,7 @@ public:
 
 private:
   ComboAddress d_remote;
-  ComboAddress d_local;
+  boost::optional<ComboAddress> d_local;
   std::thread d_worker;
   void worker();
 
@@ -153,17 +153,16 @@ private:
   mutable stat_t d_tcpdrops{0};
   stat_t d_otherrcode{0};
   std::atomic<bool> d_pleaseQuit{false};
-  bool d_setLocalBindAddress{false};
   bool d_addECS{false};
 };
 
-TeeAction::TeeAction(const ComboAddress& rca, const ComboAddress& lca, bool setLocalBindAddress, bool addECS) 
-  : d_remote(rca), d_local(lca), d_setLocalBindAddress(setLocalBindAddress), d_addECS(addECS)
+TeeAction::TeeAction(const ComboAddress& rca, const boost::optional<ComboAddress>& lca, bool addECS) 
+  : d_remote(rca), d_local(lca), d_addECS(addECS)
 {
   d_fd=SSocket(d_remote.sin4.sin_family, SOCK_DGRAM, 0);
   try {
-    if (d_setLocalBindAddress) {
-      SBind(d_fd, d_local);
+    if (d_local) {
+      SBind(d_fd, *d_local);
     }
     SConnect(d_fd, d_remote);
     setNonBlocking(d_fd);
@@ -2423,7 +2422,12 @@ void setupLuaActions(LuaContext& luaCtx)
 #endif /* DISABLE_PROTOBUF */
 
   luaCtx.writeFunction("TeeAction", [](const std::string& remote, boost::optional<bool> addECS, boost::optional<std::string> local) {
-      return std::shared_ptr<DNSAction>(new TeeAction(ComboAddress(remote, 53), ComboAddress(local ? *local : "0.0.0.0", 0), local ? true : false, addECS ? *addECS : false));
+      boost::optional<ComboAddress> localAddr{boost::none};
+      if (local) {
+        localAddr = ComboAddress(*local, 0);
+      }
+
+      return std::shared_ptr<DNSAction>(new TeeAction(ComboAddress(remote, 53), localAddr, addECS ? *addECS : false));
     });
 
   luaCtx.writeFunction("SetECSPrefixLengthAction", [](uint16_t v4PrefixLength, uint16_t v6PrefixLength) {

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1660,6 +1660,9 @@ The following actions exist.
 
 .. function:: TeeAction(remote[, addECS[, local]])
 
+  .. versionchanged:: 1.8.0
+    Added the optional parameter ``local``.
+
   Send copy of query to ``remote``, keep stats on responses.
   If ``addECS`` is set to true, EDNS Client Subnet information will be added to the query.
   If ``local`` has provided a value like "192.0.2.53", dnsdist will try binding that address as local address when sending the queries.

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1658,10 +1658,11 @@ The following actions exist.
   Before 1.7.0 this action was performed even when the query had been received over TCP, which required the use of :func:`TCPRule` to
   prevent the TC bit from being set over TCP transports.
 
-.. function:: TeeAction(remote[, addECS])
+.. function:: TeeAction(remote[, addECS[, local]])
 
   Send copy of query to ``remote``, keep stats on responses.
   If ``addECS`` is set to true, EDNS Client Subnet information will be added to the query.
+  If ``local`` has provided a value like "192.0.2.53", dnsdist will try binding that address as local address when sending the queries.
   Subsequent rules are processed after this action.
 
   :param string remote: An IP:PORT combination to send the copied queries to


### PR DESCRIPTION
### Short description
In my prod env, I need to Tee queries from specific ip address, since there are multiple ip addresses on a single interface and the receiver has source address based ACLs and Views.

So I proposed an optional parameter in TeeAction to set the socket bind address.

Usage:
    `addAction(AllRule(), TeeAction("192.0.2.54", false, "192.0.2.53"))`

    In which case, "192.0.2.54" is the ComboAddress of receiver, "192.0.2.53" is the ComboAddress of sender.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
