### PR TITLE
auth-4.7 api: do not create SOA and NS records for consumer zones

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1704,7 +1704,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       throw ApiException("You cannot give rrsets AND zone data as text");
 
     auto nameservers = document["nameservers"];
-    if (!nameservers.is_null() && !nameservers.is_array() && zonekind != DomainInfo::Slave)
+    if (!nameservers.is_null() && !nameservers.is_array() && zonekind != DomainInfo::Slave && zonekind != DomainInfo::Consumer)
       throw ApiException("Nameservers is not a list");
 
     string soa_edit_api_kind;
@@ -1764,7 +1764,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     autorr.auth = true;
     autorr.ttl = ::arg().asNum("default-ttl");
 
-    if (!have_soa && zonekind != DomainInfo::Slave) {
+    if (!have_soa && zonekind != DomainInfo::Slave && zonekind != DomainInfo::Consumer) {
       // synthesize a SOA record so the zone "really" exists
       string soa = ::arg()["default-soa-content"];
       boost::replace_all(soa, "@", zonename.toStringNoDot());


### PR DESCRIPTION
### Short description
backport of #12285

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master