### PR TITLE
rec: add feature to switch off unsupported DNSSEC algos

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -453,10 +453,25 @@ string getMessageForRRSET(const DNSName& qname, const RRSIGRecordContent& rrc, c
   return toHash;
 }
 
+std::unordered_set<unsigned int> DNSCryptoKeyEngine::s_switchedOff;
+
+bool DNSCryptoKeyEngine::isAlgorithmSwitchedOff(unsigned int algo)
+{
+  return s_switchedOff.count(algo) != 0;
+}
+
+void DNSCryptoKeyEngine::switchOffAlgorithm(unsigned int algo)
+{
+  s_switchedOff.insert(algo);
+}
+
 bool DNSCryptoKeyEngine::isAlgorithmSupported(unsigned int algo)
 {
+  if (isAlgorithmSwitchedOff(algo)) {
+    return false;
+  }
   const makers_t& makers = getMakers();
-  makers_t::const_iterator iter = makers.find(algo);
+  auto iter = makers.find(algo);
   return iter != makers.cend();
 }
 

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -231,6 +231,31 @@ vector<pair<uint8_t, string>> DNSCryptoKeyEngine::listAllAlgosWithBackend()
   return ret;
 }
 
+string DNSCryptoKeyEngine::listSupportedAlgoNames()
+{
+  set<unsigned int> algos;
+  auto pairs = DNSCryptoKeyEngine::listAllAlgosWithBackend();
+  for (const auto& pair : pairs) {
+    algos.insert(pair.first);
+  }
+  string ret;
+  bool first = true;
+  for (auto algo : algos) {
+    if (!first) {
+      ret.append(" ");
+    }
+    else {
+      first = false;
+    }
+    ret.append(DNSSECKeeper::algorithm2name(algo));
+    if (isAlgorithmSwitchedOff(algo)) {
+      ret.append("(disabled)");
+    }
+  }
+  ret.append("\n");
+  return ret;
+}
+
 void DNSCryptoKeyEngine::report(unsigned int algo, maker_t* maker, bool fallback)
 {
   getAllMakers()[algo].push_back(maker);

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -179,6 +179,7 @@ class DNSCryptoKeyEngine
     static bool testOne(int algo);
     static bool verifyOne(unsigned int algo);
     static void testVerify(unsigned int algo, maker_t* verifier);
+    static string listSupportedAlgoNames();
 
   private:
     using makers_t = std::map<unsigned int, maker_t *>;

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -177,6 +177,8 @@ class DNSCryptoKeyEngine
     static vector<pair<uint8_t, string>> listAllAlgosWithBackend();
     static bool testAll();
     static bool testOne(int algo);
+    static bool verifyOne(unsigned int algo);
+    static void testVerify(unsigned int algo, maker_t* verifier);
 
   private:
     using makers_t = std::map<unsigned int, maker_t *>;

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -178,7 +178,7 @@ class DNSCryptoKeyEngine
     static bool testAll();
     static bool testOne(int algo);
     static bool verifyOne(unsigned int algo);
-    static void testVerify(unsigned int algo, maker_t* verifier);
+    static bool testVerify(unsigned int algo, maker_t* verifier);
     static string listSupportedAlgoNames();
 
   private:
@@ -194,6 +194,7 @@ class DNSCryptoKeyEngine
       static allmakers_t s_allmakers;
       return s_allmakers;
     }
+    // Must be set before going multi-threaded and not changed after that
     static std::unordered_set<unsigned int> s_switchedOff;
 
   protected:

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -166,6 +166,8 @@ class DNSCryptoKeyEngine
     static std::unique_ptr<DNSCryptoKeyEngine> makeFromPublicKeyString(unsigned int algorithm, const std::string& raw);
     static std::unique_ptr<DNSCryptoKeyEngine> make(unsigned int algorithm);
     static bool isAlgorithmSupported(unsigned int algo);
+    static bool isAlgorithmSwitchedOff(unsigned int algo);
+    static void switchOffAlgorithm(unsigned int algo);
     static bool isDigestSupported(uint8_t digest);
 
     using maker_t = std::unique_ptr<DNSCryptoKeyEngine> (unsigned int);
