### PR TITLE
Netmask: Normalize subnet masks coming from a string

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -483,22 +483,22 @@ public:
   Netmask(const ComboAddress& network, uint8_t bits=0xff): d_network(network)
   {
     d_network.sin4.sin_port = 0;
-    setBits(network.isIPv4() ? std::min(bits, static_cast<uint8_t>(32)) : std::min(bits, static_cast<uint8_t>(128)));
+    setBits(bits);
   }
 
   Netmask(const sockaddr_in* network, uint8_t bits = 0xff): d_network(network)
   {
     d_network.sin4.sin_port = 0;
-    setBits(std::min(bits, static_cast<uint8_t>(32)));
+    setBits(bits);
   }
   Netmask(const sockaddr_in6* network, uint8_t bits = 0xff): d_network(network)
   {
     d_network.sin4.sin_port = 0;
-    setBits(std::min(bits, static_cast<uint8_t>(128)));
+    setBits(bits);
   }
   void setBits(uint8_t value)
   {
-    d_bits = value;
+    d_bits = d_network.isIPv4() ? std::min(value, static_cast<uint8_t>(32U)) : std::min(value, static_cast<uint8_t>(128U));
 
     if (d_bits < 32) {
       d_mask = ~(0xFFFFFFFF >> d_bits);

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -264,6 +264,24 @@ BOOST_AUTO_TEST_CASE(test_Netmask) {
   BOOST_CHECK(all < empty);
   BOOST_CHECK(empty > full);
   BOOST_CHECK(full < empty);
+
+  /* invalid (too large) mask */
+  {
+    Netmask invalidMaskV4("192.0.2.1/33");
+    BOOST_CHECK_EQUAL(invalidMaskV4.getBits(), 32U);
+    BOOST_CHECK(invalidMaskV4.getNetwork() == ComboAddress("192.0.2.1"));
+    Netmask invalidMaskV6("fe80::92fb:a6ff:fe4a:51da/129");
+    BOOST_CHECK_EQUAL(invalidMaskV6.getBits(), 128U);
+    BOOST_CHECK(invalidMaskV6.getNetwork() == ComboAddress("fe80::92fb:a6ff:fe4a:51da"));
+  }
+  {
+    Netmask invalidMaskV4(ComboAddress("192.0.2.1"), 33);
+    BOOST_CHECK_EQUAL(invalidMaskV4.getBits(), 32U);
+    BOOST_CHECK(invalidMaskV4.getNetwork() == ComboAddress("192.0.2.1"));
+    Netmask invalidMaskV6(ComboAddress("fe80::92fb:a6ff:fe4a:51da"), 129);
+    BOOST_CHECK_EQUAL(invalidMaskV6.getBits(), 128U);
+    BOOST_CHECK(invalidMaskV6.getNetwork() == ComboAddress("fe80::92fb:a6ff:fe4a:51da"));
+  }
 }
 
 static std::string NMGOutputToSorted(const std::string& str)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Until now we only normalized too large masks when constructed from a `ComboAddress` object and a separate mask, but not from a string.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
