### PR TITLE
Introducing TCounters

### DIFF
--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -38,9 +38,18 @@ struct Bucket
 {
   Bucket(std::string name, uint64_t boundary, uint64_t val) :
     d_name(std::move(name)), d_boundary(boundary), d_count(val) {}
-  std::string d_name;
-  uint64_t d_boundary{0};
+  const std::string d_name;
+  const uint64_t d_boundary;
   mutable uint64_t d_count{0};
+
+  Bucket(const Bucket&) = default;
+  Bucket& operator=(const Bucket& rhs)
+  {
+    assert(d_name == rhs.d_name);
+    assert(d_boundary == rhs.d_boundary);
+    d_count = rhs.d_count;
+    return *this;
+  }
 };
 
 struct AtomicBucket

--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <cassert>
 #include <algorithm>
 #include <limits>
 #include <stdexcept>
@@ -35,8 +36,10 @@ namespace pdns
 // By convention, we are using microsecond units
 struct Bucket
 {
-  const std::string d_name;
-  const uint64_t d_boundary{0};
+  Bucket(std::string name, uint64_t boundary, uint64_t val) :
+    d_name(std::move(name)), d_boundary(boundary), d_count(val) {}
+  std::string d_name;
+  uint64_t d_boundary{0};
   mutable uint64_t d_count{0};
 };
 
@@ -147,9 +150,22 @@ public:
     d_sum += d;
   }
 
+  BaseHistogram& operator+=(const BaseHistogram& rhs)
+  {
+    assert(d_name == rhs.d_name);
+    assert(d_buckets.size() == rhs.d_buckets.size());
+    for (size_t bucket = 0; bucket < d_buckets.size(); ++bucket) {
+      assert(d_buckets[bucket].d_name == rhs.d_buckets[bucket].d_name);
+      assert(d_buckets[bucket].d_boundary == rhs.d_buckets[bucket].d_boundary);
+      d_buckets[bucket].d_count += rhs.d_buckets[bucket].d_count;
+    }
+    d_sum += rhs.d_sum;
+    return *this;
+  }
+
 private:
   std::vector<B> d_buckets;
-  const std::string d_name;
+  std::string d_name;
   mutable SumType d_sum{0};
 
   std::vector<uint64_t> to125(uint64_t start, int num)

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -466,7 +466,7 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
   if(!doTCP) {
     int queryfd;
     if (ip.sin4.sin_family==AF_INET6) {
-      g_stats.ipv6queries++;
+      t_Counters.at(rec::Counter::ipv6queries)++;
     }
 
     ret = asendto((const char*)&*vpacket.begin(), vpacket.size(), 0, ip, qid, domain, type, &queryfd);
@@ -624,7 +624,7 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
 
     lwr->d_rcode = RCode::FormErr;
     lwr->d_validpacket = false;
-    g_stats.serverParseError++;
+    t_Counters.at(rec::Counter::serverParseError)++;
 
     if(outgoingLoggers) {
       logIncomingResponse(outgoingLoggers, context ? context->d_initialRequestId : boost::none, uuid, ip, domain, type, qid, doTCP, dnsOverTLS, srcmask, len, lwr->d_rcode, lwr->d_records, queryTime, exportTypes);
@@ -637,7 +637,7 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
          g_slogout->info(Logr::Notice, "Unknown error parsing packet from remote server", "server", Logging::Loggable(ip)));
   }
 
-  g_stats.serverParseError++;
+  t_Counters.at(rec::Counter::serverParseError)++;
 
  out:
   if (!lwr->d_rcode) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1626,6 +1626,11 @@ void startDoResolve(void* p)
                                           dq.validationState,
                                           std::move(pbDataForCache), dc->d_tcp);
     }
+
+    if (g_regressionTestMode) {
+      t_Counters.updateSnap(g_regressionTestMode);
+    }
+
     if (!dc->d_tcp) {
       struct msghdr msgh;
       struct iovec iov;
@@ -1807,9 +1812,6 @@ void startDoResolve(void* p)
          sr.d_slog->info(Logr::Error, "Any other exception in a resolver context"));
   }
 
-  if (g_regressionTestMode) {
-    t_Counters.updateSnap(g_regressionTestMode);
-  }
   runTaskOnce(g_logCommonErrors);
 
   t_Counters.at(rec::Counter::maxMThreadStackUsage) = max(MT->getMaxStackUsage(), t_Counters.at(rec::Counter::maxMThreadStackUsage));

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -39,7 +39,6 @@ void doCarbonDump(void*)
       config.instance_name = "recursor";
     }
 
-    registerAllStats();
     PacketBuffer msg;
     for (const auto& carbonServer : config.servers) {
       ComboAddress remote(carbonServer, 2003);

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -271,10 +271,6 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   SNMPAgent(name, masterSocket)
 {
 #ifdef HAVE_NET_SNMP
-  /* This is done so that the statistics maps are
-     initialized. */
-  registerAllStats();
-
   registerCounter64Stat("questions", questionsOID, OID_LENGTH(questionsOID));
   registerCounter64Stat("ipv6-questions", ipv6QuestionsOID, OID_LENGTH(ipv6QuestionsOID));
   registerCounter64Stat("tcp-questions", tcpQuestionsOID, OID_LENGTH(tcpQuestionsOID));

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1149,7 +1149,7 @@ static uint64_t doGetMallocated()
   return 0;
 }
 
-static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& histogram)
+static StatsMap toStatsMap(const string& name, const pdns::Histogram& histogram)
 {
   const auto& data = histogram.getCumulativeBuckets();
   const string pbasename = getPrometheusName(name);
@@ -1169,7 +1169,7 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
   return entries;
 }
 
-static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& histogram4, const pdns::AtomicHistogram& histogram6)
+static StatsMap toStatsMap(const string& name, const pdns::Histogram& histogram4, const pdns::Histogram& histogram6)
 {
   const string pbasename = getPrometheusName(name);
   StatsMap entries;
@@ -1199,13 +1199,14 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
   return entries;
 }
 
