### PR TITLE
Some cleanups to the auth remote backend

### DIFF
--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -80,16 +80,17 @@ HTTPConnector::HTTPConnector(std::map<std::string, std::string> options) :
   }
 }
 
-HTTPConnector::~HTTPConnector() {}
+HTTPConnector::~HTTPConnector() = default;
 
 void HTTPConnector::addUrlComponent(const Json& parameters, const string& element, std::stringstream& ss)
 {
   std::string sparam;
-  if (parameters[element] != Json())
+  if (parameters[element] != Json()) {
     ss << "/" << YaHTTP::Utility::encodeURL(asString(parameters[element]), false);
+  }
 }
 
-std::string HTTPConnector::buildMemberListArgs(std::string prefix, const Json& args)
+std::string HTTPConnector::buildMemberListArgs(const std::string& prefix, const Json& args)
 {
   std::stringstream stream;
 
@@ -101,7 +102,7 @@ std::string HTTPConnector::buildMemberListArgs(std::string prefix, const Json& a
       stream << prefix << "[" << YaHTTP::Utility::encodeURL(pair.first, false) << "]=";
     }
     else {
-      stream << prefix << "[" << YaHTTP::Utility::encodeURL(pair.first, false) << "]=" << YaHTTP::Utility::encodeURL(this->asString(pair.second), false);
+      stream << prefix << "[" << YaHTTP::Utility::encodeURL(pair.first, false) << "]=" << YaHTTP::Utility::encodeURL(HTTPConnector::asString(pair.second), false);
     }
     stream << "&";
   }
