### PR TITLE
rec: systemd-journal backend: escape keys that are special

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -414,17 +414,21 @@ struct CIStringCompare
 
 struct CIStringComparePOSIX
 {
-   bool operator() (const std::string& lhs, const std::string& rhs)
+   bool operator() (const std::string& lhs, const std::string& rhs) const
    {
-      std::string::const_iterator a,b;
       const std::locale &loc = std::locale("POSIX");
-      a=lhs.begin();b=rhs.begin();
-      while(a!=lhs.end()) {
-          if (b==rhs.end() || std::tolower(*b,loc)<std::tolower(*a,loc)) return false;
-          else if (std::tolower(*a,loc)<std::tolower(*b,loc)) return true;
-          ++a;++b;
+      auto lhsIter = lhs.begin();
+      auto rhsIter = rhs.begin();
+      while (lhsIter != lhs.end()) {
+        if (rhsIter == rhs.end() || std::tolower(*rhsIter,loc) < std::tolower(*lhsIter,loc)) {
+          return false;
+        }
+        if (std::tolower(*lhsIter,loc) < std::tolower(*rhsIter,loc)) {
+          return true;
+        }
+        ++lhsIter;++rhsIter;
       }
-      return (b!=rhs.end());
+      return rhsIter != rhs.end();
    }
 };
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -905,7 +905,6 @@ static const char* toTimestampStringMilli(const struct timeval& tval, std::array
   return buf.data();
 }
 
-#define HAVE_SYSTEMD
 #ifdef HAVE_SYSTEMD
 static void loggerSDBackend(const Logging::Entry& entry)
 {
@@ -928,20 +927,19 @@ static void loggerSDBackend(const Logging::Entry& entry)
     "tid",
     "unit",
     "user_unit",
-    "object_pid"
-  };
+    "object_pid"};
 
   // First map SL priority to syslog's Urgency
-  Logger::Urgency u = entry.d_priority ? Logger::Urgency(entry.d_priority) : Logger::Info;
-  if (u > s_logUrgency) {
+  Logger::Urgency urgency = entry.d_priority != 0 ? Logger::Urgency(entry.d_priority) : Logger::Info;
+  if (urgency > s_logUrgency) {
     // We do not log anything if the Urgency of the message is lower than the requested loglevel.
     // Not that lower Urgency means higher number.
     return;
   }
   // We need to keep the string in mem until sd_journal_sendv has ben called
   vector<string> strings;
-  auto appendKeyAndVal = [&strings](const string& k, const string& v) {
-    strings.emplace_back(k + "=" + v);
+  auto appendKeyAndVal = [&strings](const string& key, const string& value) {
+    strings.emplace_back(key + "=" + value);
   };
   appendKeyAndVal("MESSAGE", entry.message);
   if (entry.error) {
@@ -960,7 +958,9 @@ static void loggerSDBackend(const Logging::Entry& entry)
       key.append(value.first);
       appendKeyAndVal(toUpper(key), value.second);
     }
-    appendKeyAndVal(toUpper(value.first), value.second);
+    else {
+      appendKeyAndVal(toUpper(value.first), value.second);
+    }
   }
   // Thread id filled in by backend, since the SL code does not know about RecursorThreads
   // We use the Recursor thread, other threads get id 0. May need to revisit.
@@ -968,9 +968,9 @@ static void loggerSDBackend(const Logging::Entry& entry)
 
   vector<iovec> iov;
   iov.reserve(strings.size());
-  for (const auto& s : strings) {
+  for (const auto& str : strings) {
     // iovec has no 2 arg constructor, so make it explicit
-    iov.emplace_back(iovec{const_cast<void*>(reinterpret_cast<const void*>(s.data())), s.size()});
+    iov.emplace_back(iovec{const_cast<void*>(reinterpret_cast<const void*>(str.data())), str.size()}); // NOLINT: it's the API
   }
   sd_journal_sendv(iov.data(), static_cast<int>(iov.size()));
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes  #12468

Includes a cleanup of `CIStringComparePOSIX` and making its operator() `const` so ii can be used for a case-insensitive set.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
