### PR TITLE
dnsdist: Add logs to investigate the SNMP regression tests failure

### DIFF
--- a/regression-tests.dnsdist/test_SNMP.py
+++ b/regression-tests.dnsdist/test_SNMP.py
@@ -20,7 +20,9 @@ class TestSNMP(DNSDistTest):
     _config_template = """
     newServer{address="127.0.0.1:%s", name="servername"}
     snmpAgent(true)
+    setVerboseHealthChecks(true)
     """
+    _verboseMode = True
 
     def _checkStatsValues(self, results, queriesCountersValue):
         for i in list(range(1, 5)) + list(range(6, 20)) + list(range(24, 35)) + [ 35 ] :


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since https://github.com/PowerDNS/pdns/pull/12214 I'm seeing regular failures of the SNMP regression tests on our CI:
```
2022-11-29T11:39:46.6902570Z === configs/dnsdist_TestSNMP.log ===
2022-11-29T11:39:46.6921953Z Added downstream server 127.0.0.1:5350
2022-11-29T11:39:46.6922191Z unknown snmp version 193
2022-11-29T11:39:46.6922516Z NET-SNMP version 5.8 AgentX subagent connected
2022-11-29T11:39:46.6922670Z Listening on 127.0.0.1:5340
2022-11-29T11:39:46.6923124Z dnsdist 0.0.0-git1 comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it according to the terms of the GPL version 2
2022-11-29T11:39:46.6923289Z ACL allowing queries from: 127.0.0.1/32
2022-11-29T11:39:46.6923648Z Console ACL allowing connections from: 127.0.0.0/8, ::1/128
2022-11-29T11:39:46.6924008Z Marking downstream servername (127.0.0.1:5350) as 'up'
2022-11-29T11:39:46.6924346Z Marking downstream servername (127.0.0.1:5350) as 'down'
2022-11-29T11:39:46.6924626Z Marking downstream servername (127.0.0.1:5350) as 'up'
2022-11-29T11:39:46.6924784Z Exiting on user request
```

I have not been able to reproduce that locally, so I'm opening this PR to investigate.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

