### PR TITLE
dnsdist: cosmetic compilation warning fixes 

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -252,7 +252,7 @@ bool IncomingTCPConnectionState::canAcceptNewQueries(const struct timeval& now)
 
 void IncomingTCPConnectionState::resetForNewQuery()
 {
-  d_buffer.resize(sizeof(uint16_t));
+  d_buffer.clear();
   d_currentPos = 0;
   d_querySize = 0;
   d_state = State::waitingForQuery;
@@ -875,6 +875,7 @@ void IncomingTCPConnectionState::handleIO(std::shared_ptr<IncomingTCPConnectionS
       if (!state->d_lastIOBlocked && (state->d_state == IncomingTCPConnectionState::State::waitingForQuery ||
                                       state->d_state == IncomingTCPConnectionState::State::readingQuerySize)) {
         DEBUGLOG("reading query size");
+        state->d_buffer.resize(sizeof(uint16_t));
         iostate = state->d_handler.tryRead(state->d_buffer, state->d_currentPos, sizeof(uint16_t));
         if (state->d_currentPos > 0) {
           /* if we got at least one byte, we can't go around sending responses */

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1614,7 +1614,7 @@ bool dnsdist_ffi_metric_declare(const char* name, size_t nameLen, const char* ty
 void dnsdist_ffi_metric_inc(const char* metricName, size_t metricNameLen)
 {
   auto result = dnsdist::metrics::incrementCustomCounter(std::string_view(metricName, metricNameLen), 1U);
-  if (const auto* errorStr = std::get_if<dnsdist::metrics::Error>(&result)) {
+  if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
   }
 }
@@ -1622,7 +1622,7 @@ void dnsdist_ffi_metric_inc(const char* metricName, size_t metricNameLen)
 void dnsdist_ffi_metric_inc_by(const char* metricName, size_t metricNameLen, uint64_t value)
 {
   auto result = dnsdist::metrics::incrementCustomCounter(std::string_view(metricName, metricNameLen), value);
-  if (const auto* errorStr = std::get_if<dnsdist::metrics::Error>(&result)) {
+  if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
   }
 }
@@ -1630,7 +1630,7 @@ void dnsdist_ffi_metric_inc_by(const char* metricName, size_t metricNameLen, uin
 void dnsdist_ffi_metric_dec(const char* metricName, size_t metricNameLen)
 {
   auto result = dnsdist::metrics::decrementCustomCounter(std::string_view(metricName, metricNameLen), 1U);
-  if (const auto* errorStr = std::get_if<dnsdist::metrics::Error>(&result)) {
+  if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
   }
 }
@@ -1638,7 +1638,7 @@ void dnsdist_ffi_metric_dec(const char* metricName, size_t metricNameLen)
 void dnsdist_ffi_metric_set(const char* metricName, size_t metricNameLen, double value)
 {
   auto result = dnsdist::metrics::setCustomGauge(std::string_view(metricName, metricNameLen), value);
-  if (const auto* errorStr = std::get_if<dnsdist::metrics::Error>(&result)) {
+  if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
   }
 }
@@ -1646,7 +1646,7 @@ void dnsdist_ffi_metric_set(const char* metricName, size_t metricNameLen, double
 double dnsdist_ffi_metric_get(const char* metricName, size_t metricNameLen, bool isCounter)
 {
   auto result = dnsdist::metrics::getCustomMetric(std::string_view(metricName, metricNameLen));
-  if (const auto* errorStr = std::get_if<dnsdist::metrics::Error>(&result)) {
+  if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return 0.;
   }
   return std::get<double>(result);


### PR DESCRIPTION
### Short description
This PR clears two cosmetic warnings at compilation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
