### PR TITLE
docu typo fix: latency-doh-avg 100k -> 1M

### DIFF
--- a/pdns/dnsdistdist/docs/statistics.rst
+++ b/pdns/dnsdistdist/docs/statistics.rst
@@ -141,9 +141,9 @@ latency-doh-avg10000
 --------------------
 Average response latency, in microseconds, of the last 10000 packets received over DoH.
 
-latency-doh-avg100000
+latency-doh-avg1000000
 ---------------------
-Average response latency, in microseconds, of the last 100000 packets received over DoH.
+Average response latency, in microseconds, of the last 1000000 packets received over DoH.
 
 latency-dot-avg100
 ------------------


### PR DESCRIPTION
### Short description

This fixes a typo in the documentation of 
https://dnsdist.org/statistics.html#latency-doh-avg100000

there is no prometheus metric for latency-doh-avg100k,
but latency-doh-avg1M exists.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
