### PR TITLE
dnsdist: dnsdist's fuzzing target needs to link against arc4random

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -483,6 +483,7 @@ bin_PROGRAMS += \
 
 fuzz_targets_libs = \
 	$(LIBCRYPTO_LIBS) \
+	$(ARC4RANDOM_LIBS) \
 	$(LIB_FUZZING_ENGINE)
 
 fuzz_targets_ldflags = \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
On systems that do not provide arc4random we actually need to link the internal library in.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
