### PR TITLE
auth lmdb: when broadcasting indexes, -do- rewrite them even if they are unchanged

### DIFF
--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -164,10 +164,8 @@ struct LMDBIndexOps
 
     MDBOutVal currentvalue;
 
-    // check if the entry already exists, so we don't uselessly bump the timestamp
-    if (txn->get(d_idx, combined, currentvalue) == MDB_NOTFOUND) {
-      txn->put(d_idx, combined, empty, flags);
-    }
+    // if the entry existed already, this will just update the timestamp/txid in the LS header. This is intentional, so objects and their indexes always get synced together.
+    txn->put(d_idx, combined, empty, flags);
   }
 
   void del(MDBRWTransaction& txn, const Class& t, uint32_t id)


### PR DESCRIPTION
### Short description
before this patch, there was a chance of desync:

assume two LS+auth nodes are in sync

1. node A deletes zone example.com (this deletes the domain object, an index reference to it, and a few other things)
2. node B sends out notify for example.com which is a primary zone, and updates the domain object (last_notified)
3. LS syncs. For the domain object, the notified one is newer than the deleted one, so auth1 gets the domain object back. The index entry, however, had an older timestamp, and remains deleted

With this patch, the index entry gets a fresh timestamp too, so conflict resolution stops breaking the index.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master