### PR TITLE
dnsdist: Merge the 'main' and 'client' DoH threads in single acceptor mode

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1640,6 +1640,10 @@ static void MultipleMessagesUDPClientThread(ClientState* cs, LocalHolders& holde
   };
   const size_t vectSize = g_udpVectorSize;
 
+  if (vectSize > std::numeric_limits<uint16_t>::max()) {
+    throw std::runtime_error("The value of setUDPMultipleMessagesVectorSize is too high, the maximum value is " + std::to_string(std::numeric_limits<uint16_t>::max()));
+  }
+
   auto recvData = std::make_unique<MMReceiver[]>(vectSize);
   auto msgVec = std::make_unique<struct mmsghdr[]>(vectSize);
   auto outMsgVec = std::make_unique<struct mmsghdr[]>(vectSize);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When we are in "single acceptor thread" mode, merge the 'main' and 'client' DoH threads into a single one. We use separate threads to reduce the separate the handling of the HTTP/2 traffic from the DNS handling, to reduce latency, but that does not really make sense on small devices with a single, limited CPU core. On these we prefer using as few threads as possible to reduce the context switches and the memory usage.

<strike>Note that this pull request builds on https://github.com/PowerDNS/pdns/pull/12383 and will have to be rebased.</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

