### PR TITLE
rec: Implement padding of (DoT) messages to auth

### DIFF
--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -57,6 +57,7 @@
 
 thread_local TCPOutConnectionManager t_tcp_manager;
 std::shared_ptr<Logr::Logger> g_slogout;
+bool g_paddingOutgoing;
 
 void remoteLoggerQueueData(RemoteLoggerInterface& r, const std::string& data)
 {
@@ -423,7 +424,7 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
       weWantEDNSSubnet=true;
     }
 
-    if (dnsOverTLS /* and other conditions? */) {
+    if (dnsOverTLS && g_paddingOutgoing) {
       addPadding(pw, bufsize, opts);
     }
 

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -50,7 +50,7 @@
 #include "query-local-address.hh"
 #include "tcpiohandler.hh"
 #include "ednsoptions.hh"
-
+#include "ednspadding.hh"
 #include "rec-protozero.hh"
 #include "uuid-utils.hh"
 #include "rec-tcpout.hh"
@@ -359,6 +359,25 @@ static LWResult::Result tcpsendrecv(const ComboAddress& ip, TCPOutConnectionMana
   return LWResult::Result::Success;
 }
 
+static void addPadding(const DNSPacketWriter& pw, size_t bufsize, DNSPacketWriter::optvect_t& opts)
+{
+  const size_t currentSize = pw.getSizeWithOpts(opts);
+  if (currentSize < (bufsize - 4)) {
+    const size_t remaining = bufsize - (currentSize + 4);
+    /* from rfc8647, "4.1.  Recommended Strategy: Block-Length Padding":
+       Clients SHOULD pad queries to the closest multiple of 128 octets.
+       Note we are in the client role here.
+    */
+    const size_t blockSize = 128;
+    const size_t modulo = (currentSize + 4) % blockSize;
+    size_t padSize = 0;
+    if (modulo > 0) {
+      padSize = std::min(blockSize - modulo, remaining);
+    }
+    opts.emplace_back(EDNSOptionCode::PADDING, makeEDNSPaddingOptString(padSize));
+  }
+}
+
 /** lwr is only filled out in case 1 was returned, and even when returning 1 for 'success', lwr might contain DNS errors
     Never throws! 
  */
@@ -372,6 +391,7 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
   //  string mapped0x20=dns0x20(domain);
   uint16_t qid = dns_random_uint16();
   DNSPacketWriter pw(vpacket, domain, type);
+  bool dnsOverTLS = SyncRes::s_dot_to_port_853 && ip.getPort() == 853;
 
   pw.getHeader()->rd=sendRDQuery;
   pw.getHeader()->id=qid;
@@ -403,7 +423,11 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
       weWantEDNSSubnet=true;
     }
 
-    pw.addOpt(g_outgoingEDNSBufsize, 0, g_dnssecmode == DNSSECMode::Off ? 0 : EDNSOpts::DNSSECOK, opts); 
+    if (dnsOverTLS /* and other conditions? */) {
+      addPadding(pw, bufsize, opts);
+    }
+
+    pw.addOpt(g_outgoingEDNSBufsize, 0, g_dnssecmode == DNSSECMode::Off ? 0 : EDNSOpts::DNSSECOK, opts);
     pw.commit();
   }
   lwr->d_rcode = 0;
@@ -416,7 +440,6 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
 
   boost::uuids::uuid uuid;
   const struct timeval queryTime = *now;
-  bool dnsOverTLS = SyncRes::s_dot_to_port_853 && ip.getPort() == 853;
 
   if (outgoingLoggers) {
     uuid = getUniqueID();

--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -50,6 +50,7 @@
 void remoteLoggerQueueData(RemoteLoggerInterface&, const std::string&);
 
 extern std::shared_ptr<Logr::Logger> g_slogout;
+extern bool g_paddingOutgoing;
 
 class LWResException : public PDNSException
 {

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -703,6 +703,17 @@ List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP 
 Whether to add EDNS padding to all responses (``always``) or only to responses for queries containing the EDNS padding option (``padded-queries-only``, the default).
 In both modes, padding will only be added to responses for queries coming from `edns-padding-from`_ sources.
 
+.. _setting-edns-padding-out:
+
+``edns-padding-out``
+--------------------
+.. versionadded:: 4.8.0
+
+- Boolean
+- Default: yes
+
+Whether to add EDNS padding to outgoing DoT queries.
+
 .. _setting-edns-padding-tag:
 
 ``edns-padding-tag``

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1636,6 +1636,7 @@ static int serviceMain(int argc, char* argv[], Logr::log_t log)
     exit(1);
   }
   g_paddingTag = ::arg().asNum("edns-padding-tag");
+  g_paddingOutgoing = ::arg().mustDo("edns-padding-out");
 
   RecThreadInfo::setNumDistributorThreads(::arg().asNum("distributor-threads"));
   RecThreadInfo::setNumWorkerThreads(::arg().asNum("threads"));
@@ -2792,6 +2793,7 @@ int main(int argc, char** argv)
     ::arg().set("edns-padding-from", "List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses, provided that 'edns-padding-mode' applies") = "";
     ::arg().set("edns-padding-mode", "Whether to add EDNS padding to all responses ('always') or only to responses for queries containing the EDNS padding option ('padded-queries-only', the default). In both modes, padding will only be added to responses for queries coming from `edns-padding-from`_ sources") = "padded-queries-only";
     ::arg().set("edns-padding-tag", "Packetcache tag associated to responses sent with EDNS padding, to prevent sending these to clients for which padding is not enabled.") = "7830";
+    ::arg().setSwitch("edns-padding-out", "Whether to add EDNS padding to outgoing DoT messages") = "yes";
 
     ::arg().setSwitch("dot-to-port-853", "Force DoT connection to target port 853 if DoT compiled in") = "yes";
     ::arg().set("dot-to-auth-names", "Use DoT to authoritative servers with these names or suffixes") = "";


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

See https://www.rfc-editor.org/rfc/rfc8467 and https://www.rfc-editor.org/rfc/rfc7830

A few questions remaining:

1. Do we want to make this configurable? Currently this PR pads outgoing messages if and only if we're doing DoT. It could be we expect our outgoing traffic to be encapsulated in an encrypted channel. In that case padding could also be an option for un-encrypted outgoing traffic, but I find that a bit far fetched and not something you would do typically. 
3. (Related to 1.) Does it make sense to not want padding for DoT?
4. This PR uses a padding size of 128, as we are (kind of) client. Is that OK?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
