### PR TITLE
auth: api, nsec3param improvements

### DIFF
--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -569,6 +569,26 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(data['nsec3param'], '')
 
+    def test_create_zone_without_dnssec_unset_nsec3parm(self):
+        """
+        Create a non dnssec zone and set an empty "nsec3param"
+        """
+        name, payload, data = self.create_zone(dnssec=False)
+        r = self.session.put(self.url("/api/v1/servers/localhost/zones/" + name),
+                             data=json.dumps({'nsec3param': ''}))
+
+        self.assertEqual(r.status_code, 204)
+
+    def test_create_zone_without_dnssec_set_nsec3parm(self):
+        """
+        Create a non dnssec zone and set "nsec3param"
+        """
+        name, payload, data = self.create_zone(dnssec=False)
+        r = self.session.put(self.url("/api/v1/servers/localhost/zones/" + name),
+                             data=json.dumps({'nsec3param': '1 0 1 ab'}))
+
+        self.assertEqual(r.status_code, 422)
+
     def test_create_zone_dnssec_serial(self):
         """
         Create a zone set/unset "dnssec" and see if the serial was increased


### PR DESCRIPTION
### Short description
Successor of #11917

Closes: #11917
Fixes: #11824

API:
- Ignore NSEC3* metadata in the db for insecure zones (like the rest of the authoritative server)
- Remove existing NSEC3* metadata when dnssec is enabled (without a nsec3parm value) or disabled. This will avoid surprises caused by old NSEC3* metadata.
- Always treat an empty nsec3param as a removal request (secure and insecure zones). This will make it possible to remove old and ignored NSEC3* metadata.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
