### PR TITLE
auth: Also transfer custom properties of catalog zones

### DIFF
--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -18,7 +18,9 @@ All the important features of catalog zones version "2" are supported.
 There are however a few properties where support is limited:
 
 -  There is no support for group templates on consumers;
--  There is no support for custom extensions;
+
+Since 4.8.0, custom extensions present in catalog zones are exported to consumers.
+Before 4.8.0 all custom extensions were ignored.
 
 The implementation requires the backend to support a number of new operations.
 Currently, the following backends have been modified to support catalog zones:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Custom properties are implementation-dependent, so we might not understand them, but that should not prevent us from providing them to secondaries.
BIND defines custom properties for ACL, primaries and TSIG settings, for example: https://bind9.readthedocs.io/en/stable/chapter6.html#catalog-zone-custom-properties

My use-case is simple: I want to provision the TSIG keys and ACL to use on the secondaries for the zones learned on the consumer via the catalog zone itself.

Feedback welcome! @mind04 in particular will likely have an opinion on this :)

I have a PoC implementing consumer-side handling of some of these options to set primaries, and metadata (`AXFR-MASTER-TSIG` and `ALLOW-AXFR-FROM`) on secondaries, but this is a bit more involved so let's see how this one is received first :)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

