### PR TITLE
dnsdist: Add a 'single acceptor thread' build option, reducing the number of threads

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -424,11 +424,11 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
 #ifdef HAVE_EBPF
   luaCtx.registerFunction<void(ClientState::*)(std::shared_ptr<BPFFilter>)>("attachFilter", [](ClientState& frontend, std::shared_ptr<BPFFilter> bpf) {
       if (bpf) {
-        frontend.attachFilter(bpf);
+        frontend.attachFilter(bpf, frontend.getSocket());
       }
     });
   luaCtx.registerFunction<void(ClientState::*)()>("detachFilter", [](ClientState& frontend) {
-      frontend.detachFilter();
+      frontend.detachFilter(frontend.getSocket());
     });
 #endif /* HAVE_EBPF */
 #endif /* DISABLE_CLIENT_STATE_BINDINGS */
@@ -629,7 +629,7 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
       }
       if (bpf) {
         for (const auto& frontend : g_frontends) {
-          frontend->attachFilter(bpf);
+          frontend->attachFilter(bpf, frontend->getSocket());
         }
       }
     });

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -1305,6 +1305,7 @@ static void tcpClientThread(int pipefd, int crossProtocolQueriesPipeFD, int cros
 
     for (size_t idx = 0; idx < acceptParams.size(); idx++) {
       const auto& param = acceptParams.at(idx);
+      setNonBlocking(param.socket);
       data.mplexer->addReadFD(param.socket, acceptCallback, &param);
     }
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -618,6 +618,7 @@ struct ClientState
   std::set<int> cpus;
   std::string interface;
   ComboAddress local;
+  std::vector<std::pair<ComboAddress, int>> d_additionalAddresses;
   std::shared_ptr<DNSCryptContext> dnscryptCtx{nullptr};
   std::shared_ptr<TLSFrontend> tlsFrontend{nullptr};
   std::shared_ptr<DOHFrontend> dohFrontend{nullptr};
@@ -702,19 +703,19 @@ struct ClientState
     return result;
   }
 
-  void detachFilter()
+  void detachFilter(int socket)
   {
     if (d_filter) {
-      d_filter->removeSocket(getSocket());
+      d_filter->removeSocket(socket);
       d_filter = nullptr;
     }
   }
 
-  void attachFilter(shared_ptr<BPFFilter> bpf)
+  void attachFilter(shared_ptr<BPFFilter> bpf, int socket)
   {
-    detachFilter();
+    detachFilter(socket);
 
-    bpf->addSocket(getSocket());
+    bpf->addSocket(socket);
     d_filter = bpf;
   }
 

