### PR TITLE
Work around Red Hat 8 pooping the bed in OpenSSL's headers

### DIFF
--- a/m4/pdns_check_libcrypto.m4
+++ b/m4/pdns_check_libcrypto.m4
@@ -112,7 +112,15 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO], [
         [
             AC_MSG_RESULT([yes])
             AC_CHECK_FUNCS([RAND_bytes RAND_pseudo_bytes CRYPTO_memcmp OPENSSL_init_crypto EVP_MD_CTX_new EVP_MD_CTX_free RSA_get0_key])
-            AC_CHECK_DECL(EVP_PKEY_CTX_set1_scrypt_salt, [AC_DEFINE([HAVE_EVP_PKEY_CTX_SET1_SCRYPT_SALT], [1], [Define to 1 if you have EVP_PKEY_CTX_set1_scrypt_salt])], [], [#include <openssl/kdf.h>])
+            # you might be wondering why the stdarg.h and stddef.h includes,
+            # in which case please have a look at https://github.com/PowerDNS/pdns/issues/12926
+            # and weep, yelling at Red Hat
+            AC_CHECK_DECL(EVP_PKEY_CTX_set1_scrypt_salt,
+                          [AC_DEFINE([HAVE_EVP_PKEY_CTX_SET1_SCRYPT_SALT], [1], [Define to 1 if you have EVP_PKEY_CTX_set1_scrypt_salt])],
+                          [],
+                          [#include <stdarg.h>
+                           #include <stddef.h>
+                           #include <openssl/kdf.h>])
             $1
         ], [
             AC_MSG_RESULT([no])


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The `openssl/kdf.h` header on EL8 is invalid because someone backported a work-in-progress feature to an older OpenSSL branch and did not bother to backport the fixes that were added later.

Red Hat declined to fix their mess and helpfully suggested we do the work instead in https://bugzilla.redhat.com/show_bug.cgi?id=2215856

This will need to be backported to all the branches we want to support on RHEL 8 and co.

Fixes #12613:
- before `checking whether EVP_PKEY_CTX_set1_scrypt_salt is declared... no`
- after `checking whether EVP_PKEY_CTX_set1_scrypt_salt is declared... yes` and it actually compiles
```bash
# pdns/pdnsutil hash-password
Warning: unable to read configuration file '/usr/local/etc/pdns.conf': No such file or directory
$scrypt$ln=10,p=1,r=8$Vtrf782VeuoQNY9VE7mvUA==$KFn4DGLV0SV4O7Pxunb38MBHr3uCf5SXtfzsf30aeBc=
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
