### PR TITLE
auth LMDB: handle duplicate domain existence consistently

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -121,6 +121,17 @@ Defaults to 100 on 32 bit systems, and 16000 on 64 bit systems.
 Instead of deleting items from the database, flag them as deleted in the item's `Lightning Stream <https://doc.powerdns.com/lightningstream>`_ header.
 Only enable this if you are using Lightning Stream.
 
+``lmdb-lightning-stream``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  .. versionadded:: 4.8.0
+
+Run in Lightning Stream compatible mode. This:
+
+* forces ``flag-deleted`` on
+* forces ``random-ids`` on
+* handles duplicate entries in databases that can result from domains being added on two Lightning Stream nodes at the same time
+
 LMDB Structure
 --------------
 

--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -118,6 +118,9 @@ Defaults to 100 on 32 bit systems, and 16000 on 64 bit systems.
 
   .. versionadded:: 4.8.0
 
+-  Boolean
+-  Default: no
+
 Instead of deleting items from the database, flag them as deleted in the item's `Lightning Stream <https://doc.powerdns.com/lightningstream>`_ header.
 Only enable this if you are using Lightning Stream.
 
@@ -125,6 +128,9 @@ Only enable this if you are using Lightning Stream.
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
   .. versionadded:: 4.8.0
+
+-  Boolean
+-  Default: no
 
 Run in Lightning Stream compatible mode. This:
 

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -74,7 +74,6 @@ namespace LMDBLS {
     return lsh->getTimestamp();
   }
   bool s_flag_deleted{false};
-  bool s_handle_dups{false};
 }
 
 #endif /* #ifndef DNSDIST */

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -68,6 +68,11 @@ namespace LMDBLS {
     return (lsh->d_flags & LS_FLAG_DELETED) != 0;
   }
 
+  uint64_t LSgetTimestamp(std::string_view val) {
+    const LSheader* lsh = LSassertFixedHeaderSize(val);
+
+    return lsh->getTimestamp();
+  }
   bool s_flag_deleted{false};
   bool s_handle_dups{false};
 }

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -69,6 +69,7 @@ namespace LMDBLS {
   }
 
   bool s_flag_deleted{false};
+  bool s_handle_dups{false};
 }
 
 #endif /* #ifndef DNSDIST */

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -140,13 +140,16 @@ namespace LMDBLS {
       return std::string((char*)this, sizeof(*this)) + std::string(ntohs(d_numextra)*8, '\0');
     }
 
-
+    uint64_t getTimestamp() const {
+      return _LMDB_SAFE_BSWAP64MAYBE(d_timestamp);
+    }
   };
 
   static_assert(sizeof(LSheader)==24, "LSheader size is wrong");
 
   const size_t LS_MIN_HEADER_SIZE = sizeof(LSheader);
   const size_t LS_BLOCK_SIZE = 8;
+  const size_t LS_TIMESTAMP_OFFSET = 0;
   const size_t LS_NUMEXTRA_OFFSET = 22;
   const uint8_t LS_FLAG_DELETED = 0x01;
 
