### PR TITLE
rec: Upgrade regression tests to use pytest instead of nose

### DIFF
--- a/regression-tests.recursor-dnssec/printlogs.py
+++ b/regression-tests.recursor-dnssec/printlogs.py
@@ -5,7 +5,7 @@ import xml.etree.ElementTree
 import os.path
 import glob
 
-e = xml.etree.ElementTree.parse('nosetests.xml')
+e = xml.etree.ElementTree.parse('pysetest.xml')
 root = e.getroot()
 
 for child in root:

--- a/regression-tests.recursor-dnssec/printlogs.py
+++ b/regression-tests.recursor-dnssec/printlogs.py
@@ -5,7 +5,7 @@ import xml.etree.ElementTree
 import os.path
 import glob
 
-e = xml.etree.ElementTree.parse('pysetest.xml')
+e = xml.etree.ElementTree.parse('pytest.xml')
 root = e.getroot()
 
 for child in root:

--- a/regression-tests.recursor-dnssec/requirements.txt
+++ b/regression-tests.recursor-dnssec/requirements.txt
@@ -1,5 +1,5 @@
 dnspython>=1.11
-nose>=1.3.7
+pytest
 protobuf>=2.5; sys_platform != 'darwin'
 protobuf>=3.0; sys_platform == 'darwin'
 pyasn1==0.4.8

--- a/regression-tests.recursor-dnssec/runtests
+++ b/regression-tests.recursor-dnssec/runtests
@@ -59,7 +59,7 @@ fi
 
 # LIBFAKETIME is only added to LD_PRELOAD by the pyton code when needed
 if [ "${LIBASAN}" != "" -o "${LIBAUTHBIND}" != "" ]; then
-LD_PRELOAD="${LIBASAN} ${LIBAUTHBIND}" nosetests -I test_WellKnown.py --with-xunit $@
+LD_PRELOAD="${LIBASAN} ${LIBAUTHBIND}" pytest --ignore=test_WellKnown.py --junitxml=pytest.xml $@
 else
-nosetests -I test_WellKnown.py --with-xunit $@
+pytest --ignore=test_WellKnown.py  --junitxml=pytest.xml $@
 fi

--- a/regression-tests.recursor-dnssec/test_EDNS.py
+++ b/regression-tests.recursor-dnssec/test_EDNS.py
@@ -4,6 +4,8 @@ import socket
 import struct
 import threading
 import time
+import sys
+from unittest import SkipTest
 
 from recursortests import RecursorTest
 from twisted.internet.protocol import DatagramProtocol
@@ -35,6 +37,8 @@ class EDNSTest(RecursorTest):
         Ensure the rcode is BADVERS when we send an unsupported EDNS version and
         the query is not processed any further.
         """
+        if sys.version_info >= (3, 11) and sys.version_info <= (3, 11, 3):
+            raise SkipTest("Test skipped, see https://github.com/PowerDNS/pdns/pull/12912")
         query = dns.message.make_query('version.bind.', 'TXT', 'CH', use_edns=5,
                                        payload=4096)
         response = self.sendUDPQuery(query)

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -1006,7 +1006,7 @@ end
         """ postresolve_ffi: test that we can do a DROP for a name and type combo"""
         query = dns.message.make_query('example', 'TXT')
         res = self.sendUDPQuery(query)
-        self.assertEquals(res, None)
+        self.assertEqual(res, None)
 
     def testNXDOMAIN(self):
         """ postresolve_ffi: test that we can return a NXDOMAIN for a name and type combo"""

--- a/regression-tests.recursor-dnssec/test_Notify.py
+++ b/regression-tests.recursor-dnssec/test_Notify.py
@@ -103,9 +103,9 @@ f 3600 IN CNAME f            ; CNAME loop: dirty trick to get a ServFail in an a
             sender = getattr(self, method)
             res = sender(notify)
             self.assertRcodeEqual(res, dns.rcode.NOERROR)
-            self.assertEquals(res.opcode(), 4)
+            self.assertEqual(res.opcode(), 4)
             print(res)
-            self.assertEquals(res.question[0].to_text(), 'example. IN SOA')
+            self.assertEqual(res.question[0].to_text(), 'example. IN SOA')
 
         self.checkRecordCacheMetrics(3, 1)
 

--- a/regression-tests.recursor-dnssec/test_RecDnstap.py
+++ b/regression-tests.recursor-dnssec/test_RecDnstap.py
@@ -5,7 +5,7 @@ import sys
 import threading
 import dns
 import dnstap_pb2
-from nose import SkipTest
+from unittest import SkipTest
 from recursortests import RecursorTest
 
 FSTRM_CONTROL_ACCEPT = 0x01

--- a/regression-tests.recursor-dnssec/test_RecDnstap.py
+++ b/regression-tests.recursor-dnssec/test_RecDnstap.py
@@ -186,7 +186,7 @@ class TestRecursorDNSTap(RecursorTest):
                 fstrm_handle_bidir_connection(conn, lambda data: \
                 param.queue.put(data, True, timeout=2.0))
             except socket.error as e:
-                if e.errno == errno.EBADF or e.errno == errno.EPIPE:
+                if e.errno in (errno.EBADF, errno.EPIPE):
                     break
                 sys.stderr.write("Unexpected socket error %s\n" % str(e))
                 sys.exit(1)

--- a/regression-tests.recursor-dnssec/test_RecDnstap.py
+++ b/regression-tests.recursor-dnssec/test_RecDnstap.py
@@ -186,7 +186,7 @@ class TestRecursorDNSTap(RecursorTest):
                 fstrm_handle_bidir_connection(conn, lambda data: \
                 param.queue.put(data, True, timeout=2.0))
             except socket.error as e:
-                if e.errno == 9:
+                if e.errno == errno.EBADF or e.errno == errno.EPIPE:
                     break
                 sys.stderr.write("Unexpected socket error %s\n" % str(e))
                 sys.exit(1)


### PR DESCRIPTION
One mysterious failure on Debian bookworm spotted: test_EDNS.py does not seem to set the right edns version on the outgoing query. To be investigated.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
