### PR TITLE
expand builder-dispatch workflow for release building

### DIFF
--- a/.github/workflows/builder-dispatch.yml
+++ b/.github/workflows/builder-dispatch.yml
@@ -12,27 +12,63 @@ on:
         - recursor
         - dnsdist
       os:
-        description: OS to build for
+        description: OSes to build for, space separated
         type: string
+        default: >
+          el-7
+          el-8
+          el-9
+          debian-buster
+          debian-bullseye
+          ubuntu-bionic
+          ubuntu-focal
+          ubuntu-jammy
+      ref:
+        description: git ref to checkout
+        type: string
+        default: master
+      is_release:
+        description: is this a release build?
+        type: choice
+        options:
+        - 'NO'
+        - 'YES'
 
 jobs:
+  prepare:
+    name: generate OS list
+    runs-on: ubuntu-20.04
+    outputs:
+      oslist: ${{ steps.get-oslist.outputs.oslist }}
+    steps:
+      - run: sudo apt-get update && sudo apt-get -y install jo
+      - id: get-oslist
+        run: echo "::set-output name=oslist::"$(jo -a ${{ github.event.inputs.os }})
+      - run: echo "###::set-output name=oslist::"$(jo -a ${{ github.event.inputs.os }})
+
   build:
-    name: build ${{ github.event.inputs.product }} for ${{ github.event.inputs.os }}
+    needs: prepare
+    name: build ${{ github.event.inputs.product }} (${{ github.event.inputs.ref }}) for ${{ matrix.os }}
     # on a ubuntu-20.04 VM
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: ${{fromJson(needs.prepare.outputs.oslist)}}
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0 # for correct version numbers
           submodules: recursive
+          ref: ${{ github.event.inputs.ref }}
       # this builds packages and runs our unit tests (make check)
-      - run: builder/build.sh -v -m ${{ github.event.inputs.product }} ${{ github.event.inputs.os }}
+      - run: IS_RELEASE=${{ github.event.inputs.is_release}} builder/build.sh -v -m ${{ github.event.inputs.product }} ${{ matrix.os }}
       - name: Get version number
         run: 'echo ::set-output name=version::$(readlink builder/tmp/latest)'
         id: getversion
       - name: Upload packages
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.event.inputs.product }}-${{ github.event.inputs.os }}-${{ steps.getversion.outputs.version }}
+          name: ${{ github.event.inputs.product }}-${{ matrix.os }}-${{ steps.getversion.outputs.version }}
           path: built_pkgs/
           retention-days: 7

--- a/.github/workflows/builder-dispatch.yml
+++ b/.github/workflows/builder-dispatch.yml
@@ -44,7 +44,6 @@ jobs:
       - run: sudo apt-get update && sudo apt-get -y install jo
       - id: get-oslist
         run: echo "::set-output name=oslist::"$(jo -a ${{ github.event.inputs.os }})
-      - run: echo "###::set-output name=oslist::"$(jo -a ${{ github.event.inputs.os }})
 
   build:
     needs: prepare

--- a/.github/workflows/builder-dispatch.yml
+++ b/.github/workflows/builder-dispatch.yml
@@ -41,6 +41,9 @@ jobs:
     outputs:
       oslist: ${{ steps.get-oslist.outputs.oslist }}
     steps:
+      # instead of jo, we could use jq here, which avoids running apt, and thus would be faster.
+      # but, as this whole workflow needs at least 30 minutes to run, I prefer spending a few seconds here
+      # so that the command remains readable, because jo is simpler to use.
       - run: sudo apt-get update && sudo apt-get -y install jo
       - id: get-oslist
         run: echo "::set-output name=oslist::"$(jo -a ${{ github.event.inputs.os }})


### PR DESCRIPTION
### Short description
This makes it easier to generate packages from any branch or tag for one or more distribution targets at a time. It also adds a flag for building releases.

To try this, go to Actions on a repo that has a copy of the yaml file on any branch. Then pick the target ("Trigger specific package build") on the left, open the "Run workflow" dropdown, pick your branch with the yaml file in "Use workflow from"; then check the rest of the fields and hit "Run workflow".

Once merged, this will simplify - it will no longer be necessary to first open the "Run workflow from" dropdown.

Note that this does not magically know what distributions are available for a given product or tag/branch.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
