### PR TITLE
Introduce randomness in test order to catch hidden dependencies between unit-tests

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1514,7 +1514,7 @@ noinst_PROGRAMS = speedtest
 if UNIT_TESTS
 noinst_PROGRAMS += testrunner
 if HAVE_BOOST_GE_148
-TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message SRCDIR='$(srcdir)'
+TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message BOOST_TEST_RANDOM=1 SRCDIR='$(srcdir)'
 TESTS=testrunner
 else
 check-local:

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -119,7 +119,7 @@ bin_PROGRAMS = dnsdist
 
 if UNIT_TESTS
 noinst_PROGRAMS = testrunner
-TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message SRCDIR='$(srcdir)'
+TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message BOOST_TEST_RANDOM=1 SRCDIR='$(srcdir)'
 TESTS=testrunner
 else
 check-local:

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -91,7 +91,7 @@ TESTS=test_libcrypto
 
 if UNIT_TESTS
 noinst_PROGRAMS = testrunner
-TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message SRCDIR='$(srcdir)'
+TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message BOOST_TEST_RANDOM=1 SRCDIR='$(srcdir)'
 TESTS += testrunner
 else
 check-local:

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -1121,7 +1121,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_replace)
 
   auto diff2 = time.udiff(true);
   // Check that replace is about equally fast as insert
-  BOOST_CHECK(diff1 < diff2 * 1.2 && diff2 < diff1 * 1.2);
+  BOOST_CHECK(diff1 < diff2 * 1.3 && diff2 < diff1 * 1.3);
 }
 
 BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wiping)

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -1121,7 +1121,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_replace)
 
   auto diff2 = time.udiff(true);
   // Check that replace is about equally fast as insert
-  BOOST_CHECK(diff1 < diff2 * 1.3 && diff2 < diff1 * 1.3);
+  BOOST_CHECK(diff1 < diff2 * 2 && diff2 < diff1 * 2);
 }
 
 BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wiping)


### PR DESCRIPTION
Also be a bit more lenient in a recently introduced test that checks timing of some aggressive cache manipulations.

The random seed is written to the test log file, so it is possible to reproduce the order of a particular failed run.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
