### PR TITLE
dnsdist: Fix "Pointer to local outside storage" reported by Coverity

### DIFF
--- a/pdns/dnsdistdist/dnsdist-metrics.cc
+++ b/pdns/dnsdistdist/dnsdist-metrics.cc
@@ -160,12 +160,13 @@ std::optional<std::string> declareCustomMetric(const std::string& name, const st
     return std::string("Unable to declare metric '") + std::string(name) + std::string("': invalid name\n");
   }
 
+  const std::string finalCustomName(customName ? *customName : "");
   if (type == "counter") {
     auto customCounters = s_customCounters.write_lock();
     auto itp = customCounters->insert({name, MutableCounter()});
     if (itp.second) {
       g_stats.entries.write_lock()->emplace_back(Stats::EntryPair{name, &(*customCounters)[name].d_value});
-      dnsdist::prometheus::PrometheusMetricDefinition def{name, "counter", description, customName ? *customName : ""};
+      dnsdist::prometheus::PrometheusMetricDefinition def{name, type, description, finalCustomName};
       addMetricDefinition(def);
     }
   }
@@ -174,7 +175,7 @@ std::optional<std::string> declareCustomMetric(const std::string& name, const st
     auto itp = customGauges->insert({name, MutableGauge()});
     if (itp.second) {
       g_stats.entries.write_lock()->emplace_back(Stats::EntryPair{name, &(*customGauges)[name].d_value});
-      dnsdist::prometheus::PrometheusMetricDefinition def{name, "gauge", description, customName ? *customName : ""};
+      dnsdist::prometheus::PrometheusMetricDefinition def{name, type, description, finalCustomName};
       addMetricDefinition(def);
     }
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We use a temporary `std::string` for a very short tile after it is no longer required to exist when adding a new custom metric. Reported by Coverity as CID 394511.
This was recently introduced on master and does not need to be backported.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
