### PR TITLE
Add reminders for 53/tcp rules in the NOTRACK example rules in pdns-rec docs

### DIFF
--- a/pdns/recursordist/docs/performance.rst
+++ b/pdns/recursordist/docs/performance.rst
@@ -74,6 +74,7 @@ For high load operation (thousands of queries/second), It is advised to either t
 Sample Linux command lines would be::
 
     ## IPv4
+    ## NOTRACK rules for 53/udp, keep in mind that you also need your regular rules for 53/tcp
     iptables -t raw -I OUTPUT -p udp --dport 53 -j CT --notrack
     iptables -t raw -I OUTPUT -p udp --sport 53 -j CT --notrack
     iptables -t raw -I PREROUTING -p udp --dport 53 -j CT --notrack
@@ -84,6 +85,7 @@ Sample Linux command lines would be::
     iptables -I OUTPUT -p udp --sport 53 -j ACCEPT
 
     ## IPv6
+    ## NOTRACK rules for 53/udp, keep in mind that you also need your regular rules for 53/tcp
     ip6tables -t raw -I OUTPUT -p udp --dport 53 -j CT --notrack
     ip6tables -t raw -I OUTPUT -p udp --sport 53 -j CT --notrack
     ip6tables -t raw -I PREROUTING -p udp --sport 53 -j CT --notrack
@@ -97,6 +99,7 @@ When using FirewallD (Centos 7+ / Red Hat 7+ / Fedora 21+), connection tracking 
 The settings can be made permanent by using the ``--permanent`` flag::
 
     ## IPv4
+    ## NOTRACK rules for 53/udp, keep in mind that you also need your regular rules for 53/tcp
     firewall-cmd --direct --add-rule ipv4 raw OUTPUT 0 -p udp --dport 53 -j CT --notrack
     firewall-cmd --direct --add-rule ipv4 raw OUTPUT 0 -p udp --sport 53 -j CT --notrack
     firewall-cmd --direct --add-rule ipv4 raw PREROUTING 0 -p udp --dport 53 -j CT --notrack
@@ -107,6 +110,7 @@ The settings can be made permanent by using the ``--permanent`` flag::
     firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p udp --sport 53 -j ACCEPT
 
     ## IPv6
+    ## NOTRACK rules for 53/udp, keep in mind that you also need your regular rules for 53/tcp
     firewall-cmd --direct --add-rule ipv6 raw OUTPUT 0 -p udp --dport 53 -j CT --notrack
     firewall-cmd --direct --add-rule ipv6 raw OUTPUT 0 -p udp --sport 53 -j CT --notrack
     firewall-cmd --direct --add-rule ipv6 raw PREROUTING 0 -p udp --dport 53 -j CT --notrack


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The performance section of the PowerDNS Recursor documentation has example firewall rules for skipping conntrack for 53/udp, but it may be tempting for the reader to assume that the firewall rules shown there would be all the rules they need.

This adds a reminder (right in the context of the example rules) that they still need their regular firewall rules for 53/tcp.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
