### PR TITLE
Rec: sharded and shared packet cache

### DIFF
--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -54,6 +54,9 @@ rec MODULE-IDENTITY
     REVISION "202209120000Z"
     DESCRIPTION "Added metrics for answers from auths by rcode"
 
+    REVISION "202302240000Z"
+    DESCRIPTION "Added metrics for sharded packet cache contrntion"
+
     ::= { powerdns 2 }
 
 powerdns		OBJECT IDENTIFIER ::= { enterprises 43315 }
@@ -1211,6 +1214,22 @@ authrcode15Count OBJECT-TYPE
     DESCRIPTION
         "Number of rcode 15 answers received"
     ::= { stats 144 }
+
+packetCacheContended OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of contended packet cache lock acquisitions"
+    ::= { stats 145 }
+
+packetCacheAcquired OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of packet cache lock acquisitions"
+    ::= { stats 146 }
 
 
 ---

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -55,7 +55,7 @@ rec MODULE-IDENTITY
     DESCRIPTION "Added metrics for answers from auths by rcode"
 
     REVISION "202302240000Z"
-    DESCRIPTION "Added metrics for sharded packet cache contrntion"
+    DESCRIPTION "Added metrics for sharded packet cache contention"
 
     ::= { powerdns 2 }
 
@@ -1423,7 +1423,9 @@ recGroup OBJECT-GROUP
         authrcode12Count,
         authrcode13Count,
         authrcode14Count,
-        authrcode15Count
+        authrcode15Count,
+        packetCacheContended,
+        packetCacheAcquired
     }
     STATUS current
     DESCRIPTION "Objects conformance group for PowerDNS Recursor"

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1618,6 +1618,19 @@ Before version 4.6.0 only ``ServFail`` answers were considered as such. Starting
     This setting's maximum is capped to `packetcache-ttl`_.
     i.e. setting ``packetcache-ttl=15`` and keeping ``packetcache-servfail-ttl`` at the default will lower ``packetcache-servfail-ttl`` to ``15``.
 
+
+.. _setting-packetcache-shards:
+
+``packetcache-shards``
+------------------------
+.. versionadded:: 4.9.0
+
+-  Integer
+-  Default: 1024
+
+Sets the number of shards in the packet cache. If you have high contention as reported by ``packetcache-contented/packetcache-acquired``,
+you can try to enlarge this value or run with fewer threads.
+
 .. _setting-pdns-distributes-queries:
 
 ``pdns-distributes-queries``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -466,8 +466,7 @@ overloaded, but it will be at the cost of an increased latency.
 -  Default: 1 if `pdns-distributes-queries`_ is set, 0 otherwise
 
 If `pdns-distributes-queries`_ is set, spawn this number of distributor threads on startup. Distributor threads
-handle incoming queries and distribute them to other threads based on a hash of the query, to maximize the cache hit
-ratio.
+handle incoming queries and distribute them to other threads based on a hash of the query.
 
 .. _setting-dot-to-auth-names:
 
@@ -1636,12 +1635,17 @@ you can try to enlarge this value or run with fewer threads.
 ``pdns-distributes-queries``
 ----------------------------
 -  Boolean
--  Default: yes
+-  Default: no
 
 If set, PowerDNS will use distinct threads to listen to client sockets and distribute that work to worker-threads using a hash of the query.
-This feature should maximize the cache hit ratio.
-To use more than one thread set `distributor-threads` in version 4.2.0 or newer.
-Enabling should improve performance for medium sized resolvers.
+This feature should maximize the cache hit ratio on versions before 4.9.0.
+To use more than one thread set `distributor-threads`_ in version 4.2.0 or newer.
+Enabling should improve performance on systems where `reuseport`_ does not have the effect of
+balancing the queries evenly over multiple worker threads.
+
+.. versionchanged:: 4.9.0
+
+   Default changed to ``no``, previously it was ``yes``.
 
 .. _setting-protobuf-use-kernel-timestamp:
 
@@ -1801,11 +1805,16 @@ A typical value is 10. If the value is zero, this functionality is disabled.
 ``reuseport``
 -------------
 -  Boolean
--  Default: no
+-  Default: yes
 
 If ``SO_REUSEPORT`` support is available, allows multiple threads and processes to open listening sockets for the same port.
 
-Since 4.1.0, when ``pdns-distributes-queries`` is set to false and ``reuseport`` is enabled, every worker-thread will open a separate listening socket to let the kernel distribute the incoming queries instead of running a distributor thread (which could otherwise be a bottleneck) and avoiding thundering herd issues, thus leading to much higher performance on multi-core boxes.
+Since 4.1.0, when `pdns-distributes-queries`_ is disabled and `reuseport`_ is enabled, every worker-thread will open a separate listening socket to let the kernel distribute the incoming queries instead of running a distributor thread (which could otherwise be a bottleneck) and avoiding thundering herd issues, thus leading to much higher performance on multi-core boxes.
+
+.. versionchanged:: 4.9.0
+
+   The default is changed to ``yes``, previously it was ``no``.
+   If ``SO_REUSEPORT`` support is not available, the setting defaults to ``no``.
 
 .. _setting-rng:
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -987,7 +987,9 @@ static void doStats(void)
   uint64_t cacheMisses = g_recCache->cacheMisses;
   uint64_t cacheSize = g_recCache->size();
   auto rc_stats = g_recCache->stats();
-  double r = rc_stats.second == 0 ? 0.0 : (100.0 * rc_stats.first / rc_stats.second);
+  auto pc_stats = g_packetCache ? g_packetCache->stats() : std::pair<uint64_t, uint64_t>{0, 0};
+  double rrc = rc_stats.second == 0 ? 0.0 : (100.0 * rc_stats.first / rc_stats.second);
+  double rpc = pc_stats.second == 0 ? 0.0 : (100.0 * pc_stats.first / pc_stats.second);
   uint64_t negCacheSize = g_negCache->size();
   auto taskPushes = getTaskPushes();
   auto taskExpired = getTaskExpired();
