### PR TITLE
rec: Backport 12194 to rec-4.8.x: Fix typo in structured logging key

### DIFF
--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -555,7 +555,7 @@ void WebServer::bind()
   try {
     d_server = createServer();
     SLOG(g_log<<Logger::Warning<<d_logprefix<<"Listening for HTTP requests on "<<d_server->d_local.toStringWithPort()<<endl,
-         d_slog->info(Logr::Info, "Listening for HTTP requests", "addres", Logging::Loggable(d_server->d_local)));
+         d_slog->info(Logr::Info, "Listening for HTTP requests", "address", Logging::Loggable(d_server->d_local)));
   }
   catch(NetworkError &e) {
     SLOG(g_log<<Logger::Error<<d_logprefix<<"Listening on HTTP socket failed: "<<e.what()<<endl,


### PR DESCRIPTION
(cherry picked from commit 68dbf30cebc92d29853314b1160257a9dbc5f4f1)

Backport of #12194 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
