### PR TITLE
Signers cleanup

### DIFF
--- a/.not-formatted
+++ b/.not-formatted
@@ -292,7 +292,6 @@
 ./pdns/test-rcpgenerator_cc.cc
 ./pdns/test-sha_hh.cc
 ./pdns/test-sholder_hh.cc
-./pdns/test-signers.cc
 ./pdns/test-statbag_cc.cc
 ./pdns/test-svc_records_cc.cc
 ./pdns/test-trusted-notification-proxy_cc.cc

--- a/.not-formatted
+++ b/.not-formatted
@@ -244,7 +244,6 @@
 ./pdns/snmp-agent.hh
 ./pdns/sodcrypto.cc
 ./pdns/sodcrypto.hh
-./pdns/sodiumsigners.cc
 ./pdns/sortlist.cc
 ./pdns/sortlist.hh
 ./pdns/speedtest.cc

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -48,11 +48,11 @@ public:
    * Receives an open file handle and writes this key's contents to the
    * file.
    *
-   * \param[in] fp An open file handle for writing.
+   * \param[in] outputFile An open file handle for writing.
    *
    * \exception std::runtime_error In case of OpenSSL errors.
    */
-  void convertToPEM(std::FILE& fp) const override;
+  void convertToPEMFile(std::FILE& outputFile) const override;
 #endif
 
   [[nodiscard]] storvector_t convertToISCVector() const override;
@@ -110,14 +110,14 @@ void DecafED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc,
   }
 }
 
-void DecafED25519DNSCryptoKeyEngine::convertToPEM(std::FILE& fp) const
+void DecafED25519DNSCryptoKeyEngine::convertToPEMFile(std::FILE& outputFile) const
 {
   auto key = std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>(EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, nullptr, d_seckey, DECAF_EDDSA_25519_PRIVATE_BYTES), EVP_PKEY_free);
   if (key == nullptr) {
     throw runtime_error(getName() + ": Could not create private key from buffer");
   }
 
-  auto ret = PEM_write_PrivateKey(&fp, key.get(), nullptr, nullptr, 0, nullptr, nullptr);
+  auto ret = PEM_write_PrivateKey(&outputFile, key.get(), nullptr, nullptr, 0, nullptr, nullptr);
   if (ret == 0) {
     throw runtime_error(getName() + ": Could not convert private key to PEM");
   }
@@ -246,11 +246,11 @@ public:
    * Receives an open file handle and writes this key's contents to the
    * file.
    *
-   * \param[in] fp An open file handle for writing.
+   * \param[in] outputFile An open file handle for writing.
    *
    * \exception std::runtime_error In case of OpenSSL errors.
    */
-  void convertToPEM(std::FILE& fp) const override;
+  void convertToPEMFile(std::FILE& outputFile) const override;
 #endif
 
   storvector_t convertToISCVector() const override;
@@ -308,14 +308,14 @@ void DecafED448DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, c
   }
 }
 
-void DecafED448DNSCryptoKeyEngine::convertToPEM(std::FILE& fp) const
+void DecafED448DNSCryptoKeyEngine::convertToPEMFile(std::FILE& outputFile) const
 {
   auto key = std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>(EVP_PKEY_new_raw_private_key(EVP_PKEY_ED448, nullptr, d_seckey, DECAF_EDDSA_448_PRIVATE_BYTES), EVP_PKEY_free);
   if (key == nullptr) {
     throw runtime_error(getName() + ": Could not create private key from buffer");
   }
 
-  auto ret = PEM_write_PrivateKey(&fp, key.get(), nullptr, nullptr, 0, nullptr, nullptr);
+  auto ret = PEM_write_PrivateKey(&outputFile, key.get(), nullptr, nullptr, 0, nullptr, nullptr);
   if (ret == 0) {
     throw runtime_error(getName() + ": Could not convert private key to PEM");
   }

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -26,19 +26,15 @@ public:
   /**
    * \brief Creates an ED25519 key engine from a PEM file.
    *
-   * Receives an open file handle with PEM contents and creates an
-   * ED25519 key engine.
+   * Receives an open file handle with PEM contents and creates an ED25519 key engine.
    *
    * \param[in] drc Key record contents to be populated.
    *
-   * \param[in] filename Only used for providing filename information in
-   * error messages.
+   * \param[in] inputFile An open file handle to a file containing ED25519 PEM contents.
    *
-   * \param[in] inputFile An open file handle to a file containing ED25519 PEM
-   * contents.
+   * \param[in] filename Only used for providing filename information in error messages.
    *
-   * \return An ED25519 key engine populated with the contents of the
-   * PEM file.
+   * \return An ED25519 key engine populated with the contents of the PEM file.
    */
   void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 
@@ -224,19 +220,15 @@ public:
   /**
    * \brief Creates an ED448 key engine from a PEM file.
    *
-   * Receives an open file handle with PEM contents and creates an ED448
-   * key engine.
+   * Receives an open file handle with PEM contents and creates an ED448 key engine.
    *
    * \param[in] drc Key record contents to be populated.
    *
-   * \param[in] filename Only used for providing filename information in
-   * error messages.
+   * \param[in] inputFile An open file handle to a file containing ED448 PEM contents.
    *
-   * \param[in] inputFile An open file handle to a file containing ED448 PEM
-   * contents.
+   * \param[in] filename Only used for providing filename information in error messages.
    *
-   * \return An ED448 key engine populated with the contents of the PEM
-   * file.
+   * \return An ED448 key engine populated with the contents of the PEM file.
    */
   void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -34,13 +34,13 @@ public:
    * \param[in] filename Only used for providing filename information in
    * error messages.
    *
-   * \param[in] fp An open file handle to a file containing ED25519 PEM
+   * \param[in] inputFile An open file handle to a file containing ED25519 PEM
    * contents.
    *
    * \return An ED25519 key engine populated with the contents of the
    * PEM file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& fp) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -55,11 +55,11 @@ public:
   void convertToPEM(std::FILE& fp) const override;
 #endif
 
-  storvector_t convertToISCVector() const override;
-  std::string sign(const std::string& msg) const override;
-  bool verify(const std::string& msg, const std::string& signature) const override;
-  std::string getPublicKeyString() const override;
-  int getBits() const override;
+  [[nodiscard]] storvector_t convertToISCVector() const override;
+  [[nodiscard]] std::string sign(const std::string& msg) const override;
+  [[nodiscard]] bool verify(const std::string& msg, const std::string& signature) const override;
+  [[nodiscard]] std::string getPublicKeyString() const override;
+  [[nodiscard]] int getBits() const override;
   void fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& stormap) override;
   void fromPublicKeyString(const std::string& content) override;
 
@@ -89,10 +89,10 @@ void DecafED25519DNSCryptoKeyEngine::create(unsigned int bits)
 }
 
 #if defined(HAVE_LIBCRYPTO_ED25519)
-void DecafED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& fp)
+void DecafED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& inputFile)
 {
   drc.d_algorithm = d_algorithm;
-  auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&fp, nullptr, nullptr, nullptr), &EVP_PKEY_free);
+  auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);
   if (key == nullptr) {
     throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename + "`");
   }
