### PR TITLE
rec: refactor unsuppored qtype code and make sure we ServFail on all unsupported qtypes

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2203,16 +2203,6 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
 
   auto dc = std::make_unique<DNSComboWriter>(question, g_now, std::move(policyTags), t_pdl, std::move(data), std::move(records));
 
-  if (SyncRes::isUnsupported(dc->d_mdp.d_qtype)) {
-    g_stats.ignoredCount++;
-    if (!g_quiet) {
-      SLOG(g_log << Logger::Notice << RecThreadInfo::id() << " Unsupported qtype " << dc->d_mdp.d_qtype << " from " << source.toStringWithPort() << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << endl,
-           g_slogudpin->info(Logr::Notice, "Unsupported qtype", "qtype", Logging::Loggable(QType(dc->d_mdp.d_qtype)), "source", Logging::Loggable(source), "remote", Logging::Loggable(fromaddr)));
-    }
-
-    return 0;
-  }
-
   dc->setSocket(fd);
   dc->d_tag = ctag;
   dc->d_qhash = qhash;

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -135,7 +135,7 @@ public:
 
   const static uint16_t rfc6895MetaLowerBound = 128;
   const static uint16_t rfc6895MetaUpperBound = 254; // Note 255: ANY is not included
-  const static uint16_t rfc6896Reserved = 65535;
+  const static uint16_t rfc6895Reserved = 65535;
 
   const static map<const string, uint16_t> names;
   const static map<uint16_t, const string> numbers;

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -133,6 +133,10 @@ public:
 #endif
   };
 
+  const static uint16_t rfc6895MetaLowerBound = 128;
+  const static uint16_t rfc6895MetaUpperBound = 254; // Note 255: ANY is not included
+  const static uint16_t rfc6896Reserved = 65535;
+
   const static map<const string, uint16_t> names;
   const static map<uint16_t, const string> numbers;
 

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -355,14 +355,6 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
         }
         return;
       }
-      if (SyncRes::isUnsupported(dc->d_mdp.d_qtype)) {
-        g_stats.ignoredCount++;
-        if (g_logCommonErrors) {
-          SLOG(g_log << Logger::Error << "Unsupported qtype " << dc->d_mdp.d_qtype << " from TCP client " << conn->d_remote.toStringWithPort() << endl,
-               g_slogtcpin->info(Logr::Error, "Unsupported qtype from TCP client", "remote", Logging::Loggable(conn->d_remote), "qtype", Logging::Loggable(dc->d_mdp.d_qtype)));
-        }
-        return;
-      }
 
       dc->d_tcpConnection = conn; // carry the torch
       dc->setSocket(conn->getFD()); // this is the only time a copy is made of the actual fd

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -704,9 +704,7 @@ int SyncRes::beginResolve(const DNSName &qname, const QType qtype, QClass qclass
     return 0;                          // so do check before updating counters (we do now)
   }
 
-  auto qtypeCode = qtype.getCode();
-  /* rfc6895 section 3.1 */
-  if (qtypeCode == 0 || (qtypeCode >= 128 && qtypeCode <= 254) || qtypeCode == QType::RRSIG || qtypeCode == QType::NSEC3 || qtypeCode == QType::OPT || qtypeCode == 65535) {
+  if (isUnsupported(qtype)) {
     return -1;
   }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -436,10 +436,21 @@ public:
 
   static bool isUnsupported(QType qtype)
   {
-    switch (qtype.getCode()) {
+    auto qcode = qtype.getCode();
+    // rfc6895 section 3.1, note ANY is 255 and falls outside the range
+    if (qcode >= QType::rfc6895MetaLowerBound && qcode <= QType::rfc6895MetaUpperBound) {
+      return true;
+    }
+    switch (qcode) {
       // Internal types
-    case QType::ENT:
+    case QType::ENT: // aka TYPE0
     case QType::ADDR:
+      // RFC
+    case QType::rfc6896Reserved:
+      // Other
+    case QType::RRSIG:
+    case QType::NSEC3: // what about NSEC?
+    case QType::OPT:
       return true;
     }
     return false;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -446,7 +446,7 @@ public:
     case QType::ENT: // aka TYPE0
     case QType::ADDR:
       // RFC
-    case QType::rfc6896Reserved:
+    case QType::rfc6895Reserved:
       // Other
     case QType::RRSIG:
     case QType::NSEC3: // what about NSEC?

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -449,7 +449,7 @@ public:
     case QType::rfc6895Reserved:
       // Other
     case QType::RRSIG:
-    case QType::NSEC3: // what about NSEC?
+    case QType::NSEC3: // We use the same logic as for an auth: NSEC is queryable, NSEC3 not
     case QType::OPT:
       return true;
     }


### PR DESCRIPTION

This fixes #12251

Also I'd like to know why we ServFail on NSEC3 but not on NSEC: we should either fix that or add a comment explaining this.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
