### PR TITLE
dnsdist: Add the ability to change the qname and owner names in DNS packets

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -444,7 +444,7 @@ uint32_t DNSDistPacketCache::getKey(const DNSName::string_t& qname, size_t qname
   if (packet.size() > ((sizeof(dnsheader) + qnameWireLength))) {
     if (!d_optionsToSkip.empty()) {
       /* skip EDNS options if any */
-      result = PacketCache::hashAfterQname(pdns_string_view(reinterpret_cast<const char*>(packet.data()), packet.size()), result, sizeof(dnsheader) + qnameWireLength, d_optionsToSkip);
+      result = PacketCache::hashAfterQname(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()), result, sizeof(dnsheader) + qnameWireLength, d_optionsToSkip);
     }
     else {
       result = burtle(&packet.at(sizeof(dnsheader) + qnameWireLength), packet.size() - (sizeof(dnsheader) + qnameWireLength), result);

--- a/pdns/dnsdist-ecs.cc
+++ b/pdns/dnsdist-ecs.cc
@@ -52,7 +52,7 @@ int rewriteResponseWithoutEDNS(const PacketBuffer& initialPacket, PacketBuffer& 
   if (ntohs(dh->qdcount) == 0)
     return ENOENT;
 
-  PacketReader pr(pdns_string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size()));
+  PacketReader pr(std::string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size()));
 
   size_t idx = 0;
   DNSName rrname;
@@ -165,7 +165,7 @@ bool slowRewriteEDNSOptionInQueryWithRecords(const PacketBuffer& initialPacket, 
   optionAdded = false;
   ednsAdded = true;
 
-  PacketReader pr(pdns_string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size()));
+  PacketReader pr(std::string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size()));
 
   size_t idx = 0;
   DNSName rrname;
@@ -329,7 +329,7 @@ int locateEDNSOptRR(const PacketBuffer& packet, uint16_t * optStart, size_t * op
   if (ntohs(dh->arcount) == 0)
     return ENOENT;
 
-  PacketReader pr(pdns_string_view(reinterpret_cast<const char*>(packet.data()), packet.size()));
+  PacketReader pr(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()));
 
   size_t idx = 0;
   DNSName rrname;
@@ -760,7 +760,7 @@ int rewriteResponseWithoutEDNSOption(const PacketBuffer& initialPacket, const ui
   if (ntohs(dh->qdcount) == 0)
     return ENOENT;
 
-  PacketReader pr(pdns_string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size()));
+  PacketReader pr(std::string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size()));
 
   size_t idx = 0;
   DNSName rrname;

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -168,8 +168,8 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
     return result;
   });
 
