### PR TITLE
Ensure that 'Consumer' zones do not get API-synthesized SOA records

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1764,7 +1764,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     autorr.auth = true;
     autorr.ttl = ::arg().asNum("default-ttl");
 
-    if (!have_soa && zonekind != DomainInfo::Slave) {
+    if (!have_soa && zonekind != DomainInfo::Slave && zonekind != DomainInfo::Consumer) {
       // synthesize a SOA record so the zone "really" exists
       string soa = ::arg()["default-soa-content"];
       boost::replace_all(soa, "@", zonename.toStringNoDot());


### PR DESCRIPTION
### Short description
When a 'Consumer' zone is created via the API, it should get the same treatment as a 'Slave' zone, since it is also a 'secondary' zone kind.

Closes #12205.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master (#12212 includes this fix for master)
