### PR TITLE
Run scheduled workflows only if a var is set

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -13,6 +13,7 @@ permissions: # least privileges, see https://docs.github.com/en/actions/using-wo
 jobs:
   build-auth:
     name: build auth
+    if: ${{ !github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     runs-on: ubuntu-20.04
     env:
       ASAN_OPTIONS: detect_leaks=0
@@ -56,6 +57,7 @@ jobs:
 
   build-recursor:
     name: build recursor
+    if: ${{ !github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -104,6 +106,7 @@ jobs:
 
   build-dnsdist:
     name: build dnsdist
+    if: ${{ !github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -404,6 +407,7 @@ jobs:
       - run: inv test-dnsdist
 
   swagger-syntax-check:
+    if: ${{ !github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     runs-on: ubuntu-20.04
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -11,6 +11,7 @@ permissions: # least privileges, see https://docs.github.com/en/actions/using-wo
 jobs:
   build:
     name: build.sh
+    if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
     # on a ubuntu-20.04 VM
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@ permissions: # least privileges, see https://docs.github.com/en/actions/using-wo
 jobs:
   analyze:
     name: Analyze
+    if: ${{ !github.event.schedule || vars.SCHEDULED_CODEQL_ANALYSIS }}
     runs-on: ubuntu-20.04
 
     permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ permissions: # least privileges, see https://docs.github.com/en/actions/using-wo
 jobs:
   build:
     name: docker build
+    if: ${{ vars.SCHEDULED_DOCKER }}
     # on a ubuntu-20.04 VM
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -9,6 +9,7 @@ permissions: # least privileges, see https://docs.github.com/en/actions/using-wo
 
 jobs:
   el7-devtoolset:
+    if: ${{ vars.SCHEDULED_MISC_DAILIES }}
     runs-on: ubuntu-22.04
 
     steps:
@@ -24,6 +25,7 @@ jobs:
         fi
 
   check-debian-autoremovals:
+    if: ${{ vars.SCHEDULED_MISC_DAILIES }}
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3.1.0
@@ -36,6 +38,7 @@ jobs:
 
   coverity-auth:
     name: coverity scan of the auth
+    if: ${{ vars.SCHEDULED_MISC_DAILIES }}
     runs-on: ubuntu-20.04
     env:
       COVERITY_TOKEN: ${{ secrets.coverity_auth_token }}
@@ -61,6 +64,7 @@ jobs:
 
   coverity-dnsdist:
     name: coverity scan of dnsdist
+    if: ${{ vars.SCHEDULED_MISC_DAILIES }}
     runs-on: ubuntu-20.04
     env:
       COVERITY_TOKEN: ${{ secrets.coverity_dnsdist_token }}
@@ -90,6 +94,7 @@ jobs:
 
   coverity-rec:
     name: coverity scan of the rec
+    if: ${{ vars.SCHEDULED_MISC_DAILIES }}
     runs-on: ubuntu-20.04
     env:
       COVERITY_TOKEN: ${{ secrets.coverity_rec_token }}


### PR DESCRIPTION
### Short description

Defines vars for specific scheduled workflow files. This allows a repository to enable a specific workflow's schedule w/o enabling all of them.

Closes #12519
Fixes #12498

Note: I've only added guards to things that don't have `needs`. Ideally all of the `needs` things depend on things that are guarded.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
