### PR TITLE
dnsdist: fix backend servfail metric

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -639,7 +639,8 @@ void handleResponseSent(const DNSName& qname, const QType& qtype, double udiff, 
     ++g_stats.frontendNXDomain;
     break;
   case RCode::ServFail:
-    ++g_stats.servfailResponses;
+    if (udiff != 0.) /* came from a real backend, not a cache hit */
+      ++g_stats.servfailResponses;
     ++g_stats.frontendServFail;
     break;
   case RCode::NoError:


### PR DESCRIPTION
### Short description
Right now servfail-responses (from backends) and frontend-servfail (to clients) are the same metric. Adjust this to only increment servfail-responses if the answer came from something non-self-generated. 

We could also compare the backend server or backend port, similar to how the Lua inspection stuff does, but it seems to me all callers send udiff==0 on cache hit.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
