### PR TITLE
CI: Initialize automatic variables to a pattern in our CI 

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -331,6 +331,7 @@ def ci_auth_configure(c):
                       --prefix=/opt/pdns-auth \
                       --enable-ixfrdist \
                       --enable-fortify-source=auto \
+                      --enable-auto-var-init=pattern \
                       --enable-asan \
                       --enable-ubsan''', warn=True)
     if res.exited != 0:

--- a/tasks.py
+++ b/tasks.py
@@ -355,6 +355,7 @@ def ci_rec_configure(c):
               --with-libcap \
               --with-net-snmp \
               --enable-fortify-source=auto \
+              --enable-auto-var-init=pattern \
               --enable-dns-over-tls ''' + sanitizers, warn=True)
     if res.exited != 0:
         c.run('cat config.log')

--- a/tasks.py
+++ b/tasks.py
@@ -430,6 +430,7 @@ def ci_dnsdist_configure(c, features):
                      --enable-option-checking=fatal \
                      --enable-unit-tests \
                      --enable-fortify-source=auto \
+                     --enable-auto-var-init=pattern \
                      --prefix=/opt/dnsdist %s %s''' % (cflags, cxxflags, features_set, sanitizers), warn=True)
     if res.exited != 0:
         c.run('cat config.log')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR enables initialization of automatic variables to a pattern in our CI, in order to better catch uninitialized variables.
Enabling this option has two theoretical drawbacks:
- runtime is slightly slower
- it does hide the use of uninitialized variables from memory sanitizers like clang's Memory Sanitizer and Valgrind.

The first point should not matter much for our CI since we are already running ASAN, TSAN and/or UBSAN anyway, and the second does not apply either since we do not enable these sanitizers either (Valgrind is too slow, and memory sanitizer is hard to get right because some cases require instrumenting shared libraries as well). Note that this does not prevent from compiler from reporting the use of uninitialized variables via `-Wuninitialized` or `wmaybe-uninitialized` at compilation time.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
