### PR TITLE
OpenSSL 3.0: Stay compatible with OpenSSL 1.0 to Fix CentOS7 builds

### DIFF
--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -287,7 +287,6 @@ private:
   using MessageDigest = std::unique_ptr<EVP_MD, decltype(&EVP_MD_free)>;
 #else
   using Key = std::unique_ptr<RSA, decltype(&RSA_free)>;
-  using MessageDigest = std::unique_ptr<EVP_MD, decltype(&EVP_MD_meth_free)>;
 #endif
 
   Key d_key;
@@ -1058,12 +1057,12 @@ private:
 
 #if OPENSSL_VERSION_MAJOR >= 3
   using Key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
+  using MessageDigestContext = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
 #else
   using Key = std::unique_ptr<EC_KEY, decltype(&EC_KEY_free)>;
 #endif
 
   using KeyContext = std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)>;
-  using MessageDigestContext = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
   using Group = std::unique_ptr<EC_GROUP, decltype(&EC_GROUP_free)>;
   using Point = std::unique_ptr<EC_POINT, decltype(&EC_POINT_free)>;
   using Signature = std::unique_ptr<ECDSA_SIG, decltype(&ECDSA_SIG_free)>;


### PR DESCRIPTION
### Short description
Fix some incorrect usages of OpenSSL 1.1/3.0 functions outside of build=guarded blocks.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)