### PR TITLE
Add zone name at a few locations

### DIFF
--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -343,11 +343,11 @@ string DLNotifyHandler(const vector<string>&parts, Utility::pid_t ppid)
     try {
       domain = DNSName(parts[1]);
     } catch (...) {
-      return "Failed to parse zone as valid DNS name";
+      return "Failed to parse zone as valid DNS name for '" + domain.toLogString() + "'";
     }
     if(!Communicator.notifyDomain(DNSName(parts[1]), &B))
-      return "Failed to add to the queue - see log";
-    return "Added to queue";
+      return "Failed to add to the queue for '" + domain.toLogString() + "' - see log";
+    return "Added to queue for '" + domain.toLogString() + "'";
   }
 }
 


### PR DESCRIPTION
### Short description
Add zone name to a few locations where "pdns_control notify <zone name>" returns a message. This could help with debugging if you (like we) have scripts that create a notify for multiple zones at the same time.

The zone name is already provided if you use "pdns_control retrieve <zone name>".

No documentation includes as no documentation update is required (I checked it on https://docs.powerdns.com/authoritative/manpages/pdns_control.1.html ).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
