### PR TITLE
dnsdist: Add build-time options to disable the dynamic blocks and UDP response delay

### DIFF
--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#ifndef DISABLE_DYNBLOCKS
 #include <unordered_set>
 
 #include "dolog.hh"
@@ -435,3 +436,5 @@ private:
   static std::list<MetricsSnapshot> s_metricsData;
   static size_t s_topN;
 };
+
+#endif /* DISABLE_DYNBLOCKS */

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -94,6 +94,7 @@ static LuaArray<std::vector<boost::variant<string,double>>> getGenResponses(uint
 }
 #endif /* DISABLE_TOP_N_BINDINGS */
 
+#ifndef DISABLE_DYNBLOCKS
 #ifndef DISABLE_DEPRECATED_DYNBLOCK
 
 typedef std::unordered_map<ComboAddress, unsigned int, ComboAddress::addressOnlyHash, ComboAddress::addressOnlyEqual> counts_t;
@@ -241,6 +242,7 @@ static counts_t exceedRespByterate(unsigned int rate, int seconds)
 }
 
 #endif /* DISABLE_DEPRECATED_DYNBLOCK */
+#endif /* DISABLE_DYNBLOCKS */
 
 void setupLuaInspection(LuaContext& luaCtx)
 {
@@ -736,6 +738,7 @@ void setupLuaInspection(LuaContext& luaCtx)
       }
     });
 
+#ifndef DISABLE_DYNBLOCKS
 #ifndef DISABLE_DEPRECATED_DYNBLOCK
   luaCtx.writeFunction("exceedServFails", [](unsigned int rate, int seconds) {
       setLuaNoSideEffect();
@@ -882,4 +885,5 @@ void setupLuaInspection(LuaContext& luaCtx)
   });
   luaCtx.registerFunction("setQuiet", &DynBlockRulesGroup::setQuiet);
   luaCtx.registerFunction("toString", &DynBlockRulesGroup::toString);
+#endif /* DISABLE_DYNBLOCKS */
 }

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1438,6 +1438,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
   luaCtx.writeFunction("setECSOverride", [](bool override) { g_ECSOverride = override; });
 
+#ifndef DISABLE_DYNBLOCKS
   luaCtx.writeFunction("showDynBlocks", []() {
     setLuaNoSideEffect();
     auto slow = g_dynblockNMG.getCopy();
@@ -1571,6 +1572,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.writeFunction("setDynBlocksPurgeInterval", [](uint64_t interval) {
     DynBlockMaintenance::s_expiredDynBlocksPurgeInterval = interval;
   });
+#endif /* DISABLE_DYNBLOCKS */
 
 #ifdef HAVE_DNSCRYPT
   luaCtx.writeFunction("addDNSCryptBind", [](const std::string& addr, const std::string& providerName, LuaTypeOrArrayOf<std::string> certFiles, LuaTypeOrArrayOf<std::string> keyFiles, boost::optional<localbind_t> vars) {
@@ -1838,6 +1840,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
+#ifndef DISABLE_DYNBLOCKS
 #ifndef DISABLE_DEPRECATED_DYNBLOCK
   luaCtx.writeFunction("addBPFFilterDynBlocks", [](const std::unordered_map<ComboAddress, unsigned int, ComboAddress::addressOnlyHash, ComboAddress::addressOnlyEqual>& m, std::shared_ptr<DynBPFFilter> dynbpf, boost::optional<int> seconds, boost::optional<std::string> msg) {
     if (!dynbpf) {
@@ -1856,6 +1859,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 #endif /* DISABLE_DEPRECATED_DYNBLOCK */
+#endif /* DISABLE_DYNBLOCKS */
 
 #endif /* HAVE_EBPF */
 

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -837,6 +837,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
   addRulesToPrometheusOutput(output, g_cachehitrespruleactions);
   addRulesToPrometheusOutput(output, g_selfansweredrespruleactions);
 
+#ifndef DISABLE_DYNBLOCKS
   output << "# HELP dnsdist_dynblocks_nmg_top_offenders_hits_per_second " << "Number of hits per second blocked by Dynamic Blocks (netmasks) for the top offenders, averaged over the last 60s" << "\n";
   output << "# TYPE dnsdist_dynblocks_nmg_top_offenders_hits_per_second " << "gauge" << "\n";
   auto topNetmasksByReason = DynBlockMaintenance::getHitsForTopNetmasks();
@@ -854,6 +855,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
       output << "dnsdist_dynblocks_smt_top_offenders_hits_per_second{reason=\"" << entry.first << "\",suffix=\"" << suffix.first.toString() << "\"} " << suffix.second << "\n";
     }
   }
+#endif /* DISABLE_DYNBLOCKS */
 
   output << "# HELP dnsdist_info " << "Info from dnsdist, value is always 1" << "\n";
   output << "# TYPE dnsdist_info " << "gauge" << "\n";
@@ -914,6 +916,7 @@ static void handleJSONStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
   }
   else if (command == "dynblocklist") {
     Json::object obj;
+#ifndef DISABLE_DYNBLOCKS
     auto nmg = g_dynblockNMG.getLocal();
     struct timespec now;
     gettime(&now);
@@ -945,7 +948,7 @@ static void handleJSONStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
         obj.insert({dom, thing});
       }
     });
-
+#endif /* DISABLE_DYNBLOCKS */
     Json my_json = obj;
     resp.body = my_json.dump();
     resp.headers["Content-Type"] = "application/json";

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -937,6 +937,7 @@ static bool applyRulesToQuery(LocalHolders& holders, DNSQuestion& dq, const stru
     }
   }
 
+#ifndef DISABLE_DYNBLOCKS
   /* the Dynamic Block mechanism supports address and port ranges, so we need to pass the full address and port */
   if (auto got = holders.dynNMGBlock->lookup(AddressAndPortRange(*dq.remote, dq.remote->isIPv4() ? 32 : 128, 16))) {
     auto updateBlockStats = [&got]() {
@@ -1055,6 +1056,7 @@ static bool applyRulesToQuery(LocalHolders& holders, DNSQuestion& dq, const stru
       }
     }
   }
+#endif /* DISABLE_DYNBLOCKS */
 
   DNSAction::Action action=DNSAction::Action::None;
   string ruleresult;
@@ -1874,12 +1876,14 @@ static void maintThread()
   }
 }
 
