### PR TITLE
minicurl: fix missing CURLOPT_XFERINFOFUNCTION on old curl versions

### DIFF
--- a/pdns/minicurl.cc
+++ b/pdns/minicurl.cc
@@ -65,6 +65,7 @@ size_t MiniCurl::write_callback(char *ptr, size_t size, size_t nmemb, void *user
   return 0;
 }
 
+#if defined(LIBCURL_VERSION_NUM) && LIBCURL_VERSION_NUM >= 0x072000 // 7.32.0
 size_t MiniCurl::progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
 {
   if (clientp != nullptr) {
@@ -75,6 +76,18 @@ size_t MiniCurl::progress_callback(void *clientp, curl_off_t dltotal, curl_off_t
   }
   return 0;
 }
+#else
+size_t MiniCurl::progress_callback(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow)
+{
+  if (clientp != nullptr) {
+    MiniCurl* us = static_cast<MiniCurl*>(clientp);
+    if (us->d_byteslimit > 0 && dlnow > static_cast<double>(us->d_byteslimit)) {
+      return static_cast<size_t>(dlnow);
+    }
+  }
+  return 0;
+}
+#endif
 
 static string extractHostFromURL(const std::string& url)
 {
@@ -131,8 +144,13 @@ void MiniCurl::setupURL(const std::string& str, const ComboAddress* rem, const C
   if (d_byteslimit > 0) {
     /* enable progress meter */
     curl_easy_setopt(d_curl, CURLOPT_NOPROGRESS, 0L);
+#if defined(LIBCURL_VERSION_NUM) && LIBCURL_VERSION_NUM >= 0x072000 // 7.32.0
     curl_easy_setopt(d_curl, CURLOPT_XFERINFOFUNCTION, progress_callback);
     curl_easy_setopt(d_curl, CURLOPT_XFERINFODATA, this);
+#else
+    curl_easy_setopt(d_curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
+    curl_easy_setopt(d_curl, CURLOPT_PROGRESSDATA, this);
+#endif
   }
 
   curl_easy_setopt(d_curl, CURLOPT_TIMEOUT, static_cast<long>(timeout));

--- a/pdns/minicurl.hh
+++ b/pdns/minicurl.hh
@@ -43,7 +43,11 @@ public:
 private:
   CURL *d_curl;
   static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userdata);
+#if defined(LIBCURL_VERSION_NUM) && LIBCURL_VERSION_NUM >= 0x072000 // 7.32.0
   static size_t progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
+#else
+  static size_t progress_callback(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);
+#endif
   std::string d_data;
   size_t d_byteslimit;
   struct curl_slist* d_header_list = nullptr;


### PR DESCRIPTION
### Short description
```
minicurl.cc:134:30: error: 'CURLOPT_XFERINFOFUNCTION' was not declared in this scope; did you mean 'CURLOPT_WRITEFUNCTION'?
```
 Fix missing `CURLOPT_XFERINFOFUNCTION` for libcurl versions before 7.32.0

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
