### PR TITLE
Change the default for building with net-snmp from `auto` to `no`

### DIFF
--- a/m4/pdns_with_net_snmp.m4
+++ b/m4/pdns_with_net_snmp.m4
@@ -1,9 +1,9 @@
 AC_DEFUN([PDNS_WITH_NET_SNMP], [
   AC_MSG_CHECKING([if we need to link in Net SNMP])
   AC_ARG_WITH([net-snmp],
-    AS_HELP_STRING([--with-net-snmp],[enable net snmp support @<:@default=auto@:>@]),
+    AS_HELP_STRING([--with-net-snmp],[enable net snmp support @<:@default=no@:>@]),
     [with_net_snmp=$withval],
-    [with_net_snmp=auto],
+    [with_net_snmp=no],
   )
   AC_MSG_RESULT([$with_net_snmp])
 

--- a/tasks.py
+++ b/tasks.py
@@ -462,6 +462,7 @@ def ci_dnsdist_configure(c, features):
                       --with-libsodium \
                       --with-lua=luajit \
                       --with-libcap \
+                      --with-net-snmp \
                       --with-nghttp2 \
                       --with-re2 '
     else:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

We have had a fair amount of issues with `net-snmp` adding unexpected and unwanted values to both `CXXFLAGS` and `LDFLAGS`, and it was just reported to also define `HAVE_LIBSSL` in its public header, which messes up our own feature detection. Therefore it is likely better for everyone to prevent net-snmp from being enabled without the user intending it. For our own packages we explicitly enable net-snmp when supported, and this commit also enables it in our CI for dnsdist (it was already done for the recursor) so it should not have any impact.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
