### PR TITLE
dnsdist: Report per-incoming transport latencies in the web interface

### DIFF
--- a/pdns/dnsdistdist/html/index.html
+++ b/pdns/dnsdistdist/html/index.html
@@ -50,7 +50,8 @@
     </tr></table>
     <p>
       Uptime: <span id="uptime"></span>, Number of queries: <span id="questions"></span> (<span id="qps"></span> qps), ACL drops: <span id="acl-drops"></span>, Dynamic drops: <span id="dyn-drops"></span>, Rule drops: <span id="rule-drops"></span><br/>
-      Average response time: <span id="latency"></span> ms, CPU Usage: <span id="cpu"></span>%, Cache hitrate: <span id="phitrate"></span>%, Server selection policy: <span id="server-policy"></span><br/>
+      Average response time: UDP <span id="latency"></span> ms, TCP <span id="latency-tcp"></span> ms, DoT <span id="latency-dot"></span> ms, DoH <span id="latency-doh"></span> ms <br/>
+      CPU Usage: <span id="cpu"></span>%, Cache hitrate: <span id="phitrate"></span>%, Server selection policy: <span id="server-policy"></span><br/>
       Listening on: <span id="local"></span>, ACL: <span id="acl"></span>
     </p>
     <table width="100%" cellpadding="20">

--- a/pdns/dnsdistdist/html/local.js
+++ b/pdns/dnsdistdist/html/local.js
@@ -151,6 +151,9 @@ $(document).ready(function() {
                 $("#rule-drops").text(data["rule-drop"]);
                 $("#uptime").text(moment.duration(data["uptime"]*1000.0).humanize());
                 $("#latency").text((data["latency-avg10000"]/1000.0).toFixed(2));
+                $("#latency-tcp").text((data["latency-tcp-avg10000"]/1000.0).toFixed(2));
+                $("#latency-dot").text((data["latency-dot-avg10000"]/1000.0).toFixed(2));
+                $("#latency-doh").text((data["latency-doh-avg10000"]/1000.0).toFixed(2));
                 if(!gdata["cpu-sys-msec"]) 
                     gdata=data;
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since 1.8.0 we have separate latencies based on the incoming transport, but the internal web interface was only reporting the UDP one. After this commit the interface will display the latency for UDP, TCP, DoT and DoH queries.
Reported by Stephane Bortzmeyer (thanks!).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
