### PR TITLE
ixfrdist /metrics: formatting, cleanup, one new metric

### DIFF
--- a/pdns/ixfrdist-stats.cc
+++ b/pdns/ixfrdist-stats.cc
@@ -34,67 +34,38 @@ std::string ixfrdistStats::getStats() {
   stats<<"# TYPE "<<prefix<<"domains gauge"<<std::endl;
   stats<<prefix<<"domains "<<domainStats.size()<<std::endl;
 
-  uint64_t numSOAChecks{0}, numSOAChecksFailed{0}, numSOAinQueries{0}, numIXFRinQueries{0}, numAXFRinQueries{0}, numAXFRFailures{0}, numIXFRFailures{0};
-  bool helpAdded{false};
+  if (!domainStats.empty()) {
+    stats<<"# HELP "<<prefix<<"soa_serial The SOA serial number of a domain"<<std::endl;
+    stats<<"# TYPE "<<prefix<<"soa_serial gauge"<<std::endl;
+    stats<<"# HELP "<<prefix<<"soa_checks_total Number of times a SOA check at the master was attempted"<<std::endl;
+    stats<<"# TYPE "<<prefix<<"soa_checks_total counter"<<std::endl;
+    stats<<"# HELP "<<prefix<<"soa_checks_failed_total Number of times a SOA check at the master failed"<<std::endl;
+    stats<<"# TYPE "<<prefix<<"soa_checks_failed_total counter"<<std::endl;
+    stats<<"# HELP "<<prefix<<"soa_inqueries_total Number of times a SOA query was received"<<std::endl;
+    stats<<"# TYPE "<<prefix<<"soa_inqueries_total counter"<<std::endl;
+    stats<<"# HELP "<<prefix<<"axfr_inqueries_total Number of times an AXFR query was received"<<std::endl;
+    stats<<"# TYPE "<<prefix<<"axfr_inqueries_total counter"<<std::endl;
+    stats<<"# HELP "<<prefix<<"axfr_failures_total Number of times an AXFR query was not properly answered"<<std::endl;
+    stats<<"# TYPE "<<prefix<<"axfr_failures_total counter"<<std::endl;
+    stats<<"# HELP "<<prefix<<"ixfr_inqueries_total Number of times an IXFR query was received"<<std::endl;
+    stats<<"# TYPE "<<prefix<<"ixfr_inqueries_total counter"<<std::endl;
+    stats<<"# HELP "<<prefix<<"ixfr_failures_total Number of times an IXFR query was not properly answered"<<std::endl;
+    stats<<"# TYPE "<<prefix<<"ixfr_failures_total counter"<<std::endl;
+  }
+
   for (auto const &d : domainStats) {
-    if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"soa_serial The SOA serial number of a domain"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"soa_serial gauge"<<std::endl;
-    }
     if(d.second.haveZone)
       stats<<prefix<<"soa_serial{domain=\""<<d.first<<"\"} "<<d.second.currentSOA<<std::endl;
     else
       stats<<prefix<<"soa_serial{domain=\""<<d.first<<"\"} NaN"<<std::endl;
 
-    if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"soa_checks_total Number of times a SOA check at the master was attempted"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"soa_checks_total counter"<<std::endl;
-    }
     stats<<prefix<<"soa_checks_total{domain=\""<<d.first<<"\"} "<<d.second.numSOAChecks<<std::endl;
-    numSOAChecks += d.second.numSOAChecks;
-
-    if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"soa_checks_failed_total Number of times a SOA check at the master failed"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"soa_checks_failed_total counter"<<std::endl;
-    }
     stats<<prefix<<"soa_checks_failed_total{domain=\""<<d.first<<"\"} "<<d.second.numSOAChecksFailed<<std::endl;
