### PR TITLE
rec: Backport of 11890 to rec-4.6.x: Failure to retrieve DNSKEYs of an Insecure zone should not be fatal.

### DIFF
--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -885,7 +885,7 @@ private:
   void updateValidationState(vState& state, const vState stateUpdate);
   vState validateRecordsWithSigs(unsigned int depth, const DNSName& qname, const QType qtype, const DNSName& name, const QType type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth);
-  vState getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int depth);
+  vState getDNSKeys(const DNSName& signer, skeyset_t& keys, bool& servFailOccurred, unsigned int depth);
   dState getDenialValidationState(const NegCache::NegCacheEntry& ne, const dState expectedState, bool referralToUnsigned);
   void updateDenialValidationState(vState& neValidationState, const DNSName& neName, vState& state, const dState denialState, const dState expectedState, bool isDS, unsigned int depth);
   void computeNegCacheValidationStatus(const NegCache::NegCacheEntry& ne, const DNSName& qname, QType qtype, const int res, vState& state, unsigned int depth);


### PR DESCRIPTION
This issue happens if a record set is signed even though the zone itself is Insecure. Syncres then tries to retrieve DNSKEYs and a timeout on that would lead to an ImmediateServFailException.

Only throw exception later in validateRecordsWithSigs, after checking zone cuts, when we are sure the zone is Secure.

(cherry picked from commit 6dc8b0b2c6fb2e628356f8dc5c5de4dfd919ec5d)

Backport of #11890

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