@@ -189,6 +191,7 @@ class DNSCryptoKeyEngine
       static allmakers_t s_allmakers;
       return s_allmakers;
     }
+    static std::unordered_set<unsigned int> s_switchedOff;
 
   protected:
     const unsigned int d_algorithm;

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -181,6 +181,9 @@ help
     Shows a list of supported commands understood by the running
     :program:`pdns_recursor`
 
+list-dnssec-algos
+    List supported (and potentially disabled) DNSSEC algorithms.
+
 ping
     Check if server is alive.
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -533,6 +533,23 @@ Set the mode for DNSSEC processing, as detailed in :doc:`dnssec`.
 ``validate``
    Full blown DNSSEC validation. Send SERVFAIL to clients on bogus responses.
 
+.. _setting-dnssec-disabled-algorithms:
+
+``dnssec-disabled-algorithms``
+------------------------------
+.. versionadded:: 4.9.0
+
+- Comma separated list of DNSSEC algorithm numbers
+- Default: (none)
+
+A list of DNSSEC algorithm numbers that should be considered disabled.
+These algorithms will not be used to validate DNSSEC signatures.
+Zones (only) signed with these algorithms will be considered ``Insecure``.
+
+If this setting is empty (the default), :program:`Recursor` will determine which algorithms to disable automatically.
+This is important on systems that have a default strict crypto policy, like RHEL9 derived systems.
+On such systems not disabling some algorithms (or changing the security policy) will make affected zones to be considered ``Bogus`` as using these algorithms fails.
+
 .. _setting-dnssec-log-bogus:
 
 ``dnssec-log-bogus``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -547,6 +547,8 @@ These algorithms will not be used to validate DNSSEC signatures.
 Zones (only) signed with these algorithms will be considered ``Insecure``.
 
 If this setting is empty (the default), :program:`Recursor` will determine which algorithms to disable automatically.
+This is done for specific algorithms only, currently algorithms 5 (``RSASHA1``) and 7 (``RSASHA1NSEC3SHA1``).
+
 This is important on systems that have a default strict crypto policy, like RHEL9 derived systems.
 On such systems not disabling some algorithms (or changing the security policy) will make affected zones to be considered ``Bogus`` as using these algorithms fails.
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1455,7 +1455,9 @@ static int initDNSSEC(Logr::log_t log)
   g_maxNSEC3Iterations = ::arg().asNum("nsec3-max-iterations");
 
   vector<string> nums;
