### PR TITLE
dnsdist-protobuf: fix compilation with DoH disabled

### DIFF
--- a/pdns/dnsdist-protobuf.cc
+++ b/pdns/dnsdist-protobuf.cc
@@ -266,6 +266,7 @@ const ProtoBufMetaKey::TypeContainer ProtoBufMetaKey::s_types = {
   ProtoBufMetaKey::KeyTypeDescription{ "sni", Type::SNI, [](const DNSQuestion& dq, const std::string&, uint8_t) -> std::vector<std::string> { return {dq.sni}; }, false },
   ProtoBufMetaKey::KeyTypeDescription{ "pool", Type::Pool, [](const DNSQuestion& dq, const std::string&, uint8_t) -> std::vector<std::string> { return {dq.ids.poolName}; }, false },
   ProtoBufMetaKey::KeyTypeDescription{ "b64-content", Type::B64Content, [](const DNSQuestion& dq, const std::string&, uint8_t) -> std::vector<std::string> { const auto& data = dq.getData(); return {Base64Encode(std::string(data.begin(), data.end()))}; }, false },
+#ifdef HAVE_DNS_OVER_HTTPS
   ProtoBufMetaKey::KeyTypeDescription{ "doh-header", Type::DoHHeader, [](const DNSQuestion& dq , const std::string& name, uint8_t) -> std::vector<std::string> {
     if (!dq.ids.du) {
       return {};
@@ -301,6 +302,7 @@ const ProtoBufMetaKey::TypeContainer ProtoBufMetaKey::s_types = {
     }
     return {};
     }, false, false },
+#endif // HAVE_DNS_OVER_HTTPS
   ProtoBufMetaKey::KeyTypeDescription{ "proxy-protocol-value", Type::ProxyProtocolValue, [](const DNSQuestion& dq, const std::string&, uint8_t numericSubKey) -> std::vector<std::string> {
     if (!dq.proxyProtocolValues) {
       return {};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

When DoH is disabled, protobuf is trying to access unavailable struct fields. Don't include these in the protobuf messages since they are not available.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
