### PR TITLE
dnsdist: Give the 'flags on timeout' test more headroom

### DIFF
--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -698,7 +698,7 @@ class TestFlagsOnTimeout(DNSDistTest):
         self.assertFalse(receivedResponse)
 
         # make sure that the timeouts have been detected and recorded
-        for _ in range(3):
+        for _ in range(6):
             content = self.sendConsoleCommand("grepq('')")
             lines = content.splitlines()
             if len(lines) == 5:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It looks like it takes longer than expected for the timeout to be recorded when running on GitHub Actions.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