-    numSOAChecksFailed += d.second.numSOAChecksFailed;
-
-    if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"soa_inqueries_total Number of times a SOA query was received"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"soa_inqueries_total counter"<<std::endl;
-    }
     stats<<prefix<<"soa_inqueries_total{domain=\""<<d.first<<"\"} "<<d.second.numSOAinQueries<<std::endl;
-    numSOAinQueries += d.second.numSOAinQueries;
-
-    if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"axfr_inqueries_total Number of times an AXFR query was received"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"axfr_inqueries_total counter"<<std::endl;
-    }
     stats<<prefix<<"axfr_inqueries_total{domain=\""<<d.first<<"\"} "<<d.second.numAXFRinQueries<<std::endl;
-    numAXFRinQueries += d.second.numAXFRinQueries;
-
-    if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"axfr_failures_total Number of times an AXFR query was not properly answered"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"axfr_failures_total counter"<<std::endl;
-    }
     stats<<prefix<<"axfr_failures_total{domain=\""<<d.first<<"\"} "<<d.second.numAXFRFailures<<std::endl;
-    numAXFRFailures += d.second.numAXFRFailures;
-
-    if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"ixfr_inqueries_total Number of times an IXFR query was received"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"ixfr_inqueries_total counter"<<std::endl;
-    }
     stats<<prefix<<"ixfr_inqueries_total{domain=\""<<d.first<<"\"} "<<d.second.numIXFRinQueries<<std::endl;
-    numIXFRinQueries += d.second.numIXFRinQueries;
-
-    if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"ixfr_failures_total Number of times an IXFR query was not properly answered"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"ixfr_failures_total counter"<<std::endl;
-    }
     stats<<prefix<<"ixfr_failures_total{domain=\""<<d.first<<"\"} "<<d.second.numIXFRFailures<<std::endl;
-    numIXFRFailures += d.second.numIXFRFailures;
-    helpAdded = true;
   }
 
   stats<<"# HELP "<<prefix<<"unknown_domain_inqueries_total Number of queries received for domains unknown to us"<<std::endl;

--- a/pdns/ixfrdist-stats.cc
+++ b/pdns/ixfrdist-stats.cc
@@ -42,67 +42,60 @@ std::string ixfrdistStats::getStats() {
       stats<<"# TYPE "<<prefix<<"soa_serial gauge"<<std::endl;
     }
     if(d.second.haveZone)
-      stats<<prefix<<"soa_serial{domain="<<d.first<<"} "<<d.second.currentSOA<<std::endl;
+      stats<<prefix<<"soa_serial{domain=\""<<d.first<<"\"} "<<d.second.currentSOA<<std::endl;
     else
-      stats<<prefix<<"soa_serial{domain="<<d.first<<"} NaN"<<std::endl;
+      stats<<prefix<<"soa_serial{domain=\""<<d.first<<"\"} NaN"<<std::endl;
 
     if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"soa_checks Number of times a SOA check at the master was attempted"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"soa_checks counter"<<std::endl;
+      stats<<"# HELP "<<prefix<<"soa_checks_total Number of times a SOA check at the master was attempted"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"soa_checks_total counter"<<std::endl;
     }
-    stats<<prefix<<"soa_checks{domain="<<d.first<<"} "<<d.second.numSOAChecks<<std::endl;
+    stats<<prefix<<"soa_checks_total{domain=\""<<d.first<<"\"} "<<d.second.numSOAChecks<<std::endl;
     numSOAChecks += d.second.numSOAChecks;
 
     if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"soa_checks_failed Number of times a SOA check at the master failed"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"soa_checks_failed counter"<<std::endl;
+      stats<<"# HELP "<<prefix<<"soa_checks_failed_total Number of times a SOA check at the master failed"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"soa_checks_failed_total counter"<<std::endl;
     }
