### PR TITLE
dnsdist: Count hits in the StatNode

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dynblocks.cc
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.cc
@@ -416,7 +416,12 @@ void DynBlockRulesGroup::processResponseRules(counts_t& counts, StatNode& root, 
       }
 
       if (suffixMatchRuleMatches) {
-        root.submit(c.name, ((c.dh.rcode == 0 && c.usec == std::numeric_limits<unsigned int>::max()) ? -1 : c.dh.rcode), c.size, boost::none);
+        bool hit = c.ds.sin4.sin_family == 0;
+        if (!hit && c.ds.isIPv4() && c.ds.sin4.sin_addr.s_addr == 0 && c.ds.sin4.sin_port == 0) {
+          hit = true;
+        }
+
+        root.submit(c.name, ((c.dh.rcode == 0 && c.usec == std::numeric_limits<unsigned int>::max()) ? -1 : c.dh.rcode), c.size, hit, boost::none);
       }
     }
   }

--- a/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
@@ -54,6 +54,11 @@ uint64_t dnsdist_ffi_stat_node_get_bytes(const dnsdist_ffi_stat_node_t* node)
   return node->self.bytes;
 }
 
+uint64_t dnsdist_ffi_stat_node_get_hits(const dnsdist_ffi_stat_node_t* node)
+{
+  return node->self.hits;
+}
+
 unsigned int dnsdist_ffi_stat_node_get_labels_count(const dnsdist_ffi_stat_node_t* node)
 {
   return node->node.labelsCount;
@@ -99,6 +104,11 @@ uint64_t dnsdist_ffi_stat_node_get_children_drops_count(const dnsdist_ffi_stat_n
 uint64_t dnsdist_ffi_stat_node_get_children_bytes_count(const dnsdist_ffi_stat_node_t* node)
 {
   return node->children.bytes;
+}
+
+uint64_t dnsdist_ffi_stat_node_get_children_hits(const dnsdist_ffi_stat_node_t* node)
+{
+  return node->children.hits;
 }
 
 void dnsdist_ffi_state_node_set_reason(dnsdist_ffi_stat_node_t* node, const char* reason, size_t reasonSize)

--- a/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.hh
@@ -29,6 +29,7 @@ extern "C" {
   uint64_t dnsdist_ffi_stat_node_get_servfails_count(const dnsdist_ffi_stat_node_t* node) __attribute__ ((visibility ("default")));
   uint64_t dnsdist_ffi_stat_node_get_drops_count(const dnsdist_ffi_stat_node_t* node) __attribute__ ((visibility ("default")));
   uint64_t dnsdist_ffi_stat_node_get_bytes(const dnsdist_ffi_stat_node_t* node) __attribute__ ((visibility ("default")));
+  uint64_t dnsdist_ffi_stat_node_get_hits(const dnsdist_ffi_stat_node_t* node) __attribute__ ((visibility ("default")));
   unsigned int dnsdist_ffi_stat_node_get_labels_count(const dnsdist_ffi_stat_node_t* node) __attribute__ ((visibility ("default")));
   void dnsdist_ffi_stat_node_get_full_name_raw(const dnsdist_ffi_stat_node_t* node, const char** name, size_t* nameSize) __attribute__ ((visibility ("default")));
 
@@ -40,6 +41,7 @@ extern "C" {
   uint64_t dnsdist_ffi_stat_node_get_children_servfails_count(const dnsdist_ffi_stat_node_t* node) __attribute__ ((visibility ("default")));
   uint64_t dnsdist_ffi_stat_node_get_children_drops_count(const dnsdist_ffi_stat_node_t* node) __attribute__ ((visibility ("default")));
   uint64_t dnsdist_ffi_stat_node_get_children_bytes_count(const dnsdist_ffi_stat_node_t* node) __attribute__ ((visibility ("default")));
+  uint64_t dnsdist_ffi_stat_node_get_children_hits(const dnsdist_ffi_stat_node_t* node) __attribute__ ((visibility ("default")));
 
   void dnsdist_ffi_state_node_set_reason(dnsdist_ffi_stat_node_t* node, const char* reason, size_t reasonSize) __attribute__ ((visibility ("default")));
 }

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -358,7 +358,7 @@ try
 	      rem.sin4.sin_port=0;
 
 	      if(doServFailTree)
-		root.submit(qname, header.rcode, pr.d_len, rem);
+		root.submit(qname, header.rcode, pr.d_len, false, rem);
 	    }
 
 	    if(!qd.d_qcount || qd.d_qcount == qd.d_answercount) {

--- a/pdns/statnode.cc
+++ b/pdns/statnode.cc
@@ -13,6 +13,7 @@ StatNode::Stat StatNode::print(unsigned int depth, Stat newstat, bool silent) co
   childstat.servfails += s.servfails;
   childstat.drops += s.drops;
   childstat.bytes += s.bytes;
+  childstat.hits += s.hits;
 
   if(children.size()>1024 && !silent) {
     cout<<string(depth, ' ')<<name<<": too many to print"<<endl;
@@ -26,7 +27,8 @@ StatNode::Stat StatNode::print(unsigned int depth, Stat newstat, bool silent) co
       childstat.nxdomains<<" nxdomains, "<< 
       childstat.servfails<<" servfails, "<< 
       childstat.drops<<" drops, "<<
-      childstat.bytes<<" bytes"<<endl;
+      childstat.bytes<<" bytes, "<<
+      childstat.hits<<" hits"<<endl;
 
   newstat+=childstat;
 
@@ -48,7 +50,7 @@ void StatNode::visit(visitor_t visitor, Stat &newstat, unsigned int depth) const
 }
 
 
-void StatNode::submit(const DNSName& domain, int rcode, unsigned int bytes, boost::optional<const ComboAddress&> remote)
+void StatNode::submit(const DNSName& domain, int rcode, unsigned int bytes, bool hit, boost::optional<const ComboAddress&> remote)
 {
   //  cerr<<"FIRST submit called on '"<<domain<<"'"<<endl;
   std::vector<string> tmp = domain.getRawLabels();
@@ -57,7 +59,7 @@ void StatNode::submit(const DNSName& domain, int rcode, unsigned int bytes, boos
   }
 
   auto last = tmp.end() - 1;
-  children[*last].submit(last, tmp.begin(), "", rcode, bytes, remote, 1);
+  children[*last].submit(last, tmp.begin(), "", rcode, bytes, remote, 1, hit);
 }
 
 /* www.powerdns.com. -> 
@@ -67,7 +69,7 @@ void StatNode::submit(const DNSName& domain, int rcode, unsigned int bytes, boos
    www.powerdns.com. 
 */
 
-void StatNode::submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const std::string& domain, int rcode, unsigned int bytes, boost::optional<const ComboAddress&> remote, unsigned int count)
+void StatNode::submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const std::string& domain, int rcode, unsigned int bytes, boost::optional<const ComboAddress&> remote, unsigned int count, bool hit)
 {
   //  cerr<<"Submit called for domain='"<<domain<<"': ";
   //  for(const std::string& n :  labels) 
@@ -96,17 +98,25 @@ void StatNode::submit(std::vector<string>::const_iterator end, std::vector<strin
     //    cerr<<"Hit the end, set our fullname to '"<<fullname<<"'"<<endl<<endl;
     s.queries++;
     s.bytes += bytes;
-    if(rcode<0)
+    if (rcode < 0) {
       s.drops++;
-    else if(rcode==0)
+    }
+    else if (rcode == RCode::NoError) {
       s.noerrors++;
-    else if(rcode==2)
+    }
+    else if (rcode == RCode::ServFail) {
       s.servfails++;
-    else if(rcode==3)
+    }
+    else if (rcode == RCode::NXDomain) {
       s.nxdomains++;
+    }
 
     if (remote) {
       s.remotes[*remote]++;
+    }
+
+    if (hit) {
+      ++s.hits;
     }
   }
   else {
@@ -122,6 +132,6 @@ void StatNode::submit(std::vector<string>::const_iterator end, std::vector<strin
     }
     //    cerr<<"Not yet end, set our fullname to '"<<fullname<<"', recursing"<<endl;
     --end;
-    children[*end].submit(end, begin, fullname, rcode, bytes, remote, count+1);
+    children[*end].submit(end, begin, fullname, rcode, bytes, remote, count+1, hit);
   }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds the number of cache hits to `StatNode` objects.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
