### PR TITLE
auth API: Allow '*' in record names (rfc4592).

### DIFF
--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -391,7 +391,7 @@ string apiZoneNameToId(const DNSName& dname) {
 }
 
 void apiCheckNameAllowedCharacters(const string& name) {
-  if (name.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_/.-") != std::string::npos)
+  if (name.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_/.-*") != std::string::npos)
     throw ApiException("Name '"+name+"' contains unsupported characters");
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Allow to use wildcard records like `_acme-challenge.*.host` according rfc4592.

This is needed for provide dns challenge LetsEncrypt for wildcard zones.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
