### PR TITLE
dnsdist: Proper accounting of response and cache hits

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1114,6 +1114,8 @@ noerrors
 NOLOCK
 nometasync
 Nominet
+noncompliantqueries
+noncompliantresponses
 nonexist
 Nonnekes
 noout
@@ -1687,8 +1689,14 @@ tbhandler
 tbody
 tcely
 tcp
+tcpconnecttimeouts
 tcpdump
 TCPKEEPALIVE
+tcplatency
+tcpmaxconcurrentconnections
+tcpnewconnections
+tcpreusedconnections
+tcptoomanyconcurrentconnections
 tds
 teeaction
 Telenet
@@ -1724,6 +1732,7 @@ tinydnsbackend
 tisr
 tls
 tlsa
+tlsresumptions
 tmp
 tmpfs
 tobool

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -38,7 +38,7 @@ public:
   DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL=86400, uint32_t minTTL=0, uint32_t tempFailureTTL=60, uint32_t maxNegativeTTL=3600, uint32_t staleTTL=60, bool dontAge=false, uint32_t shards=1, bool deferrableInsertLock=true, bool parseECS=false);
 
   void insert(uint32_t key, const boost::optional<Netmask>& subnet, uint16_t queryFlags, bool dnssecOK, const DNSName& qname, uint16_t qtype, uint16_t qclass, const PacketBuffer& response, bool receivedOverUDP, uint8_t rcode, boost::optional<uint32_t> tempFailureTTL);
-  bool get(DNSQuestion& dq, uint16_t queryId, uint32_t* keyOut, boost::optional<Netmask>& subnet, bool dnssecOK, bool receivedOverUDP, uint32_t allowExpired = 0, bool skipAging = false, bool truncatedOK = true);
+  bool get(DNSQuestion& dq, uint16_t queryId, uint32_t* keyOut, boost::optional<Netmask>& subnet, bool dnssecOK, bool receivedOverUDP, uint32_t allowExpired = 0, bool skipAging = false, bool truncatedOK = true, bool recordMiss = true);
   size_t purgeExpired(size_t upTo, const time_t now);
   size_t expunge(size_t upTo=0);
   size_t expungeByName(const DNSName& name, uint16_t qtype=QType::ANY, bool suffixMatch=false);

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -565,7 +565,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
   output << "# HELP " << statesbase << "tcpavgconnduration "              << "The average duration of a TCP connection (ms)"                                        << "\n";
   output << "# TYPE " << statesbase << "tcpavgconnduration "              << "gauge"                                                                                << "\n";
   output << "# HELP " << statesbase << "tlsresumptions "                  << "The number of times a TLS session has been resumed"                                   << "\n";
-  output << "# TYPE " << statesbase << "tlsersumptions "                  << "counter"                                                                              << "\n";
+  output << "# TYPE " << statesbase << "tlsresumptions "                  << "counter"                                                                              << "\n";
   output << "# HELP " << statesbase << "tcplatency "                      << "Server's latency when answering TCP questions in milliseconds"                        << "\n";
   output << "# TYPE " << statesbase << "tcplatency "                      << "gauge"                                                                                << "\n";
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1286,6 +1286,10 @@ ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& 
             return ProcessQueryResult::Drop;
           }
 
+          ++g_stats.responses;
+          if (dq.ids.cs) {
+            ++dq.ids.cs->responses;
+          }
           return ProcessQueryResult::SendAnswer;
         }
 
@@ -1317,15 +1321,23 @@ ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& 
           return ProcessQueryResult::Drop;
         }
 
