### PR TITLE
WIP: Report Version when Testing Repositories

### DIFF
--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -151,8 +151,6 @@ def write_release_files (release):
         write_dockerfile('el', '8', release)
         write_dockerfile('debian', 'buster', release)
         write_list_file('debian', 'buster', release)
-        write_dockerfile('ubuntu', 'bionic', release)
-        write_list_file('ubuntu', 'bionic', release)
         write_dockerfile('ubuntu', 'focal', release)
         write_list_file('ubuntu', 'focal', release)
 
@@ -165,6 +163,12 @@ def write_release_files (release):
                    'dnsdist-16', 'dnsdist-17', 'dnsdist-18', 'dnsdist-master']:
         write_dockerfile('debian', 'bullseye', release)
         write_list_file('debian', 'bullseye', release)
+
+    if release in ['auth-44', 'auth-45', 'auth-46', 'auth-47', 'auth-master',
+                   'rec-45', 'rec-46', 'rec-47', 'rec-48', 'rec-master',
+                   'dnsdist-15', 'dnsdist-16', 'dnsdist-17', 'dnsdist-master']:
+        write_dockerfile('ubuntu', 'bionic', release)
+        write_list_file('ubuntu', 'bionic', release)
 
     if release in ['auth-46', 'auth-47', 'auth-master',
                    'rec-46', 'rec-47', 'rec-48', 'rec-master',

--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -25,7 +25,7 @@ from jinja2 import Environment, FileSystemLoader
 
 # Globals
 
-g_version = '0.0.1'
+g_version = '1.0.0'
 
 g_verbose = False
 
@@ -258,8 +258,9 @@ def test_release (release):
             failed_builds.append((str(df), returncode))
         else:
             (returncode, return_version) = run(tag)
-            # for some reason 99 is returned on  `cmd --version` :shrug:
-            # (not sure if this is true since using `stdout=PIPE...`)
+            # for some reason 99 is returned on `cmd --version` :shrug:
+            # (not sure if this is true since using `stdout=PIPE...`
+            #  (commit bda2db33768c103294381f539ad30238412491f7))
             if returncode != 0 and returncode != 99:
                 failed_runs.append((tag, returncode))
             if return_version:


### PR DESCRIPTION
https://github.com/PowerDNS/pdns/pull/12668 needs to be merged first and then this PR rebased on `master`

### Short description

This adds a minor feature to the repo test script where it reports the versions of the packages that were tested.

### Example Output

```
$ ./generate-repo-files.py --test rec-48
=== testing rec-48 ===
Building Docker image using Dockerfile.rec-48.centos-7...
Running Docker container tagged rec-48.centos-7...
Building Docker image using Dockerfile.rec-48.debian-bullseye...
Running Docker container tagged rec-48.debian-bullseye...
Building Docker image using Dockerfile.rec-48.debian-buster...
Running Docker container tagged rec-48.debian-buster...
Building Docker image using Dockerfile.rec-48.el-8...
Running Docker container tagged rec-48.el-8...
Building Docker image using Dockerfile.rec-48.el-9...
Running Docker container tagged rec-48.el-9...
Building Docker image using Dockerfile.rec-48.ubuntu-bionic...
Running Docker container tagged rec-48.ubuntu-bionic...
Building Docker image using Dockerfile.rec-48.ubuntu-focal...
Running Docker container tagged rec-48.ubuntu-focal...
Building Docker image using Dockerfile.rec-48.ubuntu-jammy...
Running Docker container tagged rec-48.ubuntu-jammy...
Test done.
- returned versions:
    - rec-48.centos-7: 4.8.3
    - rec-48.debian-bullseye: 4.8.3
    - rec-48.debian-buster: 4.8.3
    - rec-48.el-8: 4.8.3
    - rec-48.el-9: 4.8.3
    - rec-48.ubuntu-bionic: 4.8.3
    - rec-48.ubuntu-focal: 4.8.3
    - rec-48.ubuntu-jammy: 4.8.3
```

### Checklist

I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

