### PR TITLE
Fix wrong rfc number in docs for ZONEMD record

### DIFF
--- a/docs/appendices/types.rst
+++ b/docs/appendices/types.rst
@@ -372,7 +372,7 @@ mappings from hostnames to URIs.
 ZONEMD
 ------
 
-The ZONEMD record, specified in :rfc:`8796`, is used to validate zones.
+The ZONEMD record, specified in :rfc:`8976`, is used to validate zones.
 
 Other types
 -----------


### PR DESCRIPTION
### Short description
Docs link to a wrong rfc for ZONEMD record. 

### Checklist
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
