### PR TITLE
rec: Update validation state after a missing negative indication

### DIFF
--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -5399,7 +5399,7 @@ bool SyncRes::processAnswer(unsigned int depth, const string& prefix, LWResult& 
       LOG(prefix << qname << ": NXDOMAIN without a negative indication (missing SOA in authority) in a DNSSEC secure zone, going Bogus" << endl);
       updateValidationState(qname, state, vState::BogusMissingNegativeIndication, prefix);
     }
-    else if (state == vState::Indeterminate) {
+    else {
       /* we might not have validated any record, because we did get a NXDOMAIN without any SOA
          from an insecure zone, for example */
       updateValidationState(qname, state, tempState, prefix);
@@ -5421,7 +5421,7 @@ bool SyncRes::processAnswer(unsigned int depth, const string& prefix, LWResult& 
       LOG(prefix << qname << ": NODATA without a negative indication (missing SOA in authority) in a DNSSEC secure zone, going Bogus" << endl);
       updateValidationState(qname, state, vState::BogusMissingNegativeIndication, prefix);
     }
-    else if (state == vState::Indeterminate) {
+    else {
       /* we might not have validated any record, because we did get a NODATA without any SOA
          from an insecure zone, for example */
       updateValidationState(qname, state, tempState, prefix);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported by @mnordhoff  as `Recursor: False AD bit in empty insecure response from buggy F5`:

```
`vietnamplus.vn.` is an insecure zone.

`en.vietnamplus.vn.` is an extremely janky zone that responds poorly to everything except A queries; its NSes are `f51.vnanet.vn.` and `gtm03.vnanet.vn.`, so we can guess why. ;-)

`dig [en.vietnamplus.vn](http://en.vietnamplus.vn/) aaaa` gives an empty response with the AD bit on. (I assume this affects almost every query type; I'm using AAAA as an example.)

I'm running Recursor 4.9.0~alpha0+master.930.g791621029-1pdns.focal (latest at the time of writing) on Ubuntu 20.04 amd64.

On Quad9 (Miami PoP) PowerDNS, I've seen (empty) responses with and without the AD bit. The latter may have been cache hits; I dunno.

(Quad9 Unbound returns empty, insecure responses; 9.9.9.11 BIND returns SERVFAIL.)

Related DNSViz:

<https://dnsviz.net/d/vietnamplus.vn/Y_R0BQ/dnssec/>
<https://dnsviz.net/d/en.vietnamplus.vn/Y_R0CQ/dnssec/>

This is a bug (unless I'm mistaken somehow). It's arguably not very important -- you can't get much less important than a 100% empty NODATA response in an insecure zone.
```

I don't think this is actually a security issue since we would properly go Bogus if the zone was a secure one. Failing to update the security state does result in the AD bit being set on the empty response, which is not good but does not seem terrible to me either at the moment.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
