### PR TITLE
rec: Also set pdns-distributes-queries for bulk tests.

### DIFF
--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -31,7 +31,7 @@ rm -f recursor.pid pdns_recursor.pid
 <measurement><name>system CPU seconds</name><value>%S</value></measurement>
 <measurement><name>wallclock seconds</name><value>%e</value></measurement>
 <measurement><name>%% CPU used</name><value>%P</value></measurement>
-'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address="0.0.0.0${QLA6}" --threads=$threads --record-cache-shards=$shards --refresh-on-ttl-perc=10 --dnssec=validate --reuseport=no > recursor.log 2>&1 &
+'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address="0.0.0.0${QLA6}" --threads=$threads --record-cache-shards=$shards --refresh-on-ttl-perc=10 --dnssec=validate --pdns-distributes-queries --reuseport=no > recursor.log 2>&1 &
 sleep 3
 if [ ! -e pdns_recursor.pid ]; then
         cat recursor.log


### PR DESCRIPTION
Large imbalance seen without.

We might have to re-evaluate the changed default for `pdns-distributes-queries` and `resueport`.

BTW: I see even greater imbalance in runs before the shared packet cache was committed:
https://builder.powerdns.com/#/builders/119/builds/1714
```
Mar 30 20:16:00 msg="PowerDNS Recursor itself will distribute queries over threads" subsystem="config" level="0" prio="Notice" tid="0" ts="1680200160.814"
...
Mar 30 20:31:16 msg="Queries handled by thread" subsystem="stats" level="0" prio="Info" tid="0" ts="1680201076.890" count="0" thread="0"
Mar 30 20:31:16 msg="Queries handled by thread" subsystem="stats" level="0" prio="Info" tid="0" ts="1680201076.890" count="0" thread="1"
Mar 30 20:31:16 msg="Queries handled by thread" subsystem="stats" level="0" prio="Info" tid="0" ts="1680201076.890" count="0" thread="2"
Mar 30 20:31:16 msg="Queries handled by thread" subsystem="stats" level="0" prio="Info" tid="0" ts="1680201076.891" count="0" thread="3"
Mar 30 20:31:16 msg="Queries handled by thread" subsystem="stats" level="0" prio="Info" tid="0" ts="1680201076.891" count="0" thread="4"
Mar 30 20:31:16 msg="Queries handled by thread" subsystem="stats" level="0" prio="Info" tid="0" ts="1680201076.892" count="0" thread="5"
Mar 30 20:31:16 msg="Queries handled by thread" subsystem="stats" level="0" prio="Info" tid="0" ts="1680201076.892" count="1500000" thread="6"
Mar 30 20:31:16 msg="Queries handled by thread" subsystem="stats" level="0" prio="Info" tid="0" ts="1680201076.892" count="0" thread="7"
```
I'm puzzled... as the runs with IPv6=0 do show proper balance, but the ones with IPv6=1 not.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