@@ -173,7 +174,7 @@ void HTTPConnector::restful_requestbuilder(const std::string& method, const Json
   else if (method == "createSlaveDomain") {
     addUrlComponent(parameters, "ip", ss);
     addUrlComponent(parameters, "domain", ss);
-    if (parameters["account"].is_null() == false && parameters["account"].is_string()) {
+    if (!parameters["account"].is_null() && parameters["account"].is_string()) {
       req.POST()["account"] = parameters["account"].string_value();
     }
     req.preparePost();
@@ -316,7 +317,8 @@ void HTTPConnector::post_requestbuilder(const Json& input, YaHTTP::Request& req)
     req.body = out;
   }
   else {
-    std::stringstream url, content;
+    std::stringstream url;
+    std::stringstream content;
     // call url/method.suffix
     url << d_url << "/" << input["method"].string_value() << d_url_suffix;
     req.setup("POST", url.str());
@@ -329,7 +331,9 @@ void HTTPConnector::post_requestbuilder(const Json& input, YaHTTP::Request& req)
 
 int HTTPConnector::send_message(const Json& input)
 {
-  int rv, ec, fd;
+  int rv = 0;
+  int ec = 0;
+  int fd = 0;
 
   std::vector<std::string> members;
   std::string method;
@@ -338,10 +342,12 @@ int HTTPConnector::send_message(const Json& input)
   // perform request
   YaHTTP::Request req;
 
-  if (d_post)
+  if (d_post) {
     post_requestbuilder(input, req);
-  else
+  }
+  else {
     restful_requestbuilder(input["method"].string_value(), input["parameters"], req);
+  }
 
   rv = -1;
   req.headers["connection"] = "Keep-Alive"; // see if we can streamline requests (not needed, strictly speaking)
@@ -366,13 +372,18 @@ int HTTPConnector::send_message(const Json& input)
     }
   }
 
-  if (rv == 1)
+  if (rv == 1) {
     return rv;
+  }
 
   this->d_socket.reset();
 
   // connect using tcp
-  struct addrinfo *gAddr, *gAddrPtr, hints;
+  struct addrinfo* gAddr = nullptr;
+  struct addrinfo* gAddrPtr = nullptr;
+  struct addrinfo hints
+  {
+  };
   std::string sPort = std::to_string(d_port);
   memset(&hints, 0, sizeof hints);
   hints.ai_family = AF_UNSPEC;
@@ -383,7 +394,7 @@ int HTTPConnector::send_message(const Json& input)
     // try to connect to each address.
     gAddrPtr = gAddr;
 
-    while (gAddrPtr) {
+    while (gAddrPtr != nullptr) {
       try {
         d_socket = std::make_unique<Socket>(gAddrPtr->ai_family, gAddrPtr->ai_socktype, gAddrPtr->ai_protocol);
         d_addr.setSockaddr(gAddrPtr->ai_addr, gAddrPtr->ai_addrlen);
@@ -399,8 +410,9 @@ int HTTPConnector::send_message(const Json& input)
         g_log << Logger::Error << "While writing to HTTP endpoint " << d_addr.toStringWithPort() << ": exception caught" << std::endl;
       }
 
-      if (rv > -1)
+      if (rv > -1) {
         break;
+      }
       d_socket.reset();
       gAddrPtr = gAddrPtr->ai_next;
     }
@@ -418,27 +430,31 @@ int HTTPConnector::recv_message(Json& output)
   YaHTTP::AsyncResponseLoader arl;
   YaHTTP::Response resp;
 
-  if (d_socket == nullptr)
+  if (d_socket == nullptr) {
     return -1; // cannot receive :(
+  }
   char buffer[4096];
   int rd = -1;
-  time_t t0;
+  time_t t0 = 0;
 
   arl.initialize(&resp);
 
   try {
-    t0 = time((time_t*)NULL);
-    while (arl.ready() == false && (labs(time((time_t*)NULL) - t0) <= timeout)) {
+    t0 = time((time_t*)nullptr);
+    while (!arl.ready() && (labs(time((time_t*)nullptr) - t0) <= timeout)) {
       rd = d_socket->readWithTimeout(buffer, sizeof(buffer), timeout);
-      if (rd == 0)
+      if (rd == 0) {
         throw NetworkError("EOF while reading");
-      if (rd < 0)
+      }
+      if (rd < 0) {
         throw NetworkError(std::string(strerror(rd)));
+      }
       arl.feed(std::string(buffer, rd));
     }
     // timeout occurred.
-    if (arl.ready() == false)
+    if (!arl.ready()) {
       throw NetworkError("timeout");
+    }
   }
   catch (NetworkError& ne) {
     d_socket.reset();
@@ -459,8 +475,9 @@ int HTTPConnector::recv_message(Json& output)
   int rv = -1;
   std::string err;
   output = Json::parse(resp.body, err);
-  if (output != nullptr)
+  if (output != nullptr) {
     return resp.body.size();
+  }
   g_log << Logger::Error << "Cannot parse JSON reply: " << err << endl;
 
   return rv;

--- a/modules/remotebackend/test-remotebackend-http.cc
+++ b/modules/remotebackend/test-remotebackend-http.cc
@@ -67,7 +67,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = 0;
+    be = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -82,7 +82,7 @@ struct RemotebackendSetup
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);
     };
   }
-  ~RemotebackendSetup() {}
+  ~RemotebackendSetup() = default;
 };
 
 BOOST_GLOBAL_FIXTURE(RemotebackendSetup);

--- a/modules/remotebackend/test-remotebackend-json.cc
+++ b/modules/remotebackend/test-remotebackend-json.cc
@@ -66,7 +66,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = 0;
+    be = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -81,7 +81,7 @@ struct RemotebackendSetup
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);
     };
   }
-  ~RemotebackendSetup() {}
+  ~RemotebackendSetup() = default;
 };
 
 BOOST_GLOBAL_FIXTURE(RemotebackendSetup);

