### PR TITLE
Support OpenSSL 3.0 for ipcipher CA6 encryption/decryption

### DIFF
--- a/pdns/ipcipher.cc
+++ b/pdns/ipcipher.cc
@@ -1,5 +1,6 @@
 #include "ipcipher.hh"
 #include "ext/ipcrypt/ipcrypt.h"
+#include <cassert>
 #include <openssl/aes.h>
 #include <openssl/evp.h>
 
@@ -59,10 +60,47 @@ static ComboAddress encryptCA6(const ComboAddress& address, const std::string& k
 
   ComboAddress ret = address;
 
+#if OPENSSL_VERSION_MAJOR >= 3
+  auto ctx = std::unique_ptr<EVP_CIPHER_CTX, decltype(&EVP_CIPHER_CTX_free)>(EVP_CIPHER_CTX_new(), &EVP_CIPHER_CTX_free);
+  if (ctx == nullptr) {
+    throw pdns::OpenSSL::error("encryptCA6: Could not initialize cipher context");
+  }
+
+  auto aes128cbc = std::unique_ptr<EVP_CIPHER, decltype(&EVP_CIPHER_free)>(EVP_CIPHER_fetch(nullptr, "AES-128-CBC", nullptr), &EVP_CIPHER_free);
+
+  // NOLINTNEXTLINE(*-cast): Using OpenSSL C APIs.
+  if (EVP_EncryptInit(ctx.get(), aes128cbc.get(), reinterpret_cast<const unsigned char*>(key.c_str()), nullptr) == 0) {
+    throw pdns::OpenSSL::error("encryptCA6: Could not initialize encryption algorithm");
+  }
+
+  // Disable padding
+  const auto inSize = sizeof(address.sin6.sin6_addr.s6_addr);
+  static_assert(inSize == 16, "We disable padding and so we must assume a data size of 16 bytes");
+  const auto blockSize = EVP_CIPHER_get_block_size(aes128cbc.get());
+  assert(blockSize == 16);
+  EVP_CIPHER_CTX_set_padding(ctx.get(), 0);
+
+  int updateLen = 0;
+  // NOLINTNEXTLINE(*-cast): Using OpenSSL C APIs.
+  const auto* input = reinterpret_cast<const unsigned char*>(&address.sin6.sin6_addr.s6_addr);
+  // NOLINTNEXTLINE(*-cast): Using OpenSSL C APIs.
+  auto* output = reinterpret_cast<unsigned char*>(&ret.sin6.sin6_addr.s6_addr);
+  if (EVP_EncryptUpdate(ctx.get(), output, &updateLen, input, static_cast<int>(inSize)) == 0) {
+    throw pdns::OpenSSL::error("encryptCA6: Could not encrypt address");
+  }
+
+  int finalLen = 0;
+  if (EVP_EncryptFinal_ex(ctx.get(), output + updateLen, &finalLen) == 0) {
+    throw pdns::OpenSSL::error("encryptCA6: Could not finalize address encryption");
+  }
+
+  assert(updateLen + finalLen == inSize);
+#else
   AES_KEY wctx;
   AES_set_encrypt_key((const unsigned char*)key.c_str(), 128, &wctx);
   AES_encrypt((const unsigned char*)&address.sin6.sin6_addr.s6_addr,
               (unsigned char*)&ret.sin6.sin6_addr.s6_addr, &wctx);
+#endif
 
   return ret;
 }

--- a/pdns/ipcipher.cc
+++ b/pdns/ipcipher.cc
@@ -113,10 +113,47 @@ static ComboAddress decryptCA6(const ComboAddress& address, const std::string& k
 
   ComboAddress ret = address;
 
+#if OPENSSL_VERSION_MAJOR >= 3
+  auto ctx = std::unique_ptr<EVP_CIPHER_CTX, decltype(&EVP_CIPHER_CTX_free)>(EVP_CIPHER_CTX_new(), &EVP_CIPHER_CTX_free);
+  if (ctx == nullptr) {
+    throw pdns::OpenSSL::error("decryptCA6: Could not initialize cipher context");
+  }
+
+  auto aes128cbc = std::unique_ptr<EVP_CIPHER, decltype(&EVP_CIPHER_free)>(EVP_CIPHER_fetch(nullptr, "AES-128-CBC", nullptr), &EVP_CIPHER_free);
+
+  // NOLINTNEXTLINE(*-cast): Using OpenSSL C APIs.
+  if (EVP_DecryptInit(ctx.get(), aes128cbc.get(), reinterpret_cast<const unsigned char*>(key.c_str()), nullptr) == 0) {
+    throw pdns::OpenSSL::error("decryptCA6: Could not initialize decryption algorithm");
+  }
+
+  // Disable padding
+  const auto inSize = sizeof(address.sin6.sin6_addr.s6_addr);
+  static_assert(inSize == 16, "We disable padding and so we must assume a data size of 16 bytes");
+  const auto blockSize = EVP_CIPHER_get_block_size(aes128cbc.get());
+  assert(blockSize == 16);
+  EVP_CIPHER_CTX_set_padding(ctx.get(), 0);
+
+  int updateLen = 0;
+  // NOLINTNEXTLINE(*-cast): Using OpenSSL C APIs.
+  const auto* input = reinterpret_cast<const unsigned char*>(&address.sin6.sin6_addr.s6_addr);
+  // NOLINTNEXTLINE(*-cast): Using OpenSSL C APIs.
+  auto* output = reinterpret_cast<unsigned char*>(&ret.sin6.sin6_addr.s6_addr);
+  if (EVP_DecryptUpdate(ctx.get(), output, &updateLen, input, static_cast<int>(inSize)) == 0) {
+    throw pdns::OpenSSL::error("decryptCA6: Could not decrypt address");
+  }
+
+  int finalLen = 0;
+  if (EVP_DecryptFinal_ex(ctx.get(), output + updateLen, &finalLen) == 0) {
+    throw pdns::OpenSSL::error("decryptCA6: Could not finalize address decryption");
+  }
+
+  assert(updateLen + finalLen == inSize);
+#else
   AES_KEY wctx;
   AES_set_decrypt_key((const unsigned char*)key.c_str(), 128, &wctx);
   AES_decrypt((const unsigned char*)&address.sin6.sin6_addr.s6_addr,
               (unsigned char*)&ret.sin6.sin6_addr.s6_addr, &wctx);
+#endif
 
   return ret;
 }

--- a/pdns/ipcipher.hh
+++ b/pdns/ipcipher.hh
@@ -7,7 +7,7 @@
 // see https://powerdns.org/ipcipher
 
 #ifdef HAVE_IPCIPHER
-ComboAddress encryptCA(const ComboAddress& ca, const std::string& key);
-ComboAddress decryptCA(const ComboAddress& ca, const std::string& key);
+ComboAddress encryptCA(const ComboAddress& address, const std::string& key);
+ComboAddress decryptCA(const ComboAddress& address, const std::string& key);
 std::string makeIPCipherKey(const std::string& password);
 #endif /* HAVE_IPCIPHER */


### PR DESCRIPTION
### Short description
Support OpenSSL 3.0 for ipcipher CA6 encryption/decryption. Nothing special here, use OpenSSL 3.0's `EVP_CIPHER_*` instead of the deprecated `AES_*` API but continue to support the deprecated OpenSSL 1.1.1 API.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)