### PR TITLE
Allow wildcard records

### DIFF
--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -391,7 +391,7 @@ string apiZoneNameToId(const DNSName& dname) {
 }
 
 void apiCheckNameAllowedCharacters(const string& name) {
-  if (name.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_/.-") != std::string::npos)
+  if (name.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_/.-*") != std::string::npos)
     throw ApiException("Name '"+name+"' contains unsupported characters");
 }
 


### PR DESCRIPTION
Allow to use wildcard records like `_acme-challenge.*.host` according rfc4592.

This is needed for provide dns challenge LetsEncrypt for wildcard zones.