### PR TITLE
dnsdist: Try to fix a data race warning reported by TSAN

### DIFF
--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -45,15 +45,15 @@ public:
   bool isFull();
   string toString();
   uint64_t getSize();
-  uint64_t getHits() const { return d_hits; }
-  uint64_t getMisses() const { return d_misses; }
-  uint64_t getDeferredLookups() const { return d_deferredLookups; }
-  uint64_t getDeferredInserts() const { return d_deferredInserts; }
-  uint64_t getLookupCollisions() const { return d_lookupCollisions; }
-  uint64_t getInsertCollisions() const { return d_insertCollisions; }
+  uint64_t getHits() const { return d_hits.load(); }
+  uint64_t getMisses() const { return d_misses.load(); }
+  uint64_t getDeferredLookups() const { return d_deferredLookups.load(); }
+  uint64_t getDeferredInserts() const { return d_deferredInserts.load(); }
+  uint64_t getLookupCollisions() const { return d_lookupCollisions.load(); }
+  uint64_t getInsertCollisions() const { return d_insertCollisions.load(); }
   uint64_t getMaxEntries() const { return d_maxEntries; }
-  uint64_t getTTLTooShorts() const { return d_ttlTooShorts; }
-  uint64_t getCleanupCount() const { return d_cleanupCount; }
+  uint64_t getTTLTooShorts() const { return d_ttlTooShorts.load(); }
+  uint64_t getCleanupCount() const { return d_cleanupCount.load(); }
   uint64_t getEntriesCount();
   uint64_t dump(int fd);
 

--- a/regression-tests.dnsdist/test_Metrics.py
+++ b/regression-tests.dnsdist/test_Metrics.py
@@ -148,7 +148,7 @@ class TestRuleMetrics(DNSDistTest):
 
     def testServFailMetrics(self):
         """
-        Metrics: Check that servfail metrics are correctly updated for cache misses and hits
+        Metrics: Check that servfail metrics are correctly updated for server failures
         """
 
         for method in ("sendUDPQuery", "sendTCPQuery", "sendDOTQueryWrapper", "sendDOHQueryWrapper"):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In theory calling `std::atomic<T>::load()` is exactly the same than calling `std::atomic<T>::operator T` but I have seen TSAN choke on the former while not on the latter, so let's try it.
Also fix the description of one of our regression tests.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
