### PR TITLE
rec: Backport 12081 to rec-4.6.x: Log invalid RPZ content when obtained via IXFR

### DIFF
--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -586,5 +586,8 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
     catch (const std::exception& e) {
       g_log << Logger::Error << "Error while applying the update received over XFR for "<<zoneName<<", skipping the update: "<< e.what() <<endl;
     }
+    catch (const PDNSException& e) {
+      g_log << Logger::Error << "Error while applying the update received over XFR for "<<zoneName<<", skipping the update: "<< e.reason <<endl;
+    }
   }
 }


### PR DESCRIPTION
That kind of content was properly logged and handled when received during the initial loading (AXFR) but not when received via an incremental update.

(cherry picked from commit 55a99233728fc01e3946a97fb8dbb073a3003622)

Backport of #12081 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