-  luaCtx.registerFunction<bool(DNSQuestion::*)(const DNSName& newName)>("rebase", [](DNSQuestion& dq, const DNSName& newName) -> bool {
-    if (!dnsdist::rebaseDNSPacket(dq.getMutableData(), dq.ids.qname, newName)) {
+  luaCtx.registerFunction<bool(DNSQuestion::*)(const DNSName& newName)>("changeName", [](DNSQuestion& dq, const DNSName& newName) -> bool {
+    if (!dnsdist::changeNameInDNSPacket(dq.getMutableData(), dq.ids.qname, newName)) {
       return false;
     }
     dq.ids.qname = newName;
@@ -444,8 +444,8 @@ private:
     return dnsdist::suspendResponse(dr, asyncID, queryID, timeoutMs);
   });
 
-  luaCtx.registerFunction<bool(DNSResponse::*)(const DNSName& newName)>("rebase", [](DNSResponse& dr, const DNSName& newName) -> bool {
-    if (!dnsdist::rebaseDNSPacket(dr.getMutableData(), dr.ids.qname, newName)) {
+  luaCtx.registerFunction<bool(DNSResponse::*)(const DNSName& newName)>("changeName", [](DNSResponse& dr, const DNSName& newName) -> bool {
+    if (!dnsdist::changeNameInDNSPacket(dr.getMutableData(), dr.ids.qname, newName)) {
       return false;
     }
     dr.ids.qname = newName;

--- a/pdns/dnsdistdist/dnsdist-discovery.cc
+++ b/pdns/dnsdistdist/dnsdist-discovery.cc
@@ -53,7 +53,7 @@ static bool parseSVCParams(const PacketBuffer& answer, std::map<uint16_t, Design
 {
   std::map<DNSName, std::vector<ComboAddress>> hints;
   const struct dnsheader* dh = reinterpret_cast<const struct dnsheader*>(answer.data());
-  PacketReader pr(pdns_string_view(reinterpret_cast<const char*>(answer.data()), answer.size()));
+  PacketReader pr(std::string_view(reinterpret_cast<const char*>(answer.data()), answer.size()));
   uint16_t qdcount = ntohs(dh->qdcount);
   uint16_t ancount = ntohs(dh->ancount);
   uint16_t nscount = ntohs(dh->nscount);

--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -63,4 +63,131 @@ DNSPacketOverlay::DNSPacketOverlay(const std::string_view& packet)
     throw std::runtime_error("Unable to parse DNS packet");
   }
 }
+
+bool changeNameInDNSPacket(PacketBuffer& initialPacket, const DNSName& from, const DNSName& to)
+{
+  if (initialPacket.size() < sizeof(dnsheader)) {
+    return false;
+  }
+
+  PacketReader pr(pdns_string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size()));
+
+  dnsheader dh;
+  memcpy(&dh, initialPacket.data(), sizeof(dh));
+  size_t idx = 0;
+  DNSName rrname;
+  uint16_t qdcount = ntohs(dh.qdcount);
+  uint16_t ancount = ntohs(dh.ancount);
+  uint16_t nscount = ntohs(dh.nscount);
+  uint16_t arcount = ntohs(dh.arcount);
+  uint16_t rrtype;
+  uint16_t rrclass;
+  string blob;
+
+  size_t recordsCount = ancount + nscount + arcount;
+  struct dnsrecordheader ah;
+
+  rrname = pr.getName();
+  if (rrname == from) {
+    rrname = to;
+  }
+
+  rrtype = pr.get16BitInt();
+  rrclass = pr.get16BitInt();
+
+  PacketBuffer newContent;
+  newContent.reserve(initialPacket.size());
+  GenericDNSPacketWriter<PacketBuffer> pw(newContent, rrname, rrtype, rrclass, dh.opcode);
+  /* we want to copy the flags and ID but not the counts since we recreate the records below */
+  pw.getHeader()->id = dh.id;
+  pw.getHeader()->qr = dh.qr;
+  pw.getHeader()->aa = dh.aa;
+  pw.getHeader()->tc = dh.tc;
+  pw.getHeader()->rd = dh.rd;
+  pw.getHeader()->ra = dh.ra;
+  pw.getHeader()->ad = dh.ad;
+  pw.getHeader()->cd = dh.cd;
+  pw.getHeader()->rcode = dh.rcode;
+
+  /* consume remaining qd if any, but do not copy it */
+  if (qdcount > 1) {
+    for (idx = 1; idx < qdcount; idx++) {
+      rrname = pr.getName();
+      rrtype = pr.get16BitInt();
+      rrclass = pr.get16BitInt();
+      (void)rrtype;
+      (void)rrclass;
+    }
+  }
+
+  const std::unordered_set<QType> nameOnlyTypes{QType::NS, QType::PTR, QType::CNAME, QType::DNAME};
+  const std::unordered_set<QType> noNameTypes{QType::A, QType::AAAA, QType::DHCID, QType::TXT, QType::OPT, QType::HINFO, QType::DNSKEY, QType::CDNSKEY, QType::DS, QType::CDS, QType::DLV, QType::SSHFP, QType::KEY, QType::CERT, QType::TLSA, QType::SMIMEA, QType::OPENPGPKEY, QType::NSEC, QType::NSEC3, QType::CSYNC, QType::NSEC3PARAM, QType::LOC, QType::NID, QType::L32, QType::L64, QType::EUI48, QType::EUI64, QType::URI, QType::CAA};
+
+  /* copy AN, NS and AR */
+  for (idx = 0; idx < recordsCount; idx++) {
+    rrname = pr.getName();
+    if (rrname == from) {
+      rrname = to;
+    }
+    pr.getDnsrecordheader(ah);
+
+    auto place = idx < ancount ? DNSResourceRecord::ANSWER : (idx < (ancount + nscount) ? DNSResourceRecord::AUTHORITY : DNSResourceRecord::ADDITIONAL);
+    pw.startRecord(rrname, ah.d_type, ah.d_ttl, ah.d_class, place, true);
+    if (nameOnlyTypes.count(ah.d_type)) {
+      rrname = pr.getName();
+      pw.xfrName(rrname);
+    }
+    else if (noNameTypes.count(ah.d_type)) {
+      pr.xfrBlob(blob);
+      pw.xfrBlob(blob);
+    }
+    else if (ah.d_type == QType::RRSIG) {
+      /* good luck */
+      pr.xfrBlob(blob);
+      pw.xfrBlob(blob);
+    }
+    else if (ah.d_type == QType::MX) {
+      auto prio = pr.get16BitInt();
+      rrname = pr.getName();
+      pw.xfr16BitInt(prio);
+      pw.xfrName(rrname);
+    }
+    else if (ah.d_type == QType::SOA) {
+      auto mname = pr.getName();
+      pw.xfrName(mname);
+      auto rname = pr.getName();
+      pw.xfrName(rname);
+      /* serial */
+      pw.xfr32BitInt(pr.get32BitInt());
+      /* refresh */
+      pw.xfr32BitInt(pr.get32BitInt());
+      /* retry */
+      pw.xfr32BitInt(pr.get32BitInt());
+      /* expire */
+      pw.xfr32BitInt(pr.get32BitInt());
+      /* minimal */
+      pw.xfr32BitInt(pr.get32BitInt());
+    }
+    else if (ah.d_type == QType::SRV) {
+      /* preference */
+      pw.xfr16BitInt(pr.get16BitInt());
+      /* weight */
+      pw.xfr16BitInt(pr.get16BitInt());
+      /* port */
+      pw.xfr16BitInt(pr.get16BitInt());
+      auto target = pr.getName();
+      pw.xfrName(target);
+    }
+    else {
+      /* sorry, unsafe type */
+      return false;
+    }
+  }
+
+  pw.commit();
+  initialPacket = std::move(newContent);
+
+  return true;
+}
+
 }

--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -35,7 +35,7 @@ DNSPacketOverlay::DNSPacketOverlay(const std::string_view& packet)
   d_records.reserve(numRecords);
 
   try {
-    PacketReader reader(pdns_string_view(reinterpret_cast<const char*>(packet.data()), packet.size()));
+    PacketReader reader(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()));
 
     for (uint16_t n = 0; n < ntohs(d_header.qdcount); ++n) {
       reader.xfrName(d_qname);
@@ -70,7 +70,7 @@ bool changeNameInDNSPacket(PacketBuffer& initialPacket, const DNSName& from, con
     return false;
   }
 
-  PacketReader pr(pdns_string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size()));
+  PacketReader pr(std::string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size()));
 
   dnsheader dh;
   memcpy(&dh, initialPacket.data(), sizeof(dh));

--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -110,18 +110,14 @@ bool changeNameInDNSPacket(PacketBuffer& initialPacket, const DNSName& from, con
   pw.getHeader()->rcode = dh.rcode;
 
   /* consume remaining qd if any, but do not copy it */
-  if (qdcount > 1) {
-    for (idx = 1; idx < qdcount; idx++) {
-      rrname = pr.getName();
-      rrtype = pr.get16BitInt();
-      rrclass = pr.get16BitInt();
-      (void)rrtype;
-      (void)rrclass;
-    }
+  for (idx = 1; idx < qdcount; idx++) {
+    rrname = pr.getName();
+    (void)pr.get16BitInt();
+    (void)pr.get16BitInt();
   }
 
-  const std::unordered_set<QType> nameOnlyTypes{QType::NS, QType::PTR, QType::CNAME, QType::DNAME};
-  const std::unordered_set<QType> noNameTypes{QType::A, QType::AAAA, QType::DHCID, QType::TXT, QType::OPT, QType::HINFO, QType::DNSKEY, QType::CDNSKEY, QType::DS, QType::CDS, QType::DLV, QType::SSHFP, QType::KEY, QType::CERT, QType::TLSA, QType::SMIMEA, QType::OPENPGPKEY, QType::NSEC, QType::NSEC3, QType::CSYNC, QType::NSEC3PARAM, QType::LOC, QType::NID, QType::L32, QType::L64, QType::EUI48, QType::EUI64, QType::URI, QType::CAA};
+  static const std::unordered_set<QType> nameOnlyTypes{QType::NS, QType::PTR, QType::CNAME, QType::DNAME};
+  static const std::unordered_set<QType> noNameTypes{QType::A, QType::AAAA, QType::DHCID, QType::TXT, QType::OPT, QType::HINFO, QType::DNSKEY, QType::CDNSKEY, QType::DS, QType::CDS, QType::DLV, QType::SSHFP, QType::KEY, QType::CERT, QType::TLSA, QType::SMIMEA, QType::OPENPGPKEY, QType::NSEC, QType::NSEC3, QType::CSYNC, QType::NSEC3PARAM, QType::LOC, QType::NID, QType::L32, QType::L64, QType::EUI48, QType::EUI64, QType::URI, QType::CAA};
 
   /* copy AN, NS and AR */
   for (idx = 0; idx < recordsCount; idx++) {

--- a/pdns/dnsdistdist/dnsdist-dnsparser.hh
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.hh
@@ -47,4 +47,11 @@ public:
   uint16_t d_qclass;
   dnsheader d_header;
 };
+
+/* Rewrite, if they are exactly equal to 'from', the qname and owner name of any record
+ * to 'to'. Since that might break DNS name pointers, the whole payload is rewritten,
+ * and the operation may fail if there is at least one unsupported record in the payload,
+ * because it could contain pointers that would not be rewritten.
+ */
+bool changeNameInDNSPacket(PacketBuffer& initialPacket, const DNSName& from, const DNSName& to);
 }

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -152,6 +152,7 @@ void dnsdist_ffi_dnsresponse_limit_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t m
 /* decrease the returned TTL but _after_ inserting the original response into the packet cache */
 void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t max) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dr, uint16_t qtype) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dr, const char* initialName, size_t initialNameSize) __attribute__ ((visibility ("default")));
 
 bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsresponse_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));
@@ -160,6 +161,7 @@ bool dnsdist_ffi_resume_from_async(uint16_t asyncID, uint16_t queryID, const cha
 bool dnsdist_ffi_drop_from_async(uint16_t asyncID, uint16_t queryID) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_set_answer_from_async(uint16_t asyncID, uint16_t queryID, const char* raw, size_t rawSize) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_set_rcode_from_async(uint16_t asyncID, uint16_t queryID, uint8_t rcode, bool clearAnswers) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_resume_from_async_with_alternate_name(uint16_t asyncID, uint16_t queryID, const char* alternateName, size_t alternateNameSize, const char* tag, size_t tagSize, const char* tagValue, size_t tagValueSize, const char* formerNameTagName, size_t formerNameTagSize) __attribute__ ((visibility ("default")));
 
 typedef struct dnsdist_ffi_proxy_protocol_value {
   const char* value;
@@ -219,6 +221,7 @@ uint16_t dnsdist_ffi_dnspacket_get_record_class(const dnsdist_ffi_dnspacket_t* p
 uint32_t dnsdist_ffi_dnspacket_get_record_ttl(const dnsdist_ffi_dnspacket_t* packet, size_t idx) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnspacket_get_record_content_length(const dnsdist_ffi_dnspacket_t* packet, size_t idx) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnspacket_get_record_content_offset(const dnsdist_ffi_dnspacket_t* packet, size_t idx) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnspacket_get_name_at_offset_raw(const char* packet, size_t packetSize, size_t offset, char* name, size_t nameSize) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnspacket_free(dnsdist_ffi_dnspacket_t*) __attribute__ ((visibility ("default")));
 
 void dnsdist_ffi_metric_inc(const char* metricName, size_t metricNameLen) __attribute__ ((visibility ("default")));

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -217,6 +217,17 @@ This state can be modified from the various hooks.
 
     :returns: The trailing data as a null-safe string
 
+  .. method:: DNSQuestion:rebase(newName) -> bool
+
+    .. versionadded:: 1.8.0
+
+    Change the qname of the current query in the DNS payload.
+    The reverse operation will have to be done on the response to set it back to the initial name, or the client will be confused and likely drop the response.
+    See :func:`DNSResponse:rebase`.
+    Returns false on failure, true on success.
+
+    :param DNSName newName: The new qname to use
+
   .. method:: DNSQuestion:sendTrap(reason)
 
     Send an SNMP trap.
@@ -393,6 +404,24 @@ DNSResponse object
     Setting this TTL to 0 to leaves it unchanged
 
     :param string func: The function to call to edit TTLs.
+
+  .. method:: DNSResponse:rebase(initialName) -> bool
+
+    .. versionadded:: 1.8.0
+
+    Change the qname and records matching exactly this qname in the DNS payload of the current response to the supplied new name.
+    This only makes if the reverse operation was performed on the query, or the client will be confused and likely drop the response.
+    Note that only records whose owner name matches the qname in the initial response will be rewritten, and that only the owner name itself will be altered,
+    not the content of the record rdata. For some records this might cause an issue with compression pointers contained in the payload, as they might
+    no longer point to the correct position in the DNS payload. To prevent that, the records are checked against a list of supported record types,
+    and the rewriting will not be performed if an unsupported type is present. As of 1.8.0 the list of supported types is:
+    A, AAAA, DHCID, TXT, OPT, HINFO, DNSKEY, CDNSKEY, DS, CDS, DLV, SSHFP, KEY, CERT, TLSA, SMIMEA, OPENPGPKEY, NSEC, NSEC3, CSYNC, NSEC3PARAM, LOC, NID, L32, L64, EUI48, EUI64, URI, CAA, NS, PTR, CNAME, DNAME, RRSIG, MX, SOA, SRV
+    Therefore this functionality only makes sense when the initial query is requesting a very simple type, like A or AAAA.
+
+    See also :func:`DNSQuestion:rebase`.
+    Returns false on failure, true on success.
+
+    :param DNSName initialName: The initial qname
 
   .. method:: DNSResponse:restart()
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -217,13 +217,13 @@ This state can be modified from the various hooks.
 
     :returns: The trailing data as a null-safe string
 
-  .. method:: DNSQuestion:rebase(newName) -> bool
+  .. method:: DNSQuestion:changeName(newName) -> bool
 
     .. versionadded:: 1.8.0
 
     Change the qname of the current query in the DNS payload.
     The reverse operation will have to be done on the response to set it back to the initial name, or the client will be confused and likely drop the response.
-    See :func:`DNSResponse:rebase`.
+    See :func:`DNSResponse:changeName`.
     Returns false on failure, true on success.
 
     :param DNSName newName: The new qname to use
@@ -405,11 +405,11 @@ DNSResponse object
 
     :param string func: The function to call to edit TTLs.
 
-  .. method:: DNSResponse:rebase(initialName) -> bool
+  .. method:: DNSResponse:changeName(initialName) -> bool
 
     .. versionadded:: 1.8.0
 
-    Change the qname and records matching exactly this qname in the DNS payload of the current response to the supplied new name.
+    Change, in the DNS payload of the current response, the qname and the owner name of records to the supplied new name, if they are matching exactly the initial qname.
     This only makes if the reverse operation was performed on the query, or the client will be confused and likely drop the response.
     Note that only records whose owner name matches the qname in the initial response will be rewritten, and that only the owner name itself will be altered,
     not the content of the record rdata. For some records this might cause an issue with compression pointers contained in the payload, as they might
@@ -418,7 +418,7 @@ DNSResponse object
     A, AAAA, DHCID, TXT, OPT, HINFO, DNSKEY, CDNSKEY, DS, CDS, DLV, SSHFP, KEY, CERT, TLSA, SMIMEA, OPENPGPKEY, NSEC, NSEC3, CSYNC, NSEC3PARAM, LOC, NID, L32, L64, EUI48, EUI64, URI, CAA, NS, PTR, CNAME, DNAME, RRSIG, MX, SOA, SRV
     Therefore this functionality only makes sense when the initial query is requesting a very simple type, like A or AAAA.
 
-    See also :func:`DNSQuestion:rebase`.
+    See also :func:`DNSQuestion:changeName`.
     Returns false on failure, true on success.
 
     :param DNSName initialName: The initial qname

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -930,15 +930,15 @@ static void doh_dispatch_query(DOHServerConfig* dsc, h2o_handler_t* self, h2o_re
 }
 
 /* can only be called from the main DoH thread */
-static bool getHTTPHeaderValue(const h2o_req_t* req, const std::string& headerName, pdns_string_view& value)
+static bool getHTTPHeaderValue(const h2o_req_t* req, const std::string& headerName, std::string_view& value)
 {
   bool found = false;
   /* early versions of boost::string_ref didn't have the ability to compare to string */
-  pdns_string_view headerNameView(headerName);
+  std::string_view headerNameView(headerName);
 
   for (size_t i = 0; i < req->headers.size; ++i) {
-    if (pdns_string_view(req->headers.entries[i].name->base, req->headers.entries[i].name->len) == headerNameView) {
-      value = pdns_string_view(req->headers.entries[i].value.base, req->headers.entries[i].value.len);
+    if (std::string_view(req->headers.entries[i].name->base, req->headers.entries[i].name->len) == headerNameView) {
+      value = std::string_view(req->headers.entries[i].value.base, req->headers.entries[i].value.len);
       /* don't stop there, we might have more than one header with the same name, and we want the last one */
       found = true;
     }
@@ -951,12 +951,12 @@ static bool getHTTPHeaderValue(const h2o_req_t* req, const std::string& headerNa
 static void processForwardedForHeader(const h2o_req_t* req, ComboAddress& remote)
 {
   static const std::string headerName = "x-forwarded-for";
-  pdns_string_view value;
+  std::string_view value;
 
   if (getHTTPHeaderValue(req, headerName, value)) {
     try {
       auto pos = value.rfind(',');
-      if (pos != pdns_string_view::npos) {
+      if (pos != std::string_view::npos) {
         ++pos;
         for (; pos < value.size() && value[pos] == ' '; ++pos)
         {
@@ -1050,7 +1050,7 @@ static int doh_handler(h2o_handler_t *self, h2o_req_t *req)
       }
     }
 
-    // would be nice to be able to use a pdns_string_view there,
+    // would be nice to be able to use a std::string_view there,
     // but regex (called by matches() internally) requires a null-terminated string
     string path(req->path.base, req->path.len);
     /* the responses map can be updated at runtime, so we need to take a copy of

--- a/pdns/dnsdistdist/test-dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/test-dnsdist-dnsparser.cc
@@ -30,6 +30,356 @@
 
 BOOST_AUTO_TEST_SUITE(test_dnsdist_dnsparser)
 
+BOOST_AUTO_TEST_CASE(test_Query)
+{
+  const DNSName target("powerdns.com.");
+  const DNSName newTarget("dnsdist.org.");
+  const DNSName notTheTarget("not-powerdns.com.");
+
+  {
+    /* query for the target */
+    PacketBuffer query;
+    GenericDNSPacketWriter<PacketBuffer> pw(query, target, QType::A, QClass::IN, 0);
+    pw.getHeader()->rd = 1;
+    pw.getHeader()->id = htons(42);
+    pw.commit();
+
+    BOOST_CHECK(dnsdist::changeNameInDNSPacket(query, target, newTarget));
+
+    MOADNSParser mdp(false, reinterpret_cast<const char*>(query.data()), query.size());
+    BOOST_CHECK_EQUAL(mdp.d_qname, newTarget);
+    BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+  }
+
+  {
+    /* query smaller than a DNS header */
+    PacketBuffer query;
+    GenericDNSPacketWriter<PacketBuffer> pw(query, target, QType::A, QClass::IN, 0);
+    pw.getHeader()->rd = 1;
+    pw.getHeader()->id = htons(42);
+    pw.commit();
+
+    query.resize(sizeof(dnsheader) - 1);
+    BOOST_CHECK(!dnsdist::changeNameInDNSPacket(query, target, newTarget));
+  }
+
+  {
+    /* query for a different name than the target */
+    PacketBuffer query;
+    GenericDNSPacketWriter<PacketBuffer> pw(query, notTheTarget, QType::A, QClass::IN, 0);
+    pw.getHeader()->rd = 1;
+    pw.getHeader()->id = htons(42);
+    pw.commit();
+
+    BOOST_CHECK(dnsdist::changeNameInDNSPacket(query, target, newTarget));
+
+    MOADNSParser mdp(false, reinterpret_cast<const char*>(query.data()), query.size());
+    BOOST_CHECK_EQUAL(mdp.d_qname, notTheTarget);
+    BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_Response)
+{
+  const DNSName target("powerdns.com.");
+  const DNSName newTarget("dnsdist.org.");
+  const DNSName notTheTarget("not-powerdns.com.");
+
+  {
+    /* response for the target, A and AAAA */
+    PacketBuffer response;
+    GenericDNSPacketWriter<PacketBuffer> pwR(response, target, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.getHeader()->rd = 1;
+    pwR.getHeader()->ra = 1;
+    pwR.getHeader()->id = htons(42);
+    pwR.startRecord(target, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    ComboAddress v4("192.0.2.1");
+    pwR.xfrCAWithoutPort(4, v4);
+    pwR.commit();
+    pwR.startRecord(target, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    ComboAddress v6("2001:db8::1");
+    pwR.xfrCAWithoutPort(6, v6);
+    pwR.commit();
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    BOOST_CHECK(dnsdist::changeNameInDNSPacket(response, target, newTarget));
+
+    MOADNSParser mdp(false, reinterpret_cast<const char*>(response.data()), response.size());
+    BOOST_CHECK_EQUAL(mdp.d_qname, newTarget);
+    BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.ancount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
+    BOOST_CHECK_EQUAL(mdp.d_header.arcount, 2U);
+
+    BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 3U);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_type, static_cast<uint16_t>(QType::A));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_class, QClass::IN);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_name, newTarget);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(1).first.d_type, static_cast<uint16_t>(QType::AAAA));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(1).first.d_class, QClass::IN);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(1).first.d_name, newTarget);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(2).first.d_type, static_cast<uint16_t>(QType::OPT));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(2).first.d_name, g_rootdnsname);
+  }
+
+  {
+    /* response with A for the target, AAAA for another name */
+    PacketBuffer response;
+    GenericDNSPacketWriter<PacketBuffer> pwR(response, target, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.getHeader()->rd = 1;
+    pwR.getHeader()->ra = 1;
+    pwR.getHeader()->id = htons(42);
+    pwR.startRecord(target, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    ComboAddress v4("192.0.2.1");
+    pwR.xfrCAWithoutPort(4, v4);
+    pwR.commit();
+    pwR.startRecord(notTheTarget, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    ComboAddress v6("2001:db8::1");
+    pwR.xfrCAWithoutPort(6, v6);
+    pwR.commit();
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    BOOST_CHECK(dnsdist::changeNameInDNSPacket(response, target, newTarget));
+
+    MOADNSParser mdp(false, reinterpret_cast<const char*>(response.data()), response.size());
+    BOOST_CHECK_EQUAL(mdp.d_qname, newTarget);
+    BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.ancount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
+    BOOST_CHECK_EQUAL(mdp.d_header.arcount, 2U);
+
+    BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 3U);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_type, static_cast<uint16_t>(QType::A));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_class, QClass::IN);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_name, newTarget);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(1).first.d_type, static_cast<uint16_t>(QType::AAAA));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(1).first.d_class, QClass::IN);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(1).first.d_name, notTheTarget);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(2).first.d_type, static_cast<uint16_t>(QType::OPT));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(2).first.d_name, g_rootdnsname);
+  }
+
+  {
+    /* response with CNAME for the target, A for another name */
+    PacketBuffer response;
+    GenericDNSPacketWriter<PacketBuffer> pwR(response, target, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.getHeader()->rd = 1;
+    pwR.getHeader()->ra = 1;
+    pwR.getHeader()->id = htons(42);
+    pwR.startRecord(target, QType::CNAME, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrName(notTheTarget);
+    pwR.commit();
+    pwR.startRecord(notTheTarget, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    ComboAddress v4("192.0.2.1");
+    pwR.xfrCAWithoutPort(4, v4);
+    pwR.commit();
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    BOOST_CHECK(dnsdist::changeNameInDNSPacket(response, target, newTarget));
+
+    MOADNSParser mdp(false, reinterpret_cast<const char*>(response.data()), response.size());
+    BOOST_CHECK_EQUAL(mdp.d_qname, newTarget);
+    BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.ancount, 2U);
+    BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
+    BOOST_CHECK_EQUAL(mdp.d_header.arcount, 1U);
+
+    BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 3U);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_type, static_cast<uint16_t>(QType::CNAME));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_class, QClass::IN);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_name, newTarget);
+    auto content = std::dynamic_pointer_cast<UnknownRecordContent>(mdp.d_answers.at(0).first.d_content);
+    BOOST_REQUIRE(content != nullptr);
+    BOOST_CHECK_EQUAL(content->getRawContent().size(), notTheTarget.getStorage().size());
+
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(1).first.d_type, static_cast<uint16_t>(QType::A));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(1).first.d_class, QClass::IN);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(1).first.d_name, notTheTarget);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(2).first.d_type, static_cast<uint16_t>(QType::OPT));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(2).first.d_name, g_rootdnsname);
+  }
+
+  {
+    /* response with a lot of records for the target, all supported */
+    PacketBuffer response;
+    GenericDNSPacketWriter<PacketBuffer> pwR(response, target, QType::ANY, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.getHeader()->rd = 1;
+    pwR.getHeader()->ra = 1;
+    pwR.getHeader()->id = htons(42);
+    pwR.startRecord(target, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    ComboAddress v4("192.0.2.1");
+    pwR.xfrCAWithoutPort(4, v4);
+    pwR.commit();
+    pwR.startRecord(target, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    ComboAddress v6("2001:db8::1");
+    pwR.xfrCAWithoutPort(6, v6);
+    pwR.commit();
+    pwR.startRecord(target, QType::NS, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrName(DNSName("pdns-public-ns1.powerdns.com."));
+    pwR.commit();
+    pwR.startRecord(target, QType::MX, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfr16BitInt(75);
+    pwR.xfrName(DNSName("download1.powerdns.com."));
+    pwR.commit();
+    pwR.startRecord(target, QType::TXT, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrText("\"random text\"");
+    pwR.commit();
+    pwR.startRecord(target, QType::RRSIG, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrType(QType::TXT);
+    pwR.xfr8BitInt(13);
+    pwR.xfr8BitInt(2);
+    pwR.xfr32BitInt(42);
+    pwR.xfrTime(42);
+    pwR.xfrTime(42);
+    pwR.xfr16BitInt(42);
+    pwR.xfrName(DNSName("powerdns.com."));
+    pwR.xfrBlob(std::string());
+    pwR.commit();
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    BOOST_CHECK(dnsdist::changeNameInDNSPacket(response, target, newTarget));
+
+    MOADNSParser mdp(false, reinterpret_cast<const char*>(response.data()), response.size());
+    BOOST_CHECK_EQUAL(mdp.d_qname, newTarget);
+    BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.ancount, 6U);
+    BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
+    BOOST_CHECK_EQUAL(mdp.d_header.arcount, 1U);
+
+    BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 7U);
+    for (const auto& answer : mdp.d_answers) {
+      if (answer.first.d_type == QType::OPT) {
+        continue;
+      }
+      BOOST_CHECK_EQUAL(answer.first.d_class, QClass::IN);
+      BOOST_CHECK_EQUAL(answer.first.d_name, newTarget);
+    }
+  }
+
+  {
+    /* response with a lot of records for the target, all supported */
+    PacketBuffer response;
+    GenericDNSPacketWriter<PacketBuffer> pwR(response, target, QType::ANY, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.getHeader()->rd = 1;
+    pwR.getHeader()->ra = 1;
+    pwR.getHeader()->id = htons(42);
+    pwR.startRecord(target, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    ComboAddress v4("192.0.2.1");
+    pwR.xfrCAWithoutPort(4, v4);
+    pwR.commit();
+    pwR.startRecord(target, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    ComboAddress v6("2001:db8::1");
+    pwR.xfrCAWithoutPort(6, v6);
+    pwR.commit();
+    pwR.startRecord(target, QType::NS, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrName(DNSName("pdns-public-ns1.powerdns.com."));
+    pwR.commit();
+    pwR.startRecord(target, QType::SOA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrName(DNSName("pdns-public-ns1.powerdns.com."));
+    pwR.xfrName(DNSName("admin.powerdns.com."));
+    pwR.xfr32BitInt(1);
+    pwR.xfr32BitInt(2);
+    pwR.xfr32BitInt(3);
+    pwR.xfr32BitInt(4);
+    pwR.xfr32BitInt(5);
+    pwR.commit();
+    pwR.startRecord(target, QType::MX, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfr16BitInt(75);
+    pwR.xfrName(DNSName("download1.powerdns.com."));
+    pwR.commit();
+    pwR.startRecord(target, QType::TXT, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrText("\"random text\"");
+    pwR.commit();
+    pwR.startRecord(target, QType::SRV, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfr16BitInt(1);
+    pwR.xfr16BitInt(2);
+    pwR.xfr16BitInt(65535);
+    pwR.xfrName(DNSName("target.powerdns.com."));
+    pwR.commit();
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    {
+      // before
+      MOADNSParser mdp(false, reinterpret_cast<const char*>(response.data()), response.size());
+      BOOST_CHECK_EQUAL(mdp.d_qname, target);
+      BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+      BOOST_CHECK_EQUAL(mdp.d_header.ancount, 7U);
+      BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
+      BOOST_CHECK_EQUAL(mdp.d_header.arcount, 1U);
+
+      BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 8U);
+      for (const auto& answer : mdp.d_answers) {
+        if (answer.first.d_type == QType::OPT) {
+          continue;
+        }
+        BOOST_CHECK_EQUAL(answer.first.d_class, QClass::IN);
+        BOOST_CHECK_EQUAL(answer.first.d_name, target);
+      }
+    }
+
+    // rebasing
+    BOOST_CHECK(dnsdist::changeNameInDNSPacket(response, target, newTarget));
+
+    {
+      // after
+      MOADNSParser mdp(false, reinterpret_cast<const char*>(response.data()), response.size());
+      BOOST_CHECK_EQUAL(mdp.d_qname, newTarget);
+      BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+      BOOST_CHECK_EQUAL(mdp.d_header.ancount, 7U);
+      BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
+      BOOST_CHECK_EQUAL(mdp.d_header.arcount, 1U);
+
+      BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 8U);
+      for (const auto& answer : mdp.d_answers) {
+        if (answer.first.d_type == QType::OPT) {
+          continue;
+        }
+        BOOST_CHECK_EQUAL(answer.first.d_class, QClass::IN);
+        BOOST_CHECK_EQUAL(answer.first.d_name, newTarget);
+      }
+    }
+  }
+
+  {
+    /* response with an ALIAS record, which is not supported */
+    PacketBuffer response;
+    GenericDNSPacketWriter<PacketBuffer> pwR(response, target, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.getHeader()->rd = 1;
+    pwR.getHeader()->ra = 1;
+    pwR.getHeader()->id = htons(42);
+    pwR.startRecord(target, QType::ALIAS, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrName(notTheTarget);
+    pwR.commit();
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    BOOST_CHECK(!dnsdist::changeNameInDNSPacket(response, target, newTarget));
+
+    MOADNSParser mdp(false, reinterpret_cast<const char*>(response.data()), response.size());
+    BOOST_CHECK_EQUAL(mdp.d_qname, target);
+    BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.ancount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
+    BOOST_CHECK_EQUAL(mdp.d_header.arcount, 1U);
+
+    BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 2U);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_type, static_cast<uint16_t>(QType::ALIAS));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_class, QClass::IN);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_name, target);
+  }
+}
+
 BOOST_AUTO_TEST_CASE(test_Overlay)
 {
   const DNSName target("powerdns.com.");

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -213,7 +213,7 @@ DNSResourceRecord DNSResourceRecord::fromWire(const DNSRecord& d) {
   return rr;
 }
 
-void MOADNSParser::init(bool query, const pdns_string_view& packet)
+void MOADNSParser::init(bool query, const std::string_view& packet)
 {
   if (packet.size() < sizeof(dnsheader))
     throw MOADNSException("Packet shorter than minimal header");
@@ -793,7 +793,7 @@ static int rewritePacketWithoutRecordTypes(const PacketBuffer& initialPacket, Pa
 
     if (ntohs(dh->qdcount) == 0)
       return ENOENT;
-    auto packetView = pdns_string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size());
+    auto packetView = std::string_view(reinterpret_cast<const char*>(initialPacket.data()), initialPacket.size());
 
     PacketReader pr(packetView);
 

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -66,7 +66,7 @@ class MOADNSParser;
 class PacketReader
 {
 public:
-  PacketReader(const pdns_string_view& content, uint16_t initialPos=sizeof(dnsheader))
+  PacketReader(const std::string_view& content, uint16_t initialPos=sizeof(dnsheader))
     : d_pos(initialPos), d_startrecordpos(initialPos), d_content(content)
   {
     if(content.size() > std::numeric_limits<uint16_t>::max())
@@ -184,7 +184,7 @@ private:
   uint16_t d_startrecordpos; // needed for getBlob later on
   uint16_t d_recordlen;      // ditto
   uint16_t not_used; // Aligns the whole class on 8-byte boundaries
-  const pdns_string_view d_content;
+  const std::string_view d_content;
 };
 
 struct DNSRecord;
@@ -443,7 +443,7 @@ public:
   //! Parse from a pointer and length
   MOADNSParser(bool query, const char *packet, unsigned int len) : d_tsigPos(0)
   {
-    init(query, pdns_string_view(packet, len));
+    init(query, std::string_view(packet, len));
   }
 
   DNSName d_qname;
@@ -464,7 +464,7 @@ public:
   bool hasEDNS() const;
 
 private:
-  void init(bool query, const pdns_string_view& packet);
+  void init(bool query, const std::string_view& packet);
   uint16_t d_tsigPos;
 };
 

--- a/pdns/namespaces.hh
+++ b/pdns/namespaces.hh
@@ -48,5 +48,3 @@ using std::shared_ptr;
 using std::string;
 using std::unique_ptr;
 using std::vector;
-
-using pdns_string_view = std::string_view;

--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -33,7 +33,7 @@ public:
      - EDNS Cookie options, if any ;
      - Any given option code present in optionsToSkip
   */
-  static uint32_t hashAfterQname(const pdns_string_view& packet, uint32_t currentHash, size_t pos, const std::unordered_set<uint16_t>& optionsToSkip = {EDNSOptionCode::COOKIE})
+  static uint32_t hashAfterQname(const std::string_view& packet, uint32_t currentHash, size_t pos, const std::unordered_set<uint16_t>& optionsToSkip = {EDNSOptionCode::COOKIE})
   {
     const size_t packetSize = packet.size();
     assert(packetSize >= sizeof(dnsheader));

--- a/pdns/protozero.cc
+++ b/pdns/protozero.cc
@@ -95,7 +95,7 @@ void pdns::ProtoZero::Message::addRRsFromPacket(const char* packet, const size_t
     return;
   }
 
-  PacketReader pr(pdns_string_view(packet, len));
+  PacketReader pr(std::string_view(packet, len));
 
   size_t idx = 0;
   DNSName rrname;

--- a/pdns/recursordist/ednsextendederror.cc
+++ b/pdns/recursordist/ednsextendederror.cc
@@ -23,7 +23,7 @@
 
 #include "ednsextendederror.hh"
 
-static bool getEDNSExtendedErrorOptFromStringView(const pdns_string_view& option, EDNSExtendedError& eee)
+static bool getEDNSExtendedErrorOptFromStringView(const std::string_view& option, EDNSExtendedError& eee)
 {
   if (option.size() < sizeof(uint16_t)) {
     return false;
@@ -39,12 +39,12 @@ static bool getEDNSExtendedErrorOptFromStringView(const pdns_string_view& option
 
 bool getEDNSExtendedErrorOptFromString(const string& option, EDNSExtendedError& eee)
 {
-  return getEDNSExtendedErrorOptFromStringView(pdns_string_view(option), eee);
+  return getEDNSExtendedErrorOptFromStringView(std::string_view(option), eee);
 }
 
 bool getEDNSExtendedErrorOptFromString(const char* option, unsigned int len, EDNSExtendedError& eee)
 {
-  return getEDNSExtendedErrorOptFromStringView(pdns_string_view(option, len), eee);
+  return getEDNSExtendedErrorOptFromStringView(std::string_view(option, len), eee);
 }
 
 string makeEDNSExtendedErrorOptString(const EDNSExtendedError& eee)

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -590,55 +590,55 @@ class TestDNSQuestionTime(DNSDistTest):
             self.assertEqual(receivedQuery, query)
             self.assertEqual(receivedResponse, response)
 
-class TestRebase(DNSDistTest):
+class TestChangeName(DNSDistTest):
     _config_template = """
     local tagName = 'initial-name'
-    function luarebasequery(dq)
+    function luaChangeNamequery(dq)
       dq:setTag(tagName, dq.qname:toString())
-      if not dq:rebase(newDNSName('rebase.advanced.tests.dnsdist.org')) then
+      if not dq:changeName(newDNSName('changeName.advanced.tests.dnsdist.org')) then
         errlog('Error rebasing the query')
         return DNSAction.Drop
       end
       return DNSAction.None
     end
 
-    function luarebaseresponse(dr)
+    function luaChangeNameresponse(dr)
       local initialName = dr:getTag(tagName)
-      if not dr:rebase(newDNSName(initialName)) then
+      if not dr:changeName(newDNSName(initialName)) then
         errlog('Error rebasing the response')
         return DNSAction.Drop
       end
       return DNSAction.None
     end
 
-    addAction('rebase.advanced.tests.powerdns.com', LuaAction(luarebasequery))
-    addResponseAction('rebase.advanced.tests.dnsdist.org', LuaResponseAction(luarebaseresponse))
+    addAction('changeName.advanced.tests.powerdns.com', LuaAction(luaChangeNamequery))
+    addResponseAction('changeName.advanced.tests.dnsdist.org', LuaResponseAction(luaChangeNameresponse))
     newServer{address="127.0.0.1:%s"}
     """
 
-    def testRebase(self):
+    def testChangeName(self):
         """
-        Advanced: Rebase the query name
+        Advanced: ChangeName the query name
         """
-        name = 'rebase.advanced.tests.powerdns.com.'
+        name = 'changeName.advanced.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
 
-        rebasedName = 'rebase.advanced.tests.dnsdist.org.'
-        rebasedQuery = dns.message.make_query(rebasedName, 'A', 'IN')
-        rebasedQuery.id = query.id
+        changedName = 'changeName.advanced.tests.dnsdist.org.'
+        changedQuery = dns.message.make_query(changedName, 'A', 'IN')
+        changedQuery.id = query.id
 
-        response = dns.message.make_response(rebasedQuery)
-        rrset = dns.rrset.from_text(rebasedName,
+        response = dns.message.make_response(changedQuery)
+        rrset = dns.rrset.from_text(changedName,
                                     60,
                                     dns.rdataclass.IN,
                                     dns.rdatatype.A,
                                     '4.3.2.1')
         response.answer.append(rrset)
-        rrset = dns.rrset.from_text('sub.sub2.rebase.advanced.tests.dnsdist.org.',
+        rrset = dns.rrset.from_text('sub.sub2.changeName.advanced.tests.dnsdist.org.',
                                     60,
                                     dns.rdataclass.IN,
                                     dns.rdatatype.TXT,
-                                    'This text contains sub.sub2.rebase.advanced.tests.dnsdist.org.')
+                                    'This text contains sub.sub2.changeName.advanced.tests.dnsdist.org.')
         response.additional.append(rrset)
 
         expectedResponse = dns.message.make_response(query)
@@ -649,16 +649,16 @@ class TestRebase(DNSDistTest):
                                     '4.3.2.1')
         expectedResponse.answer.append(rrset)
         # we only rewrite records if the owner name matches the new target, nothing else
-        rrset = dns.rrset.from_text('sub.sub2.rebase.advanced.tests.dnsdist.org.',
+        rrset = dns.rrset.from_text('sub.sub2.changeName.advanced.tests.dnsdist.org.',
                                     60,
                                     dns.rdataclass.IN,
                                     dns.rdatatype.TXT,
-                                    'This text contains sub.sub2.rebase.advanced.tests.dnsdist.org.')
+                                    'This text contains sub.sub2.changeName.advanced.tests.dnsdist.org.')
         expectedResponse.additional.append(rrset)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEqual(receivedQuery, rebasedQuery)
+            self.assertEqual(receivedQuery, changedQuery)
             self.assertEqual(receivedResponse, expectedResponse)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In some setups, we might need to get the result for a different qname and change the response to set the owner names of the records matching the changed qname back to the initial qname. Note that this is brittle and should only be used in very specific cases.
<strike>This PR is based on top of https://github.com/PowerDNS/pdns/pull/12388 and will have to be rebased.</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)

