### PR TITLE
dnsdist: Enable Link-Time Optimization for our packages

### DIFF
--- a/builder-support/debian/dnsdist/debian-buster/rules
+++ b/builder-support/debian/dnsdist/debian-buster/rules
@@ -47,6 +47,7 @@ override_dh_auto_configure:
 	  --infodir=\$${prefix}/share/info \
 	  --libdir='$${prefix}/lib/$(DEB_HOST_MULTIARCH)' \
 	  --libexecdir='$${prefix}/lib' \
+	  --enable-lto=thin \
 	  --enable-dns-over-https \
 	  --enable-dns-over-tls \
 	  --enable-dnscrypt \

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -76,6 +76,7 @@ export LDFLAGS=-L/usr/lib64/boost169
   --disable-dependency-tracking \
   --disable-silent-rules \
   --enable-unit-tests \
+  --enable-lto=thin \
   --enable-dns-over-tls \
 %if 0%{?suse_version}
   --disable-dnscrypt \

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -69,6 +69,9 @@ export CPPFLAGS=-I/usr/include/boost169
 export LDFLAGS=-L/usr/lib64/boost169
 %endif
 
+export AR=gcc-ar
+export RANLIB=gcc-ranlib
+
 %configure \
   --enable-option-checking=fatal \
   --sysconfdir=/etc/dnsdist \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
dnsdist is already built and tested with LTO enabled in our CI, and I have successfully built packages against these changes using our "Trigger specific package build" workflow.
We already know that building with LTO reduces the size of the `dnsdist` binary, and we expect performance gains as well, but I have not yet measured those.

The GCC version in EL8 requires explicitly setting the `AR` and `RANLIB` to use, so I'm setting them for all RPM-based builds since it should not hurt.

This closes the dnsdist part of https://github.com/PowerDNS/pdns/issues/11032

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
