### PR TITLE
API: Auth: replace zone contents et al

### DIFF
--- a/pdns/json.hh
+++ b/pdns/json.hh
@@ -27,6 +27,8 @@
 
 int intFromJson(const json11::Json& container, const std::string& key);
 int intFromJson(const json11::Json& container, const std::string& key, const int default_value);
+unsigned int uintFromJson(const json11::Json& container, const std::string& key);
+unsigned int uintFromJson(const json11::Json& container, const std::string& key, const unsigned int default_value);
 double doubleFromJson(const json11::Json& container, const std::string& key);
 double doubleFromJson(const json11::Json& container, const std::string& key, const double default_value);
 std::string stringFromJson(const json11::Json& container, const std::string &key);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2265,7 +2265,7 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
 static bool secureZone(DNSSECKeeper& dk, const DNSName& zone)
 {
   // temp var for addKey
-  int64_t id;
+  int64_t id{-1};
 
   // parse attribute
   string k_algo = ::arg()["default-ksk-algorithm"];
@@ -3068,7 +3068,7 @@ try
         return EXIT_FAILURE;
       }
     }
-    int64_t id;
+    int64_t id{-1};
     if (!dk.addKey(zone, keyOrZone, algorithm, id, bits, active, published)) {
       cerr<<"Adding key failed, perhaps DNSSEC not enabled in configuration?"<<endl;
       return 1;
@@ -3577,7 +3577,7 @@ try
     }
     dpk.setKey(key, flags, algo);
 
-    int64_t id;
+    int64_t id{-1};
     if (!dk.addKey(DNSName(zone), dpk, id)) {
       cerr << "Adding key failed, perhaps DNSSEC not enabled in configuration?" << endl;
       return 1;
@@ -3633,7 +3633,7 @@ try
     }
     dpk.setKey(key, flags, algo);
 
-    int64_t id;
+    int64_t id{-1};
     if (!dk.addKey(DNSName(zone), dpk, id, active, published)) {
       cerr<<"Adding key failed, perhaps DNSSEC not enabled in configuration?"<<endl;
       return 1;
@@ -3963,7 +3963,6 @@ try
         return 1;
       }
 
-      int64_t id;
       bool keyOrZone = (cmds.at(4) == "ksk" ? true : false);
       string module = cmds.at(5);
       string slot = cmds.at(6);
@@ -3996,8 +3995,8 @@ try
 
       // make sure this key isn't being reused.
       B.getDomainKeys(zone, keys);
-      id = -1;
 
