### PR TITLE
Avoid the use of raw pointers in checkKey(s) routines

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -58,7 +58,7 @@ bool DNSSECKeeper::doesDNSSEC()
   return d_keymetadb->doesDNSSEC();
 }
 
-bool DNSSECKeeper::isSecuredZone(const DNSName& zone, bool useCache) 
+bool DNSSECKeeper::isSecuredZone(const DNSName& zone, bool useCache)
 {
   if(isPresigned(zone, useCache))
     return true;
@@ -159,19 +159,19 @@ static bool keyCompareByKindAndID(const DNSSECKeeper::keyset_t::value_type& a, c
 }
 
 DNSSECPrivateKey DNSSECKeeper::getKeyById(const DNSName& zname, unsigned int id)
-{  
+{
   vector<DNSBackend::KeyData> keys;
   d_keymetadb->getDomainKeys(zname, keys);
   for(const DNSBackend::KeyData& kd :  keys) {
-    if(kd.id != id) 
+    if(kd.id != id)
       continue;
-    
+
     DNSKEYRecordContent dkrc;
     auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
     DNSSECPrivateKey dpk;
     dpk.setKey(key, kd.flags, dkrc.d_algorithm);
-    
-    return dpk;    
+
+    return dpk;
   }
   throw runtime_error("Can't find a key with id "+std::to_string(id)+" for zone '"+zname.toLogString()+"'");
 }
@@ -396,10 +396,10 @@ bool DNSSECKeeper::setNSEC3PARAM(const DNSName& zname, const NSEC3PARAMRecordCon
   meta.push_back(descr);
   if (d_keymetadb->setDomainMetadata(zname, "NSEC3PARAM", meta)) {
     meta.clear();
-    
+
     if(narrow)
       meta.push_back("1");
-    
+
     return d_keymetadb->setDomainMetadata(zname, "NSEC3NARROW", meta) && clearMetaCache(zname);
   }
   return false;
@@ -658,9 +658,9 @@ void DNSSECKeeper::getPreRRSIGs(UeberBackend& db, vector<DNSZoneRecord>& rrs, ui
 bool DNSSECKeeper::TSIGGrantsAccess(const DNSName& zone, const DNSName& keyname)
 {
   vector<string> allowed;
-  
+
   d_keymetadb->getDomainMetadata(zone, "TSIG-ALLOW-AXFR", allowed);
-  
+
   for(const string& dbkey :  allowed) {
     if(DNSName(dbkey)==keyname)
       return true;
@@ -673,7 +673,7 @@ bool DNSSECKeeper::getTSIGForAccess(const DNSName& zone, const ComboAddress& mas
   vector<string> keynames;
   d_keymetadb->getDomainMetadata(zone, "AXFR-MASTER-TSIG", keynames);
   keyname->trimToLabels(0);
-  
+
   // XXX FIXME this should check for a specific master!
   for(const string& dbkey :  keynames) {
     *keyname=DNSName(dbkey);

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -614,7 +614,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
   return retkeyset;
 }
 
-bool DNSSECKeeper::checkKeys(const DNSName& zone, vector<string>* errorMessages)
+bool DNSSECKeeper::checkKeys(const DNSName& zone, std::optional<std::reference_wrapper<std::vector<std::string>>> errorMessages)
 {
   vector<DNSBackend::KeyData> dbkeyset;
   d_keymetadb->getDomainKeys(zone, dbkeyset);

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -22,6 +22,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <functional>
 #include "dnsparser.hh"
 #include "sstuff.hh"
 #include "misc.hh"
@@ -63,11 +64,11 @@ std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCFile(DNSKEYRe
   fp.reset();
 
   auto dke = makeFromISCString(drc, isc);
-  vector<string> checkKeyErrors;
+  auto checkKeyErrors = std::vector<std::string>{};
 
-  if(!dke->checkKey(&checkKeyErrors)) {
+  if(!dke->checkKey(checkKeyErrors)) {
     string reason;
-    if(checkKeyErrors.size()) {
+    if(!checkKeyErrors.empty()) {
       reason = " ("+boost::algorithm::join(checkKeyErrors, ", ")+")";
     }
     throw runtime_error("Invalid DNS Private Key in file '"+string(fname)+"'"+reason);

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <vector>
+#include <optional>
 #include <map>
 #include "misc.hh"
 
@@ -75,7 +76,7 @@ class DNSCryptoKeyEngine
     virtual void fromISCMap(DNSKEYRecordContent& drc, stormap_t& stormap) = 0;
     virtual void fromPublicKeyString(const std::string& content) = 0;
 
-    virtual bool checkKey(vector<string>* errorMessages = nullptr) const
+    [[nodiscard]] virtual bool checkKey(std::optional<std::reference_wrapper<std::vector<std::string>>> /* errorMessages */ = std::nullopt) const
     {
       return true;
     }

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -202,7 +202,7 @@ public:
   bool deactivateKey(const DNSName& zname, unsigned int id);
   bool publishKey(const DNSName& zname, unsigned int id);
   bool unpublishKey(const DNSName& zname, unsigned int id);
-  bool checkKeys(const DNSName& zname, vector<string>* errorMessages = nullptr);
+  bool checkKeys(const DNSName& zname, std::optional<std::reference_wrapper<std::vector<std::string>>> errorMessages);
 
   bool getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* n3p=nullptr, bool* narrow=nullptr, bool useCache=true);
   bool checkNSEC3PARAM(const NSEC3PARAMRecordContent& ns3p, string& msg);

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -171,13 +171,13 @@ private:
 public:
   DNSSECKeeper() : d_keymetadb( new UeberBackend("key-only")), d_ourDB(true)
   {
-    
+
   }
-  
+
   DNSSECKeeper(UeberBackend* db) : d_keymetadb(db), d_ourDB(false)
   {
   }
-  
+
   ~DNSSECKeeper()
   {
     if(d_ourDB)
@@ -221,17 +221,17 @@ public:
 
   bool TSIGGrantsAccess(const DNSName& zone, const DNSName& keyname);
   bool getTSIGForAccess(const DNSName& zone, const ComboAddress& master, DNSName* keyname);
-  
+
   void startTransaction(const DNSName& zone, int zone_id)
   {
     (*d_keymetadb->backends.begin())->startTransaction(zone, zone_id);
   }
-  
+
   void commitTransaction()
   {
     (*d_keymetadb->backends.begin())->commitTransaction();
   }
-  
+
   void getFromMetaOrDefault(const DNSName& zname, const std::string& key, std::string& value, const std::string& defaultvalue);
   bool getFromMeta(const DNSName& zname, const std::string& key, std::string& value);
   void getSoaEdit(const DNSName& zname, std::string& value, bool useCache=true);
@@ -250,17 +250,17 @@ private:
   struct KeyCacheEntry
   {
     typedef vector<DNSSECKeeper::keymeta_t> keys_t;
-  
+
     uint32_t isStale(time_t now) const
     {
       return d_ttd < now;
     }
-  
+
     DNSName d_domain;
     mutable keys_t d_keys;
     unsigned int d_ttd;
   };
-  
+
   struct METACacheEntry
   {
     time_t isStale(time_t now) const
@@ -272,11 +272,11 @@ private:
     mutable METAValues d_value;
     time_t d_ttd;
   };
-  
+
   struct KeyCacheTag{};
   struct CompositeTag{};
   struct SequencedTag{};
-  
+
   typedef multi_index_container<
     KeyCacheEntry,
     indexed_by<

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -1784,7 +1784,7 @@ public:
 
   [[nodiscard]] storvector_t convertToISCVector() const override;
   [[nodiscard]] std::string sign(const std::string& msg) const override;
-  [[nodiscard]] bool verify(const std::string& msg, const std::string& signature) const override;
+  [[nodiscard]] bool verify(const std::string& message, const std::string& signature) const override;
   [[nodiscard]] std::string getPublicKeyString() const override;
   void fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& stormap) override;
   void fromPublicKeyString(const std::string& content) override;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -299,7 +299,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, con
   bool isSecure=dk.isSecuredZone(zone);
   bool presigned=dk.isPresigned(zone);
   vector<string> checkKeyErrors;
-  bool validKeys=dk.checkKeys(zone, &checkKeyErrors);
+  bool validKeys=dk.checkKeys(zone, checkKeyErrors);
 
   if (haveNSEC3) {
     if(isSecure && zone.wirelength() > 222) {

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -390,7 +390,7 @@ static void test_generic_signer(std::shared_ptr<DNSCryptoKeyEngine> dcke, DNSKEY
   BOOST_CHECK_EQUAL(dcke->getBits(), signer.bits);
 
   vector<string> errorMessages{};
-  BOOST_CHECK_EQUAL(dcke->checkKey(&errorMessages), true);
+  BOOST_CHECK_EQUAL(dcke->checkKey(errorMessages), true);
   if (!errorMessages.empty()) {
     BOOST_TEST_MESSAGE("Errors from " + dcke->getName() + " checkKey()");
     for (auto& errorMessage : errorMessages) {


### PR DESCRIPTION
### Short description
Small cleanup. Avoid the use of raw pointers in checkKey(s) routines.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)