### PR TITLE
Fix the `clang-tidy` jobs failing

### DIFF
--- a/.github/scripts/clang-tidy.py
+++ b/.github/scripts/clang-tidy.py
@@ -39,6 +39,11 @@ def main():
     compdb = helpers.index_compdb(compdb)
 
     fixes = helpers.load_fixes_file(args.fixes_file)
+
+    if not fixes:
+        print("No diagnostics or warnings produced by clang-tidy")
+        return 0
+
     fixes = fixes["Diagnostics"]
     have_warnings = False
     for fix in fixes:

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -538,7 +538,13 @@ jobs:
     name: Check whether clang-tidy succeeded
     steps:
       - run: |
-          if [ "${{needs.build-auth.outputs.clang-tidy-failed}}" != "0" -o "${{needs.build-dnsdist.outputs.clang-tidy-failed}}" != "0" -o "${{needs.build-recursor.outputs.clang-tidy-failed}}" != "0" ]; then
+          if [ "x${{ needs.build-auth.outputs.clang-tidy-failed }}" != "x" -a "${{ needs.build-auth.outputs.clang-tidy-failed }}" != "0" ]; then
+            exit 1
+          fi
+          if [ "x${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "x" -a "${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "0" ]; then
+            exit 1
+          fi
+         if [ "x${{needs.build-recursor.outputs.clang-tidy-failed}}" != "" -a "${{needs.build-recursor.outputs.clang-tidy-failed}}" != "0" ]; then
             exit 1
           fi
 

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -22,7 +22,7 @@ jobs:
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       UNIT_TESTS: yes
     outputs:
-      clang-tidy-failed: ${{steps.clang-tidy-annotations.outputs.failed}}
+      clang-tidy-failed: ${{ steps.clang-tidy-annotations.outputs.failed }}
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -544,7 +544,7 @@ jobs:
           if [ "x${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "x" -a "${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "0" ]; then
             exit 1
           fi
-         if [ "x${{needs.build-recursor.outputs.clang-tidy-failed}}" != "x" -a "${{needs.build-recursor.outputs.clang-tidy-failed}}" != "0" ]; then
+          if [ "x${{needs.build-recursor.outputs.clang-tidy-failed}}" != "x" -a "${{needs.build-recursor.outputs.clang-tidy-failed}}" != "0" ]; then
             exit 1
           fi
 

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -22,7 +22,7 @@ jobs:
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       UNIT_TESTS: yes
     outputs:
-      clang-tidy-auth-failed: ${{ steps.clang-tidy-annotations.outputs.failed }}
+      clang-tidy-failed: ${{steps.clang-tidy-annotations.outputs.failed}}
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v3
@@ -95,7 +95,7 @@ jobs:
       run:
         working-directory: ./pdns/recursordist/
     outputs:
-      clang-tidy-recursor-failed: ${{ steps.clang-tidy-annotations.outputs.failed }}
+      clang-tidy-failed: ${{ steps.clang-tidy-annotations.outputs.failed }}
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v3
@@ -169,7 +169,7 @@ jobs:
       run:
         working-directory: ./pdns/dnsdistdist/
     outputs:
-      clang-tidy-dnsdist-failed: ${{ steps.clang-tidy-annotations.outputs.failed }}
+      clang-tidy-failed: ${{ steps.clang-tidy-annotations.outputs.failed }}
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v3
@@ -537,10 +537,10 @@ jobs:
     runs-on: ubuntu-20.04
     name: Check whether clang-tidy succeeded
     steps:
-    - run: |
-        if [ ${{ needs.build-auth.outputs.clang-tidy-auth-failed }} != 0 -o ${{ needs.build-dnsdist.outputs.clang-tidy-dnsdist-failed }} != 0 -o ${{ needs.build-recursor.outputs.clang-tidy-recursor-failed }} != 0 ]; then
-          exit 1
-        fi
+      - run: |
+          if [ "${{needs.build-auth.outputs.clang-tidy-failed}}" != "0" -o "${{needs.build-dnsdist.outputs.clang-tidy-failed}}" != "0" -o "${{needs.build-recursor.outputs.clang-tidy-failed}}" != "0" ]; then
+            exit 1
+          fi
 
   collect:
     needs:

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -544,7 +544,7 @@ jobs:
           if [ "x${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "x" -a "${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "0" ]; then
             exit 1
           fi
-         if [ "x${{needs.build-recursor.outputs.clang-tidy-failed}}" != "" -a "${{needs.build-recursor.outputs.clang-tidy-failed}}" != "0" ]; then
+         if [ "x${{needs.build-recursor.outputs.clang-tidy-failed}}" != "x" -a "${{needs.build-recursor.outputs.clang-tidy-failed}}" != "0" ]; then
             exit 1
           fi
 


### PR DESCRIPTION
### Short description
Fixes:
- https://github.com/PowerDNS/pdns/actions/runs/4914871488/jobs/8776690618?pr=12790#step:17:1
- https://github.com/PowerDNS/pdns/actions/runs/4913592644/jobs/8774214076?pr=12790#step:2:1

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)