### PR TITLE
auth-4.6.x: Revert "auth lmdb: implement alsoNotifies"

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1770,13 +1770,6 @@ bool LMDBBackend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
   return false;
 }
 
-void LMDBBackend::alsoNotifies(const DNSName& domain, set<string>* ips)
-{
-  std::vector<std::string> meta;
-  getDomainMetadata(domain, "ALSO-NOTIFY", meta);
-  ips->insert(meta.begin(), meta.end());
-}
-
 class LMDBFactory : public BackendFactory
 {
 public:

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -101,7 +101,6 @@ public:
     }
     return false;
   }
-  void alsoNotifies(const DNSName& domain, set<string>* ips) override;
 
   bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta) override;
   void setStale(uint32_t domain_id) override;


### PR DESCRIPTION
### Short description
This reverts #12267. Working also-notify is not very useful when automatic notifies also don't work - which will be fixed in 4.7.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master