### PR TITLE
dnsdist: Fix timeouts on incoming DoH connections with nghttp2

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -1198,7 +1198,7 @@ void IncomingHTTP2Connection::updateIO(IOState newState, const FDMultiplexer::ca
     if (newState == IOState::NeedRead) {
       /* use the idle TTL if the handshake has been completed (and proxy protocol payload received, if any),
          and we have processed at least one query, otherwise we use the shorter read TTL  */
-      if ((d_state == State::waitingForQuery || d_state == State::idle) && (d_queriesCount > 0 || d_currentQueriesCount)) {
+      if ((d_state == State::waitingForQuery || d_state == State::idle) && (d_queriesCount > 0 || d_currentQueriesCount > 0)) {
         ttd = getIdleClientReadTTD(now);
       }
       else {

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -86,7 +86,6 @@ private:
   std::unique_ptr<DOHUnitInterface> getDOHUnit(uint32_t streamID) override;
 
   void stopIO();
-  bool isIdle() const;
   uint32_t getConcurrentStreamsCount() const;
   void updateIO(IOState newState, const FDMultiplexer::callbackfunc_t& callback);
   void handleIOError();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR changes the way timeouts are handled for incoming DoH connections with nghttp2 to follow the existing behaviour (h2o) more closely: the TCP read timeout is used when the connection is first created, until the handshake has been completed, the proxy protocol payload received if expected, and the first query received, then the idle timeout is used
It also fixes an issue with our accounting of open streams, which were not properly erased on normal termination.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
