### PR TITLE
dnsdist: regress speedup

### DIFF
--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -72,6 +72,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     _backgroundThreads = {}
     _UDPResponder = None
     _TCPResponder = None
+    _extraStartupSleep = 0
 
     @classmethod
     def waitForTCPSocket(cls, ipaddress, port):
@@ -148,6 +149,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                 print(fdLog.read())
             print(f"*** End startDNSDist log for {logFile} ***")
             raise AssertionError('%s failed (%d)' % (dnsdistcmd, cls._dnsdist.returncode))
+        time.sleep(cls._extraStartupSleep)
 
     @classmethod
     def setUpSockets(cls):

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -849,6 +849,7 @@ class TestCachingHashingCookies(DNSDistTest):
 
 class TestTempFailureCacheTTLAction(DNSDistTest):
 
+    _extraStartupSleep = 1
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -71,6 +71,17 @@ class TestCarbon(DNSDistTest):
         cls._CarbonResponder2.setDaemon(True)
         cls._CarbonResponder2.start()
 
+    @classmethod
+    def setUpClass(cls):
+
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+        time.sleep(1)
+
+        print("Launching tests..")
+
+
     def testCarbon(self):
         """
         Carbon: send data to 2 carbon servers

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -7,6 +7,7 @@ from dnsdisttests import DNSDistTest, Queue
 
 class TestCarbon(DNSDistTest):
 
+    _extraStartupSleep = 2
     _carbonServer1Port = 8000
     _carbonServer1Name = "carbonname1"
     _carbonServer2Port = 8001
@@ -71,17 +72,6 @@ class TestCarbon(DNSDistTest):
         cls._CarbonResponder2.setDaemon(True)
         cls._CarbonResponder2.start()
 
-    @classmethod
-    def setUpClass(cls):
-
-        cls.startResponders()
-        cls.startDNSDist()
-        cls.setUpSockets()
-        time.sleep(1)
-
-        print("Launching tests..")
-
-
     def testCarbon(self):
         """
         Carbon: send data to 2 carbon servers
@@ -102,6 +92,7 @@ class TestCarbon(DNSDistTest):
         self.assertTrue(len(data1.splitlines()) > 1)
         expectedStart = b"dnsdist.%s.main." % self._carbonServer1Name.encode('UTF-8')
         for line in data1.splitlines():
+            print(line, file=sys.stderr)
             self.assertTrue(line.startswith(expectedStart))
             parts = line.split(b' ')
             self.assertEqual(len(parts), 3)
@@ -113,6 +104,7 @@ class TestCarbon(DNSDistTest):
         self.assertTrue(len(data2.splitlines()) > 1)
         expectedStart = b"dnsdist.%s.main." % self._carbonServer2Name.encode('UTF-8')
         for line in data2.splitlines():
+            print(line, file=sys.stderr)
             self.assertTrue(line.startswith(expectedStart))
             parts = line.split(b' ')
             self.assertEqual(len(parts), 3)

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -7,7 +7,6 @@ from dnsdisttests import DNSDistTest, Queue
 
 class TestCarbon(DNSDistTest):
 
-    _extraStartupSleep = 2
     _carbonServer1Port = 8000
     _carbonServer1Name = "carbonname1"
     _carbonServer2Port = 8001
@@ -72,6 +71,13 @@ class TestCarbon(DNSDistTest):
         cls._CarbonResponder2.setDaemon(True)
         cls._CarbonResponder2.start()
 