-    stats<<prefix<<"soa_checks_failed{domain="<<d.first<<"} "<<d.second.numSOAChecksFailed<<std::endl;
+    stats<<prefix<<"soa_checks_failed_total{domain=\""<<d.first<<"\"} "<<d.second.numSOAChecksFailed<<std::endl;
     numSOAChecksFailed += d.second.numSOAChecksFailed;
 
     if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"soa_inqueries Number of times a SOA query was received"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"soa_inqueries counter"<<std::endl;
+      stats<<"# HELP "<<prefix<<"soa_inqueries_total Number of times a SOA query was received"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"soa_inqueries_total counter"<<std::endl;
     }
-    stats<<prefix<<"soa_inqueries{domain="<<d.first<<"} "<<d.second.numSOAinQueries<<std::endl;
+    stats<<prefix<<"soa_inqueries_total{domain=\""<<d.first<<"\"} "<<d.second.numSOAinQueries<<std::endl;
     numSOAinQueries += d.second.numSOAinQueries;
 
     if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"axfr_inqueries Number of times an AXFR query was received"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"axfr_inqueries counter"<<std::endl;
+      stats<<"# HELP "<<prefix<<"axfr_inqueries_total Number of times an AXFR query was received"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"axfr_inqueries_total counter"<<std::endl;
     }
-    stats<<prefix<<"axfr_inqueries{domain="<<d.first<<"} "<<d.second.numAXFRinQueries<<std::endl;
+    stats<<prefix<<"axfr_inqueries_total{domain=\""<<d.first<<"\"} "<<d.second.numAXFRinQueries<<std::endl;
     numAXFRinQueries += d.second.numAXFRinQueries;
 
     if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"axfr_failures Number of times an AXFR query was not properly answered"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"axfr_failures counter"<<std::endl;
+      stats<<"# HELP "<<prefix<<"axfr_failures_total Number of times an AXFR query was not properly answered"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"axfr_failures_total counter"<<std::endl;
     }
-    stats<<prefix<<"axfr_failures{domain="<<d.first<<"} "<<d.second.numAXFRFailures<<std::endl;
+    stats<<prefix<<"axfr_failures_total{domain=\""<<d.first<<"\"} "<<d.second.numAXFRFailures<<std::endl;
     numAXFRFailures += d.second.numAXFRFailures;
 
     if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"ixfr_inqueries Number of times an IXFR query was received"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"ixfr_inqueries counter"<<std::endl;
+      stats<<"# HELP "<<prefix<<"ixfr_inqueries_total Number of times an IXFR query was received"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"ixfr_inqueries_total counter"<<std::endl;
     }
-    stats<<prefix<<"ixfr_inqueries{domain="<<d.first<<"} "<<d.second.numIXFRinQueries<<std::endl;
+    stats<<prefix<<"ixfr_inqueries_total{domain=\""<<d.first<<"\"} "<<d.second.numIXFRinQueries<<std::endl;
     numIXFRinQueries += d.second.numIXFRinQueries;
 
     if (!helpAdded) {
-      stats<<"# HELP "<<prefix<<"ixfr_failures Number of times an IXFR query was not properly answered"<<std::endl;
-      stats<<"# TYPE "<<prefix<<"ixfr_failures counter"<<std::endl;
+      stats<<"# HELP "<<prefix<<"ixfr_failures_total Number of times an IXFR query was not properly answered"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"ixfr_failures_total counter"<<std::endl;
     }
-    stats<<prefix<<"ixfr_failures{domain="<<d.first<<"} "<<d.second.numIXFRFailures<<std::endl;
+    stats<<prefix<<"ixfr_failures_total{domain=\""<<d.first<<"\"} "<<d.second.numIXFRFailures<<std::endl;
     numIXFRFailures += d.second.numIXFRFailures;
     helpAdded = true;
   }
 
