### PR TITLE
Fix code producing json

### DIFF
--- a/ext/json11/json11.cpp
+++ b/ext/json11/json11.cpp
@@ -93,10 +93,18 @@ static void dump(const string &value, string &out) {
             out += "\\r";
         } else if (ch == '\t') {
             out += "\\t";
-        } else if (static_cast<uint8_t>(ch) <= 0x1f || static_cast<uint8_t>(ch) >= 0x7f) {
+        } else if (static_cast<uint8_t>(ch) <= 0x1f) {
             char buf[8];
             snprintf(buf, sizeof buf, "\\u%04x", ch);
             out += buf;
+        } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
+                   && static_cast<uint8_t>(value[i+2]) == 0xa8) {
+            out += "\\u2028";
+            i += 2;
+        } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
+                   && static_cast<uint8_t>(value[i+2]) == 0xa9) {
+            out += "\\u2029";
+            i += 2;
         } else {
             out += ch;
         }

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1415,6 +1415,7 @@ testrunner_SOURCES = \
 	test-trusted-notification-proxy_cc.cc \
 	test-tsig.cc \
 	test-ueberbackend_cc.cc \
+	test-webserver_cc.cc \
 	test-zonemd_cc.cc \
 	test-zoneparser_tng_cc.cc \
 	testrunner.cc \
@@ -1423,7 +1424,9 @@ testrunner_SOURCES = \
 	tsigverifier.cc tsigverifier.hh \
 	ueberbackend.cc ueberbackend.hh \
 	unix_utility.cc \
+	uuid-utils.cc \
 	validate.hh \
+	webserver.cc \
 	zonemd.cc zonemd.hh \
 	zoneparser-tng.cc zoneparser-tng.hh
 
@@ -1438,7 +1441,9 @@ testrunner_LDADD = \
 	$(RT_LIBS) \
 	$(LUA_LIBS) \
 	$(LIBDL) \
-	$(IPCRYPT_LIBS)
+	$(IPCRYPT_LIBS) \
+	$(YAHTTP_LIBS) \
+	$(JSON11_LIBS)
 
 if GSS_TSIG
 testrunner_LDADD += $(GSS_LIBS)

--- a/pdns/test-webserver_cc.cc
+++ b/pdns/test-webserver_cc.cc
@@ -18,10 +18,16 @@ BOOST_AUTO_TEST_CASE(test_validURL)
     {"http://www.powerdns.com/\x7f?foo=123", false},
     {"http://www.powerdns.com/\x80?foo=123", false},
     {"http://www.powerdns.com/?\xff", false},
+    {"/?foo=123&bar", true},
+    {"/?foo=%ff&bar", true},
+    {"/?\x01foo=123", false},
+    {"/?foo=123\x01", false},
+    {"/\x7f?foo=123", false},
+    {"/\x80?foo=123", false},
+    {"/?\xff", false},
   };
 
   for (const auto& testcase : urls) {
-    cerr << testcase.first << endl;
     BOOST_CHECK_EQUAL(WebServer::validURL(testcase.first), testcase.second);
   }
 }

