### PR TITLE
dnsscope: Add a `--port` option to select a custom port

### DIFF
--- a/docs/manpages/dnsscope.1.rst
+++ b/docs/manpages/dnsscope.1.rst
@@ -27,6 +27,7 @@ INFILE
 --full-histogram <msec>                Write out histogram with specified bin-size to 'full-histogram'
 --log-histogram                        Write out a log-histogram of response times to 'log-histogram'
 --no-servfail-stats                    Remove servfail responses from latency statistics
+--port                                 The source and destination port to consider. Default is looking at packets from and to ports 53 and 5300.
 --servfail-tree                        Figure out subtrees that generate servfails.
 --stats-dir <directory>                Drop statistics files in this directory. Defaults to ./
 -l, --load-stats                       Emit per-second load statistics (questions, answers, outstanding).


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Until now `dnsscope` was only looking at packets from and to ports 53 and 5300 which is a bit restrictive.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
