### PR TITLE
rec: reduce memory needed to manage RPZs

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -120,7 +120,7 @@ The DNSQuestion object contains at least the following fields:
 
     .. attribute:: DNSQuestion.appliedPolicy.policyTrigger
 
-        The trigger (left-hand) part of the RPZ rule that was matched
+        The trigger (left-hand) part of the RPZ rule that was matched. This is a :class:`DNSName` object.
 
     .. attribute:: DNSQuestion.appliedPolicy.policyHit
 

--- a/pdns/recursordist/filterpo.cc
+++ b/pdns/recursordist/filterpo.cc
@@ -391,8 +391,7 @@ void DNSFilterEngine::Zone::addNameTrigger(std::unordered_map<DNSName, Policy>& 
     }
 
     if (pol.customRecordsSize() > 0) {
-      existingPol.allocateCustomRecords();
-      existingPol.d_custom->reserve(existingPol.customRecordsSize() + pol.customRecordsSize());
+      existingPol.allocateCustomRecords(existingPol.customRecordsSize() + pol.customRecordsSize());
       std::move(pol.d_custom->begin(), pol.d_custom->end(), std::back_inserter(*existingPol.d_custom));
     }
   }
@@ -421,8 +420,7 @@ void DNSFilterEngine::Zone::addNetmaskTrigger(NetmaskTree<Policy>& nmt, const Ne
     }
 
     if (pol.customRecordsSize() > 0) {
-      existingPol.allocateCustomRecords();
-      existingPol.d_custom->reserve(existingPol.customRecordsSize() + pol.customRecordsSize());
+      existingPol.allocateCustomRecords(existingPol.customRecordsSize() + pol.customRecordsSize());
       std::move(pol.d_custom->begin(), pol.d_custom->end(), std::back_inserter(*existingPol.d_custom));
     }
   }

--- a/pdns/recursordist/filterpo.cc
+++ b/pdns/recursordist/filterpo.cc
@@ -44,12 +44,12 @@ DNSFilterEngine::DNSFilterEngine()
 {
 }
 
-bool DNSFilterEngine::Zone::findExactQNamePolicy(const DNSName& qname, DNSFilterEngine::Policy& pol) const
+bool DNSFilterEngine::Zone::findExactQNamePolicy(const DNSName& qname, DNSFilterEngine::AppliedPolicy& pol) const
 {
   return findExactNamedPolicy(d_qpolName, qname, pol);
 }
 
