### PR TITLE
lmdb-safe: remove leftover debug variable

### DIFF
--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -653,9 +653,7 @@ public:
 
       int rc = cursor.get(out, id,  MDB_SET_RANGE);
 
-      int scanned = 0;
       while (rc == 0) {
-        scanned++;
         auto sout = out.getNoStripHeader<std::string>(); // FIXME: this (and many others) could probably be string_view
         auto thiskey = getKeyFromCombinedKey(out);
         auto sthiskey = thiskey.getNoStripHeader<std::string>();
@@ -673,7 +671,6 @@ public:
         rc = cursor.get(out, id, MDB_NEXT);
       }
 
-      // std::cerr<<"get_multi scanned="<<scanned<<std::endl;
       if (rc != 0 && rc != MDB_NOTFOUND) {
         throw std::runtime_error("error during get_multi");
       }


### PR DESCRIPTION
### Short description
Cleanup this warning:
```
In file included from ../../ext/lmdb-safe/lmdb-typed.cc:1: ../../ext/lmdb-safe/lmdb-typed.hh:656:11: warning: variable 'scanned' set but not used [-Wunused-but-set-variable]
      int scanned = 0;
          ^
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
