### PR TITLE
dnsheader: Switch from bitfield to uint16_t whenever possible

### DIFF
--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -151,7 +151,7 @@ static_assert(sizeof(EDNS0Record) == 4, "EDNS0Record size must be 4");
 #endif
 
 struct dnsheader {
-        unsigned        id :16;         /* query identification number */
+        uint16_t        id;             /* query identification number */
 #if BYTE_ORDER == BIG_ENDIAN
                         /* fields in third byte */
         unsigned        qr: 1;          /* response flag */
@@ -180,10 +180,10 @@ struct dnsheader {
         unsigned        ra :1;          /* recursion available */
 #endif
                         /* remaining bytes */
-        unsigned        qdcount :16;    /* number of question entries */
-        unsigned        ancount :16;    /* number of answer entries */
-        unsigned        nscount :16;    /* number of authority entries */
-        unsigned        arcount :16;    /* number of resource entries */
+        uint16_t        qdcount;        /* number of question entries */
+        uint16_t        ancount;        /* number of answer entries */
+        uint16_t        nscount;        /* number of authority entries */
+        uint16_t        arcount;        /* number of resource entries */
 };
 
 static_assert(sizeof(dnsheader) == 12, "dnsheader size must be 12");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
See https://github.com/PowerDNS/pdns/pull/13012 for the reason why we prefer a plain `uint16_t` to an `unsigned` bit field of the same size.

~Opening as a draft for now, mostly to see if our CI passes.~

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
