### PR TITLE
rec: backport 12054 to rec-4.8.x: Fix assertAlmostEqual call to compare absolute difference

### DIFF
--- a/regression-tests.recursor-dnssec/test_LockedCache.py
+++ b/regression-tests.recursor-dnssec/test_LockedCache.py
@@ -27,7 +27,7 @@ class testLockedCache(RecursorTest):
                 pieces = i.split(' ')
                 print(pieces)
                 if pieces[0] == 'mx1.secure.example.' and pieces[4] == 'A':
-                    return pieces[2]
+                    return int(pieces[2])
             raise AssertionError("Cache Line not found");
 
         except subprocess.CalledProcessError as e:
@@ -102,4 +102,4 @@ class testNotLockedCache(RecursorTest):
         self.assertRRsetInAnswer(res, expected2)
         self.assertMatchingRRSIGInAnswer(res, expected2)
         ttl2 = self.getCacheTTL()
-        self.assertAlmostEqual(ttl1, ttl2, 1)
+        self.assertAlmostEqual(ttl1, ttl2, delta=1)


### PR DESCRIPTION
(cherry picked from commit 67dd4251f758a695dab05e206a32199ccee6c214)
(cherry picked from commit 23064464fe298ac748470942de6e04a429be9a31)

Backport of #12054 and #12133

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
