### PR TITLE
channel unit tests: Actually retrieve the object after an overflow

### DIFF
--- a/pdns/test-channel.cc
+++ b/pdns/test-channel.cc
@@ -77,6 +77,11 @@ BOOST_AUTO_TEST_CASE(test_object_queue_full)
   auto obj = std::make_unique<MyObject>();
   obj->a = 42U;
   BOOST_CHECK(sender.send(std::move(obj)));
+  /* and to get it */
+  {
+    auto got = receiver.receive();
+    BOOST_CHECK(got);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_object_queue_throw_on_eof)


### PR DESCRIPTION
## Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Not only does this ensure that we can actually retrieve the submitted object, it prevents memory analysis tools from reporting a leak.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
