### PR TITLE
rec: Backport 12198 to rec-4.5.x: Correct skip record condition in processRecords.

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -3589,7 +3589,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
   bool referralOnDS = false;
 
   for (auto& rec : lwr.d_records) {
-    if (rec.d_type != QType::OPT && rec.d_class != QClass::IN) {
+    if (rec.d_type == QType::OPT || rec.d_class != QClass::IN) {
       continue;
     }
 


### PR DESCRIPTION
Noted the other day by @rgacogne

(cherry picked from commit d1321ff57909f8fb9d0bd7a20e3c4eb85a6b76e1)

Backport of #12198 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
