### PR TITLE
dnsdist: Fix warnings from cppcheck

### DIFF
--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -228,30 +228,30 @@ public:
   {
   }
 
-  void setQueryRate(unsigned int rate, unsigned int warningRate, unsigned int seconds, std::string reason, unsigned int blockDuration, DNSAction::Action action)
+  void setQueryRate(unsigned int rate, unsigned int warningRate, unsigned int seconds, const std::string& reason, unsigned int blockDuration, DNSAction::Action action)
   {
     d_queryRateRule = DynBlockRule(reason, blockDuration, rate, warningRate, seconds, action);
   }
 
   /* rate is in bytes per second */
-  void setResponseByteRate(unsigned int rate, unsigned int warningRate, unsigned int seconds, std::string reason, unsigned int blockDuration, DNSAction::Action action)
+  void setResponseByteRate(unsigned int rate, unsigned int warningRate, unsigned int seconds, const std::string& reason, unsigned int blockDuration, DNSAction::Action action)
   {
     d_respRateRule = DynBlockRule(reason, blockDuration, rate, warningRate, seconds, action);
   }
 
-  void setRCodeRate(uint8_t rcode, unsigned int rate, unsigned int warningRate, unsigned int seconds, std::string reason, unsigned int blockDuration, DNSAction::Action action)
+  void setRCodeRate(uint8_t rcode, unsigned int rate, unsigned int warningRate, unsigned int seconds, const std::string& reason, unsigned int blockDuration, DNSAction::Action action)
   {
     auto& entry = d_rcodeRules[rcode];
     entry = DynBlockRule(reason, blockDuration, rate, warningRate, seconds, action);
   }
 
-  void setRCodeRatio(uint8_t rcode, double ratio, double warningRatio, unsigned int seconds, std::string reason, unsigned int blockDuration, DNSAction::Action action, size_t minimumNumberOfResponses)
+  void setRCodeRatio(uint8_t rcode, double ratio, double warningRatio, unsigned int seconds, const std::string& reason, unsigned int blockDuration, DNSAction::Action action, size_t minimumNumberOfResponses)
   {
     auto& entry = d_rcodeRatioRules[rcode];
     entry = DynBlockRatioRule(reason, blockDuration, ratio, warningRatio, seconds, action, minimumNumberOfResponses);
   }
 
-  void setQTypeRate(uint16_t qtype, unsigned int rate, unsigned int warningRate, unsigned int seconds, std::string reason, unsigned int blockDuration, DNSAction::Action action)
+  void setQTypeRate(uint16_t qtype, unsigned int rate, unsigned int warningRate, unsigned int seconds, const std::string& reason, unsigned int blockDuration, DNSAction::Action action)
   {
     auto& entry = d_qtypeRules[qtype];
     entry = DynBlockRule(reason, blockDuration, rate, warningRate, seconds, action);
@@ -259,13 +259,13 @@ public:
 
   typedef std::function<std::tuple<bool, boost::optional<std::string>>(const StatNode&, const StatNode::Stat&, const StatNode::Stat&)> smtVisitor_t;
 
-  void setSuffixMatchRule(unsigned int seconds, std::string reason, unsigned int blockDuration, DNSAction::Action action, smtVisitor_t visitor)
+  void setSuffixMatchRule(unsigned int seconds, const std::string& reason, unsigned int blockDuration, DNSAction::Action action, smtVisitor_t visitor)
   {
     d_suffixMatchRule = DynBlockRule(reason, blockDuration, 0, 0, seconds, action);
     d_smtVisitor = visitor;
   }
 
-  void setSuffixMatchRuleFFI(unsigned int seconds, std::string reason, unsigned int blockDuration, DNSAction::Action action, dnsdist_ffi_stat_node_visitor_t visitor)
+  void setSuffixMatchRuleFFI(unsigned int seconds, const std::string& reason, unsigned int blockDuration, DNSAction::Action action, dnsdist_ffi_stat_node_visitor_t visitor)
   {
     d_suffixMatchRule = DynBlockRule(reason, blockDuration, 0, 0, seconds, action);
     d_smtVisitorFFI = visitor;

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -1098,10 +1098,10 @@ public:
       }
       else {
         if (d_includeTimestamp) {
-          fprintf(fp.get(), "[%llu.%lu] Packet from %s for %s %s with id %d\n", static_cast<unsigned long long>(dq->getQueryRealTime().tv_sec), static_cast<unsigned long>(dq->getQueryRealTime().tv_nsec), dq->ids.origRemote.toStringWithPort().c_str(), dq->ids.qname.toString().c_str(), QType(dq->ids.qtype).toString().c_str(), dq->getHeader()->id);
+          fprintf(fp.get(), "[%llu.%lu] Packet from %s for %s %s with id %u\n", static_cast<unsigned long long>(dq->getQueryRealTime().tv_sec), static_cast<unsigned long>(dq->getQueryRealTime().tv_nsec), dq->ids.origRemote.toStringWithPort().c_str(), dq->ids.qname.toString().c_str(), QType(dq->ids.qtype).toString().c_str(), dq->getHeader()->id);
         }
         else {
-          fprintf(fp.get(), "Packet from %s for %s %s with id %d\n", dq->ids.origRemote.toStringWithPort().c_str(), dq->ids.qname.toString().c_str(), QType(dq->ids.qtype).toString().c_str(), dq->getHeader()->id);
+          fprintf(fp.get(), "Packet from %s for %s %s with id %u\n", dq->ids.origRemote.toStringWithPort().c_str(), dq->ids.qname.toString().c_str(), QType(dq->ids.qtype).toString().c_str(), dq->getHeader()->id);
         }
       }
     }
