### PR TITLE
rec: When an exception is thrown from an mthread register stack switch (in the ASAN case)

### DIFF
--- a/pdns/mtasker.cc
+++ b/pdns/mtasker.cc
@@ -380,7 +380,13 @@ template<class Key, class Val, class Cmp>bool MTasker<Key,Val,Cmp>::schedule(con
         ttdindex.erase(i++);                  // removes the waitpoint
 
         notifyStackSwitch(d_threads[d_tid].startOfStack, d_stacksize);
-        pdns_swapcontext(d_kernel, *uc); // swaps back to the above point 'A'
+        try {
+          pdns_swapcontext(d_kernel, *uc); // swaps back to the above point 'A'
+        }
+        catch (...) {
+          notifyStackSwitchDone();
+          throw;
+        }
         notifyStackSwitchDone();
       }
       else if(i->ttd.tv_sec)

--- a/pdns/mtasker.cc
+++ b/pdns/mtasker.cc
@@ -252,7 +252,13 @@ template<class EventKey, class EventVal, class Cmp>int MTasker<EventKey,EventVal
   auto userspace=std::move(waiter->context);
   d_waiters.erase(waiter);             // removes the waitpoint
   notifyStackSwitch(d_threads[d_tid].startOfStack, d_stacksize);
-  pdns_swapcontext(d_kernel,*userspace); // swaps back to the above point 'A'
+  try {
+    pdns_swapcontext(d_kernel,*userspace); // swaps back to the above point 'A'
+  }
+  catch (...) {
+    notifyStackSwitchDone();
+    throw;
+  }
   notifyStackSwitchDone();
   return 1;
 }

--- a/pdns/mtasker.cc
+++ b/pdns/mtasker.cc
@@ -325,7 +325,14 @@ template<class Key, class Val, class Cmp>bool MTasker<Key,Val,Cmp>::schedule(con
     d_threads[d_tid].dt.start();
 #endif
     notifyStackSwitch(d_threads[d_tid].startOfStack, d_stacksize);
-    pdns_swapcontext(d_kernel, *d_threads[d_tid].context);
+    try {
+      pdns_swapcontext(d_kernel, *d_threads[d_tid].context);
+    }
+    catch (...) {
+      notifyStackSwitchDone();
+      // It is not clear if the d_runQueue.pop() should be done in this case
+      throw;
+    }
     notifyStackSwitchDone();
 
     d_runQueue.pop();

--- a/pdns/recursordist/test-mtasker.cc
+++ b/pdns/recursordist/test-mtasker.cc
@@ -78,19 +78,6 @@ BOOST_AUTO_TEST_CASE(test_AlmostStackOverflow)
   BOOST_CHECK_EQUAL(g_result, o);
 }
 
-#if defined(HAVE_FIBER_SANITIZER) && defined(__APPLE__) && defined(__arm64__)
-
-// This test is buggy on MacOS when compiled with asan. It also causes subsequents tests to report spurious issues.
-// So switch it off for now
-// See https://github.com/PowerDNS/pdns/issues/12151
-
-BOOST_AUTO_TEST_CASE(test_MtaskerException)
-{
-  cerr << "test_MtaskerException test disabled on this platform with asan enabled, please fix" << endl;
-}
-
-#else
-
 static void willThrow(void* /* p */)
 {
   throw std::runtime_error("Help!");
@@ -110,7 +97,5 @@ BOOST_AUTO_TEST_CASE(test_MtaskerException)
   },
                     std::exception);
 }
-
-#endif // defined(HAVE_FIBER_SANITIZER) && defined(__APPLE__) && defined(__arm64__)
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-rec-zonetocache.cc
+++ b/pdns/recursordist/test-rec-zonetocache.cc
@@ -169,6 +169,8 @@ static void zonemdGenericTest(const std::string& lines, pdns::ZoneMD::Config mod
 
 BOOST_AUTO_TEST_CASE(test_zonetocachegeneric)
 {
+  g_log.setLoglevel(Logger::Critical);
+  g_log.toConsole(Logger::Critical);
   zonemdGenericTest(genericTest, pdns::ZoneMD::Config::Require, pdns::ZoneMD::Config::Ignore, 4U);
   zonemdGenericTest(genericBadTest, pdns::ZoneMD::Config::Require, pdns::ZoneMD::Config::Ignore, 0U);
 }


### PR DESCRIPTION
This allows the test to be reintroduced on macOS plus the mtasker tests now start to work with ASA and randomization on: after the exception test is run other mtasker test would fail before.

I *do* wonder if the `d_runQueue.pop();` call should be done in the "exception is thrown" case. But as it is skipped in the current state of affairs, I am not pulling it iside the `catch` block for now`.

Also silence logging in the zoneToCache tests, previously an earlier test wold take care of that.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