@@ -232,13 +232,13 @@ public:
    * \param[in] filename Only used for providing filename information in
    * error messages.
    *
-   * \param[in] fp An open file handle to a file containing ED448 PEM
+   * \param[in] inputFile An open file handle to a file containing ED448 PEM
    * contents.
    *
    * \return An ED448 key engine populated with the contents of the PEM
    * file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& fp) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -287,10 +287,10 @@ void DecafED448DNSCryptoKeyEngine::create(unsigned int bits)
 }
 
 #if defined(HAVE_LIBCRYPTO_ED448)
-void DecafED448DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& fp)
+void DecafED448DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& inputFile)
 {
   drc.d_algorithm = d_algorithm;
-  auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&fp, nullptr, nullptr, nullptr), &EVP_PKEY_free);
+  auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);
   if (key == nullptr) {
     throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename + "`");
   }

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -40,7 +40,7 @@ public:
    * \return An ED25519 key engine populated with the contents of the
    * PEM file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -89,7 +89,7 @@ void DecafED25519DNSCryptoKeyEngine::create(unsigned int bits)
 }
 
 #if defined(HAVE_LIBCRYPTO_ED25519)
-void DecafED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& inputFile)
+void DecafED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const string& filename)
 {
   drc.d_algorithm = d_algorithm;
   auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);
@@ -238,7 +238,7 @@ public:
    * \return An ED448 key engine populated with the contents of the PEM
    * file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -287,7 +287,7 @@ void DecafED448DNSCryptoKeyEngine::create(unsigned int bits)
 }
 
 #if defined(HAVE_LIBCRYPTO_ED448)
-void DecafED448DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& inputFile)
+void DecafED448DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const string& filename)
 {
   drc.d_algorithm = d_algorithm;
   auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -36,7 +36,7 @@ public:
    *
    * \return An ED25519 key engine populated with the contents of the PEM file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, std::optional<std::reference_wrapper<const std::string>> filename = std::nullopt) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -85,24 +85,36 @@ void DecafED25519DNSCryptoKeyEngine::create(unsigned int bits)
 }
 
 #if defined(HAVE_LIBCRYPTO_ED25519)
-void DecafED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const string& filename)
+void DecafED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, std::optional<std::reference_wrapper<const std::string>> filename)
 {
   drc.d_algorithm = d_algorithm;
   auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);
   if (key == nullptr) {
-    throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename + "`");
+    if (filename.has_value()) {
+      throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename->get() + "`");
+    }
+
+    throw runtime_error(getName() + ": Failed to read private key from PEM contents");
   }
 
   std::size_t keylen = DECAF_EDDSA_25519_PRIVATE_BYTES;
   int ret = EVP_PKEY_get_raw_private_key(key.get(), d_seckey, &keylen);
   if (ret == 0) {
-    throw runtime_error(getName() + ": Failed to get private key from PEM file contents `" + filename + "`");
+    if (filename.has_value()) {
+      throw runtime_error(getName() + ": Failed to get private key from PEM file contents `" + filename->get() + "`");
+    }
+
+    throw runtime_error(getName() + ": Failed to get private key from PEM contents");
   }
 
   keylen = DECAF_EDDSA_25519_PUBLIC_BYTES;
   ret = EVP_PKEY_get_raw_public_key(key.get(), d_pubkey, &keylen);
   if (ret == 0) {
-    throw runtime_error(getName() + ": Failed to get public key from PEM file contents `" + filename + "`");
+    if (filename.has_value()) {
+      throw runtime_error(getName() + ": Failed to get public key from PEM file contents `" + filename->get() + "`");
+    }
+
+    throw runtime_error(getName() + ": Failed to get public key from PEM contents");
   }
 }
 
@@ -230,7 +242,7 @@ public:
    *
    * \return An ED448 key engine populated with the contents of the PEM file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, std::optional<std::reference_wrapper<const std::string>> filename = std::nullopt) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -279,24 +291,36 @@ void DecafED448DNSCryptoKeyEngine::create(unsigned int bits)
 }
 
 #if defined(HAVE_LIBCRYPTO_ED448)
-void DecafED448DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const string& filename)
+void DecafED448DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, std::optional<std::reference_wrapper<const std::string>> filename)
 {
   drc.d_algorithm = d_algorithm;
   auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);
   if (key == nullptr) {
-    throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename + "`");
+    if (filename.has_value()) {
+      throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename->get() + "`");
+    }
+
+    throw runtime_error(getName() + ": Failed to read private key from PEM contents");
   }
 
   std::size_t keylen = DECAF_EDDSA_448_PRIVATE_BYTES;
   int ret = EVP_PKEY_get_raw_private_key(key.get(), d_seckey, &keylen);
   if (ret == 0) {
-    throw runtime_error(getName() + ": Failed to get private key from PEM file contents `" + filename + "`");
+    if (filename.has_value()) {
+      throw runtime_error(getName() + ": Failed to get private key from PEM file contents `" + filename->get() + "`");
+    }
+
+    throw runtime_error(getName() + ": Failed to get private key from PEM contents");
   }
 
   keylen = DECAF_EDDSA_448_PUBLIC_BYTES;
   ret = EVP_PKEY_get_raw_public_key(key.get(), d_pubkey, &keylen);
   if (ret == 0) {
-    throw runtime_error(getName() + ": Failed to get public key from PEM file contents `" + filename + "`");
+    if (filename.has_value()) {
+      throw runtime_error(getName() + ": Failed to get public key from PEM file contents `" + filename->get() + "`");
+    }
+
+    throw runtime_error(getName() + ": Failed to get public key from PEM contents");
   }
 }
 

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -170,10 +170,10 @@ std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCString(DNSKEY
   return dpk;
 }
 
-std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& fp, const uint8_t algorithm)
+std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile, const uint8_t algorithm)
 {
   auto maker = DNSCryptoKeyEngine::make(algorithm);
-  maker->createFromPEMFile(drc, filename, fp);
+  maker->createFromPEMFile(drc, filename, inputFile);
   return maker;
 }
 

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -170,7 +170,7 @@ std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCString(DNSKEY
   return dpk;
 }
 
