### PR TITLE
swagger-syntax-check: run outside of Docker

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -538,14 +538,17 @@ jobs:
   swagger-syntax-check:
     if: ${{ !github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     runs-on: ubuntu-20.04
-    container:
-      image: ghcr.io/powerdns/base-pdns-ci-image/debian-11-pdns-base:master
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+    # FIXME: https://github.com/PowerDNS/pdns/pull/12880
+    # container:
+    #   image: ghcr.io/powerdns/base-pdns-ci-image/debian-11-pdns-base:master
+    #   options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
+      - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: recursive
+      - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
       - run: inv install-swagger-tools
       - run: inv swagger-syntax-check
 


### PR DESCRIPTION
### Short description
For reasons entirely unclear to me, this check suddenly is broken on Debian 11. I see the same failure on my local system.

Moving it back outside the container makes it work. This is not great as now we rely on Azure/Ubuntu mirrors again, but right now this makes our CI green again. Needs more investigation at some point.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
