### PR TITLE
rec: Change the way RD=0 forwarded queries are handled.

### DIFF
--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -590,7 +590,7 @@ private:
   bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet& nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state, const ComboAddress& remoteIP);
 
   int doResolve(const DNSName& qname, QType qtype, vector<DNSRecord>& ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, Context& context);
-  int doResolveNoQNameMinimization(const DNSName& qname, QType qtype, vector<DNSRecord>& ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, Context& context, bool* fromCache = NULL, StopAtDelegation* stopAtDelegation = NULL, bool considerforwards = true);
+  int doResolveNoQNameMinimization(const DNSName& qname, QType qtype, vector<DNSRecord>& ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, Context& context, bool* fromCache = NULL, StopAtDelegation* stopAtDelegation = NULL);
   bool doOOBResolve(const AuthDomain& domain, const DNSName& qname, QType qtype, vector<DNSRecord>& ret, int& res);
   bool doOOBResolve(const DNSName& qname, QType qtype, vector<DNSRecord>& ret, unsigned int depth, int& res);
   bool isRecursiveForwardOrAuth(const DNSName& qname) const;


### PR DESCRIPTION
Note: I'm marking this as "Draft" since I _might_ have overlooked a case where the forward to a forwarder in the RD=0 case is actually needed or useful. I cannot think of one and the unit tests and regression tests agree, but I do need independent confirmation on this. That said:

Since forever, there has been special case code for forwarded queries in the RD=0 case.  This special case code does a hardcoded RD=0 query to the specified forwarder.  This code has two consequences:

1. Even if the forwarder is marked recursive it gets a RD=0 query
2. The cache is not consulted at all

The corresponding unit tests actually test this behaviour, but after historic digging with help from @rgacogne it turns out the the unit test do not reflect the desired functionality, but the current state of affairs to help with a refactoring PR.  That is good, since refactoring should not change functionality.

But now the time has come to change the code to do the desired thing:

1. If an RD=0 query is received, do a cache only-lookup in all cases.
2. Never send a RD=0 query to a recursive forwarder

I already did a similar thing when I wrote the QName Minimization code, introducing a conditional that only gets set for that case, to avoid changing unrelated (to QM) functionality.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
