### PR TITLE
make builds pass with -Werror on _my_ system

### DIFF
--- a/m4/ax_check_sign.m4
+++ b/m4/ax_check_sign.m4
@@ -43,7 +43,7 @@ AC_DEFUN([AX_CHECK_SIGN], [
  AC_CACHE_CHECK([whether $1 is signed], ax_cv_decl_${typename}_signed, [
    AC_COMPILE_IFELSE(
      [AC_LANG_PROGRAM([[$4]],
-       [[ int foo @<:@ 1 - 2 * !((($1) -1) < 0) @:>@ ]])],
+       [[ [[maybe_unused]] int foo @<:@ 1 - 2 * !((($1) -1) < 0) @:>@ ]])],
      [ eval "ax_cv_decl_${typename}_signed=\"yes\"" ],
      [ eval "ax_cv_decl_${typename}_signed=\"no\"" ])
  ])

--- a/m4/ax_check_sign.m4
+++ b/m4/ax_check_sign.m4
@@ -43,7 +43,7 @@ AC_DEFUN([AX_CHECK_SIGN], [
  AC_CACHE_CHECK([whether $1 is signed], ax_cv_decl_${typename}_signed, [
    AC_COMPILE_IFELSE(
      [AC_LANG_PROGRAM([[$4]],
-       [[ [[maybe_unused]] int foo @<:@ 1 - 2 * !((($1) -1) < 0) @:>@ ]])],
+       [[ int foo @<:@ 1 - 2 * !((($1) -1) < 0) @:>@ ; (void)foo[0] ]])],
      [ eval "ax_cv_decl_${typename}_signed=\"yes\"" ],
      [ eval "ax_cv_decl_${typename}_signed=\"no\"" ])
  ])

--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -595,8 +595,7 @@ namespace cxx17
 
   namespace test_constexpr_lambdas
   {
-
-    constexpr int foo = [](){return 42;}();
+    [[maybe_unused]] constexpr int foo = [](){return 42;}();
 
   }
 


### PR DESCRIPTION
### Short description
While I would not recommend running with `-Werror` always, I find it convenient to catch silly mistakes during development. The patches in this PR make `-Werror` work on my system. After discussion, perhaps we can upstream some things to the autoconf-archive.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master