### PR TITLE
optsize off by -4 when including DNS cookie

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -333,7 +333,7 @@ void DNSPacket::wrapup(bool throwsOnTruncation)
 
   if (d_haveednscookie) {
     if (d_eco.isWellFormed()) {
-        optsize += EDNSCookiesOpt::EDNSCookieOptSize;
+        optsize += EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE + EDNSCookiesOpt::EDNSCookieOptSize;
     }
   }
 


### PR DESCRIPTION
### Short description
Hi,

I noticed these entries in my logs after rotating some DNSSEC keys:

pdns_server[514339]: Weird, trying to send a message that needs truncation, 513 > 512. Question was for domain.tld|DNSKEY

After some digging it turns out that the DNS cookie 'code' and 'length' fields are not included in optsize. This causes pdns to send out packets that should have been truncated.

dig options to reproduce: +bufsize=512 +cookie

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
