### PR TITLE
rec: Add make -C rust clean when generate.py is run

### DIFF
--- a/pdns/recursordist/settings/Makefile.am
+++ b/pdns/recursordist/settings/Makefile.am
@@ -12,8 +12,12 @@ all: cxxsettings-generated.cc
 
 BUILT_SOURCES=cxxsettings-generated.cc
 
-# It's a bit dirty that this target also generated a file inside rust/src (lib.rs)
+# It's a bit dirty that this target also generates a file inside rust/src (lib.rs). Also, we need to
+# clean in the Rust dir, as in some cases the Serde/CXX derive/generate code does not get re-run by
+# cargo after rust/src/lib.rs changed because of a generate.py run. In that case we end up with an
+# rust/src/lib.rs.h that does not contain e.g. field name or field type changes.
 cxxsettings-generated.cc: table.py generate.py rust-preamble-in.rs rust-bridge-in.rs docs-old-preamble-in.rst docs-new-preamble-in.rst
+	$(MAKE) -C rust clean
 	$(PYTHON) generate.py
 
 clean-local:


### PR DESCRIPTION
See comment for motivation. While working on the settings project, I had this line, but I thouhgt it was no longer needed so I removed it. It turns out it *is* needed. Found out when adding the recursor.tcp_threads field.

To reproduce the issue this PR fixes: rename a field in `table.py` and run make in `recursordist`. You'll see that `settings/rust/src/lib.rs.h` will not contain the name change.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
