### PR TITLE
builder-support: Prepare to make Debian-style source artifacts

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.debbuild-prepare
+++ b/builder-support/dockerfiles/Dockerfile.debbuild-prepare
@@ -17,12 +17,18 @@ COPY --from=sdist /sdist /sdist
 
 @IF [ -n "$M_authoritative$M_all" ]
 RUN tar xvf /sdist/pdns-${BUILDER_VERSION}.tar.bz2
+# create copy of source tarball with name that dpkg-source requires
+RUN cp /sdist/pdns-${BUILDER_VERSION}.tar.bz2 pdns_${BUILDER_VERSION}.orig.tar.bz2
 @ENDIF
 
 @IF [ -n "$M_recursor$M_all" ]
 RUN tar xvf /sdist/pdns-recursor-${BUILDER_VERSION}.tar.bz2
+# create copy of source tarball with name that dpkg-source requires
+RUN cp /sdist/pdns-recursor-${BUILDER_VERSION}.tar.bz2 pdns-recursor_${BUILDER_VERSION}.orig.tar.bz2
 @ENDIF
 
 @IF [ -n "$M_dnsdist$M_all" ]
 RUN tar xvf /sdist/dnsdist-${BUILDER_VERSION}.tar.bz2
+# create copy of source tarball with name that dpkg-source requires
+RUN cp /sdist/dnsdist-${BUILDER_VERSION}.tar.bz2 dnsdist_${BUILDER_VERSION}.orig.tar.bz2
 @ENDIF


### PR DESCRIPTION
### Short description
Debian requires an 'orig' tarball to be part of the source artifact set (along with the .dsc and .debian.tar.xz files), so the debbuild-prepare Dockerfile will now make a copy of the sdist-provided tarball with the proper name.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
