### PR TITLE
smysql: stop explicity setting MYSQL_OPT_RECONNECT to 0

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -489,11 +489,6 @@ void SMySQL::connect()
 
   do {
 
-#if MYSQL_VERSION_ID >= 50013
-    my_bool set_reconnect = 0;
-    mysql_options(&d_db, MYSQL_OPT_RECONNECT, &set_reconnect);
-#endif
-
 #if MYSQL_VERSION_ID >= 50100
     if (d_timeout) {
       mysql_options(&d_db, MYSQL_OPT_READ_TIMEOUT, &d_timeout);


### PR DESCRIPTION
### Short description

Setting this option, even to 0, causes spurious warnings to the console
with recent libmysqlclient versions. The upstream bug
( https://bugs.mysql.com/bug.php?id=112089, also https://bugs.launchpad.net/ubuntu/+source/mysql-8.0/+bug/2031548 )
has now been open for a month, so we're implementing a workaround.

0 was the default since at least MySQL 5.7, perhaps longer.

closes #13242

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master