### PR TITLE
rec: Backport 13209 to rec 4.9.x: Implement a more fair way to prune the aggressive cache

### DIFF
--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -175,7 +175,7 @@ void AggressiveNSECCache::prune(time_t now)
       // This is comparable to what cachecleaner.hh::pruneMutexCollectionsVector() is doing, look there for an explanation
       entriesCount -= zoneSize;
       uint64_t trimmedFromThisZone = 0;
-      for (auto it = sidx.begin(); it != sidx.end() && trimmedFromThisZone < toTrimForThisZone; ) {
+      for (auto it = sidx.begin(); it != sidx.end() && trimmedFromThisZone < toTrimForThisZone;) {
         it = sidx.erase(it);
         ++erased;
         ++trimmedFromThisZone;

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -140,7 +140,7 @@ void AggressiveNSECCache::prune(time_t now)
     const auto toLookAtForThisZone = (zoneEntry->d_entries.size() + 9) / 10;
     uint64_t lookedAt = 0;
     for (auto it = sidx.begin(); it != sidx.end() && lookedAt < toLookAtForThisZone; ++lookedAt) {
-      if (it->d_ttd < now) {
+      if (it->d_ttd <= now) {
         it = sidx.erase(it);
         ++erased;
       }

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -1208,13 +1208,13 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_pruning)
   BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3U);
 
   /* we have set a upper bound to 2 entries, so we are above,
-     and one entry are actually expired, so we will prune one entry
+     and one entry is actually expired, so we will prune one entry
      to get below the limit */
   cache->prune(now.tv_sec + 15);
   BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2U);
 
-  /* now we are at the limit, so we will scan 1/5th of all zones entries, rounded up,
-     and prune the expired ones, which mean we will also remoing twoe */
+  /* now we are at the limit, so we will scan 1/10th of all zones entries, rounded up,
+     and prune the expired ones, which mean we will also be removing the remaining two */
   cache->prune(now.tv_sec + 600);
   BOOST_CHECK_EQUAL(cache->getEntriesCount(), 0U);
 }

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -1081,7 +1081,9 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_replace)
   const size_t testSize = 10000;
   auto cache = make_unique<AggressiveNSECCache>(testSize);
 
-  struct timeval now{};
+  struct timeval now
+  {
+  };
   Utility::gettimeofday(&now, nullptr);
 
   vector<DNSName> names;
@@ -1119,7 +1121,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_replace)
 
   auto diff2 = time.udiff(true);
   // Check that replace is about equally fast as insert
-  BOOST_ASSERT(diff1 < diff2 * 1.2 && diff2 < diff1 * 1.2);
+  BOOST_CHECK(diff1 < diff2 * 1.2 && diff2 < diff1 * 1.2);
 }
 
 BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wiping)


### PR DESCRIPTION
Backport of #13209 without the specific cache dump part

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
