### PR TITLE
rec: Properly guard  TCP_DEFER_ACCEPT

### DIFF
--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -1035,7 +1035,9 @@ void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcpSockets
     throw PDNSException("No local address specified");
   }
 
+#ifdef TCP_DEFER_ACCEPT
   auto first = true;
+#endif
   const uint16_t defaultLocalPort = ::arg().asNum("local-port");
   for (const auto& localAddress : localAddresses) {
     ComboAddress address{localAddress, defaultLocalPort};
@@ -1127,6 +1129,8 @@ void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcpSockets
     SLOG(g_log << Logger::Info << "Listening for TCP queries on " << address.toStringWithPort() << endl,
          log->info(Logr::Info, "Listening for queries", "protocol", Logging::Loggable("TCP"), "address", Logging::Loggable(address)));
 
+#ifdef TCP_DEFER_ACCEPT
     first = false;
+#endif
   }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

On e.g. MacOS I saw: 
```
rec-tcp.cc:1038:8: warning: variable 'first' set but not used [-Wunused-but-set-variable]
  auto first = true;
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
