### PR TITLE
rec: Compare old and new config for protobuf logger config objects on Lua config reload

### DIFF
--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -43,6 +43,28 @@ LuaConfigItems::LuaConfigItems()
 
 /* DID YOU READ THE STORY ABOVE? */
 
+bool operator==(const ProtobufExportConfig& configA, const ProtobufExportConfig& configB)
+{
+  // clang-format off
+  return configA.exportTypes          == configB.exportTypes       &&
+         configA.servers              == configB.servers           &&
+         configA.maxQueuedEntries     == configB.maxQueuedEntries  &&
+         configA.timeout              == configB.timeout           &&
+         configA.reconnectWaitTime    == configB.reconnectWaitTime &&
+         configA.asyncConnect         == configB.asyncConnect      &&
+         configA.enabled              == configB.enabled           &&
+         configA.logQueries           == configB.logQueries        &&
+         configA.logResponses         == configB.logResponses      &&
+         configA.taggedOnly           == configB.taggedOnly        &&
+         configA.logMappedFrom        == configB.logMappedFrom;
+  // clang-format on
+}
+
+bool operator!=(const ProtobufExportConfig& configA, const ProtobufExportConfig& configB)
+{
+  return !(configA == configB);
+}
+
 bool operator==(const FrameStreamExportConfig& configA, const FrameStreamExportConfig& configB)
 {
   // clang-format off

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -45,6 +45,9 @@ struct ProtobufExportConfig
   bool logMappedFrom{false};
 };
 
