### PR TITLE
dnsdist: Fix the documentation of the `StatNode` object

### DIFF
--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -780,10 +780,10 @@ void setupLuaInspection(LuaContext& luaCtx)
   luaCtx.writeFunction("getRespRing", getRespRing);
 
   /* StatNode */
-  luaCtx.registerFunction<StatNode, unsigned int()>("numChildren",
-                                                   [](StatNode& sn) -> unsigned int {
-                                                     return sn.children.size();
-                                                   } );
+  luaCtx.registerFunction<unsigned int(StatNode::*)()const>("numChildren",
+                                                            [](const StatNode& sn) -> unsigned int {
+                                                              return sn.children.size();
+                                                            } );
   luaCtx.registerMember("fullname", &StatNode::fullname);
   luaCtx.registerMember("labelsCount", &StatNode::labelsCount);
   luaCtx.registerMember("servfails", &StatNode::Stat::servfails);

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1549,7 +1549,7 @@ faster than the existing rules.
     .. versionchanged:: 1.7.0
       This visitor function can now optionally return an additional string which will be set as the ``reason`` for the dynamic block.
 
-    Set a Lua visitor function that will be called for each label of every domain seen in queries and responses. The function receives a `StatNode` object representing the stats of the parent, a second one with the stats of the current label and one with the stats of the current node plus all its children.
+    Set a Lua visitor function that will be called for each label of every domain seen in queries and responses. The function receives a :class:`StatNode` object representing the stats of the parent, a :class:`StatNodeStats` one with the stats of the current label and a second :class:`StatNodeStats` with the stats of the current node plus all its children.
     Note that this function will not be called if a FFI version has been set using :meth:`DynBlockRulesGroup:setSuffixMatchRuleFFI`
     If the function returns true, the current label will be blocked according to the `seconds`, `reason`, `blockingTime` and `action` parameters. Since 1.7.0, the function can return an additional string, in addition to the boolean, which will be set as the ``reason`` for the dynamic block.
     Selected domains can be excluded from this processing using the :meth:`DynBlockRulesGroup:excludeDomains` method.
@@ -1623,15 +1623,7 @@ StatNode
 
 .. class:: StatNode
 
-  Represent metrics about a given node, for the visitor functions used with :meth:`DynBlockRulesGroup:setSuffixMatchRule` and :meth:`DynBlockRulesGroup:setSuffixMatchRuleFFI`. Note that some nodes includes the metrics for their children as well as their own.
-
-  .. attribute:: StatNode.bytes
-
-    The number of bytes for all responses returned for that node.
-
-  .. attribute:: StatNode.drops
-
-    The number of drops for that node.
+  Represent a given node, for the visitor functions used with :meth:`DynBlockRulesGroup:setSuffixMatchRule` and :meth:`DynBlockRulesGroup:setSuffixMatchRuleFFI`.
 
   .. attribute:: StatNode.fullname
 
@@ -1641,25 +1633,37 @@ StatNode
 
     The number of labels in that node, for example 3 for 'www.powerdns.com'.
 
-  .. attribute:: StatNode.noerrors
-
-    The number of No Error answers returned for that node.
-
-  .. attribute:: StatNode.nxdomains
-
-    The number of NXDomain answers returned for that node.
-
-  .. attribute:: StatNode.queries
-
-    The number of queries for that node.
-
-  .. attribute:: StatNode.servfails
-
-    The number of Server Failure answers returned for that node.
-
   .. method:: StatNode:numChildren
 
     The number of children of that node.
+
+.. class:: StatNodeStats
+
+  Represent the metrics for a given node, for the visitor functions used with :meth:`DynBlockRulesGroup:setSuffixMatchRule` and :meth:`DynBlockRulesGroup:setSuffixMatchRuleFFI`.
+
+  .. attribute:: StatNodeStats.bytes
+
+    The number of bytes for all responses returned for that node.
+
+  .. attribute:: StatNodeStats.drops
+
+    The number of drops for that node.
+
+  .. attribute:: StatNodeStats.noerrors
+
+    The number of No Error answers returned for that node.
+
+  .. attribute:: StatNodeStats.nxdomains
+
+    The number of NXDomain answers returned for that node.
+
+  .. attribute:: StatNodeStats.queries
+
+    The number of queries for that node.
+
+  .. attribute:: StatNodeStats.servfails
+
+    The number of Server Failure answers returned for that node.
 
 SuffixMatchNode
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We actually have two different objects, one representing a node, `StatNode`, and a second one representing the metrics of a node, `StatNodeStats` (`StatNode::Stat` in the actual C++ code).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
