### PR TITLE
auth: Document that `consistent-backends` should not be used with scoped records

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -325,9 +325,14 @@ Name of this virtual configuration - will rename the binary image. See
 .. versionadded:: 4.4.0
 
 When this is set, PowerDNS assumes that any single zone lives in only one backend.
-This allows PowerDNS to send ANY lookups to its backends, instead of sometimes requesting the exact needed type.
+This allows PowerDNS to send ``ANY`` lookups to its backends, instead of sometimes requesting the exact needed type.
 This reduces the load on backends by retrieving all the types for a given name at once, adding all of them to the cache.
 It improves performance significantly for latency-sensitive backends, like SQL ones, where a round-trip takes serious time.
+
+.. warning::
+  This behaviour is only a meaningful optimization if the returned response to the ``ANY`` query can actually be cached,
+  which is not the case if it contains at least one record with a non-zero scope. For this reason ``consistent-backends``
+  should be disabled when at least one of the backends in use returns location-based records, like the GeoIP backend.
 
 .. note::
   Pre 4.5.0 the default was no.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
As it actually makes things slightly worse in that case, because the response cannot be cached because of the scoped records, invalidating the whole response. This is especially a problem with the Geo IP backend but might be an issue with Lua and remote backends as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
