### PR TITLE
auth: Detect invalid bytes in `makeBytesFromHex()`

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -583,13 +583,13 @@ string U32ToIP(uint32_t val)
 
 string makeHexDump(const string& str)
 {
-  char tmp[5];
+  std::array<char, 5> tmp;
   string ret;
-  ret.reserve((int)(str.size()*2.2));
+  ret.reserve(static_cast<size_t>(str.size()*2.2));
 
-  for(char n : str) {
-    snprintf(tmp, sizeof(tmp), "%02x ", (unsigned char)n);
-    ret+=tmp;
+  for (char n : str) {
+    snprintf(tmp.data(), tmp.size(), "%02x ", static_cast<unsigned char>(n));
+    ret += tmp.data();
   }
   return ret;
 }

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -599,14 +599,18 @@ string makeBytesFromHex(const string &in) {
     throw std::range_error("odd number of bytes in hex string");
   }
   string ret;
-  ret.reserve(in.size());
+  ret.reserve(in.size() / 2);
+
   unsigned int num;
-  for (size_t i = 0; i < in.size(); i+=2) {
-    string numStr = in.substr(i, 2);
+  for (size_t i = 0; i < in.size(); i += 2) {
+    const auto numStr = in.substr(i, 2);
     num = 0;
-    sscanf(numStr.c_str(), "%02x", &num);
-    ret.push_back((uint8_t)num);
+    if (sscanf(numStr.c_str(), "%02x", &num) != 1) {
+      throw std::range_error("Invalid value while parsing the hex string '" + in + "'");
+    }
+    ret.push_back(static_cast<uint8_t>(num));
   }
+
   return ret;
 }
 

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -391,4 +391,10 @@ BOOST_AUTO_TEST_CASE(test_makeBytesFromHex) {
   BOOST_CHECK_THROW(makeBytesFromHex("1234GG"), std::range_error);
 }
 
+BOOST_AUTO_TEST_CASE(test_makeHexDump) {
+  auto out = makeHexDump("\x12\x34\x56\x78\x90\xab\xcd\xef");
+  // there is a trailing white space by design
+  BOOST_CHECK_EQUAL(out, "12 34 56 78 90 ab cd ef ");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -387,6 +387,8 @@ BOOST_AUTO_TEST_CASE(test_makeBytesFromHex) {
   BOOST_CHECK_EQUAL(out, "\x12\x34\x56\x78\x90\xab\xcd\xef");
 
   BOOST_CHECK_THROW(makeBytesFromHex("123"), std::range_error);
+
+  BOOST_CHECK_THROW(makeBytesFromHex("1234GG"), std::range_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Also:
- only allocate the required number of bytes in `makeBytesFromHex()`, not twice that.
- switch to a `std::array` in `makeHexDump()`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
