### PR TITLE
auth: catalog zones, avoid bulk zone reset while migrating to a catalog and fix a bug

### DIFF
--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -121,7 +121,13 @@ static bool catalogDiff(const DomainInfo& di, vector<CatalogInfo>& fromXFR, vect
       else {
         CatalogInfo ciXFR = *xfr;
         CatalogInfo ciDB = *db;
-        if (ciXFR.d_unique == ciDB.d_unique) { // update
+        if (ciDB.d_unique.empty() || ciXFR.d_unique == ciDB.d_unique) { // update
+
+          if (ciDB.d_unique.empty()) { // set unique
+            g_log << Logger::Warning << logPrefix << "set unique, zone '" << ciXFR.d_zone << "' is now a member" << endl;
+            ciDB.d_unique = ciXFR.d_unique;
+            doOptions = true;
+          }
 
           if (ciXFR.d_coo != ciDB.d_coo) { // update coo
             g_log << Logger::Warning << logPrefix << "update coo for zone '" << ciXFR.d_zone << "' to '" << ciXFR.d_coo << "'" << endl;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -92,7 +92,6 @@ static bool catalogDiff(const DomainInfo& di, vector<CatalogInfo>& fromXFR, vect
 
   bool doTransaction{true};
   bool inTransaction{false};
-  bool doOptions{false};
   CatalogInfo ciCreate, ciRemove;
   std::unordered_map<DNSName, bool> clearCache;
   vector<CatalogInfo> retrieve;
@@ -122,6 +121,7 @@ static bool catalogDiff(const DomainInfo& di, vector<CatalogInfo>& fromXFR, vect
         CatalogInfo ciXFR = *xfr;
         CatalogInfo ciDB = *db;
         if (ciDB.d_unique.empty() || ciXFR.d_unique == ciDB.d_unique) { // update
+          bool doOptions{false};
 
           if (ciDB.d_unique.empty()) { // set unique
             g_log << Logger::Warning << logPrefix << "set unique, zone '" << ciXFR.d_zone << "' is now a member" << endl;


### PR DESCRIPTION
### Short description
This pull will make it easier to move to catalog zones by not performing a zone reset when unique was empty.
It also fixes a bug. After a zone requiring an options update, options for every next zone was updated as well. This is harmless but it will result in a huge amount of unnecessary database queries.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
