### PR TITLE
Cleanup `ueberbackend.cc` a bit

### DIFF
--- a/.not-formatted
+++ b/.not-formatted
@@ -295,7 +295,6 @@
 ./pdns/tsigutils.hh
 ./pdns/tsigverifier.cc
 ./pdns/tsigverifier.hh
-./pdns/ueberbackend.cc
 ./pdns/ueberbackend.hh
 ./pdns/unix_semaphore.cc
 ./pdns/unix_utility.cc

--- a/.not-formatted
+++ b/.not-formatted
@@ -295,7 +295,6 @@
 ./pdns/tsigutils.hh
 ./pdns/tsigverifier.cc
 ./pdns/tsigverifier.hh
-./pdns/ueberbackend.hh
 ./pdns/unix_semaphore.cc
 ./pdns/unix_utility.cc
 ./pdns/utility.hh

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1447,7 +1447,7 @@ bool Bind2Backend::createSlaveDomain(const string& ip, const DNSName& domain, co
   return true;
 }
 
-bool Bind2Backend::searchRecords(const string& pattern, int maxResults, vector<DNSResourceRecord>& result)
+bool Bind2Backend::searchRecords(const string& pattern, size_t maxResults, vector<DNSResourceRecord>& result)
 {
   SimpleMatch sm(pattern, true);
   static bool mustlog = ::arg().mustDo("query-logging");
@@ -1469,7 +1469,7 @@ bool Bind2Backend::searchRecords(const string& pattern, int maxResults, vector<D
 
       shared_ptr<const recordstorage_t> rhandle = h.d_records.get();
 
-      for (recordstorage_t::const_iterator ri = rhandle->begin(); result.size() < static_cast<vector<DNSResourceRecord>::size_type>(maxResults) && ri != rhandle->end(); ri++) {
+      for (recordstorage_t::const_iterator ri = rhandle->begin(); result.size() < maxResults && ri != rhandle->end(); ri++) {
         DNSName name = ri->qname.empty() ? i.d_name : (ri->qname + i.d_name);
         if (sm.match(name) || sm.match(ri->content)) {
           DNSResourceRecord r;

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -205,7 +205,7 @@ public:
   bool commitTransaction() override;
   bool abortTransaction() override;
   void alsoNotifies(const DNSName& domain, set<string>* ips) override;
-  bool searchRecords(const string& pattern, int maxResults, vector<DNSResourceRecord>& result) override;
+  bool searchRecords(const string& pattern, size_t maxResults, vector<DNSResourceRecord>& result) override;
 
   // the DNSSEC related (getDomainMetadata has broader uses too)
   bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string>>& meta) override;

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -199,8 +199,8 @@ public:
   bool deleteTSIGKey(const DNSName& name) override;
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys) override;
   string directBackendCmd(const string& querystr) override;
-  bool searchRecords(const string& pattern, int maxResults, vector<DNSResourceRecord>& result) override;
-  bool searchComments(const string& pattern, int maxResults, vector<Comment>& result) override;
+  bool searchRecords(const string& pattern, size_t maxResults, vector<DNSResourceRecord>& result) override;
+  bool searchComments(const string& pattern, size_t maxResults, vector<Comment>& result) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
   void getUpdatedMasters(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes) override;
   void getUnfreshSlaveInfos(vector<DomainInfo>* domains) override;

--- a/modules/remotebackend/test-remotebackend-http.cc
+++ b/modules/remotebackend/test-remotebackend-http.cc
@@ -76,7 +76,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "http:url=http://localhost:62434/dns";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0];
+      be = BackendMakers().all()[0].get();
     }
     catch (PDNSException& ex) {
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);

--- a/modules/remotebackend/test-remotebackend-http.cc
+++ b/modules/remotebackend/test-remotebackend-http.cc
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <memory>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -52,7 +53,7 @@ public:
   RemoteLoader();
 };
 
-DNSBackend* be;
+std::unique_ptr<DNSBackend> backendUnderTest;
 
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
@@ -67,7 +68,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = nullptr;
+    backendUnderTest = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -76,7 +77,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "http:url=http://localhost:62434/dns";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0].get();
+      backendUnderTest = std::move(BackendMakers().all()[0]);
     }
     catch (PDNSException& ex) {
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);

--- a/modules/remotebackend/test-remotebackend-json.cc
+++ b/modules/remotebackend/test-remotebackend-json.cc
@@ -75,7 +75,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "http:url=http://localhost:62434/dns/endpoint.json,post=1,post_json=1";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0];
+      be = BackendMakers().all()[0].get();
     }
     catch (PDNSException& ex) {
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);

--- a/modules/remotebackend/test-remotebackend-json.cc
+++ b/modules/remotebackend/test-remotebackend-json.cc
@@ -51,7 +51,7 @@ public:
   RemoteLoader();
 };
 
-DNSBackend* be;
+std::unique_ptr<DNSBackend> backendUnderTest;
 
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
@@ -66,7 +66,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = nullptr;
+    backendUnderTest = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -75,7 +75,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "http:url=http://localhost:62434/dns/endpoint.json,post=1,post_json=1";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0].get();
+      backendUnderTest = std::move(BackendMakers().all()[0]);
     }
     catch (PDNSException& ex) {
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);

--- a/modules/remotebackend/test-remotebackend-pipe.cc
+++ b/modules/remotebackend/test-remotebackend-pipe.cc
@@ -75,7 +75,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "pipe:command=unittest_pipe.rb";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0];
+      be = BackendMakers().all()[0].get();
       // load few record types to help out
       SOARecordContent::report();
       NSRecordContent::report();

--- a/modules/remotebackend/test-remotebackend-pipe.cc
+++ b/modules/remotebackend/test-remotebackend-pipe.cc
@@ -60,13 +60,13 @@ public:
   RemoteLoader();
 };
 
-DNSBackend* be;
+std::unique_ptr<DNSBackend> backendUnderTest;
 
 struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = nullptr;
+    backendUnderTest = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -75,7 +75,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "pipe:command=unittest_pipe.rb";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0].get();
+      backendUnderTest = std::move(BackendMakers().all()[0]);
       // load few record types to help out
       SOARecordContent::report();
       NSRecordContent::report();

--- a/modules/remotebackend/test-remotebackend-post.cc
+++ b/modules/remotebackend/test-remotebackend-post.cc
@@ -51,7 +51,7 @@ public:
   RemoteLoader();
 };
 
-DNSBackend* be;
+std::unique_ptr<DNSBackend> backendUnderTest;
 
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
@@ -66,7 +66,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = nullptr;
+    backendUnderTest = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -75,7 +75,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "http:url=http://localhost:62434/dns,post=1";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0].get();
+      backendUnderTest = std::move(BackendMakers().all()[0]);
     }
     catch (PDNSException& ex) {
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);

--- a/modules/remotebackend/test-remotebackend-post.cc
+++ b/modules/remotebackend/test-remotebackend-post.cc
@@ -75,7 +75,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "http:url=http://localhost:62434/dns,post=1";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0];
+      be = BackendMakers().all()[0].get();
     }
     catch (PDNSException& ex) {
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);

--- a/modules/remotebackend/test-remotebackend-unix.cc
+++ b/modules/remotebackend/test-remotebackend-unix.cc
@@ -60,13 +60,13 @@ public:
   RemoteLoader();
 };
 
-DNSBackend* be;
+std::unique_ptr<DNSBackend> backendUnderTest;
 
 struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = nullptr;
+    backendUnderTest = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -75,7 +75,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "unix:path=/tmp/remotebackend.sock";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0].get();
+      backendUnderTest = std::move(BackendMakers().all()[0]);
       // load few record types to help out
       SOARecordContent::report();
       NSRecordContent::report();

--- a/modules/remotebackend/test-remotebackend-unix.cc
+++ b/modules/remotebackend/test-remotebackend-unix.cc
@@ -75,7 +75,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "unix:path=/tmp/remotebackend.sock";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0];
+      be = BackendMakers().all()[0].get();
       // load few record types to help out
       SOARecordContent::report();
       NSRecordContent::report();

--- a/modules/remotebackend/test-remotebackend-zeromq.cc
+++ b/modules/remotebackend/test-remotebackend-zeromq.cc
@@ -59,7 +59,7 @@ public:
   RemoteLoader();
 };
 
-DNSBackend* be;
+std::unique_ptr<DNSBackend> backendUnderTest;
 
 #ifdef REMOTEBACKEND_ZEROMQ
 #include <boost/test/unit_test.hpp>
@@ -68,7 +68,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = nullptr;
+    backendUnderTest = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -77,7 +77,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "zeromq:endpoint=ipc:///tmp/remotebackend.0";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0].get();
+      backendUnderTest = std::move(BackendMakers().all()[0]);
       // load few record types to help out
       SOARecordContent::report();
       NSRecordContent::report();

--- a/modules/remotebackend/test-remotebackend-zeromq.cc
+++ b/modules/remotebackend/test-remotebackend-zeromq.cc
@@ -77,7 +77,7 @@ struct RemotebackendSetup
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "zeromq:endpoint=ipc:///tmp/remotebackend.0";
       ::arg().set("remote-dnssec") = "yes";
-      be = BackendMakers().all()[0];
+      be = BackendMakers().all()[0].get();
       // load few record types to help out
       SOARecordContent::report();
       NSRecordContent::report();

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -41,41 +41,41 @@
 
 #include "test-remotebackend-keys.hh"
 
