### PR TITLE
dnsdist: Properly set the size of the UDP health-check response

### DIFF
--- a/pdns/dnsdistdist/dnsdist-healthchecks.cc
+++ b/pdns/dnsdistdist/dnsdist-healthchecks.cc
@@ -177,6 +177,7 @@ static void healthCheckUDPCallback(int fd, FDMultiplexer::funcparam_t& param)
     data->d_ds->submitHealthCheckResult(data->d_initial, false);
     return;
   }
+  data->d_buffer.resize(static_cast<size_t>(got));
 
   /* we are using a connected socket but hey.. */
   if (from != data->d_ds->d_config.remote) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We forgot to resize the response buffer to what we actually got, so the initial buffer size (512) was mistakenly used later on. Technically this should not be an issue as the buffer is large enough, but that prevents us from reporting that the response was broken if it not large enough for a DNS header, for example.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