@@ -1179,19 +1179,19 @@ public:
     if (!fp) {
       if (!d_verboseOnly || g_verbose) {
         if (d_includeTimestamp) {
-          infolog("[%u.%u] Answer to %s for %s %s (%s) with id %d", static_cast<unsigned long long>(dr->getQueryRealTime().tv_sec), static_cast<unsigned long>(dr->getQueryRealTime().tv_nsec), dr->ids.origRemote.toStringWithPort(), dr->ids.qname.toString(), QType(dr->ids.qtype).toString(), RCode::to_s(dr->getHeader()->rcode), dr->getHeader()->id);
+          infolog("[%u.%u] Answer to %s for %s %s (%s) with id %u", static_cast<unsigned long long>(dr->getQueryRealTime().tv_sec), static_cast<unsigned long>(dr->getQueryRealTime().tv_nsec), dr->ids.origRemote.toStringWithPort(), dr->ids.qname.toString(), QType(dr->ids.qtype).toString(), RCode::to_s(dr->getHeader()->rcode), dr->getHeader()->id);
         }
         else {
-          infolog("Answer to %s for %s %s (%s) with id %d", dr->ids.origRemote.toStringWithPort(), dr->ids.qname.toString(), QType(dr->ids.qtype).toString(), RCode::to_s(dr->getHeader()->rcode), dr->getHeader()->id);
+          infolog("Answer to %s for %s %s (%s) with id %u", dr->ids.origRemote.toStringWithPort(), dr->ids.qname.toString(), QType(dr->ids.qtype).toString(), RCode::to_s(dr->getHeader()->rcode), dr->getHeader()->id);
         }
       }
     }
     else {
       if (d_includeTimestamp) {
-        fprintf(fp.get(), "[%llu.%lu] Answer to %s for %s %s (%s) with id %d\n", static_cast<unsigned long long>(dr->getQueryRealTime().tv_sec), static_cast<unsigned long>(dr->getQueryRealTime().tv_nsec), dr->ids.origRemote.toStringWithPort().c_str(), dr->ids.qname.toString().c_str(), QType(dr->ids.qtype).toString().c_str(), RCode::to_s(dr->getHeader()->rcode).c_str(), dr->getHeader()->id);
+        fprintf(fp.get(), "[%llu.%lu] Answer to %s for %s %s (%s) with id %u\n", static_cast<unsigned long long>(dr->getQueryRealTime().tv_sec), static_cast<unsigned long>(dr->getQueryRealTime().tv_nsec), dr->ids.origRemote.toStringWithPort().c_str(), dr->ids.qname.toString().c_str(), QType(dr->ids.qtype).toString().c_str(), RCode::to_s(dr->getHeader()->rcode).c_str(), dr->getHeader()->id);
       }
       else {
-        fprintf(fp.get(), "Answer to %s for %s %s (%s) with id %d\n", dr->ids.origRemote.toStringWithPort().c_str(), dr->ids.qname.toString().c_str(), QType(dr->ids.qtype).toString().c_str(), RCode::to_s(dr->getHeader()->rcode).c_str(), dr->getHeader()->id);
+        fprintf(fp.get(), "Answer to %s for %s %s (%s) with id %u\n", dr->ids.origRemote.toStringWithPort().c_str(), dr->ids.qname.toString().c_str(), QType(dr->ids.qtype).toString().c_str(), RCode::to_s(dr->getHeader()->rcode).c_str(), dr->getHeader()->id);
       }
     }
     return Action::None;
