### PR TITLE
dnsdist: Reduce useless wake-ups from the event loop

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -1526,7 +1526,7 @@ void tcpAcceptorThread(std::vector<ClientState*> states)
 
     struct timeval tv;
     while (true) {
-      mplexer->run(&tv);
+      mplexer->run(&tv, -1);
     }
   }
 }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1818,7 +1818,7 @@ static void udpClientThread(std::vector<ClientState*> states)
 
         struct timeval tv;
         while (true) {
-          mplexer->run(&tv);
+          mplexer->run(&tv, -1);
         }
       }
     }

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -377,6 +377,10 @@ void DownstreamState::reportTimeoutOrError()
 
 void DownstreamState::handleUDPTimeouts()
 {
+  if (getProtocol() != dnsdist::Protocol::DoUDP) {
+    return;
+  }
+
   if (s_randomizeIDs) {
     auto map = d_idStatesMap.lock();
     for (auto it = map->begin(); it != map->end(); ) {

--- a/pdns/dnsdistdist/dnsdist-lua-network.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-network.cc
@@ -134,7 +134,7 @@ void NetworkListener::mainThread()
   struct timeval now;
 
   while (true) {
-    runOnce(now, 5000);
+    runOnce(now, -1);
   }
 }
 

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -909,7 +909,7 @@ static void dohClientThread(int crossProtocolPipeFD)
     time_t lastTimeoutScan = now.tv_sec;
 
     for (;;) {
-      data.mplexer->run(&now);
+      data.mplexer->run(&now, 1000);
 
       if (now.tv_sec > lastTimeoutScan) {
         lastTimeoutScan = now.tv_sec;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The TCP acceptor, UDP client and Lua network threads never needs to break out of the event loop. The outgoing DoH one only needs to do that once per second to check for timeouts.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
