### PR TITLE
misc: `pdns::getMessageFromErrno()` does not depend on libcrypto

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -49,7 +49,6 @@ class DNSName;
 typedef enum { TSIG_MD5, TSIG_SHA1, TSIG_SHA224, TSIG_SHA256, TSIG_SHA384, TSIG_SHA512, TSIG_GSS } TSIGHashEnum;
 namespace pdns
 {
-#if defined(HAVE_LIBCRYPTO)
 /**
  * \brief Retrieves the errno-based error message in a reentrant way.
  *
@@ -63,6 +62,7 @@ namespace pdns
  */
 auto getMessageFromErrno(int errnum) -> std::string;
 
+#if defined(HAVE_LIBCRYPTO)
 namespace OpenSSL
 {
   /**


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This prevents compiling dnsdist when libcrypto is not available, which should be possible.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
