### PR TITLE
Make Additionals documentation more accurate

### DIFF
--- a/pdns/recursordist/docs/lua-config/additionals.rst
+++ b/pdns/recursordist/docs/lua-config/additionals.rst
@@ -33,10 +33,20 @@ An example of a configuration:
 
 The first line specifies that additional records should be added to the results of ``MX`` queries using the default mode.
 The qtype of the records to be added are ``A`` and ``AAAA``.
-The default mode is ``pdns.AdditionalMode.CacheOnlyRequireAuth``, this mode will only look in the record cache.
+The default mode is ``pdns.AdditionalMode.CacheOnlyRequireAuth``; this mode will only look in the record cache.
 
 The second line specifies that three record types should be added to ``NAPTR`` answers.
 If needed, the Recursor will do an active resolve to retrieve these records.
+
+Note that with record types such as ``NAPTR`` which can return records such as ``SRV``, which may themselves return additional 
+``A`` or ``AAAA`` records, the above example would not be sufficient to return those additional ``A`` and/or ``AAAA`` records. 
+In such a case, you  would need to add an additional line to tell the recursor to fetch the additional records for the ``SRV`` 
+qtype as well. An example configuration for this case is shown below:
+
+.. code-block:: Lua
+
+  addAllowedAdditionalQType(pdns.NAPTR, {pdns.A, pdns.AAAA, pdns.SRV}, {mode=pdns.AdditionalMode.ResolveImmediately})
+  addAllowedAdditionalQType(pdns.SRV, {pdns.A, pdns.AAAA}, {mode=pdns.AdditionalMode.ResolveImmediately})
 
 The modes available are:
 


### PR DESCRIPTION
### Short description
The current documentation doesn't mention indirect additional fetching, which this PR corrects. For example NAPTR
returning an SRV record, which then returns an A record requires two lines of configuration to get all the additionals
in a single lookup.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
