### PR TITLE
build-and-test-all: Fix clang tidy checks

### DIFF
--- a/.github/scripts/clang-tidy-diff.py
+++ b/.github/scripts/clang-tidy-diff.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+#
+#===- clang-tidy-diff.py - ClangTidy Diff Checker -----------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===-----------------------------------------------------------------------===#
+
+r"""
+ClangTidy Diff Checker
+======================
+
+This script reads input from a unified diff, runs clang-tidy on all changed
+files and outputs clang-tidy warnings in changed lines only. This is useful to
+detect clang-tidy regressions in the lines touched by a specific patch.
+Example usage for git/svn users:
+
+  git diff -U0 HEAD^ | clang-tidy-diff.py -p1
+  svn diff --diff-cmd=diff -x-U0 | \
+      clang-tidy-diff.py -fix -checks=-*,modernize-use-override
+
+"""
+
+import argparse
+import glob
+import json
+import multiprocessing
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import traceback
+
+try:
+  import yaml
+except ImportError:
+  yaml = None
+
+is_py2 = sys.version[0] == '2'
+
+if is_py2:
+    import Queue as queue
+else:
+    import queue as queue
+
+
+def run_tidy(task_queue, lock, timeout):
+  watchdog = None
+  while True:
+    command = task_queue.get()
+    try:
+      proc = subprocess.Popen(command,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+
+      if timeout is not None:
+        watchdog = threading.Timer(timeout, proc.kill)
+        watchdog.start()
+
+      stdout, stderr = proc.communicate()
+
+      with lock:
+        sys.stdout.write(stdout.decode('utf-8') + '\n')
+        sys.stdout.flush()
+        if stderr:
+          sys.stderr.write(stderr.decode('utf-8') + '\n')
+          sys.stderr.flush()
+    except Exception as e:
+      with lock:
+        sys.stderr.write('Failed: ' + str(e) + ': '.join(command) + '\n')
+    finally:
+      with lock:
+        if not (timeout is None or watchdog is None):
+          if not watchdog.is_alive():
+              sys.stderr.write('Terminated by timeout: ' +
+                               ' '.join(command) + '\n')
+          watchdog.cancel()
+      task_queue.task_done()
+
+
+def start_workers(max_tasks, tidy_caller, task_queue, lock, timeout):
+  for _ in range(max_tasks):
+    t = threading.Thread(target=tidy_caller, args=(task_queue, lock, timeout))
+    t.daemon = True
+    t.start()
+
+
+def merge_replacement_files(tmpdir, mergefile):
+  """Merge all replacement files in a directory into a single file"""
+  # The fixes suggested by clang-tidy >= 4.0.0 are given under
+  # the top level key 'Diagnostics' in the output yaml files
+  mergekey = "Diagnostics"
+  merged = []
+  for replacefile in glob.iglob(os.path.join(tmpdir, '*.yaml')):
+    content = yaml.safe_load(open(replacefile, 'r'))
+    if not content:
+      continue # Skip empty files.
+    merged.extend(content.get(mergekey, []))
+
+  if merged:
+    # MainSourceFile: The key is required by the definition inside
+    # include/clang/Tooling/ReplacementsYaml.h, but the value
+    # is actually never used inside clang-apply-replacements,
+    # so we set it to '' here.
+    output = {'MainSourceFile': '', mergekey: merged}
+    with open(mergefile, 'w') as out:
+      yaml.safe_dump(output, out)
+  else:
+    # Empty the file:
+    open(mergefile, 'w').close()
+
+
+def main():
+  parser = argparse.ArgumentParser(description=
+                                   'Run clang-tidy against changed files, and '
+                                   'output diagnostics only for modified '
+                                   'lines.')
+  parser.add_argument('-clang-tidy-binary', metavar='PATH',
+                      default='clang-tidy',
+                      help='path to clang-tidy binary')
+  parser.add_argument('-p', metavar='NUM', default=0,
+                      help='strip the smallest prefix containing P slashes')
+  parser.add_argument('-regex', metavar='PATTERN', default=None,
+                      help='custom pattern selecting file paths to check '
+                      '(case sensitive, overrides -iregex)')
+  parser.add_argument('-iregex', metavar='PATTERN', default=
+                      r'.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hpp|m|mm|inc)',
+                      help='custom pattern selecting file paths to check '
+                      '(case insensitive, overridden by -regex)')
+  parser.add_argument('-j', type=int, default=1,
+                      help='number of tidy instances to be run in parallel.')
+  parser.add_argument('-timeout', type=int, default=None,
+                      help='timeout per each file in seconds.')
+  parser.add_argument('-fix', action='store_true', default=False,
+                      help='apply suggested fixes')
+  parser.add_argument('-checks',
+                      help='checks filter, when not specified, use clang-tidy '
+                      'default',
+                      default='')
+  parser.add_argument('-use-color', action='store_true',
+                      help='Use colors in output')
+  parser.add_argument('-path', dest='build_path',
+                      help='Path used to read a compile command database.')
+  if yaml:
+    parser.add_argument('-export-fixes', metavar='FILE', dest='export_fixes',
+                        help='Create a yaml file to store suggested fixes in, '
+                        'which can be applied with clang-apply-replacements.')
+  parser.add_argument('-extra-arg', dest='extra_arg',
+                      action='append', default=[],
+                      help='Additional argument to append to the compiler '
+                      'command line.')
+  parser.add_argument('-extra-arg-before', dest='extra_arg_before',
+                      action='append', default=[],
+                      help='Additional argument to prepend to the compiler '
+                      'command line.')
+  parser.add_argument('-quiet', action='store_true', default=False,
+                      help='Run clang-tidy in quiet mode')
+  parser.add_argument('-load', dest='plugins',
+                      action='append', default=[],
+                      help='Load the specified plugin in clang-tidy.')
+
+  clang_tidy_args = []
+  argv = sys.argv[1:]
+  if '--' in argv:
+    clang_tidy_args.extend(argv[argv.index('--'):])
+    argv = argv[:argv.index('--')]
+
+  args = parser.parse_args(argv)
+
+  # Extract changed lines for each file.
+  filename = None
+  lines_by_file = {}
+  for line in sys.stdin:
+    match = re.search('^\+\+\+\ \"?(.*?/){%s}([^ \t\n\"]*)' % args.p, line)
+    if match:
+      filename = match.group(2)
+    if filename is None:
+      continue
+
+    if args.regex is not None:
+      if not re.match('^%s$' % args.regex, filename):
+        continue
+    else:
+      if not re.match('^%s$' % args.iregex, filename, re.IGNORECASE):
+        continue
+
+    match = re.search('^@@.*\+(\d+)(,(\d+))?', line)
+    if match:
+      start_line = int(match.group(1))
+      line_count = 1
+      if match.group(3):
+        line_count = int(match.group(3))
+      if line_count == 0:
+        continue
+      end_line = start_line + line_count - 1
+      lines_by_file.setdefault(filename, []).append([start_line, end_line])
+
+  if not any(lines_by_file):
+    print("No relevant changes found.")
+    sys.exit(0)
+
+  max_task_count = args.j
+  if max_task_count == 0:
+      max_task_count = multiprocessing.cpu_count()
+  max_task_count = min(len(lines_by_file), max_task_count)
+
+  tmpdir = None
+  if yaml and args.export_fixes:
+    tmpdir = tempfile.mkdtemp()
+
+  # Tasks for clang-tidy.
+  task_queue = queue.Queue(max_task_count)
+  # A lock for console output.
+  lock = threading.Lock()
+
+  # Run a pool of clang-tidy workers.
+  start_workers(max_task_count, run_tidy, task_queue, lock, args.timeout)
+
+  # Form the common args list.
+  common_clang_tidy_args = []
+  if args.fix:
+    common_clang_tidy_args.append('-fix')
+  if args.checks != '':
+    common_clang_tidy_args.append('-checks=' + args.checks)
+  if args.quiet:
+    common_clang_tidy_args.append('-quiet')
+  if args.build_path is not None:
+    common_clang_tidy_args.append('-p=%s' % args.build_path)
+  if args.use_color:
+    common_clang_tidy_args.append('--use-color')
+  for arg in args.extra_arg:
+    common_clang_tidy_args.append('-extra-arg=%s' % arg)
+  for arg in args.extra_arg_before:
+    common_clang_tidy_args.append('-extra-arg-before=%s' % arg)
+  for plugin in args.plugins:
+    common_clang_tidy_args.append('-load=%s' % plugin)
+
+  for name in lines_by_file:
+    line_filter_json = json.dumps(
+      [{"name": name, "lines": lines_by_file[name]}],
+      separators=(',', ':'))
+
+    # Run clang-tidy on files containing changes.
+    command = [args.clang_tidy_binary]
+    command.append('-line-filter=' + line_filter_json)
+    if yaml and args.export_fixes:
+      # Get a temporary file. We immediately close the handle so clang-tidy can
+      # overwrite it.
+      (handle, tmp_name) = tempfile.mkstemp(suffix='.yaml', dir=tmpdir)
+      os.close(handle)
+      command.append('-export-fixes=' + tmp_name)
+    command.extend(common_clang_tidy_args)
+    command.append(name)
+    command.extend(clang_tidy_args)
+
+    task_queue.put(command)
+
+  # Wait for all threads to be done.
+  task_queue.join()
+
+  if yaml and args.export_fixes:
+    print('Writing fixes to ' + args.export_fixes + ' ...')
+    try:
+      merge_replacement_files(tmpdir, args.export_fixes)
+    except:
+      sys.stderr.write('Error exporting fixes.\n')
+      traceback.print_exc()
+
+  if tmpdir:
+    shutil.rmtree(tmpdir)
+
+
+if __name__ == '__main__':
+  main()

--- a/.github/scripts/clang-tidy-diff.py
+++ b/.github/scripts/clang-tidy-diff.py
@@ -36,6 +36,8 @@ import tempfile
 import threading
 import traceback
 
+from pathlib import Path
+
 try:
   import yaml
 except ImportError:
@@ -242,7 +244,8 @@ def main():
 
   for name in lines_by_file:
     line_filter_json = json.dumps(
-      [{"name": name, "lines": lines_by_file[name]}],
+      # clang-tidy only supports filenames in -line-filter, not paths
+      [{"name": Path(name).name, "lines": lines_by_file[name]}],
       separators=(',', ':'))
 
     # Run clang-tidy on files containing changes.

--- a/.github/scripts/clang-tidy.py
+++ b/.github/scripts/clang-tidy.py
@@ -33,6 +33,7 @@ def main():
     """Start the script."""
     args = create_argument_parser()
 
+    repo_root_dir = Path(helpers.get_repo_root())
     fixes_path = Path(args.fixes_file)
     compdb_filename = os.path.join(fixes_path.parent, "compile_commands.json")
     compdb = helpers.load_compdb(compdb_filename)
@@ -67,14 +68,6 @@ def main():
             else os.path.join(directory, filename)
         )
 