--- a/pdns/dnsdistdist/dnsdist-tcp.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp.hh
@@ -175,7 +175,7 @@ struct CrossProtocolQuery
 class TCPClientCollection
 {
 public:
-  TCPClientCollection(size_t maxThreads);
+  TCPClientCollection(size_t maxThreads, std::vector<ClientState*> tcpStates);
 
   int getThread()
   {
@@ -249,7 +249,7 @@ public:
   }
 
 private:
-  void addTCPClientThread();
+  void addTCPClientThread(std::vector<ClientState*>& tcpAcceptStates);
 
   struct TCPWorkerThread
   {

--- a/pdns/dnsdistdist/docs/install.rst
+++ b/pdns/dnsdistdist/docs/install.rst
@@ -147,3 +147,6 @@ Additionally several Lua bindings can be removed when they are not needed, as th
 * ``DISABLE_QPS_LIMITER_BINDINGS``
 * ``DISABLE_SUFFIX_MATCH_BINDINGS``
 * ``DISABLE_TOP_N_BINDINGS``
+
+Finally a build flag can be used to make use a single thread to handle all incoming UDP queries from clients, and another single thread to accept new TCP connections from clients, no matter how many :func:`addLocal` directives are present in the configuration. This option is destined to resource-constrained environments where dnsdist needs to listen on several addresses, over several interfaces, and one thread is enough to handle the traffic and therefore the overhead of using multiples threads for that task does not make sense.
+This option can be enabled by setting ``USE_SINGLE_ACCEPTOR_THREAD``.

--- a/pdns/dnsdistdist/docs/install.rst
+++ b/pdns/dnsdistdist/docs/install.rst
@@ -148,5 +148,5 @@ Additionally several Lua bindings can be removed when they are not needed, as th
 * ``DISABLE_SUFFIX_MATCH_BINDINGS``
 * ``DISABLE_TOP_N_BINDINGS``
 
-Finally a build flag can be used to make use a single thread to handle all incoming UDP queries from clients, and another single thread to accept new TCP connections from clients, no matter how many :func:`addLocal` directives are present in the configuration. This option is destined to resource-constrained environments where dnsdist needs to listen on several addresses, over several interfaces, and one thread is enough to handle the traffic and therefore the overhead of using multiples threads for that task does not make sense.
+Finally a build flag can be used to make use a single thread to handle all incoming UDP queries from clients, no matter how many :func:`addLocal` directives are present in the configuration. It also moves the task of accepting incoming TCP connections to the TCP workers themselves, removing the TCP acceptor threads. This option is destined to resource-constrained environments where dnsdist needs to listen on several addresses, over several interfaces, and one thread is enough to handle the traffic and therefore the overhead of using multiples threads for that task does not make sense.
 This option can be enabled by setting ``USE_SINGLE_ACCEPTOR_THREAD``.

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -120,7 +120,7 @@ Listen Sockets
 
   .. versionchanged:: 1.8.0
      ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`)
-     ``keepIncomingHeaders`` option added.
+     ``additionalAddresses`` and ``keepIncomingHeaders`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over HTTPS connections, presenting the specified X.509 certificate.
   If no certificate (or key) files are specified, listen for incoming DNS over HTTP connections instead.
@@ -162,6 +162,7 @@ Listen Sockets
   * ``releaseBuffers=true``: bool - Whether OpenSSL should release its I/O buffers when a connection goes idle, saving roughly 35 kB of memory per connection.
   * ``enableRenegotiation=false``: bool - Whether secure TLS renegotiation should be enabled. Disabled by default since it increases the attack surface and is seldom used for DNS.
   * ``keepIncomingHeaders``: bool - Whether to retain the incoming headers in memory, to be able to use :func:`HTTPHeaderRule` or :meth:`DNSQuestion.getHTTPHeaders`. Default is false. Before 1.8.0 the headers were always kept in-memory.
+  * ``additionalAddresses``: list - List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses.
 
 .. function:: addTLSLocal(address, certFile(s), keyFile(s) [, options])
 
@@ -174,7 +175,8 @@ Listen Sockets
   .. versionchanged:: 1.8.0
     ``tlsAsyncMode`` option added.
   .. versionchanged:: 1.8.0
-     ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`)
+     ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`).
+     ``additionalAddresses`` option added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
@@ -209,6 +211,7 @@ Listen Sockets
   * ``releaseBuffers=true``: bool - Whether OpenSSL should release its I/O buffers when a connection goes idle, saving roughly 35 kB of memory per connection.
   * ``enableRenegotiation=false``: bool - Whether secure TLS renegotiation should be enabled (OpenSSL only, the GnuTLS provider does not support it). Disabled by default since it increases the attack surface and is seldom used for DNS.
   * ``tlsAsyncMode=false``: bool - Whether to enable experimental asynchronous TLS I/O operations if OpenSSL is used as the TLS provider and an asynchronous capable SSL engine is loaded. See also :func:`loadTLSEngine` to load the engine.
+  * ``additionalAddresses``: list - List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses.
 
 .. function:: setLocal(address[, options])
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
On some environments that have very limited resources and deal with a fairly low amount of QPS, it does not make sense to have several UDP, TCP, DoT and DoH handler threads to deal with the various network interfaces, so this PR adds a build option where there is a single UDP thread to deal with all incoming queries, a TCP/DoT worker thread can deal with several/all listening IP addresses (merging the `accept()` thread into the worker) and a single DoH worker thread can deal with several/all listening IP addresses as well.
Reducing the number of threads that way yields a lower memory footprint and lower the cost of context switches.
Note that this change is not enabled by default, as it would not make sense for most environments.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
