### PR TITLE
rec: fix daemonize(), followup to #12836

### DIFF
--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -809,7 +809,13 @@ static void setupNODGlobal()
 
 static void daemonize(Logr::log_t log)
 {
-  if (fork() < 0) {
+  if (auto pid = fork(); pid != 0) {
+    if (pid < 0) {
+      int err = errno;
+      SLOG(g_log << Logger::Critical << "Fork failed: " << stringerror(err) << endl,
+           log->error(Logr::Critical, err, "Fork failed"));
+      exit(1); // NOLINT(concurrency-mt-unsafe
+    }
     exit(0); // NOLINT(concurrency-mt-unsafe
   }
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -814,9 +814,9 @@ static void daemonize(Logr::log_t log)
       int err = errno;
       SLOG(g_log << Logger::Critical << "Fork failed: " << stringerror(err) << endl,
            log->error(Logr::Critical, err, "Fork failed"));
-      exit(1); // NOLINT(concurrency-mt-unsafe
+      exit(1); // NOLINT(concurrency-mt-unsafe)
     }
-    exit(0); // NOLINT(concurrency-mt-unsafe
+    exit(0); // NOLINT(concurrency-mt-unsafe)
   }
 
   setsid();


### PR DESCRIPTION
Originally the code did not distinguish between parent return and error:

```
static void daemonize(Logr::log_t log)
{
  if (fork())
    exit(0); // bye bye

  setsid();
  ...
```
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
