### PR TITLE
rec: Unbreak FreeBSD mthread stack allocation

### DIFF
--- a/pdns/recursordist/lazy_allocator.hh
+++ b/pdns/recursordist/lazy_allocator.hh
@@ -28,8 +28,10 @@
 #include <unistd.h>
 
 // On OpenBSD mem used as stack should be marked MAP_STACK
-#if !defined(MAP_STACK)
-#define MAP_STACK 0
+#ifdef __OpenBSD__
+#define PDNS_MAP_STACK MAP_STACK
+#else
+#define PDNS_MAP_STACK 0
 #endif
 
 template <typename T>
@@ -88,7 +90,7 @@ struct lazy_allocator
 #else
     const int protection = PROT_NONE;
 #endif
-    void* p = mmap(nullptr, allocatedSize, protection, MAP_PRIVATE | MAP_ANON | MAP_STACK, -1, 0);
+    void* p = mmap(nullptr, allocatedSize, protection, MAP_PRIVATE | MAP_ANON | PDNS_MAP_STACK, -1, 0);
     if (p == MAP_FAILED) {
       throw std::bad_alloc();
     }


### PR DESCRIPTION
On FreeBSD, MAP_STACK has a completely different meaning compared to OpenBSD. So only use MAP_STACK on OpenBSD.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
