### PR TITLE
dnsdist-protocols.hh: include <cstdint>

### DIFF
--- a/pdns/dnsdist-protocols.hh
+++ b/pdns/dnsdist-protocols.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 namespace dnsdist


### PR DESCRIPTION
This fixes building dnsdist with gcc13:
```
In file included from dnsdist-protocols.cc:26:
dnsdist-protocols.hh:32:8: error: use of enum 'typeenum' without previous declaration
   32 |   enum typeenum : uint8_t
      |        ^~~~~~~~
dnsdist-protocols.hh:32:19: error: 'uint8_t' was not declared in this scope
   32 |   enum typeenum : uint8_t
      |                   ^~~~~~~
dnsdist-protocols.hh:25:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   24 | #include <vector>
  +++ |+#include <cstdint>
   25 | #include <string>
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

