### PR TITLE
dnsdist: add lua binding to downstream address

### DIFF
--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -501,15 +501,8 @@ private:
     return dnsdist::queueQueryResumptionEvent(std::move(query));
   });
 
-  luaCtx.registerMember<const ComboAddress (DNSResponse::*)>("selectedBackend", 
-    []( const DNSResponse& dr) -> const ComboAddress { 
-      if (dr.d_downstream == nullptr) {
-        return ComboAddress();
-      } else {
-        return dr.d_downstream->d_config.remote;
-      }
-    }, 
-    [](DNSResponse& dr, const ComboAddress newSelectedBackend) { (void) newSelectedBackend; }
-  );
+  luaCtx.registerFunction<std::shared_ptr<DownstreamState>(DNSResponse::*)(void)const>("getSelectedBackend", [](const DNSResponse& dr) {
+    return dr.d_downstream;
+  });
 #endif /* DISABLE_NON_FFI_DQ_BINDINGS */
 }

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -500,5 +500,16 @@ private:
     auto query = dnsdist::getInternalQueryFromDQ(dr, false);
     return dnsdist::queueQueryResumptionEvent(std::move(query));
   });
+
+  luaCtx.registerMember<const ComboAddress (DNSResponse::*)>("selectedBackend", 
+    []( const DNSResponse& dr) -> const ComboAddress { 
+      if (dr.d_downstream == nullptr) {
+        return ComboAddress();
+      } else {
+        return dr.d_downstream->d_config.remote;
+      }
+    }, 
+    [](DNSResponse& dr, const ComboAddress newSelectedBackend) { (void) newSelectedBackend; }
+  );
 #endif /* DISABLE_NON_FFI_DQ_BINDINGS */
 }

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -403,7 +403,15 @@ DNSResponse object
   - ``useECS``
 
   If the value is really needed while the response is being processed, it is possible to set a tag while the query is processed, as tags will be passed to the response object.
-  It also has one additional method:
+  The DNSResponse object has one additional attribute:
+
+  .. attribute:: DNSResponse.selectedBackend
+
+    .. versionadded:: 1.9.0
+
+    :ref:`ComboAddress` of the selected backend.
+
+  It also has additional methods:
 
   .. method:: DNSResponse:editTTLs(func)
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -403,15 +403,13 @@ DNSResponse object
   - ``useECS``
 
   If the value is really needed while the response is being processed, it is possible to set a tag while the query is processed, as tags will be passed to the response object.
-  The DNSResponse object has one additional attribute:
+  It also has additional methods:
 
-  .. attribute:: DNSResponse.selectedBackend
+  .. method:: DNSResponse.getSelectedBackend() -> Server
 
     .. versionadded:: 1.9.0
 
-    :ref:`ComboAddress` of the selected backend.
-
-  It also has additional methods:
+    Get the selected backend :class:`Server` or nil
 
   .. method:: DNSResponse:editTTLs(func)
 


### PR DESCRIPTION
### Short description

First shot to add a "selectedBackend" LUA binding to get the `ComboAddress` of the selected backend from `DNSResponse::d_downstream`. This pull request will fix #13201.

Successful testing with the following config

```lua
function alterDnstapResponse(dr, tap)
        tap:setExtra(dr.selectedBackend:toString() )
end

rl = newFrameStreamTcpLogger("10.0.0.100:6000")
addResponseAction(AllRule(), DnstapLogResponseAction("dnsdist1", rl, alterDnstapResponse))
```

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
