### PR TITLE
rec: Get DS records with QM switched on.

### DIFF
--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2229,30 +2229,6 @@ static void houseKeeping(void*)
         if (res == 0) {
           // Success, go back to the defaut period
           rootUpdateTask.setPeriod(std::max(SyncRes::s_maxcachettl * 8 / 10, minRootRefreshInterval));
-          const string msg = "Exception while priming the root NS zones";
-          try {
-            primeRootNSZones(g_dnssecmode, 0);
-          }
-          catch (const std::exception& e) {
-            SLOG(g_log << Logger::Error << "Exception while priming the root NS zones: " << e.what() << endl,
-                 log->error(Logr::Error, e.what(), msg, "exception", Logging::Loggable("std::exception")));
-          }
-          catch (const PDNSException& e) {
-            SLOG(g_log << Logger::Error << "Exception while priming the root NS zones: " << e.reason << endl,
-                 log->error(Logr::Error, e.reason, msg, "exception", Logging::Loggable("PDNSException")));
-          }
-          catch (const ImmediateServFailException& e) {
-            SLOG(g_log << Logger::Error << "Exception while priming the root NS zones: " << e.reason << endl,
-                 log->error(Logr::Error, e.reason, msg, "exception", Logging::Loggable("ImmediateServFailException")));
-          }
-          catch (const PolicyHitException& e) {
-            SLOG(g_log << Logger::Error << "Policy hit while priming the root NS zones" << endl,
-                 log->info(Logr::Error, msg, "exception", Logging::Loggable("PolicyHitException")));
-          }
-          catch (...) {
-            SLOG(g_log << Logger::Error << "Exception while priming the root NS zones" << endl,
-                 log->info(Logr::Error, "Exception while priming the root NS zones"));
-          }
         }
         else {
           // On failure, go to the middle of the remaining period (initially 80% / 8 = 10%) and shorten the interval on each

--- a/pdns/recursordist/test-syncres_cc7.cc
+++ b/pdns/recursordist/test-syncres_cc7.cc
@@ -1393,10 +1393,19 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nodata)
     if (type == QType::DS || type == QType::DNSKEY) {
       return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
     }
-    else {
-
-      setLWResult(res, 0, true, false, true);
-      return LWResult::Result::Success;
+    else if (type == QType::A) {
+      if (domain == DNSName("com.")) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, DNSName("com"), QType::SOA, "whatever.com. blah.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+        addRRSIG(keys, res->d_records, DNSName("com"), 300);
+        addNSECRecordToLW(DNSName("com"), DNSName("com."), {QType::SOA}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("com."), 300);
+        return LWResult::Result::Success;
+      }
+      else if (domain == target) {
+        setLWResult(res, 0, true, false, true);
+        return LWResult::Result::Success;
+      }
     }
 
     return LWResult::Result::Timeout;
@@ -1407,7 +1416,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nodata)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusMissingNegativeIndication);
   BOOST_REQUIRE_EQUAL(ret.size(), 0U);
-  /* com|NS, powerdns.com|DS, com|DNSKEY, powerdns.com|A */
+  /* powerdns.com|A, com|A, com|DNSKEY, powerdns.com|DS */
   BOOST_CHECK_EQUAL(queriesCount, 4U);
 
   /* again, to test the cache */
@@ -1446,10 +1455,19 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nxdomain)
     if (type == QType::DS || type == QType::DNSKEY) {
       return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
     }
-    else {
-
-      setLWResult(res, RCode::NXDomain, true, false, true);
-      return LWResult::Result::Success;
+    else if (type == QType::A) {
+      if (domain == DNSName("com.")) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, DNSName("com"), QType::SOA, "whatever.com. blah.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+        addRRSIG(keys, res->d_records, DNSName("com"), 300);
+        addNSECRecordToLW(DNSName("com"), DNSName("com."), {QType::SOA}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("com."), 300);
+        return LWResult::Result::Success;
+      }
+      else if (domain == target) {
+        setLWResult(res, RCode::NXDomain, true, false, true);
+        return LWResult::Result::Success;
+      }
     }
 
     return LWResult::Result::Timeout;
@@ -1461,7 +1479,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nxdomain)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusMissingNegativeIndication);
   BOOST_REQUIRE_EQUAL(ret.size(), 0U);
 