-        if full_filename not in compdb:
-            print(
-                f"Skipping `{full_filename}`"
-                " because it is not found"
-                " in the compilation database"
-            )
-            continue
-
         try:
             file_contents = helpers.load_file(full_filename)
         except OSError:
@@ -85,16 +78,17 @@ def main():
 
         line = helpers.get_line_from_offset(file_contents, offset)
 
+        relative_filename = Path(full_filename).resolve().relative_to(repo_root_dir)
         annotation = "".join(
             [
-                f"::warning file={full_filename},line={line}",
+                f"::warning file={relative_filename},line={line}",
                 f"::{message} ({name} - Level={level})",
             ]
         )
         print(annotation)
 
         # User-friendly printout
-        print(f"{level}: {full_filename}:{line}: {message} ({name})")
+        print(f"{level}: {relative_filename}:{line}: {message} ({name})")
 
         have_warnings = True
 

--- a/.github/scripts/git-filter.py
+++ b/.github/scripts/git-filter.py
@@ -32,25 +32,6 @@ def main():
     for patch in patch_set:
         path = os.path.join(root, patch.path)
         if path in compdb:
-            if not patch.path.startswith(pdns_path):
-                # If the file being diffed is not under the pdns/ directory, we
-                # need to reconstruct its filename in the patch adding extra
-                # paths that clang-tidy-diff will get rid of: this way
-                # clang-tidy can work with the correct file path.
-                #
-                # Example with a source file under modules/:
-                #   patch.path = modules/foo/foo.cc
-                #   path       = /home/user/workspace/pdns/modules/foo/foo.cc
-                #   cwd        = /home/user/workspace/pdns/pdns/
-                #   relpath    = ../modules/foo/foo.cc
-                #
-                # Then the patch filenames would be:
-                #   patch.source_file = a/pdns/../modules/foo/foo.cc
-                #   patch.target_file = b/pdns/../modules/foo/foo.cc
-                relpath = os.path.relpath(path, cwd)
-                if patch.source_file is not None:
-                    patch.source_file = os.path.join("a", "pdns", relpath)
-                patch.target_file = os.path.join("b", "pdns", relpath)
             print(patch)
         else:
             msg = f"Skipping {path}: it is not in the compilation db"

