### PR TITLE
Small typo in ALSO-NOTIFY

### DIFF
--- a/docs/domainmetadata.rst
+++ b/docs/domainmetadata.rst
@@ -96,7 +96,7 @@ ALSO-NOTIFY
 -----------
 
 When notifying this domain, also notify this nameserver (can occur
-multiple times). The nameserver may have contain an optional port
+multiple times). The nameserver may contain an optional port
 number. e.g.:
 
 .. code-block:: shell


### PR DESCRIPTION
### Short description
A word too many in ALSO-NOTIFY

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
