### PR TITLE
metric auth-xxx-answers is called auth-rcode-answers

### DIFF
--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -232,11 +232,11 @@ auth6-answers100-1000
 ^^^^^^^^^^^^^^^^^^^^^
 counts the number of queries answered by auth6s within 1 second (4.0)
 
-auth-xxx-answers
-^^^^^^^^^^^^^^^^
-where ``xxx`` is an rcode name (``noerror``, ``formerr``, ``servfail``, ``nxdomain``, ``notimp``, ``refused``, ``yxdomain``, ``yxrrset``, ``nxrrset``, ``notauth``, ``rcode10``, ``rcode11``, ``rcode2``, ``rcode13``, ``rcode14``, ``rcode15``).
-Counts the rcodes returned by authoritative servers.
+auth-rcode-answers
+^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.8
 
+Counts the rcodes (``noerror``, ``formerr``, ``servfail``, ``nxdomain``, ``notimp``, ``refused``, ``yxdomain``, ``yxrrset``, ``nxrrset``, ``notauth``, ``rcode10``, ``rcode11``, ``rcode2``, ``rcode13``, ``rcode14``, ``rcode15``) returned by authoritative servers.
 
 auth-zone-queries
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Short description

After reading
https://blog.powerdns.com/2022/10/05/first-beta-release-of-powerdns-recursor-4-8-0/
and testing 4.8.0 beta I stumbled on this documentation vs. actual metric name mismatch.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
