### PR TITLE
Fix issue with clang-tidy and module source files

### DIFF
--- a/.github/scripts/git-filter.py
+++ b/.github/scripts/git-filter.py
@@ -19,6 +19,8 @@ def main():
     compdb = helpers.load_compdb("compile_commands.json")
     compdb = helpers.index_compdb(compdb)
 
+    pdns_path = os.path.join("pdns", "")
+    cwd = os.getcwd()
     root = helpers.get_repo_root()
 
     diff = sys.stdin.read()
@@ -26,7 +28,29 @@ def main():
     for patch in patch_set:
         path = os.path.join(root, patch.path)
         if path in compdb:
+            if not patch.path.startswith(pdns_path):
+                # If the file being diffed is not under the pdns/ directory, we
+                # need to reconstruct its filename in the patch adding extra
+                # paths that clang-tidy-diff will get rid of: this way
+                # clang-tidy can work with the correct file path.
+                #
+                # Example with a source file under modules/:
+                #   patch.path = modules/foo/foo.cc
+                #   path       = /home/user/workspace/pdns/modules/foo/foo.cc
+                #   cwd        = /home/user/workspace/pdns/pdns/
+                #   relpath    = ../modules/foo/foo.cc
+                #
+                # Then the patch filenames would be:
+                #   patch.source_file = a/pdns/../modules/foo/foo.cc
+                #   patch.target_file = b/pdns/../modules/foo/foo.cc
+                relpath = os.path.relpath(path, cwd)
+                if patch.source_file is not None:
+                    patch.source_file = os.path.join("a", "pdns", relpath)
+                patch.target_file = os.path.join("b", "pdns", relpath)
             print(patch)
+        else:
+            msg = f"Skipping {path}: it is not in the compilation db"
+            print(msg, file=sys.stderr)
 
     return 0
 

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -559,12 +559,15 @@ jobs:
     steps:
       - run: |
           if [ "x${{ needs.build-auth.outputs.clang-tidy-failed }}" != "x" -a "${{ needs.build-auth.outputs.clang-tidy-failed }}" != "0" ]; then
-            exit 1
-          fi
-          if [ "x${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "x" -a "${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "0" ]; then
+            echo "::error::Auth clang-tidy failed"
             exit 1
           fi
           if [ "x${{needs.build-recursor.outputs.clang-tidy-failed}}" != "x" -a "${{needs.build-recursor.outputs.clang-tidy-failed}}" != "0" ]; then
+            echo "::error::Rec clang-tidy failed"
+            exit 1
+          fi
+          if [ "x${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "x" -a "${{ needs.build-dnsdist.outputs.clang-tidy-failed }}" != "0" ]; then
+            echo "::error::dnsdist clang-tidy failed"
             exit 1
           fi
 


### PR DESCRIPTION
### Short description
The problem was that clang-tidy-diff needs to truncate paths for clang-tidy to find the files relative to the current directory and where the compilation database is, so files under directories like `ext` and `modules` didn't end up being found because they were expected to be under `pdns`. What this change does is hacky, but it's all I can think of for now (short of a rework and/or changing the project structure).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
