### PR TITLE
Declare ssh_compat_getentropy in the right spot.

### DIFF
--- a/ext/arc4random/arc4random.c
+++ b/ext/arc4random/arc4random.c
@@ -48,7 +48,6 @@
  * will call a native getentropy if available then fall back as required.
  * We use a different name so that OpenSSL cannot call the wrong getentropy.
  */
-int _ssh_compat_getentropy(void *, size_t);
 #ifdef getentropy
 # undef getentropy
 #endif

--- a/ext/arc4random/includes.h
+++ b/ext/arc4random/includes.h
@@ -24,4 +24,6 @@ uint32_t arc4random_uniform(uint32_t upper_bound);
 void explicit_bzero(void *, size_t len);
 #endif
 
+int _ssh_compat_getentropy(void *, size_t);
+
 #define DEF_WEAK(x)


### PR DESCRIPTION
Avoiding a redundant and/or missing declaration (depending HAVE_* defines)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
