### PR TITLE
rec: Backport 11338 to rec-4.5.x: QType ADDR is supposed to be used internally only.

### DIFF
--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -261,7 +261,13 @@ time_t MemRecursorCache::fakeTTD(MemRecursorCache::OrderedTagIterator_t& entry, 
         return -1;
       } else {
         if (!entry->d_submitted) {
-          pushTask(qname, qtype, entry->d_ttd);
+          if (qtype == QType::ADDR) {
+            pushTask(qname, QType::A, entry->d_ttd);
+            pushTask(qname, QType::AAAA, entry->d_ttd);
+          }
+	  else {
+            pushTask(qname, qtype, entry->d_ttd);
+          }
           entry->d_submitted = true;
         }
       }

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -32,6 +32,14 @@ void runTaskOnce(bool logErrors)
 
 void pushTask(const DNSName& qname, uint16_t qtype, time_t deadline)
 {
+  switch (qtype) {
+    // Internal types
+  case QType::ENT:
+  case QType::ADDR:
+  case QType::ALIAS:
+  case QType::LUA:
+    return;
+  }
   t_taskQueue.push({qname, qtype, deadline, true});
 }
 


### PR DESCRIPTION
Should fix #11337

(cherry picked from commit 7a278799ee23e582c3b722cea578699db1791bc2)

Partial backport of #11338

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
