### PR TITLE
Cleanup rcode enums: base one is 8 bit unsigned, extended one 16 bit unsigned

### DIFF
--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -71,8 +71,9 @@ static const std::array<std::string, 10> rcodes_short_s =  {
 };
 
 std::string RCode::to_s(uint8_t rcode) {
-  if (rcode > 0xF)
+  if (rcode > 0xF) {
     return std::string("ErrOutOfRange");
+  }
   return ERCode::to_s(rcode);
 }
 
@@ -83,9 +84,10 @@ std::string RCode::to_short_s(uint8_t rcode) {
   return rcodes_short_s.at(rcode);
 }
 
-std::string ERCode::to_s(uint8_t rcode) {
-  if (rcode > RCode::rcodes_s.size()-1)
+std::string ERCode::to_s(uint16_t rcode) {
+  if (rcode >= RCode::rcodes_s.size()) {
     return std::string("Err#")+std::to_string(rcode);
+  }
   return RCode::rcodes_s.at(rcode);
 }
 

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -32,7 +32,7 @@ struct DNSRecord;
 class RCode
 {
 public:
-  enum rcodes_ { NoError=0, FormErr=1, ServFail=2, NXDomain=3, NotImp=4, Refused=5, YXDomain=6, YXRRSet=7, NXRRSet=8, NotAuth=9, NotZone=10};
+  enum rcodes_ : uint8_t { NoError=0, FormErr=1, ServFail=2, NXDomain=3, NotImp=4, Refused=5, YXDomain=6, YXRRSet=7, NXRRSet=8, NotAuth=9, NotZone=10};
   static std::string to_s(uint8_t rcode);
   static std::string to_short_s(uint8_t rcode);
   const static std::array<std::string, 24> rcodes_s;
@@ -41,8 +41,8 @@ public:
 class ERCode
 {
 public:
-  enum rcodes_ { BADVERS=16, BADSIG=16, BADKEY=17, BADTIME=18, BADMODE=19, BADNAME=20, BADALG=21, BADTRUNC=22, BADCOOKIE=23 };
-  static std::string to_s(uint8_t rcode);
+  enum rcodes_ : uint16_t { BADVERS=16, BADSIG=16, BADKEY=17, BADTIME=18, BADMODE=19, BADNAME=20, BADALG=21, BADTRUNC=22, BADCOOKIE=23 };
+  static std::string to_s(uint16_t rcode);
 };
 
 class Opcode


### PR DESCRIPTION
I hope it does not introduce subtle signed/unsigned issues as the original enum had type `int`.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