-std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile, const uint8_t algorithm)
+std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromPEMFile(DNSKEYRecordContent& drc, const uint8_t algorithm, std::FILE& inputFile, const std::string& filename)
 {
   auto maker = DNSCryptoKeyEngine::make(algorithm);
   maker->createFromPEMFile(drc, filename, inputFile);

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -177,6 +177,13 @@ std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromPEMFile(DNSKEYRe
   return maker;
 }
 
+std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromPEMString(DNSKEYRecordContent& drc, uint8_t algorithm, const std::string& contents)
+{
+  auto maker = DNSCryptoKeyEngine::make(algorithm);
+  maker->createFromPEMString(drc, contents);
+  return maker;
+}
+
 std::string DNSCryptoKeyEngine::convertToISC() const
 {
   storvector_t storvector = this->convertToISCVector();

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -173,7 +173,7 @@ std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCString(DNSKEY
 std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromPEMFile(DNSKEYRecordContent& drc, const uint8_t algorithm, std::FILE& inputFile, const std::string& filename)
 {
   auto maker = DNSCryptoKeyEngine::make(algorithm);
-  maker->createFromPEMFile(drc, filename, inputFile);
+  maker->createFromPEMFile(drc, inputFile, filename);
   return maker;
 }
 

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -86,24 +86,22 @@ class DNSCryptoKeyEngine
     /**
      * \brief Creates a key engine from a PEM file.
      *
-     * Receives an open file handle with PEM contents and creates a key
-     * engine corresponding to the algorithm requested.
+     * Receives an open file handle with PEM contents and creates a key engine
+     * corresponding to the algorithm requested.
      *
      * \param[in] drc Key record contents to be populated.
-     *
-     * \param[in] filename Only used for providing filename information
-     * in error messages.
-     *
-     * \param[in] fp An open file handle to a file containing PEM
-     * contents.
      *
      * \param[in] algorithm Which algorithm to use. See
      * https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
      *
-     * \return A key engine corresponding to the requested algorithm and
-     * populated with the contents of the PEM file.
+     * \param[in] fp An open file handle to a file containing PEM contents.
+     *
+     * \param[in] filename Only used for providing filename information in error messages.
+     *
+     * \return A key engine corresponding to the requested algorithm and populated with
+     * the contents of the PEM file.
      */
-    static std::unique_ptr<DNSCryptoKeyEngine> makeFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile, uint8_t algorithm);
+    static std::unique_ptr<DNSCryptoKeyEngine> makeFromPEMFile(DNSKEYRecordContent& drc, uint8_t algorithm, std::FILE& inputFile, const std::string& filename);
 
     static std::unique_ptr<DNSCryptoKeyEngine> makeFromISCString(DNSKEYRecordContent& drc, const std::string& content);
     static std::unique_ptr<DNSCryptoKeyEngine> makeFromPublicKeyString(unsigned int algorithm, const std::string& raw);

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -78,6 +78,25 @@ class DNSCryptoKeyEngine
       throw std::runtime_error(getName() + ": Conversion to PEM not supported");
     };
 
+    /**
+     * \brief Converts the key into a PEM string.
+     *
+     * \return A string containing the key's PEM contents.
+     */
+    [[nodiscard]] auto convertToPEMString() const -> std::string
+    {
+      const size_t buflen = 4096;
+
+      std::string output{};
+      output.resize(buflen);
+      unique_ptr<std::FILE, decltype(&std::fclose)> outputFile{fmemopen(output.data(), output.length() - 1, "w"), &std::fclose};
+      convertToPEMFile(*outputFile);
+      std::fflush(outputFile.get());
+      output.resize(std::ftell(outputFile.get()));
+
+      return output;
+    };
+
     [[nodiscard]] virtual std::string sign(const std::string& msg) const =0;
 
     [[nodiscard]] virtual std::string hash(const std::string& msg) const

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -43,7 +43,7 @@ class DNSCryptoKeyEngine
     using storvector_t = std::vector<std::pair<std::string, std::string>>;
     virtual void create(unsigned int bits)=0;
 
-    virtual void createFromPEMFile(DNSKEYRecordContent& /* drc */, const std::string& /* filename */, std::FILE& /* inputFile */)
+    virtual void createFromPEMFile(DNSKEYRecordContent& /* drc */, std::FILE& /* inputFile */, const std::string& /* filename */)
     {
       throw std::runtime_error("Can't create key from PEM file");
     }

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -43,9 +43,13 @@ class DNSCryptoKeyEngine
     using storvector_t = std::vector<std::pair<std::string, std::string>>;
     virtual void create(unsigned int bits)=0;
 
-    virtual void createFromPEMFile(DNSKEYRecordContent& /* drc */, std::FILE& /* inputFile */, const std::string& /* filename */)
+    virtual void createFromPEMFile(DNSKEYRecordContent& /* drc */, std::FILE& /* inputFile */, const std::optional<std::reference_wrapper<const std::string>> filename = std::nullopt)
     {
-      throw std::runtime_error("Can't create key from PEM file");
+      if (filename.has_value()) {
+        throw std::runtime_error("Can't create key from PEM file `" + filename->get() + "`");
+      }
+
+      throw std::runtime_error("Can't create key from PEM contents");
     }
 
     [[nodiscard]] virtual storvector_t convertToISCVector() const =0;

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -51,7 +51,7 @@ class DNSCryptoKeyEngine
     [[nodiscard]] virtual storvector_t convertToISCVector() const =0;
     [[nodiscard]] std::string convertToISC() const ;
 
-    virtual void convertToPEM(std::FILE& fp) const
+    virtual void convertToPEMFile(std::FILE& /* outputFile */) const
     {
       throw std::runtime_error(getName() + ": Conversion to PEM not supported");
     };

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -52,6 +52,24 @@ class DNSCryptoKeyEngine
       throw std::runtime_error("Can't create key from PEM contents");
     }
 
+    /**
+     * \brief Creates a key engine from a PEM string.
+     *
+     * Receives PEM contents and creates a key engine.
+     *
+     * \param[in] drc Key record contents to be populated.
+     *
+     * \param[in] contents The PEM string contents.
+     *
+     * \return A key engine populated with the contents of the PEM string.
+     */
+    void createFromPEMString(DNSKEYRecordContent& drc, const std::string& contents)
+    {
+      // NOLINTNEXTLINE(*-cast): POSIX APIs.
+      unique_ptr<std::FILE, decltype(&std::fclose)> inputFile{fmemopen(const_cast<char*>(contents.data()), contents.length(), "r"), &std::fclose};
+      createFromPEMFile(drc, *inputFile);
+    }
+
     [[nodiscard]] virtual storvector_t convertToISCVector() const =0;
     [[nodiscard]] std::string convertToISC() const ;
 
@@ -106,6 +124,24 @@ class DNSCryptoKeyEngine
      * the contents of the PEM file.
      */
     static std::unique_ptr<DNSCryptoKeyEngine> makeFromPEMFile(DNSKEYRecordContent& drc, uint8_t algorithm, std::FILE& inputFile, const std::string& filename);
+
+    /**
+     * \brief Creates a key engine from a PEM string.
+     *
+     * Receives PEM contents and creates a key engine corresponding to the algorithm
+     * requested.
+     *
+     * \param[in] drc Key record contents to be populated.
+     *
+     * \param[in] algorithm Which algorithm to use. See
+     * https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
+     *
+     * \param[in] contents The PEM contents.
+     *
+     * \return A key engine corresponding to the requested algorithm and populated with
+     * the contents of the PEM string.
+     */
+    static std::unique_ptr<DNSCryptoKeyEngine> makeFromPEMString(DNSKEYRecordContent& drc, uint8_t algorithm, const std::string& contents);
 
     static std::unique_ptr<DNSCryptoKeyEngine> makeFromISCString(DNSKEYRecordContent& drc, const std::string& content);
     static std::unique_ptr<DNSCryptoKeyEngine> makeFromPublicKeyString(unsigned int algorithm, const std::string& raw);

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -43,7 +43,7 @@ class DNSCryptoKeyEngine
     using storvector_t = std::vector<std::pair<std::string, std::string>>;
     virtual void create(unsigned int bits)=0;
 
