### PR TITLE
dnsdist: Fix 'comparison of integer expressions of different signedness' warning

### DIFF
--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -587,7 +587,7 @@ void DownstreamState::updateNextLazyHealthCheck(LazyHealthCheckStats& stats)
     else {
       time_t backOff = d_config.d_lazyHealthCheckMaxBackOff;
       const uint16_t failedTests = currentCheckFailures;
-      double backOffCoeffTmp = std::pow(2U, failedTests);
+      double backOffCoeffTmp = std::pow(2.0, failedTests);
       if (backOffCoeffTmp != HUGE_VAL && backOffCoeffTmp <= std::numeric_limits<time_t>::max()) {
         time_t backOffCoeff = static_cast<time_t>(backOffCoeffTmp);
         if ((std::numeric_limits<time_t>::max() / d_config.d_lazyHealthCheckFailedInterval) >= backOffCoeff) {

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -585,13 +585,16 @@ void DownstreamState::updateNextLazyHealthCheck(LazyHealthCheckStats& stats)
       stats.d_nextCheck = now + d_config.d_lazyHealthCheckFailedInterval;
     }
     else {
-      const uint16_t failedTests = currentCheckFailures;
-      size_t backOffCoeff = std::pow(2U, failedTests);
       time_t backOff = d_config.d_lazyHealthCheckMaxBackOff;
-      if ((static_cast<size_t>(std::numeric_limits<time_t>::max()) / d_config.d_lazyHealthCheckFailedInterval) >= backOffCoeff) {
-        backOff = d_config.d_lazyHealthCheckFailedInterval * backOffCoeff;
-        if (backOff > d_config.d_lazyHealthCheckMaxBackOff || (std::numeric_limits<time_t>::max() - now) <= backOff) {
-          backOff = d_config.d_lazyHealthCheckMaxBackOff;
+      const uint16_t failedTests = currentCheckFailures;
+      double backOffCoeffTmp = std::pow(2U, failedTests);
+      if (backOffCoeffTmp != HUGE_VAL && backOffCoeffTmp <= std::numeric_limits<time_t>::max()) {
+        time_t backOffCoeff = static_cast<time_t>(backOffCoeffTmp);
+        if ((std::numeric_limits<time_t>::max() / d_config.d_lazyHealthCheckFailedInterval) >= backOffCoeff) {
+          backOff = d_config.d_lazyHealthCheckFailedInterval * backOffCoeff;
+          if (backOff > d_config.d_lazyHealthCheckMaxBackOff || (std::numeric_limits<time_t>::max() - now) <= backOff) {
+            backOff = d_config.d_lazyHealthCheckMaxBackOff;
+          }
         }
       }
 

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -588,7 +588,7 @@ void DownstreamState::updateNextLazyHealthCheck(LazyHealthCheckStats& stats)
       const uint16_t failedTests = currentCheckFailures;
       size_t backOffCoeff = std::pow(2U, failedTests);
       time_t backOff = d_config.d_lazyHealthCheckMaxBackOff;
-      if ((std::numeric_limits<time_t>::max() / d_config.d_lazyHealthCheckFailedInterval) >= backOffCoeff) {
+      if ((static_cast<size_t>(std::numeric_limits<time_t>::max()) / d_config.d_lazyHealthCheckFailedInterval) >= backOffCoeff) {
         backOff = d_config.d_lazyHealthCheckFailedInterval * backOffCoeff;
         if (backOff > d_config.d_lazyHealthCheckMaxBackOff || (std::numeric_limits<time_t>::max() - now) <= backOff) {
           backOff = d_config.d_lazyHealthCheckMaxBackOff;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We are making sure that our computation will not overflow the maximum value of a `time_t`, and we know that this maximum value is positive, so we can use a `size_t` to do the comparison.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