+bool operator==(const ProtobufExportConfig& configA, const ProtobufExportConfig& configB);
+bool operator!=(const ProtobufExportConfig& configA, const ProtobufExportConfig& configB);
+
 struct FrameStreamExportConfig
 {
   std::vector<string> servers;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -943,8 +943,8 @@ static RemoteLoggerStats_t* pleaseGetRemoteLoggerStats()
 {
   auto ret = make_unique<RemoteLoggerStats_t>();
 
-  if (t_protobufServers) {
-    for (const auto& server : *t_protobufServers) {
+  if (t_protobufServers.servers) {
+    for (const auto& server : *t_protobufServers.servers) {
       ret->emplace(std::make_pair(server->address(), server->getStats()));
     }
   }
@@ -966,8 +966,8 @@ static RemoteLoggerStats_t* pleaseGetOutgoingRemoteLoggerStats()
 {
   auto ret = make_unique<RemoteLoggerStats_t>();
 
-  if (t_outgoingProtobufServers) {
-    for (const auto& server : *t_outgoingProtobufServers) {
+  if (t_outgoingProtobufServers.servers) {
+    for (const auto& server : *t_outgoingProtobufServers.servers) {
       ret->emplace(std::make_pair(server->address(), server->getStats()));
     }
   }

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -204,8 +204,9 @@ reload-lua-config [*FILENAME*]
     (Re)loads Lua configuration *FILENAME*. If *FILENAME* is empty, attempt
     to reload the currently loaded file. Note that *FILENAME* will be fully
     executed, any settings changed at runtime that are not modified in this
-    file, will still be active. Reloading RPZ, especially by AXFR, can take
-    some time; during which the recursor will not answer questions.
+    file, will still be active. The effects of reloading do not always take
+    place immediately, as some subsystems reload and replace configuration
+    in an asynchronous way.
 
 reload-zones
     Reload authoritative and forward zones. Retains current configuration in

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -193,13 +193,11 @@ using RemoteLoggerStats_t = std::unordered_map<std::string, RemoteLoggerInterfac
 extern bool g_logCommonErrors;
 extern size_t g_proxyProtocolMaximumSize;
 extern std::atomic<bool> g_quiet;
-extern thread_local std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>> t_protobufServers;
 extern thread_local std::shared_ptr<RecursorLua4> t_pdl;
 extern bool g_gettagNeedsEDNSOptions;
 extern NetmaskGroup g_paddingFrom;
 extern unsigned int g_paddingTag;
 extern PaddingMode g_paddingMode;
-extern thread_local std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>> t_outgoingProtobufServers;
 extern unsigned int g_maxMThreads;
 extern bool g_reusePort;
 extern bool g_anyToTcp;
@@ -248,6 +246,15 @@ extern std::string g_udr_pbtag;
 extern thread_local std::shared_ptr<nod::NODDB> t_nodDBp;
 extern thread_local std::shared_ptr<nod::UniqueResponseDB> t_udrDBp;
 #endif
+
+struct ProtobufServersInfo
+{
+  std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>> servers;
+  uint64_t generation;
+  ProtobufExportConfig config;
+};
+extern thread_local ProtobufServersInfo t_protobufServers;
+extern thread_local ProtobufServersInfo t_outgoingProtobufServers;
 
 #ifdef HAVE_FSTRM
 struct FrameStreamServersInfo

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -400,12 +400,8 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       if (checkProtobufExport(luaconfsLocal)) {
         needECS = true;
       }
-      logQuery = t_protobufServers && luaconfsLocal->protobufExportConfig.logQueries;
-      dc->d_logResponse = t_protobufServers && luaconfsLocal->protobufExportConfig.logResponses;
-
-#ifdef HAVE_FSTRM
-      checkFrameStreamExport(luaconfsLocal, luaconfsLocal->frameStreamExportConfig, t_frameStreamServersInfo);
-#endif
+      logQuery = t_protobufServers.servers && luaconfsLocal->protobufExportConfig.logQueries;
+      dc->d_logResponse = t_protobufServers.servers && luaconfsLocal->protobufExportConfig.logResponses;
 
       if (needECS || (t_pdl && (t_pdl->d_gettag_ffi || t_pdl->d_gettag)) || dc->d_mdp.d_header.opcode == Opcode::Notify) {
 
@@ -454,14 +450,14 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       const dnsheader_aligned headerdata(conn->data.data());
       const struct dnsheader* dh = headerdata.get();
 
-      if (t_protobufServers || t_outgoingProtobufServers) {
+      if (t_protobufServers.servers || t_outgoingProtobufServers.servers) {
         dc->d_requestorId = requestorId;
         dc->d_deviceId = deviceId;
         dc->d_deviceName = deviceName;
         dc->d_uuid = getUniqueID();
       }
 
-      if (t_protobufServers) {
+      if (t_protobufServers.servers) {
         try {
 
           if (logQuery && !(luaconfsLocal->protobufExportConfig.taggedOnly && dc->d_policyTags.empty())) {
@@ -570,7 +566,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
             g_stats.cumulativeAnswers(spentUsec);
             dc->d_eventTrace.add(RecEventTrace::AnswerSent);
 
-            if (t_protobufServers && dc->d_logResponse && !(luaconfsLocal->protobufExportConfig.taggedOnly && pbData && !pbData->d_tagged)) {
+            if (t_protobufServers.servers && dc->d_logResponse && !(luaconfsLocal->protobufExportConfig.taggedOnly && pbData && !pbData->d_tagged)) {
               struct timeval tv
               {
                 0, 0


### PR DESCRIPTION
We already did it for dnstap. This also does the protobuf loggers.

I'm not doing the async part now, as TSAN reports there would be a race. We do a synchronous cleanup of the old config when we see the config changed only.

The case occurring the most: no changes is now handled quickly and that is the main thing.

I'm also adding/removing a few places where the config checking is done:

- do it where we need to know if a certain logger is enabled in both the UDP and TCP input path
- do it in startDoResolve, so any thread handling a non-PC hit gets the new config.
- do it periodically since not al threads actually handle incoming packets or call startDoResolve that often.

I spotted the latter case by changing config and the looking at `rec_control get-remotelogger-stats` and seeing the olde config never being cleaned for some threads.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
