### PR TITLE
replace address of primary

### DIFF
--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -133,7 +133,7 @@ The only difference is the type, which is now set to CONSUMER.
 
 .. code-block:: shell
 
-  pdnsutil create-secondary-zone catalog.example 127.0.0.1
+  pdnsutil create-secondary-zone catalog.example 192.0.2.42
   pdnsutil set-kind catalog.example consumer
 
 Creating consumer zones is supported in the :doc:`API <http-api/zone>`, using type ``CONSUMER``.


### PR DESCRIPTION
### Short description

I think the address `127.0.0.1` makes little sense when creating a secondary zone, and I hope this is a tad less confusing.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