@@ -154,6 +157,7 @@ namespace LMDBLS {
   size_t LScheckHeaderAndGetSize(std::string_view val, size_t datasize=0);
   size_t LScheckHeaderAndGetSize(const MDBOutVal *val, size_t datasize=0);
   bool LSisDeleted(std::string_view val);
+  uint64_t LSgetTimestamp(std::string_view val);
 
   extern bool s_flag_deleted;
   extern bool s_handle_dups;

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -156,6 +156,7 @@ namespace LMDBLS {
   bool LSisDeleted(std::string_view val);
 
   extern bool s_flag_deleted;
+  extern bool s_handle_dups;
 }
 
 #undef _LMDB_SAFE_BSWAP64MAYBE

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -160,7 +160,6 @@ namespace LMDBLS {
   uint64_t LSgetTimestamp(std::string_view val);
 
   extern bool s_flag_deleted;
-  extern bool s_handle_dups;
 }
 
 #undef _LMDB_SAFE_BSWAP64MAYBE

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -149,7 +149,6 @@ namespace LMDBLS {
 
   const size_t LS_MIN_HEADER_SIZE = sizeof(LSheader);
   const size_t LS_BLOCK_SIZE = 8;
-  const size_t LS_TIMESTAMP_OFFSET = 0;
   const size_t LS_NUMEXTRA_OFFSET = 22;
   const uint8_t LS_FLAG_DELETED = 0x01;
 

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -310,6 +310,7 @@ public:
       // auto range = prefix_range<N>(key);
       LMDBIDvec ids;
 
+      // because we know we only want one item, pass onlyOldest=true to consistently get the same one out of a set of duplicates
       get_multi<N>(key, ids, true);
 
       if (ids.size() == 0) {

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -676,16 +676,17 @@ public:
           uint64_t ts = LMDBLS::LSgetTimestamp(id.getNoStripHeader<string_view>());
           uint32_t __id = _id.getNoStripHeader<uint32_t>();
 
-          if (ts < oldestts) {
-            oldestts = ts;
-            oldestid = __id;
-          }
-          ids.push_back(__id);
-        }
+          if (onlyOldest) {
+            if (ts < oldestts) {
+              oldestts = ts;
+              oldestid = __id;
 
-        if (onlyOldest && ids.size() > 1) {
-          ids.clear();
-          ids.push_back(oldestid);
+              ids.clear();
+              ids.push_back(oldestid);
+            }
+          } else {
+            ids.push_back(__id);
+          }
         }
 
         rc = cursor.get(out, id, MDB_NEXT);

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -164,6 +164,7 @@ struct LMDBIndexOps
 
     MDBOutVal currentvalue;
 
+    // check if the entry already exists, so we don't uselessly bump the timestamp
     if (txn->get(d_idx, combined, currentvalue) == MDB_NOTFOUND) {
       txn->put(d_idx, combined, empty, flags);
     }

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -162,7 +162,11 @@ struct LMDBIndexOps
     auto scombined = makeCombinedKey(keyConv(d_parent->getMember(t)), id);
     MDBInVal combined(scombined);
 
-    txn->put(d_idx, combined, empty, flags);
+    MDBOutVal currentvalue;
+
+    if (txn->get(d_idx, combined, currentvalue) == MDB_NOTFOUND) {
+      txn->put(d_idx, combined, empty, flags);
+    }
   }
 
   void del(MDBRWTransaction& txn, const Class& t, uint32_t id)

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1680,7 +1680,10 @@ void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::
       DomainInfo di;
 
       // this get grabs the oldest item if there are duplicates
-      if (!(di.id = txn.get<0>(zone, di))) {
+      di.id = txn.get<0>(zone, di);
+
+      if (di.id == 0) {
+        // .get actually found nothing for us
         continue;
       }
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -666,12 +666,12 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
   }
 
   LMDBLS::s_flag_deleted = mustDo("flag-deleted");
-  LMDBLS::s_handle_dups = false;
+  d_handle_dups = false;
 
   if (mustDo("lightning-stream")) {
     d_random_ids = true;
+    d_handle_dups = true;
     LMDBLS::s_flag_deleted = true;
-    LMDBLS::s_handle_dups = true;
   }
 
   bool opened = false;

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1661,9 +1661,8 @@ bool LMDBBackend::createDomain(const DNSName& domain, const DomainInfo::DomainKi
 
 void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow)
 {
+  auto txn = d_tdomains->getROTransaction();
   if (d_handle_dups) {
-    auto txn = d_tdomains->getROTransaction();
-
     map<DNSName, DomainInfo> zonemap;
     set<DNSName> dups;
 
@@ -1695,7 +1694,6 @@ void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::
     }
   }
   else {
-    auto txn = d_tdomains->getROTransaction();
     for (auto iter = txn.begin(); iter != txn.end(); ++iter) {
       DomainInfo di = *iter;
       di.id = iter.getID();

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "ext/lmdb-safe/lmdb-safe.hh"
 #include <lmdb.h>
 #include <utility>
 #ifdef HAVE_CONFIG_H
@@ -665,6 +666,13 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
   }
 
   LMDBLS::s_flag_deleted = mustDo("flag-deleted");
+  LMDBLS::s_handle_dups = false;
+
+  if (mustDo("lightning-stream")) {
+    d_random_ids = true;
+    LMDBLS::s_flag_deleted = true;
+    LMDBLS::s_handle_dups = true;
+  }
 
   bool opened = false;
 
@@ -2562,6 +2570,7 @@ public:
     declare(suffix, "random-ids", "Numeric IDs inside the database are generated randomly instead of sequentially", "no");
     declare(suffix, "map-size", "LMDB map size in megabytes", (sizeof(void*) == 4) ? "100" : "16000");
     declare(suffix, "flag-deleted", "Flag entries on deletion instead of deleting them", "no");
+    declare(suffix, "lightning-stream", "Run in Lightning Stream compatible mode", "no");
   }
   DNSBackend* make(const string& suffix = "") override
   {

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1679,6 +1679,7 @@ void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::
     for (const auto& zone : dups) {
       DomainInfo di;
 
+      // this get grabs the oldest item if there are duplicates
       if (!(di.id = txn.get<0>(zone, di))) {
         continue;
       }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1672,11 +1672,8 @@ void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::
       di.id = iter.getID();
       di.backend = this;
 
-      if (zonemap.count(di.zone) == 1) {
+      if (!zonemap.insert(std::make_pair(di.zone, di)).second) {
         dups.insert(di.zone);
-      }
-      else {
-        zonemap[di.zone] = di;
       }
     }
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1755,6 +1755,8 @@ void LMDBBackend::getUpdatedMasters(vector<DomainInfo>& updatedDomains, std::uno
       di.backend = this;
       return true;
     }
+
+    return false;
   });
 }
 