-bool DNSFilterEngine::Zone::findExactNSPolicy(const DNSName& qname, DNSFilterEngine::Policy& pol) const
+bool DNSFilterEngine::Zone::findExactNSPolicy(const DNSName& qname, DNSFilterEngine::AppliedPolicy& pol) const
 {
   if (findExactNamedPolicy(d_propolName, qname, pol)) {
     pol.d_trigger = qname;
@@ -59,7 +59,7 @@ bool DNSFilterEngine::Zone::findExactNSPolicy(const DNSName& qname, DNSFilterEng
   return false;
 }
 
-bool DNSFilterEngine::Zone::findNSIPPolicy(const ComboAddress& addr, DNSFilterEngine::Policy& pol) const
+bool DNSFilterEngine::Zone::findNSIPPolicy(const ComboAddress& addr, DNSFilterEngine::AppliedPolicy& pol) const
 {
   if (const auto fnd = d_propolNSAddr.lookup(addr)) {
     pol = fnd->second;
@@ -71,7 +71,7 @@ bool DNSFilterEngine::Zone::findNSIPPolicy(const ComboAddress& addr, DNSFilterEn
   return false;
 }
 
-bool DNSFilterEngine::Zone::findResponsePolicy(const ComboAddress& addr, DNSFilterEngine::Policy& pol) const
+bool DNSFilterEngine::Zone::findResponsePolicy(const ComboAddress& addr, DNSFilterEngine::AppliedPolicy& pol) const
 {
   if (const auto fnd = d_postpolAddr.lookup(addr)) {
     pol = fnd->second;
@@ -83,7 +83,7 @@ bool DNSFilterEngine::Zone::findResponsePolicy(const ComboAddress& addr, DNSFilt
   return false;
 }
 
-bool DNSFilterEngine::Zone::findClientPolicy(const ComboAddress& addr, DNSFilterEngine::Policy& pol) const
+bool DNSFilterEngine::Zone::findClientPolicy(const ComboAddress& addr, DNSFilterEngine::AppliedPolicy& pol) const
 {
   if (const auto fnd = d_qpolAddr.lookup(addr)) {
     pol = fnd->second;
@@ -95,7 +95,7 @@ bool DNSFilterEngine::Zone::findClientPolicy(const ComboAddress& addr, DNSFilter
   return false;
 }
 
-bool DNSFilterEngine::Zone::findNamedPolicy(const std::unordered_map<DNSName, DNSFilterEngine::Policy>& polmap, const DNSName& qname, DNSFilterEngine::Policy& pol)
+bool DNSFilterEngine::Zone::findNamedPolicy(const std::unordered_map<DNSName, DNSFilterEngine::Policy>& polmap, const DNSName& qname, DNSFilterEngine::AppliedPolicy& pol)
 {
   if (polmap.empty()) {
     return false;
@@ -129,7 +129,7 @@ bool DNSFilterEngine::Zone::findNamedPolicy(const std::unordered_map<DNSName, DN
   return false;
 }
 
-bool DNSFilterEngine::Zone::findExactNamedPolicy(const std::unordered_map<DNSName, DNSFilterEngine::Policy>& polmap, const DNSName& qname, DNSFilterEngine::Policy& pol)
+bool DNSFilterEngine::Zone::findExactNamedPolicy(const std::unordered_map<DNSName, DNSFilterEngine::Policy>& polmap, const DNSName& qname, DNSFilterEngine::AppliedPolicy& pol)
 {
   if (polmap.empty()) {
     return false;
@@ -146,7 +146,7 @@ bool DNSFilterEngine::Zone::findExactNamedPolicy(const std::unordered_map<DNSNam
   return false;
 }
 
-bool DNSFilterEngine::getProcessingPolicy(const DNSName& qname, const std::unordered_map<std::string, bool>& discardedPolicies, Policy& pol) const
+bool DNSFilterEngine::getProcessingPolicy(const DNSName& qname, const std::unordered_map<std::string, bool>& discardedPolicies, AppliedPolicy& pol) const
 {
   // cout<<"Got question for nameserver name "<<qname<<endl;
   std::vector<bool> zoneEnabled(d_zones.size());
@@ -211,7 +211,7 @@ bool DNSFilterEngine::getProcessingPolicy(const DNSName& qname, const std::unord
   return false;
 }
 
-bool DNSFilterEngine::getProcessingPolicy(const ComboAddress& address, const std::unordered_map<std::string, bool>& discardedPolicies, Policy& pol) const
+bool DNSFilterEngine::getProcessingPolicy(const ComboAddress& address, const std::unordered_map<std::string, bool>& discardedPolicies, AppliedPolicy& pol) const
 {
   //  cout<<"Got question for nameserver IP "<<address.toString()<<endl;
   for (const auto& z : d_zones) {
@@ -231,7 +231,7 @@ bool DNSFilterEngine::getProcessingPolicy(const ComboAddress& address, const std
   return false;
 }
 
-bool DNSFilterEngine::getClientPolicy(const ComboAddress& ca, const std::unordered_map<std::string, bool>& discardedPolicies, Policy& pol) const
+bool DNSFilterEngine::getClientPolicy(const ComboAddress& ca, const std::unordered_map<std::string, bool>& discardedPolicies, AppliedPolicy& pol) const
 {
   // cout<<"Got question from "<<ca.toString()<<endl;
   for (const auto& z : d_zones) {
@@ -251,7 +251,7 @@ bool DNSFilterEngine::getClientPolicy(const ComboAddress& ca, const std::unorder
   return false;
 }
 
-bool DNSFilterEngine::getQueryPolicy(const DNSName& qname, const std::unordered_map<std::string, bool>& discardedPolicies, Policy& pol) const
+bool DNSFilterEngine::getQueryPolicy(const DNSName& qname, const std::unordered_map<std::string, bool>& discardedPolicies, AppliedPolicy& pol) const
 {
   // cerr<<"Got question for "<<qname<<' '<< pol.getPriority()<< endl;
   std::vector<bool> zoneEnabled(d_zones.size());
@@ -320,7 +320,7 @@ bool DNSFilterEngine::getQueryPolicy(const DNSName& qname, const std::unordered_
   return false;
 }
 
-bool DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& records, const std::unordered_map<std::string, bool>& discardedPolicies, Policy& pol) const
+bool DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& records, const std::unordered_map<std::string, bool>& discardedPolicies, AppliedPolicy& pol) const
 {
   for (const auto& record : records) {
     if (getPostPolicy(record, discardedPolicies, pol)) {
@@ -331,7 +331,7 @@ bool DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& records, const std:
   return false;
 }
 
-bool DNSFilterEngine::getPostPolicy(const DNSRecord& record, const std::unordered_map<std::string, bool>& discardedPolicies, Policy& pol) const
+bool DNSFilterEngine::getPostPolicy(const DNSRecord& record, const std::unordered_map<std::string, bool>& discardedPolicies, AppliedPolicy& pol) const
 {
   ComboAddress ca;
   if (record.d_place != DNSResourceRecord::ANSWER) {
@@ -552,12 +552,12 @@ bool DNSFilterEngine::Zone::rmNSIPTrigger(const Netmask& nm, const Policy& pol)
   return rmNetmaskTrigger(d_propolNSAddr, nm, pol);
 }
 
-std::string DNSFilterEngine::Policy::getLogString() const
+std::string DNSFilterEngine::AppliedPolicy::getLogString() const
 {
   return ": RPZ Hit; PolicyName=" + getName() + "; Trigger=" + d_trigger.toLogString() + "; Hit=" + d_hit + "; Type=" + getTypeToString(d_type) + "; Kind=" + getKindToString(d_kind);
 }
 
-void DNSFilterEngine::Policy::info(Logr::Priority prio, const std::shared_ptr<Logr::Logger>& log) const
+void DNSFilterEngine::AppliedPolicy::info(Logr::Priority prio, const std::shared_ptr<Logr::Logger>& log) const
 {
   log->info(prio, "RPZ Hit", "policyName", Logging::Loggable(getName()), "trigger", Logging::Loggable(d_trigger),
             "hit", Logging::Loggable(d_hit), "type", Logging::Loggable(getTypeToString(d_type)),

--- a/pdns/recursordist/filterpo.hh
+++ b/pdns/recursordist/filterpo.hh
@@ -219,7 +219,7 @@ public:
       if (d_custom == nullptr) {
         d_custom = std::make_unique<std::vector<std::shared_ptr<const DNSRecordContent>>>();
       }
-      d_custom->reserve(res);
+      d_custom->reserve(d_custom->size() + res);
     }
 
     [[nodiscard]] size_t customRecordsSize() const

--- a/pdns/recursordist/filterpo.hh
+++ b/pdns/recursordist/filterpo.hh
@@ -112,16 +112,16 @@ public:
       d_zoneData(data), d_ttl(ttl), d_kind(kind), d_type(type)
     {
       if (!custom.empty()) {
-        allocateCustomRecords();
-        copy(custom.cbegin(), custom.cend(), d_custom->begin());
+        allocateCustomRecords(custom.size());
+        d_custom->insert(d_custom->end(), custom.begin(), custom.end());
       }
     }
 
     Policy(const Policy& pol)
     {
-      if (pol.d_custom != nullptr) {
-        allocateCustomRecords();
-        copy(pol.d_custom->cbegin(), pol.d_custom->cend(), d_custom->begin());
+      if (pol.d_custom) {
+        allocateCustomRecords(pol.d_custom->size());
+        d_custom->insert(d_custom->end(), pol.d_custom->begin(), pol.d_custom->end());
       }
       d_zoneData = pol.d_zoneData;
       d_ttl = pol.d_ttl;
@@ -135,9 +135,9 @@ public:
         return *this;
       }
       this->d_custom = nullptr;
-      if (pol.d_custom != nullptr) {
-        allocateCustomRecords();
-        copy(pol.d_custom->cbegin(), pol.d_custom->cend(), d_custom->begin());
+      if (pol.d_custom) {
+        allocateCustomRecords(pol.d_custom->size());
+        d_custom->insert(d_custom->end(), pol.d_custom->begin(), pol.d_custom->end());
       }
       d_zoneData = pol.d_zoneData;
       d_ttl = pol.d_ttl;
@@ -209,12 +209,14 @@ public:
     std::vector<DNSRecord> getCustomRecords(const DNSName& qname, uint16_t qtype) const;
     std::vector<DNSRecord> getRecords(const DNSName& qname) const;
 
-    void allocateCustomRecords()
+    void allocateCustomRecords(size_t res)
     {
       if (d_custom == nullptr) {
         d_custom = std::make_unique<std::vector<std::shared_ptr<const DNSRecordContent>>>();
       }
+      d_custom->reserve(res);
     }
+
     [[nodiscard]] size_t customRecordsSize() const
     {
       if (d_custom) {

--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -221,9 +221,9 @@ void RecursorLua4::postPrepareContext() // NOLINT(readability-function-cognitive
     [](DNSFilterEngine::Policy& pol, const std::string& name) {
       pol.setName(name);
     });
-  d_lw->registerMember("policyKind", &DNSFilterEngine::Policy::d_kind);
-  d_lw->registerMember("policyType", &DNSFilterEngine::Policy::d_type);
-  d_lw->registerMember("policyTTL", &DNSFilterEngine::Policy::d_ttl);
+  d_lw->registerMember("policyKind", &DNSFilterEngine::AppliedPolicy::d_kind);
+  d_lw->registerMember("policyType", &DNSFilterEngine::AppliedPolicy::d_type);
+  d_lw->registerMember("policyTTL", &DNSFilterEngine::AppliedPolicy::d_ttl);
   d_lw->registerMember("policyTrigger", &DNSFilterEngine::AppliedPolicy::d_trigger);
   d_lw->registerMember("policyHit", &DNSFilterEngine::AppliedPolicy::d_hit);
   d_lw->registerMember<DNSFilterEngine::Policy, std::string>("policyCustom",

--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -242,7 +242,7 @@ void RecursorLua4::postPrepareContext()
       if (pol.d_custom != nullptr) {
         pol.d_custom->clear();
       }
-      pol.allocateCustomRecords();
+      pol.allocateCustomRecords(1);
       pol.d_custom->push_back(DNSRecordContent::mastermake(QType::CNAME, QClass::IN, content));
     }
   );

--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -226,19 +226,24 @@ void RecursorLua4::postPrepareContext()
         return result;
       }
 
-      for (const auto& dr : pol.d_custom) {
-        if (!result.empty()) {
-          result += "\n";
+      if (pol.customRecordsSize() > 0) {
+        for (const auto& dr : *pol.d_custom) {
+          if (!result.empty()) {
+            result += "\n";
+          }
+          result += dr->getZoneRepresentation();
         }
-        result += dr->getZoneRepresentation();
       }
 
       return result;
     },
     [](DNSFilterEngine::Policy& pol, const std::string& content) {
       // Only CNAMES for now, when we ever add a d_custom_type, there will be pain
-      pol.d_custom.clear();
-      pol.d_custom.push_back(DNSRecordContent::mastermake(QType::CNAME, QClass::IN, content));
+      if (pol.d_custom != nullptr) {
+        pol.d_custom->clear();
+      }
+      pol.allocateCustomRecords();
+      pol.d_custom->push_back(DNSRecordContent::mastermake(QType::CNAME, QClass::IN, content));
     }
   );
   d_lw->registerFunction("getDH", &DNSQuestion::getDH);

--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -214,11 +214,11 @@ void RecursorLua4::postPrepareContext() // NOLINT(readability-function-cognitive
   d_lw->registerMember("appliedPolicy", &DNSQuestion::appliedPolicy);
   d_lw->registerMember("queryTime", &DNSQuestion::queryTime);
 
-  d_lw->registerMember<DNSFilterEngine::Policy, std::string>("policyName",
-    [](const DNSFilterEngine::Policy& pol) -> std::string {
+  d_lw->registerMember<DNSFilterEngine::AppliedPolicy, std::string>("policyName",
+    [](const DNSFilterEngine::AppliedPolicy& pol) -> std::string {
       return pol.getName();
     },
-    [](DNSFilterEngine::Policy& pol, const std::string& name) {
+    [](DNSFilterEngine::AppliedPolicy& pol, const std::string& name) {
       pol.setName(name);
     });
   d_lw->registerMember("policyKind", &DNSFilterEngine::AppliedPolicy::d_kind);
@@ -226,8 +226,8 @@ void RecursorLua4::postPrepareContext() // NOLINT(readability-function-cognitive
   d_lw->registerMember("policyTTL", &DNSFilterEngine::AppliedPolicy::d_ttl);
   d_lw->registerMember("policyTrigger", &DNSFilterEngine::AppliedPolicy::d_trigger);
   d_lw->registerMember("policyHit", &DNSFilterEngine::AppliedPolicy::d_hit);
-  d_lw->registerMember<DNSFilterEngine::Policy, std::string>("policyCustom",
-    [](const DNSFilterEngine::Policy& pol) -> std::string {
+  d_lw->registerMember<DNSFilterEngine::AppliedPolicy, std::string>("policyCustom",
+    [](const DNSFilterEngine::AppliedPolicy& pol) -> std::string {
       std::string result;
       if (pol.d_kind != DNSFilterEngine::PolicyKind::Custom) {
         return result;
@@ -244,7 +244,7 @@ void RecursorLua4::postPrepareContext() // NOLINT(readability-function-cognitive
 
       return result;
     },
-    [](DNSFilterEngine::Policy& pol, const std::string& content) {
+    [](DNSFilterEngine::AppliedPolicy& pol, const std::string& content) {
       // Only CNAMES for now, when we ever add a d_custom_type, there will be pain
       if (pol.d_custom != nullptr) {
         pol.d_custom->clear();
@@ -619,7 +619,7 @@ bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& loca
   return isok;
 }
 
-bool RecursorLua4::policyHitEventFilter(const ComboAddress& remote, const DNSName& qname, const QType& qtype, bool tcp, DNSFilterEngine::Policy& policy, std::unordered_set<std::string>& tags, std::unordered_map<std::string, bool>& discardedPolicies) const
+bool RecursorLua4::policyHitEventFilter(const ComboAddress& remote, const DNSName& qname, const QType& qtype, bool tcp, DNSFilterEngine::AppliedPolicy& policy, std::unordered_set<std::string>& tags, std::unordered_map<std::string, bool>& discardedPolicies) const
 {
   if (!d_policyHitEventFilter) {
     return false;
@@ -1080,6 +1080,7 @@ public:
   {
     return handle;
   }
+
 private:
   std::unordered_set<std::string> pool;
   RecursorLua4::PostResolveFFIHandle& handle;

--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -217,8 +217,8 @@ void RecursorLua4::postPrepareContext()
   d_lw->registerMember("policyKind", &DNSFilterEngine::Policy::d_kind);
   d_lw->registerMember("policyType", &DNSFilterEngine::Policy::d_type);
   d_lw->registerMember("policyTTL", &DNSFilterEngine::Policy::d_ttl);
-  d_lw->registerMember("policyTrigger", &DNSFilterEngine::Policy::d_trigger);
-  d_lw->registerMember("policyHit", &DNSFilterEngine::Policy::d_hit);
+  d_lw->registerMember("policyTrigger", &DNSFilterEngine::AppliedPolicy::d_trigger);
+  d_lw->registerMember("policyHit", &DNSFilterEngine::AppliedPolicy::d_hit);
   d_lw->registerMember<DNSFilterEngine::Policy, std::string>("policyCustom",
     [](const DNSFilterEngine::Policy& pol) -> std::string {
       std::string result;

--- a/pdns/recursordist/lua-recursor4.hh
+++ b/pdns/recursordist/lua-recursor4.hh
@@ -73,7 +73,11 @@ class RecursorLua4 : public BaseLua4
 {
 public:
   RecursorLua4();
-  ~RecursorLua4(); // this is so unique_ptr works with an incomplete type
+  RecursorLua4(const RecursorLua4&) = delete;
+  RecursorLua4(RecursorLua4&&) = delete;
+  RecursorLua4& operator=(const RecursorLua4&) = delete;
+  RecursorLua4& operator=(RecursorLua4&&) = delete;
+  ~RecursorLua4() override; // this is so unique_ptr works with an incomplete type
 
   struct MetaValue
   {
@@ -82,7 +86,7 @@ public:
   };
   struct DNSQuestion
   {
-    DNSQuestion(const ComboAddress& rem, const ComboAddress& loc, const DNSName& query, uint16_t type, bool tcp, bool& variable_, bool& wantsRPZ_, bool& logResponse_, bool& addPaddingToResponse_, const struct timeval& queryTime_) :
+    DNSQuestion(const ComboAddress& rem, const ComboAddress& loc, const DNSName& query, uint16_t type, bool tcp, bool& variable_, bool& wantsRPZ_, bool& logResponse_, bool& addPaddingToResponse_, const struct timeval& queryTime_) : // NOLINT
       qname(query), qtype(type), local(loc), remote(rem), isTcp(tcp), variable(variable_), wantsRPZ(wantsRPZ_), logResponse(logResponse_), addPaddingToResponse(addPaddingToResponse_), queryTime(queryTime_)
     {
     }
@@ -116,15 +120,15 @@ public:
 
     void addAnswer(uint16_t type, const std::string& content, boost::optional<int> ttl, boost::optional<string> name);
     void addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, boost::optional<int> ttl, boost::optional<string> name);
-    vector<pair<int, DNSRecord>> getRecords() const;
-    boost::optional<dnsheader> getDH() const;
-    vector<pair<uint16_t, string>> getEDNSOptions() const;
-    boost::optional<string> getEDNSOption(uint16_t code) const;
-    boost::optional<Netmask> getEDNSSubnet() const;
-    std::vector<std::pair<int, ProxyProtocolValue>> getProxyProtocolValues() const;
-    vector<string> getEDNSFlags() const;
-    bool getEDNSFlag(string flag) const;
-    void setRecords(const vector<pair<int, DNSRecord>>& records);
+    [[nodiscard]] vector<pair<int, DNSRecord>> getRecords() const;
+    [[nodiscard]] boost::optional<dnsheader> getDH() const;
+    [[nodiscard]] vector<pair<uint16_t, string>> getEDNSOptions() const;
+    [[nodiscard]] boost::optional<string> getEDNSOption(uint16_t code) const;
+    [[nodiscard]] boost::optional<Netmask> getEDNSSubnet() const;
+    [[nodiscard]] std::vector<std::pair<int, ProxyProtocolValue>> getProxyProtocolValues() const;
+    [[nodiscard]] vector<string> getEDNSFlags() const;
+    [[nodiscard]] bool getEDNSFlag(const string& flag) const;
+    void setRecords(const vector<pair<int, DNSRecord>>& recs);
 
     int rcode{0};
     // struct dnsheader, packet length would be great
@@ -160,7 +164,7 @@ public:
   struct FFIParams
   {
   public:
-    FFIParams(const DNSName& qname_, uint16_t qtype_, const ComboAddress& local_, const ComboAddress& remote_, const Netmask& ednssubnet_, LuaContext::LuaObject& data_, std::unordered_set<std::string>& policyTags_, std::vector<DNSRecord>& records_, const EDNSOptionViewMap& ednsOptions_, const std::vector<ProxyProtocolValue>& proxyProtocolValues_, std::string& requestorId_, std::string& deviceId_, std::string& deviceName_, std::string& routingTag_, boost::optional<int>& rcode_, uint32_t& ttlCap_, bool& variable_, bool tcp_, bool& logQuery_, bool& logResponse_, bool& followCNAMERecords_, boost::optional<uint16_t>& extendedErrorCode_, std::string& extendedErrorExtra_, bool& disablePadding_, std::map<std::string, MetaValue>& meta_) :
+    FFIParams(const DNSName& qname_, uint16_t qtype_, const ComboAddress& local_, const ComboAddress& remote_, const Netmask& ednssubnet_, LuaContext::LuaObject& data_, std::unordered_set<std::string>& policyTags_, std::vector<DNSRecord>& records_, const EDNSOptionViewMap& ednsOptions_, const std::vector<ProxyProtocolValue>& proxyProtocolValues_, std::string& requestorId_, std::string& deviceId_, std::string& deviceName_, std::string& routingTag_, boost::optional<int>& rcode_, uint32_t& ttlCap_, bool& variable_, bool tcp_, bool& logQuery_, bool& logResponse_, bool& followCNAMERecords_, boost::optional<uint16_t>& extendedErrorCode_, std::string& extendedErrorExtra_, bool& disablePadding_, std::map<std::string, MetaValue>& meta_) : // NOLINT
       data(data_), qname(qname_), local(local_), remote(remote_), ednssubnet(ednssubnet_), policyTags(policyTags_), records(records_), ednsOptions(ednsOptions_), proxyProtocolValues(proxyProtocolValues_), requestorId(requestorId_), deviceId(deviceId_), deviceName(deviceName_), routingTag(routingTag_), extendedErrorExtra(extendedErrorExtra_), rcode(rcode_), extendedErrorCode(extendedErrorCode_), ttlCap(ttlCap_), variable(variable_), logQuery(logQuery_), logResponse(logResponse_), followCNAMERecords(followCNAMERecords_), disablePadding(disablePadding_), qtype(qtype_), tcp(tcp_), meta(meta_)
     {
     }
@@ -199,54 +203,54 @@ public:
   unsigned int gettag_ffi(FFIParams&) const;
 
   void maintenance() const;
-  bool prerpz(DNSQuestion& dq, int& ret, RecEventTrace&) const;
-  bool preresolve(DNSQuestion& dq, int& ret, RecEventTrace&) const;
-  bool nxdomain(DNSQuestion& dq, int& ret, RecEventTrace&) const;
-  bool nodata(DNSQuestion& dq, int& ret, RecEventTrace&) const;
-  bool postresolve(DNSQuestion& dq, int& ret, RecEventTrace&) const;
+  bool prerpz(DNSQuestion& dnsq, int& ret, RecEventTrace&) const;
+  bool preresolve(DNSQuestion& dnsq, int& ret, RecEventTrace&) const;
+  bool nxdomain(DNSQuestion& dnsq, int& ret, RecEventTrace&) const;
+  bool nodata(DNSQuestion& dnsq, int& ret, RecEventTrace&) const;
+  bool postresolve(DNSQuestion& dnsq, int& ret, RecEventTrace&) const;
 
-  bool preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, RecEventTrace& et, const struct timeval& tv) const;
+  bool preoutquery(const ComboAddress& address, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, RecEventTrace& eventtrace, const struct timeval& tval) const;
   bool ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader&, RecEventTrace&) const;
 
   bool policyHitEventFilter(const ComboAddress& remote, const DNSName& qname, const QType& qtype, bool tcp, DNSFilterEngine::Policy& policy, std::unordered_set<std::string>& tags, std::unordered_map<std::string, bool>& discardedPolicies) const;
 
-  bool needDQ() const
+  [[nodiscard]] bool needDQ() const
   {
     return (d_prerpz || d_preresolve || d_nxdomain || d_nodata || d_postresolve);
   }
 
-  typedef std::function<std::tuple<unsigned int, boost::optional<std::unordered_map<int, string>>, boost::optional<LuaContext::LuaObject>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<string>>(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const EDNSOptionViewMap&, bool, const std::vector<std::pair<int, const ProxyProtocolValue*>>&)> gettag_t;
-  gettag_t d_gettag; // public so you can query if we have this hooked
+  using gettag_t = std::function<std::tuple<unsigned int, boost::optional<std::unordered_map<int, string>>, boost::optional<LuaContext::LuaObject>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<string>> (ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const EDNSOptionViewMap &, bool, const std::vector<std::pair<int, const ProxyProtocolValue *>> &)>;
+  gettag_t d_gettag; // NOLINT: public so you can query if we have this hooked
 
-  typedef std::function<boost::optional<LuaContext::LuaObject>(pdns_ffi_param_t*)> gettag_ffi_t;
-  gettag_ffi_t d_gettag_ffi;
+  using gettag_ffi_t = std::function<boost::optional<LuaContext::LuaObject> (pdns_ffi_param_t *)>;
+  gettag_ffi_t d_gettag_ffi; // NOLINT
 
   struct PostResolveFFIHandle
   {
-    PostResolveFFIHandle(DNSQuestion& dq) :
-      d_dq(dq)
+    PostResolveFFIHandle(DNSQuestion& dnsq) :
+      d_dq(dnsq)
     {
     }
     DNSQuestion& d_dq;
     bool d_ret{false};
   };
   bool postresolve_ffi(PostResolveFFIHandle&) const;
-  typedef std::function<bool(pdns_postresolve_ffi_handle_t*)> postresolve_ffi_t;
-  postresolve_ffi_t d_postresolve_ffi;
+  using postresolve_ffi_t = std::function<bool (pdns_postresolve_ffi_handle_t *)>;
+  postresolve_ffi_t d_postresolve_ffi; // NOLINT
 
 protected:
-  virtual void postPrepareContext() override;
-  virtual void postLoad() override;
-  virtual void getFeatures(Features& features) override;
+   void postPrepareContext() override;
+   void postLoad() override;
+   void getFeatures(Features& features) override;
 
 private:
-  typedef std::function<void()> luamaintenance_t;
+  using luamaintenance_t = std::function<void ()>;
   luamaintenance_t d_maintenance;
-  typedef std::function<bool(DNSQuestion*)> luacall_t;
+  using luacall_t = std::function<bool (DNSQuestion *)>;
   luacall_t d_prerpz, d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
-  bool genhook(const luacall_t& func, DNSQuestion& dq, int& ret) const;
-  typedef std::function<bool(ComboAddress, ComboAddress, struct dnsheader)> ipfilter_t;
+  bool genhook(const luacall_t& func, DNSQuestion& dnsq, int& ret) const;
+  using ipfilter_t = std::function<bool (ComboAddress, ComboAddress, struct dnsheader)>;
   ipfilter_t d_ipfilter;
-  typedef std::function<bool(PolicyEvent&)> policyEventFilter_t;
+  using policyEventFilter_t = std::function<bool (PolicyEvent &)>;
   policyEventFilter_t d_policyHitEventFilter;
 };

--- a/pdns/recursordist/lua-recursor4.hh
+++ b/pdns/recursordist/lua-recursor4.hh
@@ -100,7 +100,7 @@ public:
     const std::vector<pair<uint16_t, string>>* ednsOptions{nullptr};
     const uint16_t* ednsFlags{nullptr};
     vector<DNSRecord>* currentRecords{nullptr};
-    DNSFilterEngine::Policy* appliedPolicy{nullptr};
+    DNSFilterEngine::AppliedPolicy* appliedPolicy{nullptr};
     std::unordered_set<std::string>* policyTags{nullptr};
     const std::vector<ProxyProtocolValue>* proxyProtocolValues{nullptr};
     std::unordered_map<std::string, bool>* discardedPolicies{nullptr};
@@ -156,7 +156,7 @@ public:
     const QType qtype;
     const ComboAddress& remote;
     const bool isTcp;
-    DNSFilterEngine::Policy* appliedPolicy{nullptr};
+    DNSFilterEngine::AppliedPolicy* appliedPolicy{nullptr};
     std::unordered_set<std::string>* policyTags{nullptr};
     std::unordered_map<std::string, bool>* discardedPolicies{nullptr};
   };
@@ -212,17 +212,17 @@ public:
   bool preoutquery(const ComboAddress& address, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, RecEventTrace& eventtrace, const struct timeval& tval) const;
   bool ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader&, RecEventTrace&) const;
 
-  bool policyHitEventFilter(const ComboAddress& remote, const DNSName& qname, const QType& qtype, bool tcp, DNSFilterEngine::Policy& policy, std::unordered_set<std::string>& tags, std::unordered_map<std::string, bool>& discardedPolicies) const;
+  bool policyHitEventFilter(const ComboAddress& remote, const DNSName& qname, const QType& qtype, bool tcp, DNSFilterEngine::AppliedPolicy& policy, std::unordered_set<std::string>& tags, std::unordered_map<std::string, bool>& discardedPolicies) const;
 
   [[nodiscard]] bool needDQ() const
   {
     return (d_prerpz || d_preresolve || d_nxdomain || d_nodata || d_postresolve);
   }
 
-  using gettag_t = std::function<std::tuple<unsigned int, boost::optional<std::unordered_map<int, string>>, boost::optional<LuaContext::LuaObject>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<string>> (ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const EDNSOptionViewMap &, bool, const std::vector<std::pair<int, const ProxyProtocolValue *>> &)>;
+  using gettag_t = std::function<std::tuple<unsigned int, boost::optional<std::unordered_map<int, string>>, boost::optional<LuaContext::LuaObject>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<string>>(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const EDNSOptionViewMap&, bool, const std::vector<std::pair<int, const ProxyProtocolValue*>>&)>;
   gettag_t d_gettag; // NOLINT: public so you can query if we have this hooked
 
-  using gettag_ffi_t = std::function<boost::optional<LuaContext::LuaObject> (pdns_ffi_param_t *)>;
+  using gettag_ffi_t = std::function<boost::optional<LuaContext::LuaObject>(pdns_ffi_param_t*)>;
   gettag_ffi_t d_gettag_ffi; // NOLINT
 
   struct PostResolveFFIHandle
@@ -235,22 +235,22 @@ public:
     bool d_ret{false};
   };
   bool postresolve_ffi(PostResolveFFIHandle&) const;
-  using postresolve_ffi_t = std::function<bool (pdns_postresolve_ffi_handle_t *)>;
+  using postresolve_ffi_t = std::function<bool(pdns_postresolve_ffi_handle_t*)>;
   postresolve_ffi_t d_postresolve_ffi; // NOLINT
 
 protected:
-   void postPrepareContext() override;
-   void postLoad() override;
-   void getFeatures(Features& features) override;
+  void postPrepareContext() override;
+  void postLoad() override;
+  void getFeatures(Features& features) override;
 
 private:
-  using luamaintenance_t = std::function<void ()>;
+  using luamaintenance_t = std::function<void()>;
   luamaintenance_t d_maintenance;
-  using luacall_t = std::function<bool (DNSQuestion *)>;
+  using luacall_t = std::function<bool(DNSQuestion*)>;
   luacall_t d_prerpz, d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
   bool genhook(const luacall_t& func, DNSQuestion& dnsq, int& ret) const;
-  using ipfilter_t = std::function<bool (ComboAddress, ComboAddress, struct dnsheader)>;
+  using ipfilter_t = std::function<bool(ComboAddress, ComboAddress, struct dnsheader)>;
   ipfilter_t d_ipfilter;
-  using policyEventFilter_t = std::function<bool (PolicyEvent &)>;
+  using policyEventFilter_t = std::function<bool(PolicyEvent&)>;
   policyEventFilter_t d_policyHitEventFilter;
 };

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -494,7 +494,7 @@ enum class PolicyResult : uint8_t
   Drop
 };
 
-static PolicyResult handlePolicyHit(const DNSFilterEngine::Policy& appliedPolicy, const std::unique_ptr<DNSComboWriter>& dc, SyncRes& sr, int& res, vector<DNSRecord>& ret, DNSPacketWriter& pw, RunningResolveGuard& tcpGuard)
+static PolicyResult handlePolicyHit(const DNSFilterEngine::AppliedPolicy& appliedPolicy, const std::unique_ptr<DNSComboWriter>& dc, SyncRes& sr, int& res, vector<DNSRecord>& ret, DNSPacketWriter& pw, RunningResolveGuard& tcpGuard)
 {
   /* don't account truncate actions for TCP queries, since they are not applied */
   if (appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::Truncate || !dc->d_tcp) {
@@ -1076,7 +1076,7 @@ void startDoResolve(void* p) // NOLINT(readability-function-cognitive-complexity
     /* preresolve expects res (dq.rcode) to be set to RCode::NoError by default */
     int res = RCode::NoError;
 
-    DNSFilterEngine::Policy appliedPolicy;
+    DNSFilterEngine::AppliedPolicy appliedPolicy;
     RecursorLua4::DNSQuestion dq(dc->d_source, dc->d_destination, dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_tcp, variableAnswer, wantsRPZ, dc->d_logResponse, addPaddingToResponse, (g_useKernelTimestamp && dc->d_kernelTimestamp.tv_sec != 0) ? dc->d_kernelTimestamp : dc->d_now);
     dq.ednsFlags = &edo.d_extFlags;
     dq.ednsOptions = &ednsOpts;

--- a/pdns/recursordist/rec-lua-conf.cc
+++ b/pdns/recursordist/rec-lua-conf.cc
@@ -109,7 +109,8 @@ static void parseRPZParameters(rpzOptions_t& have, std::shared_ptr<DNSFilterEngi
     defpol->d_kind = (DNSFilterEngine::PolicyKind)boost::get<uint32_t>(have["defpol"]);
     defpol->setName(polName);
     if (defpol->d_kind == DNSFilterEngine::PolicyKind::Custom) {
-      defpol->d_custom.push_back(DNSRecordContent::mastermake(QType::CNAME, QClass::IN,
+      defpol->allocateCustomRecords();
+      defpol->d_custom->push_back(DNSRecordContent::mastermake(QType::CNAME, QClass::IN,
                                                               boost::get<string>(have["defcontent"])));
 
       if (have.count("defttl"))

--- a/pdns/recursordist/rec-lua-conf.cc
+++ b/pdns/recursordist/rec-lua-conf.cc
@@ -109,9 +109,9 @@ static void parseRPZParameters(rpzOptions_t& have, std::shared_ptr<DNSFilterEngi
     defpol->d_kind = (DNSFilterEngine::PolicyKind)boost::get<uint32_t>(have["defpol"]);
     defpol->setName(polName);
     if (defpol->d_kind == DNSFilterEngine::PolicyKind::Custom) {
-      defpol->allocateCustomRecords();
+      defpol->allocateCustomRecords(1);
       defpol->d_custom->push_back(DNSRecordContent::mastermake(QType::CNAME, QClass::IN,
-                                                              boost::get<string>(have["defcontent"])));
+                                                               boost::get<string>(have["defcontent"])));
 
       if (have.count("defttl"))
         defpol->d_ttl = static_cast<int32_t>(boost::get<uint32_t>(have["defttl"]));

--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -1,3 +1,25 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 #include "arguments.hh"
 #include "dnsparser.hh"
 #include "dnsrecords.hh"
@@ -21,65 +43,75 @@ Netmask makeNetmaskFromRPZ(const DNSName& name)
    * $NETMASK.zz (::/$NETMASK)
    * Terrible right?
    */
-  if (parts.size() < 2 || parts.size() > 9)
+  if (parts.size() < 2 || parts.size() > 9) {
     throw PDNSException("Invalid IP address in RPZ: " + name.toLogString());
+  }
 
   bool isV6 = (stoi(parts[0]) > 32);
   bool hadZZ = false;
 
   for (auto& part : parts) {
     // Check if we have an IPv4 octet
-    for (auto c : part)
-      if (!isdigit(c))
+    for (auto character : part) {
+      if (isdigit(character) == 0) {
         isV6 = true;
+      }
+    }
 
     if (pdns_iequals(part, "zz")) {
-      if (hadZZ)
+      if (hadZZ) {
         throw PDNSException("more than one 'zz' label found in RPZ name" + name.toLogString());
+      }
       part = "";
       isV6 = true;
       hadZZ = true;
     }
   }
 
-  if (isV6 && parts.size() < 9 && !hadZZ)
+  if (isV6 && parts.size() < 9 && !hadZZ) {
     throw PDNSException("No 'zz' label found in an IPv6 RPZ name shorter than 9 elements: " + name.toLogString());
+  }
 
-  if (parts.size() == 5 && !isV6)
-    return Netmask(parts[4] + "." + parts[3] + "." + parts[2] + "." + parts[1] + "/" + parts[0]);
+  if (parts.size() == 5 && !isV6) {
+    return {parts[4] + "." + parts[3] + "." + parts[2] + "." + parts[1] + "/" + parts[0]};
+  }
 
-  string v6;
+  string v6string;
 
-  if (parts[parts.size() - 1] == "") {
-    v6 += ":";
+  if (parts[parts.size() - 1].empty()) {
+    v6string += ":";
   }
   for (uint8_t i = parts.size() - 1; i > 0; i--) {
-    v6 += parts[i];
-    if (i > 1 || (i == 1 && parts[i] == "")) {
-      v6 += ":";
+    v6string += parts[i];
+    if (i > 1 || (i == 1 && parts[i].empty())) {
+      v6string += ":";
     }
   }
-  v6 += "/" + parts[0];
+  v6string += "/" + parts[0];
 
-  return Netmask(v6);
+  return {v6string};
 }
 
-static void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngine::Zone> zone, bool addOrRemove, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL, Logr::log_t log)
+static void RPZRecordToPolicy(const DNSRecord& dnsrec, const std::shared_ptr<DNSFilterEngine::Zone>& zone, bool addOrRemove, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL, Logr::log_t log)
 {
-  static const DNSName drop("rpz-drop."), truncate("rpz-tcp-only."), noaction("rpz-passthru.");
-  static const DNSName rpzClientIP("rpz-client-ip"), rpzIP("rpz-ip"),
-    rpzNSDname("rpz-nsdname"), rpzNSIP("rpz-nsip.");
+  static const DNSName drop("rpz-drop.");
+  static const DNSName truncate("rpz-tcp-only.");
+  static const DNSName noaction("rpz-passthru.");
+  static const DNSName rpzClientIP("rpz-client-ip");
+  static const DNSName rpzIP("rpz-ip");
+  static const DNSName rpzNSDname("rpz-nsdname");
+  static const DNSName rpzNSIP("rpz-nsip.");
   static const std::string rpzPrefix("rpz-");
 
   DNSFilterEngine::Policy pol;
   bool defpolApplied = false;
 
-  if (dr.d_class != QClass::IN) {
+  if (dnsrec.d_class != QClass::IN) {
     return;
   }
 
-  if (dr.d_type == QType::CNAME) {
-    auto crc = getRR<CNAMERecordContent>(dr);
+  if (dnsrec.d_type == QType::CNAME) {
+    auto crc = getRR<CNAMERecordContent>(dnsrec);
     if (!crc) {
       return;
     }
@@ -118,14 +150,14 @@ static void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngi
     else if (!crcTarget.empty() && !crcTarget.isRoot() && crcTarget.getRawLabel(crcTarget.countLabels() - 1).compare(0, rpzPrefix.length(), rpzPrefix) == 0) {
       /* this is very likely an higher format number or a configuration error,
          let's just ignore it. */
-      SLOG(g_log << Logger::Info << "Discarding unsupported RPZ entry " << crcTarget << " for " << dr.d_name << endl,
-           log->info(Logr::Info, "Discarding unsupported RPZ entry", "target", Logging::Loggable(crcTarget), "name", Logging::Loggable(dr.d_name)));
+      SLOG(g_log << Logger::Info << "Discarding unsupported RPZ entry " << crcTarget << " for " << dnsrec.d_name << endl,
+           log->info(Logr::Info, "Discarding unsupported RPZ entry", "target", Logging::Loggable(crcTarget), "name", Logging::Loggable(dnsrec.d_name)));
       return;
     }
     else {
       pol.d_kind = DNSFilterEngine::PolicyKind::Custom;
       pol.allocateCustomRecords(pol.customRecordsSize() + 1);
-      pol.d_custom->emplace_back(dr.getContent());
+      pol.d_custom->emplace_back(dnsrec.getContent());
       // cerr<<"Wants custom "<<crcTarget<<" for "<<dr.d_name<<": ";
     }
   }
@@ -137,13 +169,13 @@ static void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngi
     else {
       pol.d_kind = DNSFilterEngine::PolicyKind::Custom;
       pol.allocateCustomRecords(pol.customRecordsSize() + 1);
-      pol.d_custom->emplace_back(dr.getContent());
+      pol.d_custom->emplace_back(dnsrec.getContent());
       // cerr<<"Wants custom "<<dr.d_content->getZoneRepresentation()<<" for "<<dr.d_name<<": ";
     }
   }
 
   if (!defpolApplied || defpol->d_ttl < 0) {
-    pol.d_ttl = static_cast<int32_t>(std::min(maxTTL, dr.d_ttl));
+    pol.d_ttl = static_cast<int32_t>(std::min(maxTTL, dnsrec.d_ttl));
   }
   else {
     pol.d_ttl = static_cast<int32_t>(std::min(maxTTL, static_cast<uint32_t>(pol.d_ttl)));
@@ -151,102 +183,111 @@ static void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngi
 
   // now to DO something with that
 
-  if (dr.d_name.isPartOf(rpzNSDname)) {
-    DNSName filt = dr.d_name.makeRelative(rpzNSDname);
-    if (addOrRemove)
+  if (dnsrec.d_name.isPartOf(rpzNSDname)) {
+    DNSName filt = dnsrec.d_name.makeRelative(rpzNSDname);
+    if (addOrRemove) {
       zone->addNSTrigger(filt, std::move(pol), defpolApplied);
-    else
-      zone->rmNSTrigger(filt, std::move(pol));
+    }
+    else {
+      zone->rmNSTrigger(filt, pol);
+    }
   }
-  else if (dr.d_name.isPartOf(rpzClientIP)) {
-    DNSName filt = dr.d_name.makeRelative(rpzClientIP);
-    auto nm = makeNetmaskFromRPZ(filt);
-    if (addOrRemove)
-      zone->addClientTrigger(nm, std::move(pol), defpolApplied);
-    else
-      zone->rmClientTrigger(nm, std::move(pol));
+  else if (dnsrec.d_name.isPartOf(rpzClientIP)) {
+    DNSName filt = dnsrec.d_name.makeRelative(rpzClientIP);
+    auto netmask = makeNetmaskFromRPZ(filt);
+    if (addOrRemove) {
+      zone->addClientTrigger(netmask, std::move(pol), defpolApplied);
+    }
+    else {
+      zone->rmClientTrigger(netmask, pol);
+    }
   }
-  else if (dr.d_name.isPartOf(rpzIP)) {
+  else if (dnsrec.d_name.isPartOf(rpzIP)) {
     // cerr<<"Should apply answer content IP policy: "<<dr.d_name<<endl;
-    DNSName filt = dr.d_name.makeRelative(rpzIP);
-    auto nm = makeNetmaskFromRPZ(filt);
-    if (addOrRemove)
-      zone->addResponseTrigger(nm, std::move(pol), defpolApplied);
-    else
-      zone->rmResponseTrigger(nm, std::move(pol));
+    DNSName filt = dnsrec.d_name.makeRelative(rpzIP);
+    auto netmask = makeNetmaskFromRPZ(filt);
+    if (addOrRemove) {
+      zone->addResponseTrigger(netmask, std::move(pol), defpolApplied);
+    }
+    else {
+      zone->rmResponseTrigger(netmask, pol);
+    }
   }
-  else if (dr.d_name.isPartOf(rpzNSIP)) {
-    DNSName filt = dr.d_name.makeRelative(rpzNSIP);
-    auto nm = makeNetmaskFromRPZ(filt);
-    if (addOrRemove)
-      zone->addNSIPTrigger(nm, std::move(pol), defpolApplied);
-    else
-      zone->rmNSIPTrigger(nm, std::move(pol));
+  else if (dnsrec.d_name.isPartOf(rpzNSIP)) {
+    DNSName filt = dnsrec.d_name.makeRelative(rpzNSIP);
+    auto netmask = makeNetmaskFromRPZ(filt);
+    if (addOrRemove) {
+      zone->addNSIPTrigger(netmask, std::move(pol), defpolApplied);
+    }
+    else {
+      zone->rmNSIPTrigger(netmask, pol);
+    }
   }
   else {
     if (addOrRemove) {
       /* if we did override the existing policy with the default policy,
          we might turn two A or AAAA into a CNAME, which would trigger
          an exception. Let's just ignore it. */
-      zone->addQNameTrigger(dr.d_name, std::move(pol), defpolApplied);
+      zone->addQNameTrigger(dnsrec.d_name, std::move(pol), defpolApplied);
     }
     else {
-      zone->rmQNameTrigger(dr.d_name, std::move(pol));
+      zone->rmQNameTrigger(dnsrec.d_name, pol);
     }
   }
 }
 
-static shared_ptr<const SOARecordContent> loadRPZFromServer(Logr::log_t plogger, const ComboAddress& primary, const DNSName& zoneName, std::shared_ptr<DNSFilterEngine::Zone> zone, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, uint16_t axfrTimeout)
+static shared_ptr<const SOARecordContent> loadRPZFromServer(Logr::log_t plogger, const ComboAddress& primary, const DNSName& zoneName, const std::shared_ptr<DNSFilterEngine::Zone>& zone, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL, const TSIGTriplet& tsigtriplet, size_t maxReceivedBytes, const ComboAddress& localAddress, uint16_t axfrTimeout)
 {
 
   auto logger = plogger->withValues("primary", Logging::Loggable(primary));
   SLOG(g_log << Logger::Warning << "Loading RPZ zone '" << zoneName << "' from " << primary.toStringWithPort() << endl,
        logger->info(Logr::Info, "Loading RPZ from nameserver"));
-  if (!tt.name.empty()) {
-    SLOG(g_log << Logger::Warning << "With TSIG key '" << tt.name << "' of algorithm '" << tt.algo << "'" << endl,
-         logger->info(Logr::Info, "Using TSIG key for authentication", "tsig_key_name", Logging::Loggable(tt.name), "tsig_key_algorithm", Logging::Loggable(tt.algo)));
+  if (!tsigtriplet.name.empty()) {
+    SLOG(g_log << Logger::Warning << "With TSIG key '" << tsigtriplet.name << "' of algorithm '" << tsigtriplet.algo << "'" << endl,
+         logger->info(Logr::Info, "Using TSIG key for authentication", "tsig_key_name", Logging::Loggable(tsigtriplet.name), "tsig_key_algorithm", Logging::Loggable(tsigtriplet.algo)));
   }
 
   ComboAddress local(localAddress);
-  if (local == ComboAddress())
+  if (local == ComboAddress()) {
     local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0);
+  }
 
-  AXFRRetriever axfr(primary, zoneName, tt, &local, maxReceivedBytes, axfrTimeout);
+  AXFRRetriever axfr(primary, zoneName, tsigtriplet, &local, maxReceivedBytes, axfrTimeout);
   unsigned int nrecords = 0;
   Resolver::res_t nop;
   vector<DNSRecord> chunk;
   time_t last = 0;
   time_t axfrStart = time(nullptr);
   time_t axfrNow = time(nullptr);
-  shared_ptr<const SOARecordContent> sr;
-  while (axfr.getChunk(nop, &chunk, (axfrStart + axfrTimeout - axfrNow))) {
-    for (auto& dr : chunk) {
-      if (dr.d_type == QType::NS || dr.d_type == QType::TSIG) {
+  shared_ptr<const SOARecordContent> soa;
+  while (axfr.getChunk(nop, &chunk, (axfrStart + axfrTimeout - axfrNow)) != 0) {
+    for (auto& dnsrec : chunk) {
+      if (dnsrec.d_type == QType::NS || dnsrec.d_type == QType::TSIG) {
         continue;
       }
 
-      dr.d_name.makeUsRelative(zoneName);
-      if (dr.d_type == QType::SOA) {
-        sr = getRR<SOARecordContent>(dr);
+      dnsrec.d_name.makeUsRelative(zoneName);
+      if (dnsrec.d_type == QType::SOA) {
+        soa = getRR<SOARecordContent>(dnsrec);
         continue;
       }
 
-      RPZRecordToPolicy(dr, zone, true, defpol, defpolOverrideLocal, maxTTL, logger);
+      RPZRecordToPolicy(dnsrec, zone, true, defpol, defpolOverrideLocal, maxTTL, logger);
       nrecords++;
     }
     axfrNow = time(nullptr);
     if (axfrNow < axfrStart || axfrNow - axfrStart > axfrTimeout) {
       throw PDNSException("Total AXFR time exceeded!");
     }
-    if (last != time(0)) {
+    if (last != time(nullptr)) {
       SLOG(g_log << Logger::Info << "Loaded & indexed " << nrecords << " policy records so far for RPZ zone '" << zoneName << "'" << endl,
            logger->info(Logr::Info, "RPZ load in progress", "nrecords", Logging::Loggable(nrecords)));
-      last = time(0);
+      last = time(nullptr);
     }
   }
-  SLOG(g_log << Logger::Info << "Done: " << nrecords << " policy records active, SOA: " << sr->getZoneRepresentation() << endl,
-       logger->info(Logr::Info, "RPZ load completed", "nrecords", Logging::Loggable(nrecords), "soa", Logging::Loggable(sr->getZoneRepresentation())));
-  return sr;
+  SLOG(g_log << Logger::Info << "Done: " << nrecords << " policy records active, SOA: " << soa->getZoneRepresentation() << endl,
+       logger->info(Logr::Info, "RPZ load completed", "nrecords", Logging::Loggable(nrecords), "soa", Logging::Loggable(soa->getZoneRepresentation())));
+  return soa;
 }
 
 static LockGuarded<std::unordered_map<std::string, shared_ptr<rpzStats>>> s_rpzStats;
@@ -254,20 +295,21 @@ static LockGuarded<std::unordered_map<std::string, shared_ptr<rpzStats>>> s_rpzS
 shared_ptr<rpzStats> getRPZZoneStats(const std::string& zone)
 {
   auto stats = s_rpzStats.lock();
-  auto it = stats->find(zone);
-  if (it == stats->end()) {
+  auto iter = stats->find(zone);
+  if (iter == stats->end()) {
     auto stat = std::make_shared<rpzStats>();
     (*stats)[zone] = stat;
     return stat;
   }
-  return it->second;
+  return iter->second;
 }
 
 static void incRPZFailedTransfers(const std::string& zone)
 {
   auto stats = getRPZZoneStats(zone);
-  if (stats != nullptr)
+  if (stats != nullptr) {
     stats->d_failedTransfers++;
+  }
 }
 
 static void setRPZZoneNewState(const std::string& zone, uint32_t serial, uint64_t numberOfRecords, bool fromFile, bool wasAXFR)
@@ -288,9 +330,9 @@ static void setRPZZoneNewState(const std::string& zone, uint32_t serial, uint64_
 }
 
 // this function is silent - you do the logging
-std::shared_ptr<const SOARecordContent> loadRPZFromFile(const std::string& fname, std::shared_ptr<DNSFilterEngine::Zone> zone, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL)
+std::shared_ptr<const SOARecordContent> loadRPZFromFile(const std::string& fname, const std::shared_ptr<DNSFilterEngine::Zone>& zone, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL)
 {
-  shared_ptr<const SOARecordContent> sr = nullptr;
+  shared_ptr<const SOARecordContent> soa = nullptr;
   ZoneParserTNG zpt(fname);
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
   zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
@@ -299,20 +341,21 @@ std::shared_ptr<const SOARecordContent> loadRPZFromFile(const std::string& fname
   auto log = g_slog->withName("rpz")->withValues("file", Logging::Loggable(fname), "zone", Logging::Loggable(zone->getName()));
   while (zpt.get(drr)) {
     try {
-      if (drr.qtype.getCode() == QType::CNAME && drr.content.empty())
+      if (drr.qtype.getCode() == QType::CNAME && drr.content.empty()) {
         drr.content = ".";
-      DNSRecord dr(drr);
-      if (dr.d_type == QType::SOA) {
-        sr = getRR<SOARecordContent>(dr);
-        domain = dr.d_name;
+      }
+      DNSRecord dnsrec(drr);
+      if (dnsrec.d_type == QType::SOA) {
+        soa = getRR<SOARecordContent>(dnsrec);
+        domain = dnsrec.d_name;
         zone->setDomain(domain);
       }
-      else if (dr.d_type == QType::NS) {
+      else if (dnsrec.d_type == QType::NS) {
         continue;
       }
       else {
-        dr.d_name = dr.d_name.makeRelative(domain);
-        RPZRecordToPolicy(dr, zone, true, defpol, defpolOverrideLocal, maxTTL, log);
+        dnsrec.d_name = dnsrec.d_name.makeRelative(domain);
+        RPZRecordToPolicy(dnsrec, zone, true, defpol, defpolOverrideLocal, maxTTL, log);
       }
     }
     catch (const PDNSException& pe) {
@@ -320,35 +363,35 @@ std::shared_ptr<const SOARecordContent> loadRPZFromFile(const std::string& fname
     }
   }
 
-  if (sr != nullptr) {
-    zone->setRefresh(sr->d_st.refresh);
-    setRPZZoneNewState(zone->getName(), sr->d_st.serial, zone->size(), true, false);
+  if (soa != nullptr) {
+    zone->setRefresh(soa->d_st.refresh);
+    setRPZZoneNewState(zone->getName(), soa->d_st.serial, zone->size(), true, false);
   }
-  return sr;
+  return soa;
 }
 
 static bool dumpZoneToDisk(Logr::log_t logger, const DNSName& zoneName, const std::shared_ptr<DNSFilterEngine::Zone>& newZone, const std::string& dumpZoneFileName)
 {
   logger->info(Logr::Debug, "Dumping zone to disk", "destination_file", Logging::Loggable(dumpZoneFileName));
   std::string temp = dumpZoneFileName + "XXXXXX";
-  int fd = mkstemp(&temp.at(0));
-  if (fd < 0) {
+  int fileDesc = mkstemp(&temp.at(0));
+  if (fileDesc < 0) {
     SLOG(g_log << Logger::Warning << "Unable to open a file to dump the content of the RPZ zone " << zoneName << endl,
          logger->error(Logr::Error, errno, "Unable to create temporary file"));
     return false;
   }
 
-  auto fp = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(fd, "w+"), fclose);
-  if (!fp) {
+  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(fileDesc, "w+"), fclose);
+  if (!filePtr) {
     int err = errno;
-    close(fd);
+    close(fileDesc);
     SLOG(g_log << Logger::Warning << "Unable to open a file pointer to dump the content of the RPZ zone " << zoneName << endl,
          logger->error(Logr::Error, err, "Unable to open file pointer"));
     return false;
   }
 
   try {
-    newZone->dump(fp.get());
+    newZone->dump(filePtr.get());
   }
   catch (const std::exception& e) {
     SLOG(g_log << Logger::Warning << "Error while dumping the content of the RPZ zone " << zoneName << ": " << e.what() << endl,
@@ -356,19 +399,19 @@ static bool dumpZoneToDisk(Logr::log_t logger, const DNSName& zoneName, const st
     return false;
   }
 
-  if (fflush(fp.get()) != 0) {
+  if (fflush(filePtr.get()) != 0) {
     SLOG(g_log << Logger::Warning << "Error while flushing the content of the RPZ zone " << zoneName << " to the dump file: " << stringerror() << endl,
          logger->error(Logr::Warning, errno, "Error while flushing the content of the RPZ"));
     return false;
   }
 
-  if (fsync(fileno(fp.get())) != 0) {
+  if (fsync(fileno(filePtr.get())) != 0) {
     SLOG(g_log << Logger::Warning << "Error while syncing the content of the RPZ zone " << zoneName << " to the dump file: " << stringerror() << endl,
          logger->error(Logr::Error, errno, "Error while syncing the content of the RPZ"));
     return false;
   }
 
-  if (fclose(fp.release()) != 0) {
+  if (fclose(filePtr.release()) != 0) {
     SLOG(g_log << Logger::Warning << "Error while writing the content of the RPZ zone " << zoneName << " to the dump file: " << stringerror() << endl,
          logger->error(Logr::Error, errno, "Error while writing the content of the RPZ"));
     return false;
@@ -383,10 +426,10 @@ static bool dumpZoneToDisk(Logr::log_t logger, const DNSName& zoneName, const st
   return true;
 }
 
-void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, const uint16_t xfrTimeout, const uint32_t refreshFromConf, std::shared_ptr<const SOARecordContent> sr, const std::string& dumpZoneFileName, uint64_t configGeneration)
+void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tsigtriplet, size_t maxReceivedBytes, const ComboAddress& localAddress, const uint16_t xfrTimeout, const uint32_t refreshFromConf, std::shared_ptr<const SOARecordContent> soaRecord, const std::string& dumpZoneFileName, uint64_t configGeneration) // NOLINT(readability-function-cognitive-complexity)
 {
   setThreadName("rec/rpzixfr");
-  bool isPreloaded = sr != nullptr;
+  bool isPreloaded = soaRecord != nullptr;
   auto luaconfsLocal = g_luaconfs.getLocal();
 
   auto logger = g_slog->withName("rpz");
@@ -400,25 +443,25 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
   }
 
   // If oldZone failed to load its getRefresh() returns 0, protect against that
-  uint32_t refresh = std::max(refreshFromConf ? refreshFromConf : oldZone->getRefresh(), 10U);
+  uint32_t refresh = std::max(refreshFromConf != 0 ? refreshFromConf : oldZone->getRefresh(), 10U);
   DNSName zoneName = oldZone->getDomain();
   std::string polName = !oldZone->getName().empty() ? oldZone->getName() : zoneName.toStringNoDot();
 
   // Now that we know the name, set it in the logger
   logger = logger->withValues("zone", Logging::Loggable(zoneName));
 
-  while (!sr) {
+  while (!soaRecord) {
     /* if we received an empty sr, the zone was not really preloaded */
 
     /* full copy, as promised */
     std::shared_ptr<DNSFilterEngine::Zone> newZone = std::make_shared<DNSFilterEngine::Zone>(*oldZone);
     for (const auto& primary : primaries) {
       try {
-        sr = loadRPZFromServer(logger, primary, zoneName, newZone, defpol, defpolOverrideLocal, maxTTL, tt, maxReceivedBytes, localAddress, xfrTimeout);
-        newZone->setSerial(sr->d_st.serial);
-        newZone->setRefresh(sr->d_st.refresh);
-        refresh = std::max(refreshFromConf ? refreshFromConf : newZone->getRefresh(), 1U);
-        setRPZZoneNewState(polName, sr->d_st.serial, newZone->size(), false, true);
+        soaRecord = loadRPZFromServer(logger, primary, zoneName, newZone, defpol, defpolOverrideLocal, maxTTL, tsigtriplet, maxReceivedBytes, localAddress, xfrTimeout);
+        newZone->setSerial(soaRecord->d_st.serial);
+        newZone->setRefresh(soaRecord->d_st.refresh);
+        refresh = std::max(refreshFromConf != 0 ? refreshFromConf : newZone->getRefresh(), 1U);
+        setRPZZoneNewState(polName, soaRecord->d_st.serial, newZone->size(), false, true);
 
         g_luaconfs.modify([zoneIdx, &newZone](LuaConfigItems& lci) {
           lci.dfe.setZone(zoneIdx, newZone);
@@ -443,8 +486,8 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
       }
     }
 
-    if (!sr) {
-      sleep(refresh);
+    if (!soaRecord) {
+      std::this_thread::sleep_for(std::chrono::seconds(refresh));
     }
   }
 
@@ -452,14 +495,14 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
 
   for (;;) {
     oldZone = nullptr; // Do not keep it around, it will be re-assigned after the sleep.
-    DNSRecord dr;
-    dr.setContent(sr);
+    DNSRecord dnsrec;
+    dnsrec.setContent(soaRecord);
 
     if (skipRefreshDelay) {
       skipRefreshDelay = false;
     }
     else {
-      sleep(refresh);
+      std::this_thread::sleep_for(std::chrono::seconds(refresh));
     }
 
     if (luaconfsLocal->generation != configGeneration) {
@@ -473,7 +516,7 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
 
     vector<pair<vector<DNSRecord>, vector<DNSRecord>>> deltas;
     for (const auto& primary : primaries) {
-      auto soa = getRR<SOARecordContent>(dr);
+      auto soa = getRR<SOARecordContent>(dnsrec);
       auto serial = soa ? soa->d_st.serial : 0;
       SLOG(g_log << Logger::Info << "Getting IXFR deltas for " << zoneName << " from " << primary.toStringWithPort() << ", our serial: " << serial << endl,
            logger->info(Logr::Info, "Getting IXFR deltas", "address", Logging::Loggable(primary), "ourserial", Logging::Loggable(serial)));
@@ -484,7 +527,7 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
       }
 
       try {
-        deltas = getIXFRDeltas(primary, zoneName, dr, xfrTimeout, true, tt, &local, maxReceivedBytes);
+        deltas = getIXFRDeltas(primary, zoneName, dnsrec, xfrTimeout, true, tsigtriplet, &local, maxReceivedBytes);
 
         /* no need to try another primary */
         break;
@@ -519,9 +562,10 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
       /* we need to make a _full copy_ of the zone we are going to work on */
       std::shared_ptr<DNSFilterEngine::Zone> newZone = std::make_shared<DNSFilterEngine::Zone>(*oldZone);
       /* initialize the current serial to the last one */
-      std::shared_ptr<const SOARecordContent> currentSR = sr;
+      std::shared_ptr<const SOARecordContent> currentSR = soaRecord;
 
-      int totremove = 0, totadd = 0;
+      int totremove = 0;
+      int totadd = 0;
       bool fullUpdate = false;
       for (const auto& delta : deltas) {
         const auto& remove = delta.first;
@@ -532,11 +576,12 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
           newZone->clear();
           fullUpdate = true;
         }
-        for (const auto& rr : remove) { // should always contain the SOA
-          if (rr.d_type == QType::NS)
+        for (const auto& record : remove) { // should always contain the SOA
+          if (record.d_type == QType::NS) {
             continue;
-          if (rr.d_type == QType::SOA) {
-            auto oldsr = getRR<SOARecordContent>(rr);
+          }
+          if (record.d_type == QType::SOA) {
+            auto oldsr = getRR<SOARecordContent>(record);
             if (oldsr && oldsr->d_st.serial == currentSR->d_st.serial) {
               //	    cout<<"Got good removal of SOA serial "<<oldsr->d_st.serial<<endl;
             }
@@ -544,24 +589,23 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
               if (!oldsr) {
                 throw std::runtime_error("Unable to extract serial from SOA record while processing the removal part of an update");
               }
-              else {
-                throw std::runtime_error("Received an unexpected serial (" + std::to_string(oldsr->d_st.serial) + ", expecting " + std::to_string(currentSR->d_st.serial) + ") from SOA record while processing the removal part of an update");
-              }
+              throw std::runtime_error("Received an unexpected serial (" + std::to_string(oldsr->d_st.serial) + ", expecting " + std::to_string(currentSR->d_st.serial) + ") from SOA record while processing the removal part of an update");
             }
           }
           else {
             totremove++;
-            SLOG(g_log << (g_logRPZChanges ? Logger::Info : Logger::Debug) << "Had removal of " << rr.d_name << " from RPZ zone " << zoneName << endl,
-                 logger->info(g_logRPZChanges ? Logr::Info : Logr::Debug, "Remove from RPZ zone", "name", Logging::Loggable(rr.d_name)));
-            RPZRecordToPolicy(rr, newZone, false, defpol, defpolOverrideLocal, maxTTL, logger);
+            SLOG(g_log << (g_logRPZChanges ? Logger::Info : Logger::Debug) << "Had removal of " << record.d_name << " from RPZ zone " << zoneName << endl,
+                 logger->info(g_logRPZChanges ? Logr::Info : Logr::Debug, "Remove from RPZ zone", "name", Logging::Loggable(record.d_name)));
+            RPZRecordToPolicy(record, newZone, false, defpol, defpolOverrideLocal, maxTTL, logger);
           }
         }
 
-        for (const auto& rr : add) { // should always contain the new SOA
-          if (rr.d_type == QType::NS)
+        for (const auto& record : add) { // should always contain the new SOA
+          if (record.d_type == QType::NS) {
             continue;
-          if (rr.d_type == QType::SOA) {
-            auto tempSR = getRR<SOARecordContent>(rr);
+          }
+          if (record.d_type == QType::SOA) {
+            auto tempSR = getRR<SOARecordContent>(record);
             //	  g_log<<Logger::Info<<"New SOA serial for "<<zoneName<<": "<<currentSR->d_st.serial<<endl;
             if (tempSR) {
               currentSR = tempSR;
@@ -569,22 +613,22 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
           }
           else {
             totadd++;
-            SLOG(g_log << (g_logRPZChanges ? Logger::Info : Logger::Debug) << "Had addition of " << rr.d_name << " to RPZ zone " << zoneName << endl,
-                 logger->info(g_logRPZChanges ? Logr::Info : Logr::Debug, "Addition to RPZ zone", "name", Logging::Loggable(rr.d_name)));
-            RPZRecordToPolicy(rr, newZone, true, defpol, defpolOverrideLocal, maxTTL, logger);
+            SLOG(g_log << (g_logRPZChanges ? Logger::Info : Logger::Debug) << "Had addition of " << record.d_name << " to RPZ zone " << zoneName << endl,
+                 logger->info(g_logRPZChanges ? Logr::Info : Logr::Debug, "Addition to RPZ zone", "name", Logging::Loggable(record.d_name)));
+            RPZRecordToPolicy(record, newZone, true, defpol, defpolOverrideLocal, maxTTL, logger);
           }
         }
       }
 
       /* only update sr now that all changes have been converted */
       if (currentSR) {
-        sr = currentSR;
+        soaRecord = currentSR;
       }
-      SLOG(g_log << Logger::Info << "Had " << totremove << " RPZ removal" << addS(totremove) << ", " << totadd << " addition" << addS(totadd) << " for " << zoneName << " New serial: " << sr->d_st.serial << endl,
-           logger->info(Logr::Info, "RPZ mutations", "removals", Logging::Loggable(totremove), "additions", Logging::Loggable(totadd), "newserial", Logging::Loggable(sr->d_st.serial)));
-      newZone->setSerial(sr->d_st.serial);
-      newZone->setRefresh(sr->d_st.refresh);
-      setRPZZoneNewState(polName, sr->d_st.serial, newZone->size(), false, fullUpdate);
+      SLOG(g_log << Logger::Info << "Had " << totremove << " RPZ removal" << addS(totremove) << ", " << totadd << " addition" << addS(totadd) << " for " << zoneName << " New serial: " << soaRecord->d_st.serial << endl,
+           logger->info(Logr::Info, "RPZ mutations", "removals", Logging::Loggable(totremove), "additions", Logging::Loggable(totadd), "newserial", Logging::Loggable(soaRecord->d_st.serial)));
+      newZone->setSerial(soaRecord->d_st.serial);
+      newZone->setRefresh(soaRecord->d_st.refresh);
+      setRPZZoneNewState(polName, soaRecord->d_st.serial, newZone->size(), false, fullUpdate);
 
       /* we need to replace the existing zone with the new one,
          but we don't want to touch anything else, especially other zones,
@@ -602,7 +646,7 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
       if (!dumpZoneFileName.empty()) {
         dumpZoneToDisk(logger, zoneName, newZone, dumpZoneFileName);
       }
-      refresh = std::max(refreshFromConf ? refreshFromConf : newZone->getRefresh(), 1U);
+      refresh = std::max(refreshFromConf != 0 ? refreshFromConf : newZone->getRefresh(), 1U);
     }
     catch (const std::exception& e) {
       SLOG(g_log << Logger::Error << "Error while applying the update received over XFR for " << zoneName << ", skipping the update: " << e.what() << endl,

--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -124,7 +124,8 @@ static void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngi
     }
     else {
       pol.d_kind = DNSFilterEngine::PolicyKind::Custom;
-      pol.d_custom.emplace_back(dr.getContent());
+      pol.allocateCustomRecords();
+      pol.d_custom->emplace_back(dr.getContent());
       // cerr<<"Wants custom "<<crcTarget<<" for "<<dr.d_name<<": ";
     }
   }
@@ -135,7 +136,8 @@ static void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngi
     }
     else {
       pol.d_kind = DNSFilterEngine::PolicyKind::Custom;
-      pol.d_custom.emplace_back(dr.getContent());
+      pol.allocateCustomRecords();
+      pol.d_custom->emplace_back(dr.getContent());
       // cerr<<"Wants custom "<<dr.d_content->getZoneRepresentation()<<" for "<<dr.d_name<<": ";
     }
   }

--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -124,7 +124,7 @@ static void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngi
     }
     else {
       pol.d_kind = DNSFilterEngine::PolicyKind::Custom;
-      pol.allocateCustomRecords();
+      pol.allocateCustomRecords(pol.customRecordsSize() + 1);
       pol.d_custom->emplace_back(dr.getContent());
       // cerr<<"Wants custom "<<crcTarget<<" for "<<dr.d_name<<": ";
     }
@@ -136,7 +136,7 @@ static void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngi
     }
     else {
       pol.d_kind = DNSFilterEngine::PolicyKind::Custom;
-      pol.allocateCustomRecords();
+      pol.allocateCustomRecords(pol.customRecordsSize() + 1);
       pol.d_custom->emplace_back(dr.getContent());
       // cerr<<"Wants custom "<<dr.d_content->getZoneRepresentation()<<" for "<<dr.d_name<<": ";
     }

--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -451,6 +451,7 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
   bool skipRefreshDelay = isPreloaded;
 
   for (;;) {
+    oldZone = nullptr; // Do not keep it around, it will be re-assigned after the sleep.
     DNSRecord dr;
     dr.setContent(sr);
 

--- a/pdns/recursordist/rpzloader.hh
+++ b/pdns/recursordist/rpzloader.hh
@@ -26,8 +26,8 @@
 
 extern bool g_logRPZChanges;
 
-std::shared_ptr<const SOARecordContent> loadRPZFromFile(const std::string& fname, std::shared_ptr<DNSFilterEngine::Zone> zone, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL);
-void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, const uint16_t xfrTimeout, const uint32_t reloadFromConf, shared_ptr<const SOARecordContent> sr, const std::string& dumpZoneFileName, uint64_t configGeneration);
+std::shared_ptr<const SOARecordContent> loadRPZFromFile(const std::string& fname, const std::shared_ptr<DNSFilterEngine::Zone>& zone, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL);
+void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::optional<DNSFilterEngine::Policy>& defpol, bool defpolOverrideLocal, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tsigtriplet, size_t maxReceivedBytes, const ComboAddress& localAddress, uint16_t xfrTimeout, uint32_t refreshFromConf, shared_ptr<const SOARecordContent> soaRecord, const std::string& dumpZoneFileName, uint64_t configGeneration);
 
 struct rpzStats
 {

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -554,7 +554,7 @@ public:
   static bool s_addExtendedResolutionDNSErrors;
 
   std::unordered_map<std::string, bool> d_discardedPolicies;
-  DNSFilterEngine::Policy d_appliedPolicy;
+  DNSFilterEngine::AppliedPolicy d_appliedPolicy;
   std::unordered_set<std::string> d_policyTags;
   boost::optional<string> d_routingTag;
   ComboAddress d_fromAuthIP;

--- a/pdns/recursordist/test-filterpo_cc.cc
+++ b/pdns/recursordist/test-filterpo_cc.cc
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::NSDName);
     BOOST_CHECK(matchingPolicy.d_kind == DNSFilterEngine::PolicyKind::Drop);
 
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findExactNSPolicy(nsName, zonePolicy));
     BOOST_CHECK(zonePolicy == matchingPolicy);
 
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     BOOST_CHECK(notMatchingPolicy.d_type == DNSFilterEngine::PolicyType::None);
 
     /* a direct lookup would not match */
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findExactNSPolicy(DNSName("sub.sub.wildcard.wolf."), zonePolicy) == false);
     /* except if we look exactly for the wildcard */
     BOOST_CHECK(zone->findExactNSPolicy(nsWildcardName, zonePolicy));
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     /* allowed NS name */
     const auto matchingPolicy = dfe.getProcessingPolicy(DNSName("ns.bad.rabbit."), std::unordered_map<std::string, bool>(), DNSFilterEngine::maximumPriority);
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::None);
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findExactNSPolicy(DNSName("ns.bad.rabbit."), zonePolicy) == false);
   }
 
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     const auto matchingPolicy = dfe.getProcessingPolicy(nsIP, std::unordered_map<std::string, bool>(), DNSFilterEngine::maximumPriority);
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::NSIP);
     BOOST_CHECK(matchingPolicy.d_kind == DNSFilterEngine::PolicyKind::Drop);
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findNSIPPolicy(nsIP, zonePolicy));
     BOOST_CHECK(zonePolicy == matchingPolicy);
     BOOST_CHECK_EQUAL(zonePolicy.d_trigger, DNSName("31.0.2.0.192.rpz-nsip"));
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     /* allowed NS IP */
     const auto matchingPolicy = dfe.getProcessingPolicy(ComboAddress("192.0.2.142"), std::unordered_map<std::string, bool>(), DNSFilterEngine::maximumPriority);
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::None);
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findNSIPPolicy(ComboAddress("192.0.2.142"), zonePolicy) == false);
   }
 
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     auto matchingPolicy = dfe.getQueryPolicy(blockedName, std::unordered_map<std::string, bool>(), DNSFilterEngine::maximumPriority);
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::QName);
     BOOST_CHECK(matchingPolicy.d_kind == DNSFilterEngine::PolicyKind::Drop);
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findExactQNamePolicy(blockedName, zonePolicy));
     BOOST_CHECK(zonePolicy == matchingPolicy);
     BOOST_CHECK_EQUAL(zonePolicy.d_trigger, blockedName);
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     BOOST_CHECK(notMatchingPolicy.d_type == DNSFilterEngine::PolicyType::None);
 
     /* a direct lookup would not match */
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findExactQNamePolicy(DNSName("sub.sub.wildcard-blocked."), zonePolicy) == false);
     /* except if we look exactly for the wildcard */
     BOOST_CHECK(zone->findExactQNamePolicy(blockedWildcardName, zonePolicy));
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     const auto matchingPolicy = dfe.getClientPolicy(clientIP, std::unordered_map<std::string, bool>(), DNSFilterEngine::maximumPriority);
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::ClientIP);
     BOOST_CHECK(matchingPolicy.d_kind == DNSFilterEngine::PolicyKind::Drop);
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findClientPolicy(clientIP, zonePolicy));
     BOOST_CHECK(zonePolicy == matchingPolicy);
     BOOST_CHECK_EQUAL(zonePolicy.d_trigger, DNSName("31.128.2.0.192.rpz-client-ip"));
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     /* not blocked */
     const auto matchingPolicy = dfe.getClientPolicy(ComboAddress("192.0.2.142"), std::unordered_map<std::string, bool>(), DNSFilterEngine::maximumPriority);
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::None);
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findClientPolicy(ComboAddress("192.0.2.142"), zonePolicy) == false);
     BOOST_CHECK(zone->findExactQNamePolicy(DNSName("totally.legit."), zonePolicy) == false);
   }
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     const auto matchingPolicy = dfe.getPostPolicy({dr}, std::unordered_map<std::string, bool>(), DNSFilterEngine::maximumPriority);
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::ResponseIP);
     BOOST_CHECK(matchingPolicy.d_kind == DNSFilterEngine::PolicyKind::Drop);
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findResponsePolicy(responseIP, zonePolicy));
     BOOST_CHECK(zonePolicy == matchingPolicy);
     BOOST_CHECK_EQUAL(zonePolicy.d_trigger, DNSName("31.254.2.0.192.rpz-ip"));
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(test_filter_policies_basic)
     dr.setContent(DNSRecordContent::mastermake(QType::A, QClass::IN, "192.0.2.142"));
     const auto matchingPolicy = dfe.getPostPolicy({dr}, std::unordered_map<std::string, bool>(), DNSFilterEngine::maximumPriority);
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::None);
-    DNSFilterEngine::Policy zonePolicy;
+    DNSFilterEngine::AppliedPolicy zonePolicy;
     BOOST_CHECK(zone->findResponsePolicy(ComboAddress("192.0.2.142"), zonePolicy) == false);
   }
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -41,7 +41,7 @@ bool RecursorLua4::preoutquery(const ComboAddress& /* ns */, const ComboAddress&
   return false;
 }
 
-bool RecursorLua4::policyHitEventFilter(const ComboAddress& /* remote */, const DNSName& /* qname */, const QType& /* qtype */, bool /* tcp */, DNSFilterEngine::Policy& /* policy */, std::unordered_set<std::string>& /* tags */, std::unordered_map<std::string, bool>& /* discardedPolicies */) const
+bool RecursorLua4::policyHitEventFilter(const ComboAddress& /* remote */, const DNSName& /* qname */, const QType& /* qtype */, bool /* tcp */, DNSFilterEngine::AppliedPolicy& /* policy */, std::unordered_set<std::string>& /* tags */, std::unordered_map<std::string, bool>& /* discardedPolicies */) const
 {
   return false;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Should fix #12870

In one test I could see the required memory drop from 1.7G to 1.0G. This need more tests and eyes, in particular validation of the copy/move constructors and assignment ops. So I'm marking it as draft. 

Inlcudes delinting of related files.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
