### PR TITLE
rec: Clear taskQueue at start of test run

### DIFF
--- a/pdns/recursordist/test-recpacketcache_cc.cc
+++ b/pdns/recursordist/test-recpacketcache_cc.cc
@@ -93,6 +93,8 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimpleWithRefresh)
   uint32_t ttd = 3600;
   BOOST_CHECK_EQUAL(rpc.size(), 0U);
 
+  taskQueueClear();
+
   DNSName qname("www.powerdns.com");
   vector<uint8_t> packet;
   DNSPacketWriter pw(packet, qname, QType::A);


### PR DESCRIPTION
Not all tests leave an empty queue.
Test that use syncres get an auto clear, but this test does not use syncres.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
