### PR TITLE
dnsdist: github runners can be *very* slow wrt I/O, use a more generous timeout in tests

### DIFF
--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -10,7 +10,7 @@ from dnsdisttests import DNSDistTest
 
 class APITestsBase(DNSDistTest):
     __test__ = False
-    _webTimeout = 2.0
+    _webTimeout = 5.0
     _webServerPort = 8083
     _webServerBasicAuthPassword = 'secret'
     _webServerBasicAuthPasswordHashed = '$scrypt$ln=10,p=1,r=8$6DKLnvUYEeXWh3JNOd3iwg==$kSrhdHaRbZ7R74q3lGBqO1xetgxRxhmWzYJ2Qvfm7JM='


### PR DESCRIPTION

This issue seems to be more prominent when using a TSAN enabled dnsdist.

I do wonder what GH does to get such slowness out of their runners. On a local system, I was only able to reproduce using a slow machine, generate extra load on it and reduce the timeout to 0.5.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