--- a/modules/remotebackend/test-remotebackend-keys.hh
+++ b/modules/remotebackend/test-remotebackend-keys.hh
@@ -19,6 +19,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#include <string>
+#include <pdns/dnsbackend.hh>
+
 DNSBackend::KeyData k1 = {std::string("Private-key-format: v1.2\nAlgorithm: 5 (RSASHA1)\nModulus: qpe9fxlN4dBT38cLPWtqljZhcJjbqRprj9XsYmf2/uFu4kA5sHYrlQY7H9lpzGJPRfOAfxShBpKs1AVaVInfJQ==\nPublicExponent: AQAB\nPrivateExponent: Ad3YogzXvVDLsWuAfioY571QlolbdTbzVlhLEMLD6dSRx+xcZgw6c27ak2HAH00iSKTvqK3AyeaK8Eqy/oJ5QQ==\nPrime1: wo8LZrdU2y0xLGCeLhwziQDDtTMi18NEIwlx8tUPnhs=\nPrime2: 4HcuFqgo7NOiXFvN+V2PT+QaIt2+oi6D2m8/qtTDS78=\nExponent1: GUdCoPbi9JM7l1t6Ud1iKMPLqchaF5SMTs0UXAuous8=\nExponent2: nzgKqimX9f1corTAEw0pddrwKyEtcu8ZuhzFhZCsAxM=\nCoefficient: YGNxbulf5GTNiIu0oNKmAF0khNtx9layjOPEI0R4/RY="), 1, 257, true, true};
 
 DNSBackend::KeyData k2 = {std::string("Private-key-format: v1.2\nAlgorithm: 5 (RSASHA1)\nModulus: tY2TAMgL/whZdSbn2aci4wcMqohO24KQAaq5RlTRwQ33M8FYdW5fZ3DMdMsSLQUkjGnKJPKEdN3Qd4Z5b18f+w==\nPublicExponent: AQAB\nPrivateExponent: BB6xibPNPrBV0PUp3CQq0OdFpk9v9EZ2NiBFrA7osG5mGIZICqgOx/zlHiHKmX4OLmL28oU7jPKgogeuONXJQQ==\nPrime1: yjxe/iHQ4IBWpvCmuGqhxApWF+DY9LADIP7bM3Ejf3M=\nPrime2: 5dGWTyYEQRBVK74q1a64iXgaNuYm1pbClvvZ6ccCq1k=\nExponent1: TwM5RebmWeAqerzJFoIqw5IaQugJO8hM4KZR9A4/BTs=\nExponent2: bpV2HSmu3Fvuj7jWxbFoDIXlH0uJnrI2eg4/4hSnvSk=\nCoefficient: e2uDDWN2zXwYa2P6VQBWQ4mR1ZZjFEtO/+YqOJZun1Y="), 2, 256, true, true};

--- a/modules/remotebackend/test-remotebackend-pipe.cc
+++ b/modules/remotebackend/test-remotebackend-pipe.cc
@@ -66,7 +66,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = 0;
+    be = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -85,7 +85,7 @@ struct RemotebackendSetup
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);
     };
   }
-  ~RemotebackendSetup() {}
+  ~RemotebackendSetup() = default;
 };
 
 BOOST_GLOBAL_FIXTURE(RemotebackendSetup);

--- a/modules/remotebackend/test-remotebackend-post.cc
+++ b/modules/remotebackend/test-remotebackend-post.cc
@@ -66,7 +66,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = 0;
+    be = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -81,7 +81,7 @@ struct RemotebackendSetup
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);
     };
   }
-  ~RemotebackendSetup() {}
+  ~RemotebackendSetup() = default;
 };
 
 BOOST_GLOBAL_FIXTURE(RemotebackendSetup);

--- a/modules/remotebackend/test-remotebackend-unix.cc
+++ b/modules/remotebackend/test-remotebackend-unix.cc
@@ -66,7 +66,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = 0;
+    be = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -85,7 +85,7 @@ struct RemotebackendSetup
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);
     };
   }
-  ~RemotebackendSetup() {}
+  ~RemotebackendSetup() = default;
 };
 
 BOOST_GLOBAL_FIXTURE(RemotebackendSetup);

--- a/modules/remotebackend/test-remotebackend-zeromq.cc
+++ b/modules/remotebackend/test-remotebackend-zeromq.cc
@@ -68,7 +68,7 @@ struct RemotebackendSetup
 {
   RemotebackendSetup()
   {
-    be = 0;
+    be = nullptr;
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
@@ -87,7 +87,7 @@ struct RemotebackendSetup
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);
     };
   }
-  ~RemotebackendSetup() {}
+  ~RemotebackendSetup() = default;
 };
 
 BOOST_GLOBAL_FIXTURE(RemotebackendSetup);

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -75,8 +75,9 @@ BOOST_AUTO_TEST_CASE(test_method_list)
 
   BOOST_TEST_MESSAGE("Testing list method");
   be->list(DNSName("unit.test."), -1);
-  while (be->get(rr))
+  while (be->get(rr)) {
     record_count++;
+  }
 
   BOOST_CHECK_EQUAL(record_count, 5); // number of records our test domain has
 }
