### PR TITLE
auth: fix ColumnSize argument in SQLBindParameter #12324

### DIFF
--- a/modules/godbcbackend/sodbc.cc
+++ b/modules/godbcbackend/sodbc.cc
@@ -93,13 +93,14 @@ public:
   {
     prepareStatement();
     d_req_bind.push_back(p);
+    SQLLEN ColumnSize = (p.ParameterType == SQL_VARCHAR) ? *(p.LenPtr) : 0;
     SQLRETURN result = SQLBindParameter(
       d_statement, // StatementHandle,
       d_paridx + 1, // ParameterNumber,
       SQL_PARAM_INPUT, // InputOutputType,
       p.ValueType, // ValueType,
       p.ParameterType, // ParameterType,
-      0, // ColumnSize,
+      ColumnSize, // ColumnSize,
       0, // DecimalDigits,
       p.ParameterValuePtr, // ParameterValuePtr,
       0, // BufferLength,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixing issue #12324, Generic ODBC backend. Setting ColumnSize argument (field length of SQL_VARCHAR type parameter) in SQLBindParameter function call. It's needed to properly bind PowerDNS variables (like domain.name) to SQL statements

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
