### PR TITLE
dns random: add method to get full 32-bits of randomness

### DIFF
--- a/.not-formatted
+++ b/.not-formatted
@@ -36,8 +36,6 @@
 ./pdns/distributor.hh
 ./pdns/dns.cc
 ./pdns/dns.hh
-./pdns/dns_random.cc
-./pdns/dns_random.hh
 ./pdns/dnsbackend.cc
 ./pdns/dnsbackend.hh
 ./pdns/dnsbulktest.cc
@@ -268,7 +266,6 @@
 ./pdns/test-common.hh
 ./pdns/test-digests_hh.cc
 ./pdns/test-distributor_hh.cc
-./pdns/test-dns_random_hh.cc
 ./pdns/test-dnscrypt_cc.cc
 ./pdns/test-dnsdist_cc.cc
 ./pdns/test-dnsdistpacketcache_cc.cc

--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -256,6 +256,7 @@ uint32_t dns_random_uint32()
       if (got != sizeof(num)) {
         throw std::runtime_error("getrandom() failed: " + stringerror());
       }
+      break;
     } while (true);
     return num;
 #else
@@ -289,6 +290,7 @@ uint32_t dns_random_uint32()
         attempts--;
         continue;
       }
+      break;
     } while (true);
     return num;
   }

--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -157,7 +157,7 @@ static void dns_random_setup(bool force = false)
 
 #if defined(HAVE_GETRANDOM)
   if (chosen_rng == RNG_GETRANDOM) {
-    char buf;
+    char buf = 0;
     // some systems define getrandom but it does not really work, e.g. because it's
     // not present in kernel.
     if (getrandom(&buf, sizeof(buf), 0) == -1 && errno != EINTR) {

--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -31,7 +31,6 @@
 #include "dns_random.hh"
 #include "arguments.hh"
 #include "logger.hh"
-#include "boost/lexical_cast.hpp"
 
 #if defined(HAVE_RANDOMBYTES_STIR)
 #include <sodium.h>
@@ -234,12 +233,12 @@ uint32_t dns_random(uint32_t upper_bound)
 
   switch (chosen_rng) {
   case RNG_UNINITIALIZED:
-    throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
+    throw std::runtime_error("Unreachable at " __FILE__ ":" + std::to_string(__LINE__)); // cannot be reached
   case RNG_SODIUM:
 #if defined(HAVE_RANDOMBYTES_STIR) && !defined(USE_URANDOM_ONLY)
     return randombytes_uniform(upper_bound);
 #else
-    throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
+    throw std::runtime_error("Unreachable at " __FILE__ ":" + std::to_string(__LINE__)); // cannot be reached
 #endif /* RND_SODIUM */
   case RNG_OPENSSL: {
 #if defined(HAVE_RAND_BYTES) && !defined(USE_URANDOM_ONLY)
@@ -252,7 +251,7 @@ uint32_t dns_random(uint32_t upper_bound)
 
     return num % upper_bound;
 #else
-    throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
+    throw std::runtime_error("Unreachable at " __FILE__ ":" + std::to_string(__LINE__)); // cannot be reached
 #endif /* RNG_OPENSSL */
   }
   case RNG_GETRANDOM: {
@@ -270,14 +269,14 @@ uint32_t dns_random(uint32_t upper_bound)
 
     return num % upper_bound;
 #else
-    throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
+    throw std::runtime_error("Unreachable at " __FILE__ ":" + std::to_string(__LINE__)); // cannot be reached
 #endif
   }
   case RNG_ARC4RANDOM:
 #if defined(HAVE_ARC4RANDOM) && !defined(USE_URANDOM_ONLY)
     return arc4random_uniform(upper_bound);
 #else
-    throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
+    throw std::runtime_error("Unreachable at " __FILE__ ":" + std::to_string(__LINE__)); // cannot be reached
 #endif
   case RNG_URANDOM: {
     uint32_t num = 0;
@@ -315,7 +314,7 @@ uint32_t dns_random(uint32_t upper_bound)
   }
 #endif
   default:
-    throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
+    throw std::runtime_error("Unreachable at " __FILE__ ":" + std::to_string(__LINE__)); // cannot be reached
   };
 }
 

--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -51,7 +51,8 @@ static enum DNS_RNG {
   RNG_ARC4RANDOM,
   RNG_URANDOM,
   RNG_KISS,
-} chosen_rng = RNG_UNINITIALIZED;
+} chosen_rng
+  = RNG_UNINITIALIZED;
 
 static int urandom_fd = -1;
 
