### PR TITLE
Add note to pdnsutil manpage on how to remove zone from catalog zone

### DIFF
--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -103,6 +103,7 @@ In the example below ``example.com`` is the member and ``catalog.example`` is th
   pdnsutil set-catalog example.com catalog.example
 
 Setting catalog values is supported in the :doc:`API <http-api/zone>`, by setting the ``catalog`` property in the zone properties.
+Setting the catalog to an empty ``""`` removes the member zone from the catalog it is in.
 
 Each member zone may have one or more additional properties as defined in the draft.
 PowerDNS currently supports the following properties:

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -253,7 +253,7 @@ set-options-json *ZONE* *JSON*
 set-option *ZONE* [*producer*|*consumer*] [*coo*|*unique*|*group*] *VALUE* [*VALUE* ...]
     Set or remove an option for *ZONE*. Providing an empty value removes an option.
 set-catalog *ZONE* *CATALOG*
-    Change the catalog of *ZONE* to *CATALOG*
+    Change the catalog of *ZONE* to *CATALOG*. Setting *CATALOG* to an empty "" removes *ZONE* from the catalog it is in.
 set-account *ZONE* *ACCOUNT*
     Change the account (owner) of *ZONE* to *ACCOUNT*.
 add-meta *ZONE* *ATTRIBUTE* *VALUE* [*VALUE*]...

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2622,7 +2622,7 @@ try
     cout << "  [producer|consumer]" << endl;
     cout << "  [coo|unique|group] VALUE" << endl;
     cout << "  [VALUE ...]" << endl;
-    cout << "set-catalog ZONE CATALOG           Change the catalog of ZONE to CATALOG" << endl;
+    cout << "set-catalog ZONE CATALOG           Change the catalog of ZONE to CATALOG. Setting CATALOG to an empty "" removes ZONE from the catalog it is in" << endl;
     cout << "set-account ZONE ACCOUNT           Change the account (owner) of ZONE to ACCOUNT" << endl;
     cout << "set-nsec3 ZONE ['PARAMS' [narrow]] Enable NSEC3 with PARAMS. Optionally narrow" << endl;
     cout << "set-presigned ZONE                 Use presigned RRSIGs from storage" << endl;


### PR DESCRIPTION
### Short description
As discussed in #12903 there's no documented way of removing a zone from a catalog zone. Adding a `unset-catalog` subcommand seems straightforward.

### Checklist

I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

