### PR TITLE
ixfrdist: Make sure that our metrics are properly initialized

### DIFF
--- a/pdns/ixfrdist-stats.hh
+++ b/pdns/ixfrdist-stats.hh
@@ -71,22 +71,22 @@ class ixfrdistStats {
     class perDomainStat {
       public:
         bool                  haveZone;
-        std::atomic<uint32_t> currentSOA; // NOTE: this will wrongly be zero for unavailable zones
+        std::atomic<uint32_t> currentSOA{0}; // NOTE: this will wrongly be zero for unavailable zones
 
-        std::atomic<uint32_t> numSOAChecks;
-        std::atomic<uint32_t> numSOAChecksFailed;
+        std::atomic<uint32_t> numSOAChecks{0};
+        std::atomic<uint32_t> numSOAChecksFailed{0};
 
-        std::atomic<uint64_t> numSOAinQueries;
-        std::atomic<uint64_t> numAXFRinQueries;
-        std::atomic<uint64_t> numIXFRinQueries;
+        std::atomic<uint64_t> numSOAinQueries{0};
+        std::atomic<uint64_t> numAXFRinQueries{0};
+        std::atomic<uint64_t> numIXFRinQueries{0};
 
-        std::atomic<uint64_t> numAXFRFailures;
-        std::atomic<uint64_t> numIXFRFailures;
+        std::atomic<uint64_t> numAXFRFailures{0};
+        std::atomic<uint64_t> numIXFRFailures{0};
     };
     class programStats {
       public:
         time_t startTime;
-        std::atomic<uint32_t> unknownDomainInQueries;
+        std::atomic<uint32_t> unknownDomainInQueries{0};
     };
 
     std::map<DNSName, perDomainStat> domainStats;

--- a/regression-tests.ixfrdist/test_Stats.py
+++ b/regression-tests.ixfrdist/test_Stats.py
@@ -72,8 +72,12 @@ webserver-address: %s
                 continue
             if "{" in line:
                 continue
-            self.assertIn(line.split(" ")[0],
+            tokens = line.split(" ")
+            self.assertIn(tokens[0],
                           self.metric_prog_stats + self.metric_domain_stats)
+            if tokens[0] == 'ixfrdist_unknown_domain_inqueries_total':
+                self.assertEqual(int(tokens[1]), 0)
+
         self.checkPrometheusContentPromtool(res.content)
 
     def test_registered(self):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Before C++20 std::atomic variables are not guaranteed to be initialized, even though it looks like compilers are actually doing the initialization even in C++17.
Reported by Coverity as CID 1504405.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