-  /* com|A, powerdns.com|DS, com|DNSKEY, powerdns.com|A */
+  /* powerdns.com|A, com|A, powerdns.com|DS, com|DNSKEY */
   BOOST_CHECK_EQUAL(queriesCount, 4U);
 
   /* again, to test the cache */

--- a/pdns/recursordist/test-syncres_cc7.cc
+++ b/pdns/recursordist/test-syncres_cc7.cc
@@ -1407,8 +1407,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nodata)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusMissingNegativeIndication);
   BOOST_REQUIRE_EQUAL(ret.size(), 0U);
-  /* com|NS, powerdns.com|NS, powerdns.com|A */
-  BOOST_CHECK_EQUAL(queriesCount, 3U);
+  /* com|NS, powerdns.com|DS, com|DNSKEY, powerdns.com|A */
+  BOOST_CHECK_EQUAL(queriesCount, 4U);
 
   /* again, to test the cache */
   ret.clear();
@@ -1417,7 +1417,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nodata)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusMissingNegativeIndication);
   BOOST_REQUIRE_EQUAL(ret.size(), 0U);
   /* we don't store empty results */
-  BOOST_CHECK_EQUAL(queriesCount, 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 5U);
 }
 
 BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nxdomain)
@@ -1460,8 +1460,9 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nxdomain)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusMissingNegativeIndication);
   BOOST_REQUIRE_EQUAL(ret.size(), 0U);
-  /* com|NS, powerdns.com|NS, powerdns.com|A */
-  BOOST_CHECK_EQUAL(queriesCount, 3U);
+
+  /* com|A, powerdns.com|DS, com|DNSKEY, powerdns.com|A */
+  BOOST_CHECK_EQUAL(queriesCount, 4U);
 
   /* again, to test the cache */
   ret.clear();
@@ -1470,7 +1471,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nxdomain)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusMissingNegativeIndication);
   BOOST_REQUIRE_EQUAL(ret.size(), 0U);
   /* we don't store empty results */
-  BOOST_CHECK_EQUAL(queriesCount, 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 5U);
 }
 
 BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cut_with_cname_at_apex)

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2324,7 +2324,6 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType qtype, vector
       LOG(prefix<<qname<<": reprimed the root"<<endl);
       /* let's prevent an infinite loop */
       if (!d_updatingRootNS) {
-        primeRootNSZones(g_dnssecmode, depth);
         auto log = g_slog->withName("housekeeping");
         getRootNS(d_now, d_asyncResolve, depth, log);
       }
@@ -3611,8 +3610,10 @@ vState SyncRes::getDSRecords(const DNSName& zone, dsmap_t& ds, bool taOnly, unsi
 
   vState state = vState::Indeterminate;
   const bool oldCacheOnly = setCacheOnly(false);
+  const bool oldQM = setQNameMinimization(true);
   int rcode = doResolve(zone, QType::DS, dsrecords, depth + 1, beenthere, state);
   setCacheOnly(oldCacheOnly);
+  setQNameMinimization(oldQM);
 
   if (rcode == RCode::ServFail) {
     throw ImmediateServFailException("Server Failure while retrieving DS records for " + zone.toLogString());

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -321,9 +321,11 @@ public:
     return old;
   }
 
-  void setQNameMinimization(bool state=true)
+  bool setQNameMinimization(bool state = true)
   {
-    d_qNameMinimization=state;
+    auto old = d_qNameMinimization;
+    d_qNameMinimization = state;
+    return old;
   }
 
   void setDoEDNS0(bool state=true)
@@ -922,7 +924,6 @@ uint64_t* pleaseGetPacketCacheHits();
 uint64_t* pleaseGetPacketCacheSize();
 void doCarbonDump(void*);
 bool primeHints(time_t now = time(nullptr));
-void primeRootNSZones(DNSSECMode, unsigned int depth);
 
 struct WipeCacheResult
 {


### PR DESCRIPTION
This avoid `a.root-servers.net` going `Bogus`, which can happen if the `.net NS` are not cached and we miss the cut.

Fixes #12160 and avoids the need to prime the `.net NS` records explicitly.

Draft for now.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
