### PR TITLE
Add missing tools to pdns-tools package description (control)

### DIFF
--- a/builder-support/debian/authoritative/debian-buster/control
+++ b/builder-support/debian/authoritative/debian-buster/control
@@ -65,16 +65,24 @@ Description: Tools for DNS debugging by PowerDNS
  This package contains several tools to debug DNS issues. These tools do not
  require any part of the PowerDNS server components to work.
  .
+   * calidns: Resolver benchmark tool
    * dnsbulktest: A resolver stress-tester
    * dnsgram: Show per 5-second statistics to study intermittent resolver issues
+   * dnspcap2calidns: PCAP conversion tool (calidns format)
+   * dnspcap2protobuf: PCAP conversion tool (protobuf format)
    * dnsreplay: Replay a pcap with DNS queries
    * dnsscan: Prints the query-type amounts in a pcap
    * dnsscope: Calculates statistics without replaying traffic
    * dnstcpbench: Perform TCP benchmarking of DNS servers
    * dnswasher: Clean a pcap of identifying IP information
+   * dumresp: Dummy DNS responder
    * ixplore: Explore diffs from IXFRs
+   * nproxy: DNS notification proxy
    * nsec3dig: Calculate the correctness of NSEC3 proofs
+   * pdns_notify: Simple tool for sending DNS notifies
    * saxfr: AXFR zones and show extra information
+   * sdig: dig-like tool supporting DoH, DoT, PROXY-protocol and XPF
+   * stubquery: Stub resolver query tool
 
 Package: pdns-ixfrdist
 Architecture: any


### PR DESCRIPTION
### Short description
[pdns-tools package descriptions for Debian / Ubuntu](https://github.com/PowerDNS/pdns/blob/29d9168874867c712da624bc4173b62f07cb79bf/builder-support/debian/authoritative/debian-buster/control#L55) don't list all tools contained within pdns-tools which is a bit confusing when looking for a specific tool (such as calidns or sdig).

Closes #13016.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
