### PR TITLE
rec: Backport 13278 to rec-4.9.x: Prevent lookups for unsupported qtypes or rcode != 0 to submit refresh tasks

### DIFF
--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -336,3 +336,8 @@ uint64_t getResolveTaskExceptions()
 {
   return s_almost_expired_tasks.exceptions;
 }
+
+bool taskQTypeIsSupported(QType qtype)
+{
+  return !SyncRes::isUnsupported(qtype);
+}

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -57,4 +57,3 @@ uint64_t getAlmostExpiredTasksRun();
 uint64_t getAlmostExpiredTaskExceptions();
 
 bool taskQTypeIsSupported(QType qtype);
-

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <ctime>
+#include <qtype.hh>
 
 class DNSName;
 union ComboAddress;
@@ -54,3 +55,6 @@ uint64_t getResolveTaskExceptions();
 uint64_t getAlmostExpiredTasksPushed();
 uint64_t getAlmostExpiredTasksRun();
 uint64_t getAlmostExpiredTaskExceptions();
+
+bool taskQTypeIsSupported(QType qtype);
+

--- a/pdns/recursordist/recpacketcache.cc
+++ b/pdns/recursordist/recpacketcache.cc
@@ -129,7 +129,7 @@ bool RecursorPacketCache::checkResponseMatches(MapCombo::LockedContent& shard, s
       if (s_refresh_ttlperc > 0 && !iter->d_submitted && taskQTypeIsSupported(qtype)) {
         const dnsheader_aligned header(iter->d_packet.data());
         const auto* headerPtr = header.get();
-        if (headerPtr->rcode == RCode::NoError) {
+        if (headerPtr->rcode == static_cast<unsigned>(RCode::NoError)) {
           const uint32_t deadline = iter->getOrigTTL() * s_refresh_ttlperc / 100;
           const bool almostExpired = ttl <= deadline;
           if (almostExpired) {

--- a/pdns/recursordist/recpacketcache.hh
+++ b/pdns/recursordist/recpacketcache.hh
@@ -208,7 +208,7 @@ private:
   }
 
   static bool qrMatch(const packetCache_t::index<HashTag>::type::iterator& iter, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass);
-  bool checkResponseMatches(MapCombo::LockedContent& shard, std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);
+  static bool checkResponseMatches(MapCombo::LockedContent& shard, std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, vState* valState, OptPBData* pbdata);
 
   void setShardSizes(size_t shardSize);
 


### PR DESCRIPTION
(cherry picked from commit 11c65aeda2aef3aabeeff9aa1491bc84954ed905)

Backport of #13278 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
