### PR TITLE
recursor: restore explicit gzip compression for Ubuntu

### DIFF
--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -58,3 +58,9 @@ endif
 
 override_dh_gencontrol:
 	dh_gencontrol -- $(SUBSTVARS)
+
+# Explicitly set a compression method, as Debian and Ubuntu defaults vary widely,
+# and xz support is not available in all tools yet. Removing this override can
+# make reprepro fail.
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip


### PR DESCRIPTION

### Short description
reprepro for builder.powerdns.com cannot handle xz compression yet, but newer Debian and Ubuntu dh_builddeb turn it on by default.

Was accidentally removed in #10072.

Build failure can be seen in https://builder.powerdns.com/#/builders/109/builds/2717

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
