### PR TITLE
switch from `docker-compose` to `docker compose` and stop installing docker-compose because that uninstalls runc

### DIFF
--- a/docs/changelog/4.8.rst
+++ b/docs/changelog/4.8.rst
@@ -33,7 +33,7 @@ Changelogs for 4.8.x
     :tags: Bug Fixes
     :pullreq: 12992
 
-    YaHTTP: Prevent integer overflow on very large chunks
+    YaHTTP: Prevent integer overflow on very 3large chunks
 
   .. change::
     :tags: Improvements

--- a/regression-tests.auth-py/runtests
+++ b/regression-tests.auth-py/runtests
@@ -34,13 +34,13 @@ fi
 ignore="-I test_GSSTSIG.py"
 if [ "${WITHKERBEROS}" = "YES" ]; then
     ignore=""
-    (cd kerberos-server && docker-compose up --detach --build)
+    (cd kerberos-server && sudo docker compose up --detach --build)
 fi
 
 nosetests --with-xunit $ignore $@
 ret=$?
 
 if [ "${WITHKERBEROS}" = "YES" ]; then
-    (cd kerberos-server && docker-compose stop || exit 0)
+    (cd kerberos-server && sudo docker compose stop || exit 0)
 fi
 exit $ret

--- a/tasks.py
+++ b/tasks.py
@@ -90,7 +90,6 @@ auth_test_deps = [   # FIXME: we should be generating some of these from shlibde
     'curl',
     'default-jre-headless',
     'dnsutils',
-    'docker-compose',
     'faketime',
     'gawk',
     'krb5-user',


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master