### PR TITLE
Make DNSQType.TSIG available in dnsdist

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -2156,7 +2156,7 @@ void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)
 
   r.qtype=row[3];
 
-  if (d_upgradeContent && DNSRecordContent::isUnknownType(row[3]) && r.qtype.isSupportedType()) {
+  if (d_upgradeContent && DNSRecordContent::isUnknownType(row[3]) && r.qtype.isSupportedType() && !r.qtype.isMetadataType() && DNSRecordContent::isRegisteredType(r.qtype, r.qclass) && r.qtype != QType::NSEC && r.qtype != QType::NSEC3 && r.qtype != QType::ANY) {
     r.content = DNSRecordContent::upgradeContent(r.qname, r.qtype, row[0]);
   }
   else if (r.qtype==QType::MX || r.qtype==QType::SRV) {

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -2156,7 +2156,7 @@ void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)
 
   r.qtype=row[3];
 
-  if (d_upgradeContent && DNSRecordContent::isUnknownType(row[3]) && r.qtype.isSupportedType() && !r.qtype.isMetadataType() && DNSRecordContent::isRegisteredType(r.qtype, r.qclass) && r.qtype != QType::NSEC && r.qtype != QType::NSEC3 && r.qtype != QType::ANY) {
+  if (d_upgradeContent && DNSRecordContent::isUnknownType(row[3]) && DNSRecordContent::isRegisteredType(r.qtype, r.qclass)) {
     r.content = DNSRecordContent::upgradeContent(r.qname, r.qtype, row[0]);
   }
   else if (r.qtype==QType::MX || r.qtype==QType::SRV) {

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -195,6 +195,11 @@ DNSRecordContent::zmakermap_t& DNSRecordContent::getZmakermap()
   return zmakermap;
 }
 
+bool DNSRecordContent::isRegisteredType(uint16_t rtype, uint16_t rclass)
+{
+  return getTypemap().count(pair(rclass, rtype)) != 0;
+}
+
 DNSRecord::DNSRecord(const DNSResourceRecord& rr): d_name(rr.qname)
 {
   d_type = rr.qtype.getCode();

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -268,7 +268,7 @@ public:
     throw runtime_error("Unknown DNS type '"+name+"'");
   }
 
-  static const string NumberToType(uint16_t num, uint16_t classnum=1)
+  static const string NumberToType(uint16_t num, uint16_t classnum = QClass::IN)
   {
     auto iter = getT2Namemap().find(pair(classnum, num));
     if(iter == getT2Namemap().end())
@@ -276,6 +276,11 @@ public:
       //      throw runtime_error("Unknown DNS type with numerical id "+std::to_string(num));
     return iter->second;
   }
+
+  /**
+   * \brief Return whether we have implemented a content representation for this type
+   */
+  static bool isRegisteredType(uint16_t rtype, uint16_t rclass = QClass::IN);
 
   virtual uint16_t getType() const = 0;
 

--- a/pdns/qtype.cc
+++ b/pdns/qtype.cc
@@ -119,13 +119,10 @@ bool QType::isSupportedType() const
 
 bool QType::isMetadataType() const
 {
-  if (code == QType::AXFR ||
-      code == QType::MAILA ||
-      code == QType::MAILB ||
-      code == QType::TSIG ||
-      code == QType::IXFR)
+  // rfc6895 section 3.1, note ANY is 255 and falls outside the range
+  if (code == QType::OPT || (code >= rfc6895MetaLowerBound && code <= rfc6895MetaUpperBound)) {
     return true;
-
+  }
   return false;
 }
 

--- a/pdns/qtype.cc
+++ b/pdns/qtype.cc
@@ -84,7 +84,7 @@ const map<const string, uint16_t> QType::names = {
   {"EUI48", 108},
   {"EUI64", 109},
   {"TKEY", 249},
-  //      {"TSIG", 250},
+  {"TSIG", 250},
   {"IXFR", 251},
   {"AXFR", 252},
   {"MAILB", 253},

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -57,7 +57,18 @@ public:
     return code;
   }
 
+  /**
+   * \brief Return whether we know the name of this type.
+   *
+   * This does not presume that we have an implemented a content representation for this type,
+   * for that please see DNSRecordContent::isRegisteredType().
+   */
   bool isSupportedType() const;
+  /**
+   * \brief Whether the type is either a QTYPE or Meta-Type as defined by rfc6895 section 3.1.
+   *
+   * Note that ANY is 255 and falls outside the range.
+   */
   bool isMetadataType() const;
 
   static uint16_t chartocode(const char* p);

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -68,25 +68,31 @@ int PacketHandler::checkUpdatePrerequisites(const DNSRecord *rr, DomainInfo *di)
 // Method implements section 3.4.1 of RFC2136
 int PacketHandler::checkUpdatePrescan(const DNSRecord *rr) {
   // The RFC stats that d_class != ZCLASS, but we only support the IN class.
-  if (rr->d_class != QClass::IN && rr->d_class != QClass::NONE && rr->d_class != QClass::ANY)
+  if (rr->d_class != QClass::IN && rr->d_class != QClass::NONE && rr->d_class != QClass::ANY) {
     return RCode::FormErr;
+  }
 
   QType qtype = QType(rr->d_type);
 
-  if (! qtype.isSupportedType())
+  if (!qtype.isSupportedType()) {
     return RCode::FormErr;
+  }
 
-  if ((rr->d_class == QClass::NONE || rr->d_class == QClass::ANY) && rr->d_ttl != 0)
+  if ((rr->d_class == QClass::NONE || rr->d_class == QClass::ANY) && rr->d_ttl != 0) {
     return RCode::FormErr;
+  }
 
-  if (rr->d_class == QClass::ANY && rr->d_clen != 0)
+  if (rr->d_class == QClass::ANY && rr->d_clen != 0) {
     return RCode::FormErr;
+  }
 
-  if (qtype.isMetadataType())
-      return RCode::FormErr;
-
-  if (rr->d_class != QClass::ANY && qtype.getCode() == QType::ANY)
+  if (qtype.isMetadataType()) {
     return RCode::FormErr;
+  }
+
+  if (rr->d_class != QClass::ANY && qtype.getCode() == QType::ANY) {
+    return RCode::FormErr;
+  }
 
   return RCode::NoError;
 }


### PR DESCRIPTION
### Short description
Make DNSQType.TSIG available fot matching in dnsdist.

The TSIG line was commented in 914353c, I suspect this change was committed by mistake, but it prevents a user of dnsdist from matching incoming queries with QTypeRule(DNSQType.TSIG)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
