### PR TITLE
Rec: do not use qname minimization for infra-queries

### DIFF
--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1644,6 +1644,7 @@ static int initSyncRes(Logr::log_t log)
   SyncRes::s_nonresolvingnsmaxfails = ::arg().asNum("non-resolving-ns-max-fails");
   SyncRes::s_nonresolvingnsthrottletime = ::arg().asNum("non-resolving-ns-throttle-time");
   SyncRes::s_serverID = ::arg()["server-id"];
+  // This bound is dynamically adjusted in SyncRes, depending on qname minimization being active
   SyncRes::s_maxqperq = ::arg().asNum("max-qperq");
   SyncRes::s_maxnsperresolve = ::arg().asNum("max-ns-per-resolve");
   SyncRes::s_maxnsaddressqperq = ::arg().asNum("max-ns-address-qperq");
@@ -1685,12 +1686,6 @@ static int initSyncRes(Logr::log_t log)
   SyncRes::s_ecscachelimitttl = ::arg().asNum("ecs-cache-limit-ttl");
 
   SyncRes::s_qnameminimization = ::arg().mustDo("qname-minimization");
-
-  if (SyncRes::s_qnameminimization) {
-    // With an empty cache, a rev ipv6 query with dnssec enabled takes
-    // almost 100 queries. Default maxqperq is 60.
-    SyncRes::s_maxqperq = std::max(SyncRes::s_maxqperq, static_cast<unsigned int>(100));
-  }
 
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;
   string value = ::arg()["nothing-below-nxdomain"];

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -36,7 +36,7 @@ struct ResolveTask;
 void runTasks(size_t max, bool logErrors);
 bool runTaskOnce(bool logErrors);
 void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline, const Netmask& netmask);
-void pushResolveTask(const DNSName& qname, uint16_t qtype, time_t now, time_t deadline);
+void pushResolveTask(const DNSName& qname, uint16_t qtype, time_t now, time_t deadline, bool forceQMOff);
 bool pushTryDoTTask(const DNSName& qname, uint16_t qtype, const ComboAddress& ipAddress, time_t deadline, const DNSName& nsname);
 void taskQueueClear();
 pdns::ResolveTask taskQueuePop();

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -608,7 +608,7 @@ void SyncRes::resolveAdditionals(const DNSName& qname, QType qtype, AdditionalMo
       // There are a few cases where an answer is neither stored in the record cache nor in the neg cache.
       // An example is a SOA-less NODATA response. Rate limiting will kick in if those tasks are pushed too often.
       // We might want to fix these cases (and always either store positive or negative) some day.
-      pushResolveTask(qname, qtype, d_now.tv_sec, d_now.tv_sec + 60);
+      pushResolveTask(qname, qtype, d_now.tv_sec, d_now.tv_sec + 60, false);
       additionalsNotInCache = true;
     }
     break;
@@ -2151,7 +2151,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName& qname, unsigned int depth,
       NegCache::NegCacheEntry ne;
       bool inNegCache = g_negCache->get(qname, QType::AAAA, d_now, ne, false);
       if (!inNegCache) {
-        pushResolveTask(qname, QType::AAAA, d_now.tv_sec, d_now.tv_sec + 60);
+        pushResolveTask(qname, QType::AAAA, d_now.tv_sec, d_now.tv_sec + 60, true);
       }
     }
   }

--- a/pdns/recursordist/test-rec-taskqueue.cc
+++ b/pdns/recursordist/test-rec-taskqueue.cc
@@ -30,17 +30,17 @@ BOOST_AUTO_TEST_CASE(test_almostexpired_queue_no_dups)
 BOOST_AUTO_TEST_CASE(test_resolve_queue_rate_limit)
 {
   taskQueueClear();
-  pushResolveTask(DNSName("foo"), QType::AAAA, 0, 1);
+  pushResolveTask(DNSName("foo"), QType::AAAA, 0, 1, false);
   BOOST_CHECK_EQUAL(getTaskSize(), 1U);
   taskQueuePop();
   BOOST_CHECK_EQUAL(getTaskSize(), 0U);
 
   // Should hit rate limiting
-  pushResolveTask(DNSName("foo"), QType::AAAA, 0, 1);
+  pushResolveTask(DNSName("foo"), QType::AAAA, 0, 1, false);
   BOOST_CHECK_EQUAL(getTaskSize(), 0U);
 
   // Should not hit rate limiting as time has passed
-  pushResolveTask(DNSName("foo"), QType::AAAA, 61, 62);
+  pushResolveTask(DNSName("foo"), QType::AAAA, 61, 62, false);
   BOOST_CHECK_EQUAL(getTaskSize(), 1U);
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

An optimization reducing the number of queries sent to auths, enabled by the assumption that qname minimization does not add anything for infra-queries, i.e. queries issued by the recursor itself to resolve NS names to addresses.
Also compute the `max-qperq` bound dynamically (based on the qname minimization mode for the current query).

I'm working on this PR, I noticed that are current number of auth queries per client query for various extreme cases is much lower than the numbers reported in #8646. Likely the better zone cut algo helps a lot, and maybe some other improvements we did over the years. So that's good and might even enable us to have stricter default values for `max-qperq`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
