### PR TITLE
dnsdist: Reduce the UDP wait time for blocked queries in the tests

### DIFF
--- a/regression-tests.dnsdist/dnsdistDynBlockTests.py
+++ b/regression-tests.dnsdist/dnsdistDynBlockTests.py
@@ -77,7 +77,7 @@ class DynBlocksTest(DNSDistTest):
             waitForMaintenanceToRun()
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
-        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False, timeout=1)
         self.assertEqual(receivedResponse, None)
 
         if testViaAPI:
@@ -269,7 +269,7 @@ class DynBlocksTest(DNSDistTest):
         print(time.time())
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
-        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False, timeout=1)
         self.assertEqual(receivedResponse, None)
 
         print(self.sendConsoleCommand("showDynBlocks()"))
@@ -378,7 +378,7 @@ class DynBlocksTest(DNSDistTest):
             waitForMaintenanceToRun()
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
-        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False, timeout=1)
         self.assertEqual(receivedResponse, None)
 
         # wait until we are not blocked anymore
@@ -487,7 +487,7 @@ class DynBlocksTest(DNSDistTest):
         waitForMaintenanceToRun()
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
-        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False, timeout=1)
         self.assertEqual(receivedResponse, None)
 
         # wait until we are not blocked anymore


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We know that we are not going to get a response, and waiting for too long increases the risk that the dynamic block is no longer present and/or has expired (validity of 0s) in the subsequent API check.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
