### PR TITLE
rec: replace data in the aggressive cache if new data becomes available

### DIFF
--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -344,15 +344,21 @@ void AggressiveNSECCache::insertNSEC(const DNSName& zone, const DNSName& owner, 
     /* the TTL is already a TTD by now */
     if (!nsec3 && isWildcardExpanded(owner.countLabels(), *signatures.at(0))) {
       DNSName realOwner = getNSECOwnerName(owner, signatures);
-      auto pair = zoneEntry->d_entries.insert({record.getContent(), signatures, std::move(realOwner), std::move(next), record.d_ttl});
+      auto pair = zoneEntry->d_entries.insert({record.getContent(), signatures, realOwner, next, record.d_ttl});
       if (pair.second) {
         ++d_entriesCount;
       }
+      else {
+        zoneEntry->d_entries.replace(pair.first, {record.getContent(), signatures, realOwner, next, record.d_ttl});
+      }
     }
     else {
-      auto pair = zoneEntry->d_entries.insert({record.getContent(), signatures, owner, std::move(next), record.d_ttl});
+      auto pair = zoneEntry->d_entries.insert({record.getContent(), signatures, owner, next, record.d_ttl});
       if (pair.second) {
         ++d_entriesCount;
+      }
+      else {
+        zoneEntry->d_entries.replace(pair.first, {record.getContent(), signatures, owner, next, record.d_ttl});
       }
     }
   }


### PR DESCRIPTION
Currently, new data does not get recorded into the aggressive cache if there's an existing entry that matches. Together with the fact that in (in some cases) pruning is unfair (it scans the zones always in the same order and stops clearing when it has reached the goal) and/or not very active (when the recursor is lightly loaded) this has the consequence that old expired records can remain in the cache that prevent new data to be recorded and used.

On a lightly loaded rec I see this with `rec_control dump-cache -`:
```
; Zone .
. -36987 IN NSEC aaa. NS SOA RRSIG NSEC DNSKEY
```
Note that the root zone is last in the list, so entries in it are most likely to be skipped when pruning without pressure.

The unfairness should be fixed as well, using recent changes in ``cachecleaner.hh`` as a guide.

There's also another issue with pruning, I see on another rec in the aggressive cache:
```
...
; Zone nl.
; Zone org.
; Zone pro.
; Zone pub.
; Zone tv.
; Zone co.uk.
; Zone video.
; Zone world.
; Zone .
...
```
from looking at the pruning code these empty zones should have been cleaned up.

The pruning issues are tracked in #13109

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