+  bool automatic = true;
   if (!::arg()["dnssec-disabled-algorithms"].empty()) {
+    automatic = false;
     stringtok(nums, ::arg()["dnssec-disabled-algorithms"], ", ");
     for (auto num: nums) {
       DNSCryptoKeyEngine::switchOffAlgorithm(pdns::checked_stoi<unsigned int>(num));
@@ -1463,7 +1465,6 @@ static int initDNSSEC(Logr::log_t log)
   } else {
     for (auto algo : { DNSSECKeeper::RSASHA1, DNSSECKeeper::RSASHA1NSEC3SHA1 }) {
       if (!DNSCryptoKeyEngine::verifyOne(algo)) {
-        cerr << "XXXX " << algo << endl;
         DNSCryptoKeyEngine::switchOffAlgorithm(algo);
         nums.push_back(std::to_string(algo));
       }
@@ -1471,7 +1472,7 @@ static int initDNSSEC(Logr::log_t log)
   }
   if (!nums.empty()) {
     if (!g_slogStructured) {
-      g_log << Logger::Warning << "Disabled DNSSEC algorithm: ";
+      g_log << Logger::Warning << (automatic ? "Automatically" : "Manually") << " disabled DNSSEC algorithms: ";
       for (auto i = nums.begin(); i != nums.end(); ++i) {
         if (i != nums.begin()) {
           g_log << Logger::Warning << ", ";
@@ -1481,7 +1482,7 @@ static int initDNSSEC(Logr::log_t log)
       g_log << Logger::Warning << endl;
     }
     else {
-      log->info(Logr::Notice, "Disabled DNSSEC algorithms", "algorithms", Logging::IterLoggable(nums.begin(), nums.end()));
+      log->info(Logr::Notice, "Disabled DNSSEC algorithms", "automatically", Logging::Loggable(automatic), "algorithms", Logging::IterLoggable(nums.begin(), nums.end()));
     }
   }
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1459,11 +1459,12 @@ static int initDNSSEC(Logr::log_t log)
   if (!::arg()["dnssec-disabled-algorithms"].empty()) {
     automatic = false;
     stringtok(nums, ::arg()["dnssec-disabled-algorithms"], ", ");
-    for (const auto& num: nums) {
+    for (const auto& num : nums) {
       DNSCryptoKeyEngine::switchOffAlgorithm(pdns::checked_stoi<unsigned int>(num));
     }
-  } else {
-    for (auto algo : { DNSSECKeeper::RSASHA1, DNSSECKeeper::RSASHA1NSEC3SHA1 }) {
+  }
+  else {
+    for (auto algo : {DNSSECKeeper::RSASHA1, DNSSECKeeper::RSASHA1NSEC3SHA1}) {
       if (!DNSCryptoKeyEngine::verifyOne(algo)) {
         DNSCryptoKeyEngine::switchOffAlgorithm(algo);
         nums.push_back(std::to_string(algo));

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -38,6 +38,7 @@
 #include "rec-taskqueue.hh"
 #include "secpoll-recursor.hh"
 #include "logging.hh"
+#include "dnsseckeeper.hh"
 
 #ifdef NOD_ENABLED
 #include "nod.hh"
@@ -1460,7 +1461,13 @@ static int initDNSSEC(Logr::log_t log)
       DNSCryptoKeyEngine::switchOffAlgorithm(pdns::checked_stoi<unsigned int>(num));
     }
   } else {
-    // Auto determine algos to switch off
+    for (auto algo : { DNSSECKeeper::RSASHA1, DNSSECKeeper::RSASHA1NSEC3SHA1 }) {
+      if (!DNSCryptoKeyEngine::verifyOne(algo)) {
+        cerr << "XXXX " << algo << endl;
+        DNSCryptoKeyEngine::switchOffAlgorithm(algo);
+        nums.push_back(std::to_string(algo));
+      }
+    }
   }
   if (!nums.empty()) {
     if (!g_slogStructured) {

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1459,7 +1459,7 @@ static int initDNSSEC(Logr::log_t log)
   if (!::arg()["dnssec-disabled-algorithms"].empty()) {
     automatic = false;
     stringtok(nums, ::arg()["dnssec-disabled-algorithms"], ", ");
-    for (auto num: nums) {
+    for (const auto& num: nums) {
       DNSCryptoKeyEngine::switchOffAlgorithm(pdns::checked_stoi<unsigned int>(num));
     }
   } else {

--- a/pdns/recursordist/rec_channel.hh
+++ b/pdns/recursordist/rec_channel.hh
@@ -78,13 +78,11 @@ private:
 class RecursorControlParser
 {
 public:
-  RecursorControlParser()
-  {
-  }
-  static void nop(void) {}
-  typedef void func_t(void);
+  RecursorControlParser() = default;
+  static void nop() {}
+  using func_t = void();
 
-  RecursorControlChannel::Answer getAnswer(int s, const std::string& question, func_t** func);
+  static RecursorControlChannel::Answer getAnswer(int socket, const std::string& question, func_t** command);
 };
 
 enum class StatComponent

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2056,6 +2056,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
             "get-remotelogger-stats           get remote logger statistics\n"
             "hash-password [work-factor]      ask for a password then return the hashed version\n"
             "help                             get this list\n"
+            "list-dnssec-algos                list supported DNSSEC algorithms\n"
             "ping                             check that all threads are alive\n"
             "quit                             stop the recursor daemon\n"
             "quit-nicely                      stop the recursor daemon nicely\n"
@@ -2309,6 +2310,9 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
   }
   if (cmd == "get-remotelogger-stats") {
     return {0, getRemoteLoggerStats()};
+  }
+  if (cmd == "list-dnssec-algos") {
+    return {0, DNSCryptoKeyEngine::listSupportedAlgoNames() };
   }
 
   return {1, "Unknown command '" + cmd + "', try 'help'\n"};

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2312,7 +2312,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
     return {0, getRemoteLoggerStats()};
   }
   if (cmd == "list-dnssec-algos") {
-    return {0, DNSCryptoKeyEngine::listSupportedAlgoNames() };
+    return {0, DNSCryptoKeyEngine::listSupportedAlgoNames()};
   }
 
   return {1, "Unknown command '" + cmd + "', try 'help'\n"};

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2007,87 +2007,138 @@ static void* pleaseSupplantProxyMapping(const ProxyMapping& pm)
   return nullptr;
 }
 
-RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const string& question, RecursorControlParser::func_t** command)
+static RecursorControlChannel::Answer help()
+{
+  return {0,
+          "add-dont-throttle-names [N...]   add names that are not allowed to be throttled\n"
+          "add-dont-throttle-netmasks [N...]\n"
+          "                                 add netmasks that are not allowed to be throttled\n"
+          "add-nta DOMAIN [REASON]          add a Negative Trust Anchor for DOMAIN with the comment REASON\n"
+          "add-ta DOMAIN DSRECORD           add a Trust Anchor for DOMAIN with data DSRECORD\n"
+          "current-queries                  show currently active queries\n"
+          "clear-dont-throttle-names [N...] remove names that are not allowed to be throttled. If N is '*', remove all\n"
+          "clear-dont-throttle-netmasks [N...]\n"
+          "                                 remove netmasks that are not allowed to be throttled. If N is '*', remove all\n"
+          "clear-nta [DOMAIN]...            Clear the Negative Trust Anchor for DOMAINs, if no DOMAIN is specified, remove all\n"
+          "clear-ta [DOMAIN]...             Clear the Trust Anchor for DOMAINs\n"
+          "dump-cache <filename>            dump cache contents to the named file\n"
+          "dump-dot-probe-map <filename>    dump the contents of the DoT probe map to the named file\n"
+          "dump-edns [status] <filename>    dump EDNS status to the named file\n"
+          "dump-failedservers <filename>    dump the failed servers to the named file\n"
+          "dump-non-resolving <filename>    dump non-resolving nameservers addresses to the named file\n"
+          "dump-nsspeeds <filename>         dump nsspeeds statistics to the named file\n"
+          "dump-saved-parent-ns-sets <filename>\n"
+          "                                 dump saved parent ns sets that were successfully used as fallback\n"
+          "dump-rpz <zone name> <filename>  dump the content of a RPZ zone to the named file\n"
+          "dump-throttlemap <filename>      dump the contents of the throttle map to the named file\n"
+          "get [key1] [key2] ..             get specific statistics\n"
+          "get-all                          get all statistics\n"
+          "get-dont-throttle-names          get the list of names that are not allowed to be throttled\n"
+          "get-dont-throttle-netmasks       get the list of netmasks that are not allowed to be throttled\n"
+          "get-ntas                         get all configured Negative Trust Anchors\n"
+          "get-tas                          get all configured Trust Anchors\n"
+          "get-parameter [key1] [key2] ..   get configuration parameters\n"
+          "get-proxymapping-stats           get proxy mapping statistics\n"
+          "get-qtypelist                    get QType statistics\n"
+          "                                 notice: queries from cache aren't being counted yet\n"
+          "get-remotelogger-stats           get remote logger statistics\n"
+          "hash-password [work-factor]      ask for a password then return the hashed version\n"
+          "help                             get this list\n"
+          "list-dnssec-algos                list supported DNSSEC algorithms\n"
+          "ping                             check that all threads are alive\n"
+          "quit                             stop the recursor daemon\n"
+          "quit-nicely                      stop the recursor daemon nicely\n"
+          "reload-acls                      reload ACLS\n"
+          "reload-lua-script [filename]     (re)load Lua script\n"
+          "reload-lua-config [filename]     (re)load Lua configuration file\n"
+          "reload-zones                     reload all auth and forward zones\n"
+          "set-ecs-minimum-ttl value        set ecs-minimum-ttl-override\n"
+          "set-max-cache-entries value      set new maximum cache size\n"
+          "set-max-packetcache-entries val  set new maximum packet cache size\n"
+          "set-minimum-ttl value            set minimum-ttl-override\n"
+          "set-carbon-server                set a carbon server for telemetry\n"
+          "set-dnssec-log-bogus SETTING     enable (SETTING=yes) or disable (SETTING=no) logging of DNSSEC validation failures\n"
+          "set-event-trace-enabled SETTING  set logging of event trace messages, 0 = disabled, 1 = protobuf, 2 = log file, 3 = both\n"
+          "trace-regex [regex file]         emit resolution trace for matching queries (no arguments clears tracing)\n"
+          "top-largeanswer-remotes          show top remotes receiving large answers\n"
+          "top-queries                      show top queries\n"
+          "top-pub-queries                  show top queries grouped by public suffix list\n"
+          "top-remotes                      show top remotes\n"
+          "top-timeouts                     show top downstream timeouts\n"
+          "top-servfail-queries             show top queries receiving servfail answers\n"
+          "top-bogus-queries                show top queries validating as bogus\n"
+          "top-pub-servfail-queries         show top queries receiving servfail answers grouped by public suffix list\n"
+          "top-pub-bogus-queries            show top queries validating as bogus grouped by public suffix list\n"
+          "top-servfail-remotes             show top remotes receiving servfail answers\n"
+          "top-bogus-remotes                show top remotes receiving bogus answers\n"
+          "unload-lua-script                unload Lua script\n"
+          "version                          return Recursor version number\n"
+          "wipe-cache domain0 [domain1] ..  wipe domain data from cache\n"
+          "wipe-cache-typed type domain0 [domain1] ..  wipe domain data with qtype from cache\n"};
+}
+
+template <typename T>
+static RecursorControlChannel::Answer luaconfig(T begin, T end)
+{
+  if (begin != end) {
+    ::arg().set("lua-config-file") = *begin;
+  }
+  try {
+    luaConfigDelayedThreads delayedLuaThreads;
+    ProxyMapping proxyMapping;
+    loadRecursorLuaConfig(::arg()["lua-config-file"], delayedLuaThreads, proxyMapping);
+    startLuaConfigDelayedThreads(delayedLuaThreads, g_luaconfs.getCopy().generation);
+    broadcastFunction([=] { return pleaseSupplantProxyMapping(proxyMapping); });
+    g_log << Logger::Warning << "Reloaded Lua configuration file '" << ::arg()["lua-config-file"] << "', requested via control channel" << endl;
+    return {0, "Reloaded Lua configuration file '" + ::arg()["lua-config-file"] + "'\n"};
+  }
+  catch (std::exception& e) {
+    return {1, "Unable to load Lua script from '" + ::arg()["lua-config-file"] + "': " + e.what() + "\n"};
+  }
+  catch (const PDNSException& e) {
+    return {1, "Unable to load Lua script from '" + ::arg()["lua-config-file"] + "': " + e.reason + "\n"};
+  }
+}
+
+static RecursorControlChannel::Answer reloadACLs()
+{
+  if (!::arg()["chroot"].empty()) {
+    g_log << Logger::Error << "Unable to reload ACL when chroot()'ed, requested via control channel" << endl;
+    return {1, "Unable to reload ACL when chroot()'ed, please restart\n"};
+  }
+
+  try {
+    parseACLs();
+  }
+  catch (std::exception& e) {
+    g_log << Logger::Error << "Reloading ACLs failed (Exception: " << e.what() << ")" << endl;
+    return {1, e.what() + string("\n")};
+  }
+  catch (PDNSException& ae) {
+    g_log << Logger::Error << "Reloading ACLs failed (PDNSException: " << ae.reason << ")" << endl;
+    return {1, ae.reason + string("\n")};
+  }
+  return {0, "ok\n"};
+}
+
+RecursorControlChannel::Answer RecursorControlParser::getAnswer(int socket, const string& question, RecursorControlParser::func_t** command)
 {
   *command = nop;
   vector<string> words;
   stringtok(words, question);
 
-  if (words.empty())
+  if (words.empty()) {
     return {1, "invalid command\n"};
+  }
 
   string cmd = toLower(words[0]);
-  vector<string>::const_iterator begin = words.begin() + 1, end = words.end();
+  auto begin = words.begin() + 1;
+  auto end = words.end();
 
   // should probably have a smart dispatcher here, like auth has
-  if (cmd == "help")
-    return {0,
-            "add-dont-throttle-names [N...]   add names that are not allowed to be throttled\n"
-            "add-dont-throttle-netmasks [N...]\n"
-            "                                 add netmasks that are not allowed to be throttled\n"
-            "add-nta DOMAIN [REASON]          add a Negative Trust Anchor for DOMAIN with the comment REASON\n"
-            "add-ta DOMAIN DSRECORD           add a Trust Anchor for DOMAIN with data DSRECORD\n"
-            "current-queries                  show currently active queries\n"
-            "clear-dont-throttle-names [N...] remove names that are not allowed to be throttled. If N is '*', remove all\n"
-            "clear-dont-throttle-netmasks [N...]\n"
-            "                                 remove netmasks that are not allowed to be throttled. If N is '*', remove all\n"
-            "clear-nta [DOMAIN]...            Clear the Negative Trust Anchor for DOMAINs, if no DOMAIN is specified, remove all\n"
-            "clear-ta [DOMAIN]...             Clear the Trust Anchor for DOMAINs\n"
-            "dump-cache <filename>            dump cache contents to the named file\n"
-            "dump-dot-probe-map <filename>    dump the contents of the DoT probe map to the named file\n"
-            "dump-edns [status] <filename>    dump EDNS status to the named file\n"
-            "dump-failedservers <filename>    dump the failed servers to the named file\n"
-            "dump-non-resolving <filename>    dump non-resolving nameservers addresses to the named file\n"
-            "dump-nsspeeds <filename>         dump nsspeeds statistics to the named file\n"
-            "dump-saved-parent-ns-sets <filename>\n"
-            "                                 dump saved parent ns sets that were successfully used as fallback\n"
-            "dump-rpz <zone name> <filename>  dump the content of a RPZ zone to the named file\n"
-            "dump-throttlemap <filename>      dump the contents of the throttle map to the named file\n"
-            "get [key1] [key2] ..             get specific statistics\n"
-            "get-all                          get all statistics\n"
-            "get-dont-throttle-names          get the list of names that are not allowed to be throttled\n"
-            "get-dont-throttle-netmasks       get the list of netmasks that are not allowed to be throttled\n"
-            "get-ntas                         get all configured Negative Trust Anchors\n"
-            "get-tas                          get all configured Trust Anchors\n"
-            "get-parameter [key1] [key2] ..   get configuration parameters\n"
-            "get-proxymapping-stats           get proxy mapping statistics\n"
-            "get-qtypelist                    get QType statistics\n"
-            "                                 notice: queries from cache aren't being counted yet\n"
-            "get-remotelogger-stats           get remote logger statistics\n"
-            "hash-password [work-factor]      ask for a password then return the hashed version\n"
-            "help                             get this list\n"
-            "list-dnssec-algos                list supported DNSSEC algorithms\n"
-            "ping                             check that all threads are alive\n"
-            "quit                             stop the recursor daemon\n"
-            "quit-nicely                      stop the recursor daemon nicely\n"
-            "reload-acls                      reload ACLS\n"
-            "reload-lua-script [filename]     (re)load Lua script\n"
-            "reload-lua-config [filename]     (re)load Lua configuration file\n"
-            "reload-zones                     reload all auth and forward zones\n"
-            "set-ecs-minimum-ttl value        set ecs-minimum-ttl-override\n"
-            "set-max-cache-entries value      set new maximum cache size\n"
-            "set-max-packetcache-entries val  set new maximum packet cache size\n"
-            "set-minimum-ttl value            set minimum-ttl-override\n"
-            "set-carbon-server                set a carbon server for telemetry\n"
-            "set-dnssec-log-bogus SETTING     enable (SETTING=yes) or disable (SETTING=no) logging of DNSSEC validation failures\n"
-            "set-event-trace-enabled SETTING  set logging of event trace messages, 0 = disabled, 1 = protobuf, 2 = log file, 3 = both\n"
-            "trace-regex [regex file]         emit resolution trace for matching queries (no arguments clears tracing)\n"
-            "top-largeanswer-remotes          show top remotes receiving large answers\n"
-            "top-queries                      show top queries\n"
-            "top-pub-queries                  show top queries grouped by public suffix list\n"
-            "top-remotes                      show top remotes\n"
-            "top-timeouts                     show top downstream timeouts\n"
-            "top-servfail-queries             show top queries receiving servfail answers\n"
-            "top-bogus-queries                show top queries validating as bogus\n"
-            "top-pub-servfail-queries         show top queries receiving servfail answers grouped by public suffix list\n"
-            "top-pub-bogus-queries            show top queries validating as bogus grouped by public suffix list\n"
-            "top-servfail-remotes             show top remotes receiving servfail answers\n"
-            "top-bogus-remotes                show top remotes receiving bogus answers\n"
-            "unload-lua-script                unload Lua script\n"
-            "version                          return Recursor version number\n"
-            "wipe-cache domain0 [domain1] ..  wipe domain data from cache\n"
-            "wipe-cache-typed type domain0 [domain1] ..  wipe domain data with qtype from cache\n"};
-
+  if (cmd == "help") {
+    return help();
+  }
   if (cmd == "get-all") {
     return {0, getAllStats()};
   }
@@ -2109,31 +2160,31 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
     return {0, "bye nicely\n"};
   }
   if (cmd == "dump-cache") {
-    return doDumpCache(s);
+    return doDumpCache(socket);
   }
   if (cmd == "dump-dot-probe-map") {
-    return doDumpToFile(s, pleaseDumpDoTProbeMap, cmd, false);
+    return doDumpToFile(socket, pleaseDumpDoTProbeMap, cmd, false);
   }
   if (cmd == "dump-ednsstatus" || cmd == "dump-edns") {
-    return doDumpToFile(s, pleaseDumpEDNSMap, cmd, false);
+    return doDumpToFile(socket, pleaseDumpEDNSMap, cmd, false);
   }
   if (cmd == "dump-nsspeeds") {
-    return doDumpToFile(s, pleaseDumpNSSpeeds, cmd, false);
+    return doDumpToFile(socket, pleaseDumpNSSpeeds, cmd, false);
   }
   if (cmd == "dump-failedservers") {
-    return doDumpToFile(s, pleaseDumpFailedServers, cmd, false);
+    return doDumpToFile(socket, pleaseDumpFailedServers, cmd, false);
   }
   if (cmd == "dump-saved-parent-ns-sets") {
-    return doDumpToFile(s, pleaseDumpSavedParentNSSets, cmd, false);
+    return doDumpToFile(socket, pleaseDumpSavedParentNSSets, cmd, false);
   }
   if (cmd == "dump-rpz") {
-    return doDumpRPZ(s, begin, end);
+    return doDumpRPZ(socket, begin, end);
   }
   if (cmd == "dump-throttlemap") {
-    return doDumpToFile(s, pleaseDumpThrottleMap, cmd, false);
+    return doDumpToFile(socket, pleaseDumpThrottleMap, cmd, false);
   }
   if (cmd == "dump-non-resolving") {
-    return doDumpToFile(s, pleaseDumpNonResolvingNS, cmd, false);
+    return doDumpToFile(socket, pleaseDumpNonResolvingNS, cmd, false);
   }
   if (cmd == "wipe-cache" || cmd == "flushname") {
     return {0, doWipeCache(begin, end, 0xffff)};
@@ -2153,54 +2204,21 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
     return doQueueReloadLuaScript(begin, end);
   }
   if (cmd == "reload-lua-config") {
-    if (begin != end)
-      ::arg().set("lua-config-file") = *begin;
-
-    try {
-      luaConfigDelayedThreads delayedLuaThreads;
-      ProxyMapping proxyMapping;
-      loadRecursorLuaConfig(::arg()["lua-config-file"], delayedLuaThreads, proxyMapping);
-      startLuaConfigDelayedThreads(delayedLuaThreads, g_luaconfs.getCopy().generation);
-      broadcastFunction([=] { return pleaseSupplantProxyMapping(proxyMapping); });
-      g_log << Logger::Warning << "Reloaded Lua configuration file '" << ::arg()["lua-config-file"] << "', requested via control channel" << endl;
-      return {0, "Reloaded Lua configuration file '" + ::arg()["lua-config-file"] + "'\n"};
-    }
-    catch (std::exception& e) {
-      return {1, "Unable to load Lua script from '" + ::arg()["lua-config-file"] + "': " + e.what() + "\n"};
-    }
-    catch (const PDNSException& e) {
-      return {1, "Unable to load Lua script from '" + ::arg()["lua-config-file"] + "': " + e.reason + "\n"};
-    }
+    return luaconfig(begin, end);
   }
   if (cmd == "set-carbon-server") {
     return {0, doSetCarbonServer(begin, end)};
   }
   if (cmd == "trace-regex") {
-    return {0, doTraceRegex(begin == end ? FDWrapper(-1) : getfd(s), begin, end)};
+    return {0, doTraceRegex(begin == end ? FDWrapper(-1) : getfd(socket), begin, end)};
   }
   if (cmd == "unload-lua-script") {
     vector<string> empty;
-    empty.push_back(string());
+    empty.emplace_back();
     return doQueueReloadLuaScript(empty.begin(), empty.end());
   }
   if (cmd == "reload-acls") {
-    if (!::arg()["chroot"].empty()) {
-      g_log << Logger::Error << "Unable to reload ACL when chroot()'ed, requested via control channel" << endl;
-      return {1, "Unable to reload ACL when chroot()'ed, please restart\n"};
-    }
-
-    try {
-      parseACLs();
-    }
-    catch (std::exception& e) {
-      g_log << Logger::Error << "Reloading ACLs failed (Exception: " << e.what() << ")" << endl;
-      return {1, e.what() + string("\n")};
-    }
-    catch (PDNSException& ae) {
-      g_log << Logger::Error << "Reloading ACLs failed (PDNSException: " << ae.reason << ")" << endl;
-      return {1, ae.reason + string("\n")};
-    }
-    return {0, "ok\n"};
+    return reloadACLs();
   }
   if (cmd == "top-remotes") {
     return {0, doGenericTopRemotes(pleaseGetRemotes)};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
introduce a way to disable DNSSEC algos. Default is to determine automatically (for algos 5 and 7 only) . You can also set it manually by setting `"dnssec-disabled-algorithms` to a list of algorithm numbers.
Fixes #12890

On a Rocky Linux 9.2 system with default config:
`Jun 07 09:20:07 msg="Disabled DNSSEC algorithms" subsystem="config" level="0" prio="Notice" tid="0" ts="1686129607.324" algorithms="5 7"`
and [icann.org](http://icann.org/) is Insecure
And after setting the crypto policy to --set DEFAULT:SHA1 it does not print the log line and starts validating [icann.org](http://icann.org/)

You can get the status wit a new `rec_control command: list-dnssec-algos`. Example output:
`RSASHA1(disabled) RSASHA1-NSEC3-SHA1(disabled) RSASHA256 RSASHA512 ECDSAP256SHA256 ECDSAP384SHA384 ED25519 ED448`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
