### PR TITLE
to_string: Fix compilation with gcc12: itoa not declared in this scope

### DIFF
--- a/pdns/bindparser.yy
+++ b/pdns/bindparser.yy
@@ -1,6 +1,7 @@
 %{
 
 #include <stdio.h>
+#include <string>
 #include <string.h>
 #include <stdlib.h>
 #include <string>


### PR DESCRIPTION
```
bindparser.yy: In function ‘void yyerror(const char*)’:
bindparser.yy:39:93: error: ‘itoa’ was not declared in this scope
   39 | PDNSException("Error in bind configuration '"+string(current_filename)+"' on line "+std::to_string(linenumber)+": "+str);
      |                                                                                     ^~~~
```
### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code