### PR TITLE
Add missing comma to pdns_control ccounts

### DIFF
--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -175,6 +175,8 @@ string DLCCHandler(const vector<string>&parts, Utility::pid_t ppid)
 
     os<<i->second;
   }
+  if(!first) 
+    os<<", ";
   os<<"packets: "<<packetEntries;
 
   return os.str();


### PR DESCRIPTION
### Short description
Before:
```
# pdns_control ccounts
negative queries: 0, queries: 5packets: 4
```

After (hopefully):
```
# pdns_control ccounts
negative queries: 0, queries: 5, packets: 4
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
