### PR TITLE
Log port with all freshness check failure scenarios.

### DIFF
--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -176,7 +176,7 @@ uint16_t Resolver::sendResolve(const ComboAddress& remote, const ComboAddress& l
       // try to make socket
       sock = makeQuerySocket(local, true);
       if (sock < 0)
-        throw ResolverException("Unable to create local socket on '"+lstr+"'' to '"+remote.toStringWithPort()+"': "+stringerror());
+        throw ResolverException("Unable to create local socket on '"+lstr+"'' to '"+remote.toLogString()+"': "+stringerror());
       setNonBlocking( sock );
       locals[lstr] = sock;
     }
@@ -186,7 +186,7 @@ uint16_t Resolver::sendResolve(const ComboAddress& remote, const ComboAddress& l
     *localsock = sock;
   }
   if(sendto(sock, &packet[0], packet.size(), 0, (struct sockaddr*)(&remote), remote.getSocklen()) < 0) {
-    throw ResolverException("Unable to ask query of '"+remote.toStringWithPort()+"': "+stringerror());
+    throw ResolverException("Unable to ask query of '"+remote.toLogString()+"': "+stringerror());
   }
   return randomid;
 }
@@ -272,16 +272,16 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
   *domain = mdp.d_qname;
 
   if(domain->empty())
-    throw ResolverException("SOA query to '" + remote->toStringWithPort() + "' produced response without domain name (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
+    throw ResolverException("SOA query to '" + remote->toLogString() + "' produced response without domain name (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
 
   if(mdp.d_answers.empty())
-    throw ResolverException("Query to '" + remote->toStringWithPort() + "' for SOA of '" + domain->toLogString() + "' produced no results (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
+    throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' produced no results (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
 
   if(mdp.d_qtype != QType::SOA)
-    throw ResolverException("Query to '" + remote->toStringWithPort() + "' for SOA of '" + domain->toLogString() + "' returned wrong record type");
+    throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' returned wrong record type");
 
   if(mdp.d_header.rcode != 0)
-    throw ResolverException("Query to '" + remote->toStringWithPort() + "' for SOA of '" + domain->toLogString() + "' returned Rcode " + RCode::to_s(mdp.d_header.rcode));
+    throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' returned Rcode " + RCode::to_s(mdp.d_header.rcode));
 
   *theirInception = *theirExpire = 0;
   bool gotSOA=false;
@@ -302,7 +302,7 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
     }
   }
   if(!gotSOA)
-    throw ResolverException("Query to '" + remote->toStringWithPort() + "' for SOA of '" + domain->toLogString() + "' did not return a SOA");
+    throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' did not return a SOA");
   return true;
 }
 
@@ -328,7 +328,7 @@ int Resolver::resolve(const ComboAddress& to, const DNSName &domain, int type, R
       throw ResolverException("recvfrom error waiting for answer: "+stringerror());
 
     if (from != to) {
-      throw ResolverException("Got answer from the wrong peer while resolving ('"+from.toStringWithPort()+"' instead of '"+to.toStringWithPort()+"', discarding");
+      throw ResolverException("Got answer from the wrong peer while resolving ('"+from.toLogString()+"' instead of '"+to.toLogString()+"', discarding");
     }
 
     MOADNSParser mdp(false, buffer, len);

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -302,7 +302,7 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
     }
   }
   if(!gotSOA)
-    throw ResolverException("Query to '" + remote->toString() + "' for SOA of '" + domain->toLogString() + "' did not return a SOA");
+    throw ResolverException("Query to '" + remote->toStringWithPort() + "' for SOA of '" + domain->toLogString() + "' did not return a SOA");
   return true;
 }
 


### PR DESCRIPTION
### Short description
I noticed the port was missing in logging of one specific 'freshness check' failure event like this:
```
pdns_server[74423]: While checking domain freshness: Query to '172.17.130.204:5353' for SOA of 'somedomain.tld' returned Rcode Query Refused
pdns_server[74423]: While checking domain freshness: Query to '172.17.130.204' for SOA of 'someotherdomain.tld' did not return a SOA
```
Turned out it was a simple fix: toString() -> toStringWithPort()

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
