### PR TITLE
rec: tcounter test tweaks

### DIFF
--- a/pdns/recursordist/test-rec-tcounters_cc.cc
+++ b/pdns/recursordist/test-rec-tcounters_cc.cc
@@ -9,6 +9,7 @@
 
 #include <unistd.h>
 #include <thread>
+#include "dns_random.hh"
 #include "rec-tcounters.hh"
 
 static rec::GlobalCounters global;
@@ -49,7 +50,7 @@ BOOST_AUTO_TEST_CASE(update_fast)
       ++tlocal.at(rec::Counter::servFails);
       ++tlocal.at(rec::Counter::nxDomains);
       tlocal.at(rec::DoubleWAvgCounter::avgLatencyUsec).add(1.1);
-      if (random() % 10000 == 0) {
+      if (dns_random(10000) == 0) {
         tlocal.updateSnap();
       }
     }
@@ -60,7 +61,7 @@ BOOST_AUTO_TEST_CASE(update_fast)
       ++tlocal.at(rec::Counter::servFails);
       ++tlocal.at(rec::Counter::nxDomains);
       tlocal.at(rec::DoubleWAvgCounter::avgLatencyUsec).add(2.2);
-      if (random() % 10000 == 0) {
+      if (dns_random(10000) == 0) {
         tlocal.updateSnap();
       }
     }
@@ -90,18 +91,18 @@ BOOST_AUTO_TEST_CASE(update_with_sleep)
 
   std::atomic<int> done{};
 
-  const size_t count = 1000000;
+  const size_t count = 100;
   std::thread thread1([&done] {
     for (size_t i = 0; i < count; i++) {
       ++tlocal.at(rec::Counter::servFails);
       ++tlocal.at(rec::Counter::nxDomains);
       tlocal.at(rec::DoubleWAvgCounter::avgLatencyUsec).add(1.1);
-      if (random() % 10000 == 0) {
+      if (dns_random(10000) == 0) {
         tlocal.updateSnap();
       }
       struct timespec interval
       {
-        0, random() % 5000
+        0, dns_random(20 * 1000 * 1000)
       };
       nanosleep(&interval, nullptr);
     }
@@ -112,12 +113,12 @@ BOOST_AUTO_TEST_CASE(update_with_sleep)
       ++tlocal.at(rec::Counter::servFails);
       ++tlocal.at(rec::Counter::nxDomains);
       tlocal.at(rec::DoubleWAvgCounter::avgLatencyUsec).add(2.2);
-      if (random() % 10000 == 0) {
+      if (dns_random(10000) == 0) {
         tlocal.updateSnap();
       }
       struct timespec interval
       {
-        0, random() % 999
+        0, dns_random(40 * 1000 * 1000)
       };
       nanosleep(&interval, nullptr);
     }
@@ -132,7 +133,7 @@ BOOST_AUTO_TEST_CASE(update_with_sleep)
       BOOST_CHECK(avg == 0.0 || (avg >= 1.1 && avg <= 2.2));
       struct timespec interval
       {
-        0, random() % 10000
+        0, dns_random(80 * 1000 * 1000)
       };
       nanosleep(&interval, nullptr);
     }

--- a/pdns/recursordist/test-recpacketcache_cc.cc
+++ b/pdns/recursordist/test-recpacketcache_cc.cc
@@ -5,7 +5,6 @@
 #include "config.h"
 #endif
 #include <boost/test/unit_test.hpp>
-#include "arguments.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
 #include "dns_random.hh"
@@ -24,9 +23,6 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimple)
   uint32_t qhash = 0;
   uint32_t ttd = 3600;
   BOOST_CHECK_EQUAL(rpc.size(), 0U);
-
-  ::arg().set("rng") = "auto";
-  ::arg().set("entropy-source") = "/dev/urandom";
 
   DNSName qname("www.powerdns.com");
   vector<uint8_t> packet;
@@ -93,9 +89,6 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimplePost2038)
   uint32_t qhash = 0;
   uint32_t ttd = 3600;
   BOOST_CHECK_EQUAL(rpc.size(), 0U);
-
-  ::arg().set("rng") = "auto";
-  ::arg().set("entropy-source") = "/dev/urandom";
 
   DNSName qname("www.powerdns.com");
   vector<uint8_t> packet;
@@ -177,9 +170,6 @@ BOOST_AUTO_TEST_CASE(test_recPacketCache_Tags)
   uint32_t temphash = 0;
   uint32_t ttd = 3600;
   BOOST_CHECK_EQUAL(rpc.size(), 0U);
-
-  ::arg().set("rng") = "auto";
-  ::arg().set("entropy-source") = "/dev/urandom";
 
   DNSName qname("www.powerdns.com");
   vector<uint8_t> packet;
@@ -294,9 +284,6 @@ BOOST_AUTO_TEST_CASE(test_recPacketCache_TCP)
   uint32_t temphash = 0;
   uint32_t ttd = 3600;
   BOOST_CHECK_EQUAL(rpc.size(), 0U);
-
-  ::arg().set("rng") = "auto";
-  ::arg().set("entropy-source") = "/dev/urandom";
 
   DNSName qname("www.powerdns.com");
   vector<uint8_t> packet;

--- a/pdns/recursordist/testrunner.cc
+++ b/pdns/recursordist/testrunner.cc
@@ -31,6 +31,8 @@
 #include <iomanip>
 #include "logger.hh"
 #include "logging.hh"
+#include "arguments.hh"
+#include "dns_random.hh"
 
 static std::string s_timestampFormat = "%s";
 
@@ -76,6 +78,10 @@ static void loggerBackend(const Logging::Entry& entry)
 
 static bool init_unit_test()
 {
+  ::arg().set("rng") = "auto";
+  ::arg().set("entropy-source") = "/dev/urandom";
+  // Force init while w're still unthreaded
+  dns_random_uint16();
   g_slog = Logging::Logger::create(loggerBackend);
   reportAllTypes();
   return true;

--- a/pdns/recursordist/testrunner.cc
+++ b/pdns/recursordist/testrunner.cc
@@ -80,7 +80,7 @@ static bool init_unit_test()
 {
   ::arg().set("rng") = "auto";
   ::arg().set("entropy-source") = "/dev/urandom";
-  // Force init while w're still unthreaded
+  // Force init while we are still unthreaded
   dns_random_uint16();
   g_slog = Logging::Logger::create(loggerBackend);
   reportAllTypes();


### PR DESCRIPTION
Some system habe a low resoltion nanosleep(), which sleeps for at least a few ms. Compensate for that by running fewer loops with longer sleeps.

Also use dns_random and make sure it is initlized properly for all tests.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
