### PR TITLE
bump sdist builders to alpine 3.18

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.authoritative
+++ b/builder-support/dockerfiles/Dockerfile.authoritative
@@ -1,9 +1,9 @@
-FROM alpine:3.10 as pdns-authoritative
+FROM alpine:3.18 as pdns-authoritative
 ARG BUILDER_CACHE_BUSTER=
 
 RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \
                        libtool file boost-dev curl openssl-dev ragel python3 \
-                       flex bison git
+                       flex bison git bash
 
 # the pdns/ dir is a bit broad, but who cares :)
 ADD configure.ac Makefile.am COPYING INSTALL NOTICE README /pdns-authoritative/

--- a/builder-support/dockerfiles/Dockerfile.dnsdist
+++ b/builder-support/dockerfiles/Dockerfile.dnsdist
@@ -1,8 +1,8 @@
-FROM alpine:3.10 as dnsdist
+FROM alpine:3.18 as dnsdist
 ARG BUILDER_CACHE_BUSTER=
 
 RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \
-                       libtool file boost-dev ragel python3 git libedit-dev
+                       libtool file boost-dev ragel python3 git libedit-dev bash
 
 ADD builder/helpers/set-configure-ac-version.sh /dnsdist/builder/helpers/
 ADD COPYING /dnsdist/

--- a/builder-support/dockerfiles/Dockerfile.recursor
+++ b/builder-support/dockerfiles/Dockerfile.recursor
@@ -1,9 +1,9 @@
-FROM alpine:3.10 as pdns-recursor
+FROM alpine:3.18 as pdns-recursor
 ARG BUILDER_CACHE_BUSTER=
 
 RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \
                        libtool file boost-dev curl openssl-dev ragel python3 \
-                       flex bison git
+                       flex bison git bash
 
 ADD COPYING NOTICE /pdns-recursor/
 @EXEC sdist_dirs=(build-aux m4 pdns ext docs)

--- a/builder-support/dockerfiles/Dockerfile.target.sdist
+++ b/builder-support/dockerfiles/Dockerfile.target.sdist
@@ -10,7 +10,7 @@
 @INCLUDE Dockerfile.dnsdist
 @ENDIF
 
-FROM alpine:3.10 as sdist
+FROM alpine:3.18 as sdist
 ARG BUILDER_CACHE_BUSTER=
 
 @IF [ -z "$M_authoritative$M_recursor$M_dnsdist$M_all" ]


### PR DESCRIPTION
### Short description
we were using 3.10, which is very old. The autoconf(-archive) in that recognises Python 3.1x as 3.1, which is how somebody noticed.

This also means we bump flex, ragel, and bison. Everything appears to work.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