@@ -90,7 +91,7 @@ BOOST_AUTO_TEST_CASE(test_method_doesDNSSEC)
 BOOST_AUTO_TEST_CASE(test_method_setDomainMetadata)
 {
   std::vector<std::string> meta;
-  meta.push_back("VALUE");
+  meta.emplace_back("VALUE");
   BOOST_TEST_MESSAGE("Testing setDomainMetadata method");
   BOOST_CHECK(be->setDomainMetadata(DNSName("unit.test."), "TEST", meta));
 }
@@ -102,8 +103,9 @@ BOOST_AUTO_TEST_CASE(test_method_alsoNotifies)
   BOOST_TEST_MESSAGE("Testing alsoNotifies method");
   be->alsoNotifies(DNSName("unit.test."), &alsoNotifies);
   BOOST_CHECK_EQUAL(alsoNotifies.size(), 1);
-  if (alsoNotifies.size() > 0)
+  if (!alsoNotifies.empty()) {
     BOOST_CHECK_EQUAL(alsoNotifies.count("192.0.2.1"), 1);
+  }
   BOOST_CHECK(be->setDomainMetadata(DNSName("unit.test."), "ALSO-NOTIFY", std::vector<std::string>()));
 }
 
@@ -115,8 +117,9 @@ BOOST_AUTO_TEST_CASE(test_method_getDomainMetadata)
   BOOST_CHECK_EQUAL(meta.size(), 1);
   // in case we got more than one value, which would be unexpected
   // but not fatal
-  if (meta.size() > 0)
+  if (!meta.empty()) {
     BOOST_CHECK_EQUAL(meta[0], "VALUE");
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getAllDomainMetadata)
@@ -127,14 +130,15 @@ BOOST_AUTO_TEST_CASE(test_method_getAllDomainMetadata)
   BOOST_CHECK_EQUAL(meta.size(), 1);
   // in case we got more than one value, which would be unexpected
   // but not fatal
