### PR TITLE
Report auth settings deprecated in 4.5

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -97,7 +97,7 @@ Renamed options
 ~~~~~~~~~~~~~~~
 
 Various settings have been renamed.
-Their old names still work in 4.5.x, but will be removed in the release after it.
+Their old names still work in 4.5.x, but will be removed in a release after it.
 
 * :ref:`setting-allow-unsigned-supermaster` is now :ref:`setting-allow-unsigned-autoprimary`
 * :ref:`setting-master` is now :ref:`setting-primary`

--- a/pdns/arguments.cc
+++ b/pdns/arguments.cc
@@ -364,6 +364,13 @@ static const map<string, string> deprecateList = {
   {"snmp-master-socket", "snmp-daemon-socket"},
   {"xpf-allow-from", "Proxy Protocol"},
   {"xpf-rr-code", "Proxy Protocol"},
+  {"allow-unsigned-supermaster", "allow-unsigned-autoprimary"},
+  {"master", "primary"},
+  {"slave-cycle-interval", "xfr-cycle-interval"},
+  {"slave-renotify", "secondary-do-renotify"},
+  {"slave", "secondary"},
+  {"superslave", "autosecondary"},
+  {"domain-metadata-cache-ttl", "zone-metadata-cache-ttl"},
 };
 
 void ArgvMap::warnIfDeprecated(const string& var)


### PR DESCRIPTION
### Short description

In 4.5, a bunch of things were renamed: https://doc.powerdns.com/authoritative/upgrading.html#renamed-options, but while there's code to tell people about renames, these renames were not included. This PR adds them.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
