### PR TITLE
dnsdist: Ensure we have at least one protobuf MetaValue

### DIFF
--- a/pdns/dnsdist-protobuf.cc
+++ b/pdns/dnsdist-protobuf.cc
@@ -197,7 +197,13 @@ void DNSDistProtoBufMessage::serialize(std::string& data) const
   m.commitResponse();
 
   for (const auto& [key, values] : d_metaTags) {
-    m.setMeta(key, values, {});
+    if (!values.empty()) {
+      m.setMeta(key, values, {});
+    }
+    else {
+      /* the MetaValue field is _required_ to exist, even if we have no value */
+      m.setMeta(key, {std::string()}, {});
+    }
   }
 }
 

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -1026,3 +1026,9 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
         cls._response_headers = response_headers.getvalue()
         return (receivedQuery, message)
+
+    def sendDOHQueryWrapper(self, query, response, useQueue=True):
+        return self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
+
+    def sendDOTQueryWrapper(self, query, response, useQueue=True):
+        return self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response, self._caCert, useQueue=useQueue)

--- a/regression-tests.dnsdist/test_Metrics.py
+++ b/regression-tests.dnsdist/test_Metrics.py
@@ -75,12 +75,6 @@ class TestRuleMetrics(DNSDistTest):
 
             self.assertEquals(self.getMetric('rule-' + name), 2)
 
-    def sendDOHQueryWrapper(self, query, response, useQueue=True):
-        return self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
-
-    def sendDOTQueryWrapper(self, query, response, useQueue=True):
-        return self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response, self._caCert, useQueue=useQueue)
-
     def testCacheMetrics(self):
         """
         Metrics: Check that metrics are correctly updated for cache misses and hits

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -551,12 +551,8 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
             self.assertEqual(len(msg.meta), 5)
             tags = {}
             for entry in msg.meta:
-                if method == "sendDOHQueryWrapper":
-                    self.assertEqual(len(entry.value.stringVal), 1)
-                    tags[entry.key] = entry.value.stringVal[0]
-                else:
-                    self.assertEqual(len(entry.value.stringVal), 0)
-                    tags[entry.key] = None
+                self.assertEqual(len(entry.value.stringVal), 1)
+                tags[entry.key] = entry.value.stringVal[0]
 
             self.assertIn('agent', tags)
             if method == "sendDOHQueryWrapper":
@@ -576,12 +572,8 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
             self.assertEqual(len(msg.meta), 5)
             tags = {}
             for entry in msg.meta:
-                if method == "sendDOHQueryWrapper":
-                    self.assertEqual(len(entry.value.stringVal), 1)
-                    tags[entry.key] = entry.value.stringVal[0]
-                else:
-                    self.assertEqual(len(entry.value.stringVal), 0)
-                    tags[entry.key] = None
+                self.assertEqual(len(entry.value.stringVal), 1)
+                tags[entry.key] = entry.value.stringVal[0]
 
             self.assertIn('agent', tags)
             if method == "sendDOHQueryWrapper":

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -491,12 +491,15 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
     _serverCert = 'server.chain'
     _serverName = 'tls.tests.dnsdist.org'
     _caCert = 'ca.pem'
+    _tlsServerPort = 8453
     _dohServerPort = 8443
     _dohBaseURL = ("https://%s:%d/dns-query" % (_serverName, _dohServerPort))
-    _config_params = ['_testServerPort', '_protobufServerPort', '_dohServerPort', '_serverCert', '_serverKey']
+    _config_params = ['_testServerPort', '_protobufServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohServerPort', '_serverCert', '_serverKey']
     _config_template = """
     newServer{address="127.0.0.1:%d"}
     rl = newRemoteLogger('127.0.0.1:%d')
+
+    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
     addDOHLocal("127.0.0.1:%s", "%s", "%s", { '/dns-query' }, { keepIncomingHeaders=true })
 
     local mytags = {path='doh-path', host='doh-host', ['query-string']='doh-query-string', scheme='doh-scheme', agent='doh-header:user-agent'}
@@ -518,57 +521,79 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
                                     '127.0.0.1')
         response.answer.append(rrset)
 
-        (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, caFile=self._caCert, response=response)
+        for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHQueryWrapper"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
 
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(response, receivedResponse)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
-        # let the protobuf messages the time to get there
-        time.sleep(1)
+            # let the protobuf messages the time to get there
+            time.sleep(1)
 
-        # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+            # check the protobuf message corresponding to the query
+            msg = self.getFirstProtobufMessage()
 
