### PR TITLE
rec: Update new b-root-server.net addresses in built-in hints.

### DIFF
--- a/pdns/recursordist/root-addresses.hh
+++ b/pdns/recursordist/root-addresses.hh
@@ -26,7 +26,7 @@
 
 const std::array<const std::string, 13> rootIps4 = {
   "198.41.0.4", // a.root-servers.net.
-  "199.9.14.201", // b.root-servers.net.
+  "170.247.170.2", // b.root-servers.net.
   "192.33.4.12", // c.root-servers.net.
   "199.7.91.13", // d.root-servers.net.
   "192.203.230.10", // e.root-servers.net.
@@ -42,7 +42,7 @@ const std::array<const std::string, 13> rootIps4 = {
 
 const std::array<const std::string, 13> rootIps6 = {
   "2001:503:ba3e::2:30", // a.root-servers.net.
-  "2001:500:200::b", // b.root-servers.net.
+  "2801:1b8:10::b", // b.root-servers.net.
   "2001:500:2::c", // c.root-servers.net.
   "2001:500:2d::d", // d.root-servers.net.
   "2001:500:a8::e", // e.root-servers.net.


### PR DESCRIPTION
Is going to be effective 20231127. Both existing and new addresses
work already at the moment of writing (20231027).

https://www.lacnic.net/6869/2/lacnic/lacnic-assigns-number-resources-to-the-usc_isi-dns-root-server

Fixes https://github.com/PowerDNS/pdns/issues/12897

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
