### PR TITLE
auth lmdb: in Lightning Stream mode, during deleteDomain, use RW transaction to get ID list

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1321,7 +1321,11 @@ bool LMDBBackend::deleteDomain(const DNSName& domain)
     idvec.push_back(txn.get<0>(domain, di));
   }
   else {
-    auto txn = d_tdomains->getROTransaction();
+    // this transaction used to be RO.
+    // it is now RW to narrow a race window between PowerDNS and Lightning Stream
+    // FIXME: turn the entire delete, including this ID scan, into one RW transaction
+    // when doing that, first do a short RO check to see if we actually have anything to delete
+    auto txn = d_tdomains->getRWTransaction();
 
     txn.get_multi<0>(domain, idvec);
   }


### PR DESCRIPTION
### Short description
This reduces the window for a race with Lightning Stream. The full fix would be to make `deleteDomain` a single RW transaction.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
