### PR TITLE
dnsdist: Suppress a race warning when setting a backend health-check mode

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tsan.supp
+++ b/pdns/dnsdistdist/dnsdist-tsan.supp
@@ -15,4 +15,5 @@ race:DownstreamState::setAuto
 # eventual consistency is fine
 race:DownstreamState::stop
 race:DownstreamState::submitHealthCheckResult
+race:DownstreamState::healthCheckRequired
 race:carbonDumpThread


### PR DESCRIPTION
There is an actual race when one thread, likely the console, changes the health-check mode of a given backend just when the health-check thread is determining whether it should send a health-check probe. We are fine with getting a wrong value in the health-check thread, as long as we eventually get the new one, so let's not worry about it and add a TSAN suppression.
We already have a suppression for the methods setting the mode, but it looks like they are inlined so TSAN cannot find them.
The TSAN report was:
```
WARNING: ThreadSanitizer: data race (pid=5301)
  Read of size 1 at 0x7b78000002ae by thread T11:
    #0 DownstreamState::healthCheckRequired(std::optional<long>) /__w/pdns/pdns/pdns/dnsdistdist/dnsdist-backend.cc:555:16 (dnsdist+0x18f003)
    #1 healthChecksThread() /__w/pdns/pdns/pdns/dnsdistdist/dnsdist.cc:2046:17 (dnsdist+0x811ea9)
    #2 void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:60:14 (dnsdist+0x1dfe39)
    #3 std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:95:14 (dnsdist+0x1dfe39)
    #4 void std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:264:13 (dnsdist+0x1dfe39)
    #5 std::thread::_Invoker<std::tuple<void (*)()> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:271:11 (dnsdist+0x1dfe39)
    #6 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:215:13 (dnsdist+0x1dfe39)
    #7 <null> <null> (libstdc++.so.6+0xceecf)

  Previous write of size 1 at 0x7b78000002ae by thread T21 (mutexes: write M189):
    #0 std::enable_if<IsOptional<DownstreamState>::value, setupLuaBindings(LuaContext&, bool)::$_15>::type LuaContext::readIntoFunction<void, LuaContext::Binder<void LuaContext::registerFunctionImpl<setupLuaBindings(LuaContext&, bool)::$_15, void, DownstreamState, boost::optional<bool> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, setupLuaBindings(LuaContext&, bool)::$_15, LuaContext::tag<DownstreamState>, LuaContext::tag<void (boost::optional<bool>)>)::'lambda'(std::shared_ptr<DownstreamState> const&, boost::optional<bool>)&, std::shared_ptr<DownstreamState> const&>&, boost::optional<bool> >(lua_State*, LuaContext::tag<setupLuaBindings(LuaContext&, bool)::$_15>, void&&, int, LuaContext::tag<DownstreamState>, LuaContext::tag<boost::optional<bool> >) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp (dnsdist+0x4b6ab2)
    #1 std::enable_if<!(IsOptional<DownstreamState>::value), setupLuaBindings(LuaContext&, bool)::$_15>::type LuaContext::readIntoFunction<void, void LuaContext::registerFunctionImpl<setupLuaBindings(LuaContext&, bool)::$_15, void, DownstreamState, boost::optional<bool> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, setupLuaBindings(LuaContext&, bool)::$_15, LuaContext::tag<DownstreamState>, LuaContext::tag<void (boost::optional<bool>)>)::'lambda'(std::shared_ptr<DownstreamState> const&, boost::optional<bool>)&, std::shared_ptr<DownstreamState>, boost::optional<bool> >(lua_State*, LuaContext::tag<setupLuaBindings(LuaContext&, bool)::$_15>, void&&, int, LuaContext::tag<DownstreamState>, LuaContext::tag<boost::optional<bool> >) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:1803:16 (dnsdist+0x4b6ab2)
    #2 std::enable_if<(std::integral_constant<bool, true>::value) && (!(std::is_void<setupLuaBindings(LuaContext&, bool)::$_15>::value)), LuaContext::PushedObject>::type LuaContext::Pusher<void (std::shared_ptr<DownstreamState>, boost::optional<bool>), void>::callback2<void LuaContext::registerFunctionImpl<setupLuaBindings(LuaContext&, bool)::$_15, void, DownstreamState, boost::optional<bool> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, setupLuaBindings(LuaContext&, bool)::$_15, LuaContext::tag<DownstreamState>, LuaContext::tag<void (boost::optional<bool>)>)::'lambda'(std::shared_ptr<DownstreamState> const&, boost::optional<bool>)&>(lua_State*, setupLuaBindings(LuaContext&, bool)::$_15&&, int) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2443:9 (dnsdist+0x4b6ab2)
    #3 LuaContext::PushedObject LuaContext::Pusher<void (std::shared_ptr<DownstreamState>, boost::optional<bool>), void>::callback<void LuaContext::registerFunctionImpl<setupLuaBindings(LuaContext&, bool)::$_15, void, DownstreamState, boost::optional<bool> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, setupLuaBindings(LuaContext&, bool)::$_15, LuaContext::tag<DownstreamState>, LuaContext::tag<void (boost::optional<bool>)>)::'lambda'(std::shared_ptr<DownstreamState> const&, boost::optional<bool>)>(lua_State*, setupLuaBindings(LuaContext&, bool)::$_15*, int) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2405:20 (dnsdist+0x4b6ab2)
    #4 std::enable_if<boost::has_trivial_destructor<setupLuaBindings(LuaContext&, bool)::$_15>::value, LuaContext::PushedObject>::type LuaContext::Pusher<void (std::shared_ptr<DownstreamState>, boost::optional<bool>), void>::push<void LuaContext::registerFunctionImpl<setupLuaBindings(LuaContext&, bool)::$_15, void, DownstreamState, boost::optional<bool> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, setupLuaBindings(LuaContext&, bool)::$_15, LuaContext::tag<DownstreamState>, LuaContext::tag<void (boost::optional<bool>)>)::'lambda'(std::shared_ptr<DownstreamState> const&, boost::optional<bool>)>(lua_State*, setupLuaBindings(LuaContext&, bool)::$_15)::'lambda'(lua_State*)::operator()(lua_State*) const /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2334:20 (dnsdist+0x4b6ab2)
    #5 std::enable_if<boost::has_trivial_destructor<setupLuaBindings(LuaContext&, bool)::$_15>::value, LuaContext::PushedObject>::type LuaContext::Pusher<void (std::shared_ptr<DownstreamState>, boost::optional<bool>), void>::push<void LuaContext::registerFunctionImpl<setupLuaBindings(LuaContext&, bool)::$_15, void, DownstreamState, boost::optional<bool> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, setupLuaBindings(LuaContext&, bool)::$_15, LuaContext::tag<DownstreamState>, LuaContext::tag<void (boost::optional<bool>)>)::'lambda'(std::shared_ptr<DownstreamState> const&, boost::optional<bool>)>(lua_State*, setupLuaBindings(LuaContext&, bool)::$_15)::'lambda'(lua_State*)::__invoke(lua_State*) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2330:31 (dnsdist+0x4b6ab2)
    #6 <null> <null> (libluajit-5.1.so.2+0xa5e6)
    #7 boost::optional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<DownstreamState>, ClientState*, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > > > > LuaContext::call<boost::optional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<DownstreamState>, ClientState*, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > > > > >(lua_State*, LuaContext::PushedObject) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:1413:29 (dnsdist+0x1c2b4b)
    #8 boost::optional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<DownstreamState>, ClientState*, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > > > > LuaContext::executeCode<boost::optional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<DownstreamState>, ClientState*, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > > > > >(char const*) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:324:16 (dnsdist+0x1c2b4b)
    #9 boost::optional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<DownstreamState>, ClientState*, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > > > > LuaContext::executeCode<boost::optional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<DownstreamState>, ClientState*, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > > > > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:301:16 (dnsdist+0x1bf450)
    #10 controlClientThread(ConsoleConnection&&) /__w/pdns/pdns/pdns/dnsdistdist/dnsdist-console.cc:897:27 (dnsdist+0x1bf450)
    #11 boost::optional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<DownstreamState>, ClientState*, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > > > > LuaContext::executeCode<boost::optional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<DownstreamState>, ClientState*, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > > > > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:301:16 (dnsdist+0x1bf450)
    #12 controlClientThread(ConsoleConnection&&) /__w/pdns/pdns/pdns/dnsdistdist/dnsdist-console.cc:897:27 (dnsdist+0x1bf450)
    #13 void std::__invoke_impl<void, void (*)(ConsoleConnection&&), ConsoleConnection>(std::__invoke_other, void (*&&)(ConsoleConnection&&), ConsoleConnection&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:60:14 (dnsdist+0x1c76f3)
    #14 std::__invoke_result<void (*)(ConsoleConnection&&), ConsoleConnection>::type std::__invoke<void (*)(ConsoleConnection&&), ConsoleConnection>(void (*&&)(ConsoleConnection&&), ConsoleConnection&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:95:14 (dnsdist+0x1c76f3)
    #15 void std::thread::_Invoker<std::tuple<void (*)(ConsoleConnection&&), ConsoleConnection> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:264:13 (dnsdist+0x1c76f3)
    #16 std::thread::_Invoker<std::tuple<void (*)(ConsoleConnection&&), ConsoleConnection> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:271:11 (dnsdist+0x1c76f3)
    #17 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(ConsoleConnection&&), ConsoleConnection> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:215:13 (dnsdist+0x1c76f3)
    #18 <null> <null> (libstdc++.so.6+0xceecf)

  As if synchronized via sleep:
    #0 healthChecksThread() /__w/pdns/pdns/pdns/dnsdistdist/dnsdist.cc:2034:5 (dnsdist+0xc77e8)
    #1 void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:60:14 (dnsdist+0x811b8e)
    #2 std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:95:14 (dnsdist+0x811b8e)
    #3 void std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:264:13 (dnsdist+0x811b8e)
    #4 std::thread::_Invoker<std::tuple<void (*)()> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:271:11 (dnsdist+0x811b8e)
    #5 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:215:13 (dnsdist+0x811b8e)
    #6 <null> <null> (dnsdist+0x1dfe39)
    #7 operator new(unsigned long, std::align_val_t) <null> (libstdc++.so.6+0xceecf)

  Location is heap block of size 2880 at 0x7b7800000000 allocated by main thread:
    #0 __gnu_cxx::new_allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/ext/new_allocator.h:112:31 (dnsdist+0x13f29c)
    #1 std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> >&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/alloc_traits.h:460:20 (dnsdist+0x13f29c)
    #2 std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> >&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/allocated_ptr.h:97:21 (dnsdist+0x13f29c)
    #3 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<DownstreamState, std::allocator<DownstreamState>, DownstreamState::Config, std::shared_ptr<TLSCtx>, bool>(DownstreamState*&, std::_Sp_alloc_shared_tag<std::allocator<DownstreamState> >, DownstreamState::Config&&, std::shared_ptr<TLSCtx>&&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/shared_ptr_base.h:680:19 (dnsdist+0x13f29c)
    #4 std::__shared_ptr<DownstreamState, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<DownstreamState>, DownstreamState::Config, std::shared_ptr<TLSCtx>, bool>(std::_Sp_alloc_shared_tag<std::allocator<DownstreamState> >, DownstreamState::Config&&, std::shared_ptr<TLSCtx>&&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/shared_ptr_base.h:1371:14 (dnsdist+0x13f29c)
    #5 std::shared_ptr<DownstreamState>::shared_ptr<std::allocator<DownstreamState>, DownstreamState::Config, std::shared_ptr<TLSCtx>, bool>(std::_Sp_alloc_shared_tag<std::allocator<DownstreamState> >, DownstreamState::Config&&, std::shared_ptr<TLSCtx>&&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/shared_ptr.h:408:4 (dnsdist+0x1db3be)
    #6 std::shared_ptr<DownstreamState> std::allocate_shared<DownstreamState, std::allocator<DownstreamState>, DownstreamState::Config, std::shared_ptr<TLSCtx>, bool>(std::allocator<DownstreamState> const&, DownstreamState::Config&&, std::shared_ptr<TLSCtx>&&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/shared_ptr.h:859:14 (dnsdist+0x1db3be)
    #7 std::shared_ptr<DownstreamState> std::make_shared<DownstreamState, DownstreamState::Config, std::shared_ptr<TLSCtx>, bool>(DownstreamState::Config&&, std::shared_ptr<TLSCtx>&&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/shared_ptr.h:875:14 (dnsdist+0x1db3be)
    #8 setupLuaConfig(LuaContext&, bool, bool)::$_3::operator()(boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>) const /__w/pdns/pdns/pdns/dnsdistdist/dnsdist-lua.cc:619:37 (dnsdist+0x1db3be)
    #9 tor<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>), void>::callback2<setupLuaConfig(LuaContext&, bool, bool)::$_3&>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_3&, int) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2436:31 (dnsdist+0x69065d)
    #10 LuaContext::PushedObject LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>), void>::callback<setupLuaConfig(LuaContext&, bool, bool)::$_3>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_3*, int) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2405:20 (dnsdist+0x69065d)
    #11 std::enable_if<boost::has_trivial_destructor<setupLuaConfig(LuaContext&, bool, bool)::$_3>::value, LuaContext::PushedObject>::type LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>), void>::push<setupLuaConfig(LuaContext&, bool, bool)::$_3>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_3)::'lambda'(lua_State*)::operator()(lua_State*) const /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2334:20 (dnsdist+0x69065d)
    #12 std::enable_if<boost::has_trivial_destructor<setupLuaConfig(LuaContext&, bool, bool)::$_3>::value, LuaContext::PushedObject>::type LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>), void>::push<setupLuaConfig(LuaContext&, bool, bool)::$_3>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_3)::'lambda'(lua_State*)::__invoke(lua_State*) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2330:31 (dnsdist+0x69065d)
    #13 <null> <null> (dnsdist+0x687942)
    #14 <null> <null> (libluajit-5.1.so.2+0xa5e6)
    #15 std::tuple<> LuaContext::call<std::tuple<> >(lua_State*, LuaContext::PushedObject) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:1413:29 (dnsdist+0x577e85)
    #16 LuaContext::executeCode(std::istream&) /__w/pdns/pdns/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:267:9 (dnsdist+0x685db6)
    #17 setupLua(LuaContext&, bool, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /__w/pdns/pdns/pdns/dnsdistdist/dnsdist-lua.cc:3025:10 (dnsdist+0x67b759)
    #18 main /__w/pdns/pdns/pdns/dnsdistdist/dnsdist.cc:2668:17 (dnsdist+0x809d2c)

  Mutex M189 (0x55801da4cdf0) created at:
    #0 pthread_mutex_lock <null> (dnsdist+0xe74f8)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/x86_64-linux-gnu/c++/10/bits/gthr-default.h:749:12 (dnsdist+0x80c177)
    #2 std::mutex::lock() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/std_mutex.h:100:17 (dnsdist+0x80c177)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/std_mutex.h:159:19 (dnsdist+0x80c177)
    #4 LockGuardedHolder<LuaContext>::LockGuardedHolder(LuaContext&, std::mutex&) /__w/pdns/pdns/pdns/dnsdistdist/./lock.hh:209:60 (dnsdist+0x80c177)
    #5 LockGuarded<LuaContext>::lock() /__w/pdns/pdns/pdns/dnsdistdist/./lock.hh:289:12 (dnsdist+0x80c177)
    #6 main /__w/pdns/pdns/pdns/dnsdistdist/dnsdist.cc:2668:34 (dnsdist+0x809d0c)

  Thread T11 'dnsdist/healthC' (tid=5313, running) created by main thread at:
    #0 pthread_create <null> (dnsdist+0xca21d)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xcf144)
    #2 main /__w/pdns/pdns/pdns/dnsdistdist/dnsdist.cc:2938:12 (dnsdist+0x80b06e)

  Thread T21 'dnsdist/conscli' (tid=5325, finished) created by thread T5 at:
    #0 pthread_create <null> (dnsdist+0xca21d)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xcf144)
    #2 void std::__invoke_impl<void, void (*)(int, ComboAddress), int, ComboAddress>(std::__invoke_other, void (*&&)(int, ComboAddress), int&&, ComboAddress&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:60:14 (dnsdist+0x6c0435)
    #3 std::__invoke_result<void (*)(int, ComboAddress), int, ComboAddress>::type std::__invoke<void (*)(int, ComboAddress), int, ComboAddress>(void (*&&)(int, ComboAddress), int&&, ComboAddress&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:95:14 (dnsdist+0x6c0435)
    #4 void std::thread::_Invoker<std::tuple<void (*)(int, ComboAddress), int, ComboAddress> >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:264:13 (dnsdist+0x6c0435)
    #5 std::thread::_Invoker<std::tuple<void (*)(int, ComboAddress), int, ComboAddress> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:271:11 (dnsdist+0x6c0435)
    #6 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(int, ComboAddress), int, ComboAddress> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/thread:215:13 (dnsdist+0x6c0435)
    #7 <null> <null> (libstdc++.so.6+0xceecf)
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
