### PR TITLE
dnsdist-1.7.x: fix building with boost < 1.56

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -435,7 +435,7 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
         format = BPFFilter::MapFormat::WithActions;
       }
 
-      return std::make_shared<BPFFilter>(v4Config, v6Config, qnameConfig, format, external.value_or(false));
+      return std::make_shared<BPFFilter>(v4Config, v6Config, qnameConfig, format, external ? * external : false);
     });
 
   luaCtx.registerFunction<void(std::shared_ptr<BPFFilter>::*)(const ComboAddress& ca, boost::optional<uint32_t> action)>("block", [](std::shared_ptr<BPFFilter> bpf, const ComboAddress& ca, boost::optional<uint32_t> action) {

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -467,7 +467,7 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
   luaCtx.registerFunction<void(std::shared_ptr<BPFFilter>::*)(const DNSName& qname, boost::optional<uint16_t> qtype, boost::optional<uint32_t> action)>("blockQName", [](std::shared_ptr<BPFFilter> bpf, const DNSName& qname, boost::optional<uint16_t> qtype, boost::optional<uint32_t> action) {
       if (bpf) {
         if (!action) {
-          return bpf->block(qname, BPFFilter::MatchAction::Drop, qtype.value_or(255));
+          return bpf->block(qname, BPFFilter::MatchAction::Drop, qtype ? *qtype : 255);
         }
         else {
           BPFFilter::MatchAction match;
@@ -485,7 +485,7 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
           default:
             throw std::runtime_error("Unsupported action for BPFFilter::blockQName");
           }
-          return bpf->block(qname, match, qtype.value_or(255));
+          return bpf->block(qname, match, qtype ? *qtype : 255);
         }
       }
     });


### PR DESCRIPTION
### Short description
partial backport of #12177, plus another fix

this makes dnsdist-1.7.x build on Amazon Linux 2 again.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master