### PR TITLE
Fix build if dnstap is not enabled

### DIFF
--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -58,12 +58,6 @@
 thread_local TCPOutConnectionManager t_tcp_manager;
 std::shared_ptr<Logr::Logger> g_slogout;
 
-#ifdef HAVE_FSTRM
-#include "dnstap.hh"
-#include "fstrm_logger.hh"
-
-bool g_syslog;
-
 void remoteLoggerQueueData(RemoteLoggerInterface& r, const std::string& data)
 {
   auto ret = r.queueData(data);
@@ -94,6 +88,12 @@ void remoteLoggerQueueData(RemoteLoggerInterface& r, const std::string& data)
   }
   }
 }
+
+#ifdef HAVE_FSTRM
+#include "dnstap.hh"
+#include "fstrm_logger.hh"
+
+bool g_syslog;
 
 static bool isEnabledForQueries(const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstreamLoggers)
 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Followup to #11881
`remoteLoggerQueueData` should not be inside `#ifdef HAVE_FSTRM`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
