### PR TITLE
YaHTTP: Better detection of whether C++11 features are available

### DIFF
--- a/ext/yahttp/yahttp/reqresp.hpp
+++ b/ext/yahttp/yahttp/reqresp.hpp
@@ -1,4 +1,4 @@
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
 #include <functional>
 #define HAVE_CPP_FUNC_PTR
 namespace funcptr = std;
@@ -72,7 +72,7 @@ namespace YaHTTP {
       size_t operator()(const HTTPBase *doc __attribute__((unused)), std::ostream& os, bool chunked) const {
         char buf[4096];
         size_t n,k;
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
         std::ifstream ifs(path, std::ifstream::binary);
 #else
         std::ifstream ifs(path.c_str(), std::ifstream::binary);

--- a/ext/yahttp/yahttp/router.cpp
+++ b/ext/yahttp/yahttp/router.cpp
@@ -98,7 +98,7 @@ namespace YaHTTP {
 
   void Router::printRoutes(std::ostream &os) {
     for(TRouteList::iterator i = routes.begin(); i != routes.end(); i++) {
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
       std::streamsize ss = os.width();
       std::ios::fmtflags ff = os.setf(std::ios::left);
       os.width(10);
@@ -122,7 +122,7 @@ namespace YaHTTP {
 
     bool found = false;
     for(TRouteList::iterator i = routes.begin(); !found && i != routes.end(); i++) {
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
       if (std::get<3>(*i) == name) { mask = std::get<1>(*i); method = std::get<0>(*i); found = true; }
 #else
       if (i->get<3>() == name) { mask = i->get<1>(); method = i->get<0>(); found = true; }

--- a/ext/yahttp/yahttp/router.hpp
+++ b/ext/yahttp/yahttp/router.hpp
@@ -2,7 +2,7 @@
 /* @file 
  * @brief Defines router class and support structures
  */
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
 #include <functional>
 #include <tuple>
 #define HAVE_CPP_FUNC_PTR


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The previous version relied on having `HAVE_CXX11` defined, which is not true when you are compiling with C++17, for example, even though the C++11 features are available (`HAVE_CXX17` is defined but that does not help).

I'll open a pull request in the YaHTTP repo as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
