### PR TITLE
dnsdist-1.8.x: Stop setting SO_REUSEADDR on outgoing UDP client sockets

### DIFF
--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -72,7 +72,6 @@ bool DownstreamState::reconnect()
 #endif
 
     if (!IsAnyAddress(d_config.sourceAddr)) {
-      SSetsockopt(fd, SOL_SOCKET, SO_REUSEADDR, 1);
 #ifdef IP_BIND_ADDRESS_NO_PORT
       if (d_config.ipBindAddrNoPort) {
         SSetsockopt(fd, SOL_IP, IP_BIND_ADDRESS_NO_PORT, 1);

--- a/pdns/dnsdistdist/dnsdist-healthchecks.cc
+++ b/pdns/dnsdistdist/dnsdist-healthchecks.cc
@@ -327,7 +327,7 @@ bool queueHealthCheck(std::unique_ptr<FDMultiplexer>& mplexer, const std::shared
         SSetsockopt(sock.getHandle(), SOL_IP, IP_BIND_ADDRESS_NO_PORT, 1);
       }
 #endif
-      sock.bind(ds->d_config.sourceAddr);
+      sock.bind(ds->d_config.sourceAddr, false);
     }
 
     auto data = std::make_shared<HealthCheckData>(*mplexer, ds, std::move(checkName), checkType, checkClass, queryID);

--- a/pdns/dnsdistdist/dnsdist-healthchecks.cc
+++ b/pdns/dnsdistdist/dnsdist-healthchecks.cc
@@ -319,7 +319,9 @@ bool queueHealthCheck(std::unique_ptr<FDMultiplexer>& mplexer, const std::shared
 #endif
 
     if (!IsAnyAddress(ds->d_config.sourceAddr)) {
-      sock.setReuseAddr();
+      if (ds->doHealthcheckOverTCP()) {
+        sock.setReuseAddr();
+      }
 #ifdef IP_BIND_ADDRESS_NO_PORT
       if (ds->d_config.ipBindAddrNoPort) {
         SSetsockopt(sock.getHandle(), SOL_IP, IP_BIND_ADDRESS_NO_PORT, 1);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #12819 to rel/dnsdist-1.8.x
`SO_REUSEADDR` is useful on TCP server sockets to allow binding quickly after restarting the process without waiting `TIME_WAIT` seconds, or to allow some port reuse on BSD. It also allows reusing a port more quickly for TCP client sockets.
For UDP sockets, however, Linux allows two sockets to be bound to the same address and port, and will distribute all packets to the most recent socket, which is very unexpected, to say the least.

(cherry picked from commit b33f09f1989e938c503142a38c556df94254443a)
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
