### PR TITLE
Update pdnsutil.1.rst to offer suggestion to set-kind and document the default zone kind

### DIFF
--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -179,7 +179,9 @@ remove-autoprimary *IP* *NAMESERVER*
 list-autoprimaries
     List all autoprimaries.
 create-zone *ZONE*
-    Create an empty zone named *ZONE*.
+    Create an empty zone named *ZONE*. Note that this will create the zone of kind
+    *NATIVE* which will NOT send any NOTIFY messages. Change zone kind with
+    set-kind *ZONE* primary if you want NOTIFY message to be sent.
 create-secondary-zone *ZONE* *PRIMARY* [*PRIMARY*]...
     Create a new secondary zone *ZONE* with primaries *PRIMARY*. All *PRIMARY*\ s
     need to to be space-separated IP addresses with an optional port.


### PR DESCRIPTION
### Short description
Spent a bunch of time on a rabbit trail dealing with notify messages not being sent. Eventually figured out that it was from the default zone kind being 'NATIVE' when created with 'pdnsutil create-zone'. Would have been helpful if this was more clear in the docs.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [NA] compiled this code
- [NA] tested this code
- [X] included documentation (including possible behaviour changes)
- [NA] documented the code
- [NA] added or modified regression test(s)
- [NA] added or modified unit test(s)
