### PR TITLE
dnsdist: Use the correct source address when harvesting failed

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -174,7 +174,7 @@ static ssize_t sendfromto(int sock, const void* data, size_t len, int flags, con
   msgh.msg_name = (struct sockaddr*)&to;
   msgh.msg_namelen = to.getSocklen();
 
-  if(from.sin4.sin_family) {
+  if (from.sin4.sin_family) {
     addCMsgSrcAddr(&msgh, &cbuf, &from, 0);
   }
   else {
@@ -1612,6 +1612,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
          which is used by rules and actions to at least the correct
          address family */
       ids.origDest = cs.local;
+      ids.hopLocal.sin4.sin_family = 0;
     }
 
     std::vector<ProxyProtocolValue> proxyProtocolValues;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It is a slightly different issue than https://github.com/PowerDNS/pdns/issues/12581 because we cannot harvest the original destination address on a loopback interface, so the code path is a bit different.
Fixes https://github.com/PowerDNS/pdns/issues/12640

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
