### PR TITLE
auth: add default-catalog-zone setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -366,6 +366,18 @@ The value of :ref:`metadata-api-rectify` if it is not set on the zone.
 .. note::
   Pre 4.2.0 the default was always no.
 
+.. _setting-default-catalog-zone:
+
+``default-catalog-zone``
+------------------------
+
+- String:
+- Default: empty
+
+.. versionadded:: 4.8.3
+
+When a primary zone is created via the API, and the request does not specify a catalog zone, the name given here will be used.
+
 .. _setting-default-ksk-algorithms:
 .. _setting-default-ksk-algorithm:
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -328,6 +328,8 @@ static void declareArguments()
   ::arg().setSwitch("consistent-backends", "Assume individual zones are not divided over backends. Send only ANY lookup operations to the backend to reduce the number of lookups") = "yes";
 
   ::arg().set("rng", "Specify the random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.") = "auto";
+
+  ::arg().set("default-catalog-zone", "Catalog zone to assign newly created primary zones (via the API) to") = "";
 #ifdef ENABLE_GSS_TSIG
   ::arg().setSwitch("enable-gss-tsig", "Enable GSS TSIG processing") = "no";
 #endif
@@ -1480,6 +1482,17 @@ int main(int argc, char** argv)
   }
   catch (const PDNSException& PE) {
     g_log << Logger::Error << "Exiting because: " << PE.reason << endl;
+    exit(1);
+  }
+
+  try {
+    auto defaultCatalog = ::arg()["default-catalog-zone"];
+    if (!defaultCatalog.empty()) {
+      auto defCatalog = DNSName(defaultCatalog);
+    }
+  }
+  catch (const std::exception& e) {
+    g_log << Logger::Error << "Invalid value '" << ::arg()["default-catalog-zone"] << "' for default-catalog-zone: " << e.what() << endl;
     exit(1);
   }
   S.blacklist("special-memory-usage");

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1872,6 +1872,13 @@ static void apiServerZonesPost(HttpRequest* req, HttpResponse* resp) {
 
   updateDomainSettingsFromDocument(B, di, zonename, document, !new_records.empty());
 
+  if (!catalog && kind == DomainInfo::Master) {
+    auto defaultCatalog = ::arg()["default-catalog-zone"];
+    if (!defaultCatalog.empty()) {
+      di.backend->setCatalog(zonename, DNSName(defaultCatalog));
+    }
+  }
+
   di.backend->commitTransaction();
 
   g_zoneCache.add(zonename, static_cast<int>(di.id)); // make new zone visible

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -75,6 +75,7 @@ default-soa-edit=INCEPTION-INCREMENT
 launch+=bind
 bind-config=bindbackend.conf
 loglevel=5
+default-catalog-zone=default-catalog.example.com
 """
 
 BINDBACKEND_CONF_TPL = """

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -239,12 +239,15 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
 
     def test_create_zone_with_account(self):
         # soa_edit_api wins over serial
-        name, payload, data = self.create_zone(account='anaccount', serial=10)
+        name, payload, data = self.create_zone(account='anaccount', serial=10, kind='Master')
         print(data)
         for k in ('account', ):
             self.assertIn(k, data)
             if k in payload:
                 self.assertEqual(data[k], payload[k])
+
+        # as we did not set a catalog in our request, check that the default catalog was applied
+        self.assertEqual(data['catalog'], "default-catalog.example.com.")
 
     def test_create_zone_default_soa_edit_api(self):
         name, payload, data = self.create_zone()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master