### PR TITLE
rec: Put files generated by generate.py into tarball

### DIFF
--- a/pdns/recursordist/settings/Makefile.am
+++ b/pdns/recursordist/settings/Makefile.am
@@ -1,25 +1,30 @@
+# It's a bit dirty that this Makefile also generates a file inside rust/src (lib.rs). 
+
 EXTRA_DIST = \
+	cxxsettings-generated.cc \
 	cxxsettings-private.hh \
 	cxxsettings.hh \
-	docs-old-preamble-in.rst \
 	docs-new-preamble-in.rst \
+	docs-old-preamble-in.rst \
 	generate.py \
 	rust-bridge-in.rs \
 	rust-preamble-in.rs \
-	table.py
+	table.py \
+	rust/src/lib.rs
 
-all: cxxsettings-generated.cc
+all: cxxsettings-generated.cc rust/src/lib.rs
 
-BUILT_SOURCES=cxxsettings-generated.cc
+BUILT_SOURCES=cxxsettings-generated.cc rust/src/lib.rs
 
-# It's a bit dirty that this target also generates a file inside rust/src (lib.rs). Also, we need to
-# clean in the Rust dir, as in some cases the Serde/CXX derive/generate code does not get re-run by
-# cargo after rust/src/lib.rs changed because of a generate.py run. In that case we end up with an
-# rust/src/lib.rs.h that does not contain e.g. field name or field type changes.
-cxxsettings-generated.cc: table.py generate.py rust-preamble-in.rs rust-bridge-in.rs docs-old-preamble-in.rst docs-new-preamble-in.rst
+# We need to clean in the Rust dir, as in some cases the Serde/CXX derive/generate code does not get
+# re-run by cargo after rust/src/lib.rs changed because of a generate.py run. In that case we end up
+# with an rust/src/lib.rs.h that does not contain e.g. field name or field type changes.
+#
+# Use patterns to avoid having two instances of generate run simultaneously, a well know hack for GNU make
+cxxsettings-generated%cc rust/src/lib%rs: table.py generate.py rust-preamble-in.rs rust-bridge-in.rs docs-old-preamble-in.rst docs-new-preamble-in.rst
 	$(MAKE) -C rust clean
 	$(PYTHON) generate.py
 
 clean-local:
-	rm -f cxxsettings-generated.cc settings-old-generated.rst
+	rm -f cxxsettings-generated.cc rust/src/lib.rs
 

--- a/pdns/recursordist/settings/Makefile.am
+++ b/pdns/recursordist/settings/Makefile.am
@@ -20,7 +20,7 @@ BUILT_SOURCES=cxxsettings-generated.cc rust/src/lib.rs
 # re-run by cargo after rust/src/lib.rs changed because of a generate.py run. In that case we end up
 # with an rust/src/lib.rs.h that does not contain e.g. field name or field type changes.
 #
-# Use patterns to avoid having two instances of generate run simultaneously, a well know hack for GNU make
+# Use patterns to avoid having two instances of generate run simultaneously, a well-known hack for GNU make
 cxxsettings-generated%cc rust/src/lib%rs: table.py generate.py rust-preamble-in.rs rust-bridge-in.rs docs-old-preamble-in.rst docs-new-preamble-in.rst
 	$(MAKE) -C rust clean
 	$(PYTHON) generate.py


### PR DESCRIPTION
So dists do not have to run python to generate them. Previously python was a hidden dependency.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
