### PR TITLE
channel: Fix redundant redeclaration warning

### DIFF
--- a/pdns/channel.hh
+++ b/pdns/channel.hh
@@ -35,9 +35,18 @@
 #endif
 
 #if __SANITIZE_THREAD__
+#if defined __has_include
+#if __has_include(<sanitizer/tsan_interface.h>)
+#include <sanitizer/tsan_interface.h>
+#else /* __has_include(<sanitizer/tsan_interface.h>) */
 extern "C" void __tsan_acquire(void* addr);
 extern "C" void __tsan_release(void* addr);
-#endif
+#endif /* __has_include(<sanitizer/tsan_interface.h>) */
+#else /* defined __has_include */
+extern "C" void __tsan_acquire(void* addr);
+extern "C" void __tsan_release(void* addr);
+#endif /* defined __has_include */
+#endif /* __SANITIZE_THREAD__ */
 
 namespace pdns
 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
g++ reports:
```
In file included from channel.cc:23:
channel.hh:38:17: warning: redundant redeclaration of ‘void __tsan_acquire(void*)’ in same scope [-Wredundant-decls]
   38 | extern "C" void __tsan_acquire(void* addr);
      |                 ^~~~~~~~~~~~~~
In file included from /usr/include/c++/13.2.1/bits/shared_ptr_atomic.h:37,
                 from /usr/include/c++/13.2.1/memory:81,
                 from channel.hh:23:
/usr/lib/gcc/x86_64-pc-linux-gnu/13.2.1/include/sanitizer/tsan_interface.h:24:6: note: previous declaration of ‘void __tsan_acquire(void*)’
   24 | void __tsan_acquire(void *addr);
      |      ^~~~~~~~~~~~~~
channel.hh:39:17: warning: redundant redeclaration of ‘void __tsan_release(void*)’ in same scope [-Wredundant-decls]
   39 | extern "C" void __tsan_release(void* addr);
      |                 ^~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-pc-linux-gnu/13.2.1/include/sanitizer/tsan_interface.h:25:6: note: previous declaration of ‘void __tsan_release(void*)’
   25 | void __tsan_release(void *addr);
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
