### PR TITLE
wait for mysql.service

### DIFF
--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -3,7 +3,7 @@ Description=PowerDNS Authoritative Server
 Documentation=man:pdns_server(1) man:pdns_control(1)
 Documentation=https://doc.powerdns.com
 Wants=network-online.target
-After=network-online.target mysqld.service postgresql.service slapd.service mariadb.service time-sync.target
+After=network-online.target mysql.service mysqld.service postgresql.service slapd.service mariadb.service time-sync.target
 
 [Service]
 ExecStart=@sbindir@/pdns_server --guardian=no --daemon=no --disable-syslog --log-timestamp=no --write-pid=no


### PR DESCRIPTION
### Wait for `mysql.service` on Ubuntu.

Dear Team,

On Ubuntu there is no `mysqld.service`. Only `mysql.service` exists.
With a mysql backend in use but without waiting for `mysql.service` to start, the pdns service can fail+restart a couple of times on boot with an error like:
`systemd[1]: Failed to start PowerDNS Authoritative Server.` -> until mysql will start and accept the connections of pdns.
It's not a big deal, pdns.service will start anyways.
I'm getting the error twice in a Ubuntu 20.04 VM when booting up.
I also checked 16.04, 18.04, 22.04 and none of them has `mysqld.service` when I install mysql from repo.

Personally I also prefer the `*d.service` names and other services like OpenSSH can handle both on Ubuntu with a regular service unit file here: `/lib/systemd/system/ssh.service`
plus with a symlink which points to the same service unit file:
`/etc/systemd/system/sshd.service -> /lib/systemd/system/ssh.service`
But unfortunately this is not the case for mysql.

What do you think? Does it worth to extend the `pdns.service` unit file and wait for the `mysql.service`?

Regards,
