### PR TITLE
fix #11997 jdnssec was broken link to repository directly.

### DIFF
--- a/regression-tests/README.md
+++ b/regression-tests/README.md
@@ -7,7 +7,7 @@ We need very recent versions of:
 
  * validns (http://www.validns.net/)
  * ldns-verify-zone (part of ldns)
- * jdnssec-verifyzone (http://www.verisignlabs.com/dnssec-tools/)
+ * jdnssec-verifyzone (https://github.com/dblacka/jdnssec-tools)
  * named-checkzone (part of BIND9)
  * unbound-host (part of unbound)
  * drill (part of ldns)


### PR DESCRIPTION
### Short description
Fix a broken link `jdnssec-link` in `regression-tests/README.md`.

### Checklist

- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document