### PR TITLE
rec: Fix uninited var causing wrong `bytes` field reported in protobuf log in rare cases

### DIFF
--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -495,7 +495,7 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
 #endif /* HAVE_FSTRM */
 
     // sleep until we see an answer to this, interface to mtasker
-    ret = arecvfrom(buf, 0, ip, &len, qid, domain, type, queryfd, now);
+    ret = arecvfrom(buf, 0, ip, len, qid, domain, type, queryfd, *now);
   }
   else {
     bool isNew;

--- a/pdns/recursordist/lwres.hh
+++ b/pdns/recursordist/lwres.hh
@@ -85,7 +85,7 @@ public:
 
 LWResult::Result asendto(const char* data, size_t len, int flags, const ComboAddress& ip, uint16_t id,
                          const DNSName& domain, uint16_t qtype, bool ecs, int* fd);
-LWResult::Result arecvfrom(PacketBuffer& packet, int flags, const ComboAddress& ip, size_t* d_len, uint16_t id,
-                           const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now);
+LWResult::Result arecvfrom(PacketBuffer& packet, int flags, const ComboAddress& ip, size_t& len, uint16_t id,
+                           const DNSName& domain, uint16_t qtype, int fd, const struct timeval& now);
 
 LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstrmLoggers, const std::set<uint16_t>& exportTypes, LWResult* res, bool* chained);

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -328,12 +328,12 @@ LWResult::Result arecvfrom(PacketBuffer& packet, int /* flags */, const ComboAdd
   pident->remote = fromaddr;
 
   int ret = MT->waitEvent(pident, &packet, g_networkTimeoutMsec, &now);
+  len = 0;
 
   /* -1 means error, 0 means timeout, 1 means a result from handleUDPServerResponse() which might still be an error */
   if (ret > 0) {
     /* handleUDPServerResponse() will close the socket for us no matter what */
     if (packet.empty()) { // means "error"
-      len = 0;
       return LWResult::Result::PermanentError;
     }
 

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -315,8 +315,8 @@ LWResult::Result asendto(const char* data, size_t len, int /* flags */,
   return LWResult::Result::Success;
 }
 
-LWResult::Result arecvfrom(PacketBuffer& packet, int /* flags */, const ComboAddress& fromaddr, size_t* d_len,
-                           uint16_t id, const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now)
+LWResult::Result arecvfrom(PacketBuffer& packet, int /* flags */, const ComboAddress& fromaddr, size_t& len,
+                           uint16_t id, const DNSName& domain, uint16_t qtype, int fd, const struct timeval& now)
 {
   static const unsigned int nearMissLimit = ::arg().asNum("spoof-nearmiss-max");
 
@@ -327,16 +327,17 @@ LWResult::Result arecvfrom(PacketBuffer& packet, int /* flags */, const ComboAdd
   pident->type = qtype;
   pident->remote = fromaddr;
 
-  int ret = MT->waitEvent(pident, &packet, g_networkTimeoutMsec, now);
+  int ret = MT->waitEvent(pident, &packet, g_networkTimeoutMsec, &now);
 
   /* -1 means error, 0 means timeout, 1 means a result from handleUDPServerResponse() which might still be an error */
   if (ret > 0) {
     /* handleUDPServerResponse() will close the socket for us no matter what */
     if (packet.empty()) { // means "error"
+      len = 0;
       return LWResult::Result::PermanentError;
     }
 
-    *d_len = packet.size();
+    len = packet.size();
 
     if (nearMissLimit > 0 && pident->nearMisses > nearMissLimit) {
       /* we have received more than nearMissLimit answers on the right IP and port, from the right source (we are using connected sockets),


### PR DESCRIPTION
Reported by gcc build:
```
wres.cc: In function 'asyncresolve':
lwres.cc:631:26: warning: 'len' may be used uninitialized in this function [-Wmaybe-uninitialized]
  631 |       logIncomingResponse(outgoingLoggers, context ? context->d_initialRequestId : boost::none, uuid, ip, domain, type, qid, doTCP, dnsOverTLS, srcmask, len, lwr->d_rcode, lwr->d_records, queryTime, exportTypes);
      |                          ^
lwres.cc:390:10: note: 'len' was declared here
  390 |   size_t len;
      |          ^
```
While there, replace some mandatory pointers by refs

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