+    def isfloat(self, num):
+        try:
+            float(num)
+            return True
+        except ValueError:
+            return False
+
     def testCarbon(self):
         """
         Carbon: send data to 2 carbon servers
@@ -92,11 +98,10 @@ class TestCarbon(DNSDistTest):
         self.assertTrue(len(data1.splitlines()) > 1)
         expectedStart = b"dnsdist.%s.main." % self._carbonServer1Name.encode('UTF-8')
         for line in data1.splitlines():
-            print(line, file=sys.stderr)
             self.assertTrue(line.startswith(expectedStart))
             parts = line.split(b' ')
             self.assertEqual(len(parts), 3)
-            self.assertTrue(parts[1].isdigit())
+            self.assertTrue(self.isfloat(parts[1]))
             self.assertTrue(parts[2].isdigit())
             self.assertTrue(int(parts[2]) <= int(after))
 
@@ -104,11 +109,10 @@ class TestCarbon(DNSDistTest):
         self.assertTrue(len(data2.splitlines()) > 1)
         expectedStart = b"dnsdist.%s.main." % self._carbonServer2Name.encode('UTF-8')
         for line in data2.splitlines():
-            print(line, file=sys.stderr)
             self.assertTrue(line.startswith(expectedStart))
             parts = line.split(b' ')
             self.assertEqual(len(parts), 3)
-            self.assertTrue(parts[1].isdigit())
+            self.assertTrue(self.isfloat(parts[1]))
             self.assertTrue(parts[2].isdigit())
             self.assertTrue(int(parts[2]) <= int(after))
 

--- a/regression-tests.dnsdist/test_HealthChecks.py
+++ b/regression-tests.dnsdist/test_HealthChecks.py
@@ -183,6 +183,7 @@ _dotHealthCheckQueries = 0
 _dohHealthCheckQueries = 0
 
 class TestLazyHealthChecks(HealthCheckTest):
+    _extraStartupSleep = 1
     _do53Port = 10700
     _dotPort = 10701
     _dohPort = 10702

--- a/regression-tests.dnsdist/test_Responses.py
+++ b/regression-tests.dnsdist/test_Responses.py
@@ -55,6 +55,7 @@ class TestResponseRuleNXDelayed(DNSDistTest):
 
 class TestResponseRuleERCode(DNSDistTest):
 
+    _extraStartupSleep = 1
     _config_template = """
     newServer{address="127.0.0.1:%s"}
     addResponseAction(ERCodeRule(DNSRCode.BADVERS), DelayResponseAction(1000))

--- a/regression-tests.dnsdist/test_SNMP.py
+++ b/regression-tests.dnsdist/test_SNMP.py
@@ -6,7 +6,8 @@ from pysnmp.hlapi import *
 from dnsdisttests import DNSDistTest
 
 class TestSNMP(DNSDistTest):
-
+    # wait 1s so that the uptime is > 0
+    _extraStartupSleep = 1
     _snmpTimeout = 2.0
     _snmpServer = '127.0.0.1'
     _snmpPort = 161
@@ -98,8 +99,6 @@ class TestSNMP(DNSDistTest):
         return results
 
     def _checkStats(self, auth, name):
-        # wait 1s so that the uptime is > 0
-        time.sleep(1)
 
         results = self._getSNMPStats(auth)
         self._checkStatsValues(results, self.__class__._queriesSent)

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -10,16 +10,6 @@ from dnsdisttests import DNSDistTest
 
 class TLSTests(object):
 
-    @classmethod
-    def setUpClass(cls):
-
-        cls.startResponders()
-        cls.startDNSDist()
-        cls.setUpSockets()
-        time.sleep(1)
-
-        print("Launching tests..")
-
     def getServerCertificate(self):
         conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
         cert = conn.getpeercert()
@@ -275,6 +265,7 @@ class TLSTests(object):
 
 class TestOpenSSL(DNSDistTest, TLSTests):
 
+    _extraStartupSleep = 1
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
     _serverKey = 'server.key'

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -10,6 +10,16 @@ from dnsdisttests import DNSDistTest
 
 class TLSTests(object):
 
+    @classmethod
+    def setUpClass(cls):
+
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+        time.sleep(1)
+
+        print("Launching tests..")
+
     def getServerCertificate(self):
         conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
         cert = conn.getpeercert()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

1. On dnsdist startup, we poll the listening address and assume dnsdist is ready if a TCP connection can be established.
2. On teardown we have a better and tighter loop to poll process exit status.

Both 1 and 2 were taken from the recursor regression test framework.

A typical test run now is 16min instead of 26min.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
