### PR TITLE
auth: fix gcc warning

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -130,8 +130,6 @@ vector<std::shared_ptr<UDPNameserver>> g_udpReceivers;
 NetmaskGroup g_proxyProtocolACL;
 size_t g_proxyProtocolMaximumSize;
 
-void mainthread();
-
 ArgvMap& arg()
 {
   return theArg;

--- a/pdns/auth-main.hh
+++ b/pdns/auth-main.hh
@@ -48,7 +48,7 @@ extern double avg_latency;
 extern std::unique_ptr<TCPNameserver> TN;
 extern void declareArguments();
 extern void declareStats();
-extern void mainthread();
+void mainthread();
 extern int isGuarded(char**);
 void carbonDumpThread();
 extern bool g_anyToTcp;


### PR DESCRIPTION
### Short description
```
auth-main.cc:133:6: warning: redundant redeclaration of ‘void mainthread()’ in same scope [-Wredundant-decls]
  133 | void mainthread();
      |      ^~~~~~~~~~
In file included from auth-main.cc:55:
auth-main.hh:51:13: note: previous declaration of ‘void mainthread()’
   51 | extern void mainthread();
      |             ^~~~~~~~~~
```

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
