### PR TITLE
dnsdist: Skip signal-unsafe logging when we are about to exit, with TSAN

### DIFF
--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -89,15 +89,6 @@ private:
   bool d_needRealTime;
 };
 
-/* g++ defines __SANITIZE_THREAD__
-   clang++ supports the nice __has_feature(thread_sanitizer),
-   let's merge them */
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-#define __SANITIZE_THREAD__ 1
-#endif
-#endif
-
 struct InternalQueryState
 {
   static void DeleterPlaceHolder(DOHUnit*)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
TSAN is rightfully unhappy about this:
```
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal
```

This is not a real problem for us, as the worst case is that we crash trying to exit, but let's try to avoid the warnings in our tests.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
