### PR TITLE
rec: Fix sysconfdir handling in new settings code

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -367,8 +367,9 @@ Time to wait for data from TCP clients.
 
 - YAML setting: :ref:`setting-yaml-recursor.config_dir`
 
-Location of configuration directory (``recursor.conf``).
+Location of configuration directory (where ``recursor.conf`` or ``recursor.yml`` is stored).
 Usually ``/etc/powerdns``, but this depends on ``SYSCONFDIR`` during compile-time.
+Use default or set on command line.
 
 .. _setting-config-name:
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -363,7 +363,7 @@ Time to wait for data from TCP clients.
 ~~~~~~~~~~~~~~
 
 -  String
--  Default: /etc/powerdns
+-  Default: SYSCONFDIR
 
 - YAML setting: :ref:`setting-yaml-recursor.config_dir`
 

--- a/pdns/recursordist/docs/yamlsettings.rst
+++ b/pdns/recursordist/docs/yamlsettings.rst
@@ -2030,7 +2030,7 @@ Either do not ``chroot`` on these systems or set the 'Type' of this service to '
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 -  String
--  Default: ``/etc/powerdns``
+-  Default: ``SYSCONFDIR``
 
 - Old style setting: :ref:`setting-config-dir`
 

--- a/pdns/recursordist/docs/yamlsettings.rst
+++ b/pdns/recursordist/docs/yamlsettings.rst
@@ -2034,8 +2034,9 @@ Either do not ``chroot`` on these systems or set the 'Type' of this service to '
 
 - Old style setting: :ref:`setting-config-dir`
 
-Location of configuration directory (``recursor.conf``).
+Location of configuration directory (where ``recursor.conf`` or ``recursor.yml`` is stored).
 Usually ``/etc/powerdns``, but this depends on ``SYSCONFDIR`` during compile-time.
+Use default or set on command line.
 
 .. _setting-yaml-recursor.config_name:
 

--- a/pdns/recursordist/settings/generate.py
+++ b/pdns/recursordist/settings/generate.py
@@ -209,7 +209,8 @@ def gen_cxx_defineoldsettings(file, entries):
         elif entry['type'] == LType.Command:
             file.write(f"  ::arg().setCmd({oldname}, {helptxt});\n")
         else:
-            file.write(f"  ::arg().set({oldname}, {helptxt}) = {quote(entry['default'])};\n")
+            cxxdef = 'SYSCONFDIR' if entry['default'] == 'SYSCONFDIR' else quote(entry['default'])
+            file.write(f"  ::arg().set({oldname}, {helptxt}) = {cxxdef};\n")
     file.write('}\n\n')
 
 def gen_cxx_oldstylesettingstobridgestruct(file, entries):
@@ -402,7 +403,8 @@ def gen_rust_default_functions(entry, name, rust_type):
         return gen_rust_authzonevec_default_functions(name)
     ret = f'// DEFAULT HANDLING for {name}\n'
     ret += f'fn default_value_{name}() -> {rust_type} {{\n'
-    ret += f"    String::from({quote(entry['default'])})\n"
+    rustdef = 'env!("SYSCONFDIR")' if entry['default'] == 'SYSCONFDIR' else quote(entry['default'])
+    ret += f"    String::from({rustdef})\n"
     ret += '}\n'
     if rust_type == 'String':
         rust_type = 'str'

--- a/pdns/recursordist/settings/rust/Makefile.am
+++ b/pdns/recursordist/settings/rust/Makefile.am
@@ -11,7 +11,7 @@ EXTRA_DIST = \
 
 # should actually end up in a target specific dir...
 libsettings.a lib.rs.h: src/bridge.rs src/lib.rs src/helpers.rs Cargo.toml Cargo.lock build.rs
-	$(CARGO) build --release $(RUST_TARGET)
+	SYSCONFDIR=$(sysconfdir) $(CARGO) build --release $(RUST_TARGET)
 	cp target/$(RUSTC_TARGET_ARCH)/release/libsettings.a libsettings.a
 	cp target/$(RUSTC_TARGET_ARCH)/cxxbridge/settings/src/lib.rs.h lib.rs.h
 	cp target/$(RUSTC_TARGET_ARCH)/cxxbridge/rust/cxx.h cxx.h

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -379,7 +379,7 @@ EMPTY?  '''
         'name' : 'config_dir',
         'section' : 'recursor',
         'type' : LType.String,
-        'default' : '/etc/powerdns',
+        'default' : 'SYSCONFDIR',
         'help' : 'Location of configuration directory (recursor.conf)',
         'doc' : '''
 Location of configuration directory (``recursor.conf``).

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -380,10 +380,11 @@ EMPTY?  '''
         'section' : 'recursor',
         'type' : LType.String,
         'default' : 'SYSCONFDIR',
-        'help' : 'Location of configuration directory (recursor.conf)',
+        'help' : 'Location of configuration directory (recursor.conf or recursor.yml)',
         'doc' : '''
-Location of configuration directory (``recursor.conf``).
+Location of configuration directory (where ``recursor.conf`` or ``recursor.yml`` is stored).
 Usually ``/etc/powerdns``, but this depends on ``SYSCONFDIR`` during compile-time.
+Use default or set on command line.
  ''',
     },
     {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Partly from @RvdE, I've added the Rust side of things. It was not immediately obvious that part is needed, but there are cases where I think it is needed: running with a `config-dir` set to the default value on the command line should not produce a diff in YAML mode.

Fixes #13259

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
