### PR TITLE
dnsdist: Fix unit tests for incoming DoH w/ nghttp2

### DIFF
--- a/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
@@ -500,6 +500,10 @@ BOOST_FIXTURE_TEST_CASE(test_IncomingConnection_SelfAnswered, TestFixture)
   pwR.xfr32BitInt(0x01020304);
   pwR.commit();
 
+  /* we _NEED_ to set this function to empty otherwise we might get what was set
+     by the last test, and we might not like it at all */
+  s_processQuery = nullptr;
+
   {
     /* dnsdist drops the query right away after receiving it, client closes the connection */
     s_connectionContexts[counter++] = ExpectedData{{}, {query}, {response}, {403U}};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
These tests were failing on EL with LTO enabled, and passing everywhere else. It turns out that we did not properly reset the `s_processQuery` hack that we used in these tests to simulate the policy decision (rules and actions), and thus inherited what the last test set it to instead of the default (dropping queries), which was very unexpected.
This is a draft for now, as I only tested it on a development VM. I'll trigger the "Test package building for specific distributions" workflow in a few minutes to make sure that it indeed fixes it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