-    virtual void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& fp)
+    virtual void createFromPEMFile(DNSKEYRecordContent& /* drc */, const std::string& /* filename */, std::FILE& /* inputFile */)
     {
       throw std::runtime_error("Can't create key from PEM file");
     }

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -215,15 +215,13 @@ public:
   /**
    * \brief Creates an RSA key engine from a PEM file.
    *
-   * Receives an open file handle with PEM contents and creates an RSA key
-   * engine.
+   * Receives an open file handle with PEM contents and creates an RSA key engine.
    *
    * \param[in] drc Key record contents to be populated.
    *
-   * \param[in] filename Only used for providing filename information in error
-   * messages.
-   *
    * \param[in] inputFile An open file handle to a file containing RSA PEM contents.
+   *
+   * \param[in] filename Only used for providing filename information in error messages.
    *
    * \return An RSA key engine populated with the contents of the PEM file.
    */
@@ -999,19 +997,15 @@ public:
   /**
    * \brief Creates an ECDSA key engine from a PEM file.
    *
-   * Receives an open file handle with PEM contents and creates an ECDSA
-   * key engine.
+   * Receives an open file handle with PEM contents and creates an ECDSA key engine.
    *
    * \param[in] drc Key record contents to be populated.
    *
-   * \param[in] filename Only used for providing filename information
-   * in error messages.
+   * \param[in] inputFile An open file handle to a file containing ECDSA PEM contents.
    *
-   * \param[in] inputFile An open file handle to a file containing ECDSA PEM
-   * contents.
+   * \param[in] filename Only used for providing filename information in error messages.
    *
-   * \return An ECDSA key engine populated with the contents of the PEM
-   * file.
+   * \return An ECDSA key engine populated with the contents of the PEM file.
    */
   void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 
@@ -1754,19 +1748,15 @@ public:
   /**
    * \brief Creates an EDDSA key engine from a PEM file.
    *
-   * Receives an open file handle with PEM contents and creates an EDDSA
-   * key engine.
+   * Receives an open file handle with PEM contents and creates an EDDSA key engine.
    *
    * \param[in] drc Key record contents to be populated.
    *
-   * \param[in] filename Only used for providing filename information in
-   * error messages.
+   * \param[in] inputFile An open file handle to a file containing EDDSA PEM contents.
    *
-   * \param[in] inputFile An open file handle to a file containing EDDSA PEM
-   * contents.
+   * \param[in] filename Only used for providing filename information in error messages.
    *
-   * \return An EDDSA key engine populated with the contents of the PEM
-   * file.
+   * \return An EDDSA key engine populated with the contents of the PEM file.
    */
   void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -227,7 +227,7 @@ public:
    *
    * \return An RSA key engine populated with the contents of the PEM file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -382,7 +382,7 @@ void OpenSSLRSADNSCryptoKeyEngine::create(unsigned int bits)
 #endif
 }
 
-void OpenSSLRSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile)
+void OpenSSLRSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename)
 {
   drc.d_algorithm = d_algorithm;
 
@@ -1013,7 +1013,7 @@ public:
    * \return An ECDSA key engine populated with the contents of the PEM
    * file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -1154,7 +1154,7 @@ void OpenSSLECDSADNSCryptoKeyEngine::create(unsigned int bits)
 #endif
 }
 
-void OpenSSLECDSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& inputFile)
+void OpenSSLECDSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const string& filename)
 {
   drc.d_algorithm = d_algorithm;
 
@@ -1768,7 +1768,7 @@ public:
    * \return An EDDSA key engine populated with the contents of the PEM
    * file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -1894,7 +1894,7 @@ void OpenSSLEDDSADNSCryptoKeyEngine::create(unsigned int /* bits */)
   d_edkey.reset(newKey);
 }
 
