### PR TITLE
Handle stack memory on NetBSD as on OpenBSD

### DIFF
--- a/pdns/recursordist/lazy_allocator.hh
+++ b/pdns/recursordist/lazy_allocator.hh
@@ -27,8 +27,8 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-// On OpenBSD mem used as stack should be marked MAP_STACK
-#ifdef __OpenBSD__
+// On OpenBSD and NetBSD mem used as stack should be marked MAP_STACK
+#if defined(__OpenBSD__) || defined(__NetBSD__)
 #define PDNS_MAP_STACK MAP_STACK
 #else
 #define PDNS_MAP_STACK 0
@@ -82,8 +82,8 @@ struct lazy_allocator
     const auto padding = getAlignmentPadding(requestedSize, pageSize);
     const size_type allocatedSize = requestedSize + padding + (pageSize * 2);
 
-#ifdef __OpenBSD__
-    // OpenBSD does not like mmap MAP_STACK regions that have
+#if defined(__OpenBSD__) || defined(__NetBSD__)
+    // OpenBSD and NetBSD don't like mmap MAP_STACK regions that have
     // PROT_NONE, so allocate r/w and mprotect the guard pages
     // explicitly.
     const int protection = PROT_READ | PROT_WRITE;
@@ -96,7 +96,7 @@ struct lazy_allocator
     }
     char* basePointer = static_cast<char*>(p);
     void* usablePointer = basePointer + pageSize;
-#ifdef __OpenBSD__
+#if defined(__OpenBSD__) || defined(__NetBSD__)
     int res = mprotect(basePointer, pageSize, PROT_NONE);
     if (res != 0) {
       munmap(p, allocatedSize);


### PR DESCRIPTION
### Short description

On NetBSD, memory used as stack should be R/W, and marked MAP_STACK, as on OpenBSD.

After a fresh build of the git HEAD of pdns on NetBSD/amd64-current, both updated to 2023-10-21 state,
the pdns_recursor would not run: the worker threads it created immediately died, throwing std::bad_alloc.

Otto Moerbeek suggested that the adjustments to the "lazy allocator" done for OpenBSD might be relevant.
A ktrace of the crashing recursor showed mprotect returning an error (with errno 13, EACCES) to each of
the threads just before they crashed, so I made the accompanying changes, which turned out to resolve
the situation.

### Checklist

I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