-static StatsMap toAuthRCodeStatsMap(const string& name, const std::array<pdns::stat_t, 16>& v)
+static StatsMap toAuthRCodeStatsMap(const string& name)
 {
   const string pbasename = getPrometheusName(name);
   StatsMap entries;
 
   uint8_t n = 0;
-  for (const auto& entry : v) {
+  auto rcodes = g_Counters.sum(rec::RCode::auth).rcodeCounters;
+  for (const auto& entry : rcodes) {
     const auto key = RCode::to_short_s(n);
     std::string pname = pbasename + "{rcode=\"" + key + "\"}";
     entries.emplace("auth-" + key + "-answers", StatsMapEntry{pname, std::to_string(entry)});
@@ -1313,9 +1314,9 @@ static StatsMap toRemoteLoggerStatsMap(const string& name)
 
 static void registerAllStats1()
 {
-  addGetStat("questions", &g_stats.qcounter);
-  addGetStat("ipv6-questions", &g_stats.ipv6qcounter);
-  addGetStat("tcp-questions", &g_stats.tcpqcounter);
+  addGetStat("questions", [] { return g_Counters.sum(rec::Counter::qcounter); });
+  addGetStat("ipv6-questions", [] { return g_Counters.sum(rec::Counter::ipv6qcounter); });
+  addGetStat("tcp-questions", [] { return g_Counters.sum(rec::Counter::tcpqcounter); });
 
   addGetStat("cache-hits", doGetCacheHits);
   addGetStat("cache-misses", doGetCacheMisses);
@@ -1339,63 +1340,63 @@ static void registerAllStats1()
 
   addGetStat("malloc-bytes", doGetMallocated);
 
-  addGetStat("servfail-answers", &g_stats.servFails);
-  addGetStat("nxdomain-answers", &g_stats.nxDomains);
-  addGetStat("noerror-answers", &g_stats.noErrors);
+  addGetStat("servfail-answers", [] { return g_Counters.sum(rec::Counter::servFails); });
+  addGetStat("nxdomain-answers", [] { return g_Counters.sum(rec::Counter::nxDomains); });
+  addGetStat("noerror-answers", [] { return g_Counters.sum(rec::Counter::noErrors); });
 
-  addGetStat("unauthorized-udp", &g_stats.unauthorizedUDP);
-  addGetStat("unauthorized-tcp", &g_stats.unauthorizedTCP);
-  addGetStat("source-disallowed-notify", &g_stats.sourceDisallowedNotify);
-  addGetStat("zone-disallowed-notify", &g_stats.zoneDisallowedNotify);
-  addGetStat("tcp-client-overflow", &g_stats.tcpClientOverflow);
+  addGetStat("unauthorized-udp", [] { return g_Counters.sum(rec::Counter::unauthorizedUDP); });
+  addGetStat("unauthorized-tcp", [] { return g_Counters.sum(rec::Counter::unauthorizedTCP); });
+  addGetStat("source-disallowed-notify", [] { return g_Counters.sum(rec::Counter::sourceDisallowedNotify); });
+  addGetStat("zone-disallowed-notify", [] { return g_Counters.sum(rec::Counter::zoneDisallowedNotify); });
+  addGetStat("tcp-client-overflow", [] { return g_Counters.sum(rec::Counter::tcpClientOverflow); });
 
-  addGetStat("client-parse-errors", &g_stats.clientParseError);
-  addGetStat("server-parse-errors", &g_stats.serverParseError);
-  addGetStat("too-old-drops", &g_stats.tooOldDrops);
-  addGetStat("truncated-drops", &g_stats.truncatedDrops);
-  addGetStat("query-pipe-full-drops", &g_stats.queryPipeFullDrops);
+  addGetStat("client-parse-errors", [] { return g_Counters.sum(rec::Counter::clientParseError); });
+  addGetStat("server-parse-errors", [] { return g_Counters.sum(rec::Counter::serverParseError); });
+  addGetStat("too-old-drops", [] { return g_Counters.sum(rec::Counter::tooOldDrops); });
+  addGetStat("truncated-drops", [] { return g_Counters.sum(rec::Counter::truncatedDrops); });
+  addGetStat("query-pipe-full-drops", [] { return g_Counters.sum(rec::Counter::queryPipeFullDrops); });
 
-  addGetStat("answers0-1", []() { return g_stats.answers.getCount(0); });
-  addGetStat("answers1-10", []() { return g_stats.answers.getCount(1); });
-  addGetStat("answers10-100", []() { return g_stats.answers.getCount(2); });
-  addGetStat("answers100-1000", []() { return g_stats.answers.getCount(3); });
-  addGetStat("answers-slow", []() { return g_stats.answers.getCount(4); });
+  addGetStat("answers0-1", []() { return g_Counters.sum(rec::Histogram::answers).getCount(0); });
+  addGetStat("answers1-10", []() { return g_Counters.sum(rec::Histogram::answers).getCount(1); });
+  addGetStat("answers10-100", []() { return g_Counters.sum(rec::Histogram::answers).getCount(2); });
+  addGetStat("answers100-1000", []() { return g_Counters.sum(rec::Histogram::answers).getCount(3); });
+  addGetStat("answers-slow", []() { return g_Counters.sum(rec::Histogram::answers).getCount(4); });
 
-  addGetStat("x-ourtime0-1", []() { return g_stats.ourtime.getCount(0); });
-  addGetStat("x-ourtime1-2", []() { return g_stats.ourtime.getCount(1); });
-  addGetStat("x-ourtime2-4", []() { return g_stats.ourtime.getCount(2); });
-  addGetStat("x-ourtime4-8", []() { return g_stats.ourtime.getCount(3); });
-  addGetStat("x-ourtime8-16", []() { return g_stats.ourtime.getCount(4); });
-  addGetStat("x-ourtime16-32", []() { return g_stats.ourtime.getCount(5); });
-  addGetStat("x-ourtime-slow", []() { return g_stats.ourtime.getCount(6); });
+  addGetStat("x-ourtime0-1", []() { return g_Counters.sum(rec::Histogram::ourtime).getCount(0); });
+  addGetStat("x-ourtime1-2", []() { return g_Counters.sum(rec::Histogram::ourtime).getCount(1); });
+  addGetStat("x-ourtime2-4", []() { return g_Counters.sum(rec::Histogram::ourtime).getCount(2); });
+  addGetStat("x-ourtime4-8", []() { return g_Counters.sum(rec::Histogram::ourtime).getCount(3); });
+  addGetStat("x-ourtime8-16", []() { return g_Counters.sum(rec::Histogram::ourtime).getCount(4); });
+  addGetStat("x-ourtime16-32", []() { return g_Counters.sum(rec::Histogram::ourtime).getCount(5); });
+  addGetStat("x-ourtime-slow", []() { return g_Counters.sum(rec::Histogram::ourtime).getCount(6); });
 
-  addGetStat("auth4-answers0-1", []() { return g_stats.auth4Answers.getCount(0); });
-  addGetStat("auth4-answers1-10", []() { return g_stats.auth4Answers.getCount(1); });
-  addGetStat("auth4-answers10-100", []() { return g_stats.auth4Answers.getCount(2); });
-  addGetStat("auth4-answers100-1000", []() { return g_stats.auth4Answers.getCount(3); });
-  addGetStat("auth4-answers-slow", []() { return g_stats.auth4Answers.getCount(4); });
+  addGetStat("auth4-answers0-1", []() { return g_Counters.sum(rec::Histogram::auth4Answers).getCount(0); });
+  addGetStat("auth4-answers1-10", []() { return g_Counters.sum(rec::Histogram::auth4Answers).getCount(1); });
+  addGetStat("auth4-answers10-100", []() { return g_Counters.sum(rec::Histogram::auth4Answers).getCount(2); });
+  addGetStat("auth4-answers100-1000", []() { return g_Counters.sum(rec::Histogram::auth4Answers).getCount(3); });
+  addGetStat("auth4-answers-slow", []() { return g_Counters.sum(rec::Histogram::auth4Answers).getCount(4); });
 
-  addGetStat("auth6-answers0-1", []() { return g_stats.auth6Answers.getCount(0); });
-  addGetStat("auth6-answers1-10", []() { return g_stats.auth6Answers.getCount(1); });
-  addGetStat("auth6-answers10-100", []() { return g_stats.auth6Answers.getCount(2); });
-  addGetStat("auth6-answers100-1000", []() { return g_stats.auth6Answers.getCount(3); });
-  addGetStat("auth6-answers-slow", []() { return g_stats.auth6Answers.getCount(4); });
+  addGetStat("auth6-answers0-1", []() { return g_Counters.sum(rec::Histogram::auth6Answers).getCount(0); });
+  addGetStat("auth6-answers1-10", []() { return g_Counters.sum(rec::Histogram::auth6Answers).getCount(1); });
+  addGetStat("auth6-answers10-100", []() { return g_Counters.sum(rec::Histogram::auth6Answers).getCount(2); });
+  addGetStat("auth6-answers100-1000", []() { return g_Counters.sum(rec::Histogram::auth6Answers).getCount(3); });
+  addGetStat("auth6-answers-slow", []() { return g_Counters.sum(rec::Histogram::auth6Answers).getCount(4); });
 
-  addGetStat("qa-latency", []() { return round(g_stats.avgLatencyUsec.load()); });
-  addGetStat("x-our-latency", []() { return round(g_stats.avgLatencyOursUsec.load()); });
-  addGetStat("unexpected-packets", &g_stats.unexpectedCount);
-  addGetStat("case-mismatches", &g_stats.caseMismatchCount);
-  addGetStat("spoof-prevents", &g_stats.spoofCount);
+  addGetStat("qa-latency", []() { return round(g_Counters.avg(rec::DoubleWAvgCounter::avgLatencyUsec)); });
+  addGetStat("x-our-latency", []() { return round(g_Counters.avg(rec::DoubleWAvgCounter::avgLatencyOursUsec)); });
+  addGetStat("unexpected-packets", [] { return g_Counters.sum(rec::Counter::unexpectedCount); });
+  addGetStat("case-mismatches", [] { return g_Counters.sum(rec::Counter::caseMismatchCount); });
+  addGetStat("spoof-prevents", [] { return g_Counters.sum(rec::Counter::spoofCount); });
 
-  addGetStat("nsset-invalidations", &g_stats.nsSetInvalidations);
+  addGetStat("nsset-invalidations", [] { return g_Counters.sum(rec::Counter::nsSetInvalidations); });
 
-  addGetStat("resource-limits", &g_stats.resourceLimits);
-  addGetStat("over-capacity-drops", &g_stats.overCapacityDrops);
-  addGetStat("policy-drops", &g_stats.policyDrops);
-  addGetStat("no-packet-error", &g_stats.noPacketError);
-  addGetStat("ignored-packets", &g_stats.ignoredCount);
-  addGetStat("empty-queries", &g_stats.emptyQueriesCount);
-  addGetStat("max-mthread-stack", &g_stats.maxMThreadStackUsage);
+  addGetStat("resource-limits", [] { return g_Counters.sum(rec::Counter::resourceLimits); });
+  addGetStat("over-capacity-drops", [] { return g_Counters.sum(rec::Counter::overCapacityDrops); });
+  addGetStat("policy-drops", [] { return g_Counters.sum(rec::Counter::policyDrops); });
+  addGetStat("no-packet-error", [] { return g_Counters.sum(rec::Counter::noPacketError); });
+  addGetStat("ignored-packets", [] { return g_Counters.sum(rec::Counter::ignoredCount); });
+  addGetStat("empty-queries", [] { return g_Counters.sum(rec::Counter::emptyQueriesCount); });
+  addGetStat("max-mthread-stack", [] { return g_Counters.max(rec::Counter::maxMThreadStackUsage); });
 
   addGetStat("negcache-entries", getNegCacheSize);
   addGetStat("throttle-entries", SyncRes::getThrottledServersSize);
@@ -1406,22 +1407,22 @@ static void registerAllStats1()
 
   addGetStat("concurrent-queries", getConcurrentQueries);
   addGetStat("security-status", &g_security_status);
-  addGetStat("outgoing-timeouts", &SyncRes::s_outgoingtimeouts);
-  addGetStat("outgoing4-timeouts", &SyncRes::s_outgoing4timeouts);
-  addGetStat("outgoing6-timeouts", &SyncRes::s_outgoing6timeouts);
-  addGetStat("auth-zone-queries", &SyncRes::s_authzonequeries);
-  addGetStat("tcp-outqueries", &SyncRes::s_tcpoutqueries);
-  addGetStat("dot-outqueries", &SyncRes::s_dotoutqueries);
-  addGetStat("all-outqueries", &SyncRes::s_outqueries);
-  addGetStat("ipv6-outqueries", &g_stats.ipv6queries);
-  addGetStat("throttled-outqueries", &SyncRes::s_throttledqueries);
-  addGetStat("dont-outqueries", &SyncRes::s_dontqueries);
-  addGetStat("qname-min-fallback-success", &SyncRes::s_qnameminfallbacksuccess);
-  addGetStat("throttled-out", &SyncRes::s_throttledqueries);
-  addGetStat("unreachables", &SyncRes::s_unreachables);
+  addGetStat("outgoing-timeouts", [] { return g_Counters.sum(rec::Counter::outgoingtimeouts); });
+  addGetStat("outgoing4-timeouts", [] { return g_Counters.sum(rec::Counter::outgoing4timeouts); });
+  addGetStat("outgoing6-timeouts", [] { return g_Counters.sum(rec::Counter::outgoing6timeouts); });
+  addGetStat("auth-zone-queries", [] { return g_Counters.sum(rec::Counter::authzonequeries); });
+  addGetStat("tcp-outqueries", [] { return g_Counters.sum(rec::Counter::tcpoutqueries); });
+  addGetStat("dot-outqueries", [] { return g_Counters.sum(rec::Counter::dotoutqueries); });
+  addGetStat("all-outqueries", [] { return g_Counters.sum(rec::Counter::outqueries); });
+  addGetStat("ipv6-outqueries", [] { return g_Counters.sum(rec::Counter::ipv6queries); });
+  addGetStat("throttled-outqueries", [] { return g_Counters.sum(rec::Counter::throttledqueries); });
+  addGetStat("dont-outqueries", [] { return g_Counters.sum(rec::Counter::dontqueries); });
+  addGetStat("qname-min-fallback-success", [] { return g_Counters.sum(rec::Counter::qnameminfallbacksuccess); });
+  addGetStat("throttled-out", [] { return g_Counters.sum(rec::Counter::throttledqueries); });
+  addGetStat("unreachables", [] { return g_Counters.sum(rec::Counter::unreachables); });
   addGetStat("ecs-queries", &SyncRes::s_ecsqueries);
   addGetStat("ecs-responses", &SyncRes::s_ecsresponses);
-  addGetStat("chain-resends", &g_stats.chainResends);
+  addGetStat("chain-resends", [] { return g_Counters.sum(rec::Counter::chainResends); });
   addGetStat("tcp-clients", [] { return TCPConnection::getCurrentConnections(); });
 
 #ifdef __linux__
@@ -1437,17 +1438,17 @@ static void registerAllStats1()
   addGetStat("udp6-in-csum-errors", [] { return udp6ErrorStats("udp6-in-csum-errors"); });
 #endif
 
-  addGetStat("edns-ping-matches", &g_stats.ednsPingMatches);
-  addGetStat("edns-ping-mismatches", &g_stats.ednsPingMismatches);
-  addGetStat("dnssec-queries", &g_stats.dnssecQueries);
+  addGetStat("edns-ping-matches", [] { return g_Counters.sum(rec::Counter::ednsPingMatches); });
+  addGetStat("edns-ping-mismatches", [] { return g_Counters.sum(rec::Counter::ednsPingMismatches); });
+  addGetStat("dnssec-queries", [] { return g_Counters.sum(rec::Counter::dnssecQueries); });
 
-  addGetStat("dnssec-authentic-data-queries", &g_stats.dnssecAuthenticDataQueries);
-  addGetStat("dnssec-check-disabled-queries", &g_stats.dnssecCheckDisabledQueries);
+  addGetStat("dnssec-authentic-data-queries", [] { return g_Counters.sum(rec::Counter::dnssecAuthenticDataQueries); });
+  addGetStat("dnssec-check-disabled-queries", [] { return g_Counters.sum(rec::Counter::dnssecCheckDisabledQueries); });
 
-  addGetStat("variable-responses", &g_stats.variableResponses);
+  addGetStat("variable-responses", [] { return g_Counters.sum(rec::Counter::variableResponses); });
 
-  addGetStat("noping-outqueries", &g_stats.noPingOutQueries);
-  addGetStat("noedns-outqueries", &g_stats.noEdnsOutQueries);
+  addGetStat("noping-outqueries", [] { return g_Counters.sum(rec::Counter::noPingOutQueries); });
+  addGetStat("noedns-outqueries", [] { return g_Counters.sum(rec::Counter::noEdnsOutQueries); });
 
   addGetStat("uptime", calculateUptime);
   addGetStat("real-memory-usage", [] { return getRealMemoryUsage(string()); });
@@ -1471,7 +1472,7 @@ static void registerAllStats1()
   addGetStat("memory-allocated", [] { return g_mtracer->getTotAllocated(string()); });
 #endif
 
-  addGetStat("dnssec-validations", &g_stats.dnssecValidations);
+  addGetStat("dnssec-validations", [] { return g_Counters.sum(rec::Counter::dnssecValidations); });
   addGetStat("dnssec-result-insecure", &g_stats.dnssecResults[vState::Insecure]);
   addGetStat("dnssec-result-secure", &g_stats.dnssecResults[vState::Secure]);
   addGetStat("dnssec-result-bogus", []() {
@@ -1538,17 +1539,17 @@ static void registerAllStats1()
   addGetStat("policy-result-truncate", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Truncate]);
   addGetStat("policy-result-custom", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Custom]);
 
-  addGetStat("rebalanced-queries", &g_stats.rebalancedQueries);
+  addGetStat("rebalanced-queries", [] { return g_Counters.sum(rec::Counter::rebalancedQueries); });
 
-  addGetStat("proxy-protocol-invalid", &g_stats.proxyProtocolInvalidCount);
+  addGetStat("proxy-protocol-invalid", [] { return g_Counters.sum(rec::Counter::proxyProtocolInvalidCount); });
 
-  addGetStat("nod-lookups-dropped-oversize", &g_stats.nodLookupsDroppedOversize);
+  addGetStat("nod-lookups-dropped-oversize", [] { return g_Counters.sum(rec::Counter::nodLookupsDroppedOversize); });
 
   addGetStat("taskqueue-pushed", []() { return getTaskPushes(); });
   addGetStat("taskqueue-expired", []() { return getTaskExpired(); });
   addGetStat("taskqueue-size", []() { return getTaskSize(); });
 
-  addGetStat("dns64-prefix-answers", &g_stats.dns64prefixanswers);
+  addGetStat("dns64-prefix-answers", [] { return g_Counters.sum(rec::Counter::dns64prefixanswers); });
 
   addGetStat("almost-expired-pushed", []() { return getAlmostExpiredTasksPushed(); });
   addGetStat("almost-expired-run", []() { return getAlmostExpiredTasksRun(); });
@@ -1556,8 +1557,8 @@ static void registerAllStats1()
 
   addGetStat("idle-tcpout-connections", getCurrentIdleTCPConnections);
 
-  addGetStat("maintenance-usec", &g_stats.maintenanceUsec);
-  addGetStat("maintenance-calls", &g_stats.maintenanceCalls);
+  addGetStat("maintenance-usec", [] { return g_Counters.sum(rec::Counter::maintenanceUsec); });
+  addGetStat("maintenance-calls", [] { return g_Counters.sum(rec::Counter::maintenanceCalls); });
 
   /* make sure that the ECS stats are properly initialized */
   SyncRes::clearECSStats();
@@ -1571,10 +1572,10 @@ static void registerAllStats1()
   }
 
   addGetStat("cumul-clientanswers", []() {
-    return toStatsMap(g_stats.cumulativeAnswers.getName(), g_stats.cumulativeAnswers);
+    return toStatsMap(t_Counters.at(rec::Histogram::cumulativeAnswers).getName(), g_Counters.sum(rec::Histogram::cumulativeAnswers));
   });
   addGetStat("cumul-authanswers", []() {
-    return toStatsMap(g_stats.cumulativeAuth4Answers.getName(), g_stats.cumulativeAuth4Answers, g_stats.cumulativeAuth6Answers);
+    return toStatsMap(t_Counters.at(rec::Histogram::cumulativeAuth4Answers).getName(), g_Counters.sum(rec::Histogram::cumulativeAuth4Answers), g_Counters.sum(rec::Histogram::cumulativeAuth6Answers));
   });
   addGetStat("policy-hits", []() {
     return toRPZStatsMap("policy-hits", g_stats.policyHits);
@@ -1583,7 +1584,7 @@ static void registerAllStats1()
     return toProxyMappingStatsMap("proxy-mapping-total");
   });
   addGetStat("auth-rcode-answers", []() {
-    return toAuthRCodeStatsMap("auth-rcode-answers", g_stats.authRCode);
+    return toAuthRCodeStatsMap("auth-rcode-answers");
   });
   addGetStat("remote-logger-count", []() {
     return toRemoteLoggerStatsMap("remote-logger-count");

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1593,16 +1593,13 @@ static void registerAllStats1()
 
 void registerAllStats()
 {
-  static std::once_flag s_once;
-  std::call_once(s_once, []() {
-    try {
-      registerAllStats1();
-    }
-    catch (...) {
-      g_log << Logger::Critical << "Could not add stat entries" << endl;
-      exit(1);
-    }
-  });
+  try {
+    registerAllStats1();
+  }
+  catch (...) {
+    g_log << Logger::Critical << "Could not add stat entries" << endl;
+    exit(1);
+  }
 }
 
 void doExitGeneric(bool nicely)

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -171,6 +171,7 @@ pdns_recursor_SOURCES = \
 	rec-protozero.cc rec-protozero.hh \
 	rec-snmp.hh rec-snmp.cc \
 	rec-taskqueue.cc rec-taskqueue.hh \
+	rec-tcounters.cc rec-tcounters.hh \
 	rec-tcp.cc \
 	rec-tcpout.cc rec-tcpout.hh \
 	rec-zonetocache.cc rec-zonetocache.hh \
@@ -201,6 +202,7 @@ pdns_recursor_SOURCES = \
 	svc-records.cc svc-records.hh \
 	syncres.cc syncres.hh \
 	taskqueue.cc taskqueue.hh \
+	tcounters.hh \
 	tcpiohandler.cc tcpiohandler.hh \
 	threadname.hh threadname.cc \
 	tsigverifier.cc tsigverifier.hh \
@@ -294,6 +296,7 @@ testrunner_SOURCES = \
 	rcpgenerator.cc \
 	rec-eventtrace.cc rec-eventtrace.hh \
 	rec-taskqueue.cc rec-taskqueue.hh \
+	rec-tcounters.cc rec-tcounters.hh \
 	rec-zonetocache.cc rec-zonetocache.hh \
 	recpacketcache.cc recpacketcache.hh \
 	recursor_cache.cc recursor_cache.hh \
@@ -334,6 +337,7 @@ testrunner_SOURCES = \
 	test-packetcache_hh.cc \
 	test-rcpgenerator_cc.cc \
 	test-rec-taskqueue.cc \
+	test-rec-tcounters_cc.cc \
 	test-rec-zonetocache.cc \
 	test-recpacketcache_cc.cc \
 	test-recursorcache_cc.cc \

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2601,7 +2601,7 @@ int main(int argc, char** argv)
 #else
     ::arg().set("stack-size", "stack size per mthread") = "200000";
 #endif
-    // This mode forces metrics snap updates and dsiable root-refresh, to get consistent counters
+    // This mode forces metrics snap updates and disable root-refresh, to get consistent counters
     ::arg().setSwitch("devonly-regression-test-mode", "internal use only") = "no";
     ::arg().set("soa-minimum-ttl", "Don't change") = "0";
     ::arg().set("no-shuffle", "Don't change") = "off";

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -154,6 +154,7 @@ struct DNSComboWriter
 extern thread_local unique_ptr<FDMultiplexer> t_fdm;
 extern uint16_t g_minUdpSourcePort;
 extern uint16_t g_maxUdpSourcePort;
+extern bool g_regressionTestMode;
 
 // you can ask this class for a UDP socket to send a query from
 // this socket is not yours, don't even think about deleting it

--- a/pdns/recursordist/rec-tcounters.cc
+++ b/pdns/recursordist/rec-tcounters.cc
@@ -1,0 +1,156 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "rec-tcounters.hh"
+
+#include <sstream>
+
+namespace rec
+{
+
+Counters& Counters::merge(const Counters& data)
+{
+  // Counters are simply added
+  for (size_t i = 0; i < uint64Count.size(); i++) {
+    uint64Count.at(i) += data.uint64Count.at(i);
+  }
+  // Averages: take weight into account
+  for (size_t i = 0; i < doubleWAvg.size(); i++) {
+    auto& lhs = doubleWAvg.at(i);
+    const auto& rhs = data.doubleWAvg.at(i);
+    auto weight = lhs.weight + rhs.weight;
+    auto avg = lhs.avg * static_cast<double>(lhs.weight) + rhs.avg * static_cast<double>(rhs.weight);
+    avg = weight == 0 ? 0 : avg / weight;
+    lhs.avg = avg;
+    lhs.weight = weight;
+  }
+  // Rcode Counters are simply added
+  for (size_t i = 0; i < auth.rcodeCounters.size(); i++) {
+    auth.rcodeCounters.at(i) += data.auth.rcodeCounters.at(i);
+  }
+  // Histograms counts are added by += operator on Histograms
+  for (size_t i = 0; i < histograms.size(); i++) {
+    histograms.at(i) += data.histograms.at(i);
+  }
+
+  return *this;
+}
+
+std::string Counters::toString() const
+{
+  std::ostringstream stream;
+
+  for (auto element : uint64Count) {
+    stream << element << ' ';
+  }
+  stream << std::endl;
+  for (auto element : doubleWAvg) {
+    stream << '(' << element.avg << ' ' << element.weight << ')';
+  }
+  stream << " RCodes: ";
+  for (auto element : auth.rcodeCounters) {
+    stream << element << ' ';
+  }
+  stream << "Histograms: ";
+  for (const auto& element : histograms) {
+    stream << element.getName() << ": NYI";
+  }
+  stream << std::endl;
+  return stream.str();
+}
+
+}
+
+// Compile with:
+// c++ -DTEST_TCOUNTER_TIMING -Wall -std=c++17 -O2 rec-tcounters.cc -pthread
+
+#if TEST_TCOUNTER_TIMING
+
+#include <iostream>
+#include <vector>
+#include <atomic>
+#include <thread>
+#include <ctime>
+
+rec::GlobalCounters g_counters;
+thread_local rec::TCounters t_counters(g_counters);
+
+std::atomic<uint64_t> atomicCounter;
+
+size_t iterations;
+
+void atomicThread()
+{
+  for (size_t i = 0; i < iterations; i++) {
+    ++atomicCounter;
+  }
+}
+
+void tcounterThread()
+{
+  for (size_t i = 0; i < iterations; i++) {
+    ++t_counters.at(rec::Counter::qcounter);
+    if (i % 100 == 0) {
+      t_counters.updateSnap();
+    }
+  }
+}
+
+int main(int argc, char* argv[])
+{
+  size_t threads = std::atoi(argv[1]);
+  iterations = std::atoi(argv[2]);
+
+  std::cout << "Starting " << threads << " threads doing " << iterations << " iterations using atomics" << std::endl;
+  std::vector<std::thread> thr;
+  thr.resize(threads);
+
+  timeval start;
+  gettimeofday(&start, nullptr);
+  for (size_t i = 0; i < threads; i++) {
+    thr[i] = std::thread(atomicThread);
+  }
+  for (size_t i = 0; i < threads; i++) {
+    thr[i].join();
+  }
+  timeval stop;
+  gettimeofday(&stop, nullptr);
+  timeval diff;
+  timersub(&stop, &start, &diff);
+  auto elapsed = (diff.tv_sec + diff.tv_usec / 1e6);
+  std::cout << "Sum is " << atomicCounter << " elapsed is " << elapsed << std::endl;
+
+  std::cout << "Now doing the same with tcounters" << std::endl;
+  gettimeofday(&start, nullptr);
+  for (size_t i = 0; i < threads; i++) {
+    thr[i] = std::thread(tcounterThread);
+  }
+  for (size_t i = 0; i < threads; i++) {
+    thr[i].join();
+  }
+  gettimeofday(&stop, nullptr);
+  timersub(&stop, &start, &diff);
+  elapsed = (diff.tv_sec + diff.tv_usec / 1e6);
+  std::cout << "Sum is " << g_counters.sum(rec::Counter::qcounter) << " elapsed is " << elapsed << std::endl;
+}
+
+#endif

--- a/pdns/recursordist/rec-tcounters.hh
+++ b/pdns/recursordist/rec-tcounters.hh
@@ -95,7 +95,7 @@ enum class Counter : uint8_t
   numberOfCounters
 };
 
-// double avegares times, weighted according to how many packets they processed
+// double averages times, weighted according to how many packets they processed
 enum class DoubleWAvgCounter : uint8_t
 {
   avgLatencyUsec,
@@ -126,7 +126,7 @@ enum class Histogram : uint8_t
 
 struct Counters
 {
-  // An aray of simple counters
+  // An array of simple counters
   std::array<uint64_t, static_cast<size_t>(Counter::numberOfCounters)> uint64Count{};
 
   struct WeightedAverage
@@ -187,7 +187,7 @@ struct Counters
   // for averages, we should take the weights into account. Histograms need to sum all individual counts.
   Counters& merge(const Counters& data);
 
-  // The following accessors select the rightcounter type based on the index type
+  // The following accessors select the right counter type based on the index type
   uint64_t& at(Counter index)
   {
     return uint64Count.at(static_cast<size_t>(index));

--- a/pdns/recursordist/rec-tcounters.hh
+++ b/pdns/recursordist/rec-tcounters.hh
@@ -1,0 +1,219 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include "tcounters.hh"
+
+#include <string>
+
+#include "histogram.hh"
+
+namespace rec
+{
+
+// Simple counters
+enum class Counter : uint8_t
+{
+  syncresqueries,
+  outgoingtimeouts,
+  outgoing4timeouts,
+  outgoing6timeouts,
+  throttledqueries,
+  dontqueries,
+  qnameminfallbacksuccess,
+  authzonequeries,
+  outqueries,
+  tcpoutqueries,
+  dotoutqueries,
+  unreachables,
+  servFails,
+  nxDomains,
+  noErrors,
+  qcounter,
+  ipv6qcounter,
+  tcpqcounter,
+  unauthorizedUDP, // when this is increased, qcounter isn't
+  unauthorizedTCP, // when this is increased, qcounter isn't
+  sourceDisallowedNotify, // when this is increased, qcounter is also
+  zoneDisallowedNotify, // when this is increased, qcounter is also
+  policyDrops,
+  tcpClientOverflow,
+  clientParseError,
+  serverParseError,
+  tooOldDrops,
+  truncatedDrops,
+  queryPipeFullDrops,
+  unexpectedCount,
+  caseMismatchCount,
+  spoofCount,
+  resourceLimits,
+  overCapacityDrops,
+  ipv6queries,
+  chainResends,
+  nsSetInvalidations,
+  ednsPingMatches,
+  ednsPingMismatches,
+  noPingOutQueries,
+  noEdnsOutQueries,
+  packetCacheHits,
+  noPacketError,
+  ignoredCount,
+  emptyQueriesCount,
+  dnssecQueries,
+  dnssecAuthenticDataQueries,
+  dnssecCheckDisabledQueries,
+  variableResponses,
+  maxMThreadStackUsage,
+  dnssecValidations, // should be the sum of all dnssecResult* stats
+  rebalancedQueries,
+  proxyProtocolInvalidCount,
+  nodLookupsDroppedOversize,
+  dns64prefixanswers,
+  maintenanceUsec,
+  maintenanceCalls,
+
+  numberOfCounters
+};
+
+// double avegares times, weighted according to how many packets they processed
+enum class DoubleWAvgCounter : uint8_t
+{
+  avgLatencyUsec,
+  avgLatencyOursUsec,
+  numberOfCounters
+};
+
+// An RCode histogram
+enum class RCode : uint8_t
+{
+  auth,
+  numberOfCounters
+};
+
+// A few other histograms
+enum class Histogram : uint8_t
+{
+  answers,
+  auth4Answers,
+  auth6Answers,
+  ourtime,
+  cumulativeAnswers,
+  cumulativeAuth4Answers,
+  cumulativeAuth6Answers,
+
+  numberOfCounters
+};
+
+struct Counters
+{
+  // An aray of simple counters
+  std::array<uint64_t, static_cast<size_t>(Counter::numberOfCounters)> uint64Count{};
+
+  struct WeightedAverage
+  {
+    double avg{};
+    uint64_t weight{};
+
+    void add(double value)
+    {
+      avg = value;
+      ++weight;
+    }
+
+    void addToRollingAvg(double value, uint64_t rollsize)
+    {
+      add((1.0 - 1.0 / static_cast<double>(rollsize)) * avg + value / static_cast<double>(rollsize));
+    }
+  };
+  // And an array of weighted averaged values
+  std::array<WeightedAverage, static_cast<size_t>(DoubleWAvgCounter::numberOfCounters)> doubleWAvg{};
+
+  struct RCodeCounters
+  {
+    RCodeCounters& operator+=(const RCodeCounters& rhs)
+    {
+      for (size_t i = 0; i < rcodeCounters.size(); i++) {
+        rcodeCounters.at(i) += rhs.rcodeCounters.at(i);
+      }
+      return *this;
+    }
+    static const size_t numberoOfRCodes = 16;
+    std::array<uint64_t, numberoOfRCodes> rcodeCounters;
+  };
+  // An RCodes histogram
+  RCodeCounters auth{};
+
+  std::array<pdns::Histogram, static_cast<size_t>(Histogram::numberOfCounters)> histograms = {
+    pdns::Histogram{"answers", {1000, 10000, 100000, 1000000}},
+    pdns::Histogram{"auth4answers", {1000, 10000, 100000, 1000000}},
+    pdns::Histogram{"auth6answers", {1000, 10000, 100000, 1000000}},
+    pdns::Histogram{"ourtime", {1000, 2000, 4000, 8000, 16000, 32000}},
+    pdns::Histogram{"cumul-clientanswers-", 10, 19},
+    pdns::Histogram{"cumul-authanswers-", 1000, 13},
+    pdns::Histogram{"cumul-authanswers-", 1000, 13}};
+
+  Counters()
+  {
+    for (auto& elem : uint64Count) {
+      elem = 0;
+    }
+    // doubleWAvg has a default ct that initializes
+    for (auto& elem : auth.rcodeCounters) {
+      elem = 0;
+    }
+  }
+
+  // Merge a set of counters into an existing set of counters. For simple counters, that will be additions
+  // for averages, we should take the weights into account. Histograms need to sum all individual counts.
+  Counters& merge(const Counters& data);
+
+  // The following accessors select the rightcounter type based on the index type
+  uint64_t& at(Counter index)
+  {
+    return uint64Count.at(static_cast<size_t>(index));
+  }
+
+  WeightedAverage& at(DoubleWAvgCounter index)
+  {
+    return doubleWAvg.at(static_cast<size_t>(index));
+  }
+
+  RCodeCounters& at(RCode index)
+  {
+    // We only have a single RCode indexed Histogram, so no need to select a specific one
+    return auth;
+  }
+
+  pdns::Histogram& at(Histogram index)
+  {
+    return histograms.at(static_cast<size_t>(index));
+  }
+
+  // Mainly for debugging purposes
+  [[nodiscard]] std::string toString() const;
+};
+
+// The application specific types, one for thread local, one for the aggregator
+using TCounters = pdns::TLocalCounters<Counters>;
+using GlobalCounters = pdns::GlobalCounters<Counters>;
+}

--- a/pdns/recursordist/tcounters.hh
+++ b/pdns/recursordist/tcounters.hh
@@ -1,0 +1,1 @@
+../tcounters.hh

--- a/pdns/recursordist/test-rec-tcounters_cc.cc
+++ b/pdns/recursordist/test-rec-tcounters_cc.cc
@@ -1,0 +1,149 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <boost/test/unit_test.hpp>
+
+#include <unistd.h>
+#include <thread>
+#include "rec-tcounters.hh"
+
+static rec::GlobalCounters global;
+static thread_local rec::TCounters tlocal(global);
+
+BOOST_AUTO_TEST_SUITE(test_rec_tcounters_cc)
+
+BOOST_AUTO_TEST_CASE(destruct)
+{
+  global.reset();
+
+  const size_t count = 100000;
+  std::thread thread1([] {
+    for (size_t i = 0; i < count; i++) {
+      ++tlocal.at(rec::Counter::servFails);
+    }
+  });
+  std::thread thread2([] {
+    for (size_t i = 0; i < count; i++) {
+      ++tlocal.at(rec::Counter::nxDomains);
+    }
+  });
+  thread1.join();
+  thread2.join();
+  BOOST_CHECK_EQUAL(global.sum(rec::Counter::servFails), count);
+  BOOST_CHECK_EQUAL(global.sum(rec::Counter::nxDomains), count);
+}
+
+BOOST_AUTO_TEST_CASE(update_fast)
+{
+  global.reset();
+
+  std::atomic<uint64_t> done{};
+
+  const size_t count = 10000000;
+  std::thread thread1([&done] {
+    for (size_t i = 0; i < count; i++) {
+      ++tlocal.at(rec::Counter::servFails);
+      ++tlocal.at(rec::Counter::nxDomains);
+      tlocal.at(rec::DoubleWAvgCounter::avgLatencyUsec).add(1.1);
+      if (random() % 10000 == 0) {
+        tlocal.updateSnap();
+      }
+    }
+    done++;
+  });
+  std::thread thread2([&done] {
+    for (size_t i = 0; i < count / 2; i++) {
+      ++tlocal.at(rec::Counter::servFails);
+      ++tlocal.at(rec::Counter::nxDomains);
+      tlocal.at(rec::DoubleWAvgCounter::avgLatencyUsec).add(2.2);
+      if (random() % 10000 == 0) {
+        tlocal.updateSnap();
+      }
+    }
+    done++;
+  });
+  std::thread thread3([&done] {
+    while (done < 2) {
+      auto counts = global.aggregatedSnap();
+      BOOST_CHECK_EQUAL(counts.uint64Count[0], counts.uint64Count[1]);
+      auto avg = counts.at(rec::DoubleWAvgCounter::avgLatencyUsec).avg;
+      BOOST_CHECK(avg == 0.0 || (avg >= 1.1 && avg <= 2.2));
+    }
+  });
+  thread1.join();
+  thread2.join();
+  thread3.join();
+  BOOST_CHECK_EQUAL(global.sum(rec::Counter::servFails), count + count / 2);
+  BOOST_CHECK_EQUAL(global.sum(rec::Counter::nxDomains), count + count / 2);
+  auto avg = global.avg(rec::DoubleWAvgCounter::avgLatencyUsec);
+  BOOST_CHECK(avg >= 1.1 && avg <= 2.2);
+}
+
+BOOST_AUTO_TEST_CASE(update_with_sleep)
+{
+
+  global.reset();
+
+  std::atomic<int> done{};
+
+  const size_t count = 1000000;
+  std::thread thread1([&done] {
+    for (size_t i = 0; i < count; i++) {
+      ++tlocal.at(rec::Counter::servFails);
+      ++tlocal.at(rec::Counter::nxDomains);
+      tlocal.at(rec::DoubleWAvgCounter::avgLatencyUsec).add(1.1);
+      if (random() % 10000 == 0) {
+        tlocal.updateSnap();
+      }
+      struct timespec interval
+      {
+        0, random() % 5000
+      };
+      nanosleep(&interval, nullptr);
+    }
+    done++;
+  });
+  std::thread thread2([&done] {
+    for (size_t i = 0; i < count / 2; i++) {
+      ++tlocal.at(rec::Counter::servFails);
+      ++tlocal.at(rec::Counter::nxDomains);
+      tlocal.at(rec::DoubleWAvgCounter::avgLatencyUsec).add(2.2);
+      if (random() % 10000 == 0) {
+        tlocal.updateSnap();
+      }
+      struct timespec interval
+      {
+        0, random() % 999
+      };
+      nanosleep(&interval, nullptr);
+    }
+    done++;
+  });
+  std::thread thread3([&done] {
+    while (done < 2) {
+      auto counts = global.aggregatedSnap();
+      BOOST_CHECK_EQUAL(counts.uint64Count[0], counts.uint64Count[1]);
+      auto avg = counts.at(rec::DoubleWAvgCounter::avgLatencyUsec).avg;
+      // std::cerr << avg << std::endl;
+      BOOST_CHECK(avg == 0.0 || (avg >= 1.1 && avg <= 2.2));
+      struct timespec interval
+      {
+        0, random() % 10000
+      };
+      nanosleep(&interval, nullptr);
+    }
+  });
+  thread1.join();
+  thread2.join();
+  thread3.join();
+  BOOST_CHECK_EQUAL(global.sum(rec::Counter::servFails), count + count / 2);
+  BOOST_CHECK_EQUAL(global.sum(rec::Counter::nxDomains), count + count / 2);
+  auto avg = global.avg(rec::DoubleWAvgCounter::avgLatencyUsec);
+  BOOST_CHECK(avg >= 1.1 && avg <= 2.2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -29,10 +29,6 @@ ArgvMap& arg()
   return theArg;
 }
 
-void primeRootNSZones(DNSSECMode, unsigned int)
-{
-}
-
 BaseLua4::~BaseLua4()
 {
 }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -53,6 +53,7 @@
 #include "tcpiohandler.hh"
 #include "rec-eventtrace.hh"
 #include "logr.hh"
+#include "rec-tcounters.hh"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -458,18 +459,6 @@ public:
 
   static thread_local ThreadLocalStorage t_sstorage;
 
-  static pdns::stat_t s_queries;
-  static pdns::stat_t s_outgoingtimeouts;
-  static pdns::stat_t s_outgoing4timeouts;
-  static pdns::stat_t s_outgoing6timeouts;
-  static pdns::stat_t s_throttledqueries;
-  static pdns::stat_t s_dontqueries;
-  static pdns::stat_t s_qnameminfallbacksuccess;
-  static pdns::stat_t s_authzonequeries;
-  static pdns::stat_t s_outqueries;
-  static pdns::stat_t s_tcpoutqueries;
-  static pdns::stat_t s_dotoutqueries;
-  static pdns::stat_t s_unreachables;
   static pdns::stat_t s_ecsqueries;
   static pdns::stat_t s_ecsresponses;
   static std::map<uint8_t, pdns::stat_t> s_ecsResponsesBySubnetSize4;
@@ -760,79 +749,17 @@ struct PacketIDBirthdayCompare
 };
 extern std::unique_ptr<MemRecursorCache> g_recCache;
 
+extern rec::GlobalCounters g_Counters;
+extern thread_local rec::TCounters t_Counters;
+
 struct RecursorStats
 {
-  pdns::stat_t servFails;
-  pdns::stat_t nxDomains;
-  pdns::stat_t noErrors;
-  pdns::AtomicHistogram answers;
-  pdns::AtomicHistogram auth4Answers;
-  pdns::AtomicHistogram auth6Answers;
-  pdns::AtomicHistogram ourtime;
-  pdns::AtomicHistogram cumulativeAnswers;
-  pdns::AtomicHistogram cumulativeAuth4Answers;
-  pdns::AtomicHistogram cumulativeAuth6Answers;
-  pdns::stat_t_trait<double> avgLatencyUsec;
-  pdns::stat_t_trait<double> avgLatencyOursUsec;
-  pdns::stat_t qcounter;     // not increased for unauth packets
-  pdns::stat_t ipv6qcounter;
-  pdns::stat_t tcpqcounter;
-  pdns::stat_t unauthorizedUDP;  // when this is increased, qcounter isn't
-  pdns::stat_t unauthorizedTCP;  // when this is increased, qcounter isn't
-  pdns::stat_t sourceDisallowedNotify;  // when this is increased, qcounter is also
-  pdns::stat_t zoneDisallowedNotify;  // when this is increased, qcounter is also
-  pdns::stat_t policyDrops;
-  pdns::stat_t tcpClientOverflow;
-  pdns::stat_t clientParseError;
-  pdns::stat_t serverParseError;
-  pdns::stat_t tooOldDrops;
-  pdns::stat_t truncatedDrops;
-  pdns::stat_t queryPipeFullDrops;
-  pdns::stat_t unexpectedCount;
-  pdns::stat_t caseMismatchCount;
-  pdns::stat_t spoofCount;
-  pdns::stat_t resourceLimits;
-  pdns::stat_t overCapacityDrops;
-  pdns::stat_t ipv6queries;
-  pdns::stat_t chainResends;
-  pdns::stat_t nsSetInvalidations;
-  pdns::stat_t ednsPingMatches;
-  pdns::stat_t ednsPingMismatches;
-  pdns::stat_t noPingOutQueries, noEdnsOutQueries;
-  pdns::stat_t packetCacheHits;
-  pdns::stat_t noPacketError;
-  pdns::stat_t ignoredCount;
-  pdns::stat_t emptyQueriesCount;
   time_t startupTime{time(nullptr)};
-  pdns::stat_t dnssecQueries;
-  pdns::stat_t dnssecAuthenticDataQueries;
-  pdns::stat_t dnssecCheckDisabledQueries;
-  pdns::stat_t variableResponses;
-  pdns::stat_t maxMThreadStackUsage;
-  pdns::stat_t dnssecValidations; // should be the sum of all dnssecResult* stats
+  // XXX Convert counter below to be part of rec::Counters
   std::map<vState, pdns::stat_t > dnssecResults;
   std::map<vState, pdns::stat_t > xdnssecResults;
   std::map<DNSFilterEngine::PolicyKind, pdns::stat_t > policyResults;
   LockGuarded<std::unordered_map<std::string, pdns::stat_t>> policyHits;
-  pdns::stat_t rebalancedQueries{0};
-  pdns::stat_t proxyProtocolInvalidCount{0};
-  pdns::stat_t nodLookupsDroppedOversize{0};
-  pdns::stat_t dns64prefixanswers{0};
-  pdns::stat_t maintenanceUsec{0};
-  pdns::stat_t maintenanceCalls{0};
-  std::array<pdns::stat_t, 16> authRCode;
-
-  RecursorStats() :
-    answers("answers", { 1000, 10000, 100000, 1000000 }),
-    auth4Answers("auth4answers", { 1000, 10000, 100000, 1000000 }),
-    auth6Answers("auth6answers", { 1000, 10000, 100000, 1000000 }),
-    ourtime("ourtime", { 1000, 2000, 4000, 8000, 16000, 32000 }),
-    cumulativeAnswers("cumul-clientanswers-", 10, 19),
-    // These two will be merged when outputting
-    cumulativeAuth4Answers("cumul-authanswers-", 1000, 13),
-    cumulativeAuth6Answers("cumul-authanswers-", 1000, 13)
-  {
-  }
 };
 
 //! represents a running TCP/IP client session

--- a/pdns/tcounters.hh
+++ b/pdns/tcounters.hh
@@ -66,7 +66,7 @@ namespace pdns
 // thread T2 that increments "processed", it may happen that the value
 // of "processed" observed by sum() is higher than "received", as T1
 // might not have called updateSnap() yet while T2 did.  To avoid this
-// inconsistentcy, be careful to update related counters in a single
+// inconsistency, be careful to update related counters in a single
 // thread only.
 
 // For an example of the use of these templates, see rec-tcounters.hh

--- a/pdns/tcounters.hh
+++ b/pdns/tcounters.hh
@@ -33,13 +33,13 @@ namespace pdns
 {
 // We keep three sets of related counters:
 //
-// 1. The current counters (thread-local, updated individually by thread code very often)
+// 1. The current counters (thread local, updated individually by thread code very often)
 // 2. The snapshot counters (thread local, updated by thread code in one single mutex protected copy)
 // 3. The history counters (global) to keep track of the counters of deleted threads
 
-// We have two main clasess: one that holds the thread local counters
+// We have two main classes: one that holds the thread local counters
 // (both current and snapshot ones) and one that aggregates the
-// values for all threads adn keeps the history counters.
+// values for all threads and keeps the history counters.
 
 // The thread local current counters are the ones updated by
 // performance critical code.  Every once in a while, all values in the
@@ -53,7 +53,7 @@ namespace pdns
 // in a while. This will fill the snapshot values for that thread if some
 // time has passed since the last snap update.
 
-// To fet aggregate value call globals.sum(counter1) or
+// To fetch aggregate values, call globals.sum(counter1) or
 // globals.avg(counter2), or any aggreggation function.  If multiple
 // counters need to be collected in a consistent way:
 // auto data = globals.aggregatedSnap();

--- a/pdns/tcounters.hh
+++ b/pdns/tcounters.hh
@@ -1,0 +1,260 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <sys/time.h>
+#include <array>
+#include <set>
+#include <unistd.h>
+
+#include "lock.hh"
+
+namespace pdns
+{
+// We keep three sets of related counters:
+//
+// 1. The current counters (thread-local, updated individually by thread code very often)
+// 2. The snapshot counters (thread local, updated by thread code in one single mutex protected copy)
+// 3. The history counters (global) to keep track of the counters of deleted threads
+
+// We have two main clasess: one that holds the thread local counters
+// (both current and snapshot ones) and one that aggregates the
+// values for all threads adn keeps the history counters.
+
+// The thread local current counters are the ones updated by
+// performance critical code.  Every once in a while, all values in the
+// current counters are copied to the snapshot thread local copies in
+// a thread safe way.
+
+// The snapshot counters are aggregated by the GlobalCounters
+// class, as these can be accessed safely from multiple threads.
+
+// Make sure to call the thread local tlocal.updatesAtomics() once
+// in a while. This will fill the snapshot values for that thread if some
+// time has passed since the last snap update.
+
+// To fet aggregate value call globals.sum(counter1) or
+// globals.avg(counter2), or any aggreggation function.  If multiple
+// counters need to be collected in a consistent way:
+// auto data = globals.aggregatedSnap();
+//
+// Note that the aggregate values can mix somewhat older thread-local
+// with newer thread-local info from another thread. So it is possible
+// to see the following:
+//
+// If thread T1 increments "received" and then passes the packet to
+// thread T2 that increments "processed", it may happen that the value
+// of "processed" observed by sum() is higher than "received", as T1
+// might not have called updateSnap() yet while T2 did.  To avoid this
+// inconsistentcy, be careful to update related counters in a single
+// thread only.
+
+// For an example of the use of these templates, see rec-tcounters.hh
+
+template <typename Counters>
+class TLocalCounters;
+
+template <typename Counters>
+class GlobalCounters
+{
+public:
+  // Register a thread local set of values
+  void subscribe(TLocalCounters<Counters>* ptr)
+  {
+    auto lock = d_guarded.lock();
+    lock->d_instances.emplace(ptr);
+  }
+
+  // Unregister, typically done when a thread exits
+  void unsubscribe(TLocalCounters<Counters>* ptr, const Counters& data)
+  {
+    auto lock = d_guarded.lock();
+    lock->d_instances.erase(ptr);
+    lock->d_history.merge(data);
+  }
+
+  // Two ways of computing aggregated values for a specific counter: simple additions of all thread data, or taking weighted averages into account
+  template <typename Enum>
+  auto sum(Enum index);
+  template <typename Enum>
+  auto avg(Enum index);
+  template <typename Enum>
+  auto max(Enum index);
+
+  // Aggregate all counter data for all threads
+  Counters aggregatedSnap();
+
+  // Reset history
+  void reset()
+  {
+    auto lock = d_guarded.lock();
+    lock->d_history = Counters();
+  }
+
+private:
+  struct Guarded
+  {
+    // We have x instances, normally one per thread
+    std::set<TLocalCounters<Counters>*> d_instances;
+    // If an instance gets deleted because its thread is cleaned up, the values
+    // are accumulated in d_history
+    Counters d_history;
+  };
+  LockGuarded<Guarded> d_guarded;
+};
+
+template <typename Counters>
+class TLocalCounters
+{
+public:
+  static const suseconds_t defaultSnapUpdatePeriodus = 100000;
+  TLocalCounters(GlobalCounters<Counters>& collector, timeval interval = timeval{0, defaultSnapUpdatePeriodus}) :
+    d_collector(collector), d_interval(interval)
+  {
+    collector.subscribe(this);
+  }
+
+  ~TLocalCounters()
+  {
+    d_collector.unsubscribe(this, d_current);
+  }
+
+  TLocalCounters(const TLocalCounters&) = delete;
+  TLocalCounters(TLocalCounters&&) = delete;
+  TLocalCounters& operator=(const TLocalCounters&) = delete;
+  TLocalCounters& operator=(TLocalCounters&&) = delete;
+
+  template <typename Enum>
+  auto& at(Enum index)
+  {
+    return d_current.at(index);
+  }
+
+  template <typename Enum>
+  auto snapAt(Enum index)
+  {
+    return d_snapshot.lock()->at(index);
+  }
+
+  [[nodiscard]] Counters getSnap()
+  {
+    return *(d_snapshot.lock());
+  }
+
+  bool updateSnap(const timeval& tv_now, bool force = false)
+  {
+    timeval tv_diff{};
+
+    if (!force) {
+      timersub(&tv_now, &d_last, &tv_diff);
+    }
+    if (force || timercmp(&tv_diff, &d_interval, >=)) {
+      // It's a copy
+      *(d_snapshot.lock()) = d_current;
+      d_last = tv_now;
+      return true;
+    }
+    return false;
+  }
+
+  bool updateSnap(bool force = false)
+  {
+    timeval tv_now{};
+
+    if (!force) {
+      gettimeofday(&tv_now, nullptr);
+    }
+    return updateSnap(tv_now, force);
+  }
+
+private:
+  GlobalCounters<Counters>& d_collector;
+  Counters d_current;
+  LockGuarded<Counters> d_snapshot;
+  timeval d_last{0, 0};
+  const timeval d_interval;
+};
+
+// Sum for a specific index
+// In the future we might the move the specifics of computing an aggregated value to the
+// app specific Counters class
+template <typename Counters>
+template <typename Enum>
+auto GlobalCounters<Counters>::sum(Enum index)
+{
+  auto lock = d_guarded.lock();
+  auto sum = lock->d_history.at(index);
+  for (const auto& instance : lock->d_instances) {
+    sum += instance->snapAt(index);
+  }
+  return sum;
+}
+
+// Average for a specific index
+// In the future we might the move the specifics of computing an aggregated value to the
+// app specific Counters class
+template <typename Counters>
+template <typename Enum>
+auto GlobalCounters<Counters>::avg(Enum index)
+{
+  auto lock = d_guarded.lock();
+  auto wavg = lock->d_history.at(index);
+  auto sum = wavg.avg * wavg.weight;
+  auto count = wavg.weight;
+  for (const auto& instance : lock->d_instances) {
+    auto val = instance->snapAt(index);
+    count += val.weight;
+    sum += val.avg * val.weight;
+  }
+  return count > 0 ? sum / count : 0;
+}
+
+// Max for a specific  index
+// In the future we might the move the specifics of computing an aggregated value to the
+// app specific Counters class
+template <typename Counters>
+template <typename Enum>
+auto GlobalCounters<Counters>::max(Enum index)
+{
+  auto lock = d_guarded.lock();
+  uint64_t max = 0; // ignore history
+  for (const auto& instance : lock->d_instances) {
+    max = std::max(instance->snapAt(index), max);
+  }
+  return max;
+}
+
+// Get a consistent snap of *all* aggregated values
+template <typename Counters>
+Counters GlobalCounters<Counters>::aggregatedSnap()
+{
+  auto lock = d_guarded.lock();
+  Counters ret = lock->d_history;
+  for (const auto& instance : lock->d_instances) {
+    auto snap = instance->getSnap();
+    ret.merge(snap);
+  }
+  return ret;
+}
+
+}

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -455,8 +455,6 @@ static void prometheusMetrics(HttpRequest* req, HttpResponse* resp)
   if (req->method != "GET")
     throw HttpMethodNotAllowedException();
 
-  registerAllStats();
-
   std::ostringstream output;
 
   // Argument controls disabling of any stats. So
@@ -1194,8 +1192,6 @@ static void validatePrometheusMetrics()
 
 RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
 {
-  registerAllStats();
-
 #if CHECK_PROMETHEUS_METRICS
   validatePrometheusMetrics();
 #endif

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -39,7 +39,6 @@ class RecursorTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
     _confdir = 'recursor'
 
-    _recursorStartupDelay = 2.0
     _recursorPort = 5300
 
     _recursor = None
@@ -649,11 +648,11 @@ distributor-threads={threads}""".format(confdir=confdir,
             raise AssertionError('%s failed (%d)' % (recursorcmd, cls._recursor.returncode))
 
     @classmethod
-    def wipeRecursorCache(cls, confdir):
+    def wipeRecursorCache(cls, confdir, name='.$'):
         rec_controlCmd = [os.environ['RECCONTROL'],
                           '--config-dir=%s' % confdir,
                           'wipe-cache',
-                          '.$']
+                          name]
         try:
             subprocess.check_output(rec_controlCmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:

--- a/regression-tests.recursor-dnssec/test_RootNXTrust.py
+++ b/regression-tests.recursor-dnssec/test_RootNXTrust.py
@@ -46,6 +46,7 @@ webserver-port=%d
 webserver-address=127.0.0.1
 webserver-password=%s
 api-key=%s
+devonly-regression-test-mode
 """ % (_wsPort, _wsPassword, _apiKey)
 
     def testRootNXTrust(self):
@@ -94,6 +95,7 @@ webserver-port=%d
 webserver-address=127.0.0.1
 webserver-password=%s
 api-key=%s
+devonly-regression-test-mode
 """ % (_wsPort, _wsPassword, _apiKey)
 
     def testRootNXTrust(self):

--- a/regression-tests.recursor-dnssec/test_SimpleDoT.py
+++ b/regression-tests.recursor-dnssec/test_SimpleDoT.py
@@ -12,6 +12,7 @@ class testSimpleDoT(RecursorTest):
     _config_template = """
 dnssec=validate
 dot-to-auth-names=powerdns.com
+devonly-regression-test-mode
     """
 
     _roothints = None

--- a/regression-tests.recursor-dnssec/test_SimpleForwardOverDoT.py
+++ b/regression-tests.recursor-dnssec/test_SimpleForwardOverDoT.py
@@ -12,6 +12,7 @@ class testSimpleForwardOverDoT(RecursorTest):
     _config_template = """
 dnssec=validate
 forward-zones-recurse=.=9.9.9.9:853
+devonly-regression-test-mode
     """
 
     @classmethod


### PR DESCRIPTION
This is a mostly lockless (and not using atomics) way to keep track of counters and other metrics.

Atomic value are more expensive than you would think (especially if your platform has no native atomic support for your data type), and using locking all the time for often updated counters is very expensive as well.

The idea for `TCounters` is based on

https://github.com/ahupowerdns/mcounter

But addresses the issues raised in
https://github.com/ahupowerdns/mcounter/issues/3

Templates are used, the application has to provide a specific class to hold the values and enums to index these values.  The application specific class also has to provide a `merge()` method to merge two instances of the application specific data.  For counters that is simple: just add them. Averages (or histograms) requires a bit more work. This is demonstrated in `rec-tcounters.{cc,hh}`

From `tcounters.hh`:
```
// We keep three sets of related counters:
//
// 1. The current counters (thread-local, updated individually by thread code very often)
// 2. The snapshot counters (thread local, updated by thread code in one single mutex protected copy)
// 3. The history counters (global) to keep track of the counters of deleted threads

// We have two main clasess: one that holds the thread local counters
// (both current and snapshot ones) and one that aggregates the
// values for all threads adn keeps the history counters.

// The thread local current counters are the ones updated by
// performance critical code.  Every once in a while, all values in the
// current counters are copied to the snapshot thread local copies in
// a thread safe way.

// The snapshot counters are aggregated by the GlobalCounters
// class, as these can be accessed safely from multiple threads.

// Make sure to call the thread local tlocal.updatesAtomics() once
// in a while. This will fill the snapshot values for that thread if some
// time has passed since the last snap update.

// To fet aggregate value call globals.sum(counter1) or
// globals.avg(counter2), or any aggreggation function.  If multiple
// counters need to be collected in a consistent way:
// auto data = globals.aggregatedSnap();
//
// Note that the aggregate values can mix somewhat older thread-local
// with newer thread-local info from another thread. So it is possible
// to see the following:
//
// If thread T1 increments "received" and then passes the packet to
// thread T2 that increments "processed", it may happen that the value
// of "processed" observed by sum() is higher than "received", as T1
// might not have called updateSnap() yet while T2 did.  To avoid this
// inconsistentcy, be careful to update related counters in a single
// thread only.
```
The snapshot approach was suggested by @wojas.

This PR de demonstrates `TCounters` for a most Recursor metrics: simple counters and double typed average values. For the latter weights are kept, so that the average of averages can be computed in a proper way. Also hostograms in two variaties are done.

To work around timing specific issue in the regression tests (which in some cases read metrics) a flag has been introduced that forces snaps and avoids the root refresh to run. The latter increase outgoing queries that break some of the test that inspect the related outgoing metrics.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
