### PR TITLE
dnsdist: Add support for incoming DoH via nghttp2

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -511,6 +511,7 @@ gpgsqlbackend
 gprof
 gpsqlbackend
 grepq
+grpc
 GSQ
 gsql
 gsqlite

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -120,7 +120,7 @@ jobs:
       run: |
         cd pdns/dnsdistdist
         autoreconf -vfi
-        ./configure --enable-unit-tests --enable-dnstap --enable-dnscrypt --enable-dns-over-tls --enable-dns-over-https LIBS=-lwslay CFLAGS='-O0' CXXFLAGS='-O0'
+        ./configure --enable-unit-tests --enable-dnstap --enable-dnscrypt --enable-dns-over-tls --enable-dns-over-https --with-h2o LIBS=-lwslay CFLAGS='-O0' CXXFLAGS='-O0'
         make -j8 -C ext/arc4random
         make -j8 -C ext/ipcrypt
         make -j8 -C ext/yahttp

--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -147,7 +147,7 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint)
         errorCounters = &front->tlsFrontend->d_tlsCounters;
       }
       else if (front->dohFrontend != nullptr) {
-        errorCounters = &front->dohFrontend->d_tlsCounters;
+        errorCounters = &front->dohFrontend->d_tlsContext.d_tlsCounters;
       }
       if (errorCounters != nullptr) {
         str << base << "tlsdhkeytoosmall" << ' ' << errorCounters->d_dhKeyTooSmall << " " << now << "\r\n";
@@ -204,7 +204,7 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint)
       std::map<std::string, uint64_t> dohFrontendDuplicates;
       const string base = "dnsdist." + hostname + ".main.doh.";
       for (const auto& doh : g_dohlocals) {
-        string name = doh->d_local.toStringWithPort();
+        string name = doh->d_tlsContext.d_addr.toStringWithPort();
         boost::replace_all(name, ".", "_");
         boost::replace_all(name, ":", "_");
         boost::replace_all(name, "[", "_");

--- a/pdns/dnsdist-doh-common.hh
+++ b/pdns/dnsdist-doh-common.hh
@@ -77,6 +77,10 @@ struct DOHFrontend
   DOHFrontend()
   {
   }
+  DOHFrontend(std::shared_ptr<TLSCtx> tlsCtx):
+    d_tlsContext(std::move(tlsCtx))
+  {
+  }
 
   virtual ~DOHFrontend()
   {

--- a/pdns/dnsdist-doh-common.hh
+++ b/pdns/dnsdist-doh-common.hh
@@ -77,7 +77,7 @@ struct DOHFrontend
   DOHFrontend()
   {
   }
-  DOHFrontend(std::shared_ptr<TLSCtx> tlsCtx):
+  DOHFrontend(std::shared_ptr<TLSCtx> tlsCtx) :
     d_tlsContext(std::move(tlsCtx))
   {
   }

--- a/pdns/dnsdist-doh-common.hh
+++ b/pdns/dnsdist-doh-common.hh
@@ -77,10 +77,6 @@ struct DOHFrontend
   DOHFrontend()
   {
   }
-  DOHFrontend(std::shared_ptr<TLSCtx> tlsCtx) :
-    d_tlsContext(std::move(tlsCtx))
-  {
-  }
 
   virtual ~DOHFrontend()
   {
@@ -126,6 +122,7 @@ struct DOHFrontend
 #endif
   bool d_sendCacheControlHeaders{true};
   bool d_trustForwardedForHeader{false};
+  bool d_earlyACLDrop{true};
   /* whether we require tue query path to exactly match one of configured ones,
      or accept everything below these paths. */
   bool d_exactPathMatching{true};

--- a/pdns/dnsdist-doh-common.hh
+++ b/pdns/dnsdist-doh-common.hh
@@ -1,0 +1,240 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <unordered_map>
+#include <set>
+
+#include "config.h"
+#include "iputils.hh"
+#include "libssl.hh"
+#include "noinitvector.hh"
+#include "stat_t.hh"
+#include "tcpiohandler.hh"
+
+struct DOHServerConfig;
+
+class DOHResponseMapEntry
+{
+public:
+  DOHResponseMapEntry(const std::string& regex, uint16_t status, const PacketBuffer& content, const boost::optional<std::unordered_map<std::string, std::string>>& headers) :
+    d_regex(regex), d_customHeaders(headers), d_content(content), d_status(status)
+  {
+    if (status >= 400 && !d_content.empty() && d_content.at(d_content.size() - 1) != 0) {
+      // we need to make sure it's null-terminated
+      d_content.push_back(0);
+    }
+  }
+
+  bool matches(const std::string& path) const
+  {
+    return d_regex.match(path);
+  }
+
+  uint16_t getStatusCode() const
+  {
+    return d_status;
+  }
+
+  const PacketBuffer& getContent() const
+  {
+    return d_content;
+  }
+
+  const boost::optional<std::unordered_map<std::string, std::string>>& getHeaders() const
+  {
+    return d_customHeaders;
+  }
+
+private:
+  Regex d_regex;
+  boost::optional<std::unordered_map<std::string, std::string>> d_customHeaders;
+  PacketBuffer d_content;
+  uint16_t d_status;
+};
+
+struct DOHFrontend
+{
+  DOHFrontend()
+  {
+  }
+  DOHFrontend(std::shared_ptr<TLSCtx> tlsCtx) :
+    d_tlsContext(std::move(tlsCtx))
+  {
+  }
+
+  virtual ~DOHFrontend()
+  {
+  }
+
+  std::shared_ptr<DOHServerConfig> d_dsc{nullptr};
+  std::shared_ptr<std::vector<std::shared_ptr<DOHResponseMapEntry>>> d_responsesMap;
+  TLSFrontend d_tlsContext{TLSFrontend::ALPN::DoH};
+  std::string d_serverTokens{"h2o/dnsdist"};
+  std::unordered_map<std::string, std::string> d_customResponseHeaders;
+  std::string d_library;
+
+  uint32_t d_idleTimeout{30}; // HTTP idle timeout in seconds
+  std::set<std::string, std::less<>> d_urls;
+
+  pdns::stat_t d_httpconnects{0}; // number of TCP/IP connections established
+  pdns::stat_t d_getqueries{0}; // valid DNS queries received via GET
+  pdns::stat_t d_postqueries{0}; // valid DNS queries received via POST
+  pdns::stat_t d_badrequests{0}; // request could not be converted to dns query
+  pdns::stat_t d_errorresponses{0}; // dnsdist set 'error' on response
+  pdns::stat_t d_redirectresponses{0}; // dnsdist set 'redirect' on response
+  pdns::stat_t d_validresponses{0}; // valid responses sent out
+
+  struct HTTPVersionStats
+  {
+    pdns::stat_t d_nbQueries{0}; // valid DNS queries received
+    pdns::stat_t d_nb200Responses{0};
+    pdns::stat_t d_nb400Responses{0};
+    pdns::stat_t d_nb403Responses{0};
+    pdns::stat_t d_nb500Responses{0};
+    pdns::stat_t d_nb502Responses{0};
+    pdns::stat_t d_nbOtherResponses{0};
+  };
+
+  HTTPVersionStats d_http1Stats;
+  HTTPVersionStats d_http2Stats;
+#ifdef __linux__
+  // On Linux this gives us 128k pending queries (default is 8192 queries),
+  // which should be enough to deal with huge spikes
+  uint32_t d_internalPipeBufferSize{1024 * 1024};
+#else
+  uint32_t d_internalPipeBufferSize{0};
+#endif
+  bool d_sendCacheControlHeaders{true};
+  bool d_trustForwardedForHeader{false};
+  /* whether we require tue query path to exactly match one of configured ones,
+     or accept everything below these paths. */
+  bool d_exactPathMatching{true};
+  bool d_keepIncomingHeaders{false};
+
+  time_t getTicketsKeyRotationDelay() const
+  {
+    return d_tlsContext.d_tlsConfig.d_ticketsKeyRotationDelay;
+  }
+
+  bool isHTTPS() const
+  {
+    return !d_tlsContext.d_tlsConfig.d_certKeyPairs.empty();
+  }
+
+#ifndef HAVE_DNS_OVER_HTTPS
+  virtual void setup()
+  {
+  }
+
+  virtual void reloadCertificates()
+  {
+  }
+
+  virtual void rotateTicketsKey(time_t /* now */)
+  {
+  }
+
+  virtual void loadTicketsKeys(const std::string& /* keyFile */)
+  {
+  }
+
+  virtual void handleTicketsKeyRotation()
+  {
+  }
+
+  virtual std::string getNextTicketsKeyRotation()
+  {
+    return std::string();
+  }
+
+  virtual size_t getTicketsKeysCount() const
+  {
+    size_t res = 0;
+    return res;
+  }
+
+#else
+  virtual void setup();
+  virtual void reloadCertificates();
+
+  virtual void rotateTicketsKey(time_t now);
+  virtual void loadTicketsKeys(const std::string& keyFile);
+  virtual void handleTicketsKeyRotation();
+  virtual std::string getNextTicketsKeyRotation() const;
+  virtual size_t getTicketsKeysCount();
+#endif /* HAVE_DNS_OVER_HTTPS */
+};
+
+#include "dnsdist-idstate.hh"
+
+struct DownstreamState;
+
+#ifndef HAVE_DNS_OVER_HTTPS
+struct DOHUnitInterface
+{
+  virtual ~DOHUnitInterface()
+  {
+  }
+  static void handleTimeout(std::unique_ptr<DOHUnitInterface>)
+  {
+  }
+
+  static void handleUDPResponse(std::unique_ptr<DOHUnitInterface>, PacketBuffer&&, InternalQueryState&&, const std::shared_ptr<DownstreamState>&)
+  {
+  }
+};
+#else /* HAVE_DNS_OVER_HTTPS */
+struct DOHUnitInterface
+{
+  virtual ~DOHUnitInterface()
+  {
+  }
+
+  virtual std::string getHTTPPath() const = 0;
+  virtual std::string getHTTPQueryString() const = 0;
+  virtual const std::string& getHTTPHost() const = 0;
+  virtual const std::string& getHTTPScheme() const = 0;
+  virtual const std::unordered_map<std::string, std::string>& getHTTPHeaders() const = 0;
+  virtual void setHTTPResponse(uint16_t statusCode, PacketBuffer&& body, const std::string& contentType = "") = 0;
+  virtual void handleTimeout() = 0;
+  virtual void handleUDPResponse(PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>&) = 0;
+
+  static void handleTimeout(std::unique_ptr<DOHUnitInterface> unit)
+  {
+    if (unit) {
+      unit->handleTimeout();
+      unit.release();
+    }
+  }
+
+  static void handleUDPResponse(std::unique_ptr<DOHUnitInterface> unit, PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& ds)
+  {
+    if (unit) {
+      unit->handleUDPResponse(std::move(response), std::move(state), ds);
+      unit.release();
+    }
+  }
+
+  std::shared_ptr<DownstreamState> downstream{nullptr};
+};
+#endif /* HAVE_DNS_OVER_HTTPS  */

--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "config.h"
+#include "dnscrypt.hh"
 #include "dnsname.hh"
 #include "dnsdist-protocols.hh"
 #include "gettime.hh"
@@ -29,11 +30,12 @@
 #include "uuid-utils.hh"
 
 struct ClientState;
-struct DOHUnit;
+struct DOHUnitInterface;
 class DNSCryptQuery;
 class DNSDistPacketCache;
 
 using QTag = std::unordered_map<string, string>;
+using HeadersMap = std::unordered_map<std::string, std::string>;
 
 struct StopWatch
 {
@@ -89,6 +91,8 @@ private:
   bool d_needRealTime;
 };
 
+class CrossProtocolContext;
+
 struct InternalQueryState
 {
   struct ProtoBufData
@@ -125,7 +129,9 @@ struct InternalQueryState
   std::unique_ptr<ProtoBufData> d_protoBufData{nullptr};
   boost::optional<uint32_t> tempFailureTTL{boost::none}; // 8
   ClientState* cs{nullptr}; // 8
-  std::unique_ptr<DOHUnit> du{nullptr}; // 8
+  std::unique_ptr<DOHUnitInterface> du; // 8
+  size_t d_proxyProtocolPayloadSize{0}; // 8
+  int32_t d_streamID{-1}; // 4
   uint32_t cacheKey{0}; // 4
   uint32_t cacheKeyNoECS{0}; // 4
   // DoH-only */

--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -99,12 +99,7 @@ struct InternalQueryState
     std::string d_requestorID;
   };
 
-  static void DeleterPlaceHolder(DOHUnit*)
-  {
-  }
-
-  InternalQueryState() :
-    du(std::unique_ptr<DOHUnit, void (*)(DOHUnit*)>(nullptr, DeleterPlaceHolder))
+  InternalQueryState()
   {
     origDest.sin4.sin_family = 0;
   }
@@ -130,7 +125,7 @@ struct InternalQueryState
   std::unique_ptr<ProtoBufData> d_protoBufData{nullptr};
   boost::optional<uint32_t> tempFailureTTL{boost::none}; // 8
   ClientState* cs{nullptr}; // 8
-  std::unique_ptr<DOHUnit, void (*)(DOHUnit*)> du; // 8
+  std::unique_ptr<DOHUnit> du{nullptr}; // 8
   uint32_t cacheKey{0}; // 4
   uint32_t cacheKeyNoECS{0}; // 4
   // DoH-only */

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -284,7 +284,7 @@ public:
 
     struct timeval now;
     gettimeofday(&now, nullptr);
-    sender->notifyIOError(std::move(object->query.d_idstate), now);
+    sender->notifyIOError(now, TCPResponse(std::move(object->query)));
     return true;
   }
 

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -706,7 +706,7 @@ void setupLuaInspection(LuaContext& luaCtx)
           errorCounters = &f->tlsFrontend->d_tlsCounters;
         }
         else if (f->dohFrontend != nullptr) {
-          errorCounters = &f->dohFrontend->d_tlsCounters;
+          errorCounters = &f->dohFrontend->d_tlsContext.d_tlsCounters;
         }
         if (errorCounters == nullptr) {
           continue;

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2579,7 +2579,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     setLuaSideEffect();
 
-    shared_ptr<TLSFrontend> frontend = std::make_shared<TLSFrontend>();
+    shared_ptr<TLSFrontend> frontend = std::make_shared<TLSFrontend>(TLSFrontend::ALPN::DoT);
     if (!loadTLSCertificateAndKeys("addTLSLocal", frontend->d_tlsConfig.d_certKeyPairs, certFiles, keyFiles)) {
       return;
     }

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -57,6 +57,7 @@
 #include "dnsdist-web.hh"
 
 #include "base64.hh"
+#include "doh.hh"
 #include "dolog.hh"
 #include "sodcrypto.hh"
 #include "threadname.hh"
@@ -2336,31 +2337,39 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     setLuaSideEffect();
 
     auto frontend = std::make_shared<DOHFrontend>();
+#ifdef HAVE_LIBH2OEVLOOP
+    frontend = std::make_shared<H2ODOHFrontend>();
+    frontend->d_library = "h2o";
+#else /* HAVE_LIBH2OEVLOOP */
+    errlog("DOH bind %s is configured to use libh2o but the library is not available", addr);
+    return;
+#endif /* HAVE_LIBH2OEVLOOP */
+
     if (certFiles && !certFiles->empty()) {
-      if (!loadTLSCertificateAndKeys("addDOHLocal", frontend->d_tlsConfig.d_certKeyPairs, *certFiles, *keyFiles)) {
+      if (!loadTLSCertificateAndKeys("addDOHLocal", frontend->d_tlsContext.d_tlsConfig.d_certKeyPairs, *certFiles, *keyFiles)) {
         return;
       }
 
-      frontend->d_local = ComboAddress(addr, 443);
+      frontend->d_tlsContext.d_addr = ComboAddress(addr, 443);
     }
     else {
-      frontend->d_local = ComboAddress(addr, 80);
-      infolog("No certificate provided for DoH endpoint %s, running in DNS over HTTP mode instead of DNS over HTTPS", frontend->d_local.toStringWithPort());
+      frontend->d_tlsContext.d_addr = ComboAddress(addr, 80);
+      infolog("No certificate provided for DoH endpoint %s, running in DNS over HTTP mode instead of DNS over HTTPS", frontend->d_tlsContext.d_addr.toStringWithPort());
     }
 
     if (urls) {
       if (urls->type() == typeid(std::string)) {
-        frontend->d_urls.push_back(boost::get<std::string>(*urls));
+        frontend->d_urls.insert(boost::get<std::string>(*urls));
       }
       else if (urls->type() == typeid(LuaArray<std::string>)) {
         auto urlsVect = boost::get<LuaArray<std::string>>(*urls);
         for (const auto& p : urlsVect) {
-          frontend->d_urls.push_back(p.second);
+          frontend->d_urls.insert(p.second);
         }
       }
     }
     else {
-      frontend->d_urls = {"/dns-query"};
+      frontend->d_urls.insert("/dns-query");
     }
 
     bool reusePort = false;
@@ -2405,7 +2414,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         }
       }
 
-      parseTLSConfig(frontend->d_tlsConfig, "addDOHLocal", vars);
+      parseTLSConfig(frontend->d_tlsContext.d_tlsConfig, "addDOHLocal", vars);
 
       bool ignoreTLSConfigurationErrors = false;
       if (getOptionalValue<bool>(vars, "ignoreTLSConfigurationErrors", ignoreTLSConfigurationErrors) > 0 && ignoreTLSConfigurationErrors) {
@@ -2413,7 +2422,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         // and properly ignore the frontend before actually launching it
         try {
           std::map<int, std::string> ocspResponses = {};
-          auto ctx = libssl_init_server_context(frontend->d_tlsConfig, ocspResponses);
+          auto ctx = libssl_init_server_context(frontend->d_tlsContext.d_tlsConfig, ocspResponses);
         }
         catch (const std::runtime_error& e) {
           errlog("Ignoring DoH frontend: '%s'", e.what());
@@ -2424,7 +2433,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       checkAllParametersConsumed("addDOHLocal", vars);
     }
     g_dohlocals.push_back(frontend);
-    auto cs = std::make_unique<ClientState>(frontend->d_local, true, reusePort, tcpFastOpenQueueSize, interface, cpus);
+    auto cs = std::make_unique<ClientState>(frontend->d_tlsContext.d_addr, true, reusePort, tcpFastOpenQueueSize, interface, cpus);
     cs->dohFrontend = frontend;
     cs->d_additionalAddresses = std::move(additionalAddresses);
 
@@ -2435,9 +2444,9 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       cs->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConnections;
     }
     g_frontends.push_back(std::move(cs));
-#else
+#else /* HAVE_DNS_OVER_HTTPS */
       throw std::runtime_error("addDOHLocal() called but DNS over HTTPS support is not present!");
-#endif
+#endif /* HAVE_DNS_OVER_HTTPS */
   });
 
   luaCtx.writeFunction("showDOHFrontends", []() {
@@ -2449,7 +2458,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       ret << (fmt % "#" % "Address" % "HTTP" % "HTTP/1" % "HTTP/2" % "GET" % "POST" % "Bad" % "Errors" % "Redirects" % "Valid" % "# ticket keys" % "Rotation delay" % "Next rotation") << endl;
       size_t counter = 0;
       for (const auto& ctx : g_dohlocals) {
-        ret << (fmt % counter % ctx->d_local.toStringWithPort() % ctx->d_httpconnects % ctx->d_http1Stats.d_nbQueries % ctx->d_http2Stats.d_nbQueries % ctx->d_getqueries % ctx->d_postqueries % ctx->d_badrequests % ctx->d_errorresponses % ctx->d_redirectresponses % ctx->d_validresponses % ctx->getTicketsKeysCount() % ctx->getTicketsKeyRotationDelay() % ctx->getNextTicketsKeyRotation()) << endl;
+        ret << (fmt % counter % ctx->d_tlsContext.d_addr.toStringWithPort() % ctx->d_httpconnects % ctx->d_http1Stats.d_nbQueries % ctx->d_http2Stats.d_nbQueries % ctx->d_getqueries % ctx->d_postqueries % ctx->d_badrequests % ctx->d_errorresponses % ctx->d_redirectresponses % ctx->d_validresponses % ctx->getTicketsKeysCount() % ctx->getTicketsKeyRotationDelay() % ctx->getNextTicketsKeyRotation()) << endl;
         counter++;
       }
       g_outputBuffer = ret.str();
@@ -2473,7 +2482,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       ret << (fmt % "#" % "Address" % "200" % "400" % "403" % "500" % "502" % "Others") << endl;
       size_t counter = 0;
       for (const auto& ctx : g_dohlocals) {
-        ret << (fmt % counter % ctx->d_local.toStringWithPort() % ctx->d_http1Stats.d_nb200Responses % ctx->d_http1Stats.d_nb400Responses % ctx->d_http1Stats.d_nb403Responses % ctx->d_http1Stats.d_nb500Responses % ctx->d_http1Stats.d_nb502Responses % ctx->d_http1Stats.d_nbOtherResponses) << endl;
+        ret << (fmt % counter % ctx->d_tlsContext.d_addr.toStringWithPort() % ctx->d_http1Stats.d_nb200Responses % ctx->d_http1Stats.d_nb400Responses % ctx->d_http1Stats.d_nb403Responses % ctx->d_http1Stats.d_nb500Responses % ctx->d_http1Stats.d_nb502Responses % ctx->d_http1Stats.d_nbOtherResponses) << endl;
         counter++;
       }
       g_outputBuffer += ret.str();
@@ -2483,7 +2492,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       ret << (fmt % "#" % "Address" % "200" % "400" % "403" % "500" % "502" % "Others") << endl;
       counter = 0;
       for (const auto& ctx : g_dohlocals) {
-        ret << (fmt % counter % ctx->d_local.toStringWithPort() % ctx->d_http2Stats.d_nb200Responses % ctx->d_http2Stats.d_nb400Responses % ctx->d_http2Stats.d_nb403Responses % ctx->d_http2Stats.d_nb500Responses % ctx->d_http2Stats.d_nb502Responses % ctx->d_http2Stats.d_nbOtherResponses) << endl;
+        ret << (fmt % counter % ctx->d_tlsContext.d_addr.toStringWithPort() % ctx->d_http2Stats.d_nb200Responses % ctx->d_http2Stats.d_nb400Responses % ctx->d_http2Stats.d_nb403Responses % ctx->d_http2Stats.d_nb500Responses % ctx->d_http2Stats.d_nb502Responses % ctx->d_http2Stats.d_nbOtherResponses) << endl;
         counter++;
       }
       g_outputBuffer += ret.str();
@@ -2537,7 +2546,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.registerFunction<void (std::shared_ptr<DOHFrontend>::*)(boost::variant<std::string, std::shared_ptr<TLSCertKeyPair>, LuaArray<std::string>, LuaArray<std::shared_ptr<TLSCertKeyPair>>> certFiles, boost::variant<std::string, LuaArray<std::string>> keyFiles)>("loadNewCertificatesAndKeys", [](std::shared_ptr<DOHFrontend> frontend, boost::variant<std::string, std::shared_ptr<TLSCertKeyPair>, LuaArray<std::string>, LuaArray<std::shared_ptr<TLSCertKeyPair>>> certFiles, boost::variant<std::string, LuaArray<std::string>> keyFiles) {
 #ifdef HAVE_DNS_OVER_HTTPS
     if (frontend != nullptr) {
-      if (loadTLSCertificateAndKeys("DOHFrontend::loadNewCertificatesAndKeys", frontend->d_tlsConfig.d_certKeyPairs, certFiles, keyFiles)) {
+      if (loadTLSCertificateAndKeys("DOHFrontend::loadNewCertificatesAndKeys", frontend->d_tlsContext.d_tlsConfig.d_certKeyPairs, certFiles, keyFiles)) {
         frontend->reloadCertificates();
       }
     }
@@ -2579,7 +2588,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     setLuaSideEffect();
 
-    shared_ptr<TLSFrontend> frontend = std::make_shared<TLSFrontend>(TLSFrontend::ALPN::DoT);
+    auto frontend = std::make_shared<TLSFrontend>(TLSFrontend::ALPN::DoT);
     if (!loadTLSCertificateAndKeys("addTLSLocal", frontend->d_tlsConfig.d_certKeyPairs, certFiles, keyFiles)) {
       return;
     }

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -226,6 +226,7 @@ static void parseTLSConfig(TLSConfig& config, const std::string& context, boost:
   getOptionalValue<bool>(vars, "enableRenegotiation", config.d_enableRenegotiation);
   getOptionalValue<bool>(vars, "tlsAsyncMode", config.d_asyncMode);
   getOptionalValue<bool>(vars, "ktls", config.d_ktls);
+  getOptionalValue<bool>(vars, "readAhead", config.d_readAhead);
 }
 
 #endif // defined(HAVE_DNS_OVER_TLS) || defined(HAVE_DNS_OVER_HTTPS)

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2348,7 +2348,6 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     if (frontend->d_library == "h2o") {
 #ifdef HAVE_LIBH2OEVLOOP
       frontend = std::make_shared<H2ODOHFrontend>();
-      frontend->d_library = "h2o";
 #else /* HAVE_LIBH2OEVLOOP */
         errlog("DOH bind %s is configured to use libh2o but the library is not available", addr);
         return;

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2348,6 +2348,8 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     if (frontend->d_library == "h2o") {
 #ifdef HAVE_LIBH2OEVLOOP
       frontend = std::make_shared<H2ODOHFrontend>();
+      // we _really_ need to set it again, as we just replaced the generic frontend by a new one
+      frontend->d_library = "h2o";
 #else /* HAVE_LIBH2OEVLOOP */
         errlog("DOH bind %s is configured to use libh2o but the library is not available", addr);
         return;

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2409,6 +2409,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       getOptionalValue<std::string>(vars, "serverTokens", frontend->d_serverTokens);
       getOptionalValue<std::string>(vars, "provider", frontend->d_tlsContext.d_provider);
       boost::algorithm::to_lower(frontend->d_tlsContext.d_provider);
+      getOptionalValue<bool>(vars, "proxyProtocolOutsideTLS", frontend->d_tlsContext.d_proxyProtocolOutsideTLS);
 
       LuaAssociativeTable<std::string> customResponseHeaders;
       if (getOptionalValue<decltype(customResponseHeaders)>(vars, "customResponseHeaders", customResponseHeaders) > 0) {
@@ -2647,6 +2648,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
       getOptionalValue<std::string>(vars, "provider", frontend->d_provider);
       boost::algorithm::to_lower(frontend->d_provider);
+      getOptionalValue<bool>(vars, "proxyProtocolOutsideTLS", frontend->d_proxyProtocolOutsideTLS);
 
       LuaArray<std::string> addresses;
       if (getOptionalValue<decltype(addresses)>(vars, "additionalAddresses", addresses) > 0) {

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -375,7 +375,7 @@ void IncomingTCPConnectionState::terminateClientConnection()
 void IncomingTCPConnectionState::queueResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response)
 {
   // queue response
-  state->d_queuedResponses.push_back(std::move(response));
+  state->d_queuedResponses.emplace_back(std::move(response));
   DEBUGLOG("queueing response, state is "<<(int)state->d_state<<", queue size is now "<<state->d_queuedResponses.size());
 
   // when the response comes from a backend, there is a real possibility that we are currently

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -27,6 +27,7 @@
 #include "dnsdist.hh"
 #include "dnsdist-concurrent-connections.hh"
 #include "dnsdist-ecs.hh"
+#include "dnsdist-nghttp2-in.hh"
 #include "dnsdist-proxy-protocol.hh"
 #include "dnsdist-rings.hh"
 #include "dnsdist-tcp.hh"
@@ -94,6 +95,17 @@ IncomingTCPConnectionState::~IncomingTCPConnectionState()
   // but that way we make sure it's done before the ConnectionInfo is destroyed,
   // closing the descriptor, instead of relying on the declaration order of the objects in the class
   d_handler.close();
+}
+
+dnsdist::Protocol IncomingTCPConnectionState::getProtocol() const
+{
+  if (d_ci.cs->dohFrontend) {
+    return dnsdist::Protocol::DoH;
+  }
+  if (d_handler.isTLS()) {
+    return dnsdist::Protocol::DoT;
+  }
+  return dnsdist::Protocol::DoTCP;
 }
 
 size_t IncomingTCPConnectionState::clearAllDownstreamConnections()
@@ -173,7 +185,7 @@ static IOState sendQueuedResponses(std::shared_ptr<IncomingTCPConnectionState>& 
     TCPResponse resp = std::move(state->d_queuedResponses.front());
     state->d_queuedResponses.pop_front();
     state->d_state = IncomingTCPConnectionState::State::idle;
-    result = state->sendResponse(state, now, std::move(resp));
+    result = state->sendResponse(now, std::move(resp));
     if (result != IOState::Done) {
       return result;
     }
@@ -183,28 +195,28 @@ static IOState sendQueuedResponses(std::shared_ptr<IncomingTCPConnectionState>& 
   return IOState::Done;
 }
 
-static void handleResponseSent(std::shared_ptr<IncomingTCPConnectionState>& state, TCPResponse& currentResponse)
+void IncomingTCPConnectionState::handleResponseSent(TCPResponse& currentResponse)
 {
   if (currentResponse.d_idstate.qtype == QType::AXFR || currentResponse.d_idstate.qtype == QType::IXFR) {
     return;
   }
 
-  --state->d_currentQueriesCount;
+  --d_currentQueriesCount;
 
   const auto& ds = currentResponse.d_connection ? currentResponse.d_connection->getDS() : currentResponse.d_ds;
   if (currentResponse.d_idstate.selfGenerated == false && ds) {
     const auto& ids = currentResponse.d_idstate;
     double udiff = ids.queryRealTime.udiff();
-    vinfolog("Got answer from %s, relayed to %s (%s, %d bytes), took %f us", ds->d_config.remote.toStringWithPort(), ids.origRemote.toStringWithPort(), (state->d_handler.isTLS() ? "DoT" : "TCP"), currentResponse.d_buffer.size(), udiff);
+    vinfolog("Got answer from %s, relayed to %s (%s, %d bytes), took %f us", ds->d_config.remote.toStringWithPort(), ids.origRemote.toStringWithPort(), getProtocol().toString(), currentResponse.d_buffer.size(), udiff);
 
     auto backendProtocol = ds->getProtocol();
-    if (backendProtocol == dnsdist::Protocol::DoUDP) {
+    if (backendProtocol == dnsdist::Protocol::DoUDP && !currentResponse.d_idstate.forwardedOverUDP) {
       backendProtocol = dnsdist::Protocol::DoTCP;
     }
-    ::handleResponseSent(ids, udiff, state->d_ci.remote, ds->d_config.remote, static_cast<unsigned int>(currentResponse.d_buffer.size()), currentResponse.d_cleartextDH, backendProtocol, true);
+    ::handleResponseSent(ids, udiff, d_ci.remote, ds->d_config.remote, static_cast<unsigned int>(currentResponse.d_buffer.size()), currentResponse.d_cleartextDH, backendProtocol, true);
   } else {
     const auto& ids = currentResponse.d_idstate;
-    ::handleResponseSent(ids, 0., state->d_ci.remote, ComboAddress(), static_cast<unsigned int>(currentResponse.d_buffer.size()), currentResponse.d_cleartextDH, ids.protocol, false);
+    ::handleResponseSent(ids, 0., d_ci.remote, ComboAddress(), static_cast<unsigned int>(currentResponse.d_buffer.size()), currentResponse.d_cleartextDH, ids.protocol, false);
   }
 
   currentResponse.d_buffer.clear();
@@ -232,7 +244,8 @@ bool IncomingTCPConnectionState::canAcceptNewQueries(const struct timeval& now)
     return false;
   }
 
-  if (d_currentQueriesCount >= d_ci.cs->d_maxInFlightQueriesPerConn) {
+  // for DoH, this is already handled by the underlying library
+  if (!d_ci.cs->dohFrontend && d_currentQueriesCount >= d_ci.cs->d_maxInFlightQueriesPerConn) {
     DEBUGLOG("not accepting new queries because we already have "<<d_currentQueriesCount<<" out of "<<d_ci.cs->d_maxInFlightQueriesPerConn);
     return false;
   }
@@ -284,9 +297,9 @@ void IncomingTCPConnectionState::registerOwnedDownstreamConnection(std::shared_p
 }
 
 /* called when the buffer has been set and the rules have been processed, and only from handleIO (sometimes indirectly via handleQuery) */
-IOState IncomingTCPConnectionState::sendResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response)
+IOState IncomingTCPConnectionState::sendResponse(const struct timeval& now, TCPResponse&& response)
 {
-  state->d_state = IncomingTCPConnectionState::State::sendingResponse;
+  d_state = IncomingTCPConnectionState::State::sendingResponse;
 
   uint16_t responseSize = static_cast<uint16_t>(response.d_buffer.size());
   const uint8_t sizeBytes[] = { static_cast<uint8_t>(responseSize / 256), static_cast<uint8_t>(responseSize % 256) };
@@ -294,27 +307,27 @@ IOState IncomingTCPConnectionState::sendResponse(std::shared_ptr<IncomingTCPConn
      that could occur if we had to deal with the size during the processing,
      especially alignment issues */
   response.d_buffer.insert(response.d_buffer.begin(), sizeBytes, sizeBytes + 2);
-  state->d_currentPos = 0;
-  state->d_currentResponse = std::move(response);
+  d_currentPos = 0;
+  d_currentResponse = std::move(response);
 
   try {
-    auto iostate = state->d_handler.tryWrite(state->d_currentResponse.d_buffer, state->d_currentPos, state->d_currentResponse.d_buffer.size());
+    auto iostate = d_handler.tryWrite(d_currentResponse.d_buffer, d_currentPos, d_currentResponse.d_buffer.size());
     if (iostate == IOState::Done) {
       DEBUGLOG("response sent from "<<__PRETTY_FUNCTION__);
-      handleResponseSent(state, state->d_currentResponse);
+      handleResponseSent(d_currentResponse);
       return iostate;
     } else {
-      state->d_lastIOBlocked = true;
+      d_lastIOBlocked = true;
       DEBUGLOG("partial write");
       return iostate;
     }
   }
   catch (const std::exception& e) {
-    vinfolog("Closing TCP client connection with %s: %s", state->d_ci.remote.toStringWithPort(), e.what());
+    vinfolog("Closing TCP client connection with %s: %s", d_ci.remote.toStringWithPort(), e.what());
     DEBUGLOG("Closing TCP client connection: "<<e.what());
-    ++state->d_ci.cs->tcpDiedSendingResponse;
+    ++d_ci.cs->tcpDiedSendingResponse;
 
-    state->terminateClientConnection();
+    terminateClientConnection();
 
     return IOState::Done;
   }
@@ -408,9 +421,7 @@ void IncomingTCPConnectionState::handleAsyncReady(int fd, FDMultiplexer::funcpar
 
   if (state->active()) {
     /* and now we restart our own I/O state machine */
-    struct timeval now;
-    gettimeofday(&now, nullptr);
-    handleIO(state, now);
+    state->handleIO();
   }
   else {
     /* we were only waiting for the engine to come back,
@@ -476,16 +487,17 @@ void IncomingTCPConnectionState::handleResponse(const struct timeval& now, TCPRe
     try {
       auto& ids = response.d_idstate;
       unsigned int qnameWireLength;
-      if (!response.d_connection || !responseContentMatches(response.d_buffer, ids.qname, ids.qtype, ids.qclass, response.d_connection->getDS(), qnameWireLength)) {
+      std::shared_ptr<DownstreamState> ds = response.d_ds ? response.d_ds : (response.d_connection ? response.d_connection->getDS() : nullptr);
+      if (!ds || !responseContentMatches(response.d_buffer, ids.qname, ids.qtype, ids.qclass, ds, qnameWireLength)) {
         state->terminateClientConnection();
         return;
       }
 
-      if (response.d_connection->getDS()) {
-        ++response.d_connection->getDS()->responses;
+      if (ds) {
+        ++ds->responses;
       }
 
-      DNSResponse dr(ids, response.d_buffer, response.d_connection->getDS());
+      DNSResponse dr(ids, response.d_buffer, ds);
       dr.d_incomingTCPState = state;
 
       memcpy(&response.d_cleartextDH, dr.getHeader(), sizeof(response.d_cleartextDH));
@@ -529,7 +541,6 @@ class TCPCrossProtocolQuery : public CrossProtocolQuery
 public:
   TCPCrossProtocolQuery(PacketBuffer&& buffer, InternalQueryState&& ids, std::shared_ptr<DownstreamState> ds, std::shared_ptr<IncomingTCPConnectionState> sender): CrossProtocolQuery(InternalQuery(std::move(buffer), std::move(ids)), ds), d_sender(std::move(sender))
   {
-    proxyProtocolPayloadSize = 0;
   }
 
   ~TCPCrossProtocolQuery()
@@ -561,6 +572,11 @@ private:
   std::shared_ptr<IncomingTCPConnectionState> d_sender;
 };
 
+std::unique_ptr<CrossProtocolQuery> IncomingTCPConnectionState::getCrossProtocolQuery(PacketBuffer&& query, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& ds)
+{
+  return std::make_unique<TCPCrossProtocolQuery>(std::move(query), std::move(state), ds, shared_from_this());
+}
+
 std::unique_ptr<CrossProtocolQuery> getTCPCrossProtocolQueryFromDQ(DNSQuestion& dq)
 {
   auto state = dq.getIncomingTCPState();
@@ -587,60 +603,63 @@ void IncomingTCPConnectionState::handleCrossProtocolResponse(const struct timeva
   }
 }
 
-static void handleQuery(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now)
+IncomingTCPConnectionState::QueryProcessingResult IncomingTCPConnectionState::handleQuery(PacketBuffer&& queryIn, const struct timeval& now, std::optional<int32_t> streamID)
 {
-  if (state->d_querySize < sizeof(dnsheader)) {
+  auto query = std::move(queryIn);
+  if (query.size() < sizeof(dnsheader)) {
     ++dnsdist::metrics::g_stats.nonCompliantQueries;
-    ++state->d_ci.cs->nonCompliantQueries;
-    state->terminateClientConnection();
-    return;
+    ++d_ci.cs->nonCompliantQueries;
+    return QueryProcessingResult::TooSmall;
   }
 
-  ++state->d_queriesCount;
-  ++state->d_ci.cs->queries;
+  ++d_queriesCount;
+  ++d_ci.cs->queries;
   ++dnsdist::metrics::g_stats.queries;
 
-  if (state->d_handler.isTLS()) {
-    auto tlsVersion = state->d_handler.getTLSVersion();
+  if (d_handler.isTLS()) {
+    auto tlsVersion = d_handler.getTLSVersion();
     switch (tlsVersion) {
     case LibsslTLSVersion::TLS10:
-      ++state->d_ci.cs->tls10queries;
+      ++d_ci.cs->tls10queries;
       break;
     case LibsslTLSVersion::TLS11:
-      ++state->d_ci.cs->tls11queries;
+      ++d_ci.cs->tls11queries;
       break;
     case LibsslTLSVersion::TLS12:
-      ++state->d_ci.cs->tls12queries;
+      ++d_ci.cs->tls12queries;
       break;
     case LibsslTLSVersion::TLS13:
-      ++state->d_ci.cs->tls13queries;
+      ++d_ci.cs->tls13queries;
       break;
     default:
-      ++state->d_ci.cs->tlsUnknownqueries;
+      ++d_ci.cs->tlsUnknownqueries;
     }
   }
 
+  auto state = shared_from_this();
   InternalQueryState ids;
-  ids.origDest = state->d_proxiedDestination;
-  ids.origRemote = state->d_proxiedRemote;
-  ids.cs = state->d_ci.cs;
+  ids.origDest = d_proxiedDestination;
+  ids.origRemote = d_proxiedRemote;
+  ids.cs = d_ci.cs;
   ids.queryRealTime.start();
+  if (streamID) {
+    ids.d_streamID = *streamID;
+  }
 
-  auto dnsCryptResponse = checkDNSCryptQuery(*state->d_ci.cs, state->d_buffer, ids.dnsCryptQuery, ids.queryRealTime.d_start.tv_sec, true);
+  auto dnsCryptResponse = checkDNSCryptQuery(*d_ci.cs, query, ids.dnsCryptQuery, ids.queryRealTime.d_start.tv_sec, true);
   if (dnsCryptResponse) {
     TCPResponse response;
-    state->d_state = IncomingTCPConnectionState::State::idle;
-    ++state->d_currentQueriesCount;
-    state->queueResponse(state, now, std::move(response));
-    return;
+    d_state = IncomingTCPConnectionState::State::idle;
+    ++d_currentQueriesCount;
+    queueResponse(state, now, std::move(response));
+    return QueryProcessingResult::SelfAnswered;
   }
 
   {
     /* this pointer will be invalidated the second the buffer is resized, don't hold onto it! */
-    auto* dh = reinterpret_cast<dnsheader*>(state->d_buffer.data());
-    if (!checkQueryHeaders(dh, *state->d_ci.cs)) {
-      state->terminateClientConnection();
-      return;
+    auto* dh = reinterpret_cast<dnsheader*>(query.data());
+    if (!checkQueryHeaders(dh, *d_ci.cs)) {
+      return QueryProcessingResult::InvalidHeaders;
     }
 
     if (dh->qdcount == 0) {
@@ -648,81 +667,105 @@ static void handleQuery(std::shared_ptr<IncomingTCPConnectionState>& state, cons
       dh->rcode = RCode::NotImp;
       dh->qr = true;
       response.d_idstate.selfGenerated = true;
-      response.d_buffer = std::move(state->d_buffer);
-      state->d_state = IncomingTCPConnectionState::State::idle;
-      ++state->d_currentQueriesCount;
-      state->queueResponse(state, now, std::move(response));
-      return;
+      response.d_buffer = std::move(query);
+      d_state = IncomingTCPConnectionState::State::idle;
+      ++d_currentQueriesCount;
+      queueResponse(state, now, std::move(response));
+      return QueryProcessingResult::Empty;
     }
   }
 
-  ids.qname = DNSName(reinterpret_cast<const char*>(state->d_buffer.data()), state->d_buffer.size(), sizeof(dnsheader), false, &ids.qtype, &ids.qclass);
-  ids.protocol = dnsdist::Protocol::DoTCP;
+  ids.qname = DNSName(reinterpret_cast<const char*>(query.data()), query.size(), sizeof(dnsheader), false, &ids.qtype, &ids.qclass);
+  ids.protocol = getProtocol();
   if (ids.dnsCryptQuery) {
     ids.protocol = dnsdist::Protocol::DNSCryptTCP;
   }
-  else if (state->d_handler.isTLS()) {
-    ids.protocol = dnsdist::Protocol::DoT;
-  }
 
-  DNSQuestion dq(ids, state->d_buffer);
+  DNSQuestion dq(ids, query);
   const uint16_t* flags = getFlagsFromDNSHeader(dq.getHeader());
   ids.origFlags = *flags;
   dq.d_incomingTCPState = state;
-  dq.sni = state->d_handler.getServerNameIndication();
+  dq.sni = d_handler.getServerNameIndication();
 
-  if (state->d_proxyProtocolValues) {
+  if (d_proxyProtocolValues) {
     /* we need to copy them, because the next queries received on that connection will
        need to get the _unaltered_ values */
-    dq.proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>(*state->d_proxyProtocolValues);
+    dq.proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>(*d_proxyProtocolValues);
   }
 
   if (dq.ids.qtype == QType::AXFR || dq.ids.qtype == QType::IXFR) {
     dq.ids.skipCache = true;
   }
 
+  if (forwardViaUDPFirst()) {
+    // if there was no EDNS, we add it with a large buffer size
+    // so we can use UDP to talk to the backend.
+    auto dh = const_cast<struct dnsheader*>(reinterpret_cast<const struct dnsheader*>(query.data()));
+    if (!dh->arcount) {
+      if (addEDNS(query, 4096, false, 4096, 0)) {
+        dq.ids.ednsAdded = true;
+      }
+    }
+  }
+
+  if (streamID) {
+    auto unit = getDOHUnit(*streamID);
+    dq.ids.du = std::move(unit);
+  }
+
   std::shared_ptr<DownstreamState> ds;
-  auto result = processQuery(dq, state->d_threadData.holders, ds);
+  auto result = processQuery(dq, d_threadData.holders, ds);
+
+  if (result == ProcessQueryResult::Asynchronous) {
+    /* we are done for now */
+    ++d_currentQueriesCount;
+    return QueryProcessingResult::Asynchronous;
+  }
+
+  if (streamID) {
+    restoreDOHUnit(std::move(dq.ids.du));
+  }
 
   if (result == ProcessQueryResult::Drop) {
-    state->terminateClientConnection();
-    return;
-  }
-  else if (result == ProcessQueryResult::Asynchronous) {
-    /* we are done for now */
-    ++state->d_currentQueriesCount;
-    return;
+    return QueryProcessingResult::Dropped;
   }
 
   // the buffer might have been invalidated by now
-  const dnsheader* dh = dq.getHeader();
+  uint16_t queryID;
+  {
+    const dnsheader* dh = dq.getHeader();
+    queryID = dh->id;
+  }
+
   if (result == ProcessQueryResult::SendAnswer) {
     TCPResponse response;
-    memcpy(&response.d_cleartextDH, dh, sizeof(response.d_cleartextDH));
+    {
+      const dnsheader* dh = dq.getHeader();
+      memcpy(&response.d_cleartextDH, dh, sizeof(response.d_cleartextDH));
+    }
     response.d_idstate = std::move(ids);
-    response.d_idstate.origID = dh->id;
+    response.d_idstate.origID = queryID;
     response.d_idstate.selfGenerated = true;
-    response.d_idstate.cs = state->d_ci.cs;
-    response.d_buffer = std::move(state->d_buffer);
+    response.d_idstate.cs = d_ci.cs;
+    response.d_buffer = std::move(query);
 
-    state->d_state = IncomingTCPConnectionState::State::idle;
-    ++state->d_currentQueriesCount;
-    state->queueResponse(state, now, std::move(response));
-    return;
+    d_state = IncomingTCPConnectionState::State::idle;
+    ++d_currentQueriesCount;
+    queueResponse(state, now, std::move(response));
+    return QueryProcessingResult::SelfAnswered;
   }
 
   if (result != ProcessQueryResult::PassToBackend || ds == nullptr) {
-    state->terminateClientConnection();
-    return;
+    return QueryProcessingResult::NoBackend;
   }
 
-  dq.ids.origID = dh->id;
+  dq.ids.origID = queryID;
 
-  ++state->d_currentQueriesCount;
+  ++d_currentQueriesCount;
 
   std::string proxyProtocolPayload;
   if (ds->isDoH()) {
-    vinfolog("Got query for %s|%s from %s (%s, %d bytes), relayed to %s", ids.qname.toLogString(), QType(ids.qtype).toString(), state->d_proxiedRemote.toStringWithPort(), (state->d_handler.isTLS() ? "DoT" : "TCP"), state->d_buffer.size(), ds->getNameWithAddr());
+    vinfolog("Got query for %s|%s from %s (%s, %d bytes), relayed to %s", ids.qname.toLogString(), QType(ids.qtype).toString(), d_proxiedRemote.toStringWithPort(), getProtocol().toString(), query.size(), ds->getNameWithAddr());
 
     /* we need to do this _before_ creating the cross protocol query because
        after that the buffer will have been moved */
@@ -730,21 +773,30 @@ static void handleQuery(std::shared_ptr<IncomingTCPConnectionState>& state, cons
       proxyProtocolPayload = getProxyProtocolPayload(dq);
     }
 
-    auto cpq = std::make_unique<TCPCrossProtocolQuery>(std::move(state->d_buffer), std::move(ids), ds, state);
+    auto cpq = std::make_unique<TCPCrossProtocolQuery>(std::move(query), std::move(ids), ds, state);
     cpq->query.d_proxyProtocolPayload = std::move(proxyProtocolPayload);
 
     ds->passCrossProtocolQuery(std::move(cpq));
-    return;
+    return QueryProcessingResult::Forwarded;
+  }
+  else if (!ds->isTCPOnly() && forwardViaUDPFirst()) {
+    auto unit = getDOHUnit(*streamID);
+    dq.ids.du = std::move(unit);
+    if (assignOutgoingUDPQueryToBackend(ds, queryID, dq, query)) {
+      return QueryProcessingResult::Forwarded;
+    }
+    restoreDOHUnit(std::move(dq.ids.du));
+    // fallback to the normal flow
   }
 
-  prependSizeToTCPQuery(state->d_buffer, 0);
+  prependSizeToTCPQuery(query, 0);
 
-  auto downstreamConnection = state->getDownstreamConnection(ds, dq.proxyProtocolValues, now);
+  auto downstreamConnection = getDownstreamConnection(ds, dq.proxyProtocolValues, now);
 
   if (ds->d_config.useProxyProtocol) {
     /* if we ever sent a TLV over a connection, we can never go back */
-    if (!state->d_proxyProtocolPayloadHasTLV) {
-      state->d_proxyProtocolPayloadHasTLV = dq.proxyProtocolValues && !dq.proxyProtocolValues->empty();
+    if (!d_proxyProtocolPayloadHasTLV) {
+      d_proxyProtocolPayloadHasTLV = dq.proxyProtocolValues && !dq.proxyProtocolValues->empty();
     }
 
     proxyProtocolPayload = getProxyProtocolPayload(dq);
@@ -754,12 +806,13 @@ static void handleQuery(std::shared_ptr<IncomingTCPConnectionState>& state, cons
     downstreamConnection->setProxyProtocolValuesSent(std::move(dq.proxyProtocolValues));
   }
 
-  TCPQuery query(std::move(state->d_buffer), std::move(ids));
-  query.d_proxyProtocolPayload = std::move(proxyProtocolPayload);
+  TCPQuery tcpquery(std::move(query), std::move(ids));
+  tcpquery.d_proxyProtocolPayload = std::move(proxyProtocolPayload);
 
-  vinfolog("Got query for %s|%s from %s (%s, %d bytes), relayed to %s", query.d_idstate.qname.toLogString(), QType(query.d_idstate.qtype).toString(), state->d_proxiedRemote.toStringWithPort(), (state->d_handler.isTLS() ? "DoT" : "TCP"), query.d_buffer.size(), ds->getNameWithAddr());
+  vinfolog("Got query for %s|%s from %s (%s, %d bytes), relayed to %s", tcpquery.d_idstate.qname.toLogString(), QType(tcpquery.d_idstate.qtype).toString(), d_proxiedRemote.toStringWithPort(), getProtocol().toString(), tcpquery.d_buffer.size(), ds->getNameWithAddr());
   std::shared_ptr<TCPQuerySender> incoming = state;
-  downstreamConnection->queueQuery(incoming, std::move(query));
+  downstreamConnection->queueQuery(incoming, std::move(tcpquery));
+  return QueryProcessingResult::Forwarded;
 }
 
 void IncomingTCPConnectionState::handleIOCallback(int fd, FDMultiplexer::funcparam_t& param)
@@ -769,159 +822,194 @@ void IncomingTCPConnectionState::handleIOCallback(int fd, FDMultiplexer::funcpar
     throw std::runtime_error("Unexpected socket descriptor " + std::to_string(fd) + " received in " + std::string(__PRETTY_FUNCTION__) + ", expected " + std::to_string(conn->d_handler.getDescriptor()));
   }
 
-  struct timeval now;
-  gettimeofday(&now, nullptr);
-  handleIO(conn, now);
+  conn->handleIO();
 }
 
-void IncomingTCPConnectionState::handleIO(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now)
+void IncomingTCPConnectionState::handleHandshakeDone(const struct timeval& now)
+{
+  if (d_handler.isTLS()) {
+    if (!d_handler.hasTLSSessionBeenResumed()) {
+      ++d_ci.cs->tlsNewSessions;
+    }
+    else {
+      ++d_ci.cs->tlsResumptions;
+    }
+    if (d_handler.getResumedFromInactiveTicketKey()) {
+      ++d_ci.cs->tlsInactiveTicketKey;
+    }
+    if (d_handler.getUnknownTicketKey()) {
+      ++d_ci.cs->tlsUnknownTicketKey;
+    }
+  }
+
+  d_handshakeDoneTime = now;
+}
+
+IncomingTCPConnectionState::ProxyProtocolResult IncomingTCPConnectionState::handleProxyProtocolPayload()
+{
+  do {
+    DEBUGLOG("reading proxy protocol header");
+    auto iostate = d_handler.tryRead(d_buffer, d_currentPos, d_proxyProtocolNeed);
+    if (iostate == IOState::Done) {
+      d_buffer.resize(d_currentPos);
+      ssize_t remaining = isProxyHeaderComplete(d_buffer);
+      if (remaining == 0) {
+        vinfolog("Unable to consume proxy protocol header in packet from TCP client %s", d_ci.remote.toStringWithPort());
+        ++dnsdist::metrics::g_stats.proxyProtocolInvalid;
+        return ProxyProtocolResult::Error;
+      }
+      else if (remaining < 0) {
+        d_proxyProtocolNeed += -remaining;
+        d_buffer.resize(d_currentPos + d_proxyProtocolNeed);
+        /* we need to keep reading, since we might have buffered data */
+      }
+      else {
+        /* proxy header received */
+        std::vector<ProxyProtocolValue> proxyProtocolValues;
+        if (!handleProxyProtocol(d_ci.remote, true, *d_threadData.holders.acl, d_buffer, d_proxiedRemote, d_proxiedDestination, proxyProtocolValues)) {
+          vinfolog("Error handling the Proxy Protocol received from TCP client %s", d_ci.remote.toStringWithPort());
+          return ProxyProtocolResult::Error;
+        }
+
+        if (!proxyProtocolValues.empty()) {
+          d_proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>(std::move(proxyProtocolValues));
+        }
+
+        return ProxyProtocolResult::Done;
+      }
+    }
+    else {
+      d_lastIOBlocked = true;
+    }
+  }
+  while (active() && !d_lastIOBlocked);
+
+  return ProxyProtocolResult::Reading;
+}
+
+void IncomingTCPConnectionState::handleIO()
 {
   // why do we loop? Because the TLS layer does buffering, and thus can have data ready to read
   // even though the underlying socket is not ready, so we need to actually ask for the data first
   IOState iostate = IOState::Done;
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
   do {
     iostate = IOState::Done;
-    IOStateGuard ioGuard(state->d_ioState);
+    IOStateGuard ioGuard(d_ioState);
 
-    if (state->maxConnectionDurationReached(g_maxTCPConnectionDuration, now)) {
-      vinfolog("Terminating TCP connection from %s because it reached the maximum TCP connection duration", state->d_ci.remote.toStringWithPort());
+    if (maxConnectionDurationReached(g_maxTCPConnectionDuration, now)) {
+      vinfolog("Terminating TCP connection from %s because it reached the maximum TCP connection duration", d_ci.remote.toStringWithPort());
       // will be handled by the ioGuard
       //handleNewIOState(state, IOState::Done, fd, handleIOCallback);
       return;
     }
 
-    state->d_lastIOBlocked = false;
+    d_lastIOBlocked = false;
 
     try {
-      if (state->d_state == IncomingTCPConnectionState::State::doingHandshake) {
+      if (d_state == IncomingTCPConnectionState::State::doingHandshake) {
         DEBUGLOG("doing handshake");
-        iostate = state->d_handler.tryHandshake();
+        iostate = d_handler.tryHandshake();
         if (iostate == IOState::Done) {
           DEBUGLOG("handshake done");
-          if (state->d_handler.isTLS()) {
-            if (!state->d_handler.hasTLSSessionBeenResumed()) {
-              ++state->d_ci.cs->tlsNewSessions;
-            }
-            else {
-              ++state->d_ci.cs->tlsResumptions;
-            }
-            if (state->d_handler.getResumedFromInactiveTicketKey()) {
-              ++state->d_ci.cs->tlsInactiveTicketKey;
-            }
-            if (state->d_handler.getUnknownTicketKey()) {
-              ++state->d_ci.cs->tlsUnknownTicketKey;
-            }
-          }
+          handleHandshakeDone(now);
 
-          state->d_handshakeDoneTime = now;
-          if (expectProxyProtocolFrom(state->d_ci.remote)) {
-            state->d_state = IncomingTCPConnectionState::State::readingProxyProtocolHeader;
-            state->d_buffer.resize(s_proxyProtocolMinimumHeaderSize);
-            state->d_proxyProtocolNeed = s_proxyProtocolMinimumHeaderSize;
+          if (expectProxyProtocolFrom(d_ci.remote)) {
+            d_state = IncomingTCPConnectionState::State::readingProxyProtocolHeader;
+            d_buffer.resize(s_proxyProtocolMinimumHeaderSize);
+            d_proxyProtocolNeed = s_proxyProtocolMinimumHeaderSize;
           }
           else {
-            state->d_state = IncomingTCPConnectionState::State::readingQuerySize;
+            d_state = IncomingTCPConnectionState::State::readingQuerySize;
           }
         }
         else {
-          state->d_lastIOBlocked = true;
+          d_lastIOBlocked = true;
         }
       }
 
-      if (!state->d_lastIOBlocked && state->d_state == IncomingTCPConnectionState::State::readingProxyProtocolHeader) {
-        do {
-          DEBUGLOG("reading proxy protocol header");
-          iostate = state->d_handler.tryRead(state->d_buffer, state->d_currentPos, state->d_proxyProtocolNeed);
-          if (iostate == IOState::Done) {
-            state->d_buffer.resize(state->d_currentPos);
-            ssize_t remaining = isProxyHeaderComplete(state->d_buffer);
-            if (remaining == 0) {
-              vinfolog("Unable to consume proxy protocol header in packet from TCP client %s", state->d_ci.remote.toStringWithPort());
-              ++dnsdist::metrics::g_stats.proxyProtocolInvalid;
-              break;
-            }
-            else if (remaining < 0) {
-              state->d_proxyProtocolNeed += -remaining;
-              state->d_buffer.resize(state->d_currentPos + state->d_proxyProtocolNeed);
-              /* we need to keep reading, since we might have buffered data */
-              iostate = IOState::NeedRead;
-            }
-            else {
-              /* proxy header received */
-              std::vector<ProxyProtocolValue> proxyProtocolValues;
-              if (!handleProxyProtocol(state->d_ci.remote, true, *state->d_threadData.holders.acl, state->d_buffer, state->d_proxiedRemote, state->d_proxiedDestination, proxyProtocolValues)) {
-                vinfolog("Error handling the Proxy Protocol received from TCP client %s", state->d_ci.remote.toStringWithPort());
-                break;
-              }
-
-              if (!proxyProtocolValues.empty()) {
-                state->d_proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>(std::move(proxyProtocolValues));
-              }
-
-              state->d_state = IncomingTCPConnectionState::State::readingQuerySize;
-              state->d_buffer.resize(sizeof(uint16_t));
-              state->d_currentPos = 0;
-              state->d_proxyProtocolNeed = 0;
-              break;
-            }
-          }
-          else {
-            state->d_lastIOBlocked = true;
-          }
+      if (!d_lastIOBlocked && d_state == IncomingTCPConnectionState::State::readingProxyProtocolHeader) {
+        auto status = handleProxyProtocolPayload();
+        if (status == ProxyProtocolResult::Done) {
+          d_state = IncomingTCPConnectionState::State::readingQuerySize;
+          d_buffer.resize(sizeof(uint16_t));
+          d_currentPos = 0;
+          d_proxyProtocolNeed = 0;
         }
-        while (state->active() && !state->d_lastIOBlocked);
+        else if (status == ProxyProtocolResult::Error) {
+          iostate = IOState::Done;
+        }
+        else {
+          iostate = IOState::NeedRead;
+        }
       }
 
-      if (!state->d_lastIOBlocked && (state->d_state == IncomingTCPConnectionState::State::waitingForQuery ||
-                                      state->d_state == IncomingTCPConnectionState::State::readingQuerySize)) {
+      if (!d_lastIOBlocked && (d_state == IncomingTCPConnectionState::State::waitingForQuery ||
+                                      d_state == IncomingTCPConnectionState::State::readingQuerySize)) {
         DEBUGLOG("reading query size");
-        state->d_buffer.resize(sizeof(uint16_t));
-        iostate = state->d_handler.tryRead(state->d_buffer, state->d_currentPos, sizeof(uint16_t));
-        if (state->d_currentPos > 0) {
+        d_buffer.resize(sizeof(uint16_t));
+        iostate = d_handler.tryRead(d_buffer, d_currentPos, sizeof(uint16_t));
+        if (d_currentPos > 0) {
           /* if we got at least one byte, we can't go around sending responses */
-          state->d_state = IncomingTCPConnectionState::State::readingQuerySize;
+          d_state = IncomingTCPConnectionState::State::readingQuerySize;
         }
 
         if (iostate == IOState::Done) {
           DEBUGLOG("query size received");
-          state->d_state = IncomingTCPConnectionState::State::readingQuery;
-          state->d_querySizeReadTime = now;
-          if (state->d_queriesCount == 0) {
-            state->d_firstQuerySizeReadTime = now;
+          d_state = IncomingTCPConnectionState::State::readingQuery;
+          d_querySizeReadTime = now;
+          if (d_queriesCount == 0) {
+            d_firstQuerySizeReadTime = now;
           }
-          state->d_querySize = state->d_buffer.at(0) * 256 + state->d_buffer.at(1);
-          if (state->d_querySize < sizeof(dnsheader)) {
+          d_querySize = d_buffer.at(0) * 256 + d_buffer.at(1);
+          if (d_querySize < sizeof(dnsheader)) {
             /* go away */
-            state->terminateClientConnection();
+            terminateClientConnection();
             return;
           }
 
           /* allocate a bit more memory to be able to spoof the content, get an answer from the cache
              or to add ECS without allocating a new buffer */
-          state->d_buffer.resize(std::max(state->d_querySize + static_cast<size_t>(512), s_maxPacketCacheEntrySize));
-          state->d_currentPos = 0;
+          d_buffer.resize(std::max(d_querySize + static_cast<size_t>(512), s_maxPacketCacheEntrySize));
+          d_currentPos = 0;
         }
         else {
-          state->d_lastIOBlocked = true;
+          d_lastIOBlocked = true;
         }
       }
 
-      if (!state->d_lastIOBlocked && state->d_state == IncomingTCPConnectionState::State::readingQuery) {
+      if (!d_lastIOBlocked && d_state == IncomingTCPConnectionState::State::readingQuery) {
         DEBUGLOG("reading query");
-        iostate = state->d_handler.tryRead(state->d_buffer, state->d_currentPos, state->d_querySize);
+        iostate = d_handler.tryRead(d_buffer, d_currentPos, d_querySize);
         if (iostate == IOState::Done) {
           DEBUGLOG("query received");
-          state->d_buffer.resize(state->d_querySize);
+          d_buffer.resize(d_querySize);
 
-          state->d_state = IncomingTCPConnectionState::State::idle;
-          handleQuery(state, now);
+          d_state = IncomingTCPConnectionState::State::idle;
+          auto processingResult = handleQuery(std::move(d_buffer), now, std::nullopt);
+          switch (processingResult) {
+          case QueryProcessingResult::TooSmall:
+            /* fall-through */
+          case QueryProcessingResult::InvalidHeaders:
+            /* fall-through */
+          case QueryProcessingResult::Dropped:
+            /* fall-through */
+          case QueryProcessingResult::NoBackend:
+            terminateClientConnection();
+            break;
+          default:
+            break;
+          }
+
           /* the state might have been updated in the meantime, we don't want to override it
              in that case */
-          if (state->active() && state->d_state != IncomingTCPConnectionState::State::idle) {
-            if (state->d_ioState->isWaitingForRead()) {
+          if (active() && d_state != IncomingTCPConnectionState::State::idle) {
+            if (d_ioState->isWaitingForRead()) {
               iostate = IOState::NeedRead;
             }
-            else if (state->d_ioState->isWaitingForWrite()) {
+            else if (d_ioState->isWaitingForWrite()) {
               iostate = IOState::NeedWrite;
             }
             else {
@@ -930,55 +1018,56 @@ void IncomingTCPConnectionState::handleIO(std::shared_ptr<IncomingTCPConnectionS
           }
         }
         else {
-          state->d_lastIOBlocked = true;
+          d_lastIOBlocked = true;
         }
       }
 
-      if (!state->d_lastIOBlocked && state->d_state == IncomingTCPConnectionState::State::sendingResponse) {
+      if (!d_lastIOBlocked && d_state == IncomingTCPConnectionState::State::sendingResponse) {
         DEBUGLOG("sending response");
-        iostate = state->d_handler.tryWrite(state->d_currentResponse.d_buffer, state->d_currentPos, state->d_currentResponse.d_buffer.size());
+        iostate = d_handler.tryWrite(d_currentResponse.d_buffer, d_currentPos, d_currentResponse.d_buffer.size());
         if (iostate == IOState::Done) {
           DEBUGLOG("response sent from "<<__PRETTY_FUNCTION__);
-          handleResponseSent(state, state->d_currentResponse);
-          state->d_state = IncomingTCPConnectionState::State::idle;
+          handleResponseSent(d_currentResponse);
+          d_state = IncomingTCPConnectionState::State::idle;
         }
         else {
-          state->d_lastIOBlocked = true;
+          d_lastIOBlocked = true;
         }
       }
 
-      if (state->active() &&
-          !state->d_lastIOBlocked &&
+      if (active() &&
+          !d_lastIOBlocked &&
           iostate == IOState::Done &&
-          (state->d_state == IncomingTCPConnectionState::State::idle ||
-           state->d_state == IncomingTCPConnectionState::State::waitingForQuery))
+          (d_state == IncomingTCPConnectionState::State::idle ||
+           d_state == IncomingTCPConnectionState::State::waitingForQuery))
       {
         // try sending queued responses
         DEBUGLOG("send responses, if any");
+        auto state = shared_from_this();
         iostate = sendQueuedResponses(state, now);
 
-        if (!state->d_lastIOBlocked && state->active() && iostate == IOState::Done) {
+        if (!d_lastIOBlocked && active() && iostate == IOState::Done) {
           // if the query has been passed to a backend, or dropped, and the responses have been sent,
           // we can start reading again
-          if (state->canAcceptNewQueries(now)) {
-            state->resetForNewQuery();
+          if (canAcceptNewQueries(now)) {
+            resetForNewQuery();
             iostate = IOState::NeedRead;
           }
           else {
-            state->d_state = IncomingTCPConnectionState::State::idle;
+            d_state = IncomingTCPConnectionState::State::idle;
             iostate = IOState::Done;
           }
         }
       }
 
-      if (state->d_state != IncomingTCPConnectionState::State::idle &&
-          state->d_state != IncomingTCPConnectionState::State::doingHandshake &&
-          state->d_state != IncomingTCPConnectionState::State::readingProxyProtocolHeader &&
-          state->d_state != IncomingTCPConnectionState::State::waitingForQuery &&
-          state->d_state != IncomingTCPConnectionState::State::readingQuerySize &&
-          state->d_state != IncomingTCPConnectionState::State::readingQuery &&
-          state->d_state != IncomingTCPConnectionState::State::sendingResponse) {
-        vinfolog("Unexpected state %d in handleIOCallback", static_cast<int>(state->d_state));
+      if (d_state != IncomingTCPConnectionState::State::idle &&
+          d_state != IncomingTCPConnectionState::State::doingHandshake &&
+          d_state != IncomingTCPConnectionState::State::readingProxyProtocolHeader &&
+          d_state != IncomingTCPConnectionState::State::waitingForQuery &&
+          d_state != IncomingTCPConnectionState::State::readingQuerySize &&
+          d_state != IncomingTCPConnectionState::State::readingQuery &&
+          d_state != IncomingTCPConnectionState::State::sendingResponse) {
+        vinfolog("Unexpected state %d in handleIOCallback", static_cast<int>(d_state));
       }
     }
     catch (const std::exception& e) {
@@ -986,55 +1075,56 @@ void IncomingTCPConnectionState::handleIO(std::shared_ptr<IncomingTCPConnectionS
          but it might also be a real IO error or something else.
          Let's just drop the connection
       */
-      if (state->d_state == IncomingTCPConnectionState::State::idle ||
-          state->d_state == IncomingTCPConnectionState::State::waitingForQuery) {
+      if (d_state == IncomingTCPConnectionState::State::idle ||
+          d_state == IncomingTCPConnectionState::State::waitingForQuery) {
         /* no need to increase any counters in that case, the client is simply done with us */
       }
-      else if (state->d_state == IncomingTCPConnectionState::State::doingHandshake ||
-               state->d_state != IncomingTCPConnectionState::State::readingProxyProtocolHeader ||
-               state->d_state == IncomingTCPConnectionState::State::waitingForQuery ||
-               state->d_state == IncomingTCPConnectionState::State::readingQuerySize ||
-               state->d_state == IncomingTCPConnectionState::State::readingQuery) {
-        ++state->d_ci.cs->tcpDiedReadingQuery;
+      else if (d_state == IncomingTCPConnectionState::State::doingHandshake ||
+               d_state != IncomingTCPConnectionState::State::readingProxyProtocolHeader ||
+               d_state == IncomingTCPConnectionState::State::waitingForQuery ||
+               d_state == IncomingTCPConnectionState::State::readingQuerySize ||
+               d_state == IncomingTCPConnectionState::State::readingQuery) {
+        ++d_ci.cs->tcpDiedReadingQuery;
       }
-      else if (state->d_state == IncomingTCPConnectionState::State::sendingResponse) {
+      else if (d_state == IncomingTCPConnectionState::State::sendingResponse) {
         /* unlikely to happen here, the exception should be handled in sendResponse() */
-        ++state->d_ci.cs->tcpDiedSendingResponse;
+        ++d_ci.cs->tcpDiedSendingResponse;
       }
 
-      if (state->d_ioState->isWaitingForWrite() || state->d_queriesCount == 0) {
+      if (d_ioState->isWaitingForWrite() || d_queriesCount == 0) {
         DEBUGLOG("Got an exception while handling TCP query: "<<e.what());
-        vinfolog("Got an exception while handling (%s) TCP query from %s: %s", (state->d_ioState->isWaitingForRead() ? "reading" : "writing"), state->d_ci.remote.toStringWithPort(), e.what());
+        vinfolog("Got an exception while handling (%s) TCP query from %s: %s", (d_ioState->isWaitingForRead() ? "reading" : "writing"), d_ci.remote.toStringWithPort(), e.what());
       }
       else {
-        vinfolog("Closing TCP client connection with %s: %s", state->d_ci.remote.toStringWithPort(), e.what());
+        vinfolog("Closing TCP client connection with %s: %s", d_ci.remote.toStringWithPort(), e.what());
         DEBUGLOG("Closing TCP client connection: "<<e.what());
       }
       /* remove this FD from the IO multiplexer */
-      state->terminateClientConnection();
+      terminateClientConnection();
     }
 
-    if (!state->active()) {
+    if (!active()) {
       DEBUGLOG("state is no longer active");
       return;
     }
 
+    auto state = shared_from_this();
     if (iostate == IOState::Done) {
-      state->d_ioState->update(iostate, handleIOCallback, state);
+      d_ioState->update(iostate, handleIOCallback, state);
     }
     else {
       updateIO(state, iostate, now);
     }
     ioGuard.release();
   }
-  while ((iostate == IOState::NeedRead || iostate == IOState::NeedWrite) && !state->d_lastIOBlocked);
+  while ((iostate == IOState::NeedRead || iostate == IOState::NeedWrite) && !d_lastIOBlocked);
 }
 
-void IncomingTCPConnectionState::notifyIOError(InternalQueryState&& query, const struct timeval& now)
+void IncomingTCPConnectionState::notifyIOError(const struct timeval& now, TCPResponse&& response)
 {
   if (std::this_thread::get_id() != d_creatorThreadID) {
     /* empty buffer will signal an IO error */
-    TCPResponse response(PacketBuffer(), std::move(query), nullptr, nullptr);
+    response.d_buffer.clear();
     handleCrossProtocolResponse(now, std::move(response));
     return;
   }
@@ -1115,8 +1205,17 @@ static void handleIncomingTCPQuery(int pipefd, FDMultiplexer::funcparam_t& param
 
   struct timeval now;
   gettimeofday(&now, nullptr);
-  auto state = std::make_shared<IncomingTCPConnectionState>(std::move(*citmp), *threadData, now);
-  IncomingTCPConnectionState::handleIO(state, now);
+
+  if (citmp->cs->dohFrontend) {
+#ifdef HAVE_NGHTTP2
+    auto state = std::make_shared<IncomingHTTP2Connection>(std::move(*citmp), *threadData, now);
+    state->handleIO();
+#endif /* HAVE_NGHTTP2 */
+  }
+  else {
+    auto state = std::make_shared<IncomingTCPConnectionState>(std::move(*citmp), *threadData, now);
+    state->handleIO();
+  }
 }
 
 static void handleCrossProtocolQuery(int pipefd, FDMultiplexer::funcparam_t& param)
@@ -1141,20 +1240,18 @@ static void handleCrossProtocolQuery(int pipefd, FDMultiplexer::funcparam_t& par
   std::shared_ptr<TCPQuerySender> tqs = cpq->getTCPQuerySender();
   auto query = std::move(cpq->query);
   auto downstreamServer = std::move(cpq->downstream);
-  auto proxyProtocolPayloadSize = cpq->proxyProtocolPayloadSize;
 
   try {
     auto downstream = t_downstreamTCPConnectionsManager.getConnectionToDownstream(threadData->mplexer, downstreamServer, now, std::string());
 
-    prependSizeToTCPQuery(query.d_buffer, proxyProtocolPayloadSize);
-    query.d_proxyProtocolPayloadAddedSize = proxyProtocolPayloadSize;
+    prependSizeToTCPQuery(query.d_buffer, query.d_idstate.d_proxyProtocolPayloadSize);
 
     vinfolog("Got query for %s|%s from %s (%s, %d bytes), relayed to %s", query.d_idstate.qname.toLogString(), QType(query.d_idstate.qtype).toString(), query.d_idstate.origRemote.toStringWithPort(), query.d_idstate.protocol.toString(), query.d_buffer.size(), downstreamServer->getNameWithAddr());
 
     downstream->queueQuery(tqs, std::move(query));
   }
   catch (...) {
-    tqs->notifyIOError(std::move(query.d_idstate), now);
+    tqs->notifyIOError(now, std::move(query));
   }
 }
 
@@ -1178,7 +1275,7 @@ static void handleCrossProtocolResponse(int pipefd, FDMultiplexer::funcparam_t& 
 
   try {
     if (response.d_response.d_buffer.empty()) {
-      response.d_state->notifyIOError(std::move(response.d_response.d_idstate), response.d_now);
+      response.d_state->notifyIOError(response.d_now, std::move(response.d_response));
     }
     else if (response.d_response.d_idstate.qtype == QType::AXFR || response.d_response.d_idstate.qtype == QType::IXFR) {
       response.d_state->handleXFRResponse(response.d_now, std::move(response.d_response));
@@ -1337,7 +1434,8 @@ static void acceptNewConnection(const TCPAcceptorParam& param, TCPClientThreadDa
 {
   auto& cs = param.cs;
   auto& acl = param.acl;
-  int socket = param.socket;
+  const bool checkACL = !cs.dohFrontend || (!cs.dohFrontend->d_trustForwardedForHeader && cs.dohFrontend->d_earlyACLDrop);
+  const int socket = param.socket;
   bool tcpClientCountIncremented = false;
   ComboAddress remote;
   remote.sin4.sin_family = param.local.sin4.sin_family;
@@ -1358,7 +1456,7 @@ static void acceptNewConnection(const TCPAcceptorParam& param, TCPClientThreadDa
       throw std::runtime_error((boost::format("accepting new connection on socket: %s") % stringerror()).str());
     }
 
-    if (!acl->match(remote)) {
+    if (checkACL && !acl->match(remote)) {
       ++dnsdist::metrics::g_stats.aclDrops;
       vinfolog("Dropped TCP connection from %s because of ACL", remote.toStringWithPort());
       return;
@@ -1395,6 +1493,7 @@ static void acceptNewConnection(const TCPAcceptorParam& param, TCPClientThreadDa
     vinfolog("Got TCP connection from %s", remote.toStringWithPort());
 
     ci.remote = remote;
+
     if (threadData == nullptr) {
       if (!g_tcpclientthreads->passConnectionToThread(std::make_unique<ConnectionInfo>(std::move(ci)))) {
         if (tcpClientCountIncremented) {
@@ -1405,8 +1504,17 @@ static void acceptNewConnection(const TCPAcceptorParam& param, TCPClientThreadDa
     else {
       struct timeval now;
       gettimeofday(&now, nullptr);
-      auto state = std::make_shared<IncomingTCPConnectionState>(std::move(ci), *threadData, now);
-      IncomingTCPConnectionState::handleIO(state, now);
+
+      if (ci.cs->dohFrontend) {
+#ifdef HAVE_NGHTTP2        
+        auto state = std::make_shared<IncomingHTTP2Connection>(std::move(ci), *threadData, now);
+        state->handleIO();
+#endif /* HAVE_NGHTTP2 */
+      }
+      else {
+        auto state = std::make_shared<IncomingTCPConnectionState>(std::move(ci), *threadData, now);
+        state->handleIO();
+      }
     }
   }
   catch (const std::exception& e) {

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -741,7 +741,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
           errorCounters = &front->tlsFrontend->d_tlsCounters;
         }
         else if (front->dohFrontend != nullptr) {
-          errorCounters = &front->dohFrontend->d_tlsCounters;
+          errorCounters = &front->dohFrontend->d_tlsContext.d_tlsCounters;
         }
 
         if (errorCounters != nullptr) {
@@ -779,7 +779,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
 #ifdef HAVE_DNS_OVER_HTTPS
   std::map<std::string,uint64_t> dohFrontendDuplicates;
   for(const auto& doh : g_dohlocals) {
-    const string frontName = doh->d_local.toStringWithPort();
+    const string frontName = doh->d_tlsContext.d_addr.toStringWithPort();
     uint64_t threadNumber = 0;
     auto dupPair = frontendDuplicates.emplace(frontName, 1);
     if (!dupPair.second) {
@@ -1149,7 +1149,7 @@ static void handleStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
       errorCounters = &front->tlsFrontend->d_tlsCounters;
     }
     else if (front->dohFrontend != nullptr) {
-      errorCounters = &front->dohFrontend->d_tlsCounters;
+      errorCounters = &front->dohFrontend->d_tlsContext.d_tlsCounters;
     }
     if (errorCounters != nullptr) {
       frontend["tlsHandshakeFailuresDHKeyTooSmall"] = (double)errorCounters->d_dhKeyTooSmall;
@@ -1172,7 +1172,7 @@ static void handleStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
     for (const auto& doh : g_dohlocals) {
       dohs.emplace_back(Json::object{
         { "id", num++ },
-        { "address", doh->d_local.toStringWithPort() },
+        { "address", doh->d_tlsContext.d_addr.toStringWithPort() },
         { "http-connects", (double) doh->d_httpconnects },
         { "http1-queries", (double) doh->d_http1Stats.d_nbQueries },
         { "http2-queries", (double) doh->d_http2Stats.d_nbQueries },

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1469,7 +1469,7 @@ public:
     return handleResponse(now, std::move(response));
   }
 
-  void notifyIOError(InternalQueryState&& query, const struct timeval& now) override
+  void notifyIOError(const struct timeval&, TCPResponse&&) override
   {
     // nothing to do
   }
@@ -2573,18 +2573,24 @@ int main(int argc, char** argv)
         cout<<"gnutls";
 #ifdef HAVE_LIBSSL
         cout<<" ";
-#endif /* HAVE_LIBSSL */
+#endif
 #endif /* HAVE_GNUTLS */
 #ifdef HAVE_LIBSSL
         cout<<"openssl";
-#endif /* HAVE_LIBSSL */
+#endif
         cout<<") ";
 #endif /* HAVE_DNS_OVER_TLS */
 #ifdef HAVE_DNS_OVER_HTTPS
         cout<<"dns-over-https(";
 #ifdef HAVE_LIBH2OEVLOOP
         cout<<"h2o";
+#ifdef HAVE_NGHTTP2
+        cout<<" ";
+#endif
 #endif /* HAVE_LIBH2OEVLOOP */
+#ifdef HAVE_NGHTTP2
+        cout<<"nghttp2";
+#endif
         cout<<") ";
 #endif /* HAVE_DNS_OVER_HTTPS */
 #ifdef HAVE_DNSCRYPT
@@ -2607,9 +2613,6 @@ int main(int argc, char** argv)
 #endif
 #ifdef HAVE_LMDB
         cout<<"lmdb ";
-#endif
-#ifdef HAVE_NGHTTP2
-        cout<<"outgoing-dns-over-https(nghttp2) ";
 #endif
 #ifndef DISABLE_PROTOBUF
         cout<<"protobuf ";
@@ -2914,8 +2917,8 @@ int main(int argc, char** argv)
 
     std::vector<ClientState*> tcpStates;
     std::vector<ClientState*> udpStates;
-    for(auto& cs : g_frontends) {
-      if (cs->dohFrontend != nullptr) {
+    for (auto& cs : g_frontends) {
+      if (cs->dohFrontend != nullptr && cs->dohFrontend->d_library == "h2o") {
 #ifdef HAVE_DNS_OVER_HTTPS
 #ifdef HAVE_LIBH2OEVLOOP
         std::thread t1(dohThread, cs.get());

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2576,16 +2576,20 @@ int main(int argc, char** argv)
         cout<<"gnutls";
 #ifdef HAVE_LIBSSL
         cout<<" ";
-#endif
-#endif
+#endif /* HAVE_LIBSSL */
+#endif /* HAVE_GNUTLS */
 #ifdef HAVE_LIBSSL
         cout<<"openssl";
-#endif
+#endif /* HAVE_LIBSSL */
         cout<<") ";
-#endif
+#endif /* HAVE_DNS_OVER_TLS */
 #ifdef HAVE_DNS_OVER_HTTPS
-        cout<<"dns-over-https(DOH) ";
-#endif
+        cout<<"dns-over-https(";
+#ifdef HAVE_LIBH2OEVLOOP
+        cout<<"h2o";
+#endif /* HAVE_LIBH2OEVLOOP */
+        cout<<") ";
+#endif /* HAVE_DNS_OVER_HTTPS */
 #ifdef HAVE_DNSCRYPT
         cout<<"dnscrypt ";
 #endif
@@ -2916,11 +2920,13 @@ int main(int argc, char** argv)
     for(auto& cs : g_frontends) {
       if (cs->dohFrontend != nullptr) {
 #ifdef HAVE_DNS_OVER_HTTPS
+#ifdef HAVE_LIBH2OEVLOOP
         std::thread t1(dohThread, cs.get());
         if (!cs->cpus.empty()) {
           mapThreadToCPUList(t1.native_handle(), cs->cpus);
         }
         t1.detach();
+#endif /* HAVE_LIBH2OEVLOOP */
 #endif /* HAVE_DNS_OVER_HTTPS */
         continue;
       }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2584,13 +2584,13 @@ int main(int argc, char** argv)
         cout<<"dns-over-https(";
 #ifdef HAVE_LIBH2OEVLOOP
         cout<<"h2o";
-#ifdef HAVE_NGHTTP2
-        cout<<" ";
-#endif
 #endif /* HAVE_LIBH2OEVLOOP */
+#if defined(HAVE_LIBH2OEVLOOP) && defined(HAVE_NGHTTP2)
+        cout<<" ";
+#endif /* defined(HAVE_LIBH2OEVLOOP) && defined(HAVE_NGHTTP2) */
 #ifdef HAVE_NGHTTP2
         cout<<"nghttp2";
-#endif
+#endif /* HAVE_NGHTTP2 */
         cout<<") ";
 #endif /* HAVE_DNS_OVER_HTTPS */
 #ifdef HAVE_DNSCRYPT

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -529,6 +529,17 @@ struct ClientState
     return tlsFrontend != nullptr || (dohFrontend != nullptr && dohFrontend->isHTTPS());
   }
 
+  const TLSFrontend& getTLSFrontend() const
+  {
+    if (tlsFrontend != nullptr) {
+      return *tlsFrontend;
+    }
+    if (dohFrontend) {
+      return dohFrontend->d_tlsContext;
+    }
+    throw std::runtime_error("Trying to get a TLS frontend from a non-TLS ClientState");
+  }
+
   dnsdist::Protocol getProtocol() const
   {
     if (dnscryptCtx) {

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -42,7 +42,7 @@
 #include "dnsdist-lbpolicies.hh"
 #include "dnsdist-protocols.hh"
 #include "dnsname.hh"
-#include "doh.hh"
+#include "dnsdist-doh-common.hh"
 #include "ednsoptions.hh"
 #include "iputils.hh"
 #include "misc.hh"
@@ -1088,10 +1088,6 @@ struct LocalHolders
 
 void tcpAcceptorThread(std::vector<ClientState*> states);
 
-#ifdef HAVE_DNS_OVER_HTTPS
-void dohThread(ClientState* cs);
-#endif /* HAVE_DNS_OVER_HTTPS */
-
 void setLuaNoSideEffect(); // if nothing has been declared, set that there are no side effects
 void setLuaSideEffect();   // set to report a side effect, cancelling all _no_ side effect calls
 bool getLuaNoSideEffect(); // set if there were only explicit declarations of _no_ side effect
@@ -1123,7 +1119,7 @@ bool processResponse(PacketBuffer& response, const std::vector<DNSDistResponseRu
 bool processRulesResult(const DNSAction::Action& action, DNSQuestion& dq, std::string& ruleresult, bool& drop);
 bool processResponseAfterRules(PacketBuffer& response, const std::vector<DNSDistResponseRuleAction>& cacheInsertedRespRuleActions, DNSResponse& dr, bool muted);
 
-bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer& query, ComboAddress& dest);
+bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer& query);
 
 ssize_t udpClientSendRequestToBackend(const std::shared_ptr<DownstreamState>& ss, const int sd, const PacketBuffer& request, bool healthCheck = false);
 bool sendUDPResponse(int origFD, const PacketBuffer& response, const int delayMsec, const ComboAddress& origDest, const ComboAddress& origRemote);

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -207,7 +207,7 @@ dnsdist_SOURCES = \
 	dnsparser.hh dnsparser.cc \
 	dnstap.cc dnstap.hh \
 	dnswriter.cc dnswriter.hh \
-	doh.hh doh.cc \
+	doh.hh \
 	dolog.hh \
 	ednscookies.cc ednscookies.hh \
 	ednsoptions.cc ednsoptions.hh \
@@ -424,6 +424,7 @@ dnsdist_LDADD += -lgnutls
 endif
 
 if HAVE_LIBH2OEVLOOP
+dnsdist_SOURCES += doh.cc
 dnsdist_LDADD += $(LIBH2OEVLOOP_LIBS)
 endif
 

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -80,6 +80,10 @@ if HAVE_LIBSSL
 AM_CPPFLAGS += $(LIBSSL_CFLAGS)
 endif
 
+if HAVE_GNUTLS
+AM_CPPFLAGS += $(GNUTLS_CFLAGS)
+endif
+
 if HAVE_LIBH2OEVLOOP
 AM_CPPFLAGS += $(LIBH2OEVLOOP_CFLAGS)
 endif
@@ -178,6 +182,7 @@ dnsdist_SOURCES = \
 	dnsdist-lua.cc dnsdist-lua.hh \
 	dnsdist-mac-address.cc dnsdist-mac-address.hh \
 	dnsdist-metrics.cc dnsdist-metrics.hh \
+	dnsdist-nghttp2-in.cc dnsdist-nghttp2-in.hh \
 	dnsdist-nghttp2.cc dnsdist-nghttp2.hh \
 	dnsdist-prometheus.hh \
 	dnsdist-protobuf.cc dnsdist-protobuf.hh \
@@ -274,6 +279,7 @@ testrunner_SOURCES = \
 	dnsdist-lua-vars.cc \
 	dnsdist-mac-address.cc dnsdist-mac-address.hh \
 	dnsdist-metrics.cc dnsdist-metrics.hh \
+	dnsdist-nghttp2-in.cc dnsdist-nghttp2-in.hh \
 	dnsdist-nghttp2.cc dnsdist-nghttp2.hh \
 	dnsdist-protocols.cc dnsdist-protocols.hh \
 	dnsdist-proxy-protocol.cc dnsdist-proxy-protocol.hh \
@@ -410,6 +416,10 @@ endif
 endif
 
 if HAVE_DNS_OVER_HTTPS
+
+if HAVE_GNUTLS
+dnsdist_LDADD += -lgnutls
+endif
 
 if HAVE_LIBH2OEVLOOP
 dnsdist_LDADD += $(LIBH2OEVLOOP_LIBS)

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -332,7 +332,9 @@ testrunner_SOURCES = \
 	test-dnsdistkvs_cc.cc \
 	test-dnsdistlbpolicies_cc.cc \
 	test-dnsdistluanetwork.cc \
+	test-dnsdistnghttp2-in_cc.cc \
 	test-dnsdistnghttp2_cc.cc \
+	test-dnsdistnghttp2_common.hh \
 	test-dnsdistpacketcache_cc.cc \
 	test-dnsdistrings_cc.cc \
 	test-dnsdistrules_cc.cc \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -147,6 +147,7 @@ dnsdist_SOURCES = \
 	dnsdist-discovery.cc dnsdist-discovery.hh \
 	dnsdist-dnscrypt.cc \
 	dnsdist-dnsparser.cc dnsdist-dnsparser.hh \
+	dnsdist-doh-common.cc dnsdist-doh-common.hh \
 	dnsdist-downstream-connection.hh \
 	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
 	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \
@@ -256,6 +257,7 @@ testrunner_SOURCES = \
 	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-concurrent-connections.hh \
 	dnsdist-dnsparser.cc dnsdist-dnsparser.hh \
+	dnsdist-doh-common.cc dnsdist-doh-common.hh \
 	dnsdist-downstream-connection.hh \
 	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
 	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -66,10 +66,11 @@ AS_IF([test "x$LUAPC" = "xluajit"], [
 ])
 PDNS_CHECK_LUA_HPP
 
+AM_CONDITIONAL([HAVE_CDB], [false])
 AM_CONDITIONAL([HAVE_GNUTLS], [false])
+AM_CONDITIONAL([HAVE_LIBH2OEVLOOP], [false])
 AM_CONDITIONAL([HAVE_LIBSSL], [false])
 AM_CONDITIONAL([HAVE_LMDB], [false])
-AM_CONDITIONAL([HAVE_CDB], [false])
 
 PDNS_CHECK_LIBCRYPTO
 
@@ -90,8 +91,9 @@ AS_IF([test "x$enable_dns_over_tls" != "xno"], [
   ])
 ])
 
-PDNS_CHECK_LIBH2OEVLOOP
 AS_IF([test "x$enable_dns_over_https" != "xno"], [
+  PDNS_WITH_LIBH2OEVLOOP
+
   AS_IF([test "x$HAVE_LIBH2OEVLOOP" != "x1"], [
     AC_MSG_ERROR([DNS over HTTPS support requested but libh2o-evloop was not found])
   ])
@@ -242,6 +244,10 @@ AS_IF([test "x$enable_dns_over_tls" != "xno" -o "x$enable_dns_over_https" != "xn
     [AC_MSG_NOTICE([OpenSSL: yes])],
     [AC_MSG_NOTICE([OpenSSL: no])]
   )]
+)
+AS_IF([test "x$LIBH2OEVLOOP_LIBS" != "x"],
+  [AC_MSG_NOTICE([h2o-evloop: yes])],
+  [AC_MSG_NOTICE([h2o-evloop: no])]
 )
 AS_IF([test "x$NGHTTP2_LIBS" != "x"],
   [AC_MSG_NOTICE([nghttp2: yes])],

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -71,6 +71,7 @@ AM_CONDITIONAL([HAVE_GNUTLS], [false])
 AM_CONDITIONAL([HAVE_LIBH2OEVLOOP], [false])
 AM_CONDITIONAL([HAVE_LIBSSL], [false])
 AM_CONDITIONAL([HAVE_LMDB], [false])
+AM_CONDITIONAL([HAVE_NGHTTP2], [false])
 
 PDNS_CHECK_LIBCRYPTO
 
@@ -81,29 +82,27 @@ DNSDIST_ENABLE_DNS_OVER_HTTPS
 
 AS_IF([test "x$enable_dns_over_tls" != "xno" -o "x$enable_dns_over_https" != "xno"], [
   PDNS_WITH_LIBSSL
+  PDNS_WITH_GNUTLS
 ])
 
 AS_IF([test "x$enable_dns_over_tls" != "xno"], [
-  PDNS_WITH_GNUTLS
-
   AS_IF([test "x$HAVE_GNUTLS" != "x1" -a "x$HAVE_LIBSSL" != "x1"], [
     AC_MSG_ERROR([DNS over TLS support requested but neither GnuTLS nor OpenSSL are available])
   ])
 ])
 
 AS_IF([test "x$enable_dns_over_https" != "xno"], [
+  PDNS_WITH_NGHTTP2
   PDNS_WITH_LIBH2OEVLOOP
 
-  AS_IF([test "x$HAVE_LIBH2OEVLOOP" != "x1"], [
-    AC_MSG_ERROR([DNS over HTTPS support requested but libh2o-evloop was not found])
+  AS_IF([test "x$HAVE_LIBH2OEVLOOP" != "x1" -a "x$HAVE_NGHTTP2" != "x1" ], [
+    AC_MSG_ERROR([DNS over HTTPS support requested but neither libh2o-evloop nor nghttp2 was not found])
   ])
 
-  AS_IF([test "x$HAVE_LIBSSL" != "x1"], [
-    AC_MSG_ERROR([DNS over HTTPS support requested but OpenSSL was not found])
+  AS_IF([test "x$HAVE_GNUTLS" != "x1" -a "x$HAVE_LIBSSL" != "x1"], [
+    AC_MSG_ERROR([DNS over HTTPS support requested but neither GnuTLS nor OpenSSL are available])
   ])
 ])
-
-PDNS_WITH_NGHTTP2
 
 DNSDIST_WITH_CDB
 PDNS_CHECK_LMDB

--- a/pdns/dnsdistdist/dnsdist-async.cc
+++ b/pdns/dnsdistdist/dnsdist-async.cc
@@ -137,7 +137,8 @@ void AsynchronousHolder::mainThread(std::shared_ptr<Data> data)
         vinfolog("Asynchronous query %d has expired at %d.%d, notifying the sender", queryID, now.tv_sec, now.tv_usec);
         auto sender = query->getTCPQuerySender();
         if (sender) {
-          sender->notifyIOError(std::move(query->query.d_idstate), now);
+          TCPResponse tresponse(std::move(query->query));
+          sender->notifyIOError(now, std::move(tresponse));
         }
       }
       else {

--- a/pdns/dnsdistdist/dnsdist-async.cc
+++ b/pdns/dnsdistdist/dnsdist-async.cc
@@ -282,7 +282,6 @@ bool resumeQuery(std::unique_ptr<CrossProtocolQuery>&& query)
     return resumeResponse(std::move(query));
   }
 
-  auto& ids = query->query.d_idstate;
   DNSQuestion dnsQuestion = query->getDQ();
   LocalHolders holders;
 
@@ -311,7 +310,7 @@ bool resumeQuery(std::unique_ptr<CrossProtocolQuery>&& query)
     /* at this point 'du', if it is not nullptr, is owned by the DoHCrossProtocolQuery
        which will stop existing when we return, so we need to increment the reference count
     */
-    return assignOutgoingUDPQueryToBackend(query->downstream, queryID, dnsQuestion, query->query.d_buffer, ids.origDest);
+    return assignOutgoingUDPQueryToBackend(query->downstream, queryID, dnsQuestion, query->query.d_buffer);
   }
   if (result == ProcessQueryResult::SendAnswer) {
     auto sender = query->getTCPQuerySender();

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -360,7 +360,7 @@ void DownstreamState::handleUDPTimeout(IDState& ids)
 {
   ids.age = 0;
   ids.inUse = false;
-  handleDOHTimeout(std::move(ids.internal.du));
+  DOHUnitInterface::handleTimeout(std::move(ids.internal.du));
   ++reuseds;
   --outstanding;
   ++dnsdist::metrics::g_stats.downstreamTimeouts; // this is an 'actively' discovered timeout
@@ -463,7 +463,7 @@ uint16_t DownstreamState::saveState(InternalQueryState&& state)
         auto oldDU = std::move(it->second.internal.du);
         ++reuseds;
         ++dnsdist::metrics::g_stats.downstreamTimeouts;
-        handleDOHTimeout(std::move(oldDU));
+        DOHUnitInterface::handleTimeout(std::move(oldDU));
       }
       else {
         ++outstanding;
@@ -490,7 +490,7 @@ uint16_t DownstreamState::saveState(InternalQueryState&& state)
       auto oldDU = std::move(ids.internal.du);
       ++reuseds;
       ++dnsdist::metrics::g_stats.downstreamTimeouts;
-      handleDOHTimeout(std::move(oldDU));
+      DOHUnitInterface::handleTimeout(std::move(oldDU));
     }
     else {
       ++outstanding;
@@ -513,7 +513,7 @@ void DownstreamState::restoreState(uint16_t id, InternalQueryState&& state)
       /* already used */
       ++reuseds;
       ++dnsdist::metrics::g_stats.downstreamTimeouts;
-      handleDOHTimeout(std::move(state.du));
+      DOHUnitInterface::handleTimeout(std::move(state.du));
     }
     else {
       it->second.internal = std::move(state);
@@ -528,14 +528,14 @@ void DownstreamState::restoreState(uint16_t id, InternalQueryState&& state)
     /* already used */
     ++reuseds;
     ++dnsdist::metrics::g_stats.downstreamTimeouts;
-    handleDOHTimeout(std::move(state.du));
+    DOHUnitInterface::handleTimeout(std::move(state.du));
     return;
   }
   if (ids.isInUse()) {
     /* already used */
     ++reuseds;
     ++dnsdist::metrics::g_stats.downstreamTimeouts;
-    handleDOHTimeout(std::move(state.du));
+    DOHUnitInterface::handleTimeout(std::move(state.du));
     return;
   }
   ids.internal = std::move(state);

--- a/pdns/dnsdistdist/dnsdist-doh-common.cc
+++ b/pdns/dnsdistdist/dnsdist-doh-common.cc
@@ -49,8 +49,8 @@ string HTTPHeaderRule::toString() const
   return d_visual;
 }
 
-HTTPPathRule::HTTPPathRule(const std::string& path) :
-  d_path(path)
+HTTPPathRule::HTTPPathRule(std::string path) :
+  d_path(std::move(path))
 {
 }
 

--- a/pdns/dnsdistdist/dnsdist-doh-common.cc
+++ b/pdns/dnsdistdist/dnsdist-doh-common.cc
@@ -1,0 +1,129 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "dnsdist-doh-common.hh"
+#include "dnsdist-rules.hh"
+
+#ifdef HAVE_DNS_OVER_HTTPS
+
+HTTPHeaderRule::HTTPHeaderRule(const std::string& header, const std::string& regex) :
+  d_header(toLower(header)), d_regex(regex), d_visual("http[" + header + "] ~ " + regex)
+{
+}
+
+bool HTTPHeaderRule::matches(const DNSQuestion* dq) const
+{
+  if (!dq->ids.du) {
+    return false;
+  }
+
+  const auto& headers = dq->ids.du->getHTTPHeaders();
+  for (const auto& header : headers) {
+    if (header.first == d_header) {
+      return d_regex.match(header.second);
+    }
+  }
+  return false;
+}
+
+string HTTPHeaderRule::toString() const
+{
+  return d_visual;
+}
+
+HTTPPathRule::HTTPPathRule(const std::string& path) :
+  d_path(path)
+{
+}
+
+bool HTTPPathRule::matches(const DNSQuestion* dq) const
+{
+  if (!dq->ids.du) {
+    return false;
+  }
+
+  const auto path = dq->ids.du->getHTTPPath();
+  return d_path == path;
+}
+
+string HTTPPathRule::toString() const
+{
+  return "url path == " + d_path;
+}
+
+HTTPPathRegexRule::HTTPPathRegexRule(const std::string& regex) :
+  d_regex(regex), d_visual("http path ~ " + regex)
+{
+}
+
+bool HTTPPathRegexRule::matches(const DNSQuestion* dq) const
+{
+  if (!dq->ids.du) {
+    return false;
+  }
+
+  return d_regex.match(dq->ids.du->getHTTPPath());
+}
+
+string HTTPPathRegexRule::toString() const
+{
+  return d_visual;
+}
+
+void DOHFrontend::rotateTicketsKey(time_t now)
+{
+  return d_tlsContext.rotateTicketsKey(now);
+}
+
+void DOHFrontend::loadTicketsKeys(const std::string& keyFile)
+{
+  return d_tlsContext.loadTicketsKeys(keyFile);
+}
+
+void DOHFrontend::handleTicketsKeyRotation()
+{
+}
+
+std::string DOHFrontend::getNextTicketsKeyRotation() const
+{
+  return d_tlsContext.getNextTicketsKeyRotation();
+}
+
+size_t DOHFrontend::getTicketsKeysCount()
+{
+  return d_tlsContext.getTicketsKeysCount();
+}
+
+void DOHFrontend::reloadCertificates()
+{
+  d_tlsContext.setupTLS();
+}
+
+void DOHFrontend::setup()
+{
+  if (isHTTPS()) {
+    if (!d_tlsContext.setupTLS()) {
+      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + d_tlsContext.d_addr.toStringWithPort());
+    }
+  }
+}
+
+#endif /* HAVE_DNS_OVER_HTTPS */

--- a/pdns/dnsdistdist/dnsdist-doh-common.hh
+++ b/pdns/dnsdistdist/dnsdist-doh-common.hh
@@ -1,0 +1,1 @@
+../dnsdist-doh-common.hh

--- a/pdns/dnsdistdist/dnsdist-healthchecks.cc
+++ b/pdns/dnsdistdist/dnsdist-healthchecks.cc
@@ -168,7 +168,7 @@ public:
     throw std::runtime_error("Unexpected XFR reponse to a health check query");
   }
 
-  void notifyIOError(const struct timeval& now, TCPResponse&&) override
+  void notifyIOError(const struct timeval& now, [[maybe_unused]] TCPResponse&& response) override
   {
     ++d_data->d_ds->d_healthCheckMetrics.d_networkErrors;
     d_data->d_ds->submitHealthCheckResult(d_data->d_initial, false);

--- a/pdns/dnsdistdist/dnsdist-healthchecks.cc
+++ b/pdns/dnsdistdist/dnsdist-healthchecks.cc
@@ -168,7 +168,7 @@ public:
     throw std::runtime_error("Unexpected XFR reponse to a health check query");
   }
 
-  void notifyIOError(InternalQueryState&& query, const struct timeval& now) override
+  void notifyIOError(const struct timeval& now, TCPResponse&&) override
   {
     ++d_data->d_ds->d_healthCheckMetrics.d_networkErrors;
     d_data->d_ds->submitHealthCheckResult(d_data->d_initial, false);

--- a/pdns/dnsdistdist/dnsdist-internal-queries.cc
+++ b/pdns/dnsdistdist/dnsdist-internal-queries.cc
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "dnsdist-internal-queries.hh"
+#include "dnsdist-nghttp2-in.hh"
 #include "dnsdist-tcp.hh"
 #include "doh.hh"
 
@@ -35,7 +36,12 @@ std::unique_ptr<CrossProtocolQuery> getInternalQueryFromDQ(DNSQuestion& dq, bool
   }
 #ifdef HAVE_DNS_OVER_HTTPS
   else if (protocol == dnsdist::Protocol::DoH) {
-    return getDoHCrossProtocolQueryFromDQ(dq, isResponse);
+#ifdef HAVE_LIBH2OEVLOOP
+    if (dq.ids.cs->dohFrontend->d_library == "h2o") {
+      return getDoHCrossProtocolQueryFromDQ(dq, isResponse);
+    }
+#endif /* HAVE_LIBH2OEVLOOP */
+    return getTCPCrossProtocolQueryFromDQ(dq);
   }
 #endif
   else {

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -929,7 +929,8 @@ bool dnsdist_ffi_drop_from_async(uint16_t asyncID, uint16_t queryID)
 
   struct timeval now;
   gettimeofday(&now, nullptr);
-  sender->notifyIOError(std::move(query->query.d_idstate), now);
+  TCPResponse tresponse(std::move(query->query));
+  sender->notifyIOError(now, std::move(tresponse));
 
   return true;
 }

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -189,6 +189,7 @@ void IncomingHTTP2Connection::handleResponse(const struct timeval& now, TCPRespo
     dnsheader* responseDH = reinterpret_cast<struct dnsheader*>(response.d_buffer.data());
 
     if (responseDH->tc && state.d_packet && state.d_packet->size() > state.d_proxyProtocolPayloadSize && state.d_packet->size() - state.d_proxyProtocolPayloadSize > sizeof(dnsheader)) {
+      vinfolog("Response received from backend %s via UDP, for query %d received from %s via DoH, is truncated, retrying over TCP", response.d_ds->getNameWithAddr(), state.d_streamID, state.origRemote.toStringWithPort());
       auto& query = *state.d_packet;
       dnsheader* queryDH = reinterpret_cast<struct dnsheader*>(query.data() + state.d_proxyProtocolPayloadSize);
       /* restoring the original ID */

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -1,0 +1,1214 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "base64.hh"
+#include "dnsdist-nghttp2-in.hh"
+#include "dnsdist-proxy-protocol.hh"
+#include "dnsparser.hh"
+
+#ifdef HAVE_NGHTTP2
+
+#if 0
+class IncomingDoHCrossProtocolContext : public CrossProtocolContext
+{
+public:
+  IncomingDoHCrossProtocolContext(IncomingHTTP2Connection::PendingQuery&& query, std::shared_ptr<IncomingHTTP2Connection> connection, IncomingHTTP2Connection::StreamID streamID): CrossProtocolContext(std::move(query.d_buffer)), d_connection(connection), d_query(std::move(query))
+  {
+  }
+
+  std::optional<std::string> getHTTPPath() const override
+  {
+    return d_query.d_path;
+  }
+
+  std::optional<std::string> getHTTPScheme() const override
+  {
+    return d_query.d_scheme;
+  }
+
+  std::optional<std::string> getHTTPHost() const override
+  {
+    return d_query.d_host;
+  }
+
+  std::optional<std::string> getHTTPQueryString() const override
+  {
+    return d_query.d_queryString;
+  }
+
+  std::optional<HeadersMap> getHTTPHeaders() const override
+  {
+    if (!d_query.d_headers) {
+      return std::nullopt;
+    }
+    return *d_query.d_headers;
+  }
+
+  void handleResponse(PacketBuffer&& response, InternalQueryState&& state) override
+  {
+    auto conn = d_connection.lock();
+    if (!conn) {
+      /* the connection has been closed in the meantime */
+      return;
+    }
+  }
+
+  void handleTimeout() override
+  {
+    auto conn = d_connection.lock();
+    if (!conn) {
+      /* the connection has been closed in the meantime */
+      return;
+    }
+  }
+
+  ~IncomingDoHCrossProtocolContext() override
+  {
+  }
+
+private:
+  std::weak_ptr<IncomingHTTP2Connection> d_connection;
+  IncomingHTTP2Connection::PendingQuery d_query;
+  IncomingHTTP2Connection::StreamID d_streamID{-1};
+};
+#endif
+
+class IncomingDoHCrossProtocolContext : public DOHUnitInterface
+{
+public:
+  IncomingDoHCrossProtocolContext(IncomingHTTP2Connection::PendingQuery&& query, std::shared_ptr<IncomingHTTP2Connection> connection, IncomingHTTP2Connection::StreamID streamID) :
+    d_connection(connection), d_query(std::move(query)), d_streamID(streamID)
+  {
+  }
+
+  std::string getHTTPPath() const override
+  {
+    return d_query.d_path;
+  }
+
+  const std::string& getHTTPScheme() const override
+  {
+    return d_query.d_scheme;
+  }
+
+  const std::string& getHTTPHost() const override
+  {
+    return d_query.d_host;
+  }
+
+  std::string getHTTPQueryString() const override
+  {
+    return d_query.d_queryString;
+  }
+
+  const HeadersMap& getHTTPHeaders() const override
+  {
+    if (!d_query.d_headers) {
+      static const HeadersMap empty{};
+      return empty;
+    }
+    return *d_query.d_headers;
+  }
+
+  void setHTTPResponse(uint16_t statusCode, PacketBuffer&& body, const std::string& contentType = "") override
+  {
+    d_query.d_statusCode = statusCode;
+    d_query.d_response = std::move(body);
+    d_query.d_contentTypeOut = contentType;
+  }
+
+  void handleUDPResponse(PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& ds) override
+  {
+    std::unique_ptr<DOHUnitInterface> unit(this);
+    auto conn = d_connection.lock();
+    if (!conn) {
+      /* the connection has been closed in the meantime */
+      return;
+    }
+
+    state.du = std::move(unit);
+    TCPResponse resp(std::move(response), std::move(state), nullptr, nullptr);
+    resp.d_ds = ds;
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+    conn->handleResponse(now, std::move(resp));
+  }
+
+  void handleTimeout() override
+  {
+    std::unique_ptr<DOHUnitInterface> unit(this);
+    auto conn = d_connection.lock();
+    if (!conn) {
+      /* the connection has been closed in the meantime */
+      return;
+    }
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+    TCPResponse resp;
+    resp.d_idstate.d_streamID = d_streamID;
+    conn->notifyIOError(now, std::move(resp));
+  }
+
+  ~IncomingDoHCrossProtocolContext() override
+  {
+  }
+
+  std::weak_ptr<IncomingHTTP2Connection> d_connection;
+  IncomingHTTP2Connection::PendingQuery d_query;
+  IncomingHTTP2Connection::StreamID d_streamID{-1};
+};
+
+void IncomingHTTP2Connection::handleResponse(const struct timeval& now, TCPResponse&& response)
+{
+  if (std::this_thread::get_id() != d_creatorThreadID) {
+    handleCrossProtocolResponse(now, std::move(response));
+    return;
+  }
+
+  auto& state = response.d_idstate;
+  if (state.forwardedOverUDP) {
+    dnsheader* responseDH = reinterpret_cast<struct dnsheader*>(response.d_buffer.data());
+
+    if (responseDH->tc && state.d_packet && state.d_packet->size() > state.d_proxyProtocolPayloadSize && state.d_packet->size() - state.d_proxyProtocolPayloadSize > sizeof(dnsheader)) {
+      auto& query = *state.d_packet;
+      dnsheader* queryDH = reinterpret_cast<struct dnsheader*>(query.data() + state.d_proxyProtocolPayloadSize);
+      /* restoring the original ID */
+      queryDH->id = state.origID;
+
+      state.forwardedOverUDP = false;
+      auto cpq = getCrossProtocolQuery(std::move(query), std::move(state), response.d_ds);
+      cpq->query.d_proxyProtocolPayloadAdded = state.d_proxyProtocolPayloadSize > 0;
+      if (g_tcpclientthreads && g_tcpclientthreads->passCrossProtocolQueryToThread(std::move(cpq))) {
+        return;
+      }
+      else {
+        vinfolog("Unable to pass DoH query to a TCP worker thread after getting a TC response over UDP");
+        notifyIOError(now, std::move(response));
+        return;
+      }
+    }
+  }
+
+  IncomingTCPConnectionState::handleResponse(now, std::move(response));
+}
+
+std::unique_ptr<DOHUnitInterface> IncomingHTTP2Connection::getDOHUnit(uint32_t streamID)
+{
+  auto query = std::move(d_currentStreams.at(streamID));
+  return std::make_unique<IncomingDoHCrossProtocolContext>(std::move(query), std::dynamic_pointer_cast<IncomingHTTP2Connection>(shared_from_this()), streamID);
+}
+
+void IncomingHTTP2Connection::restoreDOHUnit(std::unique_ptr<DOHUnitInterface>&& unit)
+{
+  auto context = std::unique_ptr<IncomingDoHCrossProtocolContext>(dynamic_cast<IncomingDoHCrossProtocolContext*>(unit.release()));
+  d_currentStreams.at(context->d_streamID) = std::move(context->d_query);
+}
+
+void IncomingHTTP2Connection::restoreContext(uint32_t streamID, IncomingHTTP2Connection::PendingQuery&& context)
+{
+  d_currentStreams.at(streamID) = std::move(context);
+}
+
+IncomingHTTP2Connection::IncomingHTTP2Connection(ConnectionInfo&& ci, TCPClientThreadData& threadData, const struct timeval& now) :
+  IncomingTCPConnectionState(std::move(ci), threadData, now)
+{
+  nghttp2_session_callbacks* cbs = nullptr;
+  if (nghttp2_session_callbacks_new(&cbs) != 0) {
+    throw std::runtime_error("Unable to create a callback object for a new incoming HTTP/2 session");
+  }
+  std::unique_ptr<nghttp2_session_callbacks, void (*)(nghttp2_session_callbacks*)> callbacks(cbs, nghttp2_session_callbacks_del);
+  cbs = nullptr;
+
+  nghttp2_session_callbacks_set_send_callback(callbacks.get(), send_callback);
+  nghttp2_session_callbacks_set_on_frame_recv_callback(callbacks.get(), on_frame_recv_callback);
+  nghttp2_session_callbacks_set_on_stream_close_callback(callbacks.get(), on_stream_close_callback);
+  nghttp2_session_callbacks_set_on_begin_headers_callback(callbacks.get(), on_begin_headers_callback);
+  nghttp2_session_callbacks_set_on_header_callback(callbacks.get(), on_header_callback);
+  nghttp2_session_callbacks_set_on_data_chunk_recv_callback(callbacks.get(), on_data_chunk_recv_callback);
+  nghttp2_session_callbacks_set_error_callback2(callbacks.get(), on_error_callback);
+
+  nghttp2_session* sess = nullptr;
+  if (nghttp2_session_server_new(&sess, callbacks.get(), this) != 0) {
+    throw std::runtime_error("Coult not allocate a new incoming HTTP/2 session");
+  }
+
+  d_session = std::unique_ptr<nghttp2_session, decltype(&nghttp2_session_del)>(sess, nghttp2_session_del);
+  sess = nullptr;
+}
+
+bool IncomingHTTP2Connection::checkALPN()
+{
+  constexpr std::array<uint8_t, 2> h2{'h', '2'};
+  auto protocols = d_handler.getNextProtocol();
+  if (protocols.size() == h2.size() && memcmp(protocols.data(), h2.data(), h2.size()) == 0) {
+    return true;
+  }
+  vinfolog("DoH connection from %s expected ALPN value 'h2', got '%s'", d_ci.remote.toStringWithPort(), std::string(protocols.begin(), protocols.end()));
+  return false;
+}
+
+void IncomingHTTP2Connection::handleConnectionReady()
+{
+  constexpr std::array<nghttp2_settings_entry, 1> iv{{{NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 100U}}};
+  auto ret = nghttp2_submit_settings(d_session.get(), NGHTTP2_FLAG_NONE, iv.data(), iv.size());
+  if (ret != 0) {
+    throw std::runtime_error("Fatal error: " + std::string(nghttp2_strerror(ret)));
+  }
+  ret = nghttp2_session_send(d_session.get());
+  if (ret != 0) {
+    throw std::runtime_error("Fatal error: " + std::string(nghttp2_strerror(ret)));
+  }
+}
+
+void IncomingHTTP2Connection::handleIO()
+{
+  IOState iostate = IOState::Done;
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
+  try {
+    if (maxConnectionDurationReached(g_maxTCPConnectionDuration, now)) {
+      vinfolog("Terminating DoH connection from %s because it reached the maximum TCP connection duration", d_ci.remote.toStringWithPort());
+      stopIO();
+      d_connectionDied = true;
+      return;
+    }
+
+    if (d_state == State::doingHandshake) {
+      iostate = d_handler.tryHandshake();
+      if (iostate == IOState::Done) {
+        handleHandshakeDone(now);
+        if (d_handler.isTLS()) {
+          if (!checkALPN()) {
+            d_connectionDied = true;
+            stopIO();
+            return;
+          }
+        }
+
+        if (expectProxyProtocolFrom(d_ci.remote)) {
+          d_state = IncomingTCPConnectionState::State::readingProxyProtocolHeader;
+          d_buffer.resize(s_proxyProtocolMinimumHeaderSize);
+          d_proxyProtocolNeed = s_proxyProtocolMinimumHeaderSize;
+        }
+        else {
+          d_state = State::waitingForQuery;
+          handleConnectionReady();
+        }
+      }
+    }
+
+    if (d_state == IncomingTCPConnectionState::State::readingProxyProtocolHeader) {
+      auto status = handleProxyProtocolPayload();
+      if (status == ProxyProtocolResult::Done) {
+        d_currentPos = 0;
+        d_proxyProtocolNeed = 0;
+        d_buffer.clear();
+        d_state = State::waitingForQuery;
+        handleConnectionReady();
+      }
+      else if (status == ProxyProtocolResult::Error) {
+        d_connectionDied = true;
+        stopIO();
+        return;
+      }
+    }
+
+    if (d_state == State::waitingForQuery) {
+      readHTTPData();
+    }
+
+    if (!d_connectionDied) {
+      auto shared = std::dynamic_pointer_cast<IncomingHTTP2Connection>(shared_from_this());
+      if (nghttp2_session_want_read(d_session.get())) {
+        d_ioState->add(IOState::NeedRead, &handleReadableIOCallback, shared, boost::none);
+      }
+      if (nghttp2_session_want_write(d_session.get())) {
+        d_ioState->add(IOState::NeedWrite, &handleWritableIOCallback, shared, boost::none);
+      }
+    }
+  }
+  catch (const std::exception& e) {
+    vinfolog("Exception when processing IO for incoming DoH connection from %s: %s", d_ci.remote.toStringWithPort(), e.what());
+    d_connectionDied = true;
+    stopIO();
+  }
+}
+
+ssize_t IncomingHTTP2Connection::send_callback(nghttp2_session* session, const uint8_t* data, size_t length, int flags, void* user_data)
+{
+  IncomingHTTP2Connection* conn = reinterpret_cast<IncomingHTTP2Connection*>(user_data);
+  bool bufferWasEmpty = conn->d_out.empty();
+  conn->d_out.insert(conn->d_out.end(), data, data + length);
+
+  if (bufferWasEmpty) {
+    try {
+      auto state = conn->d_handler.tryWrite(conn->d_out, conn->d_outPos, conn->d_out.size());
+      if (state == IOState::Done) {
+        conn->d_out.clear();
+        conn->d_outPos = 0;
+        if (!conn->isIdle()) {
+          conn->updateIO(IOState::NeedRead, handleReadableIOCallback);
+        }
+        else {
+          conn->watchForRemoteHostClosingConnection();
+        }
+      }
+      else {
+        conn->updateIO(state, handleWritableIOCallback);
+      }
+    }
+    catch (const std::exception& e) {
+      vinfolog("Exception while trying to write (send) to incoming HTTP connection: %s", e.what());
+      conn->handleIOError();
+    }
+  }
+
+  return length;
+}
+
+static const std::unordered_map<std::string, std::string> s_constants{
+  {"200-value", "200"},
+  {"method-name", ":method"},
+  {"method-value", "POST"},
+  {"scheme-name", ":scheme"},
+  {"scheme-value", "https"},
+  {"authority-name", ":authority"},
+  {"x-forwarded-for-name", "x-forwarded-for"},
+  {"path-name", ":path"},
+  {"content-length-name", "content-length"},
+  {"status-name", ":status"},
+  {"location-name", "location"},
+  {"accept-name", "accept"},
+  {"accept-value", "application/dns-message"},
+  {"cache-control-name", "cache-control"},
+  {"content-type-name", "content-type"},
+  {"content-type-value", "application/dns-message"},
+  {"user-agent-name", "user-agent"},
+  {"user-agent-value", "nghttp2-" NGHTTP2_VERSION "/dnsdist"},
+  {"x-forwarded-port-name", "x-forwarded-port"},
+  {"x-forwarded-proto-name", "x-forwarded-proto"},
+  {"x-forwarded-proto-value-dns-over-udp", "dns-over-udp"},
+  {"x-forwarded-proto-value-dns-over-tcp", "dns-over-tcp"},
+  {"x-forwarded-proto-value-dns-over-tls", "dns-over-tls"},
+  {"x-forwarded-proto-value-dns-over-http", "dns-over-http"},
+  {"x-forwarded-proto-value-dns-over-https", "dns-over-https"},
+};
+
+static const std::string s_authorityHeaderName(":authority");
+static const std::string s_pathHeaderName(":path");
+static const std::string s_methodHeaderName(":method");
+static const std::string s_schemeHeaderName(":scheme");
+static const std::string s_xForwardedForHeaderName("x-forwarded-for");
+
+void NGHTTP2Headers::addStaticHeader(std::vector<nghttp2_nv>& headers, const std::string& nameKey, const std::string& valueKey)
+{
+  const auto& name = s_constants.at(nameKey);
+  const auto& value = s_constants.at(valueKey);
+
+  headers.push_back({const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(name.c_str())), const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(value.c_str())), name.size(), value.size(), NGHTTP2_NV_FLAG_NO_COPY_NAME | NGHTTP2_NV_FLAG_NO_COPY_VALUE});
+}
+
+void NGHTTP2Headers::addCustomDynamicHeader(std::vector<nghttp2_nv>& headers, const std::string& name, const std::string_view& value)
+{
+  headers.push_back({const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(name.data())), const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(value.data())), name.size(), value.size(), NGHTTP2_NV_FLAG_NO_COPY_NAME | NGHTTP2_NV_FLAG_NO_COPY_VALUE});
+}
+
+void NGHTTP2Headers::addDynamicHeader(std::vector<nghttp2_nv>& headers, const std::string& nameKey, const std::string_view& value)
+{
+  const auto& name = s_constants.at(nameKey);
+  NGHTTP2Headers::addCustomDynamicHeader(headers, name, value);
+}
+
+IOState IncomingHTTP2Connection::sendResponse(const struct timeval& now, TCPResponse&& response)
+{
+  assert(response.d_idstate.d_streamID != -1);
+  auto& context = d_currentStreams.at(response.d_idstate.d_streamID);
+
+  uint32_t statusCode = 200U;
+  std::string contentType;
+  bool sendContentType = true;
+  auto& responseBuffer = context.d_buffer;
+  if (context.d_statusCode != 0) {
+    responseBuffer = std::move(context.d_response);
+    statusCode = context.d_statusCode;
+    contentType = std::move(context.d_contentTypeOut);
+  }
+  else {
+    responseBuffer = std::move(response.d_buffer);
+  }
+
+  sendResponse(response.d_idstate.d_streamID, statusCode, d_ci.cs->dohFrontend->d_customResponseHeaders, contentType, sendContentType);
+  handleResponseSent(response);
+
+  return IOState::Done;
+}
+
+void IncomingHTTP2Connection::notifyIOError(const struct timeval& now, TCPResponse&& response)
+{
+  if (std::this_thread::get_id() != d_creatorThreadID) {
+    /* empty buffer will signal an IO error */
+    response.d_buffer.clear();
+    handleCrossProtocolResponse(now, std::move(response));
+    return;
+  }
+
+  assert(response.d_idstate.d_streamID != -1);
+  d_currentStreams.at(response.d_idstate.d_streamID).d_buffer = std::move(response.d_buffer);
+  sendResponse(response.d_idstate.d_streamID, 502, d_ci.cs->dohFrontend->d_customResponseHeaders);
+}
+
+bool IncomingHTTP2Connection::sendResponse(IncomingHTTP2Connection::StreamID streamID, uint16_t responseCode, const HeadersMap& customResponseHeaders, const std::string& contentType, bool addContentType)
+{
+  /* if data_prd is not NULL, it provides data which will be sent in subsequent DATA frames. In this case, a method that allows request message bodies (https://tools.ietf.org/html/rfc7231#section-4) must be specified with :method key (e.g. POST). This function does not take ownership of the data_prd. The function copies the members of the data_prd. If data_prd is NULL, HEADERS have END_STREAM set.
+   */
+  nghttp2_data_provider data_provider;
+
+  data_provider.source.ptr = this;
+  data_provider.read_callback = [](nghttp2_session*, IncomingHTTP2Connection::StreamID stream_id, uint8_t* buf, size_t length, uint32_t* data_flags, nghttp2_data_source* source, void* cb_data) -> ssize_t {
+    auto connection = reinterpret_cast<IncomingHTTP2Connection*>(cb_data);
+    auto& obj = connection->d_currentStreams.at(stream_id);
+    size_t toCopy = 0;
+    if (obj.d_queryPos < obj.d_buffer.size()) {
+      size_t remaining = obj.d_buffer.size() - obj.d_queryPos;
+      toCopy = length > remaining ? remaining : length;
+      memcpy(buf, &obj.d_buffer.at(obj.d_queryPos), toCopy);
+      obj.d_queryPos += toCopy;
+    }
+
+    if (obj.d_queryPos >= obj.d_buffer.size()) {
+      *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+    }
+    return toCopy;
+  };
+
+  const auto& df = d_ci.cs->dohFrontend;
+  auto& responseBody = d_currentStreams.at(streamID).d_buffer;
+
+  std::vector<nghttp2_nv> headers;
+  std::string responseCodeStr;
+  std::string cacheControlValue;
+  std::string location;
+  /* remember that dynamic header values should be kept alive
+     until we have called nghttp2_submit_response(), at least */
+
+  if (responseCode == 200) {
+    NGHTTP2Headers::addStaticHeader(headers, "status-name", "200-value");
+    ++df->d_validresponses;
+    ++df->d_http2Stats.d_nb200Responses;
+
+    if (addContentType) {
+      if (contentType.empty()) {
+        NGHTTP2Headers::addStaticHeader(headers, "content-type-name", "content-type-value");
+      }
+      else {
+        NGHTTP2Headers::addDynamicHeader(headers, "content-type-name", contentType);
+      }
+    }
+
+    if (df->d_sendCacheControlHeaders && responseBody.size() > sizeof(dnsheader)) {
+      uint32_t minTTL = getDNSPacketMinTTL(reinterpret_cast<const char*>(responseBody.data()), responseBody.size());
+      if (minTTL != std::numeric_limits<uint32_t>::max()) {
+        cacheControlValue = "max-age=" + std::to_string(minTTL);
+        NGHTTP2Headers::addDynamicHeader(headers, "cache-control-name", cacheControlValue);
+      }
+    }
+  }
+  else {
+    responseCodeStr = std::to_string(responseCode);
+    NGHTTP2Headers::addDynamicHeader(headers, "status-name", responseCodeStr);
+
+    if (responseCode >= 300 && responseCode < 400) {
+      location = std::string(reinterpret_cast<const char*>(responseBody.data()), responseBody.size());
+      NGHTTP2Headers::addDynamicHeader(headers, "content-type-name", "text/html; charset=utf-8");
+      NGHTTP2Headers::addDynamicHeader(headers, "location-name", location);
+      static const std::string s_redirectStart{"<!DOCTYPE html><TITLE>Moved</TITLE><P>The document has moved <A HREF=\""};
+      static const std::string s_redirectEnd{"\">here</A>"};
+      responseBody.reserve(s_redirectStart.size() + responseBody.size() + s_redirectEnd.size());
+      responseBody.insert(responseBody.begin(), s_redirectStart.begin(), s_redirectStart.end());
+      responseBody.insert(responseBody.end(), s_redirectEnd.begin(), s_redirectEnd.end());
+      ++df->d_redirectresponses;
+    }
+    else {
+      ++df->d_errorresponses;
+      switch (responseCode) {
+      case 400:
+        ++df->d_http2Stats.d_nb400Responses;
+        break;
+      case 403:
+        ++df->d_http2Stats.d_nb403Responses;
+        break;
+      case 500:
+        ++df->d_http2Stats.d_nb500Responses;
+        break;
+      case 502:
+        ++df->d_http2Stats.d_nb502Responses;
+        break;
+      default:
+        ++df->d_http2Stats.d_nbOtherResponses;
+        break;
+      }
+
+      if (!responseBody.empty()) {
+        NGHTTP2Headers::addDynamicHeader(headers, "content-type-name", "text/plain; charset=utf-8");
+      }
+      else {
+        static const std::string invalid{"invalid DNS query"};
+        static const std::string notAllowed{"dns query not allowed"};
+        static const std::string noDownstream{"no downstream server available"};
+        static const std::string internalServerError{"Internal Server Error"};
+
+        switch (responseCode) {
+        case 400:
+          responseBody.insert(responseBody.begin(), invalid.begin(), invalid.end());
+          break;
+        case 403:
+          responseBody.insert(responseBody.begin(), notAllowed.begin(), notAllowed.end());
+          break;
+        case 502:
+          responseBody.insert(responseBody.begin(), noDownstream.begin(), noDownstream.end());
+          break;
+        case 500:
+          /* fall-through */
+        default:
+          responseBody.insert(responseBody.begin(), internalServerError.begin(), internalServerError.end());
+          break;
+        }
+      }
+    }
+  }
+
+  const std::string contentLength = std::to_string(responseBody.size());
+  NGHTTP2Headers::addDynamicHeader(headers, "content-length-name", contentLength);
+
+  for (const auto& [key, value] : customResponseHeaders) {
+    NGHTTP2Headers::addCustomDynamicHeader(headers, key, value);
+  }
+
+  auto ret = nghttp2_submit_response(d_session.get(), streamID, headers.data(), headers.size(), &data_provider);
+  if (ret != 0) {
+    d_currentStreams.erase(streamID);
+    vinfolog("Error submitting HTTP response for stream %d: %s", streamID, nghttp2_strerror(ret));
+    return false;
+  }
+
+  ret = nghttp2_session_send(d_session.get());
+  if (ret != 0) {
+    d_currentStreams.erase(streamID);
+    vinfolog("Error flushing HTTP response for stream %d: %s", streamID, nghttp2_strerror(ret));
+    return false;
+  }
+
+  return true;
+}
+
+static void processForwardedForHeader(const std::unique_ptr<HeadersMap>& headers, ComboAddress& remote)
+{
+  if (!headers) {
+    return;
+  }
+
+  auto it = headers->find(s_xForwardedForHeaderName);
+  if (it == headers->end()) {
+    return;
+  }
+
+  std::string_view value = it->second;
+  try {
+    auto pos = value.rfind(',');
+    if (pos != std::string_view::npos) {
+      ++pos;
+      for (; pos < value.size() && value[pos] == ' '; ++pos) {
+      }
+
+      if (pos < value.size()) {
+        value = value.substr(pos);
+      }
+    }
+    auto newRemote = ComboAddress(std::string(value));
+    remote = newRemote;
+  }
+  catch (const std::exception& e) {
+    vinfolog("Invalid X-Forwarded-For header ('%s') received from %s : %s", std::string(value), remote.toStringWithPort(), e.what());
+  }
+  catch (const PDNSException& e) {
+    vinfolog("Invalid X-Forwarded-For header ('%s') received from %s : %s", std::string(value), remote.toStringWithPort(), e.reason);
+  }
+}
+
+static std::optional<PacketBuffer> getPayloadFromPath(const std::string_view& path)
+{
+  std::optional<PacketBuffer> result{std::nullopt};
+
+  if (path.size() <= 5) {
+    return result;
+  }
+
+  auto pos = path.find("?dns=");
+  if (pos == string::npos) {
+    pos = path.find("&dns=");
+  }
+
+  if (pos == string::npos) {
+    return result;
+  }
+
+  // need to base64url decode this
+  string sdns(path.substr(pos + 5));
+  boost::replace_all(sdns, "-", "+");
+  boost::replace_all(sdns, "_", "/");
+
+  // re-add padding that may have been missing
+  switch (sdns.size() % 4) {
+  case 2:
+    sdns.append(2, '=');
+    break;
+  case 3:
+    sdns.append(1, '=');
+    break;
+  }
+
+  PacketBuffer decoded;
+  /* rough estimate so we hopefully don't need a new allocation later */
+  /* We reserve at few additional bytes to be able to add EDNS later */
+  const size_t estimate = ((sdns.size() * 3) / 4);
+  decoded.reserve(estimate);
+  if (B64Decode(sdns, decoded) < 0) {
+    return result;
+  }
+
+  result = std::move(decoded);
+  return result;
+}
+
+void IncomingHTTP2Connection::handleIncomingQuery(IncomingHTTP2Connection::PendingQuery&& query, IncomingHTTP2Connection::StreamID streamID)
+{
+  const auto handleImmediateResponse = [this, &query, streamID](uint16_t code, const std::string& reason, PacketBuffer&& response = PacketBuffer()) {
+    if (response.empty()) {
+      query.d_buffer.clear();
+      query.d_buffer.insert(query.d_buffer.begin(), reason.begin(), reason.end());
+    }
+    else {
+      query.d_buffer = std::move(response);
+    }
+    vinfolog("Sending an immediate %d response to incoming DoH query: %s", code, reason);
+    sendResponse(streamID, code, d_ci.cs->dohFrontend->d_customResponseHeaders);
+  };
+
+  ++d_ci.cs->dohFrontend->d_http2Stats.d_nbQueries;
+
+  if (d_ci.cs->dohFrontend->d_trustForwardedForHeader) {
+    processForwardedForHeader(query.d_headers, d_proxiedRemote);
+
+    /* second ACL lookup based on the updated address */
+    auto& holders = d_threadData.holders;
+    if (!holders.acl->match(d_proxiedRemote)) {
+      ++dnsdist::metrics::g_stats.aclDrops;
+      vinfolog("Query from %s (%s) (DoH) dropped because of ACL", d_ci.remote.toStringWithPort(), d_proxiedRemote.toStringWithPort());
+      handleImmediateResponse(403, "DoH query not allowed because of ACL");
+      return;
+    }
+
+    if (!d_ci.cs->dohFrontend->d_keepIncomingHeaders) {
+      query.d_headers.reset();
+    }
+  }
+
+  if (d_ci.cs->dohFrontend->d_exactPathMatching) {
+    if (d_ci.cs->dohFrontend->d_urls.count(query.d_path) == 0) {
+      handleImmediateResponse(404, "there is no endpoint configured for this path");
+      return;
+    }
+  }
+  else {
+    bool found = false;
+    for (const auto& path : d_ci.cs->dohFrontend->d_urls) {
+      if (boost::starts_with(query.d_path, path)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      handleImmediateResponse(404, "there is no endpoint configured for this path");
+      return;
+    }
+  }
+
+  /* the responses map can be updated at runtime, so we need to take a copy of
+     the shared pointer, increasing the reference counter */
+  auto responsesMap = d_ci.cs->dohFrontend->d_responsesMap;
+  if (responsesMap) {
+    for (const auto& entry : *responsesMap) {
+      if (entry->matches(query.d_path)) {
+        const auto& customHeaders = entry->getHeaders();
+        query.d_buffer = entry->getContent();
+        if (entry->getStatusCode() >= 400 && query.d_buffer.size() >= 1) {
+          // legacy trailing 0 from the h2o era
+          query.d_buffer.pop_back();
+        }
+
+        sendResponse(streamID, entry->getStatusCode(), customHeaders ? *customHeaders : d_ci.cs->dohFrontend->d_customResponseHeaders, std::string(), false);
+        return;
+      }
+    }
+  }
+
+  if (query.d_buffer.empty() && query.d_method == PendingQuery::Method::Get && !query.d_queryString.empty()) {
+    auto payload = getPayloadFromPath(query.d_queryString);
+    if (payload) {
+      query.d_buffer = std::move(*payload);
+    }
+    else {
+      ++d_ci.cs->dohFrontend->d_badrequests;
+      handleImmediateResponse(400, "DoH unable to decode BASE64-URL");
+      return;
+    }
+  }
+
+  if (query.d_method == PendingQuery::Method::Get) {
+    ++d_ci.cs->dohFrontend->d_getqueries;
+  }
+  else if (query.d_method == PendingQuery::Method::Post) {
+    ++d_ci.cs->dohFrontend->d_postqueries;
+  }
+
+  try {
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+    auto processingResult = handleQuery(std::move(query.d_buffer), now, streamID);
+
+    switch (processingResult) {
+    case QueryProcessingResult::TooSmall:
+      handleImmediateResponse(400, "DoH non-compliant query");
+      break;
+    case QueryProcessingResult::InvalidHeaders:
+      handleImmediateResponse(400, "DoH invalid headers");
+      break;
+    case QueryProcessingResult::Empty:
+      handleImmediateResponse(200, "DoH empty query", std::move(query.d_buffer));
+      break;
+    case QueryProcessingResult::Dropped:
+      handleImmediateResponse(403, "DoH dropped query");
+      break;
+    case QueryProcessingResult::NoBackend:
+      handleImmediateResponse(502, "DoH no backend available");
+      return;
+    case QueryProcessingResult::Forwarded:
+    case QueryProcessingResult::Asynchronous:
+    case QueryProcessingResult::SelfAnswered:
+      break;
+    }
+  }
+  catch (const std::exception& e) {
+    vinfolog("Exception while processing DoH query: %s", e.what());
+    handleImmediateResponse(400, "DoH non-compliant query");
+    return;
+  }
+}
+
+int IncomingHTTP2Connection::on_frame_recv_callback(nghttp2_session* session, const nghttp2_frame* frame, void* user_data)
+{
+  IncomingHTTP2Connection* conn = reinterpret_cast<IncomingHTTP2Connection*>(user_data);
+#if 0
+  switch (frame->hd.type) {
+  case NGHTTP2_HEADERS:
+    cerr<<"got headers"<<endl;
+    if (frame->headers.cat == NGHTTP2_HCAT_RESPONSE) {
+      cerr<<"All headers received"<<endl;
+    }
+    if (frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
+      cerr<<"All headers received - query"<<endl;
+    }
+    break;
+  case NGHTTP2_WINDOW_UPDATE:
+    cerr<<"got window update"<<endl;
+    break;
+  case NGHTTP2_SETTINGS:
+    cerr<<"got settings"<<endl;
+    cerr<<frame->settings.niv<<endl;
+    for (size_t idx = 0; idx < frame->settings.niv; idx++) {
+      cerr<<"- "<<frame->settings.iv[idx].settings_id<<" "<<frame->settings.iv[idx].value<<endl;
+    }
+    break;
+  case NGHTTP2_DATA:
+    cerr<<"got data"<<endl;
+    break;
+  }
+#endif
+
+  if (frame->hd.type == NGHTTP2_GOAWAY) {
+    conn->stopIO();
+    if (conn->isIdle()) {
+      if (nghttp2_session_want_write(conn->d_session.get())) {
+        conn->d_ioState->add(IOState::NeedWrite, &handleWritableIOCallback, conn, boost::none);
+      }
+    }
+  }
+
+  /* is this the last frame for this stream? */
+  else if ((frame->hd.type == NGHTTP2_HEADERS || frame->hd.type == NGHTTP2_DATA) && frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
+    auto streamID = frame->hd.stream_id;
+    auto stream = conn->d_currentStreams.find(streamID);
+    if (stream != conn->d_currentStreams.end()) {
+      conn->handleIncomingQuery(std::move(stream->second), streamID);
+
+      if (conn->isIdle()) {
+        conn->watchForRemoteHostClosingConnection();
+      }
+    }
+    else {
+      vinfolog("Stream %d NOT FOUND", streamID);
+      return NGHTTP2_ERR_CALLBACK_FAILURE;
+    }
+  }
+
+  return 0;
+}
+
+int IncomingHTTP2Connection::on_stream_close_callback(nghttp2_session* session, IncomingHTTP2Connection::StreamID stream_id, uint32_t error_code, void* user_data)
+{
+  IncomingHTTP2Connection* conn = reinterpret_cast<IncomingHTTP2Connection*>(user_data);
+
+  if (error_code == 0) {
+    return 0;
+  }
+
+  auto stream = conn->d_currentStreams.find(stream_id);
+  if (stream == conn->d_currentStreams.end()) {
+    /* we don't care, then */
+    return 0;
+  }
+
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+  auto request = std::move(stream->second);
+  conn->d_currentStreams.erase(stream->first);
+
+  if (conn->isIdle()) {
+    conn->watchForRemoteHostClosingConnection();
+  }
+
+  return 0;
+}
+
+int IncomingHTTP2Connection::on_begin_headers_callback(nghttp2_session* session, const nghttp2_frame* frame, void* user_data)
+{
+  if (frame->hd.type != NGHTTP2_HEADERS || frame->headers.cat != NGHTTP2_HCAT_REQUEST) {
+    return 0;
+  }
+
+  IncomingHTTP2Connection* conn = reinterpret_cast<IncomingHTTP2Connection*>(user_data);
+  auto insertPair = conn->d_currentStreams.insert({frame->hd.stream_id, PendingQuery()});
+  if (!insertPair.second) {
+    /* there is a stream ID collision, something is very wrong! */
+    vinfolog("Stream ID collision (%d) on connection from %d", frame->hd.stream_id, conn->d_ci.remote.toStringWithPort());
+    conn->d_connectionDied = true;
+    nghttp2_session_terminate_session(conn->d_session.get(), NGHTTP2_NO_ERROR);
+    auto ret = nghttp2_session_send(conn->d_session.get());
+    if (ret != 0) {
+      vinfolog("Error flushing HTTP response for stream %d from %s: %s", frame->hd.stream_id, conn->d_ci.remote.toStringWithPort(), nghttp2_strerror(ret));
+      return NGHTTP2_ERR_CALLBACK_FAILURE;
+    }
+
+    return 0;
+  }
+
+  return 0;
+}
+
+static std::string::size_type getLengthOfPathWithoutParameters(const std::string_view& path)
+{
+  auto pos = path.find("?");
+  if (pos == string::npos) {
+    return path.size();
+  }
+
+  return pos;
+}
+
+int IncomingHTTP2Connection::on_header_callback(nghttp2_session* session, const nghttp2_frame* frame, const uint8_t* name, size_t nameLen, const uint8_t* value, size_t valuelen, uint8_t flags, void* user_data)
+{
+  IncomingHTTP2Connection* conn = reinterpret_cast<IncomingHTTP2Connection*>(user_data);
+
+  if (frame->hd.type == NGHTTP2_HEADERS && frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
+    if (nghttp2_check_header_name(name, nameLen) == 0) {
+      vinfolog("Invalid header name");
+      return NGHTTP2_ERR_CALLBACK_FAILURE;
+    }
+
+#if HAVE_NGHTTP2_CHECK_HEADER_VALUE_RFC9113
+    if (nghttp2_check_header_value_rfc9113(value, valuelen) == 0) {
+      vinfolog("Invalid header value");
+      return NGHTTP2_ERR_CALLBACK_FAILURE;
+    }
+#endif /* HAVE_NGHTTP2_CHECK_HEADER_VALUE_RFC9113 */
+
+    auto headerMatches = [name, nameLen](const std::string& expected) -> bool {
+      return nameLen == expected.size() && memcmp(name, expected.data(), expected.size()) == 0;
+    };
+
+    auto stream = conn->d_currentStreams.find(frame->hd.stream_id);
+    if (stream == conn->d_currentStreams.end()) {
+      vinfolog("Unable to match the stream ID %d to a known one!", frame->hd.stream_id);
+      return NGHTTP2_ERR_CALLBACK_FAILURE;
+    }
+    auto& query = stream->second;
+    auto valueView = std::string_view(reinterpret_cast<const char*>(value), valuelen);
+    if (headerMatches(s_pathHeaderName)) {
+#if HAVE_NGHTTP2_CHECK_PATH
+      if (nghttp2_check_path(value, valuelen) == 0) {
+        vinfolog("Invalid path value");
+        return NGHTTP2_ERR_CALLBACK_FAILURE;
+      }
+#endif /* HAVE_NGHTTP2_CHECK_PATH */
+
+      auto pathLen = getLengthOfPathWithoutParameters(valueView);
+      query.d_path = valueView.substr(0, pathLen);
+      if (pathLen < valueView.size()) {
+        query.d_queryString = valueView.substr(pathLen);
+      }
+    }
+    else if (headerMatches(s_authorityHeaderName)) {
+      query.d_host = valueView;
+    }
+    else if (headerMatches(s_schemeHeaderName)) {
+      query.d_scheme = valueView;
+    }
+    else if (headerMatches(s_methodHeaderName)) {
+#if HAVE_NGHTTP2_CHECK_METHOD
+      if (nghttp2_check_method(value, valuelen) == 0) {
+        vinfolog("Invalid method value");
+        return NGHTTP2_ERR_CALLBACK_FAILURE;
+      }
+#endif /* HAVE_NGHTTP2_CHECK_METHOD */
+
+      if (valueView == "GET") {
+        query.d_method = PendingQuery::Method::Get;
+      }
+      else if (valueView == "POST") {
+        query.d_method = PendingQuery::Method::Post;
+      }
+      else {
+        vinfolog("Unsupported method value");
+        return NGHTTP2_ERR_CALLBACK_FAILURE;
+      }
+    }
+
+    if (conn->d_ci.cs->dohFrontend->d_keepIncomingHeaders || (conn->d_ci.cs->dohFrontend->d_trustForwardedForHeader && headerMatches(s_xForwardedForHeaderName))) {
+      if (!query.d_headers) {
+        query.d_headers = std::make_unique<HeadersMap>();
+      }
+      query.d_headers->insert({std::string(reinterpret_cast<const char*>(name), nameLen), std::string(valueView)});
+    }
+  }
+  return 0;
+}
+
+int IncomingHTTP2Connection::on_data_chunk_recv_callback(nghttp2_session* session, uint8_t flags, IncomingHTTP2Connection::StreamID stream_id, const uint8_t* data, size_t len, void* user_data)
+{
+  IncomingHTTP2Connection* conn = reinterpret_cast<IncomingHTTP2Connection*>(user_data);
+  auto stream = conn->d_currentStreams.find(stream_id);
+  if (stream == conn->d_currentStreams.end()) {
+    vinfolog("Unable to match the stream ID %d to a known one!", stream_id);
+    return NGHTTP2_ERR_CALLBACK_FAILURE;
+  }
+  if (len > std::numeric_limits<uint16_t>::max() || (std::numeric_limits<uint16_t>::max() - stream->second.d_buffer.size()) < len) {
+    vinfolog("Data frame of size %d is too large for a DNS query (we already have %d)", len, stream->second.d_buffer.size());
+    return NGHTTP2_ERR_CALLBACK_FAILURE;
+  }
+
+  stream->second.d_buffer.insert(stream->second.d_buffer.end(), data, data + len);
+
+  return 0;
+}
+
+int IncomingHTTP2Connection::on_error_callback(nghttp2_session* session, int lib_error_code, const char* msg, size_t len, void* user_data)
+{
+  IncomingHTTP2Connection* conn = reinterpret_cast<IncomingHTTP2Connection*>(user_data);
+
+  vinfolog("Error in HTTP/2 connection from %d: %s", conn->d_ci.remote.toStringWithPort(), std::string(msg, len));
+  conn->d_connectionDied = true;
+  nghttp2_session_terminate_session(conn->d_session.get(), NGHTTP2_NO_ERROR);
+  auto ret = nghttp2_session_send(conn->d_session.get());
+  if (ret != 0) {
+    vinfolog("Error flushing HTTP response on connection from %s: %s", conn->d_ci.remote.toStringWithPort(), nghttp2_strerror(ret));
+    return NGHTTP2_ERR_CALLBACK_FAILURE;
+  }
+
+  return 0;
+}
+
+void IncomingHTTP2Connection::readHTTPData()
+{
+  IOStateGuard ioGuard(d_ioState);
+  do {
+    size_t got = 0;
+    d_in.resize(d_in.size() + 512);
+    try {
+      IOState newState = d_handler.tryRead(d_in, got, d_in.size(), true);
+      d_in.resize(got);
+
+      if (got > 0) {
+        /* we got something */
+        auto readlen = nghttp2_session_mem_recv(d_session.get(), d_in.data(), d_in.size());
+        /* as long as we don't require a pause by returning nghttp2_error.NGHTTP2_ERR_PAUSE from a CB,
+           all data should be consumed before returning */
+        if (readlen < 0 || static_cast<size_t>(readlen) < d_in.size()) {
+          throw std::runtime_error("Fatal error while passing received data to nghttp2: " + std::string(nghttp2_strerror((int)readlen)));
+        }
+
+        nghttp2_session_send(d_session.get());
+      }
+
+      if (newState == IOState::Done) {
+        if (isIdle()) {
+          watchForRemoteHostClosingConnection();
+          ioGuard.release();
+          break;
+        }
+      }
+      else {
+        if (newState == IOState::NeedWrite) {
+          updateIO(IOState::NeedWrite, handleReadableIOCallback);
+        }
+        ioGuard.release();
+        break;
+      }
+    }
+    catch (const std::exception& e) {
+      vinfolog("Exception while trying to read from HTTP backend connection: %s", e.what());
+      handleIOError();
+      break;
+    }
+  } while (getConcurrentStreamsCount() > 0);
+}
+
+void IncomingHTTP2Connection::handleReadableIOCallback(int fd, FDMultiplexer::funcparam_t& param)
+{
+  auto conn = boost::any_cast<std::shared_ptr<IncomingHTTP2Connection>>(param);
+  conn->handleIO();
+}
+
+void IncomingHTTP2Connection::handleWritableIOCallback(int fd, FDMultiplexer::funcparam_t& param)
+{
+  auto conn = boost::any_cast<std::shared_ptr<IncomingHTTP2Connection>>(param);
+  IOStateGuard ioGuard(conn->d_ioState);
+
+  try {
+    IOState newState = conn->d_handler.tryWrite(conn->d_out, conn->d_outPos, conn->d_out.size());
+    if (newState == IOState::NeedRead) {
+      conn->updateIO(IOState::NeedRead, handleWritableIOCallback);
+    }
+    else if (newState == IOState::Done) {
+      conn->d_out.clear();
+      conn->d_outPos = 0;
+      if (!conn->isIdle()) {
+        conn->updateIO(IOState::NeedRead, handleReadableIOCallback);
+      }
+      else {
+        conn->watchForRemoteHostClosingConnection();
+      }
+    }
+    ioGuard.release();
+  }
+  catch (const std::exception& e) {
+    vinfolog("Exception while trying to write (ready) to HTTP backend connection: %s", e.what());
+    conn->handleIOError();
+  }
+}
+
+bool IncomingHTTP2Connection::isIdle() const
+{
+  return getConcurrentStreamsCount() == 0;
+}
+
+void IncomingHTTP2Connection::stopIO()
+{
+  d_ioState->reset();
+}
+
+uint32_t IncomingHTTP2Connection::getConcurrentStreamsCount() const
+{
+  return d_currentStreams.size();
+}
+
+boost::optional<struct timeval> IncomingHTTP2Connection::getIdleClientReadTTD(struct timeval now) const
+{
+  auto idleTimeout = d_ci.cs->dohFrontend->d_idleTimeout;
+  if (g_maxTCPConnectionDuration == 0 && idleTimeout == 0) {
+    return boost::none;
+  }
+
+  if (g_maxTCPConnectionDuration > 0) {
+    auto elapsed = now.tv_sec - d_connectionStartTime.tv_sec;
+    if (elapsed < 0 || (static_cast<size_t>(elapsed) >= g_maxTCPConnectionDuration)) {
+      return now;
+    }
+    auto remaining = g_maxTCPConnectionDuration - elapsed;
+    if (idleTimeout == 0 || remaining <= static_cast<size_t>(idleTimeout)) {
+      now.tv_sec += remaining;
+      return now;
+    }
+  }
+
+  now.tv_sec += idleTimeout;
+  return now;
+}
+
+void IncomingHTTP2Connection::updateIO(IOState newState, FDMultiplexer::callbackfunc_t callback)
+{
+  boost::optional<struct timeval> ttd{boost::none};
+
+  auto shared = std::dynamic_pointer_cast<IncomingHTTP2Connection>(shared_from_this());
+  if (shared) {
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+
+    if (newState == IOState::NeedRead) {
+      if (isIdle()) {
+        ttd = getIdleClientReadTTD(now);
+      }
+      else {
+        ttd = getClientReadTTD(now);
+      }
+      d_ioState->update(newState, callback, shared, ttd);
+    }
+    else if (newState == IOState::NeedWrite) {
+      ttd = getClientWriteTTD(now);
+      d_ioState->update(newState, callback, shared, ttd);
+    }
+  }
+}
+
+void IncomingHTTP2Connection::watchForRemoteHostClosingConnection()
+{
+  updateIO(IOState::NeedRead, handleReadableIOCallback);
+}
+
+void IncomingHTTP2Connection::handleIOError()
+{
+  d_connectionDied = true;
+  nghttp2_session_terminate_session(d_session.get(), NGHTTP2_PROTOCOL_ERROR);
+  d_currentStreams.clear();
+  stopIO();
+}
+#endif /* HAVE_NGHTTP2 */

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -106,8 +106,37 @@ private:
 class NGHTTP2Headers
 {
 public:
-  static void addStaticHeader(std::vector<nghttp2_nv>& headers, const std::string& nameKey, const std::string& valueKey);
-  static void addDynamicHeader(std::vector<nghttp2_nv>& headers, const std::string& nameKey, const std::string_view& value);
+  enum class HeaderConstantIndexes {
+    OK_200_VALUE = 0,
+    METHOD_NAME,
+    METHOD_VALUE,
+    SCHEME_NAME,
+    SCHEME_VALUE,
+    AUTHORITY_NAME,
+    X_FORWARDED_FOR_NAME,
+    PATH_NAME,
+    CONTENT_LENGTH_NAME,
+    STATUS_NAME,
+    LOCATION_NAME,
+    ACCEPT_NAME,
+    ACCEPT_VALUE,
+    CACHE_CONTROL_NAME,
+    CONTENT_TYPE_NAME,
+    CONTENT_TYPE_VALUE,
+    USER_AGENT_NAME,
+    USER_AGENT_VALUE,
+    X_FORWARDED_PORT_NAME,
+    X_FORWARDED_PROTO_NAME,
+    X_FORWARDED_PROTO_VALUE_DNS_OVER_UDP,
+    X_FORWARDED_PROTO_VALUE_DNS_OVER_TCP,
+    X_FORWARDED_PROTO_VALUE_DNS_OVER_TLS,
+    X_FORWARDED_PROTO_VALUE_DNS_OVER_HTTP,
+    X_FORWARDED_PROTO_VALUE_DNS_OVER_HTTPS,
+    COUNT
+  };
+
+  static void addStaticHeader(std::vector<nghttp2_nv>& headers, HeaderConstantIndexes nameKey, HeaderConstantIndexes valueKey);
+  static void addDynamicHeader(std::vector<nghttp2_nv>& headers, HeaderConstantIndexes nameKey, const std::string_view& value);
   static void addCustomDynamicHeader(std::vector<nghttp2_nv>& headers, const std::string& name, const std::string_view& value);
 };
 

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -95,6 +95,7 @@ private:
   bool checkALPN();
   IOState readHTTPData();
   void handleConnectionReady();
+  IOState handleHandshake(const struct timeval& now) override;
   bool hasPendingWrite() const;
   void writeToSocket(bool socketReady);
   boost::optional<struct timeval> getIdleClientReadTTD(struct timeval now) const;

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -56,12 +56,11 @@ public:
     Method d_method{Method::Unknown};
   };
 
-  IncomingHTTP2Connection(ConnectionInfo&& ci, TCPClientThreadData& threadData, const struct timeval& now);
+  IncomingHTTP2Connection(ConnectionInfo&& connectionInfo, TCPClientThreadData& threadData, const struct timeval& now);
   ~IncomingHTTP2Connection() = default;
   void handleIO() override;
   void handleResponse(const struct timeval& now, TCPResponse&& response) override;
   void notifyIOError(const struct timeval& now, TCPResponse&& response) override;
-  void restoreContext(uint32_t streamID, PendingQuery&& context);
 
 private:
   static ssize_t send_callback(nghttp2_session* session, const uint8_t* data, size_t length, int flags, void* user_data);
@@ -71,8 +70,8 @@ private:
   static int on_header_callback(nghttp2_session* session, const nghttp2_frame* frame, const uint8_t* name, size_t namelen, const uint8_t* value, size_t valuelen, uint8_t flags, void* user_data);
   static int on_begin_headers_callback(nghttp2_session* session, const nghttp2_frame* frame, void* user_data);
   static int on_error_callback(nghttp2_session* session, int lib_error_code, const char* msg, size_t len, void* user_data);
-  static void handleReadableIOCallback(int fd, FDMultiplexer::funcparam_t& param);
-  static void handleWritableIOCallback(int fd, FDMultiplexer::funcparam_t& param);
+  static void handleReadableIOCallback(int descriptor, FDMultiplexer::funcparam_t& param);
+  static void handleWritableIOCallback(int descriptor, FDMultiplexer::funcparam_t& param);
 
   IOState sendResponse(const struct timeval& now, TCPResponse&& response) override;
   bool forwardViaUDPFirst() const override
@@ -85,7 +84,7 @@ private:
   void stopIO();
   bool isIdle() const;
   uint32_t getConcurrentStreamsCount() const;
-  void updateIO(IOState newState, FDMultiplexer::callbackfunc_t callback);
+  void updateIO(IOState newState, const FDMultiplexer::callbackfunc_t& callback);
   void watchForRemoteHostClosingConnection();
   void handleIOError();
   bool sendResponse(StreamID streamID, PendingQuery& context, uint16_t responseCode, const HeadersMap& customResponseHeaders, const std::string& contentType = "", bool addContentType = true);

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -88,7 +88,7 @@ private:
   void updateIO(IOState newState, FDMultiplexer::callbackfunc_t callback);
   void watchForRemoteHostClosingConnection();
   void handleIOError();
-  bool sendResponse(StreamID streamID, uint16_t responseCode, const HeadersMap& customResponseHeaders, const std::string& contentType = "", bool addContentType = true);
+  bool sendResponse(StreamID streamID, PendingQuery& context, uint16_t responseCode, const HeadersMap& customResponseHeaders, const std::string& contentType = "", bool addContentType = true);
   void handleIncomingQuery(PendingQuery&& query, StreamID streamID);
   bool checkALPN();
   void readHTTPData();

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -89,7 +89,6 @@ private:
   bool isIdle() const;
   uint32_t getConcurrentStreamsCount() const;
   void updateIO(IOState newState, const FDMultiplexer::callbackfunc_t& callback);
-  void watchForRemoteHostClosingConnection();
   void handleIOError();
   bool sendResponse(StreamID streamID, PendingQuery& context, uint16_t responseCode, const HeadersMap& customResponseHeaders, const std::string& contentType = "", bool addContentType = true);
   void handleIncomingQuery(PendingQuery&& query, StreamID streamID);

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -101,12 +101,14 @@ private:
   PacketBuffer d_in;
   size_t d_outPos{0};
   bool d_connectionDied{false};
+  bool d_needFlush{false};
 };
 
 class NGHTTP2Headers
 {
 public:
-  enum class HeaderConstantIndexes {
+  enum class HeaderConstantIndexes
+  {
     OK_200_VALUE = 0,
     METHOD_NAME,
     METHOD_VALUE,

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -1,0 +1,114 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "config.h"
+#ifdef HAVE_NGHTTP2
+#include <nghttp2/nghttp2.h>
+
+#include "dnsdist-tcp-upstream.hh"
+
+class IncomingHTTP2Connection : public IncomingTCPConnectionState
+{
+public:
+  using StreamID = int32_t;
+
+  class PendingQuery
+  {
+  public:
+    enum class Method : uint8_t
+    {
+      Unknown,
+      Get,
+      Post
+    };
+
+    PacketBuffer d_buffer;
+    PacketBuffer d_response;
+    std::string d_path;
+    std::string d_scheme;
+    std::string d_host;
+    std::string d_queryString;
+    std::string d_sni;
+    std::string d_contentTypeOut;
+    std::unique_ptr<HeadersMap> d_headers;
+    size_t d_queryPos{0};
+    uint32_t d_statusCode{0};
+    Method d_method{Method::Unknown};
+  };
+
+  IncomingHTTP2Connection(ConnectionInfo&& ci, TCPClientThreadData& threadData, const struct timeval& now);
+  ~IncomingHTTP2Connection() = default;
+  void handleIO() override;
+  void handleResponse(const struct timeval& now, TCPResponse&& response) override;
+  void notifyIOError(const struct timeval& now, TCPResponse&& response) override;
+  void restoreContext(uint32_t streamID, PendingQuery&& context);
+
+private:
+  static ssize_t send_callback(nghttp2_session* session, const uint8_t* data, size_t length, int flags, void* user_data);
+  static int on_frame_recv_callback(nghttp2_session* session, const nghttp2_frame* frame, void* user_data);
+  static int on_data_chunk_recv_callback(nghttp2_session* session, uint8_t flags, StreamID stream_id, const uint8_t* data, size_t len, void* user_data);
+  static int on_stream_close_callback(nghttp2_session* session, StreamID stream_id, uint32_t error_code, void* user_data);
+  static int on_header_callback(nghttp2_session* session, const nghttp2_frame* frame, const uint8_t* name, size_t namelen, const uint8_t* value, size_t valuelen, uint8_t flags, void* user_data);
+  static int on_begin_headers_callback(nghttp2_session* session, const nghttp2_frame* frame, void* user_data);
+  static int on_error_callback(nghttp2_session* session, int lib_error_code, const char* msg, size_t len, void* user_data);
+  static void handleReadableIOCallback(int fd, FDMultiplexer::funcparam_t& param);
+  static void handleWritableIOCallback(int fd, FDMultiplexer::funcparam_t& param);
+
+  IOState sendResponse(const struct timeval& now, TCPResponse&& response) override;
+  bool forwardViaUDPFirst() const override
+  {
+    return true;
+  }
+  void restoreDOHUnit(std::unique_ptr<DOHUnitInterface>&&) override;
+  std::unique_ptr<DOHUnitInterface> getDOHUnit(uint32_t streamID) override;
+
+  void stopIO();
+  bool isIdle() const;
+  uint32_t getConcurrentStreamsCount() const;
+  void updateIO(IOState newState, FDMultiplexer::callbackfunc_t callback);
+  void watchForRemoteHostClosingConnection();
+  void handleIOError();
+  bool sendResponse(StreamID streamID, uint16_t responseCode, const HeadersMap& customResponseHeaders, const std::string& contentType = "", bool addContentType = true);
+  void handleIncomingQuery(PendingQuery&& query, StreamID streamID);
+  bool checkALPN();
+  void readHTTPData();
+  void handleConnectionReady();
+  boost::optional<struct timeval> getIdleClientReadTTD(struct timeval now) const;
+
+  std::unique_ptr<nghttp2_session, decltype(&nghttp2_session_del)> d_session{nullptr, nghttp2_session_del};
+  std::unordered_map<StreamID, PendingQuery> d_currentStreams;
+  PacketBuffer d_out;
+  PacketBuffer d_in;
+  size_t d_outPos{0};
+  bool d_connectionDied{false};
+};
+
+class NGHTTP2Headers
+{
+public:
+  static void addStaticHeader(std::vector<nghttp2_nv>& headers, const std::string& nameKey, const std::string& valueKey);
+  static void addDynamicHeader(std::vector<nghttp2_nv>& headers, const std::string& nameKey, const std::string_view& value);
+  static void addCustomDynamicHeader(std::vector<nghttp2_nv>& headers, const std::string& name, const std::string_view& value);
+};
+
+#endif /* HAVE_NGHTTP2 */

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -300,10 +300,9 @@ void DoHConnectionToBackend::queueQuery(std::shared_ptr<TCPQuerySender>& sender,
    */
   nghttp2_data_provider data_provider;
 
-  /* we will not use this pointer */
   data_provider.source.ptr = this;
   data_provider.read_callback = [](nghttp2_session* session, int32_t stream_id, uint8_t* buf, size_t length, uint32_t* data_flags, nghttp2_data_source* source, void* user_data) -> ssize_t {
-    auto conn = reinterpret_cast<DoHConnectionToBackend*>(user_data);
+    auto conn = static_cast<DoHConnectionToBackend*>(user_data);
     auto& request = conn->d_currentStreams.at(stream_id);
     size_t toCopy = 0;
     if (request.d_queryPos < request.d_query.d_buffer.size()) {

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -84,9 +84,6 @@ private:
   static void handleReadableIOCallback(int fd, FDMultiplexer::funcparam_t& param);
   static void handleWritableIOCallback(int fd, FDMultiplexer::funcparam_t& param);
 
-  static void addStaticHeader(std::vector<nghttp2_nv>& headers, const std::string& nameKey, const std::string& valueKey);
-  static void addDynamicHeader(std::vector<nghttp2_nv>& headers, const std::string& nameKey, const std::string& value);
-
   class PendingRequest
   {
   public:
@@ -251,37 +248,37 @@ void DoHConnectionToBackend::queueQuery(std::shared_ptr<TCPQuerySender>& sender,
   headers.reserve(8 + (addXForwarded ? 3 : 0));
 
   /* Pseudo-headers need to come first (rfc7540 8.1.2.1) */
-  NGHTTP2Headers::addStaticHeader(headers, "method-name", "method-value");
-  NGHTTP2Headers::addStaticHeader(headers, "scheme-name", "scheme-value");
-  NGHTTP2Headers::addDynamicHeader(headers, "authority-name", d_ds->d_config.d_tlsSubjectName);
-  NGHTTP2Headers::addDynamicHeader(headers, "path-name", d_ds->d_config.d_dohPath);
-  NGHTTP2Headers::addStaticHeader(headers, "accept-name", "accept-value");
-  NGHTTP2Headers::addStaticHeader(headers, "content-type-name", "content-type-value");
-  NGHTTP2Headers::addStaticHeader(headers, "user-agent-name", "user-agent-value");
-  NGHTTP2Headers::addDynamicHeader(headers, "content-length-name", payloadSize);
+  NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::METHOD_NAME, NGHTTP2Headers::HeaderConstantIndexes::METHOD_VALUE);
+  NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::SCHEME_NAME, NGHTTP2Headers::HeaderConstantIndexes::SCHEME_VALUE);
+  NGHTTP2Headers::addDynamicHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::AUTHORITY_NAME, d_ds->d_config.d_tlsSubjectName);
+  NGHTTP2Headers::addDynamicHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::PATH_NAME, d_ds->d_config.d_dohPath);
+  NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::ACCEPT_NAME, NGHTTP2Headers::HeaderConstantIndexes::ACCEPT_VALUE);
+  NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::CONTENT_TYPE_NAME, NGHTTP2Headers::HeaderConstantIndexes::CONTENT_TYPE_VALUE);
+  NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::USER_AGENT_NAME, NGHTTP2Headers::HeaderConstantIndexes::USER_AGENT_VALUE);
+  NGHTTP2Headers::addDynamicHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::CONTENT_LENGTH_NAME, payloadSize);
   /* no need to add these headers for health-check queries */
   if (addXForwarded && query.d_idstate.origRemote.getPort() != 0) {
     remote = query.d_idstate.origRemote.toString();
     remotePort = std::to_string(query.d_idstate.origRemote.getPort());
-    NGHTTP2Headers::addDynamicHeader(headers, "x-forwarded-for-name", remote);
-    NGHTTP2Headers::addDynamicHeader(headers, "x-forwarded-port-name", remotePort);
+    NGHTTP2Headers::addDynamicHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_FOR_NAME, remote);
+    NGHTTP2Headers::addDynamicHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PORT_NAME, remotePort);
     if (query.d_idstate.cs != nullptr) {
       if (query.d_idstate.cs->isUDP()) {
-        NGHTTP2Headers::addStaticHeader(headers, "x-forwarded-proto-name", "x-forwarded-proto-value-dns-over-udp");
+        NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_NAME, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_VALUE_DNS_OVER_UDP);
       }
       else if (query.d_idstate.cs->isDoH()) {
         if (query.d_idstate.cs->hasTLS()) {
-          NGHTTP2Headers::addStaticHeader(headers, "x-forwarded-proto-name", "x-forwarded-proto-value-dns-over-https");
+          NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_NAME, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_VALUE_DNS_OVER_HTTPS);
         }
         else {
-          NGHTTP2Headers::addStaticHeader(headers, "x-forwarded-proto-name", "x-forwarded-proto-value-dns-over-http");
+          NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_NAME, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_VALUE_DNS_OVER_HTTP);
         }
       }
       else if (query.d_idstate.cs->hasTLS()) {
-        NGHTTP2Headers::addStaticHeader(headers, "x-forwarded-proto-name", "x-forwarded-proto-value-dns-over-tls");
+        NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_NAME, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_VALUE_DNS_OVER_TLS);
       }
       else {
-        NGHTTP2Headers::addStaticHeader(headers, "x-forwarded-proto-name", "x-forwarded-proto-value-dns-over-tcp");
+        NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_NAME, NGHTTP2Headers::HeaderConstantIndexes::X_FORWARDED_PROTO_VALUE_DNS_OVER_TCP);
       }
     }
   }

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -301,7 +301,7 @@ void DoHConnectionToBackend::queueQuery(std::shared_ptr<TCPQuerySender>& sender,
 
   data_provider.source.ptr = this;
   data_provider.read_callback = [](nghttp2_session* session, int32_t stream_id, uint8_t* buf, size_t length, uint32_t* data_flags, nghttp2_data_source* source, void* user_data) -> ssize_t {
-    auto conn = static_cast<DoHConnectionToBackend*>(user_data);
+    auto* conn = static_cast<DoHConnectionToBackend*>(user_data);
     auto& request = conn->d_currentStreams.at(stream_id);
     size_t toCopy = 0;
     if (request.d_queryPos < request.d_query.d_buffer.size()) {

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -557,7 +557,7 @@ private:
 class HTTPPathRule : public DNSRule
 {
 public:
-  HTTPPathRule(const std::string& path);
+  HTTPPathRule(std::string path);
   bool matches(const DNSQuestion* dq) const override;
   string toString() const override;
 private:

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -118,7 +118,7 @@ bool ConnectionToBackend::reconnect()
       return true;
     }
     catch (const std::runtime_error& e) {
-      vinfolog("Connection to downstream server %s failed: %s", d_ds->getName(), e.what());
+      vinfolog("Connection to downstream server %s failed: %s", d_ds->getNameWithAddr(), e.what());
       d_downstreamFailures++;
       if (d_downstreamFailures >= d_ds->d_config.d_retries) {
         throw;
@@ -269,7 +269,7 @@ IOState TCPConnectionToBackend::queueNextQuery(std::shared_ptr<TCPConnectionToBa
 
 IOState TCPConnectionToBackend::sendQuery(std::shared_ptr<TCPConnectionToBackend>& conn, const struct timeval& now)
 {
-  DEBUGLOG("sending query to backend "<<conn->getDS()->getName()<<" over FD "<<conn->d_handler->getDescriptor());
+  DEBUGLOG("sending query to backend "<<conn->getDS()->getNameWithAddr()<<" over FD "<<conn->d_handler->getDescriptor());
 
   IOState state = conn->d_handler->tryWrite(conn->d_currentQuery.d_query.d_buffer, conn->d_currentPos, conn->d_currentQuery.d_query.d_buffer.size());
 
@@ -555,16 +555,16 @@ void TCPConnectionToBackend::handleTimeout(const struct timeval& now, bool write
   if (write) {
     if (isFresh() && d_queries == 0) {
       ++d_ds->tcpConnectTimeouts;
-      vinfolog("Timeout while connecting to TCP backend %s", d_ds->getName());
+      vinfolog("Timeout while connecting to TCP backend %s", d_ds->getNameWithAddr());
     }
     else {
       ++d_ds->tcpWriteTimeouts;
-      vinfolog("Timeout while writing to TCP backend %s", d_ds->getName());
+      vinfolog("Timeout while writing to TCP backend %s", d_ds->getNameWithAddr());
     }
   }
   else {
     ++d_ds->tcpReadTimeouts;
-    vinfolog("Timeout while reading from TCP backend %s", d_ds->getName());
+    vinfolog("Timeout while reading from TCP backend %s", d_ds->getNameWithAddr());
   }
 
   try {

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -240,7 +240,8 @@ static void prepareQueryForSending(TCPQuery& query, uint16_t id, QueryState quer
       if (query.d_buffer.size() < query.d_idstate.d_proxyProtocolPayloadSize) {
         throw std::runtime_error("Trying to remove a proxy protocol payload of size " + std::to_string(query.d_proxyProtocolPayload.size()) + " from a buffer of size " + std::to_string(query.d_buffer.size()));
       }
-      query.d_buffer.erase(query.d_buffer.begin(), query.d_buffer.begin() + query.d_idstate.d_proxyProtocolPayloadSize);
+      // NOLINTNEXTLINE(*-narrowing-conversions): the size of the payload is limited to 2^16-1
+      query.d_buffer.erase(query.d_buffer.begin(), query.d_buffer.begin() + static_cast<ssize_t>(query.d_idstate.d_proxyProtocolPayloadSize));
       query.d_proxyProtocolPayloadAdded = false;
       query.d_idstate.d_proxyProtocolPayloadSize = 0;
     }

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -126,7 +126,7 @@ public:
   static void handleAsyncReady(int fd, FDMultiplexer::funcparam_t& param);
   static void updateIO(std::shared_ptr<IncomingTCPConnectionState>& state, IOState newState, const struct timeval& now);
 
-  static void queueResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response);
+  static void queueResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response, bool fromBackend);
   static void handleTimeout(std::shared_ptr<IncomingTCPConnectionState>& state, bool write);
 
   virtual void handleIO();

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -2,6 +2,7 @@
 
 #include "dolog.hh"
 #include "dnsdist-tcp.hh"
+#include "dnsdist-tcp-downstream.hh"
 
 struct TCPCrossProtocolResponse;
 
@@ -26,7 +27,10 @@ public:
 class IncomingTCPConnectionState : public TCPQuerySender, public std::enable_shared_from_this<IncomingTCPConnectionState>
 {
 public:
-  IncomingTCPConnectionState(ConnectionInfo&& ci, TCPClientThreadData& threadData, const struct timeval& now): d_buffer(s_maxPacketCacheEntrySize), d_ci(std::move(ci)), d_handler(d_ci.fd, timeval{g_tcpRecvTimeout,0}, d_ci.cs->tlsFrontend ? d_ci.cs->tlsFrontend->getContext() : nullptr, now.tv_sec), d_connectionStartTime(now), d_ioState(make_unique<IOStateHandler>(*threadData.mplexer, d_ci.fd)), d_threadData(threadData), d_creatorThreadID(std::this_thread::get_id())
+  enum class QueryProcessingResult : uint8_t { Forwarded, TooSmall, InvalidHeaders, Empty, Dropped, SelfAnswered, NoBackend, Asynchronous };
+  enum class ProxyProtocolResult : uint8_t { Reading, Done, Error };
+
+  IncomingTCPConnectionState(ConnectionInfo&& ci, TCPClientThreadData& threadData, const struct timeval& now): d_buffer(s_maxPacketCacheEntrySize), d_ci(std::move(ci)), d_handler(d_ci.fd, timeval{g_tcpRecvTimeout,0}, d_ci.cs->tlsFrontend ? d_ci.cs->tlsFrontend->getContext() : (d_ci.cs->dohFrontend ? d_ci.cs->dohFrontend->d_tlsContext.getContext() : nullptr), now.tv_sec), d_connectionStartTime(now), d_ioState(make_unique<IOStateHandler>(*threadData.mplexer, d_ci.fd)), d_threadData(threadData), d_creatorThreadID(std::this_thread::get_id())
   {
     d_origDest.reset();
     d_origDest.sin4.sin_family = d_ci.remote.sin4.sin_family;
@@ -46,7 +50,7 @@ public:
   IncomingTCPConnectionState(const IncomingTCPConnectionState& rhs) = delete;
   IncomingTCPConnectionState& operator=(const IncomingTCPConnectionState& rhs) = delete;
 
-  ~IncomingTCPConnectionState();
+  virtual ~IncomingTCPConnectionState();
 
   void resetForNewQuery();
 
@@ -118,24 +122,27 @@ public:
 
   static size_t clearAllDownstreamConnections();
 
-  static void handleIO(std::shared_ptr<IncomingTCPConnectionState>& conn, const struct timeval& now);
   static void handleIOCallback(int fd, FDMultiplexer::funcparam_t& param);
   static void handleAsyncReady(int fd, FDMultiplexer::funcparam_t& param);
   static void updateIO(std::shared_ptr<IncomingTCPConnectionState>& state, IOState newState, const struct timeval& now);
 
-  static IOState sendResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response);
   static void queueResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response);
-static void handleTimeout(std::shared_ptr<IncomingTCPConnectionState>& state, bool write);
+  static void handleTimeout(std::shared_ptr<IncomingTCPConnectionState>& state, bool write);
 
-  /* we take a copy of a shared pointer, not a reference, because the initial shared pointer might be released during the handling of the response */
-  void handleResponse(const struct timeval& now, TCPResponse&& response) override;
+  virtual void handleIO();
+
+  QueryProcessingResult handleQuery(PacketBuffer&& query, const struct timeval& now, std::optional<int32_t> streamID);
+  virtual void handleResponse(const struct timeval& now, TCPResponse&& response) override;
+  virtual void notifyIOError(const struct timeval& now, TCPResponse&& response) override;
   void handleXFRResponse(const struct timeval& now, TCPResponse&& response) override;
-  void notifyIOError(InternalQueryState&& query, const struct timeval& now) override;
 
+  virtual IOState sendResponse(const struct timeval& now, TCPResponse&& response);
+  void handleResponseSent(TCPResponse& currentResponse);
+  void handleHandshakeDone(const struct timeval& now);
+  ProxyProtocolResult handleProxyProtocolPayload();
   void handleCrossProtocolResponse(const struct timeval& now, TCPResponse&& response);
 
   void terminateClientConnection();
-  void queueQuery(TCPQuery&& query);
 
   bool canAcceptNewQueries(const struct timeval& now);
 
@@ -143,6 +150,20 @@ static void handleTimeout(std::shared_ptr<IncomingTCPConnectionState>& state, bo
   {
     return d_ioState != nullptr;
   }
+  virtual bool forwardViaUDPFirst() const
+  {
+    return false;
+  }
+  virtual std::unique_ptr<DOHUnitInterface> getDOHUnit(uint32_t streamID)
+  {
+    throw std::runtime_error("Getting a DOHUnit state from a generic TCP/DoT connection is not supported");
+  }
+  virtual void restoreDOHUnit(std::unique_ptr<DOHUnitInterface>&&)
+  {
+    throw std::runtime_error("Restoring a DOHUnit state to a generic TCP/DoT connection is not supported");
+  }
+
+  std::unique_ptr<CrossProtocolQuery> getCrossProtocolQuery(PacketBuffer&& query, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& ds);
 
   std::string toString() const
   {
@@ -150,6 +171,8 @@ static void handleTimeout(std::shared_ptr<IncomingTCPConnectionState>& state, bo
     o << "Incoming TCP connection from "<<d_ci.remote.toStringWithPort()<<" over FD "<<d_handler.getDescriptor()<<", state is "<<(int)d_state<<", io state is "<<(d_ioState ? d_ioState->getState() : "empty")<<", queries count is "<<d_queriesCount<<", current queries count is "<<d_currentQueriesCount<<", "<<d_queuedResponses.size()<<" queued responses, "<<d_ownedConnectionsToBackend.size()<<" owned connections to a backend";
     return o.str();
   }
+
+  dnsdist::Protocol getProtocol() const;
 
   enum class State : uint8_t { doingHandshake, readingProxyProtocolHeader, waitingForQuery, readingQuerySize, readingQuery, sendingResponse, idle /* in case of XFR, we stop processing queries */ };
 

--- a/pdns/dnsdistdist/dnsdist-tcp.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <optional>
 #include <unistd.h>
 #include "channel.hh"
 #include "iputils.hh"
@@ -100,7 +101,6 @@ public:
   InternalQueryState d_idstate;
   std::string d_proxyProtocolPayload;
   PacketBuffer d_buffer;
-  uint32_t d_proxyProtocolPayloadAddedSize{0};
   uint32_t d_ixfrQuerySerial{0};
   uint32_t d_xfrMasterSerial{0};
   uint32_t d_xfrSerialCount{0};
@@ -133,6 +133,17 @@ struct TCPResponse : public TCPQuery
     }
   }
 
+  TCPResponse(TCPQuery&& query) :
+    TCPQuery(std::move(query))
+  {
+    if (d_buffer.size() >= sizeof(dnsheader)) {
+      memcpy(&d_cleartextDH, reinterpret_cast<const dnsheader*>(d_buffer.data()), sizeof(d_cleartextDH));
+    }
+    else {
+      memset(&d_cleartextDH, 0, sizeof(d_cleartextDH));
+    }
+  }
+
   bool isAsync() const
   {
     return d_async;
@@ -154,7 +165,7 @@ public:
   virtual bool active() const = 0;
   virtual void handleResponse(const struct timeval& now, TCPResponse&& response) = 0;
   virtual void handleXFRResponse(const struct timeval& now, TCPResponse&& response) = 0;
-  virtual void notifyIOError(InternalQueryState&& query, const struct timeval& now) = 0;
+  virtual void notifyIOError(const struct timeval& now, TCPResponse&& response) = 0;
 
   /* whether the connection should be automatically released to the pool after handleResponse()
      has been called */
@@ -199,7 +210,6 @@ struct CrossProtocolQuery
 
   InternalQuery query;
   std::shared_ptr<DownstreamState> downstream{nullptr};
-  size_t proxyProtocolPayloadSize{0};
   bool d_isResponse{false};
 };
 

--- a/pdns/dnsdistdist/docs/guides/dns-over-https.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-https.rst
@@ -62,7 +62,7 @@ preferred library for incoming DoH support, because ``h2o`` has unfortunately re
 (see https://github.com/h2o/h2o/issues/3230). While we took great care to make the migration as painless as possible, ``h2o`` supported HTTP/1 while ``nghttp2``
 does not. This is not an issue for actual DNS over HTTPS clients that support HTTP/2, but might be one in setups running dnsdist behind a reverse-proxy that
 does not support HTTP/1, like nginx. We do not plan on implementing HTTP/1, and recommend using HTTP/2 between the reverse-proxy and dnsdist for performance reasons.
-For nginx in particular, a possible work-around is to use the `gprc_pass <http://nginx.org/r/grpc_pass>`_ directive as suggested in their `bugtracker <https://trac.nginx.org/nginx/ticket/1875>`_.
+For nginx in particular, a possible work-around is to use the `grpc_pass <http://nginx.org/r/grpc_pass>`_ directive as suggested in their `bug tracker <https://trac.nginx.org/nginx/ticket/1875>`_.
 
 Internal design
 ^^^^^^^^^^^^^^^

--- a/pdns/dnsdistdist/docs/guides/dns-over-https.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-https.rst
@@ -3,7 +3,7 @@ DNS-over-HTTPS (DoH)
 
 :program:`dnsdist` supports DNS-over-HTTPS (DoH, standardized in RFC 8484) for incoming queries since 1.4.0, and for outgoing queries since 1.7.0.
 To see if the installation supports this, run ``dnsdist --version``.
-If the output shows ``dns-over-https(DOH)``, incoming DNS-over-HTTPS is supported. If ``outgoing-dns-over-https(nghttp2)`` shows up then outgoing DNS-over-HTTPS is supported.
+If the output shows ``dns-over-https(DOH)`` (``dns-over-https(h2o nghttp2)``, ``dns-over-https(h2o)`` or ``dns-over-https(nghttp2)`` since 1.9.0) , incoming DNS-over-HTTPS is supported. If ``outgoing-dns-over-https(nghttp2)`` shows up then outgoing DNS-over-HTTPS is supported.
 
 Incoming
 --------
@@ -53,6 +53,16 @@ To let dnsdist listen for DoH queries over HTTP on localhost at port 8053 add on
 
   addDOHLocal("127.0.0.1:8053")
   addDOHLocal("127.0.0.1:8053", nil, nil, "/", { reusePort=true })
+
+HTTP/1 support
+^^^^^^^^^^^^^^
+
+dnsdist initially relied on the ``h2o`` library to support incoming DNS over HTTPS. Since 1.9.0, ``h2o`` has been deprecated and ``nghttp2`` is the
+preferred library for incoming DoH support, because ``h2o`` has unfortunately really never been maintained in a way that is suitable for use as a library
+(see https://github.com/h2o/h2o/issues/3230). While we took great care to make the migration as painless as possible, ``h2o`` supported HTTP/1 while ``nghttp2``
+does not. This is not an issue for actual DNS over HTTPS clients that support HTTP/2, but might be one in setups running dnsdist behind a reverse-proxy that
+does not support HTTP/1, like nginx. We do not plan on implementing HTTP/1, and recommend using HTTP/2 between the reverse-proxy and dnsdist for performance reasons.
+For nginx in particular, a possible work-around is to use the `gprc_pass <http://nginx.org/r/grpc_pass>`_ directive as suggested in their `bugtracker <https://trac.nginx.org/nginx/ticket/1875>`_.
 
 Internal design
 ^^^^^^^^^^^^^^^

--- a/pdns/dnsdistdist/docs/guides/dns-over-https.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-https.rst
@@ -61,7 +61,7 @@ dnsdist initially relied on the ``h2o`` library to support incoming DNS over HTT
 preferred library for incoming DoH support, because ``h2o`` has unfortunately really never been maintained in a way that is suitable for use as a library
 (see https://github.com/h2o/h2o/issues/3230). While we took great care to make the migration as painless as possible, ``h2o`` supported HTTP/1 while ``nghttp2``
 does not. This is not an issue for actual DNS over HTTPS clients that support HTTP/2, but might be one in setups running dnsdist behind a reverse-proxy that
-does not support HTTP/1, like nginx. We do not plan on implementing HTTP/1, and recommend using HTTP/2 between the reverse-proxy and dnsdist for performance reasons.
+does not support HTTP/2, like nginx. We do not plan on implementing HTTP/1, and recommend using HTTP/2 between the reverse-proxy and dnsdist for performance reasons.
 For nginx in particular, a possible work-around is to use the `grpc_pass <http://nginx.org/r/grpc_pass>`_ directive as suggested in their `bug tracker <https://trac.nginx.org/nginx/ticket/1875>`_.
 
 Internal design

--- a/pdns/dnsdistdist/docs/install.rst
+++ b/pdns/dnsdistdist/docs/install.rst
@@ -50,7 +50,7 @@ dnsdist depends on the following libraries:
 * `Editline (libedit) <http://thrysoee.dk/editline/>`_
 * `libfstrm <https://github.com/farsightsec/fstrm>`_ (optional, dnstap support)
 * `GnuTLS <https://www.gnutls.org/>`_ (optional, DoT and outgoing DoH support)
-* `libh2o <https://github.com/h2o/h2o>`_ (optional, incoming DoH support)
+* `libh2o <https://github.com/h2o/h2o>`_ (optional, incoming DoH support, deprecated in 1.9.0 in favor of ``nghttp2``)
 * `libcap <https://sites.google.com/site/fullycapable/>`_ (optional, capabilities support)
 * `libsodium <https://download.libsodium.org/doc/>`_ (optional, DNSCrypt and console encryption support)
 * `LMDB <http://www.lmdb.tech/doc/>`_ (optional, LMDB support)

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -122,6 +122,9 @@ Listen Sockets
      ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`)
      ``additionalAddresses``, ``ignoreTLSConfigurationErrors`` and ``keepIncomingHeaders`` options added.
 
+  .. versionchanged:: 1.9.0
+     ``library``, ``readAhead`` and ``proxyProtocolOutsideTLS`` options added.
+
   Listen on the specified address and TCP port for incoming DNS over HTTPS connections, presenting the specified X.509 certificate.
   If no certificate (or key) files are specified, listen for incoming DNS over HTTP connections instead.
 
@@ -164,6 +167,9 @@ Listen Sockets
   * ``keepIncomingHeaders``: bool - Whether to retain the incoming headers in memory, to be able to use :func:`HTTPHeaderRule` or :meth:`DNSQuestion.getHTTPHeaders`. Default is false. Before 1.8.0 the headers were always kept in-memory.
   * ``additionalAddresses``: list - List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses.
   * ``ignoreTLSConfigurationErrors=false``: bool - Ignore TLS configuration errors (such as invalid certificate path) and just issue a warning instead of aborting the whole process
+  * ``library``: str - Which underlying HTTP2 library should be used, either h2o or nghttp2. Until 1.9.0 only h2o was available, but the use of this library is now deprecated as it is no longer maintained. nghttp2 is the new default since 1.9.0.
+  * ``readAhead``: bool - When the TLS provider is set to OpenSSL, whether we tell the library to read as many input bytes as possible, which leads to better performance by reducing the number of syscalls. Default is true.
+  * ``proxyProtocolOutsideTLS``: bool - When the use of incoming proxy protocol is enabled, whether the payload is prepended after the start of the TLS session (so inside, meaning it is protected by the TLS layer providing encryption and authentication) or not (outside, meaning it is in clear-text). Default is false which means inside. Note that most third-party software like HAproxy expect the proxy protocol payload to be outside, in clear-text.
 
 .. function:: addTLSLocal(address, certFile(s), keyFile(s) [, options])
 
@@ -178,6 +184,8 @@ Listen Sockets
   .. versionchanged:: 1.8.0
      ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`).
      ``additionalAddresses``, ``ignoreTLSConfigurationErrors`` and ``ktls`` options added.
+  .. versionchanged:: 1.9.0
+     ``readAhead`` and ``proxyProtocolOutsideTLS`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
@@ -215,6 +223,8 @@ Listen Sockets
   * ``additionalAddresses``: list - List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses.
   * ``ignoreTLSConfigurationErrors=false``: bool - Ignore TLS configuration errors (such as invalid certificate path) and just issue a warning instead of aborting the whole process
   * ``ktls=false``: bool - Whether to enable the experimental kernel TLS support on Linux, if both the kernel and the OpenSSL library support it. Default is false.
+  * ``readAhead``: bool - When the TLS provider is set to OpenSSL, whether we tell the library to read as many input bytes as possible, which leads to better performance by reducing the number of syscalls. Default is true.
+  * ``proxyProtocolOutsideTLS``: bool - When the use of incoming proxy protocol is enabled, whether the payload is prepended after the start of the TLS session (so inside, meaning it is protected by the TLS layer providing encryption and authentication) or not (outside, meaning it is in clear-text). Default is false which means inside. Note that most third-party software like HAproxy expect the proxy protocol payload to be outside, in clear-text.
 
 .. function:: setLocal(address[, options])
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -144,7 +144,7 @@ Listen Sockets
   * ``idleTimeout=30``: int - Set the idle timeout, in seconds.
   * ``ciphers``: str - The TLS ciphers to use, in OpenSSL format. Ciphers for TLS 1.3 must be specified via ``ciphersTLS13``.
   * ``ciphersTLS13``: str - The TLS ciphers to use for TLS 1.3, in OpenSSL format.
-  * ``serverTokens``: str - The content of the Server: HTTP header returned by dnsdist. The default is "h2o/dnsdist".
+  * ``serverTokens``: str - The content of the Server: HTTP header returned by dnsdist. The default is "h2o/dnsdist" when ``h2o`` is used, "nghttp2-<version>/dnsdist" when ``nghttp2`` is.
   * ``customResponseHeaders={}``: table - Set custom HTTP header(s) returned by dnsdist.
   * ``ocspResponses``: list - List of files containing OCSP responses, in the same order than the certificates and keys, that will be used to provide OCSP stapling responses.
   * ``minTLSVersion``: str - Minimum version of the TLS protocol to support. Possible values are 'tls1.0', 'tls1.1', 'tls1.2' and 'tls1.3'. Default is to require at least TLS 1.0.

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -831,7 +831,8 @@ These ``DNSRule``\ s be one of the following items:
   sense for DoT or DoH, and for that last one matching on the HTTP Host header using :func:`HTTPHeaderRule`
   might provide more consistent results.
   As of the version 2.3.0-beta of h2o, it is unfortunately not possible to extract the SNI value from DoH
-  connections, and it is therefore necessary to use the HTTP Host header until version 2.3.0 is released.
+  connections, and it is therefore necessary to use the HTTP Host header until version 2.3.0 is released,
+  or ``nghttp2`` is used for incoming DoH instead (1.9.0+).
 
   :param str name: The exact SNI name to match.
 

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -9,7 +9,7 @@ but is now deprecated and will be removed in the future, as it is unfortunately 
 (see https://github.com/h2o/h2o/issues/3230). See the ``library`` parameter on the :func:`addDOHLocal` directive for more information on how to select
 the library used when dnsdist is built with support for both ``h2o`` and ``nghttp2``. The default is now ``nghttp2`` whenever possible.
 Note that ``nghttp2`` only supports HTTP/2, and not HTTP/1, while ``h2o`` supported both. This is not an issue for actual DNS over HTTPS clients that
-support HTTP/2, but might be one in setups running dnsdist behind a reverse-proxy that does not support HTTP/1. See :doc:`guides/dns-over-https` for some work-arounds.
+support HTTP/2, but might be one in setups running dnsdist behind a reverse-proxy that does not support HTTP/1. See :doc:`guides/dns-over-https` for some work-around.
 
 1.7.x to 1.8.0
 --------------

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -1,6 +1,16 @@
 Upgrade Guide
 =============
 
+1.8.x to 1.9.0
+--------------
+
+dnsdist now supports a new library for dealing with incoming DNS over HTTPS queries: ``nghttp2``. The previously used library, ``h2o``, can still be used
+but is now deprecated and will be removed in the future, as it is unfortunately no longer maintained in a way that is suitable for use as a library
+(see https://github.com/h2o/h2o/issues/3230). See the ``library`` parameter on the :func:`addDOHLocal` directive for more information on how to select
+the library used when dnsdist is built with support for both ``h2o`` and ``nghttp2``. The default is now ``nghttp2`` whenever possible.
+Note that ``nghttp2`` only supports HTTP/2, and not HTTP/1, while ``h2o`` supported both. This is not an issue for actual DNS over HTTPS clients that
+support HTTP/2, but might be one in setups running dnsdist behind a reverse-proxy that does not support HTTP/1. See :doc:`guides/dns-over-https` for some work-arounds.
+
 1.7.x to 1.8.0
 --------------
 

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1618,7 +1618,7 @@ void dohThread(ClientState* clientState)
   }
 }
 
-void DOHUnit::handleUDPResponse(PacketBuffer&& udpResponse, InternalQueryState&& state, [[maybe_unused]] const std::shared_ptr<DownstreamState>& downstream)
+void DOHUnit::handleUDPResponse(PacketBuffer&& udpResponse, InternalQueryState&& state, [[maybe_unused]] const std::shared_ptr<DownstreamState>& downstream_)
 {
   auto dohUnit = std::unique_ptr<DOHUnit>(this);
   dohUnit->ids = std::move(state);

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1731,4 +1731,4 @@ void H2ODOHFrontend::setup()
 }
 
 #endif /* HAVE_LIBH2OEVLOOP */
-#endif /* HAVE_LIBH2OEVLOOP */
+#endif /* HAVE_DNS_OVER_HTTPS */

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -167,6 +167,8 @@ private:
   std::atomic_flag d_rotatingTicketsKey;
 };
 
+struct DOHUnit;
+
 // we create one of these per thread, and pass around a pointer to it
 // through the bowels of h2o
 struct DOHServerConfig
@@ -215,6 +217,61 @@ struct DOHServerConfig
   pdns::channel::Receiver<DOHUnit> d_responseReceiver;
 };
 
+struct DOHUnit : public DOHUnitInterface
+{
+  DOHUnit(PacketBuffer&& q, std::string&& p, std::string&& h): path(std::move(p)), host(std::move(h)), query(std::move(q))
+  {
+    ids.ednsAdded = false;
+  }
+  ~DOHUnit()
+  {
+    if (self) {
+      *self = nullptr;
+    }
+  }
+
+  DOHUnit(const DOHUnit&) = delete;
+  DOHUnit& operator=(const DOHUnit&) = delete;
+
+  InternalQueryState ids;
+  std::string sni;
+  std::string path;
+  std::string scheme;
+  std::string host;
+  std::string contentType;
+  PacketBuffer query;
+  PacketBuffer response;
+  std::unique_ptr<std::unordered_map<std::string, std::string>> headers;
+  st_h2o_req_t* req{nullptr};
+  DOHUnit** self{nullptr};
+  DOHServerConfig* dsc{nullptr};
+  pdns::channel::Sender<DOHUnit>* responseSender{nullptr};
+  size_t query_at{0};
+  int rsock{-1};
+  /* the status_code is set from
+     processDOHQuery() (which is executed in
+     the DOH client thread) so that the correct
+     response can be sent in on_dnsdist(),
+     after the DOHUnit has been passed back to
+     the main DoH thread.
+  */
+  uint16_t status_code{200};
+  /* whether the query was re-sent to the backend over
+     TCP after receiving a truncated answer over UDP */
+  bool tcp{false};
+  bool truncated{false};
+
+  std::string getHTTPPath() const override;
+  std::string getHTTPQueryString() const override;
+  const std::string& getHTTPHost() const override;
+  const std::string& getHTTPScheme() const override;
+  const std::unordered_map<std::string, std::string>& getHTTPHeaders() const override;
+  void setHTTPResponse(uint16_t statusCode, PacketBuffer&& body, const std::string& contentType="") override;
+  virtual void handleTimeout() override;
+  virtual void handleUDPResponse(PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>&) override;
+};
+using DOHUnitUniquePtr = std::unique_ptr<DOHUnit>;
+
 /* This internal function sends back the object to the main thread to send a reply.
    The caller should NOT release or touch the unit after calling this function */
 static void sendDoHUnitToTheMainThread(DOHUnitUniquePtr&& du, const char* description)
@@ -233,18 +290,11 @@ static void sendDoHUnitToTheMainThread(DOHUnitUniquePtr&& du, const char* descri
 }
 
 /* This function is called from other threads than the main DoH one,
-   instructing it to send a 502 error to the client.
-   It takes ownership of the unit. */
-void handleDOHTimeout(DOHUnitUniquePtr&& oldDU)
+   instructing it to send a 502 error to the client. */
+void DOHUnit::handleTimeout()
 {
-  if (oldDU == nullptr) {
-    return;
-  }
-
-  /* we are about to erase an existing DU */
-  oldDU->status_code = 502;
-
-  sendDoHUnitToTheMainThread(std::move(oldDU), "DoH timeout");
+  status_code = 502;
+  sendDoHUnitToTheMainThread(std::unique_ptr<DOHUnit>(this), "DoH timeout");
 }
 
 struct DOHConnection
@@ -385,7 +435,7 @@ static void handleResponse(DOHFrontend& df, st_h2o_req_t* req, uint16_t statusCo
         h2o_send_error_400(req, getReasonFromStatusCode(statusCode).c_str(), "invalid DNS query" , 0);
         break;
       case 403:
-        h2o_send_error_403(req, getReasonFromStatusCode(statusCode).c_str(), "dns query not allowed", 0);
+        h2o_send_error_403(req, getReasonFromStatusCode(statusCode).c_str(), "DoH query not allowed", 0);
         break;
       case 502:
         h2o_send_error_502(req, getReasonFromStatusCode(statusCode).c_str(), "no downstream server available", 0);
@@ -400,6 +450,12 @@ static void handleResponse(DOHFrontend& df, st_h2o_req_t* req, uint16_t statusCo
 
     ++df.d_errorresponses;
   }
+}
+
+static std::unique_ptr<DOHUnit> getDUFromIDS(InternalQueryState& ids)
+{
+  auto du = std::unique_ptr<DOHUnit>(dynamic_cast<DOHUnit*>(ids.du.release()));
+  return du;
 }
 
 class DoHTCPCrossQuerySender : public TCPQuerySender
@@ -420,7 +476,7 @@ public:
       return;
     }
 
-    auto du = std::move(response.d_idstate.du);
+    auto du = getDUFromIDS(response.d_idstate);
     if (du->responseSender == nullptr) {
       return;
     }
@@ -438,10 +494,11 @@ public:
 
       dr.ids.du = std::move(du);
 
-      if (!processResponse(dr.ids.du->response, *localRespRuleActions, *localCacheInsertedRespRuleActions, dr, false)) {
+      if (!processResponse(dynamic_cast<DOHUnit*>(dr.ids.du.get())->response, *localRespRuleActions, *localCacheInsertedRespRuleActions, dr, false)) {
         if (dr.ids.du) {
-          dr.ids.du->status_code = 503;
-          sendDoHUnitToTheMainThread(std::move(dr.ids.du), "Response dropped by rules");
+          du = getDUFromIDS(dr.ids);
+          du->status_code = 503;
+          sendDoHUnitToTheMainThread(std::move(du), "Response dropped by rules");
         }
         return;
       }
@@ -450,7 +507,7 @@ public:
         return;
       }
 
-      du = std::move(dr.ids.du);
+      du = getDUFromIDS(dr.ids);
     }
 
     if (!du->ids.selfGenerated) {
@@ -483,11 +540,11 @@ public:
       return;
     }
 
-    if (query.du->responseSender == nullptr) {
+    auto du = getDUFromIDS(query);
+    if (du->responseSender == nullptr) {
       return;
     }
 
-    auto du = std::move(query.du);
     du->ids = std::move(query);
     du->status_code = 502;
     sendDoHUnitToTheMainThread(std::move(du), "cross-protocol error response");
@@ -519,20 +576,23 @@ public:
        Leave it for now because we know that the onky case where the payload has been
        added is when we tried over UDP, got a TC=1 answer and retried over TCP/DoT,
        and we know the TCP/DoT code can handle it. */
-    query.d_proxyProtocolPayloadAdded = query.d_idstate.du->proxyProtocolPayloadSize > 0;
+    query.d_proxyProtocolPayloadAdded = query.d_idstate.d_proxyProtocolPayloadSize > 0;
     downstream = query.d_idstate.du->downstream;
-    proxyProtocolPayloadSize = query.d_idstate.du->proxyProtocolPayloadSize;
   }
 
   void handleInternalError()
   {
-    query.d_idstate.du->status_code = 502;
-    sendDoHUnitToTheMainThread(std::move(query.d_idstate.du), "DoH internal error");
+    auto du = getDUFromIDS(query.d_idstate);
+    if (!du) {
+      return;
+    }
+    du->status_code = 502;
+    sendDoHUnitToTheMainThread(std::move(du), "DoH internal error");
   }
 
   std::shared_ptr<TCPQuerySender> getTCPQuerySender() override
   {
-    query.d_idstate.du->downstream = downstream;
+    dynamic_cast<DOHUnit*>(query.d_idstate.du.get())->downstream = downstream;
     return s_sender;
   }
 
@@ -550,9 +610,9 @@ public:
     return dr;
    }
 
-  DOHUnitUniquePtr&& releaseDU()
+  DOHUnitUniquePtr releaseDU()
   {
-    return std::move(query.d_idstate.du);
+    return getDUFromIDS(query.d_idstate);
   }
 
 private:
@@ -567,7 +627,7 @@ std::unique_ptr<CrossProtocolQuery> getDoHCrossProtocolQueryFromDQ(DNSQuestion& 
     throw std::runtime_error("Trying to create a DoH cross protocol query without a valid DoH unit");
   }
 
-  auto du = std::move(dq.ids.du);
+  auto du = getDUFromIDS(dq.ids);
   if (&dq.ids != &du->ids) {
    du->ids = std::move(dq.ids);
   }
@@ -606,121 +666,116 @@ static void processDOHQuery(DOHUnitUniquePtr&& unit, bool inMainThread = false)
   };
 
   auto& ids = unit->ids;
-  ids.du = std::move(unit);
-  auto& du = ids.du;
   uint16_t queryId = 0;
   ComboAddress remote;
 
   try {
-    if (!du->req) {
+    if (!unit->req) {
       // we got closed meanwhile. XXX small race condition here
       // but we should be fine as long as we don't touch du->req
       // outside of the main DoH thread
-      du->status_code = 500;
-      handleImmediateResponse(std::move(du), "DoH killed in flight");
+      unit->status_code = 500;
+      handleImmediateResponse(std::move(unit), "DoH killed in flight");
       return;
     }
 
-    {
-      // if there was no EDNS, we add it with a large buffer size
-      // so we can use UDP to talk to the backend.
-      auto dh = const_cast<struct dnsheader*>(reinterpret_cast<const struct dnsheader*>(du->query.data()));
-
-      if (!dh->arcount) {
-        if (generateOptRR(std::string(), du->query, 4096, 4096, 0, false)) {
-          dh = const_cast<struct dnsheader*>(reinterpret_cast<const struct dnsheader*>(du->query.data())); // may have reallocated
-          dh->arcount = htons(1);
-          du->ids.ednsAdded = true;
-        }
-      }
-      else {
-        // we leave existing EDNS in place
-      }
-    }
-
-    remote = du->ids.origRemote;
-    DOHServerConfig* dsc = du->dsc;
+    remote = ids.origRemote;
+    DOHServerConfig* dsc = unit->dsc;
     auto& holders = dsc->holders;
     ClientState& cs = *dsc->cs;
 
-    if (du->query.size() < sizeof(dnsheader)) {
+    if (unit->query.size() < sizeof(dnsheader)) {
       ++dnsdist::metrics::g_stats.nonCompliantQueries;
       ++cs.nonCompliantQueries;
-      du->status_code = 400;
-      handleImmediateResponse(std::move(du), "DoH non-compliant query");
+      unit->status_code = 400;
+      handleImmediateResponse(std::move(unit), "DoH non-compliant query");
       return;
     }
 
     ++cs.queries;
     ++dnsdist::metrics::g_stats.queries;
-    du->ids.queryRealTime.start();
+    ids.queryRealTime.start();
 
     {
       /* don't keep that pointer around, it will be invalidated if the buffer is ever resized */
-      struct dnsheader* dh = reinterpret_cast<struct dnsheader*>(du->query.data());
+      struct dnsheader* dh = reinterpret_cast<struct dnsheader*>(unit->query.data());
 
       if (!checkQueryHeaders(dh, cs)) {
-        du->status_code = 400;
-        handleImmediateResponse(std::move(du), "DoH invalid headers");
+        unit->status_code = 400;
+        handleImmediateResponse(std::move(unit), "DoH invalid headers");
         return;
       }
 
       if (dh->qdcount == 0) {
         dh->rcode = RCode::NotImp;
         dh->qr = true;
-        du->response = std::move(du->query);
+        unit->response = std::move(unit->query);
 
-        handleImmediateResponse(std::move(du), "DoH empty query");
+        handleImmediateResponse(std::move(unit), "DoH empty query");
         return;
       }
 
       queryId = ntohs(dh->id);
     }
 
-    auto downstream = du->downstream;
-    du->ids.qname = DNSName(reinterpret_cast<const char*>(du->query.data()), du->query.size(), sizeof(dnsheader), false, &du->ids.qtype, &du->ids.qclass);
-    DNSQuestion dq(du->ids, du->query);
+    {
+      // if there was no EDNS, we add it with a large buffer size
+      // so we can use UDP to talk to the backend.
+      auto dh = const_cast<struct dnsheader*>(reinterpret_cast<const struct dnsheader*>(unit->query.data()));
+      if (!dh->arcount) {
+        if (addEDNS(unit->query, 4096, false, 4096, 0)) {
+          ids.ednsAdded = true;
+        }
+      }
+    }
+
+    auto downstream = unit->downstream;
+    ids.qname = DNSName(reinterpret_cast<const char*>(unit->query.data()), unit->query.size(), sizeof(dnsheader), false, &ids.qtype, &ids.qclass);
+    DNSQuestion dq(ids, unit->query);
     const uint16_t* flags = getFlagsFromDNSHeader(dq.getHeader());
     ids.origFlags = *flags;
-    du->ids.cs = &cs;
-    dq.sni = std::move(du->sni);
-
+    ids.cs = &cs;
+    dq.sni = std::move(unit->sni);
+    ids.du = std::move(unit);
     auto result = processQuery(dq, holders, downstream);
 
     if (result == ProcessQueryResult::Drop) {
-      du->status_code = 403;
-      handleImmediateResponse(std::move(du), "DoH dropped query");
+      unit = getDUFromIDS(ids);
+      unit->status_code = 403;
+      handleImmediateResponse(std::move(unit), "DoH dropped query");
       return;
     }
     else if (result == ProcessQueryResult::Asynchronous) {
       return;
     }
     else if (result == ProcessQueryResult::SendAnswer) {
-      if (du->response.empty()) {
-        du->response = std::move(du->query);
+      unit = getDUFromIDS(ids);
+      if (unit->response.empty()) {
+        unit->response = std::move(unit->query);
       }
-      if (du->response.size() >= sizeof(dnsheader) && du->contentType.empty()) {
-        auto dh = reinterpret_cast<const struct dnsheader*>(du->response.data());
+      if (unit->response.size() >= sizeof(dnsheader) && unit->contentType.empty()) {
+        auto dh = reinterpret_cast<const struct dnsheader*>(unit->response.data());
 
-        handleResponseSent(du->ids.qname, QType(du->ids.qtype), 0., du->ids.origDest, ComboAddress(), du->response.size(), *dh, dnsdist::Protocol::DoH, dnsdist::Protocol::DoH, false);
+        handleResponseSent(unit->ids.qname, QType(unit->ids.qtype), 0., unit->ids.origDest, ComboAddress(), unit->response.size(), *dh, dnsdist::Protocol::DoH, dnsdist::Protocol::DoH, false);
       }
-      handleImmediateResponse(std::move(du), "DoH self-answered response");
+      handleImmediateResponse(std::move(unit), "DoH self-answered response");
       return;
     }
 
+    unit = getDUFromIDS(ids);
     if (result != ProcessQueryResult::PassToBackend) {
-      du->status_code = 500;
-      handleImmediateResponse(std::move(du), "DoH no backend available");
+      unit->status_code = 500;
+      handleImmediateResponse(std::move(unit), "DoH no backend available");
       return;
     }
 
     if (downstream == nullptr) {
-      du->status_code = 502;
-      handleImmediateResponse(std::move(du), "DoH no backend available");
+      unit->status_code = 502;
+      handleImmediateResponse(std::move(unit), "DoH no backend available");
       return;
     }
 
-    du->downstream = downstream;
+    unit->downstream = downstream;
 
     if (downstream->isTCPOnly()) {
       std::string proxyProtocolPayload;
@@ -730,11 +785,11 @@ static void processDOHQuery(DOHUnitUniquePtr&& unit, bool inMainThread = false)
         proxyProtocolPayload = getProxyProtocolPayload(dq);
       }
 
-      du->ids.origID = htons(queryId);
-      du->tcp = true;
+      unit->ids.origID = htons(queryId);
+      unit->tcp = true;
 
       /* this moves du->ids, careful! */
-      auto cpq = std::make_unique<DoHCrossProtocolQuery>(std::move(du), false);
+      auto cpq = std::make_unique<DoHCrossProtocolQuery>(std::move(unit), false);
       cpq->query.d_proxyProtocolPayload = std::move(proxyProtocolPayload);
 
       if (downstream->passCrossProtocolQuery(std::move(cpq))) {
@@ -742,9 +797,9 @@ static void processDOHQuery(DOHUnitUniquePtr&& unit, bool inMainThread = false)
       }
       else {
         if (inMainThread) {
-          du = cpq->releaseDU();
-          du->status_code = 502;
-          handleImmediateResponse(std::move(du), "DoH internal error");
+          unit = cpq->releaseDU();
+          unit->status_code = 502;
+          handleImmediateResponse(std::move(unit), "DoH internal error");
         }
         else {
           cpq->handleInternalError();
@@ -753,17 +808,19 @@ static void processDOHQuery(DOHUnitUniquePtr&& unit, bool inMainThread = false)
       }
     }
 
-    ComboAddress dest = dq.ids.origDest;
-    if (!assignOutgoingUDPQueryToBackend(downstream, htons(queryId), dq, du->query, dest)) {
-      du->status_code = 502;
-      handleImmediateResponse(std::move(du), "DoH internal error");
+    auto& query = unit->query;
+    ids.du = std::move(unit);
+    if (!assignOutgoingUDPQueryToBackend(downstream, htons(queryId), dq, query)) {
+      unit = getDUFromIDS(ids);
+      unit->status_code = 502;
+      handleImmediateResponse(std::move(unit), "DoH internal error");
       return;
     }
   }
   catch (const std::exception& e) {
     vinfolog("Got an error in DOH question thread while parsing a query from %s, id %d: %s", remote.toStringWithPort(), queryId, e.what());
-    du->status_code = 500;
-    handleImmediateResponse(std::move(du), "DoH internal error");
+    unit->status_code = 500;
+    handleImmediateResponse(std::move(unit), "DoH internal error");
     return;
   }
 
@@ -838,7 +895,7 @@ static void doh_dispatch_query(DOHServerConfig* dsc, h2o_handler_t* self, h2o_re
     /* we are doing quite some copies here, sorry about that,
        but we can't keep accessing the req object once we are in a different thread
        because the request might get killed by h2o at pretty much any time */
-    auto du = std::make_unique<DOHUnit>(std::move(query), std::move(path), std::string(req->authority.base, req->authority.len));
+    auto du = DOHUnitUniquePtr(new DOHUnit(std::move(query), std::move(path), std::string(req->authority.base, req->authority.len)));
     du->dsc = dsc;
     du->req = req;
     du->ids.origDest = local;
@@ -869,7 +926,7 @@ static void doh_dispatch_query(DOHServerConfig* dsc, h2o_handler_t* self, h2o_re
     *(du->self) = du.get();
 
 #ifdef USE_SINGLE_ACCEPTOR_THREAD
-    processDOHQuery(du, true);
+    processDOHQuery(std::move(du), true);
 #else /* USE_SINGLE_ACCEPTOR_THREAD */
     try {
       if (!dsc->d_querySender.send(std::move(du))) {
@@ -1102,85 +1159,13 @@ static int doh_handler(h2o_handler_t *self, h2o_req_t *req)
   }
 }
 
-HTTPHeaderRule::HTTPHeaderRule(const std::string& header, const std::string& regex)
-  : d_header(toLower(header)), d_regex(regex), d_visual("http[" + header+ "] ~ " + regex)
+const std::unordered_map<std::string, std::string>& DOHUnit::getHTTPHeaders() const
 {
-}
-
-bool HTTPHeaderRule::matches(const DNSQuestion* dq) const
-{
-  if (!dq->ids.du || !dq->ids.du->headers) {
-    return false;
+  if (!headers) {
+    static const HeadersMap empty{};
+    return empty;
   }
-
-  for (const auto& header : *dq->ids.du->headers) {
-    if (header.first == d_header) {
-      return d_regex.match(header.second);
-    }
-  }
-  return false;
-}
-
-string HTTPHeaderRule::toString() const
-{
-  return d_visual;
-}
-
-HTTPPathRule::HTTPPathRule(const std::string& path)
-  :  d_path(path)
-{
-
-}
-
-bool HTTPPathRule::matches(const DNSQuestion* dq) const
-{
-  if (!dq->ids.du) {
-    return false;
-  }
-
-  if (dq->ids.du->query_at == SIZE_MAX) {
-    return dq->ids.du->path == d_path;
-  }
-  else {
-    return d_path.compare(0, d_path.size(), dq->ids.du->path, 0, dq->ids.du->query_at) == 0;
-  }
-}
-
-string HTTPPathRule::toString() const
-{
-  return "url path == " + d_path;
-}
-
-HTTPPathRegexRule::HTTPPathRegexRule(const std::string& regex): d_regex(regex), d_visual("http path ~ " + regex)
-{
-}
-
-bool HTTPPathRegexRule::matches(const DNSQuestion* dq) const
-{
-  if (!dq->ids.du) {
-    return false;
-  }
-
-  return d_regex.match(dq->ids.du->getHTTPPath());
-}
-
-string HTTPPathRegexRule::toString() const
-{
-  return d_visual;
-}
-
-std::unordered_map<std::string, std::string> DOHUnit::getHTTPHeaders() const
-{
-  std::unordered_map<std::string, std::string> results;
-  if (headers) {
-    results.reserve(headers->size());
-
-    for (const auto& header : *headers) {
-      results.insert(header);
-    }
-  }
-
-  return results;
+  return *headers;
 }
 
 std::string DOHUnit::getHTTPPath() const
@@ -1193,12 +1178,12 @@ std::string DOHUnit::getHTTPPath() const
   }
 }
 
-std::string DOHUnit::getHTTPHost() const
+const std::string& DOHUnit::getHTTPHost() const
 {
   return host;
 }
 
-std::string DOHUnit::getHTTPScheme() const
+const std::string& DOHUnit::getHTTPScheme() const
 {
   return scheme;
 }
@@ -1280,7 +1265,7 @@ static void on_dnsdist(h2o_socket_t *listener, const char *err)
      memory and likely coming up too late after the client has gone away */
   auto* dsc = static_cast<DOHServerConfig*>(listener->data);
   while (true) {
-    std::unique_ptr<DOHUnit> du{nullptr};
+    DOHUnitUniquePtr du{nullptr};
     try {
       auto tmp = dsc->d_responseReceiver.receive();
       if (!tmp) {
@@ -1300,10 +1285,10 @@ static void on_dnsdist(h2o_socket_t *listener, const char *err)
 
     if (!du->tcp &&
         du->truncated &&
-        du->query.size() > du->proxyProtocolPayloadSize &&
-        (du->query.size() - du->proxyProtocolPayloadSize) > sizeof(dnsheader)) {
+        du->query.size() > du->ids.d_proxyProtocolPayloadSize &&
+        (du->query.size() - du->ids.d_proxyProtocolPayloadSize) > sizeof(dnsheader)) {
       /* restoring the original ID */
-      dnsheader* queryDH = reinterpret_cast<struct dnsheader*>(du->query.data() + du->proxyProtocolPayloadSize);
+      dnsheader* queryDH = reinterpret_cast<struct dnsheader*>(du->query.data() + du->ids.d_proxyProtocolPayloadSize);
       queryDH->id = du->ids.origID;
       du->ids.forwardedOverUDP = false;
       du->tcp = true;
@@ -1494,82 +1479,20 @@ static void setupAcceptContext(DOHAcceptContext& ctx, DOHServerConfig& dsc, bool
   auto nativeCtx = ctx.get();
   nativeCtx->ctx = &dsc.h2o_ctx;
   nativeCtx->hosts = dsc.h2o_config.hosts;
-  ctx.d_ticketsKeyRotationDelay = dsc.df->d_tlsConfig.d_ticketsKeyRotationDelay;
+  auto df = std::atomic_load_explicit(&dsc.df, std::memory_order_acquire);
+  ctx.d_ticketsKeyRotationDelay = df->d_tlsContext.d_tlsConfig.d_ticketsKeyRotationDelay;
 
-  if (setupTLS && dsc.df->isHTTPS()) {
+  if (setupTLS && df->isHTTPS()) {
     try {
       setupTLSContext(ctx,
-                      dsc.df->d_tlsConfig,
-                      dsc.df->d_tlsCounters);
+                      df->d_tlsContext.d_tlsConfig,
+                      df->d_tlsContext.d_tlsCounters);
     }
     catch (const std::runtime_error& e) {
-      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + dsc.df->d_local.toStringWithPort() + "': " + e.what());
+      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + df->d_tlsContext.d_addr.toStringWithPort() + "': " + e.what());
     }
   }
   ctx.d_cs = dsc.cs;
-}
-
-void DOHFrontend::rotateTicketsKey(time_t now)
-{
-  if (d_dsc && d_dsc->accept_ctx) {
-    d_dsc->accept_ctx->rotateTicketsKey(now);
-  }
-}
-
-void DOHFrontend::loadTicketsKeys(const std::string& keyFile)
-{
-  if (d_dsc && d_dsc->accept_ctx) {
-    d_dsc->accept_ctx->loadTicketsKeys(keyFile);
-  }
-}
-
-void DOHFrontend::handleTicketsKeyRotation()
-{
-  if (d_dsc && d_dsc->accept_ctx) {
-    d_dsc->accept_ctx->handleTicketsKeyRotation();
-  }
-}
-
-time_t DOHFrontend::getNextTicketsKeyRotation() const
-{
-  if (d_dsc && d_dsc->accept_ctx) {
-    return d_dsc->accept_ctx->getNextTicketsKeyRotation();
-  }
-  return 0;
-}
-
-size_t DOHFrontend::getTicketsKeysCount() const
-{
-  size_t res = 0;
-  if (d_dsc && d_dsc->accept_ctx) {
-    res = d_dsc->accept_ctx->getTicketsKeysCount();
-  }
-  return res;
-}
-
-void DOHFrontend::reloadCertificates()
-{
-  auto newAcceptContext = std::make_shared<DOHAcceptContext>();
-  setupAcceptContext(*newAcceptContext, *d_dsc, true);
-  std::atomic_store_explicit(&d_dsc->accept_ctx, newAcceptContext, std::memory_order_release);
-}
-
-void DOHFrontend::setup()
-{
-  registerOpenSSLUser();
-
-  d_dsc = std::make_shared<DOHServerConfig>(d_idleTimeout, d_internalPipeBufferSize);
-
-  if  (isHTTPS()) {
-    try {
-      setupTLSContext(*d_dsc->accept_ctx,
-                      d_tlsConfig,
-                      d_tlsCounters);
-    }
-    catch (const std::runtime_error& e) {
-      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + d_local.toStringWithPort() + "': " + e.what());
-    }
-  }
 }
 
 static h2o_pathconf_t *register_handler(h2o_hostconf_t *hostconf, const char *path, int (*on_req)(h2o_handler_t *, h2o_req_t *))
@@ -1598,7 +1521,7 @@ void dohThread(ClientState* cs)
     std::shared_ptr<DOHFrontend>& df = cs->dohFrontend;
     auto& dsc = df->d_dsc;
     dsc->cs = cs;
-    dsc->df = cs->dohFrontend;
+    std::atomic_store_explicit(&dsc->df, cs->dohFrontend, std::memory_order_release);
     dsc->h2o_config.server_name = h2o_iovec_init(df->d_serverTokens.c_str(), df->d_serverTokens.size());
 
 #ifndef USE_SINGLE_ACCEPTOR_THREAD
@@ -1609,11 +1532,11 @@ void dohThread(ClientState* cs)
     setThreadName("dnsdist/doh");
     // I wonder if this registers an IP address.. I think it does
     // this may mean we need to actually register a site "name" here and not the IP address
-    h2o_hostconf_t *hostconf = h2o_config_register_host(&dsc->h2o_config, h2o_iovec_init(df->d_local.toString().c_str(), df->d_local.toString().size()), 65535);
+    h2o_hostconf_t *hostconf = h2o_config_register_host(&dsc->h2o_config, h2o_iovec_init(df->d_tlsContext.d_addr.toString().c_str(), df->d_tlsContext.d_addr.toString().size()), 65535);
 
-    for(const auto& url : df->d_urls) {
+    dsc->paths = df->d_urls;
+    for (const auto& url : dsc->paths) {
       register_handler(hostconf, url.c_str(), doh_handler);
-      dsc->paths.insert(url);
     }
 
     h2o_context_init(&dsc->h2o_ctx, h2o_evloop_create(), &dsc->h2o_config);
@@ -1632,11 +1555,11 @@ void dohThread(ClientState* cs)
     setupAcceptContext(*dsc->accept_ctx, *dsc, false);
 
     if (create_listener(dsc, cs->tcpFD) != 0) {
-      throw std::runtime_error("DOH server failed to listen on " + df->d_local.toStringWithPort() + ": " + strerror(errno));
+      throw std::runtime_error("DOH server failed to listen on " + df->d_tlsContext.d_addr.toStringWithPort() + ": " + strerror(errno));
     }
     for (const auto& [addr, fd] : cs->d_additionalAddresses) {
       if (create_listener(dsc, fd) != 0) {
-        throw std::runtime_error("DOH server failed to listen on additional address " + addr.toStringWithPort() + " for DOH local" + df->d_local.toStringWithPort() + ": " + strerror(errno));
+        throw std::runtime_error("DOH server failed to listen on additional address " + addr.toStringWithPort() + " for DOH local" + df->d_tlsContext.d_addr.toStringWithPort() + ": " + strerror(errno));
       }
     }
 
@@ -1661,25 +1584,31 @@ void dohThread(ClientState* cs)
   }
 }
 
-void handleUDPResponseForDoH(DOHUnitUniquePtr&& du, PacketBuffer&& udpResponse, InternalQueryState&& state)
+void DOHUnit::handleUDPResponse(PacketBuffer&& udpResponse, InternalQueryState&& state, const std::shared_ptr<DownstreamState>&)
 {
-  du->response = std::move(udpResponse);
+  auto du = std::unique_ptr<DOHUnit>(this);
   du->ids = std::move(state);
 
-  const dnsheader* dh = reinterpret_cast<const struct dnsheader*>(du->response.data());
-  if (!dh->tc) {
+  {
+    const dnsheader* dh = reinterpret_cast<const struct dnsheader*>(udpResponse.data());
+    if (dh->tc) {
+      du->truncated = true;
+    }
+  }
+  if (!du->truncated) {
     static thread_local LocalStateHolder<vector<DNSDistResponseRuleAction>> localRespRuleActions = g_respruleactions.getLocal();
     static thread_local LocalStateHolder<vector<DNSDistResponseRuleAction>> localCacheInsertedRespRuleActions = g_cacheInsertedRespRuleActions.getLocal();
 
-    DNSResponse dr(du->ids, du->response, du->downstream);
+    DNSResponse dr(du->ids, udpResponse, du->downstream);
     dnsheader cleartextDH;
     memcpy(&cleartextDH, dr.getHeader(), sizeof(cleartextDH));
 
     dr.ids.du = std::move(du);
-    if (!processResponse(dr.ids.du->response, *localRespRuleActions, *localCacheInsertedRespRuleActions, dr, false)) {
+    if (!processResponse(udpResponse, *localRespRuleActions, *localCacheInsertedRespRuleActions, dr, false)) {
       if (dr.ids.du) {
-        dr.ids.du->status_code = 503;
-        sendDoHUnitToTheMainThread(std::move(dr.ids.du), "Response dropped by rules");
+        du = getDUFromIDS(dr.ids);
+        du->status_code = 503;
+        sendDoHUnitToTheMainThread(std::move(du), "Response dropped by rules");
       }
       return;
     }
@@ -1688,7 +1617,8 @@ void handleUDPResponseForDoH(DOHUnitUniquePtr&& du, PacketBuffer&& udpResponse, 
       return;
     }
 
-    du = std::move(dr.ids.du);
+    du = getDUFromIDS(dr.ids);
+    du->response = std::move(udpResponse);
     double udiff = du->ids.queryRealTime.udiff();
     vinfolog("Got answer from %s, relayed to %s (https), took %f us", du->downstream->d_config.remote.toStringWithPort(), du->ids.origRemote.toStringWithPort(), udiff);
 
@@ -1699,17 +1629,72 @@ void handleUDPResponseForDoH(DOHUnitUniquePtr&& du, PacketBuffer&& udpResponse, 
       ++du->ids.cs->responses;
     }
   }
-  else {
-    du->truncated = true;
-  }
 
   sendDoHUnitToTheMainThread(std::move(du), "DoH response");
 }
-#endif /* HAVE_LIBH2OEVLOOP */
-#else /* HAVE_DNS_OVER_HTTPS */
 
-void handleDOHTimeout(DOHUnitUniquePtr&& oldDU)
+void H2ODOHFrontend::rotateTicketsKey(time_t now)
 {
+  if (d_dsc && d_dsc->accept_ctx) {
+    d_dsc->accept_ctx->rotateTicketsKey(now);
+  }
 }
 
-#endif /* HAVE_DNS_OVER_HTTPS */
+void H2ODOHFrontend::loadTicketsKeys(const std::string& keyFile)
+{
+  if (d_dsc && d_dsc->accept_ctx) {
+    d_dsc->accept_ctx->loadTicketsKeys(keyFile);
+  }
+}
+
+void H2ODOHFrontend::handleTicketsKeyRotation()
+{
+  if (d_dsc && d_dsc->accept_ctx) {
+    d_dsc->accept_ctx->handleTicketsKeyRotation();
+  }
+}
+
+std::string H2ODOHFrontend::getNextTicketsKeyRotation() const
+{
+  if (d_dsc && d_dsc->accept_ctx) {
+    return std::to_string(d_dsc->accept_ctx->getNextTicketsKeyRotation());
+  }
+  return 0;
+}
+
+size_t H2ODOHFrontend::getTicketsKeysCount()
+{
+  size_t res = 0;
+  if (d_dsc && d_dsc->accept_ctx) {
+    res = d_dsc->accept_ctx->getTicketsKeysCount();
+  }
+  return res;
+}
+
+void H2ODOHFrontend::reloadCertificates()
+{
+  auto newAcceptContext = std::make_shared<DOHAcceptContext>();
+  setupAcceptContext(*newAcceptContext, *d_dsc, true);
+  std::atomic_store_explicit(&d_dsc->accept_ctx, newAcceptContext, std::memory_order_release);
+}
+
+void H2ODOHFrontend::setup()
+{
+  registerOpenSSLUser();
+
+  d_dsc = std::make_shared<DOHServerConfig>(d_idleTimeout, d_internalPipeBufferSize);
+
+  if  (isHTTPS()) {
+    try {
+      setupTLSContext(*d_dsc->accept_ctx,
+                      d_tlsContext.d_tlsConfig,
+                      d_tlsContext.d_tlsCounters);
+    }
+    catch (const std::runtime_error& e) {
+      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + d_tlsContext.d_addr.toStringWithPort() + "': " + e.what());
+    }
+  }
+}
+
+#endif /* HAVE_LIBH2OEVLOOP */
+#endif /* HAVE_LIBH2OEVLOOP */

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -2,6 +2,7 @@
 #include "doh.hh"
 
 #ifdef HAVE_DNS_OVER_HTTPS
+#ifdef HAVE_LIBH2OEVLOOP
 #define H2O_USE_EPOLL 1
 
 #include <cerrno>
@@ -1705,7 +1706,7 @@ void handleUDPResponseForDoH(DOHUnitUniquePtr&& du, PacketBuffer&& udpResponse, 
 
   sendDoHUnitToTheMainThread(std::move(du), "DoH response");
 }
-
+#endif /* HAVE_LIBH2OEVLOOP */
 #else /* HAVE_DNS_OVER_HTTPS */
 
 void handleDOHTimeout(DOHUnitUniquePtr&& oldDU)

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -163,7 +163,6 @@ public:
 
 private:
   h2o_accept_ctx_t d_h2o_accept_ctx;
-  std::atomic<uint64_t> d_refcnt{1};
   time_t d_ticketsKeyNextRotation{0};
   std::atomic_flag d_rotatingTicketsKey;
 };
@@ -176,14 +175,14 @@ struct DOHServerConfig
   {
 #ifndef USE_SINGLE_ACCEPTOR_THREAD
     {
-      auto [sender, receiver] = pdns::channel::createObjectQueue<DOHUnit, void(*)(DOHUnit*)>(pdns::channel::SenderBlockingMode::SenderNonBlocking, pdns::channel::ReceiverBlockingMode::ReceiverBlocking, internalPipeBufferSize);
+      auto [sender, receiver] = pdns::channel::createObjectQueue<DOHUnit>(pdns::channel::SenderBlockingMode::SenderNonBlocking, pdns::channel::ReceiverBlockingMode::ReceiverBlocking, internalPipeBufferSize);
       d_querySender = std::move(sender);
       d_queryReceiver = std::move(receiver);
     }
 #endif /* USE_SINGLE_ACCEPTOR_THREAD */
 
     {
-      auto [sender, receiver] = pdns::channel::createObjectQueue<DOHUnit, void(*)(DOHUnit*)>(pdns::channel::SenderBlockingMode::SenderNonBlocking, pdns::channel::ReceiverBlockingMode::ReceiverNonBlocking, internalPipeBufferSize);
+      auto [sender, receiver] = pdns::channel::createObjectQueue<DOHUnit>(pdns::channel::SenderBlockingMode::SenderNonBlocking, pdns::channel::ReceiverBlockingMode::ReceiverNonBlocking, internalPipeBufferSize);
       d_responseSender = std::move(sender);
       d_responseReceiver = std::move(receiver);
     }
@@ -209,11 +208,11 @@ struct DOHServerConfig
   ClientState* cs{nullptr};
   std::shared_ptr<DOHFrontend> df{nullptr};
 #ifndef USE_SINGLE_ACCEPTOR_THREAD
-  pdns::channel::Sender<DOHUnit, void(*)(DOHUnit*)> d_querySender;
-  pdns::channel::Receiver<DOHUnit, void(*)(DOHUnit*)> d_queryReceiver;
+  pdns::channel::Sender<DOHUnit> d_querySender;
+  pdns::channel::Receiver<DOHUnit> d_queryReceiver;
 #endif /* USE_SINGLE_ACCEPTOR_THREAD */
-  pdns::channel::Sender<DOHUnit, void(*)(DOHUnit*)> d_responseSender;
-  pdns::channel::Receiver<DOHUnit, void(*)(DOHUnit*)> d_responseReceiver;
+  pdns::channel::Sender<DOHUnit> d_responseSender;
+  pdns::channel::Receiver<DOHUnit> d_responseReceiver;
 };
 
 /* This internal function sends back the object to the main thread to send a reply.
@@ -839,7 +838,7 @@ static void doh_dispatch_query(DOHServerConfig* dsc, h2o_handler_t* self, h2o_re
     /* we are doing quite some copies here, sorry about that,
        but we can't keep accessing the req object once we are in a different thread
        because the request might get killed by h2o at pretty much any time */
-    auto du = std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>(new DOHUnit(std::move(query), std::move(path), std::string(req->authority.base, req->authority.len)), DOHUnit::release);
+    auto du = std::make_unique<DOHUnit>(std::move(query), std::move(path), std::string(req->authority.base, req->authority.len));
     du->dsc = dsc;
     du->req = req;
     du->ids.origDest = local;
@@ -870,7 +869,7 @@ static void doh_dispatch_query(DOHServerConfig* dsc, h2o_handler_t* self, h2o_re
     *(du->self) = du.get();
 
 #ifdef USE_SINGLE_ACCEPTOR_THREAD
-    processDOHQuery(DOHUnitUniquePtr(du.release(), DOHUnit::release), true);
+    processDOHQuery(du, true);
 #else /* USE_SINGLE_ACCEPTOR_THREAD */
     try {
       if (!dsc->d_querySender.send(std::move(du))) {
@@ -1232,13 +1231,13 @@ void DOHUnit::setHTTPResponse(uint16_t statusCode, PacketBuffer&& body_, const s
 /* query has been parsed by h2o, which called doh_handler() in the main DoH thread.
    In order not to block for long, doh_handler() called doh_dispatch_query() which allocated
    a DOHUnit object and passed it to us */
-static void dnsdistclient(pdns::channel::Receiver<DOHUnit, void(*)(DOHUnit*)>&& receiver)
+static void dnsdistclient(pdns::channel::Receiver<DOHUnit>&& receiver)
 {
   setThreadName("dnsdist/doh-cli");
 
   for(;;) {
     try {
-      auto tmp = receiver.receive(DOHUnit::release);
+      auto tmp = receiver.receive();
       if (!tmp) {
         continue;
       }
@@ -1281,9 +1280,9 @@ static void on_dnsdist(h2o_socket_t *listener, const char *err)
      memory and likely coming up too late after the client has gone away */
   auto* dsc = static_cast<DOHServerConfig*>(listener->data);
   while (true) {
-    std::unique_ptr<DOHUnit, void(*)(DOHUnit*)> du{nullptr, DOHUnit::release};
+    std::unique_ptr<DOHUnit> du{nullptr};
     try {
-      auto tmp = dsc->d_responseReceiver.receive(DOHUnit::release);
+      auto tmp = dsc->d_responseReceiver.receive();
       if (!tmp) {
         return;
       }

--- a/pdns/dnsdistdist/m4/dnsdist_enable_doh.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_enable_doh.m4
@@ -1,7 +1,7 @@
 AC_DEFUN([DNSDIST_ENABLE_DNS_OVER_HTTPS], [
   AC_MSG_CHECKING([whether to enable incoming DNS over HTTPS (DoH) support])
   AC_ARG_ENABLE([dns-over-https],
-    AS_HELP_STRING([--enable-dns-over-https], [enable incoming DNS over HTTPS (DoH) support (requires libh2o) @<:@default=no@:>@]),
+    AS_HELP_STRING([--enable-dns-over-https], [enable incoming DNS over HTTPS (DoH) support (requires libh2o or nghttp2) @<:@default=no@:>@]),
     [enable_dns_over_https=$enableval],
     [enable_dns_over_https=no]
   )

--- a/pdns/dnsdistdist/m4/pdns_check_libh2o_evloop.m4
+++ b/pdns/dnsdistdist/m4/pdns_check_libh2o_evloop.m4
@@ -1,21 +1,40 @@
-AC_DEFUN([PDNS_CHECK_LIBH2OEVLOOP], [
+AC_DEFUN([PDNS_WITH_LIBH2OEVLOOP], [
+  AC_MSG_CHECKING([whether we will be linking in libh2o-evloop])
   HAVE_LIBH2OEVLOOP=0
-  PKG_CHECK_MODULES([LIBH2OEVLOOP], [libh2o-evloop], [
-    [HAVE_LIBH2OEVLOOP=1]
-    AC_DEFINE([HAVE_LIBH2OEVLOOP], [1], [Define to 1 if you have libh2o-evloop])
-    save_CFLAGS=$CFLAGS
-    save_LIBS=$LIBS
-    CFLAGS="$LIBH2OEVLOOP_CFLAGS $CFLAGS"
-    LIBS="$LIBH2OEVLOOP_LIBS $LIBS"
-    AC_CHECK_DECLS([h2o_socket_get_ssl_server_name], [
+  AC_ARG_WITH([h2o],
+    AS_HELP_STRING([--with-h2o],[use libh2o-evloop @<:@default=no@:>@]),
+    [with_h2o=$withval],
+    [with_h2o=no],
+  )
+  AC_MSG_RESULT([$with_h2o])
+
+  AS_IF([test "x$with_h2o" = "xyes" -o "x$with_h2o" = "xauto"], [
+    PKG_CHECK_MODULES([LIBH2OEVLOOP], [libh2o-evloop], [
+      [HAVE_LIBH2OEVLOOP=1]
+      AC_DEFINE([HAVE_LIBH2OEVLOOP], [1], [Define to 1 if you have libh2o-evloop])
+      save_CFLAGS=$CFLAGS
+      save_LIBS=$LIBS
+      CFLAGS="$LIBH2OEVLOOP_CFLAGS $CFLAGS"
+      LIBS="$LIBH2OEVLOOP_LIBS $LIBS"
+      AC_CHECK_DECLS([h2o_socket_get_ssl_server_name], [
           AC_DEFINE([HAVE_H2O_SOCKET_GET_SSL_SERVER_NAME], [1], [define to 1 if h2o_socket_get_ssl_server_name is available.])
         ],
         [ : ],
         [AC_INCLUDES_DEFAULT
           #include <h2o/socket.h>
       ])
-    CFLAGS=$save_CFLAGS
-    LIBS=$save_LIBS
-  ], [ : ])
+      CFLAGS=$save_CFLAGS
+      LIBS=$save_LIBS
+    ], [ : ])
+  ])
   AM_CONDITIONAL([HAVE_LIBH2OEVLOOP], [test "x$LIBH2OEVLOOP_LIBS" != "x"])
+  AM_COND_IF([HAVE_LIBH2OEVLOOP], [
+    AC_DEFINE([HAVE_LIBH2OEVLOOP], [1], [Define to 1 if you enable h2o-evloop support])
+  ])
+
+  AS_IF([test "x$with_h2o" = "xyes"], [
+    AS_IF([test x"LIBH2OEVLOOP_LIBS" = "x"], [
+      AC_MSG_ERROR([h2o-evloop requested but libraries were not found])
+    ])
+  ])
 ])

--- a/pdns/dnsdistdist/m4/pdns_with_nghttp2.m4
+++ b/pdns/dnsdistdist/m4/pdns_with_nghttp2.m4
@@ -13,6 +13,13 @@ AC_DEFUN([PDNS_WITH_NGHTTP2], [
       PKG_CHECK_MODULES([NGHTTP2], [libnghttp2], [
         [HAVE_NGHTTP2=1]
         AC_DEFINE([HAVE_NGHTTP2], [1], [Define to 1 if you have nghttp2])
+        save_CFLAGS=$CFLAGS
+        save_LIBS=$LIBS
+        CFLAGS="$NGHTTP2_CFLAGS $CFLAGS"
+        LIBS="$NGHTTP2_LIBS $LIBS"
+        AC_CHECK_FUNCS([nghttp2_check_header_value_rfc9113 nghttp2_check_method nghttp2_check_path])
+        CFLAGS=$save_CFLAGS
+        LIBS=$save_LIBS
       ], [ : ])
     ])
   ])

--- a/pdns/dnsdistdist/test-dnsdistasync.cc
+++ b/pdns/dnsdistdist/test-dnsdistasync.cc
@@ -44,7 +44,7 @@ public:
   {
   }
 
-  void notifyIOError(InternalQueryState&&, const struct timeval&) override
+  void notifyIOError(const struct timeval&, TCPResponse&&) override
   {
     errorRaised = true;
   }

--- a/pdns/dnsdistdist/test-dnsdistasync.cc
+++ b/pdns/dnsdistdist/test-dnsdistasync.cc
@@ -36,15 +36,15 @@ public:
     return true;
   }
 
-  void handleResponse(const struct timeval&, TCPResponse&&) override
+  void handleResponse([[maybe_unused]] const struct timeval& now, [[maybe_unused]] TCPResponse&& response) override
   {
   }
 
-  void handleXFRResponse(const struct timeval&, TCPResponse&&) override
+  void handleXFRResponse([[maybe_unused]] const struct timeval& now, [[maybe_unused]] TCPResponse&& response) override
   {
   }
 
-  void notifyIOError(const struct timeval&, TCPResponse&&) override
+  void notifyIOError([[maybe_unused]] const struct timeval& now, [[maybe_unused]] TCPResponse&& response) override
   {
     errorRaised = true;
   }

--- a/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
@@ -34,6 +34,7 @@ std::vector<std::unique_ptr<ClientState>> g_frontends;
 /* add stub implementations, we don't want to include the corresponding object files
    and their dependencies */
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static): this is a stub, the real one is not that simple..
 bool TLSFrontend::setupTLS()
 {
   return true;

--- a/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
@@ -34,39 +34,10 @@ std::vector<std::unique_ptr<ClientState>> g_frontends;
 /* add stub implementations, we don't want to include the corresponding object files
    and their dependencies */
 
-#ifdef HAVE_DNS_OVER_HTTPS
-std::unordered_map<std::string, std::string> DOHUnit::getHTTPHeaders() const
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static): this is a stub, the real one is not that simple..
+bool TLSFrontend::setupTLS()
 {
-  return {};
-}
-
-std::string DOHUnit::getHTTPPath() const
-{
-  return "";
-}
-
-std::string DOHUnit::getHTTPHost() const
-{
-  return "";
-}
-
-std::string DOHUnit::getHTTPScheme() const
-{
-  return "";
-}
-
-std::string DOHUnit::getHTTPQueryString() const
-{
-  return "";
-}
-
-void DOHUnit::setHTTPResponse(uint16_t statusCode, PacketBuffer&& body_, const std::string& contentType_)
-{
-}
-#endif /* HAVE_DNS_OVER_HTTPS */
-
-void handleDOHTimeout(DOHUnitUniquePtr&& oldDU)
-{
+  return true;
 }
 
 std::string DNSQuestion::getTrailingData() const

--- a/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
@@ -34,7 +34,6 @@ std::vector<std::unique_ptr<ClientState>> g_frontends;
 /* add stub implementations, we don't want to include the corresponding object files
    and their dependencies */
 
-// NOLINTNEXTLINE(readability-convert-member-functions-to-static): this is a stub, the real one is not that simple..
 bool TLSFrontend::setupTLS()
 {
   return true;

--- a/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
@@ -90,7 +90,7 @@ public:
   {
     const auto& context = s_connectionContexts.at(connectionID);
     d_clientOutBuffer.insert(d_clientOutBuffer.begin(), context.d_proxyProtocolPayload.begin(), context.d_proxyProtocolPayload.end());
-    
+
     nghttp2_session_callbacks* cbs = nullptr;
     nghttp2_session_callbacks_new(&cbs);
     std::unique_ptr<nghttp2_session_callbacks, void (*)(nghttp2_session_callbacks*)> callbacks(cbs, nghttp2_session_callbacks_del);
@@ -499,19 +499,19 @@ BOOST_FIXTURE_TEST_CASE(test_IncomingConnection_SelfAnswered, TestFixture)
     s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, {403U}};
     s_steps = {
       /* opening */
-      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done},
       /* settings server -> client */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15},
       /* settings + headers + data client -> server.. */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128},
       /* .. continued */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60},
       /* headers + data */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, std::numeric_limits<size_t>::max() },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, std::numeric_limits<size_t>::max()},
       /* wait for next query, but the client closes the connection */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0},
       /* server close */
-      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::closeClient, IOState::Done},
     };
 
     auto state = std::make_shared<IncomingHTTP2Connection>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
@@ -520,18 +520,18 @@ BOOST_FIXTURE_TEST_CASE(test_IncomingConnection_SelfAnswered, TestFixture)
 
   {
     /* client closes the connection right in the middle of sending the query */
-    s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, { 403U }};
+    s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, {403U}};
     s_steps = {
       /* opening */
-      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done},
       /* settings server -> client */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15},
       /* client sends one byte */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead, 1 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead, 1},
       /* then closes the connection */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0},
       /* server close */
-      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::closeClient, IOState::Done},
     };
 
     /* mark the incoming FD as always ready */
@@ -556,19 +556,19 @@ BOOST_FIXTURE_TEST_CASE(test_IncomingConnection_SelfAnswered, TestFixture)
 
     s_steps = {
       /* opening */
-      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done},
       /* settings server -> client */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15},
       /* settings + headers + data client -> server.. */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128},
       /* .. continued */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60},
       /* headers + data */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, std::numeric_limits<size_t>::max() },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, std::numeric_limits<size_t>::max()},
       /* wait for next query, but the client closes the connection */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0},
       /* server close */
-      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::closeClient, IOState::Done},
     };
 
     auto state = std::make_shared<IncomingHTTP2Connection>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
@@ -587,17 +587,17 @@ BOOST_FIXTURE_TEST_CASE(test_IncomingConnection_SelfAnswered, TestFixture)
 
     s_steps = {
       /* opening */
-      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done},
       /* settings server -> client */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15},
       /* settings + headers + data client -> server.. */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128},
       /* .. continued */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60},
       /* we want to send the response but the client closes the connection */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 0 },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 0},
       /* server close */
-      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::closeClient, IOState::Done},
     };
 
     /* mark the incoming FD as always ready */
@@ -622,21 +622,21 @@ BOOST_FIXTURE_TEST_CASE(test_IncomingConnection_SelfAnswered, TestFixture)
 
     s_steps = {
       /* opening */
-      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done},
       /* settings server -> client */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15},
       /* settings + headers + data client -> server.. */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128},
       /* .. continued */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60},
       /* headers + data (partial write) */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::NeedWrite, 1 },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::NeedWrite, 1},
       /* nothing to read after that */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead, 0 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead, 0},
       /* then the client closes the connection before we are done  */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 0 },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 0},
       /* server close */
-      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::closeClient, IOState::Done},
     };
 
     /* mark the incoming FD as always ready */
@@ -691,25 +691,24 @@ BOOST_FIXTURE_TEST_CASE(test_IncomingConnection_BackendTimeout, TestFixture)
     s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, {502U}};
     s_steps = {
       /* opening */
-      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done},
       /* settings server -> client */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15},
       /* settings + headers + data client -> server.. */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128},
       /* .. continued */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
-        /* trying to read a new request while processing the first one */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60},
+      /* trying to read a new request while processing the first one */
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead},
       /* headers + data */
-      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, std::numeric_limits<size_t>::max(), [&threadData](int desc) {
-          /* set the incoming descriptor as ready */
-          dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(desc);
-        }
-      },
+      {ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, std::numeric_limits<size_t>::max(), [&threadData](int desc) {
+         /* set the incoming descriptor as ready */
+         dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(desc);
+       }},
       /* wait for next query, but the client closes the connection */
-      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0 },
+      {ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0},
       /* server close */
-      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+      {ExpectedStep::ExpectedRequest::closeClient, IOState::Done},
     };
 
     auto state = std::make_shared<IncomingHTTP2Connection>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);

--- a/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
@@ -362,11 +362,6 @@ public:
     BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::closeClient);
   }
 
-  bool hasBufferedData() const override
-  {
-    return false;
-  }
-
   bool isUsable() const override
   {
     return true;

--- a/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
@@ -104,7 +104,7 @@ public:
     nghttp2_session_client_new(&sess, callbacks.get(), this);
     d_session = std::unique_ptr<nghttp2_session, void (*)(nghttp2_session*)>(sess, nghttp2_session_del);
 
-    std::array<nghttp2_settings_entry,3> settings{
+    std::array<nghttp2_settings_entry, 3> settings{
       /* rfc7540 section-8.2.2:
          "Advertising a SETTINGS_MAX_CONCURRENT_STREAMS value of zero disables
          server push by preventing the server from creating the necessary

--- a/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
@@ -1,0 +1,727 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include "dnswriter.hh"
+#include "dnsdist.hh"
+#include "dnsdist-proxy-protocol.hh"
+#include "dnsdist-nghttp2-in.hh"
+
+#ifdef HAVE_NGHTTP2
+#include <nghttp2/nghttp2.h>
+
+extern std::function<ProcessQueryResult(DNSQuestion& dq, std::shared_ptr<DownstreamState>& selectedBackend)> s_processQuery;
+
+BOOST_AUTO_TEST_SUITE(test_dnsdistnghttp2_in_cc)
+
+struct ExpectedStep
+{
+public:
+  enum class ExpectedRequest
+  {
+    handshakeClient,
+    readFromClient,
+    writeToClient,
+    closeClient,
+  };
+
+  ExpectedStep(ExpectedRequest r, IOState n, size_t b = 0, std::function<void(int descriptor)> fn = nullptr) :
+    cb(fn), request(r), nextState(n), bytes(b)
+  {
+  }
+
+  std::function<void(int descriptor)> cb{nullptr};
+  ExpectedRequest request;
+  IOState nextState;
+  size_t bytes{0};
+};
+
+struct ExpectedData
+{
+  PacketBuffer d_proxyProtocolPayload;
+  std::vector<PacketBuffer> d_queries;
+  std::vector<PacketBuffer> d_responses;
+  std::vector<uint16_t> d_responseCodes;
+};
+
+class DOHConnection;
+
+static std::deque<ExpectedStep> s_steps;
+static std::map<uint64_t, ExpectedData> s_connectionContexts;
+static std::map<int, std::unique_ptr<DOHConnection>> s_connectionBuffers;
+static uint64_t s_connectionID{0};
+
+std::ostream& operator<<(std::ostream& os, const ExpectedStep::ExpectedRequest d);
+
+std::ostream& operator<<(std::ostream& os, const ExpectedStep::ExpectedRequest d)
+{
+  static const std::vector<std::string> requests = {"handshake with client", "read from client", "write to client", "close connection to client", "connect to the backend", "read from the backend", "write to the backend", "close connection to backend"};
+  os << requests.at(static_cast<size_t>(d));
+  return os;
+}
+
+class DOHConnection
+{
+public:
+  DOHConnection(uint64_t connectionID) :
+    d_session(std::unique_ptr<nghttp2_session, void (*)(nghttp2_session*)>(nullptr, nghttp2_session_del)), d_connectionID(connectionID)
+  {
+    const auto& context = s_connectionContexts.at(connectionID);
+    d_clientOutBuffer.insert(d_clientOutBuffer.begin(), context.d_proxyProtocolPayload.begin(), context.d_proxyProtocolPayload.end());
+    
+    nghttp2_session_callbacks* cbs = nullptr;
+    nghttp2_session_callbacks_new(&cbs);
+    std::unique_ptr<nghttp2_session_callbacks, void (*)(nghttp2_session_callbacks*)> callbacks(cbs, nghttp2_session_callbacks_del);
+    cbs = nullptr;
+    nghttp2_session_callbacks_set_send_callback(callbacks.get(), send_callback);
+    nghttp2_session_callbacks_set_on_frame_recv_callback(callbacks.get(), on_frame_recv_callback);
+    nghttp2_session_callbacks_set_on_header_callback(callbacks.get(), on_header_callback);
+    nghttp2_session_callbacks_set_on_data_chunk_recv_callback(callbacks.get(), on_data_chunk_recv_callback);
+    nghttp2_session_callbacks_set_on_stream_close_callback(callbacks.get(), on_stream_close_callback);
+    nghttp2_session* sess = nullptr;
+    nghttp2_session_client_new(&sess, callbacks.get(), this);
+    d_session = std::unique_ptr<nghttp2_session, void (*)(nghttp2_session*)>(sess, nghttp2_session_del);
+
+    nghttp2_settings_entry iv[] = {
+      /* rfc7540 section-8.2.2:
+         "Advertising a SETTINGS_MAX_CONCURRENT_STREAMS value of zero disables
+         server push by preventing the server from creating the necessary
+         streams."
+      */
+      {NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 0},
+      {NGHTTP2_SETTINGS_ENABLE_PUSH, 0},
+      /* we might want to make the initial window size configurable, but 16M is a large enough default */
+      {NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE, 16 * 1024 * 1024}};
+    /* client 24 bytes magic string will be sent by nghttp2 library */
+    auto result = nghttp2_submit_settings(d_session.get(), NGHTTP2_FLAG_NONE, iv, sizeof(iv) / sizeof(*iv));
+    if (result != 0) {
+      throw std::runtime_error("Error submitting settings:" + std::string(nghttp2_strerror(result)));
+    }
+
+    const std::string host("unit-tests");
+    const std::string path("/dns-query");
+    for (const auto& query : context.d_queries) {
+      const auto querySize = std::to_string(query.size());
+      std::vector<nghttp2_nv> headers;
+      /* Pseudo-headers need to come first (rfc7540 8.1.2.1) */
+      NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::METHOD_NAME, NGHTTP2Headers::HeaderConstantIndexes::METHOD_VALUE);
+      NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::SCHEME_NAME, NGHTTP2Headers::HeaderConstantIndexes::SCHEME_VALUE);
+      NGHTTP2Headers::addDynamicHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::AUTHORITY_NAME, host);
+      NGHTTP2Headers::addDynamicHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::PATH_NAME, path);
+      NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::ACCEPT_NAME, NGHTTP2Headers::HeaderConstantIndexes::ACCEPT_VALUE);
+      NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::CONTENT_TYPE_NAME, NGHTTP2Headers::HeaderConstantIndexes::CONTENT_TYPE_VALUE);
+      NGHTTP2Headers::addStaticHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::USER_AGENT_NAME, NGHTTP2Headers::HeaderConstantIndexes::USER_AGENT_VALUE);
+      NGHTTP2Headers::addDynamicHeader(headers, NGHTTP2Headers::HeaderConstantIndexes::CONTENT_LENGTH_NAME, querySize);
+
+      d_position = 0;
+      d_currentQuery = query;
+      nghttp2_data_provider data_provider;
+      data_provider.source.ptr = this;
+      data_provider.read_callback = [](nghttp2_session* session, int32_t stream_id, uint8_t* buf, size_t length, uint32_t* data_flags, nghttp2_data_source* source, void* user_data) -> ssize_t {
+        auto* conn = static_cast<DOHConnection*>(user_data);
+        auto& pos = conn->d_position;
+        const auto& currentQuery = conn->d_currentQuery;
+        size_t toCopy = 0;
+        if (pos < currentQuery.size()) {
+          size_t remaining = currentQuery.size() - pos;
+          toCopy = length > remaining ? remaining : length;
+          memcpy(buf, &currentQuery.at(pos), toCopy);
+          pos += toCopy;
+        }
+
+        if (pos >= currentQuery.size()) {
+          *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+        }
+        return toCopy;
+      };
+
+      auto newStreamId = nghttp2_submit_request(d_session.get(), nullptr, headers.data(), headers.size(), &data_provider, this);
+      if (newStreamId < 0) {
+        throw std::runtime_error("Error submitting HTTP request:" + std::string(nghttp2_strerror(newStreamId)));
+      }
+
+      result = nghttp2_session_send(d_session.get());
+      if (result != 0) {
+        throw std::runtime_error("Error in nghttp2_session_send:" + std::to_string(result));
+      }
+    }
+  }
+
+  std::map<int32_t, PacketBuffer> d_responses;
+  std::map<int32_t, uint16_t> d_responseCodes;
+  std::unique_ptr<nghttp2_session, void (*)(nghttp2_session*)> d_session;
+  PacketBuffer d_currentQuery;
+  PacketBuffer d_clientOutBuffer;
+  uint64_t d_connectionID{0};
+  size_t d_position{0};
+
+  size_t submitIncoming(const PacketBuffer& data, size_t pos, size_t toWrite)
+  {
+    ssize_t readlen = nghttp2_session_mem_recv(d_session.get(), &data.at(pos), toWrite);
+    if (readlen < 0) {
+      throw("Fatal error while submitting line " + std::to_string(__LINE__) + ": " + std::string(nghttp2_strerror(static_cast<int>(readlen))));
+    }
+
+    /* just in case, see if we have anything to send */
+    int rv = nghttp2_session_send(d_session.get());
+    if (rv != 0) {
+      throw("Fatal error while sending: " + std::string(nghttp2_strerror(rv)));
+    }
+
+    return readlen;
+  }
+
+private:
+  static ssize_t send_callback(nghttp2_session* session, const uint8_t* data, size_t length, int flags, void* user_data)
+  {
+    DOHConnection* conn = static_cast<DOHConnection*>(user_data);
+    conn->d_clientOutBuffer.insert(conn->d_clientOutBuffer.end(), data, data + length);
+    return static_cast<ssize_t>(length);
+  }
+
+  static int on_frame_recv_callback(nghttp2_session* session, const nghttp2_frame* frame, void* user_data)
+  {
+    DOHConnection* conn = static_cast<DOHConnection*>(user_data);
+    if ((frame->hd.type == NGHTTP2_HEADERS || frame->hd.type == NGHTTP2_DATA) && frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
+      const auto& response = conn->d_responses.at(frame->hd.stream_id);
+      if (conn->d_responseCodes.at(frame->hd.stream_id) != 200U) {
+        return 0;
+      }
+
+      BOOST_REQUIRE_GT(response.size(), sizeof(dnsheader));
+      const auto* dh = reinterpret_cast<const dnsheader*>(response.data());
+      uint16_t id = ntohs(dh->id);
+
+      const auto& expected = s_connectionContexts.at(conn->d_connectionID).d_responses.at(id);
+      BOOST_REQUIRE_EQUAL(expected.size(), response.size());
+      for (size_t idx = 0; idx < response.size(); idx++) {
+        if (expected.at(idx) != response.at(idx)) {
+          cerr << "Mismatch at offset " << idx << ", expected " << std::to_string(response.at(idx)) << " got " << std::to_string(expected.at(idx)) << endl;
+          BOOST_CHECK(false);
+        }
+      }
+    }
+
+    return 0;
+  }
+
+  static int on_data_chunk_recv_callback(nghttp2_session* session, uint8_t flags, int32_t stream_id, const uint8_t* data, size_t len, void* user_data)
+  {
+    DOHConnection* conn = static_cast<DOHConnection*>(user_data);
+    auto& response = conn->d_responses[stream_id];
+    response.insert(response.end(), data, data + len);
+    return 0;
+  }
+
+  static int on_header_callback(nghttp2_session* session, const nghttp2_frame* frame, const uint8_t* name, size_t namelen, const uint8_t* value, size_t valuelen, uint8_t flags, void* user_data)
+  {
+    DOHConnection* conn = static_cast<DOHConnection*>(user_data);
+
+    const std::string status(":status");
+    if (frame->hd.type == NGHTTP2_HEADERS && frame->headers.cat == NGHTTP2_HCAT_RESPONSE) {
+      if (namelen == status.size() && memcmp(status.data(), name, status.size()) == 0) {
+        try {
+          uint16_t responseCode{0};
+          auto expected = s_connectionContexts.at(conn->d_connectionID).d_responseCodes.at((frame->hd.stream_id - 1) / 2);
+          pdns::checked_stoi_into(responseCode, std::string(reinterpret_cast<const char*>(value), valuelen));
+          conn->d_responseCodes[frame->hd.stream_id] = responseCode;
+          if (responseCode != expected) {
+            cerr << "Mismatch response code, expected " << std::to_string(expected) << " got " << std::to_string(responseCode) << endl;
+            BOOST_CHECK(false);
+          }
+        }
+        catch (const std::exception& e) {
+          infolog("Error parsing the status header for stream ID %d: %s", frame->hd.stream_id, e.what());
+          return NGHTTP2_ERR_CALLBACK_FAILURE;
+        }
+      }
+    }
+    return 0;
+  }
+
+  static int on_stream_close_callback(nghttp2_session* session, int32_t stream_id, uint32_t error_code, void* user_data)
+  {
+    return 0;
+  }
+};
+
+class MockupTLSConnection : public TLSConnection
+{
+public:
+  MockupTLSConnection(int descriptor, [[maybe_unused]] bool client = false, [[maybe_unused]] bool needProxyProtocol = false) :
+    d_descriptor(descriptor)
+  {
+    auto connectionID = s_connectionID++;
+    auto conn = std::make_unique<DOHConnection>(connectionID);
+    s_connectionBuffers[d_descriptor] = std::move(conn);
+  }
+
+  ~MockupTLSConnection() {}
+
+  IOState tryHandshake() override
+  {
+    auto step = getStep();
+    BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::handshakeClient);
+
+    return step.nextState;
+  }
+
+  IOState tryWrite(const PacketBuffer& buffer, size_t& pos, size_t toWrite) override
+  {
+    auto& conn = s_connectionBuffers.at(d_descriptor);
+    auto step = getStep();
+    BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::writeToClient);
+
+    if (step.bytes == 0) {
+      if (step.nextState == IOState::NeedWrite) {
+        return step.nextState;
+      }
+      throw std::runtime_error("Remote host closed the connection");
+    }
+
+    toWrite -= pos;
+    BOOST_REQUIRE_GE(buffer.size(), pos + toWrite);
+
+    if (step.bytes < toWrite) {
+      toWrite = step.bytes;
+    }
+
+    conn->submitIncoming(buffer, pos, toWrite);
+    pos += toWrite;
+
+    return step.nextState;
+  }
+
+  IOState tryRead(PacketBuffer& buffer, size_t& pos, size_t toRead, bool allowIncomplete = false) override
+  {
+    auto& conn = s_connectionBuffers.at(d_descriptor);
+    auto step = getStep();
+    BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::readFromClient);
+
+    if (step.bytes == 0) {
+      if (step.nextState == IOState::NeedRead) {
+        return step.nextState;
+      }
+      throw std::runtime_error("Remote host closed the connection");
+    }
+
+    auto& externalBuffer = conn->d_clientOutBuffer;
+    toRead -= pos;
+
+    if (step.bytes < toRead) {
+      toRead = step.bytes;
+    }
+    if (allowIncomplete) {
+      if (toRead > externalBuffer.size()) {
+        toRead = externalBuffer.size();
+      }
+    }
+    else {
+      BOOST_REQUIRE_GE(externalBuffer.size(), toRead);
+    }
+
+    BOOST_REQUIRE_GE(buffer.size(), toRead);
+
+    std::copy(externalBuffer.begin(), externalBuffer.begin() + toRead, buffer.begin() + pos);
+    pos += toRead;
+    externalBuffer.erase(externalBuffer.begin(), externalBuffer.begin() + toRead);
+
+    return step.nextState;
+  }
+
+  IOState tryConnect(bool fastOpen, const ComboAddress& remote) override
+  {
+    throw std::runtime_error("Should not happen");
+  }
+
+  void close() override
+  {
+    auto step = getStep();
+    BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::closeClient);
+  }
+
+  bool hasBufferedData() const override
+  {
+    return false;
+  }
+
+  bool isUsable() const override
+  {
+    return true;
+  }
+
+  std::string getServerNameIndication() const override
+  {
+    return "";
+  }
+
+  std::vector<uint8_t> getNextProtocol() const override
+  {
+    return std::vector<uint8_t>{'h', '2'};
+  }
+
+  LibsslTLSVersion getTLSVersion() const override
+  {
+    return LibsslTLSVersion::TLS13;
+  }
+
+  bool hasSessionBeenResumed() const override
+  {
+    return false;
+  }
+
+  std::vector<std::unique_ptr<TLSSession>> getSessions() override
+  {
+    return {};
+  }
+
+  void setSession(std::unique_ptr<TLSSession>& session) override
+  {
+  }
+
+  std::vector<int> getAsyncFDs() override
+  {
+    return {};
+  }
+
+  /* unused in that context, don't bother */
+  void doHandshake() override
+  {
+  }
+
+  void connect(bool fastOpen, const ComboAddress& remote, const struct timeval& timeout) override
+  {
+  }
+
+  size_t read(void* buffer, size_t bufferSize, const struct timeval& readTimeout, const struct timeval& totalTimeout = {0, 0}, bool allowIncomplete = false) override
+  {
+    return 0;
+  }
+
+  size_t write(const void* buffer, size_t bufferSize, const struct timeval& writeTimeout) override
+  {
+    return 0;
+  }
+
+private:
+  ExpectedStep getStep() const
+  {
+    BOOST_REQUIRE(!s_steps.empty());
+    auto step = s_steps.front();
+    s_steps.pop_front();
+
+    if (step.cb) {
+      step.cb(d_descriptor);
+    }
+
+    return step;
+  }
+
+  const int d_descriptor;
+};
+
+#include "test-dnsdistnghttp2_common.hh"
+
+struct TestFixture
+{
+  TestFixture()
+  {
+    s_steps.clear();
+    s_connectionContexts.clear();
+    s_connectionBuffers.clear();
+    s_connectionID = 0;
+    s_mplexer = std::make_unique<MockupFDMultiplexer>();
+  }
+  ~TestFixture()
+  {
+    s_steps.clear();
+    s_connectionContexts.clear();
+    s_connectionBuffers.clear();
+    s_connectionID = 0;
+    s_mplexer.reset();
+  }
+};
+
+BOOST_FIXTURE_TEST_CASE(test_IncomingConnection_SelfAnswered, TestFixture)
+{
+  auto local = getBackendAddress("1", 80);
+  ClientState localCS(local, true, false, false, "", {});
+  localCS.dohFrontend = std::make_shared<DOHFrontend>(std::make_shared<MockupTLSCtx>());
+  localCS.dohFrontend->d_urls.insert("/dns-query");
+
+  TCPClientThreadData threadData;
+  threadData.mplexer = std::make_unique<MockupFDMultiplexer>();
+
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
+  size_t counter = 0;
+  DNSName name("powerdns.com.");
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, name, QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+  pwQ.getHeader()->id = htons(counter);
+
+  PacketBuffer response;
+  GenericDNSPacketWriter<PacketBuffer> pwR(response, name, QType::A, QClass::IN, 0);
+  pwR.getHeader()->qr = 1;
+  pwR.getHeader()->rd = 1;
+  pwR.getHeader()->ra = 1;
+  pwR.getHeader()->id = htons(counter);
+  pwR.startRecord(name, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+  pwR.xfr32BitInt(0x01020304);
+  pwR.commit();
+
+  {
+    /* dnsdist drops the query right away after receiving it, client closes the connection */
+    s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, {403U}};
+    s_steps = {
+      /* opening */
+      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      /* settings server -> client */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      /* settings + headers + data client -> server.. */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      /* .. continued */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
+      /* headers + data */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, std::numeric_limits<size_t>::max() },
+      /* wait for next query, but the client closes the connection */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0 },
+      /* server close */
+      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+    };
+
+    auto state = std::make_shared<IncomingHTTP2Connection>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
+    state->handleIO();
+  }
+
+  {
+    /* client closes the connection right in the middle of sending the query */
+    s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, { 403U }};
+    s_steps = {
+      /* opening */
+      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      /* settings server -> client */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      /* client sends one byte */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead, 1 },
+      /* then closes the connection */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0 },
+      /* server close */
+      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+    };
+
+    /* mark the incoming FD as always ready */
+    dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(-1);
+
+    auto state = std::make_shared<IncomingHTTP2Connection>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
+    state->handleIO();
+    while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
+      threadData.mplexer->run(&now);
+    }
+  }
+
+  {
+    /* dnsdist sends a response right away, client closes the connection after getting the response */
+    s_processQuery = [response](DNSQuestion& dq, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      /* self answered */
+      dq.getMutableData() = response;
+      return ProcessQueryResult::SendAnswer;
+    };
+
+    s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, {200U}};
+
+    s_steps = {
+      /* opening */
+      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      /* settings server -> client */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      /* settings + headers + data client -> server.. */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      /* .. continued */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
+      /* headers + data */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, std::numeric_limits<size_t>::max() },
+      /* wait for next query, but the client closes the connection */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0 },
+      /* server close */
+      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+    };
+
+    auto state = std::make_shared<IncomingHTTP2Connection>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
+    state->handleIO();
+  }
+
+  {
+    /* dnsdist sends a response right away, but the client closes the connection without even reading the response */
+    s_processQuery = [response](DNSQuestion& dq, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      /* self answered */
+      dq.getMutableData() = response;
+      return ProcessQueryResult::SendAnswer;
+    };
+
+    s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, {200U}};
+
+    s_steps = {
+      /* opening */
+      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      /* settings server -> client */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      /* settings + headers + data client -> server.. */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      /* .. continued */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
+      /* we want to send the response but the client closes the connection */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 0 },
+      /* server close */
+      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+    };
+
+    /* mark the incoming FD as always ready */
+    dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(-1);
+
+    auto state = std::make_shared<IncomingHTTP2Connection>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
+    state->handleIO();
+    while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
+      threadData.mplexer->run(&now);
+    }
+  }
+
+  {
+    /* dnsdist sends a response right away, client closes the connection while getting the response */
+    s_processQuery = [response](DNSQuestion& dq, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      /* self answered */
+      dq.getMutableData() = response;
+      return ProcessQueryResult::SendAnswer;
+    };
+
+    s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, {200U}};
+
+    s_steps = {
+      /* opening */
+      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      /* settings server -> client */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      /* settings + headers + data client -> server.. */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      /* .. continued */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
+      /* headers + data (partial write) */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::NeedWrite, 1 },
+      /* nothing to read after that */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead, 0 },
+      /* then the client closes the connection before we are done  */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 0 },
+      /* server close */
+      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+    };
+
+    /* mark the incoming FD as always ready */
+    dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(-1);
+
+    auto state = std::make_shared<IncomingHTTP2Connection>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
+    state->handleIO();
+    while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
+      threadData.mplexer->run(&now);
+    }
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE(test_IncomingConnection_BackendTimeout, TestFixture)
+{
+  auto local = getBackendAddress("1", 80);
+  ClientState localCS(local, true, false, false, "", {});
+  localCS.dohFrontend = std::make_shared<DOHFrontend>(std::make_shared<MockupTLSCtx>());
+  localCS.dohFrontend->d_urls.insert("/dns-query");
+
+  TCPClientThreadData threadData;
+  threadData.mplexer = std::make_unique<MockupFDMultiplexer>();
+
+  auto backend = std::make_shared<DownstreamState>(getBackendAddress("42", 53));
+
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
+  size_t counter = 0;
+  DNSName name("powerdns.com.");
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, name, QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+  pwQ.getHeader()->id = htons(counter);
+
+  PacketBuffer response;
+  GenericDNSPacketWriter<PacketBuffer> pwR(response, name, QType::A, QClass::IN, 0);
+  pwR.getHeader()->qr = 1;
+  pwR.getHeader()->rd = 1;
+  pwR.getHeader()->ra = 1;
+  pwR.getHeader()->id = htons(counter);
+  pwR.startRecord(name, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
+  pwR.xfr32BitInt(0x01020304);
+  pwR.commit();
+
+  {
+    /* dnsdist forwards the query to the backend, which does not answer -> timeout */
+    s_processQuery = [backend](DNSQuestion& dq, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, {502U}};
+    s_steps = {
+      /* opening */
+      { ExpectedStep::ExpectedRequest::handshakeClient, IOState::Done },
+      /* settings server -> client */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, 15 },
+      /* settings + headers + data client -> server.. */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 128 },
+      /* .. continued */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 60 },
+        /* trying to read a new request while processing the first one */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::NeedRead },
+      /* headers + data */
+      { ExpectedStep::ExpectedRequest::writeToClient, IOState::Done, std::numeric_limits<size_t>::max(), [&threadData](int desc) {
+          /* set the incoming descriptor as ready */
+          dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(desc);
+        }
+      },
+      /* wait for next query, but the client closes the connection */
+      { ExpectedStep::ExpectedRequest::readFromClient, IOState::Done, 0 },
+      /* server close */
+      { ExpectedStep::ExpectedRequest::closeClient, IOState::Done },
+    };
+
+    auto state = std::make_shared<IncomingHTTP2Connection>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
+    state->handleIO();
+    TCPResponse resp;
+    resp.d_idstate.d_streamID = 1;
+    state->notifyIOError(now, std::move(resp));
+    while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
+      threadData.mplexer->run(&now);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END();
+#endif /* HAVE_NGHTTP2 */

--- a/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
@@ -626,11 +626,11 @@ public:
     d_valid = true;
   }
 
-  void handleXFRResponse(const struct timeval&, TCPResponse&&) override
+  void handleXFRResponse([[maybe_unused]] const struct timeval& now, [[maybe_unused]] TCPResponse&& response) override
   {
   }
 
-  void notifyIOError(const struct timeval&, TCPResponse&&) override
+  void notifyIOError([[maybe_unused]] const struct timeval& now, [[maybe_unused]] TCPResponse&& response) override
   {
     d_error = true;
   }

--- a/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
@@ -405,11 +405,6 @@ public:
     BOOST_REQUIRE_EQUAL(step.request, !d_client ? ExpectedStep::ExpectedRequest::closeClient : ExpectedStep::ExpectedRequest::closeBackend);
   }
 
-  bool hasBufferedData() const override
-  {
-    return false;
-  }
-
   bool isUsable() const override
   {
     return true;

--- a/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
@@ -626,11 +626,11 @@ public:
     d_valid = true;
   }
 
-  void handleXFRResponse(const struct timeval& now, TCPResponse&& response) override
+  void handleXFRResponse(const struct timeval&, TCPResponse&&) override
   {
   }
 
-  void notifyIOError(InternalQueryState&& query, const struct timeval& now) override
+  void notifyIOError(const struct timeval&, TCPResponse&&) override
   {
     d_error = true;
   }

--- a/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
@@ -486,110 +486,7 @@ private:
   bool d_client{false};
 };
 
-class MockupTLSCtx : public TLSCtx
-{
-public:
-  ~MockupTLSCtx()
-  {
-  }
-
-  std::unique_ptr<TLSConnection> getConnection(int socket, const struct timeval& timeout, time_t now) override
-  {
-    return std::make_unique<MockupTLSConnection>(socket);
-  }
-
-  std::unique_ptr<TLSConnection> getClientConnection(const std::string& host, bool hostIsAddr, int socket, const struct timeval& timeout) override
-  {
-    return std::make_unique<MockupTLSConnection>(socket, true, d_needProxyProtocol);
-  }
-
-  void rotateTicketsKey(time_t now) override
-  {
-  }
-
-  size_t getTicketsKeysCount() override
-  {
-    return 0;
-  }
-
-  std::string getName() const override
-  {
-    return "Mockup TLS";
-  }
-
-  bool d_needProxyProtocol{false};
-};
-
-class MockupFDMultiplexer : public FDMultiplexer
-{
-public:
-  MockupFDMultiplexer()
-  {
-  }
-
-  ~MockupFDMultiplexer()
-  {
-  }
-
-  int run(struct timeval* tv, int timeout = 500) override
-  {
-    int ret = 0;
-
-    gettimeofday(tv, nullptr); // MANDATORY
-
-    /* 'ready' might be altered by a callback while we are iterating */
-    const auto readyFDs = ready;
-    for (const auto fd : readyFDs) {
-      {
-        const auto& it = d_readCallbacks.find(fd);
-
-        if (it != d_readCallbacks.end()) {
-          it->d_callback(it->d_fd, it->d_parameter);
-        }
-      }
-
-      {
-        const auto& it = d_writeCallbacks.find(fd);
-
-        if (it != d_writeCallbacks.end()) {
-          it->d_callback(it->d_fd, it->d_parameter);
-        }
-      }
-    }
-
-    return ret;
-  }
-
-  void getAvailableFDs(std::vector<int>& fds, int timeout) override
-  {
-  }
-
-  void addFD(int fd, FDMultiplexer::EventKind kind) override
-  {
-  }
-
-  void removeFD(int fd, FDMultiplexer::EventKind) override
-  {
-  }
-
-  string getName() const override
-  {
-    return "mockup";
-  }
-
-  void setReady(int fd)
-  {
-    ready.insert(fd);
-  }
-
-  void setNotReady(int fd)
-  {
-    ready.erase(fd);
-  }
-
-private:
-  std::set<int> ready;
-};
+#include "test-dnsdistnghttp2_common.hh"
 
 class MockupQuerySender : public TCPQuerySender
 {
@@ -640,36 +537,6 @@ public:
   bool d_valid{false};
   bool d_error{false};
 };
-
-static bool isIPv6Supported()
-{
-  try {
-    ComboAddress addr("[2001:db8:53::1]:53");
-    auto socket = std::make_unique<Socket>(addr.sin4.sin_family, SOCK_STREAM, 0);
-    socket->setNonBlocking();
-    int res = SConnectWithTimeout(socket->getHandle(), addr, timeval{0, 0});
-    if (res == 0 || res == EINPROGRESS) {
-      return true;
-    }
-    return false;
-  }
-  catch (const std::exception& e) {
-    return false;
-  }
-}
-
-static ComboAddress getBackendAddress(const std::string& lastDigit, uint16_t port)
-{
-  static const bool useV6 = isIPv6Supported();
-
-  if (useV6) {
-    return ComboAddress("2001:db8:53::" + lastDigit, port);
-  }
-
-  return ComboAddress("192.0.2." + lastDigit, port);
-}
-
-static std::unique_ptr<FDMultiplexer> s_mplexer;
 
 struct TestFixture
 {

--- a/pdns/dnsdistdist/test-dnsdistnghttp2_common.hh
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2_common.hh
@@ -1,0 +1,157 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+class MockupTLSCtx : public TLSCtx
+{
+public:
+  ~MockupTLSCtx()
+  {
+  }
+
+  std::unique_ptr<TLSConnection> getConnection(int socket, const struct timeval& timeout, time_t now) override
+  {
+    return std::make_unique<MockupTLSConnection>(socket);
+  }
+
+  std::unique_ptr<TLSConnection> getClientConnection(const std::string& host, bool hostIsAddr, int socket, const struct timeval& timeout) override
+  {
+    return std::make_unique<MockupTLSConnection>(socket, true, d_needProxyProtocol);
+  }
+
+  void rotateTicketsKey(time_t now) override
+  {
+  }
+
+  size_t getTicketsKeysCount() override
+  {
+    return 0;
+  }
+
+  std::string getName() const override
+  {
+    return "Mockup TLS";
+  }
+
+  bool d_needProxyProtocol{false};
+};
+
+class MockupFDMultiplexer : public FDMultiplexer
+{
+public:
+  MockupFDMultiplexer()
+  {
+  }
+
+  ~MockupFDMultiplexer()
+  {
+  }
+
+  int run(struct timeval* tv, int timeout = 500) override
+  {
+    int ret = 0;
+
+    gettimeofday(tv, nullptr); // MANDATORY
+
+    /* 'ready' might be altered by a callback while we are iterating */
+    const auto readyFDs = ready;
+    for (const auto fd : readyFDs) {
+      {
+        const auto& it = d_readCallbacks.find(fd);
+
+        if (it != d_readCallbacks.end()) {
+          it->d_callback(it->d_fd, it->d_parameter);
+        }
+      }
+
+      {
+        const auto& it = d_writeCallbacks.find(fd);
+
+        if (it != d_writeCallbacks.end()) {
+          it->d_callback(it->d_fd, it->d_parameter);
+        }
+      }
+    }
+
+    return ret;
+  }
+
+  void getAvailableFDs(std::vector<int>& fds, int timeout) override
+  {
+  }
+
+  void addFD(int fd, FDMultiplexer::EventKind kind) override
+  {
+  }
+
+  void removeFD(int fd, FDMultiplexer::EventKind) override
+  {
+  }
+
+  string getName() const override
+  {
+    return "mockup";
+  }
+
+  void setReady(int fd)
+  {
+    ready.insert(fd);
+  }
+
+  void setNotReady(int fd)
+  {
+    ready.erase(fd);
+  }
+
+private:
+  std::set<int> ready;
+};
+
+static bool isIPv6Supported()
+{
+  try {
+    ComboAddress addr("[2001:db8:53::1]:53");
+    auto socket = std::make_unique<Socket>(addr.sin4.sin_family, SOCK_STREAM, 0);
+    socket->setNonBlocking();
+    int res = SConnectWithTimeout(socket->getHandle(), addr, timeval{0, 0});
+    if (res == 0 || res == EINPROGRESS) {
+      return true;
+    }
+    return false;
+  }
+  catch (const std::exception& e) {
+    return false;
+  }
+}
+
+static ComboAddress getBackendAddress(const std::string& lastDigit, uint16_t port)
+{
+  static const bool useV6 = isIPv6Supported();
+
+  if (useV6) {
+    return ComboAddress("2001:db8:53::" + lastDigit, port);
+  }
+
+  return ComboAddress("192.0.2." + lastDigit, port);
+}
+
+static std::unique_ptr<FDMultiplexer> s_mplexer;

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -62,7 +62,7 @@ void handleResponseSent(const InternalQueryState& ids, double udiff, const Combo
 {
 }
 
-static std::function<ProcessQueryResult(DNSQuestion& dq, std::shared_ptr<DownstreamState>& selectedBackend)> s_processQuery;
+std::function<ProcessQueryResult(DNSQuestion& dq, std::shared_ptr<DownstreamState>& selectedBackend)> s_processQuery;
 
 ProcessQueryResult processQuery(DNSQuestion& dq, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend)
 {

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -208,11 +208,6 @@ public:
     BOOST_REQUIRE_EQUAL(step.request, !d_client ? ExpectedStep::ExpectedRequest::closeClient : ExpectedStep::ExpectedRequest::closeBackend);
   }
 
-  bool hasBufferedData() const override
-  {
-    return false;
-  }
-
   bool isUsable() const override
   {
     return true;

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -500,7 +500,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
   }
 
@@ -523,7 +523,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
     BOOST_CHECK(s_writeBuffer == query);
   }
@@ -558,7 +558,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
     dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(-1);
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
       threadData.mplexer->run(&now);
     }
@@ -582,7 +582,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
   }
 
@@ -610,7 +610,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size() * count);
 #endif
   }
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
     dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setNotReady(-1);
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0);
     struct timeval later = now;
     later.tv_sec += g_tcpRecvTimeout + 1;
@@ -672,7 +672,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
     dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setNotReady(-1);
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0);
     struct timeval later = now;
     later.tv_sec += g_tcpRecvTimeout + 1;
@@ -705,7 +705,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
   }
 }
@@ -766,7 +766,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionWithProxyProtocol_SelfAnswered)
     dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setNotReady(-1);
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0);
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size() * 2U);
   }
@@ -793,7 +793,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionWithProxyProtocol_SelfAnswered)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
 
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
   }
@@ -823,7 +823,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionWithProxyProtocol_SelfAnswered)
     dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setNotReady(-1);
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0);
     struct timeval later = now;
     later.tv_sec += g_tcpRecvTimeout + 1;
@@ -903,7 +903,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
     BOOST_CHECK(s_writeBuffer == query);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
@@ -943,7 +943,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
     BOOST_CHECK(s_backendWriteBuffer == query);
@@ -982,7 +982,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
     BOOST_CHECK(s_backendWriteBuffer == query);
@@ -1025,7 +1025,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
     BOOST_CHECK(s_backendWriteBuffer == query);
@@ -1052,7 +1052,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(backend->outstanding.load(), 0U);
@@ -1090,7 +1090,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
     BOOST_CHECK_EQUAL(backend->outstanding.load(), 0U);
@@ -1160,7 +1160,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     /* set the incoming descriptor as ready! */
     dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(-1);
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
       threadData.mplexer->run(&now);
     }
@@ -1221,7 +1221,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(backend->outstanding.load(), 0U);
@@ -1257,7 +1257,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     struct timeval later = now;
     later.tv_sec += backend->d_config.tcpSendTimeout + 1;
     auto expiredWriteConns = threadData.mplexer->getTimeouts(later, true);
@@ -1303,7 +1303,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     struct timeval later = now;
     later.tv_sec += backend->d_config.tcpRecvTimeout + 1;
     auto expiredConns = threadData.mplexer->getTimeouts(later, false);
@@ -1360,7 +1360,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(backend->outstanding.load(), 0U);
@@ -1416,7 +1416,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
     BOOST_CHECK(s_writeBuffer == query);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
@@ -1475,7 +1475,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(backend->outstanding.load(), 0U);
@@ -1527,7 +1527,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size() * backend->d_config.d_retries);
     BOOST_CHECK_EQUAL(backend->outstanding.load(), 0U);
@@ -1587,7 +1587,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
     BOOST_CHECK(s_writeBuffer == query);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size() * backend->d_config.d_retries);
@@ -1628,7 +1628,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
     BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
     BOOST_CHECK(s_backendWriteBuffer == query);
@@ -1690,7 +1690,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size() * count);
     BOOST_CHECK_EQUAL(backend->outstanding.load(), 0U);
 
@@ -1732,7 +1732,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     BOOST_CHECK_EQUAL(backend->outstanding.load(), 0U);
 
     /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
@@ -1916,7 +1916,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
       threadData.mplexer->run(&now);
     }
@@ -2048,7 +2048,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
 
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
@@ -2228,7 +2228,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
 
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
@@ -2304,7 +2304,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
     }
@@ -2387,7 +2387,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while ((threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
     }
@@ -2504,7 +2504,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
     }
@@ -2656,7 +2656,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
       threadData.mplexer->run(&now);
     }
@@ -2863,7 +2863,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
     }
@@ -3037,7 +3037,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
     }
@@ -3301,7 +3301,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
     }
@@ -3427,7 +3427,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
       threadData.mplexer->run(&now);
     }
@@ -3512,7 +3512,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
       threadData.mplexer->run(&now);
     }
@@ -3577,7 +3577,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
     }
@@ -3768,7 +3768,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
       threadData.mplexer->run(&now);
     }
@@ -3853,7 +3853,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
     }
@@ -4085,7 +4085,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendNotOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
       threadData.mplexer->run(&now);
     }
@@ -4137,7 +4137,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendNotOOOR)
     };
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS, getBackendAddress("84", 4242)), threadData, now);
-    IncomingTCPConnectionState::handleIO(state, now);
+    state->handleIO();
     while (!timeout && (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0)) {
       threadData.mplexer->run(&now);
     }

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -51,7 +51,7 @@ public:
   size_t getTicketsKeysCount() override;
 };
 
-void dohThread(ClientState* cs);
+void dohThread(ClientState* clientState);
 
 #endif /* HAVE_LIBH2OEVLOOP */
 #endif /* HAVE_DNS_OVER_HTTPS  */

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -21,236 +21,37 @@
  */
 #pragma once
 
-#pragma once
+#include "config.h"
 
-#include <unordered_map>
-
-#include "channel.hh"
-#include "iputils.hh"
-#include "libssl.hh"
-#include "noinitvector.hh"
-#include "stat_t.hh"
-
-struct DOHServerConfig;
-
-class DOHResponseMapEntry
-{
-public:
-  DOHResponseMapEntry(const std::string& regex, uint16_t status, const PacketBuffer& content, const boost::optional<std::unordered_map<std::string, std::string>>& headers): d_regex(regex), d_customHeaders(headers), d_content(content), d_status(status)
-  {
-    if (status >= 400 && !d_content.empty() && d_content.at(d_content.size() -1) != 0) {
-      // we need to make sure it's null-terminated
-      d_content.push_back(0);
-    }
-  }
-
-  bool matches(const std::string& path) const
-  {
-    return d_regex.match(path);
-  }
-
-  uint16_t getStatusCode() const
-  {
-    return d_status;
-  }
-
-  const PacketBuffer& getContent() const
-  {
-    return d_content;
-  }
-
-  const boost::optional<std::unordered_map<std::string, std::string>>& getHeaders() const
-  {
-    return d_customHeaders;
-  }
-
-private:
-  Regex d_regex;
-  boost::optional<std::unordered_map<std::string, std::string>> d_customHeaders;
-  PacketBuffer d_content;
-  uint16_t d_status;
-};
-
-struct DOHFrontend
-{
-  DOHFrontend()
-  {
-  }
-
-  std::shared_ptr<DOHServerConfig> d_dsc{nullptr};
-  std::shared_ptr<std::vector<std::shared_ptr<DOHResponseMapEntry>>> d_responsesMap;
-  TLSConfig d_tlsConfig;
-  TLSErrorCounters d_tlsCounters;
-  std::string d_serverTokens{"h2o/dnsdist"};
-  std::unordered_map<std::string, std::string> d_customResponseHeaders;
-  ComboAddress d_local;
-
-  uint32_t d_idleTimeout{30};             // HTTP idle timeout in seconds
-  std::vector<std::string> d_urls;
-
-  pdns::stat_t d_httpconnects{0};   // number of TCP/IP connections established
-  pdns::stat_t d_getqueries{0};     // valid DNS queries received via GET
-  pdns::stat_t d_postqueries{0};    // valid DNS queries received via POST
-  pdns::stat_t d_badrequests{0};     // request could not be converted to dns query
-  pdns::stat_t d_errorresponses{0}; // dnsdist set 'error' on response
-  pdns::stat_t d_redirectresponses{0}; // dnsdist set 'redirect' on response
-  pdns::stat_t d_validresponses{0}; // valid responses sent out
-
-  struct HTTPVersionStats
-  {
-    pdns::stat_t d_nbQueries{0}; // valid DNS queries received
-    pdns::stat_t d_nb200Responses{0};
-    pdns::stat_t d_nb400Responses{0};
-    pdns::stat_t d_nb403Responses{0};
-    pdns::stat_t d_nb500Responses{0};
-    pdns::stat_t d_nb502Responses{0};
-    pdns::stat_t d_nbOtherResponses{0};
-  };
-
-  HTTPVersionStats d_http1Stats;
-  HTTPVersionStats d_http2Stats;
-#ifdef __linux__
-  // On Linux this gives us 128k pending queries (default is 8192 queries),
-  // which should be enough to deal with huge spikes
-  uint32_t d_internalPipeBufferSize{1024*1024};
-#else
-  uint32_t d_internalPipeBufferSize{0};
-#endif
-  bool d_sendCacheControlHeaders{true};
-  bool d_trustForwardedForHeader{false};
-  /* whether we require tue query path to exactly match one of configured ones,
-     or accept everything below these paths. */
-  bool d_exactPathMatching{true};
-  bool d_keepIncomingHeaders{false};
-
-  time_t getTicketsKeyRotationDelay() const
-  {
-    return d_tlsConfig.d_ticketsKeyRotationDelay;
-  }
-
-  bool isHTTPS() const
-  {
-    return !d_tlsConfig.d_certKeyPairs.empty();
-  }
-
-#ifndef HAVE_DNS_OVER_HTTPS
-  void setup()
-  {
-  }
-
-  void reloadCertificates()
-  {
-  }
-
-  void rotateTicketsKey(time_t /* now */)
-  {
-  }
-
-  void loadTicketsKeys(const std::string& /* keyFile */)
-  {
-  }
-
-  void handleTicketsKeyRotation()
-  {
-  }
-
-  time_t getNextTicketsKeyRotation() const
-  {
-    return 0;
-  }
-
-  size_t getTicketsKeysCount() const
-  {
-    size_t res = 0;
-    return res;
-  }
-
-#else
-  void setup();
-  void reloadCertificates();
-
-  void rotateTicketsKey(time_t now);
-  void loadTicketsKeys(const std::string& keyFile);
-  void handleTicketsKeyRotation();
-  time_t getNextTicketsKeyRotation() const;
-  size_t getTicketsKeysCount() const;
-#endif /* HAVE_DNS_OVER_HTTPS */
-};
-
-#ifndef HAVE_DNS_OVER_HTTPS
-struct DOHUnit
-{
-  size_t proxyProtocolPayloadSize{0};
-  uint16_t status_code{200};
-};
-
-#else /* HAVE_DNS_OVER_HTTPS */
+#ifdef HAVE_DNS_OVER_HTTPS
 #ifdef HAVE_LIBH2OEVLOOP
-#include <unordered_map>
 
-#include "dnsdist-idstate.hh"
-
-struct st_h2o_req_t;
-struct DownstreamState;
-
-struct DOHUnit
-{
-  DOHUnit(PacketBuffer&& q, std::string&& p, std::string&& h): path(std::move(p)), host(std::move(h)), query(std::move(q))
-  {
-    ids.ednsAdded = false;
-  }
-
-  DOHUnit(const DOHUnit&) = delete;
-  DOHUnit& operator=(const DOHUnit&) = delete;
-
-  InternalQueryState ids;
-  std::string sni;
-  std::string path;
-  std::string scheme;
-  std::string host;
-  std::string contentType;
-  PacketBuffer query;
-  PacketBuffer response;
-  std::shared_ptr<DownstreamState> downstream{nullptr};
-  std::unique_ptr<std::unordered_map<std::string, std::string>> headers;
-  st_h2o_req_t* req{nullptr};
-  DOHUnit** self{nullptr};
-  DOHServerConfig* dsc{nullptr};
-  pdns::channel::Sender<DOHUnit>* responseSender{nullptr};
-  size_t query_at{0};
-  size_t proxyProtocolPayloadSize{0};
-  int rsock{-1};
-  /* the status_code is set from
-     processDOHQuery() (which is executed in
-     the DOH client thread) so that the correct
-     response can be sent in on_dnsdist(),
-     after the DOHUnit has been passed back to
-     the main DoH thread.
-  */
-  uint16_t status_code{200};
-  /* whether the query was re-sent to the backend over
-     TCP after receiving a truncated answer over UDP */
-  bool tcp{false};
-  bool truncated{false};
-
-  std::string getHTTPPath() const;
-  std::string getHTTPHost() const;
-  std::string getHTTPScheme() const;
-  std::string getHTTPQueryString() const;
-  std::unordered_map<std::string, std::string> getHTTPHeaders() const;
-  void setHTTPResponse(uint16_t statusCode, PacketBuffer&& body, const std::string& contentType="");
-};
-
-void handleUDPResponseForDoH(std::unique_ptr<DOHUnit>&&, PacketBuffer&& response, InternalQueryState&& state);
+#include <ctime>
+#include <memory>
+#include <string>
 
 struct CrossProtocolQuery;
 struct DNSQuestion;
 
 std::unique_ptr<CrossProtocolQuery> getDoHCrossProtocolQueryFromDQ(DNSQuestion& dq, bool isResponse);
 
+#include "dnsdist-doh-common.hh"
+
+struct H2ODOHFrontend : public DOHFrontend
+{
+public:
+
+  void setup() override;
+  void reloadCertificates() override;
+
+  void rotateTicketsKey(time_t now) override;
+  void loadTicketsKeys(const std::string& keyFile) override;
+  void handleTicketsKeyRotation() override;
+  std::string getNextTicketsKeyRotation() const override;
+  size_t getTicketsKeysCount() override;
+};
+
+void dohThread(ClientState* clientState);
+
 #endif /* HAVE_LIBH2OEVLOOP */
 #endif /* HAVE_DNS_OVER_HTTPS  */
-
-using DOHUnitUniquePtr = std::unique_ptr<DOHUnit>;
-
-void handleDOHTimeout(DOHUnitUniquePtr&& oldDU);

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -197,6 +197,7 @@ struct DOHUnit
 };
 
 #else /* HAVE_DNS_OVER_HTTPS */
+#ifdef HAVE_LIBH2OEVLOOP
 #include <unordered_map>
 
 #include "dnsdist-idstate.hh"
@@ -283,6 +284,7 @@ struct DNSQuestion;
 
 std::unique_ptr<CrossProtocolQuery> getDoHCrossProtocolQueryFromDQ(DNSQuestion& dq, bool isResponse);
 
+#endif /* HAVE_LIBH2OEVLOOP */
 #endif /* HAVE_DNS_OVER_HTTPS  */
 
 using DOHUnitUniquePtr = std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>;

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -180,18 +180,6 @@ struct DOHFrontend
 #ifndef HAVE_DNS_OVER_HTTPS
 struct DOHUnit
 {
-  static void release(DOHUnit*)
-  {
-  }
-
-  void get()
-  {
-  }
-
-  void release()
-  {
-  }
-
   size_t proxyProtocolPayloadSize{0};
   uint16_t status_code{200};
 };
@@ -215,29 +203,6 @@ struct DOHUnit
   DOHUnit(const DOHUnit&) = delete;
   DOHUnit& operator=(const DOHUnit&) = delete;
 
-  void get()
-  {
-    ++d_refcnt;
-  }
-
-  void release()
-  {
-    if (--d_refcnt == 0) {
-      if (self) {
-        *self = nullptr;
-      }
-
-      delete this;
-    }
-  }
-
-  static void release(DOHUnit* ptr)
-  {
-    if (ptr) {
-      ptr->release();
-    }
-  }
-
   InternalQueryState ids;
   std::string sni;
   std::string path;
@@ -251,8 +216,7 @@ struct DOHUnit
   st_h2o_req_t* req{nullptr};
   DOHUnit** self{nullptr};
   DOHServerConfig* dsc{nullptr};
-  pdns::channel::Sender<DOHUnit, void(*)(DOHUnit*)>* responseSender{nullptr};
-  std::atomic<uint64_t> d_refcnt{1};
+  pdns::channel::Sender<DOHUnit>* responseSender{nullptr};
   size_t query_at{0};
   size_t proxyProtocolPayloadSize{0};
   int rsock{-1};
@@ -277,7 +241,7 @@ struct DOHUnit
   void setHTTPResponse(uint16_t statusCode, PacketBuffer&& body, const std::string& contentType="");
 };
 
-void handleUDPResponseForDoH(std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>&&, PacketBuffer&& response, InternalQueryState&& state);
+void handleUDPResponseForDoH(std::unique_ptr<DOHUnit>&&, PacketBuffer&& response, InternalQueryState&& state);
 
 struct CrossProtocolQuery;
 struct DNSQuestion;
@@ -287,6 +251,6 @@ std::unique_ptr<CrossProtocolQuery> getDoHCrossProtocolQueryFromDQ(DNSQuestion& 
 #endif /* HAVE_LIBH2OEVLOOP */
 #endif /* HAVE_DNS_OVER_HTTPS  */
 
-using DOHUnitUniquePtr = std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>;
+using DOHUnitUniquePtr = std::unique_ptr<DOHUnit>;
 
 void handleDOHTimeout(DOHUnitUniquePtr&& oldDU);

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -51,7 +51,7 @@ public:
   size_t getTicketsKeysCount() override;
 };
 
-void dohThread(ClientState* clientState);
+void dohThread(ClientState* cs);
 
 #endif /* HAVE_LIBH2OEVLOOP */
 #endif /* HAVE_DNS_OVER_HTTPS  */

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -54,7 +54,7 @@ public:
   /* enable kTLS mode, if supported */
   bool d_ktls{false};
   /* set read ahead mode, if supported */
-  bool d_readAhead{false};
+  bool d_readAhead{true};
 };
 
 struct TLSErrorCounters

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -53,6 +53,8 @@ public:
   bool d_asyncMode{false};
   /* enable kTLS mode, if supported */
   bool d_ktls{false};
+  /* set read ahead mode, if supported */
+  bool d_readAhead{false};
 };
 
 struct TLSErrorCounters

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -1826,25 +1826,25 @@ bool TLSFrontend::setupTLS()
 #if defined(HAVE_DNS_OVER_TLS) || defined(HAVE_DNS_OVER_HTTPS)
   std::shared_ptr<TLSCtx> newCtx{nullptr};
   /* get the "best" available provider */
-#ifdef HAVE_GNUTLS
+#if defined(HAVE_GNUTLS)
   if (d_provider == "gnutls") {
     newCtx = std::make_shared<GnuTLSIOCtx>(*this);
   }
 #endif /* HAVE_GNUTLS */
-#ifdef HAVE_LIBSSL
+#if defined(HAVE_LIBSSL)
   if (d_provider == "openssl") {
     newCtx = std::make_shared<OpenSSLTLSIOCtx>(*this);
   }
 #endif /* HAVE_LIBSSL */
 
   if (!newCtx) {
-#ifdef HAVE_LIBSSL
+#if defined(HAVE_LIBSSL)
     newCtx = std::make_shared<OpenSSLTLSIOCtx>(*this);
-#else /* HAVE_LIBSSL */
-#ifdef HAVE_GNUTLS
+#elif defined(HAVE_GNUTLS)
     newCtx = std::make_shared<GnuTLSIOCtx>(*this);
-#endif /* HAVE_GNUTLS */
-#endif /* HAVE_LIBSSL */
+#else
+#error "TLS support needed but neither libssl nor GnuTLS were selected"
+#endif
   }
 
   if (d_alpn == ALPN::DoT) {
@@ -1864,25 +1864,25 @@ std::shared_ptr<TLSCtx> getTLSContext([[maybe_unused]] const TLSContextParameter
 #ifdef HAVE_DNS_OVER_TLS
   /* get the "best" available provider */
   if (!params.d_provider.empty()) {
-#ifdef HAVE_GNUTLS
+#if defined(HAVE_GNUTLS)
     if (params.d_provider == "gnutls") {
       return std::make_shared<GnuTLSIOCtx>(params);
     }
 #endif /* HAVE_GNUTLS */
-#ifdef HAVE_LIBSSL
+#if defined(HAVE_LIBSSL)
     if (params.d_provider == "openssl") {
       return std::make_shared<OpenSSLTLSIOCtx>(params);
     }
 #endif /* HAVE_LIBSSL */
   }
 
-#ifdef HAVE_LIBSSL
+#if defined(HAVE_LIBSSL)
   return std::make_shared<OpenSSLTLSIOCtx>(params);
-#else /* HAVE_LIBSSL */
-#ifdef HAVE_GNUTLS
+#elif defined(HAVE_GNUTLS)
   return std::make_shared<GnuTLSIOCtx>(params);
-#endif /* HAVE_GNUTLS */
-#endif /* HAVE_LIBSSL */
+#else
+#error "DNS over TLS support needed but neither libssl nor GnuTLS were selected"
+#endif
 
 #endif /* HAVE_DNS_OVER_TLS */
   return nullptr;

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -432,16 +432,6 @@ public:
     return got;
   }
 
-  bool hasBufferedData() const override
-  {
-    if (d_conn) {
-      /* this is broken when read-ahead is set, unfortunately */
-      return SSL_pending(d_conn.get()) > 0;
-    }
-
-    return false;
-  }
-
   bool isUsable() const override
   {
     if (!d_conn) {
@@ -1443,15 +1433,6 @@ public:
     while (got < bufferSize);
 
     return got;
-  }
-
-  bool hasBufferedData() const override
-  {
-    if (d_conn) {
-      return gnutls_record_check_pending(d_conn.get()) > 0;
-    }
-
-    return false;
   }
 
   bool isUsable() const override

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -629,6 +629,10 @@ public:
     }
 #endif /* DISABLE_OCSP_STAPLING */
 
+    if (fe.d_tlsConfig.d_readAhead) {
+      SSL_CTX_set_read_ahead(d_feContext->d_tlsCtx.get(), 1);
+    }
+
     libssl_set_error_counters_callback(d_feContext->d_tlsCtx, &fe.d_tlsCounters);
 
     if (!fe.d_tlsConfig.d_keyLogFile.empty()) {

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -1850,6 +1850,7 @@ bool TLSFrontend::setupTLS()
     newCtx = std::make_shared<OpenSSLTLSIOCtx>(*this);
   }
 #endif /* HAVE_LIBSSL */
+
   if (!newCtx) {
 #ifdef HAVE_LIBSSL
     newCtx = std::make_shared<OpenSSLTLSIOCtx>(*this);
@@ -1874,7 +1875,7 @@ bool TLSFrontend::setupTLS()
 
 std::shared_ptr<TLSCtx> getTLSContext([[maybe_unused]] const TLSContextParameters& params)
 {
-#if defined(HAVE_DNS_OVER_TLS) || defined(HAVE_DNS_OVER_HTTPS)
+#ifdef HAVE_DNS_OVER_TLS
   /* get the "best" available provider */
   if (!params.d_provider.empty()) {
 #ifdef HAVE_GNUTLS
@@ -1897,6 +1898,6 @@ std::shared_ptr<TLSCtx> getTLSContext([[maybe_unused]] const TLSContextParameter
 #endif /* HAVE_GNUTLS */
 #endif /* HAVE_LIBSSL */
 
-#endif /* HAVE_DNS_OVER_TLS || HAVE_DNS_OVER_HTTPS */
+#endif /* HAVE_DNS_OVER_TLS */
   return nullptr;
 }

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -435,6 +435,7 @@ public:
   bool hasBufferedData() const override
   {
     if (d_conn) {
+      /* this is broken when read-ahead is set, unfortunately */
       return SSL_pending(d_conn.get()) > 0;
     }
 

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -32,7 +32,6 @@ public:
   virtual size_t write(const void* buffer, size_t bufferSize, const struct timeval& writeTimeout) = 0;
   virtual IOState tryWrite(const PacketBuffer& buffer, size_t& pos, size_t toWrite) = 0;
   virtual IOState tryRead(PacketBuffer& buffer, size_t& pos, size_t toRead, bool allowIncomplete=false) = 0;
-  virtual bool hasBufferedData() const = 0;
   virtual std::string getServerNameIndication() const = 0;
   virtual std::vector<uint8_t> getNextProtocol() const = 0;
   virtual LibsslTLSVersion getTLSVersion() const = 0;
@@ -474,14 +473,6 @@ public:
 #endif /* MSG_FASTOPEN */
 
     return writen2WithTimeout(d_socket, buffer, bufferSize, writeTimeout);
-  }
-
-  bool hasBufferedData() const
-  {
-    if (d_conn) {
-      return d_conn->hasBufferedData();
-    }
-    return false;
   }
 
   std::string getServerNameIndication() const

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -136,7 +136,9 @@ protected:
 class TLSFrontend
 {
 public:
-  TLSFrontend()
+  enum class ALPN : uint8_t { Unset, DoT, DoH };
+
+  TLSFrontend(ALPN alpn) : d_alpn(alpn)
   {
   }
 
@@ -223,7 +225,7 @@ public:
   TLSErrorCounters d_tlsCounters;
   ComboAddress d_addr;
   std::string d_provider;
-
+  ALPN d_alpn{ALPN::Unset};
 protected:
   std::shared_ptr<TLSCtx> d_ctx{nullptr};
 };
@@ -582,3 +584,4 @@ struct TLSContextParameters
 
 std::shared_ptr<TLSCtx> getTLSContext(const TLSContextParameters& params);
 bool setupDoTProtocolNegotiation(std::shared_ptr<TLSCtx>& ctx);
+bool setupDoHProtocolNegotiation(std::shared_ptr<TLSCtx>& ctx);

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -138,7 +138,7 @@ class TLSFrontend
 public:
   enum class ALPN : uint8_t { Unset, DoT, DoH };
 
-  TLSFrontend(ALPN alpn) : d_alpn(alpn)
+  TLSFrontend(ALPN alpn): d_alpn(alpn)
   {
   }
 
@@ -233,7 +233,6 @@ protected:
 class TCPIOHandler
 {
 public:
-  enum class Type : uint8_t { Client, Server };
 
   TCPIOHandler(const std::string& host, bool hostIsAddr, int socket, const struct timeval& timeout, std::shared_ptr<TLSCtx> ctx): d_socket(socket)
   {

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -56,7 +56,7 @@ bool sendUDPResponse(int origFD, const PacketBuffer& response, const int delayMs
 
 bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer& query)
 {
-  return false;
+  return true;
 }
 
 namespace dnsdist {

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -54,9 +54,9 @@ bool sendUDPResponse(int origFD, const PacketBuffer& response, const int delayMs
   return false;
 }
 
-bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer& query, ComboAddress& dest)
+bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer& query)
 {
-  return false;
+  return true;
 }
 
 namespace dnsdist {

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -56,7 +56,7 @@ bool sendUDPResponse(int origFD, const PacketBuffer& response, const int delayMs
 
 bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& ds, uint16_t queryID, DNSQuestion& dq, PacketBuffer& query)
 {
-  return true;
+  return false;
 }
 
 namespace dnsdist {

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -1079,5 +1079,11 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     def sendDOHQueryWrapper(self, query, response, useQueue=True):
         return self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
 
+    def sendDOHWithNGHTTP2QueryWrapper(self, query, response, useQueue=True):
+        return self.sendDOHQuery(self._dohWithNGHTTP2ServerPort, self._serverName, self._dohWithNGHTTP2BaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
+
+    def sendDOHWithH2OQueryWrapper(self, query, response, useQueue=True):
+        return self.sendDOHQuery(self._dohWithH2OServerPort, self._serverName, self._dohWithH2OBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
+
     def sendDOTQueryWrapper(self, query, response, useQueue=True):
         return self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response, self._caCert, useQueue=useQueue)

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -624,7 +624,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         return sock
 
     @classmethod
-    def openTLSConnection(cls, port, serverName, caCert=None, timeout=None):
+    def openTLSConnection(cls, port, serverName, caCert=None, timeout=None, alpn=[]):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         if timeout:
@@ -633,6 +633,8 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         # 2.7.9+
         if hasattr(ssl, 'create_default_context'):
             sslctx = ssl.create_default_context(cafile=caCert)
+            if len(alpn)> 0 and hasattr(sslctx, 'set_alpn_protocols'):
+              sslctx.set_alpn_protocols(alpn)
             sslsock = sslctx.wrap_socket(sock, server_hostname=serverName)
         else:
             sslsock = ssl.wrap_socket(sock, ca_certs=caCert, cert_reqs=ssl.CERT_REQUIRED)
@@ -992,6 +994,8 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         #conn.setopt(pycurl.VERBOSE, True)
         conn.setopt(pycurl.URL, url)
         conn.setopt(pycurl.RESOLVE, ["%s:%d:127.0.0.1" % (servername, port)])
+        # this means "really do HTTP/2, not HTTP/1 with Upgrade headers"
+        conn.setopt(pycurl.HTTP_VERSION, pycurl.CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE)
         if useHTTPS:
             conn.setopt(pycurl.SSL_VERIFYPEER, 1)
             conn.setopt(pycurl.SSL_VERIFYHOST, 2)
@@ -1036,6 +1040,8 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         #conn.setopt(pycurl.VERBOSE, True)
         conn.setopt(pycurl.URL, url)
         conn.setopt(pycurl.RESOLVE, ["%s:%d:127.0.0.1" % (servername, port)])
+        # this means "really do HTTP/2, not HTTP/1 with Upgrade headers"
+        conn.setopt(pycurl.HTTP_VERSION, pycurl.CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE)
         if useHTTPS:
             conn.setopt(pycurl.SSL_VERIFYPEER, 1)
             conn.setopt(pycurl.SSL_VERIFYHOST, 2)

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -657,7 +657,6 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
     @classmethod
     def recvTCPResponseOverConnection(cls, sock, useQueue=False, timeout=2.0):
-        print("reading data")
         message = None
         data = sock.recv(2)
         if data:
@@ -671,7 +670,6 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         print(useQueue)
         if useQueue and not cls._fromResponderQueue.empty():
             receivedQuery = cls._fromResponderQueue.get(True, timeout)
-            print("Got from queue")
             print(receivedQuery)
             return (receivedQuery, message)
         else:
@@ -707,7 +705,6 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         receivedQuery = None
         print(useQueue)
         if useQueue and not cls._fromResponderQueue.empty():
-            print("Got from queue")
             print(receivedQuery)
             receivedQuery = cls._fromResponderQueue.get(True, timeout)
         else:
@@ -991,13 +988,11 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         url = cls.getDOHGetURL(baseurl, query, rawQuery)
 
         if not conn:
-            print('creating a new connection')
             conn = cls.openDOHConnection(port, caFile=caFile, timeout=timeout)
             # this means "really do HTTP/2, not HTTP/1 with Upgrade headers"
             conn.setopt(pycurl.HTTP_VERSION, pycurl.CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE)
 
         if useHTTPS:
-            print("disabling verify")
             conn.setopt(pycurl.SSL_VERIFYPEER, 1)
             conn.setopt(pycurl.SSL_VERIFYHOST, 2)
             if caFile:
@@ -1020,7 +1015,6 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         receivedQuery = None
         message = None
         cls._response_headers = ''
-        print('performing')
         data = conn.perform_rb()
         cls._rcode = conn.getinfo(pycurl.RESPONSE_CODE)
         if cls._rcode == 200 and not rawResponse:

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -987,7 +987,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         return conn
 
     @classmethod
-    def sendDOHQuery(cls, port, servername, baseurl, query, response=None, timeout=2.0, caFile=None, useQueue=True, rawQuery=False, rawResponse=False, customHeaders=[], useHTTPS=True, fromQueue=None, toQueue=None, useProxyProtocol=False, conn=None):
+    def sendDOHQuery(cls, port, servername, baseurl, query, response=None, timeout=2.0, caFile=None, useQueue=True, rawQuery=False, rawResponse=False, customHeaders=[], useHTTPS=True, fromQueue=None, toQueue=None, conn=None):
         url = cls.getDOHGetURL(baseurl, query, rawQuery)
 
         if not conn:
@@ -1002,11 +1002,6 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             conn.setopt(pycurl.SSL_VERIFYHOST, 2)
             if caFile:
                 conn.setopt(pycurl.CAINFO, caFile)
-
-        if useProxyProtocol:
-            print('enabling PP')
-            # 274 is CURLOPT_HAPROXYPROTOCOL
-            conn.setopt(274, 1)
 
         response_headers = BytesIO()
         #conn.setopt(pycurl.VERBOSE, True)
@@ -1088,8 +1083,8 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         cls._response_headers = response_headers.getvalue()
         return (receivedQuery, message)
 
-    def sendDOHQueryWrapper(self, query, response, useQueue=True, useProxyProtocol=False):
-        return self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue, useProxyProtocol=useProxyProtocol)
+    def sendDOHQueryWrapper(self, query, response, useQueue=True):
+        return self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
 
     def sendDOHWithNGHTTP2QueryWrapper(self, query, response, useQueue=True):
         return self.sendDOHQuery(self._dohWithNGHTTP2ServerPort, self._serverName, self._dohWithNGHTTP2BaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)

--- a/regression-tests.dnsdist/test_Async.py
+++ b/regression-tests.dnsdist/test_Async.py
@@ -86,6 +86,22 @@ asyncResponder.daemon = True
 asyncResponder.start()
 
 class AsyncTests(object):
+    _serverKey = 'server.key'
+    _serverCert = 'server.chain'
+    _serverName = 'tls.tests.dnsdist.org'
+    _caCert = 'ca.pem'
+    _tlsServerPort = pickAvailablePort()
+    _dohWithNGHTTP2ServerPort = pickAvailablePort()
+    _dohWithH2OServerPort = pickAvailablePort()
+    _dohWithNGHTTP2BaseURL = ("https://%s:%d/" % (_serverName, _dohWithNGHTTP2ServerPort))
+    _dohWithH2OBaseURL = ("https://%s:%d/" % (_serverName, _dohWithH2OServerPort))
+
+    def sendDOHWithNGHTTP2QueryWrapper(self, query, response, useQueue=True):
+        return self.sendDOHQuery(self._dohWithNGHTTP2ServerPort, self._serverName, self._dohWithNGHTTP2BaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
+
+    def sendDOHWithH2OQueryWrapper(self, query, response, useQueue=True):
+        return self.sendDOHQuery(self._dohWithH2OServerPort, self._serverName, self._dohWithH2OBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
+
     def testPass(self):
         """
         Async: Accept
@@ -101,22 +117,12 @@ class AsyncTests(object):
                                         '192.0.2.1')
             response.answer.append(rrset)
 
-            for method in ("sendUDPQuery", "sendTCPQuery"):
+            for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
                 sender = getattr(self, method)
                 (receivedQuery, receivedResponse) = sender(query, response)
                 receivedQuery.id = query.id
                 self.assertEqual(query, receivedQuery)
                 self.assertEqual(response, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(response, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(response, receivedResponse)
 
     def testPassCached(self):
         """
@@ -133,28 +139,20 @@ class AsyncTests(object):
                                     '192.0.2.1')
         response.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
-            # first time to fill the cache
+        for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
             sender = getattr(self, method)
-            (receivedQuery, receivedResponse) = sender(query, response)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(response, receivedResponse)
+            if method != 'sendDOTQueryWrapper' and method != 'sendDOHWithH2OQueryWrapper':
+                # first time to fill the cache
+                # disabled for DoT since it was already filled via TCP
+                (receivedQuery, receivedResponse) = sender(query, response)
+                receivedQuery.id = query.id
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
+
             # second time from the cache
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertEqual(response, receivedResponse)
-
-        (_, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=None, useQueue=False, caFile=self._caCert)
-        self.assertEqual(response, receivedResponse)
-
-        (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(response, receivedResponse)
-
-        (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=None, useQueue=False, caFile=self._caCert)
-        self.assertEqual(response, receivedResponse)
 
     def testTimeoutThenAccept(self):
         """
@@ -171,22 +169,12 @@ class AsyncTests(object):
                                         '192.0.2.1')
             response.answer.append(rrset)
 
-            for method in ("sendUDPQuery", "sendTCPQuery"):
+            for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
                 sender = getattr(self, method)
                 (receivedQuery, receivedResponse) = sender(query, response)
                 receivedQuery.id = query.id
                 self.assertEqual(query, receivedQuery)
                 self.assertEqual(response, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(response, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(response, receivedResponse)
 
     def testAcceptThenTimeout(self):
         """
@@ -203,22 +191,12 @@ class AsyncTests(object):
                                         '192.0.2.1')
             response.answer.append(rrset)
 
-            for method in ("sendUDPQuery", "sendTCPQuery"):
+            for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
                 sender = getattr(self, method)
                 (receivedQuery, receivedResponse) = sender(query, response)
                 receivedQuery.id = query.id
                 self.assertEqual(query, receivedQuery)
                 self.assertEqual(response, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(response, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(response, receivedResponse)
 
     def testAcceptThenRefuse(self):
         """
@@ -239,22 +217,12 @@ class AsyncTests(object):
             expectedResponse.flags |= dns.flags.RA
             expectedResponse.set_rcode(dns.rcode.REFUSED)
 
-            for method in ("sendUDPQuery", "sendTCPQuery"):
+            for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
                 sender = getattr(self, method)
                 (receivedQuery, receivedResponse) = sender(query, response)
                 receivedQuery.id = query.id
                 self.assertEqual(query, receivedQuery)
                 self.assertEqual(expectedResponse, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(expectedResponse, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(expectedResponse, receivedResponse)
 
     def testAcceptThenCustom(self):
         """
@@ -278,22 +246,12 @@ class AsyncTests(object):
             expectedResponse.flags |= dns.flags.RA
             expectedResponse.set_rcode(dns.rcode.FORMERR)
 
-            for method in ("sendUDPQuery", "sendTCPQuery"):
+            for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
                 sender = getattr(self, method)
                 (receivedQuery, receivedResponse) = sender(query, response)
                 receivedQuery.id = query.id
                 self.assertEqual(query, receivedQuery)
                 self.assertEqual(expectedResponse, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(expectedResponse, receivedResponse)
-
-            (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(expectedResponse, receivedResponse)
 
     def testAcceptThenDrop(self):
         """
@@ -310,22 +268,12 @@ class AsyncTests(object):
                                         '192.0.2.1')
             response.answer.append(rrset)
 
-            for method in ("sendUDPQuery", "sendTCPQuery"):
+            for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
                 sender = getattr(self, method)
                 (receivedQuery, receivedResponse) = sender(query, response)
                 receivedQuery.id = query.id
                 self.assertEqual(query, receivedQuery)
                 self.assertEqual(receivedResponse, None)
-
-            (receivedQuery, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(receivedResponse, None)
-
-            (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(receivedResponse, None)
 
     def testRefused(self):
         """
@@ -338,17 +286,11 @@ class AsyncTests(object):
         expectedResponse.flags |= dns.flags.RA
         expectedResponse.set_rcode(dns.rcode.REFUSED)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
             self.assertEqual(expectedResponse, receivedResponse)
-
-        (_, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=None, caFile=self._caCert, useQueue=False)
-        self.assertEqual(expectedResponse, receivedResponse)
-
-        (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=None, caFile=self._caCert, useQueue=False)
-        self.assertEqual(expectedResponse, receivedResponse)
 
     def testDrop(self):
         """
@@ -357,16 +299,10 @@ class AsyncTests(object):
         name = 'drop.async.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertEqual(receivedResponse, None)
-
-        (_, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=None, caFile=self._caCert, useQueue=False)
-        self.assertEqual(receivedResponse, None)
-
-        (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=None, caFile=self._caCert, useQueue=False)
-        self.assertEqual(receivedResponse, None)
 
     def testCustom(self):
         """
@@ -379,17 +315,11 @@ class AsyncTests(object):
         expectedResponse.flags |= dns.flags.RA
         expectedResponse.set_rcode(dns.rcode.FORMERR)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
             self.assertEqual(expectedResponse, receivedResponse)
-
-        (_, receivedResponse) = self.sendDOTQuery(self._tlsServerPort, self._serverName, query, response=None, caFile=self._caCert, useQueue=False)
-        self.assertEqual(expectedResponse, receivedResponse)
-
-        (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=None, caFile=self._caCert, useQueue=False)
-        self.assertEqual(expectedResponse, receivedResponse)
 
     def testTruncation(self):
         """
@@ -397,59 +327,54 @@ class AsyncTests(object):
         """
         # the query is first forwarded over UDP, leading to a TC=1 answer from the
         # backend, then over TCP
-        name = 'timeout-then-accept.tc.async.tests.powerdns.com.'
-        query = dns.message.make_query(name, 'A', 'IN')
-        query.id = 42
-        expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096)
-        expectedQuery.id = 42
-        response = dns.message.make_response(query)
-        rrset = dns.rrset.from_text(name,
-                                    3600,
-                                    dns.rdataclass.IN,
-                                    dns.rdatatype.A,
-                                    '127.0.0.1')
-        response.answer.append(rrset)
 
-        # first response is a TC=1
-        tcResponse = dns.message.make_response(query)
-        tcResponse.flags |= dns.flags.TC
-        self._toResponderQueue.put(tcResponse, True, 2.0)
+        for method in ("sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
+            sender = getattr(self, method)
+            name = 'timeout-then-accept.' + method + '.tc.async.tests.powerdns.com.'
+            query = dns.message.make_query(name, 'A', 'IN')
+            query.id = 42
+            expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096)
+            expectedQuery.id = 42
+            response = dns.message.make_response(query)
+            rrset = dns.rrset.from_text(name,
+                                        3600,
+                                        dns.rdataclass.IN,
+                                        dns.rdatatype.A,
+                                        '127.0.0.1')
+            response.answer.append(rrset)
 
-        (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, caFile=self._caCert, response=response)
-        # first query, received by the responder over UDP
-        self.assertTrue(receivedQuery)
-        receivedQuery.id = expectedQuery.id
-        self.assertEqual(expectedQuery, receivedQuery)
-        self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
+            # first response is a TC=1
+            tcResponse = dns.message.make_response(query)
+            tcResponse.flags |= dns.flags.TC
+            self._toResponderQueue.put(tcResponse, True, 2.0)
 
-        # check the response
-        self.assertTrue(receivedResponse)
-        self.assertEqual(response, receivedResponse)
+            # first query, received by the responder over UDP
+            (receivedQuery, receivedResponse) = sender(query, response=response)
+            self.assertTrue(receivedQuery)
+            receivedQuery.id = expectedQuery.id
+            self.assertEqual(expectedQuery, receivedQuery)
+            self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
 
-        # check the second query, received by the responder over TCP
-        receivedQuery = self._fromResponderQueue.get(True, 2.0)
-        self.assertTrue(receivedQuery)
-        receivedQuery.id = expectedQuery.id
-        self.assertEqual(expectedQuery, receivedQuery)
-        self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
+            # check the response
+            self.assertTrue(receivedResponse)
+            self.assertEqual(response, receivedResponse)
+
+            # check the second query, received by the responder over TCP
+            receivedQuery = self._fromResponderQueue.get(True, 2.0)
+            self.assertTrue(receivedQuery)
+            receivedQuery.id = expectedQuery.id
+            self.assertEqual(expectedQuery, receivedQuery)
+            self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
 
 @unittest.skipIf('SKIP_DOH_TESTS' in os.environ, 'DNS over HTTPS tests are disabled')
 class TestAsyncFFI(DNSDistTest, AsyncTests):
-
-    _serverKey = 'server.key'
-    _serverCert = 'server.chain'
-    _serverName = 'tls.tests.dnsdist.org'
-    _caCert = 'ca.pem'
-    _tlsServerPort = pickAvailablePort()
-    _dohServerPort = pickAvailablePort()
-    _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
-
     _config_template = """
-    newServer{address="127.0.0.1:%s", pool={'', 'cache'}}
-    newServer{address="127.0.0.1:%s", pool="tcp-only", tcpOnly=true }
+    newServer{address="127.0.0.1:%d", pool={'', 'cache'}}
+    newServer{address="127.0.0.1:%d", pool="tcp-only", tcpOnly=true }
 
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/"})
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl" })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", {"/"}, {library="h2o"})
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", {"/"}, {library="nghttp2"})
 
     local ffi = require("ffi")
     local C = ffi.C
@@ -540,26 +465,18 @@ class TestAsyncFFI(DNSDistTest, AsyncTests):
     """
     _asyncResponderSocketPath = asyncResponderSocketPath
     _dnsdistSocketPath = dnsdistSocketPath
-    _config_params = ['_testServerPort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohServerPort', '_serverCert', '_serverKey', '_asyncResponderSocketPath', '_dnsdistSocketPath']
+    _config_params = ['_testServerPort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohWithH2OServerPort', '_serverCert', '_serverKey', '_dohWithNGHTTP2ServerPort', '_serverCert', '_serverKey', '_asyncResponderSocketPath', '_dnsdistSocketPath']
     _verboseMode = True
 
 @unittest.skipIf('SKIP_DOH_TESTS' in os.environ, 'DNS over HTTPS tests are disabled')
 class TestAsyncLua(DNSDistTest, AsyncTests):
-
-    _serverKey = 'server.key'
-    _serverCert = 'server.chain'
-    _serverName = 'tls.tests.dnsdist.org'
-    _caCert = 'ca.pem'
-    _tlsServerPort = pickAvailablePort()
-    _dohServerPort = pickAvailablePort()
-    _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
-
     _config_template = """
-    newServer{address="127.0.0.1:%s", pool={'', 'cache'}}
-    newServer{address="127.0.0.1:%s", pool="tcp-only", tcpOnly=true }
+    newServer{address="127.0.0.1:%d", pool={'', 'cache'}}
+    newServer{address="127.0.0.1:%d", pool="tcp-only", tcpOnly=true }
 
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/"})
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl" })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", {"/"}, {library="h2o"})
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", {"/"}, {library="nghttp2"})
 
     local filteringTagName = 'filtering'
     local filteringTagValue = 'pass'
@@ -648,5 +565,5 @@ class TestAsyncLua(DNSDistTest, AsyncTests):
     """
     _asyncResponderSocketPath = asyncResponderSocketPath
     _dnsdistSocketPath = dnsdistSocketPath
-    _config_params = ['_testServerPort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohServerPort', '_serverCert', '_serverKey', '_asyncResponderSocketPath', '_dnsdistSocketPath']
+    _config_params = ['_testServerPort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohWithH2OServerPort', '_serverCert', '_serverKey', '_dohWithNGHTTP2ServerPort', '_serverCert', '_serverKey', '_asyncResponderSocketPath', '_dnsdistSocketPath']
     _verboseMode = True

--- a/regression-tests.dnsdist/test_Async.py
+++ b/regression-tests.dnsdist/test_Async.py
@@ -96,12 +96,6 @@ class AsyncTests(object):
     _dohWithNGHTTP2BaseURL = ("https://%s:%d/" % (_serverName, _dohWithNGHTTP2ServerPort))
     _dohWithH2OBaseURL = ("https://%s:%d/" % (_serverName, _dohWithH2OServerPort))
 
-    def sendDOHWithNGHTTP2QueryWrapper(self, query, response, useQueue=True):
-        return self.sendDOHQuery(self._dohWithNGHTTP2ServerPort, self._serverName, self._dohWithNGHTTP2BaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
-
-    def sendDOHWithH2OQueryWrapper(self, query, response, useQueue=True):
-        return self.sendDOHQuery(self._dohWithH2OServerPort, self._serverName, self._dohWithH2OBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
-
     def testPass(self):
         """
         Async: Accept

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -510,12 +510,6 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
     """
     _config_params = ['_testServerPort', '_protobufServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohWithNGHTTP2ServerPort', '_serverCert', '_serverKey', '_dohWithH2OServerPort', '_serverCert', '_serverKey']
 
-    def sendDOHWithNGHTTP2QueryWrapper(self, query, response, useQueue=True):
-        return self.sendDOHQuery(self._dohWithNGHTTP2ServerPort, self._serverName, self._dohWithNGHTTP2BaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
-
-    def sendDOHWithH2OQueryWrapper(self, query, response, useQueue=True):
-        return self.sendDOHQuery(self._dohWithH2OServerPort, self._serverName, self._dohWithH2OBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
-
     def testProtobufMetaDoH(self):
         """
         Protobuf: Meta values - DoH

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -546,7 +546,6 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
             elif method == "sendDOHQueryWrapper":
                 pbMessageType = dnsmessage_pb2.PBDNSMessage.DOH
 
-            print(method)
             self.checkProtobufQuery(msg, pbMessageType, query, dns.rdataclass.IN, dns.rdatatype.A, name)
             self.assertEqual(len(msg.meta), 5)
             tags = {}

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -492,20 +492,29 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
     _serverName = 'tls.tests.dnsdist.org'
     _caCert = 'ca.pem'
     _tlsServerPort = pickAvailablePort()
-    _dohServerPort = pickAvailablePort()
-    _dohBaseURL = ("https://%s:%d/dns-query" % (_serverName, _dohServerPort))
-    _config_params = ['_testServerPort', '_protobufServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohServerPort', '_serverCert', '_serverKey']
+    _dohWithNGHTTP2ServerPort = pickAvailablePort()
+    _dohWithNGHTTP2BaseURL = ("https://%s:%d/dns-query" % (_serverName, _dohWithNGHTTP2ServerPort))
+    _dohWithH2OServerPort = pickAvailablePort()
+    _dohWithH2OBaseURL = ("https://%s:%d/dns-query" % (_serverName, _dohWithH2OServerPort))
     _config_template = """
     newServer{address="127.0.0.1:%d"}
     rl = newRemoteLogger('127.0.0.1:%d')
 
     addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { '/dns-query' }, { keepIncomingHeaders=true })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { '/dns-query' }, { keepIncomingHeaders=true, library='nghttp2' })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { '/dns-query' }, { keepIncomingHeaders=true, library='h2o' })
 
     local mytags = {path='doh-path', host='doh-host', ['query-string']='doh-query-string', scheme='doh-scheme', agent='doh-header:user-agent'}
     addAction(AllRule(), RemoteLogAction(rl, nil, {serverID='dnsdist-server-1'}, mytags))
     addResponseAction(AllRule(), RemoteLogResponseAction(rl, nil, false, {serverID='dnsdist-server-1'}, mytags))
     """
+    _config_params = ['_testServerPort', '_protobufServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohWithNGHTTP2ServerPort', '_serverCert', '_serverKey', '_dohWithH2OServerPort', '_serverCert', '_serverKey']
+
+    def sendDOHWithNGHTTP2QueryWrapper(self, query, response, useQueue=True):
+        return self.sendDOHQuery(self._dohWithNGHTTP2ServerPort, self._serverName, self._dohWithNGHTTP2BaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
+
+    def sendDOHWithH2OQueryWrapper(self, query, response, useQueue=True):
+        return self.sendDOHQuery(self._dohWithH2OServerPort, self._serverName, self._dohWithH2OBaseURL, query, response=response, caFile=self._caCert, useQueue=useQueue)
 
     def testProtobufMetaDoH(self):
         """
@@ -521,7 +530,7 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
                                     '127.0.0.1')
         response.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHQueryWrapper"):
+        for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper", "sendDOHWithH2OQueryWrapper"):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
 
@@ -543,7 +552,7 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
                 pbMessageType = dnsmessage_pb2.PBDNSMessage.TCP
             elif method == "sendDOTQueryWrapper":
                 pbMessageType = dnsmessage_pb2.PBDNSMessage.DOT
-            elif method == "sendDOHQueryWrapper":
+            elif method == "sendDOHWithNGHTTP2QueryWrapper" or method == "sendDOHWithH2OQueryWrapper":
                 pbMessageType = dnsmessage_pb2.PBDNSMessage.DOH
 
             self.checkProtobufQuery(msg, pbMessageType, query, dns.rdataclass.IN, dns.rdatatype.A, name)
@@ -554,10 +563,13 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
                 tags[entry.key] = entry.value.stringVal[0]
 
             self.assertIn('agent', tags)
-            if method == "sendDOHQueryWrapper":
+            if method == "sendDOHWithNGHTTP2QueryWrapper" or method == "sendDOHWithH2OQueryWrapper":
                 self.assertIn('PycURL', tags['agent'])
                 self.assertIn('host', tags)
-                self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohServerPort))
+                if method == "sendDOHWithNGHTTP2QueryWrapper":
+                    self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohWithNGHTTP2ServerPort))
+                elif method == "sendDOHWithH2OQueryWrapper":
+                    self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohWithH2OServerPort))
                 self.assertIn('path', tags)
                 self.assertEqual(tags['path'], '/dns-query')
                 self.assertIn('query-string', tags)
@@ -575,10 +587,13 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
                 tags[entry.key] = entry.value.stringVal[0]
 
             self.assertIn('agent', tags)
-            if method == "sendDOHQueryWrapper":
+            if method == "sendDOHWithNGHTTP2QueryWrapper" or method == "sendDOHWithH2OQueryWrapper":
                 self.assertIn('PycURL', tags['agent'])
                 self.assertIn('host', tags)
-                self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohServerPort))
+                if method == "sendDOHWithNGHTTP2QueryWrapper":
+                    self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohWithNGHTTP2ServerPort))
+                elif method == "sendDOHWithH2OQueryWrapper":
+                    self.assertEqual(tags['host'], self._serverName + ':' + str(self._dohWithH2OServerPort))
                 self.assertIn('path', tags)
                 self.assertEqual(tags['path'], '/dns-query')
                 self.assertIn('query-string', tags)

--- a/regression-tests.dnsdist/test_ProxyProtocol.py
+++ b/regression-tests.dnsdist/test_ProxyProtocol.py
@@ -531,8 +531,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
     _serverCert = 'server.chain'
     _serverName = 'tls.tests.dnsdist.org'
     _caCert = 'ca.pem'
-    _dohServerPPOutsidePort = 8443
-    _dohServerPPInsidePort = 9443
+    _dohServerPPOutsidePort = pickAvailablePort()
+    _dohServerPPInsidePort = pickAvailablePort()
     _config_params = ['_dohServerPPOutsidePort', '_serverCert', '_serverKey', '_dohServerPPInsidePort', '_serverCert', '_serverKey', '_proxyResponderPort']
 
     def testNoHeader(self):
@@ -769,9 +769,10 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
 
         wire = query.to_wire()
 
-        reverseProxyPort = 13053
+        reverseProxyPort = pickAvailablePort()
         reverseProxy = threading.Thread(name='Mock Proxy Protocol Reverse Proxy', target=MockTCPReverseProxyAddingProxyProtocol, args=[reverseProxyPort, self._dohServerPPOutsidePort])
         reverseProxy.start()
+        time.sleep(1)
 
         receivedResponse = None
         conn = self.openDOHConnection(reverseProxyPort, self._caCert, timeout=2.0)
@@ -818,7 +819,7 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
 
         wire = query.to_wire()
 
-        reverseProxyPort = 14053
+        reverseProxyPort = pickAvailablePort()
         tlsContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         tlsContext.load_cert_chain(self._serverCert, self._serverKey)
         tlsContext.set_alpn_protocols(['h2'])

--- a/regression-tests.dnsdist/test_TLSSessionResumption.py
+++ b/regression-tests.dnsdist/test_TLSSessionResumption.py
@@ -65,21 +65,24 @@ class TestNoTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
     _serverCert = 'server.chain'
     _serverName = 'tls.tests.dnsdist.org'
     _caCert = 'ca.pem'
-    _dohServerPort = pickAvailablePort()
+    _dohWithNGHTTP2ServerPort = pickAvailablePort()
+    _dohWithH2OServerPort = pickAvailablePort()
     _numberOfKeys = 0
     _config_template = """
     newServer{address="127.0.0.1:%s"}
 
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d, numberOfStoredSessions=0, sessionTickets=false })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d, numberOfStoredSessions=0, sessionTickets=false, library='nghttp2' })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d, numberOfStoredSessions=0, sessionTickets=false, library='h2o' })
     """
-    _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_numberOfKeys']
+    _config_params = ['_testServerPort', '_dohWithNGHTTP2ServerPort', '_serverCert', '_serverKey', '_numberOfKeys', '_dohWithH2OServerPort', '_serverCert', '_serverKey', '_numberOfKeys']
 
     def testNoSessionResumption(self):
         """
         Session Resumption: DoH (disabled)
         """
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/no-session.out.doh', None, allowNoTicket=True))
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/no-session.out.doh', '/tmp/no-session.out.doh', allowNoTicket=True))
+        for port in [self._dohWithNGHTTP2ServerPort, self._dohWithH2OServerPort]:
+          self.assertFalse(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/no-session.out.doh', None, allowNoTicket=True))
+          self.assertFalse(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/no-session.out.doh', '/tmp/no-session.out.doh', allowNoTicket=True))
 
 @unittest.skipIf('SKIP_DOH_TESTS' in os.environ, 'DNS over HTTPS tests are disabled')
 class TestTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
@@ -88,93 +91,96 @@ class TestTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
     _serverCert = 'server.chain'
     _serverName = 'tls.tests.dnsdist.org'
     _caCert = 'ca.pem'
-    _dohServerPort = pickAvailablePort()
+    _dohWithNGHTTP2ServerPort = pickAvailablePort()
+    _dohWithH2OServerPort = pickAvailablePort()
     _numberOfKeys = 5
     _config_template = """
     setKey("%s")
     controlSocket("127.0.0.1:%s")
     newServer{address="127.0.0.1:%s"}
 
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d, library='nghttp2' })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d, library='h2o' })
     """
-    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_numberOfKeys']
+    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_dohWithNGHTTP2ServerPort', '_serverCert', '_serverKey', '_numberOfKeys', '_dohWithH2OServerPort', '_serverCert', '_serverKey', '_numberOfKeys']
 
     def testSessionResumption(self):
         """
         Session Resumption: DoH
         """
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', None))
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
+        for (port, bindIdx) in [(self._dohWithNGHTTP2ServerPort, 0), (self._dohWithH2OServerPort, 1)]:
+          self.assertFalse(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', None))
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
-        # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
-        for _ in range(self._numberOfKeys - 1):
-            self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
+          # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
+          for _ in range(self._numberOfKeys - 1):
+            self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):rotateTicketsKey()")
 
-        # the session should be resumed and a new ticket, encrypted with the newly active key, should be stored
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
+          # the session should be resumed and a new ticket, encrypted with the newly active key, should be stored
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
-        # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
-        for _ in range(self._numberOfKeys - 1):
-            self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
+          # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
+          for _ in range(self._numberOfKeys - 1):
+            self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):rotateTicketsKey()")
 
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
-        # rotate the TLS session ticket keys several times, not keeping any key around this time!
-        for _ in range(self._numberOfKeys):
-            self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
+          # rotate the TLS session ticket keys several times, not keeping any key around this time!
+          for _ in range(self._numberOfKeys):
+            self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):rotateTicketsKey()")
 
-        # we should not be able to resume
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
+          # we should not be able to resume
+          self.assertFalse(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
-        # generate a file containing _numberOfKeys ticket keys
-        self.generateTicketKeysFile(self._numberOfKeys, '/tmp/ticketKeys.1')
-        self.generateTicketKeysFile(self._numberOfKeys - 1, '/tmp/ticketKeys.2')
-        # load all ticket keys from the file
-        self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.1')")
+          # generate a file containing _numberOfKeys ticket keys
+          self.generateTicketKeysFile(self._numberOfKeys, '/tmp/ticketKeys.1')
+          self.generateTicketKeysFile(self._numberOfKeys - 1, '/tmp/ticketKeys.2')
+          # load all ticket keys from the file
+          self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):loadTicketsKeys('/tmp/ticketKeys.1')")
 
-        # create a new session, resume it
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', None))
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
+          # create a new session, resume it
+          self.assertFalse(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', None))
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
-        # reload the same keys
-        self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.1')")
+          # reload the same keys
+          self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):loadTicketsKeys('/tmp/ticketKeys.1')")
 
-        # should still be able to resume
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
+          # should still be able to resume
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
-        # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
-        for _ in range(self._numberOfKeys - 1):
-            self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
-        # should still be able to resume
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
+          # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
+          for _ in range(self._numberOfKeys - 1):
+            self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):rotateTicketsKey()")
+          # should still be able to resume
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
-        # reload the same keys
-        self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.1')")
-        # since the last key was only present in memory, we should not be able to resume
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
+          # reload the same keys
+          self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):loadTicketsKeys('/tmp/ticketKeys.1')")
+          # since the last key was only present in memory, we should not be able to resume
+          self.assertFalse(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
-        # but now we can
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
+          # but now we can
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
-        # generate a file with only _numberOfKeys - 1 keys, so the last active one should still be around after loading that one
-        self.generateTicketKeysFile(self._numberOfKeys - 1, '/tmp/ticketKeys.2')
-        self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.2')")
-        # we should be able to resume, and the ticket should be re-encrypted with the new key (NOTE THAT we store into a new file!!)
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh.2', '/tmp/session.doh'))
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh.2', '/tmp/session.doh.2', allowNoTicket=True))
+          # generate a file with only _numberOfKeys - 1 keys, so the last active one should still be around after loading that one
+          self.generateTicketKeysFile(self._numberOfKeys - 1, '/tmp/ticketKeys.2')
+          self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):loadTicketsKeys('/tmp/ticketKeys.2')")
+          # we should be able to resume, and the ticket should be re-encrypted with the new key (NOTE THAT we store into a new file!!)
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh.2', '/tmp/session.doh'))
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh.2', '/tmp/session.doh.2', allowNoTicket=True))
 
-        # rotate all keys, we should not be able to resume
-        for _ in range(self._numberOfKeys):
-            self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh.3', '/tmp/session.doh.2'))
+          # rotate all keys, we should not be able to resume
+          for _ in range(self._numberOfKeys):
+            self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):rotateTicketsKey()")
+          self.assertFalse(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh.3', '/tmp/session.doh.2'))
 
-        # reload from file 1, the old session should resume
-        self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.1')")
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
+          # reload from file 1, the old session should resume
+          self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):loadTicketsKeys('/tmp/ticketKeys.1')")
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
-        # reload from file 2, the latest session should resume
-        self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.2')")
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh.2', '/tmp/session.doh.2', allowNoTicket=True))
+          # reload from file 2, the latest session should resume
+          self.sendConsoleCommand(f"getDOHFrontend({bindIdx}):loadTicketsKeys('/tmp/ticketKeys.2')")
+          self.assertTrue(self.checkSessionResumed('127.0.0.1', port, self._serverName, self._caCert, '/tmp/session.doh.2', '/tmp/session.doh.2', allowNoTicket=True))
 
 class TestNoTLSSessionResumptionDOT(DNSDistTLSSessionResumptionTest):
 

--- a/tasks.py
+++ b/tasks.py
@@ -458,6 +458,7 @@ def ci_dnsdist_configure(c, features):
                       --enable-systemd \
                       --prefix=/opt/dnsdist \
                       --with-gnutls \
+                      --with-h2o \
                       --with-libsodium \
                       --with-lua=luajit \
                       --with-libcap \
@@ -472,6 +473,7 @@ def ci_dnsdist_configure(c, features):
                       --without-cdb \
                       --without-ebpf \
                       --without-gnutls \
+                      --without-h2o \
                       --without-libedit \
                       --without-libsodium \
                       --without-lmdb \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This needs much more testing, do not put in production!

This PR adds support for incoming DNS over HTTPS using the `nghttp2` library instead of `h2o`. `h2o` is a very nice library but the development is now pretty much done for Fastly needs only, and there has been no release for several years and none planned. Distributions are stating to drop it, or have never packaged it to begin with requiring a special build step for our packages. It's sad that the DNS ecosystem is losing diversity, but it's time to move on.
The new code should be compatible with existing configurations without any changes, with the caveat that we no longer support HTTP/1, which was never intended for DoH anyway.
The expected benefits are:
- up-to-date library, properly packaged
- incoming proxy protocol support
- `GnuTLS` should now be supported for incoming DoH along `OpenSSL`
- hardware-accelerated TLS should now work for incoming DoH, including Linux's `kTLS` and Intel's QAT

<strike>TODO:
- more tests, especially memory leaks, load testing, GnuTLS
- write documentation
- ensure that we can still build without `nghttp2`, with or without `h2o`
- ensure that we can build without `h2o` but with `nghttp2` (probably broken right now)
- squash the commits on this branch :)</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
