### PR TITLE
rec: less bulk test variations and enable TSAN for bulk tests

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -345,7 +345,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        sanitizers: [ubsan+asan]
+        sanitizers: [ubsan+asan, tsan]
         threads: [1, 2, 3, 4, 8]
         mthreads: [2048]
         shards: [1, 2, 1024]

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -346,8 +346,8 @@ jobs:
     strategy:
       matrix:
         sanitizers: [ubsan+asan]
-        threads: [1, 2, 3, 4, 8, 16]
-        mthreads: [2048, 4096]
+        threads: [1, 2, 3, 4, 8]
+        mthreads: [2048]
         shards: [1, 2, 1024]
     env:
       UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp'

--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -44,9 +44,10 @@ fi
 echo
 echo === First run with limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
-echo
 kill -USR1 $(cat pdns_recursor.pid) || true
 ${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. get-all || true
+
+sleep 5
 
 # rerun 1 with hot cache
 echo
@@ -54,6 +55,8 @@ echo === Second run with limit=$limit threads=$threads mthreads=$mthreads shards
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
 kill -USR1 $(cat pdns_recursor.pid) || true
 ${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. get-all || true
+
+sleep 5
 
 # rerun 2 with hot cache
 echo


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

It seems that putting a sleep between the `dnsbulktest` runs in `regression-tests/recursor-test` circumvents the UDP packet loss issues we have been seeing without the sleep.

Still have to find out how and why.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
