### PR TITLE
auth: fix invalid catalog zone sql query for gpgsqlbackend

### DIFF
--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -140,7 +140,7 @@ public:
     declare(suffix, "update-serial-query", "", "update domains set notified_serial=$1 where id=$2");
     declare(suffix, "update-lastcheck-query", "", "update domains set last_check=$1 where id=$2");
     declare(suffix, "info-all-master-query", "", "select domains.id, domains.name, domains.type, domains.notified_serial, domains.options, domains.catalog, records.content from records join domains on records.domain_id=domains.id and records.name=domains.name where records.type='SOA' and records.disabled=false and domains.type in ('MASTER', 'PRODUCER')");
-    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type='MASTER' and domains.catalog=$1 and records.type='SOA' and records.disabled=0");
+    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type='MASTER' and domains.catalog=$1 and records.type='SOA' and records.disabled=false");
     declare(suffix, "info-consumer-members-query", "", "select id, name, options, master from domains where type='SLAVE' and catalog=$1");
     declare(suffix, "delete-domain-query", "", "delete from domains where name=$1");
     declare(suffix, "delete-zone-query", "", "delete from records where domain_id=$1");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
I tried to setup a catalog zone but it didn't work. I use PostgreSQL as a backend. The following error was logged repeatedly. PostgreSQL doesn't convert integers (0 in this case) to a boolean. I replaced 0 with false to get a valid SQL statement. I tested the SQL statement itself via psql and it worked, but I did not compile PowerDNS.

```
Oct 23 14:19:17 ns1.example.com pdns_server[924]: AXFR-out zone 'catalog.example.com', client '2001:abcd:99:ef::2a0:1', transfer initiated
Oct 23 14:19:17 ns1.example.com pdns_server[924]: TCP server is without backend connections in doAXFR, launching
Oct 23 14:19:17 ns1.example.com pdns_server[924]: TCP nameserver had error, cycling backend: virtual bool GSQLBackend::getCatalogMembers(const DNSName&, std::vector<CatalogInfo>&, CatalogInfo::CatalogType) unable to retrieve list of member zones: Fatal error during prePQpreparepare: select domains.id, domains.name, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type='MASTER' and domains.catalog=$1 and records.type='SOA' and records.disabled=0: ERROR:  operator does not exist: boolean = integer
Oct 23 14:19:17 ns1.example.com pdns_server[924]: LINE 1: ...ins.catalog=$1 and records.type='SOA' and records.disabled=0
Oct 23 14:19:17 ns1.example.com pdns_server[924]:                                                                      ^
Oct 23 14:19:17 ns1.example.com pdns_server[924]: HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
