### PR TITLE
m4: Clean up the fortify and LTO m4 by not directly editing flags

### DIFF
--- a/m4/pdns_d_fortify_source.m4
+++ b/m4/pdns_d_fortify_source.m4
@@ -27,9 +27,6 @@ AC_DEFUN([AC_CC_D_FORTIFY_SOURCE],[
 
   AS_IF([test "x$enable_fortify_source" != "xno"], [
 
-    OLD_CXXFLAGS="$CXXFLAGS"
-    CXXFLAGS="-Wall -W -Werror $CXXFLAGS"
-
     dnl Auto means the highest version we support, which is currently 3
     AS_IF([test "x$enable_fortify_source" == "xauto"],
       [enable_fortify_source=3],
@@ -40,29 +37,26 @@ AC_DEFUN([AC_CC_D_FORTIFY_SOURCE],[
     AS_IF([test "x$enable_fortify_source" == "x3"], [
       gl_COMPILER_OPTION_IF([-D_FORTIFY_SOURCE=3], [
         CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 $CFLAGS"
-        CXXFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 $OLD_CXXFLAGS"
-      ], [enable_fortify_source=2],
-      [AC_LANG_PROGRAM([[#include <stdio.h>]],[])])
+        CXXFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 $CXXFLAGS"
+      ], [enable_fortify_source=2])
     ])
 
     dnl If 2 is not supported, we try to fallback to 1
     AS_IF([test "x$enable_fortify_source" == "x2"], [
       gl_COMPILER_OPTION_IF([-D_FORTIFY_SOURCE=2], [
         CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $CFLAGS"
-        CXXFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $OLD_CXXFLAGS"
-      ], [enable_fortify_source=1],
-      [AC_LANG_PROGRAM([[#include <stdio.h>]],[])])
+        CXXFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $CXXFLAGS"
+      ], [enable_fortify_source=1])
     ])
 
     AS_IF([test "x$enable_fortify_source" == "x1"], [
       gl_COMPILER_OPTION_IF([-D_FORTIFY_SOURCE=1], [
         CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 $CFLAGS"
-        CXXFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 $OLD_CXXFLAGS"
-      ], [enable_fortify_source=no],
-      [AC_LANG_PROGRAM([[#include <stdio.h>]],[])])
+        CXXFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 $CXXFLAGS"
+      ], [enable_fortify_source=no])
     ])
 
-  ], [])
+  ])
 
   AC_MSG_CHECKING([whether FORTIFY_SOURCE is supported])
   AC_MSG_RESULT([$enable_fortify_source])

--- a/m4/pdns_enable_lto.m4
+++ b/m4/pdns_enable_lto.m4
@@ -7,40 +7,32 @@ AC_DEFUN([PDNS_ENABLE_LTO],[
 
   AS_IF([test "x$enable_lto" != "xno"], [
 
-    OLD_CXXFLAGS="$CXXFLAGS"
-    OLD_LDFLAGS="$LDFLAGS"
-    CXXFLAGS="-Wall -W -Werror $CXXFLAGS"
-
     dnl If thin is not supported, we try to fallback to auto
     AS_IF([test "x$enable_lto" == "xthin"], [
       gl_COMPILER_OPTION_IF([-flto=thin], [
         CFLAGS="-flto=thin $CFLAGS"
-        CXXFLAGS="-flto=thin $OLD_CXXFLAGS"
-        LDFLAGS="-flto=thin $OLD_LDFLAGS"
-      ], [enable_lto=auto],
-      [AC_LANG_PROGRAM([[#include <stdio.h>]],[])])
+        CXXFLAGS="-flto=thin $CXXFLAGS"
+        LDFLAGS="-flto=thin $LDFLAGS"
+      ], [enable_lto=auto])
     ])
 
     dnl If auto is not supported, we try to fallback -flto
     AS_IF([test "x$enable_lto" == "xauto"], [
       gl_COMPILER_OPTION_IF([-flto=auto], [
         CFLAGS="-flto=auto $CFLAGS"
-        CXXFLAGS="-flto=auto $OLD_CXXFLAGS"
-        LDFLAGS="-flto=auto $OLD_LDFLAGS"
-      ], [enable_lto=yes],
-      [AC_LANG_PROGRAM([[#include <stdio.h>]],[])])
+        CXXFLAGS="-flto=auto $CXXFLAGS"
+        LDFLAGS="-flto=auto $LDFLAGS"
+      ], [enable_lto=yes])
     ])
 
     AS_IF([test "x$enable_lto" == "xyes"], [
       gl_COMPILER_OPTION_IF([-flto], [
         CFLAGS="-flto $CFLAGS"
-        CXXFLAGS="-flto $OLD_CXXFLAGS"
-        LDFLAGS="-flto $OLD_LDFLAGS"
-      ], [enable_lto=no],
-      [AC_LANG_PROGRAM([[#include <stdio.h>]],[])])
+        CXXFLAGS="-flto $CXXFLAGS"
+        LDFLAGS="-flto $LDFLAGS"
+      ], [enable_lto=no])
     ])
-
-  ], [])
+  ])
 
   AC_MSG_CHECKING([whether link-time optimization is supported])
   AC_MSG_RESULT([$enable_lto])


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`gl_COMPILER_OPTION_IF` already does the needful, so we do not need to tinker with the flags.
This might help with the issue reported in https://github.com/PowerDNS/pdns/issues/11032 but I'm unfortunately unable to reproduce it, so I'm not sure.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
