### PR TITLE
dnsdist: Stronger guarantees against data race in the UDP path 

### DIFF
--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -160,7 +160,7 @@ struct IDState
   }
 
   IDState(const IDState& orig) = delete;
-  IDState(IDState&& rhs) noexcept:
+  IDState(IDState&& rhs) noexcept :
     internal(std::move(rhs.internal))
   {
     inUse.store(rhs.inUse.load());

--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -160,14 +160,13 @@ struct IDState
   }
 
   IDState(const IDState& orig) = delete;
-  IDState(IDState&& rhs)
+  IDState(IDState&& rhs) noexcept: internal(std::move(rhs.internal))
   {
     inUse.store(rhs.inUse.load());
     age.store(rhs.age.load());
-    internal = std::move(rhs.internal);
   }
 
-  IDState& operator=(IDState&& rhs)
+  IDState& operator=(IDState&& rhs) noexcept
   {
     inUse.store(rhs.inUse.load());
     age.store(rhs.age.load());
@@ -177,7 +176,7 @@ struct IDState
 
   bool isInUse() const
   {
-    return inUse == true;
+    return inUse;
   }
 
   /* For performance reasons we don't want to use a lock here, but that means

--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -160,7 +160,8 @@ struct IDState
   }
 
   IDState(const IDState& orig) = delete;
-  IDState(IDState&& rhs) noexcept: internal(std::move(rhs.internal))
+  IDState(IDState&& rhs) noexcept:
+    internal(std::move(rhs.internal))
   {
     inUse.store(rhs.inUse.load());
     age.store(rhs.age.load());

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1460,7 +1460,7 @@ bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint1
       }
     }
     catch (const std::exception& e) {
-      vinfolog("Adding proxy protocol payload to %squery from %s failed: %s", (dq.ids.du ? "DoH" : ""), dq.ids.origDest.toStringWithPort(), e.what());
+      vinfolog("Adding proxy protocol payload to %s query from %s failed: %s", (dq.ids.du ? "DoH" : ""), dq.ids.origDest.toStringWithPort(), e.what());
       return false;
     }
   }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -634,7 +634,7 @@ void handleResponseSent(const DNSName& qname, const QType& qtype, double udiff, 
   doLatencyStats(incomingProtocol, udiff);
 }
 
-static void handleResponseForUDPClient(InternalQueryState& ids, PacketBuffer& response, const std::vector<DNSDistResponseRuleAction>& respRuleActions, const std::vector<DNSDistResponseRuleAction>& cacheInsertedRespRuleActions, const std::shared_ptr<DownstreamState>& ds, bool selfGenerated, std::optional<uint16_t> queryId)
+static void handleResponseForUDPClient(InternalQueryState& ids, PacketBuffer& response, const std::vector<DNSDistResponseRuleAction>& respRuleActions, const std::vector<DNSDistResponseRuleAction>& cacheInsertedRespRuleActions, const std::shared_ptr<DownstreamState>& ds, bool selfGenerated)
 {
   DNSResponse dr(ids, response, ds);
 
@@ -653,9 +653,6 @@ static void handleResponseForUDPClient(InternalQueryState& ids, PacketBuffer& re
   memcpy(&cleartextDH, dr.getHeader(), sizeof(cleartextDH));
 
   if (!processResponse(response, respRuleActions, cacheInsertedRespRuleActions, dr, ids.cs && ids.cs->muted)) {
-    if (queryId) {
-      ds->releaseState(*queryId);
-    }
     return;
   }
 
@@ -685,10 +682,6 @@ static void handleResponseForUDPClient(InternalQueryState& ids, PacketBuffer& re
   }
   else {
     handleResponseSent(ids, 0., dr.ids.origRemote, ComboAddress(), response.size(), cleartextDH, dnsdist::Protocol::DoUDP);
-  }
-
-  if (queryId) {
-    ds->releaseState(*queryId);
   }
 }
 
@@ -728,57 +721,23 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
         dnsheader* dh = reinterpret_cast<struct dnsheader*>(response.data());
         queryId = dh->id;
 
-        IDState* ids = dss->getExistingState(queryId);
-        if (ids == nullptr) {
+        auto ids = dss->getState(queryId);
+        if (!ids) {
           continue;
         }
-
-        int64_t usageIndicator = ids->usageIndicator;
-
-        if (!IDState::isInUse(usageIndicator)) {
-          /* the corresponding state is marked as not in use, meaning that:
-             - it was already cleaned up by another thread and the state is gone ;
-             - we already got a response for this query and this one is a duplicate.
-             Either way, we don't touch it.
-          */
-          continue;
-        }
-
-        /* setting age to 0 to prevent the maintainer thread from
-           cleaning this IDS while we process the response.
-        */
-        ids->age = 0;
 
         unsigned int qnameWireLength = 0;
