### PR TITLE
rec: Call the right wipe function for negcache in the serve-stale case

### DIFF
--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -242,7 +242,7 @@ size_t NegCache::wipe(const DNSName& name, bool subtree)
   return ret;
 }
 
-size_t NegCache::wipe(const DNSName& qname, QType qtype)
+size_t NegCache::wipeTyped(const DNSName& qname, QType qtype)
 {
   size_t ret = 0;
   auto& map = getMap(qname);

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -96,7 +96,7 @@ public:
   void clear();
   size_t doDump(int fd, size_t maxCacheEntries);
   size_t wipe(const DNSName& name, bool subtree = false);
-  size_t wipe(const DNSName& name, QType qtype);
+  size_t wipeTyped(const DNSName& name, QType qtype);
   size_t size() const;
 
 private:

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -4567,7 +4567,7 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, const string&
         // Delete potential negcache entry. When a record recovers with serve-stale the negcache entry can cause the wrong entry to
         // be served, as negcache entries are checked before record cache entries
         if (NegCache::s_maxServedStaleExtensions > 0) {
-          g_negCache->wipe(i->first.name, i->first.type);
+          g_negCache->wipeTyped(i->first.name, i->first.type);
         }
 
         if (g_aggressiveNSECCache && needWildcardProof && recordState == vState::Secure && i->first.place == DNSResourceRecord::ANSWER && i->first.name == qname && !i->second.signatures.empty() && !d_routingTag && !ednsmask) {

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -438,6 +438,44 @@ BOOST_AUTO_TEST_CASE(test_wipe_subtree)
   BOOST_CHECK_EQUAL(cache.size(), 400U);
 }
 
+BOOST_AUTO_TEST_CASE(test_wipe_typed)
+{
+  string qname(".powerdns.com");
+  DNSName auth("powerdns.com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  NegCache::NegCacheEntry ne;
+  ne = genNegCacheEntry(auth, auth, now, QType::A);
+  cache.add(ne);
+
+  for (int i = 0; i < 400; i++) {
+    ne = genNegCacheEntry(DNSName(std::to_string(i) + qname), auth, now, QType::A);
+    cache.add(ne);
+  }
+
+  BOOST_CHECK_EQUAL(cache.size(), 401U);
+
+  // Should only wipe the powerdns.com entry
+  cache.wipeTyped(auth, QType::A);
+  BOOST_CHECK_EQUAL(cache.size(), 400U);
+
+  NegCache::NegCacheEntry ne2;
+  bool ret = cache.get(auth, QType(1), now, ne2);
+
+  BOOST_CHECK_EQUAL(ret, false);
+
+  cache.wipeTyped(DNSName("1.powerdns.com"), QType::A);
+  BOOST_CHECK_EQUAL(cache.size(), 399U);
+
+  NegCache::NegCacheEntry ne3;
+  ret = cache.get(auth, QType(1), now, ne3);
+
+  BOOST_CHECK_EQUAL(ret, false);
+}
+
 BOOST_AUTO_TEST_CASE(test_clear)
 {
   string qname(".powerdns.com");


### PR DESCRIPTION
This is a reason serve-stale is causing an intermittent high CPU load: the wipe function actually called was deleting a (potentially large) subtree of the negcache on all shards. Root cause was an unaccounted for conversion between short and bool.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