@@ -71,17 +72,17 @@ kiss_init(unsigned int seed)
 static unsigned int
 kiss_rand(void)
 {
-  kiss_z = 36969 * (kiss_z&65535) + (kiss_z>>16);
-  kiss_w = 18000 * (kiss_w&65535) + (kiss_w>>16);
+  kiss_z = 36969 * (kiss_z & 65535) + (kiss_z >> 16);
+  kiss_w = 18000 * (kiss_w & 65535) + (kiss_w >> 16);
   kiss_jcong = 69069 * kiss_jcong + 1234567;
-  kiss_jsr^=(kiss_jsr<<13); /* <<17, >>13 gives cycle length 2^28.2 max */
-  kiss_jsr^=(kiss_jsr>>17); /* <<13, >>17 gives maximal cycle length */
-  kiss_jsr^=(kiss_jsr<<5);
-  return (((kiss_z<<16) + kiss_w) ^ kiss_jcong) + kiss_jsr;
+  kiss_jsr ^= (kiss_jsr << 13); /* <<17, >>13 gives cycle length 2^28.2 max */
+  kiss_jsr ^= (kiss_jsr >> 17); /* <<13, >>17 gives maximal cycle length */
+  kiss_jsr ^= (kiss_jsr << 5);
+  return (((kiss_z << 16) + kiss_w) ^ kiss_jcong) + kiss_jsr;
 }
 #endif
 
