### PR TITLE
libssl: Fix a memory leak when processing TLS tickets w/ OpenSSL 3.x

### DIFF
--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -762,6 +762,7 @@ int OpenSSLTLSTicketKey::encrypt(unsigned char keyName[TLS_TICKETS_KEY_NAME_SIZE
 
 #if OPENSSL_VERSION_MAJOR >= 3
   using ParamsBuilder = std::unique_ptr<OSSL_PARAM_BLD, decltype(&OSSL_PARAM_BLD_free)>;
+  using Params = std::unique_ptr<OSSL_PARAM, decltype(&OSSL_PARAM_free)>;
 
   auto params_build = ParamsBuilder(OSSL_PARAM_BLD_new(), OSSL_PARAM_BLD_free);
   if (params_build == nullptr) {
@@ -772,12 +773,12 @@ int OpenSSLTLSTicketKey::encrypt(unsigned char keyName[TLS_TICKETS_KEY_NAME_SIZE
     return -1;
   }
 
-  auto* params = OSSL_PARAM_BLD_to_param(params_build.get());
+  auto params = Params(OSSL_PARAM_BLD_to_param(params_build.get()), OSSL_PARAM_free);
   if (params == nullptr) {
     return -1;
   }
 
-  if (EVP_MAC_CTX_set_params(hctx, params) == 0) {
+  if (EVP_MAC_CTX_set_params(hctx, params.get()) == 0) {
     return -1;
   }
 
@@ -801,6 +802,7 @@ bool OpenSSLTLSTicketKey::decrypt(const unsigned char* iv, EVP_CIPHER_CTX* ectx,
 {
 #if OPENSSL_VERSION_MAJOR >= 3
   using ParamsBuilder = std::unique_ptr<OSSL_PARAM_BLD, decltype(&OSSL_PARAM_BLD_free)>;
+  using Params = std::unique_ptr<OSSL_PARAM, decltype(&OSSL_PARAM_free)>;
 
   auto params_build = ParamsBuilder(OSSL_PARAM_BLD_new(), OSSL_PARAM_BLD_free);
   if (params_build == nullptr) {
@@ -811,12 +813,12 @@ bool OpenSSLTLSTicketKey::decrypt(const unsigned char* iv, EVP_CIPHER_CTX* ectx,
     return false;
   }
 
-  auto* params = OSSL_PARAM_BLD_to_param(params_build.get());
+  auto params = Params(OSSL_PARAM_BLD_to_param(params_build.get()), OSSL_PARAM_free);
   if (params == nullptr) {
     return false;
   }
 
-  if (EVP_MAC_CTX_set_params(hctx, params) == 0) {
+  if (EVP_MAC_CTX_set_params(hctx, params.get()) == 0) {
     return false;
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`EVP_MAC_CTX_set_params` doesn't consume the allocated memory, so it's up to us to free it. This means that we are leaking a small bit of memory every time we process an incoming or outgoing TLS connections involving a TLS ticket.
Reported by Valgrind.

This was introduced in #12412 which was not backported, so only dnsdist 1.8.0 is impacted, and only when compiled with OpenSSL 3.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
