### PR TITLE
dnsdist: Prevent spurious failures of the async unit tests

### DIFF
--- a/pdns/dnsdistdist/test-dnsdistasync.cc
+++ b/pdns/dnsdistdist/test-dnsdistasync.cc
@@ -112,23 +112,28 @@ BOOST_AUTO_TEST_CASE(test_TimeoutFailClose)
   auto holder = std::make_unique<dnsdist::AsynchronousHolder>(false);
   uint16_t asyncID = 1;
   uint16_t queryID = 42;
-  struct timeval ttd;
-  gettimeofday(&ttd, nullptr);
-  // timeout in 10 ms
-  const timeval add{0, 10000};
-  ttd = ttd + add;
+  struct timeval ttd{
+  };
 
   std::shared_ptr<DummyQuerySender> sender{nullptr};
   {
+    // timeout in 10 ms
+    const timeval add{0, 10000};
     auto query = std::make_unique<DummyCrossProtocolQuery>();
     sender = query->d_sender;
     BOOST_REQUIRE(sender != nullptr);
+    gettimeofday(&ttd, nullptr);
+    ttd = ttd + add;
     holder->push(asyncID, queryID, ttd, std::move(query));
     BOOST_CHECK(!holder->empty());
   }
 
-  // sleep for 20 ms, to be sure
-  usleep(20000);
+  // the event should be triggered after 10 ms, but we have seen
+  // many spurious failures on our CI, likely because the box is
+  // overloaded, so sleep for up to 100 ms to be sure
+  for (size_t counter = 0; !holder->empty() && counter < 10; counter++) {
+    usleep(10000);
+  }
 
   BOOST_CHECK(holder->empty());
   BOOST_CHECK(sender->errorRaised);
@@ -155,8 +160,13 @@ BOOST_AUTO_TEST_CASE(test_AddingExpiredEvent)
     holder->push(asyncID, queryID, ttd, std::move(query));
   }
 
-  // sleep for 20 ms
-  usleep(20000);
+  // the expired event should be triggered almost immediately,
+  // but we have seen many spurious failures on our CI,
+  // likely because the box is overloaded, so sleep for up to
+  // 100 ms to be sure
+  for (size_t counter = 0; !holder->empty() && counter < 10; counter++) {
+    usleep(10000);
+  }
 
   BOOST_CHECK(holder->empty());
   BOOST_CHECK(sender->errorRaised);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The events should be triggered either almost immediately or after 10 ms, but we have seen many spurious failures on our CI, likely because the box is overloaded, so sleep for up to 100 ms to be sure. I managed to reproduce the issue locally by running this command in parallel of the tests, for reference: `stress --cpu <number of HT cores>`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
