### PR TITLE
Improve error message when invalid values for `local-address` are provided in recursor config file

### DIFF
--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -82,14 +82,14 @@ public:
     d_nqueue.push_back(nr);
   }
 
-  bool removeIf(const string &remote, uint16_t id, const DNSName &domain)
+  bool removeIf(const string& remote, uint16_t id, const DNSName& domain)
   {
     ServiceTuple stRemote, stQueued;
     parseService(remote, stRemote);
 
-    for(d_nqueue_t::iterator i=d_nqueue.begin(); i!=d_nqueue.end(); ++i) {
+    for (d_nqueue_t::iterator i = d_nqueue.begin(); i != d_nqueue.end(); ++i) {
       parseService(i->ip, stQueued);
-      if(i->id==id && stQueued.host == stRemote.host && i->domain==domain) {
+      if (i->id == id && stQueued.host == stRemote.host && i->domain == domain) {
         d_nqueue.erase(i);
         return true;
       }
@@ -99,7 +99,7 @@ public:
 
   bool getOne(DNSName &domain, string &ip, uint16_t *id, bool &purged)
   {
-    for(d_nqueue_t::iterator i=d_nqueue.begin();i!=d_nqueue.end();++i) 
+    for(d_nqueue_t::iterator i=d_nqueue.begin();i!=d_nqueue.end();++i)
       if(i->next <= time(0)) {
         i->attempts++;
         purged=false;
@@ -119,8 +119,8 @@ public:
 
   time_t earliest()
   {
-    time_t early=std::numeric_limits<time_t>::max() - 1; 
-    for(d_nqueue_t::const_iterator i=d_nqueue.begin();i!=d_nqueue.end();++i) 
+    time_t early=std::numeric_limits<time_t>::max() - 1;
+    for(d_nqueue_t::const_iterator i=d_nqueue.begin();i!=d_nqueue.end();++i)
       early=min(early,i->next);
     return early-time(0);
   }
@@ -150,7 +150,7 @@ struct ZoneStatus;
 class CommunicatorClass
 {
 public:
-  CommunicatorClass() 
+  CommunicatorClass()
   {
     d_tickinterval=60;
     d_slaveschanged = true;
@@ -160,8 +160,8 @@ public:
   }
   time_t doNotifications(PacketHandler *P);
   void go();
-  
-  
+
+
   void drillHole(const DNSName &domain, const string &ip);
   bool justNotified(const DNSName &domain, const string &ip);
   void addSuckRequest(const DNSName &domain, const ComboAddress& master, SuckRequest::RequestPriority, bool force=false);
@@ -227,7 +227,7 @@ private:
   {
     explicit RemoveSentinel(const DNSName& dn, CommunicatorClass* cc) : d_dn(dn), d_cc(cc)
     {}
-    
+
     ~RemoveSentinel()
     {
       try {
@@ -251,7 +251,7 @@ public:
     vector<string> addresses;
 
     this->resolve_name(&addresses, name);
-    
+
     if(b) {
         b->lookup(QType(QType::ANY),name,-1);
         DNSZoneRecord rr;

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -82,12 +82,12 @@ public:
     d_nqueue.push_back(nr);
   }
 
-  bool removeIf(const string& remote, uint16_t id, const DNSName& domain)
+  bool removeIf(const ComboAddress& remote, uint16_t id, const DNSName& domain)
   {
     ServiceTuple stRemote, stQueued;
     parseService(remote, stRemote);
 
-    for (d_nqueue_t::iterator i = d_nqueue.begin(); i != d_nqueue.end(); ++i) {
+    for (auto i = d_nqueue.begin(); i != d_nqueue.end(); ++i) {
       parseService(i->ip, stQueued);
       if (i->id == id && stQueued.host == stRemote.host && i->domain == domain) {
         d_nqueue.erase(i);

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -84,12 +84,9 @@ public:
 
   bool removeIf(const ComboAddress& remote, uint16_t id, const DNSName& domain)
   {
-    ServiceTuple stRemote, stQueued;
-    parseService(remote, stRemote);
-
     for (auto i = d_nqueue.begin(); i != d_nqueue.end(); ++i) {
-      parseService(i->ip, stQueued);
-      if (i->id == id && stQueued.host == stRemote.host && i->domain == domain) {
+      ComboAddress stQueued{i->ip};
+      if (i->id == id && stQueued == remote && i->domain == domain) {
         d_nqueue.erase(i);
         return true;
       }

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -126,7 +126,7 @@ bool CommunicatorClass::notifyDomain(const DNSName &domain, UeberBackend* B)
   if (di.serial != di.notified_serial)
     di.backend->setNotified(di.id, di.serial);
 
-  return true; 
+  return true;
 }
 
 void NotificationQueue::dump()
@@ -212,9 +212,9 @@ void CommunicatorClass::masterUpdateCheck(PacketHandler *P)
   }
 }
 
-time_t CommunicatorClass::doNotifications(PacketHandler *P)
+time_t CommunicatorClass::doNotifications(PacketHandler* P)
 {
-  UeberBackend *B=P->getBackend();
+  UeberBackend* B = P->getBackend();
   ComboAddress from;
   Utility::socklen_t fromlen;
   char buffer[1500];
@@ -223,59 +223,58 @@ time_t CommunicatorClass::doNotifications(PacketHandler *P)
   set<int> fds = {d_nsock4, d_nsock6};
 
   // receive incoming notifications on the nonblocking socket and take them off the list
-  while(waitForMultiData(fds, 0, 0, &sock) > 0) {
-    fromlen=sizeof(from);
-    size=recvfrom(sock,buffer,sizeof(buffer),0,(struct sockaddr *)&from,&fromlen);
-    if(size < 0)
+  while (waitForMultiData(fds, 0, 0, &sock) > 0) {
+    fromlen = sizeof(from);
+    size = recvfrom(sock, buffer, sizeof(buffer), 0, (struct sockaddr*)&from, &fromlen);
+    if (size < 0)
       break;
     DNSPacket p(true);
 
     p.setRemote(&from);
 
-    if(p.parse(buffer,(size_t)size)<0) {
-      g_log<<Logger::Warning<<"Unable to parse SOA notification answer from "<<p.getRemote()<<endl;
+    if (p.parse(buffer, (size_t)size) < 0) {
+      g_log << Logger::Warning << "Unable to parse SOA notification answer from " << p.getRemote() << endl;
       continue;
     }
 
-    if(p.d.rcode)
-      g_log<<Logger::Warning<<"Received unsuccessful notification report for '"<<p.qdomain<<"' from "<<from.toStringWithPort()<<", error: "<<RCode::to_s(p.d.rcode)<<endl;      
+    if (p.d.rcode)
+      g_log << Logger::Warning << "Received unsuccessful notification report for '" << p.qdomain << "' from " << from.toStringWithPort() << ", error: " << RCode::to_s(p.d.rcode) << endl;
 
-    if(d_nq.removeIf(from.toStringWithPort(), p.d.id, p.qdomain))
-      g_log<<Logger::Notice<<"Removed from notification list: '"<<p.qdomain<<"' to "<<from.toStringWithPort()<<" "<< (p.d.rcode ? RCode::to_s(p.d.rcode) : "(was acknowledged)")<<endl;
+    if (d_nq.removeIf(from.toStringWithPort(), p.d.id, p.qdomain))
+      g_log << Logger::Notice << "Removed from notification list: '" << p.qdomain << "' to " << from.toStringWithPort() << " " << (p.d.rcode ? RCode::to_s(p.d.rcode) : "(was acknowledged)") << endl;
     else {
-      g_log<<Logger::Warning<<"Received spurious notify answer for '"<<p.qdomain<<"' from "<< from.toStringWithPort()<<endl;
-      //d_nq.dump();
+      g_log << Logger::Warning << "Received spurious notify answer for '" << p.qdomain << "' from " << from.toStringWithPort() << endl;
+      // d_nq.dump();
     }
   }
 
   // send out possible new notifications
   DNSName domain;
   string ip;
-  uint16_t id=0;
+  uint16_t id = 0;
 
   bool purged;
-  while(d_nq.getOne(domain, ip, &id, purged)) {
-    if(!purged) {
+  while (d_nq.getOne(domain, ip, &id, purged)) {
+    if (!purged) {
       try {
         ComboAddress remote(ip, 53); // default to 53
-        if((d_nsock6 < 0 && remote.sin4.sin_family == AF_INET6) ||
-           (d_nsock4 < 0 && remote.sin4.sin_family == AF_INET)) {
-             g_log<<Logger::Warning<<"Unable to notify "<<remote.toStringWithPort()<<" for domain '"<<domain<<"', address family is disabled. Is an IPv"<<(remote.sin4.sin_family == AF_INET ? "4" : "6")<<" address set in query-local-address?"<<endl;
-             d_nq.removeIf(remote.toStringWithPort(), id, domain); // Remove, we'll never be able to notify
-             continue; // don't try to notify what we can't!
+        if ((d_nsock6 < 0 && remote.sin4.sin_family == AF_INET6) || (d_nsock4 < 0 && remote.sin4.sin_family == AF_INET)) {
+          g_log << Logger::Warning << "Unable to notify " << remote.toStringWithPort() << " for domain '" << domain << "', address family is disabled. Is an IPv" << (remote.sin4.sin_family == AF_INET ? "4" : "6") << " address set in query-local-address?" << endl;
+          d_nq.removeIf(remote.toStringWithPort(), id, domain); // Remove, we'll never be able to notify
+          continue; // don't try to notify what we can't!
         }
-        if(d_preventSelfNotification && AddressIsUs(remote))
+        if (d_preventSelfNotification && AddressIsUs(remote))
           continue;
 
         sendNotification(remote.sin4.sin_family == AF_INET ? d_nsock4 : d_nsock6, domain, remote, id, B);
         drillHole(domain, ip);
       }
-      catch(ResolverException &re) {
-        g_log<<Logger::Warning<<"Error trying to resolve '"<<ip<<"' for notifying '"<<domain<<"' to server: "<<re.reason<<endl;
+      catch (ResolverException& re) {
+        g_log << Logger::Warning << "Error trying to resolve '" << ip << "' for notifying '" << domain << "' to server: " << re.reason << endl;
       }
     }
     else
-      g_log<<Logger::Warning<<"Notification for "<<domain<<" to "<<ip<<" failed after retries"<<endl;
+      g_log << Logger::Warning << "Notification for " << domain << " to " << ip << " failed after retries" << endl;
   }
 
   return d_nq.earliest();
@@ -296,7 +295,7 @@ void CommunicatorClass::sendNotification(int sock, const DNSName& domain, const 
   vector<uint8_t> packet;
   DNSPacketWriter pw(packet, domain, QType::SOA, 1, Opcode::Notify);
   pw.getHeader()->id = id;
-  pw.getHeader()->aa = true; 
+  pw.getHeader()->aa = true;
 
   if (tsigkeyname.empty() == false) {
     if (!B->getTSIGKey(tsigkeyname, tsigalgorithm, tsigsecret64)) {
@@ -343,7 +342,7 @@ bool CommunicatorClass::justNotified(const DNSName &domain, const string &ip)
     return true;
   }
 
-  // do we want to purge this? XXX FIXME 
+  // do we want to purge this? XXX FIXME
   return false;
 }
 

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -240,7 +240,7 @@ time_t CommunicatorClass::doNotifications(PacketHandler* P)
       g_log << Logger::Warning << "Received unsuccessful notification report for '" << p.qdomain << "' from " << from.toStringWithPort() << ", error: " << RCode::to_s(p.d.rcode) << endl;
     }
 
-    if (d_nq.removeIf(from.toStringWithPort(), p.d.id, p.qdomain)) {
+    if (d_nq.removeIf(from, p.d.id, p.qdomain)) {
       g_log << Logger::Notice << "Removed from notification list: '" << p.qdomain << "' to " << from.toStringWithPort() << " " << (p.d.rcode ? RCode::to_s(p.d.rcode) : "(was acknowledged)") << endl;
     }
     else {
@@ -261,7 +261,7 @@ time_t CommunicatorClass::doNotifications(PacketHandler* P)
         ComboAddress remote(ip, 53); // default to 53
         if ((d_nsock6 < 0 && remote.sin4.sin_family == AF_INET6) || (d_nsock4 < 0 && remote.sin4.sin_family == AF_INET)) {
           g_log << Logger::Warning << "Unable to notify " << remote.toStringWithPort() << " for domain '" << domain << "', address family is disabled. Is an IPv" << (remote.sin4.sin_family == AF_INET ? "4" : "6") << " address set in query-local-address?" << endl;
-          d_nq.removeIf(remote.toStringWithPort(), id, domain); // Remove, we'll never be able to notify
+          d_nq.removeIf(remote, id, domain); // Remove, we'll never be able to notify
           continue; // don't try to notify what we can't!
         }
         if (d_preventSelfNotification && AddressIsUs(remote)) {

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -310,51 +310,6 @@ bool stripDomainSuffix(string *qname, const string &domain)
   return true;
 }
 
-static void parseService4(const string& descr, ServiceTuple& st)
-{
-  vector<string> parts;
-  stringtok(parts, descr, ":");
-  if (parts.empty()) {
-    throw PDNSException("Unable to parse '" + descr + "' as a service");
-  }
-  st.host = parts[0];
-  if (parts.size() > 1) {
-    pdns::checked_stoi_into(st.port, parts[1]);
-  }
-}
-
-static void parseService6(const string& descr, ServiceTuple& st)
-{
-  string::size_type pos = descr.find(']');
-  if (pos == string::npos) {
-    throw PDNSException("Unable to parse '" + descr + "' as an IPv6 service");
-  }
-
-  st.host = descr.substr(1, pos - 1);
-  if (pos + 2 < descr.length()) {
-    pdns::checked_stoi_into(st.port, descr.substr(pos + 2));
-  }
-}
-
-void parseService(const string &descr, ServiceTuple &st)
-{
-  if(descr.empty())
-    throw PDNSException("Unable to parse '"+descr+"' as a service");
-
-  vector<string> parts;
-  stringtok(parts, descr, ":");
-
-  if(descr[0]=='[') {
-    parseService6(descr, st);
-  }
-  else if(descr[0]==':' || parts.size() > 2 || descr.find("::") != string::npos) {
-    st.host=descr;
-  }
-  else {
-    parseService4(descr, st);
-  }
-}
-
 // returns -1 in case if error, 0 if no data is available, 1 if there is. In the first two cases, errno is set
 int waitForData(int fd, int seconds, int useconds)
 {

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -68,7 +68,8 @@ const string unquotify(const string &item);
 string humanDuration(time_t passed);
 bool stripDomainSuffix(string *qname, const string &domain);
 void stripLine(string &line);
-string getHostname();
+std::optional<string> getHostname();
+std::string getCarbonHostName();
 string urlEncode(const string &text);
 int waitForData(int fd, int seconds, int useconds=0);
 int waitFor2Data(int fd1, int fd2, int seconds, int useconds, int* fd);
@@ -756,7 +757,6 @@ std::vector<ComboAddress> getResolvers(const std::string& resolvConfPath);
 
 DNSName reverseNameFromIP(const ComboAddress& ip);
 
-std::string getCarbonHostName();
 size_t parseRFC1035CharString(const std::string &in, std::string &val); // from ragel
 size_t parseSVCBValueListFromParsedRFC1035CharString(const std::string &in, vector<std::string> &val); // from ragel
 size_t parseSVCBValueList(const std::string &in, vector<std::string> &val);

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -84,13 +84,6 @@ DNSName getTSIGAlgoName(TSIGHashEnum& algoEnum);
 
 int logFacilityToLOG(unsigned int facility);
 
-struct ServiceTuple
-{
-  string host;
-  uint16_t port;
-};
-void parseService(const string &descr, ServiceTuple &st);
-
 template<typename Container>
 void
 stringtok (Container &container, string const &in,

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1481,11 +1481,10 @@ static int serviceMain(int argc, char* argv[], Logr::log_t log)
     g_quiet = false;
     g_dnssecLOG = true;
   }
-  string myHostname = getHostname();
-  if (myHostname == "UNKNOWN") {
+  auto myHostname = getHostname();
+  if (!myHostname.has_value()) {
     SLOG(g_log << Logger::Warning << "Unable to get the hostname, NSID and id.server values will be empty" << endl,
          log->info(Logr::Warning, "Unable to get the hostname, NSID and id.server values will be empty"));
-    myHostname = "";
   }
 
   SyncRes::s_minimumTTL = ::arg().asNum("minimum-ttl-override");
@@ -1534,7 +1533,7 @@ static int serviceMain(int argc, char* argv[], Logr::log_t log)
   }
 
   if (SyncRes::s_serverID.empty()) {
-    SyncRes::s_serverID = myHostname;
+    SyncRes::s_serverID = myHostname.has_value() ? *myHostname : "";
   }
 
   SyncRes::s_ecsipv4limit = ::arg().asNum("ecs-ipv4-bits");
@@ -1864,7 +1863,7 @@ static int serviceMain(int argc, char* argv[], Logr::log_t log)
   dns_random_init();
 
   if (::arg()["server-id"].empty()) {
-    ::arg().set("server-id") = myHostname;
+    ::arg().set("server-id") = myHostname.has_value() ? *myHostname : "";
   }
 
   int newgid = 0;

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -127,21 +127,12 @@ BOOST_AUTO_TEST_CASE(test_endianness) {
   uint32_t i = 1;
 #if BYTE_ORDER == BIG_ENDIAN
   BOOST_CHECK_EQUAL(i, htonl(i));
-#elif BYTE_ORDER == LITTLE_ENDIAN 
+#elif BYTE_ORDER == LITTLE_ENDIAN
   uint32_t j=0x01000000;
   BOOST_CHECK_EQUAL(i, ntohl(j));
 #else
   BOOST_FAIL("Did not detect endianness at all");
 #endif
-}
-
-BOOST_AUTO_TEST_CASE(test_parseService) {
-    ServiceTuple tp;
-    parseService("smtp.powerdns.com:25", tp);
-    BOOST_CHECK_EQUAL(tp.host, "smtp.powerdns.com");
-    BOOST_CHECK_EQUAL(tp.port, 25);
-    parseService("smtp.powerdns.com", tp);    
-    BOOST_CHECK_EQUAL(tp.port, 25);
 }
 
 BOOST_AUTO_TEST_CASE(test_ternary) {


### PR DESCRIPTION
### Short description
Improve error message when invalid values for `local-address` are provided in recursor config file. The recursor used to depend on `parseService` subroutines to parse addresses. This subroutine didn't do much except "scan until colon or EOF is reached".

This PR replaces the use of `parseService` with `ComboAddress` which offers better parsing and error reporting for address values.

This PR also cleans up and modernizes `getHostname`.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)