-extern DNSBackend* be;
+extern std::unique_ptr<DNSBackend> backendUnderTest;
 
 BOOST_AUTO_TEST_SUITE(test_remotebackend_so)
 
 BOOST_AUTO_TEST_CASE(test_method_lookup)
 {
   BOOST_TEST_MESSAGE("Testing lookup method");
-  DNSResourceRecord rr;
-  be->lookup(QType(QType::SOA), DNSName("unit.test."));
+  DNSResourceRecord resourceRecord;
+  backendUnderTest->lookup(QType(QType::SOA), DNSName("unit.test."));
   // then try to get()
-  BOOST_CHECK(be->get(rr)); // and this should be TRUE.
+  BOOST_CHECK(backendUnderTest->get(resourceRecord)); // and this should be TRUE.
   // then we check rr contains what we expect
-  BOOST_CHECK_EQUAL(rr.qname.toString(), "unit.test.");
-  BOOST_CHECK_MESSAGE(rr.qtype == QType::SOA, "returned qtype was not SOA");
-  BOOST_CHECK_EQUAL(rr.content, "ns.unit.test. hostmaster.unit.test. 1 2 3 4 5");
-  BOOST_CHECK_EQUAL(rr.ttl, 300);
+  BOOST_CHECK_EQUAL(resourceRecord.qname.toString(), "unit.test.");
+  BOOST_CHECK_MESSAGE(resourceRecord.qtype == QType::SOA, "returned qtype was not SOA");
+  BOOST_CHECK_EQUAL(resourceRecord.content, "ns.unit.test. hostmaster.unit.test. 1 2 3 4 5");
+  BOOST_CHECK_EQUAL(resourceRecord.ttl, 300);
 }
 
 BOOST_AUTO_TEST_CASE(test_method_lookup_empty)
 {
   BOOST_TEST_MESSAGE("Testing lookup method with empty result");
-  DNSResourceRecord rr;
-  be->lookup(QType(QType::SOA), DNSName("empty.unit.test."));
+  DNSResourceRecord resourceRecord;
+  backendUnderTest->lookup(QType(QType::SOA), DNSName("empty.unit.test."));
   // then try to get()
-  BOOST_CHECK(!be->get(rr)); // and this should be FALSE
+  BOOST_CHECK(!backendUnderTest->get(resourceRecord)); // and this should be FALSE
 }
 
 BOOST_AUTO_TEST_CASE(test_method_list)
 {
   int record_count = 0;
-  DNSResourceRecord rr;
+  DNSResourceRecord resourceRecord;
 
   BOOST_TEST_MESSAGE("Testing list method");
-  be->list(DNSName("unit.test."), -1);
-  while (be->get(rr)) {
+  backendUnderTest->list(DNSName("unit.test."), -1);
+  while (backendUnderTest->get(resourceRecord)) {
     record_count++;
   }
 
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(test_method_list)
 BOOST_AUTO_TEST_CASE(test_method_doesDNSSEC)
 {
   BOOST_TEST_MESSAGE("Testing doesDNSSEC method");
-  BOOST_CHECK(be->doesDNSSEC()); // should be true
+  BOOST_CHECK(backendUnderTest->doesDNSSEC()); // should be true
 }
 
 BOOST_AUTO_TEST_CASE(test_method_setDomainMetadata)
@@ -93,27 +93,27 @@ BOOST_AUTO_TEST_CASE(test_method_setDomainMetadata)
   std::vector<std::string> meta;
   meta.emplace_back("VALUE");
   BOOST_TEST_MESSAGE("Testing setDomainMetadata method");
-  BOOST_CHECK(be->setDomainMetadata(DNSName("unit.test."), "TEST", meta));
+  BOOST_CHECK(backendUnderTest->setDomainMetadata(DNSName("unit.test."), "TEST", meta));
 }
 
 BOOST_AUTO_TEST_CASE(test_method_alsoNotifies)
 {
-  BOOST_CHECK(be->setDomainMetadata(DNSName("unit.test."), "ALSO-NOTIFY", {"192.0.2.1"}));
+  BOOST_CHECK(backendUnderTest->setDomainMetadata(DNSName("unit.test."), "ALSO-NOTIFY", {"192.0.2.1"}));
   std::set<std::string> alsoNotifies;
   BOOST_TEST_MESSAGE("Testing alsoNotifies method");
-  be->alsoNotifies(DNSName("unit.test."), &alsoNotifies);
+  backendUnderTest->alsoNotifies(DNSName("unit.test."), &alsoNotifies);
   BOOST_CHECK_EQUAL(alsoNotifies.size(), 1);
   if (!alsoNotifies.empty()) {
     BOOST_CHECK_EQUAL(alsoNotifies.count("192.0.2.1"), 1);
   }
-  BOOST_CHECK(be->setDomainMetadata(DNSName("unit.test."), "ALSO-NOTIFY", std::vector<std::string>()));
+  BOOST_CHECK(backendUnderTest->setDomainMetadata(DNSName("unit.test."), "ALSO-NOTIFY", std::vector<std::string>()));
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getDomainMetadata)
 {
   std::vector<std::string> meta;
   BOOST_TEST_MESSAGE("Testing getDomainMetadata method");
-  be->getDomainMetadata(DNSName("unit.test."), "TEST", meta);
+  backendUnderTest->getDomainMetadata(DNSName("unit.test."), "TEST", meta);
   BOOST_CHECK_EQUAL(meta.size(), 1);
   // in case we got more than one value, which would be unexpected
   // but not fatal
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_method_getAllDomainMetadata)
 {
   std::map<std::string, std::vector<std::string>> meta;
   BOOST_TEST_MESSAGE("Testing getAllDomainMetadata method");
-  be->getAllDomainMetadata(DNSName("unit.test."), meta);
+  backendUnderTest->getAllDomainMetadata(DNSName("unit.test."), meta);
   BOOST_CHECK_EQUAL(meta.size(), 1);
   // in case we got more than one value, which would be unexpected
   // but not fatal
@@ -138,11 +138,11 @@ BOOST_AUTO_TEST_CASE(test_method_getAllDomainMetadata)
 BOOST_AUTO_TEST_CASE(test_method_addDomainKey)
 {
   BOOST_TEST_MESSAGE("Testing addDomainKey method");
-  int64_t id = 0;
-  be->addDomainKey(DNSName("unit.test."), k1, id);
-  BOOST_CHECK_EQUAL(id, 1);
-  be->addDomainKey(DNSName("unit.test."), k2, id);
-  BOOST_CHECK_EQUAL(id, 2);
+  int64_t keyID = 0;
+  backendUnderTest->addDomainKey(DNSName("unit.test."), k1, keyID);
+  BOOST_CHECK_EQUAL(keyID, 1);
+  backendUnderTest->addDomainKey(DNSName("unit.test."), k2, keyID);
+  BOOST_CHECK_EQUAL(keyID, 2);
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getDomainKeys)
@@ -150,18 +150,18 @@ BOOST_AUTO_TEST_CASE(test_method_getDomainKeys)
   std::vector<DNSBackend::KeyData> keys;
   BOOST_TEST_MESSAGE("Testing getDomainKeys method");
   // we expect to get two keys
-  be->getDomainKeys(DNSName("unit.test."), keys);
+  backendUnderTest->getDomainKeys(DNSName("unit.test."), keys);
   BOOST_CHECK_EQUAL(keys.size(), 2);
   // in case we got more than 2 keys, which would be unexpected
   // but not fatal
   if (keys.size() > 1) {
     // check that we have two keys
-    for (DNSBackend::KeyData& kd : keys) {
-      BOOST_CHECK(kd.id > 0);
-      BOOST_CHECK(kd.flags == 256 || kd.flags == 257);
-      BOOST_CHECK(kd.active == true);
-      BOOST_CHECK(kd.published == true);
-      BOOST_CHECK(kd.content.size() > 500);
+    for (DNSBackend::KeyData& keyData : keys) {
+      BOOST_CHECK(keyData.id > 0);
+      BOOST_CHECK(keyData.flags == 256 || keyData.flags == 257);
+      BOOST_CHECK(keyData.active == true);
+      BOOST_CHECK(keyData.published == true);
+      BOOST_CHECK(keyData.content.size() > 500);
     }
   }
 }
@@ -169,19 +169,19 @@ BOOST_AUTO_TEST_CASE(test_method_getDomainKeys)
 BOOST_AUTO_TEST_CASE(test_method_deactivateDomainKey)
 {
   BOOST_TEST_MESSAGE("Testing deactivateDomainKey method");
-  BOOST_CHECK(be->deactivateDomainKey(DNSName("unit.test."), 1));
+  BOOST_CHECK(backendUnderTest->deactivateDomainKey(DNSName("unit.test."), 1));
 }
 
 BOOST_AUTO_TEST_CASE(test_method_activateDomainKey)
 {
   BOOST_TEST_MESSAGE("Testing activateDomainKey method");
-  BOOST_CHECK(be->activateDomainKey(DNSName("unit.test."), 1));
+  BOOST_CHECK(backendUnderTest->activateDomainKey(DNSName("unit.test."), 1));
 }
 
 BOOST_AUTO_TEST_CASE(test_method_removeDomainKey)
 {
-  BOOST_CHECK(be->removeDomainKey(DNSName("unit.test."), 2));
-  BOOST_CHECK(be->removeDomainKey(DNSName("unit.test."), 1));
+  BOOST_CHECK(backendUnderTest->removeDomainKey(DNSName("unit.test."), 2));
+  BOOST_CHECK(backendUnderTest->removeDomainKey(DNSName("unit.test."), 1));
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getBeforeAndAfterNamesAbsolute)
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(test_method_getBeforeAndAfterNamesAbsolute)
   DNSName after;
   BOOST_TEST_MESSAGE("Testing getBeforeAndAfterNamesAbsolute method");
 
-  be->getBeforeAndAfterNamesAbsolute(-1, DNSName("middle.unit.test."), unhashed, before, after);
+  backendUnderTest->getBeforeAndAfterNamesAbsolute(-1, DNSName("middle.unit.test."), unhashed, before, after);
   BOOST_CHECK_EQUAL(unhashed.toString(), "middle.");
   BOOST_CHECK_EQUAL(before.toString(), "begin.");
   BOOST_CHECK_EQUAL(after.toString(), "stop.");
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(test_method_setTSIGKey)
   std::string algorithm;
   std::string content;
   BOOST_TEST_MESSAGE("Testing setTSIGKey method");
-  BOOST_CHECK_MESSAGE(be->setTSIGKey(DNSName("unit.test."), DNSName("hmac-md5."), "kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys="), "did not return true");
+  BOOST_CHECK_MESSAGE(backendUnderTest->setTSIGKey(DNSName("unit.test."), DNSName("hmac-md5."), "kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys="), "did not return true");
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getTSIGKey)
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(test_method_getTSIGKey)
   DNSName algorithm;
   std::string content;
   BOOST_TEST_MESSAGE("Testing getTSIGKey method");
-  be->getTSIGKey(DNSName("unit.test."), algorithm, content);
+  backendUnderTest->getTSIGKey(DNSName("unit.test."), algorithm, content);
   BOOST_CHECK_EQUAL(algorithm.toString(), "hmac-md5.");
   BOOST_CHECK_EQUAL(content, "kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys=");
 }
@@ -220,14 +220,14 @@ BOOST_AUTO_TEST_CASE(test_method_deleteTSIGKey)
   std::string algorithm;
   std::string content;
   BOOST_TEST_MESSAGE("Testing deleteTSIGKey method");