-static void dns_random_setup(bool force=false)
+static void dns_random_setup(bool force = false)
 {
   string rdev;
   string rng;
@@ -99,66 +100,73 @@ static void dns_random_setup(bool force=false)
   rng = ::arg()["rng"];
   rdev = ::arg()["entropy-source"];
   if (rng == "auto") {
-# if defined(HAVE_GETRANDOM)
+#if defined(HAVE_GETRANDOM)
     chosen_rng = RNG_GETRANDOM;
-# elif defined(HAVE_ARC4RANDOM)
+#elif defined(HAVE_ARC4RANDOM)
     chosen_rng = RNG_ARC4RANDOM;
-# elif defined(HAVE_RANDOMBYTES_STIR)
+#elif defined(HAVE_RANDOMBYTES_STIR)
     chosen_rng = RNG_SODIUM;
-# elif defined(HAVE_RAND_BYTES)
+#elif defined(HAVE_RAND_BYTES)
     chosen_rng = RNG_OPENSSL;
-# else
+#else
     chosen_rng = RNG_URANDOM;
-# endif
-# if defined(HAVE_RANDOMBYTES_STIR)
-  } else if (rng == "sodium") {
+#endif
+#if defined(HAVE_RANDOMBYTES_STIR)
+  }
+  else if (rng == "sodium") {
     chosen_rng = RNG_SODIUM;
-# endif
-# if defined(HAVE_RAND_BYTES)
-  } else if (rng == "openssl") {
+#endif
+#if defined(HAVE_RAND_BYTES)
+  }
+  else if (rng == "openssl") {
     chosen_rng = RNG_OPENSSL;
-# endif
-# if defined(HAVE_GETRANDOM)
-  } else if (rng == "getrandom") {
+#endif
+#if defined(HAVE_GETRANDOM)
+  }
+  else if (rng == "getrandom") {
     chosen_rng = RNG_GETRANDOM;
-# endif
-# if defined(HAVE_ARC4RANDOM)
-  } else if (rng == "arc4random") {
+#endif
+#if defined(HAVE_ARC4RANDOM)
+  }
+  else if (rng == "arc4random") {
     chosen_rng = RNG_ARC4RANDOM;
-# endif
-  } else if (rng == "urandom") {
+#endif
+  }
+  else if (rng == "urandom") {
     chosen_rng = RNG_URANDOM;
 #if defined(HAVE_KISS_RNG)
-  } else if (rng == "kiss") {
+  }
+  else if (rng == "kiss") {
     chosen_rng = RNG_KISS;
-    g_log<<Logger::Warning<<"kiss rng should not be used in production environment"<<std::endl;
+    g_log << Logger::Warning << "kiss rng should not be used in production environment" << std::endl;
 #endif
-  } else {
+  }
+  else {
     throw std::runtime_error("Unsupported rng '" + rng + "'");
   }
 
-# if defined(HAVE_RANDOMBYTES_STIR)
+#if defined(HAVE_RANDOMBYTES_STIR)
   if (chosen_rng == RNG_SODIUM) {
     if (sodium_init() == -1)
       throw std::runtime_error("Unable to initialize sodium crypto library");
     /*  make sure it's set up */
     randombytes_stir();
   }
-# endif
+#endif
 
-# if defined(HAVE_GETRANDOM)
+#if defined(HAVE_GETRANDOM)
   if (chosen_rng == RNG_GETRANDOM) {
     char buf[1];
     // some systems define getrandom but it does not really work, e.g. because it's
     // not present in kernel.
     if (getrandom(buf, sizeof(buf), 0) == -1 && errno != EINTR) {
-       g_log<<Logger::Warning<<"getrandom() failed: "<<stringerror()<<", falling back to " + rdev<<std::endl;
-       chosen_rng = RNG_URANDOM;
+      g_log << Logger::Warning << "getrandom() failed: " << stringerror() << ", falling back to " + rdev << std::endl;
+      chosen_rng = RNG_URANDOM;
     }
   }
-# endif
+#endif
 
-# if defined(HAVE_RAND_BYTES)
+#if defined(HAVE_RAND_BYTES)
   if (chosen_rng == RNG_OPENSSL) {
     int ret;
     unsigned char buf[1];
@@ -167,7 +175,7 @@ static void dns_random_setup(bool force=false)
     if (ret == 0)
       throw std::runtime_error("Openssl RNG was not seeded");
   }
-# endif
+#endif
 #endif /* USE_URANDOM_ONLY */
   if (chosen_rng == RNG_URANDOM) {
     urandom_fd = open(rdev.c_str(), O_RDONLY);
@@ -190,7 +198,8 @@ static void dns_random_setup(bool force=false)
 #endif
 }
 
-void dns_random_init(const string& data __attribute__((unused)), bool force) {
+void dns_random_init(const string& data __attribute__((unused)), bool force)
+{
   dns_random_setup(force);
   (void)dns_random(1);
   // init should occur already in dns_random_setup
@@ -201,15 +210,13 @@ void dns_random_init(const string& data __attribute__((unused)), bool force) {
     return;
   if (data.size() != 16)
     throw std::runtime_error("invalid seed");
-  seed = (data[0] + (data[1]<<8) + (data[2]<<16) + (data[3]<<24)) ^
-         (data[4] + (data[5]<<8) + (data[6]<<16) + (data[7]<<24)) ^
-         (data[8] + (data[9]<<8) + (data[10]<<16) + (data[11]<<24)) ^
-         (data[12] + (data[13]<<8) + (data[14]<<16) + (data[15]<<24));
+  seed = (data[0] + (data[1] << 8) + (data[2] << 16) + (data[3] << 24)) ^ (data[4] + (data[5] << 8) + (data[6] << 16) + (data[7] << 24)) ^ (data[8] + (data[9] << 8) + (data[10] << 16) + (data[11] << 24)) ^ (data[12] + (data[13] << 8) + (data[14] << 16) + (data[15] << 24));
   kiss_init(seed);
 #endif
 }
 
-uint32_t dns_random(uint32_t upper_bound) {
+uint32_t dns_random(uint32_t upper_bound)
+{
   if (chosen_rng == RNG_UNINITIALIZED)
     dns_random_setup();
 
@@ -218,7 +225,7 @@ uint32_t dns_random(uint32_t upper_bound) {
 
   unsigned int min = pdns::random_minimum_acceptable_value(upper_bound);
 
-  switch(chosen_rng) {
+  switch (chosen_rng) {
   case RNG_UNINITIALIZED:
     throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
   case RNG_SODIUM:
@@ -229,37 +236,35 @@ uint32_t dns_random(uint32_t upper_bound) {
 #endif /* RND_SODIUM */
   case RNG_OPENSSL: {
 #if defined(HAVE_RAND_BYTES) && !defined(USE_URANDOM_ONLY)
-      uint32_t num = 0;
-      do {
-        if (RAND_bytes(reinterpret_cast<unsigned char*>(&num), sizeof(num)) < 1)
-          throw std::runtime_error("Openssl RNG was not seeded");
-      }
-      while(num < min);
+    uint32_t num = 0;
+    do {
+      if (RAND_bytes(reinterpret_cast<unsigned char*>(&num), sizeof(num)) < 1)
+        throw std::runtime_error("Openssl RNG was not seeded");
+    } while (num < min);
 
-      return num % upper_bound;
+    return num % upper_bound;
 #else
-      throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
+    throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
 #endif /* RNG_OPENSSL */
-     }
+  }
   case RNG_GETRANDOM: {
 #if defined(HAVE_GETRANDOM) && !defined(USE_URANDOM_ONLY)
-      uint32_t num = 0;
-      do {
-        auto got = getrandom(&num, sizeof(num), 0);
-        if (got == -1 && errno == EINTR) {
-          continue;
-        }
-        if (got != sizeof(num)) {
-          throw std::runtime_error("getrandom() failed: " + stringerror());
-        }
+    uint32_t num = 0;
+    do {
+      auto got = getrandom(&num, sizeof(num), 0);
+      if (got == -1 && errno == EINTR) {
+        continue;
       }
-      while(num < min);
+      if (got != sizeof(num)) {
+        throw std::runtime_error("getrandom() failed: " + stringerror());
+      }
+    } while (num < min);
 
-      return num % upper_bound;
+    return num % upper_bound;
 #else
-      throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
+    throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
 #endif
-      }
+  }
   case RNG_ARC4RANDOM:
 #if defined(HAVE_ARC4RANDOM) && !defined(USE_URANDOM_ONLY)
     return arc4random_uniform(upper_bound);
@@ -267,41 +272,39 @@ uint32_t dns_random(uint32_t upper_bound) {
     throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
 #endif
   case RNG_URANDOM: {
-      uint32_t num = 0;
-      size_t attempts = 5;
-      do {
-        ssize_t got = read(urandom_fd, &num, sizeof(num));
-        if (got < 0) {
-          if (errno == EINTR) {
-            continue;
-          }
-
-          (void)close(urandom_fd);
-          throw std::runtime_error("Cannot read random device");
-        }
-        else if (static_cast<size_t>(got) != sizeof(num)) {
-          /* short read, let's retry */
-          if (attempts == 0) {
-            throw std::runtime_error("Too many short reads on random device");
-          }
-          attempts--;
+    uint32_t num = 0;
+    size_t attempts = 5;
+    do {
+      ssize_t got = read(urandom_fd, &num, sizeof(num));
+      if (got < 0) {
+        if (errno == EINTR) {
           continue;
         }
-      }
-      while(num < min);
 
-      return num % upper_bound;
-    }
+        (void)close(urandom_fd);
+        throw std::runtime_error("Cannot read random device");
+      }
+      else if (static_cast<size_t>(got) != sizeof(num)) {
+        /* short read, let's retry */
+        if (attempts == 0) {
+          throw std::runtime_error("Too many short reads on random device");
+        }
+        attempts--;
+        continue;
+      }
+    } while (num < min);
+
+    return num % upper_bound;
+  }
 #if defined(HAVE_KISS_RNG)
   case RNG_KISS: {
-      uint32_t num = 0;
-      do {
-        num = kiss_rand();
-      }
-      while(num < min);
+    uint32_t num = 0;
+    do {
+      num = kiss_rand();
+    } while (num < min);
 
-      return num % upper_bound;
-    }
+    return num % upper_bound;
+  }
 #endif
   default:
     throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached

--- a/pdns/dns_random.hh
+++ b/pdns/dns_random.hh
@@ -28,50 +28,52 @@ void dns_random_init(const std::string& data = "", bool force_reinit = false);
 uint32_t dns_random(uint32_t n);
 uint16_t dns_random_uint16();
 
-namespace pdns {
-  struct dns_random_engine {
+namespace pdns
+{
+struct dns_random_engine
+{
 
-    typedef uint32_t result_type;
+  typedef uint32_t result_type;
 
-    static constexpr result_type min()
-    {
-      return 0;
-    }
-
-    static constexpr result_type max()
-    {
-      return std::numeric_limits<result_type>::max() - 1;
-    }
-
-    result_type operator()()
-    {
-      return dns_random(std::numeric_limits<result_type>::max());
-    }
-  };
-
-  /* minimum value that a PRNG should return for this upper bound to avoid a modulo bias */
-  inline unsigned int random_minimum_acceptable_value(uint32_t upper_bound)
+  static constexpr result_type min()
   {
-    /* Parts of this code come from arc4random_uniform */
-    /* To avoid "modulo bias" for some methods, calculate
-       minimum acceptable value for random number to improve
-       uniformity.
-
-       On applicable rngs, we loop until the rng spews out
-       value larger than min, and then take modulo out of that.
-    */
-    unsigned int min;
-#if (ULONG_MAX > 0xffffffffUL)
-    min = 0x100000000UL % upper_bound;
-#else
-    /* Calculate (2**32 % upper_bound) avoiding 64-bit math */
-    if (upper_bound > 0x80000000)
-      min = 1 + ~upper_bound; /* 2**32 - upper_bound */
-    else {
-      /* (2**32 - (x * 2)) % x == 2**32 % x when x <= 2**31 */
-      min = ((0xffffffff - (upper_bound * 2)) + 1) % upper_bound;
-    }
-#endif
-    return min;
+    return 0;
   }
+
+  static constexpr result_type max()
+  {
+    return std::numeric_limits<result_type>::max() - 1;
+  }
+
+  result_type operator()()
+  {
+    return dns_random(std::numeric_limits<result_type>::max());
+  }
+};
+
+/* minimum value that a PRNG should return for this upper bound to avoid a modulo bias */
+inline unsigned int random_minimum_acceptable_value(uint32_t upper_bound)
+{
+  /* Parts of this code come from arc4random_uniform */
+  /* To avoid "modulo bias" for some methods, calculate
+     minimum acceptable value for random number to improve
+     uniformity.
+
+     On applicable rngs, we loop until the rng spews out
+     value larger than min, and then take modulo out of that.
+  */
+  unsigned int min;
+#if (ULONG_MAX > 0xffffffffUL)
+  min = 0x100000000UL % upper_bound;
+#else
+  /* Calculate (2**32 % upper_bound) avoiding 64-bit math */
+  if (upper_bound > 0x80000000)
+    min = 1 + ~upper_bound; /* 2**32 - upper_bound */
+  else {
+    /* (2**32 - (x * 2)) % x == 2**32 % x when x <= 2**31 */
+    min = ((0xffffffff - (upper_bound * 2)) + 1) % upper_bound;
+  }
+#endif
+  return min;
+}
 }

--- a/pdns/dns_random.hh
+++ b/pdns/dns_random.hh
@@ -25,7 +25,7 @@
 #include <string>
 
 void dns_random_init(const std::string& data = "", bool force_reinit = false);
-uint32_t dns_random(uint32_t n);
+uint32_t dns_random(uint32_t upper_bound);
 uint16_t dns_random_uint16();
 
 namespace pdns
@@ -33,7 +33,7 @@ namespace pdns
 struct dns_random_engine
 {
 
-  typedef uint32_t result_type;
+  using result_type = uint32_t;
 
   static constexpr result_type min()
   {
@@ -62,7 +62,7 @@ inline unsigned int random_minimum_acceptable_value(uint32_t upper_bound)
      On applicable rngs, we loop until the rng spews out
      value larger than min, and then take modulo out of that.
   */
-  unsigned int min;
+  unsigned int min = 0;
 #if (ULONG_MAX > 0xffffffffUL)
   min = 0x100000000UL % upper_bound;
 #else

--- a/pdns/dns_random.hh
+++ b/pdns/dns_random.hh
@@ -26,6 +26,7 @@
 
 void dns_random_init(const std::string& data = "", bool force_reinit = false);
 uint32_t dns_random(uint32_t upper_bound);
+uint32_t dns_random_uint32();
 uint16_t dns_random_uint16();
 
 namespace pdns
@@ -42,12 +43,12 @@ struct dns_random_engine
 
   static constexpr result_type max()
   {
-    return std::numeric_limits<result_type>::max() - 1;
+    return std::numeric_limits<result_type>::max();
   }
 
   result_type operator()()
   {
-    return dns_random(std::numeric_limits<result_type>::max());
+    return dns_random_uint32();
   }
 };
 

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -239,7 +239,9 @@ void BaseLua4::prepareContext() {
     SLOG(g_log << (Logger::Urgency)loglevel.get_value_or(Logger::Warning) << msg<<endl,
          g_slog->withName("lua")->info(static_cast<Logr::Priority>(loglevel.get_value_or(Logr::Warning)), msg));
   });
-  d_lw->writeFunction("pdnsrandom", [](boost::optional<uint32_t> maximum) { return dns_random(maximum.get_value_or(0xffffffff)); });
+  d_lw->writeFunction("pdnsrandom", [](boost::optional<uint32_t> maximum) {
+    return maximum ? dns_random(*maximum) : dns_random_uint32();
+  });
 
   // certain constants
 

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -180,7 +180,7 @@ void openssl_seed()
 
   unsigned int r;
   for (int i = 0; i < 1024; i += 4) {
-    r = dns_random(0xffffffff);
+    r = dns_random_uint32();
     entropy.append((const char*)&r, 4);
   }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1852,7 +1852,7 @@ static void testSpeed(const DNSName& zone, const string& /* remote */, int cores
   DTime dt;
   dt.set();
   for(unsigned int n=0; n < 100000; ++n) {
-    rnd = dns_random(UINT32_MAX);
+    rnd = dns_random_uint32();
     snprintf(tmp, sizeof(tmp), "%d.%d.%d.%d",
       octets[0], octets[1], octets[2], octets[3]);
     rr.content=tmp;

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1962,7 +1962,7 @@ static int serviceMain(Logr::log_t log)
 
   showProductVersion();
 
-  g_disthashseed = dns_random(0xffffffff);
+  g_disthashseed = dns_random_uint32();
 
   int ret = initNet(log);
   if (ret != 0) {

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -19,32 +19,27 @@
 #include "dns_random.hh"
 #include "namespaces.hh"
 
-
 using namespace boost;
 using namespace boost::accumulators;
 
 typedef accumulator_set<
-  double
-  , stats<boost::accumulators::tag::median(with_p_square_quantile),
-          boost::accumulators::tag::mean(immediate)
-          >
-  > acc_t;
-
-
+  double, stats<boost::accumulators::tag::median(with_p_square_quantile), boost::accumulators::tag::mean(immediate)>>
+  acc_t;
 
 BOOST_AUTO_TEST_SUITE(test_dns_random_hh)
 
-BOOST_AUTO_TEST_CASE(test_dns_random_auto_average) {
+BOOST_AUTO_TEST_CASE(test_dns_random_auto_average)
+{
 
-  ::arg().set("rng")="auto";
-  ::arg().set("entropy-source")="/dev/urandom";
+  ::arg().set("rng") = "auto";
+  ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   acc_t acc;
 
-  for(unsigned int n=0; n < 100000; ++n)  {
-    acc(dns_random(100000)/100000.0);
+  for (unsigned int n = 0; n < 100000; ++n) {
+    acc(dns_random(100000) / 100000.0);
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
   BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
@@ -52,17 +47,18 @@ BOOST_AUTO_TEST_CASE(test_dns_random_auto_average) {
   // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
 
-BOOST_AUTO_TEST_CASE(test_dns_random_urandom_average) {
+BOOST_AUTO_TEST_CASE(test_dns_random_urandom_average)
+{
 
-  ::arg().set("rng")="urandom";
-  ::arg().set("entropy-source")="/dev/urandom";
+  ::arg().set("rng") = "urandom";
+  ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   acc_t acc;
 
-  for(unsigned int n=0; n < 100000; ++n)  {
-    acc(dns_random(100000)/100000.0);
+  for (unsigned int n = 0; n < 100000; ++n) {
+    acc(dns_random(100000) / 100000.0);
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
   BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
@@ -70,22 +66,24 @@ BOOST_AUTO_TEST_CASE(test_dns_random_urandom_average) {
   // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
 
-BOOST_AUTO_TEST_CASE(test_dns_random_garbage) {
+BOOST_AUTO_TEST_CASE(test_dns_random_garbage)
+{
 
-  ::arg().set("rng")="garbage";
-  ::arg().set("entropy-source")="/dev/urandom";
+  ::arg().set("rng") = "garbage";
+  ::arg().set("entropy-source") = "/dev/urandom";
 
   BOOST_CHECK_THROW(dns_random_init("", true), std::runtime_error);
 }
 
-BOOST_AUTO_TEST_CASE(test_dns_random_upper_bound) {
-  ::arg().set("rng")="auto";
-  ::arg().set("entropy-source")="/dev/urandom";
+BOOST_AUTO_TEST_CASE(test_dns_random_upper_bound)
+{
+  ::arg().set("rng") = "auto";
+  ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   map<int, bool> seen;
-  for(unsigned int n=0; n < 100000; ++n) {
+  for (unsigned int n = 0; n < 100000; ++n) {
     seen[dns_random(10)] = true;
   }
 
@@ -103,17 +101,18 @@ BOOST_AUTO_TEST_CASE(test_dns_random_upper_bound) {
 }
 
 #if defined(HAVE_GETRANDOM)
-BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average) {
+BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average)
+{
 
-  ::arg().set("rng")="getrandom";
-  ::arg().set("entropy-source")="/dev/urandom";
+  ::arg().set("rng") = "getrandom";
+  ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   acc_t acc;
 
-  for(unsigned int n=0; n < 100000; ++n)  {
-    acc(dns_random(100000)/100000.0);
+  for (unsigned int n = 0; n < 100000; ++n) {
+    acc(dns_random(100000) / 100000.0);
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
   BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
@@ -123,17 +122,18 @@ BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average) {
 #endif
 
 #if defined(HAVE_ARC4RANDOM)
-BOOST_AUTO_TEST_CASE(test_dns_random_arc4random_average) {
+BOOST_AUTO_TEST_CASE(test_dns_random_arc4random_average)
+{
 
-  ::arg().set("rng")="arc4random";
-  ::arg().set("entropy-source")="/dev/urandom";
+  ::arg().set("rng") = "arc4random";
+  ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   acc_t acc;
 
-  for(unsigned int n=0; n < 100000; ++n)  {
-    acc(dns_random(100000)/100000.0);
+  for (unsigned int n = 0; n < 100000; ++n) {
+    acc(dns_random(100000) / 100000.0);
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
   BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
@@ -143,17 +143,18 @@ BOOST_AUTO_TEST_CASE(test_dns_random_arc4random_average) {
 #endif
 
 #if defined(HAVE_RANDOMBYTES_STIR)
-BOOST_AUTO_TEST_CASE(test_dns_random_sodium_average) {
+BOOST_AUTO_TEST_CASE(test_dns_random_sodium_average)
+{
 
-  ::arg().set("rng")="sodium";
-  ::arg().set("entropy-source")="/dev/urandom";
+  ::arg().set("rng") = "sodium";
+  ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   acc_t acc;
 
-  for(unsigned int n=0; n < 100000; ++n)  {
-    acc(dns_random(100000)/100000.0);
+  for (unsigned int n = 0; n < 100000; ++n) {
+    acc(dns_random(100000) / 100000.0);
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
   BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
@@ -163,17 +164,18 @@ BOOST_AUTO_TEST_CASE(test_dns_random_sodium_average) {
 #endif
 
 #if defined(HAVE_RAND_BYTES)
-BOOST_AUTO_TEST_CASE(test_dns_random_openssl_average) {
+BOOST_AUTO_TEST_CASE(test_dns_random_openssl_average)
+{
 
-  ::arg().set("rng")="openssl";
-  ::arg().set("entropy-source")="/dev/urandom";
+  ::arg().set("rng") = "openssl";
+  ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   acc_t acc;
 
-  for(unsigned int n=0; n < 100000; ++n)  {
-    acc(dns_random(100000)/100000.0);
+  for (unsigned int n = 0; n < 100000; ++n) {
+    acc(dns_random(100000) / 100000.0);
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
   BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
@@ -183,17 +185,18 @@ BOOST_AUTO_TEST_CASE(test_dns_random_openssl_average) {
 #endif
 
 #if defined(HAVE_KISS_RNG)
-BOOST_AUTO_TEST_CASE(test_dns_random_kiss_average) {
+BOOST_AUTO_TEST_CASE(test_dns_random_kiss_average)
+{
 
-  ::arg().set("rng")="kiss";
-  ::arg().set("entropy-source")="/dev/urandom";
+  ::arg().set("rng") = "kiss";
+  ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   acc_t acc;
 
-  for(unsigned int n=0; n < 100000; ++n)  {
-    acc(dns_random(100000)/100000.0);
+  for (unsigned int n = 0; n < 100000; ++n) {
+    acc(dns_random(100000) / 100000.0);
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
   BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
@@ -201,7 +204,6 @@ BOOST_AUTO_TEST_CASE(test_dns_random_kiss_average) {
   // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
 #endif
-
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -18,7 +18,7 @@
 
 using namespace boost::accumulators;
 
-using acc_t = accumulator_set<double, stats<tag::median (with_p_square_quantile), tag::mean (immediate)>>;
+using acc_t = accumulator_set<double, stats<tag::median(with_p_square_quantile), tag::mean(immediate)>>;
 
 BOOST_AUTO_TEST_SUITE(test_dns_random_hh)
 
@@ -28,9 +28,9 @@ const std::vector<string> rndSources = {
 #if defined(HAVE_GETRANDOM)
   "getrandom",
 #endif
-  #if defined(HAVE_ARC4RANDOM)
+#if defined(HAVE_ARC4RANDOM)
   "arc4random",
-  #endif
+#endif
 #if defined(HAVE_RANDOMBYTES_STIR)
   "sodium",
 #endif
@@ -41,7 +41,6 @@ const std::vector<string> rndSources = {
   "kiss",
 #endif
 };
-
 
 BOOST_AUTO_TEST_CASE(test_dns_random_garbage)
 {
@@ -127,7 +126,4 @@ BOOST_AUTO_TEST_CASE(test_dns_random_uint32_average)
   }
 }
 
-
 BOOST_AUTO_TEST_SUITE_END()
-
-

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -28,6 +28,25 @@ typedef accumulator_set<
 
 BOOST_AUTO_TEST_SUITE(test_dns_random_hh)
 
+BOOST_AUTO_TEST_CASE(test_dns_random_uint32_auto_average)
+{
+
+  ::arg().set("rng") = "auto";
+  ::arg().set("entropy-source") = "/dev/urandom";
+
+  dns_random_init("", true);
+
+  acc_t acc;
+
+  for (unsigned int n = 0; n < 100000; ++n) {
+    acc(dns_random_unint32() / static_cast<double>(pdns::dns_random_engine::max() + 1));
+  }
+  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
+  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
+
+  // please add covariance tests, chi-square, Kolmogorov-Smirnov
+}
+
 BOOST_AUTO_TEST_CASE(test_dns_random_auto_average)
 {
 

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -1,9 +1,6 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_NO_MAIN
 
-// Disable this code for gcc 4.8 and lower
-#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 8) || !__GNUC__
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -19,71 +16,32 @@
 #include "dns_random.hh"
 #include "namespaces.hh"
 
-using namespace boost;
 using namespace boost::accumulators;
 
-typedef accumulator_set<
-  double, stats<boost::accumulators::tag::median(with_p_square_quantile), boost::accumulators::tag::mean(immediate)>>
-  acc_t;
+using acc_t = accumulator_set<double, stats<tag::median (with_p_square_quantile), tag::mean (immediate)>>;
 
 BOOST_AUTO_TEST_SUITE(test_dns_random_hh)
 
-BOOST_AUTO_TEST_CASE(test_dns_random_uint32_auto_average)
-{
+const std::vector<string> rndSources = {
+  "auto",
+  "urandom",
+#if defined(HAVE_GETRANDOM)
+  "getrandom",
+#endif
+  #if defined(HAVE_ARC4RANDOM)
+  "arc4random",
+  #endif
+#if defined(HAVE_RANDOMBYTES_STIR)
+  "sodium",
+#endif
+#if defined(HAVE_RAND_BYTES)
+  "openssl",
+#endif
+#if defined(HAVE_KISS_RNG)
+  "kiss",
+#endif
+};
 
-  ::arg().set("rng") = "auto";
-  ::arg().set("entropy-source") = "/dev/urandom";
-
-  dns_random_init("", true);
-
-  acc_t acc;
-
-  for (unsigned int n = 0; n < 100000; ++n) {
-    acc(dns_random_unint32() / static_cast<double>(pdns::dns_random_engine::max() + 1));
-  }
-  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
-  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
-
-  // please add covariance tests, chi-square, Kolmogorov-Smirnov
-}
-
-BOOST_AUTO_TEST_CASE(test_dns_random_auto_average)
-{
-
-  ::arg().set("rng") = "auto";
-  ::arg().set("entropy-source") = "/dev/urandom";
-
-  dns_random_init("", true);
-
-  acc_t acc;
-
-  for (unsigned int n = 0; n < 100000; ++n) {
-    acc(dns_random(100000) / 100000.0);
-  }
-  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
-  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
-
-  // please add covariance tests, chi-square, Kolmogorov-Smirnov
-}
-
-BOOST_AUTO_TEST_CASE(test_dns_random_urandom_average)
-{
-
-  ::arg().set("rng") = "urandom";
-  ::arg().set("entropy-source") = "/dev/urandom";
-
-  dns_random_init("", true);
-
-  acc_t acc;
-
-  for (unsigned int n = 0; n < 100000; ++n) {
-    acc(dns_random(100000) / 100000.0);
-  }
-  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
-  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
-
-  // please add covariance tests, chi-square, Kolmogorov-Smirnov
-}
 
 BOOST_AUTO_TEST_CASE(test_dns_random_garbage)
 {
@@ -101,8 +59,8 @@ BOOST_AUTO_TEST_CASE(test_dns_random_upper_bound)
 
   dns_random_init("", true);
 
-  map<int, bool> seen;
-  for (unsigned int n = 0; n < 100000; ++n) {
+  map<unsigned int, bool> seen;
+  for (unsigned int iteration = 0; iteration < 100000; ++iteration) {
     seen[dns_random(10)] = true;
   }
 
@@ -119,18 +77,16 @@ BOOST_AUTO_TEST_CASE(test_dns_random_upper_bound)
   BOOST_CHECK_EQUAL(seen[10], false);
 }
 
-#if defined(HAVE_GETRANDOM)
-BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average)
+static void test_dns_random_avg(const string& source)
 {
-
-  ::arg().set("rng") = "getrandom";
+  ::arg().set("rng") = source;
   ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   acc_t acc;
 
-  for (unsigned int n = 0; n < 100000; ++n) {
+  for (unsigned int iteration = 0; iteration < 100000; ++iteration) {
     acc(dns_random(100000) / 100000.0);
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
@@ -138,92 +94,40 @@ BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average)
 
   // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
-#endif
 
-#if defined(HAVE_ARC4RANDOM)
-BOOST_AUTO_TEST_CASE(test_dns_random_arc4random_average)
+static void test_dns_random_uint32_avg(const string& source)
 {
-
-  ::arg().set("rng") = "arc4random";
+  ::arg().set("rng") = source;
   ::arg().set("entropy-source") = "/dev/urandom";
 
   dns_random_init("", true);
 
   acc_t acc;
 
-  for (unsigned int n = 0; n < 100000; ++n) {
-    acc(dns_random(100000) / 100000.0);
+  for (unsigned int iteration = 0; iteration < 100000; ++iteration) {
+    acc(dns_random_uint32() / static_cast<double>(pdns::dns_random_engine::max()));
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
   BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
 
   // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
-#endif
 
-#if defined(HAVE_RANDOMBYTES_STIR)
-BOOST_AUTO_TEST_CASE(test_dns_random_sodium_average)
+BOOST_AUTO_TEST_CASE(test_dns_random_average)
 {
-
-  ::arg().set("rng") = "sodium";
-  ::arg().set("entropy-source") = "/dev/urandom";
-
-  dns_random_init("", true);
-
-  acc_t acc;
-
-  for (unsigned int n = 0; n < 100000; ++n) {
-    acc(dns_random(100000) / 100000.0);
+  for (const auto& source : rndSources) {
+    test_dns_random_avg(source);
   }
-  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
-  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
-
-  // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
-#endif
 
-#if defined(HAVE_RAND_BYTES)
-BOOST_AUTO_TEST_CASE(test_dns_random_openssl_average)
+BOOST_AUTO_TEST_CASE(test_dns_random_uint32_average)
 {
-
-  ::arg().set("rng") = "openssl";
-  ::arg().set("entropy-source") = "/dev/urandom";
-
-  dns_random_init("", true);
-
-  acc_t acc;
-
-  for (unsigned int n = 0; n < 100000; ++n) {
-    acc(dns_random(100000) / 100000.0);
+  for (const auto& source : rndSources) {
+    test_dns_random_uint32_avg(source);
   }
-  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
-  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
-
-  // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
-#endif
 
-#if defined(HAVE_KISS_RNG)
-BOOST_AUTO_TEST_CASE(test_dns_random_kiss_average)
-{
-
-  ::arg().set("rng") = "kiss";
-  ::arg().set("entropy-source") = "/dev/urandom";
-
-  dns_random_init("", true);
-
-  acc_t acc;
-
-  for (unsigned int n = 0; n < 100000; ++n) {
-    acc(dns_random(100000) / 100000.0);
-  }
-  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
-  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
-
-  // please add covariance tests, chi-square, Kolmogorov-Smirnov
-}
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 
-#endif
+

--- a/pdns/tsigutils.cc
+++ b/pdns/tsigutils.cc
@@ -51,7 +51,7 @@ std::string makeTSIGKey(const DNSName& algorithm) {
 
   // Fill out the key
   for (size_t i = 0; i < klen; i += sizeof(uint32_t)) {
-    uint32_t t = dns_random(std::numeric_limits<uint32_t>::max());
+    uint32_t t = dns_random_uint32();
     memcpy(&tmpkey.at(i), &t, sizeof(uint32_t));
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Currently `dns_random(uint32_t upper_bound)` has a drawbacks: the exclusive upper bound is mandatory. So the simple case: get full 32-bit randomness is not covered and the code to avoid modulo-bias is always executed. This is wasteful.

So add ``dns_random_uint32()`.

Start with using it in `pdns::dns_random_engine` and ` dns_random_uint16()`.

Also: reformat, cleanup, delint and refactor and *enable* tests.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
