### PR TITLE
Auth: Cleanup unused argument warnings, and other things

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,8 @@ AC_CONFIG_HEADERS([config.h])
 
 AC_CANONICAL_HOST
 # Add some default CFLAGS and CXXFLAGS, can be appended to using the environment variables
-CFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CFLAGS"
-CXXFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CXXFLAGS"
+CFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wmissing-declarations -Wredundant-decls $CFLAGS"
+CXXFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wmissing-declarations -Wredundant-decls $CXXFLAGS"
 
 AC_SUBST([pdns_configure_args], ["$ac_configure_args"])
 AC_DEFINE_UNQUOTED([PDNS_CONFIG_ARGS],

--- a/ext/json11/json11.cpp
+++ b/ext/json11/json11.cpp
@@ -144,7 +144,7 @@ protected:
 
     // Constructors
     explicit Value(const T &value) : m_value(value) {}
-    explicit Value(T &&value)      : m_value(move(value)) {}
+    explicit Value(T &&value)      : m_value(std::move(value)) {}
 
     // Get type tag
     Json::Type type() const override {
@@ -191,7 +191,7 @@ class JsonString final : public Value<Json::STRING, string> {
     const string &string_value() const override { return m_value; }
 public:
     explicit JsonString(const string &value) : Value(value) {}
-    explicit JsonString(string &&value)      : Value(move(value)) {}
+    explicit JsonString(string &&value)      : Value(std::move(value)) {}
 };
 
 class JsonArray final : public Value<Json::ARRAY, Json::array> {
@@ -199,7 +199,7 @@ class JsonArray final : public Value<Json::ARRAY, Json::array> {
     const Json & operator[](size_t i) const override;
 public:
     explicit JsonArray(const Json::array &value) : Value(value) {}
-    explicit JsonArray(Json::array &&value)      : Value(move(value)) {}
+    explicit JsonArray(Json::array &&value)      : Value(std::move(value)) {}
 };
 
 class JsonObject final : public Value<Json::OBJECT, Json::object> {
@@ -207,7 +207,7 @@ class JsonObject final : public Value<Json::OBJECT, Json::object> {
     const Json & operator[](const string &key) const override;
 public:
     explicit JsonObject(const Json::object &value) : Value(value) {}
-    explicit JsonObject(Json::object &&value)      : Value(move(value)) {}
+    explicit JsonObject(Json::object &&value)      : Value(std::move(value)) {}
 };
 
 class JsonNull final : public Value<Json::NUL, NullStruct> {
@@ -249,12 +249,12 @@ Json::Json(double value)               : m_ptr(make_shared<JsonDouble>(value)) {
 Json::Json(int value)                  : m_ptr(make_shared<JsonInt>(value)) {}
 Json::Json(bool value)                 : m_ptr(value ? statics().t : statics().f) {}
 Json::Json(const string &value)        : m_ptr(make_shared<JsonString>(value)) {}
-Json::Json(string &&value)             : m_ptr(make_shared<JsonString>(move(value))) {}
+Json::Json(string &&value)             : m_ptr(make_shared<JsonString>(std::move(value))) {}
 Json::Json(const char * value)         : m_ptr(make_shared<JsonString>(value)) {}
 Json::Json(const Json::array &values)  : m_ptr(make_shared<JsonArray>(values)) {}
-Json::Json(Json::array &&values)       : m_ptr(make_shared<JsonArray>(move(values))) {}
+Json::Json(Json::array &&values)       : m_ptr(make_shared<JsonArray>(std::move(values))) {}
 Json::Json(const Json::object &values) : m_ptr(make_shared<JsonObject>(values)) {}
-Json::Json(Json::object &&values)      : m_ptr(make_shared<JsonObject>(move(values))) {}
+Json::Json(Json::object &&values)      : m_ptr(make_shared<JsonObject>(std::move(values))) {}
 
 /* * * * * * * * * * * * * * * * * * * *
  * Accessors
@@ -348,7 +348,7 @@ struct JsonParser final {
      * Mark this parse as failed.
      */
     Json fail(string &&msg) {
-        return fail(move(msg), Json());
+        return fail(std::move(msg), Json());
     }
 
     template <typename T>

--- a/ext/json11/json11.cpp
+++ b/ext/json11/json11.cpp
@@ -43,15 +43,15 @@ using std::move;
  * it may not be orderable.
  */
 struct NullStruct {
-    bool operator==(NullStruct) const { return true; }
-    bool operator<(NullStruct) const { return false; }
+    bool operator==(NullStruct /*unused*/) const { return true; }
+    bool operator<(NullStruct /*unused*/) const { return false; }
 };
 
 /* * * * * * * * * * * * * * * * * * * *
  * Serialization
  */
 
-static void dump(NullStruct, string &out) {
+static void dump(NullStruct /*unused*/, string &out) {
     out += "null";
 }
 

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -19,11 +19,11 @@ static string MDBError(int rc)
 MDBDbi::MDBDbi(MDB_env* env, MDB_txn* txn, const string_view dbname, int flags)
 {
   // A transaction that uses this function must finish (either commit or abort) before any other transaction in the process may use this function.
-  
+
   int rc = mdb_dbi_open(txn, dbname.empty() ? 0 : &dbname[0], flags, &d_dbi);
   if(rc)
     throw std::runtime_error("Unable to open named database: " + MDBError(rc));
-  
+
   // Database names are keys in the unnamed database, and may be read but not written.
 }
 
@@ -95,10 +95,10 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64
     weak_ptr<MDBEnv> wp;
     int flags;
   };
-  
+
   static std::map<tuple<dev_t, ino_t>, Value> s_envs;
   static std::mutex mut;
-  
+
   struct stat statbuf;
   if(stat(fname, &statbuf)) {
     if(errno != ENOENT)
@@ -132,7 +132,7 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64
 
   auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
   s_envs[key] = {fresh, flags};
-  
+
   return fresh;
 }
 
@@ -145,7 +145,7 @@ MDBDbi MDBEnv::openDB(const string_view dbname, int flags)
     This function must not be called from multiple concurrent transactions in the same process. A transaction that uses this function must finish (either commit or abort) before any other transaction in the process may use this function.
   */
   std::lock_guard<std::mutex> l(d_openmut);
-  
+
   if(!(envflags & MDB_RDONLY)) {
     auto rwt = getRWTransaction();
     MDBDbi ret = rwt->openDB(dbname, flags);
@@ -155,7 +155,7 @@ MDBDbi MDBEnv::openDB(const string_view dbname, int flags)
 
   MDBDbi ret;
   {
-    auto rwt = getROTransaction(); 
+    auto rwt = getROTransaction();
     ret = rwt->openDB(dbname, flags);
   }
   return ret;
@@ -230,7 +230,7 @@ MDB_txn *MDBROTransactionImpl::openROTransaction(MDBEnv *env, MDB_txn *parent, i
 {
   if(env->getRWTX())
     throw std::runtime_error("Duplicate RO transaction");
-  
+
   /*
     A transaction and its cursors must only be used by a single thread, and a thread may only have a single transaction at a time. If MDB_NOTLS is in use, this does not apply to read-only transactions. */
   MDB_txn *result = nullptr;

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -16,7 +16,7 @@ static string MDBError(int rc)
   return mdb_strerror(rc);
 }
 
-MDBDbi::MDBDbi(MDB_env* /* env */, MDB_txn* txn, const string_view dbname, int flags)
+MDBDbi::MDBDbi(MDB_env* env, MDB_txn* txn, const string_view dbname, int flags)
 {
   // A transaction that uses this function must finish (either commit or abort) before any other transaction in the process may use this function.
 

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -16,7 +16,7 @@ static string MDBError(int rc)
   return mdb_strerror(rc);
 }
 
-MDBDbi::MDBDbi(MDB_env* env, MDB_txn* txn, const string_view dbname, int flags)
+MDBDbi::MDBDbi(MDB_env* /* env */, MDB_txn* txn, const string_view dbname, int flags)
 {
   // A transaction that uses this function must finish (either commit or abort) before any other transaction in the process may use this function.
 

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -159,17 +159,17 @@ struct index_on_function : LMDBIndexOps<Class, Type, index_on_function<Class, Ty
 /** nop index, so we can fill our N indexes, even if you don't use them all */
 struct nullindex_t
 {
-  template<typename Class>
-  void put(MDBRWTransaction& txn, const Class& t, uint32_t id, int flags=0)
-  {}
-  template<typename Class>
-  void del(MDBRWTransaction& txn, const Class& t, uint32_t id)
+  template <typename Class>
+  void put(MDBRWTransaction& /* txn */, const Class& /* t */, uint32_t /* id */, int /* flags */ = 0)
   {}
 
-  void openDB(std::shared_ptr<MDBEnv>& env, string_view str, int flags)
-  {
+  template <typename Class>
+  void del(MDBRWTransaction& /* txn */, const Class& /* t */, uint32_t /* id */)
+  {}
 
-  }
+  void openDB(std::shared_ptr<MDBEnv>& /* env */, string_view /* str */, int /* flags */)
+  {}
+
   typedef uint32_t type; // dummy
 };
 
@@ -330,12 +330,12 @@ public:
         d_cursor.del();
       }
 
-      bool operator!=(const eiter_t& rhs) const
+      bool operator!=(const eiter_t& /* rhs */) const
       {
         return !d_end;
       }
 
-      bool operator==(const eiter_t& rhs) const
+      bool operator==(const eiter_t& /* rhs */) const
       {
         return d_end;
       }

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -173,7 +173,6 @@ struct nullindex_t
   typedef uint32_t type; // dummy
 };
 
-
 /** The main class. Templatized only on the indexes and typename right now */
 template<typename T, class I1=nullindex_t, class I2=nullindex_t, class I3 = nullindex_t, class I4 = nullindex_t>
 class TypedDBI

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -159,17 +159,17 @@ struct index_on_function : LMDBIndexOps<Class, Type, index_on_function<Class, Ty
 /** nop index, so we can fill our N indexes, even if you don't use them all */
 struct nullindex_t
 {
-  template <typename Class>
-  void put(MDBRWTransaction& /* txn */, const Class& /* t */, uint32_t /* id */, int /* flags */ = 0)
+  template<typename Class>
+  void put(MDBRWTransaction& txn, const Class& t, uint32_t id, int flags=0)
+  {}
+  template<typename Class>
+  void del(MDBRWTransaction& txn, const Class& t, uint32_t id)
   {}
 
-  template <typename Class>
-  void del(MDBRWTransaction& /* txn */, const Class& /* t */, uint32_t /* id */)
-  {}
+  void openDB(std::shared_ptr<MDBEnv>& env, string_view str, int flags)
+  {
 
-  void openDB(std::shared_ptr<MDBEnv>& /* env */, string_view /* str */, int /* flags */)
-  {}
-
+  }
   typedef uint32_t type; // dummy
 };
 
@@ -330,12 +330,12 @@ public:
         d_cursor.del();
       }
 
-      bool operator!=(const eiter_t& /* rhs */) const
+      bool operator!=(const eiter_t& rhs) const
       {
         return !d_end;
       }
 
-      bool operator==(const eiter_t& /* rhs */) const
+      bool operator==(const eiter_t& rhs) const
       {
         return d_end;
       }

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -56,7 +56,7 @@
 #include "pdns/auth-zonecache.hh"
 #include "pdns/auth-caches.hh"
 
-/* 
+/*
    All instances of this backend share one s_state, which is indexed by zone name and zone id.
    The s_state is protected by a read/write lock, and the goal it to only interact with it briefly.
    When a query comes in, we take a read lock and COPY the best zone to answer from s_state (BB2DomainInfo object)

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -275,7 +275,7 @@ bool Bind2Backend::abortTransaction()
   return true;
 }
 
-bool Bind2Backend::feedRecord(const DNSResourceRecord& rr, const DNSName& ordername, bool ordernameIsNSEC3)
+bool Bind2Backend::feedRecord(const DNSResourceRecord& rr, const DNSName& /* ordername */, bool /* ordernameIsNSEC3 */)
 {
   if (d_transaction_id < 1) {
     throw DBException("Bind2Backend::feedRecord() called outside of transaction");
@@ -318,7 +318,7 @@ bool Bind2Backend::feedRecord(const DNSResourceRecord& rr, const DNSName& ordern
   return true;
 }
 
-void Bind2Backend::getUpdatedMasters(vector<DomainInfo>& changedDomains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes)
+void Bind2Backend::getUpdatedMasters(vector<DomainInfo>& changedDomains, std::unordered_set<DNSName>& /* catalogs */, CatalogHashMap& /* catalogHashes */)
 {
   vector<DomainInfo> consider;
   {
@@ -362,7 +362,7 @@ void Bind2Backend::getUpdatedMasters(vector<DomainInfo>& changedDomains, std::un
   }
 }
 
-void Bind2Backend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled)
+void Bind2Backend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool /* include_disabled */)
 {
   SOAData soadata;
 
@@ -562,7 +562,7 @@ void Bind2Backend::insertRecord(std::shared_ptr<recordstorage_t>& records, const
   records->insert(std::move(bdr));
 }
 
-string Bind2Backend::DLReloadNowHandler(const vector<string>& parts, Utility::pid_t ppid)
+string Bind2Backend::DLReloadNowHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   ostringstream ret;
 
@@ -587,7 +587,7 @@ string Bind2Backend::DLReloadNowHandler(const vector<string>& parts, Utility::pi
   return ret.str();
 }
 
-string Bind2Backend::DLDomStatusHandler(const vector<string>& parts, Utility::pid_t ppid)
+string Bind2Backend::DLDomStatusHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   ostringstream ret;
 
@@ -649,7 +649,7 @@ static void printDomainExtendedStatus(ostringstream& ret, const BB2DomainInfo& i
   ret << "\t Last notified: " << info.d_lastnotified << std::endl;
 }
 
-string Bind2Backend::DLDomExtendedStatusHandler(const vector<string>& parts, Utility::pid_t ppid)
+string Bind2Backend::DLDomExtendedStatusHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   ostringstream ret;
 
@@ -678,7 +678,7 @@ string Bind2Backend::DLDomExtendedStatusHandler(const vector<string>& parts, Uti
   return ret.str();
 }
 
-string Bind2Backend::DLListRejectsHandler(const vector<string>& parts, Utility::pid_t ppid)
+string Bind2Backend::DLListRejectsHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   ostringstream ret;
   auto rstate = s_state.read_lock();
@@ -689,7 +689,7 @@ string Bind2Backend::DLListRejectsHandler(const vector<string>& parts, Utility::
   return ret.str();
 }
 
-string Bind2Backend::DLAddDomainHandler(const vector<string>& parts, Utility::pid_t ppid)
+string Bind2Backend::DLAddDomainHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   if (parts.size() < 3)
     return "ERROR: Domain name and zone filename are required";
@@ -1075,7 +1075,7 @@ void Bind2Backend::queueReloadAndStore(unsigned int id)
   }
 }
 
-bool Bind2Backend::findBeforeAndAfterUnhashed(std::shared_ptr<const recordstorage_t>& records, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after)
+bool Bind2Backend::findBeforeAndAfterUnhashed(std::shared_ptr<const recordstorage_t>& records, const DNSName& qname, DNSName& /* unhashed */, DNSName& before, DNSName& after)
 {
   // for(const auto& record: *records)
   //   cerr<<record.qname<<"\t"<<makeHexDump(record.qname.toDNSString())<<endl;
@@ -1145,7 +1145,7 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qn
   }
 }
 
-void Bind2Backend::lookup(const QType& qtype, const DNSName& qname, int zoneId, DNSPacket* pkt_p)
+void Bind2Backend::lookup(const QType& qtype, const DNSName& qname, int zoneId, DNSPacket* /* pkt_p */)
 {
   d_handle.reset();
 
@@ -1287,7 +1287,7 @@ bool Bind2Backend::handle::get_normal(DNSResourceRecord& r)
   return true;
 }
 
-bool Bind2Backend::list(const DNSName& target, int id, bool include_disabled)
+bool Bind2Backend::list(const DNSName& /* target */, int id, bool /* include_disabled */)
 {
   BB2DomainInfo bbd;
 
@@ -1351,7 +1351,7 @@ bool Bind2Backend::autoPrimariesList(std::vector<AutoPrimary>& primaries)
   return true;
 }
 
-bool Bind2Backend::superMasterBackend(const string& ip, const DNSName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** db)
+bool Bind2Backend::superMasterBackend(const string& ip, const DNSName& /* domain */, const vector<DNSResourceRecord>& /* nsset */, string* /* nameserver */, string* account, DNSBackend** db)
 {
   // Check whether we have a configfile available.
   if (getArg("supermaster-config").empty())
@@ -1410,7 +1410,7 @@ BB2DomainInfo Bind2Backend::createDomainEntry(const DNSName& domain, const strin
   return bbd;
 }
 
-bool Bind2Backend::createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account)
+bool Bind2Backend::createSlaveDomain(const string& ip, const DNSName& domain, const string& /* nameserver */, const string& account)
 {
   string filename = getArg("supermaster-destdir") + '/' + domain.toStringNoDot();
 

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -827,12 +827,12 @@ void GeoIPBackend::reload()
   }
 }
 
-void GeoIPBackend::rediscover(string* status)
+void GeoIPBackend::rediscover(string* /* status */)
 {
   reload();
 }
 
-bool GeoIPBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial)
+bool GeoIPBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool /* getSerial */)
 {
   ReadLock rl(&s_state_lock);
 
@@ -851,7 +851,7 @@ bool GeoIPBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool get
   return false;
 }
 
-void GeoIPBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled)
+void GeoIPBackend::getAllDomains(vector<DomainInfo>* domains, bool /* getSerial */, bool /* include_disabled */)
 {
   ReadLock rl(&s_state_lock);
 
@@ -1094,12 +1094,12 @@ bool GeoIPBackend::deactivateDomainKey(const DNSName& name, unsigned int id)
   return false;
 }
 
-bool GeoIPBackend::publishDomainKey(const DNSName& name, unsigned int id)
+bool GeoIPBackend::publishDomainKey(const DNSName& /* name */, unsigned int /* id */)
 {
   return false;
 }
 
-bool GeoIPBackend::unpublishDomainKey(const DNSName& name, unsigned int id)
+bool GeoIPBackend::unpublishDomainKey(const DNSName& /* name */, unsigned int /* id */)
 {
   return false;
 }

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -50,10 +50,10 @@ public:
   ~GeoIPBackend();
 
   void lookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p = nullptr) override;
-  bool list(const DNSName& target, int domain_id, bool include_disabled = false) override { return false; } // not supported
+  bool list(const DNSName& /* target */, int /* domain_id */, bool /* include_disabled */ = false) override { return false; } // not supported
   bool get(DNSResourceRecord& r) override;
   void reload() override;
-  void rediscover(string* status = 0) override;
+  void rediscover(string* status = nullptr) override;
   bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial = true) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
 

