### PR TITLE
auth: api, do not create SOA and NS records for consumer zones

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1705,7 +1705,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       throw ApiException("You cannot give rrsets AND zone data as text");
 
     auto nameservers = document["nameservers"];
-    if (!nameservers.is_null() && !nameservers.is_array() && zonekind != DomainInfo::Slave)
+    if (!nameservers.is_null() && !nameservers.is_array() && zonekind != DomainInfo::Slave && zonekind != DomainInfo::Consumer)
       throw ApiException("Nameservers is not a list");
 
     // if records/comments are given, load and check them
@@ -1755,7 +1755,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     autorr.auth = true;
     autorr.ttl = ::arg().asNum("default-ttl");
 
-    if (!have_soa && zonekind != DomainInfo::Slave) {
+    if (!have_soa && zonekind != DomainInfo::Slave && zonekind != DomainInfo::Consumer) {
       // synthesize a SOA record so the zone "really" exists
       string soa = ::arg()["default-soa-content"];
       boost::replace_all(soa, "@", zonename.toStringNoDot());

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -706,6 +706,29 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         self.assertEqual(data['serial'], 0)
         self.assertEqual(data['rrsets'], [])
 
+    def test_create_consumer_zone(self):
+        # Test that nameservers can be absent for consumer zones.
+        name, payload, data = self.create_zone(kind='Consumer', nameservers=None, masters=['127.0.0.2'])
+        for k in ('name', 'masters', 'kind'):
+            self.assertIn(k, data)
+            self.assertEqual(data[k], payload[k])
+        print("payload:", payload)
+        print("data:", data)
+        # Because consumer zones don't get a SOA, we need to test that they'll show up in the zone list.
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones"))
+        zonelist = r.json()
+        print("zonelist:", zonelist)
+        self.assertIn(payload['name'], [zone['name'] for zone in zonelist])
+        # Also test that fetching the zone works.
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + data['id']))
+        data = r.json()
+        print("zone (fetched):", data)
+        for k in ('name', 'masters', 'kind'):
+            self.assertIn(k, data)
+            self.assertEqual(data[k], payload[k])
+        self.assertEqual(data['serial'], 0)
+        self.assertEqual(data['rrsets'], [])
+
     def test_find_zone_by_name(self):
         name = 'foo/' + unique_zone_name()
         name, payload, data = self.create_zone(name=name)
@@ -716,6 +739,11 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
 
     def test_delete_slave_zone(self):
         name, payload, data = self.create_zone(kind='Slave', nameservers=None, masters=['127.0.0.2'])
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/" + data['id']))
+        r.raise_for_status()
+
+    def test_delete_consumer_zone(self):
+        name, payload, data = self.create_zone(kind='Consumer', nameservers=None, masters=['127.0.0.2'])
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/" + data['id']))
         r.raise_for_status()
 


### PR DESCRIPTION
### Short description
treat consumer zones as secondary type in the api

Related #12212

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
