### PR TITLE
Avoid Microsoft repo for ODBC packages. Step 2 of 3: prioritize ubuntu mirror

### DIFF
--- a/set-ubuntu-mirror/action.yml
+++ b/set-ubuntu-mirror/action.yml
@@ -1,8 +1,15 @@
 name: 'choose Ubuntu mirror for PowerDNS builds in Github Actions'
+inputs:
+  apt-repository:
+    description: 'Default Ubuntu APT repository mirror'
+    required: true
+    default: 'mirror.leaseweb.net'
 runs:
   using: "composite"
   steps:
     #- run: echo not changing mirror, using default Azure mirror
     #  shell: bash
-    - run: sudo sed -i 's/azure\.archive\.ubuntu\.com/mirror.leaseweb.net/' /etc/apt/sources.list
+    - run: sudo sed -i 's/azure\.archive\.ubuntu\.com/${{ inputs.apt-repository }}/' /etc/apt/sources.list
+      shell: bash
+    - run: "echo -e 'Package: *odbc*\nPin: origin \"${{ inputs.apt-repository }}\"\nPin-Priority: 1001' | sudo tee /etc/apt/preferences"
       shell: bash


### PR DESCRIPTION
### Short description
Modifying the action set-ubuntu-mirror to add prioritization of the ubuntu mirror over the Microsoft repo for ODBC packages.

Checklist

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
