### PR TITLE
rec: Support for populating forward-zones using catalog zones

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -110,7 +110,7 @@ Like `allow-notify-for`_, except reading from file. To use this
 feature, supply one domain name per line, with optional comments
 preceded by a "#".
 
-NOTIFY-allowed zones can also be specified using `forward-zones-file`_ and `forward-zones-catalog`_.
+NOTIFY-allowed zones can also be specified using `forward-zones-file`_ and `forward-zones-catalogs`_.
 
 .. _setting-allow-notify-from:
 
@@ -136,7 +136,7 @@ NOTIFY operations received from a client listed in one of these netmasks
 will be accepted and used to wipe any cache entries whose zones match
 the zone specified in the NOTIFY operation, but only if that zone (or
 one of its parents) is included in `allow-notify-for`_,
-`allow-notify-for-file`_, `forward-zones-file`_ with a '^' prefix, or `forward-zones-catalog`_.
+`allow-notify-for-file`_, `forward-zones-file`_ with a '^' prefix, or `forward-zones-catalogs`_.
 
 .. _setting-allow-notify-from-file:
 
@@ -574,7 +574,7 @@ This can have odd effects, depending on your network, and may even be a security
 Therefore, the PowerDNS Recursor by default does not query private space IP addresses.
 This setting can be used to expand or reduce the limitations.
 
-Queries for names in forward zones and to addresses as configured in any of the settings `forward-zones`_, `forward-zones-file`_, `forward-zones-recurse`_, or `forward-zones-catalog`_ are performed regardless of these limitations.
+Queries for names in forward zones and to addresses as configured in any of the settings `forward-zones`_, `forward-zones-file`_, `forward-zones-recurse`_, or `forward-zones-catalogs`_ are performed regardless of these limitations.
 
 .. _setting-ecs-add-for:
 
@@ -884,30 +884,32 @@ To prevent this, add a Negative Trust Anchor (NTA) for this zone in the `lua-con
 If this forwarded zone is signed, instead of adding NTA, add the DS record to the `lua-config-file`_.
 See the :doc:`dnssec` information.
 
-.. _setting-forward-zones-catalog
+.. _setting-forward-zones-catalogs
 
-``forward-zones-catalog``
--------------------------
+``forward-zones-catalogs``
+--------------------------
 .. versionadded:: 4.10.0
--  'zonename=IP[:port]'
+-  List of 'zone=IP[:port]' pairs, separated by commas
 
-The contents of the specified ``catalog zone`` will be retrieved from
-the server at the specified IP (or IP:port).  Each entry in the
-catalog zone will be added to the `forward-zones`_ list.
+The contents of the specified ``catalog zones`` will be retrieved from
+the servers at the specified IPs (or IP:port combinations).  Each
+entry in the catalog zones will be added to the `forward-zones`_ list.
 
 .. code-block:: none
 
-    forward-zones-catalog=catalog1.example.org=203.0.113.210
-    forward-zones-catalog=catalog2.example.org=[2001:DB8::1:3]:5300
+    forward-zones-catalogs=catalog1.example.org=203.0.113.210
+    forward-zones-catalogs+=catalog2.example.org=[2001:DB8::1:3]:5300
 
-The catalog zone itself will be added to the `allow-notify-for`_ list,
-but when NOTIFY queries are received the recursor will not perform any
-cache-clearing operations; instead it will retrieve the SOA record for
-the zone, and if the serial number is higher than the serial number
-last seen, the zone contents will be retrieved. Any zones which have
-been removed from the catalog zone will also be removed from the
-`forward-zones`_ list; any zones which have been added to the catalog
-zone will be added to the `forward-zones`_ list.
+The catalog zones themselves will be added to the `allow-notify-for`_
+list, but when NOTIFY queries are received for them the recursor will
+not perform any cache-clearing operations; instead it will retrieve
+the SOA record for the catalog zone in the NOTIFY query, and if the
+serial number is higher than the serial number last seen, the zone
+contents will be retrieved. Any zones in the `forward-zones`_ list
+which were learned from the previous version of the catalog zone, and
+which are no longer present in the catalog zone, will be removed from
+the `forward-zones`_ list; any zones which have been added to the
+catalog zone will be added to the `forward-zones`_ list.
 
 Forwarded queries for zones obtained from a catalog zone will be sent
 to the IP/port used to retrieve the contents of the catalog zone.
@@ -916,7 +918,7 @@ Forwarded queries for zones obtained from a catalog zone will have the
 ``recursion desired (RD)`` bit set to ``0``. See the `forward-zones`_
 setting for more details.
 
-Zones added to the `forward-zones`_ list due to inclusion in the
+Zones added to the `forward-zones`_ list due to inclusion in a
 catalog zone will also be added to the `allow-notify-for`_ list; the
 recursor's behavior when a NOTIFY query is received for such a zone
 will be the same as described in that setting.

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2913,6 +2913,7 @@ static void initArgs()
   ::arg().set("forward-zones", "Zones for which we forward queries, comma separated domain=ip pairs") = "";
   ::arg().set("forward-zones-recurse", "Zones for which we forward queries with recursion bit, comma separated domain=ip pairs") = "";
   ::arg().set("forward-zones-file", "File with (+)domain=ip pairs for forwarding") = "";
+  ::arg().set("forward-zones-catalogs", "Catalog zones from which we will obtain a list of zones for query forwarding, comma separated zone=ip/port pairs") = "";
   ::arg().set("export-etc-hosts", "If we should serve up contents from /etc/hosts") = "off";
   ::arg().set("export-etc-hosts-search-suffix", "Also serve up the contents of /etc/hosts with this suffix") = "";
   ::arg().set("etc-hosts-file", "Path to 'hosts' file") = "/etc/hosts";


### PR DESCRIPTION
### Short description
Adds support for catalog zones in recursor; their contents are used to populate the `forward-zones` list.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
