### PR TITLE
[clang-tidy:array] in dns.cc/hh std::array instead of c array.

### DIFF
--- a/pdns/auth-catalogzone.hh
+++ b/pdns/auth-catalogzone.hh
@@ -41,7 +41,7 @@ public:
     Consumer
   };
 
-  static const char* getTypeString(enum CatalogType type)
+  static constexpr const char* getTypeString(enum CatalogType type)
   {
     const char* types[] = {"none", "producer", "consumer"};
     return types[type];

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -30,32 +30,32 @@
 #include <boost/assign/list_of.hpp>
 #include "dnsparser.hh"
 
-std::vector<std::string> RCode::rcodes_s = boost::assign::list_of 
-  ("No Error")
-  ("Form Error")
-  ("Server Failure")
-  ("Non-Existent domain")
-  ("Not Implemented")
-  ("Query Refused")
-  ("Name Exists when it should not")
-  ("RR Set Exists when it should not")
-  ("RR Set that should exist does not")
-  ("Server Not Authoritative for zone / Not Authorized")
-  ("Name not contained in zone")
-  ("Err#11")
-  ("Err#12")
-  ("Err#13")
-  ("Err#14")
-  ("Err#15")  // Last non-extended RCode
-  ("Bad OPT Version / TSIG Signature Failure")
-  ("Key not recognized")
-  ("Signature out of time window")
-  ("Bad TKEY Mode")
-  ("Duplicate key name")
-  ("Algorithm not supported")
-  ("Bad Truncation")
-  ("Bad/missing Server Cookie")
-;
+const std::array<std::string, 24> RCode::rcodes_s = {
+  "No Error",
+  "Form Error",
+  "Server Failure",
+  "Non-Existent domain",
+  "Not Implemented",
+  "Query Refused",
+  "Name Exists when it should not",
+  "RR Set Exists when it should not",
+  "RR Set that should exist does not",
+  "Server Not Authoritative for zone / Not Authorized",
+  "Name not contained in zone",
+  "Err#11",
+  "Err#12",
+  "Err#13",
+  "Err#14",
+  "Err#15",  // Last non-extended RCode
+  "Bad OPT Version / TSIG Signature Failure",
+  "Key not recognized",
+  "Signature out of time window",
+  "Bad TKEY Mode",
+  "Duplicate key name",
+  "Algorithm not supported",
+  "Bad Truncation",
+  "Bad/missing Server Cookie"
+};
 
 static const std::array<std::string, 10> rcodes_short_s =  {
   "noerror",
@@ -86,11 +86,11 @@ std::string RCode::to_short_s(uint8_t rcode) {
 std::string ERCode::to_s(uint8_t rcode) {
   if (rcode > RCode::rcodes_s.size()-1)
     return std::string("Err#")+std::to_string(rcode);
-  return RCode::rcodes_s[rcode];
+  return RCode::rcodes_s.at(rcode);
 }
 
 std::string Opcode::to_s(uint8_t opcode) {
-  static const std::vector<std::string> s_opcodes = { "Query", "IQuery", "Status", "3", "Notify", "Update" };
+  static const std::array<std::string, 6> s_opcodes = { "Query", "IQuery", "Status", "3", "Notify", "Update" };
 
   if (opcode >= s_opcodes.size()) {
     return std::to_string(opcode);

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -35,7 +35,7 @@ public:
   enum rcodes_ { NoError=0, FormErr=1, ServFail=2, NXDomain=3, NotImp=4, Refused=5, YXDomain=6, YXRRSet=7, NXRRSet=8, NotAuth=9, NotZone=10};
   static std::string to_s(uint8_t rcode);
   static std::string to_short_s(uint8_t rcode);
-  static std::vector<std::string> rcodes_s;
+  const static std::array<std::string, 24> rcodes_s;
 };
 
 class ERCode


### PR DESCRIPTION
### Short description

Small rewrite to use a C++ array + constExpr in `dns.cc`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code: ran reg test suite `./start-test-stop 5300 sqlite3`