### PR TITLE
arc4random: Fix 'redundant redeclaration’ warnings

### DIFF
--- a/ext/arc4random/arc4random.hh
+++ b/ext/arc4random/arc4random.hh
@@ -1,7 +1,8 @@
 #pragma once
-
 #include <cstddef>
 #include <cinttypes>
+
+#include "config.h"
 
 extern "C"
 {


### PR DESCRIPTION
If `arc4random.hh` is included before `config.h`, the `HAVE_*` defines are not yet available and thus we include the definition of the following functions even though they might be available in the standard headers:
- `arc4random`
- `arc4random_buf`
- `arc4random_uniform`
- `explicit_bzero`

Yielding warnings:
```
In file included from dns_random.hh:27,
                 from tsigutils.cc:25:
../ext/arc4random/arc4random.hh:9:12: warning: redundant redeclaration of ‘uint32_t arc4random()’ in same scope [-Wredundant-decls]
    9 |   uint32_t arc4random(void);
      |            ^~~~~~~~~~
In file included from /usr/include/c++/13.2.1/cstdlib:79,
                 from /usr/include/c++/13.2.1/ext/string_conversions.h:43,
                 from /usr/include/c++/13.2.1/bits/basic_string.h:4097,
                 from /usr/include/c++/13.2.1/string:54,
                 from dnsname.hh:26,
                 from tsigutils.cc:23:
/usr/include/stdlib.h:657:19: note: previous declaration of ‘__uint32_t arc4random()’
  657 | extern __uint32_t arc4random (void)
      |                   ^~~~~~~~~~
../ext/arc4random/arc4random.hh:12:8: warning: redundant redeclaration of ‘void arc4random_buf(void*, size_t)’ in same scope [-Wredundant-decls]
   12 |   void arc4random_buf(void* buf, size_t nbytes);
      |        ^~~~~~~~~~~~~~
/usr/include/stdlib.h:661:13: note: previous declaration of ‘void arc4random_buf(void*, size_t)’
  661 | extern void arc4random_buf (void *__buf, size_t __size)
      |             ^~~~~~~~~~~~~~
../ext/arc4random/arc4random.hh:15:12: warning: redundant redeclaration of ‘uint32_t arc4random_uniform(uint32_t)’ in same scope [-Wredundant-decls]
   15 |   uint32_t arc4random_uniform(uint32_t upper_bound);
      |            ^~~~~~~~~~~~~~~~~~
/usr/include/stdlib.h:666:19: note: previous declaration of ‘__uint32_t arc4random_uniform(__uint32_t)’
  666 | extern __uint32_t arc4random_uniform (__uint32_t __upper_bound)
      |                   ^~~~~~~~~~~~~~~~~~
../ext/arc4random/arc4random.hh:18:8: warning: redundant redeclaration of ‘void explicit_bzero(void*, size_t)’ in same scope [-Wredundant-decls]
   18 |   void explicit_bzero(void*, size_t len);
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