-        if (fd != ids->internal.backendFD || !responseContentMatches(response, ids->internal.qname, ids->internal.qtype, ids->internal.qclass, dss, qnameWireLength)) {
+        if (fd != ids->backendFD || !responseContentMatches(response, ids->qname, ids->qtype, ids->qclass, dss, qnameWireLength)) {
+          dss->restoreState(queryId, std::move(*ids));
           continue;
         }
 
-        DOHUnitUniquePtr du(nullptr, DOHUnit::release);
-        /* atomically mark the state as available, but only if it has not been altered
-           in the meantime */
-        if (ids->tryMarkUnused(usageIndicator)) {
-          /* clear the potential DOHUnit asap, it's ours now
-           and since we just marked the state as unused,
-           someone could overwrite it. */
-          du = std::move(ids->internal.du);
-          /* we only decrement the outstanding counter if the value was not
-             altered in the meantime, which would mean that the state has been actively reused
-             and the other thread has not incremented the outstanding counter, so we don't
-             want it to be decremented twice. */
-          --dss->outstanding;  // you'd think an attacker could game this, but we're using connected socket
-        } else {
-          /* someone updated the state in the meantime, we can't touch the existing pointer */
-          du.release();
-          /* since the state has been updated, we can't safely access it so let's just drop
-             this response */
-          continue;
-        }
+        auto du = std::move(ids->du);
 
-        dh->id = ids->internal.origID;
+        dh->id = ids->origID;
         ++dss->responses;
 
-        double udiff = ids->internal.queryRealTime.udiff();
+        double udiff = ids->queryRealTime.udiff();
         // do that _before_ the processing, otherwise it's not fair to the backend
         dss->latencyUsec = (127.0 * dss->latencyUsec / 128.0) + udiff / 128.0;
         dss->reportResponse(dh->rcode);
@@ -787,13 +746,12 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
         if (du) {
 #ifdef HAVE_DNS_OVER_HTTPS
           // DoH query, we cannot touch du after that
-          handleUDPResponseForDoH(std::move(du), std::move(response), std::move(ids->internal));
+          handleUDPResponseForDoH(std::move(du), std::move(response), std::move(*ids));
 #endif
-          dss->releaseState(queryId);
           continue;
         }
 
-        handleResponseForUDPClient(ids->internal, response, *localRespRuleActions, *localCacheInsertedRespRuleActions, dss, false, queryId);
+        handleResponseForUDPClient(*ids, response, *localRespRuleActions, *localCacheInsertedRespRuleActions, dss, false);
       }
     }
     catch (const std::exception& e) {
@@ -1445,7 +1403,7 @@ public:
     static thread_local LocalStateHolder<vector<DNSDistResponseRuleAction>> localRespRuleActions = g_respruleactions.getLocal();
     static thread_local LocalStateHolder<vector<DNSDistResponseRuleAction>> localCacheInsertedRespRuleActions = g_cacheInsertedRespRuleActions.getLocal();
 
-    handleResponseForUDPClient(ids, response.d_buffer, *localRespRuleActions, *localCacheInsertedRespRuleActions, d_ds, response.d_selfGenerated, std::nullopt);
+    handleResponseForUDPClient(ids, response.d_buffer, *localRespRuleActions, *localCacheInsertedRespRuleActions, d_ds, response.d_selfGenerated);
   }
 
   void handleXFRResponse(const struct timeval& now, TCPResponse&& response) override
@@ -1487,62 +1445,55 @@ public:
   }
 };
 
-bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer&& query, ComboAddress& dest)
+bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer& query, ComboAddress& dest)
 {
   bool doh = dq.ids.du != nullptr;
-  unsigned int idOffset = 0;
-  int64_t generation;
-  IDState* ids = ds->getIDState(idOffset, generation);
-
-  dq.getHeader()->id = idOffset;
 
   bool failed = false;
+  size_t proxyPayloadSize = 0;
   if (ds->d_config.useProxyProtocol) {
     try {
-      size_t payloadSize = 0;
-      if (addProxyProtocol(dq, &payloadSize)) {
+      if (addProxyProtocol(dq, &proxyPayloadSize)) {
         if (dq.ids.du) {
-          dq.ids.du->proxyProtocolPayloadSize = payloadSize;
+          dq.ids.du->proxyProtocolPayloadSize = proxyPayloadSize;
         }
       }
     }
     catch (const std::exception& e) {
       vinfolog("Adding proxy protocol payload to %squery from %s failed: %s", (dq.ids.du ? "DoH" : ""), dq.ids.origDest.toStringWithPort(), e.what());
-      failed = true;
+      return false;
     }
   }
 
   try {
-    if (!failed) {
-      int fd = ds->pickSocketForSending();
-      dq.ids.backendFD = fd;
-      dq.ids.origID = queryID;
-      dq.ids.forwardedOverUDP = true;
-      ids->internal = std::move(dq.ids);
+    int fd = ds->pickSocketForSending();
+    dq.ids.backendFD = fd;
+    dq.ids.origID = queryID;
+    dq.ids.forwardedOverUDP = true;
 
-      vinfolog("Got query for %s|%s from %s%s, relayed to %s", ids->internal.qname.toLogString(), QType(ids->internal.qtype).toString(), ids->internal.origRemote.toStringWithPort(), (doh ? " (https)" : ""), ds->getNameWithAddr());
-      /* you can't touch du after this line, unless the call returned a non-negative value,
-         because it might already have been freed */
-      ssize_t ret = udpClientSendRequestToBackend(ds, fd, query);
+    vinfolog("Got query for %s|%s from %s%s, relayed to %s", dq.ids.qname.toLogString(), QType(dq.ids.qtype).toString(), dq.ids.origRemote.toStringWithPort(), (doh ? " (https)" : ""), ds->getNameWithAddr());
 
-      if (ret < 0) {
-        failed = true;
-      }
-    }
-    else {
-      ids->internal = std::move(dq.ids);
+    auto idOffset = ds->saveState(std::move(dq.ids));
+    /* set the correct ID */
+    memcpy(query.data() + proxyPayloadSize, &idOffset, sizeof(idOffset));
+
+    /* you can't touch ids or du after this line, unless the call returned a non-negative value,
+       because it might already have been freed */
+    ssize_t ret = udpClientSendRequestToBackend(ds, fd, query);
+
+    if (ret < 0) {
+      failed = true;
     }
 
     if (failed) {
-      /* we are about to handle the error, make sure that
-         this pointer is not accessed when the state is cleaned,
-         but first check that it still belongs to us */
-      if (ids->tryMarkUnused(generation) && ids->internal.du) {
-        dq.ids.du = std::move(ids->internal.du);
-        --ds->outstanding;
-      }
-      if (dq.ids.du) {
-        dq.ids.du->status_code = 502;
+      /* clear up the state. In the very unlikely event it was reused
+         in the meantime, so be it. */
+      auto cleared = ds->getState(idOffset);
+      if (cleared) {
+        dq.ids.du = std::move(cleared->du);
+        if (dq.ids.du) {
+          dq.ids.du->status_code = 502;
+        }
       }
       ++g_stats.downstreamSendErrors;
       ++ds->sendErrors;
@@ -1667,7 +1618,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
       return;
     }
 
-    assignOutgoingUDPQueryToBackend(ss, dh->id, dq, std::move(query), dest);
+    assignOutgoingUDPQueryToBackend(ss, dh->id, dq, query, dest);
   }
   catch(const std::exception& e){
     vinfolog("Got an error in UDP question thread while parsing a query from %s, id %d: %s", ids.origRemote.toStringWithPort(), queryId, e.what());

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1002,13 +1002,13 @@ public:
   int pickSocketForSending();
   void pickSocketsReadyForReceiving(std::vector<int>& ready);
   void handleUDPTimeouts();
-  IDState* getIDState(unsigned int& id, int64_t& generation);
-  IDState* getExistingState(unsigned int id);
-  void releaseState(unsigned int id);
   void reportTimeoutOrError();
   void reportResponse(uint8_t rcode);
   void submitHealthCheckResult(bool initial, bool newState);
   time_t getNextLazyHealthCheck();
+  uint16_t saveState(InternalQueryState&&);
+  void restoreState(uint16_t id, InternalQueryState&&);
+  std::optional<InternalQueryState> getState(uint16_t id);
 
   dnsdist::Protocol getProtocol() const
   {
@@ -1206,7 +1206,7 @@ static const size_t s_maxPacketCacheEntrySize{4096}; // don't cache responses la
 enum class ProcessQueryResult : uint8_t { Drop, SendAnswer, PassToBackend };
 ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend);
 
-bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer&& query, ComboAddress& dest);
+bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer& query, ComboAddress& dest);
 
 ssize_t udpClientSendRequestToBackend(const std::shared_ptr<DownstreamState>& ss, const int sd, const PacketBuffer& request, bool healthCheck = false);
 void handleResponseSent(const DNSName& qname, const QType& qtype, double udiff, const ComboAddress& client, const ComboAddress& backend, unsigned int size, const dnsheader& cleartextDH, dnsdist::Protocol outgoingProtocol, dnsdist::Protocol incomingProtocol);

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -447,17 +447,16 @@ uint16_t DownstreamState::saveState(InternalQueryState&& state)
   }
 
   do {
-    IDState* ids = nullptr;
     uint16_t selectedID = (idOffset++) % idStates.size();
-    ids = &idStates[selectedID];
-    auto guard = ids->acquire();
+    IDState& ids = idStates[selectedID];
+    auto guard = ids.acquire();
     if (!guard) {
       continue;
     }
-    if (ids->isInUse()) {
+    if (ids.isInUse()) {
       /* we are reusing a state, no change in outstanding but if there was an existing DOHUnit we need
          to handle it because it's about to be overwritten. */
-      auto oldDU = std::move(ids->internal.du);
+      auto oldDU = std::move(ids.internal.du);
       ++reuseds;
       ++g_stats.downstreamTimeouts;
       handleDOHTimeout(std::move(oldDU));
@@ -465,9 +464,9 @@ uint16_t DownstreamState::saveState(InternalQueryState&& state)
     else {
       ++outstanding;
     }
-    ids->internal = std::move(state);
-    ids->age.store(0);
-    ids->inUse = true;
+    ids.internal = std::move(state);
+    ids.age.store(0);
+    ids.inUse = true;
     return selectedID;
   }
   while (true);

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -321,19 +321,16 @@ bool DownstreamState::s_randomizeSockets{false};
 bool DownstreamState::s_randomizeIDs{false};
 int DownstreamState::s_udpTimeout{2};
 
-static bool isIDSExpired(IDState& ids)
+static bool isIDSExpired(const IDState& ids)
 {
-  auto age = ids.age++;
+  auto age = ids.age.load();
   return age > DownstreamState::s_udpTimeout;
 }
 
 void DownstreamState::handleUDPTimeout(IDState& ids)
 {
-  /* We mark the state as unused as soon as possible
-     to limit the risk of racing with the
-     responder thread.
-  */
   ids.age = 0;
+  ids.inUse = false;
   handleDOHTimeout(std::move(ids.internal.du));
   reuseds++;
   --outstanding;
@@ -386,20 +383,26 @@ void DownstreamState::handleUDPTimeouts()
         it = map->erase(it);
         continue;
       }
+      ++ids.age;
       ++it;
     }
   }
   else {
     if (outstanding.load() > 0) {
       for (IDState& ids : idStates) {
-        int64_t usageIndicator = ids.usageIndicator;
-        if (IDState::isInUse(usageIndicator) && isIDSExpired(ids)) {
-          if (!ids.tryMarkUnused(usageIndicator)) {
-            /* this state has been altered in the meantime,
-               don't go anywhere near it */
-            continue;
-          }
-
+        if (!ids.isInUse()) {
+          continue;
+        }
+        if (!isIDSExpired(ids)) {
+          ++ids.age;
+          continue;
+        }
+        auto guard = ids.acquire();
+        if (!guard) {
+          continue;
+        }
+        /* check again, now that we have locked this state */
+        if (ids.isInUse() && isIDSExpired(ids)) {
           handleUDPTimeout(ids);
         }
       }
@@ -407,43 +410,8 @@ void DownstreamState::handleUDPTimeouts()
   }
 }
 
-IDState* DownstreamState::getExistingState(unsigned int stateId)
+uint16_t DownstreamState::saveState(InternalQueryState&& state)
 {
-  if (s_randomizeIDs) {
-    auto map = d_idStatesMap.lock();
-    auto it = map->find(stateId);
-    if (it == map->end()) {
-      return nullptr;
-    }
-    return &it->second;
-  }
-  else {
-    if (stateId >= idStates.size()) {
-      return nullptr;
-    }
-    return &idStates[stateId];
-  }
-}
-
-void DownstreamState::releaseState(unsigned int stateId)
-{
-  if (s_randomizeIDs) {
-    auto map = d_idStatesMap.lock();
-    auto it = map->find(stateId);
-    if (it == map->end()) {
-      return;
-    }
-    if (it->second.isInUse()) {
-      return;
-    }
-    map->erase(it);
-  }
-}
-
-IDState* DownstreamState::getIDState(unsigned int& selectedID, int64_t& generation)
-{
-  DOHUnitUniquePtr du(nullptr, DOHUnit::release);
-  IDState* ids = nullptr;
   if (s_randomizeIDs) {
     /* if the state is already in use we will retry,
        up to 5 five times. The last selected one is used
@@ -451,45 +419,134 @@ IDState* DownstreamState::getIDState(unsigned int& selectedID, int64_t& generati
     size_t remainingAttempts = 5;
     auto map = d_idStatesMap.lock();
 
-    bool done = false;
     do {
-      selectedID = dnsdist::getRandomValue(std::numeric_limits<uint16_t>::max());
-      auto [it, inserted] = map->insert({selectedID, IDState()});
-      ids = &it->second;
-      if (inserted) {
-        done = true;
+      uint16_t selectedID = dnsdist::getRandomValue(std::numeric_limits<uint16_t>::max());
+      auto [it, inserted] = map->emplace(selectedID, IDState());
+
+      if (!inserted) {
+        remainingAttempts--;
+        if (remainingAttempts > 0) {
+          continue;
+        }
+
+        auto oldDU = std::move(it->second.internal.du);
+        ++reuseds;
+        ++g_stats.downstreamTimeouts;
+        handleDOHTimeout(std::move(oldDU));
       }
       else {
-        remainingAttempts--;
+        ++outstanding;
       }
+
+      it->second.internal = std::move(state);
+      it->second.age.store(0);
+
+      return it->first;
     }
-    while (!done && remainingAttempts > 0);
+    while (true);
   }
-  else {
-    selectedID = (idOffset++) % idStates.size();
+
+  do {
+    IDState* ids = nullptr;
+    uint16_t selectedID = (idOffset++) % idStates.size();
     ids = &idStates[selectedID];
+    auto guard = ids->acquire();
+    if (!guard) {
+      continue;
+    }
+    if (ids->isInUse()) {
+      /* we are reusing a state, no change in outstanding but if there was an existing DOHUnit we need
+         to handle it because it's about to be overwritten. */
+      auto oldDU = std::move(ids->internal.du);
+      ++reuseds;
+      ++g_stats.downstreamTimeouts;
+      handleDOHTimeout(std::move(oldDU));
+    }
+    else {
+      ++outstanding;
+    }
+    ids->internal = std::move(state);
+    ids->age.store(0);
+    ids->inUse = true;
+    return selectedID;
+  }
+  while (true);
+}
+
+void DownstreamState::restoreState(uint16_t id, InternalQueryState&& state)
+{
+  if (s_randomizeIDs) {
+    auto map = d_idStatesMap.lock();
+
+    auto [it, inserted] = map->emplace(id, IDState());
+    if (!inserted) {
+      /* already used */
+      ++reuseds;
+      ++g_stats.downstreamTimeouts;
+      handleDOHTimeout(std::move(state.du));
+    }
+    else {
+      it->second.internal = std::move(state);
+      ++outstanding;
+    }
+    return;
   }
 
-  ids->age = 0;
-
-  /* we atomically replace the value, we now own this state */
-  generation = ids->generation++;
-  if (!ids->markAsUsed(generation)) {
-    /* the state was not in use.
-       we reset 'du' because it might have still been in use when we read it. */
-    du.release();
-    ++outstanding;
-  }
-  else {
-    /* we are reusing a state, no change in outstanding but if there was an existing DOHUnit we need
-       to handle it because it's about to be overwritten. */
-    auto oldDU = std::move(ids->internal.du);
+  auto& ids = idStates[id];
+  auto guard = ids.acquire();
+  if (!guard) {
+    /* already used */
     ++reuseds;
     ++g_stats.downstreamTimeouts;
-    handleDOHTimeout(std::move(oldDU));
+    handleDOHTimeout(std::move(state.du));
+    return;
+  }
+  if (ids.isInUse()) {
+    /* already used */
+    ++reuseds;
+    ++g_stats.downstreamTimeouts;
+    handleDOHTimeout(std::move(state.du));
+    return;
+  }
+  ids.internal = std::move(state);
+  ids.inUse = true;
+  ++outstanding;
+}
+
+std::optional<InternalQueryState> DownstreamState::getState(uint16_t id)
+{
+  std::optional<InternalQueryState> result = std::nullopt;
+
+  if (s_randomizeIDs) {
+    auto map = d_idStatesMap.lock();
+
+    auto it = map->find(id);
+    if (it == map->end()) {
+      return result;
+    }
+
+    result = std::move(it->second.internal);
+    map->erase(it);
+    --outstanding;
+    return result;
   }
 
-  return ids;
+  if (id > idStates.size()) {
+    return result;
+  }
+
+  auto& ids = idStates[id];
+  auto guard = ids.acquire();
+  if (!guard) {
+    return result;
+  }
+
+  if (ids.isInUse()) {
+    result = std::move(ids.internal);
+    --outstanding;
+  }
+  ids.inUse = false;
+  return result;
 }
 
 bool DownstreamState::healthCheckRequired(std::optional<time_t> currentTime)

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -677,7 +677,7 @@ static void processDOHQuery(DOHUnitUniquePtr&& unit)
     }
 
     ComboAddress dest = dq.ids.origDest;
-    if (!assignOutgoingUDPQueryToBackend(downstream, htons(queryId), dq, std::move(du->query), dest)) {
+    if (!assignOutgoingUDPQueryToBackend(downstream, htons(queryId), dq, du->query, dest)) {
             sendDoHUnitToTheMainThread(std::move(du), "DoH internal error");
       return;
     }

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -678,7 +678,8 @@ static void processDOHQuery(DOHUnitUniquePtr&& unit)
 
     ComboAddress dest = dq.ids.origDest;
     if (!assignOutgoingUDPQueryToBackend(downstream, htons(queryId), dq, du->query, dest)) {
-            sendDoHUnitToTheMainThread(std::move(du), "DoH internal error");
+      du->status_code = 500;
+      sendDoHUnitToTheMainThread(std::move(du), "DoH internal error");
       return;
     }
   }

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -42,7 +42,7 @@ bool DNSDistSNMPAgent::sendBackendStatusChangeTrap(DownstreamState const&)
   return false;
 }
 
-bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer&& query, ComboAddress& dest)
+bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer& query, ComboAddress& dest)
 {
   return false;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This pull request replaces the existing mechanism to ensure that UDP states can be safely accessed by several threads with a simpler, more robust one. This is possible now that we introduced the `InternalQueryState`, splitting the data from `IDState`.

<strike>Note that this pull request builds on https://github.com/PowerDNS/pdns/pull/12354 and will have to be rebased.</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
