### PR TITLE
API: Auth: fix newly created zone not rectified

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -657,7 +657,7 @@ static void extractDomainInfoFromDocument(const Json& document, boost::optional<
 }
 
 // Must be called within backend transaction.
-static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& di, const DNSName& zonename, const Json& document) {
+static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& di, const DNSName& zonename, const Json& document, bool zoneWasModified) {
   boost::optional<DomainInfo::DomainKind> kind;
   boost::optional<vector<ComboAddress>> masters;
   boost::optional<DNSName> catalog;
@@ -692,7 +692,7 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
 
 
   DNSSECKeeper dk(&B);
-  bool shouldRectify = false;
+  bool shouldRectify = zoneWasModified;
   bool dnssecInJSON = false;
   bool dnssecDocVal = false;
   bool nsec3paramInJSON = false;
@@ -1708,15 +1708,6 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     if (!nameservers.is_null() && !nameservers.is_array() && zonekind != DomainInfo::Slave)
       throw ApiException("Nameservers is not a list");
 
-    string soa_edit_api_kind;
-    if (document["soa_edit_api"].is_string()) {
-      soa_edit_api_kind = document["soa_edit_api"].string_value();
-    }
-    else {
-      soa_edit_api_kind = "DEFAULT";
-    }
-    string soa_edit_kind = document["soa_edit"].string_value();
-
     // if records/comments are given, load and check them
     bool have_soa = false;
     bool have_zone_ns = false;
@@ -1752,7 +1743,6 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
 
       if (rr.qtype.getCode() == QType::SOA && rr.qname==zonename) {
         have_soa = true;
-        increaseSOARecord(rr, soa_edit_api_kind, soa_edit_kind);
       }
       if (rr.qtype.getCode() == QType::NS && rr.qname==zonename) {
         have_zone_ns = true;
@@ -1774,7 +1764,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       sd.serial=document["serial"].int_value();
       autorr.qtype = QType::SOA;
       autorr.content = makeSOAContent(sd)->getZoneRepresentation(true);
-      increaseSOARecord(autorr, soa_edit_api_kind, soa_edit_kind);
+      // updateDomainSettingsFromDocument will apply SOA-EDIT-API as needed
       new_records.push_back(autorr);
     }
 
@@ -1827,10 +1817,8 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
 
     di.backend->startTransaction(zonename, di.id);
 
-    // updateDomainSettingsFromDocument does NOT fill out the default we've established above.
-    if (!soa_edit_api_kind.empty()) {
-      di.backend->setDomainMetadataOne(zonename, "SOA-EDIT-API", soa_edit_api_kind);
-    }
+    // will be overridden by updateDomainSettingsFromDocument, if given in document.
+    di.backend->setDomainMetadataOne(zonename, "SOA-EDIT-API", "DEFAULT");
 
     for(auto rr : new_records) {
       rr.domain_id = di.id;
@@ -1841,7 +1829,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       di.backend->feedComment(c);
     }
 
-    updateDomainSettingsFromDocument(B, di, zonename, document);
+    updateDomainSettingsFromDocument(B, di, zonename, document, !new_records.empty());
 
     di.backend->commitTransaction();
 
@@ -1908,7 +1896,7 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
     // update domain settings
 
     di.backend->startTransaction(zonename, -1);
-    updateDomainSettingsFromDocument(B, di, zonename, req->json());
+    updateDomainSettingsFromDocument(B, di, zonename, req->json(), false);
     di.backend->commitTransaction();
 
     resp->body = "";

--- a/regression-tests.api/test_helper.py
+++ b/regression-tests.api/test_helper.py
@@ -116,10 +116,11 @@ def pdnsutil_rectify(zonename):
     pdnsutil('rectify-zone', zonename)
 
 def sdig(*args):
+    sdig_command_line = [SDIG, '127.0.0.1', str(DNSPORT)] + list(args)
     try:
-        return subprocess.check_call([SDIG, '127.0.0.1', str(DNSPORT)] + list(args))
+        return subprocess.check_output(sdig_command_line).decode('utf-8')
     except subprocess.CalledProcessError as except_inst:
-        raise RuntimeError("sdig %s %s failed: %s" % (command, args, except_inst.output.decode('ascii', errors='replace')))
+        raise RuntimeError("sdig %s failed: %s" % (sdig_command_line, except_inst.output.decode('ascii', errors='replace')))
 
 def get_db_tsigkeys(keyname):
     db, placeholder = get_auth_db()


### PR DESCRIPTION
### Short description

default-api-rectify defaults to "yes" nowadays, therefore one should expect newly created zones to be rectified, even if they are not DNSSEC-enabled.
Fixing this also slightly simplifies the create zone code, as it can now rely on updateDomainSettingsFromDocument applying SOA-EDIT-API transformations.

Found while working on #12086. 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
