### PR TITLE
rec: packetcache submit task fixes

### DIFF
--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -167,7 +167,7 @@ uint64_t pruneMutexCollectionsVector(C& container, std::vector<T>& maps, uint64_
         container.preRemoval(*shard, *i);
         i = sidx.erase(i);
         erased++;
-        --content.d_entriesCount;
+        content.decEntriesCount();
       }
       else {
         ++i;
@@ -226,7 +226,7 @@ uint64_t pruneMutexCollectionsVector(C& container, std::vector<T>& maps, uint64_
     for (auto i = sidx.begin(); i != sidx.end() && removed < toTrimForThisShard; removed++) {
       container.preRemoval(*shard, *i);
       i = sidx.erase(i);
-      --content.d_entriesCount;
+      content.decEntriesCount();
       ++totErased;
       if (--toTrim == 0) {
         return totErased;

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -39,7 +39,7 @@ size_t NegCache::size() const
 {
   size_t count = 0;
   for (const auto& map : d_maps) {
-    count += map.d_entriesCount;
+    count += map.getEntriesCount();
   }
   return count;
 }
@@ -161,7 +161,7 @@ void NegCache::add(const NegCacheEntry& ne)
   auto content = map.lock();
   inserted = lruReplacingInsert<SequenceTag>(content->d_map, ne);
   if (inserted) {
-    ++map.d_entriesCount;
+    map.incEntriesCount();
   }
 }
 
@@ -229,7 +229,7 @@ size_t NegCache::wipe(const DNSName& name, bool subtree)
           break;
         i = m->d_map.erase(i);
         ret++;
-        --map.d_entriesCount;
+        map.decEntriesCount();
       }
     }
     return ret;
@@ -242,7 +242,7 @@ size_t NegCache::wipe(const DNSName& name, bool subtree)
   while (i != range.second) {
     i = content->d_map.erase(i);
     ret++;
-    --map.d_entriesCount;
+    map.decEntriesCount();
   }
   return ret;
 }
@@ -258,7 +258,7 @@ size_t NegCache::wipeTyped(const DNSName& qname, QType qtype)
     if (i->d_qtype == QType::ENT || i->d_qtype == qtype) {
       i = content->d_map.erase(i);
       ++ret;
-      --map.d_entriesCount;
+      map.decEntriesCount();
     }
     else {
       ++i;
@@ -275,7 +275,7 @@ void NegCache::clear()
   for (auto& map : d_maps) {
     auto m = map.lock();
     m->d_map.clear();
-    map.d_entriesCount = 0;
+    map.clearEntriesCount();
   }
 }
 

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -141,7 +141,6 @@ private:
       uint64_t d_acquired_count{0};
       void invalidate() {}
     };
-    pdns::stat_t d_entriesCount{0};
 
     LockGuardedTryHolder<MapCombo::LockedContent> lock()
     {
@@ -154,8 +153,29 @@ private:
       return locked;
     }
 
+    [[nodiscard]] auto getEntriesCount() const
+    {
+      return d_entriesCount.load();
+    }
+
+    void incEntriesCount()
+    {
+      ++d_entriesCount;
+    }
+
+    void decEntriesCount()
+    {
+      --d_entriesCount;
+    }
+
+    void clearEntriesCount()
+    {
+      d_entriesCount = 0;
+    }
+
   private:
     LockGuarded<LockedContent> d_content;
+    pdns::stat_t d_entriesCount{0};
   };
 
   vector<MapCombo> d_maps;

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -336,3 +336,8 @@ uint64_t getResolveTaskExceptions()
 {
   return s_almost_expired_tasks.exceptions;
 }
+
+bool taskQTypeIsSupported(QType qtype)
+{
+  return !SyncRes::isUnsupported(qtype);
+}

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -57,4 +57,3 @@ uint64_t getAlmostExpiredTasksRun();
 uint64_t getAlmostExpiredTaskExceptions();
 
 bool taskQTypeIsSupported(QType qtype);
-

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <ctime>
+#include <qtype.hh>
 
 class DNSName;
 union ComboAddress;
@@ -54,3 +55,6 @@ uint64_t getResolveTaskExceptions();
 uint64_t getAlmostExpiredTasksPushed();
 uint64_t getAlmostExpiredTasksRun();
 uint64_t getAlmostExpiredTaskExceptions();
+
+bool taskQTypeIsSupported(QType qtype);
+