-        self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.DOH, query, dns.rdataclass.IN, dns.rdatatype.A, name)
-        self.assertEqual(len(msg.meta), 5)
-        tags = {}
-        for entry in msg.meta:
-            self.assertEqual(len(entry.value.stringVal), 1)
-            tags[entry.key] = entry.value.stringVal[0]
+            if method == "sendUDPQuery":
+                pbMessageType = dnsmessage_pb2.PBDNSMessage.UDP
+            elif method == "sendTCPQuery":
+                pbMessageType = dnsmessage_pb2.PBDNSMessage.TCP
+            elif method == "sendDOTQueryWrapper":
+                pbMessageType = dnsmessage_pb2.PBDNSMessage.DOT
+            elif method == "sendDOHQueryWrapper":
+                pbMessageType = dnsmessage_pb2.PBDNSMessage.DOH
 
-        self.assertIn('agent', tags)
-        self.assertIn('PycURL', tags['agent'])
-        self.assertIn('host', tags)
-        self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohServerPort))
-        self.assertIn('path', tags)
-        self.assertEqual(tags['path'], '/dns-query')
-        self.assertIn('query-string', tags)
-        self.assertIn('?dns=', tags['query-string'])
-        self.assertIn('scheme', tags)
-        self.assertEqual(tags['scheme'], 'https')
+            print(method)
+            self.checkProtobufQuery(msg, pbMessageType, query, dns.rdataclass.IN, dns.rdatatype.A, name)
+            self.assertEqual(len(msg.meta), 5)
+            tags = {}
+            for entry in msg.meta:
+                if method == "sendDOHQueryWrapper":
+                    self.assertEqual(len(entry.value.stringVal), 1)
+                    tags[entry.key] = entry.value.stringVal[0]
+                else:
+                    self.assertEqual(len(entry.value.stringVal), 0)
+                    tags[entry.key] = None
 
-        # check the protobuf message corresponding to the UDP response
-        msg = self.getFirstProtobufMessage()
-        self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.DOH, response)
-        self.assertEqual(len(msg.meta), 5)
-        tags = {}
-        for entry in msg.meta:
-            self.assertEqual(len(entry.value.stringVal), 1)
-            tags[entry.key] = entry.value.stringVal[0]
+            self.assertIn('agent', tags)
+            if method == "sendDOHQueryWrapper":
+                self.assertIn('PycURL', tags['agent'])
+                self.assertIn('host', tags)
+                self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohServerPort))
+                self.assertIn('path', tags)
+                self.assertEqual(tags['path'], '/dns-query')
+                self.assertIn('query-string', tags)
+                self.assertIn('?dns=', tags['query-string'])
+                self.assertIn('scheme', tags)
+                self.assertEqual(tags['scheme'], 'https')
 
-        self.assertIn('agent', tags)
-        self.assertIn('PycURL', tags['agent'])
-        self.assertIn('host', tags)
-        self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohServerPort))
-        self.assertIn('path', tags)
-        self.assertEqual(tags['path'], '/dns-query')
-        self.assertIn('query-string', tags)
-        self.assertIn('?dns=', tags['query-string'])
-        self.assertIn('scheme', tags)
-        self.assertEqual(tags['scheme'], 'https')
+            # check the protobuf message corresponding to the response
+            msg = self.getFirstProtobufMessage()
+            self.checkProtobufResponse(msg, pbMessageType, response)
+            self.assertEqual(len(msg.meta), 5)
+            tags = {}
+            for entry in msg.meta:
+                if method == "sendDOHQueryWrapper":
+                    self.assertEqual(len(entry.value.stringVal), 1)
+                    tags[entry.key] = entry.value.stringVal[0]
+                else:
+                    self.assertEqual(len(entry.value.stringVal), 0)
+                    tags[entry.key] = None
+
+            self.assertIn('agent', tags)
+            if method == "sendDOHQueryWrapper":
+                self.assertIn('PycURL', tags['agent'])
+                self.assertIn('host', tags)
+                self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohServerPort))
+                self.assertIn('path', tags)
+                self.assertEqual(tags['path'], '/dns-query')
+                self.assertIn('query-string', tags)
+                self.assertIn('?dns=', tags['query-string'])
+                self.assertIn('scheme', tags)
+                self.assertEqual(tags['scheme'], 'https')
 
 class TestProtobufMetaProxy(DNSDistProtobufTest):
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The `MetaValue` is required to exist, which means that we need to have at least one value.

The DoH-related values should be empty non-DoH protocols, but the protocol buffer messages should still be sent, with the expected content.
Fixes https://github.com/PowerDNS/pdns/issues/12560

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
