### PR TITLE
coverity: bump to ubuntu 22.04

### DIFF
--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -42,7 +42,7 @@ jobs:
   coverity-auth:
     name: coverity scan of the auth
     if: ${{ vars.SCHEDULED_MISC_DAILIES }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERITY_TOKEN: ${{ secrets.coverity_auth_token }}
       FUZZING_TARGETS: no
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
-      - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
+      - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
       - run: inv install-clang
       - run: inv install-auth-build-deps
       - run: inv install-coverity-tools PowerDNS
@@ -68,7 +68,7 @@ jobs:
   coverity-dnsdist:
     name: coverity scan of dnsdist
     if: ${{ vars.SCHEDULED_MISC_DAILIES }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERITY_TOKEN: ${{ secrets.coverity_dnsdist_token }}
       SANITIZERS:
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
-      - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
+      - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
       - run: inv install-clang
       - run: inv install-dnsdist-build-deps
       - run: inv install-coverity-tools dnsdist
@@ -98,7 +98,7 @@ jobs:
   coverity-rec:
     name: coverity scan of the rec
     if: ${{ vars.SCHEDULED_MISC_DAILIES }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERITY_TOKEN: ${{ secrets.coverity_rec_token }}
       SANITIZERS:
@@ -109,7 +109,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
-      - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
+      - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
       - run: inv install-clang
       - run: inv install-rec-build-deps
       - run: inv install-coverity-tools 'PowerDNS+Recursor'


### PR DESCRIPTION
### Short description
#10776 means doc building requires Python 3.9 now, so bump coverity runs to an Ubuntu that has that.

I bumped the rec and dnsdist builds too, just as future proofing.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master