### PR TITLE
rec: Log if the answer was marked variable by SyncRes and if it was stored into  the packet cache (if !quiet)

### DIFF
--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -1802,7 +1802,9 @@ void startDoResolve(void* p)
                         "tcpout", Logging::Loggable(sr.d_tcpoutqueries),
                         "dotout", Logging::Loggable(sr.d_dotoutqueries),
                         "rcode", Logging::Loggable(res),
-                        "validationState", Logging::Loggable(sr.getValidationState()));
+                        "validationState", Logging::Loggable(sr.getValidationState()),
+                        "answer-is-variable", Logging::Loggable(sr.wasVariable()),
+                        "into-packetcache", Logging::Loggable(g_packetCache && !variableAnswer && !sr.wasVariable()));
       }
     }
 


### PR DESCRIPTION
Ideally we would log the received scope info as well, but we do not have access ot that information in the spot where the log object is created.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)