### PR TITLE
docs: harmonize `an experimental feature`

### DIFF
--- a/docs/dnssec/pkcs11.rst
+++ b/docs/dnssec/pkcs11.rst
@@ -2,7 +2,7 @@ PKCS#11 support
 ===============
 
 .. note::
-  This feature is experimental, use at your own risk!
+  This is an experimental feature, use at your own risk!
 
 To enable it, compile PowerDNS Authoritative Server using ``--enable-experimental-pkcs11`` flag on configure.
 This requires you to have the p11-kit libraries and headers.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -142,7 +142,7 @@ Migrating Data from one Backend to Another Backend
 --------------------------------------------------
 
 .. note::
-  This is experimental feature.
+  This is an experimental feature.
 
 Syntax: ``pdnsutil b2b-migrate OLD NEW``
 

--- a/docs/tsig.rst
+++ b/docs/tsig.rst
@@ -124,7 +124,7 @@ GSS-TSIG allows authentication and authorization of DNS updates or AXFR
 using Kerberos with TSIG signatures.
 
 .. note::
-  This feature is experimental and subject to change in future releases.
+  This is an experimental feature and subject to change in future releases.
 
 Prerequisites
 ~~~~~~~~~~~~~

--- a/pdns/recursordist/docs/changelog/pre-4.0.rst
+++ b/pdns/recursordist/docs/changelog/pre-4.0.rst
@@ -923,7 +923,7 @@ Improvements
    1677 <http://wiki.powerdns.com/projects/trac/changeset/1677>`__.
 -  On some platforms, it may be better to have PowerDNS itself
    distribute queries over threads (instead of leaving it up to the
-   kernel). This experimental feature can be enabled with the
+   kernel). This is an experimental feature and can be enabled with the
    'pdns-distributes-queries' setting. Code in `commit
    1678 <http://wiki.powerdns.com/projects/trac/changeset/1678>`__ and
    beyond. Speeds up Solaris measurably.

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -807,7 +807,7 @@ This file can be used to serve data authoritatively using `export-etc-hosts`_.
 - Integer
 - Default: 0
 
-Enable the recording and logging of ref:`event traces`. This is an experimental feature subject to change.
+Enable the recording and logging of ref:`event traces`. This is an experimental feature and subject to change.
 Possible values are 0: (disabled), 1 (add information to protobuf logging messages) and 2 (write to log) and 3 (both).
 
 .. _setting-export-etc-hosts:


### PR DESCRIPTION
### Short description
both `feature is experimental` and `an experimental feature` were used in the repository (although, some hits are from doxygen's config, which shouldn't be counted)... this picks the one that seems to be used most by pdns docs...

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
