### PR TITLE
auth: pdnsutil check-zone, skip metadata check for backends without g…

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -834,22 +834,20 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, con
   }
 
   std::map<std::string, std::vector<std::string>> metadatas;
-  if (!B.getAllDomainMetadata(zone, metadatas)) {
-    cout << "[Error] Unable to retrieve metadata for zone " << zone << endl;
-    numerrors++;
-  }
+  if (B.getAllDomainMetadata(zone, metadatas)) {
+    for (const auto& metaData : metadatas) {
+      set<string> seen;
+      set<string> messaged;
 
-  for (const auto &metaData : metadatas) {
-    set<string> seen;
-    set<string> messaged;
-
-    for (const auto &value : metaData.second) {
-      if (seen.count(value) == 0) {
-        seen.insert(value);
-      } else if (messaged.count(value) <= 0) {
-        cout << "[Error] Found duplicate metadata key value pair for zone " << zone << " with key '" << metaData.first << "' and value '" << value << "'" << endl;
-        numerrors++;
-        messaged.insert(value);
+      for (const auto& value : metaData.second) {
+        if (seen.count(value) == 0) {
+          seen.insert(value);
+        }
+        else if (messaged.count(value) <= 0) {
+          cout << "[Error] Found duplicate metadata key value pair for zone " << zone << " with key '" << metaData.first << "' and value '" << value << "'" << endl;
+          numerrors++;
+          messaged.insert(value);
+        }
       }
     }
   }


### PR DESCRIPTION
…etAllDomainMetadata()

### Short description
Absence of a getAllDomainMetadata() function in a backend is not an error. Skip the duplicate metadata check for such backends.

Fixes #10684

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
