### PR TITLE
dnsdist: The security status for 1.8.0-rc1 should be 2, not 3

### DIFF
--- a/docs/secpoll.zone
+++ b/docs/secpoll.zone
@@ -1,4 +1,4 @@
-@       86400   IN  SOA pdns-public-ns1.powerdns.com. peter\.van\.dijk.powerdns.com. 2023022300 10800 3600 604800 10800
+@       86400   IN  SOA pdns-public-ns1.powerdns.com. peter\.van\.dijk.powerdns.com. 2023022301 10800 3600 604800 10800
 @       3600    IN  NS  pdns-public-ns1.powerdns.com.
 @       3600    IN  NS  pdns-public-ns2.powerdns.com.
 
@@ -492,4 +492,4 @@ dnsdist-1.7.0.security-status                              60 IN TXT "1 OK"
 dnsdist-1.7.1.security-status                              60 IN TXT "1 OK"
 dnsdist-1.7.2.security-status                              60 IN TXT "1 OK"
 dnsdist-1.7.3.security-status                              60 IN TXT "1 OK"
-dnsdist-1.8.0-rc1.security-status                          60 IN TXT "3 Unsupported pre-release"
+dnsdist-1.8.0-rc1.security-status                          60 IN TXT "2 Unsupported pre-release"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Which means Update recommended instead of mandatory. Neither are nice, so perhaps we need a different level for pre-releases?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
