### PR TITLE
auth-4.6.x: initialize zone cache after dropping privileges; Detect invalid bytes in makeBytesFromHex() 

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -753,6 +753,23 @@ void mainthread()
 
   pdns::parseTrustedNotificationProxy(::arg()["trusted-notification-proxy"]);
 
+  UeberBackend::go();
+
+  // Setup the zone cache
+  g_zoneCache.setRefreshInterval(::arg().asNum("zone-cache-refresh-interval"));
+  try {
+    UeberBackend B;
+    B.updateZoneCache();
+  }
+  catch (PDNSException& e) {
+    g_log << Logger::Error << "PDNSException while filling the zone cache: " << e.reason << endl;
+    exit(1);
+  }
+  catch (std::exception& e) {
+    g_log << Logger::Error << "STL Exception while filling the zone cache: " << e.what() << endl;
+    exit(1);
+  }
+
   // NOW SAFE TO CREATE THREADS!
   dl->go();
 

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -582,14 +582,18 @@ string makeBytesFromHex(const string &in) {
     throw std::range_error("odd number of bytes in hex string");
   }
   string ret;
-  ret.reserve(in.size());
+  ret.reserve(in.size() / 2);
+
   unsigned int num;
-  for (size_t i = 0; i < in.size(); i+=2) {
-    string numStr = in.substr(i, 2);
+  for (size_t i = 0; i < in.size(); i += 2) {
+    const auto numStr = in.substr(i, 2);
     num = 0;
-    sscanf(numStr.c_str(), "%02x", &num);
-    ret.push_back((uint8_t)num);
+    if (sscanf(numStr.c_str(), "%02x", &num) != 1) {
+      throw std::range_error("Invalid value while parsing the hex string '" + in + "'");
+    }
+    ret.push_back(static_cast<uint8_t>(num));
   }
+
   return ret;
 }
 

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -627,14 +627,6 @@ int main(int argc, char **argv)
       }
     }
 
-    UeberBackend::go();
-
-    g_zoneCache.setRefreshInterval(::arg().asNum("zone-cache-refresh-interval"));
-    {
-      UeberBackend B;
-      B.updateZoneCache();
-    }
-
     N=std::make_shared<UDPNameserver>(); // this fails when we are not root, throws exception
     g_udpReceivers.push_back(N);
 

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -396,6 +396,8 @@ BOOST_AUTO_TEST_CASE(test_makeBytesFromHex) {
   BOOST_CHECK_EQUAL(out, "\x12\x34\x56\x78\x90\xab\xcd\xef");
 
   BOOST_CHECK_THROW(makeBytesFromHex("123"), std::range_error);
+
+  BOOST_CHECK_THROW(makeBytesFromHex("1234GG"), std::range_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
Backport of #11908 and #12066

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] checked that this code was merged to master
