### PR TITLE
auth: calm down the communicator loop

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -210,7 +210,7 @@ static void declareArguments()
   ::arg().set("only-notify", "Only send AXFR NOTIFY to these IP addresses or netmasks") = "0.0.0.0/0,::/0";
   ::arg().set("also-notify", "When notifying a zone, also notify these nameservers") = "";
   ::arg().set("allow-notify-from", "Allow AXFR NOTIFY from these IP ranges. If empty, drop all incoming notifies.") = "0.0.0.0/0,::/0";
-  ::arg().set("slave-cycle-interval", "Schedule slave freshness checks once every .. seconds") = "60";
+  ::arg().set("slave-cycle-interval", "Schedule slave freshness checks once every .. seconds") = "";
   ::arg().set("xfr-cycle-interval", "Schedule primary/secondary SOA freshness checks once every .. seconds") = "60";
   ::arg().set("secondary-check-signature-freshness", "Check signatures in SOA freshness check. Sets DO flag on SOA queries. Outside some very problematic scenarios, say yes here.") = "yes";
 
@@ -1241,6 +1241,8 @@ int main(int argc, char** argv)
       ::arg().set("allow-unsigned-autoprimary") = "yes";
     if (!::arg().isEmpty("domain-metadata-cache-ttl"))
       ::arg().set("zone-metadata-cache-ttl") = ::arg()["domain-metadata-cache-ttl"];
+    if (!::arg().isEmpty("slave-cycle-interval"))
+      ::arg().set("xfr-cycle-interval") = ::arg()["slave-cycle-interval"];
 
     // this mirroring back is on purpose, so that config dumps reflect the actual setting on both names
     if (::arg().mustDo("primary"))
@@ -1254,6 +1256,7 @@ int main(int argc, char** argv)
     if (::arg().mustDo("allow-unsigned-autoprimary"))
       ::arg().set("allow-unsigned-supermaster") = "yes";
     ::arg().set("domain-metadata-cache-ttl") = ::arg()["zone-metadata-cache-ttl"];
+    ::arg().set("slave-cycle-interval") = ::arg()["xfr-cycle-interval"];
 
     g_log.setLoglevel((Logger::Urgency)(::arg().asNum("loglevel")));
     g_log.disableSyslog(::arg().mustDo("disable-syslog"));

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -118,22 +118,22 @@ void CommunicatorClass::mainloop()
   try {
     setThreadName("pdns/comm-main");
     signal(SIGPIPE,SIG_IGN);
-    g_log<<Logger::Error<<"Primary/secondary communicator launching"<<endl;
-    PacketHandler P;
-    d_tickinterval=min(::arg().asNum("slave-cycle-interval"), ::arg().asNum("xfr-cycle-interval"));
-    makeNotifySockets();
+    g_log << Logger::Warning << "Primary/secondary communicator launching" << endl;
+
+    d_tickinterval = ::arg().asNum("xfr-cycle-interval");
 
     int rc;
-    time_t next, tick;
+    time_t next;
+    PacketHandler P;
+
+    makeNotifySockets();
 
     for(;;) {
       slaveRefresh(&P);
       masterUpdateCheck(&P);
-      tick=doNotifications(&P); // this processes any notification acknowledgements and actually send out our own notifications
-      
-      tick = min (tick, d_tickinterval); 
-      
-      next=time(nullptr)+tick;
+      doNotifications(&P); // this processes any notification acknowledgements and actually send out our own notifications
+
+      next = time(nullptr) + d_tickinterval;
 
       while(time(nullptr) < next) {
         rc=d_any_sem.tryWait();
@@ -156,7 +156,7 @@ void CommunicatorClass::mainloop()
           }
           break; // something happened
         }
-        // this gets executed at least once every second
+        // this gets executed about once per second
         doNotifications(&P);
       }
     }
@@ -176,4 +176,3 @@ void CommunicatorClass::mainloop()
     _exit(1);
   }
 }
-

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -366,5 +366,4 @@ void CommunicatorClass::makeNotifySockets()
 void CommunicatorClass::notify(const DNSName &domain, const string &ip)
 {
   d_nq.add(domain, ip);
-  d_any_sem.post();
 }


### PR DESCRIPTION
### Short description
Kicking the communicator loop for notifies is counter productive since the delay caused by the extra slaveRefresh() and masterUpdateCheck() calls is fare bigger than the time we gain on average. Since #7790 doNotifications() is already called about once every second.

The increased freshness check frequentie is also resulting in a significant load increase. Especially in larger setups when catalog zones are in use.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