+#ifndef DISABLE_DYNBLOCKS
 static void dynBlockMaintenanceThread()
 {
   setThreadName("dnsdist/dynBloc");
 
   DynBlockMaintenance::run();
 }
+#endif
 
 #ifndef DISABLE_SECPOLL
 static void secPollThread()
@@ -2757,8 +2761,10 @@ int main(int argc, char** argv)
 
     thread healththread(healthChecksThread);
 
+#ifndef DISABLE_DYNBLOCKS
     thread dynBlockMaintThread(dynBlockMaintenanceThread);
     dynBlockMaintThread.detach();
+#endif /* DISABLE_DYNBLOCKS */
 
 #ifndef DISABLE_SECPOLL
     if (!g_secPollSuffix.empty()) {

--- a/pdns/dnsdistdist/dnsdist-dynblocks.cc
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.cc
@@ -6,6 +6,8 @@ GlobalStateHolder<NetmaskTree<DynBlock, AddressAndPortRange>> g_dynblockNMG;
 GlobalStateHolder<SuffixMatchTree<DynBlock>> g_dynblockSMT;
 DNSAction::Action g_dynBlockAction = DNSAction::Action::Drop;
 
+#ifndef DISABLE_DYNBLOCKS
+
 void DynBlockRulesGroup::apply(const struct timespec& now)
 {
   counts_t counts;
@@ -754,3 +756,4 @@ std::map<std::string, std::list<std::pair<DNSName, unsigned int>>> DynBlockMaint
 {
   return s_tops.lock()->topSMTsByReason;
 }
+#endif /* DISABLE_DYNBLOCKS */

--- a/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
@@ -23,6 +23,7 @@
 #include "dnsdist.hh"
 #include "dnsdist-dynblocks.hh"
 
+#ifndef DISABLE_DYNBLOCKS
 uint64_t dnsdist_ffi_stat_node_get_queries_count(const dnsdist_ffi_stat_node_t* node)
 {
   return node->self.queries;
@@ -104,3 +105,4 @@ void dnsdist_ffi_state_node_set_reason(dnsdist_ffi_stat_node_t* node, const char
 {
   node->reason = std::string(reason, reasonSize);
 }
+#endif /* DISABLE_DYNBLOCKS */

--- a/pdns/dnsdistdist/docs/install.rst
+++ b/pdns/dnsdistdist/docs/install.rst
@@ -116,7 +116,9 @@ Our ``configure`` script provides a fair number of options with regard to which 
 * ``DISABLE_BUILTIN_HTML`` removes the built-in web pages
 * ``DISABLE_CARBON`` for carbon support
 * ``DISABLE_COMPLETION`` for completion support in the console
+* ``DISABLE_DELAY_PIPE`` removes the ability to delay UDP responses
 * ``DISABLE_DEPRECATED_DYNBLOCK`` for legacy dynamic blocks not using the new ``DynBlockRulesGroup`` interface
+* ``DISABLE_DYNBLOCKS`` disables the new dynamic block interface
 * ``DISABLE_ECS_ACTIONS`` to disable actions altering EDNS Client Subnet
 * ``DISABLE_FALSE_SHARING_PADDING`` to disable the padding of atomic counters, which is inserted to prevent false sharing but increases the memory use significantly
 * ``DISABLE_HASHED_CREDENTIALS`` to disable password-hashing support

--- a/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
+++ b/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
@@ -11,6 +11,8 @@
 Rings g_rings;
 shared_ptr<BPFFilter> g_defaultBPFFilter{nullptr};
 
+#ifndef DISABLE_DYNBLOCKS
+
 BOOST_AUTO_TEST_SUITE(dnsdistdynblocks_hh)
 
 BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_QueryRate) {
@@ -1504,3 +1506,4 @@ BOOST_AUTO_TEST_CASE(test_NetmaskTreePort) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+#endif /* DISABLE_DYNBLOCKS */

--- a/tasks.py
+++ b/tasks.py
@@ -334,6 +334,8 @@ def ci_dnsdist_configure(c, features):
                       --without-nghttp2 \
                       --without-re2 '
       additional_flags = '-DDISABLE_COMPLETION \
+                          -DDISABLE_DELAY_PIPE \
+                          -DDISABLE_DYNBLOCKS \
                           -DDISABLE_PROMETHEUS \
                           -DDISABLE_PROTOBUF \
                           -DDISABLE_BUILTIN_HTML \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Each of these features involves an extra thread, which we might want to avoid on some architectures.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
