### PR TITLE
dnsdist: Fix a use-after-free in the incoming DoH path

### DIFF
--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -304,8 +304,9 @@ static void on_socketclose(void *data)
       conn->d_acceptCtx->d_cs->updateTCPMetrics(conn->d_nbQueries, diff.tv_sec * 1000 + diff.tv_usec / 1000);
     }
 
-    t_conns.erase(conn->d_desc);
     dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(conn->d_remote);
+    // you can no longer touch conn, or data, after this call
+    t_conns.erase(conn->d_desc);
   }
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
During the recent addition of the concurrent connection checks for incoming DoH connections, I introduced a bug by using the connection object just after it has been released.
This was fortunately spotted by ASAN pretty quickly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
