### PR TITLE
rec: QM can get confused by expiring infra records

### DIFF
--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -464,7 +464,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheReplaceAuthByNonAuthMargin)
   MRC.replace(now, ns1.d_name, QType(ns1.d_type), records, signatures, authRecords, false, DNSName("powerdns.com."), boost::none);
   BOOST_CHECK_EQUAL(MRC.size(), 1U);
 
-  // Let time pass, if we did not insert the non-auth record, it wil be expired
+  // Let time pass, if we did not insert the non-auth record, it will be expired
   now += expiry / 2;
 
   std::vector<DNSRecord> retrieved;


### PR DESCRIPTION
So be a bit more lenient with replacing auth records by unauth, as unauth (typically infra records) might come in while we are resolving.

Should fix #12078. 

But the issue of doing multiple cache lookups that assume records do no expire in-between during the resolving process is a fundamental issue. In the future we might create a separate infra cache which should take this fundamental  issue into account.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
