### PR TITLE
dnsdist: Wait a bit longer for the process to exit before killing it

### DIFF
--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -174,7 +174,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             return
         try:
             p.terminate()
-            for count in range(10):
+            for count in range(20):
                 x = p.poll()
                 if x is not None:
                     break


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This prevents a long list of
```
kill... <Popen: returncode: None args: ['../pdns/dnsdistdist/dnsdist', '--supervised...>
```
lines when running with TSAN-enabled.
In my tests it did not seem to really slow the build: roughly 3% slower but that might even be in the error margin for these tests.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
