### PR TITLE
ixfrdist: set AA=1 on SOA responses

### DIFF
--- a/contrib/assert-equal-DNSMessage/eqdnsmessage.py
+++ b/contrib/assert-equal-DNSMessage/eqdnsmessage.py
@@ -26,5 +26,6 @@ class AssertEqualDNSMessageMixin(unittest.TestCase):
 
     def setUp(self):
         self.addTypeEqualityFunc(dns.message.Message, self.assertEqualDNSMessage)
+        self.addTypeEqualityFunc(dns.message.QueryMessage, self.assertEqualDNSMessage)
 
         super(AssertEqualDNSMessageMixin, self).setUp()

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -532,6 +532,7 @@ static bool makeSOAPacket(const MOADNSParser& mdp, vector<uint8_t>& packet) {
   pw.getHeader()->id = mdp.d_header.id;
   pw.getHeader()->rd = mdp.d_header.rd;
   pw.getHeader()->qr = 1;
+  pw.getHeader()->aa = 1;
 
   pw.startRecord(mdp.d_qname, QType::SOA, zoneInfo->soaTTL);
   zoneInfo->soa->toPacket(pw);

--- a/regression-tests.ixfrdist/test_IXFR.py
+++ b/regression-tests.ixfrdist/test_IXFR.py
@@ -194,6 +194,7 @@ class IXFRDistBasicTest(IXFRDistTest):
     def test_b_UDP_SOA_existing(self):
         query = dns.message.make_query('example.', 'SOA')
         expected = dns.message.make_response(query)
+        expected.flags |= dns.flags.AA
         expected.answer.append(xfrServer._getSOAForSerial(2))
 
         response = self.sendUDPQuery(query)


### PR DESCRIPTION
### Short description
fixes #11378

this PR also fixes eqdnsmessage because it looks like dnspython shuffled some types around

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master