### PR TITLE
auth: Fix uninitialized scalar field warnings from Coverity

### DIFF
--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -113,7 +113,7 @@ private:
   bool d_logDNSDetails;
   bool d_doDNAME;
   bool d_doExpandALIAS;
-  bool d_dnssec;
+  bool d_dnssec{false};
   SOAData d_sd;
   std::unique_ptr<AuthLua4> d_pdl;
   std::unique_ptr<AuthLua4> d_update_policy_lua;

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -285,9 +285,9 @@ class Pkcs11Token {
   private:
     std::shared_ptr<LockGuarded<Pkcs11Slot>> d_slot;
 
-    CK_OBJECT_HANDLE d_public_key;
-    CK_OBJECT_HANDLE d_private_key;
-    CK_KEY_TYPE d_key_type;
+    CK_OBJECT_HANDLE d_public_key{0};
+    CK_OBJECT_HANDLE d_private_key{0};
+    CK_KEY_TYPE d_key_type{0};
     bool d_always_auth{false};
 
     CK_ULONG d_bits;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
