### PR TITLE
retain output when expunging from multiple caches

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -166,7 +166,7 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
                   qname = DNSName(boost::get<string>(dname));
                 }
                 if (cache) {
-                  g_outputBuffer="Expunged " + std::to_string(cache->expungeByName(qname, qtype ? *qtype : QType(QType::ANY).getCode(), suffixMatch ? *suffixMatch : false)) + " records\n";
+                  g_outputBuffer+="Expunged " + std::to_string(cache->expungeByName(qname, qtype ? *qtype : QType(QType::ANY).getCode(), suffixMatch ? *suffixMatch : false)) + " records\n";
                 }
     });
   luaCtx.registerFunction<void(std::shared_ptr<DNSDistPacketCache>::*)()const>("printStats", [](const std::shared_ptr<DNSDistPacketCache>& cache) {


### PR DESCRIPTION
### Short description
append to the output buffer in expungeByName (instead of overwriting)

### Checklist
I have:
- [X ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ X] compiled this code
- [ X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X ] <!-- remove this line if your PR is against master --> checked that this code was merged to master

This fix addresses #12075 