--- a/pdns/test-webserver_cc.cc
+++ b/pdns/test-webserver_cc.cc
@@ -1,0 +1,29 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+#include "webserver.hh"
+
+BOOST_AUTO_TEST_SUITE(test_webserver_cc)
+
+BOOST_AUTO_TEST_CASE(test_validURL)
+{
+  // We cannot test\x00 as embedded NULs are not handled by YaHTTP other than stopping the parsing
+  const std::vector<std::pair<string, bool>> urls = {
+    {"http://www.powerdns.com/?foo=123", true},
+    {"http://ww.powerdns.com/?foo=%ff", true},
+    {"http://\x01ww.powerdns.com/?foo=123", false},
+    {"http://\xffwww.powerdns.com/?foo=123", false},
+    {"http://www.powerdns.com/?foo=123\x01", false},
+    {"http://www.powerdns.com/\x7f?foo=123", false},
+    {"http://www.powerdns.com/\x80?foo=123", false},
+    {"http://www.powerdns.com/?\xff", false},
+  };
+
+  for (const auto& testcase : urls) {
+    cerr << testcase.first << endl;
+    BOOST_CHECK_EQUAL(WebServer::validURL(testcase.first), testcase.second);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -535,7 +535,7 @@ void WebServer::serveConnection(const std::shared_ptr<Socket>& client) const {
   }
 
   if (d_loglevel >= WebServer::LogLevel::Normal) {
-    SLOG(g_log<<Logger::Notice<<logprefix<<remote<<" \""<<req.method<<" "<<YaHTTP::Utility::encodeURL(req.url.path)<<" HTTP/"<<req.versionStr(req.version)<<"\" "<<resp.status<<" "<<reply.size()<<endl,
+    SLOG(g_log<<Logger::Notice<<logprefix<<remote<<" \""<<req.method<<" "<<req.url.path<<" HTTP/"<<req.versionStr(req.version)<<"\" "<<resp.status<<" "<<reply.size()<<endl,
          d_slog->info(Logr::Info, "Request", "remote", Logging::Loggable(remote), "method", Logging::Loggable(req.method),
                       "urlpath", Logging::Loggable(req.url.path), "HTTPVersion", Logging::Loggable(req.versionStr(req.version)),
                       "status", Logging::Loggable(resp.status), "respsize",  Logging::Loggable(reply.size())));

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -36,6 +36,8 @@
 #include "json.hh"
 #include "uuid-utils.hh"
 #include <yahttp/router.hpp>
+#include <algorithm>
+#include <unordered_set>
 
 json11::Json HttpRequest::json()
 {
@@ -461,6 +463,53 @@ void WebServer::logResponse(const HttpResponse& resp, const ComboAddress& /* rem
   }
 }
 
+
+struct ValidChars {
+  ValidChars()
+  {
+    // letter may be signed, but we only pass positive values
+    for (auto letter : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=") {
+      set.set(letter);
+    }
+  }
+  std::bitset<127> set;
+};
+
+static const ValidChars validChars;
+
+static bool validURLChars(const string& str)
+{
+  for (auto iter = str.begin(); iter != str.end(); ++iter) {
+    if (*iter == '%') {
+      ++iter;
+      if (iter == str.end() || isxdigit(static_cast<unsigned char>(*iter)) == 0) {
+        return false;
+      }
+      ++iter;
+      if (iter == str.end() || isxdigit(static_cast<unsigned char>(*iter)) == 0) {
+        return false;
+      }
+    }
+    else if (static_cast<size_t>(*iter) >= validChars.set.size() || !validChars.set[*iter]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool WebServer::validURL(const YaHTTP::URL& url)
+{
+  bool isOK = true;
+  isOK = isOK && validURLChars(url.protocol);
+  isOK = isOK && validURLChars(url.host);
+  isOK = isOK && validURLChars(url.username);
+  isOK = isOK && validURLChars(url.password);
+  isOK = isOK && validURLChars(url.path);
+  isOK = isOK && validURLChars(url.parameters);
+  isOK = isOK && validURLChars(url.anchor);
+  return isOK;
+}
+
 void WebServer::serveConnection(const std::shared_ptr<Socket>& client) const {
   const auto unique = getUniqueID();
   const string logprefix = d_logprefix + to_string(unique) + " ";
@@ -504,6 +553,9 @@ void WebServer::serveConnection(const std::shared_ptr<Socket>& client) const {
            d_slog->error(Logr::Warning, e.what(), "Unable to parse request"));
     }
 
+    if (!validURL(req.url)) {
+      throw PDNSException("Received request with invalid URL");
+    }
     // Uses of `remote` below guarded by d_loglevel
     if (d_loglevel > WebServer::LogLevel::None) {
       client->getRemote(remote);

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -213,6 +213,8 @@ public:
     d_acl = nmg;
   }
 
+  static bool validURL(const YaHTTP::URL& url);
+
   void bind();
   void go();
 

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -251,7 +251,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
                   "type": "soa",  # test uppercasing of type, too.
                   "comments": [{
                       "account": "test1",
-                      "content": "blah blah and test a few non-ASCII chars: ö, € and 😀",
+                      "content": "blah blah and test a few non-ASCII chars: ö, €",
                       "modified_at": 11112,
                   }],
               },

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -251,7 +251,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
                   "type": "soa",  # test uppercasing of type, too.
                   "comments": [{
                       "account": "test1",
-                      "content": "blah blah",
+                      "content": "blah blah and test a few non-ASCII chars: ö, € and 😀",
                       "modified_at": 11112,
                   }],
               },


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Should fix #13050, followup to #12260.

This reverts #12260 and adds a function to test if a URL passed in is valid.

There remains one potential issue: through the API, it is possible to produce data that is not properly UTF8, e.g. by retrieving log lines which themselves can contains arbitrary data (I'm assuming this to be on the safe side as I have no evidence otherwise). Currently we pass that data through, so it ends up in the json output. At the moment we do not have any function to validate if the source data we pass through via json is valid UTF8, and so it's hard to filter invalid data out. There's code to be found on the internet to validate if data is valid UTF8 (e.g. http://bjoern.hoehrmann.de/utf-8/decoder/dfa/), we could use that, but there still remains to decide what to do if we encounter invalid UTF8: skip, encode in some form, fix the source, ...

Draft as this needs more tests.

(BTW, I noticed the API does not handle % encoded, but valid URLs, e.g. `http://localhost:8083/metric%73` (`s` is ASCII `0x73`) I'm wondering if this a defect in YaHTTP, or in the code that matches requests to handlers).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
