### PR TITLE
auth: Fix CID 1497843: Execution cannot reach this statement

### DIFF
--- a/pdns/tkey.cc
+++ b/pdns/tkey.cc
@@ -16,7 +16,9 @@ void PacketHandler::tkeyHandler(const DNSPacket& p, std::unique_ptr<DNSPacket>& 
   TKEYRecordContent tkey_in;
   std::shared_ptr<TKEYRecordContent> tkey_out(new TKEYRecordContent());
   DNSName name;
+#ifdef ENABLE_GSS_TSIG
   bool sign = false;
+#endif
 
   if (!p.getTKEYRecord(&tkey_in, &name)) {
     g_log<<Logger::Error<<"TKEY request but no TKEY RR found"<<endl;
@@ -109,6 +111,7 @@ void PacketHandler::tkeyHandler(const DNSPacket& p, std::unique_ptr<DNSPacket>& 
   zrr.dr.d_place = DNSResourceRecord::ANSWER;
   r->addRecord(std::move(zrr));
 
+#ifdef ENABLE_GSS_TSIG
   if (sign)
   {
     TSIGRecordContent trc;
@@ -122,6 +125,7 @@ void PacketHandler::tkeyHandler(const DNSPacket& p, std::unique_ptr<DNSPacket>& 
     // this should cause it to lookup name context
     r->setTSIGDetails(trc, name, name.toStringNoDot(), "", false);
   }
+#endif
 
   r->commitD();
 }


### PR DESCRIPTION
Followup to #11143.

Not a bug per se, but the unreachable code should be guarded by proper #ifdef

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