--- a/modules/geoipbackend/geoipinterface-dat.cc
+++ b/modules/geoipbackend/geoipinterface-dat.cc
@@ -433,7 +433,7 @@ public:
 
   bool queryLocationV6(GeoIPNetmask& gl, const string& ip,
                        double& latitude, double& longitude,
-                       boost::optional<int>& alt, boost::optional<int>& prec) override
+                       boost::optional<int>& /* alt */, boost::optional<int>& /* prec */) override
   {
     if (d_db_type == GEOIP_REGION_EDITION_REV0 || d_db_type == GEOIP_REGION_EDITION_REV1 || d_db_type == GEOIP_CITY_EDITION_REV0_V6 || d_db_type == GEOIP_CITY_EDITION_REV1_V6) {
       std::unique_ptr<GeoIPRecord, geoiprecord_deleter> gir(GeoIP_record_by_addr_v6(d_gi.get(), ip.c_str()));
@@ -449,7 +449,7 @@ public:
 
   bool queryLocation(GeoIPNetmask& gl, const string& ip,
                      double& latitude, double& longitude,
-                     boost::optional<int>& alt, boost::optional<int>& prec) override
+                     boost::optional<int>& /* alt */, boost::optional<int>& /* prec */) override
   {
     if (d_db_type == GEOIP_REGION_EDITION_REV0 || d_db_type == GEOIP_REGION_EDITION_REV1 || d_db_type == GEOIP_CITY_EDITION_REV0 || d_db_type == GEOIP_CITY_EDITION_REV1) {
       std::unique_ptr<GeoIPRecord, geoiprecord_deleter> gir(GeoIP_record_by_addr(d_gi.get(), ip.c_str()));

--- a/modules/geoipbackend/geoipinterface-mmdb.cc
+++ b/modules/geoipbackend/geoipinterface-mmdb.cc
@@ -208,7 +208,7 @@ public:
 
   bool queryLocation(GeoIPNetmask& gl, const string& ip,
                      double& latitude, double& longitude,
-                     boost::optional<int>& alt, boost::optional<int>& prec) override
+                     boost::optional<int>& /* alt */, boost::optional<int>& prec) override
   {
     MMDB_entry_data_s data;
     MMDB_lookup_result_s res;
@@ -228,7 +228,7 @@ public:
 
   bool queryLocationV6(GeoIPNetmask& gl, const string& ip,
                        double& latitude, double& longitude,
-                       boost::optional<int>& alt, boost::optional<int>& prec) override
+                       boost::optional<int>& /* alt */, boost::optional<int>& prec) override
   {
     MMDB_entry_data_s data;
     MMDB_lookup_result_s res;

--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -88,7 +88,7 @@ public:
     }
   }
 
-  SSqlStatement* bind(const string& name, bool value)
+  SSqlStatement* bind(const string& /* name */, bool value)
   {
     prepareStatement();
     if (d_paridx >= d_parnum) {
@@ -109,7 +109,7 @@ public:
   {
     return bind(name, (unsigned long)value);
   }
-  SSqlStatement* bind(const string& name, long value)
+  SSqlStatement* bind(const string& /* name */, long value)
   {
     prepareStatement();
     if (d_paridx >= d_parnum) {
@@ -122,7 +122,7 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bind(const string& name, unsigned long value)
+  SSqlStatement* bind(const string& /* name */, unsigned long value)
   {
     prepareStatement();
     if (d_paridx >= d_parnum) {
@@ -136,7 +136,7 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bind(const string& name, long long value)
+  SSqlStatement* bind(const string& /* name */, long long value)
   {
     prepareStatement();
     if (d_paridx >= d_parnum) {
@@ -149,7 +149,7 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bind(const string& name, unsigned long long value)
+  SSqlStatement* bind(const string& /* name */, unsigned long long value)
   {
     prepareStatement();
     if (d_paridx >= d_parnum) {
@@ -163,7 +163,7 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bind(const string& name, const std::string& value)
+  SSqlStatement* bind(const string& /* name */, const std::string& value)
   {
     prepareStatement();
     if (d_paridx >= d_parnum) {
@@ -180,7 +180,7 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bindNull(const string& name)
+  SSqlStatement* bindNull(const string& /* name */)
   {
     prepareStatement();
     if (d_paridx >= d_parnum) {

--- a/modules/godbcbackend/sodbc.cc
+++ b/modules/godbcbackend/sodbc.cc
@@ -89,7 +89,7 @@ public:
 
   vector<ODBCParam> d_req_bind;
 
-  SSqlStatement* bind(const string& name, ODBCParam& p)
+  SSqlStatement* bind(const string& /* name */, ODBCParam& p)
   {
     prepareStatement();
     d_req_bind.push_back(p);

--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -51,7 +51,7 @@ public:
   SSqlStatement* bind(const string& name, unsigned long value) { return bind(name, std::to_string(value)); }
   SSqlStatement* bind(const string& name, long long value) { return bind(name, std::to_string(value)); }
   SSqlStatement* bind(const string& name, unsigned long long value) { return bind(name, std::to_string(value)); }
-  SSqlStatement* bind(const string& name, const std::string& value)
+  SSqlStatement* bind(const string& /* name */, const std::string& value)
   {
     prepareStatement();
     allocate();
@@ -66,7 +66,7 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bindNull(const string& name)
+  SSqlStatement* bindNull(const string& /* name */)
   {
     prepareStatement();
     d_paridx++;

--- a/modules/ldapbackend/ldapauthenticator.cc
+++ b/modules/ldapbackend/ldapauthenticator.cc
@@ -74,12 +74,12 @@ void LdapSimpleAuthenticator::fillLastError(LDAP* conn, int code)
  *
  ****************************/
 
-static int ldapGssapiAuthenticatorSaslInteractCallback(LDAP* conn, unsigned flags, void* defaults, void* in)
+static int ldapGssapiAuthenticatorSaslInteractCallback(LDAP* /* conn */, unsigned /* flags */, void* /* defaults */, void* /* in */)
 {
   return LDAP_SUCCESS;
 }
 
-LdapGssapiAuthenticator::LdapGssapiAuthenticator(const std::string& kt, const std::string& ccache, int tmout) :
+LdapGssapiAuthenticator::LdapGssapiAuthenticator(const std::string& kt, const std::string& ccache, int /* tmout */) :
   d_logPrefix("[LDAP GSSAPI] "), d_keytabFile(kt), d_cCacheFile(ccache)
 {
   krb5_error_code code;

--- a/modules/ldapbackend/ldapauthenticator.cc
+++ b/modules/ldapbackend/ldapauthenticator.cc
@@ -22,9 +22,9 @@
 #include "ldaputils.hh"
 
 /*****************************
- * 
+ *
  * LdapSimpleAuthenticator
- * 
+ *
  ****************************/
 
 LdapSimpleAuthenticator::LdapSimpleAuthenticator(const std::string& dn, const std::string& pw, int tmout) :
@@ -69,9 +69,9 @@ void LdapSimpleAuthenticator::fillLastError(LDAP* conn, int code)
 }
 
 /*****************************
- * 
+ *
  * LdapGssapiAuthenticator
- * 
+ *
  ****************************/
 
 static int ldapGssapiAuthenticatorSaslInteractCallback(LDAP* conn, unsigned flags, void* defaults, void* in)

--- a/modules/ldapbackend/native.cc
+++ b/modules/ldapbackend/native.cc
@@ -24,7 +24,7 @@
 #include "ldapbackend.hh"
 #include <cstdlib>
 
-bool LdapBackend::list(const DNSName& target, int domain_id, bool include_disabled)
+bool LdapBackend::list(const DNSName& target, int domain_id, bool /* include_disabled */)
 {
   try {
     d_in_list = true;
@@ -57,7 +57,7 @@ bool LdapBackend::list(const DNSName& target, int domain_id, bool include_disabl
   return false;
 }
 
-bool LdapBackend::list_simple(const DNSName& target, int domain_id)
+bool LdapBackend::list_simple(const DNSName& target, int /* domain_id */)
 {
   string dn;
   string filter;
@@ -136,7 +136,7 @@ void LdapBackend::lookup(const QType& qtype, const DNSName& qname, int zoneid, D
   }
 }
 
-void LdapBackend::lookup_simple(const QType& qtype, const DNSName& qname, DNSPacket* dnspkt, int zoneid)
+void LdapBackend::lookup_simple(const QType& qtype, const DNSName& qname, DNSPacket* /* dnspkt */, int /* zoneid */)
 {
   string filter, attr, qesc;
   const char** attributes = ldap_attrany + 1; // skip associatedDomain
@@ -158,7 +158,7 @@ void LdapBackend::lookup_simple(const QType& qtype, const DNSName& qname, DNSPac
   d_search = d_pldap->search(getArg("basedn"), LDAP_SCOPE_SUBTREE, filter, attributes);
 }
 
-void LdapBackend::lookup_strict(const QType& qtype, const DNSName& qname, DNSPacket* dnspkt, int zoneid)
+void LdapBackend::lookup_strict(const QType& qtype, const DNSName& qname, DNSPacket* /* dnspkt */, int /* zoneid */)
 {
   int len;
   vector<string> parts;
@@ -200,7 +200,7 @@ void LdapBackend::lookup_strict(const QType& qtype, const DNSName& qname, DNSPac
   d_search = d_pldap->search(getArg("basedn"), LDAP_SCOPE_SUBTREE, filter, attributes);
 }
 
-void LdapBackend::lookup_tree(const QType& qtype, const DNSName& qname, DNSPacket* dnspkt, int zoneid)
+void LdapBackend::lookup_tree(const QType& qtype, const DNSName& qname, DNSPacket* /* dnspkt */, int /* zoneid */)
 {
   string filter, attr, qesc, dn;
   const char** attributes = ldap_attrany + 1; // skip associatedDomain
@@ -318,7 +318,7 @@ bool LdapBackend::get(DNSResourceRecord& rr)
   return true;
 }
 
-bool LdapBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial)
+bool LdapBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool /* getSerial */)
 {
   string filter;
   SOAData sd;

--- a/modules/ldapbackend/powerldap.cc
+++ b/modules/ldapbackend/powerldap.cc
@@ -42,7 +42,7 @@ PowerLDAP::SearchResult::~SearchResult()
       // not much we can do now
 }
 
-bool PowerLDAP::SearchResult::getNext(PowerLDAP::sentry_t& entry, bool dn, int timeout)
+bool PowerLDAP::SearchResult::getNext(PowerLDAP::sentry_t& entry, bool dn, int /* timeout */)
 {
   int i;
   char* attr;
@@ -214,7 +214,7 @@ void PowerLDAP::bind(LdapAuthenticator* authenticator)
     throw LDAPException("Failed to bind to LDAP server: " + authenticator->getError());
 }
 
-void PowerLDAP::bind(const string& ldapbinddn, const string& ldapsecret, int method)
+void PowerLDAP::bind(const string& ldapbinddn, const string& ldapsecret, int /* method */)
 {
   int msgid;
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -155,7 +155,7 @@ namespace serialization
 {
 
   template <class Archive>
-  void save(Archive& ar, const DNSName& g, const unsigned int /* version */)
+  void save(Archive& ar, const DNSName& g, const unsigned int version)
   {
     if (g.empty()) {
       ar& std::string();
@@ -166,7 +166,7 @@ namespace serialization
   }
 
   template <class Archive>
-  void load(Archive& ar, DNSName& g, const unsigned int /* version */)
+  void load(Archive& ar, DNSName& g, const unsigned int version)
   {
     string tmp;
     ar& tmp;
@@ -179,13 +179,13 @@ namespace serialization
   }
 
   template <class Archive>
-  void save(Archive& ar, const QType& g, const unsigned int /* version */)
+  void save(Archive& ar, const QType& g, const unsigned int version)
   {
     ar& g.getCode();
   }
 
   template <class Archive>
-  void load(Archive& ar, QType& g, const unsigned int /* version */)
+  void load(Archive& ar, QType& g, const unsigned int version)
   {
     uint16_t tmp;
     ar& tmp;
@@ -193,7 +193,7 @@ namespace serialization
   }
 
   template <class Archive>
-  void save(Archive& ar, const DomainInfo& g, const unsigned int /* version */)
+  void save(Archive& ar, const DomainInfo& g, const unsigned int version)
   {
     ar& g.zone;
     ar& g.last_check;
@@ -227,13 +227,13 @@ namespace serialization
   }
 
   template <class Archive>
-  void serialize(Archive& ar, LMDBBackend::DomainMeta& g, const unsigned int /* version */)
+  void serialize(Archive& ar, LMDBBackend::DomainMeta& g, const unsigned int version)
   {
     ar& g.domain& g.key& g.value;
   }
 
   template <class Archive>
-  void save(Archive& ar, const LMDBBackend::KeyDataDB& g, const unsigned int /* version */)
+  void save(Archive& ar, const LMDBBackend::KeyDataDB& g, const unsigned int version)
   {
     ar& g.domain& g.content& g.flags& g.active& g.published;
   }
@@ -251,7 +251,7 @@ namespace serialization
   }
 
   template <class Archive>
-  void serialize(Archive& ar, TSIGKey& g, const unsigned int /* version */)
+  void serialize(Archive& ar, TSIGKey& g, const unsigned int version)
   {
     ar& g.name;
     ar& g.algorithm; // this is the ordername
@@ -725,7 +725,7 @@ bool LMDBBackend::deleteDomain(const DNSName& domain)
   return true;
 }
 
-bool LMDBBackend::list(const DNSName& target, int /* id */, bool include_disabled)
+bool LMDBBackend::list(const DNSName& target, int id, bool include_disabled)
 {
   d_includedisabled = include_disabled;
 
@@ -761,7 +761,7 @@ bool LMDBBackend::list(const DNSName& target, int /* id */, bool include_disable
   return true;
 }
 
-void LMDBBackend::lookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* /* p */)
+void LMDBBackend::lookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* p)
 {
   if (d_dolog) {
     g_log << Logger::Warning << "Got lookup for " << qdomain << "|" << type.toString() << " in zone " << zoneId << endl;
@@ -1022,7 +1022,7 @@ bool LMDBBackend::createDomain(const DNSName& domain, const DomainInfo::DomainKi
   return true;
 }
 
-void LMDBBackend::getAllDomains(vector<DomainInfo>* domains, bool /* doSerial */, bool include_disabled)
+void LMDBBackend::getAllDomains(vector<DomainInfo>* domains, bool doSerial, bool include_disabled)
 {
   domains->clear();
   auto txn = d_tdomains->getROTransaction();

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -373,8 +373,8 @@ void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, uint32_t domain
 }
 
 /* Here's the complicated story. Other backends have just one transaction, which is either
-   on or not. 
-   
+   on or not.
+
    You can't call feedRecord without a transaction started with startTransaction.
 
    However, other functions can be called after startTransaction() or without startTransaction()

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -155,7 +155,7 @@ namespace serialization
 {
 
   template <class Archive>
-  void save(Archive& ar, const DNSName& g, const unsigned int version)
+  void save(Archive& ar, const DNSName& g, const unsigned int /* version */)
   {
     if (g.empty()) {
       ar& std::string();
@@ -166,7 +166,7 @@ namespace serialization
   }
 
   template <class Archive>
-  void load(Archive& ar, DNSName& g, const unsigned int version)
+  void load(Archive& ar, DNSName& g, const unsigned int /* version */)
   {
     string tmp;
     ar& tmp;
@@ -179,13 +179,13 @@ namespace serialization
   }
 
   template <class Archive>
-  void save(Archive& ar, const QType& g, const unsigned int version)
+  void save(Archive& ar, const QType& g, const unsigned int /* version */)
   {
     ar& g.getCode();
   }
 
   template <class Archive>
-  void load(Archive& ar, QType& g, const unsigned int version)
+  void load(Archive& ar, QType& g, const unsigned int /* version */)
   {
     uint16_t tmp;
     ar& tmp;
@@ -193,7 +193,7 @@ namespace serialization
   }
 
   template <class Archive>
-  void save(Archive& ar, const DomainInfo& g, const unsigned int version)
+  void save(Archive& ar, const DomainInfo& g, const unsigned int /* version */)
   {
     ar& g.zone;
     ar& g.last_check;
@@ -227,13 +227,13 @@ namespace serialization
   }
 
   template <class Archive>
-  void serialize(Archive& ar, LMDBBackend::DomainMeta& g, const unsigned int version)
+  void serialize(Archive& ar, LMDBBackend::DomainMeta& g, const unsigned int /* version */)
   {
     ar& g.domain& g.key& g.value;
   }
 
   template <class Archive>
-  void save(Archive& ar, const LMDBBackend::KeyDataDB& g, const unsigned int version)
+  void save(Archive& ar, const LMDBBackend::KeyDataDB& g, const unsigned int /* version */)
   {
     ar& g.domain& g.content& g.flags& g.active& g.published;
   }
@@ -251,7 +251,7 @@ namespace serialization
   }
 
   template <class Archive>
-  void serialize(Archive& ar, TSIGKey& g, const unsigned int version)
+  void serialize(Archive& ar, TSIGKey& g, const unsigned int /* version */)
   {
     ar& g.name;
     ar& g.algorithm; // this is the ordername
@@ -725,7 +725,7 @@ bool LMDBBackend::deleteDomain(const DNSName& domain)
   return true;
 }
 
-bool LMDBBackend::list(const DNSName& target, int id, bool include_disabled)
+bool LMDBBackend::list(const DNSName& target, int /* id */, bool include_disabled)
 {
   d_includedisabled = include_disabled;
 
@@ -761,7 +761,7 @@ bool LMDBBackend::list(const DNSName& target, int id, bool include_disabled)
   return true;
 }
 
-void LMDBBackend::lookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* p)
+void LMDBBackend::lookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* /* p */)
 {
   if (d_dolog) {
     g_log << Logger::Warning << "Got lookup for " << qdomain << "|" << type.toString() << " in zone " << zoneId << endl;
@@ -1022,7 +1022,7 @@ bool LMDBBackend::createDomain(const DNSName& domain, const DomainInfo::DomainKi
   return true;
 }
 
-void LMDBBackend::getAllDomains(vector<DomainInfo>* domains, bool doSerial, bool include_disabled)
+void LMDBBackend::getAllDomains(vector<DomainInfo>* domains, bool /* doSerial */, bool include_disabled)
 {
   domains->clear();
   auto txn = d_tdomains->getROTransaction();

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -176,7 +176,7 @@ public:
       g_log << Logger::Debug << "[" << getPrefix() << "] Got empty result" << endl;
   }
 
-  bool list(const DNSName& target, int domain_id, bool include_disabled = false) override
+  bool list(const DNSName& target, int domain_id, bool /* include_disabled */ = false) override
   {
     if (f_list == nullptr) {
       g_log << Logger::Error << "[" << getPrefix() << "] dns_list missing - cannot do AXFR" << endl;
@@ -272,7 +272,7 @@ public:
     logResult("zone=" << di.zone << ",serial=" << di.serial << ",kind=" << di.getKindString());
   }
 
-  bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial = true) override
+  bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool /* getSerial */ = true) override
   {
     if (f_get_domaininfo == nullptr) {
       // use getAuth instead
@@ -298,7 +298,7 @@ public:
     return true;
   }
 
-  void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override
+  void getAllDomains(vector<DomainInfo>* domains, bool /* getSerial */, bool /* include_disabled */) override
   {
     if (f_get_all_domains == nullptr)
       return;

--- a/modules/pipebackend/coprocess.cc
+++ b/modules/pipebackend/coprocess.cc
@@ -218,7 +218,7 @@ void CoProcess::sendReceive(const string& snd, string& rcv)
   receive(rcv);
 }
 
-UnixRemote::UnixRemote(const string& path, int timeout)
+UnixRemote::UnixRemote(const string& path, int /* timeout */)
 {
   d_fd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (d_fd < 0)

--- a/modules/pipebackend/coprocess.cc
+++ b/modules/pipebackend/coprocess.cc
@@ -218,7 +218,7 @@ void CoProcess::sendReceive(const string& snd, string& rcv)
   receive(rcv);
 }
 
-UnixRemote::UnixRemote(const string& path, int /* timeout */)
+UnixRemote::UnixRemote(const string& path)
 {
   d_fd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (d_fd < 0)

--- a/modules/pipebackend/coprocess.hh
+++ b/modules/pipebackend/coprocess.hh
@@ -60,7 +60,7 @@ private:
 class UnixRemote : public CoRemote
 {
 public:
-  UnixRemote(const string& path, int timeout = 0);
+  UnixRemote(const string& path);
   void sendReceive(const string& send, string& receive) override;
   void receive(string& rcv) override;
   void send(const string& send) override;

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -66,7 +66,7 @@ void CoWrapper::launch()
     throw ArgException("pipe-command is not specified");
 
   if (isUnixSocket(d_command)) {
-    d_cp = std::make_unique<UnixRemote>(d_command, d_timeout);
+    d_cp = std::make_unique<UnixRemote>(d_command);
   }
   else {
     auto coprocess = std::make_unique<CoProcess>(d_command, d_timeout);

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -197,7 +197,7 @@ void PipeBackend::lookup(const QType& qtype, const DNSName& qname, int zoneId, D
   d_qname = qname;
 }
 
-bool PipeBackend::list(const DNSName& target, int inZoneId, bool include_disabled)
+bool PipeBackend::list(const DNSName& target, int inZoneId, bool /* include_disabled */)
 {
   try {
     launch();

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -600,7 +600,7 @@ void RemoteBackend::parseDomainInfo(const Json& obj, DomainInfo& di)
   di.backend = this;
 }
 
-bool RemoteBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial)
+bool RemoteBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool /* getSerial */)
 {
   if (domain.empty())
     return false;
@@ -705,7 +705,7 @@ bool RemoteBackend::replaceRRSet(uint32_t domain_id, const DNSName& qname, const
   return true;
 }
 
-bool RemoteBackend::feedRecord(const DNSResourceRecord& rr, const DNSName& ordername, bool ordernameIsNSEC3)
+bool RemoteBackend::feedRecord(const DNSResourceRecord& rr, const DNSName& ordername, bool /* ordernameIsNSEC3 */)
 {
   Json query = Json::object{
     {"method", "feedRecord"},
@@ -852,13 +852,13 @@ bool RemoteBackend::searchRecords(const string& pattern, int maxResults, vector<
   return true;
 }
 
-bool RemoteBackend::searchComments(const string& pattern, int maxResults, vector<Comment>& result)
+bool RemoteBackend::searchComments(const string& /* pattern */, int /* maxResults */, vector<Comment>& /* result */)
 {
   // FIXME: Implement Comment API
   return false;
 }
 
-void RemoteBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled)
+void RemoteBackend::getAllDomains(vector<DomainInfo>* domains, bool /* getSerial */, bool include_disabled)
 {
   Json query = Json::object{
     {"method", "getAllDomains"},
@@ -878,7 +878,7 @@ void RemoteBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, b
   }
 }
 
-void RemoteBackend::getUpdatedMasters(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes)
+void RemoteBackend::getUpdatedMasters(vector<DomainInfo>& domains, std::unordered_set<DNSName>& /* catalogs */, CatalogHashMap& /* catalogHashes */)
 {
   Json query = Json::object{
     {"method", "getUpdatedMasters"},

--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -88,7 +88,7 @@ TinyDNSBackend::TinyDNSBackend(const string& suffix)
   d_isWildcardQuery = false;
 }
 
-void TinyDNSBackend::getUpdatedMasters(vector<DomainInfo>& retDomains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes)
+void TinyDNSBackend::getUpdatedMasters(vector<DomainInfo>& retDomains, std::unordered_set<DNSName>& /* catalogs */, CatalogHashMap& /* catalogHashes */)
 {
   auto domainInfo = s_domainInfo.lock(); //TODO: We could actually lock less if we do it per suffix.
   if (!domainInfo->count(d_suffix)) {
@@ -151,7 +151,7 @@ void TinyDNSBackend::setNotified(uint32_t id, uint32_t serial)
   (*domainInfo)[d_suffix] = *domains;
 }
 
-void TinyDNSBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled)
+void TinyDNSBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool /* include_disabled */)
 {
   d_isAxfr = true;
   d_isGetDomains = true;
@@ -195,7 +195,7 @@ void TinyDNSBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, 
   }
 }
 
-bool TinyDNSBackend::list(const DNSName& target, int domain_id, bool include_disabled)
+bool TinyDNSBackend::list(const DNSName& target, int /* domain_id */, bool /* include_disabled */)
 {
   d_isAxfr = true;
   d_isGetDomains = false;
@@ -211,7 +211,7 @@ bool TinyDNSBackend::list(const DNSName& target, int domain_id, bool include_dis
   return d_cdbReader->searchSuffix(key);
 }
 
-void TinyDNSBackend::lookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p)
+void TinyDNSBackend::lookup(const QType& qtype, const DNSName& qdomain, int /* zoneId */, DNSPacket* pkt_p)
 {
   d_isAxfr = false;
   d_isGetDomains = false;

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -334,7 +334,7 @@ static void declareArguments()
 }
 
 static time_t s_start = time(nullptr);
-static uint64_t uptimeOfProcess(const std::string& str)
+static uint64_t uptimeOfProcess(const std::string& /* str */)
 {
   return time(nullptr) - s_start;
 }
@@ -351,12 +351,12 @@ static uint64_t getSysUserTimeMsec(const std::string& str)
     return (ru.ru_utime.tv_sec * 1000ULL + ru.ru_utime.tv_usec / 1000);
 }
 
-static uint64_t getTCPConnectionCount(const std::string& str)
+static uint64_t getTCPConnectionCount(const std::string& /* str */)
 {
   return s_tcpNameserver->numTCPConnections();
 }
 
-static uint64_t getQCount(const std::string& str)
+static uint64_t getQCount(const std::string& /* str */)
 try {
   int totcount = 0;
   for (const auto& d : s_distributors) {
@@ -375,27 +375,27 @@ catch (PDNSException& e) {
   return 0;
 }
 
-static uint64_t getLatency(const std::string& str)
+static uint64_t getLatency(const std::string& /* str */)
 {
   return round(avg_latency);
 }
 
-static uint64_t getReceiveLatency(const std::string& str)
+static uint64_t getReceiveLatency(const std::string& /* str */)
 {
   return round(receive_latency);
 }
 
-static uint64_t getCacheLatency(const std::string& str)
+static uint64_t getCacheLatency(const std::string& /* str */)
 {
   return round(cache_latency);
 }
 
-static uint64_t getBackendLatency(const std::string& str)
+static uint64_t getBackendLatency(const std::string& /* str */)
 {
   return round(backend_latency);
 }
 
-static uint64_t getSendLatency(const std::string& str)
+static uint64_t getSendLatency(const std::string& /* str */)
 {
   return round(send_latency);
 }
@@ -925,7 +925,7 @@ static void daemonize()
 }
 
 static int cpid;
-static void takedown(int i)
+static void takedown(int /* i */)
 {
   if (cpid) {
     g_log << Logger::Error << "Guardian is killed, taking down children with us" << endl;
@@ -963,7 +963,7 @@ static FILE* g_fp;
 static std::mutex g_guardian_lock;
 
 // The next two methods are not in dynhandler.cc because they use a few items declared in this file.
-static string DLCycleHandler(const vector<string>& parts, pid_t ppid)
+static string DLCycleHandler(const vector<string>& /* parts */, pid_t /* ppid */)
 {
   kill(cpid, SIGKILL); // why?
   kill(cpid, SIGKILL); // why?
@@ -971,7 +971,7 @@ static string DLCycleHandler(const vector<string>& parts, pid_t ppid)
   return "ok";
 }
 
-static string DLRestHandler(const vector<string>& parts, pid_t ppid)
+static string DLRestHandler(const vector<string>& parts, pid_t /* ppid */)
 {
   string line;
 

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1326,7 +1326,7 @@ bool GSQLBackend::setDomainMetadata(const DNSName& name, const std::string& kind
   return true;
 }
 
-void GSQLBackend::lookup(const QType &qtype,const DNSName &qname, int domain_id, DNSPacket *pkt_p)
+void GSQLBackend::lookup(const QType& qtype, const DNSName& qname, int domain_id, DNSPacket* /* pkt_p */)
 {
   try {
     reconnectIfNeeded();
@@ -1790,7 +1790,7 @@ bool GSQLBackend::replaceRRSet(uint32_t domain_id, const DNSName& qname, const Q
   return true;
 }
 
-bool GSQLBackend::feedRecord(const DNSResourceRecord &r, const DNSName &ordername, bool ordernameIsNSEC3)
+bool GSQLBackend::feedRecord(const DNSResourceRecord& r, const DNSName& ordername, bool /* ordernameIsNSEC3 */)
 {
   int prio=0;
   string content(r.content);
@@ -1856,7 +1856,7 @@ bool GSQLBackend::feedEnts(int domain_id, map<DNSName,bool>& nonterm)
   return true;
 }
 
-bool GSQLBackend::feedEnts3(int domain_id, const DNSName &domain, map<DNSName,bool> &nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow)
+bool GSQLBackend::feedEnts3(int domain_id, const DNSName& /* domain */, map<DNSName, bool>& nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow)
 {
   if(!d_dnssecQueries)
       return false;

--- a/pdns/backends/gsql/ssql.hh
+++ b/pdns/backends/gsql/ssql.hh
@@ -81,7 +81,7 @@ public:
   virtual void startTransaction()=0;
   virtual void rollback()=0;
   virtual void commit()=0;
-  virtual void setLog(bool state){}
+  virtual void setLog(bool /* state */){}
   virtual bool isConnectionUsable()
   {
     return true;

--- a/pdns/backends/gsql/ssql.hh
+++ b/pdns/backends/gsql/ssql.hh
@@ -27,13 +27,13 @@
 #include "../../namespaces.hh"
 #include "../../misc.hh"
 
-class SSqlException 
+class SSqlException
 {
-public: 
+public:
   SSqlException(const string &reason) : d_reason(reason)
   {
   }
-  
+
   string txtReason()
   {
     return d_reason;
@@ -41,7 +41,7 @@ public:
 private:
   string d_reason;
 };
- 
+
 class SSqlStatement
 {
 public:

--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -30,8 +30,8 @@
 // this function can clean any cache that has an isStale() method on its entries, a preRemoval() method and a 'sequence' index as its second index
 // the ritual is that the oldest entries are in *front* of the sequence collection, so on a hit, move an item to the end
 // and optionally, on a miss, move it to the beginning
-template <typename S, typename C, typename T>
-void pruneCollection(C& /* container */, T& collection, size_t maxCached, size_t scanFraction = 1000)
+template <typename S, typename T>
+void pruneCollection(T& collection, size_t maxCached, size_t scanFraction = 1000)
 {
   const time_t now = time(nullptr);
   size_t toTrim = 0;
@@ -47,7 +47,8 @@ void pruneCollection(C& /* container */, T& collection, size_t maxCached, size_t
   // and nuke everything that is expired
   // otherwise, scan first 5*toTrim records, and stop once we've nuked enough
   const size_t lookAt = toTrim ? 5 * toTrim : cacheSize / scanFraction;
-  size_t tried = 0, erased = 0;
+  size_t tried = 0;
+  size_t erased = 0;
 
   for (auto iter = sidx.begin(); iter != sidx.end() && tried < lookAt; ++tried) {
     if (iter->isStale(now)) {

--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -31,7 +31,7 @@
 // the ritual is that the oldest entries are in *front* of the sequence collection, so on a hit, move an item to the end
 // and optionally, on a miss, move it to the beginning
 template <typename S, typename C, typename T>
-void pruneCollection(C& container, T& collection, size_t maxCached, size_t scanFraction = 1000)
+void pruneCollection(C& /* container */, T& collection, size_t maxCached, size_t scanFraction = 1000)
 {
   const time_t now = time(nullptr);
   size_t toTrim = 0;

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -179,8 +179,7 @@ private:
   LockGuarded<map<pair<DNSName,string>,time_t>> d_holes;
 
   void suck(const DNSName &domain, const ComboAddress& remote, bool force=false);
-  void ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, std::unique_ptr<AuthLua4>& pdl,
-                ZoneStatus& zs, vector<DNSRecord>* axfr);
+  void ixfrSuck(const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, ZoneStatus& zs, vector<DNSRecord>* axfr);
 
   void slaveRefresh(PacketHandler *P);
   void masterUpdateCheck(PacketHandler *P);

--- a/pdns/credentials.cc
+++ b/pdns/credentials.cc
@@ -444,7 +444,7 @@ SensitiveData CredentialsHolder::readFromTerminal()
   struct sigaction sa;
   sigemptyset(&sa.sa_mask);
   sa.sa_flags = 0;
-  sa.sa_handler = [](int s) {};
+  sa.sa_handler = [](int /* s */) {};
   sigaction(SIGALRM, &sa, &signals[SIGALRM]);
   sigaction(SIGHUP, &sa, &signals[SIGHUP]);
   sigaction(SIGINT, &sa, &signals[SIGINT]);

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -961,10 +961,10 @@ void DNSSECKeeper::cleanup()
 
   if(now.tv_sec - s_last_prune > (time_t)(30)) {
     {
-      pruneCollection<SequencedTag>(*this, (*s_metacache.write_lock()), s_maxEntries);
+      pruneCollection<SequencedTag>((*s_metacache.write_lock()), s_maxEntries);
     }
     {
-      pruneCollection<SequencedTag>(*this, (*s_keycache.write_lock()), s_maxEntries);
+      pruneCollection<SequencedTag>((*s_keycache.write_lock()), s_maxEntries);
     }
     s_last_prune = time(nullptr);
   }

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -682,7 +682,7 @@ bool DNSSECKeeper::getTSIGForAccess(const DNSName& zone, const ComboAddress& /* 
   return false;
 }
 
-bool DNSSECKeeper::unSecureZone(const DNSName& zone, string& error, string& /* info */) {
+bool DNSSECKeeper::unSecureZone(const DNSName& zone, string& error) {
   // Not calling isSecuredZone(), as it will return false for zones with zero
   // active keys.
   DNSSECKeeper::keyset_t keyset=getKeys(zone);

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -668,7 +668,7 @@ bool DNSSECKeeper::TSIGGrantsAccess(const DNSName& zone, const DNSName& keyname)
   return false;
 }
 
-bool DNSSECKeeper::getTSIGForAccess(const DNSName& zone, const ComboAddress& master, DNSName* keyname)
+bool DNSSECKeeper::getTSIGForAccess(const DNSName& zone, const ComboAddress& /* master */, DNSName* keyname)
 {
   vector<string> keynames;
   d_keymetadb->getDomainMetadata(zone, "AXFR-MASTER-TSIG", keynames);
@@ -682,7 +682,7 @@ bool DNSSECKeeper::getTSIGForAccess(const DNSName& zone, const ComboAddress& mas
   return false;
 }
 
-bool DNSSECKeeper::unSecureZone(const DNSName& zone, string& error, string& info) {
+bool DNSSECKeeper::unSecureZone(const DNSName& zone, string& error, string& /* info */) {
   // Not calling isSecuredZone(), as it will return false for zones with zero
   // active keys.
   DNSSECKeeper::keyset_t keyset=getKeys(zone);

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -304,7 +304,7 @@ bool DNSBackend::getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, co
   return ret;
 }
 
-void DNSBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled)
+void DNSBackend::getAllDomains(vector<DomainInfo>* /* domains */, bool /* getSerial */, bool /* include_disabled */)
 {
   if (g_zoneCache.isEnabled()) {
     g_log << Logger::Error << "One of the backends does not support zone caching. Put zone-cache-refresh-interval=0 in the config file to disable this cache." << endl;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -173,12 +173,12 @@ public:
   //! fills the soadata struct with the SOA details. Returns false if there is no SOA.
   virtual bool getSOA(const DNSName &name, SOAData &soadata);
 
-  virtual bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset)
+  virtual bool replaceRRSet(uint32_t /* domain_id */, const DNSName& /* qname */, const QType& /* qt */, const vector<DNSResourceRecord>& /* rrset */)
   {
     return false;
   }
 
-  virtual bool listSubZone(const DNSName &zone, int domain_id)
+  virtual bool listSubZone(const DNSName& /* zone */, int /* domain_id */)
   {
     return false;
   }
@@ -187,8 +187,8 @@ public:
   bool isDnssecDomainMetadata (const string& name) {
     return (name == "PRESIGNED" || name == "NSEC3PARAM" || name == "NSEC3NARROW");
   }
-  virtual bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string> >& meta) { return false; };
-  virtual bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta) { return false; }
+  virtual bool getAllDomainMetadata(const DNSName& /* name */, std::map<std::string, std::vector<std::string>>& /* meta */) { return false; };
+  virtual bool getDomainMetadata(const DNSName& /* name */, const std::string& /* kind */, std::vector<std::string>& /* meta */) { return false; }
   virtual bool getDomainMetadataOne(const DNSName& name, const std::string& kind, std::string& value)
   {
     std::vector<std::string> meta;
@@ -201,7 +201,7 @@ public:
     return false;
   }
 
-  virtual bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta) {return false;}
+  virtual bool setDomainMetadata(const DNSName& /* name */, const std::string& /* kind */, const std::vector<std::string>& /* meta */) { return false; }
   virtual bool setDomainMetadataOne(const DNSName& name, const std::string& kind, const std::string& value)
   {
     const std::vector<std::string> meta(1, value);
@@ -211,7 +211,7 @@ public:
   virtual void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled);
 
   /** Determines if we are authoritative for a zone, and at what level */
-  virtual bool getAuth(const DNSName &target, SOAData *sd);
+  virtual bool getAuth(const DNSName& target, SOAData* /* sd */);
 
   struct KeyData {
     std::string content;
@@ -221,34 +221,34 @@ public:
     bool published;
   };
 
-  virtual bool getDomainKeys(const DNSName& name, std::vector<KeyData>& keys) { return false;}
-  virtual bool removeDomainKey(const DNSName& name, unsigned int id) { return false; }
-  virtual bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id){ return false; }
-  virtual bool activateDomainKey(const DNSName& name, unsigned int id) { return false; }
-  virtual bool deactivateDomainKey(const DNSName& name, unsigned int id) { return false; }
-  virtual bool publishDomainKey(const DNSName& name, unsigned int id) { return false; }
-  virtual bool unpublishDomainKey(const DNSName& name, unsigned int id) { return false; }
+  virtual bool getDomainKeys(const DNSName& /* name */, std::vector<KeyData>& /* keys */) { return false; }
+  virtual bool removeDomainKey(const DNSName& /* name */, unsigned int /* id */) { return false; }
+  virtual bool addDomainKey(const DNSName& /* name */, const KeyData& /* key */, int64_t& /* id */) { return false; }
+  virtual bool activateDomainKey(const DNSName& /* name */, unsigned int /* id */) { return false; }
+  virtual bool deactivateDomainKey(const DNSName& /* name */, unsigned int /* id */) { return false; }
+  virtual bool publishDomainKey(const DNSName& /* name */, unsigned int /* id */) { return false; }
+  virtual bool unpublishDomainKey(const DNSName& /* name */, unsigned int /* id */) { return false; }
 
-  virtual bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) { return false; }
-  virtual bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content) { return false; }
-  virtual bool getTSIGKeys(std::vector<struct TSIGKey>& keys) { return false; }
-  virtual bool deleteTSIGKey(const DNSName& name) { return false; }
+  virtual bool setTSIGKey(const DNSName& /* name */, const DNSName& /* algorithm */, const string& /* content */) { return false; }
+  virtual bool getTSIGKey(const DNSName& /* name */, DNSName& /* algorithm */, string& /* content */) { return false; }
+  virtual bool getTSIGKeys(std::vector<struct TSIGKey>& /* keys */) { return false; }
+  virtual bool deleteTSIGKey(const DNSName& /* name */) { return false; }
 
-  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after)
+  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t /* id */, const DNSName& /* qname */, DNSName& /* unhashed */, DNSName& /* before */, DNSName& /* after */)
   {
-    std::cerr<<"Default beforeAndAfterAbsolute called!"<<std::endl;
+    std::cerr << "Default beforeAndAfterAbsolute called!" << std::endl;
     abort();
     return false;
   }
 
-  virtual bool getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, const DNSName& qname, DNSName& before, DNSName& after);
+  virtual bool getBeforeAndAfterNames(uint32_t /* id */, const DNSName& zonename, const DNSName& qname, DNSName& before, DNSName& after);
 
-  virtual bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype=QType::ANY)
+  virtual bool updateDNSSECOrderNameAndAuth(uint32_t /* domain_id */, const DNSName& /* qname */, const DNSName& /* ordername */, bool /* auth */, const uint16_t /* qtype */ = QType::ANY)
   {
     return false;
   }
 
-  virtual bool updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& insert, set<DNSName>& erase, bool remove)
+  virtual bool updateEmptyNonTerminals(uint32_t /* domain_id */, set<DNSName>& /* insert */, set<DNSName>& /* erase */, bool /* remove */)
   {
     return false;
   }
@@ -261,28 +261,28 @@ public:
   // end DNSSEC
 
   // comments support
-  virtual bool listComments(uint32_t domain_id)
+  virtual bool listComments(uint32_t /* domain_id */)
   {
     return false; // unsupported by this backend
   }
 
-  virtual bool getComment(Comment& comment)
+  virtual bool getComment(Comment& /* comment */)
   {
     return false;
   }
 
-  virtual void feedComment(const Comment& comment)
+  virtual void feedComment(const Comment& /* comment */)
   {
   }
 
-  virtual bool replaceComments(const uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<Comment>& comments)
+  virtual bool replaceComments(const uint32_t /* domain_id */, const DNSName& /* qname */, const QType& /* qt */, const vector<Comment>& /* comments */)
   {
     return false;
   }
 
   //! returns true if master ip is master for domain name.
   //! starts the transaction for updating domain qname (FIXME: what is id?)
-  virtual bool startTransaction(const DNSName &qname, int id=-1)
+  virtual bool startTransaction(const DNSName& /* qname */, int /* id */ = -1)
   {
     return false;
   }
@@ -308,36 +308,36 @@ public:
   {
   }
 
-  virtual void rediscover(string* status=0)
+  virtual void rediscover(string* /* status */ = nullptr)
   {
   }
 
   //! feeds a record to a zone, needs a call to startTransaction first
-  virtual bool feedRecord(const DNSResourceRecord &rr, const DNSName &ordername, bool ordernameIsNSEC3=false)
+  virtual bool feedRecord(const DNSResourceRecord& /* rr */, const DNSName& /* ordername */, bool /* ordernameIsNSEC3 */ = false)
   {
     return false; // no problem!
   }
-  virtual bool feedEnts(int domain_id, map<DNSName,bool> &nonterm)
+  virtual bool feedEnts(int /* domain_id */, map<DNSName, bool>& /* nonterm */)
   {
     return false;
   }
-  virtual bool feedEnts3(int domain_id, const DNSName &domain, map<DNSName,bool> &nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow)
+  virtual bool feedEnts3(int /* domain_id */, const DNSName& /* domain */, map<DNSName, bool>& /* nonterm */, const NSEC3PARAMRecordContent& /* ns3prc */, bool /* narrow */)
   {
     return false;
   }
 
   //! if this returns true, DomainInfo di contains information about the domain
-  virtual bool getDomainInfo(const DNSName &domain, DomainInfo &di, bool getSerial=true)
+  virtual bool getDomainInfo(const DNSName& /* domain */, DomainInfo& /* di */, bool /* getSerial */ = true)
   {
     return false;
   }
   //! slave capable backends should return a list of slaves that should be rechecked for staleness
-  virtual void getUnfreshSlaveInfos(vector<DomainInfo>* domains)
+  virtual void getUnfreshSlaveInfos(vector<DomainInfo>* /* domains */)
   {
   }
 
   //! get a list of IP addresses that should also be notified for a domain
-  virtual void alsoNotifies(const DNSName &domain, set<string> *ips)
+  virtual void alsoNotifies(const DNSName& domain, set<string>* ips)
   {
     std::vector<std::string> meta;
     getDomainMetadata(domain, "ALSO-NOTIFY", meta);
@@ -345,57 +345,57 @@ public:
   }
 
   //! get list of domains that have been changed since their last notification to slaves
-  virtual void getUpdatedMasters(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes)
+  virtual void getUpdatedMasters(vector<DomainInfo>& /* domains */, std::unordered_set<DNSName>& /* catalogs */, CatalogHashMap& /* catalogHashes */)
   {
   }
 
   //! get list of all members in a catalog
-  virtual bool getCatalogMembers(const DNSName& catalog, vector<CatalogInfo>& members, CatalogInfo::CatalogType type)
+  virtual bool getCatalogMembers(const DNSName& /* catalog */, vector<CatalogInfo>& /* members */, CatalogInfo::CatalogType /* type */)
   {
     return false;
   }
 
   //! Called by PowerDNS to inform a backend that a domain need to be checked for freshness
-  virtual void setStale(uint32_t domain_id)
+  virtual void setStale(uint32_t /* domain_id */)
   {
   }
 
   //! Called by PowerDNS to inform a backend that a domain has been checked for freshness
-  virtual void setFresh(uint32_t domain_id)
+  virtual void setFresh(uint32_t /* domain_id */)
   {
   }
 
   //! Called by PowerDNS to inform a backend that the changes in the domain have been reported to slaves
-  virtual void setNotified(uint32_t id, uint32_t serial)
+  virtual void setNotified(uint32_t /* id */, uint32_t /* serial */)
   {
   }
 
   //! Called when the Master list of a domain should be changed
-  virtual bool setMasters(const DNSName &domain, const vector<ComboAddress> &masters)
+  virtual bool setMasters(const DNSName& /* domain */, const vector<ComboAddress>& /* masters */)
   {
     return false;
   }
 
   //! Called when the Kind of a domain should be changed (master -> native and similar)
-  virtual bool setKind(const DNSName &domain, const DomainInfo::DomainKind kind)
+  virtual bool setKind(const DNSName& /* domain */, const DomainInfo::DomainKind /* kind */)
   {
     return false;
   }
 
   //! Called when the options of a domain should be changed
-  virtual bool setOptions(const DNSName& domain, const string& options)
+  virtual bool setOptions(const DNSName& /* domain */, const string& /* options */)
   {
     return false;
   }
 
   //! Called when the catalog of a domain should be changed
-  virtual bool setCatalog(const DNSName& domain, const DNSName& catalog)
+  virtual bool setCatalog(const DNSName& /* domain */, const DNSName& /* catalog */)
   {
     return false;
   }
 
   //! Called when the Account of a domain should be changed
-  virtual bool setAccount(const DNSName &domain, const string &account)
+  virtual bool setAccount(const DNSName& /* domain */, const string& /* account */)
   {
     return false;
   }
@@ -404,60 +404,60 @@ public:
   void setArgPrefix(const string &prefix);
 
   //! Add an entry for a super master
-  virtual bool superMasterAdd(const struct AutoPrimary& primary)
+  virtual bool superMasterAdd(const struct AutoPrimary& /* primary */)
   {
-    return false; 
+    return false;
   }
 
   //! Remove an entry for a super master
-  virtual bool autoPrimaryRemove(const struct AutoPrimary& primary)
+  virtual bool autoPrimaryRemove(const struct AutoPrimary& /* primary */)
   {
     return false;
   }
 
   //! List all SuperMasters, returns false if feature not supported.
-  virtual bool autoPrimariesList(std::vector<AutoPrimary>& primaries)
+  virtual bool autoPrimariesList(std::vector<AutoPrimary>& /* primaries */)
   {
     return false;
   }
 
   //! determine if ip is a supermaster or a domain
-  virtual bool superMasterBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db)
+  virtual bool superMasterBackend(const string& /* ip */, const DNSName& /* domain */, const vector<DNSResourceRecord>& /* nsset */, string* /* nameserver */, string* /* account */, DNSBackend** /* db */)
   {
     return false;
   }
 
   //! called by PowerDNS to create a new domain
-  virtual bool createDomain(const DNSName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& masters, const string& account)
+  virtual bool createDomain(const DNSName& /* domain */, const DomainInfo::DomainKind /* kind */, const vector<ComboAddress>& /* masters */, const string& /* account */)
   {
     return false;
   }
 
   //! called by PowerDNS to create a slave record for a superMaster
-  virtual bool createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account)
+  virtual bool createSlaveDomain(const string& /* ip */, const DNSName& /* domain */, const string& /* nameserver */, const string& /* account */)
   {
     return false;
   }
 
   //! called to delete a domain, incl. all metadata, zone contents, etc.
-  virtual bool deleteDomain(const DNSName &domain)
+  virtual bool deleteDomain(const DNSName& /* domain */)
   {
     return false;
   }
 
-  virtual string directBackendCmd(const string &query)
+  virtual string directBackendCmd(const string& /* query */)
   {
     return "directBackendCmd not supported for this backend\n";
   }
 
   //! Search for records, returns true if search was done successfully.
-  virtual bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result)
+  virtual bool searchRecords(const string& /* pattern */, int /* maxResults */, vector<DNSResourceRecord>& /* result */)
   {
     return false;
   }
 
   //! Search for comments, returns true if search was done successfully.
-  virtual bool searchComments(const string &pattern, int maxResults, vector<Comment>& result)
+  virtual bool searchComments(const string& /* pattern */, int /* maxResults */, vector<Comment>& /* result */)
   {
     return false;
   }
@@ -482,9 +482,9 @@ public:
   {
     return this->make(suffix);
   }
-  virtual void declareArguments(const string &suffix=""){}
-  const string &getName() const;
-  
+  virtual void declareArguments(const string& /* suffix */ = "") {}
+  [[nodiscard]] const string& getName() const;
+
 protected:
   void declare(const string &suffix, const string &param, const string &explanation, const string &value);
 

--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -299,8 +299,8 @@ bool DNSDistPacketCache::get(DNSQuestion& dq, uint16_t queryId, uint32_t* keyOut
       ageDNSPacket(reinterpret_cast<char *>(&response[0]), response.size(), age);
     }
     else {
-      editDNSPacketTTL(reinterpret_cast<char *>(&response[0]), response.size(),
-        [staleTTL = d_staleTTL](uint8_t section, uint16_t class_, uint16_t type, uint32_t ttl) { return staleTTL; });
+      editDNSPacketTTL(reinterpret_cast<char*>(&response[0]), response.size(),
+                       [staleTTL = d_staleTTL](uint8_t /* section */, uint16_t /* class_ */, uint16_t /* type */, uint32_t /* ttl */) { return staleTTL; });
     }
   }
 
@@ -533,8 +533,7 @@ std::set<DNSName> DNSDistPacketCache::getDomainsContainingRecords(const ComboAdd
         }
 
         bool found = false;
-        bool valid = visitDNSPacket(value.value, [addr, &found](uint8_t section, uint16_t qclass, uint16_t qtype, uint32_t ttl, uint16_t rdatalength, const char* rdata) {
-
+        bool valid = visitDNSPacket(value.value, [addr, &found](uint8_t /* section */, uint16_t qclass, uint16_t qtype, uint32_t /* ttl */, uint16_t rdatalength, const char* rdata) {
           if (qtype == QType::A && qclass == QClass::IN && addr.isIPv4() && rdatalength == 4 && rdata != nullptr) {
             ComboAddress parsed;
             parsed.sin4.sin_family = AF_INET;
@@ -595,8 +594,7 @@ std::set<ComboAddress> DNSDistPacketCache::getRecordsForDomain(const DNSName& do
           continue;
         }
 
-        visitDNSPacket(value.value, [&addresses](uint8_t section, uint16_t qclass, uint16_t qtype, uint32_t ttl, uint16_t rdatalength, const char* rdata) {
-
+        visitDNSPacket(value.value, [&addresses](uint8_t /* section */, uint16_t qclass, uint16_t qtype, uint32_t /* ttl */, uint16_t rdatalength, const char* rdata) {
           if (qtype == QType::A && qclass == QClass::IN && rdatalength == 4 && rdata != nullptr) {
             ComboAddress parsed;
             parsed.sin4.sin_family = AF_INET;

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -110,7 +110,7 @@ private:
     CacheShard()
     {
     }
-    CacheShard(const CacheShard& old)
+    CacheShard(const CacheShard& /* old */)
     {
     }
 

--- a/pdns/dnsdistdist/dnsdist-discovery.cc
+++ b/pdns/dnsdistdist/dnsdist-discovery.cc
@@ -367,8 +367,7 @@ static bool checkBackendUsability(std::shared_ptr<DownstreamState>& ds)
       sock.bind(ds->d_config.sourceAddr);
     }
 
-    time_t now = time(nullptr);
-    auto handler = std::make_unique<TCPIOHandler>(ds->d_config.d_tlsSubjectName, ds->d_config.d_tlsSubjectIsAddr, sock.releaseHandle(), timeval{ds->d_config.checkTimeout, 0}, ds->d_tlsCtx, now);
+    auto handler = std::make_unique<TCPIOHandler>(ds->d_config.d_tlsSubjectName, ds->d_config.d_tlsSubjectIsAddr, sock.releaseHandle(), timeval{ds->d_config.checkTimeout, 0}, ds->d_tlsCtx);
     handler->connect(ds->d_config.tcpFastOpen, ds->d_config.remote, timeval{ds->d_config.checkTimeout, 0});
     return true;
   }

--- a/pdns/dnsdistdist/dnsdist-healthchecks.cc
+++ b/pdns/dnsdistdist/dnsdist-healthchecks.cc
@@ -360,7 +360,7 @@ bool queueHealthCheck(std::unique_ptr<FDMultiplexer>& mplexer, const std::shared
     }
     else {
       time_t now = time(nullptr);
-      data->d_tcpHandler = std::make_unique<TCPIOHandler>(ds->d_config.d_tlsSubjectName, ds->d_config.d_tlsSubjectIsAddr, sock.releaseHandle(), timeval{ds->d_config.checkTimeout,0}, ds->d_tlsCtx, now);
+      data->d_tcpHandler = std::make_unique<TCPIOHandler>(ds->d_config.d_tlsSubjectName, ds->d_config.d_tlsSubjectIsAddr, sock.releaseHandle(), timeval{ds->d_config.checkTimeout,0}, ds->d_tlsCtx);
       data->d_ioState = std::make_unique<IOStateHandler>(*mplexer, data->d_tcpHandler->getDescriptor());
       if (ds->d_tlsCtx) {
         try {

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -103,7 +103,7 @@ bool ConnectionToBackend::reconnect()
       socket.setNonBlocking();
 
       gettimeofday(&d_connectionStartTime, nullptr);
-      auto handler = std::make_unique<TCPIOHandler>(d_ds->d_config.d_tlsSubjectName, d_ds->d_config.d_tlsSubjectIsAddr, socket.releaseHandle(), timeval{0,0}, d_ds->d_tlsCtx, d_connectionStartTime.tv_sec);
+      auto handler = std::make_unique<TCPIOHandler>(d_ds->d_config.d_tlsSubjectName, d_ds->d_config.d_tlsSubjectIsAddr, socket.releaseHandle(), timeval{0,0}, d_ds->d_tlsCtx);
       if (!tlsSession && d_ds->d_tlsCtx) {
         tlsSession = g_sessionCache.getSession(d_ds->getID(), d_connectionStartTime.tv_sec);
       }

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -61,7 +61,7 @@ UnknownRecordContent::UnknownRecordContent(const string& zone)
   d_record.insert(d_record.end(), out.begin(), out.end());
 }
 
-string UnknownRecordContent::getZoneRepresentation(bool noDot) const
+string UnknownRecordContent::getZoneRepresentation(bool /* noDot */) const
 {
   ostringstream str;
   str<<"\\# "<<(unsigned int)d_record.size()<<" ";
@@ -678,7 +678,7 @@ void PacketReader::xfrSvcParamKeyVals(set<SvcParam> &kvs) {
 }
 
 
-void PacketReader::xfrHexBlob(string& blob, bool keepReading)
+void PacketReader::xfrHexBlob(string& blob, bool /* keepReading */)
 {
   xfrBlob(blob);
 }

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -135,10 +135,9 @@ public:
     val=get8BitInt();
   }
 
-
-  void xfrName(DNSName &name, bool compress=false, bool noDot=false)
+  void xfrName(DNSName& name, bool /* compress */ = false, bool /* noDot */ = false)
   {
-    name=getName();
+    name = getName();
   }
 
   void xfrText(string &text, bool multi=false, bool lenField=true)

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -476,7 +476,8 @@ void EUI48RecordContent::toPacket(DNSPacketWriter& pw)
     string blob(d_eui48, d_eui48+6);
     pw.xfrBlob(blob);
 }
-string EUI48RecordContent::getZoneRepresentation(bool noDot) const
+
+string EUI48RecordContent::getZoneRepresentation(bool /* noDot */) const
 {
     char tmp[18];
     snprintf(tmp,sizeof(tmp),"%02x-%02x-%02x-%02x-%02x-%02x",
@@ -520,7 +521,8 @@ void EUI64RecordContent::toPacket(DNSPacketWriter& pw)
     string blob(d_eui64, d_eui64+8);
     pw.xfrBlob(blob);
 }
-string EUI64RecordContent::getZoneRepresentation(bool noDot) const
+
+string EUI64RecordContent::getZoneRepresentation(bool /* noDot */) const
 {
     char tmp[24];
     snprintf(tmp,sizeof(tmp),"%02x-%02x-%02x-%02x-%02x-%02x-%02x-%02x",
@@ -703,7 +705,7 @@ void APLRecordContent::toPacket(DNSPacketWriter& pw) {
 }
 
 // Decode record into string
-string APLRecordContent::getZoneRepresentation(bool noDot) const {
+string APLRecordContent::getZoneRepresentation(bool /* noDot */) const {
   string s_n, s_family, output;
   ComboAddress ca;
   Netmask nm;
@@ -886,7 +888,7 @@ bool getEDNSOpts(const MOADNSParser& mdp, EDNSOpts* eo)
   return false;
 }
 
-DNSRecord makeOpt(const uint16_t udpsize, const uint16_t extRCode, const uint16_t extFlags)
+DNSRecord makeOpt(const uint16_t udpsize, const uint16_t /* extRCode */, const uint16_t extFlags)
 {
   EDNS0Record stuff;
   stuff.extRCode=0;

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -888,25 +888,6 @@ bool getEDNSOpts(const MOADNSParser& mdp, EDNSOpts* eo)
   return false;
 }
 
-DNSRecord makeOpt(const uint16_t udpsize, const uint16_t /* extRCode */, const uint16_t extFlags)
-{
-  EDNS0Record stuff;
-  stuff.extRCode=0;
-  stuff.version=0;
-  stuff.extFlags=htons(extFlags);
-  DNSRecord dr;
-  static_assert(sizeof(EDNS0Record) == sizeof(dr.d_ttl), "sizeof(EDNS0Record) must match sizeof(DNSRecord.d_ttl)");
-  memcpy(&dr.d_ttl, &stuff, sizeof(stuff));
-  dr.d_ttl=ntohl(dr.d_ttl);
-  dr.d_name=g_rootdnsname;
-  dr.d_type = QType::OPT;
-  dr.d_class=udpsize;
-  dr.d_place=DNSResourceRecord::ADDITIONAL;
-  dr.d_content = std::make_shared<OPTRecordContent>();
-  // if we ever do options, I think we stuff them into OPTRecordContent::data
-  return dr;
-}
-
 void reportBasicTypes()
 {
   ARecordContent::report();

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -1055,7 +1055,6 @@ struct EDNSOpts
 
 class MOADNSParser;
 bool getEDNSOpts(const MOADNSParser& mdp, EDNSOpts* eo);
-DNSRecord makeOpt(const uint16_t udpsize, const uint16_t extRCode, const uint16_t extFlags);
 void reportBasicTypes();
 void reportOtherTypes();
 void reportAllTypes();

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -1034,14 +1034,14 @@ string RNAME##RecordContent::getZoneRepresentation(bool noDot) const            
 }
 
 
-#define boilerplate_conv(RNAME, CONV)                             \
-boilerplate(RNAME)                                                \
-template<class Convertor>                                         \
-void RNAME##RecordContent::xfrPacket(Convertor& conv, bool noDot) \
-{                                                                 \
-  CONV;                                                           \
+#define boilerplate_conv(RNAME, CONV)                                   \
+boilerplate(RNAME)                                                      \
+template<class Convertor>                                               \
+void RNAME##RecordContent::xfrPacket(Convertor& conv, bool /* noDot */) \
+{                                                                       \
+  CONV;                                                                 \
   if (conv.eof() == false) throw MOADNSException("When parsing " #RNAME " trailing data was not parsed: '" + conv.getRemaining() + "'"); \
-}                                                                 \
+}                                                                       \
 
 struct EDNSOpts
 {

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -106,7 +106,7 @@ struct LiveCounts
   }
 };
 
-static void visitor(const StatNode* node, const StatNode::Stat& selfstat, const StatNode::Stat& childstat)
+static void visitor(const StatNode* node, const StatNode::Stat& /* selfstat */, const StatNode::Stat& childstat)
 {
   // 20% servfails, >100 children, on average less than 2 copies of a query
   // >100 different subqueries

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -49,7 +49,7 @@ namespace po = boost::program_options;
 po::variables_map g_vm;
 
 ArgvMap& arg()
-{	
+{
   static ArgvMap theArg;
   return theArg;
 }
@@ -150,21 +150,21 @@ try
     ("stats-dir", po::value<string>()->default_value("."), "Directory where statistics will be saved")
     ("write-failures,w", po::value<string>()->default_value(""), "if set, write weird packets to this PCAP file")
     ("verbose,v", "be verbose");
-    
+
   hidden.add_options()
     ("files", po::value<vector<string> >(), "files");
 
-  alloptions.add(desc).add(hidden); 
+  alloptions.add(desc).add(hidden);
 
   po::positional_options_description p;
   p.add("files", -1);
 
   po::store(po::command_line_parser(argc, argv).options(alloptions).positional(p).run(), g_vm);
   po::notify(g_vm);
- 
+
   vector<string> files;
-  if(g_vm.count("files")) 
-    files = g_vm["files"].as<vector<string> >(); 
+  if(g_vm.count("files"))
+    files = g_vm["files"].as<vector<string> >();
 
   if(g_vm.count("version")) {
     cerr<<"dnsscope "<<VERSION<<endl;
@@ -210,7 +210,7 @@ try
   unsigned int reuses=0;
   typedef map<uint16_t,uint32_t> rcodes_t;
   rcodes_t rcodes;
-  
+
   time_t lowestTime=0, highestTime=0;
   time_t lastsec=0;
   LiveCounts lastcounts;
@@ -250,12 +250,12 @@ try
 	    rdFilterMismatch++;
 	    continue;
 	  }
-          
+
           if(!filtername.empty() && !qname.isPartOf(filtername)) {
             nameMismatch++;
             continue;
           }
-          
+
 	  if(!header.qr) {
             uint16_t udpsize, z;
             if(getEDNSUDPPayloadSizeAndZ((const char*)pr.d_payload, pr.d_len, &udpsize, &z)) {
@@ -269,17 +269,17 @@ try
             }
           }
 
-	  if(pr.d_ip->ip_v == 4) 
+	  if(pr.d_ip->ip_v == 4)
 	    ++ipv4DNSPackets;
 	  else
 	    ++ipv6DNSPackets;
-        
+
 	  if(pr.d_pheader.ts.tv_sec != lastsec) {
 	    LiveCounts lc;
 	    if(lastsec) {
 	      lc.questions = queries;
 	      lc.answers = answers;
-	      lc.outstanding = liveQuestions(); 
+	      lc.outstanding = liveQuestions();
 
 	      LiveCounts diff = lc - lastcounts;
               pcounts.emplace_back(pr.d_pheader.ts.tv_sec, diff);
@@ -302,10 +302,10 @@ try
 
 	    ComboAddress rem = pr.getSource();
 	    rem.sin4.sin_port=0;
-	    requestors.insert(rem);	  
+	    requestors.insert(rem);
 
             QuestionData& qd=statmap[qi];
-          
+
 	    if(!qd.d_firstquestiontime.tv_sec)
 	      qd.d_firstquestiontime=pr.d_pheader.ts;
 	    else {
@@ -329,11 +329,11 @@ try
 	      rdNonRAAnswers++;
 	      rdnonra.insert(pr.getDest());
 	    }
-	  
+
 	    if(header.ra) {
 	      ComboAddress rem = pr.getDest();
 	      rem.sin4.sin_port=0;
-	      recipients.insert(rem);	  
+	      recipients.insert(rem);
 	    }
 
 	    QuestionData& qd=statmap[qi];
@@ -345,14 +345,14 @@ try
 	    qd.d_answercount++;
 
 	    if(qd.d_qcount) {
-	      uint32_t usecs= (pr.d_pheader.ts.tv_sec - qd.d_firstquestiontime.tv_sec) * 1000000 +  
+	      uint32_t usecs= (pr.d_pheader.ts.tv_sec - qd.d_firstquestiontime.tv_sec) * 1000000 +
 		(pr.d_pheader.ts.tv_usec - qd.d_firstquestiontime.tv_usec) ;
 
 	      //	      cout<<"Usecs for "<<qi<<": "<<usecs<<endl;
               if(!noservfailstats || header.rcode != 2)
                 cumul[usecs]++;
-            
-	      if(header.rcode != 0 && header.rcode!=3) 
+
+	      if(header.rcode != 0 && header.rcode!=3)
 		errorresult++;
 	      ComboAddress rem = pr.getDest();
 	      rem.sin4.sin_port=0;
@@ -394,7 +394,7 @@ try
     cout<<a.first<<": qcount="<<a.second.d_qcount<<", answercount="<<a.second.d_answercount<<endl;
   }
   */
-  
+
   cout<<"Timespan: "<<(highestTime-lowestTime)/3600.0<<" hours"<<endl;
 
   cout<<nonDNSIP<<" non-DNS UDP, "<<dnserrors<<" dns decoding errors, "<<parsefail<<" packets failed to parse"<<endl;
@@ -437,7 +437,7 @@ try
     totpairs+=i->second;
     tottime+=i->first*i->second;
   }
-  
+
   typedef map<uint32_t, bool> done_t;
   done_t done;
   for(auto a : {50, 100, 200, 300, 400, 800, 1000, 2000, 4000, 8000, 32000, 64000, 256000, 1024000, 2048000})
@@ -466,7 +466,7 @@ try
   }
 #endif
 
-  
+
   sum=0;
   double lastperc=0, perc=0;
   uint64_t lastsum=0;
@@ -481,7 +481,7 @@ try
           cout<< perc <<"% of questions answered within " << j->first << " usec (";
         else
           cout<< perc <<"% of questions answered within " << j->first/1000.0 << " msec (";
-        
+
         cout<<perc-lastperc<<"%)\n";
         lastperc=sum*100.0/totpairs;
         lastsum=sum;
@@ -497,24 +497,24 @@ try
         cout<< perc <<"% of questions answered within " << j->first << " usec (";
       else
         cout<< perc <<"% of questions answered within " << j->first/1000.0 << " msec (";
-      
+
       cout<<perc-lastperc<<"%)\n";
       lastperc=sum*100.0/totpairs;
       lastsum=sum;
       break;
     }
   }
-  
+
   cout<< (totpairs-lastsum)<<" responses ("<<((totpairs-lastsum)*100.0/answers) <<"%) older than "<< (done.rbegin()->first/1000000.0) <<" seconds"<<endl;
   if(totpairs)
     cout<<"Average non-late response time: "<<tottime/totpairs<<" usec"<<endl;
 
   if(!g_vm["load-stats"].as<string>().empty()) {
     ofstream load(g_vm["load-stats"].as<string>().c_str());
-    if(!load) 
+    if(!load)
       throw runtime_error("Error writing load statistics to "+g_vm["load-stats"].as<string>());
     for(pcounts_t::value_type& val :  pcounts) {
-      load<<val.first<<'\t'<<val.second.questions<<'\t'<<val.second.answers<<'\t'<<val.second.outstanding<<'\n';  
+      load<<val.first<<'\t'<<val.second.questions<<'\t'<<val.second.answers<<'\t'<<val.second.outstanding<<'\n';
     }
   }
 
@@ -528,7 +528,7 @@ try
   vector<ComboAddress> diff;
   set_difference(requestors.begin(), requestors.end(), recipients.begin(), recipients.end(), back_inserter(diff), ComboAddress::addressOnlyLessThan());
   cout<<"Saw "<<diff.size()<<" unique remotes asking questions, but not getting RA answers"<<endl;
-  
+
   ofstream ignored("ignored");
   for(const ComboAddress& rem :  diff) {
     ignored<<rem.toString()<<'\n';

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -235,7 +235,7 @@ public:
   void getFromMetaOrDefault(const DNSName& zname, const std::string& key, std::string& value, const std::string& defaultvalue);
   bool getFromMeta(const DNSName& zname, const std::string& key, std::string& value);
   void getSoaEdit(const DNSName& zname, std::string& value, bool useCache=true);
-  bool unSecureZone(const DNSName& zone, std::string& error, std::string& info);
+  bool unSecureZone(const DNSName& zone, std::string& error);
   bool rectifyZone(const DNSName& zone, std::string& error, std::string& info, bool doTransaction);
 
   static void setMaxEntries(size_t maxEntries);

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -176,7 +176,7 @@ static void addSignature(DNSSECKeeper& dk, UeberBackend& db, const DNSName& sign
   toSign.clear();
 }
 
-uint64_t signatureCacheSize(const std::string& str)
+uint64_t signatureCacheSize(const std::string& /* str */)
 {
   return g_signatures.read_lock()->size();
 }

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -114,7 +114,7 @@ static int getRRSIGsForRRSET(DNSSECKeeper& dk, const DNSName& signer, const DNSN
   rrc.d_type=signQType;
 
   rrc.d_labels=signQName.countLabels()-signQName.isWildcard();
-  rrc.d_originalttl=signTTL; 
+  rrc.d_originalttl=signTTL;
   rrc.d_siginception=startOfWeek - 7*86400; // XXX should come from zone metadata
   rrc.d_sigexpire=startOfWeek + 14*86400;
   rrc.d_signer = signer;
@@ -157,8 +157,8 @@ static void addSignature(DNSSECKeeper& dk, UeberBackend& db, const DNSName& sign
     if(getRRSIGsForRRSET(dk, signer, wildcardname.countLabels() ? wildcardname : signQName, signQType, signTTL, toSign, rrcs) < 0)  {
       // cerr<<"Error signing a record!"<<endl;
       return;
-    } 
-  
+    }
+
     DNSZoneRecord rr;
     rr.dr.d_name=signQName;
     rr.dr.d_type=QType::RRSIG;
@@ -197,19 +197,19 @@ static bool getBestAuthFromSet(const set<DNSName>& authSet, const DNSName& name,
     }
   }
   while(sname.chopOff());
-  
+
   return false;
 }
 
 void addRRSigs(DNSSECKeeper& dk, UeberBackend& db, const set<DNSName>& authSet, vector<DNSZoneRecord>& rrs)
 {
   stable_sort(rrs.begin(), rrs.end(), rrsigncomp);
-  
+
   DNSName signQName, wildcardQName;
   uint16_t signQType=0;
   uint32_t signTTL=0;
   uint32_t origTTL=0;
-  
+
   DNSResourceRecord::Place signPlace=DNSResourceRecord::ANSWER;
   sortedRecords_t toSign;
 

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -33,10 +33,10 @@
 #include <limits.h>
 
 /* d_content:                                      <---- d_stuff ---->
-                                      v d_truncatemarker  
+                                      v d_truncatemarker
    dnsheader | qname | qtype | qclass | {recordname| dnsrecordheader | record }
-                                        ^ d_rollbackmarker           ^ d_sor 
-    
+                                        ^ d_rollbackmarker           ^ d_sor
+
 
 */
 
@@ -213,7 +213,7 @@ template <typename Container> uint16_t GenericDNSPacketWriter<Container>::lookup
 
   /* name might be a.root-servers.net, we need to be able to benefit from finding:
      b.root-servers.net, or even:
-     b\xc0\x0c 
+     b\xc0\x0c
   */
   unsigned int bestpos=0;
   *matchLen=0;
@@ -236,10 +236,10 @@ template <typename Container> uint16_t GenericDNSPacketWriter<Container>::lookup
       cout<<"Domain "<<name<<" too large to compress"<<endl;
     return 0;
   }
-  
+
   if(l_verbose) {
     cout<<"Input vector for lookup "<<name<<": ";
-    for(const auto n : nvect) 
+    for(const auto n : nvect)
       cout << n<<" ";
     cout<<endl;
     cout<<makeHexDump(string(raw.c_str(), raw.c_str()+raw.size()))<<endl;
@@ -285,7 +285,7 @@ template <typename Container> uint16_t GenericDNSPacketWriter<Container>::lookup
     }
     if(l_verbose) {
       cout<<"Packet vector: "<<endl;
-      for(const auto n : pvect) 
+      for(const auto n : pvect)
         cout << n<<" ";
       cout<<endl;
     }
@@ -334,7 +334,7 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfrName(co
   uint16_t li=0;
   uint16_t matchlen=0;
   if(d_compress && compress && (li=lookupName(name, &matchlen)) && li < maxCompressionOffset) {
-    const auto& dns=name.getStorage(); 
+    const auto& dns=name.getStorage();
     if(l_verbose)
       cout<<"Found a substring of "<<matchlen<<" bytes from the back, offset: "<<li<<", dnslen: "<<dns.size()<<endl;
     // found a substring, if www.powerdns.com matched powerdns.com, we get back matchlen = 13

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -392,7 +392,7 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfrBlobNoS
   xfrBlob(blob);
 }
 
-template <typename Container> void GenericDNSPacketWriter<Container>::xfrHexBlob(const string& blob, bool keepReading)
+template <typename Container> void GenericDNSPacketWriter<Container>::xfrHexBlob(const string& blob, bool /* keepReading */)
 {
   xfrBlob(blob);
 }

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -139,11 +139,11 @@ struct DOHFrontend
   {
   }
 
-  void rotateTicketsKey(time_t now)
+  void rotateTicketsKey(time_t /* now */)
   {
   }
 
-  void loadTicketsKeys(const std::string& keyFile)
+  void loadTicketsKeys(const std::string& /* keyFile */)
   {
   }
 

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -50,7 +50,7 @@ bool DLQuitPlease()
   return s_pleasequit;
 }
 
-string DLQuitHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLQuitHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   string ret="No return value";
   if(parts[0]=="QUIT") {
@@ -66,7 +66,7 @@ static void dokill(int)
   exit(0);
 }
 
-string DLCurrentConfigHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLCurrentConfigHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   if(parts.size() > 1) {
     if(parts.size() == 2 && parts[1] == "diff") {
@@ -77,19 +77,20 @@ string DLCurrentConfigHandler(const vector<string>&parts, Utility::pid_t ppid)
   return ::arg().configstring(true, true);
 }
 
-string DLRQuitHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLRQuitHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   signal(SIGALRM, dokill);
   alarm(1);
   return "Exiting";
 }
 
-string DLPingHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLPingHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   return "PONG";
 }
 
-string DLShowHandler(const vector<string>&parts, Utility::pid_t ppid) {
+string DLShowHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
+{
   try {
     extern StatBag S;
     string ret("Wrong number of parameters");
@@ -114,21 +115,21 @@ void setStatus(const string &str)
   d_status=str;
 }
 
-string DLStatusHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLStatusHandler(const vector<string>& /* parts */, Utility::pid_t ppid)
 {
   ostringstream os;
   os<<ppid<<": "<<d_status;
   return os.str();
 }
 
-string DLUptimeHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLUptimeHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   ostringstream os;
   os<<humanDuration(time(nullptr)-g_starttime);
   return os.str();
 }
 
-string DLPurgeHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLPurgeHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   ostringstream os;
   int ret=0;
@@ -153,7 +154,7 @@ string DLPurgeHandler(const vector<string>&parts, Utility::pid_t ppid)
   return os.str();
 }
 
-string DLCCHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLCCHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   extern AuthPacketCache PC;
   extern AuthQueryCache QC;
@@ -162,7 +163,7 @@ string DLCCHandler(const vector<string>&parts, Utility::pid_t ppid)
   ostringstream os;
   bool first=true;
   for(map<char,uint64_t>::const_iterator i=counts.begin();i!=counts.end();++i) {
-    if(!first) 
+    if(!first)
       os<<", ";
     first=false;
 
@@ -170,24 +171,24 @@ string DLCCHandler(const vector<string>&parts, Utility::pid_t ppid)
       os<<"negative queries: ";
     else if(i->first=='Q')
       os<<"queries: ";
-    else 
+    else
       os<<"unknown: ";
 
     os<<i->second;
   }
-  if(!first) 
+  if(!first)
     os<<", ";
   os<<"packets: "<<packetEntries;
 
   return os.str();
 }
 
-string DLQTypesHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLQTypesHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   return g_rs.getQTypeReport();
 }
 
-string DLRSizesHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLRSizesHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   typedef map<uint16_t, uint64_t> respsizes_t;
   respsizes_t respsizes = g_rs.getSizeResponseCounts();
@@ -199,7 +200,7 @@ string DLRSizesHandler(const vector<string>&parts, Utility::pid_t ppid)
   return os.str();
 }
 
-string DLRemotesHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLRemotesHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   extern StatBag S;
   typedef vector<pair<string, unsigned int> > totals_t;
@@ -212,7 +213,7 @@ string DLRemotesHandler(const vector<string>&parts, Utility::pid_t ppid)
   return ret;
 }
 
-string DLSettingsHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLSettingsHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   static const char *whitelist[]={"query-logging",nullptr};
   const char **p;
@@ -220,7 +221,7 @@ string DLSettingsHandler(const vector<string>&parts, Utility::pid_t ppid)
   if(parts.size()!=3) {
     return "Syntax: set variable value";
   }
-  
+
   for(p=whitelist;*p;p++)
     if(*p==parts[1])
       break;
@@ -234,12 +235,12 @@ string DLSettingsHandler(const vector<string>&parts, Utility::pid_t ppid)
 
 }
 
-string DLVersionHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLVersionHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   return VERSION;
 }
 
-string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLNotifyRetrieveHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   extern CommunicatorClass Communicator;
   ostringstream os;
@@ -285,7 +286,7 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
   return "Added retrieval request for '" + domain.toLogString() + "' from primary " + master.toLogString();
 }
 
-string DLNotifyHostHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLNotifyHostHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   extern CommunicatorClass Communicator;
   ostringstream os;
@@ -313,7 +314,7 @@ string DLNotifyHostHandler(const vector<string>&parts, Utility::pid_t ppid)
   return "Added to queue";
 }
 
-string DLNotifyHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLNotifyHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   extern CommunicatorClass Communicator;
   UeberBackend B;
@@ -353,7 +354,7 @@ string DLNotifyHandler(const vector<string>&parts, Utility::pid_t ppid)
   }
 }
 
-string DLRediscoverHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLRediscoverHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   UeberBackend B;
   try {
@@ -368,7 +369,7 @@ string DLRediscoverHandler(const vector<string>&parts, Utility::pid_t ppid)
 
 }
 
-string DLReloadHandler(const vector<string>&parts, Utility::pid_t ppid)
+string DLReloadHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
   UeberBackend B;
   B.reload();
@@ -376,8 +377,7 @@ string DLReloadHandler(const vector<string>&parts, Utility::pid_t ppid)
   return "Ok";
 }
 
-
-string DLListZones(const vector<string>&parts, Utility::pid_t ppid)
+string DLListZones(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   UeberBackend B;
   g_log<<Logger::Notice<<"Received request to list zones."<<endl;
@@ -410,7 +410,7 @@ string DLListZones(const vector<string>&parts, Utility::pid_t ppid)
 extern bool PKCS11ModuleSlotLogin(const std::string& module, const string& tokenId, const std::string& pin);
 #endif
 
-string DLTokenLogin(const vector<string>&parts, Utility::pid_t ppid)
+string DLTokenLogin(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
 #ifndef HAVE_P11KIT1
   return "PKCS#11 support not compiled in";
@@ -427,7 +427,8 @@ string DLTokenLogin(const vector<string>&parts, Utility::pid_t ppid)
 #endif
 }
 
-string DLSuckRequests(const vector<string> &parts, Utility::pid_t ppid) {
+string DLSuckRequests(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
+{
   string ret;
   for (auto const &d: Communicator.getSuckRequests()) {
     ret += d.first.toString() + " " + d.second.toString() + "\n";

--- a/pdns/ixfrdist-stats.hh
+++ b/pdns/ixfrdist-stats.hh
@@ -64,9 +64,12 @@ class ixfrdistStats {
     void registerDomain(const DNSName& d) {
       domainStats[d].haveZone = false;
     }
-    void incrementUnknownDomainInQueries(const DNSName &d) { // the name is ignored. It would be great to report it, but we don't want to blow up Prometheus
+
+    void incrementUnknownDomainInQueries(const DNSName& /* d */)
+    { // the name is ignored. It would be great to report it, but we don't want to blow up Prometheus
       progStats.unknownDomainInQueries += 1;
     }
+
   private:
     class perDomainStat {
       public:

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -665,7 +665,7 @@ static bool handleAXFR(int fd, const MOADNSParser& mdp) {
 /* Produces an IXFR if one can be made according to the rules in RFC 1995 and
  * creates a SOA or AXFR packet when required by the RFC.
  */
-static bool handleIXFR(int fd, const ComboAddress& /* destination */, const MOADNSParser& mdp, const shared_ptr<SOARecordContent>& clientSOA) {
+static bool handleIXFR(int fd, const MOADNSParser& mdp, const shared_ptr<SOARecordContent>& clientSOA) {
   vector<std::shared_ptr<ixfrdiff_t>> toSend;
 
   /* we get a shared pointer of the zone info that we can't modify, ever.
@@ -943,7 +943,7 @@ static void tcpWorker(int tid) {
           continue;
         }
 
-        if (!handleIXFR(cfd, saddr, mdp, clientSOA)) {
+        if (!handleIXFR(cfd, mdp, clientSOA)) {
           close(cfd);
           continue;
         }

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -665,7 +665,7 @@ static bool handleAXFR(int fd, const MOADNSParser& mdp) {
 /* Produces an IXFR if one can be made according to the rules in RFC 1995 and
  * creates a SOA or AXFR packet when required by the RFC.
  */
-static bool handleIXFR(int fd, const ComboAddress& destination, const MOADNSParser& mdp, const shared_ptr<SOARecordContent>& clientSOA) {
+static bool handleIXFR(int fd, const ComboAddress& /* destination */, const MOADNSParser& mdp, const shared_ptr<SOARecordContent>& clientSOA) {
   vector<std::shared_ptr<ixfrdiff_t>> toSend;
 
   /* we get a shared pointer of the zone info that we can't modify, ever.

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -350,11 +350,11 @@ static T pickWeightedRandom(const vector< pair<int, T> >& items)
     sum += i.first;
     pick.emplace_back(sum, i.second);
   }
-  
+
   if (sum == 0) {
     throw std::invalid_argument("The sum of items cannot be zero");
   }
-  
+
   int r = dns_random(sum);
   auto p = upper_bound(pick.begin(), pick.end(), r, [](int rarg, const typename decltype(pick)::value_type& a) { return rarg < a.first; });
   return p->second;
@@ -374,7 +374,7 @@ static T pickWeightedHashed(const ComboAddress& bestwho, vector< pair<int, T> >&
     sum += i.first;
     pick.push_back({sum, i.second});
   }
-  
+
   if (sum == 0) {
     throw std::invalid_argument("The sum of items cannot be zero");
   }
@@ -386,27 +386,27 @@ static T pickWeightedHashed(const ComboAddress& bestwho, vector< pair<int, T> >&
 }
 
 template <typename T>
-static vector<T> pickRandomSample(int n, const vector<T>& items) 
+static vector<T> pickRandomSample(int n, const vector<T>& items)
 {
   if (items.empty()) {
     throw std::invalid_argument("The items list cannot be empty");
   }
-  
+
   vector<T> pick;
   pick.reserve(items.size());
-  
+
   for(auto& item : items) {
     pick.push_back(item);
   }
-  
+
   int count = std::min(std::max<size_t>(0, n), items.size());
 
   if (count == 0) {
     return vector<T>();
-  }  
+  }
 
   std::shuffle(pick.begin(), pick.end(), pdns::dns_random_engine());
-  
+
   vector<T> result = {pick.begin(), pick.begin() + count};
   return result;
 }
@@ -637,9 +637,9 @@ static void setupLuaRecords(LuaContext& lua)
         auto labels = s_lua_record_ctx->qname.getRawLabels();
         if(labels.size()<4)
           return std::string("unknown");
-        
+
         vector<ComboAddress> candidates;
-        
+
         // so, query comes in for 4.3.2.1.in-addr.arpa, zone is called 2.1.in-addr.arpa
         // e["1.2.3.4"]="bert.powerdns.com" then provides an exception
         if(e) {
@@ -652,7 +652,7 @@ static void setupLuaRecords(LuaContext& lua)
         boost::format fmt(format);
         fmt.exceptions( boost::io::all_error_bits ^ ( boost::io::too_many_args_bit | boost::io::too_few_args_bit )  );
         fmt % labels[3] % labels[2] % labels[1] % labels[0];
-        
+
         fmt % (labels[3]+"-"+labels[2]+"-"+labels[1]+"-"+labels[0]);
 
         boost::format fmt2("%02x%02x%02x%02x");
@@ -1070,7 +1070,7 @@ static void setupLuaRecords(LuaContext& lua)
   lua.writeFunction("all", [](const vector< pair<int,string> >& ips) {
       vector<string> result;
 	  result.reserve(ips.size());
-	  
+
       for(const auto& ip : ips) {
           result.emplace_back(ip.second);
       }
@@ -1117,7 +1117,7 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
   s_lua_record_ctx->qname = query;
   s_lua_record_ctx->zone = zone;
   s_lua_record_ctx->zoneid = zoneid;
-  
+
   lua.writeVariable("qname", query);
   lua.writeVariable("zone", zone);
   lua.writeVariable("zoneid", zoneid);

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -972,7 +972,7 @@ static void setupLuaRecords(LuaContext& lua)
       lua.executeCode(boost::str(boost::format("debug.sethook(report, '', %d)") % g_luaRecordExecLimit));
   }
 
-  lua.writeFunction("report", [](string event, boost::optional<string> line){
+  lua.writeFunction("report", [](string /* event */, boost::optional<string> /* line */){
       throw std::runtime_error("Script took too long");
     });
 

--- a/pdns/minicurl.cc
+++ b/pdns/minicurl.cc
@@ -80,7 +80,7 @@ size_t MiniCurl::write_callback(char *ptr, size_t size, size_t nmemb, void *user
 }
 
 #if defined(LIBCURL_VERSION_NUM) && LIBCURL_VERSION_NUM >= 0x072000 // 7.32.0
-size_t MiniCurl::progress_callback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
+size_t MiniCurl::progress_callback(void *clientp, curl_off_t /* dltotal */, curl_off_t dlnow, curl_off_t /* ultotal */, curl_off_t /* ulnow */)
 {
   if (clientp != nullptr) {
     MiniCurl* us = static_cast<MiniCurl*>(clientp);

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1257,7 +1257,7 @@ uint64_t udp6ErrorStats(const std::string& str)
   return 0;
 }
 
-uint64_t tcpErrorStats(const std::string& str)
+uint64_t tcpErrorStats(const std::string& /* str */)
 {
 #ifdef __linux__
   ifstream ifs("/proc/net/netstat");
@@ -1282,7 +1282,7 @@ uint64_t tcpErrorStats(const std::string& str)
   return 0;
 }
 
-uint64_t getCPUIOWait(const std::string& str)
+uint64_t getCPUIOWait(const std::string& /* str */)
 {
 #ifdef __linux__
   ifstream ifs("/proc/stat");
@@ -1307,7 +1307,7 @@ uint64_t getCPUIOWait(const std::string& str)
   return 0;
 }
 
-uint64_t getCPUSteal(const std::string& str)
+uint64_t getCPUSteal(const std::string& /* str */)
 {
 #ifdef __linux__
   ifstream ifs("/proc/stat");

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -192,7 +192,7 @@ void NSECRecordContent::toPacket(DNSPacketWriter& pw)
   d_bitmap.toPacket(pw);
 }
 
-std::shared_ptr<NSECRecordContent::DNSRecordContent> NSECRecordContent::make(const DNSRecord &dr, PacketReader& pr)
+std::shared_ptr<NSECRecordContent::DNSRecordContent> NSECRecordContent::make(const DNSRecord & /* dr */, PacketReader& pr)
 {
   auto ret=std::make_shared<NSECRecordContent>();
   pr.xfrName(ret->d_next);
@@ -202,7 +202,7 @@ std::shared_ptr<NSECRecordContent::DNSRecordContent> NSECRecordContent::make(con
   return ret;
 }
 
-string NSECRecordContent::getZoneRepresentation(bool noDot) const
+string NSECRecordContent::getZoneRepresentation(bool /* noDot */) const
 {
   string ret;
   RecordTextWriter rtw(ret);
@@ -254,7 +254,7 @@ void NSEC3RecordContent::toPacket(DNSPacketWriter& pw)
   d_bitmap.toPacket(pw);
 }
 
-std::shared_ptr<NSEC3RecordContent::DNSRecordContent> NSEC3RecordContent::make(const DNSRecord &dr, PacketReader& pr)
+std::shared_ptr<NSEC3RecordContent::DNSRecordContent> NSEC3RecordContent::make(const DNSRecord& /* dr */, PacketReader& pr)
 {
   auto ret=std::make_shared<NSEC3RecordContent>();
   pr.xfr8BitInt(ret->d_algorithm);
@@ -271,7 +271,7 @@ std::shared_ptr<NSEC3RecordContent::DNSRecordContent> NSEC3RecordContent::make(c
   return ret;
 }
 
-string NSEC3RecordContent::getZoneRepresentation(bool noDot) const
+string NSEC3RecordContent::getZoneRepresentation(bool /* noDot */) const
 {
   string ret;
   RecordTextWriter rtw(ret);
@@ -316,7 +316,7 @@ void NSEC3PARAMRecordContent::toPacket(DNSPacketWriter& pw)
   pw.xfrBlob(d_salt);
 }
 
-std::shared_ptr<NSEC3PARAMRecordContent::DNSRecordContent> NSEC3PARAMRecordContent::make(const DNSRecord &dr, PacketReader& pr)
+std::shared_ptr<NSEC3PARAMRecordContent::DNSRecordContent> NSEC3PARAMRecordContent::make(const DNSRecord& /* dr */, PacketReader& pr)
 {
   auto ret=std::make_shared<NSEC3PARAMRecordContent>();
   pr.xfr8BitInt(ret->d_algorithm);
@@ -328,7 +328,7 @@ std::shared_ptr<NSEC3PARAMRecordContent::DNSRecordContent> NSEC3PARAMRecordConte
   return ret;
 }
 
-string NSEC3PARAMRecordContent::getZoneRepresentation(bool noDot) const
+string NSEC3PARAMRecordContent::getZoneRepresentation(bool /* noDot */) const
 {
   string ret;
   RecordTextWriter rtw(ret);
@@ -374,7 +374,7 @@ void CSYNCRecordContent::toPacket(DNSPacketWriter& pw)
   d_bitmap.toPacket(pw);
 }
 
-std::shared_ptr<CSYNCRecordContent::DNSRecordContent> CSYNCRecordContent::make(const DNSRecord &dr, PacketReader& pr)
+std::shared_ptr<CSYNCRecordContent::DNSRecordContent> CSYNCRecordContent::make(const DNSRecord& /* dr */, PacketReader& pr)
 {
   auto ret=std::make_shared<CSYNCRecordContent>();
   pr.xfr32BitInt(ret->d_serial);
@@ -384,7 +384,7 @@ std::shared_ptr<CSYNCRecordContent::DNSRecordContent> CSYNCRecordContent::make(c
   return ret;
 }
 
-string CSYNCRecordContent::getZoneRepresentation(bool noDot) const
+string CSYNCRecordContent::getZoneRepresentation(bool /* noDot */) const
 {
   string ret;
   RecordTextWriter rtw(ret);

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -108,7 +108,7 @@ void NSECBitmap::fromPacket(PacketReader& pr)
   if(bitmap.size() < 2) {
     throw MOADNSException("NSEC record with impossibly small bitmap");
   }
-  
+
   for(unsigned int n = 0; n+1 < bitmap.size();) {
     uint8_t window=static_cast<uint8_t>(bitmap[n++]);
     uint8_t blen=static_cast<uint8_t>(bitmap[n++]);
@@ -232,7 +232,7 @@ NSEC3RecordContent::NSEC3RecordContent(const string& content, const DNSName& zon
 
   rtr.xfrHexBlob(d_salt);
   rtr.xfrBase32HexBlob(d_nexthash);
-  
+
   while(!rtr.eof()) {
     uint16_t type;
     rtr.xfrType(type);
@@ -240,7 +240,7 @@ NSEC3RecordContent::NSEC3RecordContent(const string& content, const DNSName& zon
   }
 }
 
-void NSEC3RecordContent::toPacket(DNSPacketWriter& pw) 
+void NSEC3RecordContent::toPacket(DNSPacketWriter& pw)
 {
   pw.xfr8BitInt(d_algorithm);
   pw.xfr8BitInt(d_flags);
@@ -300,17 +300,17 @@ std::shared_ptr<DNSRecordContent> NSEC3PARAMRecordContent::make(const string& co
 NSEC3PARAMRecordContent::NSEC3PARAMRecordContent(const string& content, const DNSName& zone)
 {
   RecordTextReader rtr(content, zone);
-  rtr.xfr8BitInt(d_algorithm); 
-  rtr.xfr8BitInt(d_flags); 
-  rtr.xfr16BitInt(d_iterations); 
+  rtr.xfr8BitInt(d_algorithm);
+  rtr.xfr8BitInt(d_flags);
+  rtr.xfr16BitInt(d_iterations);
   rtr.xfrHexBlob(d_salt);
 }
 
-void NSEC3PARAMRecordContent::toPacket(DNSPacketWriter& pw) 
+void NSEC3PARAMRecordContent::toPacket(DNSPacketWriter& pw)
 {
-  pw.xfr8BitInt(d_algorithm); 
-        pw.xfr8BitInt(d_flags); 
-        pw.xfr16BitInt(d_iterations); 
+  pw.xfr8BitInt(d_algorithm);
+        pw.xfr8BitInt(d_flags);
+        pw.xfr16BitInt(d_iterations);
   pw.xfr8BitInt(d_salt.length());
   // cerr<<"salt: '"<<makeHexDump(d_salt)<<"', "<<d_salt.length()<<endl;
   pw.xfrBlob(d_salt);
@@ -319,9 +319,9 @@ void NSEC3PARAMRecordContent::toPacket(DNSPacketWriter& pw)
 std::shared_ptr<NSEC3PARAMRecordContent::DNSRecordContent> NSEC3PARAMRecordContent::make(const DNSRecord &dr, PacketReader& pr)
 {
   auto ret=std::make_shared<NSEC3PARAMRecordContent>();
-  pr.xfr8BitInt(ret->d_algorithm); 
-        pr.xfr8BitInt(ret->d_flags); 
-        pr.xfr16BitInt(ret->d_iterations); 
+  pr.xfr8BitInt(ret->d_algorithm);
+        pr.xfr8BitInt(ret->d_flags);
+        pr.xfr16BitInt(ret->d_iterations);
   uint8_t len;
   pr.xfr8BitInt(len);
   pr.xfrHexBlob(ret->d_salt, len);
@@ -332,9 +332,9 @@ string NSEC3PARAMRecordContent::getZoneRepresentation(bool noDot) const
 {
   string ret;
   RecordTextWriter rtw(ret);
-  rtw.xfr8BitInt(d_algorithm); 
-        rtw.xfr8BitInt(d_flags); 
-        rtw.xfr16BitInt(d_iterations); 
+  rtw.xfr8BitInt(d_algorithm);
+        rtw.xfr8BitInt(d_flags);
+        rtw.xfr16BitInt(d_iterations);
   rtw.xfrHexBlob(d_salt);
   return ret;
 }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -459,7 +459,7 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
   return haveSomething;
 }
 
-DNSName PacketHandler::doAdditionalServiceProcessing(const DNSName &firstTarget, const uint16_t &qtype, std::unique_ptr<DNSPacket>& r, vector<DNSZoneRecord>& extraRecords) {
+DNSName PacketHandler::doAdditionalServiceProcessing(const DNSName &firstTarget, const uint16_t &qtype, std::unique_ptr<DNSPacket>& /* r */, vector<DNSZoneRecord>& extraRecords) {
   DNSName ret = firstTarget;
   size_t ctr = 5; // Max 5 SVCB Aliasforms per query
   bool done = false;
@@ -909,7 +909,7 @@ void PacketHandler::addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const 
   }
 }
 
-void PacketHandler::addNSEC(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName& target, const DNSName& wildcard, int mode)
+void PacketHandler::addNSEC(DNSPacket& /* p */, std::unique_ptr<DNSPacket>& r, const DNSName& target, const DNSName& wildcard, int mode)
 {
   DLOG(g_log<<"addNSEC() mode="<<mode<<" auth="<<d_sd.qname<<" target="<<target<<" wildcard="<<wildcard<<endl);
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1881,7 +1881,7 @@ static bool disableDNSSECOnZone(DNSSECKeeper& dk, const DNSName& zone)
   }
 
   string error, info;
-  bool ret = dk.unSecureZone(zone, error, info);
+  bool ret = dk.unSecureZone(zone, error);
   if (!ret) {
     cerr << error << endl;
   }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1120,7 +1120,7 @@ static int read1char(){
     return c;
 }
 
-static int clearZone(DNSSECKeeper& dk, const DNSName &zone) {
+static int clearZone(DNSSECKeeper& /* dk */, const DNSName &zone) {
   UeberBackend B;
   DomainInfo di;
 
@@ -1785,7 +1785,7 @@ static bool testAlgorithms()
   return DNSCryptoKeyEngine::testAll();
 }
 
-static void testSpeed(DNSSECKeeper& dk, const DNSName& zone, const string& remote, int cores)
+static void testSpeed(DNSSECKeeper& /* dk */, const DNSName& zone, const string& /* remote */, int cores)
 {
   DNSResourceRecord rr;
   rr.qname=DNSName("blah")+zone;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1120,7 +1120,7 @@ static int read1char(){
     return c;
 }
 
-static int clearZone(DNSSECKeeper& /* dk */, const DNSName &zone) {
+static int clearZone(const DNSName &zone) {
   UeberBackend B;
   DomainInfo di;
 
@@ -1785,7 +1785,7 @@ static bool testAlgorithms()
   return DNSCryptoKeyEngine::testAll();
 }
 
-static void testSpeed(DNSSECKeeper& /* dk */, const DNSName& zone, const string& /* remote */, int cores)
+static void testSpeed(const DNSName& zone, const string& /* remote */, int cores)
 {
   DNSResourceRecord rr;
   rr.qname=DNSName("blah")+zone;
@@ -2814,7 +2814,7 @@ try
       cerr << "Syntax: pdnsutil test-speed numcores [signing-server]"<<endl;
       return 0;
     }
-    testSpeed(dk, DNSName(cmds.at(1)), (cmds.size() > 3) ? cmds.at(3) : "", pdns::checked_stoi<int>(cmds.at(2)));
+    testSpeed(DNSName(cmds.at(1)), (cmds.size() > 3) ? cmds.at(3) : "", pdns::checked_stoi<int>(cmds.at(2)));
   }
   else if (cmds.at(0) == "verify-crypto") {
     if(cmds.size() != 2) {
@@ -3131,7 +3131,7 @@ try
     if (cmds.at(1) == ".")
       cmds.at(1).clear();
 
-    return clearZone(dk, DNSName(cmds.at(1)));
+    return clearZone(DNSName(cmds.at(1)));
   }
   else if (cmds.at(0) == "list-keys") {
     if(cmds.size() > 2) {

--- a/pdns/pkcs11signers.hh
+++ b/pdns/pkcs11signers.hh
@@ -34,10 +34,6 @@ class PKCS11DNSCryptoKeyEngine : public DNSCryptoKeyEngine
     PKCS11DNSCryptoKeyEngine(unsigned int algorithm);
     ~PKCS11DNSCryptoKeyEngine();
 
-    bool operator<(const PKCS11DNSCryptoKeyEngine& /* rhs */) const
-    {
-      return false;
-    }
     PKCS11DNSCryptoKeyEngine(const PKCS11DNSCryptoKeyEngine& orig);
 
     string getName() const override { return "P11 Kit PKCS#11"; };

--- a/pdns/pkcs11signers.hh
+++ b/pdns/pkcs11signers.hh
@@ -34,7 +34,7 @@ class PKCS11DNSCryptoKeyEngine : public DNSCryptoKeyEngine
     PKCS11DNSCryptoKeyEngine(unsigned int algorithm);
     ~PKCS11DNSCryptoKeyEngine();
 
-    bool operator<(const PKCS11DNSCryptoKeyEngine& rhs) const
+    bool operator<(const PKCS11DNSCryptoKeyEngine& /* rhs */) const
     {
       return false;
     }
@@ -57,7 +57,7 @@ class PKCS11DNSCryptoKeyEngine : public DNSCryptoKeyEngine
 
     void fromISCMap(DNSKEYRecordContent& drc, stormap_t& stormap) override;
 
-    void fromPublicKeyString(const std::string& content) override { throw "Unimplemented"; };
+    void fromPublicKeyString(const std::string& /* content */) override { throw "Unimplemented"; };
 
     static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm);
 };

--- a/pdns/pollmplexer.cc
+++ b/pdns/pollmplexer.cc
@@ -28,7 +28,7 @@ FDMultiplexer* FDMultiplexer::getMultiplexerSilent(unsigned int maxEventsHint)
 class PollFDMultiplexer : public FDMultiplexer
 {
 public:
-  PollFDMultiplexer(unsigned int maxEventsHint)
+  PollFDMultiplexer(unsigned int /* maxEventsHint */)
   {}
   ~PollFDMultiplexer()
   {

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -568,7 +568,7 @@ void RecordTextWriter::xfrBase32HexBlob(const string& val)
 }
 
 
-void RecordTextReader::xfrText(string& val, bool multi, bool lenField)
+void RecordTextReader::xfrText(string& val, bool multi, bool /* lenField */)
 {
   val.clear();
   val.reserve(d_end - d_pos);
@@ -607,7 +607,7 @@ void RecordTextReader::xfrText(string& val, bool multi, bool lenField)
   }
 }
 
-void RecordTextReader::xfrUnquotedText(string& val, bool lenField)
+void RecordTextReader::xfrUnquotedText(string& val, bool /* lenField */)
 {
   val.clear();
   val.reserve(d_end - d_pos);
@@ -741,7 +741,7 @@ void RecordTextWriter::xfrIP6(const std::string& val)
   d_string += std::string(addrbuf);
 }
 
-void RecordTextWriter::xfrCAWithoutPort(uint8_t version, ComboAddress &val)
+void RecordTextWriter::xfrCAWithoutPort(uint8_t /* version */, ComboAddress &val)
 {
   string ip = val.toString();
 
@@ -781,7 +781,7 @@ void RecordTextWriter::xfr8BitInt(const uint8_t& val)
 }
 
 // should not mess with the escapes
-void RecordTextWriter::xfrName(const DNSName& val, bool, bool noDot)
+void RecordTextWriter::xfrName(const DNSName& val, bool /* unused */, bool /* noDot */)
 {
   if(!d_string.empty())
     d_string.append(1,' ');
@@ -941,7 +941,7 @@ void RecordTextWriter::xfrSvcParamKeyVals(const set<SvcParam>& val) {
   }
 }
 
-void RecordTextWriter::xfrText(const string& val, bool multi, bool lenField)
+void RecordTextWriter::xfrText(const string& val, bool /* multi */, bool /* lenField */)
 {
   if(!d_string.empty())
     d_string.append(1,' ');
@@ -949,7 +949,7 @@ void RecordTextWriter::xfrText(const string& val, bool multi, bool lenField)
   d_string.append(val);
 }
 
-void RecordTextWriter::xfrUnquotedText(const string& val, bool lenField)
+void RecordTextWriter::xfrUnquotedText(const string& val, bool /* lenField */)
 {
   if(!d_string.empty())
     d_string.append(1,' ');

--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -26,7 +26,7 @@
 #include "lwres.hh"
 #include <iostream>
 #include "dnsrecords.hh"
-#include <errno.h>
+#include <cerrno>
 #include "misc.hh"
 #include <algorithm>
 #include <sstream>

--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -314,7 +314,7 @@ static bool tcpconnect(const struct timeval& now, const ComboAddress& ip, TCPOut
       dnsOverTLS = false;
     }
   }
-  connection.d_handler = std::make_shared<TCPIOHandler>(nsName, false, s.releaseHandle(), timeout, tlsCtx, now.tv_sec);
+  connection.d_handler = std::make_shared<TCPIOHandler>(nsName, false, s.releaseHandle(), timeout, tlsCtx);
   // Returned state ignored
   // This can throw an exception, retry will need to happen at higher level
   connection.d_handler->tryConnect(SyncRes::s_tcp_fast_open_connect, ip);

--- a/pdns/recursordist/rec-carbon.cc
+++ b/pdns/recursordist/rec-carbon.cc
@@ -49,7 +49,7 @@ void doCarbonDump(void*)
       {
         g_networkTimeoutMsec / 1000, static_cast<suseconds_t>(g_networkTimeoutMsec) % 1000 * 1000
       };
-      auto handler = std::make_shared<TCPIOHandler>("", false, s.releaseHandle(), timeout, tlsCtx, time(nullptr));
+      auto handler = std::make_shared<TCPIOHandler>("", false, s.releaseHandle(), timeout, tlsCtx);
       handler->tryConnect(SyncRes::s_tcp_fast_open_connect, remote); // we do the connect so the first attempt happens while we gather stats
 
       if (msg.empty()) {

--- a/pdns/recursordist/recpacketcache.cc
+++ b/pdns/recursordist/recpacketcache.cc
@@ -201,7 +201,7 @@ uint64_t RecursorPacketCache::bytes() const
 
 void RecursorPacketCache::doPruneTo(size_t maxCached)
 {
-  pruneCollection<SequencedTag>(*this, d_packetCache, maxCached);
+  pruneCollection<SequencedTag>(d_packetCache, maxCached);
 }
 
 uint64_t RecursorPacketCache::doDump(int fd)

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -1408,7 +1408,7 @@ void AsyncWebServer::serveConnection(std::shared_ptr<Socket> client) const
     if (d_loglevel > WebServer::LogLevel::None) {
       client->getRemote(remote);
     }
-    auto handler = std::make_shared<TCPIOHandler>("", false, client->releaseHandle(), timeout, tlsCtx, time(nullptr));
+    auto handler = std::make_shared<TCPIOHandler>("", false, client->releaseHandle(), timeout, tlsCtx);
 
     PacketBuffer data;
     try {

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -193,7 +193,7 @@ uint16_t Resolver::sendResolve(const ComboAddress& remote, const ComboAddress& l
 
 namespace pdns {
   namespace resolver {
-    int parseResult(MOADNSParser& mdp, const DNSName& origQname, uint16_t origQtype, uint16_t id, Resolver::res_t* result)
+    int parseResult(MOADNSParser& mdp, const DNSName& origQname, uint16_t /* origQtype */, uint16_t id, Resolver::res_t* result)
     {
       result->clear();
 

--- a/pdns/responsestats.cc
+++ b/pdns/responsestats.cc
@@ -47,7 +47,7 @@ void ResponseStats::submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rc
   submitResponse(qtype, respsize, udpOrTCP);
 }
 
-void ResponseStats::submitResponse(uint16_t qtype, uint16_t respsize, bool udpOrTCP) const
+void ResponseStats::submitResponse(uint16_t qtype, uint16_t respsize, bool /* udpOrTCP */) const
 {
   d_qtypecounters.at(qtype).value++;
   d_sizecounters(respsize);

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -417,7 +417,7 @@ try {
     Socket sock(dest.sin4.sin_family, SOCK_STREAM);
     sock.setNonBlocking();
     setTCPNoDelay(sock.getHandle()); // disable NAGLE, which does not play nicely with delayed ACKs
-    TCPIOHandler handler(subjectName, false, sock.releaseHandle(), timeout, tlsCtx, time(nullptr));
+    TCPIOHandler handler(subjectName, false, sock.releaseHandle(), timeout, tlsCtx);
     handler.connect(fastOpen, dest, timeout);
     // we are writing the proxyheader inside the TLS connection. Is that right?
     if (proxyheader.size() > 0 && handler.write(proxyheader.data(), proxyheader.size(), timeout) != proxyheader.size()) {

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -180,7 +180,7 @@ void LOCRecordContent::toPacket(DNSPacketWriter& pw)
   pw.xfr32BitInt(d_altitude);
 }
 
-std::shared_ptr<LOCRecordContent::DNSRecordContent> LOCRecordContent::make(const DNSRecord &dr, PacketReader& pr) 
+std::shared_ptr<LOCRecordContent::DNSRecordContent> LOCRecordContent::make(const DNSRecord& /* dr */, PacketReader& pr)
 {
   auto ret=std::make_shared<LOCRecordContent>();
   pr.xfr8BitInt(ret->d_version);
@@ -195,7 +195,7 @@ std::shared_ptr<LOCRecordContent::DNSRecordContent> LOCRecordContent::make(const
   return ret;
 }
 
-LOCRecordContent::LOCRecordContent(const string& content, const string& zone) 
+LOCRecordContent::LOCRecordContent(const string& content, const string& /* zone */)
 {
   // 51 59 00.000 N 5 55 00.000 E 4.00m 1.00m 10000.00m 10.00m
   // convert this to d_version, d_size, d_horiz/vertpre, d_latitude, d_longitude, d_altitude
@@ -296,7 +296,7 @@ LOCRecordContent::LOCRecordContent(const string& content, const string& zone)
 }
 
 
-string LOCRecordContent::getZoneRepresentation(bool noDot) const
+string LOCRecordContent::getZoneRepresentation(bool /* noDot */) const
 {
   // convert d_version, d_size, d_horiz/vertpre, d_latitude, d_longitude, d_altitude to:
   // 51 59 00.000 N 5 55 00.000 E 4.00m 1.00m 10000.00m 10.00m

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -69,22 +69,22 @@ latlon2ul(const char **latlonstrptr, int *which)
 
   while (isdigit(*cp))
     deg = deg * 10 + (*cp++ - '0');
-  
+
   while (isspace(*cp))
     cp++;
-  
+
   if (!(isdigit(*cp)))
     goto fndhemi;
-  
+
   while (isdigit(*cp))
     min = min * 10 + (*cp++ - '0');
-    
+
   while (isspace(*cp))
     cp++;
-  
+
   if (*cp && !(isdigit(*cp)))
     goto fndhemi;
-  
+
   while (isdigit(*cp))
     secs = secs * 10 + (*cp++ - '0');
 
@@ -100,13 +100,13 @@ latlon2ul(const char **latlonstrptr, int *which)
       }
     }
   }
-  
+
   while (*cp && !isspace(*cp))   /* if any trailing garbage */
     cp++;
-  
+
   while (isspace(*cp))
     cp++;
-  
+
  fndhemi:
   switch (*cp) {
   case 'N': case 'n':
@@ -125,7 +125,7 @@ latlon2ul(const char **latlonstrptr, int *which)
     retval = 0;     /* invalid value -- indicates error */
     break;
   }
-  
+
   switch (*cp) {
   case 'N': case 'n':
   case 'S': case 's':
@@ -144,15 +144,15 @@ latlon2ul(const char **latlonstrptr, int *which)
     return 0;
 
   cp++;                   /* skip the hemisphere */
-  
+
   while (*cp && !isspace(*cp))   /* if any trailing garbage */
     cp++;
-  
+
   while (isspace(*cp))    /* move to next field */
     cp++;
-  
+
   *latlonstrptr = cp;
-  
+
   return (retval);
 }
 
@@ -191,7 +191,7 @@ std::shared_ptr<LOCRecordContent::DNSRecordContent> LOCRecordContent::make(const
   pr.xfr32BitInt(ret->d_latitude);
   pr.xfr32BitInt(ret->d_longitude);
   pr.xfr32BitInt(ret->d_altitude);
-  
+
   return ret;
 }
 
@@ -202,7 +202,7 @@ LOCRecordContent::LOCRecordContent(const string& content, const string& zone)
   d_version = 0;
 
   const char *cp, *maxcp;
-  
+
   uint32_t lltemp1 = 0, lltemp2 = 0;
   int altmeters = 0, altfrac = 0, altsign = 1;
   d_horizpre = 0x16;    /* default = 1e6 cm = 10000.00m = 10km */
@@ -240,10 +240,10 @@ LOCRecordContent::LOCRecordContent(const string& content, const string& zone)
 
   if (*cp == '+')
     cp++;
-  
+
   while (isdigit(*cp))
     altmeters = altmeters * 10 + (*cp++ - '0');
-  
+
   if (*cp == '.') {               /* decimal meters */
     cp++;
     if (isdigit(*cp)) {
@@ -253,44 +253,44 @@ LOCRecordContent::LOCRecordContent(const string& content, const string& zone)
       }
     }
   }
-  
+
   d_altitude = (10000000 + (altsign * (altmeters * 100 + altfrac)));
-  
+
   while (!isspace(*cp) && (cp < maxcp))
     /* if trailing garbage or m */
     cp++;
-  
+
   while (isspace(*cp) && (cp < maxcp))
     cp++;
-  
-  
+
+
   if (cp >= maxcp)
     goto defaults;
-  
+
   d_size = precsize_aton(&cp);
-  
+
   while (!isspace(*cp) && (cp < maxcp))/*if trailing garbage or m*/
     cp++;
-  
+
   while (isspace(*cp) && (cp < maxcp))
     cp++;
-  
+
   if (cp >= maxcp)
     goto defaults;
-  
+
   d_horizpre = precsize_aton(&cp);
-  
+
   while (!isspace(*cp) && (cp < maxcp))/*if trailing garbage or m*/
     cp++;
-  
+
   while (isspace(*cp) && (cp < maxcp))
     cp++;
-  
+
   if (cp >= maxcp)
     goto defaults;
-  
+
   d_vertpre = precsize_aton(&cp);
-  
+
  defaults:
   ;
 }
@@ -304,7 +304,7 @@ string LOCRecordContent::getZoneRepresentation(bool noDot) const
   double latitude= ((int32_t)((uint32_t)d_latitude  - ((uint32_t)1<<31)))/3600000.0;
   double longitude=((int32_t)((uint32_t)d_longitude - ((uint32_t)1<<31)))/3600000.0;
   double altitude= ((int32_t)d_altitude           )/100.0 - 100000;
-  
+
   double size=0.01*((d_size>>4)&0xf);
   int count=d_size & 0xf;
   while(count--)

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -454,27 +454,27 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
     auto deltas = getIXFRDeltas(remote, domain, drsoa, xfrTimeout, false, tt, laddr.sin4.sin_family ? &laddr : nullptr, ((size_t) ::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024);
     zs.numDeltas=deltas.size();
     //    cout<<"Got "<<deltas.size()<<" deltas from serial "<<di.serial<<", applying.."<<endl;
-    
+
     for(const auto& d : deltas) {
       const auto& remove = d.first;
       const auto& add = d.second;
       //      cout<<"Delta sizes: "<<remove.size()<<", "<<add.size()<<endl;
-      
+
       if(remove.empty()) { // we got passed an AXFR!
         *axfr = add;
         return;
       }
-        
+
 
       // our hammer is 'replaceRRSet(domain_id, qname, qt, vector<DNSResourceRecord>& rrset)
       // which thinks in terms of RRSETs
       // however, IXFR does not, and removes and adds *records* (bummer)
       // this means that we must group updates by {qname,qtype}, retrieve the RRSET, apply
-      // the add/remove updates, and replaceRRSet the whole thing. 
-      
-      
+      // the add/remove updates, and replaceRRSet the whole thing.
+
+
       map<pair<DNSName,uint16_t>, pair<vector<DNSRecord>, vector<DNSRecord> > > grouped;
-      
+
       for(const auto& x: remove)
         grouped[{x.d_name, x.d_type}].first.push_back(x);
       for(const auto& x: add)
@@ -492,9 +492,9 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
           }
         }
         // O(N^2)!
-        rrset.erase(remove_if(rrset.begin(), rrset.end(), 
+        rrset.erase(remove_if(rrset.begin(), rrset.end(),
                               [&g](const DNSRecord& dr) {
-                                return count(g.second.first.cbegin(), 
+                                return count(g.second.first.cbegin(),
                                              g.second.first.cend(), dr);
                               }), rrset.end());
         // the DNSRecord== operator compares on name, type, class and lowercase content representation
@@ -513,7 +513,7 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
             auto sr = getRR<SOARecordContent>(dr);
             zs.soa_serial=sr->d_st.serial;
           }
-          
+
           replacement.push_back(rr);
         }
 
@@ -529,14 +529,13 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
   catch(PDNSException& p) {
     g_log<<Logger::Error<<logPrefix<<"got exception (PDNSException): "<<p.reason<<endl;
     throw;
-  }  
+  }
 }
-
 
 static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResourceRecord& rr, ZoneStatus& zs)
 {
   switch(rr.qtype.getCode()) {
-  case QType::NSEC3PARAM: 
+  case QType::NSEC3PARAM:
     zs.ns3pr = NSEC3PARAMRecordContent(rr.content);
     zs.isDnssecZone = zs.isNSEC3 = true;
     zs.isNarrow = false;
@@ -555,12 +554,12 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
     }
     return false;
   }
-  
-  case QType::NSEC: 
+
+  case QType::NSEC:
     zs.isDnssecZone = zs.isPresigned = true;
     return false;
-  
-  case QType::NS: 
+
+  case QType::NS:
     if(rr.qname!=domain)
       zs.nsset.insert(rr.qname);
     break;
@@ -572,7 +571,7 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
   return true;
 }
 
-/* So this code does a number of things. 
+/* So this code does a number of things.
    1) It will AXFR a domain from a master
       The code can retrieve the current serial number in the database itself.
       It may attempt an IXFR
@@ -636,7 +635,7 @@ static vector<DNSResourceRecord> doAxfr(const ComboAddress& raddr, const DNSName
     }
   }
   return rrs;
-}   
+}
 
 
 void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, bool force)
@@ -644,7 +643,7 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
   {
     auto data = d_data.lock();
     if (data->d_inprogress.count(domain)) {
-      return; 
+      return;
     }
     data->d_inprogress.insert(domain);
   }

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -421,7 +421,7 @@ static bool catalogProcess(const DomainInfo& di, vector<DNSResourceRecord>& rrs,
   return catalogDiff(di, fromXFR, fromDB, logPrefix);
 }
 
-void CommunicatorClass::ixfrSuck(const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, unique_ptr<AuthLua4>& /* pdl */, ZoneStatus& zs, vector<DNSRecord>* axfr)
+void CommunicatorClass::ixfrSuck(const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, ZoneStatus& zs, vector<DNSRecord>* axfr)
 {
   string logPrefix="IXFR-in zone '"+domain.toLogString()+"', primary '"+remote.toString()+"', ";
 
@@ -754,7 +754,7 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
         logPrefix = "I" + logPrefix; // XFR -> IXFR
         vector<DNSRecord> axfr;
         g_log<<Logger::Notice<<logPrefix<<"starting IXFR"<<endl;
-        ixfrSuck(domain, tt, laddr, remote, pdl, zs, &axfr);
+        ixfrSuck(domain, tt, laddr, remote, zs, &axfr);
         if(!axfr.empty()) {
           g_log<<Logger::Notice<<logPrefix<<"IXFR turned into an AXFR"<<endl;
           logPrefix[0]='A'; // IXFR -> AXFR

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -421,8 +421,7 @@ static bool catalogProcess(const DomainInfo& di, vector<DNSResourceRecord>& rrs,
   return catalogDiff(di, fromXFR, fromDB, logPrefix);
 }
 
-void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, unique_ptr<AuthLua4>& pdl,
-                                 ZoneStatus& zs, vector<DNSRecord>* axfr)
+void CommunicatorClass::ixfrSuck(const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, unique_ptr<AuthLua4>& /* pdl */, ZoneStatus& zs, vector<DNSRecord>* axfr)
 {
   string logPrefix="IXFR-in zone '"+domain.toLogString()+"', primary '"+remote.toString()+"', ";
 
@@ -1045,7 +1044,7 @@ struct SlaveSenderReceiver
   {
   }
 
-  void deliverTimeout(const Identifier& i)
+  void deliverTimeout(const Identifier& /* i */)
   {
   }
 
@@ -1073,7 +1072,7 @@ struct SlaveSenderReceiver
     return d_resolver.tryGetSOASerial(&(std::get<0>(id)), &(std::get<1>(id)), &a.theirSerial, &a.theirInception, &a.theirExpire, &(std::get<2>(id)));
   }
 
-  void deliverAnswer(const DomainNotificationInfo& dni, const Answer& a, unsigned int usec)
+  void deliverAnswer(const DomainNotificationInfo& dni, const Answer& a, unsigned int /* usec */)
   {
     d_freshness[dni.di.id]=a;
   }

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -184,7 +184,7 @@ public:
     dgram.assign(d_buffer, 0, static_cast<size_t>(bytes));
   }
 
-  bool recvFromAsync(string &dgram, ComboAddress &ep)
+  bool recvFromAsync(string &dgram, ComboAddress& /* ep */)
   {
     struct sockaddr_in remote;
     socklen_t remlen = sizeof(remote);

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -184,7 +184,7 @@ public:
     dgram.assign(d_buffer, 0, static_cast<size_t>(bytes));
   }
 
-  bool recvFromAsync(string &dgram, ComboAddress& /* ep */)
+  bool recvFromAsync(string &dgram)
   {
     struct sockaddr_in remote;
     socklen_t remlen = sizeof(remote);

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -180,7 +180,7 @@ public:
     d_buffer.resize(s_buflen);
     if((bytes=recvfrom(d_socket, &d_buffer[0], s_buflen, 0, reinterpret_cast<sockaddr *>(&ep) , &remlen)) <0)
       throw NetworkError("After recvfrom: "+stringerror());
-    
+
     dgram.assign(d_buffer, 0, static_cast<size_t>(bytes));
   }
 
@@ -217,7 +217,7 @@ public:
       throw NetworkError("After send: "+stringerror());
   }
 
-  
+
   /** For datagram sockets, send a datagram to a destination
       \param dgram The datagram
       \param ep The intended destination of the datagram */
@@ -227,7 +227,7 @@ public:
   }
 
 
-  //! Write this data to the socket, taking care that all bytes are written out 
+  //! Write this data to the socket, taking care that all bytes are written out
   void writen(const string &data)
   {
     if(data.empty())
@@ -239,7 +239,7 @@ public:
 
     do {
       res=::send(d_socket, ptr, toWrite, 0);
-      if(res<0) 
+      if(res<0)
         throw NetworkError("Writing to a socket: "+stringerror());
       if(!res)
         throw NetworkError("EOF on socket");
@@ -266,7 +266,7 @@ public:
 
     if(errno==EAGAIN)
       return 0;
-    
+
     throw NetworkError("Writing to a socket: "+stringerror());
   }
 
@@ -310,7 +310,7 @@ public:
     }
   }
 
-  //! reads one character from the socket 
+  //! reads one character from the socket
   int getChar()
   {
     char c;
@@ -337,7 +337,7 @@ public:
   {
     d_buffer.resize(s_buflen);
     ssize_t res=::recv(d_socket, &d_buffer[0], s_buflen, 0);
-    if(res<0) 
+    if(res<0)
       throw NetworkError("Reading from a socket: "+stringerror());
     data.assign(d_buffer, 0, static_cast<size_t>(res));
   }
@@ -346,7 +346,7 @@ public:
   size_t read(char *buffer, size_t bytes)
   {
     ssize_t res=::recv(d_socket, buffer, bytes, 0);
-    if(res<0) 
+    if(res<0)
       throw NetworkError("Reading from a socket: "+stringerror());
     return static_cast<size_t>(res);
   }
@@ -363,7 +363,7 @@ public:
     return read(buffer, n);
   }
 
-  //! Sets the socket to listen with a default listen backlog of 10 pending connections 
+  //! Sets the socket to listen with a default listen backlog of 10 pending connections
   void listen(unsigned int length=10)
   {
     if(::listen(d_socket,length)<0)

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -233,7 +233,7 @@ class TCPIOHandler
 public:
   enum class Type : uint8_t { Client, Server };
 
-  TCPIOHandler(const std::string& host, bool hostIsAddr, int socket, const struct timeval& timeout, std::shared_ptr<TLSCtx> ctx, time_t /* now */): d_socket(socket)
+  TCPIOHandler(const std::string& host, bool hostIsAddr, int socket, const struct timeval& timeout, std::shared_ptr<TLSCtx> ctx): d_socket(socket)
   {
     if (ctx) {
       d_conn = ctx->getClientConnection(host, hostIsAddr, d_socket, timeout);

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -80,7 +80,7 @@ public:
   virtual std::unique_ptr<TLSConnection> getConnection(int socket, const struct timeval& timeout, time_t now) = 0;
   virtual std::unique_ptr<TLSConnection> getClientConnection(const std::string& host, bool hostIsAddr, int socket, const struct timeval& timeout) = 0;
   virtual void rotateTicketsKey(time_t now) = 0;
-  virtual void loadTicketsKeys(const std::string& file)
+  virtual void loadTicketsKeys(const std::string& /* file */)
   {
     throw std::runtime_error("This TLS backend does not have the capability to load a tickets key from a file");
   }
@@ -116,7 +116,7 @@ public:
   virtual std::string getName() const = 0;
 
   /* set the advertised ALPN protocols, in client or server context */
-  virtual bool setALPNProtos(const std::vector<std::vector<uint8_t>>& protos)
+  virtual bool setALPNProtos(const std::vector<std::vector<uint8_t>>& /* protos */)
   {
     return false;
   }
@@ -233,7 +233,7 @@ class TCPIOHandler
 public:
   enum class Type : uint8_t { Client, Server };
 
-  TCPIOHandler(const std::string& host, bool hostIsAddr, int socket, const struct timeval& timeout, std::shared_ptr<TLSCtx> ctx, time_t now): d_socket(socket)
+  TCPIOHandler(const std::string& host, bool hostIsAddr, int socket, const struct timeval& timeout, std::shared_ptr<TLSCtx> ctx, time_t /* now */): d_socket(socket)
   {
     if (ctx) {
       d_conn = ctx->getClientConnection(host, hostIsAddr, d_socket, timeout);

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -36,7 +36,7 @@ struct Backend
 };
 
 static std::atomic<int> g_receivedAnswers;
-static void report(std::unique_ptr<DNSPacket>& A, int B)
+static void report(std::unique_ptr<DNSPacket>& /* A */, int /* B */)
 {
   g_receivedAnswers++;
 }
@@ -70,7 +70,7 @@ struct BackendSlow
 };
 
 static std::atomic<int> g_receivedAnswers1;
-static void report1(std::unique_ptr<DNSPacket>& A, int B)
+static void report1(std::unique_ptr<DNSPacket>& /* A */, int /* B */)
 {
   g_receivedAnswers1++;
 }
@@ -104,7 +104,7 @@ struct BackendDies
   ~BackendDies()
   {
   }
-  std::unique_ptr<DNSPacket> question(Question& q)
+  std::unique_ptr<DNSPacket> question(Question& /* q */)
   {
     //  cout<<"Q: "<<q->qdomain<<endl;
     if(!d_ourcount && ++d_count == 10) {
@@ -122,7 +122,7 @@ std::atomic<int> BackendDies::s_count;
 
 std::atomic<int> g_receivedAnswers2;
 
-static void report2(std::unique_ptr<DNSPacket>& A, int B)
+static void report2(std::unique_ptr<DNSPacket>& /* A */, int /* B */)
 {
   g_receivedAnswers2++;
 }

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(test_distributor_basic) {
   int n;
   for(n=0; n < 100; ++n)  {
     Question q;
-    q.d_dt.set(); 
+    q.d_dt.set();
     d->question(q, report);
   }
   sleep(1);
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(test_distributor_queue) {
     // bound should be higher than max-queue-length
     for(n=0; n < 2000; ++n)  {
       Question q;
-      q.d_dt.set(); 
+      q.d_dt.set();
       d->question(q, report1);
     }
     }, DistributorFatal, [](DistributorFatal) { return true; });
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_distributor_dies) {
   try {
     for(int n=0; n < 100; ++n)  {
       Question q;
-      q.d_dt.set(); 
+      q.d_dt.set();
       q.qdomain=DNSName(std::to_string(n));
       q.qtype = QType(QType::A);
       d->question(q, report2);

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
  }
 }
 
-static bool test_dnsrecords_cc_predicate( std::exception const &ex ) { return true; }
+static bool test_dnsrecords_cc_predicate(std::exception const& /* ex */) { return true; }
 
 // these *MUST NOT* parse properly!
 BOOST_AUTO_TEST_CASE(test_record_types_bad_values) {

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -184,7 +184,7 @@ public:
     return true;
   }
 
-  bool list(const DNSName& target, int zoneId, bool include_disabled = false) override
+  bool list(const DNSName& target, int zoneId, bool /* include_disabled */ = false) override
   {
     findZone(target, zoneId, d_records, d_currentZone);
 
@@ -283,12 +283,12 @@ public:
   {
   }
 
-  bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta) override
+  bool getDomainMetadata(const DNSName& /* name */, const std::string& /* kind */, std::vector<std::string>& /* meta */) override
   {
     return false;
   }
 
-  bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta) override
+  bool setDomainMetadata(const DNSName& /* name */, const std::string& /* kind */, const std::vector<std::string>& /* meta */) override
   {
     return false;
   }

--- a/pdns/unix_utility.cc
+++ b/pdns/unix_utility.cc
@@ -133,7 +133,7 @@ void Utility::usleep(unsigned long usec)
   ts.tv_sec = usec / 1000000;
   ts.tv_nsec = (usec % 1000000) * 1000;
   // POSIX.1 recommends using nanosleep instead of usleep
-  ::nanosleep(&ts, nullptr); 
+  ::nanosleep(&ts, nullptr);
 }
 
 
@@ -225,7 +225,7 @@ static int isleap(int year) {
   return (!(year%4) && ((year%100) || !(year%400)));
 }
 
-time_t Utility::timegm(struct tm *const t) 
+time_t Utility::timegm(struct tm *const t)
 {
   const static short spm[13] = /* days per month -- nonleap! */
   { 0,
@@ -251,7 +251,7 @@ time_t Utility::timegm(struct tm *const t)
   if (t->tm_min>60) { t->tm_hour += t->tm_min/60; t->tm_min%=60; }
   if (t->tm_hour>60) { t->tm_mday += t->tm_hour/60; t->tm_hour%=60; }
   if (t->tm_mon>11) { t->tm_year += t->tm_mon/12; t->tm_mon%=12; }
- 
+
   while (t->tm_mday>spm[1+t->tm_mon]) {
     if (t->tm_mon==1 && isleap(t->tm_year+1900)) {
       if (t->tm_mon==31+29) break;
@@ -289,4 +289,3 @@ time_t Utility::timegm(struct tm *const t)
   i = 60;
   return ((day + t->tm_hour) * i + t->tm_min) * i + t->tm_sec;
 }
-

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -431,7 +431,7 @@ void WebServer::logRequest(const HttpRequest& req, const ComboAddress& remote) c
   }
 }
 
-void WebServer::logResponse(const HttpResponse& resp, const ComboAddress& remote, const string& logprefix) const {
+void WebServer::logResponse(const HttpResponse& resp, const ComboAddress& /* remote */, const string& logprefix) const {
   if (d_loglevel >= WebServer::LogLevel::Detailed) {
 #ifdef RECURSOR
     if (!g_slogStructured) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -536,7 +536,7 @@ static void validateGatheredRRType(const DNSResourceRecord& rr) {
   }
 }
 
-static void gatherRecords(UeberBackend& /* B */, const string& /* logprefix */, const Json& container, const DNSName& qname, const QType& qtype, const int ttl, vector<DNSResourceRecord>& new_records) {
+static void gatherRecords(const Json& container, const DNSName& qname, const QType& qtype, const int ttl, vector<DNSResourceRecord>& new_records) {
   DNSResourceRecord rr;
   rr.qname = qname;
   rr.qtype = qtype;
@@ -1728,7 +1728,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
         }
         if (rrset["records"].is_array()) {
           int ttl = intFromJson(rrset, "ttl");
-          gatherRecords(B, req->logprefix, rrset, qname, qtype, ttl, new_records);
+          gatherRecords(rrset, qname, qtype, ttl, new_records);
         }
         if (rrset["comments"].is_array()) {
           gatherComments(rrset, qname, qtype, new_comments);
@@ -2112,7 +2112,7 @@ static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp) {
           // ttl shouldn't be part of DELETE, and it shouldn't be required if we don't get new records.
           int ttl = intFromJson(rrset, "ttl");
 
-          gatherRecords(B, req->logprefix, rrset, qname, qtype, ttl, new_records);
+          gatherRecords(rrset, qname, qtype, ttl, new_records);
 
           for(DNSResourceRecord& rr : new_records) {
             rr.domain_id = di.id;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -536,7 +536,7 @@ static void validateGatheredRRType(const DNSResourceRecord& rr) {
   }
 }
 
-static void gatherRecords(UeberBackend& B, const string& logprefix, const Json& container, const DNSName& qname, const QType& qtype, const int ttl, vector<DNSResourceRecord>& new_records) {
+static void gatherRecords(UeberBackend& /* B */, const string& /* logprefix */, const Json& container, const DNSName& qname, const QType& qtype, const int ttl, vector<DNSResourceRecord>& new_records) {
   DNSResourceRecord rr;
   rr.qname = qname;
   rr.qtype = qtype;
@@ -2397,7 +2397,7 @@ static void prometheusMetrics(HttpRequest* req, HttpResponse* resp) {
   resp->status = 200;
 }
 
-void AuthWebServer::cssfunction(HttpRequest* req, HttpResponse* resp)
+void AuthWebServer::cssfunction(HttpRequest* /* req */, HttpResponse* resp)
 {
   resp->headers["Cache-Control"] = "max-age=86400";
   resp->headers["Content-Type"] = "text/css";

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -752,7 +752,7 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
       // "dnssec": false in json
       if (isDNSSECZone) {
         string info, error;
-        if (!dk.unSecureZone(zonename, error, info)) {
+        if (!dk.unSecureZone(zonename, error)) {
           throw ApiException("Error while un-securing zone '"+ zonename.toString()+"': " + error);
         }
         isDNSSECZone = dk.isSecuredZone(zonename, false);

--- a/pdns/zone2json.cc
+++ b/pdns/zone2json.cc
@@ -53,7 +53,7 @@ using namespace json11;
 StatBag S;
 static int g_numRecords;
 
-static Json::object emitRecord(const string& zoneName, const DNSName &DNSqname, const string &qtype, const string &ocontent, int ttl)
+static Json::object emitRecord(const string& /* zoneName */, const DNSName &DNSqname, const string &qtype, const string &ocontent, int ttl)
 {
   int prio=0;
   string retval;

--- a/pdns/zone2json.cc
+++ b/pdns/zone2json.cc
@@ -53,7 +53,7 @@ using namespace json11;
 StatBag S;
 static int g_numRecords;
 
-static Json::object emitRecord(const string& /* zoneName */, const DNSName &DNSqname, const string &qtype, const string &ocontent, int ttl)
+static Json::object emitRecord(const DNSName &DNSqname, const string &qtype, const string &ocontent, int ttl)
 {
   int prio=0;
   string retval;
@@ -177,7 +177,7 @@ try
             obj["name"] = i->name.toString();
 
             while(zpt.get(rr))
-              recs.push_back(emitRecord(i->name.toString(), rr.qname, rr.qtype.toString(), rr.content, rr.ttl));
+              recs.push_back(emitRecord(rr.qname, rr.qtype.toString(), rr.content, rr.ttl));
             obj["records"] = recs;
             Json tmp = obj;
             cout<<tmp.dump();
@@ -213,7 +213,7 @@ try
       obj["name"] = ::arg()["zone-name"];
 
       while(zpt.get(rr))
-        records.push_back(emitRecord(::arg()["zone-name"], rr.qname, rr.qtype.toString(), rr.content, rr.ttl));
+        records.push_back(emitRecord(rr.qname, rr.qtype.toString(), rr.content, rr.ttl));
       obj["records"] = records;
 
       Json tmp = obj;


### PR DESCRIPTION
### Short description
Building with `-Wall -Wextra -Werror=vla -Werror=shadow -Wformat=2 -Werror=format-security -Werror=string-plus-int` throws a lot of warnings, mostly about unused arguments. A lot of them are coming from header files which tend to spam the compiler output, making it easier to miss more important ones. This PR fixes most of these build-time warnings.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)