### PR TITLE
dnsdist: Account for the health-check run time between two runs

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2027,11 +2027,24 @@ static void healthChecksThread()
 {
   setThreadName("dnsdist/healthC");
 
-  constexpr int interval = 1;
+  constexpr int intervalUsec = 1000 * 1000;
+  struct timeval lastRound{
+    .tv_sec = 0,
+    .tv_usec = 0
+  };
   auto states = g_dstates.getLocal(); // this points to the actual shared_ptrs!
 
   for (;;) {
-    sleep(interval);
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+    auto elapsedTimeUsec = uSec(now - lastRound);
+    if (elapsedTimeUsec < intervalUsec) {
+      usleep(intervalUsec - elapsedTimeUsec);
+      gettimeofday(&lastRound, nullptr);
+    }
+    else {
+      lastRound = now;
+    }
 
     std::unique_ptr<FDMultiplexer> mplexer{nullptr};
     for (auto& dss : *states) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to wait one full second between every run, which only makes sense if the runs are not taking a long time. But as soon as we have at least one check timing out, the run is taking roughly the time of the longest timeout configured, so after this commit we:
- do not wait at all if the last run took more than a full second
- wait one second minus the elapsed time of the last run otherwise

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
