### PR TITLE
Add Lua function to pick records via name hash

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1008,6 +1008,7 @@ pickhashed
 pickrandom
 pickrandomsample
 pickwhashed
+picknamehashed
 pickwrandom
 piddir
 pidfile

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -237,7 +237,8 @@ Record creation functions
   :param values: table of weight, string (such as IPv4 or IPv6 address).
 
   This allows basic persistent load balancing across a number of backends.  It means that
-  test.example.com will always resolve to the same IP, but test2.example.com may go elsewhere.
+  test.mydomain.example.com will always resolve to the same IP, but test2.mydomain.example.com
+  may go elsewhere.  This function is only useful for wildcard records.
 
   This works similar to round-robin load balancing, but has the advantage of making traffic
   for the same domain always end up on the same server which can help cache hit rates.
@@ -246,7 +247,7 @@ Record creation functions
 
   An example::
 
-    mydomain.example.com    IN    LUA    A ("picknamehashed({                             "
+    *.mydomain.example.com    IN    LUA    A ("picknamehashed({                        "
                                             "        {15,  "192.0.2.1"},               "
                                             "        {100, "198.51.100.5"}             "
                                             "})                                        ")

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -228,6 +228,29 @@ Record creation functions
                                             "        {100, "198.51.100.5"}             "
                                             "})                                        ")
 
+.. function:: picknamehashed(values)
+
+  Based on the hash of the DNS record name, returns a string from the list
+  supplied, as weighted by the various ``weight`` parameters.
+  Performs no uptime checking.
+
+  :param values: table of weight, string (such as IPv4 or IPv6 address).
+
+  This allows basic persistent load balancing across a number of backends.  It means that
+  test.example.com will always resolve to the same IP, but test2.example.com may go elsewhere.
+
+  This works similar to round-robin load balanacing, but has the advantage of making traffic
+  for the same domain always end up on the same server which can help cache hit rates.
+
+  This function also works for CNAME or TXT records.
+
+  An example::
+
+    mydomain.example.com    IN    LUA    A ("picknamehashed({                             "
+                                            "        {15,  "192.0.2.1"},               "
+                                            "        {100, "198.51.100.5"}             "
+                                            "})                                        ")
+
 
 .. function:: pickwrandom(values)
 

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -239,7 +239,7 @@ Record creation functions
   This allows basic persistent load balancing across a number of backends.  It means that
   test.example.com will always resolve to the same IP, but test2.example.com may go elsewhere.
 
-  This works similar to round-robin load balanacing, but has the advantage of making traffic
+  This works similar to round-robin load balancing, but has the advantage of making traffic
   for the same domain always end up on the same server which can help cache hit rates.
 
   This function also works for CNAME or TXT records.

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -230,27 +230,25 @@ Record creation functions
 
 .. function:: picknamehashed(values)
 
-  Based on the hash of the DNS record name, returns a string from the list
-  supplied, as weighted by the various ``weight`` parameters.
+  Based on the hash of the DNS record name, returns a string from the list supplied, as weighted by the various ``weight`` parameters.
   Performs no uptime checking.
 
   :param values: table of weight, string (such as IPv4 or IPv6 address).
 
-  This allows basic persistent load balancing across a number of backends.  It means that
-  test.mydomain.example.com will always resolve to the same IP, but test2.mydomain.example.com
-  may go elsewhere.  This function is only useful for wildcard records.
+  This allows basic persistent load balancing across a number of backends.
+  It means that ``test.mydomain.example.com`` will always resolve to the same IP, but ``test2.mydomain.example.com`` may go elsewhere.
+  This function is only useful for wildcard records.
 
-  This works similar to round-robin load balancing, but has the advantage of making traffic
-  for the same domain always end up on the same server which can help cache hit rates.
+  This works similar to round-robin load balancing, but has the advantage of making traffic for the same domain always end up on the same server which can help cache hit rates.
 
   This function also works for CNAME or TXT records.
 
   An example::
 
     *.mydomain.example.com    IN    LUA    A ("picknamehashed({                        "
-                                            "        {15,  "192.0.2.1"},               "
-                                            "        {100, "198.51.100.5"}             "
-                                            "})                                        ")
+                                              "        {15,  "192.0.2.1"},             "
+                                              "        {100, "198.51.100.5"}           "
+                                              "})                                      ")
 
 
 .. function:: pickwrandom(values)

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -388,7 +388,7 @@ static T pickWeightedNameHashed(const DNSName& dnsname, vector< pair<int, T> >& 
   if (items.empty()) {
     throw std::invalid_argument("The items list cannot be empty");
   }
-  int sum=0;
+  size_t sum=0;
   vector< pair<int, T> > pick;
   pick.reserve(items.size());
 
@@ -401,7 +401,7 @@ static T pickWeightedNameHashed(const DNSName& dnsname, vector< pair<int, T> >& 
     throw std::invalid_argument("The sum of items cannot be zero");
   }
 
-  int r = dnsname.hash() % sum;
+  size_t r = dnsname.hash() % sum;
   auto p = upper_bound(pick.begin(), pick.end(), r, [](int rarg, const typename decltype(pick)::value_type& a) { return rarg < a.first; });
   return p->second;
 }
@@ -672,7 +672,7 @@ static vector<string> genericIfUp(const boost::variant<iplist_t, ipunitlist_t>& 
   return convComboAddressListToString(res);
 }
 
-static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cognitive-complexity
+static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cognitive-complexity)
 {
   lua.writeFunction("latlon", []() {
       double lat = 0, lon = 0;
@@ -1030,7 +1030,9 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
 
       items.reserve(ips.size());
       for(auto& i : ips)
+      {
         items.emplace_back(atoi(i.second[1].c_str()), i.second[2]);
+      }
 
       return pickWeightedNameHashed<string>(s_lua_record_ctx->qname, items);
     });

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -801,16 +801,16 @@ createforward6.example.org.                 3600 IN NS   ns2.example.org.
 
         queries = [
             {
+                'query': dns.message.make_query('test.namehashed.example.org', 'A'),
                 'expected': dns.rrset.from_text('test.namehashed.example.org.', 0,
                                        dns.rdataclass.IN, 'A',
                                        '1.2.3.4'),
-                'query': dns.message.make_query('test.namehashed.example.org', 'A')
             },
             {
+                'query': dns.message.make_query('test2.namehashed.example.org', 'A'),
                 'expected': dns.rrset.from_text('test2.namehashed.example.org.', 0,
                                        dns.rdataclass.IN, 'A',
                                        '4.3.2.1'),
-                'query': dns.message.make_query('test2.namehashed.example.org', 'A')
             }
         ]
         for query in queries :


### PR DESCRIPTION
### Short description
This adds a Lua function to return a record based on a weighted hash of the DNS record name.  One use case here is to consistently return the same IP address for a particular cache server based on what subdomain is requesting the data.

This is pretty much a copy and paste of pickwhashed

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