-  BOOST_CHECK_MESSAGE(be->deleteTSIGKey(DNSName("unit.test.")), "did not return true");
+  BOOST_CHECK_MESSAGE(backendUnderTest->deleteTSIGKey(DNSName("unit.test.")), "did not return true");
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getTSIGKeys)
 {
   std::vector<struct TSIGKey> keys;
   BOOST_TEST_MESSAGE("Testing getTSIGKeys method");
-  be->getTSIGKeys(keys);
+  backendUnderTest->getTSIGKeys(keys);
   BOOST_CHECK(!keys.empty());
   if (!keys.empty()) {
     BOOST_CHECK_EQUAL(keys[0].name.toString(), "test.");
@@ -239,159 +239,159 @@ BOOST_AUTO_TEST_CASE(test_method_getTSIGKeys)
 BOOST_AUTO_TEST_CASE(test_method_setNotified)
 {
   BOOST_TEST_MESSAGE("Testing setNotified method");
-  be->setNotified(1, 2);
+  backendUnderTest->setNotified(1, 2);
   BOOST_CHECK(true); // we check this on next step
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getDomainInfo)
 {
-  DomainInfo di;
+  DomainInfo domainInfo;
   BOOST_TEST_MESSAGE("Testing getDomainInfo method");
-  be->getDomainInfo(DNSName("unit.test."), di);
-  BOOST_CHECK_EQUAL(di.zone.toString(), "unit.test.");
-  BOOST_CHECK_EQUAL(di.serial, 2);
-  BOOST_CHECK_EQUAL(di.notified_serial, 2);
-  BOOST_CHECK_EQUAL(di.kind, DomainInfo::Native);
-  BOOST_CHECK_EQUAL(di.backend, be);
+  backendUnderTest->getDomainInfo(DNSName("unit.test."), domainInfo);
+  BOOST_CHECK_EQUAL(domainInfo.zone.toString(), "unit.test.");
+  BOOST_CHECK_EQUAL(domainInfo.serial, 2);
+  BOOST_CHECK_EQUAL(domainInfo.notified_serial, 2);
+  BOOST_CHECK_EQUAL(domainInfo.kind, DomainInfo::Native);
+  BOOST_CHECK_EQUAL(domainInfo.backend, backendUnderTest.get());
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getAllDomains)
 {
-  DomainInfo di;
+  DomainInfo domainInfo;
   BOOST_TEST_MESSAGE("Testing getAllDomains method");
   vector<DomainInfo> result;
 
-  be->getAllDomains(&result, true, true);
+  backendUnderTest->getAllDomains(&result, true, true);
 
   BOOST_REQUIRE(!result.empty());
-  di = result.at(0);
-  BOOST_CHECK_EQUAL(di.zone.toString(), "unit.test.");
-  BOOST_CHECK_EQUAL(di.serial, 2);
-  BOOST_CHECK_EQUAL(di.notified_serial, 2);
-  BOOST_CHECK_EQUAL(di.kind, DomainInfo::Native);
-  BOOST_CHECK_EQUAL(di.backend, be);
+  domainInfo = result.at(0);
+  BOOST_CHECK_EQUAL(domainInfo.zone.toString(), "unit.test.");
+  BOOST_CHECK_EQUAL(domainInfo.serial, 2);
+  BOOST_CHECK_EQUAL(domainInfo.notified_serial, 2);
+  BOOST_CHECK_EQUAL(domainInfo.kind, DomainInfo::Native);
+  BOOST_CHECK_EQUAL(domainInfo.backend, backendUnderTest.get());
 }
 
 BOOST_AUTO_TEST_CASE(test_method_superMasterBackend)
 {
-  DNSResourceRecord rr;
+  DNSResourceRecord resourceRecord;
   std::vector<DNSResourceRecord> nsset;
   DNSBackend* dbd = nullptr;
   BOOST_TEST_MESSAGE("Testing superMasterBackend method");
 
-  rr.qname = DNSName("example.com.");
-  rr.qtype = QType::NS;
-  rr.qclass = QClass::IN;
-  rr.ttl = 300;
-  rr.content = "ns1.example.com.";
-  nsset.push_back(rr);
-  rr.qname = DNSName("example.com.");
-  rr.qtype = QType::NS;
-  rr.qclass = QClass::IN;
-  rr.ttl = 300;
-  rr.content = "ns2.example.com.";
-  nsset.push_back(rr);
+  resourceRecord.qname = DNSName("example.com.");
+  resourceRecord.qtype = QType::NS;
+  resourceRecord.qclass = QClass::IN;
+  resourceRecord.ttl = 300;
+  resourceRecord.content = "ns1.example.com.";
+  nsset.push_back(resourceRecord);
+  resourceRecord.qname = DNSName("example.com.");
+  resourceRecord.qtype = QType::NS;
+  resourceRecord.qclass = QClass::IN;
+  resourceRecord.ttl = 300;
+  resourceRecord.content = "ns2.example.com.";
+  nsset.push_back(resourceRecord);
 
-  BOOST_CHECK(be->superMasterBackend("10.0.0.1", DNSName("example.com."), nsset, nullptr, nullptr, &dbd));
+  BOOST_CHECK(backendUnderTest->superMasterBackend("10.0.0.1", DNSName("example.com."), nsset, nullptr, nullptr, &dbd));
 
   // let's see what we got
-  BOOST_CHECK_EQUAL(dbd, be);
+  BOOST_CHECK_EQUAL(dbd, backendUnderTest.get());
 }
 
 BOOST_AUTO_TEST_CASE(test_method_createSlaveDomain)
 {
   BOOST_TEST_MESSAGE("Testing createSlaveDomain method");
-  BOOST_CHECK(be->createSlaveDomain("10.0.0.1", DNSName("pirate.unit.test."), "", ""));
+  BOOST_CHECK(backendUnderTest->createSlaveDomain("10.0.0.1", DNSName("pirate.unit.test."), "", ""));
 }
 
 BOOST_AUTO_TEST_CASE(test_method_feedRecord)
 {
-  DNSResourceRecord rr;
+  DNSResourceRecord resourceRecord;
   BOOST_TEST_MESSAGE("Testing feedRecord method");
-  be->startTransaction(DNSName("example.com."), 2);
-  rr.qname = DNSName("example.com.");
-  rr.qtype = QType::SOA;
-  rr.qclass = QClass::IN;
-  rr.ttl = 300;
-  rr.content = "ns1.example.com. hostmaster.example.com. 2013013441 7200 3600 1209600 300";
-  BOOST_CHECK(be->feedRecord(rr, DNSName()));
-  rr.qname = DNSName("replace.example.com.");
-  rr.qtype = QType::A;
-  rr.qclass = QClass::IN;
-  rr.ttl = 300;
-  rr.content = "127.0.0.1";
-  BOOST_CHECK(be->feedRecord(rr, DNSName()));
-  be->commitTransaction();
+  backendUnderTest->startTransaction(DNSName("example.com."), 2);
+  resourceRecord.qname = DNSName("example.com.");
+  resourceRecord.qtype = QType::SOA;
+  resourceRecord.qclass = QClass::IN;
+  resourceRecord.ttl = 300;
+  resourceRecord.content = "ns1.example.com. hostmaster.example.com. 2013013441 7200 3600 1209600 300";
+  BOOST_CHECK(backendUnderTest->feedRecord(resourceRecord, DNSName()));
+  resourceRecord.qname = DNSName("replace.example.com.");
+  resourceRecord.qtype = QType::A;
+  resourceRecord.qclass = QClass::IN;
+  resourceRecord.ttl = 300;
+  resourceRecord.content = "127.0.0.1";
+  BOOST_CHECK(backendUnderTest->feedRecord(resourceRecord, DNSName()));
+  backendUnderTest->commitTransaction();
 }
 
 BOOST_AUTO_TEST_CASE(test_method_replaceRRSet)
 {
-  be->startTransaction(DNSName("example.com."), 2);
-  DNSResourceRecord rr;
+  backendUnderTest->startTransaction(DNSName("example.com."), 2);
+  DNSResourceRecord resourceRecord;
   std::vector<DNSResourceRecord> rrset;
   BOOST_TEST_MESSAGE("Testing replaceRRSet method");
-  rr.qname = DNSName("replace.example.com.");
-  rr.qtype = QType::A;
-  rr.qclass = QClass::IN;
-  rr.ttl = 300;
-  rr.content = "1.1.1.1";
-  rrset.push_back(rr);
-  BOOST_CHECK(be->replaceRRSet(2, DNSName("replace.example.com."), QType(QType::A), rrset));
-  be->commitTransaction();
+  resourceRecord.qname = DNSName("replace.example.com.");
+  resourceRecord.qtype = QType::A;
+  resourceRecord.qclass = QClass::IN;
+  resourceRecord.ttl = 300;
+  resourceRecord.content = "1.1.1.1";
+  rrset.push_back(resourceRecord);
+  BOOST_CHECK(backendUnderTest->replaceRRSet(2, DNSName("replace.example.com."), QType(QType::A), rrset));
+  backendUnderTest->commitTransaction();
 }
 
 BOOST_AUTO_TEST_CASE(test_method_feedEnts)
 {
   BOOST_TEST_MESSAGE("Testing feedEnts method");
-  be->startTransaction(DNSName("example.com."), 2);
+  backendUnderTest->startTransaction(DNSName("example.com."), 2);
   map<DNSName, bool> nonterm = boost::assign::map_list_of(DNSName("_udp"), true)(DNSName("_sip._udp"), true);
-  BOOST_CHECK(be->feedEnts(2, nonterm));
-  be->commitTransaction();
+  BOOST_CHECK(backendUnderTest->feedEnts(2, nonterm));
+  backendUnderTest->commitTransaction();
 }
 
 BOOST_AUTO_TEST_CASE(test_method_feedEnts3)
 {
   BOOST_TEST_MESSAGE("Testing feedEnts3 method");
-  be->startTransaction(DNSName("example.com"), 2);
+  backendUnderTest->startTransaction(DNSName("example.com"), 2);
   NSEC3PARAMRecordContent ns3prc;
   ns3prc.d_iterations = 1;
   ns3prc.d_salt = "\u00aa\u00bb\u00cc\u00dd";
   map<DNSName, bool> nonterm = boost::assign::map_list_of(DNSName("_udp"), true)(DNSName("_sip._udp"), true);
-  BOOST_CHECK(be->feedEnts3(2, DNSName("example.com."), nonterm, ns3prc, 0));
-  be->commitTransaction();
+  BOOST_CHECK(backendUnderTest->feedEnts3(2, DNSName("example.com."), nonterm, ns3prc, 0));
+  backendUnderTest->commitTransaction();
 }
 
 BOOST_AUTO_TEST_CASE(test_method_abortTransaction)
 {
   BOOST_TEST_MESSAGE("Testing abortTransaction method");
-  be->startTransaction(DNSName("example.com."), 2);
-  BOOST_CHECK(be->abortTransaction());
+  backendUnderTest->startTransaction(DNSName("example.com."), 2);
+  BOOST_CHECK(backendUnderTest->abortTransaction());
 }
 
 BOOST_AUTO_TEST_CASE(test_method_directBackendCmd)
 {
   BOOST_TEST_MESSAGE("Testing directBackendCmd method");
-  BOOST_CHECK_EQUAL(be->directBackendCmd("PING 1234"), "PING 1234");
+  BOOST_CHECK_EQUAL(backendUnderTest->directBackendCmd("PING 1234"), "PING 1234");
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getUpdatedMasters)
 {
-  DomainInfo di;
+  DomainInfo domainInfo;
   BOOST_TEST_MESSAGE("Testing getUpdatedMasters method");
   vector<DomainInfo> result;
   std::unordered_set<DNSName> catalogs;
   CatalogHashMap hashes;
 
-  be->getUpdatedMasters(result, catalogs, hashes);
+  backendUnderTest->getUpdatedMasters(result, catalogs, hashes);
 
   BOOST_REQUIRE(!result.empty());
 
-  di = result.at(0);
-  BOOST_CHECK_EQUAL(di.zone.toString(), "master.test.");
-  BOOST_CHECK_EQUAL(di.serial, 2);
-  BOOST_CHECK_EQUAL(di.notified_serial, 2);
-  BOOST_CHECK_EQUAL(di.kind, DomainInfo::Master);
-  BOOST_CHECK_EQUAL(di.backend, be);
+  domainInfo = result.at(0);
+  BOOST_CHECK_EQUAL(domainInfo.zone.toString(), "master.test.");
+  BOOST_CHECK_EQUAL(domainInfo.serial, 2);
+  BOOST_CHECK_EQUAL(domainInfo.notified_serial, 2);
+  BOOST_CHECK_EQUAL(domainInfo.kind, DomainInfo::Master);
+  BOOST_CHECK_EQUAL(domainInfo.backend, backendUnderTest.get());
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -2075,7 +2075,7 @@ string GSQLBackend::pattern2SQLPattern(const string &pattern)
   return escaped_pattern;
 }
 
-bool GSQLBackend::searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result)
+bool GSQLBackend::searchRecords(const string &pattern, size_t maxResults, vector<DNSResourceRecord>& result)
 {
   d_qname.clear();
   string escaped_pattern = pattern2SQLPattern(pattern);
@@ -2111,7 +2111,7 @@ bool GSQLBackend::searchRecords(const string &pattern, int maxResults, vector<DN
   }
 }
 
-bool GSQLBackend::searchComments(const string &pattern, int maxResults, vector<Comment>& result)
+bool GSQLBackend::searchComments(const string &pattern, size_t maxResults, vector<Comment>& result)
 {
   Comment c;
   string escaped_pattern = pattern2SQLPattern(pattern);

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -29,7 +29,7 @@
 
 bool isDnssecDomainMetadata (const string& name);
 
-/* 
+/*
 GSQLBackend is a generic backend used by other sql backends
 */
 class GSQLBackend : public DNSBackend
@@ -41,7 +41,7 @@ public:
     freeStatements();
     d_db.reset();
   }
-  
+
   void setDB(SSql *db)
   {
     freeStatements();
@@ -66,7 +66,7 @@ protected:
       d_InfoOfAllSlaveDomainsQuery_stmt = d_db->prepare(d_InfoOfAllSlaveDomainsQuery, 0);
       d_SuperMasterInfoQuery_stmt = d_db->prepare(d_SuperMasterInfoQuery, 2);
       d_GetSuperMasterIPs_stmt = d_db->prepare(d_GetSuperMasterIPs, 2);
-      d_AddSuperMaster_stmt = d_db->prepare(d_AddSuperMaster, 3); 
+      d_AddSuperMaster_stmt = d_db->prepare(d_AddSuperMaster, 3);
       d_RemoveAutoPrimary_stmt = d_db->prepare(d_RemoveAutoPrimaryQuery, 2);
       d_ListAutoPrimaries_stmt = d_db->prepare(d_ListAutoPrimariesQuery, 0);
       d_InsertZoneQuery_stmt = d_db->prepare(d_InsertZoneQuery, 4);
@@ -237,7 +237,7 @@ public:
   bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string> >& meta) override;
   bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta) override;
   bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta) override;
-  
+
   bool removeDomainKey(const DNSName& name, unsigned int id) override;
   bool activateDomainKey(const DNSName& name, unsigned int id) override;
   bool deactivateDomainKey(const DNSName& name, unsigned int id) override;
@@ -254,8 +254,8 @@ public:
   bool feedComment(const Comment& comment) override;
   bool replaceComments(const uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<Comment>& comments) override;
   string directBackendCmd(const string &query) override;
-  bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result) override;
-  bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
+  bool searchRecords(const string &pattern, size_t maxResults, vector<DNSResourceRecord>& result) override;
+  bool searchComments(const string &pattern, size_t maxResults, vector<Comment>& result) override;
 
 protected:
   string pattern2SQLPattern(const string& pattern);

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstddef>
 class DNSPacket;
 
 #include "utility.hh"
@@ -449,13 +450,13 @@ public:
   }
 
   //! Search for records, returns true if search was done successfully.
-  virtual bool searchRecords(const string& /* pattern */, int /* maxResults */, vector<DNSResourceRecord>& /* result */)
+  virtual bool searchRecords(const string& /* pattern */, size_t /* maxResults */, vector<DNSResourceRecord>& /* result */)
   {
     return false;
   }
 
   //! Search for comments, returns true if search was done successfully.
-  virtual bool searchComments(const string& /* pattern */, int /* maxResults */, vector<Comment>& /* result */)
+  virtual bool searchComments(const string& /* pattern */, size_t /* maxResults */, vector<Comment>& /* result */)
   {
     return false;
   }

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -496,7 +496,7 @@ class BackendMakerClass
 public:
   void report(BackendFactory *bf);
   void launch(const string &instr);
