### PR TITLE
dnsdist: Fix Coverity CID 1523748: Performance inefficiencies in dolog.hh

### DIFF
--- a/pdns/dolog.hh
+++ b/pdns/dolog.hh
@@ -58,7 +58,7 @@ inline void dolog(std::ostream& os, const char*s)
 }
 
 template<typename T, typename... Args>
-void dolog(std::ostream& os, const char* s, T value, Args&&... args)
+void dolog(std::ostream& os, const char* s, T value, const Args&... args)
 {
   while (*s) {
     if (*s == '%') {
@@ -68,7 +68,7 @@ void dolog(std::ostream& os, const char* s, T value, Args&&... args)
       else {
 	os << value;
 	s += 2;
-	dolog(os, s, std::forward<Args>(args)...);
+	dolog(os, s, args...);
 	return;
       }
     }
@@ -91,10 +91,10 @@ inline void setSyslogFacility(int facility)
 }
 
 template<typename... Args>
-void genlog(std::ostream& stream, int level, bool doSyslog, const char* s, Args&&... args)
+void genlog(std::ostream& stream, int level, bool doSyslog, const char* s, const Args&... args)
 {
   std::ostringstream str;
-  dolog(str, s, std::forward<Args>(args)...);
+  dolog(str, s, args...);
 
   auto output = str.str();
 
@@ -120,15 +120,15 @@ void genlog(std::ostream& stream, int level, bool doSyslog, const char* s, Args&
 }
 
 template<typename... Args>
-void verboselog(const char* s, Args&&... args)
+void verboselog(const char* s, const Args&... args)
 {
 #ifdef DNSDIST
   if (g_verboseStream) {
-    genlog(*g_verboseStream, LOG_DEBUG, false, s, std::forward<Args>(args)...);
+    genlog(*g_verboseStream, LOG_DEBUG, false, s, args...);
   }
   else {
 #endif /* DNSDIST */
-    genlog(std::cout, LOG_DEBUG, g_syslog, s, std::forward<Args>(args)...);
+    genlog(std::cout, LOG_DEBUG, g_syslog, s, args...);
 #ifdef DNSDIST
   }
 #endif /* DNSDIST */
@@ -137,21 +137,21 @@ void verboselog(const char* s, Args&&... args)
 #define vinfolog if (g_verbose) verboselog
 
 template<typename... Args>
-void infolog(const char* s, Args&&... args)
+void infolog(const char* s, const Args&... args)
 {
-  genlog(std::cout, LOG_INFO, g_syslog, s, std::forward<Args>(args)...);
+  genlog(std::cout, LOG_INFO, g_syslog, s, args...);
 }
 
 template<typename... Args>
-void warnlog(const char* s, Args&&... args)
+void warnlog(const char* s, const Args&... args)
 {
-  genlog(std::cout, LOG_WARNING, g_syslog, s, std::forward<Args>(args)...);
+  genlog(std::cout, LOG_WARNING, g_syslog, s, args...);
 }
 
 template<typename... Args>
-void errlog(const char* s, Args&&... args)
+void errlog(const char* s, const Args&... args)
 {
-  genlog(std::cout, LOG_ERR, g_syslog, s, std::forward<Args>(args)...);
+  genlog(std::cout, LOG_ERR, g_syslog, s, args...);
 }
 
 #else // RECURSOR
@@ -169,7 +169,7 @@ inline void dolog(const char* s)
 }
 
 template<typename T, typename... Args>
-void dolog(Logger::Urgency u, const char* s, T value, Args&&... args)
+void dolog(Logger::Urgency u, const char* s, T value, const Args&... args)
 {
   g_log << u;
   while (*s) {
@@ -180,7 +180,7 @@ void dolog(Logger::Urgency u, const char* s, T value, Args&&... args)
       else {
 	g_log << value;
 	s += 2;
-	dolog(s, std::forward<Args>(args)...);
+	dolog(s, args...);
 	return;
       }
     }
@@ -191,21 +191,21 @@ void dolog(Logger::Urgency u, const char* s, T value, Args&&... args)
 #define vinfolog if(g_verbose)infolog
 
 template<typename... Args>
-void infolog(const char* s, Args&&... args)
+void infolog(const char* s, const Args&... args)
 {
-  dolog(Logger::Info, s, std::forward<Args>(args)...);
+  dolog(Logger::Info, s, args...);
 }
 
 template<typename... Args>
-void warnlog(const char* s, Args&&... args)
+void warnlog(const char* s, const Args&... args)
 {
-  dolog(Logger::Warning, s, std::forward<Args>(args)...);
+  dolog(Logger::Warning, s, args...);
 }
 
 template<typename... Args>
-void errlog(const char* s, Args&&... args)
+void errlog(const char* s, const Args&... args)
 {
-  dolog(Logger::Error, s, std::forward<Args>(args)...);
+  dolog(Logger::Error, s, args...);
 }
 
 #endif

--- a/pdns/dolog.hh
+++ b/pdns/dolog.hh
@@ -58,7 +58,7 @@ inline void dolog(std::ostream& os, const char*s)
 }
 
 template<typename T, typename... Args>
-void dolog(std::ostream& os, const char* s, T value, Args... args)
+void dolog(std::ostream& os, const char* s, T value, Args&&... args)
 {
   while (*s) {
     if (*s == '%') {
@@ -68,7 +68,7 @@ void dolog(std::ostream& os, const char* s, T value, Args... args)
       else {
 	os << value;
 	s += 2;
-	dolog(os, s, args...);
+	dolog(os, s, std::forward<Args>(args)...);
 	return;
       }
     }
@@ -91,10 +91,10 @@ inline void setSyslogFacility(int facility)
 }
 
 template<typename... Args>
-void genlog(std::ostream& stream, int level, bool doSyslog, const char* s, Args... args)
+void genlog(std::ostream& stream, int level, bool doSyslog, const char* s, Args&&... args)
 {
   std::ostringstream str;
-  dolog(str, s, args...);
+  dolog(str, s, std::forward<Args>(args)...);
 
   auto output = str.str();
 
@@ -120,15 +120,15 @@ void genlog(std::ostream& stream, int level, bool doSyslog, const char* s, Args.
 }
 
 template<typename... Args>
-void verboselog(const char* s, Args... args)
+void verboselog(const char* s, Args&&... args)
 {
 #ifdef DNSDIST
   if (g_verboseStream) {
-    genlog(*g_verboseStream, LOG_DEBUG, false, s, args...);
+    genlog(*g_verboseStream, LOG_DEBUG, false, s, std::forward<Args>(args)...);
   }
   else {
 #endif /* DNSDIST */
-    genlog(std::cout, LOG_DEBUG, g_syslog, s, args...);
+    genlog(std::cout, LOG_DEBUG, g_syslog, s, std::forward<Args>(args)...);
 #ifdef DNSDIST
   }
 #endif /* DNSDIST */
@@ -137,21 +137,21 @@ void verboselog(const char* s, Args... args)
 #define vinfolog if (g_verbose) verboselog
 
 template<typename... Args>
-void infolog(const char* s, Args... args)
+void infolog(const char* s, Args&&... args)
 {
-  genlog(std::cout, LOG_INFO, g_syslog, s, args...);
+  genlog(std::cout, LOG_INFO, g_syslog, s, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-void warnlog(const char* s, Args... args)
+void warnlog(const char* s, Args&&... args)
 {
-  genlog(std::cout, LOG_WARNING, g_syslog, s, args...);
+  genlog(std::cout, LOG_WARNING, g_syslog, s, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-void errlog(const char* s, Args... args)
+void errlog(const char* s, Args&&... args)
 {
-  genlog(std::cout, LOG_ERR, g_syslog, s, args...);
+  genlog(std::cout, LOG_ERR, g_syslog, s, std::forward<Args>(args)...);
 }
 
 #else // RECURSOR
@@ -169,7 +169,7 @@ inline void dolog(const char* s)
 }
 
 template<typename T, typename... Args>
-void dolog(Logger::Urgency u, const char* s, T value, Args... args)
+void dolog(Logger::Urgency u, const char* s, T value, Args&&... args)
 {
   g_log << u;
   while (*s) {
@@ -180,7 +180,7 @@ void dolog(Logger::Urgency u, const char* s, T value, Args... args)
       else {
 	g_log << value;
 	s += 2;
-	dolog(s, args...);
+	dolog(s, std::forward<Args>(args)...);
 	return;
       }
     }
@@ -191,21 +191,21 @@ void dolog(Logger::Urgency u, const char* s, T value, Args... args)
 #define vinfolog if(g_verbose)infolog
 
 template<typename... Args>
-void infolog(const char* s, Args... args)
+void infolog(const char* s, Args&&... args)
 {
-  dolog(Logger::Info, s, args...);
+  dolog(Logger::Info, s, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-void warnlog(const char* s, Args... args)
+void warnlog(const char* s, Args&&... args)
 {
-  dolog(Logger::Warning, s, args...);
+  dolog(Logger::Warning, s, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-void errlog(const char* s, Args... args)
+void errlog(const char* s, Args&&... args)
 {
-  dolog(Logger::Error, s, args...);
+  dolog(Logger::Error, s, std::forward<Args>(args)...);
 }
 
 #endif


### PR DESCRIPTION
Coverity reports:
```
Performance inefficiencies (COPY_INSTEAD_OF_MOVE): "args" is
passed-by-value as parameter to "dolog" when it could be moved instead.
```
This PR implements perfect forwarding for the variadic template parameters of DNSdist's logging methods to address it, even though the performance of these functions should not matter much.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