-void OpenSSLEDDSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& inputFile)
+void OpenSSLEDDSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const string& filename)
 {
   drc.d_algorithm = d_algorithm;
   d_edkey = Key(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -239,7 +239,7 @@ public:
    *
    * \exception std::runtime_error In case of OpenSSL errors.
    */
-  void convertToPEM(std::FILE& outputFile) const override;
+  void convertToPEMFile(std::FILE& outputFile) const override;
 
   [[nodiscard]] storvector_t convertToISCVector() const override;
 
@@ -401,7 +401,7 @@ void OpenSSLRSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, c
 #endif
 }
 
-void OpenSSLRSADNSCryptoKeyEngine::convertToPEM(std::FILE& outputFile) const
+void OpenSSLRSADNSCryptoKeyEngine::convertToPEMFile(std::FILE& outputFile) const
 {
 #if OPENSSL_VERSION_MAJOR >= 3
   if (PEM_write_PrivateKey(&outputFile, d_key.get(), nullptr, nullptr, 0, nullptr, nullptr) == 0) {
@@ -1025,7 +1025,7 @@ public:
    *
    * \exception std::runtime_error In case of OpenSSL errors.
    */
-  void convertToPEM(std::FILE& outputFile) const override;
+  void convertToPEMFile(std::FILE& outputFile) const override;
 
   [[nodiscard]] storvector_t convertToISCVector() const override;
   [[nodiscard]] std::string hash(const std::string& message) const override;
@@ -1198,7 +1198,7 @@ void OpenSSLECDSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc,
 #endif
 }
 
-void OpenSSLECDSADNSCryptoKeyEngine::convertToPEM(std::FILE& outputFile) const
+void OpenSSLECDSADNSCryptoKeyEngine::convertToPEMFile(std::FILE& outputFile) const
 {
 #if OPENSSL_VERSION_MAJOR >= 3
   if (PEM_write_PrivateKey(&outputFile, d_eckey.get(), nullptr, nullptr, 0, nullptr, nullptr) == 0) {
@@ -1780,7 +1780,7 @@ public:
    *
    * \exception std::runtime_error In case of OpenSSL errors.
    */
-  void convertToPEM(std::FILE& outputFile) const override;
+  void convertToPEMFile(std::FILE& outputFile) const override;
 
   [[nodiscard]] storvector_t convertToISCVector() const override;
   [[nodiscard]] std::string sign(const std::string& msg) const override;
@@ -1903,7 +1903,7 @@ void OpenSSLEDDSADNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc,
   }
 }
 
-void OpenSSLEDDSADNSCryptoKeyEngine::convertToPEM(std::FILE& outputFile) const
+void OpenSSLEDDSADNSCryptoKeyEngine::convertToPEMFile(std::FILE& outputFile) const
 {
   auto ret = PEM_write_PrivateKey(&outputFile, d_edkey.get(), nullptr, nullptr, 0, nullptr, nullptr);
   if (ret == 0) {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3481,7 +3481,7 @@ try
     }
 
     DNSKEYRecordContent drc;
-    shared_ptr<DNSCryptoKeyEngine> key{DNSCryptoKeyEngine::makeFromPEMFile(drc, filename, *fp, algorithm)};
+    shared_ptr<DNSCryptoKeyEngine> key{DNSCryptoKeyEngine::makeFromPEMFile(drc, algorithm, *fp, filename)};
     if (!key) {
       cerr << "Could not convert key from PEM to internal format" << endl;
       return 1;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3454,7 +3454,7 @@ try
     string zone = cmds.at(1);
     auto id = pdns::checked_stoi<unsigned int>(cmds.at(2));
     DNSSECPrivateKey dpk = dk.getKeyById(DNSName(zone), id);
-    dpk.getKey()->convertToPEM(*stdout);
+    dpk.getKey()->convertToPEMFile(*stdout);
   }
   else if (cmds.at(0) == "increase-serial") {
     if (cmds.size() < 2) {

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -1,6 +1,7 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
-extern "C" {
+extern "C"
+{
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -12,7 +13,8 @@ extern "C" {
 class SodiumED25519DNSCryptoKeyEngine : public DNSCryptoKeyEngine
 {
 public:
-  explicit SodiumED25519DNSCryptoKeyEngine(unsigned int algo) : DNSCryptoKeyEngine(algo)
+  explicit SodiumED25519DNSCryptoKeyEngine(unsigned int algo) :
+    DNSCryptoKeyEngine(algo)
   {}
   string getName() const override { return "Sodium ED25519"; }
   void create(unsigned int bits) override;
@@ -70,8 +72,8 @@ private:
 
 void SodiumED25519DNSCryptoKeyEngine::create(unsigned int bits)
 {
-  if(bits != crypto_sign_ed25519_SEEDBYTES * 8) {
-    throw runtime_error("Unsupported key length of "+std::to_string(bits)+" bits requested, SodiumED25519 class");
+  if (bits != crypto_sign_ed25519_SEEDBYTES * 8) {
+    throw runtime_error("Unsupported key length of " + std::to_string(bits) + " bits requested, SodiumED25519 class");
   }
   crypto_sign_ed25519_keypair(d_pubkey, d_seckey);
 }
@@ -140,7 +142,7 @@ DNSCryptoKeyEngine::storvector_t SodiumED25519DNSCryptoKeyEngine::convertToISCVe
   return storvector;
 }
 
-void SodiumED25519DNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& stormap )
+void SodiumED25519DNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& stormap)
 {
   /*
     Private-key-format: v1.2
@@ -194,7 +196,8 @@ bool SodiumED25519DNSCryptoKeyEngine::verify(const std::string& msg, const std::
   return crypto_sign_ed25519_verify_detached((const unsigned char*)signature.c_str(), (const unsigned char*)msg.c_str(), msg.length(), d_pubkey) == 0;
 }
 
-namespace {
+namespace
+{
 const struct LoaderSodiumStruct
 {
   LoaderSodiumStruct()

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -31,13 +31,13 @@ public:
    * \param[in] filename Only used for providing filename information in
    * error messages.
    *
-   * \param[in] fp An open file handle to a file containing ED25519 PEM
+   * \param[in] inputFile An open file handle to a file containing ED25519 PEM
    * contents.
    *
    * \return An ED25519 key engine populated with the contents of the
    * PEM file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& fp) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -52,11 +52,11 @@ public:
   void convertToPEM(std::FILE& fp) const override;
 #endif
 
-  storvector_t convertToISCVector() const override;
-  std::string sign(const std::string& msg) const override;
-  bool verify(const std::string& msg, const std::string& signature) const override;
-  std::string getPublicKeyString() const override;
-  int getBits() const override;
+  [[nodiscard]] storvector_t convertToISCVector() const override;
+  [[nodiscard]] std::string sign(const std::string& msg) const override;
+  [[nodiscard]] bool verify(const std::string& msg, const std::string& signature) const override;
+  [[nodiscard]] std::string getPublicKeyString() const override;
+  [[nodiscard]] int getBits() const override;
   void fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& stormap) override;
   void fromPublicKeyString(const std::string& content) override;
 
@@ -79,10 +79,10 @@ void SodiumED25519DNSCryptoKeyEngine::create(unsigned int bits)
 }
 
 #if defined(HAVE_LIBCRYPTO_ED25519)
-void SodiumED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& fp)
+void SodiumED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& inputFile)
 {
   drc.d_algorithm = d_algorithm;
-  auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&fp, nullptr, nullptr, nullptr), &EVP_PKEY_free);
+  auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);
   if (key == nullptr) {
     throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename + "`");
   }

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -33,7 +33,7 @@ public:
    *
    * \return An ED25519 key engine populated with the contents of the PEM file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, std::optional<std::reference_wrapper<const std::string>> filename = std::nullopt) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -75,12 +75,16 @@ void SodiumED25519DNSCryptoKeyEngine::create(unsigned int bits)
 }
 
 #if defined(HAVE_LIBCRYPTO_ED25519)
-void SodiumED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const string& filename)
+void SodiumED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, std::optional<std::reference_wrapper<const std::string>> filename)
 {
   drc.d_algorithm = d_algorithm;
   auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);
   if (key == nullptr) {
-    throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename + "`");
+    if (filename.has_value()) {
+      throw runtime_error(getName() + ": Failed to read private key from PEM file `" + filename->get() + "`");
+    }
+
+    throw runtime_error(getName() + ": Failed to read private key from PEM contents");
   }
 
   // The secret key is 64 bytes according to libsodium. But OpenSSL returns 32 in
@@ -88,13 +92,21 @@ void SodiumED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc
   std::size_t secKeyLen = crypto_sign_ed25519_SECRETKEYBYTES;
   int ret = EVP_PKEY_get_raw_private_key(key.get(), d_seckey, &secKeyLen);
   if (ret == 0) {
-    throw runtime_error(getName() + ": Failed to get private key from PEM file contents `" + filename + "`");
+    if (filename.has_value()) {
+      throw runtime_error(getName() + ": Failed to get private key from PEM file contents `" + filename->get() + "`");
+    }
+
+    throw runtime_error(getName() + ": Failed to get private key from PEM contents");
   }
 
   std::size_t pubKeyLen = crypto_sign_ed25519_PUBLICKEYBYTES;
   ret = EVP_PKEY_get_raw_public_key(key.get(), d_pubkey, &pubKeyLen);
   if (ret == 0) {
-    throw runtime_error(getName() + ": Failed to get public key from PEM file contents `" + filename + "`");
+    if (filename.has_value()) {
+      throw runtime_error(getName() + ": Failed to get public key from PEM file contents `" + filename->get() + "`");
+    }
+
+    throw runtime_error(getName() + ": Failed to get public key from PEM contents");
   }
 
   // It looks like libsodium expects the public key to be appended to the private key,

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -45,11 +45,11 @@ public:
    * Receives an open file handle and writes this key's contents to the
    * file.
    *
-   * \param[in] fp An open file handle for writing.
+   * \param[in] outputFile An open file handle for writing.
    *
    * \exception std::runtime_error In case of OpenSSL errors.
    */
-  void convertToPEM(std::FILE& fp) const override;
+  void convertToPEMFile(std::FILE& outputFile) const override;
 #endif
 
   [[nodiscard]] storvector_t convertToISCVector() const override;
@@ -106,14 +106,14 @@ void SodiumED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc
   memcpy(d_seckey + secKeyLen, d_pubkey, pubKeyLen);
 }
 
-void SodiumED25519DNSCryptoKeyEngine::convertToPEM(std::FILE& fp) const
+void SodiumED25519DNSCryptoKeyEngine::convertToPEMFile(std::FILE& outputFile) const
 {
   auto key = std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>(EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, nullptr, d_seckey, crypto_sign_ed25519_SEEDBYTES), EVP_PKEY_free);
   if (key == nullptr) {
     throw runtime_error(getName() + ": Could not create private key from buffer");
   }
 
-  auto ret = PEM_write_PrivateKey(&fp, key.get(), nullptr, nullptr, 0, nullptr, nullptr);
+  auto ret = PEM_write_PrivateKey(&outputFile, key.get(), nullptr, nullptr, 0, nullptr, nullptr);
   if (ret == 0) {
     throw runtime_error(getName() + ": Could not convert private key to PEM");
   }

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -37,7 +37,7 @@ public:
    * \return An ED25519 key engine populated with the contents of the
    * PEM file.
    */
-  void createFromPEMFile(DNSKEYRecordContent& drc, const std::string& filename, std::FILE& inputFile) override;
+  void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 
   /**
    * \brief Writes this key's contents to a file.
@@ -79,7 +79,7 @@ void SodiumED25519DNSCryptoKeyEngine::create(unsigned int bits)
 }
 
 #if defined(HAVE_LIBCRYPTO_ED25519)
-void SodiumED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, const string& filename, std::FILE& inputFile)
+void SodiumED25519DNSCryptoKeyEngine::createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const string& filename)
 {
   drc.d_algorithm = d_algorithm;
   auto key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(PEM_read_PrivateKey(&inputFile, nullptr, nullptr, nullptr), &EVP_PKEY_free);

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -23,19 +23,15 @@ public:
   /**
    * \brief Creates an ED25519 key engine from a PEM file.
    *
-   * Receives an open file handle with PEM contents and creates an
-   * ED25519 key engine.
+   * Receives an open file handle with PEM contents and creates an ED25519 key engine.
    *
    * \param[in] drc Key record contents to be populated.
    *
-   * \param[in] filename Only used for providing filename information in
-   * error messages.
+   * \param[in] inputFile An open file handle to a file containing ED25519 PEM contents.
    *
-   * \param[in] inputFile An open file handle to a file containing ED25519 PEM
-   * contents.
+   * \param[in] filename Only used for providing filename information in error messages.
    *
-   * \return An ED25519 key engine populated with the contents of the
-   * PEM file.
+   * \return An ED25519 key engine populated with the contents of the PEM file.
    */
   void createFromPEMFile(DNSKEYRecordContent& drc, std::FILE& inputFile, const std::string& filename) override;
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -472,7 +472,7 @@ BOOST_FIXTURE_TEST_CASE(test_generic_signers, Fixture)
     std::string dckePEMOutput{};
     dckePEMOutput.resize(buflen);
     unique_ptr<std::FILE, decltype(&std::fclose)> dckePEMOutputFp{fmemopen(static_cast<void*>(dckePEMOutput.data()), dckePEMOutput.length() - 1, "w"), &std::fclose};
-    dcke->convertToPEM(*dckePEMOutputFp);
+    dcke->convertToPEMFile(*dckePEMOutputFp);
     std::fflush(dckePEMOutputFp.get());
     dckePEMOutput.resize(std::ftell(dckePEMOutputFp.get()));
 
@@ -481,7 +481,7 @@ BOOST_FIXTURE_TEST_CASE(test_generic_signers, Fixture)
     std::string pemKeyOutput{};
     pemKeyOutput.resize(buflen);
     unique_ptr<std::FILE, decltype(&std::fclose)> pemKeyOutputFp{fmemopen(static_cast<void*>(pemKeyOutput.data()), pemKeyOutput.length() - 1, "w"), &std::fclose};
-    pemKey->convertToPEM(*pemKeyOutputFp);
+    pemKey->convertToPEMFile(*pemKeyOutputFp);
     std::fflush(pemKeyOutputFp.get());
     pemKeyOutput.resize(std::ftell(pemKeyOutputFp.get()));
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -458,12 +458,8 @@ BOOST_FIXTURE_TEST_CASE(test_generic_signers, Fixture)
     auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(drc, signer.iscMap));
     test_generic_signer(dcke, drc, signer, message);
 
-    unique_ptr<std::FILE, decltype(&std::fclose)> inputFile{fmemopen((void*)signer.pem.c_str(), signer.pem.length(), "r"), &std::fclose};
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Boost stuff.
-    BOOST_REQUIRE(inputFile.get() != nullptr);
-
     DNSKEYRecordContent pemDRC;
-    shared_ptr<DNSCryptoKeyEngine> pemKey{DNSCryptoKeyEngine::makeFromPEMFile(pemDRC, signer.algorithm, *inputFile, "<buffer>")};
+    shared_ptr<DNSCryptoKeyEngine> pemKey{DNSCryptoKeyEngine::makeFromPEMString(pemDRC, signer.algorithm, signer.pem)};
 
     BOOST_CHECK_EQUAL(pemKey->convertToISC(), dcke->convertToISC());
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -37,6 +37,7 @@ struct SignerParams
   std::string pem;
 };
 
+// clang-format off
 static const SignerParams rsaSha256SignerParams = SignerParams
 {
   .iscMap = "Algorithm: 8\n"
@@ -59,7 +60,6 @@ static const SignerParams rsaSha256SignerParams = SignerParams
               "22ea940600dc2d9a98b1126c26ac0dc5c91b31eb50fe784b"
               "36ad675e9eecfe6573c1f85c53b6bc94580f3ac443d13c4c",
 
-  // clang-format off
   /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
   .signature = {
     0x93, 0x93, 0x5f, 0xd8, 0xa1, 0x2b, 0x4c, 0x0b, 0xf3, 0x67, 0x42, 0x13, 0x52,
@@ -68,7 +68,6 @@ static const SignerParams rsaSha256SignerParams = SignerParams
     0x63, 0x44, 0x85, 0x06, 0x13, 0xaa, 0x01, 0x3c, 0x58, 0x52, 0xa3, 0x98, 0x20,
     0x65, 0x03, 0xd0, 0x40, 0xc8, 0xa0, 0xe9, 0xd2, 0xc0, 0x03, 0x5a, 0xab
   },
-  // clang-format on
 
   .zoneRepresentation = "256 3 8 "
                         "AwEAAarbp0oh52KuF0SwXoSgMNRpcW/uPKCKQAu8NyYaY+"
@@ -110,10 +109,12 @@ static const SignerParams rsaSha256SignerParams = SignerParams
          "-----END RSA PRIVATE KEY-----\n"
 #endif
 };
+// clang-format on
 
 /* ECDSA-P256-SHA256 from
  * https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h
  */
+// clang-format off
 static const SignerParams ecdsaSha256 = SignerParams
 {
   .iscMap = "Algorithm: 13\n"
@@ -129,7 +130,6 @@ static const SignerParams ecdsaSha256 = SignerParams
               "a0ac6790483872be72a258314200a88ab75cdd70f66a18a0"
               "9f0f414c074df0989fdb1df0e67d82d4312cda67b93a76c1",
 
-  // clang-format off
   /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
   .signature = {
     0xa2, 0x95, 0x76, 0xb5, 0xf5, 0x7e, 0xbd, 0xdd, 0xf5, 0x62, 0xa2, 0xc3, 0xa4,
@@ -138,7 +138,6 @@ static const SignerParams ecdsaSha256 = SignerParams
     0xd3, 0x8c, 0x88, 0xc3, 0xee, 0x12, 0x0e, 0x69, 0x70, 0x55, 0x99, 0xec, 0xd5,
     0xf6, 0x4f, 0x4b, 0xe2, 0x41, 0xd9, 0x10, 0x7e, 0x67, 0xe5, 0xad, 0x2f
   },
-  // clang-format on
 
   .zoneRepresentation = "256 3 13 "
                         "8uD7C4THTM/w7uhryRSToeE/jKT78/p853RX0L5EwrZ"
@@ -171,10 +170,12 @@ static const SignerParams ecdsaSha256 = SignerParams
          "-----END EC PRIVATE KEY-----\n"
 #endif
 };
+// clang-format on
 
 /* Ed25519 from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h,
  * also from rfc8080 section 6.1
  */
+// clang-format off
 static const SignerParams ed25519 = SignerParams{
   .iscMap = "Algorithm: 15\n"
             "PrivateKey: ODIyNjAzODQ2MjgwODAxMjI2NDUxOTAyMDQxNDIyNjI=\n",
@@ -189,7 +190,6 @@ static const SignerParams ed25519 = SignerParams{
               "d11831153af4985efbd0ae792c967eb4aff3c35488db95f7"
               "e2f85dcec74ae8f59f9a72641798c91c67c675db1d710c18",
 
-  // clang-format off
   /* from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sign.c */
   .signature = {
     0x0a, 0x9e, 0x51, 0x5f, 0x16, 0x89, 0x49, 0x27, 0x0e, 0x98, 0x34, 0xd3, 0x48,
@@ -198,7 +198,6 @@ static const SignerParams ed25519 = SignerParams{
     0x1f, 0x1d, 0x08, 0x10, 0x20, 0x1c, 0x01, 0x77, 0x1b, 0x5a, 0x48, 0xd6, 0xe5,
     0x1c, 0xf9, 0xe3, 0xe0, 0x70, 0x34, 0x5e, 0x02, 0x49, 0xfb, 0x9e, 0x05
   },
-  // clang-format on
 
   .zoneRepresentation = "256 3 15 l02Woi0iS8Aa25FQkUd9RMzZHJpBoRQwAQEX1SxZJA4=",
 
@@ -225,10 +224,13 @@ static const SignerParams ed25519 = SignerParams{
 
   .pem = "-----BEGIN PRIVATE KEY-----\n"
          "MC4CAQAwBQYDK2VwBCIEIDgyMjYwMzg0NjI4MDgwMTIyNjQ1MTkwMjA0MTQyMjYy\n"
-         "-----END PRIVATE KEY-----\n"};
+         "-----END PRIVATE KEY-----\n"
+};
+// clang-format on
 
 /* Ed448.
  */
+// clang-format off
 static const SignerParams ed448 = SignerParams{
   .iscMap = "Private-key-format: v1.2\n"
             "Algorithm: 16 (ED448)\n"
@@ -244,7 +246,6 @@ static const SignerParams ed448 = SignerParams{
               "3876e5d892d3f31725f9964a332f9b9afd791171833480f2"
               "e71af78efb985cde9900ba95315287123a5908ca8f334369",
 
-  // clang-format off
   .signature = {
     0xb5, 0xcc, 0x21, 0x5a, 0x52, 0x21, 0x60, 0xa3, 0xb8, 0xd9, 0x3a, 0xd7, 0x05,
     0xdd, 0x4a, 0x32, 0x96, 0xce, 0x08, 0xde, 0x74, 0x5f, 0xdb, 0xde, 0x54, 0x95,
@@ -256,7 +257,6 @@ static const SignerParams ed448 = SignerParams{
     0x0f, 0x43, 0x72, 0x77, 0x86, 0xec, 0x88, 0x1a, 0x96, 0x95, 0x4a, 0x01, 0xfe,
     0xf2, 0xe6, 0x77, 0x4a, 0x2e, 0x43, 0xdd, 0x60, 0x29, 0x00,
   },
-  // clang-format on
 
   .zoneRepresentation = "256 3 16 "
                         "3kgROaDjrh0H2iuixWBrc8g2EpBBLCdGzHmn+"
@@ -287,7 +287,9 @@ static const SignerParams ed448 = SignerParams{
   .pem = "-----BEGIN PRIVATE KEY-----\n"
          "MEcCAQAwBQYDK2VxBDsEOcWfuQoJuOt8boLZGOQdCcenqxU16dd62HoLLdKkbTbD\n"
          "mJ2laTMdGf3ORIgPcfMFmww3Lf1NxYWFgA==\n"
-         "-----END PRIVATE KEY-----\n"};
+         "-----END PRIVATE KEY-----\n"
+};
+// clang-format on
 
 struct Fixture
 {

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -305,18 +305,18 @@ struct Fixture
 
     addSignerParams(DNSSECKeeper::RSASHA256, "RSA SHA256", rsaSha256SignerParams);
 
-    #ifdef HAVE_LIBCRYPTO_ECDSA
+#ifdef HAVE_LIBCRYPTO_ECDSA
     addSignerParams(DNSSECKeeper::ECDSA256, "ECDSA SHA256", ecdsaSha256);
-    #endif
+#endif
 
-    // We need to have HAVE_LIBCRYPTO_ED25519 for the PEM reader/writer.
-    #if defined(HAVE_LIBCRYPTO_ED25519)
+// We need to have HAVE_LIBCRYPTO_ED25519 for the PEM reader/writer.
+#if defined(HAVE_LIBCRYPTO_ED25519)
     addSignerParams(DNSSECKeeper::ED25519, "ED25519", ed25519);
-    #endif
+#endif
 
-    #if defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED448)
+#if defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED448)
     addSignerParams(DNSSECKeeper::ED448, "ED448", ed448);
-    #endif
+#endif
   }
 
   void addSignerParams(const uint8_t algorithm, const std::string& name, const SignerParams& params)
@@ -492,24 +492,25 @@ BOOST_FIXTURE_TEST_CASE(test_generic_signers, Fixture)
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,readability-identifier-length): Boost stuff.
-BOOST_AUTO_TEST_CASE(test_hash_qname_with_salt) {
+BOOST_AUTO_TEST_CASE(test_hash_qname_with_salt)
+{
   {
     // rfc5155 appendix A
-    const unsigned char salt[] = { 0xaa, 0xbb, 0xcc, 0xdd };
+    const unsigned char salt[] = {0xaa, 0xbb, 0xcc, 0xdd};
     const unsigned int iterations{12};
     const std::vector<std::pair<std::string, std::string>> namesToHashes = {
-      { "example", "0p9mhaveqvm6t7vbl5lop2u3t2rp3tom" },
-      { "a.example", "35mthgpgcu1qg68fab165klnsnk3dpvl" },
-      { "ai.example", "gjeqe526plbf1g8mklp59enfd789njgi" },
-      { "ns1.example", "2t7b4g4vsa5smi47k61mv5bv1a22bojr" },
-      { "ns2.example", "q04jkcevqvmu85r014c7dkba38o0ji5r" },
-      { "w.example", "k8udemvp1j2f7eg6jebps17vp3n8i58h" },
-      { "*.w.example", "r53bq7cc2uvmubfu5ocmm6pers9tk9en" },
-      { "x.w.example", "b4um86eghhds6nea196smvmlo4ors995" },
-      { "y.w.example", "ji6neoaepv8b5o6k4ev33abha8ht9fgc" },
-      { "x.y.w.example", "2vptu5timamqttgl4luu9kg21e0aor3s" },
-      { "xx.example", "t644ebqk9bibcna874givr6joj62mlhv" },
-      { "2t7b4g4vsa5smi47k61mv5bv1a22bojr.example", "kohar7mbb8dc2ce8a9qvl8hon4k53uhi" },
+      {"example", "0p9mhaveqvm6t7vbl5lop2u3t2rp3tom"},
+      {"a.example", "35mthgpgcu1qg68fab165klnsnk3dpvl"},
+      {"ai.example", "gjeqe526plbf1g8mklp59enfd789njgi"},
+      {"ns1.example", "2t7b4g4vsa5smi47k61mv5bv1a22bojr"},
+      {"ns2.example", "q04jkcevqvmu85r014c7dkba38o0ji5r"},
+      {"w.example", "k8udemvp1j2f7eg6jebps17vp3n8i58h"},
+      {"*.w.example", "r53bq7cc2uvmubfu5ocmm6pers9tk9en"},
+      {"x.w.example", "b4um86eghhds6nea196smvmlo4ors995"},
+      {"y.w.example", "ji6neoaepv8b5o6k4ev33abha8ht9fgc"},
+      {"x.y.w.example", "2vptu5timamqttgl4luu9kg21e0aor3s"},
+      {"xx.example", "t644ebqk9bibcna874givr6joj62mlhv"},
+      {"2t7b4g4vsa5smi47k61mv5bv1a22bojr.example", "kohar7mbb8dc2ce8a9qvl8hon4k53uhi"},
     };
 
     for (const auto& [name, expectedHash] : namesToHashes) {
@@ -520,10 +521,10 @@ BOOST_AUTO_TEST_CASE(test_hash_qname_with_salt) {
 
   {
     /* no additional iterations, very short salt */
-    const unsigned char salt[] = { 0xFF };
+    const unsigned char salt[] = {0xFF};
     const unsigned int iterations{0};
     const std::vector<std::pair<std::string, std::string>> namesToHashes = {
-      { "example", "s9dp8o2l6jgqgg26ecobtjooe7p019cs" },
+      {"example", "s9dp8o2l6jgqgg26ecobtjooe7p019cs"},
     };
 
     for (const auto& [name, expectedHash] : namesToHashes) {
@@ -534,10 +535,10 @@ BOOST_AUTO_TEST_CASE(test_hash_qname_with_salt) {
 
   {
     /* only one iteration */
-    const unsigned char salt[] = { 0xaa, 0xbb, 0xcc, 0xdd };
+    const unsigned char salt[] = {0xaa, 0xbb, 0xcc, 0xdd};
     const unsigned int iterations{1};
     const std::vector<std::pair<std::string, std::string>> namesToHashes = {
-      { "example", "ulddquehrj5jpf50ga76vgqr1oq40133" },
+      {"example", "ulddquehrj5jpf50ga76vgqr1oq40133"},
     };
 
     for (const auto& [name, expectedHash] : namesToHashes) {
@@ -554,7 +555,7 @@ BOOST_AUTO_TEST_CASE(test_hash_qname_with_salt) {
     };
     const unsigned int iterations{65535};
     const std::vector<std::pair<std::string, std::string>> namesToHashes = {
-      { "example", "no95j4cfile8avstr7bn4aj9he18trri" },
+      {"example", "no95j4cfile8avstr7bn4aj9he18trri"},
     };
 
     for (const auto& [name, expectedHash] : namesToHashes) {

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -463,7 +463,7 @@ BOOST_FIXTURE_TEST_CASE(test_generic_signers, Fixture)
     BOOST_REQUIRE(inputFile.get() != nullptr);
 
     DNSKEYRecordContent pemDRC;
-    shared_ptr<DNSCryptoKeyEngine> pemKey{DNSCryptoKeyEngine::makeFromPEMFile(pemDRC, "<buffer>", *inputFile, signer.algorithm)};
+    shared_ptr<DNSCryptoKeyEngine> pemKey{DNSCryptoKeyEngine::makeFromPEMFile(pemDRC, signer.algorithm, *inputFile, "<buffer>")};
 
     BOOST_CHECK_EQUAL(pemKey->convertToISC(), dcke->convertToISC());
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -465,24 +465,10 @@ BOOST_FIXTURE_TEST_CASE(test_generic_signers, Fixture)
 
     test_generic_signer(pemKey, pemDRC, signer, message);
 
-    const size_t buflen = 4096;
-
-    std::string dckePEMOutput{};
-    dckePEMOutput.resize(buflen);
-    unique_ptr<std::FILE, decltype(&std::fclose)> dckePEMOutputFp{fmemopen(static_cast<void*>(dckePEMOutput.data()), dckePEMOutput.length() - 1, "w"), &std::fclose};
-    dcke->convertToPEMFile(*dckePEMOutputFp);
-    std::fflush(dckePEMOutputFp.get());
-    dckePEMOutput.resize(std::ftell(dckePEMOutputFp.get()));
-
+    auto dckePEMOutput = dcke->convertToPEMString();
     BOOST_CHECK_EQUAL(dckePEMOutput, signer.pem);
 
-    std::string pemKeyOutput{};
-    pemKeyOutput.resize(buflen);
-    unique_ptr<std::FILE, decltype(&std::fclose)> pemKeyOutputFp{fmemopen(static_cast<void*>(pemKeyOutput.data()), pemKeyOutput.length() - 1, "w"), &std::fclose};
-    pemKey->convertToPEMFile(*pemKeyOutputFp);
-    std::fflush(pemKeyOutputFp.get());
-    pemKeyOutput.resize(std::ftell(pemKeyOutputFp.get()));
-
+    auto pemKeyOutput = pemKey->convertToPEMString();
     BOOST_CHECK_EQUAL(pemKeyOutput, signer.pem);
   }
 }


### PR DESCRIPTION
### Short description
- Fixes some confusing argument ordering and method naming.
- Instead of PEM-related functions only being able to handle files, introduce helpers to handle (import/export from) strings as well.
- Use the new helpers to simplify the tests a little.
- Some documentation formatting.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)