### PR TITLE
Run `clang-tidy` on auth, rec and dnsdist when opening PRs

### DIFF
--- a/.github/scripts/clang-tidy.py
+++ b/.github/scripts/clang-tidy.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+"""Clang-tidy to Github Actions annotations converter.
+
+Convert the YAML file produced by clang-tidy-diff containing warnings and
+suggested fixes to Github Actions annotations.
+
+"""
+
+import argparse
+import os
+import sys
+
+import yaml
+
+
+def create_argument_parser():
+    """Create command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Convert clang-tidy output to Github Actions"
+    )
+    parser.add_argument(
+        "--fixes-file",
+        type=str,
+        required=True,
+        help="Path to the clang-tidy fixes YAML",
+    )
+    # parser.add_argument(
+    #     "--prefix-dir",
+    #     type=str,
+    #     required=True,
+    #     help="Project subdirectory",
+    # )
+    return parser.parse_args()
+
+
+def get_line_from_offset(file_contents, offset):
+    """Calculate line number from byte offset in source file."""
+    return file_contents[:offset].count("\n") + 1
+
+
+def load_fixes_file(filename):
+    """Load the clang-tidy YAML fixes file."""
+    with open(filename, encoding="utf_8") as file:
+        return yaml.safe_load(file)
+
+
+def load_file(filename):
+    """Load the entire contents of a file."""
+    with open(filename, encoding="utf-8") as file:
+        contents = file.read()
+        return contents
+
+
+def main():
+    """Start the script."""
+    args = create_argument_parser()
+
+    fixes = load_fixes_file(args.fixes_file)
+    fixes = fixes["Diagnostics"]
+    have_warnings = False
+    for fix in fixes:
+        name = fix["DiagnosticName"]
+        level = fix["Level"]
+        directory = fix["BuildDirectory"]
+        diagnostic = fix["DiagnosticMessage"]
+        offset = diagnostic["FileOffset"]
+        filename = diagnostic["FilePath"]
+        message = diagnostic["Message"]
+
+        full_filename = directory + os.path.sep + filename
+        try:
+            file_contents = load_file(full_filename)
+        except OSError:
+            # Skip in case the file can't be found. This is usually one of
+            # those "too many errors emitted, stopping now" clang messages.
+            print(f"Skipping {full_filename}")
+            continue
+
+        line = get_line_from_offset(file_contents, offset)
+
+        annotation = "".join(
+            [
+                f"::warning file={full_filename},line={line}",
+                f"::{message} ({name} - Level={level})",
+            ]
+        )
+        print(annotation)
+
+        # User-friendly printout
+        print(f"{level}: {full_filename}:{line}: {message} ({name})")
+
+        have_warnings = True
+
+    return 1 if have_warnings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -108,3 +108,55 @@ jobs:
           if [ -f clang-tidy-results/rec-fixes.yml ]; then
             python .github/scripts/clang-tidy.py --fixes-file clang-tidy-results/rec-fixes.yml
           fi
+
+  clang-tidy-dnsdist:
+    name: dnsdist clang-tidy
+    runs-on: ubuntu-20.04
+    env:
+      UNIT_TESTS: yes
+      SANITIZERS:
+    steps:
+      - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 2
+      - name: get timestamp for cache
+        id: get-stamp
+        shell: bash
+        run: |
+          echo "stamp=$(/bin/date +%s)" >> "$GITHUB_OUTPUT"
+      - name: let GitHub cache our ccache data
+        uses: actions/cache@v3.2.5
+        with:
+          path: ~/.ccache
+          key: dnsdist-full-ccache-${{ steps.get-stamp.outputs.stamp }}
+          restore-keys: dnsdist-full-ccache-
+      - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
+      - run: inv apt-fresh
+      - run: inv install-clang
+      - run: inv install-clang-tidy-tools
+      - run: inv install-dnsdist-build-deps
+      - run: inv ci-autoconf
+        working-directory: pdns/dnsdistdist/
+      - run: inv ci-dnsdist-configure full
+        working-directory: pdns/dnsdistdist/
+      - run: inv ci-dnsdist-make-bear
+        working-directory: pdns/dnsdistdist/
+      - run: ccache -s
+      - run: mkdir clang-tidy-results
+      - run: ln -s .clang-tidy.full .clang-tidy
+      - name: Run clang-tidy
+        working-directory: pdns/dnsdistdist/
+        run: git diff -U0 HEAD^ | python /usr/bin/clang-tidy-diff-12.py -p3 -export-fixes ../../clang-tidy-results/dnsdist-fixes.yml
+      - name: Print clang-tidy fixes YAML
+        shell: bash
+        run: |
+          if [ -f clang-tidy-results/dnsdist-fixes.yml ]; then
+            cat clang-tidy-results/dnsdist-fixes.yml
+          fi
+      - name: Result annotations
+        shell: bash
+        run: |
+          if [ -f clang-tidy-results/dnsdist-fixes.yml ]; then
+            python .github/scripts/clang-tidy.py --fixes-file clang-tidy-results/dnsdist-fixes.yml
+          fi

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,58 @@
+---
+name: 'clang-tidy'
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  clang-tidy:
+    name: auth clang-tidy
+    runs-on: ubuntu-20.04
+    env:
+      UNIT_TESTS: yes
+      SANITIZERS:
+    steps:
+      - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 2
+      - name: get timestamp for cache
+        id: get-stamp
+        shell: bash
+        run: |
+          echo "stamp=$(/bin/date +%s)" >> "$GITHUB_OUTPUT"
+      - name: let GitHub cache our ccache data
+        uses: actions/cache@v3.2.5
+        with:
+          path: ~/.ccache
+          key: auth-ccache-${{ steps.get-stamp.outputs.stamp }}
+          restore-keys: auth-ccache-
+      - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
+      - run: inv install-clang
+      - run: inv install-clang-tidy-tools
+      - run: inv install-auth-build-deps
+      - run: inv ci-autoconf
+      - run: inv ci-auth-configure
+      - run: inv ci-auth-make-bear
+      - run: ccache -s
+      - run: mkdir clang-tidy-results
+      - run: ln -s .clang-tidy.full .clang-tidy
+      - name: Run clang-tidy
+        working-directory: pdns
+        run: git diff -U0 HEAD^ | python /usr/bin/clang-tidy-diff-12.py -p2 -export-fixes ../clang-tidy-results/auth-fixes.yml
+      - name: Print clang-tidy fixes YAML
+        shell: bash
+        run: |
+          if [ -f clang-tidy-results/auth-fixes.yml ]; then
+            cat clang-tidy-results/auth-fixes.yml
+          fi
+      - name: Result annotations
+        shell: bash
+        run: |
+          if [ -f clang-tidy-results/auth-fixes.yml ]; then
+            python .github/scripts/clang-tidy.py --fixes-file clang-tidy-results/auth-fixes.yml
+          fi

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  clang-tidy:
+  clang-tidy-auth:
     name: auth clang-tidy
     runs-on: ubuntu-20.04
     env:
@@ -55,4 +55,56 @@ jobs:
         run: |
           if [ -f clang-tidy-results/auth-fixes.yml ]; then
             python .github/scripts/clang-tidy.py --fixes-file clang-tidy-results/auth-fixes.yml
+          fi
+
+  clang-tidy-rec:
+    name: rec clang-tidy
+    runs-on: ubuntu-20.04
+    env:
+      UNIT_TESTS: yes
+      SANITIZERS:
+    steps:
+      - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 2
+      - name: get timestamp for cache
+        id: get-stamp
+        shell: bash
+        run: |
+          echo "stamp=$(/bin/date +%s)" >> "$GITHUB_OUTPUT"
+      - name: let GitHub cache our ccache data
+        uses: actions/cache@v3.2.5
+        with:
+          path: ~/.ccache
+          key: recursor-ccache-${{ steps.get-stamp.outputs.stamp }}
+          restore-keys: recursor-ccache-
+      - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
+      - run: inv apt-fresh
+      - run: inv install-clang
+      - run: inv install-clang-tidy-tools
+      - run: inv install-rec-build-deps
+      - run: inv ci-autoconf
+        working-directory: pdns/recursordist/
+      - run: inv ci-rec-configure
+        working-directory: pdns/recursordist/
+      - run: inv ci-rec-make-bear
+        working-directory: pdns/recursordist/
+      - run: ccache -s
+      - run: mkdir clang-tidy-results
+      - run: ln -s .clang-tidy.full .clang-tidy
+      - name: Run clang-tidy
+        working-directory: pdns/recursordist/
+        run: git diff -U0 HEAD^ | python /usr/bin/clang-tidy-diff-12.py -p3 -export-fixes ../../clang-tidy-results/rec-fixes.yml
+      - name: Print clang-tidy fixes YAML
+        shell: bash
+        run: |
+          if [ -f clang-tidy-results/rec-fixes.yml ]; then
+            cat clang-tidy-results/rec-fixes.yml
+          fi
+      - name: Result annotations
+        shell: bash
+        run: |
+          if [ -f clang-tidy-results/rec-fixes.yml ]; then
+            python .github/scripts/clang-tidy.py --fixes-file clang-tidy-results/rec-fixes.yml
           fi

--- a/regression-tests/tests/.gitignore
+++ b/regression-tests/tests/.gitignore
@@ -3,3 +3,4 @@ real_result
 *.out
 start
 step.*
+verify-dnssec-zone/allow-missing

--- a/tasks.py
+++ b/tasks.py
@@ -537,6 +537,11 @@ def ci_rec_make(c):
     c.run('make -j8 -k V=1')
 
 @task
+def ci_rec_make_bear(c):
+    # Assumed to be running under ./pdns/recursordist/
+    c.run('bear --append make -j8 -k V=1')
+
+@task
 def ci_dnsdist_make(c):
     c.run('make -j4 -k V=1')
 

--- a/tasks.py
+++ b/tasks.py
@@ -156,6 +156,10 @@ def install_clang(c):
     c.sudo('apt-get -qq -y --no-install-recommends install clang-12 llvm-12')
 
 @task
+def install_clang_tidy_tools(c):
+    c.sudo('apt-get -qq -y --no-install-recommends install clang-tidy-12 clang-tools-12 bear python-yaml')
+
+@task
 def install_clang_runtime(c):
     # this gives us the symbolizer, for symbols in asan/ubsan traces
     c.sudo('apt-get -qq -y --no-install-recommends install clang-12')
@@ -521,6 +525,12 @@ def ci_dnsdist_configure(c, features):
 @task
 def ci_auth_make(c):
     c.run('make -j8 -k V=1')
+
+@task
+def ci_auth_make_bear(c):
+    # Needed for clang-tidy -line-filter vs project structure shenanigans
+    with c.cd('pdns'):
+        c.run('bear --append make -j8 -k V=1 -C ..')
 
 @task
 def ci_rec_make(c):

--- a/tasks.py
+++ b/tasks.py
@@ -546,6 +546,11 @@ def ci_dnsdist_make(c):
     c.run('make -j4 -k V=1')
 
 @task
+def ci_dnsdist_make_bear(c):
+    # Assumed to be running under ./pdns/dnsdistdist/
+    c.run('bear --append make -j4 -k V=1')
+
+@task
 def ci_auth_install_remotebackend_test_deps(c):
     with c.cd('modules/remotebackend'):
       # c.run('bundle config set path vendor/bundle')

--- a/tasks.py
+++ b/tasks.py
@@ -301,9 +301,18 @@ def ci_docs_build_pdf(c):
 
 @task
 def ci_docs_upload_master(c, docs_host, pdf, username, product, directory=""):
-    c.run(f"rsync -crv --delete --no-p --chmod=g=rwX --exclude '*~' ./docs/_build/{product}-html-docs/ {username}@{docs_host}:{directory}")
-    c.run(f"rsync -crv --no-p --chmod=g=rwX --exclude '*~' ./docs/_build/{product}-html-docs.tar.bz2 {username}@{docs_host}:{directory}/html-docs.tar.bz2")
-    c.run(f"rsync -crv --no-p --chmod=g=rwX --exclude '*~' ./docs/_build/latex/{pdf} {username}@{docs_host}:{directory}")
+    rsync_cmd = " ".join([
+        "rsync",
+        "--checksum",
+        "--recursive",
+        "--verbose",
+        "--no-p",
+        "--chmod=g=rwX",
+        "--exclude '*~'",
+    ])
+    c.run(f"{rsync_cmd} --delete ./docs/_build/{product}-html-docs/ {username}@{docs_host}:{directory}")
+    c.run(f"{rsync_cmd} ./docs/_build/{product}-html-docs.tar.bz2 {username}@{docs_host}:{directory}/html-docs.tar.bz2")
+    c.run(f"{rsync_cmd} ./docs/_build/latex/{pdf} {username}@{docs_host}:{directory}")
 
 @task
 def ci_docs_add_ssh(c, ssh_key, host_key):

--- a/tasks.py
+++ b/tasks.py
@@ -321,58 +321,121 @@ def ci_docs_add_ssh(c, ssh_key, host_key):
     c.run('chmod 600 ~/.ssh/id_ed25519')
     c.run(f'echo "{host_key}" > ~/.ssh/known_hosts')
 
+
+def get_sanitizers():
+    sanitizers = os.getenv('SANITIZERS')
+    if sanitizers != '':
+        sanitizers = sanitizers.split('+')
+        sanitizers = ['--enable-' + sanitizer for sanitizer in sanitizers]
+        sanitizers = ' '.join(sanitizers)
+    return sanitizers
+
+
+def get_cflags():
+    return " ".join([
+        "-O1",
+        "-Werror=vla",
+        "-Werror=shadow",
+        "-Wformat=2",
+        "-Werror=format-security",
+        "-Werror=string-plus-int",
+    ])
+
+
+def get_cxxflags():
+    return " ".join([
+        get_cflags(),
+        "-Wp,-D_GLIBCXX_ASSERTIONS",
+    ])
+
+
+def get_base_configure_cmd():
+    return " ".join([
+        f'CFLAGS="{get_cflags()}"',
+        f'CXXFLAGS="{get_cxxflags()}"',
+        './configure',
+        "CC='clang-12'",
+        "CXX='clang++-12'",
+        "--enable-option-checking=fatal",
+        "--enable-systemd",
+        "--with-libsodium",
+        "--enable-fortify-source=auto",
+        "--enable-auto-var-init=pattern",
+    ])
+
+
 @task
 def ci_auth_configure(c):
-    sanitizers = ' '.join('--enable-'+x for x in os.getenv('SANITIZERS').split('+')) if os.getenv('SANITIZERS') != '' else ''
-    unittests = ' --enable-unit-tests --enable-backend-unit-tests' if os.getenv('UNIT_TESTS') == 'yes' else ''
-    fuzzingtargets = ' --enable-fuzz-targets' if os.getenv('FUZZING_TARGETS') == 'yes' else ''
-    res = c.run('''CFLAGS="-O1 -Werror=vla -Werror=shadow -Wformat=2 -Werror=format-security -Werror=string-plus-int" \
-                   CXXFLAGS="-O1 -Werror=vla -Werror=shadow -Wformat=2 -Werror=format-security -Werror=string-plus-int -Wp,-D_GLIBCXX_ASSERTIONS" \
-                   ./configure \
-                      CC='clang-12' \
-                      CXX='clang++-12' \
-                      LDFLAGS='-L/usr/local/lib -Wl,-rpath,/usr/local/lib' \
-                      --enable-option-checking=fatal \
-                      --with-modules='bind geoip gmysql godbc gpgsql gsqlite3 ldap lmdb lua2 pipe remote tinydns' \
-                      --enable-systemd \
-                      --enable-tools \
-                      --enable-fuzz-targets \
-                      --enable-experimental-pkcs11 \
-                      --enable-experimental-gss-tsig \
-                      --enable-remotebackend-zeromq \
-                      --with-lmdb=/usr \
-                      --with-libsodium \
-                      --with-libdecaf \
-                      --prefix=/opt/pdns-auth \
-                      --enable-ixfrdist \
-                      --enable-fortify-source=auto \
-                      --enable-auto-var-init=pattern ''' + sanitizers + unittests + fuzzingtargets, warn=True)
+    sanitizers = get_sanitizers()
+
+    unittests = os.getenv('UNIT_TESTS')
+    if unittests == 'yes':
+        unittests = '--enable-unit-tests --enable-backend-unit-tests'
+    else:
+        unittests = ''
+
+    fuzz_targets = os.getenv('FUZZING_TARGETS')
+    fuzz_targets = '--enable-fuzz-targets' if fuzz_targets == 'yes' else ''
+
+    modules = " ".join([
+        "bind",
+        "geoip",
+        "gmysql",
+        "godbc",
+        "gpgsql",
+        "gsqlite3",
+        "ldap",
+        "lmdb",
+        "lua2",
+        "pipe",
+        "remote",
+        "tinydns",
+    ])
+    configure_cmd = " ".join([
+        get_base_configure_cmd(),
+        "LDFLAGS='-L/usr/local/lib -Wl,-rpath,/usr/local/lib'",
+        f"--with-modules='{modules}'",
+        "--enable-tools",
+        "--enable-experimental-pkcs11",
+        "--enable-experimental-gss-tsig",
+        "--enable-remotebackend-zeromq",
+        "--with-lmdb=/usr",
+        "--with-libdecaf",
+        "--prefix=/opt/pdns-auth",
+        "--enable-ixfrdist",
+        sanitizers,
+        unittests,
+        fuzz_targets,
+    ])
+    res = c.run(configure_cmd, warn=True)
     if res.exited != 0:
         c.run('cat config.log')
         raise UnexpectedExit(res)
+
+
 @task
 def ci_rec_configure(c):
-    sanitizers = ' '.join('--enable-'+x for x in os.getenv('SANITIZERS').split('+')) if os.getenv('SANITIZERS') != '' else ''
-    unittests = ' --enable-unit-tests' if os.getenv('UNIT_TESTS') == 'yes' else ''
-    res = c.run('''            CFLAGS="-O1 -Werror=vla -Werror=shadow -Wformat=2 -Werror=format-security -Werror=string-plus-int" \
-            CXXFLAGS="-O1 -Werror=vla -Werror=shadow -Wformat=2 -Werror=format-security -Werror=string-plus-int -Wp,-D_GLIBCXX_ASSERTIONS" \
-            ./configure \
-              CC='clang-12' \
-              CXX='clang++-12' \
-              --enable-option-checking=fatal \
-              --enable-nod \
-              --enable-systemd \
-              --prefix=/opt/pdns-recursor \
-              --with-libsodium \
-              --with-lua=luajit \
-              --with-libcap \
-              --with-net-snmp \
-              --enable-fortify-source=auto \
-              --enable-auto-var-init=pattern \
-              --enable-dns-over-tls ''' + sanitizers + unittests, warn=True)
+    sanitizers = get_sanitizers()
+
+    unittests = os.getenv('UNIT_TESTS')
+    unittests = '--enable-unit-tests' if unittests == 'yes' else ''
+
+    configure_cmd = " ".join([
+        get_base_configure_cmd(),
+        "--enable-nod",
+        "--prefix=/opt/pdns-recursor",
+        "--with-lua=luajit",
+        "--with-libcap",
+        "--with-net-snmp",
+        "--enable-dns-over-tls",
+        sanitizers,
+        unittests,
+    ])
+    res = c.run(configure_cmd, warn=True)
     if res.exited != 0:
         c.run('cat config.log')
         raise UnexpectedExit(res)
+
 
 @task
 def ci_dnsdist_configure(c, features):


### PR DESCRIPTION
### Short description
Run `clang-tidy` on auth, rec and dnsdist when opening PRs.

This adds a new Github Actions (CI) workflow with 3 jobs that configure, build and lint (using `clang-tidy`) the auth, rec and dnsdist. The lint messages are then posted as Github annotations which [show up on the summary page of the action's run](https://github.com/fredmorcos/pdns/actions/runs/4415458994), and also [show up as code comments on the PR's diff](https://github.com/fredmorcos/pdns/pull/1/files). Next to the annotations, "user-friendly" messages are also output in the console in case that's more convenient, here are examples for [auth](https://github.com/fredmorcos/pdns/actions/runs/4415458994/jobs/7738451560), [rec](https://github.com/fredmorcos/pdns/actions/runs/4415458994/jobs/7738451725) and [dnsdist](https://github.com/fredmorcos/pdns/actions/runs/4415458994/jobs/7738451309).

The annotations are produced by a python script which reads the messages from the `clang-tidy` YAML output and exports them to the Github format. The compilation database for each product is generated using `bear` through `pyinvoke` tasks.

This also cleans up the auth and rec pyinvoke configure tasks.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)