### PR TITLE
rec: Use correct logic for isEntryUsable()

### DIFF
--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -418,7 +418,7 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qt, F
         firstIndexIterator = map->d_map.project<OrderedTag>(i);
 
         // When serving stale, we consider expired records
-        if (i->isEntryUsable(now, serveStale)) {
+        if (!i->isEntryUsable(now, serveStale)) {
           moveCacheItemToFront<SequencedTag>(map->d_map, firstIndexIterator);
           continue;
         }
@@ -459,7 +459,7 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qt, F
       firstIndexIterator = map->d_map.project<OrderedTag>(i);
 
       // When serving stale, we consider expired records
-      if (i->isEntryUsable(now, serveStale)) {
+      if (!i->isEntryUsable(now, serveStale)) {
         moveCacheItemToFront<SequencedTag>(map->d_map, firstIndexIterator);
         continue;
       }

--- a/pdns/recursordist/recursor_cache.hh
+++ b/pdns/recursordist/recursor_cache.hh
@@ -104,7 +104,7 @@ private:
     bool isEntryUsable(time_t now, bool serveStale) const
     {
       // When serving stale, we consider expired records
-      return d_ttd <= now && !serveStale && d_servedStale == 0;
+      return d_ttd > now || serveStale || d_servedStale != 0;
     }
 
     bool shouldReplace(time_t now, bool auth, vState state, bool refresh);


### PR DESCRIPTION
Existing code was correct but used the wrong name for the method: isEntryUsable() actually tested for isUnusable, but the caller compensated for it. Reverse logic to make it more clear.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
