### PR TITLE
recL Backport to rec-4.8.x: Infra queries should not use refresh mode

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2073,9 +2073,6 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   if (d_serveStale) {
     flags |= MemRecursorCache::ServeStale;
   }
-  if (d_refresh) {
-    flags |= MemRecursorCache::Refresh;
-  }
   try {
     // First look for both A and AAAA in the cache
     res_t cset;
@@ -2222,9 +2219,6 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType qtype, vector
   MemRecursorCache::Flags flags = MemRecursorCache::None;
   if (d_serveStale) {
     flags |= MemRecursorCache::ServeStale;
-  }
-  if (d_refresh) {
-    flags |= MemRecursorCache::Refresh;
   }
   do {
     if (cutOffDomain && (subdomain == *cutOffDomain || !subdomain.isPartOf(*cutOffDomain))) {


### PR DESCRIPTION
When I introduced serve state in #11776, I reintroduced the mistake previously fixed in #11376. Fixes #12078

(cherry picked from commit 28a3eea55d15d33a65b2108c1598c15d00e0173c)

Backport of  #12219

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
