### PR TITLE
Add Bookworm to repo test script.

### DIFF
--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -25,7 +25,7 @@ from jinja2 import Environment, FileSystemLoader
 
 # Globals
 
-g_version = '1.0.2'
+g_version = '1.0.3'
 
 g_verbose = False
 
@@ -181,6 +181,10 @@ def write_release_files (release):
                    'rec-47', 'rec-48', 'rec-49', 'rec-master',
                    'dnsdist-17', 'dnsdist-18', 'dnsdist-master']:
         write_dockerfile('el', '9', release)
+
+    if release in ['auth-48', 'auth-master']:
+        write_dockerfile('debian', 'bookworm', release)
+        write_list_file('debian', 'bookworm', release)
 
 # Test Release Functions
 


### PR DESCRIPTION
### Short description

Add Debian Bookworm for `auth-master` & `auth-48` to repo test script.

### Checklist

I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)