### PR TITLE
auth: add setting workaround-11804-max-chunk-records

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1985,12 +1985,12 @@ If a PID file should be written.
 .. _setting-workaround-11804:
 
 ``workaround-11804``
--------------------
+--------------------
 
 -  Boolean
 -  Default: no
 
-Workaround for issue https://github.com/PowerDNS/pdns/issues/11804.
+Workaround for `issue #11804 (outgoing AXFR may try to overfill a chunk and fail) <https://github.com/PowerDNS/pdns/issues/11804>`_.
 
 Default of no implies the pre-4.8 behaviour of up to 100 RRs per AXFR chunk.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1982,6 +1982,20 @@ If the webserver should print arguments.
 
 If a PID file should be written.
 
+.. _setting-workaround-11804:
+
+``workaround-11804``
+-------------------
+
+-  Boolean
+-  Default: no
+
+Workaround for issue https://github.com/PowerDNS/pdns/issues/11804.
+
+Default of no implies the pre-4.8 behaviour of up to 100 RRs per AXFR chunk.
+
+If enabled, only a single RR will be put into each AXFR chunk, making some zones transferable when they were not.
+
 .. _setting-xfr-cycle-interval:
 
 ``xfr-cycle-interval``

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -196,6 +196,7 @@ static void declareArguments()
   ::arg().set("log-timestamp", "Print timestamps in log lines") = "yes";
   ::arg().set("distributor-threads", "Default number of Distributor (backend) threads to start") = "3";
   ::arg().set("signing-threads", "Default number of signer threads to start") = "3";
+  ::arg().setSwitch("workaround-11804", "Workaround for issue 11804: send single RR per AXFR chunk") = "no";
   ::arg().set("receiver-threads", "Default number of receiver threads to start") = "1";
   ::arg().set("queue-limit", "Maximum number of milliseconds to queue a query") = "1500";
   ::arg().set("resolver", "Use this resolver for ALIAS and the internal stub resolver") = "no";

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1842,7 +1842,7 @@ static void testSpeed(const DNSName& zone, const string& /* remote */, int cores
     throw runtime_error("No backends available for DNSSEC key storage");
   }
 
-  ChunkedSigningPipe csp(DNSName(zone), true, cores);
+  ChunkedSigningPipe csp(DNSName(zone), true, cores, 100);
 
   vector<DNSZoneRecord> signatures;
   uint32_t rnd;

--- a/pdns/signingpipe.cc
+++ b/pdns/signingpipe.cc
@@ -57,9 +57,9 @@ catch(...) {
   return nullptr;
 }
 
-ChunkedSigningPipe::ChunkedSigningPipe(DNSName  signerName, bool mustSign, unsigned int workers)
+ChunkedSigningPipe::ChunkedSigningPipe(DNSName  signerName, bool mustSign, unsigned int workers, unsigned int maxChunkRecords)
   : d_signed(0), d_queued(0), d_outstanding(0), d_numworkers(workers), d_submitted(0), d_signer(std::move(signerName)),
-    d_maxchunkrecords(100), d_threads(d_numworkers), d_mustSign(mustSign), d_final(false)
+    d_maxchunkrecords(maxChunkRecords), d_threads(d_numworkers), d_mustSign(mustSign), d_final(false)
 {
   d_rrsetToSign = make_unique<rrset_t>();
   d_chunks.push_back(vector<DNSZoneRecord>()); // load an empty chunk

--- a/pdns/signingpipe.hh
+++ b/pdns/signingpipe.hh
@@ -42,7 +42,7 @@ public:
   
   ChunkedSigningPipe(const ChunkedSigningPipe&) = delete;
   void operator=(const ChunkedSigningPipe&) = delete;
-  ChunkedSigningPipe(DNSName  signerName, bool mustSign, unsigned int numWorkers=3);
+  ChunkedSigningPipe(DNSName  signerName, bool mustSign, unsigned int numWorkers, unsigned int maxChunkRecords);
   ~ChunkedSigningPipe();
   bool submit(const DNSZoneRecord& rr);
   chunk_t getChunk(bool final=false);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -987,7 +987,7 @@ send:
   typedef map<DNSName, NSECXEntry, CanonDNSNameCompare> nsecxrepo_t;
   nsecxrepo_t nsecxrepo;
 
-  ChunkedSigningPipe csp(target, (securedZone && !presignedZone), ::arg().asNum("signing-threads", 1));
+  ChunkedSigningPipe csp(target, (securedZone && !presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
 
   DNSName keyname;
   unsigned int udiff;


### PR DESCRIPTION

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Workaround for https://github.com/PowerDNS/pdns/issues/11804. Defaults to previously hard-coded value of 100.

I will add docs.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
