### PR TITLE
auth: fix gcc warning, no prevous declaration for ‘void carbonDumpT…

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -130,9 +130,6 @@ static vector<std::shared_ptr<UDPNameserver>> s_udpReceivers;
 NetmaskGroup g_proxyProtocolACL;
 size_t g_proxyProtocolMaximumSize;
 
-// Implemented in auth-carbon.cc. Avoids having an auth-carbon.hh declaring exactly one function.
-void carbonDumpThread();
-
 ArgvMap& arg()
 {
   return theArg;

--- a/pdns/auth-main.hh
+++ b/pdns/auth-main.hh
@@ -42,6 +42,7 @@ extern AuthPacketCache PC; //!< This is the main PacketCache, shared across all 
 extern AuthQueryCache QC;
 extern std::unique_ptr<DNSProxy> DP;
 extern CommunicatorClass Communicator;
+void carbonDumpThread(); // Implemented in auth-carbon.cc. Avoids having an auth-carbon.hh declaring exactly one function.
 extern bool g_anyToTcp;
 extern bool g_8bitDNS;
 extern NetmaskGroup g_proxyProtocolACL;


### PR DESCRIPTION
### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
