### PR TITLE
rec: If new data is auth and existing data is not, replace even if cache locking is active

### DIFF
--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -502,6 +502,10 @@ bool MemRecursorCache::CacheEntry::shouldReplace(time_t now, bool auth, vState s
       /* the new entry is Bogus, the existing one is not and is still valid, let's keep the existing one */
       return false;
     }
+    // Always allow upgrade unauth data to auth
+    if (!d_auth) {
+      return true;
+    }
   }
 
   if (SyncRes::s_locked_ttlperc > 0) {

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1707,6 +1707,7 @@ A value of 100 means only expired record sets will be replaced.
 There are a few cases where records will be replaced anyway:
 
 - Record sets that are expired will always be replaced.
+- Authoritative record sets will replace unauthoritative record sets unless DNSSEC validation of the new record set failed.
 - If the new record set belongs to a DNSSEC-secure zone and successfully passed validation it will replace an existing entry.
 - Record sets produced by :ref:`setting-refresh-on-ttl-perc` tasks will also replace existing record sets.
 

--- a/pdns/recursordist/test-syncres_cc10.cc
+++ b/pdns/recursordist/test-syncres_cc10.cc
@@ -1512,8 +1512,8 @@ BOOST_AUTO_TEST_CASE(test_glued_referral_additional_no_update_because_locked)
 
 BOOST_AUTO_TEST_CASE(test_locked_nonauth_update_to_auth)
 {
-  // Test that additional records do not update the cache
-  // We use two zones that share NS and their addresses
+  // Test that a non-bogus authoritative record replaces a non-authoritative one
+  // even if the cache is locked
   std::unique_ptr<SyncRes> sr;
   initSR(sr);
   // Set the lock

--- a/pdns/recursordist/test-syncres_cc10.cc
+++ b/pdns/recursordist/test-syncres_cc10.cc
@@ -1510,4 +1510,78 @@ BOOST_AUTO_TEST_CASE(test_glued_referral_additional_no_update_because_locked)
   BOOST_CHECK_NE(firstTTL, secondTTL);
 }
 
+BOOST_AUTO_TEST_CASE(test_locked_nonauth_update_to_auth)
+{
+  // Test that additional records do not update the cache
+  // We use two zones that share NS and their addresses
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr);
+  // Set the lock
+  SyncRes::s_locked_ttlperc = 50;
+
+  primeHints();
+
+  const DNSName target("powerdns.com.");
+
+  sr->setAsyncCallback([=](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    /* this will cause issue with qname minimization if we ever implement it */
+    if (domain != target) {
+      return LWResult::Result::Timeout;
+    }
+
+    if (isRootServer(ip)) {
+      setLWResult(res, 0, false, false, true);
+      addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
+      addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+      addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
+      return LWResult::Result::Success;
+    }
+    else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
+      setLWResult(res, 0, false, false, true);
+      addRecordToLW(res, target, QType::NS, "pdns-public-ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
+      addRecordToLW(res, target, QType::NS, "pdns-public-ns2.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
+      addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 172800);
+      addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::AAAA, "2001:DB8::2", DNSResourceRecord::ADDITIONAL, 172800);
+      addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 172800);
+      addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 172800);
+      return LWResult::Result::Success;
+    }
+    else if (ip == ComboAddress("192.0.2.2:53") || ip == ComboAddress("192.0.2.3:53") || ip == ComboAddress("[2001:DB8::2]:53") || ip == ComboAddress("[2001:DB8::3]:53")) {
+      if (type == QType::A) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, target, QType::A, "192.0.2.4");
+        return LWResult::Result::Success;
+      }
+      else if (type == QType::NS) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, target, QType::NS, "pdns-public-ns1.powerdns.com.", DNSResourceRecord::ANSWER, 172800);
+        addRecordToLW(res, target, QType::NS, "pdns-public-ns2.powerdns.com.", DNSResourceRecord::ANSWER, 172800);
+        return LWResult::Result::Success;
+      }
+    }
+    return LWResult::Result::Timeout;
+  });
+
+  // Lookup first name. We should see the (unauth) nameserver in the cache
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_REQUIRE_EQUAL(ret.size(), 1U);
+  BOOST_CHECK(ret[0].d_type == QType::A);
+  BOOST_CHECK_EQUAL(ret[0].d_name, target);
+
+  auto firstTTL = g_recCache->get(sr->getNow().tv_sec, target, QType::NS, MemRecursorCache::None, nullptr, ComboAddress());
+  BOOST_CHECK_GT(firstTTL, 0);
+
+  // Lookup NS records. We should see the nameserver in the cache being updated to auth
+  ret.clear();
+  res = sr->beginResolve(target, QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_REQUIRE_EQUAL(ret.size(), 2U);
+  BOOST_CHECK(ret[0].d_type == QType::NS);
+
+  auto secondTTL = g_recCache->get(sr->getNow().tv_sec, target, QType::NS, MemRecursorCache::RequireAuth, nullptr, ComboAddress());
+  BOOST_CHECK_GT(secondTTL, 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Followup to #11958

Current code gives the right answer (the authoritative records) to the client but does not replace the unauthoritative record set  in the cache by the authoritative one. That's a bit too strict interpretation of the locking feature.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
