### PR TITLE
dnsdist: Properly handle single-SOA XFR responses

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -803,7 +803,7 @@ bool TCPConnectionToBackend::isXFRFinished(const TCPResponse& response, TCPQuery
         if (query.d_xfrMasterSerial == 0) {
           // store the first SOA in our client's connection metadata
           query.d_xfrMasterSerial = serial;
-          if (query.d_xfrMasterSerial == query.d_xfrQuerySerial) {
+          if (query.d_xfrMasterSerial <= query.d_xfrQuerySerial) {
             /* This is the first message with a master SOA:
                RFC 1995 Section 2:
                  If an IXFR query with the same or newer version number

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -803,7 +803,7 @@ bool TCPConnectionToBackend::isXFRFinished(const TCPResponse& response, TCPQuery
         if (query.d_xfrMasterSerial == 0) {
           // store the first SOA in our client's connection metadata
           query.d_xfrMasterSerial = serial;
-          if (query.d_idstate.qtype == QType::IXFR && query.d_xfrMasterSerial <= query.d_ixfrQuerySerial) {
+          if (query.d_idstate.qtype == QType::IXFR && (query.d_xfrMasterSerial == query.d_ixfrQuerySerial || rfc1982LessThan(query.d_xfrMasterSerial, query.d_ixfrQuerySerial))) {
             /* This is the first message with a master SOA:
                RFC 1995 Section 2:
                  If an IXFR query with the same or newer version number

--- a/pdns/dnsdistdist/dnsdist-tcp.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp.hh
@@ -98,6 +98,7 @@ struct InternalQuery
   std::string d_proxyProtocolPayload;
   PacketBuffer d_buffer;
   uint32_t d_proxyProtocolPayloadAddedSize{0};
+  uint32_t d_xfrQuerySerial{0};
   uint32_t d_xfrMasterSerial{0};
   uint32_t d_xfrSerialCount{0};
   uint32_t d_downstreamFailures{0};

--- a/pdns/dnsdistdist/dnsdist-tcp.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp.hh
@@ -98,7 +98,7 @@ struct InternalQuery
   std::string d_proxyProtocolPayload;
   PacketBuffer d_buffer;
   uint32_t d_proxyProtocolPayloadAddedSize{0};
-  uint32_t d_xfrQuerySerial{0};
+  uint32_t d_ixfrQuerySerial{0};
   uint32_t d_xfrMasterSerial{0};
   uint32_t d_xfrSerialCount{0};
   uint32_t d_downstreamFailures{0};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
From rfc1995 section 2 "Brief Description of the Protocol":

"If an IXFR query with the same or newer version number than that of the server is received, it is replied to with a single SOA record of the server's current version, just as in AXFR."

Until now we considered such a message to be an unfinished response to the pending {A,I}XFR, waiting for more DNS messages to come up and keeping the connection open for as long as the remote host was willing to accept that. This causes an issue for servers keeping the connection open for a very long time, like ixfrdist.

Fixes #12099 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
