### PR TITLE
dnsdist: Fix the documentation of `dq:restart` to prevent an endless loop

### DIFF
--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -463,7 +463,8 @@ DNSResponse object
         return DNSAction.None
       end
       function restartOnServFail(dr)
-        if dr.rcode == DNSRCode.SERVFAIL then
+        -- if the query was SERVFAIL and not already tried on the restarted pool
+        if dr.rcode == DNSRCode.SERVFAIL and dr.pool ~= 'restarted' then
           -- assign this query to a new pool
           dr.pool = 'restarted'
           -- discard the received response and


### PR DESCRIPTION
### Short description
If the re-try is also a servfail, dnsdist will restart it endlessly. Give some tips to not do that.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)