### PR TITLE
Auth: Print the list of loaded modules next to the config.h preset

### DIFF
--- a/pdns/version.cc
+++ b/pdns/version.cc
@@ -24,6 +24,9 @@
 #endif
 #include "logger.hh"
 #include "version.hh"
+#include "dnsbackend.hh"
+
+#include <boost/algorithm/string/join.hpp>
 
 static ProductType productType;
 
@@ -153,7 +156,9 @@ void showBuildConfiguration()
     endl;
 #ifdef PDNS_MODULES
   // Auth only
-  g_log<<Logger::Warning<<"Built-in modules: "<<PDNS_MODULES<<endl;
+  g_log << Logger::Warning << "Built-in modules: " << PDNS_MODULES << endl;
+  const auto& modules = BackendMakers().getModules();
+  g_log << Logger::Warning << "Loaded modules: " << boost::join(modules, " ") << endl;
 #endif
 #ifdef PDNS_CONFIG_ARGS
 #define double_escape(s) #s


### PR DESCRIPTION
### Short description
This prints the list of auth modules that were loaded next to the printout of modules that were compiled in.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)