### PR TITLE
Clear systemd-units dependency 

### DIFF
--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -10,10 +10,9 @@ License: GPLv2
 URL: https://powerdns.com
 Source0: %{name}-%{getenv:BUILDER_VERSION}.tar.bz2
 
-Requires(post): systemd-sysv
-Requires(post): systemd-units
-Requires(preun): systemd-units
-Requires(postun): systemd-units
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
 BuildRequires: systemd
 BuildRequires: systemd-units
 BuildRequires: systemd-devel


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>

### Short description
Allows the EL package to be installed on openSUSE / SLE without errors. Currently the following is printed:

```
# zypper in pdns                                                                                                         
Loading repository data...                                                                                                               
Reading installed packages...                                                                                                            
Resolving package dependencies...                                                                                                                                                                                                                                                 
Problem: nothing provides 'systemd-units' needed by the to be installed pdns-4.7.2-1pdns.el8.x86_64                                      
 Solution 1: do not install pdns-4.7.2-1pdns.el8.x86_64                                                                                  
 Solution 2: break pdns-4.7.2-1pdns.el8.x86_64 by ignoring some of its dependencies                                                      
                                                                                                                                         
Choose from above solutions by number or cancel [1/2/c/d/?] (c): 2
```

The dependency can safely be skipped, as the %post macros are already present on modern SUSE based distributions:

```
$ rpm -E '%systemd_post'
:
if [ -x /usr/bin/systemctl ]; then
        for service in  ; do
                if [ -e "/run/systemd/rpm/needs-preset/$service" ]; then
                        /usr/bin/systemctl preset "$service" || :
                        rm "/run/systemd/rpm/needs-preset/$service" || :
                fi
        done
fi
```

In fact, simply choosing the option to "break pdns", will install and run the service just fine.

Whilst the package is of course designed for RHEL and users should preferably use the SUSE distribution package for `pdns`, I think this patch is small enough to better support the edge case of someone preferring the upstream package.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
