### PR TITLE
auth-4.7.x: switch from `docker-compose` to `docker compose` and stop installing docker-compose because that uninstalls runc

### DIFF
--- a/regression-tests.auth-py/runtests
+++ b/regression-tests.auth-py/runtests
@@ -34,13 +34,13 @@ fi
 ignore="-I test_GSSTSIG.py"
 if [ "${WITHKERBEROS}" = "YES" ]; then
     ignore=""
-    (cd kerberos-server && docker-compose up --detach --build)
+    (cd kerberos-server && docker compose up --detach --build)
 fi
 
 nosetests --with-xunit $ignore $@
 ret=$?
 
 if [ "${WITHKERBEROS}" = "YES" ]; then
-    (cd kerberos-server && docker-compose stop || exit 0)
+    (cd kerberos-server && docker compose stop || exit 0)
 fi
 exit $ret

--- a/tasks.py
+++ b/tasks.py
@@ -85,7 +85,6 @@ auth_test_deps = [   # FIXME: we should be generating some of these from shlibde
     'curl',
     'default-jre-headless',
     'dnsutils',
-    'docker-compose',
     'faketime',
     'gawk',
     'krb5-user',


### PR DESCRIPTION
### Short description
partial backport of #13194

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master