### PR TITLE
axfr-retriever: abort on chunk with TC set

### DIFF
--- a/pdns/axfr-retriever.cc
+++ b/pdns/axfr-retriever.cc
@@ -133,6 +133,10 @@ int AXFRRetriever::getChunk(Resolver::res_t &res, vector<DNSRecord>* records, ui
     throw ResolverException("AXFR chunk error: " + RCode::to_s(err));
   }
 
+  if(mdp.d_header.tc) {
+    throw ResolverException("AXFR chunk had TC bit set");
+  }
+
   try {
     d_tsigVerifier.check(std::string(d_buf.data(), len), mdp);
   }


### PR DESCRIPTION
### Short description
This avoids zones missing whole chunks of data on the secondary side, as described in #11804

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master