@@ -1769,7 +1771,7 @@ bool LMDBBackend::getCatalogMembers(const DNSName& catalog, vector<CatalogInfo>&
 {
   vector<DomainInfo> scratch;
 
-  getAllDomainsFiltered(&scratch, [this, &catalog, &members, &type](DomainInfo& di) {
+  getAllDomainsFiltered(&scratch, [&catalog, &members, &type](DomainInfo& di) {
     if ((type == CatalogInfo::CatalogType::Producer && di.kind != DomainInfo::Master) || (type == CatalogInfo::CatalogType::Consumer && di.kind != DomainInfo::Slave) || di.catalog != catalog) {
       return false;
     }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1659,7 +1659,8 @@ bool LMDBBackend::createDomain(const DNSName& domain, const DomainInfo::DomainKi
   return true;
 }
 
-void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow) {
+void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow)
+{
   if (d_handle_dups) {
     auto txn = d_tdomains->getROTransaction();
 
@@ -1683,15 +1684,15 @@ void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::
       DomainInfo di;
 
       if (!(di.id = txn.get<0>(zone, di))) {
-       continue;
+        continue;
       }
 
       di.backend = this;
       zonemap[di.zone] = di;
     }
 
-    for (auto [k,v] : zonemap) {
-      if (allow (v)) {
+    for (auto [k, v] : zonemap) {
+      if (allow(v)) {
         domains->push_back(v);
       }
     }
@@ -1703,7 +1704,7 @@ void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::
       di.id = iter.getID();
       di.backend = this;
 
-      if (allow (di)) {
+      if (allow(di)) {
         domains->push_back(di);
       }
     }
@@ -1721,7 +1722,6 @@ void LMDBBackend::getAllDomains(vector<DomainInfo>* domains, bool /* doSerial */
 
     return true;
   });
-
 }
 
 void LMDBBackend::getUnfreshSlaveInfos(vector<DomainInfo>* domains)
@@ -1732,7 +1732,7 @@ void LMDBBackend::getUnfreshSlaveInfos(vector<DomainInfo>* domains)
   soatimes st;
 
   getAllDomainsFiltered(domains, [this, &lrr, &st, &now, &serial](DomainInfo& di) {
-     if (!di.isSecondaryType()) {
+    if (!di.isSecondaryType()) {
       return false;
     }
 
@@ -1772,7 +1772,7 @@ void LMDBBackend::setFresh(uint32_t domain_id)
 void LMDBBackend::getUpdatedMasters(vector<DomainInfo>& updatedDomains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes)
 {
   CatalogInfo ci;
-  
+
   getAllDomainsFiltered(&(updatedDomains), [this, &catalogs, &catalogHashes, &ci](DomainInfo& di) {
     if (!di.isPrimaryType()) {
       return false;

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1661,7 +1661,6 @@ bool LMDBBackend::createDomain(const DNSName& domain, const DomainInfo::DomainKi
 
 void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow) {
   if (d_handle_dups) {
-    cerr<<"handling dups"<<endl;
     auto txn = d_tdomains->getROTransaction();
 
     map<DNSName, DomainInfo> zonemap;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -330,5 +330,6 @@ private:
   uint32_t d_transactiondomainid;
   bool d_dolog;
   bool d_random_ids;
+  bool d_handle_dups;
   DTime d_dtime; // used only for logging
 };

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -309,6 +309,8 @@ private:
   int genChangeDomain(uint32_t id, std::function<void(DomainInfo&)> func);
   void deleteDomainRecords(RecordsRWTransaction& txn, uint32_t domain_id, uint16_t qtype = QType::ANY);
 
+  void getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow);
+
   bool getSerial(DomainInfo& di);
 
   bool upgradeToSchemav3();


### PR DESCRIPTION
### Short description
When two LightningStream writers add the same zone, they most likely will get different zone IDs, and LightningStream will then synchronise both copies to all receivers. With this PR, auth handles that situation consistently across a cluster.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
