### PR TITLE
Include (with precautions) offending data in messages about too long a label

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -44,8 +44,8 @@ std::ostream & operator<<(std::ostream &os, const DNSName& d)
 void DNSName::throwSafeRangeError(const std::string& msg, const char* buf, size_t length)
 {
   std::string dots;
-  if (length > maxDNSNameLength) {
-    length = maxDNSNameLength;
+  if (length > s_maxDNSNameLength) {
+    length = s_maxDNSNameLength;
     dots = "...";
   }
   std::string label;
@@ -80,7 +80,7 @@ DNSName::DNSName(const char* p, size_t length)
         if(labellen > 63)
           throwSafeRangeError("label too long to append: ", p, length);
 
-        if(iter-pbegin > static_cast<ptrdiff_t>(maxDNSNameLength - 1)) // reserve two bytes, one for length and one for the root label
+        if(iter-pbegin > static_cast<ptrdiff_t>(s_maxDNSNameLength - 1)) // reserve two bytes, one for length and one for the root label
           throwSafeRangeError("name too long to append: ", p, length);
 
         d_storage[lenpos]=labellen;
@@ -89,7 +89,7 @@ DNSName::DNSName(const char* p, size_t length)
     }
     else {
       d_storage=segmentDNSNameRaw(p, length);
-      if(d_storage.size() > maxDNSNameLength) {
+      if(d_storage.size() > s_maxDNSNameLength) {
         throwSafeRangeError("name too long: ", p, length);
       }
     }
@@ -340,7 +340,7 @@ void DNSName::appendRawLabel(const char* start, unsigned int length)
     throw std::range_error("no such thing as an empty label to append");
   if(length > 63)
     throw std::range_error("label too long to append");
-  if(d_storage.size() + length > maxDNSNameLength - 1) // reserve one byte for the label length
+  if(d_storage.size() + length > s_maxDNSNameLength - 1) // reserve one byte for the label length
     throw std::range_error("name too long to append");
 
   if(d_storage.empty()) {
@@ -359,7 +359,7 @@ void DNSName::prependRawLabel(const std::string& label)
     throw std::range_error("no such thing as an empty label to prepend");
   if(label.size() > 63)
     throw std::range_error("label too long to prepend");
-  if(d_storage.size() + label.size() > maxDNSNameLength - 1) // reserve one byte for the label length
+  if(d_storage.size() + label.size() > s_maxDNSNameLength - 1) // reserve one byte for the label length
     throw std::range_error("name too long to prepend");
 
   if(d_storage.empty())

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -44,7 +44,6 @@ std::ostream & operator<<(std::ostream &os, const DNSName& d)
 void DNSName::throwSafeRangeError(const std::string& msg, const char* buf, size_t length)
 {
   std::string dots;
-  const size_t maxDNSNameLength = 255; // Maybe this should be a symbol in DNSName itself
   if (length > maxDNSNameLength) {
     length = maxDNSNameLength;
     dots = "...";
@@ -81,7 +80,7 @@ DNSName::DNSName(const char* p, size_t length)
         if(labellen > 63)
           throwSafeRangeError("label too long to append: ", p, length);
 
-        if(iter-pbegin > 254) // reserve two bytes, one for length and one for the root label
+        if(iter-pbegin > static_cast<ptrdiff_t>(maxDNSNameLength - 1)) // reserve two bytes, one for length and one for the root label
           throwSafeRangeError("name too long to append: ", p, length);
 
         d_storage[lenpos]=labellen;
@@ -90,7 +89,7 @@ DNSName::DNSName(const char* p, size_t length)
     }
     else {
       d_storage=segmentDNSNameRaw(p, length);
-      if(d_storage.size() > 255) {
+      if(d_storage.size() > maxDNSNameLength) {
         throwSafeRangeError("name too long: ", p, length);
       }
     }
@@ -341,7 +340,7 @@ void DNSName::appendRawLabel(const char* start, unsigned int length)
     throw std::range_error("no such thing as an empty label to append");
   if(length > 63)
     throw std::range_error("label too long to append");
-  if(d_storage.size() + length > 254) // reserve one byte for the label length
+  if(d_storage.size() + length > maxDNSNameLength - 1) // reserve one byte for the label length
     throw std::range_error("name too long to append");
 
   if(d_storage.empty()) {
@@ -360,7 +359,7 @@ void DNSName::prependRawLabel(const std::string& label)
     throw std::range_error("no such thing as an empty label to prepend");
   if(label.size() > 63)
     throw std::range_error("label too long to prepend");
-  if(d_storage.size() + label.size() > 254) // reserve one byte for the label length
+  if(d_storage.size() + label.size() > maxDNSNameLength - 1) // reserve one byte for the label length
     throw std::range_error("name too long to prepend");
 
   if(d_storage.empty())

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -149,7 +149,7 @@ public:
   DNSName& operator+=(const DNSName& rhs)
   {
     if(d_storage.size() + rhs.d_storage.size() > 256) // one extra byte for the second root label
-      throw std::range_error("name too long");
+      throwSafeRangeError("name too long", rhs.d_storage.data(), rhs.d_storage.size());
     if(rhs.empty())
       return *this;
 
@@ -217,6 +217,7 @@ private:
   void packetParser(const char* p, int len, int offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset);
   static void appendEscapedLabel(std::string& appendTo, const char* orig, size_t len);
   static std::string unescapeLabel(const std::string& orig);
+  static void throwSafeRangeError(const std::string& msg, const char* buf, size_t length);
 };
 
 size_t hash_value(DNSName const& d);

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -77,6 +77,8 @@ inline unsigned char dns_tolower(unsigned char c)
 class DNSName
 {
 public:
+  static const size_t maxDNSNameLength = 255;
+
   DNSName()  {}          //!< Constructs an *empty* DNSName, NOT the root!
   // Work around assertion in some boost versions that do not like self-assignment of boost::container::string
   DNSName& operator=(const DNSName& rhs)
@@ -148,8 +150,8 @@ public:
   }
   DNSName& operator+=(const DNSName& rhs)
   {
-    if(d_storage.size() + rhs.d_storage.size() > 256) // one extra byte for the second root label
-      throwSafeRangeError("name too long", rhs.d_storage.data(), rhs.d_storage.size());
+    if(d_storage.size() + rhs.d_storage.size() > maxDNSNameLength + 1) // one extra byte for the second root label
+      throwSafeRangeError("resulting name too long", rhs.d_storage.data(), rhs.d_storage.size());
     if(rhs.empty())
       return *this;
 

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -77,7 +77,7 @@ inline unsigned char dns_tolower(unsigned char c)
 class DNSName
 {
 public:
-  static const size_t maxDNSNameLength = 255;
+  static const size_t s_maxDNSNameLength = 255;
 
   DNSName()  {}          //!< Constructs an *empty* DNSName, NOT the root!
   // Work around assertion in some boost versions that do not like self-assignment of boost::container::string
@@ -150,7 +150,7 @@ public:
   }
   DNSName& operator+=(const DNSName& rhs)
   {
-    if(d_storage.size() + rhs.d_storage.size() > maxDNSNameLength + 1) // one extra byte for the second root label
+    if(d_storage.size() + rhs.d_storage.size() > s_maxDNSNameLength + 1) // one extra byte for the second root label
       throwSafeRangeError("resulting name too long", rhs.d_storage.data(), rhs.d_storage.size());
     if(rhs.empty())
       return *this;


### PR DESCRIPTION
Fixes #12014

Since we do not know the callers of this, we need to be extra careful not to print random strings. Especially call errors like `DNSName(p, -1)` should not be disastrous.

Note: the `throw std::runtime_error("Found . in wrong position in DNSName "+string(p));` case becomes a `range_error`. If that is not acceptable I should add a `throwSafeRuntimeError` function.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
