### PR TITLE
add getPoolNames() function, returning a list of pool names

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -526,6 +526,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "getOutgoingTLSSessionCacheSize", true, "", "returns the number of TLS sessions (for outgoing connections) currently cached" },
   { "getPool", true, "name", "return the pool named `name`, or \"\" for the default pool" },
   { "getPoolServers", true, "pool", "return servers part of this pool" },
+  { "getPoolNames", true, "", "returns a table with all the pool names" },
   { "getQueryCounters", true, "[max=10]", "show current buffer of query counters, limited by 'max' if provided" },
   { "getResponseRing", true, "", "return the current content of the response ring" },
   { "getRespRing", true, "", "return the qname/rcode content of the response ring" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1735,6 +1735,19 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
+  luaCtx.writeFunction("getPoolNames", []() {
+    setLuaNoSideEffect();
+    LuaArray<std::string> ret;
+        int count = 1;
+    const auto localPools = g_pools.getCopy();
+    for (const auto& entry : localPools) {
+      const string& name = entry.first;
+      ret.push_back(make_pair(count++, name));
+
+    }
+    return ret;
+  });
+
   luaCtx.writeFunction("getPool", [client](const string& poolName) {
     if (client) {
       return std::make_shared<ServerPool>();

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1738,7 +1738,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.writeFunction("getPoolNames", []() {
     setLuaNoSideEffect();
     LuaArray<std::string> ret;
-        int count = 1;
+    int count = 1;
     const auto localPools = g_pools.getCopy();
     for (const auto& entry : localPools) {
       const string& name = entry.first;

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1743,7 +1743,6 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     for (const auto& entry : localPools) {
       const string& name = entry.first;
       ret.push_back(make_pair(count++, name));
-
     }
     return ret;
   });

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -779,6 +779,8 @@ Servers that are not assigned to a specific pool get assigned to the default poo
 
 .. function:: getPoolNames() -> [ table of names]
 
+  .. versionadded:: 1.8.0
+
   Returns a table of all pool names
 
 .. function:: showPools()

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -777,6 +777,10 @@ Servers that are not assigned to a specific pool get assigned to the default poo
 
   :param string name: The name of the pool
 
+.. function:: getPoolNames() -> [ table of names]
+
+  Returns a table of all pool names
+
 .. function:: showPools()
 
    Display the name, associated cache, server policy and associated servers for every pool.


### PR DESCRIPTION
### Short description
PR adds a function to return the list of pool names, so it is possible to iterate over all defined pools.
Use case is to remove a FQDN from all caches via expungeByName. This patch adds the missing list of pool names for getPool(name):getCache():expungeByName("...")
Implements feature request #12073 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ X] compiled this code
- [ X] tested this code
- [ X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X ]  checked that this code was merged to master
