### PR TITLE
dnsdist: Enable back h2o support in our packages

### DIFF
--- a/builder-support/debian/dnsdist/debian-buster/rules
+++ b/builder-support/debian/dnsdist/debian-buster/rules
@@ -53,6 +53,7 @@ override_dh_auto_configure:
 	  --enable-dnscrypt \
 	  --enable-dnstap \
 	  --with-gnutls \
+	  --with-h2o \
 	  --with-net-snmp \
 	  --with-libcap \
 	  --with-libsodium \

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -80,6 +80,7 @@ export RANLIB=gcc-ranlib
   --enable-unit-tests \
   --enable-lto=thin \
   --enable-dns-over-tls \
+  --with-h2o \
 %if 0%{?suse_version}
   --disable-dnscrypt \
   --without-libsodium \

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -5,7 +5,7 @@ Upgrade Guide
 --------------
 
 dnsdist now supports a new library for dealing with incoming DNS over HTTPS queries: ``nghttp2``. The previously used library, ``h2o``, can still be used
-but is now deprecated and will be removed in the future, as it is unfortunately no longer maintained in a way that is suitable for use as a library
+but is now deprecated, disabled by default (see ``--with-h2o`` to enable it back) and will be removed in the future, as it is unfortunately no longer maintained in a way that is suitable for use as a library
 (see https://github.com/h2o/h2o/issues/3230). See the ``library`` parameter on the :func:`addDOHLocal` directive for more information on how to select
 the library used when dnsdist is built with support for both ``h2o`` and ``nghttp2``. The default is now ``nghttp2`` whenever possible.
 Note that ``nghttp2`` only supports HTTP/2, and not HTTP/1, while ``h2o`` supported both. This is not an issue for actual DNS over HTTPS clients that


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
As we promised we would..
Also document that h2o is no longer built by default in the upgrade guide.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
