### PR TITLE
dnsdist: Add Lua helpers to look into the content of DNS payloads

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1,4 +1,4 @@
-aaaarecord
+aaarecord
 aae
 aaldering
 ababd
@@ -404,6 +404,7 @@ dnsname
 dnsnameset
 dnsop
 dnspacket
+dnsparser
 dnspcap
 dnsquestion
 DNSR

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -3050,6 +3050,7 @@ vector<std::function<void(void)>> setupLua(LuaContext& luaCtx, bool client, bool
   setupLuaConfig(luaCtx, client, configCheck);
   setupLuaBindings(luaCtx, client);
   setupLuaBindingsDNSCrypt(luaCtx, client);
+  setupLuaBindingsDNSParser(luaCtx);
   setupLuaBindingsDNSQuestion(luaCtx);
   setupLuaBindingsKVS(luaCtx, client);
   setupLuaBindingsNetwork(luaCtx, client);

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -146,6 +146,7 @@ vector<std::function<void(void)>> setupLua(LuaContext& luaCtx, bool client, bool
 void setupLuaActions(LuaContext& luaCtx);
 void setupLuaBindings(LuaContext& luaCtx, bool client);
 void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client);
+void setupLuaBindingsDNSParser(LuaContext& luaCtx);
 void setupLuaBindingsDNSQuestion(LuaContext& luaCtx);
 void setupLuaBindingsKVS(LuaContext& luaCtx, bool client);
 void setupLuaBindingsNetwork(LuaContext& luaCtx, bool client);

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -151,6 +151,7 @@ dnsdist_SOURCES = \
 	dnsdist-lbpolicies.cc dnsdist-lbpolicies.hh \
 	dnsdist-lua-actions.cc \
 	dnsdist-lua-bindings-dnscrypt.cc \
+	dnsdist-lua-bindings-dnsparser.cc \
 	dnsdist-lua-bindings-dnsquestion.cc \
 	dnsdist-lua-bindings-kvs.cc \
 	dnsdist-lua-bindings-network.cc \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -301,6 +301,7 @@ testrunner_SOURCES = \
 	test-delaypipe_hh.cc \
 	test-dnscrypt_cc.cc \
 	test-dnsdist-connections-cache.cc \
+	test-dnsdist-dnsparser.cc \
 	test-dnsdist_cc.cc \
 	test-dnsdistdynblocks_hh.cc \
 	test-dnsdistkvs_cc.cc \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -140,6 +140,7 @@ dnsdist_SOURCES = \
 	dnsdist-console.cc dnsdist-console.hh \
 	dnsdist-discovery.cc dnsdist-discovery.hh \
 	dnsdist-dnscrypt.cc \
+	dnsdist-dnsparser.cc dnsdist-dnsparser.hh \
 	dnsdist-downstream-connection.hh \
 	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
 	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \
@@ -242,6 +243,7 @@ testrunner_SOURCES = \
 	dnscrypt.cc dnscrypt.hh \
 	dnsdist-backend.cc \
 	dnsdist-cache.cc dnsdist-cache.hh \
+	dnsdist-dnsparser.cc dnsdist-dnsparser.hh \
 	dnsdist-downstream-connection.hh \
 	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
 	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \

--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -1,0 +1,71 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "dnsdist-dnsparser.hh"
+#include "dnsparser.hh"
+
+namespace dnsdist
+{
+DNSPacketOverlay::DNSPacketOverlay(const std::string_view& packet)
+{
+  if (packet.size() < sizeof(dnsheader)) {
+    throw std::runtime_error("Packet is too small for a DNS packet");
+  }
+
+  memcpy(&d_header, packet.data(), sizeof(dnsheader));
+  uint64_t numRecords = ntohs(d_header.ancount) + ntohs(d_header.nscount) + ntohs(d_header.arcount);
+  d_records.reserve(numRecords);
+
+  try
+  {
+    PacketReader reader(pdns_string_view(reinterpret_cast<const char*>(packet.data()), packet.size()));
+
+    for (uint16_t n = 0; n < ntohs(d_header.qdcount) ; ++n) {
+      reader.xfrName(d_qname);
+      reader.xfrType(d_qtype);
+      reader.xfrType(d_qclass);
+    }
+
+    for (uint64_t n = 0; n < numRecords; ++n) {
+      Record rec;
+      reader.xfrName(rec.d_name);
+      rec.d_place = n < ntohs(d_header.ancount) ? DNSResourceRecord::ANSWER : (n < (ntohs(d_header.ancount) + ntohs(d_header.nscount)) ? DNSResourceRecord::AUTHORITY : DNSResourceRecord::ADDITIONAL);
+      reader.xfrType(rec.d_type);
+      reader.xfrType(rec.d_class);
+      reader.xfr32BitInt(rec.d_ttl);
+      reader.xfr16BitInt(rec.d_contentLength);
+      rec.d_contentOffset = reader.getPosition();
+      reader.skip(rec.d_contentLength);
+      d_records.push_back(std::move(rec));
+    }
+  }
+  catch (const std::exception& e) {
+    throw std::runtime_error("Unable to parse DNS packet: " + std::string(e.what()));
+  }
+  catch (const PDNSException& e) {
+    throw std::runtime_error("Unable to parse DNS packet: " + e.reason);
+  }
+  catch (...) {
+    throw std::runtime_error("Unable to parse DNS packet");
+  }
+}
+}
+

--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -60,9 +60,6 @@ DNSPacketOverlay::DNSPacketOverlay(const std::string_view& packet)
   catch (const std::exception& e) {
     throw std::runtime_error("Unable to parse DNS packet: " + std::string(e.what()));
   }
-  catch (const PDNSException& e) {
-    throw std::runtime_error("Unable to parse DNS packet: " + e.reason);
-  }
   catch (...) {
     throw std::runtime_error("Unable to parse DNS packet");
   }

--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -34,11 +34,10 @@ DNSPacketOverlay::DNSPacketOverlay(const std::string_view& packet)
   uint64_t numRecords = ntohs(d_header.ancount) + ntohs(d_header.nscount) + ntohs(d_header.arcount);
   d_records.reserve(numRecords);
 
-  try
-  {
+  try {
     PacketReader reader(pdns_string_view(reinterpret_cast<const char*>(packet.data()), packet.size()));
 
-    for (uint16_t n = 0; n < ntohs(d_header.qdcount) ; ++n) {
+    for (uint16_t n = 0; n < ntohs(d_header.qdcount); ++n) {
       reader.xfrName(d_qname);
       reader.xfrType(d_qtype);
       reader.xfrType(d_qclass);
@@ -65,4 +64,3 @@ DNSPacketOverlay::DNSPacketOverlay(const std::string_view& packet)
   }
 }
 }
-

--- a/pdns/dnsdistdist/dnsdist-dnsparser.hh
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.hh
@@ -1,0 +1,50 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "dnsparser.hh"
+
+namespace dnsdist
+{
+class DNSPacketOverlay
+{
+public:
+  DNSPacketOverlay(const std::string_view& packet);
+
+  struct Record
+  {
+    DNSName d_name;
+    uint32_t d_ttl;
+    uint16_t d_type;
+    uint16_t d_class;
+    uint16_t d_contentLength;
+    uint16_t d_contentOffset;
+    DNSResourceRecord::Place d_place;
+  };
+
+  DNSName d_qname;
+  std::vector<Record> d_records;
+  uint16_t d_qtype;
+  uint16_t d_qclass;
+  dnsheader d_header;
+};
+}

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnsparser.cc
@@ -1,0 +1,66 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "dnsdist.hh"
+#include "dnsdist-dnsparser.hh"
+#include "dnsdist-lua.hh"
+
+void setupLuaBindingsDNSParser(LuaContext& luaCtx)
+{
+#ifndef DISABLE_DNSPACKET_BINDINGS
+  luaCtx.writeFunction("newDNSPacketOverlay", [](const std::string& packet) {
+    dnsdist::DNSPacketOverlay dpo(packet);
+    return dpo;
+  });
+
+  luaCtx.registerMember<DNSName(dnsdist::DNSPacketOverlay::*)>(std::string("qname"), [](const dnsdist::DNSPacketOverlay& overlay) { return overlay.d_qname; });
+  luaCtx.registerMember<uint16_t(dnsdist::DNSPacketOverlay::*)>(std::string("qtype"), [](const dnsdist::DNSPacketOverlay& overlay) { return overlay.d_qtype; });
+  luaCtx.registerMember<uint16_t(dnsdist::DNSPacketOverlay::*)>(std::string("qclass"), [](const dnsdist::DNSPacketOverlay& overlay) { return overlay.d_qclass; });
+  luaCtx.registerMember<dnsheader(dnsdist::DNSPacketOverlay::*)>(std::string("dh"), [](const dnsdist::DNSPacketOverlay& overlay) { return overlay.d_header; });
+
+  luaCtx.registerFunction<uint16_t (dnsdist::DNSPacketOverlay::*)(uint8_t) const>("getRecordsCountInSection", [](const dnsdist::DNSPacketOverlay& overlay, uint8_t section) -> uint16_t {
+    if (section > 3) {
+      return 0;
+    }
+    uint16_t count = 0;
+    for (const auto& record : overlay.d_records) {
+      if (record.d_place == section) {
+        count++;
+      }
+    }
+
+    return count;
+  });
+
+  luaCtx.registerFunction<dnsdist::DNSPacketOverlay::Record (dnsdist::DNSPacketOverlay::*)(size_t) const>("getRecord", [](const dnsdist::DNSPacketOverlay& overlay, size_t idx) {
+    return overlay.d_records.at(idx);
+  });
+
+  luaCtx.registerMember<DNSName(dnsdist::DNSPacketOverlay::Record::*)>(std::string("name"), [](const dnsdist::DNSPacketOverlay::Record& record) { return record.d_name; });
+  luaCtx.registerMember<uint16_t(dnsdist::DNSPacketOverlay::Record::*)>(std::string("type"), [](const dnsdist::DNSPacketOverlay::Record& record) { return record.d_type; });
+  luaCtx.registerMember<uint16_t(dnsdist::DNSPacketOverlay::Record::*)>(std::string("class"), [](const dnsdist::DNSPacketOverlay::Record& record) { return record.d_class; });
+  luaCtx.registerMember<uint32_t(dnsdist::DNSPacketOverlay::Record::*)>(std::string("ttl"), [](const dnsdist::DNSPacketOverlay::Record& record) { return record.d_ttl; });
+  luaCtx.registerMember<uint8_t(dnsdist::DNSPacketOverlay::Record::*)>(std::string("place"), [](const dnsdist::DNSPacketOverlay::Record& record) { return record.d_place; });
+  luaCtx.registerMember<uint16_t(dnsdist::DNSPacketOverlay::Record::*)>(std::string("contentLength"), [](const dnsdist::DNSPacketOverlay::Record& record) { return record.d_contentLength; });
+  luaCtx.registerMember<uint16_t(dnsdist::DNSPacketOverlay::Record::*)>(std::string("contentOffset"), [](const dnsdist::DNSPacketOverlay::Record& record) { return record.d_contentOffset; });
+
+#endif /* DISABLE_DNSPACKET_BINDINGS */
+}

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnsparser.cc
@@ -37,7 +37,7 @@ void setupLuaBindingsDNSParser(LuaContext& luaCtx)
   luaCtx.registerMember<dnsheader(dnsdist::DNSPacketOverlay::*)>(std::string("dh"), [](const dnsdist::DNSPacketOverlay& overlay) { return overlay.d_header; });
 
   luaCtx.registerFunction<uint16_t (dnsdist::DNSPacketOverlay::*)(uint8_t) const>("getRecordsCountInSection", [](const dnsdist::DNSPacketOverlay& overlay, uint8_t section) -> uint16_t {
-    if (section > 3) {
+    if (section > DNSResourceRecord::ADDITIONAL) {
       return 0;
     }
     uint16_t count = 0;

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -187,3 +187,18 @@ bool dnsdist_ffi_network_endpoint_new(const char* path, size_t pathSize, dnsdist
 bool dnsdist_ffi_network_endpoint_is_valid(const dnsdist_ffi_network_endpoint_t* endpoint) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_network_endpoint_send(const dnsdist_ffi_network_endpoint_t* endpoint, const char* payload, size_t payloadSize) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_network_endpoint_free(dnsdist_ffi_network_endpoint_t* endpoint) __attribute__ ((visibility ("default")));
+
+typedef struct dnsdist_ffi_dnspacket_t dnsdist_ffi_dnspacket_t;
+
+bool dnsdist_ffi_dnspacket_parse(const char* packet, size_t packetSize, dnsdist_ffi_dnspacket_t** out) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnspacket_get_qname_raw(const dnsdist_ffi_dnspacket_t* packet, const char** qname, size_t* qnameSize) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnspacket_get_qtype(const dnsdist_ffi_dnspacket_t* packet) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnspacket_get_qclass(const dnsdist_ffi_dnspacket_t* packet) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnspacket_get_records_count_in_section(const dnsdist_ffi_dnspacket_t* packet, uint8_t section) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnspacket_get_record_name_raw(const dnsdist_ffi_dnspacket_t* packet, size_t idx, const char** name, size_t* nameSize) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnspacket_get_record_type(const dnsdist_ffi_dnspacket_t* packet, size_t idx) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnspacket_get_record_class(const dnsdist_ffi_dnspacket_t* packet, size_t idx) __attribute__ ((visibility ("default")));
+uint32_t dnsdist_ffi_dnspacket_get_record_ttl(const dnsdist_ffi_dnspacket_t* packet, size_t idx) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnspacket_get_record_content_length(const dnsdist_ffi_dnspacket_t* packet, size_t idx) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnspacket_get_record_content_offset(const dnsdist_ffi_dnspacket_t* packet, size_t idx) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnspacket_free(dnsdist_ffi_dnspacket_t*) __attribute__ ((visibility ("default")));

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1195,7 +1195,7 @@ uint16_t dnsdist_ffi_dnspacket_get_records_count_in_section(const dnsdist_ffi_dn
 
 void dnsdist_ffi_dnspacket_get_record_name_raw(const dnsdist_ffi_dnspacket_t* packet, size_t idx, const char** name, size_t* nameSize)
 {
-  if (packet == nullptr || name == nullptr || nameSize == nullptr || idx > packet->overlay.d_records.size()) {
+  if (packet == nullptr || name == nullptr || nameSize == nullptr || idx >= packet->overlay.d_records.size()) {
     return;
   }
   const auto& storage = packet->overlay.d_records.at(idx).d_name.getStorage();
@@ -1205,7 +1205,7 @@ void dnsdist_ffi_dnspacket_get_record_name_raw(const dnsdist_ffi_dnspacket_t* pa
 
 uint16_t dnsdist_ffi_dnspacket_get_record_type(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
 {
-  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+  if (packet == nullptr || idx >= packet->overlay.d_records.size()) {
     return 0;
   }
   return packet->overlay.d_records.at(idx).d_type;
@@ -1213,7 +1213,7 @@ uint16_t dnsdist_ffi_dnspacket_get_record_type(const dnsdist_ffi_dnspacket_t* pa
 
 uint16_t dnsdist_ffi_dnspacket_get_record_class(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
 {
-  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+  if (packet == nullptr || idx >= packet->overlay.d_records.size()) {
     return 0;
   }
   return packet->overlay.d_records.at(idx).d_class;
@@ -1221,7 +1221,7 @@ uint16_t dnsdist_ffi_dnspacket_get_record_class(const dnsdist_ffi_dnspacket_t* p
 
 uint32_t dnsdist_ffi_dnspacket_get_record_ttl(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
 {
-  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+  if (packet == nullptr || idx >= packet->overlay.d_records.size()) {
     return 0;
   }
   return packet->overlay.d_records.at(idx).d_ttl;
@@ -1229,7 +1229,7 @@ uint32_t dnsdist_ffi_dnspacket_get_record_ttl(const dnsdist_ffi_dnspacket_t* pac
 
 uint16_t dnsdist_ffi_dnspacket_get_record_content_length(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
 {
-  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+  if (packet == nullptr || idx >= packet->overlay.d_records.size()) {
     return 0;
   }
   return packet->overlay.d_records.at(idx).d_contentLength;
@@ -1237,7 +1237,7 @@ uint16_t dnsdist_ffi_dnspacket_get_record_content_length(const dnsdist_ffi_dnspa
 
 uint16_t dnsdist_ffi_dnspacket_get_record_content_offset(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
 {
-  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+  if (packet == nullptr || idx >= packet->overlay.d_records.size()) {
     return 0;
   }
   return packet->overlay.d_records.at(idx).d_contentOffset;

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "dnsdist-dnsparser.hh"
 #include "dnsdist-lua-ffi.hh"
 #include "dnsdist-mac-address.hh"
 #include "dnsdist-lua-network.hh"
@@ -1123,4 +1124,128 @@ bool dnsdist_ffi_network_endpoint_send(const dnsdist_ffi_network_endpoint_t* end
 void dnsdist_ffi_network_endpoint_free(dnsdist_ffi_network_endpoint_t* endpoint)
 {
   delete endpoint;
+}
+
+struct dnsdist_ffi_dnspacket_t
+{
+  dnsdist::DNSPacketOverlay overlay;
+};
+
+bool dnsdist_ffi_dnspacket_parse(const char* packet, size_t packetSize, dnsdist_ffi_dnspacket_t** out)
+{
+  if (out == nullptr || packetSize < sizeof(dnsheader)) {
+    return false;
+  }
+
+  try {
+    dnsdist::DNSPacketOverlay overlay(std::string_view(packet, packetSize));
+    *out = new dnsdist_ffi_dnspacket_t{std::move(overlay)};
+    return true;
+  }
+  catch (const std::exception& e) {
+    vinfolog("Error in dnsdist_ffi_dnspacket_parse: %s", e.what());
+  }
+  catch (...) {
+    vinfolog("Error in dnsdist_ffi_dnspacket_parse");
+  }
+  return false;
+}
+
+void dnsdist_ffi_dnspacket_get_qname_raw(const dnsdist_ffi_dnspacket_t* packet, const char** qname, size_t* qnameSize)
+{
+  if (packet == nullptr || qname == nullptr || qnameSize == nullptr) {
+    return;
+  }
+  const auto& storage = packet->overlay.d_qname.getStorage();
+  *qname = storage.data();
+  *qnameSize = storage.size();
+}
+
+uint16_t dnsdist_ffi_dnspacket_get_qtype(const dnsdist_ffi_dnspacket_t* packet)
+{
+  if (packet != nullptr) {
+    return packet->overlay.d_qtype;
+  }
+  return 0;
+}
+
+uint16_t dnsdist_ffi_dnspacket_get_qclass(const dnsdist_ffi_dnspacket_t* packet)
+{
+  if (packet != nullptr) {
+    return packet->overlay.d_qclass;
+  }
+  return 0;
+}
+
+uint16_t dnsdist_ffi_dnspacket_get_records_count_in_section(const dnsdist_ffi_dnspacket_t* packet, uint8_t section)
+{
+  if (packet == nullptr || section > 3) {
+    return 0;
+  }
+
+  uint16_t count = 0;
+  for (const auto& record : packet->overlay.d_records) {
+    if (record.d_place == section) {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+void dnsdist_ffi_dnspacket_get_record_name_raw(const dnsdist_ffi_dnspacket_t* packet, size_t idx, const char** name, size_t* nameSize)
+{
+  if (packet == nullptr || name == nullptr || nameSize == nullptr || idx > packet->overlay.d_records.size()) {
+    return;
+  }
+  const auto& storage = packet->overlay.d_records.at(idx).d_name.getStorage();
+  *name = storage.data();
+  *nameSize = storage.size();
+}
+
+uint16_t dnsdist_ffi_dnspacket_get_record_type(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
+{
+  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+    return 0;
+  }
+  return packet->overlay.d_records.at(idx).d_type;
+}
+
+uint16_t dnsdist_ffi_dnspacket_get_record_class(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
+{
+  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+    return 0;
+  }
+  return packet->overlay.d_records.at(idx).d_class;
+}
+
+uint32_t dnsdist_ffi_dnspacket_get_record_ttl(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
+{
+  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+    return 0;
+  }
+  return packet->overlay.d_records.at(idx).d_ttl;
+}
+
+uint16_t dnsdist_ffi_dnspacket_get_record_content_length(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
+{
+  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+    return 0;
+  }
+  return packet->overlay.d_records.at(idx).d_contentLength;
+}
+
+uint16_t dnsdist_ffi_dnspacket_get_record_content_offset(const dnsdist_ffi_dnspacket_t* packet, size_t idx)
+{
+  if (packet == nullptr || idx > packet->overlay.d_records.size()) {
+    return 0;
+  }
+  return packet->overlay.d_records.at(idx).d_contentOffset;
+}
+
+void dnsdist_ffi_dnspacket_free(dnsdist_ffi_dnspacket_t* packet)
+{
+  if (packet != nullptr) {
+    delete packet;
+  }
 }

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1133,7 +1133,7 @@ struct dnsdist_ffi_dnspacket_t
 
 bool dnsdist_ffi_dnspacket_parse(const char* packet, size_t packetSize, dnsdist_ffi_dnspacket_t** out)
 {
-  if (out == nullptr || packetSize < sizeof(dnsheader)) {
+  if (packet == nullptr || out == nullptr || packetSize < sizeof(dnsheader)) {
     return false;
   }
 
@@ -1179,7 +1179,7 @@ uint16_t dnsdist_ffi_dnspacket_get_qclass(const dnsdist_ffi_dnspacket_t* packet)
 
 uint16_t dnsdist_ffi_dnspacket_get_records_count_in_section(const dnsdist_ffi_dnspacket_t* packet, uint8_t section)
 {
-  if (packet == nullptr || section > 3) {
+  if (packet == nullptr || section > DNSResourceRecord::ADDITIONAL) {
     return 0;
   }
 

--- a/pdns/dnsdistdist/docs/reference/dnsparser.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsparser.rst
@@ -1,0 +1,123 @@
+DNS Parser
+==========
+
+Since 1.8.0, dnsdist contains a limited DNS parser class that can be used to inspect
+the content of DNS queries and responses in Lua.
+
+The first step is to get the content of the DNS payload into a Lua string,
+for example using :meth:`DNSQuestion:getContent`, or :meth:`DNSResponse:getContent`,
+and then to create a :class:`DNSPacketOverlay` object:
+
+.. code-block:: lua
+
+  function dumpPacket(dq)
+    local packet = dq:getContent()
+    local overlay = newDNSPacketOverlay(packet)
+    print(overlay.qname)
+    print(overlay.qtype)
+    print(overlay.qclass)
+    local count = overlay:getRecordsCountInSection(1)
+    print(count)
+    for idx=0, count-1 do
+      local record = overlay:getRecord(idx)
+      print(record.name)
+      print(record.type)
+      print(record.class)
+      print(record.ttl)
+      print(record.place)
+      print(record.contentLength)
+      print(record.contentOffset)
+    end
+    return DNSAction.None
+  end
+
+  addAction(AllRule(), LuaAction(dumpPacket))
+
+
+.. function:: newDNSPacketOverlay(packet) -> DNSPacketOverlay
+
+  .. versionadded:: 1.8.0
+
+  Returns a DNSPacketOverlay
+
+  :param str packet: The DNS payload
+
+.. class:: DNSPacketOverlay
+
+  .. versionadded:: 1.8.0
+
+  The DNSPacketOverlay object has several attributes, all of them read-only:
+
+  .. attribute:: DNSPacketOverlay.qname
+
+    The qname of this packet, as a :ref:`DNSName`.
+
+  .. attribute:: DNSPacketOverlay.qtype
+
+    The type of the query in this packet.
+
+  .. attribute:: DNSPacketOverlay.qclass
+
+    The class of the query in this packet.
+
+  .. attribute:: DNSPacketOverlay.dh
+
+  It also supports the following methods:
+
+  .. method:: DNSPacketOverlay:getRecordsCountInSection(section) -> int
+
+    Returns the number of records in the ANSWER (1), AUTHORITY (2) and
+    ADDITIONAL (3) section of this packet. The number of records in the
+    QUESTION (0) is always set to 0, look at the dnsheader if you need
+    the actual qdcount.
+
+    :param int section: The section, see above
+
+  .. method:: DNSPacketOverlay:getRecord(idx) -> DNSRecord
+
+    Get the record at the requested position. The records in the
+    QUESTION sections are not taken into account, so the first record
+    in the answer section would be at position 0.
+
+    :param int idx: The position of the requested record
+
+
+.. _DNSRecord:
+
+DNSRecord object
+==================
+
+.. class:: DNSRecord
+
+  .. versionadded:: 1.8.0
+
+  This object represents an unparsed DNS record, as returned by the :ref:`DNSPacketOverlay` class. It has several attributes, all of them read-only:
+
+  .. attribute:: DNSRecord.name
+
+    The name of this record, as a :ref:`DNSName`.
+
+  .. attribute:: DNSRecord.type
+
+    The type of this record.
+
+  .. attribute:: DNSRecord.class
+
+    The class of this record.
+
+  .. attribute:: DNSRecord.ttl
+
+    The TTL of this record.
+
+  .. attribute:: DNSRecord.place
+
+    The place (section) of this record.
+
+  .. attribute:: DNSRecord.contentLength
+
+    The length, in bytes, of the rdata content of this record.
+
+  .. attribute:: DNSRecord.contentOffset
+
+    The offset since the beginning of the DNS payload, in bytes, at which the
+    rdata content of this record starts.

--- a/pdns/dnsdistdist/docs/reference/dnsparser.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsparser.rst
@@ -16,7 +16,7 @@ and then to create a :class:`DNSPacketOverlay` object:
     print(overlay.qname)
     print(overlay.qtype)
     print(overlay.qclass)
-    local count = overlay:getRecordsCountInSection(1)
+    local count = overlay:getRecordsCountInSection(DNSSection.Answer)
     print(count)
     for idx=0, count-1 do
       local record = overlay:getRecord(idx)
@@ -67,7 +67,7 @@ and then to create a :class:`DNSPacketOverlay` object:
   .. method:: DNSPacketOverlay:getRecordsCountInSection(section) -> int
 
     Returns the number of records in the ANSWER (1), AUTHORITY (2) and
-    ADDITIONAL (3) section of this packet. The number of records in the
+    ADDITIONAL (3) :ref:`DNSSection` of this packet. The number of records in the
     QUESTION (0) is always set to 0, look at the dnsheader if you need
     the actual qdcount.
 

--- a/pdns/dnsdistdist/docs/reference/index.rst
+++ b/pdns/dnsdistdist/docs/reference/index.rst
@@ -16,6 +16,7 @@ These chapters contain extensive information on all functions and object availab
   dq
   ebpf
   dnscrypt
+  dnsparser
   protobuf
   dnstap
   carbon

--- a/pdns/dnsdistdist/test-dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/test-dnsdist-dnsparser.cc
@@ -1,0 +1,105 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include "dnsdist-dnsparser.hh"
+#include "dnswriter.hh"
+#include "dnsparser.hh"
+
+BOOST_AUTO_TEST_SUITE(test_dnsdist_dnsparser)
+
+BOOST_AUTO_TEST_CASE(test_Overlay)
+{
+  const DNSName target("powerdns.com.");
+
+  {
+    PacketBuffer response;
+    GenericDNSPacketWriter<PacketBuffer> pwR(response, target, QType::ANY, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.getHeader()->rd = 1;
+    pwR.getHeader()->ra = 1;
+    pwR.getHeader()->id = htons(42);
+    pwR.startRecord(target, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    ComboAddress v4("192.0.2.1");
+    pwR.xfrCAWithoutPort(4, v4);
+    pwR.commit();
+    pwR.startRecord(target, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    ComboAddress v6("2001:db8::1");
+    pwR.xfrCAWithoutPort(6, v6);
+    pwR.commit();
+    pwR.startRecord(target, QType::NS, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrName(DNSName("pdns-public-ns1.powerdns.com."));
+    pwR.commit();
+    pwR.startRecord(target, QType::SOA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrName(DNSName("pdns-public-ns1.powerdns.com."));
+    pwR.xfrName(DNSName("admin.powerdns.com."));
+    pwR.xfr32BitInt(1);
+    pwR.xfr32BitInt(2);
+    pwR.xfr32BitInt(3);
+    pwR.xfr32BitInt(4);
+    pwR.xfr32BitInt(5);
+    pwR.commit();
+    pwR.startRecord(target, QType::MX, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfr16BitInt(75);
+    pwR.xfrName(DNSName("download1.powerdns.com."));
+    pwR.commit();
+    pwR.startRecord(target, QType::TXT, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrText("\"random text\"");
+    pwR.commit();
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    dnsdist::DNSPacketOverlay overlay(std::string_view(reinterpret_cast<const char*>(response.data()), response.size()));
+    BOOST_CHECK_EQUAL(overlay.d_qname, target);
+    BOOST_CHECK_EQUAL(overlay.d_qtype, QType::ANY);
+    BOOST_CHECK_EQUAL(overlay.d_qclass, QClass::IN);
+    BOOST_CHECK_EQUAL(overlay.d_header.qr, 1U);
+    BOOST_CHECK_EQUAL(overlay.d_header.rd, 1U);
+    BOOST_CHECK_EQUAL(overlay.d_header.ra, 1U);
+    BOOST_CHECK_EQUAL(overlay.d_header.id, htons(42));
+    BOOST_CHECK_EQUAL(ntohs(overlay.d_header.qdcount), 1U);
+    BOOST_CHECK_EQUAL(ntohs(overlay.d_header.ancount), 6U);
+    BOOST_CHECK_EQUAL(ntohs(overlay.d_header.nscount), 0U);
+    BOOST_CHECK_EQUAL(ntohs(overlay.d_header.arcount), 1U);
+    BOOST_CHECK_EQUAL(overlay.d_records.size(), 7U);
+
+    /* this is off, of course, but we are only doing a sanity check here */
+    uint16_t lastOffset = sizeof(dnsheader) + target.wirelength() + sizeof(uint16_t) + sizeof(uint16_t);
+    for (const auto& record : overlay.d_records) {
+      if (record.d_type == QType::OPT) {
+        continue;
+      }
+
+      BOOST_CHECK_EQUAL(record.d_name, target);
+      BOOST_CHECK_EQUAL(record.d_class, QClass::IN);
+      BOOST_CHECK_EQUAL(record.d_ttl, 7200);
+      BOOST_CHECK_EQUAL(record.d_place, 1U);
+      BOOST_CHECK_GE(record.d_contentOffset, lastOffset);
+      lastOffset = record.d_contentOffset + record.d_contentLength;
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/regression-tests.dnsdist/test_DNSParser.py
+++ b/regression-tests.dnsdist/test_DNSParser.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+import unittest
+import dns
+from dnsdisttests import DNSDistTest
+
+class TestDNSParser(DNSDistTest):
+
+    _verboseMode = True
+    _config_template = """
+  function checkQueryPacket(dq)
+    local packet = dq:getContent()
+    if #packet ~= 41 then
+      return DNSAction.Spoof, #packet..".invalid.query.size."
+    end
+
+    local overlay = newDNSPacketOverlay(packet)
+    if overlay.qname:toString() ~= "powerdns.com." then
+      return DNSAction.Spoof, overlay.qname:toString().."invalid.query.qname."
+    end
+    if overlay.qtype ~= DNSQType.A then
+      return DNSAction.Spoof, overlay.qtype..".invalid.query.qtype."
+    end
+    if overlay.qclass ~= DNSClass.IN then
+      return DNSAction.Spoof, overlay.qclass..".invalid.query.qclass."
+    end
+    local count = overlay:getRecordsCountInSection(0)
+    if count ~= 0 then
+      return DNSAction.Spoof, count..".invalid.query.count.in.q."
+    end
+    count = overlay:getRecordsCountInSection(1)
+    if count ~= 0 then
+      return DNSAction.Spoof, count..".invalid.query.count.in.a."
+    end
+    count = overlay:getRecordsCountInSection(2)
+    if count ~= 0 then
+      return DNSAction.Spoof, count..".invalid.query.count.in.auth."
+    end
+    count = overlay:getRecordsCountInSection(3)
+    -- for OPT
+    if count ~= 1 then
+      return DNSAction.Spoof, count..".invalid.query.count.in.add."
+    end
+    return DNSAction.None
+  end
+
+  function checkResponsePacket(dq)
+    local packet = dq:getContent()
+    if #packet ~= 57 then
+      print(#packet..".invalid.size.")
+      return DNSResponseAction.ServFail
+    end
+
+    local overlay = newDNSPacketOverlay(packet)
+    if overlay.qname:toString() ~= "powerdns.com." then
+      print(overlay.qname:toString().."invalid.qname.")
+      return DNSResponseAction.ServFail
+    end
+    if overlay.qtype ~= DNSQType.A then
+      print(overlay.qtype..".invalid.qtype.")
+      return DNSResponseAction.ServFail
+    end
+    if overlay.qclass ~= DNSClass.IN then
+      print(overlay.qclass..".invalid.qclass.")
+      return DNSResponseAction.ServFail
+    end
+    local count = overlay:getRecordsCountInSection(0)
+    if count ~= 0 then
+      print(count..".invalid.count.in.q.")
+      return DNSResponseAction.ServFail
+    end
+    count = overlay:getRecordsCountInSection(1)
+    if count ~= 1 then
+      print(count..".invalid.count.in.a.")
+      return DNSResponseAction.ServFail
+    end
+    count = overlay:getRecordsCountInSection(2)
+    if count ~= 0 then
+      print(count..".invalid.count.in.auth.")
+      return DNSResponseAction.ServFail
+    end
+    count = overlay:getRecordsCountInSection(3)
+    -- for OPT
+    if count ~= 1 then
+      print(count..".invalid.count.in.add.")
+      return DNSResponseAction.ServFail
+    end
+    local record = overlay:getRecord(0)
+    if record.name:toString() ~= "powerdns.com." then
+      print(record.name:toString()..".invalid.name.")
+      return DNSResponseAction.ServFail
+    end
+    if record.type ~= DNSQType.A then
+      print(record.type..".invalid.type.")
+      return DNSResponseAction.ServFail
+    end
+    if record.class ~= DNSClass.IN then
+      print(record.class..".invalid.class.")
+      return DNSResponseAction.ServFail
+    end
+    if record.ttl ~= 3600 then
+      print(record.ttl..".invalid.ttl.")
+      return DNSResponseAction.ServFail
+    end
+    if record.place ~= 1 then
+      print(record.place..".invalid.place.")
+      return DNSResponseAction.ServFail
+    end
+    if record.contentLength ~= 4 then
+      print(record.contentLength..".invalid.contentLength.")
+      return DNSResponseAction.ServFail
+    end
+    if record.contentOffset ~= 42 then
+      print(record.contentOffset..".invalid.contentOffset.")
+      return DNSResponseAction.ServFail
+    end
+    return DNSAction.None
+  end
+
+  addAction(AllRule(), LuaAction(checkQueryPacket))
+  addResponseAction(AllRule(), LuaResponseAction(checkResponsePacket))
+  newServer{address="127.0.0.1:%s"}
+    """
+
+    def testQuestionAndResponse(self):
+        """
+        DNS Parser: basic checks
+        """
+        name = 'powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '192.0.2.1')
+        response.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            print(receivedResponse)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR provides regular and FFI bindings allowing to look at the DNS records contained in a DNS payload. There is no parsing of the rdata (content) of the DNS records, though, and at this point this is not something we want to add.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
