### PR TITLE
Add support for docker's secrets

### DIFF
--- a/Docker-README.md
+++ b/Docker-README.md
@@ -19,6 +19,7 @@ Other data involved in the Docker build process can be found at https://github.c
 
 The images are ready to run with limited functionality.
 At container startup, the startup.py wrapper (from the dockerdata directory linked above) checks for `PDNS_RECURSOR_API_KEY` / `PDNS_AUTH_API_KEY` / `DNSDIST_API_KEY` environment variables for the product you are running.
+You can also use `PDNS_RECURSOR_API_KEY_FILE` / `PDNS_AUTH_API_KEY_FILE` / `DNSDIST_API_KEY_FILE` variables for Docker's secret.
 If such a variable is found, `/etc/powerdns-api.conf` or `/etc/dnsdist-api.conf` is written, enabling the webserver in all products, and the dnsdist console.
 For the dnsdist console, make sure that your API key is in a format suitable for the console (use `makeKey()`).
 

--- a/dockerdata/startup.py
+++ b/dockerdata/startup.py
@@ -44,7 +44,19 @@ setConsoleACL('0.0.0.0/0')
     templateroot = '/etc/dnsdist/templates.d'
     templatedestination = '/etc/dnsdist/conf.d'
 
-apikey = os.getenv(apienvvar)
+# _FILE suffix will allow to read value from file, useful for Docker's secrets feature
+apikey = None
+if apienvvar + '_FILE' in os.environ:
+    if apienvvar in os.environ:
+        raise AttributeError(
+            "Both {} and {} are set but are mutually exclusive."
+            .format(apienvvar, apienvvar + '_FILE')
+        )
+    with open(os.environ[apienvvar + '_FILE']) as f:
+        apikey = f.read()
+elif apienvvar in os.environ:
+    apikey = os.getenv(apienvvar)
+
 if apikey is not None:
     webserver_conf = jinja2.Template(apiconftemplate).render(apikey=apikey)
     conffile = os.path.join(templatedestination, '_api.conf')


### PR DESCRIPTION
### Short description
Add support for docker's secrets in `PDNS_RECURSOR_API_KEY` / `PDNS_AUTH_API_KEY` / `DNSDIST_API_KEY` environment variables

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
