### PR TITLE
Update settings.rst -- clarify edns-subnet-allow-list

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -791,6 +791,8 @@ List of netmasks and domains that :rfc:`EDNS Client Subnet <7871>` should be ena
 For example, an EDNS Client Subnet option containing the address of the initial requestor (but see `ecs-add-for`_) will be added to an outgoing query sent to server 192.0.2.1 for domain X if 192.0.2.1 matches one of the supplied netmasks, or if X matches one of the supplied domains.
 The initial requestor address will be truncated to 24 bits for IPv4 (see `ecs-ipv4-bits`_) and to 56 bits for IPv6 (see `ecs-ipv6-bits`_), as recommended in the privacy section of RFC 7871.
 
+Note that this setting describes the destination of outgoing queries, not the sources of incoming queries, nor the subnets described in the EDNS Client Subnet option.
+
 By default, this option is empty, meaning no EDNS Client Subnet information is sent.
 
 .. _setting-entropy-source:


### PR DESCRIPTION
Try to reduce confusion about what the edns-subnet-allow-list setting does and doesn't affect.

### Short description

We had a discussion on IRC about this setting. I had misunderstood the purpose of it pretty badly. So, I've tried to clarify the meaning.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