@@ -2225,7 +2225,7 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new LuaFFIAction(func));
     });
 
-  luaCtx.writeFunction("LuaFFIPerThreadAction", [](std::string code) {
+  luaCtx.writeFunction("LuaFFIPerThreadAction", [](const std::string& code) {
       setLuaSideEffect();
       return std::shared_ptr<DNSAction>(new LuaFFIPerThreadAction(code));
     });
@@ -2442,7 +2442,7 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSResponseAction>(new LuaFFIResponseAction(func));
     });
 
-  luaCtx.writeFunction("LuaFFIPerThreadResponseAction", [](std::string code) {
+  luaCtx.writeFunction("LuaFFIPerThreadResponseAction", [](const std::string& code) {
       setLuaSideEffect();
       return std::shared_ptr<DNSResponseAction>(new LuaFFIPerThreadResponseAction(code));
     });
@@ -2516,7 +2516,7 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new SetDisableECSAction());
     });
 
-  luaCtx.writeFunction("SetECSAction", [](const std::string v4, boost::optional<std::string> v6) {
+  luaCtx.writeFunction("SetECSAction", [](const std::string& v4, boost::optional<std::string> v6) {
       if (v6) {
         return std::shared_ptr<DNSAction>(new SetECSAction(Netmask(v4), Netmask(*v6)));
       }
@@ -2533,11 +2533,11 @@ void setupLuaActions(LuaContext& luaCtx)
     });
 #endif /* HAVE_NET_SNMP */
 
-  luaCtx.writeFunction("SetTagAction", [](std::string tag, std::string value) {
+  luaCtx.writeFunction("SetTagAction", [](const std::string& tag, const std::string& value) {
       return std::shared_ptr<DNSAction>(new SetTagAction(tag, value));
     });
 
-  luaCtx.writeFunction("SetTagResponseAction", [](std::string tag, std::string value) {
+  luaCtx.writeFunction("SetTagResponseAction", [](const std::string& tag, const std::string& value) {
       return std::shared_ptr<DNSResponseAction>(new SetTagResponseAction(tag, value));
     });
 

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -33,7 +33,7 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
   /* DNSQuestion */
   /* PowerDNS DNSQuestion compat */
   luaCtx.registerMember<const ComboAddress (DNSQuestion::*)>("localaddr", [](const DNSQuestion& dq) -> const ComboAddress { return dq.ids.origDest; }, [](DNSQuestion& dq, const ComboAddress newLocal) { (void) newLocal; });
-  luaCtx.registerMember<const DNSName (DNSQuestion::*)>("qname", [](const DNSQuestion& dq) -> const DNSName { return dq.ids.qname; }, [](DNSQuestion& dq, const DNSName newName) { (void) newName; });
+  luaCtx.registerMember<const DNSName (DNSQuestion::*)>("qname", [](const DNSQuestion& dq) -> const DNSName { return dq.ids.qname; }, [](DNSQuestion& dq, const DNSName& newName) { (void) newName; });
   luaCtx.registerMember<uint16_t (DNSQuestion::*)>("qtype", [](const DNSQuestion& dq) -> uint16_t { return dq.ids.qtype; }, [](DNSQuestion& dq, uint16_t newType) { (void) newType; });
   luaCtx.registerMember<uint16_t (DNSQuestion::*)>("qclass", [](const DNSQuestion& dq) -> uint16_t { return dq.ids.qclass; }, [](DNSQuestion& dq, uint16_t newClass) { (void) newClass; });
   luaCtx.registerMember<int (DNSQuestion::*)>("rcode", [](const DNSQuestion& dq) -> int { return dq.getHeader()->rcode; }, [](DNSQuestion& dq, int newRCode) { dq.getHeader()->rcode = newRCode; });
@@ -72,6 +72,9 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
   luaCtx.registerFunction<std::map<uint16_t, EDNSOptionView>(DNSQuestion::*)()const>("getEDNSOptions", [](const DNSQuestion& dq) {
       if (dq.ednsOptions == nullptr) {
         parseEDNSOptions(dq);
+        if (dq.ednsOptions == nullptr) {
+          throw std::runtime_error("parseEDNSOptions should have populated the EDNS options");
+        }
       }
 
       return *dq.ednsOptions;
@@ -294,7 +297,7 @@ private:
 
   /* LuaWrapper doesn't support inheritance */
   luaCtx.registerMember<const ComboAddress (DNSResponse::*)>("localaddr", [](const DNSResponse& dq) -> const ComboAddress { return dq.ids.origDest; }, [](DNSResponse& dq, const ComboAddress newLocal) { (void) newLocal; });
-  luaCtx.registerMember<const DNSName (DNSResponse::*)>("qname", [](const DNSResponse& dq) -> const DNSName { return dq.ids.qname; }, [](DNSResponse& dq, const DNSName newName) { (void) newName; });
+  luaCtx.registerMember<const DNSName (DNSResponse::*)>("qname", [](const DNSResponse& dq) -> const DNSName { return dq.ids.qname; }, [](DNSResponse& dq, const DNSName& newName) { (void) newName; });
   luaCtx.registerMember<uint16_t (DNSResponse::*)>("qtype", [](const DNSResponse& dq) -> uint16_t { return dq.ids.qtype; }, [](DNSResponse& dq, uint16_t newType) { (void) newType; });
   luaCtx.registerMember<uint16_t (DNSResponse::*)>("qclass", [](const DNSResponse& dq) -> uint16_t { return dq.ids.qclass; }, [](DNSResponse& dq, uint16_t newClass) { (void) newClass; });
   luaCtx.registerMember<int (DNSResponse::*)>("rcode", [](const DNSResponse& dq) -> int { return dq.getHeader()->rcode; }, [](DNSResponse& dq, int newRCode) { dq.getHeader()->rcode = newRCode; });
@@ -325,6 +328,9 @@ private:
   luaCtx.registerFunction<std::map<uint16_t, EDNSOptionView>(DNSResponse::*)()const>("getEDNSOptions", [](const DNSResponse& dq) {
       if (dq.ednsOptions == nullptr) {
         parseEDNSOptions(dq);
+        if (dq.ednsOptions == nullptr) {
+          throw std::runtime_error("parseEDNSOptions should have populated the EDNS options");
+        }
       }
 
       return *dq.ednsOptions;

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -455,7 +455,7 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
       }
       std::unordered_map<std::string, BPFFilter::MapConfiguration> mapsConfig;
 
-      const auto convertParamsToConfig = [&](const std::string name, BPFFilter::MapType type) {
+      const auto convertParamsToConfig = [&](const std::string& name, BPFFilter::MapType type) {
         BPFFilter::MapConfiguration config;
         config.d_type = type;
         if (const string key = name + "MaxItems"; opts.count(key)) {

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -509,11 +509,11 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new OpcodeRule(code));
     });
 
-  luaCtx.writeFunction("AndRule", [](LuaArray<std::shared_ptr<DNSRule>> a) {
+  luaCtx.writeFunction("AndRule", [](const LuaArray<std::shared_ptr<DNSRule>>& a) {
       return std::shared_ptr<DNSRule>(new AndRule(a));
     });
 
-  luaCtx.writeFunction("OrRule", [](LuaArray<std::shared_ptr<DNSRule>>a) {
+  luaCtx.writeFunction("OrRule", [](const LuaArray<std::shared_ptr<DNSRule>>& a) {
       return std::shared_ptr<DNSRule>(new OrRule(a));
     });
 
@@ -530,7 +530,7 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new DNSSECRule());
     });
 
-  luaCtx.writeFunction("NotRule", [](std::shared_ptr<DNSRule>rule) {
+  luaCtx.writeFunction("NotRule", [](const std::shared_ptr<DNSRule>& rule) {
       return std::shared_ptr<DNSRule>(new NotRule(rule));
     });
 
@@ -591,7 +591,7 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new RDRule());
     });
 
-  luaCtx.writeFunction("TagRule", [](std::string tag, boost::optional<std::string> value) {
+  luaCtx.writeFunction("TagRule", [](const std::string& tag, boost::optional<std::string> value) {
       return std::shared_ptr<DNSRule>(new TagRule(tag, value));
     });
 
@@ -599,11 +599,11 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<TimedIPSetRule>(new TimedIPSetRule());
     });
 
-  luaCtx.writeFunction("PoolAvailableRule", [](std::string poolname) {
+  luaCtx.writeFunction("PoolAvailableRule", [](const std::string& poolname) {
     return std::shared_ptr<DNSRule>(new PoolAvailableRule(poolname));
   });
 
-  luaCtx.writeFunction("PoolOutstandingRule", [](std::string poolname, uint64_t limit) {
+  luaCtx.writeFunction("PoolOutstandingRule", [](const std::string& poolname, uint64_t limit) {
     return std::shared_ptr<DNSRule>(new PoolOutstandingRule(poolname, limit));
   });
 
@@ -648,7 +648,7 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new LuaFFIRule(func));
     });
 
-  luaCtx.writeFunction("LuaFFIPerThreadRule", [](std::string code) {
+  luaCtx.writeFunction("LuaFFIPerThreadRule", [](const std::string& code) {
     return std::shared_ptr<DNSRule>(new LuaFFIPerThreadRule(code));
   });
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -234,7 +234,7 @@ void checkParameterBound(const std::string& parameter, uint64_t value, size_t ma
   }
 }
 
-static void LuaThread(const std::string code)
+static void LuaThread(const std::string& code)
 {
   setThreadName("dnsdist/lua-bg");
   LuaContext l;
@@ -941,7 +941,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     return ret;
   });
 
-  luaCtx.writeFunction("getPoolServers", [](string pool) {
+  luaCtx.writeFunction("getPoolServers", [](const string& pool) {
     const auto poolServers = getDownstreamCandidates(g_pools.getCopy(), pool);
     return *poolServers;
   });
@@ -1869,7 +1869,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
       if (boost::ends_with(ent->d_name, ".conf")) {
         std::ostringstream namebuf;
-        namebuf << dirname.c_str() << "/" << ent->d_name;
+        namebuf << dirname << "/" << ent->d_name;
 
         if (stat(namebuf.str().c_str(), &st) || !S_ISREG(st.st_mode)) {
           continue;
@@ -2045,18 +2045,18 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     g_policy.setState(policy);
   });
 
-  luaCtx.writeFunction("setServerPolicyLua", [](string name, ServerPolicy::policyfunc_t policy) {
+  luaCtx.writeFunction("setServerPolicyLua", [](const string& name, ServerPolicy::policyfunc_t policy) {
     setLuaSideEffect();
     g_policy.setState(ServerPolicy{name, policy, true});
   });
 
-  luaCtx.writeFunction("setServerPolicyLuaFFI", [](string name, ServerPolicy::ffipolicyfunc_t policy) {
+  luaCtx.writeFunction("setServerPolicyLuaFFI", [](const string& name, ServerPolicy::ffipolicyfunc_t policy) {
     setLuaSideEffect();
     auto pol = ServerPolicy(name, policy);
     g_policy.setState(std::move(pol));
   });
 
-  luaCtx.writeFunction("setServerPolicyLuaFFIPerThread", [](string name, const std::string& policyCode) {
+  luaCtx.writeFunction("setServerPolicyLuaFFIPerThread", [](const string& name, const std::string& policyCode) {
     setLuaSideEffect();
     auto pol = ServerPolicy(name, policyCode);
     g_policy.setState(std::move(pol));
@@ -2067,35 +2067,35 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     g_outputBuffer = g_policy.getLocal()->getName() + "\n";
   });
 
-  luaCtx.writeFunction("setPoolServerPolicy", [](ServerPolicy policy, string pool) {
+  luaCtx.writeFunction("setPoolServerPolicy", [](ServerPolicy policy, const string& pool) {
     setLuaSideEffect();
     auto localPools = g_pools.getCopy();
     setPoolPolicy(localPools, pool, std::make_shared<ServerPolicy>(policy));
     g_pools.setState(localPools);
   });
 
-  luaCtx.writeFunction("setPoolServerPolicyLua", [](string name, ServerPolicy::policyfunc_t policy, string pool) {
+  luaCtx.writeFunction("setPoolServerPolicyLua", [](const string& name, ServerPolicy::policyfunc_t policy, const string& pool) {
     setLuaSideEffect();
     auto localPools = g_pools.getCopy();
     setPoolPolicy(localPools, pool, std::make_shared<ServerPolicy>(ServerPolicy{name, policy, true}));
     g_pools.setState(localPools);
   });
 
-  luaCtx.writeFunction("setPoolServerPolicyLuaFFI", [](string name, ServerPolicy::ffipolicyfunc_t policy, string pool) {
+  luaCtx.writeFunction("setPoolServerPolicyLuaFFI", [](const string& name, ServerPolicy::ffipolicyfunc_t policy, const string& pool) {
     setLuaSideEffect();
     auto localPools = g_pools.getCopy();
     setPoolPolicy(localPools, pool, std::make_shared<ServerPolicy>(ServerPolicy{name, policy}));
     g_pools.setState(localPools);
   });
 
-  luaCtx.writeFunction("setPoolServerPolicyLuaFFIPerThread", [](string name, const std::string& policyCode, string pool) {
+  luaCtx.writeFunction("setPoolServerPolicyLuaFFIPerThread", [](const string& name, const std::string& policyCode, const std::string& pool) {
     setLuaSideEffect();
     auto localPools = g_pools.getCopy();
     setPoolPolicy(localPools, pool, std::make_shared<ServerPolicy>(ServerPolicy{name, policyCode}));
     g_pools.setState(localPools);
   });
 
-  luaCtx.writeFunction("showPoolServerPolicy", [](string pool) {
+  luaCtx.writeFunction("showPoolServerPolicy", [](const std::string& pool) {
     setLuaSideEffect();
     auto localPools = g_pools.getCopy();
     auto poolObj = getPool(localPools, pool);

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -100,7 +100,7 @@ class LimitTTLResponseAction : public DNSResponseAction, public boost::noncopyab
 public:
   LimitTTLResponseAction() {}
 
-  LimitTTLResponseAction(uint32_t min, uint32_t max = std::numeric_limits<uint32_t>::max(), std::unordered_set<QType> types = {}) : d_types(types), d_min(min), d_max(max)
+  LimitTTLResponseAction(uint32_t min, uint32_t max = std::numeric_limits<uint32_t>::max(), const std::unordered_set<QType>& types = {}) : d_types(types), d_min(min), d_max(max)
   {
   }
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -485,7 +485,7 @@ static bool applyRulesToResponse(const std::vector<DNSDistResponseRuleAction>& r
   std::string ruleresult;
   for (const auto& lr : respRuleActions) {
     if (lr.d_rule->matches(&dr)) {
-      lr.d_rule->d_matches++;
+      ++lr.d_rule->d_matches;
       action = (*lr.d_action)(&dr, &ruleresult);
       switch (action) {
       case DNSResponseAction::Action::Allow:
@@ -1165,7 +1165,7 @@ static bool isUDPQueryAcceptable(ClientState& cs, LocalHolders& holders, const s
     dest.sin4.sin_family = 0;
   }
 
-  cs.queries++;
+  ++cs.queries;
   ++g_stats.queries;
 
   return true;
@@ -1323,9 +1323,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dq, LocalHolders& holders
           }
 
           ++g_stats.responses;
-          if (dq.ids.cs) {
-            ++dq.ids.cs->responses;
-          }
+          ++dq.ids.cs->responses;
           return ProcessQueryResult::SendAnswer;
         }
 
@@ -1358,9 +1356,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dq, LocalHolders& holders
         }
 
         ++g_stats.responses;
-        if (dq.ids.cs) {
-          ++dq.ids.cs->responses;
-        }
+        ++dq.ids.cs->responses;
         return ProcessQueryResult::SendAnswer;
       }
       else if (dq.ids.protocol == dnsdist::Protocol::DoH && !forwardedOverUDP) {
@@ -1371,9 +1367,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dq, LocalHolders& holders
           }
 
           ++g_stats.responses;
-          if (dq.ids.cs) {
-            ++dq.ids.cs->responses;
-          }
+          ++dq.ids.cs->responses;
           return ProcessQueryResult::SendAnswer;
         }
       }
@@ -1397,9 +1391,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dq, LocalHolders& holders
           return ProcessQueryResult::Drop;
         }
         ++g_stats.responses;
-        if (dq.ids.cs) {
-          ++dq.ids.cs->responses;
-        }
+        ++dq.ids.cs->responses;
         // no response-only statistics counter to update.
         return ProcessQueryResult::SendAnswer;
       }
@@ -2746,11 +2738,11 @@ int main(int argc, char** argv)
     gid_t newuid=geteuid();
 
     if (!g_cmdLine.gid.empty()) {
-      newgid = strToGID(g_cmdLine.gid.c_str());
+      newgid = strToGID(g_cmdLine.gid);
     }
 
     if (!g_cmdLine.uid.empty()) {
-      newuid = strToUID(g_cmdLine.uid.c_str());
+      newuid = strToUID(g_cmdLine.uid);
     }
 
     bool retainedCapabilities = true;

--- a/pdns/dnsdistdist/dnsdist-async.cc
+++ b/pdns/dnsdistdist/dnsdist-async.cc
@@ -27,9 +27,9 @@
 namespace dnsdist
 {
 
-AsynchronousHolder::AsynchronousHolder(bool failOpen)
+AsynchronousHolder::AsynchronousHolder(bool failOpen) :
+  d_data(std::make_shared<Data>())
 {
-  d_data = std::make_shared<Data>();
   d_data->d_failOpen = failOpen;
 
   int fds[2] = {-1, -1};

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -332,7 +332,7 @@ void DownstreamState::handleUDPTimeout(IDState& ids)
   ids.age = 0;
   ids.inUse = false;
   handleDOHTimeout(std::move(ids.internal.du));
-  reuseds++;
+  ++reuseds;
   --outstanding;
   ++g_stats.downstreamTimeouts; // this is an 'actively' discovered timeout
   vinfolog("Had a downstream timeout from %s (%s) for query for %s|%s from %s",

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
@@ -152,7 +152,7 @@ void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client)
     luaCtx.registerFunction<uint32_t(DNSCryptCert::*)()const>("getTSStart", [](const DNSCryptCert& cert) { return ntohl(cert.getTSStart()); });
     luaCtx.registerFunction<uint32_t(DNSCryptCert::*)()const>("getTSEnd", [](const DNSCryptCert& cert) { return ntohl(cert.getTSEnd()); });
 
-    luaCtx.writeFunction("generateDNSCryptCertificate", [client](const std::string& providerPrivateKeyFile, const std::string& certificateFile, const std::string privateKeyFile, uint32_t serial, time_t begin, time_t end, boost::optional<DNSCryptExchangeVersion> version) {
+    luaCtx.writeFunction("generateDNSCryptCertificate", [client](const std::string& providerPrivateKeyFile, const std::string& certificateFile, const std::string& privateKeyFile, uint32_t serial, time_t begin, time_t end, boost::optional<DNSCryptExchangeVersion> version) {
       setLuaNoSideEffect();
       if (client) {
         return;
@@ -172,7 +172,7 @@ void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client)
       }
     });
 
-    luaCtx.writeFunction("generateDNSCryptProviderKeys", [client](const std::string& publicKeyFile, const std::string privateKeyFile) {
+    luaCtx.writeFunction("generateDNSCryptProviderKeys", [client](const std::string& publicKeyFile, const std::string& privateKeyFile) {
       setLuaNoSideEffect();
       if (client) {
         return;

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -426,10 +426,11 @@ public:
 class AndRule : public DNSRule
 {
 public:
-  AndRule(const vector<pair<int, shared_ptr<DNSRule> > >& rules)
+  AndRule(const std::vector<pair<int, std::shared_ptr<DNSRule> > >& rules)
   {
-    for(const auto& r : rules)
+    for (const auto& r : rules) {
       d_rules.push_back(r.second);
+    }
   }
 
   bool matches(const DNSQuestion* dq) const override
@@ -445,27 +446,27 @@ public:
   string toString() const override
   {
     string ret;
-    for(const auto& rule : d_rules) {
-      if(!ret.empty())
+    for (const auto& rule : d_rules) {
+      if (!ret.empty()) {
         ret+= " && ";
+      }
       ret += "("+ rule->toString()+")";
     }
     return ret;
   }
 private:
-
-  vector<std::shared_ptr<DNSRule> > d_rules;
-
+  std::vector<std::shared_ptr<DNSRule> > d_rules;
 };
 
 
 class OrRule : public DNSRule
 {
 public:
-  OrRule(const vector<pair<int, shared_ptr<DNSRule> > >& rules)
+  OrRule(const std::vector<pair<int, std::shared_ptr<DNSRule> > >& rules)
   {
-    for(const auto& r : rules)
+    for (const auto& r : rules) {
       d_rules.push_back(r.second);
+    }
   }
 
   bool matches(const DNSQuestion* dq) const override
@@ -481,17 +482,16 @@ public:
   string toString() const override
   {
     string ret;
-    for(const auto& rule : d_rules) {
-      if(!ret.empty())
+    for (const auto& rule : d_rules) {
+      if (!ret.empty()) {
         ret+= " || ";
+      }
       ret += "("+ rule->toString()+")";
     }
     return ret;
   }
 private:
-
-  vector<std::shared_ptr<DNSRule> > d_rules;
-
+  std::vector<std::shared_ptr<DNSRule> > d_rules;
 };
 
 
@@ -746,7 +746,7 @@ private:
 class NotRule : public DNSRule
 {
 public:
-  NotRule(shared_ptr<DNSRule>& rule): d_rule(rule)
+  NotRule(const std::shared_ptr<DNSRule>& rule): d_rule(rule)
   {
   }
   bool matches(const DNSQuestion* dq) const override
@@ -758,7 +758,7 @@ public:
     return "!("+ d_rule->toString()+")";
   }
 private:
-  shared_ptr<DNSRule> d_rule;
+  std::shared_ptr<DNSRule> d_rule;
 };
 
 class RecordsCountRule : public DNSRule

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -131,13 +131,13 @@ template <typename Container> void GenericDNSPacketWriter<Container>::addOpt(con
 
 template <typename Container> void GenericDNSPacketWriter<Container>::xfr48BitInt(uint64_t val)
 {
-  unsigned char bytes[6];
+  std::array<unsigned char, 6> bytes;
   uint16_t theLeft = htons((val >> 32)&0xffffU);
   uint32_t theRight = htonl(val & 0xffffffffU);
-  memcpy(bytes, (void*)&theLeft, sizeof(theLeft));
-  memcpy(bytes+2, (void*)&theRight, sizeof(theRight));
+  memcpy(&bytes[0], (void*)&theLeft, sizeof(theLeft));
+  memcpy(&bytes[2], (void*)&theRight, sizeof(theRight));
 
-  d_content.insert(d_content.end(), bytes, bytes + sizeof(bytes));
+  d_content.insert(d_content.end(), bytes.begin(), bytes.end());
 }
 
 template <typename Container> void GenericDNSPacketWriter<Container>::xfrNodeOrLocatorID(const NodeOrLocatorID& val)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Most of these are 'performance' warnings in parts of code where performance does not really matter (or the compiler should already do the right thing without our help), but there is no harm in being more consistent. It also makes it easier to spot more meaningful warnings in the future. The remaining changes are false-positives where `cppcheck` does not detect that null-pointer dereferences cannot actually happen, so I edited the code to make it clearer (removing redundant checks in some cases, actually adding some in other cases).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
