### PR TITLE
Test ANY bind UDP handling for the v4 case

### DIFF
--- a/regression-tests.auth-py/test_AnyBind.py
+++ b/regression-tests.auth-py/test_AnyBind.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import dns
+import os
+import socket
+
+from authtests import AuthTest
+
+
+class TestBindAny(AuthTest):
+    _config_template = """
+launch=bind
+"""
+
+    _zones = {
+        'example.org': """
+example.org.                 3600 IN SOA  {soa}
+example.org.                 3600 IN NS   ns1.example.org.
+example.org.                 3600 IN NS   ns2.example.org.
+ns1.example.org.             3600 IN A    192.0.2.10
+ns2.example.org.             3600 IN A    192.0.2.11
+
+www.example.org.             3600 IN A    192.0.2.5
+        """,
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setUpSockets()
+
+        cls.startResponders()
+
+        confdir = os.path.join('configs', cls._confdir)
+        cls.createConfigDir(confdir)
+
+        cls.generateAllAuthConfig(confdir)
+        cls.startAuth(confdir, "0.0.0.0")
+
+        print("Launching tests..")
+
+    @classmethod
+    def setUpSockets(cls):
+         print("Setting up UDP socket..")
+         cls._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+         cls._sock.settimeout(2.0)
+         cls._sock.connect((cls._PREFIX + ".2", cls._authPort))
+
+    def testA(self):
+        """Test to see if we get a reply from 127.0.0.2 if auth is bound to ANY address"""
+        query = dns.message.make_query('www.example.org', 'A')
+        res = self.sendUDPQuery(query)
+        self.assertRcodeEqual(res, 0)

--- a/regression-tests.recursor-dnssec/test_AnyBind.py
+++ b/regression-tests.recursor-dnssec/test_AnyBind.py
@@ -1,0 +1,41 @@
+import dns
+import os
+import socket
+from recursortests import RecursorTest
+
+class testAnyBind(RecursorTest):
+    _confdir = 'AnyBind'
+
+    _config_template = """dnssec=validate
+    local-address=0.0.0.0
+auth-zones=authzone.example=configs/%s/authzone.zone""" % _confdir
+
+    @classmethod
+    def generateRecursorConfig(cls, confdir):
+        authzonepath = os.path.join(confdir, 'authzone.zone')
+        with open(authzonepath, 'w') as authzone:
+            authzone.write("""$ORIGIN authzone.example.
+@ 3600 IN SOA {soa}
+@ 3600 IN A 192.0.2.88
+""".format(soa=cls._SOA))
+        super(testAnyBind, cls).generateRecursorConfig(confdir)
+
+    @classmethod
+    def setUpSockets(cls):
+        print("Setting up UDP socket..")
+        cls._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        cls._sock.settimeout(2.0)
+        cls._sock.connect(("127.0.0.2", cls._recursorPort))
+
+    def testA(self):
+        """Test to see if we get a reply from 127.0.0.2 if rec is bound to ANY address"""
+        expected = dns.rrset.from_text('ns.secure.example.', 0, dns.rdataclass.IN, 'A', '{prefix}.9'.format(prefix=self._PREFIX))
+        query = dns.message.make_query('ns.secure.example', 'A', want_dnssec=True)
+        query.flags |= dns.flags.AD
+
+        res = self.sendUDPQuery(query)
+
+        self.assertMessageIsAuthenticated(res)
+        self.assertRRsetInAnswer(res, expected)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+


### PR DESCRIPTION
v6 is more work, as the test client code assumes v4

Tested by neutering IsAnyAddress handling of auth and rec and verifying the tests fail.

Fixes #3965 (at least th v4 part).

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