@@ -1007,7 +1009,8 @@ static void doStats(void)
   if (qcounter > 0 && (cacheHits + cacheMisses) > 0 && syncresqueries > 0 && outqueries > 0) {
     if (!g_slogStructured) {
       g_log << Logger::Notice << "stats: " << qcounter << " questions, " << cacheSize << " cache entries, " << negCacheSize << " negative entries, " << ratePercentage(cacheHits, cacheHits + cacheMisses) << "% cache hits" << endl;
-      g_log << Logger::Notice << "stats: cache contended/acquired " << rc_stats.first << '/' << rc_stats.second << " = " << r << '%' << endl;
+      g_log << Logger::Notice << "stats: record cache contended/acquired " << rc_stats.first << '/' << rc_stats.second << " = " << rrc << '%' << endl;
+      g_log << Logger::Notice << "stats: packet cache contended/acquired " << pc_stats.first << '/' << pc_stats.second << " = " << rpc << '%' << endl;
 
       g_log << Logger::Notice << "stats: throttle map: "
             << SyncRes::getThrottledServersSize() << ", ns speeds: "
@@ -1034,7 +1037,10 @@ static void doStats(void)
                 "record-cache-hitratio-perc", Logging::Loggable(ratePercentage(cacheHits, cacheHits + cacheMisses)),
                 "record-cache-contended", Logging::Loggable(rc_stats.first),
                 "record-cache-acquired", Logging::Loggable(rc_stats.second),
-                "record-cache-contended-perc", Logging::Loggable(r));
+                "record-cache-contended-perc", Logging::Loggable(rrc),
+                "packet-cache-contended", Logging::Loggable(pc_stats.first),
+                "packet-cache-acquired", Logging::Loggable(pc_stats.second),
+                "packet-cache-contended-perc", Logging::Loggable(rpc));
       log->info(Logr::Info, m,
                 "throttle-entries", Logging::Loggable(SyncRes::getThrottledServersSize()),
                 "nsspeed-entries", Logging::Loggable(SyncRes::getNSSpeedsSize()),

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2739,7 +2739,7 @@ int main(int argc, char** argv)
     ::arg().set("ecs-add-for", "List of client netmasks for which EDNS Client Subnet will be added") = "0.0.0.0/0, ::/0, " LOCAL_NETS_INVERSE;
     ::arg().set("ecs-scope-zero-address", "Address to send to allow-listed authoritative servers for incoming queries with ECS prefix-length source of 0") = "";
     ::arg().setSwitch("use-incoming-edns-subnet", "Pass along received EDNS Client Subnet information") = "no";
-    ::arg().setSwitch("pdns-distributes-queries", "If PowerDNS itself should distribute queries over threads") = "yes";
+    ::arg().setSwitch("pdns-distributes-queries", "If PowerDNS itself should distribute queries over threads") = "no";
     ::arg().setSwitch("root-nx-trust", "If set, believe that an NXDOMAIN from the root means the TLD does not exist") = "yes";
     ::arg().setSwitch("any-to-tcp", "Answer ANY queries with tc=1, shunting to TCP") = "no";
     ::arg().setSwitch("lowercase-outgoing", "Force outgoing questions to lowercase") = "no";
@@ -2759,8 +2759,11 @@ int main(int argc, char** argv)
     ::arg().set("include-dir", "Include *.conf files from this directory") = "";
     ::arg().set("security-poll-suffix", "Domain name from which to query security update notifications") = "secpoll.powerdns.com.";
 
+#ifdef SO_REUSEPORT
+    ::arg().setSwitch("reuseport", "Enable SO_REUSEPORT allowing multiple recursors processes to listen to 1 address") = "yes";
+#else
     ::arg().setSwitch("reuseport", "Enable SO_REUSEPORT allowing multiple recursors processes to listen to 1 address") = "no";
-
+#endif
     ::arg().setSwitch("snmp-agent", "If set, register as an SNMP agent") = "no";
     ::arg().set("snmp-master-socket", "If set and snmp-agent is set, the socket to use to register to the SNMP daemon (deprecated)") = "";
     ::arg().set("snmp-daemon-socket", "If set and snmp-agent is set, the socket to use to register to the SNMP daemon") = "";

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1038,9 +1038,9 @@ static void doStats(void)
                 "record-cache-contended", Logging::Loggable(rc_stats.first),
                 "record-cache-acquired", Logging::Loggable(rc_stats.second),
                 "record-cache-contended-perc", Logging::Loggable(rrc),
-                "packet-cache-contended", Logging::Loggable(pc_stats.first),
-                "packet-cache-acquired", Logging::Loggable(pc_stats.second),
-                "packet-cache-contended-perc", Logging::Loggable(rpc));
+                "packetcache-contended", Logging::Loggable(pc_stats.first),
+                "packetcache-acquired", Logging::Loggable(pc_stats.second),
+                "packetcache-contended-perc", Logging::Loggable(rpc));
       log->info(Logr::Info, m,
                 "throttle-entries", Logging::Loggable(SyncRes::getThrottledServersSize()),
                 "nsspeed-entries", Logging::Loggable(SyncRes::getNSSpeedsSize()),
@@ -2808,7 +2808,10 @@ int main(int argc, char** argv)
     ::arg().setSwitch("nothing-below-nxdomain", "When an NXDOMAIN exists in cache for a name with fewer labels than the qname, send NXDOMAIN without doing a lookup (see RFC 8020)") = "dnssec";
     ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file") = "0";
     ::arg().set("max-include-depth", "Maximum nested $INCLUDE depth when loading a zone from a file") = "20";
+
     ::arg().set("record-cache-shards", "Number of shards in the record cache") = "1024";
+    ::arg().set("packetcache-shards", "Number of shards in the packet cache") = "1024";
+
     ::arg().set("refresh-on-ttl-perc", "If a record is requested from the cache and only this % of original TTL remains, refetch") = "0";
     ::arg().set("record-cache-locked-ttl-perc", "Replace records in record cache only after this % of original TTL has passed") = "0";
 
@@ -3035,7 +3038,7 @@ int main(int argc, char** argv)
     g_negCache = std::make_unique<NegCache>(::arg().asNum("record-cache-shards") / 8);
     if (!::arg().mustDo("disable-packetcache")) {
       g_maxPacketCacheEntries = ::arg().asNum("max-packetcache-entries");
-      g_packetCache = std::make_unique<RecursorPacketCache>(g_maxPacketCacheEntries, ::arg().asNum("record-cache-shards")); // XXX
+      g_packetCache = std::make_unique<RecursorPacketCache>(g_maxPacketCacheEntries, ::arg().asNum("packetcache-shards"));
     }
 
     ret = serviceMain(argc, argv, startupLog);

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -187,7 +187,7 @@ enum class PaddingMode
 
 typedef MTasker<std::shared_ptr<PacketID>, PacketBuffer, PacketIDCompare> MT_t;
 extern thread_local std::unique_ptr<MT_t> MT; // the big MTasker
-extern thread_local std::unique_ptr<RecursorPacketCache> t_packetCache;
+extern std::unique_ptr<RecursorPacketCache> g_packetCache;
 
 using RemoteLoggerStats_t = std::unordered_map<std::string, RemoteLoggerInterface::Stats>;
 

--- a/pdns/recursordist/rec-snmp.cc
+++ b/pdns/recursordist/rec-snmp.cc
@@ -167,6 +167,9 @@ static const oid rcode13AnswersOID[] = {RECURSOR_STATS_OID, 142};
 static const oid rcode14AnswersOID[] = {RECURSOR_STATS_OID, 143};
 static const oid rcode15AnswersOID[] = {RECURSOR_STATS_OID, 144};
 
+static const oid packetCacheContendedOID[] = {RECURSOR_STATS_OID, 145};
+static const oid packetCacheAcquiredOID[] = {RECURSOR_STATS_OID, 146};
+
 static std::unordered_map<oid, std::string> s_statsMap;
 
 /* We are never called for a GETNEXT if it's registered as a
@@ -401,6 +404,8 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   registerCounter64Stat("non-resolving-nameserver-entries", nonResolvingNameserverEntriesOID, OID_LENGTH(nonResolvingNameserverEntriesOID));
   registerCounter64Stat("maintenance-usec", maintenanceUSecOID, OID_LENGTH(maintenanceUSecOID));
   registerCounter64Stat("maintenance-calls", maintenanceCallsOID, OID_LENGTH(maintenanceCallsOID));
+  registerCounter64Stat("packetcache-contended", packetCacheContendedOID, OID_LENGTH(packetCacheContendedOID));
+  registerCounter64Stat("packetcache-acquired", packetCacheAcquiredOID, OID_LENGTH(packetCacheAcquiredOID));
 
 #define RCODE(num) registerCounter64Stat("auth-" + RCode::to_short_s(num) + "-answers", rcode##num##AnswersOID, OID_LENGTH(rcode##num##AnswersOID))
   RCODE(0);

--- a/pdns/recursordist/rec-tcounters.hh
+++ b/pdns/recursordist/rec-tcounters.hh
@@ -95,6 +95,8 @@ enum class Counter : uint8_t
   maintenanceUsec,
   maintenanceCalls,
 
+  pcHits,
+  pcMisses,
   numberOfCounters
 };
 

--- a/pdns/recursordist/rec-tcounters.hh
+++ b/pdns/recursordist/rec-tcounters.hh
@@ -95,8 +95,6 @@ enum class Counter : uint8_t
   maintenanceUsec,
   maintenanceCalls,
 
-  pcHits,
-  pcMisses,
   numberOfCounters
 };
 

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -844,6 +844,7 @@ static string setMaxPacketCacheEntries(T begin, T end)
   }
   try {
     g_maxPacketCacheEntries = pdns::checked_stoi<uint32_t>(*begin);
+    g_packetCache->setMaxSize(g_maxPacketCacheEntries);
     return "New max packetcache entries: " + std::to_string(g_maxPacketCacheEntries) + "\n";
   }
   catch (const std::exception& e) {

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -334,11 +334,6 @@ static uint64_t dumpAggressiveNSECCache(int fd)
   return g_aggressiveNSECCache->dumpToFile(fp, now);
 }
 
-static uint64_t* pleaseDump(int fd)
-{
-  return new uint64_t(t_packetCache ? t_packetCache->doDump(fd) : 0);
-}
-
 static uint64_t* pleaseDumpEDNSMap(int fd)
 {
   return new uint64_t(SyncRes::doEDNSDump(fd));
@@ -416,7 +411,8 @@ static RecursorControlChannel::Answer doDumpCache(int s)
   uint64_t total = 0;
   try {
     int fd = fdw;
-    total = g_recCache->doDump(fd, g_maxCacheEntries.load()) + g_negCache->doDump(fd, g_maxCacheEntries.load() / 8) + broadcastAccFunction<uint64_t>([fd] { return pleaseDump(fd); }) + dumpAggressiveNSECCache(fd);
+    total = g_recCache->doDump(fd, g_maxCacheEntries.load()) + g_negCache->doDump(fd, g_maxCacheEntries.load() / 8) +
+      (g_packetCache ? g_packetCache->doDump(fd) : 0) + dumpAggressiveNSECCache(fd);
   }
   catch (...) {
   }
@@ -1078,46 +1074,6 @@ static uint64_t doGetCacheMisses()
   return g_recCache->cacheMisses;
 }
 
-uint64_t* pleaseGetPacketCacheSize()
-{
-  return new uint64_t(t_packetCache ? t_packetCache->size() : 0);
-}
-
-static uint64_t* pleaseGetPacketCacheBytes()
-{
-  return new uint64_t(t_packetCache ? t_packetCache->bytes() : 0);
-}
-
-static uint64_t doGetPacketCacheSize()
-{
-  return broadcastAccFunction<uint64_t>(pleaseGetPacketCacheSize);
-}
-
-static uint64_t doGetPacketCacheBytes()
-{
-  return broadcastAccFunction<uint64_t>(pleaseGetPacketCacheBytes);
-}
-
-uint64_t* pleaseGetPacketCacheHits()
-{
-  return new uint64_t(t_packetCache ? t_packetCache->d_hits : 0);
-}
-
-static uint64_t doGetPacketCacheHits()
-{
-  return broadcastAccFunction<uint64_t>(pleaseGetPacketCacheHits);
-}
-
-static uint64_t* pleaseGetPacketCacheMisses()
-{
-  return new uint64_t(t_packetCache ? t_packetCache->d_misses : 0);
-}
-
-static uint64_t doGetPacketCacheMisses()
-{
-  return broadcastAccFunction<uint64_t>(pleaseGetPacketCacheMisses);
-}
-
 static uint64_t doGetMallocated()
 {
   // this turned out to be broken
@@ -1306,10 +1262,10 @@ static void registerAllStats1()
   addGetStat("record-cache-contended", []() { return g_recCache->stats().first; });
   addGetStat("record-cache-acquired", []() { return g_recCache->stats().second; });
 
-  addGetStat("packetcache-hits", doGetPacketCacheHits);
-  addGetStat("packetcache-misses", doGetPacketCacheMisses);
-  addGetStat("packetcache-entries", doGetPacketCacheSize);
-  addGetStat("packetcache-bytes", doGetPacketCacheBytes);
+  addGetStat("packetcache-hits", [] { return g_packetCache ? g_packetCache->getHits() : 0; });
+  addGetStat("packetcache-misses", [] { return g_packetCache ? g_packetCache->getMisses() : 0; });
+  addGetStat("packetcache-entries", [] { return g_packetCache ? g_packetCache->size() : 0; });
+  addGetStat("packetcache-bytes", [] { return g_packetCache ? g_packetCache->bytes() : 0; });;
 
   addGetStat("aggressive-nsec-cache-entries", []() { return g_aggressiveNSECCache ? g_aggressiveNSECCache->getEntriesCount() : 0; });
   addGetStat("aggressive-nsec-cache-nsec-hits", []() { return g_aggressiveNSECCache ? g_aggressiveNSECCache->getNSECHits() : 0; });

--- a/pdns/recursordist/recpacketcache.cc
+++ b/pdns/recursordist/recpacketcache.cc
@@ -53,6 +53,18 @@ uint64_t RecursorPacketCache::getMisses()
   return sum;
 }
 
+pair<uint64_t, uint64_t> RecursorPacketCache::stats()
+{
+  uint64_t contended = 0;
+  uint64_t acquired = 0;
+  for (auto& shard : d_maps) {
+    auto content = shard.lock();
+    contended += content->d_contended_count;
+    acquired += content->d_acquired_count;
+  }
+  return {contended, acquired};
+}
+
 uint64_t RecursorPacketCache::doWipePacketCache(const DNSName& name, uint16_t qtype, bool subtree)
 {
   uint64_t count = 0;
@@ -260,7 +272,7 @@ uint64_t RecursorPacketCache::doDump(int file)
     min = std::min(min, shardSize);
     max = std::max(max, shardSize);
     shardNum++;
-  for (const auto& entry : sidx) {
+    for (const auto& entry : sidx) {
       count++;
       try {
         fprintf(filePtr.get(), "%s %" PRId64 " %s  ; tag %d %s\n", entry.d_name.toString().c_str(), static_cast<int64_t>(entry.d_ttd - now), DNSRecordContent::NumberToType(entry.d_type).c_str(), entry.d_tag, entry.d_tcp ? "tcp" : "udp");

--- a/pdns/recursordist/recpacketcache.hh
+++ b/pdns/recursordist/recpacketcache.hh
@@ -95,18 +95,10 @@ public:
     d_maxSize = size;
   }
 
-  [[nodiscard]] uint64_t size() const
-  {
-    uint64_t count = 0;
-    for (const auto& map : d_maps) {
-      count += map.d_entriesCount;
-    }
-    return count;
-  }
+  [[nodiscard]] uint64_t size() const;
   [[nodiscard]] uint64_t bytes();
-
-  uint64_t d_hits{0};
-  uint64_t d_misses{0};
+  [[nodiscard]] uint64_t getHits();
+  [[nodiscard]] uint64_t getMisses();
 
 private:
   struct Entry
@@ -169,6 +161,8 @@ private:
     struct LockedContent
     {
       packetCache_t d_map;
+      uint64_t d_hits{0};
+      uint64_t d_misses{0};
       uint64_t d_contended_count{0};
       uint64_t d_acquired_count{0};
       void invalidate() {}
@@ -213,7 +207,7 @@ private:
   size_t d_maxSize;
 
   static bool qrMatch(const packetCache_t::index<HashTag>::type::iterator& iter, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass);
-  bool checkResponseMatches(packetCache_t& shard, std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);
+bool checkResponseMatches(MapCombo::LockedContent& shard, std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);
 public:
   void preRemoval(MapCombo::LockedContent& map, const Entry& entry)
   {

--- a/pdns/recursordist/recpacketcache.hh
+++ b/pdns/recursordist/recpacketcache.hh
@@ -99,6 +99,7 @@ public:
   [[nodiscard]] uint64_t bytes();
   [[nodiscard]] uint64_t getHits();
   [[nodiscard]] uint64_t getMisses();
+  [[nodiscard]] pair<uint64_t, uint64_t> stats();
 
 private:
   struct Entry
@@ -207,7 +208,8 @@ private:
   size_t d_maxSize;
 
   static bool qrMatch(const packetCache_t::index<HashTag>::type::iterator& iter, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass);
-bool checkResponseMatches(MapCombo::LockedContent& shard, std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);
+  bool checkResponseMatches(MapCombo::LockedContent& shard, std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);
+
 public:
   void preRemoval(MapCombo::LockedContent& map, const Entry& entry)
   {

--- a/pdns/recursordist/recpacketcache.hh
+++ b/pdns/recursordist/recpacketcache.hh
@@ -156,7 +156,7 @@ private:
 
   struct MapCombo
   {
-    MapCombo() {}
+    MapCombo() = default;
     MapCombo(const MapCombo&) = delete;
     MapCombo& operator=(const MapCombo&) = delete;
     struct LockedContent
@@ -188,7 +188,7 @@ private:
 
   vector<MapCombo> d_maps;
 
-  size_t combine(unsigned int tag, uint32_t hash, bool tcp) const
+  static size_t combine(unsigned int tag, uint32_t hash, bool tcp)
   {
     size_t ret = 0;
     boost::hash_combine(ret, tag);
@@ -201,10 +201,11 @@ private:
   {
     return d_maps.at(combine(tag, hash, tcp) % d_maps.size());
   }
-  // const MapCombo& getMap(unsigned int tag, uint32_t hash, bool tcp) const
-  // {
-  //   return d_maps.at(combine(hash, hash, tcp) % d_maps.size());
-  // }
+
+  [[nodiscard]] const MapCombo& getMap(unsigned int tag, uint32_t hash, bool tcp) const
+  {
+    return d_maps.at(combine(hash, hash, tcp) % d_maps.size());
+  }
 
   static bool qrMatch(const packetCache_t::index<HashTag>::type::iterator& iter, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass);
   bool checkResponseMatches(MapCombo::LockedContent& shard, std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);

--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -62,30 +62,31 @@ MemRecursorCache::MemRecursorCache(size_t mapsCount) :
 size_t MemRecursorCache::size() const
 {
   size_t count = 0;
-  for (const auto& map : d_maps) {
-    count += map.d_entriesCount;
+  for (const auto& shard : d_maps) {
+    count += shard.d_entriesCount;
   }
   return count;
 }
 
 pair<uint64_t, uint64_t> MemRecursorCache::stats()
 {
-  uint64_t c = 0, a = 0;
-  for (auto& mc : d_maps) {
-    auto content = mc.lock();
-    c += content->d_contended_count;
-    a += content->d_acquired_count;
+  uint64_t contended = 0;
+  uint64_t acquired = 0;
+  for (auto& shard : d_maps) {
+    auto lockedShard = shard.lock();
+    contended += lockedShard->d_contended_count;
+    acquired += lockedShard->d_acquired_count;
   }
-  return pair<uint64_t, uint64_t>(c, a);
+  return {contended, acquired};
 }
 
 size_t MemRecursorCache::ecsIndexSize()
 {
   // XXX!
   size_t count = 0;
-  for (auto& mc : d_maps) {
-    auto content = mc.lock();
-    count += content->d_ecsIndex.size();
+  for (auto& shard : d_maps) {
+    auto lockedShard = shard.lock();
+    count += lockedShard->d_ecsIndex.size();
   }
   return count;
 }
@@ -94,12 +95,12 @@ size_t MemRecursorCache::ecsIndexSize()
 size_t MemRecursorCache::bytes()
 {
   size_t ret = 0;
-  for (auto& mc : d_maps) {
-    auto m = mc.lock();
-    for (const auto& i : m->d_map) {
+  for (auto& shard : d_maps) {
+    auto lockedShard = shard.lock();
+    for (const auto& entry : lockedShard->d_map) {
       ret += sizeof(struct CacheEntry);
-      ret += i.d_qname.toString().length();
-      for (const auto& record : i.d_records) {
+      ret += entry.d_qname.toString().length();
+      for (const auto& record : entry.d_records) {
         ret += sizeof(record); // XXX WRONG we don't know the stored size!
       }
     }
@@ -145,45 +146,45 @@ time_t MemRecursorCache::handleHit(MapCombo::LockedContent& content, MemRecursor
   time_t ttd = entry->d_ttd;
   origTTL = entry->d_orig_ttl;
 
-  if (variable && (!entry->d_netmask.empty() || entry->d_rtag)) {
+  if (variable != nullptr && (!entry->d_netmask.empty() || entry->d_rtag)) {
     *variable = true;
   }
 
-  if (res) {
+  if (res != nullptr) {
     res->reserve(res->size() + entry->d_records.size());
 
-    for (const auto& k : entry->d_records) {
-      DNSRecord dr;
-      dr.d_name = qname;
-      dr.d_type = entry->d_qtype;
-      dr.d_class = QClass::IN;
-      dr.setContent(k);
+    for (const auto& record : entry->d_records) {
+      DNSRecord result;
+      result.d_name = qname;
+      result.d_type = entry->d_qtype;
+      result.d_class = QClass::IN;
+      result.setContent(record);
       // coverity[store_truncates_time_t]
-      dr.d_ttl = static_cast<uint32_t>(entry->d_ttd);
-      dr.d_place = DNSResourceRecord::ANSWER;
-      res->push_back(std::move(dr));
+      result.d_ttl = static_cast<uint32_t>(entry->d_ttd);
+      result.d_place = DNSResourceRecord::ANSWER;
+      res->push_back(std::move(result));
     }
   }
 
-  if (signatures) {
+  if (signatures != nullptr) {
     signatures->insert(signatures->end(), entry->d_signatures.begin(), entry->d_signatures.end());
   }
 
-  if (authorityRecs) {
+  if (authorityRecs != nullptr) {
     authorityRecs->insert(authorityRecs->end(), entry->d_authorityRecs.begin(), entry->d_authorityRecs.end());
   }
 
   updateDNSSECValidationStateFromCache(state, entry->d_state);
 
-  if (wasAuth) {
+  if (wasAuth != nullptr) {
     *wasAuth = *wasAuth && entry->d_auth;
   }
 
-  if (fromAuthZone) {
+  if (fromAuthZone != nullptr) {
     *fromAuthZone = entry->d_authZone;
   }
 
-  if (fromAuthIP) {
+  if (fromAuthIP != nullptr) {
     *fromAuthIP = entry->d_from;
   }
 
@@ -354,32 +355,32 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qt, F
   boost::optional<vState> cachedState{boost::none};
   uint32_t origTTL;
 
-  if (res) {
+  if (res != nullptr) {
     res->clear();
   }
   const uint16_t qtype = qt.getCode();
-  if (wasAuth) {
+  if (wasAuth != nullptr) {
     // we might retrieve more than one entry, we need to set that to true
     // so it will be set to false if at least one entry is not auth
     *wasAuth = true;
   }
 
-  auto& mc = getMap(qname);
-  auto map = mc.lock();
+  auto& shard = getMap(qname);
+  auto lockedShard = shard.lock();
 
   /* If we don't have any netmask-specific entries at all, let's just skip this
      to be able to use the nice d_cachecache hack. */
-  if (qtype != QType::ANY && !map->d_ecsIndex.empty() && !routingTag) {
+  if (qtype != QType::ANY && !lockedShard->d_ecsIndex.empty() && !routingTag) {
     if (qtype == QType::ADDR) {
       time_t ret = -1;
 
-      auto entryA = getEntryUsingECSIndex(*map, now, qname, QType::A, requireAuth, who, serveStale);
-      if (entryA != map->d_map.end()) {
-        ret = handleHit(*map, entryA, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
+      auto entryA = getEntryUsingECSIndex(*lockedShard, now, qname, QType::A, requireAuth, who, serveStale);
+      if (entryA != lockedShard->d_map.end()) {
+        ret = handleHit(*lockedShard, entryA, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
       }
-      auto entryAAAA = getEntryUsingECSIndex(*map, now, qname, QType::AAAA, requireAuth, who, serveStale);
-      if (entryAAAA != map->d_map.end()) {
-        time_t ttdAAAA = handleHit(*map, entryAAAA, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
+      auto entryAAAA = getEntryUsingECSIndex(*lockedShard, now, qname, QType::AAAA, requireAuth, who, serveStale);
+      if (entryAAAA != lockedShard->d_map.end()) {
+        time_t ttdAAAA = handleHit(*lockedShard, entryAAAA, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
         if (ret > 0) {
           ret = std::min(ret, ttdAAAA);
         }
@@ -395,9 +396,9 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qt, F
       return ret > 0 ? (ret - now) : ret;
     }
     else {
-      auto entry = getEntryUsingECSIndex(*map, now, qname, qtype, requireAuth, who, serveStale);
-      if (entry != map->d_map.end()) {
-        time_t ret = handleHit(*map, entry, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
+      auto entry = getEntryUsingECSIndex(*lockedShard, now, qname, qtype, requireAuth, who, serveStale);
+      if (entry != lockedShard->d_map.end()) {
+        time_t ret = handleHit(*lockedShard, entry, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
         if (state && cachedState) {
           *state = *cachedState;
         }
@@ -408,18 +409,18 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qt, F
   }
 
   if (routingTag) {
-    auto entries = getEntries(*map, qname, qt, routingTag);
+    auto entries = getEntries(*lockedShard, qname, qt, routingTag);
     bool found = false;
     time_t ttd;
 
     if (entries.first != entries.second) {
       OrderedTagIterator_t firstIndexIterator;
       for (auto i = entries.first; i != entries.second; ++i) {
-        firstIndexIterator = map->d_map.project<OrderedTag>(i);
+        firstIndexIterator = lockedShard->d_map.project<OrderedTag>(i);
 
         // When serving stale, we consider expired records
         if (!i->isEntryUsable(now, serveStale)) {
-          moveCacheItemToFront<SequencedTag>(map->d_map, firstIndexIterator);
+          moveCacheItemToFront<SequencedTag>(lockedShard->d_map, firstIndexIterator);
           continue;
         }
 
@@ -430,7 +431,7 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qt, F
 
         handleServeStaleBookkeeping(now, serveStale, firstIndexIterator);
 
-        ttd = handleHit(*map, firstIndexIterator, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
+        ttd = handleHit(*lockedShard, firstIndexIterator, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
 
         if (qt != QType::ANY && qt != QType::ADDR) { // normally if we have a hit, we are done
           break;
@@ -448,7 +449,7 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qt, F
     }
   }
   // Try (again) without tag
-  auto entries = getEntries(*map, qname, qt, boost::none);
+  auto entries = getEntries(*lockedShard, qname, qt, boost::none);
 
   if (entries.first != entries.second) {
     OrderedTagIterator_t firstIndexIterator;
@@ -456,11 +457,11 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qt, F
     time_t ttd;
 
     for (auto i = entries.first; i != entries.second; ++i) {
-      firstIndexIterator = map->d_map.project<OrderedTag>(i);
+      firstIndexIterator = lockedShard->d_map.project<OrderedTag>(i);
 
       // When serving stale, we consider expired records
       if (!i->isEntryUsable(now, serveStale)) {
-        moveCacheItemToFront<SequencedTag>(map->d_map, firstIndexIterator);
+        moveCacheItemToFront<SequencedTag>(lockedShard->d_map, firstIndexIterator);
         continue;
       }
 
@@ -471,7 +472,7 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qt, F
 
       handleServeStaleBookkeeping(now, serveStale, firstIndexIterator);
 
-      ttd = handleHit(*map, firstIndexIterator, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
+      ttd = handleHit(*lockedShard, firstIndexIterator, qname, origTTL, res, signatures, authorityRecs, variable, cachedState, wasAuth, fromAuthZone, fromAuthIP);
 
       if (qt != QType::ANY && qt != QType::ADDR) { // normally if we have a hit, we are done
         break;
@@ -532,10 +533,10 @@ bool MemRecursorCache::CacheEntry::shouldReplace(time_t now, bool auth, vState s
 
 void MemRecursorCache::replace(time_t now, const DNSName& qname, const QType qt, const vector<DNSRecord>& content, const vector<shared_ptr<const RRSIGRecordContent>>& signatures, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs, bool auth, const DNSName& authZone, boost::optional<Netmask> ednsmask, const OptTag& routingTag, vState state, boost::optional<ComboAddress> from, bool refresh)
 {
-  auto& mc = getMap(qname);
-  auto map = mc.lock();
+  auto& shard = getMap(qname);
+  auto lockedShard = shard.lock();
 
-  map->d_cachecachevalid = false;
+  lockedShard->d_cachecachevalid = false;
   if (ednsmask) {
     ednsmask = ednsmask->getNormalized();
   }
@@ -544,10 +545,10 @@ void MemRecursorCache::replace(time_t now, const DNSName& qname, const QType qt,
   // We only store an ednsmask if we do not have a tag and we do have a mask.
   auto key = std::make_tuple(qname, qt.getCode(), ednsmask ? routingTag : boost::none, (ednsmask && !routingTag) ? *ednsmask : Netmask());
   bool isNew = false;
-  cache_t::iterator stored = map->d_map.find(key);
-  if (stored == map->d_map.end()) {
-    stored = map->d_map.insert(CacheEntry(key, auth)).first;
-    ++mc.d_entriesCount;
+  cache_t::iterator stored = lockedShard->d_map.find(key);
+  if (stored == lockedShard->d_map.end()) {
+    stored = lockedShard->d_map.insert(CacheEntry(key, auth)).first;
+    ++shard.d_entriesCount;
     isNew = true;
   }
 
@@ -560,9 +561,9 @@ void MemRecursorCache::replace(time_t now, const DNSName& qname, const QType qt,
     /* don't bother building an ecsIndex if we don't have any netmask-specific entries */
     if (!routingTag && ednsmask && !ednsmask->empty()) {
       auto ecsIndexKey = std::make_tuple(qname, qt.getCode());
-      auto ecsIndex = map->d_ecsIndex.find(ecsIndexKey);
-      if (ecsIndex == map->d_ecsIndex.end()) {
-        ecsIndex = map->d_ecsIndex.insert(ECSIndexEntry(qname, qt.getCode())).first;
+      auto ecsIndex = lockedShard->d_ecsIndex.find(ecsIndexKey);
+      if (ecsIndex == lockedShard->d_ecsIndex.end()) {
+        ecsIndex = lockedShard->d_ecsIndex.insert(ECSIndexEntry(qname, qt.getCode())).first;
       }
       ecsIndex->addMask(*ednsmask);
     }
@@ -611,11 +612,11 @@ void MemRecursorCache::replace(time_t now, const DNSName& qname, const QType qt,
   }
 
   if (!isNew) {
-    moveCacheItemToBack<SequencedTag>(map->d_map, stored);
+    moveCacheItemToBack<SequencedTag>(lockedShard->d_map, stored);
   }
   ce.d_submitted = false;
   ce.d_servedStale = 0;
-  map->d_map.replace(stored, ce);
+  lockedShard->d_map.replace(stored, ce);
 }
 
 size_t MemRecursorCache::doWipeCache(const DNSName& name, bool sub, const QType qtype)
@@ -623,17 +624,17 @@ size_t MemRecursorCache::doWipeCache(const DNSName& name, bool sub, const QType 
   size_t count = 0;
 
   if (!sub) {
-    auto& mc = getMap(name);
-    auto map = mc.lock();
-    map->d_cachecachevalid = false;
-    auto& idx = map->d_map.get<OrderedTag>();
+    auto& shard = getMap(name);
+    auto lockedShard = shard.lock();
+    lockedShard->d_cachecachevalid = false;
+    auto& idx = lockedShard->d_map.get<OrderedTag>();
     auto range = idx.equal_range(name);
     auto i = range.first;
     while (i != range.second) {
       if (i->d_qtype == qtype || qtype == 0xffff) {
         i = idx.erase(i);
         count++;
-        --mc.d_entriesCount;
+        --shard.d_entriesCount;
       }
       else {
         ++i;
@@ -641,12 +642,12 @@ size_t MemRecursorCache::doWipeCache(const DNSName& name, bool sub, const QType 
     }
 
     if (qtype == 0xffff) {
-      auto& ecsIdx = map->d_ecsIndex.get<OrderedTag>();
+      auto& ecsIdx = lockedShard->d_ecsIndex.get<OrderedTag>();
       auto ecsIndexRange = ecsIdx.equal_range(name);
       ecsIdx.erase(ecsIndexRange.first, ecsIndexRange.second);
     }
     else {
-      auto& ecsIdx = map->d_ecsIndex.get<HashedTag>();
+      auto& ecsIdx = lockedShard->d_ecsIndex.get<HashedTag>();
       auto ecsIndexRange = ecsIdx.equal_range(std::tie(name, qtype));
       ecsIdx.erase(ecsIndexRange.first, ecsIndexRange.second);
     }
@@ -687,26 +688,27 @@ size_t MemRecursorCache::doWipeCache(const DNSName& name, bool sub, const QType 
 // Name should be doLimitTime or so
 bool MemRecursorCache::doAgeCache(time_t now, const DNSName& name, const QType qtype, uint32_t newTTL)
 {
-  auto& mc = getMap(name);
-  auto map = mc.lock();
-  cache_t::iterator iter = map->d_map.find(std::tie(name, qtype));
-  if (iter == map->d_map.end()) {
+  auto& shard = getMap(name);
+  auto lockedShard = shard.lock();
+  cache_t::iterator iter = lockedShard->d_map.find(std::tie(name, qtype));
+  if (iter == lockedShard->d_map.end()) {
     return false;
   }
 
   CacheEntry ce = *iter;
-  if (ce.d_ttd < now)
+  if (ce.d_ttd < now) {
     return false; // would be dead anyhow
+  }
 
   uint32_t maxTTL = static_cast<uint32_t>(ce.d_ttd - now);
   if (maxTTL > newTTL) {
-    map->d_cachecachevalid = false;
+    lockedShard->d_cachecachevalid = false;
 
     time_t newTTD = now + newTTL;
 
     if (ce.d_ttd > newTTD) {
       ce.d_ttd = newTTD;
-      map->d_map.replace(iter, ce);
+      lockedShard->d_map.replace(iter, ce);
     }
     return true;
   }
@@ -775,17 +777,17 @@ uint64_t MemRecursorCache::doDump(int fd, size_t maxCacheEntries)
 
   fprintf(fp.get(), "; main record cache dump follows\n;\n");
   uint64_t count = 0;
-  size_t shard = 0;
+  size_t shardNumber = 0;
   size_t min = std::numeric_limits<size_t>::max();
   size_t max = 0;
-  for (auto& mc : d_maps) {
-    auto map = mc.lock();
-    const auto shardSize = map->d_map.size();
-    fprintf(fp.get(), "; record cache shard %zu; size %zu\n", shard, shardSize);
+  for (auto& shard : d_maps) {
+    auto lockedShard = shard.lock();
+    const auto shardSize = lockedShard->d_map.size();
+    fprintf(fp.get(), "; record cache shard %zu; size %zu\n", shardNumber, shardSize);
     min = std::min(min, shardSize);
     max = std::max(max, shardSize);
-    shard++;
-    const auto& sidx = map->d_map.get<SequencedTag>();
+    shardNumber++;
+    const auto& sidx = lockedShard->d_map.get<SequencedTag>();
     time_t now = time(nullptr);
     for (const auto& i : sidx) {
       for (const auto& j : i.d_records) {
@@ -820,8 +822,8 @@ void MemRecursorCache::doPrune(size_t keep)
 
 namespace boost
 {
-size_t hash_value(const MemRecursorCache::OptTag& o)
+size_t hash_value(const MemRecursorCache::OptTag& rtag)
 {
-  return o ? hash_value(o.get()) : 0xcafebaaf;
+  return rtag ? hash_value(rtag.get()) : 0xcafebaaf;
 }
 }

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -922,8 +922,6 @@ uint64_t* pleaseGetNsSpeedsSize();
 uint64_t* pleaseGetFailedServersSize();
 uint64_t* pleaseGetConcurrentQueries();
 uint64_t* pleaseGetThrottleSize();
-uint64_t* pleaseGetPacketCacheHits();
-uint64_t* pleaseGetPacketCacheSize();
 void doCarbonDump(void*);
 bool primeHints(time_t now = time(nullptr));
 const char* isoDateTimeMillis(const struct timeval& tv, char* buf, size_t sz);

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -1070,7 +1070,15 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::d_metrics
 
   {"record-cache-contended",
    MetricDefinition(PrometheusMetricType::counter,
-                    "Number of contented record cache lock acquisitions")},
+                    "Number of contended record cache lock acquisitions")},
+
+  {"packetcache-acquired",
+   MetricDefinition(PrometheusMetricType::counter,
+                    "Number of packet cache lock acquisitions")},
+
+  {"packetcache-contended",
+   MetricDefinition(PrometheusMetricType::counter,
+                    "Number of contended packet cache lock acquisitions")},
 
   {"taskqueue-expired",
    MetricDefinition(PrometheusMetricType::counter,

--- a/regression-tests.recursor-dnssec/test_PacketCache.py
+++ b/regression-tests.recursor-dnssec/test_PacketCache.py
@@ -47,6 +47,7 @@ f 3600 IN CNAME f            ; CNAME loop: dirty trick to get a ServFail in an a
         super(PacketCacheRecursorTest, cls).generateRecursorConfig(confdir)
 
     def checkPacketCacheMetrics(self, expectedHits, expectedMisses):
+        self.waitForTCPSocket("127.0.0.1", self._wsPort)
         headers = {'x-api-key': self._apiKey}
         url = 'http://127.0.0.1:' + str(self._wsPort) + '/api/v1/servers/localhost/statistics'
         r = requests.get(url, headers=headers, timeout=self._wsTimeout)

--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -31,7 +31,7 @@ rm -f recursor.pid pdns_recursor.pid
 <measurement><name>system CPU seconds</name><value>%S</value></measurement>
 <measurement><name>wallclock seconds</name><value>%e</value></measurement>
 <measurement><name>%% CPU used</name><value>%P</value></measurement>
-'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address="0.0.0.0${QLA6}" --threads=$threads --record-cache-shards=$shards --disable-packetcache --refresh-on-ttl-perc=10 --dnssec=validate > recursor.log 2>&1 &
+'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address="0.0.0.0${QLA6}" --threads=$threads --record-cache-shards=$shards --refresh-on-ttl-perc=10 --dnssec=validate > recursor.log 2>&1 &
 sleep 3
 if [ ! -e pdns_recursor.pid ]; then
         cat recursor.log


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Initial draft version, not very much tested, but appears to work as designed. Note that this only changes the PC itself. In the future, this will open up possibilities to reorganise incoming packet handling.

TODO
- [x] performance tests (initial rough tests do seem to provide better throughput with not much contention seen). These tests need to be done on a wide variety of systems.
- [X] TSAN checking: on debian bullseye rec is getting OOM-killed when running tests with many names filling the PC. No idea if this is a problem with the code or TSAN itself yet. I do see the resident memory growing fast (virtual size is always very big with TSAN). Without TSAN memory usage seems to stay within reasonable limits. Note added: Confirmed to happen on master as well. I suppose TSAN isn't really suitable for very large test runs. Small tests run fine btw.
- [x] Currently # shards setting is shared with the record cache. Might need a separate setting 
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
