### PR TITLE
dnsdist-1.8.x: Remove a racy test in the AsynchronousHolder unit tests

### DIFF
--- a/pdns/dnsdistdist/test-dnsdistasync.cc
+++ b/pdns/dnsdistdist/test-dnsdistasync.cc
@@ -153,7 +153,6 @@ BOOST_AUTO_TEST_CASE(test_AddingExpiredEvent)
     sender = query->d_sender;
     BOOST_REQUIRE(sender != nullptr);
     holder->push(asyncID, queryID, ttd, std::move(query));
-    BOOST_CHECK(!holder->empty());
   }
 
   // sleep for 20 ms


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of https://github.com/PowerDNS/pdns/pull/12905 to rel/dnsdist-1.8.x

We are adding an expired event so the worker thread of the AsynchronousHolder can pick it up immediately, even before we come back from the call to push(), which leads to a racy test. This was observed on GitHub Actions when running with TSAN:
```
FAIL: testrunner
================

Running 170 test cases...
test-dnsdistasync.cc(156): error: in "test_dnsdistasync/test_AddingExpiredEvent": check !holder->empty() has failed

*** 1 failure is detected in the test module "unit"
FAIL testrunner (exit status: 201)
```

(cherry picked from commit 35bbac75efbd4fb8a9523ab3974bea5507484f65)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
