### PR TITLE
Clang tidy/geoipbackend

### DIFF
--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -62,8 +62,8 @@ struct GeoIPDomain
 static vector<GeoIPDomain> s_domains;
 static int s_rc = 0; // refcount - always accessed under lock
 
-static string GeoIP_WEEKDAYS[] = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"};
-static string GeoIP_MONTHS[] = {"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"};
+const static std::array<string, 7> GeoIP_WEEKDAYS = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"};
+const static std::array<string, 12> GeoIP_MONTHS = {"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"};
 
 /* So how does it work - we have static records and services. Static records "win".
    We also insert empty non terminals for records and services.
@@ -757,12 +757,12 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
     }
     else if (!sformat.compare(cur, 4, "%wds")) {
       nrep = 4;
-      rep = GeoIP_WEEKDAYS[gtm.tm_wday];
+      rep = GeoIP_WEEKDAYS.at(gtm.tm_wday);
       tmp_gl.netmask = (addr.isIPv6() ? 128 : 32);
     }
     else if (!sformat.compare(cur, 4, "%mos")) {
       nrep = 4;
-      rep = GeoIP_MONTHS[gtm.tm_mon];
+      rep = GeoIP_MONTHS.at(gtm.tm_mon);
       tmp_gl.netmask = (addr.isIPv6() ? 128 : 32);
     }
     else if (!sformat.compare(cur, 3, "%wd")) {

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -81,7 +81,7 @@ GeoIPBackend::GeoIPBackend(const string& suffix)
   setArgPrefix("geoip" + suffix);
   if (getArg("dnssec-keydir").empty() == false) {
     DIR* d = opendir(getArg("dnssec-keydir").c_str());
-    if (d == NULL) {
+    if (d == nullptr) {
       throw PDNSException("dnssec-keydir " + getArg("dnssec-keydir") + " does not exist");
     }
     d_dnssec = true;
@@ -454,7 +454,7 @@ void GeoIPBackend::lookup(const QType& qtype, const DNSName& qdomain, int zoneId
   }
 
   Netmask addr{"0.0.0.0/0"};
-  if (pkt_p != NULL)
+  if (pkt_p != nullptr)
     addr = Netmask(pkt_p->getRealRemote());
 
   gl.netmask = 0;
@@ -466,7 +466,7 @@ void GeoIPBackend::lookup(const QType& qtype, const DNSName& qdomain, int zoneId
     return; // no hit
 
   const NetmaskTree<vector<string>>::node_type* node = target->second.masks.lookup(addr);
-  if (node == NULL)
+  if (node == nullptr)
     return; // no hit, again.
 
   DNSName sformat;
@@ -649,7 +649,7 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
   string::size_type cur, last;
   boost::optional<int> alt, prec;
   double lat, lon;
-  time_t t = time((time_t*)NULL);
+  time_t t = time(nullptr);
   GeoIPNetmask tmp_gl; // largest wins
   struct tm gtm;
   gmtime_r(&t, &gtm);
@@ -919,7 +919,7 @@ bool GeoIPBackend::getDomainKeys(const DNSName& name, std::vector<DNSBackend::Ke
       ostringstream pathname;
       pathname << getArg("dnssec-keydir") << "/" << dom.domain.toStringNoDot() << "*.key";
       glob_t glob_result;
-      if (glob(pathname.str().c_str(), GLOB_ERR, NULL, &glob_result) == 0) {
+      if (glob(pathname.str().c_str(), GLOB_ERR, nullptr, &glob_result) == 0) {
         for (size_t i = 0; i < glob_result.gl_pathc; i++) {
           if (regexec(&reg, glob_result.gl_pathv[i], 5, regm, 0) == 0) {
             DNSBackend::KeyData kd;
@@ -965,7 +965,7 @@ bool GeoIPBackend::removeDomainKey(const DNSName& name, unsigned int id)
       ostringstream pathname;
       pathname << getArg("dnssec-keydir") << "/" << dom.domain.toStringNoDot() << "*.key";
       glob_t glob_result;
-      if (glob(pathname.str().c_str(), GLOB_ERR, NULL, &glob_result) == 0) {
+      if (glob(pathname.str().c_str(), GLOB_ERR, nullptr, &glob_result) == 0) {
         for (size_t i = 0; i < glob_result.gl_pathc; i++) {
           if (regexec(&reg, glob_result.gl_pathv[i], 5, regm, 0) == 0) {
             auto kid = pdns::checked_stoi<unsigned int>(glob_result.gl_pathv[i] + regm[3].rm_so);
@@ -1001,7 +1001,7 @@ bool GeoIPBackend::addDomainKey(const DNSName& name, const KeyData& key, int64_t
       ostringstream pathname;
       pathname << getArg("dnssec-keydir") << "/" << dom.domain.toStringNoDot() << "*.key";
       glob_t glob_result;
-      if (glob(pathname.str().c_str(), GLOB_ERR, NULL, &glob_result) == 0) {
+      if (glob(pathname.str().c_str(), GLOB_ERR, nullptr, &glob_result) == 0) {
         for (size_t i = 0; i < glob_result.gl_pathc; i++) {
           if (regexec(&reg, glob_result.gl_pathv[i], 5, regm, 0) == 0) {
             auto kid = pdns::checked_stoi<unsigned int>(glob_result.gl_pathv[i] + regm[3].rm_so);
@@ -1037,7 +1037,7 @@ bool GeoIPBackend::activateDomainKey(const DNSName& name, unsigned int id)
       ostringstream pathname;
       pathname << getArg("dnssec-keydir") << "/" << dom.domain.toStringNoDot() << "*.key";
       glob_t glob_result;
-      if (glob(pathname.str().c_str(), GLOB_ERR, NULL, &glob_result) == 0) {
+      if (glob(pathname.str().c_str(), GLOB_ERR, nullptr, &glob_result) == 0) {
         for (size_t i = 0; i < glob_result.gl_pathc; i++) {
           if (regexec(&reg, glob_result.gl_pathv[i], 5, regm, 0) == 0) {
             auto kid = pdns::checked_stoi<unsigned int>(glob_result.gl_pathv[i] + regm[3].rm_so);
@@ -1072,7 +1072,7 @@ bool GeoIPBackend::deactivateDomainKey(const DNSName& name, unsigned int id)
       ostringstream pathname;
       pathname << getArg("dnssec-keydir") << "/" << dom.domain.toStringNoDot() << "*.key";
       glob_t glob_result;
-      if (glob(pathname.str().c_str(), GLOB_ERR, NULL, &glob_result) == 0) {
+      if (glob(pathname.str().c_str(), GLOB_ERR, nullptr, &glob_result) == 0) {
         for (size_t i = 0; i < glob_result.gl_pathc; i++) {
           if (regexec(&reg, glob_result.gl_pathv[i], 5, regm, 0) == 0) {
             auto kid = pdns::checked_stoi<unsigned int>(glob_result.gl_pathv[i] + regm[3].rm_so);
@@ -1109,7 +1109,7 @@ bool GeoIPBackend::hasDNSSECkey(const DNSName& name)
   ostringstream pathname;
   pathname << getArg("dnssec-keydir") << "/" << name.toStringNoDot() << "*.key";
   glob_t glob_result;
-  if (glob(pathname.str().c_str(), GLOB_ERR, NULL, &glob_result) == 0) {
+  if (glob(pathname.str().c_str(), GLOB_ERR, nullptr, &glob_result) == 0) {
     globfree(&glob_result);
     return true;
   }

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -655,7 +655,7 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
   gmtime_r(&t, &gtm);
   last = 0;
 
-  while ((cur = sformat.find("%", last)) != string::npos) {
+  while ((cur = sformat.find('%', last)) != string::npos) {
     string rep;
     int nrep = 3;
     tmp_gl.netmask = 0;


### PR DESCRIPTION
### Short description

An other clang-tidy PR.

- NULL -> nullptr
- Use std::array
- Use better overload for a `find` before a `string/char*` now a `char`.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code runned regtest `./start-test-stop 5300 geoip`
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
