### PR TITLE
Refresh of negcache stale entry might use wrong qtype

### DIFF
--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -87,11 +87,11 @@ public:
   };
 
   void add(const NegCacheEntry& ne);
-  void updateValidationStatus(const DNSName& qname, const QType& qtype, const vState newState, boost::optional<time_t> capTTD);
-  bool get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne, bool typeMustMatch = false, bool serverStale = false, bool refresh = false);
+  void updateValidationStatus(const DNSName& qname, QType qtype, vState newState, boost::optional<time_t> capTTD);
+  bool get(const DNSName& qname, QType qtype, const struct timeval& now, NegCacheEntry& ne, bool typeMustMatch = false, bool serverStale = false, bool refresh = false);
   bool getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne, bool serveStale, bool refresh);
   size_t count(const DNSName& qname);
-  size_t count(const DNSName& qname, const QType qtype);
+  size_t count(const DNSName& qname, QType qtype);
   void prune(size_t maxEntries);
   void clear();
   size_t dumpToFile(FILE* fd, const struct timeval& now);
@@ -120,7 +120,7 @@ private:
                         member<NegCacheEntry, DNSName, &NegCacheEntry::d_name>>>>
     negcache_t;
 
-  void updateStaleEntry(time_t now, negcache_t::iterator& entry, const QType& qtype);
+  void updateStaleEntry(time_t now, negcache_t::iterator& entry, QType qtype);
 
   struct MapCombo
   {

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -120,7 +120,7 @@ private:
                         member<NegCacheEntry, DNSName, &NegCacheEntry::d_name>>>>
     negcache_t;
 
-  void updateStaleEntry(time_t now, negcache_t::iterator& entry);
+  void updateStaleEntry(time_t now, negcache_t::iterator& entry, const QType& qtype);
 
   struct MapCombo
   {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When searching in negcache, when the stale function is triggered and the type of the cache is type0, the asynchronous expired task request resolution type is A record, and the actual client request is AAAA type request, so the request type of the asynchronous expired task should be changed Change to the type requested by the user
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
