### PR TITLE
dnsdist: Fix a race in the Async unit tests

### DIFF
--- a/pdns/dnsdistdist/test-dnsdistasync.cc
+++ b/pdns/dnsdistdist/test-dnsdistasync.cc
@@ -49,7 +49,7 @@ public:
     errorRaised = true;
   }
 
-  bool errorRaised{false};
+  std::atomic<bool> errorRaised{false};
 };
 
 struct DummyCrossProtocolQuery : public CrossProtocolQuery
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(test_TimeoutFailClose)
   }
 
   BOOST_CHECK(holder->empty());
-  BOOST_CHECK(sender->errorRaised);
+  BOOST_CHECK(sender->errorRaised.load());
 
   holder->stop();
 }
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(test_AddingExpiredEvent)
   }
 
   BOOST_CHECK(holder->empty());
-  BOOST_CHECK(sender->errorRaised);
+  BOOST_CHECK(sender->errorRaised.load());
 
   holder->stop();
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to set the `errorRaised` variable from the `AsynchronousHolder` thread then check its value from the main thread, which is correctly reported as TSAN as a data race. We do know that we have waited enough, and that otherwise it's fine to fail, but TSAN cannot know that. Switching to a `std::atomic<bool>` fixes it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
