### PR TITLE
Fixes a typo in pdnsutil clear-zone help output

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3179,7 +3179,7 @@ try
   }
   else if (cmds.at(0) == "clear-zone") {
     if(cmds.size() != 2) {
-      cerr<<"Syntax: pdnsutil edit-zone ZONE"<<endl;
+      cerr<<"Syntax: pdnsutil clear-zone ZONE"<<endl;
       return 0;
     }
     if (cmds.at(1) == ".")


### PR DESCRIPTION
### Short description
Fixes a typo in pdnsutil clear-zone help output

from
```bash
$ pdnsutil clear-zone foo bar
Syntax: pdnsutil edit-zone ZONE
```

to
```bash
$ pdnsutil clear-zone foo bar
Syntax: pdnsutil clear-zone ZONE
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
