### PR TITLE
dnsdist: Implement a small MAC address cache

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -25,6 +25,7 @@
 #include "dnsdist-ecs.hh"
 #include "dnsdist-lua.hh"
 #include "dnsdist-lua-ffi.hh"
+#include "dnsdist-mac-address.hh"
 #include "dnsdist-protobuf.hh"
 #include "dnsdist-kvs.hh"
 #include "dnsdist-svc.hh"
@@ -932,8 +933,9 @@ public:
 
   DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
-    std::string mac = getMACAddress(*dq->remote);
-    if (mac.empty()) {
+    char mac[6];
+    int res = dnsdist::MacAddressesCache::get(*dq->remote, mac, sizeof(mac));
+    if (res != 0) {
       return Action::None;
     }
 

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -933,14 +933,14 @@ public:
 
   DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
-    char mac[6];
-    int res = dnsdist::MacAddressesCache::get(*dq->remote, mac, sizeof(mac));
+    dnsdist::MacAddress mac;
+    int res = dnsdist::MacAddressesCache::get(*dq->remote, mac.data(), mac.size());
     if (res != 0) {
       return Action::None;
     }
 
     std::string optRData;
-    generateEDNSOption(d_code, mac, optRData);
+    generateEDNSOption(d_code, reinterpret_cast<const char*>(mac.data()), optRData);
 
     if (dq->getHeader()->arcount) {
       bool ednsAdded = false;

--- a/pdns/dnsdist-rings.hh
+++ b/pdns/dnsdist-rings.hh
@@ -32,6 +32,7 @@
 #include "lock.hh"
 #include "stat_t.hh"
 #include "dnsdist-protocols.hh"
+#include "dnsdist-mac-address.hh"
 
 struct Rings {
   struct Query
@@ -105,7 +106,7 @@ struct Rings {
 #if defined(DNSDIST_RINGS_WITH_MACADDRESS)
     char macaddress[6];
     bool hasmac{false};
-    if (getMACAddress(requestor, macaddress, sizeof(macaddress)) == 0) {
+    if (dnsdist::MacAddressesCache::get(requestor, macaddress, sizeof(macaddress)) == 0) {
       hasmac = true;
     }
 #endif

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -163,6 +163,7 @@ dnsdist_SOURCES = \
 	dnsdist-lua-vars.cc \
 	dnsdist-lua-web.cc \
 	dnsdist-lua.cc dnsdist-lua.hh \
+	dnsdist-mac-address.cc dnsdist-mac-address.hh \
 	dnsdist-nghttp2.cc dnsdist-nghttp2.hh \
 	dnsdist-prometheus.hh \
 	dnsdist-protobuf.cc dnsdist-protobuf.hh \
@@ -251,6 +252,7 @@ testrunner_SOURCES = \
 	dnsdist-lua-ffi-interface.h dnsdist-lua-ffi-interface.inc \
 	dnsdist-lua-ffi.cc dnsdist-lua-ffi.hh \
 	dnsdist-lua-vars.cc \
+	dnsdist-mac-address.cc dnsdist-mac-address.hh \
 	dnsdist-nghttp2.cc dnsdist-nghttp2.hh \
 	dnsdist-protocols.cc dnsdist-protocols.hh \
 	dnsdist-proxy-protocol.cc dnsdist-proxy-protocol.hh \

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -64,7 +64,7 @@ size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dq,
     return 0;
   }
 
-  auto ret = dnsdist::MacAddressesCache::get(*dq->dq->remote, reinterpret_cast<char*>(buffer), bufferSize);
+  auto ret = dnsdist::MacAddressesCache::get(*dq->dq->remote, reinterpret_cast<unsigned char*>(buffer), bufferSize);
   if (ret != 0) {
     return 0;
   }

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -21,6 +21,7 @@
  */
 
 #include "dnsdist-lua-ffi.hh"
+#include "dnsdist-mac-address.hh"
 #include "dnsdist-lua.hh"
 #include "dnsdist-ecs.hh"
 #include "dolog.hh"
@@ -63,7 +64,7 @@ size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dq,
     return 0;
   }
 
-  auto ret = getMACAddress(*dq->dq->remote, reinterpret_cast<char*>(buffer), bufferSize);
+  auto ret = dnsdist::MacAddressesCache::get(*dq->dq->remote, reinterpret_cast<char*>(buffer), bufferSize);
   if (ret != 0) {
     return 0;
   }

--- a/pdns/dnsdistdist/dnsdist-mac-address.cc
+++ b/pdns/dnsdistdist/dnsdist-mac-address.cc
@@ -1,0 +1,75 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "dnsdist-mac-address.hh"
+#include "misc.hh"
+
+namespace dnsdist
+{
+LockGuarded<boost::circular_buffer<MacAddressesCache::Entry>> MacAddressesCache::s_cache;
+
+int MacAddressesCache::get(const ComboAddress& ca, char* dest, size_t destLen)
+{
+  if (dest == nullptr || destLen < sizeof(Entry::mac)) {
+    return EINVAL;
+  }
+
+  auto compare = ComboAddress::addressOnlyEqual();
+  time_t now = time(nullptr);
+
+  {
+    auto cache = s_cache.lock();
+    for (const auto& entry : *cache) {
+      if (entry.ttd >= now && compare(entry.ca, ca) == true) {
+        if (!entry.found) {
+          // negative entry
+          return ENOENT;
+        }
+        memcpy(dest, entry.mac, sizeof(entry.mac));
+        return 0;
+      }
+    }
+  }
+
+  auto res = getMACAddress(ca, dest, destLen);
+  {
+    auto cache = s_cache.lock();
+    if (cache->capacity() == 0) {
+      cache->set_capacity(MacAddressesCache::s_cacheSize);
+    }
+    Entry entry;
+    entry.ca = ca;
+    if (res == 0) {
+      memcpy(entry.mac, dest, sizeof(entry.mac));
+      entry.found = true;
+    }
+    else {
+      memset(entry.mac, 0, sizeof(entry.mac));
+      entry.found = false;
+    }
+    entry.ttd = now + MacAddressesCache::s_cacheValiditySeconds;
+    cache->push_back(std::move(entry));
+  }
+
+  return res;
+}
+}

--- a/pdns/dnsdistdist/dnsdist-mac-address.hh
+++ b/pdns/dnsdistdist/dnsdist-mac-address.hh
@@ -1,0 +1,48 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "circular_buffer.hh"
+#include "iputils.hh"
+#include "lock.hh"
+
+namespace dnsdist
+{
+class MacAddressesCache
+{
+public:
+  static int get(const ComboAddress& ca, char* dest, size_t len);
+
+private:
+  struct Entry
+  {
+    ComboAddress ca;
+    char mac[6];
+    time_t ttd;
+    bool found;
+  };
+
+  static constexpr size_t s_cacheSize{10};
+  static constexpr time_t s_cacheValiditySeconds{60};
+  static LockGuarded<boost::circular_buffer<Entry>> s_cache;
+};
+}

--- a/pdns/dnsdistdist/dnsdist-mac-address.hh
+++ b/pdns/dnsdistdist/dnsdist-mac-address.hh
@@ -27,16 +27,18 @@
 
 namespace dnsdist
 {
+using MacAddress = std::array<uint8_t, 6>;
+
 class MacAddressesCache
 {
 public:
-  static int get(const ComboAddress& ca, char* dest, size_t len);
+  static int get(const ComboAddress& ca, unsigned char* dest, size_t len);
 
 private:
   struct Entry
   {
     ComboAddress ca;
-    char mac[6];
+    MacAddress mac;
     time_t ttd;
     bool found;
   };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When the MAC address feature is enabled, dnsdist usually keeps seeing the same devices, so it makes sense to keep a tiny (10 entries), short-lived (60s) cache of MAC addresses to speed things up.
We might want to make the size configurable at a later point if this proves useful.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