+      int64_t id{-1};
       for(DNSBackend::KeyData& kd :  keys) {
         if (kd.content == iscString.str()) {
           // it's this one, I guess...

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -629,14 +629,14 @@ static void addDefaultDNSSECKeys(DNSSECKeeper& dk, const DNSName& zonename) {
   int z_size = arg().asNum("default-zsk-size");
 
   if (k_algo != -1) {
-    int64_t id;
+    int64_t id{-1};
     if (!dk.addKey(zonename, true, k_algo, id, k_size)) {
       throwUnableToSecure(zonename);
     }
   }
 
   if (z_algo != -1) {
-    int64_t id;
+    int64_t id{-1};
     if (!dk.addKey(zonename, false, z_algo, id, z_size)) {
       throwUnableToSecure(zonename);
     }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -536,7 +536,7 @@ static void validateGatheredRRType(const DNSResourceRecord& rr) {
   }
 }
 
-static void gatherRecords(const Json& container, const DNSName& qname, const QType& qtype, const int ttl, vector<DNSResourceRecord>& new_records) {
+static void gatherRecords(const Json& container, const DNSName& qname, const QType& qtype, const uint32_t ttl, vector<DNSResourceRecord>& new_records) {
   DNSResourceRecord rr;
   rr.qname = qname;
   rr.qtype = qtype;
@@ -1732,7 +1732,7 @@ static void apiServerZonesPost(HttpRequest* req, HttpResponse* resp) {
           throw ApiException("RRset "+qname.toString()+" IN "+stringFromJson(rrset, "type")+": unknown type given");
         }
         if (rrset["records"].is_array()) {
-          int ttl = uintFromJson(rrset, "ttl");
+          uint32_t ttl = uintFromJson(rrset, "ttl");
           gatherRecords(rrset, qname, qtype, ttl, new_records);
         }
         if (rrset["comments"].is_array()) {
@@ -1954,7 +1954,7 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
             throw ApiException("RRset "+qname.toString()+" IN "+stringFromJson(rrset, "type")+": unknown type given");
           }
           if (rrset["records"].is_array()) {
-            int ttl = uintFromJson(rrset, "ttl");
+            uint32_t ttl = uintFromJson(rrset, "ttl");
             gatherRecords(rrset, qname, qtype, ttl, new_records);
           }
           if (rrset["comments"].is_array()) {
@@ -2216,7 +2216,7 @@ static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp) {
         try {
           if (replace_records) {
             // ttl shouldn't be part of DELETE, and it shouldn't be required if we don't get new records.
-            int ttl = uintFromJson(rrset, "ttl");
+            uint32_t ttl = uintFromJson(rrset, "ttl");
             gatherRecords(rrset, qname, qtype, ttl, new_records);
 
             for(DNSResourceRecord& rr : new_records) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1811,7 +1811,7 @@ static void apiServerZonesPost(HttpRequest* req, HttpResponse* resp) {
 
     if(document["nsec3param"].string_value().length() > 0) {
       NSEC3PARAMRecordContent ns3pr(document["nsec3param"].string_value());
-      string error_msg = "";
+      string error_msg;
       if (!dk.checkNSEC3PARAM(ns3pr, error_msg)) {
         throw ApiException("NSEC3PARAMs provided for zone '"+zonename.toString()+"' are invalid. " + error_msg);
       }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1981,6 +1981,8 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
     updateDomainSettingsFromDocument(B, di, zonename, document, zoneWasModified);
     di.backend->commitTransaction();
 
+    purgeAuthCaches(zonename.toString() + "$");
+
     resp->body = "";
     resp->status = 204; // No Content, but indicate success
     return;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1705,7 +1705,7 @@ static void apiServerZonesPost(HttpRequest* req, HttpResponse* resp) {
 
   string zonestring = document["zone"].string_value();
   auto rrsets = document["rrsets"];
-  if (rrsets.is_array() && zonestring != "")
+  if (rrsets.is_array() && !zonestring.empty())
     throw ApiException("You cannot give rrsets AND zone data as text");
 
   auto nameservers = document["nameservers"];
@@ -1736,7 +1736,7 @@ static void apiServerZonesPost(HttpRequest* req, HttpResponse* resp) {
           gatherComments(rrset, qname, qtype, new_comments);
         }
       }
-    } else if (zonestring != "") {
+    } else if (!zonestring.empty()) {
       gatherRecordsFromZone(zonestring, new_records, zonename);
     }
   }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1824,17 +1824,17 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     if(!B.getDomainInfo(zonename, di))
       throw ApiException("Creating domain '"+zonename.toString()+"' failed: lookup of domain ID failed");
 
-    di.backend->startTransaction(zonename, di.id);
+    di.backend->startTransaction(zonename, static_cast<int>(di.id));
 
     // will be overridden by updateDomainSettingsFromDocument, if given in document.
     di.backend->setDomainMetadataOne(zonename, "SOA-EDIT-API", "DEFAULT");
 
     for(auto& rr : new_records) {
-      rr.domain_id = di.id;
+      rr.domain_id = static_cast<int>(di.id);
       di.backend->feedRecord(rr, DNSName());
     }
     for(Comment& c : new_comments) {
-      c.domain_id = di.id;
+      c.domain_id = static_cast<int>(di.id);
       if (!di.backend->feedComment(c)) {
         throw ApiException("Hosting backend does not support editing comments.");
       }
@@ -1844,7 +1844,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
 
     di.backend->commitTransaction();
 
-    g_zoneCache.add(zonename, di.id); // make new zone visible
+    g_zoneCache.add(zonename, static_cast<int>(di.id)); // make new zone visible
 
     fillZone(B, zonename, resp, req);
     resp->status = 201;
@@ -1963,13 +1963,13 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
 
       checkNewRecords(new_records, zonename);
 
-      di.backend->startTransaction(zonename, di.id);
+      di.backend->startTransaction(zonename, static_cast<int>(di.id));
       for(auto& rr : new_records) {
-        rr.domain_id = di.id;
+        rr.domain_id = static_cast<int>(di.id);
         di.backend->feedRecord(rr, DNSName());
       }
       for(Comment& c : new_comments) {
-        c.domain_id = di.id;
+        c.domain_id = static_cast<int>(di.id);
         di.backend->feedComment(c);
       }
     } else {
@@ -2196,7 +2196,7 @@ static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp) {
             gatherRecords(rrset, qname, qtype, ttl, new_records);
 
             for(DNSResourceRecord& rr : new_records) {
-              rr.domain_id = di.id;
+              rr.domain_id = static_cast<int>(di.id);
               if (rr.qtype.getCode() == QType::SOA && rr.qname==zonename) {
                 soa_edit_done = increaseSOARecord(rr, soa_edit_api_kind, soa_edit_kind);
               }
@@ -2208,7 +2208,7 @@ static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp) {
             gatherComments(rrset, qname, qtype, new_comments);
 
             for(Comment& c : new_comments) {
-              c.domain_id = di.id;
+              c.domain_id = static_cast<int>(di.id);
             }
           }
         }
@@ -2434,7 +2434,7 @@ static void apiServerCacheFlush(HttpRequest* req, HttpResponse* resp) {
     if (B.getDomainInfo(canon, di, false)) {
       // zone exists (uncached), add/update it in the zone cache.
       // Handle this first, to avoid concurrent queries re-populating the other caches.
-      g_zoneCache.add(di.zone, di.id);
+      g_zoneCache.add(di.zone, static_cast<int>(di.id));
     }
     else {
       g_zoneCache.remove(di.zone);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2146,7 +2146,8 @@ static void apiServerZoneRectify(HttpRequest* req, HttpResponse* resp) {
   resp->setSuccessResult("Rectified");
 }
 
-static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp) {
+static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp)  // NOLINT(readability-function-cognitive-complexity)
+{
   bool zone_disabled;
   SOAData sd;
   DomainInfo di;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1490,7 +1490,7 @@ static void checkNewRecords(vector<DNSResourceRecord>& records, const DNSName& z
     try {
       checkHostnameCorrectness(rec);
     } catch (const std::exception& e) {
-      throw ApiException("RRset "+rec.qname.toString()+" IN "+rec.qtype.toString() + " " + e.what());
+      throw ApiException("RRset "+rec.qname.toString()+" IN "+rec.qtype.toString() + ": " + e.what());
     }
 
     previous = rec;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1951,7 +1951,6 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
 
         if (rr.qtype.getCode() == QType::SOA && rr.qname==zonename) {
           haveSoa = true;
-          increaseSOARecord(rr, soaEditApiKind, soaEditKind);
         }
       }
 
@@ -1978,6 +1977,7 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
       di.backend->startTransaction(zonename, -1);
     }
 
+    // updateDomainSettingsFromDocument will rectify the zone and update SOA serial.
     updateDomainSettingsFromDocument(B, di, zonename, document, zoneWasModified);
     di.backend->commitTransaction();
 

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1945,7 +1945,7 @@ $ORIGIN %NAME%
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
         self.assertEqual(r.status_code, 422)
-        self.assertIn("Value for key 'modified_at' is out of range", r.json()['error'])
+        self.assertIn("Key 'modified_at' is out of range", r.json()['error'])
 
     @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
     def test_zone_comment_stay_intact(self):
@@ -2372,6 +2372,12 @@ $ORIGIN %NAME%
         name, _, _ = self.create_zone(kind='Secondary', nameservers=None, masters=['127.0.0.2'])
         self.put_zone(name, {'rrsets': []}, expect_error='Must give SOA record for zone when replacing all RR sets')
 
+    def test_zone_replace_rrsets_negative_ttl(self):
+        name, _, _ = self.create_zone(dnssec=False, soa_edit='', soa_edit_api='')
+        rrsets = [
+            {'name': name, 'type': 'SOA', 'ttl': -1, 'records': [{'content': 'invalid. hostmaster.invalid. 1 10800 3600 604800 3600'}]},
+        ]
+        self.put_zone(name, {'rrsets': rrsets}, expect_error="Key 'ttl' is not a positive Integer")
 
 @unittest.skipIf(not is_auth(), "Not applicable")
 class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):


### PR DESCRIPTION
### Short description
Implementation of #8717.

For emptying out secondary zones, sending an empty rrset array should work. 

Also:
- forbid negative TTL in RRsets
- forbid changing RRsets in Consumer zones (deleting them all is still okay)
- reduce code directly in updateDomainSettingsFromDocument, to make clang-tidy happy

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
