### PR TITLE
Pass the requested qtype to lookup method

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1574,7 +1574,7 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
 #endif
 
     // see what we get..
-    B.lookup(QType(QType::ANY), target, d_sd.domain_id, &p);
+    B.lookup(p.qtype, target, d_sd.domain_id, &p);
     rrset.clear();
     haveAlias.clear();
     aliasScopeMask = 0;


### PR DESCRIPTION
Closes #13140

### Short description
I'm using PowerDNS with remote HTTP backend and PowerDNS is always using ANY qtype on lookups regardless of consistent-backend property.
So I've changed this behaviour to pass initial QType to Lookup method.

### Checklist
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
