### PR TITLE
builder-dispatch: Explicitly grant permissions to the build package workflow

### DIFF
--- a/.github/workflows/builder-dispatch.yml
+++ b/.github/workflows/builder-dispatch.yml
@@ -35,6 +35,11 @@ on:
         - 'NO'
         - 'YES'
 
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  actions: read
+  contents: write # To be able to upload assets as release artifacts
+  id-token: write # To sign the provenance in the build packages reusable workflow.
+
 jobs:
   call-build-packages:
     uses: PowerDNS/pdns/.github/workflows/build-packages.yml@master


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
So that we can use it from forks:
> For reusable workflows outside your enterprise or organization, the permissions setting for id-token should be explicitly set to write at the caller workflow level or in the specific job that calls the reusable workflow.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
