### PR TITLE
Switch from set-output to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -25,7 +25,7 @@ jobs:
       - name: get timestamp for cache
         id: get-stamp
         run: |
-          echo "::set-output name=stamp::$(/bin/date +%s)"
+          echo "stamp=$(/bin/date +%s)" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: let GitHub cache our ccache data
         uses: actions/cache@v3.0.11
@@ -71,7 +71,7 @@ jobs:
       - name: get timestamp for cache
         id: get-stamp
         run: |
-          echo "::set-output name=stamp::$(/bin/date +%s)"
+          echo "stamp=$(/bin/date +%s)" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: let GitHub cache our ccache data
         uses: actions/cache@v3.0.11
@@ -121,7 +121,7 @@ jobs:
       - name: get timestamp for cache
         id: get-stamp
         run: |
-          echo "::set-output name=stamp::$(/bin/date +%s)"
+          echo "stamp=$(/bin/date +%s)" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: let GitHub cache our ccache data
         uses: actions/cache@v3.0.11

--- a/.github/workflows/builder-dispatch.yml
+++ b/.github/workflows/builder-dispatch.yml
@@ -49,7 +49,7 @@ jobs:
       # so that the command remains readable, because jo is simpler to use.
       - run: sudo apt-get update && sudo apt-get -y install jo
       - id: get-oslist
-        run: echo "::set-output name=oslist::"$(jo -a ${{ github.event.inputs.os }})
+        run: echo "oslist=$(jo -a ${{ github.event.inputs.os }})" >> "$GITHUB_OUTPUT"
 
   build:
     needs: prepare


### PR DESCRIPTION
### Short description
`::set-output` is deprecated in favor of `$GITHUB_OUTPUT`

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
