### PR TITLE
[clang-tidy] Use nullptr in getNSEC3PARAM + init bool at callsite

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -491,7 +491,7 @@ void Bind2Backend::alsoNotifies(const DNSName& domain, set<string>* ips)
 void Bind2Backend::parseZoneFile(BB2DomainInfo* bbd)
 {
   NSEC3PARAMRecordContent ns3pr;
-  bool nsec3zone;
+  bool nsec3zone = false;
   if (d_hybrid) {
     DNSSECKeeper dk;
     nsec3zone = dk.getNSEC3PARAM(bbd->d_name, &ns3pr);

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -209,7 +209,7 @@ bool Bind2Backend::getNSEC3PARAM(const DNSName& name, NSEC3PARAMRecordContent* n
   if (!safeGetBBDomainInfo(name, &bbd))
     return false;
 
-  if (ns3p) {
+  if (ns3p != nullptr) {
     *ns3p = bbd.d_nsec3param;
   }
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -336,7 +336,7 @@ bool DNSSECKeeper::getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* 
   }
 
   static int maxNSEC3Iterations=::arg().asNum("max-nsec3-iterations");
-  if(ns3p) {
+  if(ns3p != nullptr) {
     *ns3p = NSEC3PARAMRecordContent(value);
     if (ns3p->d_iterations > maxNSEC3Iterations && !isPresigned(zname, useCache)) {
       ns3p->d_iterations = maxNSEC3Iterations;
@@ -347,7 +347,7 @@ bool DNSSECKeeper::getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* 
       ns3p->d_algorithm = 1;
     }
   }
-  if(narrow) {
+  if(narrow != nullptr) {
     if(useCache) {
       getFromMeta(zname, "NSEC3NARROW", value);
     }

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -204,7 +204,7 @@ public:
   bool unpublishKey(const DNSName& zname, unsigned int id);
   bool checkKeys(const DNSName& zname, vector<string>* errorMessages = nullptr);
 
-  bool getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* n3p=0, bool* narrow=0, bool useCache=true);
+  bool getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* n3p=nullptr, bool* narrow=nullptr, bool useCache=true);
   bool checkNSEC3PARAM(const NSEC3PARAMRecordContent& ns3p, string& msg);
   bool setNSEC3PARAM(const DNSName& zname, const NSEC3PARAMRecordContent& n3p, const bool& narrow=false);
   bool unsetNSEC3PARAM(const DNSName& zname);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -789,7 +789,7 @@ void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRec
 void PacketHandler::addNSECX(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName& target, const DNSName& wildcard, int mode)
 {
   NSEC3PARAMRecordContent ns3rc;
-  bool narrow;
+  bool narrow = false;
   if(d_dk.getNSEC3PARAM(d_sd.qname, &ns3rc, &narrow))  {
     if (mode != 5) // no direct NSEC3 queries, rfc5155 7.2.8
       addNSEC3(p, r, target, wildcard, ns3rc, narrow, mode);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -934,7 +934,7 @@ static int increaseSerial(const DNSName& zone, DNSSECKeeper &dk)
 
   if (sd.db->doesDNSSEC()) {
     NSEC3PARAMRecordContent ns3pr;
-    bool narrow;
+    bool narrow = false;
     bool haveNSEC3=dk.getNSEC3PARAM(zone, &ns3pr, &narrow);
 
     DNSName ordername;
@@ -2027,7 +2027,7 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
   }
 
   NSEC3PARAMRecordContent ns3pr;
-  bool narrow;
+  bool narrow = false;
   bool haveNSEC3=dk.getNSEC3PARAM(zone, &ns3pr, &narrow);
 
   DNSSECKeeper::keyset_t keyset=dk.getKeys(zone);
@@ -3383,7 +3383,7 @@ try
     DNSName zone(cmds.at(1));
     DNSName record(cmds.at(2));
     NSEC3PARAMRecordContent ns3pr;
-    bool narrow;
+    bool narrow = false;
     if(!dk.getNSEC3PARAM(zone, &ns3pr, &narrow)) {
       cerr<<"The '"<<zone<<"' zone does not use NSEC3"<<endl;
       return 0;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1211,7 +1211,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock)
 
     DNSSECKeeper dk((*packetHandler)->getBackend());
     DNSSECKeeper::clearCaches(q->qdomain);
-    bool narrow;
+    bool narrow = false;
     securedZone = dk.isSecuredZone(q->qdomain);
     if(dk.getNSEC3PARAM(q->qdomain, nullptr, &narrow)) {
       if(narrow) {


### PR DESCRIPTION
### Short description

Small cpp modernization found with `clang-tidy`:

- Initialize out parameter to `false` at call site of `getNSEC3PARAM`
- Use `nullptr` instead of `0`
- Avoid bool auto conv check for `p != nullptr` instead

## Alternative

I didn't digged the `std::optional` way, ~due to the absence of `optional` in pdns sources and~ mostly because i am inexperienced with. ~No hard feeling about it.~ It's used in pdns source see for example: <https://github.com/PowerDNS/pdns/blob/9e912e583ac8954fa26c4f1b93782515741caeda/pdns/dnstap.hh> (redacted to add an example).
Why redacted? Made a typo while searching. :facepalm:.

https://en.cppreference.com/w/cpp/utility/optional

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code runned unit-test / reg test (partially)
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
