### PR TITLE
rec: If we encounter a loop in QM, continue with the next iteration.

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1737,6 +1737,19 @@ int SyncRes::doResolve(const DNSName &qname, const QType qtype, vector<DNSRecord
         return res;
       }
 
+      // If we have seen this child during resolution already; just skip it. We tried to QM it already or otherwise broken.
+      bool skipStep4 = false;
+      for (const auto& visitedNS : beenthere) {
+        if (visitedNS.qname == child) {
+          skipStep4 = true;
+          break;
+        }
+      }
+      if (skipStep4) {
+        QLOG("Step4 Being skipped as visited this child name already");
+        continue;
+      }
+
       // Step 4
       QLOG("Step4 Resolve A for child");
       bool oldFollowCNAME = d_followCNAME;


### PR DESCRIPTION
We would not make progres anyway, and end up repeatedly asking the full name from the roots as the "Trying less specific NS" code path is hit.

Noted by and fix from  @phonedph1

Fixes #12090

As this is an optimzation for broken domains, this is not an immediate candidate for backporting, though it should be considered for that after more testing.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
