### PR TITLE
ednscookies: Fix another store_truncates_time_t coverity report

### DIFF
--- a/pdns/ednscookies.cc
+++ b/pdns/ednscookies.cc
@@ -87,6 +87,7 @@ bool EDNSCookiesOpt::isValid(const string& secret, const ComboAddress& source) c
   uint32_t ts;
   memcpy(&ts, &server[4], sizeof(ts));
   ts = ntohl(ts);
+  // coverity[store_truncates_time_t]
   uint32_t now = static_cast<uint32_t>(time(nullptr));
   // RFC 9018 section 4.3:
   //    The DNS server


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The truncation is due to DNS specific protocol properties.

Fixes Coverity CID 380097.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
