### PR TITLE
rec: include qname when logging skip of step 4 of qname minimization

### DIFF
--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -1746,7 +1746,7 @@ int SyncRes::doResolve(const DNSName& qname, const QType qtype, vector<DNSRecord
         }
       }
       if (skipStep4) {
-        LOG(prefix << ": Step4 Being skipped as visited this child name already" << endl);
+        LOG(prefix << qname << ": Step4 Being skipped as visited this child name already" << endl);
         continue;
       }
 


### PR DESCRIPTION
### Short description
Fixes an issue where the trace looks whack because the log line doesn't include the qname.  Also affects 4.9

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
