### PR TITLE
rec: Backport 12892 to rec-4.7.x: YaHTTP: Prevent integer overflow on very large chunks

### DIFF
--- a/ext/yahttp/yahttp/reqresp.cpp
+++ b/ext/yahttp/yahttp/reqresp.cpp
@@ -1,5 +1,7 @@
 #include "yahttp.hpp"
 
+#include <limits>
+
 namespace YaHTTP {
 
   template class AsyncLoader<Request>;
@@ -177,6 +179,9 @@ namespace YaHTTP {
             throw ParseError("Unable to parse chunk size");
           }
           if (chunk_size == 0) { state = 3; break; } // last chunk
+          if (chunk_size > (std::numeric_limits<decltype(chunk_size)>::max() - 2)) {
+            throw ParseError("Chunk is too large");
+          }
         } else {
           int crlf=1;
           if (buffer.size() < static_cast<size_t>(chunk_size+1)) return false; // expect newline


### PR DESCRIPTION
If the chunk_size is very close to the maximum value of an integer, we trigger an integer overflow when checking if we have a trailing newline after the payload.
Reported by OSS-Fuzz as:
https://oss-fuzz.com/testcase-detail/6439610474692608 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56804

(cherry picked from commit b602982fc5b4fb9139dec591541e0c070ceb47f5)

Backport of #12892 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
