### PR TITLE
dnsdist: Move the certs handling to a Makefile in the regression tests

### DIFF
--- a/regression-tests.dnsdist/.gitignore
+++ b/regression-tests.dnsdist/.gitignore
@@ -17,3 +17,5 @@
 /server.ocsp
 /server.p12
 /configs
+/dnsdist.log
+/dnsdist_test.conf

--- a/regression-tests.dnsdist/Makefile
+++ b/regression-tests.dnsdist/Makefile
@@ -1,6 +1,6 @@
 clean-certs:
 	rm -f ca.key ca.pem ca.srl server.csr server.key server.pem server.chain server.ocsp
-clean-config:
+clean-configs:
 	rm -rf configs/*
 certs:
 	# Generate a new CA

--- a/regression-tests.dnsdist/Makefile
+++ b/regression-tests.dnsdist/Makefile
@@ -1,0 +1,15 @@
+clean-certs:
+	rm -f ca.key ca.pem ca.srl server.csr server.key server.pem server.chain server.ocsp
+clean-config:
+	rm -rf configs/*
+certs:
+	# Generate a new CA
+	openssl req -new -x509 -days 1 -extensions v3_ca -keyout ca.key -out ca.pem -nodes -config configCA.conf
+	# Generate a new server certificate request
+	openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr -config configServer.conf
+	# Sign the server cert
+	openssl x509 -req -days 1 -CA ca.pem -CAkey ca.key -CAcreateserial -in server.csr -out server.pem -extfile configServer.conf -extensions v3_req
+	# Generate a chain
+	cat server.pem ca.pem > server.chain
+	# Generate a password-protected PKCS12 file
+	openssl pkcs12 -export -passout pass:passw0rd -clcerts -in server.pem -CAfile ca.pem -inkey server.key -out server.p12

--- a/regression-tests.dnsdist/runtests
+++ b/regression-tests.dnsdist/runtests
@@ -39,19 +39,9 @@ if [ "${PDNS_DEBUG}" = "YES" ]; then
   set -x
 fi
 
-rm -f ca.key ca.pem ca.srl server.csr server.key server.pem server.chain server.ocsp
-rm -rf configs/*
-
-# Generate a new CA
-openssl req -new -x509 -days 1 -extensions v3_ca -keyout ca.key -out ca.pem -nodes -config configCA.conf
-# Generate a new server certificate request
-openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr -config configServer.conf
-# Sign the server cert
-openssl x509 -req -days 1 -CA ca.pem -CAkey ca.key -CAcreateserial -in server.csr -out server.pem -extfile configServer.conf -extensions v3_req
-# Generate a chain
-cat server.pem ca.pem > server.chain
-# Generate a password-protected PKCS12 file
-openssl pkcs12 -export -passout pass:passw0rd -clcerts -in server.pem -CAfile ca.pem -inkey server.key -out server.p12
+make clean-certs
+make clean-configs
+make certs
 
 out=$(mktemp)
 set -o pipefail
@@ -68,4 +58,4 @@ if ! nosetests --with-xunit $@ 2>&1 | tee "${out}" ; then
 fi
 rm -f "${out}"
 
-rm -f ca.key ca.pem ca.srl server.csr server.key server.pem server.chain server.ocsp
+make clean-certs


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This makes my life easier during testing, and feels cleaner.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
