### PR TITLE
ixfrdist: add a per domain max-soa-refresh option

### DIFF
--- a/docs/manpages/ixfrdist.yml.5.rst
+++ b/docs/manpages/ixfrdist.yml.5.rst
@@ -37,6 +37,7 @@ Example
   domains:
     - domain: example.com
       master: 192.0.2.18:5301
+      max-soa-refresh: 1800
     - domain: example.net
       master: 2001:DB8:ABCD::2
 
@@ -103,6 +104,8 @@ Options
            Mandatory.
   :master: IP address of the server to transfer this domain from.
            Mandatory.
+  :max-soa-refresh: Cap the refresh time to the given maximum (in seconds).
+           Optional.
 
 :webserver-address:
   IP address to listen on for the built-in webserver.

--- a/pdns/ixfrdist.example.yml
+++ b/pdns/ixfrdist.example.yml
@@ -98,9 +98,13 @@ webserver-loglevel: normal
 # When no port is specified, 53 is used. When specifying ports for IPv6, use the
 # "bracket" notation:
 #
+# You can optionally cap the refresh time of the SOA using 'max-soa-refresh' (seconds)
+# Otherwise, or if set to 0, the retreived SOA refresh time will be used
+#
 #    domains:
 #      - domain: example.com
 #        master: 192.0.2.15
+#        max-soa-refresh: 180
 #      - domain: rpz.example
 #        master: [2001:DB8:a34:543::53]:5353
 #


### PR DESCRIPTION
This option allows to cap the refresh interval to a lower value than the one retreived from the SOA.

Fix #6996 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
