### PR TITLE
(I)XFR: handle partial read of len prefix

### DIFF
--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -295,7 +295,7 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord>>> getIXFRDeltas(const ComboAddr
         if(r.first.d_type == QType::OPT)
           continue;
 
-        throw std::runtime_error("Unexpected record (" +QType(r.first.d_type).toString()+") in non-answer section ("+std::to_string(r.first.d_place)+")in IXFR response for zone '"+zone.toLogString()+"' from primary '"+primary.toStringWithPort());
+        throw std::runtime_error("Unexpected record (" +QType(r.first.d_type).toString()+") in non-answer section ("+std::to_string(r.first.d_place)+") in IXFR response for zone '"+zone.toLogString()+"' from primary '"+primary.toStringWithPort());
       }
 
       r.first.d_name.makeUsRelative(zone);

--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -206,7 +206,6 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord>>> getIXFRDeltas(const ComboAddr
 
   std::string state;
   for (;;) {
-    state = "start";
     // IXFR or AXFR style end reached? We don't want to process trailing data after the closing SOA
     if (style == AXFR && primarySOACount == expectedSOAForAXFR) {
       state = "AXFRdone";

--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -185,7 +185,12 @@ class RPZServer(object):
                 break
 
             wire = answer.to_wire()
-            conn.send(struct.pack("!H", len(wire)))
+            lenprefix = struct.pack("!H", len(wire))
+
+            for b in lenprefix:
+                conn.send(bytes([b]))
+                time.sleep(0.5)
+
             conn.send(wire)
             self._currentSerial = serial
             break


### PR DESCRIPTION
### Short description
While reading (I)XFR responses from remotes, if the two octet header for a chunk is read partially, we end the transfer immediately. This is wrong.

* this PR adds a test for that
* the commit that adds the test also has a bad fix (it's bad because it turns EOF into an Exception, which, for example, hides the problem mentioned in #13104 even deeper)
* the commit after it has a better fix but it's not pretty. It should at least recalculate `elapsed` once more I think. (added another commit that does that. Besides that, not sure we can get clang-tidy entirely happy.)

Besides that, this PR:

* adds the value of `primarySOACount` to all three exceptions
* fixes a typo

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master