### PR TITLE
Dnsdist: coverity 20220928

### DIFF
--- a/pdns/dnscrypt.cc
+++ b/pdns/dnscrypt.cc
@@ -215,7 +215,9 @@ void DNSCryptContext::generateCertificate(uint32_t serial, time_t begin, time_t 
   memcpy(cert.signedData.resolverPK, pubK, sizeof(cert.signedData.resolverPK));
   memcpy(cert.signedData.clientMagic, pubK, sizeof(cert.signedData.clientMagic));
   cert.signedData.serial = htonl(serial);
+  // coverity[store_truncates_time_t]
   cert.signedData.tsStart = htonl((uint32_t) begin);
+  // coverity[store_truncates_time_t]
   cert.signedData.tsEnd = htonl((uint32_t) end);
 
   unsigned long long signatureSize = 0;

--- a/pdns/dnscrypt.cc
+++ b/pdns/dnscrypt.cc
@@ -289,7 +289,7 @@ void DNSCryptContext::addNewCertificate(std::shared_ptr<DNSCryptCertificatePair>
 {
   auto certs = d_certs.write_lock();
 
-  for (auto pair : *certs) {
+  for (const auto& pair : *certs) {
     if (pair->cert.getSerial() == newCert->cert.getSerial()) {
       if (reload) {
         /* on reload we just assume that this is the same certificate */
@@ -356,7 +356,7 @@ std::vector<std::shared_ptr<DNSCryptCertificatePair>> DNSCryptContext::getCertif
 
 void DNSCryptContext::markActive(uint32_t serial)
 {
-  for (auto pair : *d_certs.write_lock()) {
+  for (const auto& pair : *d_certs.write_lock()) {
     if (pair->active == false && pair->cert.getSerial() == serial) {
       pair->active = true;
       return;
@@ -367,7 +367,7 @@ void DNSCryptContext::markActive(uint32_t serial)
 
 void DNSCryptContext::markInactive(uint32_t serial)
 {
-  for (auto pair : *d_certs.write_lock()) {
+  for (const auto& pair : *d_certs.write_lock()) {
     if (pair->active == true && pair->cert.getSerial() == serial) {
       pair->active = false;
       return;

--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -119,6 +119,7 @@ public:
   }
   bool isValid(time_t now) const
   {
+    // coverity[store_truncates_time_t]
     return ntohl(getTSStart()) <= static_cast<uint32_t>(now) && static_cast<uint32_t>(now) <= ntohl(getTSEnd());
   }
   unsigned char magic[DNSCRYPT_CERT_MAGIC_SIZE];

--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -275,6 +275,7 @@ bool DNSDistPacketCache::get(DNSQuestion& dq, uint16_t queryId, uint32_t* keyOut
 
   if (!d_dontAge && !skipAging) {
     if (!stale) {
+      // coverity[store_truncates_time_t]
       ageDNSPacket(reinterpret_cast<char *>(&response[0]), response.size(), age);
     }
     else {

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -298,7 +298,8 @@ void setupLuaInspection(LuaContext& luaCtx)
 	unsigned int lab = *labels;
         for (const auto& shard : g_rings.d_shards) {
           auto rl = shard->queryRing.lock();
-          for(auto a : *rl) {
+          // coverity[auto_causes_copy]
+          for (auto a : *rl) {
             a.name.trimToLabels(lab);
             counts[a.name]++;
             total++;

--- a/pdns/dnsdist-protobuf.cc
+++ b/pdns/dnsdist-protobuf.cc
@@ -160,6 +160,7 @@ void DNSDistProtoBufMessage::serialize(std::string& data) const
 
   m.startResponse();
   if (d_queryTime) {
+    // coverity[store_truncates_time_t]
     m.setQueryTime(d_queryTime->first, d_queryTime->second);
   }
   else {

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -1412,7 +1412,7 @@ static void handleAllowFrom(const YaHTTP::Request& req, YaHTTP::Response& resp)
       auto aclList = doc["value"];
       if (aclList.is_array()) {
 
-        for (auto value : aclList.array_items()) {
+        for (const auto& value : aclList.array_items()) {
           try {
             nmg.addMask(value.string_value());
           } catch (NetmaskException &e) {

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1899,6 +1899,7 @@ static void secPollThread()
     }
     catch(...) {
     }
+    // coverity[store_truncates_time_t]
     sleep(g_secPollInterval);
   }
 }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1865,7 +1865,7 @@ static void maintThread()
       }
 
       const time_t now = time(nullptr);
-      for (auto pair : caches) {
+      for (const auto& pair : caches) {
         /* shall we keep expired entries ? */
         if (pair.second == true) {
           continue;

--- a/pdns/dnsdistdist/dnsdist-dynblocks.cc
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.cc
@@ -709,6 +709,7 @@ void DynBlockMaintenance::run()
     sleepDelay = std::min(sleepDelay, (nextMetricsCollect - now));
     sleepDelay = std::min(sleepDelay, (nextMetricsGeneration - now));
 
+    // coverity[store_truncates_time_t]
     sleep(sleepDelay);
 
     try {

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
@@ -56,7 +56,7 @@ void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client)
 
       if (ctx != nullptr) {
         size_t idx = 1;
-        for (auto pair : ctx->getCertificates()) {
+        for (const auto& pair : ctx->getCertificates()) {
           result.push_back({idx++, pair});
         }
       }
@@ -101,7 +101,7 @@ void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client)
         boost::format fmt("%1$-3d %|5t|%2$-8d %|10t|%3$-7d %|20t|%4$-21.21s %|41t|%5$-21.21s");
         ret << (fmt % "#" % "Serial" % "Version" % "From" % "To" ) << endl;
 
-        for (auto pair : ctx->getCertificates()) {
+        for (const auto& pair : ctx->getCertificates()) {
           const auto cert = pair->cert;
           const DNSCryptExchangeVersion version = DNSCryptContext::getExchangeVersion(cert);
 

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -95,7 +95,7 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
           }
         }
         if (vars->count("skipOptions")) {
-          for (auto option: boost::get<LuaArray<uint16_t>>(vars->at("skipOptions"))) {
+          for (const auto& option: boost::get<LuaArray<uint16_t>>(vars->at("skipOptions"))) {
             optionsToSkip.insert(option.second);
           }
         }

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -271,6 +271,7 @@ public:
     else {
       auto res = d_ip6s.write_lock()->insert({{ca}, ttd});
       if (!res.second && (time_t)res.first->second < ttd) {
+        // coverity[store_truncates_time_t]
         res.first->second = (uint32_t)ttd;
       }
     }

--- a/pdns/ednscookies.cc
+++ b/pdns/ednscookies.cc
@@ -121,6 +121,7 @@ bool EDNSCookiesOpt::shouldRefresh() const
   uint32_t ts;
   memcpy(&ts, &server[4], sizeof(ts));
   ts = ntohl(ts);
+  // coverity[store_truncates_time_t]
   uint32_t now = static_cast<uint32_t>(time(nullptr));
   // RFC 9018 section 4.3:
   //    The DNS server
@@ -154,6 +155,7 @@ bool EDNSCookiesOpt::makeServerCookie(const string& secret, const ComboAddress& 
   server.reserve(16);
   server = "\x01"; // Version
   server.resize(4, '\0'); // 3 reserved bytes
+  // coverity[store_truncates_time_t]
   uint32_t now = htonl(static_cast<uint32_t>(time(nullptr)));
   server += string(reinterpret_cast<const char*>(&now), sizeof(now));
   server.resize(8);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Two sets of coverity reports. Should make dnsdist clean again.

Two last two in `dnscryp.cc` look strange as we're modifying through a `const &`. But that happens via the lock guard `operator->` which returns a `T*`, not a `const T*`. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
