### PR TITLE
dnsdist: Allow building of dnsdist against boringssl on OpenBSD

### DIFF
--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#include <unordered_map>
+
 #include "config.h"
 #include "dnscrypt.hh"
 #include "dnsname.hh"

--- a/pdns/dnsdistdist/m4/dnsdist_enable_doq.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_enable_doq.m4
@@ -1,5 +1,5 @@
 AC_DEFUN([DNSDIST_ENABLE_DNS_OVER_QUIC], [
-  AC_MSG_CHECKING([whether to enable incoming DNS over QUIC (DoH) support])
+  AC_MSG_CHECKING([whether to enable incoming DNS over QUIC (DoQ) support])
   AC_ARG_ENABLE([dns-over-quic],
     AS_HELP_STRING([--enable-dns-over-quic], [enable incoming DNS over QUIC (DoQ) support (requires quiche) @<:@default=no@:>@]),
     [enable_dns_over_quic=$enableval],

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -290,12 +290,9 @@ int libssl_ticket_key_callback(SSL* /* s */, OpenSSLTLSTicketKeysRing& keyring, 
   return 1;
 }
 
-static int libssl_server_name_callback(SSL* ssl, int* al, void* arg)
+static int libssl_server_name_callback(SSL* ssl, int* /* alert */, void* /* arg */)
 {
-  (void) al;
-  (void) arg;
-
-  if (SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name)) {
+  if (SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name) != nullptr) {
     return SSL_TLSEXT_ERR_OK;
   }
 

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -32,6 +32,8 @@
 #include <openssl/core.h>
 #include <openssl/core_names.h>
 #include <openssl/evp.h>
+#else
+#include <openssl/hmac.h>
 #endif
 
 #ifdef HAVE_LIBSODIUM
@@ -288,7 +290,7 @@ int libssl_ticket_key_callback(SSL* /* s */, OpenSSLTLSTicketKeysRing& keyring, 
   return 1;
 }
 
-static long libssl_server_name_callback(SSL* ssl, int* al, void* arg)
+static int libssl_server_name_callback(SSL* ssl, int* al, void* arg)
 {
   (void) al;
   (void) arg;


### PR DESCRIPTION
DISABLE_OCSP_STAPLING has to be defined as well, since boring does not seem to have it.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Including a copy-paste and an include fix.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