-  vector<DNSBackend *> all(bool skipBIND=false);
+  vector<std::unique_ptr<DNSBackend>> all(bool metadataOnly=false);
   void load(const string &module);
   [[nodiscard]] size_t numLauncheable() const;
   vector<string> getModules();

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -1053,8 +1053,10 @@ BOOST_AUTO_TEST_CASE(test_multi_backends_best_soa) {
 
     auto testFunction = [](UeberBackend& ub) -> void {
     {
-      auto sbba = dynamic_cast<SimpleBackendBestAuth*>(ub.backends.at(0));
+      auto* sbba = dynamic_cast<SimpleBackendBestAuth*>(ub.backends.at(0).get());
       BOOST_REQUIRE(sbba != nullptr);
+
+      // NOLINTNEXTLINE (clang-analyzer-core.NullDereference): Not sure.
       sbba->d_authLookupCount = 0;
 
       // test getAuth()

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -516,33 +516,41 @@ bool UeberBackend::getSOAUncached(const DNSName& domain, SOAData& sd)
 
 bool UeberBackend::superMasterAdd(const AutoPrimary& primary)
 {
-  for (auto backend : backends)
-    if (backend->superMasterAdd(primary))
+  for (auto* backend : backends) {
+    if (backend->superMasterAdd(primary)) {
       return true;
+    }
+  }
   return false;
 }
 
 bool UeberBackend::autoPrimaryRemove(const AutoPrimary& primary)
 {
-  for (auto backend : backends)
-    if (backend->autoPrimaryRemove(primary))
+  for (auto* backend : backends) {
+    if (backend->autoPrimaryRemove(primary)) {
       return true;
+    }
+  }
   return false;
 }
 
 bool UeberBackend::autoPrimariesList(std::vector<AutoPrimary>& primaries)
 {
-  for (auto backend : backends)
-    if (backend->autoPrimariesList(primaries))
+  for (auto* backend : backends) {
+    if (backend->autoPrimariesList(primaries)) {
       return true;
+    }
+  }
   return false;
 }
 
 bool UeberBackend::superMasterBackend(const string& ip, const DNSName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** db)
 {
-  for (auto backend : backends)
-    if (backend->superMasterBackend(ip, domain, nsset, nameserver, account, db))
+  for (auto* backend : backends) {
+    if (backend->superMasterBackend(ip, domain, nsset, nameserver, account, db)) {
       return true;
+    }
+  }
   return false;
 }
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -65,6 +65,7 @@ bool UeberBackend::loadmodule(const string& name)
   void* dlib = dlopen(name.c_str(), RTLD_NOW);
 
   if (dlib == nullptr) {
+    // NOLINTNEXTLINE(concurrency-mt-unsafe): There's no thread-safe alternative to dlerror().
     g_log << Logger::Error << "Unable to load module '" << name << "': " << dlerror() << endl;
     return false;
   }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -860,22 +860,22 @@ bool UeberBackend::deleteTSIGKey(const DNSName& name)
 
 // API Search
 //
-bool UeberBackend::searchRecords(const string& pattern, int maxResults, vector<DNSResourceRecord>& result)
+bool UeberBackend::searchRecords(const string& pattern, size_t maxResults, vector<DNSResourceRecord>& result)
 {
   bool ret = false;
-  for (auto i = backends.begin(); result.size() < static_cast<vector<DNSResourceRecord>::size_type>(maxResults) && i != backends.end(); ++i) {
-    if ((*i)->searchRecords(pattern, maxResults - result.size(), result)) {
+  for (auto backend = backends.begin(); result.size() < maxResults && backend != backends.end(); ++backend) {
+    if ((*backend)->searchRecords(pattern, maxResults - result.size(), result)) {
       ret = true;
     }
   }
   return ret;
 }
 
-bool UeberBackend::searchComments(const string& pattern, int maxResults, vector<Comment>& result)
+bool UeberBackend::searchComments(const string& pattern, size_t maxResults, vector<Comment>& result)
 {
   bool ret = false;
-  for (auto i = backends.begin(); result.size() < static_cast<vector<Comment>::size_type>(maxResults) && i != backends.end(); ++i) {
-    if ((*i)->searchComments(pattern, maxResults - result.size(), result)) {
+  for (auto backend = backends.begin(); result.size() < maxResults && backend != backends.end(); ++backend) {
+    if ((*backend)->searchComments(pattern, maxResults - result.size(), result)) {
       ret = true;
     }
   }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -322,9 +322,10 @@ void UeberBackend::getUpdatedMasters(vector<DomainInfo>& domains, std::unordered
 
 bool UeberBackend::inTransaction()
 {
-  for (auto* b : backends) {
-    if (b->inTransaction())
+  for (auto* backend : backends) {
+    if (backend->inTransaction()) {
       return true;
+    }
   }
   return false;
 }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -29,7 +29,6 @@
 #include "auth-zonecache.hh"
 #include "utility.hh"
 
-
 #include <dlfcn.h>
 #include <string>
 #include <map>
@@ -50,24 +49,24 @@
 
 extern StatBag S;
 
-LockGuarded<vector<UeberBackend *>> UeberBackend::d_instances;
+LockGuarded<vector<UeberBackend*>> UeberBackend::d_instances;
 
 // initially we are blocked
-bool UeberBackend::d_go=false;
-bool UeberBackend::s_doANYLookupsOnly=false;
+bool UeberBackend::d_go = false;
+bool UeberBackend::s_doANYLookupsOnly = false;
 std::mutex UeberBackend::d_mut;
 std::condition_variable UeberBackend::d_cond;
 AtomicCounter* UeberBackend::s_backendQueries = nullptr;
 
 //! Loads a module and reports it to all UeberBackend threads
-bool UeberBackend::loadmodule(const string &name)
+bool UeberBackend::loadmodule(const string& name)
 {
-  g_log<<Logger::Warning <<"Loading '"<<name<<"'" << endl;
+  g_log << Logger::Warning << "Loading '" << name << "'" << endl;
 
-  void *dlib=dlopen(name.c_str(), RTLD_NOW);
+  void* dlib = dlopen(name.c_str(), RTLD_NOW);
 
-  if(dlib == nullptr) {
-    g_log<<Logger::Error <<"Unable to load module '"<<name<<"': "<<dlerror() << endl;
+  if (dlib == nullptr) {
+    g_log << Logger::Error << "Unable to load module '" << name << "': " << dlerror() << endl;
     return false;
   }
 
@@ -76,15 +75,17 @@ bool UeberBackend::loadmodule(const string &name)
 
 bool UeberBackend::loadModules(const vector<string>& modules, const string& path)
 {
-  for (const auto& module: modules) {
+  for (const auto& module : modules) {
     bool res;
-    if (module.find('.')==string::npos) {
-      res = UeberBackend::loadmodule(path+"/lib"+module+"backend.so");
-    } else if (module[0]=='/' || (module[0]=='.' && module[1]=='/') || (module[0]=='.' && module[1]=='.')) {
+    if (module.find('.') == string::npos) {
+      res = UeberBackend::loadmodule(path + "/lib" + module + "backend.so");
+    }
+    else if (module[0] == '/' || (module[0] == '.' && module[1] == '/') || (module[0] == '.' && module[1] == '.')) {
       // absolute or current path
       res = UeberBackend::loadmodule(module);
-    } else {
-      res = UeberBackend::loadmodule(path+"/"+module);
+    }
+    else {
+      res = UeberBackend::loadmodule(path + "/" + module);
     }
 
     if (res == false) {
@@ -110,17 +111,17 @@ void UeberBackend::go()
   d_cond.notify_all();
 }
 
-bool UeberBackend::getDomainInfo(const DNSName &domain, DomainInfo &di, bool getSerial)
+bool UeberBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial)
 {
-  for(auto backend : backends)
-    if(backend->getDomainInfo(domain, di, getSerial))
+  for (auto backend : backends)
+    if (backend->getDomainInfo(domain, di, getSerial))
       return true;
   return false;
 }
 
-bool UeberBackend::createDomain(const DNSName &domain, const DomainInfo::DomainKind kind, const vector<ComboAddress> &masters, const string &account)
+bool UeberBackend::createDomain(const DNSName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& masters, const string& account)
 {
-  for(DNSBackend* mydb :  backends) {
+  for (DNSBackend* mydb : backends) {
     if (mydb->createDomain(domain, kind, masters, account)) {
       return true;
     }
@@ -130,8 +131,8 @@ bool UeberBackend::createDomain(const DNSName &domain, const DomainInfo::DomainK
 
 bool UeberBackend::doesDNSSEC()
 {
-  for(auto* db :  backends) {
-    if(db->doesDNSSEC())
+  for (auto* db : backends) {
+    if (db->doesDNSSEC())
       return true;
   }
   return false;
@@ -140,25 +141,25 @@ bool UeberBackend::doesDNSSEC()
 bool UeberBackend::addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& id)
 {
   id = -1;
-  for(DNSBackend* db :  backends) {
-    if(db->addDomainKey(name, key, id))
+  for (DNSBackend* db : backends) {
+    if (db->addDomainKey(name, key, id))
       return true;
   }
   return false;
 }
 bool UeberBackend::getDomainKeys(const DNSName& name, std::vector<DNSBackend::KeyData>& keys)
 {
-  for(DNSBackend* db :  backends) {
-    if(db->getDomainKeys(name, keys))
+  for (DNSBackend* db : backends) {
+    if (db->getDomainKeys(name, keys))
       return true;
   }
   return false;
 }
 
-bool UeberBackend::getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string> >& meta)
+bool UeberBackend::getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string>>& meta)
 {
-  for(DNSBackend* db :  backends) {
-    if(db->getAllDomainMetadata(name, meta))
+  for (DNSBackend* db : backends) {
+    if (db->getAllDomainMetadata(name, meta))
       return true;
   }
   return false;
@@ -166,8 +167,8 @@ bool UeberBackend::getAllDomainMetadata(const DNSName& name, std::map<std::strin
 
 bool UeberBackend::getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta)
 {
-  for(DNSBackend* db :  backends) {
-    if(db->getDomainMetadata(name, kind, meta))
+  for (DNSBackend* db : backends) {
+    if (db->getDomainMetadata(name, kind, meta))
       return true;
   }
   return false;
@@ -186,8 +187,8 @@ bool UeberBackend::getDomainMetadata(const DNSName& name, const std::string& kin
 
 bool UeberBackend::setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta)
 {
-  for(DNSBackend* db :  backends) {
-    if(db->setDomainMetadata(name, kind, meta))
+  for (DNSBackend* db : backends) {
+    if (db->setDomainMetadata(name, kind, meta))
       return true;
   }
   return false;
@@ -204,8 +205,8 @@ bool UeberBackend::setDomainMetadata(const DNSName& name, const std::string& kin
 
 bool UeberBackend::activateDomainKey(const DNSName& name, unsigned int id)
 {
-  for(DNSBackend* db :  backends) {
-    if(db->activateDomainKey(name, id))
+  for (DNSBackend* db : backends) {
+    if (db->activateDomainKey(name, id))
       return true;
   }
   return false;
@@ -213,8 +214,8 @@ bool UeberBackend::activateDomainKey(const DNSName& name, unsigned int id)
 
 bool UeberBackend::deactivateDomainKey(const DNSName& name, unsigned int id)
 {
-  for(DNSBackend* db :  backends) {
-    if(db->deactivateDomainKey(name, id))
+  for (DNSBackend* db : backends) {
+    if (db->deactivateDomainKey(name, id))
       return true;
   }
   return false;
@@ -222,8 +223,8 @@ bool UeberBackend::deactivateDomainKey(const DNSName& name, unsigned int id)
 
 bool UeberBackend::publishDomainKey(const DNSName& name, unsigned int id)
 {
-  for(DNSBackend* db :  backends) {
-    if(db->publishDomainKey(name, id))
+  for (DNSBackend* db : backends) {
+    if (db->publishDomainKey(name, id))
       return true;
   }
   return false;
@@ -231,34 +232,31 @@ bool UeberBackend::publishDomainKey(const DNSName& name, unsigned int id)
 
 bool UeberBackend::unpublishDomainKey(const DNSName& name, unsigned int id)
 {
-  for(DNSBackend* db :  backends) {
-    if(db->unpublishDomainKey(name, id))
+  for (DNSBackend* db : backends) {
+    if (db->unpublishDomainKey(name, id))
       return true;
   }
   return false;
 }
-
 
 bool UeberBackend::removeDomainKey(const DNSName& name, unsigned int id)
 {
-  for(DNSBackend* db :  backends) {
-    if(db->removeDomainKey(name, id))
+  for (DNSBackend* db : backends) {
+    if (db->removeDomainKey(name, id))
       return true;
   }
   return false;
 }
 
-
-
 void UeberBackend::reload()
 {
-  for (auto & backend : backends)
-  {
+  for (auto& backend : backends) {
     backend->reload();
   }
 }
 
-void UeberBackend::updateZoneCache() {
+void UeberBackend::updateZoneCache()
+{
   if (!g_zoneCache.isEnabled()) {
     return;
   }
@@ -266,58 +264,52 @@ void UeberBackend::updateZoneCache() {
   vector<std::tuple<DNSName, int>> zone_indices;
   g_zoneCache.setReplacePending();
 
-  for (vector<DNSBackend*>::iterator i = backends.begin(); i != backends.end(); ++i )
-  {
+  for (vector<DNSBackend*>::iterator i = backends.begin(); i != backends.end(); ++i) {
     vector<DomainInfo> zones;
     (*i)->getAllDomains(&zones, false, true);
-    for(auto& di: zones) {
+    for (auto& di : zones) {
       zone_indices.emplace_back(std::move(di.zone), (int)di.id); // this cast should not be necessary
     }
   }
   g_zoneCache.replace(zone_indices);
 }
 
-void UeberBackend::rediscover(string *status)
+void UeberBackend::rediscover(string* status)
 {
-  for ( vector< DNSBackend * >::iterator i = backends.begin(); i != backends.end(); ++i )
-  {
+  for (vector<DNSBackend*>::iterator i = backends.begin(); i != backends.end(); ++i) {
     string tmpstr;
-    ( *i )->rediscover(&tmpstr);
-    if(status) 
-      *status+=tmpstr + (i!=backends.begin() ? "\n" : "");
+    (*i)->rediscover(&tmpstr);
+    if (status)
+      *status += tmpstr + (i != backends.begin() ? "\n" : "");
   }
 
   updateZoneCache();
 }
 
-
 void UeberBackend::getUnfreshSlaveInfos(vector<DomainInfo>* domains)
 {
-  for (auto & backend : backends)
-  {
-    backend->getUnfreshSlaveInfos( domains );
-  }  
+  for (auto& backend : backends) {
+    backend->getUnfreshSlaveInfos(domains);
+  }
 }
 
 void UeberBackend::getUpdatedMasters(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes)
 {
-  for (auto & backend : backends)
-  {
+  for (auto& backend : backends) {
     backend->getUpdatedMasters(domains, catalogs, catalogHashes);
   }
 }
 
 bool UeberBackend::inTransaction()
 {
-  for (auto* b : backends )
-  {
-    if(b->inTransaction())
+  for (auto* b : backends) {
+    if (b->inTransaction())
       return true;
   }
   return false;
 }
 
-bool UeberBackend::getAuth(const DNSName &target, const QType& qtype, SOAData* sd, bool cachedOk)
+bool UeberBackend::getAuth(const DNSName& target, const QType& qtype, SOAData* sd, bool cachedOk)
 {
   // A backend can respond to our authority request with the 'best' match it
   // has. For example, when asked for a.b.c.example.com. it might respond with
@@ -328,10 +320,10 @@ bool UeberBackend::getAuth(const DNSName &target, const QType& qtype, SOAData* s
   bool found = false;
   int cstat;
   DNSName shorter(target);
-  vector<pair<size_t, SOAData> > bestmatch (backends.size(), pair(target.wirelength()+1, SOAData()));
+  vector<pair<size_t, SOAData>> bestmatch(backends.size(), pair(target.wirelength() + 1, SOAData()));
   do {
     int zoneId{-1};
-    if(cachedOk && g_zoneCache.isEnabled()) {
+    if (cachedOk && g_zoneCache.isEnabled()) {
       if (g_zoneCache.getEntry(shorter, zoneId)) {
         // Zone exists in zone cache, directly look up SOA.
         DNSZoneRecord zr;
@@ -341,7 +333,7 @@ bool UeberBackend::getAuth(const DNSName &target, const QType& qtype, SOAData* s
           continue;
         }
         if (zr.dr.d_name != shorter) {
-          throw PDNSException("getAuth() returned an SOA for the wrong zone. Zone '"+zr.dr.d_name.toLogString()+"' is not equal to looked up zone '"+shorter.toLogString()+"'");
+          throw PDNSException("getAuth() returned an SOA for the wrong zone. Zone '" + zr.dr.d_name.toLogString() + "' is not equal to looked up zone '" + shorter.toLogString() + "'");
         }
         // fill sd
         sd->qname = zr.dr.d_name;
@@ -374,69 +366,75 @@ bool UeberBackend::getAuth(const DNSName &target, const QType& qtype, SOAData* s
     d_question.zoneId = zoneId;
 
     // Check cache
-    if(cachedOk && (d_cache_ttl || d_negcache_ttl)) {
-      cstat = cacheHas(d_question,d_answers);
+    if (cachedOk && (d_cache_ttl || d_negcache_ttl)) {
+      cstat = cacheHas(d_question, d_answers);
 
-      if(cstat == 1 && !d_answers.empty() && d_cache_ttl) {
-        DLOG(g_log<<Logger::Error<<"has pos cache entry: "<<shorter<<endl);
+      if (cstat == 1 && !d_answers.empty() && d_cache_ttl) {
+        DLOG(g_log << Logger::Error << "has pos cache entry: " << shorter << endl);
         fillSOAData(d_answers[0], *sd);
 
         if (backends.size() == 1) {
           sd->db = *backends.begin();
-        } else {
+        }
+        else {
           sd->db = nullptr;
         }
         sd->qname = shorter;
         goto found;
-      } else if(cstat == 0 && d_negcache_ttl) {
-        DLOG(g_log<<Logger::Error<<"has neg cache entry: "<<shorter<<endl);
+      }
+      else if (cstat == 0 && d_negcache_ttl) {
+        DLOG(g_log << Logger::Error << "has neg cache entry: " << shorter << endl);
         continue;
       }
     }
 
     // Check backends
     {
-      vector<DNSBackend *>::const_iterator i = backends.begin();
-      vector<pair<size_t, SOAData> >::iterator j = bestmatch.begin();
-      for(; i != backends.end() && j != bestmatch.end(); ++i, ++j) {
+      vector<DNSBackend*>::const_iterator i = backends.begin();
+      vector<pair<size_t, SOAData>>::iterator j = bestmatch.begin();
+      for (; i != backends.end() && j != bestmatch.end(); ++i, ++j) {
 
-        DLOG(g_log<<Logger::Error<<"backend: "<<i-backends.begin()<<", qname: "<<shorter<<endl);
+        DLOG(g_log << Logger::Error << "backend: " << i - backends.begin() << ", qname: " << shorter << endl);
 
-        if(j->first < shorter.wirelength()) {
-          DLOG(g_log<<Logger::Error<<"skipped, we already found a shorter best match in this backend: "<<j->second.qname<<endl);
+        if (j->first < shorter.wirelength()) {
+          DLOG(g_log << Logger::Error << "skipped, we already found a shorter best match in this backend: " << j->second.qname << endl);
           continue;
-        } else if(j->first == shorter.wirelength()) {
-          DLOG(g_log<<Logger::Error<<"use shorter best match: "<<j->second.qname<<endl);
+        }
+        else if (j->first == shorter.wirelength()) {
+          DLOG(g_log << Logger::Error << "use shorter best match: " << j->second.qname << endl);
           *sd = j->second;
           break;
-        } else {
-          DLOG(g_log<<Logger::Error<<"lookup: "<<shorter<<endl);
-          if((*i)->getAuth(shorter, sd)) {
-            DLOG(g_log<<Logger::Error<<"got: "<<sd->qname<<endl);
-            if(!sd->qname.empty() && !shorter.isPartOf(sd->qname)) {
-              throw PDNSException("getAuth() returned an SOA for the wrong zone. Zone '"+sd->qname.toLogString()+"' is not part of '"+shorter.toLogString()+"'");
+        }
+        else {
+          DLOG(g_log << Logger::Error << "lookup: " << shorter << endl);
+          if ((*i)->getAuth(shorter, sd)) {
+            DLOG(g_log << Logger::Error << "got: " << sd->qname << endl);
+            if (!sd->qname.empty() && !shorter.isPartOf(sd->qname)) {
+              throw PDNSException("getAuth() returned an SOA for the wrong zone. Zone '" + sd->qname.toLogString() + "' is not part of '" + shorter.toLogString() + "'");
             }
             j->first = sd->qname.wirelength();
             j->second = *sd;
-            if(sd->qname == shorter) {
+            if (sd->qname == shorter) {
               break;
             }
-          } else {
-            DLOG(g_log<<Logger::Error<<"no match for: "<<shorter<<endl);
+          }
+          else {
+            DLOG(g_log << Logger::Error << "no match for: " << shorter << endl);
           }
         }
       }
 
       // Add to cache
-      if(i == backends.end()) {
-        if(d_negcache_ttl) {
-          DLOG(g_log<<Logger::Error<<"add neg cache entry:"<<shorter<<endl);
-          d_question.qname=shorter;
+      if (i == backends.end()) {
+        if (d_negcache_ttl) {
+          DLOG(g_log << Logger::Error << "add neg cache entry:" << shorter << endl);
+          d_question.qname = shorter;
           addNegCache(d_question);
         }
         continue;
-      } else if(d_cache_ttl) {
-        DLOG(g_log<<Logger::Error<<"add pos cache entry: "<<sd->qname<<endl);
+      }
+      else if (d_cache_ttl) {
+        DLOG(g_log << Logger::Error << "add pos cache entry: " << sd->qname << endl);
         d_question.qtype = QType::SOA;
         d_question.qname = sd->qname;
         d_question.zoneId = zoneId;
@@ -452,31 +450,32 @@ bool UeberBackend::getAuth(const DNSName &target, const QType& qtype, SOAData* s
       }
     }
 
-found:
-    if(found == (qtype == QType::DS) || target != shorter) {
-      DLOG(g_log<<Logger::Error<<"found: "<<sd->qname<<endl);
+  found:
+    if (found == (qtype == QType::DS) || target != shorter) {
+      DLOG(g_log << Logger::Error << "found: " << sd->qname << endl);
       return true;
-    } else {
-      DLOG(g_log<<Logger::Error<<"chasing next: "<<sd->qname<<endl);
+    }
+    else {
+      DLOG(g_log << Logger::Error << "chasing next: " << sd->qname << endl);
       found = true;
     }
 
-  } while(shorter.chopOff());
+  } while (shorter.chopOff());
   return found;
 }
 
-bool UeberBackend::getSOAUncached(const DNSName &domain, SOAData &sd)
+bool UeberBackend::getSOAUncached(const DNSName& domain, SOAData& sd)
 {
-  d_question.qtype=QType::SOA;
-  d_question.qname=domain;
-  d_question.zoneId=-1;
+  d_question.qtype = QType::SOA;
+  d_question.qname = domain;
+  d_question.zoneId = -1;
 
-  for(auto backend : backends)
-    if(backend->getSOA(domain, sd)) {
-      if(domain != sd.qname) {
-        throw PDNSException("getSOA() returned an SOA for the wrong zone. Question: '"+domain.toLogString()+"', answer: '"+sd.qname.toLogString()+"'");
+  for (auto backend : backends)
+    if (backend->getSOA(domain, sd)) {
+      if (domain != sd.qname) {
+        throw PDNSException("getSOA() returned an SOA for the wrong zone. Question: '" + domain.toLogString() + "', answer: '" + sd.qname.toLogString() + "'");
       }
-      if(d_cache_ttl) {
+      if (d_cache_ttl) {
         DNSZoneRecord rr;
         rr.dr.d_name = sd.qname;
         rr.dr.d_type = QType::SOA;
@@ -485,62 +484,61 @@ bool UeberBackend::getSOAUncached(const DNSName &domain, SOAData &sd)
         rr.domain_id = sd.domain_id;
 
         addCache(d_question, {rr});
-
       }
       return true;
     }
 
-  if(d_negcache_ttl)
+  if (d_negcache_ttl)
     addNegCache(d_question);
   return false;
 }
 
-bool UeberBackend::superMasterAdd(const AutoPrimary &primary)
+bool UeberBackend::superMasterAdd(const AutoPrimary& primary)
 {
-  for(auto backend : backends)
-    if(backend->superMasterAdd(primary))
+  for (auto backend : backends)
+    if (backend->superMasterAdd(primary))
       return true;
   return false;
 }
 
-bool UeberBackend::autoPrimaryRemove(const AutoPrimary &primary)
+bool UeberBackend::autoPrimaryRemove(const AutoPrimary& primary)
 {
-  for(auto backend : backends)
-    if(backend->autoPrimaryRemove(primary))
+  for (auto backend : backends)
+    if (backend->autoPrimaryRemove(primary))
       return true;
   return false;
 }
 
 bool UeberBackend::autoPrimariesList(std::vector<AutoPrimary>& primaries)
 {
-   for(auto backend : backends)
-     if(backend->autoPrimariesList(primaries))
-       return true;
-   return false;
-}
-
-bool UeberBackend::superMasterBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db)
-{
-  for(auto backend : backends)
-    if(backend->superMasterBackend(ip, domain, nsset, nameserver, account, db))
+  for (auto backend : backends)
+    if (backend->autoPrimariesList(primaries))
       return true;
   return false;
 }
 
-UeberBackend::UeberBackend(const string &pname)
+bool UeberBackend::superMasterBackend(const string& ip, const DNSName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** db)
+{
+  for (auto backend : backends)
+    if (backend->superMasterBackend(ip, domain, nsset, nameserver, account, db))
+      return true;
+  return false;
+}
+
+UeberBackend::UeberBackend(const string& pname)
 {
   {
     d_instances.lock()->push_back(this); // report to the static list of ourself
   }
 
-  d_negcached=false;
-  d_cached=false;
+  d_negcached = false;
+  d_cached = false;
   d_cache_ttl = ::arg().asNum("query-cache-ttl");
   d_negcache_ttl = ::arg().asNum("negquery-cache-ttl");
   d_qtype = 0;
   d_stale = false;
 
-  backends=BackendMakers().all(pname=="key-only");
+  backends = BackendMakers().all(pname == "key-only");
 }
 
 static void del(DNSBackend* d)
@@ -553,164 +551,163 @@ void UeberBackend::cleanup()
   {
     auto instances = d_instances.lock();
     remove(instances->begin(), instances->end(), this);
-    instances->resize(instances->size()-1);
+    instances->resize(instances->size() - 1);
   }
 
-  for_each(backends.begin(),backends.end(),del);
+  for_each(backends.begin(), backends.end(), del);
 }
 
 // returns -1 for miss, 0 for negative match, 1 for hit
-int UeberBackend::cacheHas(const Question &q, vector<DNSZoneRecord> &rrs)
+int UeberBackend::cacheHas(const Question& q, vector<DNSZoneRecord>& rrs)
 {
   extern AuthQueryCache QC;
 
-  if(!d_cache_ttl && ! d_negcache_ttl) {
+  if (!d_cache_ttl && !d_negcache_ttl) {
     return -1;
   }
 
   rrs.clear();
   //  g_log<<Logger::Warning<<"looking up: '"<<q.qname+"'|N|"+q.qtype.getName()+"|"+itoa(q.zoneId)<<endl;
 
-  bool ret=QC.getEntry(q.qname, q.qtype, rrs, q.zoneId);   // think about lowercasing here
-  if(!ret) {
+  bool ret = QC.getEntry(q.qname, q.qtype, rrs, q.zoneId); // think about lowercasing here
+  if (!ret) {
     return -1;
   }
-  if(rrs.empty()) // negatively cached
+  if (rrs.empty()) // negatively cached
     return 0;
-  
+
   return 1;
 }
 
-void UeberBackend::addNegCache(const Question &q)
+void UeberBackend::addNegCache(const Question& q)
 {
   extern AuthQueryCache QC;
-  if(!d_negcache_ttl)
+  if (!d_negcache_ttl)
     return;
   // we should also not be storing negative answers if a pipebackend does scopeMask, but we can't pass a negative scopeMask in an empty set!
   QC.insert(q.qname, q.qtype, vector<DNSZoneRecord>(), d_negcache_ttl, q.zoneId);
 }
 
-void UeberBackend::addCache(const Question &q, vector<DNSZoneRecord> &&rrs)
+void UeberBackend::addCache(const Question& q, vector<DNSZoneRecord>&& rrs)
 {
   extern AuthQueryCache QC;
 
-  if(!d_cache_ttl)
+  if (!d_cache_ttl)
     return;
 
-  for(const auto& rr : rrs) {
-   if (rr.scopeMask)
-     return;
+  for (const auto& rr : rrs) {
+    if (rr.scopeMask)
+      return;
   }
 
   QC.insert(q.qname, q.qtype, std::move(rrs), d_cache_ttl, q.zoneId);
 }
 
-void UeberBackend::alsoNotifies(const DNSName &domain, set<string> *ips)
+void UeberBackend::alsoNotifies(const DNSName& domain, set<string>* ips)
 {
-  for (auto & backend : backends)
-    backend->alsoNotifies(domain,ips);
+  for (auto& backend : backends)
+    backend->alsoNotifies(domain, ips);
 }
 
 UeberBackend::~UeberBackend()
 {
-  DLOG(g_log<<Logger::Error<<"UeberBackend destructor called, removing ourselves from instances, and deleting our backends"<<endl);
+  DLOG(g_log << Logger::Error << "UeberBackend destructor called, removing ourselves from instances, and deleting our backends" << endl);
   cleanup();
 }
 
 // this handle is more magic than most
-void UeberBackend::lookup(const QType &qtype,const DNSName &qname, int zoneId, DNSPacket *pkt_p)
+void UeberBackend::lookup(const QType& qtype, const DNSName& qname, int zoneId, DNSPacket* pkt_p)
 {
-  if(d_stale) {
-    g_log<<Logger::Error<<"Stale ueberbackend received question, signalling that we want to be recycled"<<endl;
+  if (d_stale) {
+    g_log << Logger::Error << "Stale ueberbackend received question, signalling that we want to be recycled" << endl;
     throw PDNSException("We are stale, please recycle");
   }
 
-  DLOG(g_log<<"UeberBackend received question for "<<qtype<<" of "<<qname<<endl);
+  DLOG(g_log << "UeberBackend received question for " << qtype << " of " << qname << endl);
   if (!d_go) {
-    g_log<<Logger::Error<<"UeberBackend is blocked, waiting for 'go'"<<endl;
+    g_log << Logger::Error << "UeberBackend is blocked, waiting for 'go'" << endl;
     std::unique_lock<std::mutex> l(d_mut);
-    d_cond.wait(l, []{ return d_go == true; });
-    g_log<<Logger::Error<<"Broadcast received, unblocked"<<endl;
+    d_cond.wait(l, [] { return d_go == true; });
+    g_log << Logger::Error << "Broadcast received, unblocked" << endl;
   }
 
-  d_qtype=qtype.getCode();
+  d_qtype = qtype.getCode();
 
-  d_handle.i=0;
-  d_handle.qtype=s_doANYLookupsOnly ? QType::ANY : qtype;
-  d_handle.qname=qname;
-  d_handle.zoneId=zoneId;
-  d_handle.pkt_p=pkt_p;
+  d_handle.i = 0;
+  d_handle.qtype = s_doANYLookupsOnly ? QType::ANY : qtype;
+  d_handle.qname = qname;
+  d_handle.zoneId = zoneId;
+  d_handle.pkt_p = pkt_p;
 
-  if(!backends.size()) {
-    g_log<<Logger::Error<<"No database backends available - unable to answer questions."<<endl;
-    d_stale=true; // please recycle us!
+  if (!backends.size()) {
+    g_log << Logger::Error << "No database backends available - unable to answer questions." << endl;
+    d_stale = true; // please recycle us!
     throw PDNSException("We are stale, please recycle");
   }
   else {
-    d_question.qtype=d_handle.qtype;
-    d_question.qname=qname;
-    d_question.zoneId=d_handle.zoneId;
+    d_question.qtype = d_handle.qtype;
+    d_question.qname = qname;
+    d_question.zoneId = d_handle.zoneId;
 
-    int cstat=cacheHas(d_question, d_answers);
-    if(cstat<0) { // nothing
+    int cstat = cacheHas(d_question, d_answers);
+    if (cstat < 0) { // nothing
       //      cout<<"UeberBackend::lookup("<<qname<<"|"<<DNSRecordContent::NumberToType(qtype.getCode())<<"): uncached"<<endl;
-      d_negcached=d_cached=false;
-      d_answers.clear(); 
-      (d_handle.d_hinterBackend=backends[d_handle.i++])->lookup(d_handle.qtype, d_handle.qname, d_handle.zoneId, d_handle.pkt_p);
+      d_negcached = d_cached = false;
+      d_answers.clear();
+      (d_handle.d_hinterBackend = backends[d_handle.i++])->lookup(d_handle.qtype, d_handle.qname, d_handle.zoneId, d_handle.pkt_p);
       ++(*s_backendQueries);
-    } 
-    else if(cstat==0) {
+    }
+    else if (cstat == 0) {
       //      cout<<"UeberBackend::lookup("<<qname<<"|"<<DNSRecordContent::NumberToType(qtype.getCode())<<"): NEGcached"<<endl;
-      d_negcached=true;
-      d_cached=false;
+      d_negcached = true;
+      d_cached = false;
       d_answers.clear();
     }
     else {
       // cout<<"UeberBackend::lookup("<<qname<<"|"<<DNSRecordContent::NumberToType(qtype.getCode())<<"): CACHED"<<endl;
-      d_negcached=false;
-      d_cached=true;
+      d_negcached = false;
+      d_cached = true;
       d_cachehandleiter = d_answers.begin();
     }
   }
 
-  d_handle.parent=this;
+  d_handle.parent = this;
 }
 
 void UeberBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled)
 {
-  for (auto & backend : backends)
-  {
+  for (auto& backend : backends) {
     backend->getAllDomains(domains, getSerial, include_disabled);
   }
 }
 
-bool UeberBackend::get(DNSZoneRecord &rr)
+bool UeberBackend::get(DNSZoneRecord& rr)
 {
   // cout<<"UeberBackend::get(DNSZoneRecord) called"<<endl;
-  if(d_negcached) {
-    return false; 
+  if (d_negcached) {
+    return false;
   }
 
-  if(d_cached) {
-    while(d_cachehandleiter != d_answers.end()) {
-      rr=*d_cachehandleiter++;;
-      if((d_qtype == QType::ANY || rr.dr.d_type == d_qtype)) {
+  if (d_cached) {
+    while (d_cachehandleiter != d_answers.end()) {
+      rr = *d_cachehandleiter++;
+      if ((d_qtype == QType::ANY || rr.dr.d_type == d_qtype)) {
         return true;
       }
     }
     return false;
   }
 
-  while(d_handle.get(rr)) {
-    rr.dr.d_place=DNSResourceRecord::ANSWER;
+  while (d_handle.get(rr)) {
+    rr.dr.d_place = DNSResourceRecord::ANSWER;
     d_answers.push_back(rr);
-    if((d_qtype == QType::ANY || rr.dr.d_type == d_qtype)) {
+    if ((d_qtype == QType::ANY || rr.dr.d_type == d_qtype)) {
       return true;
     }
   }
 
   // cout<<"end of ueberbackend get, seeing if we should cache"<<endl;
-  if(d_answers.empty()) {
+  if (d_answers.empty()) {
     // cout<<"adding negcache"<<endl;
     addNegCache(d_question);
   }
@@ -774,16 +771,18 @@ bool UeberBackend::deleteTSIGKey(const DNSName& name)
 bool UeberBackend::searchRecords(const string& pattern, int maxResults, vector<DNSResourceRecord>& result)
 {
   bool rc = false;
-  for ( vector< DNSBackend * >::iterator i = backends.begin(); result.size() < static_cast<vector<DNSResourceRecord>::size_type>(maxResults) && i != backends.end(); ++i )
-    if ((*i)->searchRecords(pattern, maxResults - result.size(), result)) rc = true;
+  for (vector<DNSBackend*>::iterator i = backends.begin(); result.size() < static_cast<vector<DNSResourceRecord>::size_type>(maxResults) && i != backends.end(); ++i)
+    if ((*i)->searchRecords(pattern, maxResults - result.size(), result))
+      rc = true;
   return rc;
 }
 
 bool UeberBackend::searchComments(const string& pattern, int maxResults, vector<Comment>& result)
 {
   bool rc = false;
-  for ( vector< DNSBackend * >::iterator i = backends.begin(); result.size() < static_cast<vector<Comment>::size_type>(maxResults) && i != backends.end(); ++i )
-    if ((*i)->searchComments(pattern, maxResults - result.size(), result)) rc = true;
+  for (vector<DNSBackend*>::iterator i = backends.begin(); result.size() < static_cast<vector<Comment>::size_type>(maxResults) && i != backends.end(); ++i)
+    if ((*i)->searchComments(pattern, maxResults - result.size(), result))
+      rc = true;
   return rc;
 }
 
@@ -793,10 +792,10 @@ UeberBackend::handle::handle()
 {
   //  g_log<<Logger::Warning<<"Handle instances: "<<instances<<endl;
   ++instances;
-  parent=nullptr;
-  d_hinterBackend=nullptr;
-  pkt_p=nullptr;
-  i=0;
+  parent = nullptr;
+  d_hinterBackend = nullptr;
+  pkt_p = nullptr;
+  i = 0;
   zoneId = -1;
 }
 
@@ -805,31 +804,31 @@ UeberBackend::handle::~handle()
   --instances;
 }
 
-bool UeberBackend::handle::get(DNSZoneRecord &r)
+bool UeberBackend::handle::get(DNSZoneRecord& r)
 {
-  DLOG(g_log << "Ueber get() was called for a "<<qtype<<" record" << endl);
-  bool isMore=false;
-  while(d_hinterBackend && !(isMore=d_hinterBackend->get(r))) { // this backend out of answers
-    if(i<parent->backends.size()) {
-      DLOG(g_log<<"Backend #"<<i<<" of "<<parent->backends.size()
-           <<" out of answers, taking next"<<endl);
-      
-      d_hinterBackend=parent->backends[i++];
-      d_hinterBackend->lookup(qtype,qname,zoneId,pkt_p);
+  DLOG(g_log << "Ueber get() was called for a " << qtype << " record" << endl);
+  bool isMore = false;
+  while (d_hinterBackend && !(isMore = d_hinterBackend->get(r))) { // this backend out of answers
+    if (i < parent->backends.size()) {
+      DLOG(g_log << "Backend #" << i << " of " << parent->backends.size()
+                 << " out of answers, taking next" << endl);
+
+      d_hinterBackend = parent->backends[i++];
+      d_hinterBackend->lookup(qtype, qname, zoneId, pkt_p);
       ++(*s_backendQueries);
     }
-    else 
+    else
       break;
 
-    DLOG(g_log<<"Now asking backend #"<<i<<endl);
+    DLOG(g_log << "Now asking backend #" << i << endl);
   }
 
-  if(!isMore && i==parent->backends.size()) {
-    DLOG(g_log<<"UeberBackend reached end of backends"<<endl);
+  if (!isMore && i == parent->backends.size()) {
+    DLOG(g_log << "UeberBackend reached end of backends" << endl);
     return false;
   }
 
-  DLOG(g_log<<"Found an answering backend - will not try another one"<<endl);
-  i=parent->backends.size(); // don't go on to the next backend
+  DLOG(g_log << "Found an answering backend - will not try another one" << endl);
+  i = parent->backends.size(); // don't go on to the next backend
   return true;
 }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -491,7 +491,7 @@ bool UeberBackend::getSOAUncached(const DNSName& domain, SOAData& sd)
   d_question.qname = domain;
   d_question.zoneId = -1;
 
-  for (auto backend : backends)
+  for (auto* backend : backends) {
     if (backend->getSOA(domain, sd)) {
       if (domain != sd.qname) {
         throw PDNSException("getSOA() returned an SOA for the wrong zone. Question: '" + domain.toLogString() + "', answer: '" + sd.qname.toLogString() + "'");
@@ -508,9 +508,11 @@ bool UeberBackend::getSOAUncached(const DNSName& domain, SOAData& sd)
       }
       return true;
     }
+  }
 
-  if (d_negcache_ttl)
+  if (d_negcache_ttl) {
     addNegCache(d_question);
+  }
   return false;
 }
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -150,48 +150,52 @@ bool UeberBackend::doesDNSSEC()
   return false;
 }
 
-bool UeberBackend::addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& id)
+bool UeberBackend::addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& keyID)
 {
-  id = -1;
-  for (DNSBackend* db : backends) {
-    if (db->addDomainKey(name, key, id))
+  keyID = -1;
+  for (DNSBackend* backend : backends) {
+    if (backend->addDomainKey(name, key, keyID)) {
       return true;
+    }
   }
   return false;
 }
 bool UeberBackend::getDomainKeys(const DNSName& name, std::vector<DNSBackend::KeyData>& keys)
 {
-  for (DNSBackend* db : backends) {
-    if (db->getDomainKeys(name, keys))
+  for (DNSBackend* backend : backends) {
+    if (backend->getDomainKeys(name, keys)) {
       return true;
+    }
   }
   return false;
 }
 
 bool UeberBackend::getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string>>& meta)
 {
-  for (DNSBackend* db : backends) {
-    if (db->getAllDomainMetadata(name, meta))
+  for (DNSBackend* backend : backends) {
+    if (backend->getAllDomainMetadata(name, meta)) {
       return true;
+    }
   }
   return false;
 }
 
 bool UeberBackend::getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta)
 {
-  for (DNSBackend* db : backends) {
-    if (db->getDomainMetadata(name, kind, meta))
+  for (DNSBackend* backend : backends) {
+    if (backend->getDomainMetadata(name, kind, meta)) {
       return true;
+    }
   }
   return false;
 }
 
 bool UeberBackend::getDomainMetadata(const DNSName& name, const std::string& kind, std::string& meta)
 {
-  bool ret;
   meta.clear();
   std::vector<string> tmp;
-  if ((ret = getDomainMetadata(name, kind, tmp)) && !tmp.empty()) {
+  const bool ret = getDomainMetadata(name, kind, tmp);
+  if (ret && !tmp.empty()) {
     meta = *tmp.begin();
   }
   return ret;
@@ -199,9 +203,10 @@ bool UeberBackend::getDomainMetadata(const DNSName& name, const std::string& kin
 
 bool UeberBackend::setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta)
 {
-  for (DNSBackend* db : backends) {
-    if (db->setDomainMetadata(name, kind, meta))
+  for (DNSBackend* backend : backends) {
+    if (backend->setDomainMetadata(name, kind, meta)) {
       return true;
+    }
   }
   return false;
 }
@@ -215,47 +220,52 @@ bool UeberBackend::setDomainMetadata(const DNSName& name, const std::string& kin
   return setDomainMetadata(name, kind, tmp);
 }
 
-bool UeberBackend::activateDomainKey(const DNSName& name, unsigned int id)
+bool UeberBackend::activateDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* db : backends) {
-    if (db->activateDomainKey(name, id))
+  for (DNSBackend* backend : backends) {
+    if (backend->activateDomainKey(name, keyID)) {
       return true;
+    }
   }
   return false;
 }
 
-bool UeberBackend::deactivateDomainKey(const DNSName& name, unsigned int id)
+bool UeberBackend::deactivateDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* db : backends) {
-    if (db->deactivateDomainKey(name, id))
+  for (DNSBackend* backend : backends) {
+    if (backend->deactivateDomainKey(name, keyID)) {
       return true;
+    }
   }
   return false;
 }
 
-bool UeberBackend::publishDomainKey(const DNSName& name, unsigned int id)
+bool UeberBackend::publishDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* db : backends) {
-    if (db->publishDomainKey(name, id))
+  for (DNSBackend* backend : backends) {
+    if (backend->publishDomainKey(name, keyID)) {
       return true;
+    }
   }
   return false;
 }
 
-bool UeberBackend::unpublishDomainKey(const DNSName& name, unsigned int id)
+bool UeberBackend::unpublishDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* db : backends) {
-    if (db->unpublishDomainKey(name, id))
+  for (DNSBackend* backend : backends) {
+    if (backend->unpublishDomainKey(name, keyID)) {
       return true;
+    }
   }
   return false;
 }
 
-bool UeberBackend::removeDomainKey(const DNSName& name, unsigned int id)
+bool UeberBackend::removeDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* db : backends) {
-    if (db->removeDomainKey(name, id))
+  for (DNSBackend* backend : backends) {
+    if (backend->removeDomainKey(name, keyID)) {
       return true;
+    }
   }
   return false;
 }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -556,14 +556,13 @@ bool UeberBackend::superMasterBackend(const string& ip, const DNSName& domain, c
   return false;
 }
 
-UeberBackend::UeberBackend(const string& pname)
+UeberBackend::UeberBackend(const string& pname) :
+  d_negcached(false), d_cached(false)
 {
   {
     d_instances.lock()->push_back(this); // report to the static list of ourself
   }
 
-  d_negcached = false;
-  d_cached = false;
   d_cache_ttl = ::arg().asNum("query-cache-ttl");
   d_negcache_ttl = ::arg().asNum("negquery-cache-ttl");
   d_qtype = 0;

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -38,6 +38,7 @@
 #include <iostream>
 #include <sstream>
 #include <functional>
+#include <string>
 
 #include "dns.hh"
 #include "arguments.hh"
@@ -76,19 +77,27 @@ bool UeberBackend::loadmodule(const string& name)
 bool UeberBackend::loadModules(const vector<string>& modules, const string& path)
 {
   for (const auto& module : modules) {
-    bool res;
+    bool res = false;
+
     if (module.find('.') == string::npos) {
-      res = UeberBackend::loadmodule(path + "/lib" + module + "backend.so");
+      auto fullPath = path;
+      fullPath += "/lib";
+      fullPath += module;
+      fullPath += "backend.so";
+      res = UeberBackend::loadmodule(fullPath);
     }
     else if (module[0] == '/' || (module[0] == '.' && module[1] == '/') || (module[0] == '.' && module[1] == '.')) {
       // absolute or current path
       res = UeberBackend::loadmodule(module);
     }
     else {
-      res = UeberBackend::loadmodule(path + "/" + module);
+      auto fullPath = path;
+      fullPath += "/";
+      fullPath += module;
+      res = UeberBackend::loadmodule(fullPath);
     }
 
-    if (res == false) {
+    if (!res) {
       return false;
     }
   }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -639,8 +639,9 @@ void UeberBackend::addCache(const Question& q, vector<DNSZoneRecord>&& rrs) cons
 
 void UeberBackend::alsoNotifies(const DNSName& domain, set<string>* ips)
 {
-  for (auto& backend : backends)
+  for (auto& backend : backends) {
     backend->alsoNotifies(domain, ips);
+  }
 }
 
 UeberBackend::~UeberBackend()
@@ -757,8 +758,8 @@ bool UeberBackend::get(DNSZoneRecord& rr)
 //
 bool UeberBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content)
 {
-  for (auto* b : backends) {
-    if (b->setTSIGKey(name, algorithm, content)) {
+  for (auto* backend : backends) {
+    if (backend->setTSIGKey(name, algorithm, content)) {
       return true;
     }
   }
@@ -770,8 +771,8 @@ bool UeberBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& c
   algorithm.clear();
   content.clear();
 
-  for (auto* b : backends) {
-    if (b->getTSIGKey(name, algorithm, content)) {
+  for (auto* backend : backends) {
+    if (backend->getTSIGKey(name, algorithm, content)) {
       break;
     }
   }
@@ -782,8 +783,8 @@ bool UeberBackend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
 {
   keys.clear();
 
-  for (auto* b : backends) {
-    if (b->getTSIGKeys(keys)) {
+  for (auto* backend : backends) {
+    if (backend->getTSIGKeys(keys)) {
       return true;
     }
   }
@@ -792,8 +793,8 @@ bool UeberBackend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
 
 bool UeberBackend::deleteTSIGKey(const DNSName& name)
 {
-  for (auto* b : backends) {
-    if (b->deleteTSIGKey(name)) {
+  for (auto* backend : backends) {
+    if (backend->deleteTSIGKey(name)) {
       return true;
     }
   }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -434,16 +434,14 @@ static std::vector<std::unique_ptr<DNSBackend>>::iterator findBestMatchingBacken
   return backend;
 }
 
-static bool foundTarget(const DNSName& target, const DNSName& shorter, const QType& qtype, SOAData* soaData, const bool found)
+static bool foundTarget(const DNSName& target, const DNSName& shorter, const QType& qtype, [[maybe_unused]] SOAData* soaData, const bool found)
 {
-  auto name = soaData->qname;
-
   if (found == (qtype == QType::DS) || target != shorter) {
-    DLOG(g_log << Logger::Error << "found: " << name << endl);
+    DLOG(g_log << Logger::Error << "found: " << soaData->qname << endl);
     return true;
   }
 
-  DLOG(g_log << Logger::Error << "chasing next: " << name << endl);
+  DLOG(g_log << Logger::Error << "chasing next: " << soaData->qname << endl);
   return false;
 }
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -19,6 +19,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#include <memory>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -121,7 +122,7 @@ void UeberBackend::go()
 
 bool UeberBackend::getDomainInfo(const DNSName& domain, DomainInfo& domainInfo, bool getSerial)
 {
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->getDomainInfo(domain, domainInfo, getSerial)) {
       return true;
     }
@@ -131,8 +132,8 @@ bool UeberBackend::getDomainInfo(const DNSName& domain, DomainInfo& domainInfo, 
 
 bool UeberBackend::createDomain(const DNSName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& masters, const string& account)
 {
-  for (DNSBackend* mydb : backends) {
-    if (mydb->createDomain(domain, kind, masters, account)) {
+  for (auto& backend : backends) {
+    if (backend->createDomain(domain, kind, masters, account)) {
       return true;
     }
   }
@@ -141,7 +142,7 @@ bool UeberBackend::createDomain(const DNSName& domain, const DomainInfo::DomainK
 
 bool UeberBackend::doesDNSSEC()
 {
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->doesDNSSEC()) {
       return true;
     }
@@ -152,7 +153,7 @@ bool UeberBackend::doesDNSSEC()
 bool UeberBackend::addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& keyID)
 {
   keyID = -1;
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->addDomainKey(name, key, keyID)) {
       return true;
     }
@@ -161,7 +162,7 @@ bool UeberBackend::addDomainKey(const DNSName& name, const DNSBackend::KeyData& 
 }
 bool UeberBackend::getDomainKeys(const DNSName& name, std::vector<DNSBackend::KeyData>& keys)
 {
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->getDomainKeys(name, keys)) {
       return true;
     }
@@ -171,7 +172,7 @@ bool UeberBackend::getDomainKeys(const DNSName& name, std::vector<DNSBackend::Ke
 
 bool UeberBackend::getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string>>& meta)
 {
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->getAllDomainMetadata(name, meta)) {
       return true;
     }
@@ -181,7 +182,7 @@ bool UeberBackend::getAllDomainMetadata(const DNSName& name, std::map<std::strin
 
 bool UeberBackend::getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta)
 {
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->getDomainMetadata(name, kind, meta)) {
       return true;
     }
@@ -202,7 +203,7 @@ bool UeberBackend::getDomainMetadata(const DNSName& name, const std::string& kin
 
 bool UeberBackend::setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta)
 {
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->setDomainMetadata(name, kind, meta)) {
       return true;
     }
@@ -221,7 +222,7 @@ bool UeberBackend::setDomainMetadata(const DNSName& name, const std::string& kin
 
 bool UeberBackend::activateDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->activateDomainKey(name, keyID)) {
       return true;
     }
@@ -231,7 +232,7 @@ bool UeberBackend::activateDomainKey(const DNSName& name, unsigned int keyID)
 
 bool UeberBackend::deactivateDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->deactivateDomainKey(name, keyID)) {
       return true;
     }
@@ -241,7 +242,7 @@ bool UeberBackend::deactivateDomainKey(const DNSName& name, unsigned int keyID)
 
 bool UeberBackend::publishDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->publishDomainKey(name, keyID)) {
       return true;
     }
@@ -251,7 +252,7 @@ bool UeberBackend::publishDomainKey(const DNSName& name, unsigned int keyID)
 
 bool UeberBackend::unpublishDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->unpublishDomainKey(name, keyID)) {
       return true;
     }
@@ -261,7 +262,7 @@ bool UeberBackend::unpublishDomainKey(const DNSName& name, unsigned int keyID)
 
 bool UeberBackend::removeDomainKey(const DNSName& name, unsigned int keyID)
 {
-  for (DNSBackend* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->removeDomainKey(name, keyID)) {
       return true;
     }
@@ -324,7 +325,7 @@ void UeberBackend::getUpdatedMasters(vector<DomainInfo>& domains, std::unordered
 
 bool UeberBackend::inTransaction()
 {
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->inTransaction()) {
       return true;
     }
@@ -363,7 +364,7 @@ bool UeberBackend::fillSOAFromZoneRecord(DNSName& shorter, const int zoneId, SOA
     return false;
   }
 
-  soaData->db = backends.size() == 1 ? *backends.begin() : nullptr;
+  soaData->db = backends.size() == 1 ? backends.begin()->get() : nullptr;
 
   // Leave database handle in a consistent state.
   while (get(zoneRecord)) {
@@ -381,7 +382,7 @@ UeberBackend::CacheResult UeberBackend::fillSOAFromCache(SOAData* soaData, DNSNa
     DLOG(g_log << Logger::Error << "has pos cache entry: " << shorter << endl);
     fillSOAData(d_answers[0], *soaData);
 
-    soaData->db = backends.size() == 1 ? *backends.begin() : nullptr;
+    soaData->db = backends.size() == 1 ? backends.begin()->get() : nullptr;
     soaData->qname = shorter;
   }
   else if (cacheResult == CacheResult::NegativeMatch && d_negcache_ttl != 0U) {
@@ -391,7 +392,7 @@ UeberBackend::CacheResult UeberBackend::fillSOAFromCache(SOAData* soaData, DNSNa
   return cacheResult;
 }
 
-static std::vector<DNSBackend*>::iterator findBestMatchingBackend(std::vector<DNSBackend*>& backends, std::vector<std::pair<std::size_t, SOAData>>& bestMatches, const DNSName& shorter, SOAData* soaData)
+static std::vector<std::unique_ptr<DNSBackend>>::iterator findBestMatchingBackend(std::vector<std::unique_ptr<DNSBackend>>& backends, std::vector<std::pair<std::size_t, SOAData>>& bestMatches, const DNSName& shorter, SOAData* soaData)
 {
   auto backend = backends.begin();
   for (auto bestMatch = bestMatches.begin(); backend != backends.end() && bestMatch != bestMatches.end(); ++backend, ++bestMatch) {
@@ -552,7 +553,7 @@ bool UeberBackend::getSOAUncached(const DNSName& domain, SOAData& soaData)
   d_question.qname = domain;
   d_question.zoneId = -1;
 
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->getSOA(domain, soaData)) {
       if (domain != soaData.qname) {
         throw PDNSException("getSOA() returned an SOA for the wrong zone. Question: '" + domain.toLogString() + "', answer: '" + soaData.qname.toLogString() + "'");
@@ -579,7 +580,7 @@ bool UeberBackend::getSOAUncached(const DNSName& domain, SOAData& soaData)
 
 bool UeberBackend::superMasterAdd(const AutoPrimary& primary)
 {
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->superMasterAdd(primary)) {
       return true;
     }
@@ -589,7 +590,7 @@ bool UeberBackend::superMasterAdd(const AutoPrimary& primary)
 
 bool UeberBackend::autoPrimaryRemove(const AutoPrimary& primary)
 {
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->autoPrimaryRemove(primary)) {
       return true;
     }
@@ -599,7 +600,7 @@ bool UeberBackend::autoPrimaryRemove(const AutoPrimary& primary)
 
 bool UeberBackend::autoPrimariesList(std::vector<AutoPrimary>& primaries)
 {
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->autoPrimariesList(primaries)) {
       return true;
     }
@@ -609,7 +610,7 @@ bool UeberBackend::autoPrimariesList(std::vector<AutoPrimary>& primaries)
 
 bool UeberBackend::superMasterBackend(const string& ip, const DNSName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** dnsBackend)
 {
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->superMasterBackend(ip, domain, nsset, nameserver, account, dnsBackend)) {
       return true;
     }
@@ -627,22 +628,6 @@ UeberBackend::UeberBackend(const string& pname)
   d_negcache_ttl = ::arg().asNum("negquery-cache-ttl");
 
   backends = BackendMakers().all(pname == "key-only");
-}
-
-static void del(DNSBackend* backend)
-{
-  delete backend;
-}
-
-void UeberBackend::cleanup()
-{
-  {
-    auto instances = d_instances.lock();
-    remove(instances->begin(), instances->end(), this);
-    instances->resize(instances->size() - 1);
-  }
-
-  for_each(backends.begin(), backends.end(), del);
 }
 
 // returns -1 for miss, 0 for negative match, 1 for hit
@@ -705,7 +690,14 @@ void UeberBackend::alsoNotifies(const DNSName& domain, set<string>* ips)
 UeberBackend::~UeberBackend()
 {
   DLOG(g_log << Logger::Error << "UeberBackend destructor called, removing ourselves from instances, and deleting our backends" << endl);
-  cleanup();
+
+  {
+    auto instances = d_instances.lock();
+    [[maybe_unused]] auto end = remove(instances->begin(), instances->end(), this);
+    instances->resize(instances->size() - 1);
+  }
+
+  backends.clear();
 }
 
 // this handle is more magic than most
@@ -747,7 +739,7 @@ void UeberBackend::lookup(const QType& qtype, const DNSName& qname, int zoneId, 
     //      cout<<"UeberBackend::lookup("<<qname<<"|"<<DNSRecordContent::NumberToType(qtype.getCode())<<"): uncached"<<endl;
     d_negcached = d_cached = false;
     d_answers.clear();
-    (d_handle.d_hinterBackend = backends[d_handle.i++])->lookup(d_handle.qtype, d_handle.qname, d_handle.zoneId, d_handle.pkt_p);
+    (d_handle.d_hinterBackend = backends[d_handle.i++].get())->lookup(d_handle.qtype, d_handle.qname, d_handle.zoneId, d_handle.pkt_p);
     ++(*s_backendQueries);
   }
   else if (cacheResult == CacheResult::NegativeMatch) {
@@ -815,7 +807,7 @@ bool UeberBackend::get(DNSZoneRecord& resourceRecord)
 //
 bool UeberBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content)
 {
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->setTSIGKey(name, algorithm, content)) {
       return true;
     }
@@ -828,7 +820,7 @@ bool UeberBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& c
   algorithm.clear();
   content.clear();
 
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->getTSIGKey(name, algorithm, content)) {
       break;
     }
@@ -840,7 +832,7 @@ bool UeberBackend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
 {
   keys.clear();
 
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->getTSIGKeys(keys)) {
       return true;
     }
@@ -850,7 +842,7 @@ bool UeberBackend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
 
 bool UeberBackend::deleteTSIGKey(const DNSName& name)
 {
-  for (auto* backend : backends) {
+  for (auto& backend : backends) {
     if (backend->deleteTSIGKey(name)) {
       return true;
     }
@@ -904,7 +896,7 @@ bool UeberBackend::handle::get(DNSZoneRecord& record)
       DLOG(g_log << "Backend #" << i << " of " << parent->backends.size()
                  << " out of answers, taking next" << endl);
 
-      d_hinterBackend = parent->backends[i++];
+      d_hinterBackend = parent->backends[i++].get();
       d_hinterBackend->lookup(qtype, qname, zoneId, pkt_p);
       ++(*s_backendQueries);
     }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -29,16 +29,14 @@
 #include "auth-zonecache.hh"
 #include "utility.hh"
 
-#include <dlfcn.h>
-#include <string>
-#include <map>
-#include <sys/types.h>
-#include <sstream>
 #include <cerrno>
-#include <iostream>
-#include <sstream>
+#include <dlfcn.h>
 #include <functional>
+#include <iostream>
+#include <map>
+#include <sstream>
 #include <string>
+#include <sys/types.h>
 
 #include "dns.hh"
 #include "arguments.hh"

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -142,9 +142,10 @@ bool UeberBackend::createDomain(const DNSName& domain, const DomainInfo::DomainK
 
 bool UeberBackend::doesDNSSEC()
 {
-  for (auto* db : backends) {
-    if (db->doesDNSSEC())
+  for (auto* backend : backends) {
+    if (backend->doesDNSSEC()) {
       return true;
+    }
   }
   return false;
 }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -120,11 +120,13 @@ void UeberBackend::go()
   d_cond.notify_all();
 }
 
-bool UeberBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial)
+bool UeberBackend::getDomainInfo(const DNSName& domain, DomainInfo& domainInfo, bool getSerial)
 {
-  for (auto backend : backends)
-    if (backend->getDomainInfo(domain, di, getSerial))
+  for (auto* backend : backends) {
+    if (backend->getDomainInfo(domain, domainInfo, getSerial)) {
       return true;
+    }
+  }
   return false;
 }
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -488,32 +488,32 @@ bool UeberBackend::getAuth(const DNSName& target, const QType& qtype, SOAData* s
   return found;
 }
 
-bool UeberBackend::getSOAUncached(const DNSName& domain, SOAData& sd)
+bool UeberBackend::getSOAUncached(const DNSName& domain, SOAData& soaData)
 {
   d_question.qtype = QType::SOA;
   d_question.qname = domain;
   d_question.zoneId = -1;
 
   for (auto* backend : backends) {
-    if (backend->getSOA(domain, sd)) {
-      if (domain != sd.qname) {
-        throw PDNSException("getSOA() returned an SOA for the wrong zone. Question: '" + domain.toLogString() + "', answer: '" + sd.qname.toLogString() + "'");
+    if (backend->getSOA(domain, soaData)) {
+      if (domain != soaData.qname) {
+        throw PDNSException("getSOA() returned an SOA for the wrong zone. Question: '" + domain.toLogString() + "', answer: '" + soaData.qname.toLogString() + "'");
       }
-      if (d_cache_ttl) {
-        DNSZoneRecord rr;
-        rr.dr.d_name = sd.qname;
-        rr.dr.d_type = QType::SOA;
-        rr.dr.setContent(makeSOAContent(sd));
-        rr.dr.d_ttl = sd.ttl;
-        rr.domain_id = sd.domain_id;
+      if (d_cache_ttl != 0U) {
+        DNSZoneRecord zoneRecord;
+        zoneRecord.dr.d_name = soaData.qname;
+        zoneRecord.dr.d_type = QType::SOA;
+        zoneRecord.dr.setContent(makeSOAContent(soaData));
+        zoneRecord.dr.d_ttl = soaData.ttl;
+        zoneRecord.domain_id = soaData.domain_id;
 
-        addCache(d_question, {rr});
+        addCache(d_question, {zoneRecord});
       }
       return true;
     }
   }
 
-  if (d_negcache_ttl) {
+  if (d_negcache_ttl != 0U) {
     addNegCache(d_question);
   }
   return false;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -65,9 +65,7 @@ public:
 
   /** This contains all registered backends. The DynListener modifies this list for us when
       new modules are loaded */
-  vector<DNSBackend*> backends;
-
-  void cleanup();
+  vector<std::unique_ptr<DNSBackend>> backends;
 
   //! the very magic handle for UeberBackend questions
   class handle

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -133,8 +133,8 @@ public:
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys);
   bool deleteTSIGKey(const DNSName& name);
 
-  bool searchRecords(const string& pattern, int maxResults, vector<DNSResourceRecord>& result);
-  bool searchComments(const string& pattern, int maxResults, vector<Comment>& result);
+  bool searchRecords(const string& pattern, vector<DNSResourceRecord>::size_type maxResults, vector<DNSResourceRecord>& result);
+  bool searchComments(const string& pattern, size_t maxResults, vector<Comment>& result);
 
   void updateZoneCache();
 

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -95,7 +95,7 @@ public:
     static AtomicCounter instances;
   };
 
-  void lookup(const QType&, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p = nullptr);
+  void lookup(const QType& qtype, const DNSName& qname, int zoneId, DNSPacket* pkt_p = nullptr);
 
   /** Determines if we are authoritative for a zone, and at what level */
   bool getAuth(const DNSName& target, const QType& qtype, SOAData* sd, bool cachedOk = true);
@@ -106,8 +106,8 @@ public:
 
   void getUnfreshSlaveInfos(vector<DomainInfo>* domains);
   void getUpdatedMasters(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes);
-  bool createDomain(const DNSName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& masters, const string& account);
   bool getDomainInfo(const DNSName& domain, DomainInfo& domainInfo, bool getSerial = true);
+  bool createDomain(const DNSName& domain, DomainInfo::DomainKind kind, const vector<ComboAddress>& masters, const string& account);
 
   bool doesDNSSEC();
   bool addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& id);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -165,7 +165,7 @@ private:
   bool d_stale;
   static bool s_doANYLookupsOnly;
 
-  int cacheHas(const Question& q, vector<DNSZoneRecord>& rrs);
-  void addNegCache(const Question& q);
-  void addCache(const Question& q, vector<DNSZoneRecord>&& rrs);
+  int cacheHas(const Question& q, vector<DNSZoneRecord>& rrs) const;
+  void addNegCache(const Question& q) const;
+  void addCache(const Question& q, vector<DNSZoneRecord>&& rrs) const;
 };

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -106,8 +106,8 @@ public:
 
   void getUnfreshSlaveInfos(vector<DomainInfo>* domains);
   void getUpdatedMasters(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes);
-  bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial = true);
   bool createDomain(const DNSName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& masters, const string& account);
+  bool getDomainInfo(const DNSName& domain, DomainInfo& domainInfo, bool getSerial = true);
 
   bool doesDNSSEC();
   bool addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& id);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -177,4 +177,5 @@ private:
   void addCache(const Question& q, vector<DNSZoneRecord>&& rrs) const;
 
   bool fillSOAFromZoneRecord(DNSName& shorter, int zoneId, SOAData* soaData);
+  CacheResult fillSOAFromCache(SOAData* soaData, DNSName& shorter);
 };

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -98,7 +98,7 @@ public:
   void lookup(const QType& qtype, const DNSName& qname, int zoneId, DNSPacket* pkt_p = nullptr);
 
   /** Determines if we are authoritative for a zone, and at what level */
-  bool getAuth(const DNSName& target, const QType& qtype, SOAData* sd, bool cachedOk = true);
+  bool getAuth(const DNSName& target, const QType& qtype, SOAData* soaData, bool cachedOk = true);
   /** Load SOA info from backends, ignoring the cache.*/
   bool getSOAUncached(const DNSName& domain, SOAData& soaData);
   bool get(DNSZoneRecord& r);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -165,7 +165,14 @@ private:
   bool d_stale;
   static bool s_doANYLookupsOnly;
 
-  int cacheHas(const Question& q, vector<DNSZoneRecord>& rrs) const;
+  enum CacheResult
+  {
+    Miss = -1,
+    NegativeMatch = 0,
+    Hit = 1,
+  };
+
+  CacheResult cacheHas(const Question& question, vector<DNSZoneRecord>& resourceRecords) const;
   void addNegCache(const Question& q) const;
   void addCache(const Question& q, vector<DNSZoneRecord>&& rrs) const;
 

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -168,4 +168,6 @@ private:
   int cacheHas(const Question& q, vector<DNSZoneRecord>& rrs) const;
   void addNegCache(const Question& q) const;
   void addCache(const Question& q, vector<DNSZoneRecord>&& rrs) const;
+
+  bool fillSOAFromZoneRecord(DNSName& shorter, int zoneId, SOAData* soaData);
 };

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -100,7 +100,7 @@ public:
   /** Determines if we are authoritative for a zone, and at what level */
   bool getAuth(const DNSName& target, const QType& qtype, SOAData* sd, bool cachedOk = true);
   /** Load SOA info from backends, ignoring the cache.*/
-  bool getSOAUncached(const DNSName& domain, SOAData& sd);
+  bool getSOAUncached(const DNSName& domain, SOAData& soaData);
   bool get(DNSZoneRecord& r);
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled);
 

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -36,7 +36,7 @@
 
 /** This is a very magic backend that allows us to load modules dynamically,
     and query them in order. This is persistent over all UeberBackend instantiations
-    across multiple threads. 
+    across multiple threads.
 
     The UeberBackend is transparent for exceptions, which should fall straight through.
 */
@@ -44,28 +44,28 @@
 class UeberBackend : public boost::noncopyable
 {
 public:
-  UeberBackend(const string &pname="default");
+  UeberBackend(const string& pname = "default");
   ~UeberBackend();
 
-  bool superMasterBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db);
+  bool superMasterBackend(const string& ip, const DNSName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** db);
 
-  bool superMasterAdd(const AutoPrimary &primary);
+  bool superMasterAdd(const AutoPrimary& primary);
   bool autoPrimaryRemove(const struct AutoPrimary& primary);
   bool autoPrimariesList(std::vector<AutoPrimary>& primaries);
 
   /** Tracks all created UeberBackend instances for us. We use this vector to notify
-      existing threads of new modules 
+      existing threads of new modules
   */
-  static LockGuarded<vector<UeberBackend *>> d_instances;
+  static LockGuarded<vector<UeberBackend*>> d_instances;
 
-  static bool loadmodule(const string &name);
+  static bool loadmodule(const string& name);
   static bool loadModules(const vector<string>& modules, const string& path);
 
   static void go(void);
 
   /** This contains all registered backends. The DynListener modifies this list for us when
       new modules are loaded */
-  vector<DNSBackend*> backends; 
+  vector<DNSBackend*> backends;
 
   void cleanup();
 
@@ -73,14 +73,14 @@ public:
   class handle
   {
   public:
-    bool get(DNSZoneRecord &dr);
+    bool get(DNSZoneRecord& dr);
     handle();
     ~handle();
 
     //! The UeberBackend class where this handle belongs to
-    UeberBackend *parent;
+    UeberBackend* parent;
     //! The current real backend, which is answering questions
-    DNSBackend *d_hinterBackend;
+    DNSBackend* d_hinterBackend;
 
     //! DNSPacket who asked this question
     DNSPacket* pkt_p;
@@ -92,28 +92,27 @@ public:
     int zoneId;
 
   private:
-
     static AtomicCounter instances;
   };
 
-  void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *pkt_p=nullptr);
+  void lookup(const QType&, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p = nullptr);
 
   /** Determines if we are authoritative for a zone, and at what level */
-  bool getAuth(const DNSName &target, const QType &qtype, SOAData* sd, bool cachedOk=true);
+  bool getAuth(const DNSName& target, const QType& qtype, SOAData* sd, bool cachedOk = true);
   /** Load SOA info from backends, ignoring the cache.*/
-  bool getSOAUncached(const DNSName &domain, SOAData &sd);
-  bool get(DNSZoneRecord &r);
+  bool getSOAUncached(const DNSName& domain, SOAData& sd);
+  bool get(DNSZoneRecord& r);
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled);
 
   void getUnfreshSlaveInfos(vector<DomainInfo>* domains);
   void getUpdatedMasters(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes);
-  bool getDomainInfo(const DNSName &domain, DomainInfo &di, bool getSerial=true);
-  bool createDomain(const DNSName &domain, const DomainInfo::DomainKind kind, const vector<ComboAddress> &masters, const string &account);
-  
+  bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial = true);
+  bool createDomain(const DNSName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& masters, const string& account);
+
   bool doesDNSSEC();
   bool addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& id);
   bool getDomainKeys(const DNSName& name, std::vector<DNSBackend::KeyData>& keys);
-  bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string> >& meta);
+  bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string>>& meta);
   bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta);
   bool getDomainMetadata(const DNSName& name, const std::string& kind, std::string& meta);
   bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta);
@@ -125,8 +124,8 @@ public:
   bool publishDomainKey(const DNSName& name, unsigned int id);
   bool unpublishDomainKey(const DNSName& name, unsigned int id);
 
-  void alsoNotifies(const DNSName &domain, set<string> *ips); 
-  void rediscover(string* status=0);
+  void alsoNotifies(const DNSName& domain, set<string>* ips);
+  void rediscover(string* status = 0);
   void reload();
 
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content);
@@ -134,8 +133,8 @@ public:
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys);
   bool deleteTSIGKey(const DNSName& name);
 
-  bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result);
-  bool searchComments(const string &pattern, int maxResults, vector<Comment>& result);
+  bool searchRecords(const string& pattern, int maxResults, vector<DNSResourceRecord>& result);
+  bool searchComments(const string& pattern, int maxResults, vector<Comment>& result);
 
   void updateZoneCache();
 
@@ -154,7 +153,7 @@ private:
     DNSName qname;
     int zoneId;
     QType qtype;
-  }d_question;
+  } d_question;
 
   unsigned int d_cache_ttl, d_negcache_ttl;
   uint16_t d_qtype;
@@ -166,7 +165,7 @@ private:
   bool d_stale;
   static bool s_doANYLookupsOnly;
 
-  int cacheHas(const Question &q, vector<DNSZoneRecord> &rrs);
-  void addNegCache(const Question &q);
-  void addCache(const Question &q, vector<DNSZoneRecord>&& rrs);
+  int cacheHas(const Question& q, vector<DNSZoneRecord>& rrs);
+  void addNegCache(const Question& q);
+  void addCache(const Question& q, vector<DNSZoneRecord>&& rrs);
 };

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2384,8 +2384,8 @@ static void apiServerSearchData(HttpRequest* req, HttpResponse* resp) {
   string sMax = req->getvars["max"];
   string sObjectType = req->getvars["object_type"];
 
-  int maxEnts = 100;
-  int ents = 0;
+  size_t maxEnts = 100;
+  size_t ents = 0;
 
   // the following types of data can be searched for using the api
   enum class ObjectType


### PR DESCRIPTION
### Short description
While I was fixing an issue with meson on MacOS related to the loading of backend shared modules when they are dynamically loaded, I formatted and cleaned up `ueberbackend.cc` a bit.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)