### PR TITLE
rec: bound maximum recursion depth to 16.

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1292,7 +1292,7 @@ This setting, which defaults to 3600 seconds, puts a maximum on the amount of ti
 ``max-recursion-depth``
 -----------------------
 -  Integer
--  Default: 40
+-  Default: 16
 
 Total maximum number of internal recursion calls the server may use to answer a single query.
 0 means unlimited.
@@ -1303,6 +1303,10 @@ If `qname-minimization`_ is enabled, the fallback code in case of a failing reso
 .. versionchanged:: 4.1.0
 
     Before 4.1.0, this settings was unlimited.
+
+.. versionchanged:: 4.9.0
+
+   Before 4.9.0 this setting's default was 40 and the limit on ``CNAME`` chains (fixed at 16) acted as a bound on he recursion depth.
 
 .. _setting-max-tcp-clients:
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2867,7 +2867,7 @@ static void initArgs()
   ::arg().set("max-ns-per-resolve", "Maximum number of NS records to consider to resolve a name, 0 is no limit") = "13";
   ::arg().set("max-ns-address-qperq", "Maximum outgoing NS address queries per query") = "10";
   ::arg().set("max-total-msec", "Maximum total wall-clock time per query in milliseconds, 0 for unlimited") = "7000";
-  ::arg().set("max-recursion-depth", "Maximum number of internal recursion calls per query, 0 for unlimited") = "40";
+  ::arg().set("max-recursion-depth", "Maximum number of internal recursion calls per query, 0 for unlimited") = "16";
   ::arg().set("max-udp-queries-per-round", "Maximum number of UDP queries processed per recvmsg() round, before returning back to normal processing") = "10000";
   ::arg().set("protobuf-use-kernel-timestamp", "Compute the latency of queries in protobuf messages by using the timestamp set by the kernel when the query was received (when available)") = "";
   ::arg().set("distribution-pipe-buffer-size", "Size in bytes of the internal buffer of the pipe used by the distributor to pass incoming queries to a worker thread") = "0";


### PR DESCRIPTION
Before #12779, the fixed limit on CNAME chain length (16) effectively worked as recursion depth limit.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
