### PR TITLE
enable structured logging by default in systemd

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -28,18 +28,6 @@ the inner process and terminate it, after which it terminates itself.
 Requests that require data from the actual nameserver are passed to the
 inner process as well.
 
-Logging to syslog on systemd-based operating systems
-----------------------------------------------------
-
-By default, logging to syslog is disabled in the the systemd unit file
-to prevent the service logging twice, as the systemd journal picks up
-the output from the process itself.
-
-Removing the ``--disable-syslog`` option from the ``ExecStart`` line
-using ``systemctl edit --full pdns`` enables logging to syslog.
-
-.. _logging-to-syslog:
-
 Logging to syslog
 -----------------
 This chapter assumes familiarity with syslog, the unix logging device.

--- a/pdns/recursordist/pdns-recursor.service.in
+++ b/pdns/recursordist/pdns-recursor.service.in
@@ -7,7 +7,7 @@ Before=nss-lookup.target
 After=network-online.target
 
 [Service]
-ExecStart=@sbindir@/pdns_recursor --daemon=no --write-pid=no --disable-syslog --log-timestamp=no
+ExecStart=@sbindir@/pdns_recursor --daemon=no --write-pid=no --structured-logging-backend=systemd-journal
 User=@service_user@
 Group=@service_group@
 Type=notify


### PR DESCRIPTION
when running as a systemd service - we want to enable structured logging, also allows removing some now-outdated settings

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

would you want me to propagate this change on other places as well?
