### PR TITLE
rec: do not chain ecs enabled queries

### DIFF
--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -422,7 +422,6 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
       eo.source = *srcmask;
       outgoingECSBits = srcmask->getBits();
       outgoingECSAddr = srcmask->getNetwork();
-      //      cout<<"Adding request mask: "<<eo.source.toString()<<endl;
       opts.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(eo));
       weWantEDNSSubnet = true;
     }
@@ -472,7 +471,7 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
       t_Counters.at(rec::Counter::ipv6queries)++;
     }
 
-    ret = asendto((const char*)&*vpacket.begin(), vpacket.size(), 0, ip, qid, domain, type, &queryfd);
+    ret = asendto((const char*)&*vpacket.begin(), vpacket.size(), 0, ip, qid, domain, type, weWantEDNSSubnet, &queryfd);
 
     if (ret != LWResult::Result::Success) {
       return ret;
@@ -595,7 +594,6 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
           if (opt.first == EDNSOptionCode::ECS) {
             EDNSSubnetOpts reso;
             if (getEDNSSubnetOptsFromString(opt.second, &reso)) {
-              //	    cerr<<"EDNS Subnet response: "<<reso.source.toString()<<", scope: "<<reso.scope.toString()<<", family = "<<reso.scope.getNetwork().sin4.sin_family<<endl;
               /* rfc7871 states that 0 "indicate[s] that the answer is suitable for all addresses in FAMILY",
                  so we might want to still pass the information along to be able to differentiate between
                  IPv4 and IPv6. Still I'm pretty sure it doesn't matter in real life, so let's not duplicate

--- a/pdns/recursordist/lwres.hh
+++ b/pdns/recursordist/lwres.hh
@@ -84,7 +84,7 @@ public:
 };
 
 LWResult::Result asendto(const char* data, size_t len, int flags, const ComboAddress& ip, uint16_t id,
-                         const DNSName& domain, uint16_t qtype, int* fd);
+                         const DNSName& domain, uint16_t qtype, bool ecs, int* fd);
 LWResult::Result arecvfrom(PacketBuffer& packet, int flags, const ComboAddress& ip, size_t* d_len, uint16_t id,
                            const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now);
 

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -277,7 +277,7 @@ LWResult::Result asendto(const char* data, size_t len, int flags,
     auto chain = MT->d_waiters.equal_range(pident, PacketIDBirthdayCompare());
 
     for (; chain.first != chain.second; chain.first++) {
-      // Line below detected an issue with the two ways of ordering PackeIDs (birtday and non-birthday)
+      // Line below detected an issue with the two ways of ordering PacketIDs (birthday and non-birthday)
       assert(chain.first->key->domain == pident->domain);
       // don't chain onto existing chained waiter or a chain already processed
       if (chain.first->key->fd > -1 && !chain.first->key->closed) {

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -259,7 +259,7 @@ thread_local std::unique_ptr<UDPClientSocks> t_udpclientsocks;
 
 /* these two functions are used by LWRes */
 LWResult::Result asendto(const char* data, size_t len, int flags,
-                         const ComboAddress& toaddr, uint16_t id, const DNSName& domain, uint16_t qtype, int* fd)
+                         const ComboAddress& toaddr, uint16_t id, const DNSName& domain, uint16_t qtype, bool ecs, int* fd)
 {
 
   auto pident = std::make_shared<PacketID>();
@@ -267,18 +267,24 @@ LWResult::Result asendto(const char* data, size_t len, int flags,
   pident->remote = toaddr;
   pident->type = qtype;
 
-  // see if there is an existing outstanding request we can chain on to, using partial equivalence function looking for the same
-  // query (qname and qtype) to the same host, but with a different message ID
-  pair<MT_t::waiters_t::iterator, MT_t::waiters_t::iterator> chain = MT->d_waiters.equal_range(pident, PacketIDBirthdayCompare());
+  // We might want to put the ecs netmask into the PacketID key, but we take the easy way:
+  // Avoid processing a chain with queries having different ECS data by lwres:asyncresolve() as it
+  // assumes the mask received corresponds to the mask sent out, so do not chain ecs queries.
+  if (!ecs) {
+    // See if there is an existing outstanding request we can chain on to, using partial equivalence
+    // function looking for the same query (qname and qtype) to the same host, but with a different
+    // message ID.
+    auto chain = MT->d_waiters.equal_range(pident, PacketIDBirthdayCompare());
 
-  for (; chain.first != chain.second; chain.first++) {
-    // Line below detected an issue with the two ways of ordering PackeIDs (birtday and non-birthday)
-    assert(chain.first->key->domain == pident->domain);
-    if (chain.first->key->fd > -1 && !chain.first->key->closed) { // don't chain onto existing chained waiter or a chain already processed
-      // cerr << "Insert " << id << ' ' << pident << " into chain for  " << chain.first->key << endl;
-      chain.first->key->chain.insert(id); // we can chain
-      *fd = -1; // gets used in waitEvent / sendEvent later on
-      return LWResult::Result::Success;
+    for (; chain.first != chain.second; chain.first++) {
+      // Line below detected an issue with the two ways of ordering PackeIDs (birtday and non-birthday)
+      assert(chain.first->key->domain == pident->domain);
+      // don't chain onto existing chained waiter or a chain already processed
+      if (chain.first->key->fd > -1 && !chain.first->key->closed) {
+        chain.first->key->chain.insert(id); // we can chain
+        *fd = -1;                           // gets used in waitEvent / sendEvent later on
+        return LWResult::Result::Success;
+      }
     }
   }
 

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -267,7 +267,7 @@ LWResult::Result asendto(const char* data, size_t len, int flags,
   pident->remote = toaddr;
   pident->type = qtype;
 
-  // We cannot merge ECS-enabled queries based on the ECS source only, as the scope 
+  // We cannot merge ECS-enabled queries based on the ECS source only, as the scope
   // of the response might be narrower, so instead we do not chain ECS-enabled queries
   // at all.
   if (!ecs) {
@@ -282,7 +282,7 @@ LWResult::Result asendto(const char* data, size_t len, int flags,
       // don't chain onto existing chained waiter or a chain already processed
       if (chain.first->key->fd > -1 && !chain.first->key->closed) {
         chain.first->key->chain.insert(id); // we can chain
-        *fd = -1;                           // gets used in waitEvent / sendEvent later on
+        *fd = -1; // gets used in waitEvent / sendEvent later on
         return LWResult::Result::Success;
       }
     }

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -267,9 +267,9 @@ LWResult::Result asendto(const char* data, size_t len, int flags,
   pident->remote = toaddr;
   pident->type = qtype;
 
-  // We might want to put the ecs netmask into the PacketID key, but we take the easy way:
-  // Avoid processing a chain with queries having different ECS data by lwres:asyncresolve() as it
-  // assumes the mask received corresponds to the mask sent out, so do not chain ecs queries.
+  // We cannot merge ECS-enabled queries based on the ECS source only, as the scope 
+  // of the response might be narrower, so instead we do not chain ECS-enabled queries
+  // at all.
   if (!ecs) {
     // See if there is an existing outstanding request we can chain on to, using partial equivalence
     // function looking for the same query (qname and qtype) to the same host, but with a different


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Avoid processing a chain with queries having different ECS data by lwres:asyncresolve() as it assumes the mask received corresponds to the mask sent out, so do not chain ecs queries.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