+        ++g_stats.responses;
+        if (dq.ids.cs) {
+          ++dq.ids.cs->responses;
+        }
         return ProcessQueryResult::SendAnswer;
       }
       else if (dq.ids.protocol == dnsdist::Protocol::DoH && !forwardedOverUDP) {
         /* do a second-lookup for UDP responses, but we do not want TC=1 answers */
-        if (dq.ids.packetCache->get(dq, dq.getHeader()->id, &dq.ids.cacheKeyUDP, dq.ids.subnet, dq.ids.dnssecOK, true, allowExpired, false)) {
+        if (dq.ids.packetCache->get(dq, dq.getHeader()->id, &dq.ids.cacheKeyUDP, dq.ids.subnet, dq.ids.dnssecOK, true, allowExpired, false, false, false)) {
           if (!prepareOutgoingResponse(holders, cs, dq, true)) {
             return ProcessQueryResult::Drop;
           }
 
+          ++g_stats.responses;
+          if (dq.ids.cs) {
+            ++dq.ids.cs->responses;
+          }
           return ProcessQueryResult::SendAnswer;
         }
       }
@@ -1347,6 +1359,10 @@ ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& 
 
         if (!prepareOutgoingResponse(holders, cs, dq, false)) {
           return ProcessQueryResult::Drop;
+        }
+        ++g_stats.responses;
+        if (dq.ids.cs) {
+          ++dq.ids.cs->responses;
         }
         // no response-only statistics counter to update.
         return ProcessQueryResult::SendAnswer;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1278,7 +1278,7 @@ ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& 
       // we need ECS parsing (parseECS) to be true so we can be sure that the initial incoming query did not have an existing
       // ECS option, which would make it unsuitable for the zero-scope feature.
       if (dq.ids.packetCache && !dq.ids.skipCache && (!selectedBackend || !selectedBackend->d_config.disableZeroScope) && dq.ids.packetCache->isECSParsingEnabled()) {
-        if (dq.ids.packetCache->get(dq, dq.getHeader()->id, &dq.ids.cacheKeyNoECS, dq.ids.subnet, dq.ids.dnssecOK, !dq.overTCP(), allowExpired)) {
+        if (dq.ids.packetCache->get(dq, dq.getHeader()->id, &dq.ids.cacheKeyNoECS, dq.ids.subnet, dq.ids.dnssecOK, !dq.overTCP(), allowExpired, false, true, false)) {
 
           vinfolog("Packet cache hit for query for %s|%s from %s (%s, %d bytes)", dq.ids.qname.toLogString(), QType(dq.ids.qtype).toString(), dq.ids.origRemote.toStringWithPort(), dq.ids.protocol.toString(), dq.getData().size());
 
@@ -1311,7 +1311,7 @@ ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& 
         forwardedOverUDP = false;
       }
 
-      if (dq.ids.packetCache->get(dq, dq.getHeader()->id, &dq.ids.cacheKey, dq.ids.subnet, dq.ids.dnssecOK, forwardedOverUDP, allowExpired)) {
+      if (dq.ids.packetCache->get(dq, dq.getHeader()->id, &dq.ids.cacheKey, dq.ids.subnet, dq.ids.dnssecOK, forwardedOverUDP, allowExpired, false, true, true)) {
 
         restoreFlags(dq.getHeader(), dq.ids.origFlags);
 

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -140,6 +140,15 @@ URL Endpoints
       # HELP dnsdist_queries Number of received queries
       # TYPE dnsdist_queries counter
       dnsdist_queries 0
+      # HELP dnsdist_frontend_nxdomain Number of NXDomain answers sent to clients
+      # TYPE dnsdist_frontend_nxdomain counter
+      dnsdist_frontend_nxdomain 0
+      # HELP dnsdist_frontend_servfail Number of SERVFAIL answers sent to clients
+      # TYPE dnsdist_frontend_servfail counter
+      dnsdist_frontend_servfail 0
+      # HELP dnsdist_frontend_noerror Number of NoError answers sent to clients
+      # TYPE dnsdist_frontend_noerror counter
+      dnsdist_frontend_noerror 0
       # HELP dnsdist_acl_drops Number of packets dropped because of the ACL
       # TYPE dnsdist_acl_drops counter
       dnsdist_acl_drops 0
@@ -155,6 +164,9 @@ URL Endpoints
       # HELP dnsdist_rule_servfail Number of SERVFAIL answers received because of a rule
       # TYPE dnsdist_rule_servfail counter
       dnsdist_rule_servfail 0
+      # HELP dnsdist_rule_truncated Number of truncated answers returned because of a rule
+      # TYPE dnsdist_rule_truncated counter
+      dnsdist_rule_truncated 0
       # HELP dnsdist_self_answered Number of self-answered responses
       # TYPE dnsdist_self_answered counter
       dnsdist_self_answered 0
@@ -200,18 +212,90 @@ URL Endpoints
       # HELP dnsdist_latency_avg1000000 Average response latency in microseconds of the last 1000000 packets
       # TYPE dnsdist_latency_avg1000000 gauge
       dnsdist_latency_avg1000000 0
+      # HELP dnsdist_latency_tcp_avg100 Average response latency, in microseconds, of the last 100 packets received over TCP
+      # TYPE dnsdist_latency_tcp_avg100 gauge
+      dnsdist_latency_tcp_avg100 0
+      # HELP dnsdist_latency_tcp_avg1000 Average response latency, in microseconds, of the last 1000 packets received over TCP
+      # TYPE dnsdist_latency_tcp_avg1000 gauge
+      dnsdist_latency_tcp_avg1000 0
+      # HELP dnsdist_latency_tcp_avg10000 Average response latency, in microseconds, of the last 10000 packets received over TCP
+      # TYPE dnsdist_latency_tcp_avg10000 gauge
+      dnsdist_latency_tcp_avg10000 0
+      # HELP dnsdist_latency_tcp_avg1000000 Average response latency, in microseconds, of the last 1000000 packets received over TCP
+      # TYPE dnsdist_latency_tcp_avg1000000 gauge
+      dnsdist_latency_tcp_avg1000000 0
+      # HELP dnsdist_latency_dot_avg100 Average response latency, in microseconds, of the last 100 packets received over DoT
+      # TYPE dnsdist_latency_dot_avg100 gauge
+      dnsdist_latency_dot_avg100 0
+      # HELP dnsdist_latency_dot_avg1000 Average response latency, in microseconds, of the last 1000 packets received over DoT
+      # TYPE dnsdist_latency_dot_avg1000 gauge
+      dnsdist_latency_dot_avg1000 0
+      # HELP dnsdist_latency_dot_avg10000 Average response latency, in microseconds, of the last 10000 packets received over DoT
+      # TYPE dnsdist_latency_dot_avg10000 gauge
+      dnsdist_latency_dot_avg10000 0
+      # HELP dnsdist_latency_dot_avg1000000 Average response latency, in microseconds, of the last 1000000 packets received over DoT
+      # TYPE dnsdist_latency_dot_avg1000000 gauge
+      dnsdist_latency_dot_avg1000000 0
+      # HELP dnsdist_latency_doh_avg100 Average response latency, in microseconds, of the last 100 packets received over DoH
+      # TYPE dnsdist_latency_doh_avg100 gauge
+      dnsdist_latency_doh_avg100 0
+      # HELP dnsdist_latency_doh_avg1000 Average response latency, in microseconds, of the last 1000 packets received over DoH
+      # TYPE dnsdist_latency_doh_avg1000 gauge
+      dnsdist_latency_doh_avg1000 0
+      # HELP dnsdist_latency_doh_avg10000 Average response latency, in microseconds, of the last 10000 packets received over DoH
+      # TYPE dnsdist_latency_doh_avg10000 gauge
+      dnsdist_latency_doh_avg10000 0
+      # HELP dnsdist_latency_doh_avg1000000 Average response latency, in microseconds, of the last 1000000 packets received over DoH
+      # TYPE dnsdist_latency_doh_avg1000000 gauge
+      dnsdist_latency_doh_avg1000000 0
       # HELP dnsdist_uptime Uptime of the dnsdist process in seconds
       # TYPE dnsdist_uptime gauge
-      dnsdist_uptime 39
+      dnsdist_uptime 19
       # HELP dnsdist_real_memory_usage Current memory usage in bytes
       # TYPE dnsdist_real_memory_usage gauge
-      dnsdist_real_memory_usage 10276864
+      dnsdist_real_memory_usage 52269056
+      # HELP dnsdist_udp_in_errors From /proc/net/snmp InErrors
+      # TYPE dnsdist_udp_in_errors counter
+      dnsdist_udp_in_errors 0
+      # HELP dnsdist_udp_noport_errors From /proc/net/snmp NoPorts
+      # TYPE dnsdist_udp_noport_errors counter
+      dnsdist_udp_noport_errors 86
+      # HELP dnsdist_udp_recvbuf_errors From /proc/net/snmp RcvbufErrors
+      # TYPE dnsdist_udp_recvbuf_errors counter
+      dnsdist_udp_recvbuf_errors 0
+      # HELP dnsdist_udp_sndbuf_errors From /proc/net/snmp SndbufErrors
+      # TYPE dnsdist_udp_sndbuf_errors counter
+      dnsdist_udp_sndbuf_errors 0
+      # HELP dnsdist_udp_in_csum_errors From /proc/net/snmp InCsumErrors
+      # TYPE dnsdist_udp_in_csum_errors counter
+      dnsdist_udp_in_csum_errors 0
+      # HELP dnsdist_udp6_in_errors From /proc/net/snmp6 Udp6InErrors
+      # TYPE dnsdist_udp6_in_errors counter
+      dnsdist_udp6_in_errors 0
+      # HELP dnsdist_udp6_recvbuf_errors From /proc/net/snmp6 Udp6RcvbufErrors
+      # TYPE dnsdist_udp6_recvbuf_errors counter
+      dnsdist_udp6_recvbuf_errors 0
+      # HELP dnsdist_udp6_sndbuf_errors From /proc/net/snmp6 Udp6SndbufErrors
+      # TYPE dnsdist_udp6_sndbuf_errors counter
+      dnsdist_udp6_sndbuf_errors 0
+      # HELP dnsdist_udp6_noport_errors From /proc/net/snmp6 Udp6NoPorts
+      # TYPE dnsdist_udp6_noport_errors counter
+      dnsdist_udp6_noport_errors 195
+      # HELP dnsdist_udp6_in_csum_errors From /proc/net/snmp6 Udp6InCsumErrors
+      # TYPE dnsdist_udp6_in_csum_errors counter
+      dnsdist_udp6_in_csum_errors 0
+      # HELP dnsdist_tcp_listen_overflows From /proc/net/netstat ListenOverflows
+      # TYPE dnsdist_tcp_listen_overflows counter
+      dnsdist_tcp_listen_overflows 0
       # HELP dnsdist_noncompliant_queries Number of queries dropped as non-compliant
       # TYPE dnsdist_noncompliant_queries counter
       dnsdist_noncompliant_queries 0
       # HELP dnsdist_noncompliant_responses Number of answers from a backend dropped as non-compliant
       # TYPE dnsdist_noncompliant_responses counter
       dnsdist_noncompliant_responses 0
+      # HELP dnsdist_proxy_protocol_invalid Number of queries dropped because of an invalid Proxy Protocol header
+      # TYPE dnsdist_proxy_protocol_invalid counter
+      dnsdist_proxy_protocol_invalid 0
       # HELP dnsdist_rdqueries Number of received queries with the recursion desired bit set
       # TYPE dnsdist_rdqueries counter
       dnsdist_rdqueries 0
@@ -224,39 +308,300 @@ URL Endpoints
       # HELP dnsdist_cache_misses Number of times an answer not found in the cache
       # TYPE dnsdist_cache_misses counter
       dnsdist_cache_misses 0
-      # HELP dnsdist_cpu_user_msec Milliseconds spent by dnsdist in the user state
-      # TYPE dnsdist_cpu_user_msec counter
-      dnsdist_cpu_user_msec 28
+      # HELP dnsdist_cpu_iowait Time waiting for I/O to complete by the whole system, in units of USER_HZ
+      # TYPE dnsdist_cpu_iowait counter
+      dnsdist_cpu_iowait 0
+      # HELP dnsdist_cpu_steal Stolen time, which is the time spent by the whole system in other operating systems when running in a virtualized environment, in units of USER_HZ
+      # TYPE dnsdist_cpu_steal counter
+      dnsdist_cpu_steal 0
       # HELP dnsdist_cpu_sys_msec Milliseconds spent by dnsdist in the system state
       # TYPE dnsdist_cpu_sys_msec counter
-      dnsdist_cpu_sys_msec 32
+      dnsdist_cpu_sys_msec 38
+      # HELP dnsdist_cpu_user_msec Milliseconds spent by dnsdist in the user state
+      # TYPE dnsdist_cpu_user_msec counter
+      dnsdist_cpu_user_msec 38
       # HELP dnsdist_fd_usage Number of currently used file descriptors
       # TYPE dnsdist_fd_usage gauge
-      dnsdist_fd_usage 17
+      dnsdist_fd_usage 32
       # HELP dnsdist_dyn_blocked Number of queries dropped because of a dynamic block
       # TYPE dnsdist_dyn_blocked counter
       dnsdist_dyn_blocked 0
       # HELP dnsdist_dyn_block_nmg_size Number of dynamic blocks entries
       # TYPE dnsdist_dyn_block_nmg_size gauge
       dnsdist_dyn_block_nmg_size 0
-      dnsdist_server_queries{server="1_1_1_1",address="1.1.1.1:53"} 0
-      dnsdist_server_drops{server="1_1_1_1",address="1.1.1.1:53"} 0
-      dnsdist_server_latency{server="1_1_1_1",address="1.1.1.1:53"} 0
-      dnsdist_server_senderrors{server="1_1_1_1",address="1.1.1.1:53"} 0
-      dnsdist_server_outstanding{server="1_1_1_1",address="1.1.1.1:53"} 0
-      dnsdist_server_order{server="1_1_1_1",address="1.1.1.1:53"} 1
-      dnsdist_server_weight{server="1_1_1_1",address="1.1.1.1:53"} 1
-      dnsdist_server_queries{server="1_0_0_1",address="1.0.0.1:53"} 0
-      dnsdist_server_drops{server="1_0_0_1",address="1.0.0.1:53"} 0
-      dnsdist_server_latency{server="1_0_0_1",address="1.0.0.1:53"} 0
-      dnsdist_server_senderrors{server="1_0_0_1",address="1.0.0.1:53"} 0
-      dnsdist_server_outstanding{server="1_0_0_1",address="1.0.0.1:53"} 0
-      dnsdist_server_order{server="1_0_0_1",address="1.0.0.1:53"} 1
-      dnsdist_server_weight{server="1_0_0_1",address="1.0.0.1:53"} 2
-      dnsdist_frontend_queries{frontend="127.0.0.1:1153",proto="udp"} 0
-      dnsdist_frontend_queries{frontend="127.0.0.1:1153",proto="tcp"} 0
-      dnsdist_pool_servers{pool="_default_"} 2
-      dnsdist_pool_cache_size{pool="_default_"} 200000
+      # HELP dnsdist_security_status Security status of this software. 0=unknown, 1=OK, 2=upgrade recommended, 3=upgrade mandatory
+      # TYPE dnsdist_security_status gauge
+      dnsdist_security_status 0
+      # HELP dnsdist_doh_query_pipe_full Number of DoH queries dropped because the internal pipe used to distribute queries was full
+      # TYPE dnsdist_doh_query_pipe_full counter
+      dnsdist_doh_query_pipe_full 0
+      # HELP dnsdist_doh_response_pipe_full Number of DoH responses dropped because the internal pipe used to distribute responses was full
+      # TYPE dnsdist_doh_response_pipe_full counter
+      dnsdist_doh_response_pipe_full 0
+      # HELP dnsdist_outgoing_doh_query_pipe_full Number of outgoing DoH queries dropped because the internal pipe used to distribute queries was full
+      # TYPE dnsdist_outgoing_doh_query_pipe_full counter
+      dnsdist_outgoing_doh_query_pipe_full 0
+      # HELP dnsdist_tcp_query_pipe_full Number of TCP queries dropped because the internal pipe used to distribute queries was full
+      # TYPE dnsdist_tcp_query_pipe_full counter
+      dnsdist_tcp_query_pipe_full 0
+      # HELP dnsdist_tcp_cross_protocol_query_pipe_full Number of TCP cross-protocol queries dropped because the internal pipe used to distribute queries was full
+      # TYPE dnsdist_tcp_cross_protocol_query_pipe_full counter
+      dnsdist_tcp_cross_protocol_query_pipe_full 0
+      # HELP dnsdist_tcp_cross_protocol_response_pipe_full Number of TCP cross-protocol responses dropped because the internal pipe used to distribute queries was full
+      # TYPE dnsdist_tcp_cross_protocol_response_pipe_full counter
+      dnsdist_tcp_cross_protocol_response_pipe_full 0
+      # HELP dnsdist_latency Histogram of responses by latency (in milliseconds)
+      # TYPE dnsdist_latency histogram
+      dnsdist_latency_bucket{le="1"} 0
+      dnsdist_latency_bucket{le="10"} 0
+      dnsdist_latency_bucket{le="50"} 0
+      dnsdist_latency_bucket{le="100"} 0
+      dnsdist_latency_bucket{le="1000"} 0
+      dnsdist_latency_bucket{le="+Inf"} 0
+      dnsdist_latency_sum 0
+      dnsdist_latency_count 0
+      # HELP dnsdist_server_status Whether this backend is up (1) or down (0)
+      # TYPE dnsdist_server_status gauge
+      # HELP dnsdist_server_queries Amount of queries relayed to server
+      # TYPE dnsdist_server_queries counter
+      # HELP dnsdist_server_responses Amount of responses received from this server
+      # TYPE dnsdist_server_responses counter
+      # HELP dnsdist_server_noncompliantresponses Amount of non-compliant responses received from this server
+      # TYPE dnsdist_server_noncompliantresponses counter
+      # HELP dnsdist_server_drops Amount of queries not answered by server
+      # TYPE dnsdist_server_drops counter
+      # HELP dnsdist_server_latency Server's latency when answering questions in milliseconds
+      # TYPE dnsdist_server_latency gauge
+      # HELP dnsdist_server_senderrors Total number of OS send errors while relaying queries
+      # TYPE dnsdist_server_senderrors counter
+      # HELP dnsdist_server_outstanding Current number of queries that are waiting for a backend response
+      # TYPE dnsdist_server_outstanding gauge
+      # HELP dnsdist_server_order The order in which this server is picked
+      # TYPE dnsdist_server_order gauge
+      # HELP dnsdist_server_weight The weight within the order in which this server is picked
+      # TYPE dnsdist_server_weight gauge
+      # HELP dnsdist_server_tcpdiedsendingquery The number of TCP I/O errors while sending the query
+      # TYPE dnsdist_server_tcpdiedsendingquery counter
+      # HELP dnsdist_server_tcpdiedreadingresponse The number of TCP I/O errors while reading the response
+      # TYPE dnsdist_server_tcpdiedreadingresponse counter
+      # HELP dnsdist_server_tcpgaveup The number of TCP connections failing after too many attempts
+      # TYPE dnsdist_server_tcpgaveup counter
+      # HELP dnsdist_server_tcpconnecttimeouts The number of TCP connect timeouts
+      # TYPE dnsdist_server_tcpconnecttimeouts counter
+      # HELP dnsdist_server_tcpreadtimeouts The number of TCP read timeouts
+      # TYPE dnsdist_server_tcpreadtimeouts counter
+      # HELP dnsdist_server_tcpwritetimeouts The number of TCP write timeouts
+      # TYPE dnsdist_server_tcpwritetimeouts counter
+      # HELP dnsdist_server_tcpcurrentconnections The number of current TCP connections
+      # TYPE dnsdist_server_tcpcurrentconnections gauge
+      # HELP dnsdist_server_tcpmaxconcurrentconnections The maximum number of concurrent TCP connections
+      # TYPE dnsdist_server_tcpmaxconcurrentconnections counter
+      # HELP dnsdist_server_tcptoomanyconcurrentconnections Number of times we had to enforce the maximum number of concurrent TCP connections
+      # TYPE dnsdist_server_tcptoomanyconcurrentconnections counter
+      # HELP dnsdist_server_tcpnewconnections The number of established TCP connections in total
+      # TYPE dnsdist_server_tcpnewconnections counter
+      # HELP dnsdist_server_tcpreusedconnections The number of times a TCP connection has been reused
+      # TYPE dnsdist_server_tcpreusedconnections counter
+      # HELP dnsdist_server_tcpavgqueriesperconn The average number of queries per TCP connection
+      # TYPE dnsdist_server_tcpavgqueriesperconn gauge
+      # HELP dnsdist_server_tcpavgconnduration The average duration of a TCP connection (ms)
+      # TYPE dnsdist_server_tcpavgconnduration gauge
+      # HELP dnsdist_server_tlsresumptions The number of times a TLS session has been resumed
+      # TYPE dnsdist_server_tlsersumptions counter
+      # HELP dnsdist_server_tcplatency Server's latency when answering TCP questions in milliseconds
+      # TYPE dnsdist_server_tcplatency gauge
+      dnsdist_server_status{server="9_9_9_9:443",address="9.9.9.9:443"} 1
+      dnsdist_server_queries{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_responses{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_noncompliantresponses{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_drops{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_latency{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcplatency{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_senderrors{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_outstanding{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_order{server="9_9_9_9:443",address="9.9.9.9:443"} 1
+      dnsdist_server_weight{server="9_9_9_9:443",address="9.9.9.9:443"} 1
+      dnsdist_server_tcpdiedsendingquery{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcpdiedreadingresponse{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcpgaveup{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcpreadtimeouts{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcpwritetimeouts{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcpconnecttimeouts{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcpcurrentconnections{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcpmaxconcurrentconnections{server="9_9_9_9:443",address="9.9.9.9:443"} 1
+      dnsdist_server_tcptoomanyconcurrentconnections{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcpnewconnections{server="9_9_9_9:443",address="9.9.9.9:443"} 19
+      dnsdist_server_tcpreusedconnections{server="9_9_9_9:443",address="9.9.9.9:443"} 0
+      dnsdist_server_tcpavgqueriesperconn{server="9_9_9_9:443",address="9.9.9.9:443"} 0.173831
+      dnsdist_server_tcpavgconnduration{server="9_9_9_9:443",address="9.9.9.9:443"} 3.92628
+      dnsdist_server_tlsresumptions{server="9_9_9_9:443",address="9.9.9.9:443"} 18
+      # HELP dnsdist_frontend_queries Amount of queries received by this frontend
+      # TYPE dnsdist_frontend_queries counter
+      # HELP dnsdist_frontend_noncompliantqueries Amount of non-compliant queries received by this frontend
+      # TYPE dnsdist_frontend_noncompliantqueries counter
+      # HELP dnsdist_frontend_responses Amount of responses sent by this frontend
+      # TYPE dnsdist_frontend_responses counter
+      # HELP dnsdist_frontend_tcpdiedreadingquery Amount of TCP connections terminated while reading the query from the client
+      # TYPE dnsdist_frontend_tcpdiedreadingquery counter
+      # HELP dnsdist_frontend_tcpdiedsendingresponse Amount of TCP connections terminated while sending a response to the client
+      # TYPE dnsdist_frontend_tcpdiedsendingresponse counter
+      # HELP dnsdist_frontend_tcpgaveup Amount of TCP connections terminated after too many attempts to get a connection to the backend
+      # TYPE dnsdist_frontend_tcpgaveup counter
+      # HELP dnsdist_frontend_tcpclientimeouts Amount of TCP connections terminated by a timeout while reading from the client
+      # TYPE dnsdist_frontend_tcpclientimeouts counter
+      # HELP dnsdist_frontend_tcpdownstreamtimeouts Amount of TCP connections terminated by a timeout while reading from the backend
+      # TYPE dnsdist_frontend_tcpdownstreamtimeouts counter
+      # HELP dnsdist_frontend_tcpcurrentconnections Amount of current incoming TCP connections from clients
+      # TYPE dnsdist_frontend_tcpcurrentconnections gauge
+      # HELP dnsdist_frontend_tcpmaxconcurrentconnections Maximum number of concurrent incoming TCP connections from clients
+      # TYPE dnsdist_frontend_tcpmaxconcurrentconnections counter
+      # HELP dnsdist_frontend_tcpavgqueriesperconnection The average number of queries per TCP connection
+      # TYPE dnsdist_frontend_tcpavgqueriesperconnection gauge
+      # HELP dnsdist_frontend_tcpavgconnectionduration The average duration of a TCP connection (ms)
+      # TYPE dnsdist_frontend_tcpavgconnectionduration gauge
+      # HELP dnsdist_frontend_tlsqueries Number of queries received by dnsdist over TLS, by TLS version
+      # TYPE dnsdist_frontend_tlsqueries counter
+      # HELP dnsdist_frontend_tlsnewsessions Amount of new TLS sessions negotiated
+      # TYPE dnsdist_frontend_tlsnewsessions counter
+      # HELP dnsdist_frontend_tlsresumptions Amount of TLS sessions resumed
+      # TYPE dnsdist_frontend_tlsresumptions counter
+      # HELP dnsdist_frontend_tlsunknownticketkeys Amount of attempts to resume TLS session from an unknown key (possibly expired)
+      # TYPE dnsdist_frontend_tlsunknownticketkeys counter
+      # HELP dnsdist_frontend_tlsinactiveticketkeys Amount of TLS sessions resumed from an inactive key
+      # TYPE dnsdist_frontend_tlsinactiveticketkeys counter
+      # HELP dnsdist_frontend_tlshandshakefailures Amount of TLS handshake failures
+      # TYPE dnsdist_frontend_tlshandshakefailures counter
+      dnsdist_frontend_queries{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_noncompliantqueries{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_responses{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tcpdiedreadingquery{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tcpdiedsendingresponse{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tcpgaveup{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tcpclientimeouts{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tcpdownstreamtimeouts{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tcpcurrentconnections{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tcpmaxconcurrentconnections{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tcpavgqueriesperconnection{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tcpavgconnectionduration{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tlsnewsessions{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tlsresumptions{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tlsunknownticketkeys{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tlsinactiveticketkeys{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0"} 0
+      dnsdist_frontend_tlsqueries{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",tls="tls10"} 0
+      dnsdist_frontend_tlsqueries{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",tls="tls11"} 0
+      dnsdist_frontend_tlsqueries{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",tls="tls12"} 0
+      dnsdist_frontend_tlsqueries{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",tls="tls13"} 0
+      dnsdist_frontend_tlsqueries{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",tls="unknown"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",error="dhKeyTooSmall"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",error="inappropriateFallBack"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",error="noSharedCipher"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",error="unknownCipherType"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",error="unknownKeyExchangeType"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",error="unknownProtocol"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",error="unsupportedEC"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="127.0.0.1:853",proto="TCP (DNS over TLS)",thread="0",error="unsupportedProtocol"} 0
+      dnsdist_frontend_queries{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_noncompliantqueries{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_responses{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tcpdiedreadingquery{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tcpdiedsendingresponse{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tcpgaveup{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tcpclientimeouts{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tcpdownstreamtimeouts{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tcpcurrentconnections{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tcpmaxconcurrentconnections{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tcpavgqueriesperconnection{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tcpavgconnectionduration{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tlsnewsessions{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tlsresumptions{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tlsunknownticketkeys{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tlsinactiveticketkeys{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0"} 0
+      dnsdist_frontend_tlsqueries{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",tls="tls10"} 0
+      dnsdist_frontend_tlsqueries{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",tls="tls11"} 0
+      dnsdist_frontend_tlsqueries{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",tls="tls12"} 0
+      dnsdist_frontend_tlsqueries{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",tls="tls13"} 0
+      dnsdist_frontend_tlsqueries{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",tls="unknown"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",error="dhKeyTooSmall"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",error="inappropriateFallBack"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",error="noSharedCipher"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",error="unknownCipherType"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",error="unknownKeyExchangeType"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",error="unknownProtocol"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",error="unsupportedEC"} 0
+      dnsdist_frontend_tlshandshakefailures{frontend="[::1]:443",proto="TCP (DNS over HTTPS)",thread="0",error="unsupportedProtocol"} 0
+      dnsdist_frontend_queries{frontend="127.0.0.1:53",proto="UDP",thread="0"} 0
+      dnsdist_frontend_noncompliantqueries{frontend="127.0.0.1:53",proto="UDP",thread="0"} 0
+      dnsdist_frontend_responses{frontend="127.0.0.1:53",proto="UDP",thread="0"} 0
+      dnsdist_frontend_queries{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_noncompliantqueries{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_responses{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_tcpdiedreadingquery{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_tcpdiedsendingresponse{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_tcpgaveup{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_tcpclientimeouts{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_tcpdownstreamtimeouts{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_tcpcurrentconnections{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_tcpmaxconcurrentconnections{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_tcpavgqueriesperconnection{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      dnsdist_frontend_tcpavgconnectionduration{frontend="127.0.0.1:53",proto="TCP",thread="0"} 0
+      # HELP dnsdist_frontend_http_connects Number of DoH TCP connections established to this frontend
+      # TYPE dnsdist_frontend_http_connects counter
+      # HELP dnsdist_frontend_doh_http_method_queries Number of DoH queries received by dnsdist, by HTTP method
+      # TYPE dnsdist_frontend_doh_http_method_queries counter
+      # HELP dnsdist_frontend_doh_http_version_queries Number of DoH queries received by dnsdist, by HTTP version
+      # TYPE dnsdist_frontend_doh_http_version_queries counter
+      # HELP dnsdist_frontend_doh_bad_requests Number of requests that could not be converted to a DNS query
+      # TYPE dnsdist_frontend_doh_bad_requests counter
+      # HELP dnsdist_frontend_doh_responses Number of responses sent, by type
+      # TYPE dnsdist_frontend_doh_responses counter
+      # HELP dnsdist_frontend_doh_version_status_responses Number of requests that could not be converted to a DNS query
+      # TYPE dnsdist_frontend_doh_version_status_responses counter
+      dnsdist_frontend_http_connects{frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_http_method_queries{method="get",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_http_method_queries{method="post",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_http_version_queries{version="1",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_http_version_queries{version="2",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_bad_requests{frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_responses{type="error",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_responses{type="redirect",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_responses{type="valid",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="1",status="200",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="1",status="400",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="1",status="403",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="1",status="500",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="1",status="502",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="1",status="other",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="2",status="200",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="2",status="400",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="2",status="403",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="2",status="500",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="2",status="502",frontend="[::1]:443",thread="0"} 0
+      dnsdist_frontend_doh_version_status_responses{httpversion="2",status="other",frontend="[::1]:443",thread="0"} 0
+      # HELP dnsdist_pool_servers Number of servers in that pool
+      # TYPE dnsdist_pool_servers gauge
+      # HELP dnsdist_pool_active_servers Number of available servers in that pool
+      # TYPE dnsdist_pool_active_servers gauge
+      # HELP dnsdist_pool_cache_size Maximum number of entries that this cache can hold
+      # TYPE dnsdist_pool_cache_size gauge
+      # HELP dnsdist_pool_cache_entries Number of entries currently present in that cache
+      # TYPE dnsdist_pool_cache_entries gauge
+      # HELP dnsdist_pool_cache_hits Number of hits from that cache
+      # TYPE dnsdist_pool_cache_hits counter
+      # HELP dnsdist_pool_cache_misses Number of misses from that cache
+      # TYPE dnsdist_pool_cache_misses counter
+      # HELP dnsdist_pool_cache_deferred_inserts Number of insertions into that cache skipped because it was already locked
+      # TYPE dnsdist_pool_cache_deferred_inserts counter
+      # HELP dnsdist_pool_cache_deferred_lookups Number of lookups into that cache skipped because it was already locked
+      # TYPE dnsdist_pool_cache_deferred_lookups counter
+      # HELP dnsdist_pool_cache_lookup_collisions Number of lookups into that cache that triggered a collision (same hash but different entry)
+      # TYPE dnsdist_pool_cache_lookup_collisions counter
+      # HELP dnsdist_pool_cache_insert_collisions Number of insertions into that cache that triggered a collision (same hash but different entry)
+      # TYPE dnsdist_pool_cache_insert_collisions counter
+      # HELP dnsdist_pool_cache_ttl_too_shorts Number of insertions into that cache skipped because the TTL of the answer was not long enough
+      # TYPE dnsdist_pool_cache_ttl_too_shorts counter
+      dnsdist_pool_servers{pool="_default_"} 1
+      dnsdist_pool_active_servers{pool="_default_"} 1
+      dnsdist_pool_cache_size{pool="_default_"} 100
       dnsdist_pool_cache_entries{pool="_default_"} 0
       dnsdist_pool_cache_hits{pool="_default_"} 0
       dnsdist_pool_cache_misses{pool="_default_"} 0
@@ -265,6 +610,16 @@ URL Endpoints
       dnsdist_pool_cache_lookup_collisions{pool="_default_"} 0
       dnsdist_pool_cache_insert_collisions{pool="_default_"} 0
       dnsdist_pool_cache_ttl_too_shorts{pool="_default_"} 0
+      dnsdist_pool_cache_cleanup_count{pool="_default_"} 0
+      # HELP dnsdist_rule_hits Number of hits of that rule
+      # TYPE dnsdist_rule_hits counter
+      # HELP dnsdist_dynblocks_nmg_top_offenders_hits_per_second Number of hits per second blocked by Dynamic Blocks (netmasks) for the top offenders, averaged over the last 60s
+      # TYPE dnsdist_dynblocks_nmg_top_offenders_hits_per_second gauge
+      # HELP dnsdist_dynblocks_smt_top_offenders_hits_per_second Number of this per second blocked by Dynamic Blocks (suffixes) for the top offenders, averaged over the last 60s
+      # TYPE dnsdist_dynblocks_smt_top_offenders_hits_per_second gauge
+      # HELP dnsdist_info Info from dnsdist, value is always 1
+      # TYPE dnsdist_info gauge
+      dnsdist_info{version="1.7.3"} 1
 
   **Example prometheus configuration**:
 

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -407,7 +407,7 @@ URL Endpoints
       # HELP dnsdist_server_tcpavgconnduration The average duration of a TCP connection (ms)
       # TYPE dnsdist_server_tcpavgconnduration gauge
       # HELP dnsdist_server_tlsresumptions The number of times a TLS session has been resumed
-      # TYPE dnsdist_server_tlsersumptions counter
+      # TYPE dnsdist_server_tlsresumptions counter
       # HELP dnsdist_server_tcplatency Server's latency when answering TCP questions in milliseconds
       # TYPE dnsdist_server_tcplatency gauge
       dnsdist_server_status{server="9_9_9_9:443",address="9.9.9.9:443"} 1

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -1,6 +1,11 @@
 Upgrade Guide
 =============
 
+1.7.x to 1.8.0
+--------------
+
+Cache-hits are now counted as responses in our metrics.
+
 1.7.0 to 1.7.1
 --------------
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Properly record cache-hits as responses: For a very long time we have not been adding cache-hits to the responses counter, which is wrong. Let's fix it now. Closes https://github.com/PowerDNS/pdns/issues/12045.
- Only record one hit or miss per query in the cache metrics: The scope-zero feature and the DoH paths can actually do more than one lookup per query, and until now this led to an increase of the per-cache metric for every lookup, while the global `cache-hits` and `cache-misses` metrics were only updated once per query. This has led to several questions and misunderstandings, so we now only update the per-cache metrics once per query as well. Closes https://github.com/PowerDNS/pdns/issues/12398.
- Update the prometheus sample in the documentation: It was very old and not up-to-date.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
