### PR TITLE
auth: Fix coverity time_t related warnings

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -430,6 +430,7 @@ void Bind2Backend::getUnfreshSlaveInfos(vector<DomainInfo>* unfreshDomains)
     catch (...) {
     }
     sd.serial = soadata.serial;
+    // coverity[store_truncates_time_t]
     if (sd.last_check + soadata.refresh < (unsigned int)time(nullptr))
       unfreshDomains->push_back(std::move(sd));
   }

--- a/pdns/auth-zonecache.hh
+++ b/pdns/auth-zonecache.hh
@@ -43,6 +43,7 @@ public:
 
   uint32_t getRefreshInterval() const
   {
+    // coverity[store_truncates_time_t]
     return d_refreshinterval;
   }
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -533,6 +533,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getEntryPoints(const DNSName& zname)
 DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
 {
   static int ttl = ::arg().asNum("dnssec-key-cache-ttl");
+  // coverity[store_truncates_time_t]
   unsigned int now = time(nullptr);
 
   if(!((++s_ops) % 100000)) {

--- a/pdns/ixplore.cc
+++ b/pdns/ixplore.cc
@@ -180,7 +180,7 @@ int main(int argc, char** argv) {
       shared_ptr<const SOARecordContent> sr;
       uint32_t serial = getSerialFromMaster(master, zone, sr, tt);
       if(ourSerial == serial) {
-        time_t sleepTime = sr ? sr->d_st.refresh : 60;
+        unsigned int sleepTime = sr ? sr->d_st.refresh : 60;
         cout<<"still up to date, their serial is "<<serial<<", sleeping "<<sleepTime<<" seconds"<<endl;
         sleep(sleepTime);
         continue;

--- a/pdns/saxfr.cc
+++ b/pdns/saxfr.cc
@@ -105,6 +105,7 @@ try
       DNSPacketWriter pwtkey(packet, gssctx.getLabel(), QType::TKEY, QClass::ANY);
       TKEYRecordContent tkrc;
       tkrc.d_algo = DNSName("gss-tsig.");
+      // coverity[store_truncates_time_t]
       tkrc.d_inception = time((time_t*)NULL);
       tkrc.d_expiration = tkrc.d_inception+15;
       tkrc.d_mode = 3;

--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -59,6 +59,7 @@ uint32_t calculateEditSOA(uint32_t old_serial, const string& kind, const DNSName
     return (old_serial + (inception / (7*86400)));
   }
   else if(pdns_iequals(kind,"EPOCH")) {
+    // coverity[store_truncates_time_t]
     return time(nullptr);
   }
   else if(pdns_iequals(kind,"INCEPTION-EPOCH")) {
@@ -107,6 +108,7 @@ static uint32_t calculateIncreaseSOA(uint32_t old_serial, const string& increase
     return old_serial + 1;
   }
   else if (pdns_iequals(increaseKind, "EPOCH")) {
+    // coverity[store_truncates_time_t]
     return time(nullptr);
   }
   else if (pdns_iequals(increaseKind, "DEFAULT")) {

--- a/pdns/tkey.cc
+++ b/pdns/tkey.cc
@@ -31,6 +31,7 @@ void PacketHandler::tkeyHandler(const DNSPacket& p, std::unique_ptr<DNSPacket>& 
   tkey_out->d_error = 0;
   tkey_out->d_mode = tkey_in.d_mode;
   tkey_out->d_algo = tkey_in.d_algo;
+  // coverity[store_truncates_time_t]
   tkey_out->d_inception = inception;
   tkey_out->d_expiration = tkey_out->d_inception+15;
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -583,6 +583,7 @@ static void gatherComments(const Json& container, const DNSName& qname, const QT
 
   time_t now = time(nullptr);
   for (const auto& comment : container["comments"].array_items()) {
+    // FIXME this is converting to a *signed* int, 2036 issue
     c.modified_at = intFromJson(comment, "modified_at", now);
     c.content = stringFromJson(comment, "content");
     c.account = stringFromJson(comment, "account");


### PR DESCRIPTION
Most are not *really* bad, as we convert time_t or unsigned int, which is good for quite some time. One case of converting time_t to *signed* int spotted.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
