### PR TITLE
[clang-tidy]: DynListener::getLine.

### DIFF
--- a/pdns/dynlistener.cc
+++ b/pdns/dynlistener.cc
@@ -268,20 +268,26 @@ string DynListener::getLine()
     }
   }
   else {
-    if(isatty(0) != 0)
-      if(write(1, "% ", 2) !=2)
-        throw PDNSException("Writing to console: "+stringerror());
+    if (isatty(0) != 0) {
+      if (write(1, "% ", 2) != 2) {
+        throw PDNSException("Writing to console: " + stringerror());
+      }
+    }
 
     ssize_t len = read(0, mesg.data(), mesg.size());
-    if (len < 0)
-      throw PDNSException("Reading from the control pipe: "+stringerror());
-    else if(len==0)
+    if (len < 0) {
+      throw PDNSException("Reading from the control pipe: " + stringerror());
+    }
+
+    if (len == 0) {
       throw PDNSException("Guardian exited - going down as well");
+    }
 
-    if(static_cast<size_t>(len) == mesg.size())
+    if (static_cast<size_t>(len) == mesg.size()) {
       throw PDNSException("Line on control console was too long");
+    }
 
-    mesg[len]=0;
+    mesg[len] = 0;
   }
 
   return mesg.data();

--- a/pdns/dynlistener.cc
+++ b/pdns/dynlistener.cc
@@ -214,8 +214,6 @@ string DynListener::getLine()
   vector<char> mesg;
   mesg.resize(1024000);
 
-  ssize_t len = 0;
-
   ComboAddress remote;
   socklen_t remlen=remote.getSocklen();
 
@@ -273,7 +271,9 @@ string DynListener::getLine()
     if(isatty(0) != 0)
       if(write(1, "% ", 2) !=2)
         throw PDNSException("Writing to console: "+stringerror());
-    if((len=read(0, mesg.data(), mesg.size())) < 0)
+
+    ssize_t len = read(0, mesg.data(), mesg.size());
+    if (len < 0)
       throw PDNSException("Reading from the control pipe: "+stringerror());
     else if(len==0)
       throw PDNSException("Guardian exited - going down as well");

--- a/pdns/dynlistener.cc
+++ b/pdns/dynlistener.cc
@@ -219,7 +219,7 @@ string DynListener::getLine()
 
   if(d_nonlocal) {
     for(;;) {
-      d_client=accept(d_s,(sockaddr*)&remote,&remlen);
+      d_client = accept(d_s, reinterpret_cast<sockaddr *>(&remote), &remlen);
       if(d_client<0) {
         if(errno!=EINTR)
           g_log<<Logger::Error<<"Unable to accept controlsocket connection ("<<d_s<<"): "<<stringerror()<<endl;


### PR DESCRIPTION
## Description

Changes in `pdns/dynlistener.cc` to comply with clang-tidy.
If theses patches are welcome, I may do some on personal time.

To the reviewer: take caution as said before i am not a pro-cpp dev prefers a really conservative review! :)

## Types of changes:

Fix founds with:

- [readability-implicit-bool-conversion]
  - pdns/dynlistener.cc:256
  - pdns/dynlistener.cc:272:8

- [readability-container-data-pointer]
  - pdns/dynlistener.cc:240:19
  - pdns/dynlistener.cc:245:25
  - pdns/dynlistener.cc:256:17
  - dns/dynlistener.cc:263:17

- [bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions]
  - pdns/dynlistener.cc:240:29
  - pdns/dynlistener.cc:256:27

Avoided to fix `if` related to avoid making too much git noise.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)