### PR TITLE
Restrict permissions for GITHUB_TOKEN in our workflows

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 22 * * 3'
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   build-auth:
     name: build auth

--- a/.github/workflows/builder-dispatch.yml
+++ b/.github/workflows/builder-dispatch.yml
@@ -34,6 +34,9 @@ on:
         - 'NO'
         - 'YES'
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   prepare:
     name: generate OS list

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 1 * * *'
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   build:
     name: build.sh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,10 +6,18 @@ on:
   schedule:
     - cron: '0 22 * * 2'
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-20.04
+
+    permissions:
+      actions: read # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   build:
     name: docker build

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -5,6 +5,9 @@ on:
   push:
   pull_request:
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   build:
     name: verify formatting and Makefile.am sort order

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,5 +1,9 @@
 name: CIFuzz
 on: [pull_request]
+
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-20.04

--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '34 4 * * *'
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   el7-devtoolset:
     runs-on: ubuntu-22.04

--- a/.github/workflows/secpoll.yml
+++ b/.github/workflows/secpoll.yml
@@ -5,6 +5,9 @@ on:
   push:
   pull_request:
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   build:
     name: check secpoll zone

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ''
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
 jobs:
   placeholder:
     name: Should be disabled


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Added using https://github.com/step-security/secure-workflows For more information see:
- https://github.com/ossf/scorecard/blob/d8fefc9b246db3600c777e9d60d441d7c386ce1d/docs/checks.md#token-permissions
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
- 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

