### PR TITLE
rec: Name recursor threads consistently with a "rec/" prefix.

### DIFF
--- a/pdns/recursordist/nod.cc
+++ b/pdns/recursordist/nod.cc
@@ -193,7 +193,7 @@ bool PersistentSBF::snapshotCurrent(std::thread::id tid)
 
 void NODDB::housekeepingThread(std::thread::id tid)
 {
-  setThreadName("pdns-r/NOD-hk");
+  setThreadName("rec/nod-hk");
   for (;;) {
     sleep(d_snapshot_interval);
     {
@@ -263,7 +263,7 @@ void UniqueResponseDB::addResponse(const std::string& response)
 
 void UniqueResponseDB::housekeepingThread(std::thread::id tid)
 {
-  setThreadName("pdns-r/UDR-hk");
+  setThreadName("rec/udr-hk");
   for (;;) {
     sleep(d_snapshot_interval);
     {

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -224,7 +224,7 @@ int RecThreadInfo::runThreads(Logr::log_t log)
     handlerInfo.start(0, "web+stat", cpusMap, log);
     auto& taskInfo = RecThreadInfo::info(2);
     taskInfo.setTaskThread();
-    taskInfo.start(2, "taskThread", cpusMap, log);
+    taskInfo.start(2, "task", cpusMap, log);
 
     auto& info = RecThreadInfo::info(currentThreadId);
     info.setListener();
@@ -278,7 +278,7 @@ int RecThreadInfo::runThreads(Logr::log_t log)
 
     for (unsigned int n = 0; n < RecThreadInfo::numTaskThreads(); ++n) {
       auto& info = RecThreadInfo::info(currentThreadId);
-      info.start(currentThreadId++, "taskThread", cpusMap, log);
+      info.start(currentThreadId++, "task", cpusMap, log);
     }
 
     /* This thread handles the web server, carbon, statistics and the control channel */

--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -383,7 +383,7 @@ static bool dumpZoneToDisk(Logr::log_t logger, const DNSName& zoneName, const st
 
 void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, const uint16_t xfrTimeout, const uint32_t refreshFromConf, std::shared_ptr<SOARecordContent> sr, const std::string& dumpZoneFileName, uint64_t configGeneration)
 {
-  setThreadName("pdns-r/RPZIXFR");
+  setThreadName("rec/rpzixfr");
   bool isPreloaded = sr != nullptr;
   auto luaconfsLocal = g_luaconfs.getLocal();
 

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -191,7 +191,7 @@ void RemoteLogger::maintenanceThread()
 {
   try {
 #ifdef WE_ARE_RECURSOR
-    string threadName = "pdns-r/remLog";
+    string threadName = "rec/remlog";
 #else
     string threadName = "dnsdist/remLog";
 #endif

--- a/pdns/snmp-agent.cc
+++ b/pdns/snmp-agent.cc
@@ -107,7 +107,7 @@ void SNMPAgent::worker()
   }
 
 #ifdef RECURSOR
-  string threadName = "pdns-r/SNMP";
+  string threadName = "rec/snmp";
 #else
   string threadName = "dnsdist/SNMP";
 #endif

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -237,7 +237,7 @@ void WebServer::registerWebHandler(const string& url, const HandlerFunction& han
 }
 
 static void *WebServerConnectionThreadStart(const WebServer* webServer, std::shared_ptr<Socket> client) {
-  setThreadName("pdns-r/webhndlr");
+  setThreadName("rec/webhndlr");
   const std::string msg = "Exception while serving a connection in main webserver thread";
   try {
     webServer->serveConnection(client);


### PR DESCRIPTION
Use thread names without capitals, as they look a bit ugly otherwise.

Threads started by libfstrm are not named, as they are created internally by the lib.

Partly supsersedes #11138

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