--- a/pdns/recursordist/recpacketcache.hh
+++ b/pdns/recursordist/recpacketcache.hh
@@ -105,8 +105,19 @@ private:
   struct Entry
   {
     Entry(DNSName&& qname, uint16_t qtype, uint16_t qclass, std::string&& packet, std::string&& query, bool tcp,
-          uint32_t qhash, time_t ttd, time_t now, uint32_t tag, vState vstate) : // NOLINT
-      d_name(std::move(qname)), d_packet(std::move(packet)), d_query(std::move(query)), d_ttd(ttd), d_creation(now), d_qhash(qhash), d_tag(tag), d_type(qtype), d_class(qclass), d_vstate(vstate), d_tcp(tcp)
+          // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+          uint32_t qhash, time_t ttd, time_t now, uint32_t tag, vState vstate) :
+      d_name(std::move(qname)),
+      d_packet(std::move(packet)),
+      d_query(std::move(query)),
+      d_ttd(ttd),
+      d_creation(now),
+      d_qhash(qhash),
+      d_tag(tag),
+      d_type(qtype),
+      d_class(qclass),
+      d_vstate(vstate),
+      d_tcp(tcp)
     {
     }
 

--- a/pdns/recursordist/recpacketcache.hh
+++ b/pdns/recursordist/recpacketcache.hh
@@ -208,7 +208,7 @@ private:
   }
 
   static bool qrMatch(const packetCache_t::index<HashTag>::type::iterator& iter, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass);
-  bool checkResponseMatches(MapCombo::LockedContent& shard, std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);
+  static bool checkResponseMatches(MapCombo::LockedContent& shard, std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);
 
   void setShardSizes(size_t shardSize);
 

--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -63,7 +63,7 @@ size_t MemRecursorCache::size() const
 {
   size_t count = 0;
   for (const auto& shard : d_maps) {
-    count += shard.d_entriesCount;
+    count += shard.getEntriesCount();
   }
   return count;
 }
@@ -548,7 +548,7 @@ void MemRecursorCache::replace(time_t now, const DNSName& qname, const QType qt,
   cache_t::iterator stored = lockedShard->d_map.find(key);
   if (stored == lockedShard->d_map.end()) {
     stored = lockedShard->d_map.insert(CacheEntry(key, auth)).first;
-    ++shard.d_entriesCount;
+    shard.incEntriesCount();
     isNew = true;
   }
 
@@ -641,7 +641,7 @@ size_t MemRecursorCache::doWipeCache(const DNSName& name, bool sub, const QType 
       if (i->d_qtype == qtype || qtype == 0xffff) {
         i = idx.erase(i);
         count++;
-        --shard.d_entriesCount;
+        shard.decEntriesCount();
       }
       else {
         ++i;
@@ -670,7 +670,7 @@ size_t MemRecursorCache::doWipeCache(const DNSName& name, bool sub, const QType 
         if (i->d_qtype == qtype || qtype == 0xffff) {
           count++;
           i = idx.erase(i);
-          --mc.d_entriesCount;
+          mc.decEntriesCount();
         }
         else {
           ++i;

--- a/pdns/recursordist/recursor_cache.hh
+++ b/pdns/recursordist/recursor_cache.hh
@@ -249,8 +249,6 @@ private:
       }
     };
 
-    pdns::stat_t d_entriesCount{0};
-
     LockGuardedTryHolder<LockedContent> lock()
     {
       auto locked = d_content.try_lock();
@@ -262,8 +260,29 @@ private:
       return locked;
     }
 
+    [[nodiscard]] auto getEntriesCount() const
+    {
+      return d_entriesCount.load();
+    }
+
+    void incEntriesCount()
+    {
+      ++d_entriesCount;
+    }
+
+    void decEntriesCount()
+    {
+      --d_entriesCount;
+    }
+
+    void clearEntriesCount()
+    {
+      d_entriesCount = 0;
+    }
+
   private:
     LockGuarded<LockedContent> d_content;
+    pdns::stat_t d_entriesCount{0};
   };
 
   vector<MapCombo> d_maps;

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -7,6 +7,7 @@
 #include "root-dnssec.hh"
 #include "rec-taskqueue.hh"
 #include "test-syncres_cc.hh"
+#include "recpacketcache.hh"
 
 GlobalStateHolder<LuaConfigItems> g_luaconfs;
 GlobalStateHolder<SuffixMatchNode> g_xdnssec;
@@ -139,6 +140,7 @@ void initSR(bool debug)
     g_log.toConsole(Logger::Error);
   }
 
+  RecursorPacketCache::s_refresh_ttlperc = 0;
   MemRecursorCache::s_maxServedStaleExtensions = 0;
   NegCache::s_maxServedStaleExtensions = 0;
   g_recCache = std::make_unique<MemRecursorCache>();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes #13266.

ALso, only submit tasks that produce rcode 0 result. While it is not _wrong_ to submit tasks for queries that previously produced rcode != 0, these cache entries or governed by different (smaller) TTLs, so we are likely to submit more tasks than makes sense.
When these rcode != 0 entries with small TTLs are expired, on repeated client queries we'll trigger regular query processing (using the record cache), which itself wil trigger tasks if relevant.

Also include some general delinting of common cache code.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