-  if (meta.size() > 0)
+  if (!meta.empty()) {
     BOOST_CHECK_EQUAL(meta["TEST"][0], "VALUE");
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_method_addDomainKey)
 {
   BOOST_TEST_MESSAGE("Testing addDomainKey method");
-  int64_t id;
+  int64_t id = 0;
   be->addDomainKey(DNSName("unit.test."), k1, id);
   BOOST_CHECK_EQUAL(id, 1);
   be->addDomainKey(DNSName("unit.test."), k2, id);
@@ -182,7 +186,9 @@ BOOST_AUTO_TEST_CASE(test_method_removeDomainKey)
 
 BOOST_AUTO_TEST_CASE(test_method_getBeforeAndAfterNamesAbsolute)
 {
-  DNSName unhashed, before, after;
+  DNSName unhashed;
+  DNSName before;
+  DNSName after;
   BOOST_TEST_MESSAGE("Testing getBeforeAndAfterNamesAbsolute method");
 
   be->getBeforeAndAfterNamesAbsolute(-1, DNSName("middle.unit.test."), unhashed, before, after);
@@ -193,7 +199,8 @@ BOOST_AUTO_TEST_CASE(test_method_getBeforeAndAfterNamesAbsolute)
 
 BOOST_AUTO_TEST_CASE(test_method_setTSIGKey)
 {
-  std::string algorithm, content;
+  std::string algorithm;
+  std::string content;
   BOOST_TEST_MESSAGE("Testing setTSIGKey method");
   BOOST_CHECK_MESSAGE(be->setTSIGKey(DNSName("unit.test."), DNSName("hmac-md5."), "kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys="), "did not return true");
 }
@@ -210,7 +217,8 @@ BOOST_AUTO_TEST_CASE(test_method_getTSIGKey)
 
 BOOST_AUTO_TEST_CASE(test_method_deleteTSIGKey)
 {
-  std::string algorithm, content;
+  std::string algorithm;
+  std::string content;
   BOOST_TEST_MESSAGE("Testing deleteTSIGKey method");
   BOOST_CHECK_MESSAGE(be->deleteTSIGKey(DNSName("unit.test.")), "did not return true");
 }
@@ -220,8 +228,8 @@ BOOST_AUTO_TEST_CASE(test_method_getTSIGKeys)
   std::vector<struct TSIGKey> keys;
   BOOST_TEST_MESSAGE("Testing getTSIGKeys method");
   be->getTSIGKeys(keys);
-  BOOST_CHECK(keys.size() > 0);
-  if (keys.size() > 0) {
+  BOOST_CHECK(!keys.empty());
+  if (!keys.empty()) {
     BOOST_CHECK_EQUAL(keys[0].name.toString(), "test.");
     BOOST_CHECK_EQUAL(keys[0].algorithm.toString(), "NULL.");
     BOOST_CHECK_EQUAL(keys[0].key, "NULL");
@@ -268,7 +276,7 @@ BOOST_AUTO_TEST_CASE(test_method_superMasterBackend)
 {
   DNSResourceRecord rr;
   std::vector<DNSResourceRecord> nsset;
-  DNSBackend* dbd;
+  DNSBackend* dbd = nullptr;
   BOOST_TEST_MESSAGE("Testing superMasterBackend method");
 
   rr.qname = DNSName("example.com.");
@@ -284,7 +292,7 @@ BOOST_AUTO_TEST_CASE(test_method_superMasterBackend)
   rr.content = "ns2.example.com.";
   nsset.push_back(rr);
 
-  BOOST_CHECK(be->superMasterBackend("10.0.0.1", DNSName("example.com."), nsset, NULL, NULL, &dbd));
+  BOOST_CHECK(be->superMasterBackend("10.0.0.1", DNSName("example.com."), nsset, nullptr, nullptr, &dbd));
 
   // let's see what we got
   BOOST_CHECK_EQUAL(dbd, be);
@@ -376,7 +384,7 @@ BOOST_AUTO_TEST_CASE(test_method_getUpdatedMasters)
 
   be->getUpdatedMasters(result, catalogs, hashes);
 
-  BOOST_REQUIRE(result.size() > 0);
+  BOOST_REQUIRE(!result.empty());
 
   di = result.at(0);
   BOOST_CHECK_EQUAL(di.zone.toString(), "master.test.");

--- a/modules/remotebackend/zmqconnector.cc
+++ b/modules/remotebackend/zmqconnector.cc
@@ -59,13 +59,13 @@ ZeroMQConnector::ZeroMQConnector(std::map<std::string, std::string> options) :
 
   this->send(msg);
   msg = nullptr;
-  if (this->recv(msg) == false) {
+  if (!this->recv(msg)) {
     g_log << Logger::Error << "Failed to initialize zeromq" << std::endl;
     throw PDNSException("Failed to initialize zeromq");
   }
 };
 
-ZeroMQConnector::~ZeroMQConnector() {}
+ZeroMQConnector::~ZeroMQConnector() = default;
 
 int ZeroMQConnector::send_message(const Json& input)
 {
@@ -88,8 +88,9 @@ int ZeroMQConnector::send_message(const Json& input)
           // message was not sent
           g_log << Logger::Error << "Cannot send to " << this->d_endpoint << ": " << zmq_strerror(errno) << std::endl;
         }
-        else
+        else {
           return line.size();
+        }
       }
     }
   }
@@ -120,7 +121,7 @@ int ZeroMQConnector::recv_message(Json& output)
         // we have an event
         if ((item.revents & ZMQ_POLLIN) == ZMQ_POLLIN) {
           string data;
-          size_t msg_size;
+          size_t msg_size = 0;
           zmq_msg_init(&message);
           // read something
           if (zmq_msg_recv(&message, this->d_sock.get(), ZMQ_NOBLOCK) > 0) {
@@ -129,18 +130,18 @@ int ZeroMQConnector::recv_message(Json& output)
             data.assign(reinterpret_cast<const char*>(zmq_msg_data(&message)), msg_size);
             zmq_msg_close(&message);
             output = Json::parse(data, err);
-            if (output != nullptr)
+            if (output != nullptr) {
               rv = msg_size;
-            else
+            }
+            else {
               g_log << Logger::Error << "Cannot parse JSON reply from " << this->d_endpoint << ": " << err << endl;
+            }
             break;
           }
-          else if (errno == EAGAIN) {
+          if (errno == EAGAIN) {
             continue; // try again }
           }
-          else {
-            break;
-          }
+          break;
         }
       }
     }


### PR DESCRIPTION
### Short description
Some cleanups to the auth remote backend. They are entirely automated by `clang-tidy`.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)