### PR TITLE
dnsdist: Wait until dnsdist is listening on the requested port in the tests

### DIFF
--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -73,6 +73,8 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     _checkConfigExpectedOutput = None
     _verboseMode = False
     _skipListeningOnCL = False
+    _alternateListeningAddr = None
+    _alternateListeningPort = None
     _backgroundThreads = {}
     _UDPResponder = None
     _TCPResponder = None
@@ -146,7 +148,10 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         with open(logFile, 'w') as fdLog:
           cls._dnsdist = subprocess.Popen(dnsdistcmd, close_fds=True, stdout=fdLog, stderr=fdLog)
 
-        cls.waitForTCPSocket(cls._dnsDistListeningAddr, cls._dnsDistPort);
+        if cls._alternateListeningAddr and cls._alternateListeningPort:
+            cls.waitForTCPSocket(cls._alternateListeningAddr, cls._alternateListeningPort)
+        else:
+            cls.waitForTCPSocket(cls._dnsDistListeningAddr, cls._dnsDistPort)
 
         if cls._dnsdist.poll() is not None:
             print(f"\n*** startDNSDist log for {logFile} ***")

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -58,7 +58,6 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     _toResponderQueue = Queue()
     _fromResponderQueue = Queue()
     _queueTimeout = 1
-    _dnsdistStartupDelay = 2.0
     _dnsdist = None
     _responsesCounter = {}
     _config_template = """

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -41,6 +41,15 @@ class APITestsBase(DNSDistTest):
                         'doh-query-pipe-full', 'doh-response-pipe-full', 'proxy-protocol-invalid', 'tcp-listen-overflows',
                         'outgoing-doh-query-pipe-full', 'tcp-query-pipe-full', 'tcp-cross-protocol-query-pipe-full',
                         'tcp-cross-protocol-response-pipe-full']
+    _verboseMode = True
+
+    @classmethod
+    def setUpClass(cls):
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+        cls.waitForTCPSocket('127.0.0.1', cls._webServerPort)
+        print("Launching tests..")
 
 class TestAPIBasics(APITestsBase):
 

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -777,6 +777,14 @@ class TestWebConcurrentConnections(APITestsBase):
     setWebserverConfig({password="%s", apiKey="%s", maxConcurrentConnections=%d})
     """
 
+    @classmethod
+    def setUpClass(cls):
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+        # do no check if the web server socket is up, because this
+        # might mess up the concurrent connections counter
+
     def testConcurrentConnections(self):
         """
         Web: Concurrent connections

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -425,6 +425,8 @@ class TestAdvancedGetLocalAddressOnNonDefaultLoopbackBind(DNSDistTest):
     _config_params = ['_testServerPort', '_dnsDistPort']
     _acl = ['127.0.0.1/32']
     _skipListeningOnCL = True
+    _alternateListeningAddr = '127.0.1.19'
+    _alternateListeningPort = DNSDistTest._dnsDistPort
 
     def testAdvancedCheckSourceAddrOnNonDefaultLoopbackBind(self):
         """

--- a/regression-tests.dnsdist/test_DNSCrypt.py
+++ b/regression-tests.dnsdist/test_DNSCrypt.py
@@ -29,8 +29,6 @@ class DNSCryptTest(DNSDistTest):
     _resolverCertificateValidFrom = int(time.time() - 60)
     _resolverCertificateValidUntil = int(time.time() + 7200)
 
-    _dnsdistStartupDelay = 10
-
     def doDNSCryptQuery(self, client, query, response, tcp):
         self._toResponderQueue.put(response)
         data = client.query(query.to_wire(), tcp=tcp)

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -1173,6 +1173,8 @@ class TestDOHFrontendLimits(DNSDistDOHTest):
     addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, { maxConcurrentTCPConnections=%d })
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_maxTCPConnsPerDOHFrontend']
+    _alternateListeningAddr = '127.0.0.1'
+    _alternateListeningPort = _dohServerPort
 
     def testTCPConnsPerDOHFrontend(self):
         """

--- a/regression-tests.dnsdist/test_Metrics.py
+++ b/regression-tests.dnsdist/test_Metrics.py
@@ -39,6 +39,14 @@ class TestRuleMetrics(DNSDistTest):
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_params = ['_tlsServerPort', '_serverCert', '_serverKey', '_dohServerPort', '_serverCert', '_serverKey', '_testServerPort', '_webServerPort', '_webServerAPIKeyHashed']
 
+    @classmethod
+    def setUpClass(cls):
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+        cls.waitForTCPSocket('127.0.0.1', cls._webServerPort)
+        print("Launching tests..")
+
     def getMetric(self, name):
         headers = {'x-api-key': self._webServerAPIKey}
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost'

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -393,6 +393,8 @@ class TestTLSFrontendLimits(DNSDistTest):
     addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl", maxConcurrentTCPConnections=%d })
     """
     _config_params = ['_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_maxTCPConnsPerTLSFrontend']
+    _alternateListeningAddr = '127.0.0.1'
+    _alternateListeningPort = _tlsServerPort
 
     def testTCPConnsPerTLSFrontend(self):
         """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Some of the tests need the API port to be available in addition to the regular Do53 ones. In addition some of the tests are not using the default listening address or port, so we need to wait for the correct one to come up.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
