### PR TITLE
build-packages: Fix the package buikding workflow

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -94,12 +94,21 @@ jobs:
           name: ${{ inputs.product }}-${{ matrix.os }}-${{ steps.getversion.outputs.version }}
           path: built_pkgs/
           retention-days: 7
+      - name: Normalize package name
+        id: normalize-name
+        run: |
+          if [ "x${{ inputs.product }}" = "xrecursor" ]; then
+            echo "normalized-package-name=pdns-recursor" >> $GITHUB_OUTPUT
+          else
+            echo "normalized-package-name=${{ inputs.product }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Extract packages from the tarball
         # so we get provenance for individual packages (and the JSON package manifests from the builder)
         id: extract
         run: |
           mkdir -m 700 -p ./packages/
-          tar xvf ./built_pkgs/*/*/${{ inputs.product }}-${{ steps.getversion.outputs.version }}-${{ matrix.os }}.tar.bz2 -C ./packages/ --transform='s/.*\///'
+          tar xvf ./built_pkgs/*/*/${{ steps.normalize-name.outputs.normalized-package-name }}-${{ steps.getversion.outputs.version }}-${{ matrix.os }}.tar.bz2 -C ./packages/ --transform='s/.*\///'
       - name: Generate package hashes for provenance
         shell: bash
         id: pkghashes

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -97,7 +97,9 @@ jobs:
       - name: Normalize package name
         id: normalize-name
         run: |
-          if [ "x${{ inputs.product }}" = "xrecursor" ]; then
+          if [ "x${{ inputs.product }}" = "xauthoritative" ]; then
+            echo "normalized-package-name=pdns" >> $GITHUB_OUTPUT
+          elif [ "x${{ inputs.product }}" = "xrecursor" ]; then
             echo "normalized-package-name=pdns-recursor" >> $GITHUB_OUTPUT
           else
             echo "normalized-package-name=${{ inputs.product }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-tags.yml
+++ b/.github/workflows/build-tags.yml
@@ -14,7 +14,7 @@ jobs:
     if: startsWith(github.ref_name, 'auth')
     with:
       is_release: 'YES'
-      product: 'auth'
+      product: 'authoritative'
       ref: ${{ github.ref_name }}
     secrets:
       DOWNLOADS_AUTOBUILT_SECRET: ${{ secrets.DOWNLOADS_AUTOBUILT_SECRET }}
@@ -38,7 +38,7 @@ jobs:
     if: startsWith(github.ref_name, 'rec')
     with:
       is_release: 'YES'
-      product: 'auth'
+      product: 'recursor'
       ref: ${{ github.ref_name }}
     secrets:
       DOWNLOADS_AUTOBUILT_SECRET: ${{ secrets.DOWNLOADS_AUTOBUILT_SECRET }}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR:
- fixes the package building workflow: we need to normalize the name of the product being built: `authoritative` yields packages named `pdns`, `recursor` `pdns-recursor`
- fixes the names used when invoking the workflow after a tag has been pushed: the product names were not correct for `auth` and `rec`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
