### PR TITLE
dnsdist: Better code coverage stats when enabled

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -310,6 +310,13 @@ static void LuaThread(const std::string code)
   }
 }
 
+#ifdef COVERAGE
+extern "C"
+{
+  void __gcov_dump(void);
+}
+#endif
+
 static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 {
   typedef LuaAssociativeTable<boost::variant<bool, std::string, LuaArray<std::string>, DownstreamState::checkfunc_t>> newserver_t;
@@ -894,14 +901,17 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     sd_notify(0, "STOPPING=1");
 #endif /* HAVE_SYSTEMD */
 #if 0
-      // Useful for debugging leaks, but might lead to race under load
-      // since other threads are still running.
-      for(auto& frontend : g_tlslocals) {
-        frontend->cleanup();
-      }
-      g_tlslocals.clear();
-      g_rings.clear();
+    // Useful for debugging leaks, but might lead to race under load
+    // since other threads are still running.
+    for (auto& frontend : g_tlslocals) {
+      frontend->cleanup();
+    }
+    g_tlslocals.clear();
+    g_rings.clear();
 #endif /* 0 */
+#ifdef COVERAGE
+    __gcov_dump();
+#endif
     _exit(0);
   });
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2238,6 +2238,11 @@ static void usage()
 }
 
 #ifdef COVERAGE
+extern "C"
+{
+  void __gcov_dump(void);
+}
+
 static void cleanupLuaObjects()
 {
   /* when our coverage mode is enabled, we need to make
@@ -2254,7 +2259,8 @@ static void cleanupLuaObjects()
 static void sigTermHandler(int)
 {
   cleanupLuaObjects();
-  exit(EXIT_SUCCESS);
+  __gcov_dump();
+  _exit(EXIT_SUCCESS);
 }
 #else /* COVERAGE */
 static void sigTermHandler(int)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When exiting on user request, dnsdist calls `_Exit()` to avoid any issue caused by the order in which the destructors of our long-lived objects are called (it would be nice to fix this properly, but it would require a fairly large refactoring).
Since the static destructors are not called in that case, the most recent coverage data is not always properly dumped to disk. Explicitly calling __gcov_dump` before exiting ensures that no data is lost.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
