### PR TITLE
docs: lmdb - Add blank line after explicit markup

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -112,6 +112,7 @@ This number can be increased later, but never decreased.
 Defaults to 100 on 32 bit systems, and 16000 on 64 bit systems.
 
 .. _settings-lmdb-flag-deleted:
+
 ``lmdb-flag-deleted``
 ^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### Short description
Fixes warning

```
docs/backends/lmdb.rst:115: WARNING: Explicit markup ends without a blank line; unexpected unindent.
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
