### PR TITLE
dnsdist: Stop the responders more quickly during the tests

### DIFF
--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -247,7 +247,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         sock.bind(("127.0.0.1", port))
-        sock.settimeout(1.0)
+        sock.settimeout(0.5)
         while True:
             try:
               data, addr = sock.recvfrom(4096)
@@ -363,7 +363,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             sys.exit(1)
 
         sock.listen(100)
-        sock.settimeout(1.0)
+        sock.settimeout(0.5)
         if tlsContext:
           sock = tlsContext.wrap_socket(sock, server_side=True)
 
@@ -506,7 +506,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             sys.exit(1)
 
         sock.listen(100)
-        sock.settimeout(1.0)
+        sock.settimeout(0.5)
         if tlsContext:
             sock = tlsContext.wrap_socket(sock, server_side=True)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We use `SO_REUSEPORT` in these tests so if the old responder is still around when the next test starts, it is quite likely that it might get one of the new queries. This is usually fine because responders with a different behaviour listen on different ports, but if a query is queued to an old responder socket right during the time that responder is checking whether it should stop and the actual exit, the query will be lost.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

