### PR TITLE
dnsdist: Prevent an underflow of the TCP d_queued counter

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp.hh
@@ -182,17 +182,6 @@ class TCPClientCollection
 public:
   TCPClientCollection(size_t maxThreads, std::vector<ClientState*> tcpStates);
 
-  int getThread()
-  {
-    if (d_numthreads == 0) {
-      throw std::runtime_error("No TCP worker thread yet");
-    }
-
-    uint64_t pos = d_pos++;
-    ++d_queued;
-    return d_tcpclientthreads.at(pos % d_numthreads).d_newConnectionPipe.getHandle();
-  }
-
   bool passConnectionToThread(std::unique_ptr<ConnectionInfo>&& conn)
   {
     if (d_numthreads == 0) {
@@ -203,13 +192,17 @@ public:
     auto pipe = d_tcpclientthreads.at(pos % d_numthreads).d_newConnectionPipe.getHandle();
     auto tmp = conn.release();
 
+    /* we need to increment this counter _before_ writing to the pipe,
+       otherwise there is a very real possiblity that the other end
+       decrement the counter before we can increment it, leading to an underflow */
+    ++d_queued;
     if (write(pipe, &tmp, sizeof(tmp)) != sizeof(tmp)) {
+      --d_queued;
       ++g_stats.tcpQueryPipeFull;
       delete tmp;
       tmp = nullptr;
       return false;
     }
-    ++d_queued;
     return true;
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
By incrementing it _before_ writing to the pipe, and decrementing it in case of an error, we prevent a very possible underflow from occurring if the reader manages to decrement before we can return from write and increment it.
Fixes #12357 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

