### PR TITLE
rec doc: serve-stale-extensions works on 30s so an hour should be 120x

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1855,7 +1855,7 @@ Individual parts of these zones can still be loaded or forwarded.
 Maximum number of times an expired record's TTL is extended by 30s when serving stale.
 Extension only occurs if a record cannot be refreshed.
 A value of 0 means the ``Serve Stale`` mechanism is not used.
-To allow records becoming stale to be served for an hour, use a value of 200.
+To allow records becoming stale to be served for an hour, use a value of 120.
 See :ref:`serve-stale` for a description of the Serve Stale mechanism.
 
 .. _setting-server-down-max-fails:


### PR DESCRIPTION
### Short description
If I understood `serve-stale-extensions` correctly it's working on 30s intervals. Thus an hour should be 120 and not 200, at least if your hours also have 3600 seconds. :wink:

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
