### PR TITLE
dnsdist-1.8.x: Fix a crash when X-Forwarded-For overrides the initial source IP

### DIFF
--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -1064,6 +1064,9 @@ class TestDOHForwardedFor(DNSDistDOHTest):
 
     setACL('192.0.2.1/32')
     addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, {trustForwardedForHeader=true})
+    -- Set a maximum number of TCP connections per client, to exercise
+    -- that code along with X-Forwarded-For support
+    setMaxTCPConnectionsPerClient(2)
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey']
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of https://github.com/PowerDNS/pdns/pull/12976 to rel/dnsdist-1.8.x.

When both the processing of X-Forwarded-For DNS-over-https headers (`trustForwardedForHeader=true`) and a maximum number of concurrent TCP connections per client (`setMaxTCPConnectionsPerClient()`) are enabled, dnsdist could crash because of an uncaught exception:
```
dnsdist[X]: terminate called after throwing an instance of 'std::runtime_error'
dnsdist[X]:   what():  DOH thread failed to launch: map::at
```
This was caused by the TCP connection being first accounted for with the initial source IP (from the upstream HTTP proxy) but later released using the IP extracted from the X-Forwarded-For header, leading to an unexpected failure to locate the corresponding entry in the map.

We might not actually want to enforce the maximum number of concurrent TCP connections per client when X-Forwarded-For processing is enabled, though, because we usually want to rate limit the actual client and not the HTTP proxy, but X-Forwarded-For being set per HTTP query, instead of per-connection, makes that pretty much impossible at our level since the same connection from the HTTP proxy can be reused for several clients. The proxy protocol would be a better option to enforce that limit.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