-  stats<<prefix<<"soa_checks "<<numSOAChecks<<std::endl;
-  stats<<prefix<<"soa_checks_failed "<<numSOAChecksFailed<<std::endl;
-  stats<<prefix<<"soa_inqueries "<<numSOAinQueries<<std::endl;
-  stats<<prefix<<"axfr_inqueries "<<numAXFRinQueries<<std::endl;
-  stats<<prefix<<"ixfr_inqueries "<<numIXFRinQueries<<std::endl;
-  stats<<prefix<<"axfr_failures "<<numAXFRFailures<<std::endl;
-  stats<<prefix<<"ixfr_failures "<<numIXFRFailures<<std::endl;
   return stats.str();
 }

--- a/pdns/ixfrdist-stats.cc
+++ b/pdns/ixfrdist-stats.cc
@@ -97,5 +97,9 @@ std::string ixfrdistStats::getStats() {
     helpAdded = true;
   }
 
+  stats<<"# HELP "<<prefix<<"unknown_domain_inqueries_total Number of queries received for domains unknown to us"<<std::endl;
+  stats<<"# TYPE "<<prefix<<"unknown_domain_inqueries_total counter"<<std::endl;
+  stats<<prefix<<"unknown_domain_inqueries_total "<<progStats.unknownDomainInQueries<<std::endl;
+
   return stats.str();
 }

--- a/pdns/ixfrdist-stats.hh
+++ b/pdns/ixfrdist-stats.hh
@@ -64,6 +64,9 @@ class ixfrdistStats {
     void registerDomain(const DNSName& d) {
       domainStats[d].haveZone = false;
     }
+    void incrementUnknownDomainInQueries(const DNSName &d) { // the name is ignored. It would be great to report it, but we don't want to blow up Prometheus
+      progStats.unknownDomainInQueries += 1;
+    }
   private:
     class perDomainStat {
       public:
@@ -83,6 +86,7 @@ class ixfrdistStats {
     class programStats {
       public:
         time_t startTime;
+        std::atomic<uint32_t> unknownDomainInQueries;
     };
 
     std::map<DNSName, perDomainStat> domainStats;

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -818,6 +818,7 @@ static void handleUDPRequest(int fd, boost::any&) {
     g_stats.incrementSOAinQueries(mdp.d_qname); // FIXME: this also counts IXFR queries (but the response is the same as to a SOA query)
     makeSOAPacket(mdp, packet);
   } else {
+    g_stats.incrementUnknownDomainInQueries(mdp.d_qname);
     makeRefusedPacket(mdp, packet);
   }
 

--- a/regression-tests.ixfrdist/test_Stats.py
+++ b/regression-tests.ixfrdist/test_Stats.py
@@ -29,7 +29,7 @@ webserver-address: %s
 
     _config_domains = {'example': '127.0.0.1:' + str(xfrServerPort)}
 
-    metric_prog_stats = ["ixfrdist_uptime_seconds", "ixfrdist_domains"]
+    metric_prog_stats = ["ixfrdist_uptime_seconds", "ixfrdist_domains", "ixfrdist_unknown_domain_inqueries_total"]
     metric_domain_stats = ["ixfrdist_soa_serial", "ixfrdist_soa_checks_total",
                            "ixfrdist_soa_checks_failed_total",
                            "ixfrdist_soa_inqueries_total",

--- a/tasks.py
+++ b/tasks.py
@@ -108,6 +108,7 @@ auth_test_deps = [   # FIXME: we should be generating some of these from shlibde
     'libsystemd0',
     'libyaml-cpp0.6',
     'libzmq3-dev',
+    'prometheus',
     'ruby-bundler',
     'ruby-dev',
     'socat',


### PR DESCRIPTION
### Short description
Without the quoting, the output isn't even valid. Once it's valid (quoted), promtool warns that counters should be suffixed with `_total`, so I changed that too.

While this looks like breaking changes marked with `backport-to-auth-4.7.x?`, before this PR, the metrics endpoint did not work at all, so I've decided to take the opportunity to sneak some improvements in. I'll likely do another PR to add some more stats like CPU/RAM/FD usage.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