--- a/.github/scripts/git-filter.py
+++ b/.github/scripts/git-filter.py
@@ -16,6 +16,10 @@ import unidiff
 
 def main():
     """Start the script."""
+    # It might be tempting to normalize the paths here instead of
+    # rewriting the compilation database, but then clang-tidy
+    # loses the depth of files in the repository, outputing for
+    # example "credentials.cc" instead of "pdns/credentials.cc"
     compdb = helpers.load_compdb("compile_commands.json")
     compdb = helpers.index_compdb(compdb)
 

--- a/.github/scripts/normalize_paths_in_compilation_database.py
+++ b/.github/scripts/normalize_paths_in_compilation_database.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+
+import json
+
+import helpers
+
+def create_argument_parser():
+    """Create command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Normalize paths in compilation database"
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        required=True,
+        help="Version number of the current build",
+    )
+    parser.add_argument('database')
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    """Start the script."""
+    args = create_argument_parser()
+
+    compDB = helpers.load_compdb(args.database)
+    for entry in compDB:
+        for key in ['file', 'directory']:
+            if key in entry:
+                entry[key] = helpers.normalize_dist_dir(args.version, entry[key])
+
+    with open(args.database + '.temp', 'w', encoding='utf-8') as outputFile:
+        json.dump(compDB, outputFile, ensure_ascii=False, indent=2)
+
+    os.rename(args.database + '.temp', args.database)

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -62,12 +62,19 @@ jobs:
         working-directory: .
       - run: inv ci-auth-configure
       - run: inv ci-auth-make-bear  # This runs under pdns-$BUILDER_VERSION/pdns/
-      - run: ln -s ../clang-tidy.full .clang-tidy
+      - name: Normalize paths in compilation DB
+        working-directory: .
+        run: python3 .github/scripts/normalize_paths_in_compilation_database.py --version $BUILDER_VERSION pdns-$BUILDER_VERSION/pdns/compile_commands.json
+      - name: Copy the compilation DB
+        working-directory: .
+        run: cp pdns-$BUILDER_VERSION/pdns/compile_commands.json .
+      - run: ln -s .clang-tidy.full .clang-tidy
+        working-directory: .
       - name: Run clang-tidy
-        working-directory: ./pdns-${{ env.BUILDER_VERSION }}/pdns
-        run: git diff -U0 HEAD^..HEAD | python3 ../../.github/scripts/git-filter.py | python3 /usr/bin/clang-tidy-diff-${CLANG_VERSION}.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p2 -export-fixes clang-tidy-auth.yml
+        working-directory: .
+        run: git diff -U0 HEAD^..HEAD | python3 .github/scripts/git-filter.py | python3 .github/scripts/clang-tidy-diff.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p1 -export-fixes clang-tidy-auth.yml
       - name: Print clang-tidy fixes YAML
-        working-directory: ./pdns-${{ env.BUILDER_VERSION }}/pdns
+        working-directory: .
         shell: bash
         run: |
           if [ -f clang-tidy-auth.yml ]; then
@@ -75,12 +82,12 @@ jobs:
           fi
       - name: Result annotations
         id: clang-tidy-annotations
+        working-directory: .
         shell: bash
-        working-directory: ./pdns-${{ env.BUILDER_VERSION }}/pdns
         run: |
           if [ -f clang-tidy-auth.yml ]; then
             set +e
-            python3 ../../.github/scripts/clang-tidy.py --fixes-file clang-tidy-auth.yml
+            python3 .github/scripts/clang-tidy.py --fixes-file clang-tidy-auth.yml
             echo "failed=$?" >> $GITHUB_OUTPUT
           fi
       - run: inv ci-auth-install-remotebackend-test-deps
@@ -143,10 +150,19 @@ jobs:
         working-directory: ./pdns/recursordist/
       - run: inv ci-rec-configure
       - run: inv ci-rec-make-bear
-      - run: ln -s ../../../.clang-tidy.full .clang-tidy
+      - name: Normalize paths in compilation DB
+        working-directory: .
+        run: python3 .github/scripts/normalize_paths_in_compilation_database.py --version $BUILDER_VERSION ./pdns/recursordist/pdns-recursor-$BUILDER_VERSION/compile_commands.json
+      - name: Copy compilation DB
+        working-directory: .
+        run: cp ./pdns/recursordist/pdns-recursor-$BUILDER_VERSION/compile_commands.json .
+      - run: ln -s .clang-tidy.full .clang-tidy
+        working-directory: .
       - name: Run clang-tidy
-        run: git diff -U0 HEAD^..HEAD | python3 ../../../.github/scripts/git-filter.py | python3 /usr/bin/clang-tidy-diff-${CLANG_VERSION}.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p3 -export-fixes clang-tidy-rec.yml
+        working-directory: .
+        run: git diff -U0 HEAD^..HEAD | python3 .github/scripts/git-filter.py | python3 .github/scripts/clang-tidy-diff.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p1 -export-fixes clang-tidy-rec.yml
       - name: Print clang-tidy fixes YAML
+        working-directory: .
         shell: bash
         run: |
           if [ -f clang-tidy-rec.yml ]; then
@@ -154,11 +170,12 @@ jobs:
           fi
       - name: Result annotations
         id: clang-tidy-annotations
+        working-directory: .
         shell: bash
         run: |
           if [ -f clang-tidy-rec.yml ]; then
             set +e
-            python ../../../.github/scripts/clang-tidy.py --fixes-file clang-tidy-rec.yml
+            python .github/scripts/clang-tidy.py --fixes-file clang-tidy-rec.yml
             echo "failed=$?" >> $GITHUB_OUTPUT
           fi
       - run: inv ci-rec-run-unit-tests
@@ -223,10 +240,19 @@ jobs:
         working-directory: ./pdns/dnsdistdist/
       - run: inv ci-dnsdist-configure ${{ matrix.features }}
       - run: inv ci-dnsdist-make-bear
-      - run: ln -s ../../../.clang-tidy.full .clang-tidy
+      - name: Normalize paths in compilation DB
+        working-directory: .
+        run: python3 .github/scripts/normalize_paths_in_compilation_database.py --version $BUILDER_VERSION ./pdns/dnsdistdist/dnsdist-$BUILDER_VERSION/compile_commands.json
+      - name: Copy compilation DB
+        run: cp ./pdns/dnsdistdist/dnsdist-$BUILDER_VERSION/compile_commands.json  compile_commands.json
+        working-directory: .
+      - run: ln -s .clang-tidy.full .clang-tidy
+        working-directory: .
       - name: Run clang-tidy
-        run: git diff -U0 HEAD^..HEAD | python3 ../../../.github/scripts/git-filter.py | python3 /usr/bin/clang-tidy-diff-${CLANG_VERSION}.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p3 -export-fixes clang-tidy-dnsdist.yml
+        working-directory: .
+        run: git diff -U0 HEAD^..HEAD | python3 .github/scripts/git-filter.py | python3 .github/scripts/clang-tidy-diff.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p1 -export-fixes clang-tidy-dnsdist.yml
       - name: Print clang-tidy fixes YAML
+        working-directory: .
         shell: bash
         run: |
           if [ -f clang-tidy-dnsdist.yml ]; then
@@ -234,11 +260,12 @@ jobs:
           fi
       - name: Result annotations
         id: clang-tidy-annotations
+        working-directory: .
         shell: bash
         run: |
           if [ -f clang-tidy-dnsdist.yml ]; then
             set +e
-            python ../../../.github/scripts/clang-tidy.py --fixes-file clang-tidy-dnsdist.yml
+            python .github/scripts/clang-tidy.py --fixes-file clang-tidy-dnsdist.yml
             echo "failed=$?" >> $GITHUB_OUTPUT
           fi
       - run: inv ci-dnsdist-run-unit-tests


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We now build in `dist` directories instead of building directly in the repository hierarchy, which makes matching files from the `git diff` against the compilation database harder, and then reporting the findings to the correct file in the repository even so.
This PR fixes that by rewriting the paths inside the compilation database to match the paths in the git repository, so that clang-tidy is run against these, from the root of the repository. It then ensures that the correct paths are used in the annotations generated from the clang-tidy output.

I had to import and modify a version of the `clang-tidy-diff.py` utility into our repository because `clang-tidy` only supports filenames in `-line-filter`, not paths, and the upstream `clang-tidy-diff.py` utility doesn't handle that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
