### PR TITLE
docs: Clarify schema change filename

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -15,7 +15,7 @@ Schema changes
 ^^^^^^^^^^^^^^
 
 The new Catalog Zones feature comes with a mandatory schema change for the gsql database backends.
-See files named ``4.3.0_to_4.7.0_schema.pgsql.sql`` for your database backend in our Git repo, tarball, or distro-specific documentation path.
+See files named ``4.3.0_to_4.7.0_schema.X.sql`` for your database backend in our Git repo, tarball, or distro-specific documentation path.
 For the LMDB backend, please review :ref:`setting-lmdb-schema-version`.
 The new LMDB schema version is 4.
 


### PR DESCRIPTION
### Short description
The Auth 4.7 upgrade note said every backend used `...schema.pgsql.sql`.

`X.sql` matches an older note.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)