### PR TITLE
dnsdist: Also test metrics with recvmmsg support enabled

### DIFF
--- a/regression-tests.dnsdist/test_Metrics.py
+++ b/regression-tests.dnsdist/test_Metrics.py
@@ -8,7 +8,7 @@ import unittest
 import dns
 from dnsdisttests import DNSDistTest, pickAvailablePort
 
-class TestRuleMetrics(DNSDistTest):
+class RuleMetricsTest(object):
 
     _config_template = """
     addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
@@ -176,3 +176,12 @@ class TestRuleMetrics(DNSDistTest):
             self.assertEqual(self.getMetric('frontend-servfail'), frontendBefore + 2)
             self.assertEqual(self.getMetric('servfail-responses'), servfailBefore + 1)
             self.assertEqual(self.getMetric('rule-servfail'), ruleBefore)
+
+class TestRuleMetricsDefault(RuleMetricsTest, DNSDistTest):
+    None
+
+class TestRuleMetricsRecvmmsg(RuleMetricsTest, DNSDistTest):
+    # test the metrics with recvmmsg/sendmmsg support enabled as well
+    _config_template = RuleMetricsTest._config_template + """
+        setUDPMultipleMessagesVectorSize(10)
+    """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We have seen in https://github.com/PowerDNS/pdns/issues/13148 that we can easily break frontend metrics when `recvmmsg`/`sendmmsg` support is enabled via `setUDPMultipleMessagesVectorSize()`, so let's test the metrics in that case explicitly so we do not break them again in the future.
Closes https://github.com/PowerDNS/pdns/issues/13180

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
