### PR TITLE
dnsdist: Disable the send wrappers in our CI

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -368,8 +368,9 @@ jobs:
         sanitizers: [ubsan+asan, tsan]
     env:
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
-      ASAN_OPTIONS: detect_leaks=0
-      TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ github.workspace }}/pdns/dnsdistdist/dnsdist-tsan.supp"
+      # Disabling (intercept_send=0) the custom send wrappers for ASAN and TSAN because they cause the tools to report a race that doesn't exist on actual implementations of send(), see https://github.com/google/sanitizers/issues/1498
+      ASAN_OPTIONS: detect_leaks=0:intercept_send=0
+      TSAN_OPTIONS: "halt_on_error=1:intercept_send=0:suppressions=${{ github.workspace }}/pdns/dnsdistdist/dnsdist-tsan.supp"
       # IncludeDir tests are disabled because of a weird interaction between TSAN and these tests which ever only happens on GH actions
       SKIP_INCLUDEDIR_TESTS: yes
     steps:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The way the send wrappers are implemented, reading the data _after_ it has been sent, cause them to report a data race that does not exist with existing implementations:
- we call `send()` from thread 1 to send a query to a backend, never touching the data or associated metadata again from that thread
- we get a response from the backend in a different thread, thread 2, which will then access the metadata and sometimes (truncated UDP answers following a DoH query) even modify the data itself
- ASAN and TSAN complain because the wrapper might still be reading the data after the UDP datagram has been sent, which is effectively a race, but it does not really make any sense for an actual implementation of `send()` to do that.

We work around that by disabling the `send()` wrappers in our CI, for the dnsdist regression tests only, via `intercept_send=0`.

See https://github.com/PowerDNS/pdns/pull/11427#issuecomment-1344504581 and https://github.com/google/sanitizers/issues/1498 for more details.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

