### PR TITLE
rec: describe the YAML transition plan in three phases

### DIFF
--- a/pdns/recursordist/settings/docs-new-preamble-in.rst
+++ b/pdns/recursordist/settings/docs-new-preamble-in.rst
@@ -5,10 +5,19 @@ Each setting can appear on the command line, prefixed by ``--`` and using the ol
 Settings on the command line are processed after the file-based settings are processed.
 
 .. note::
-   Starting with version 5.0.0., :program:`Recursor` supports a new YAML syntax for configuration files
+   Starting with version 5.0.0, :program:`Recursor` supports a new YAML syntax for configuration files
    as described here.
+   If both ``recursor.conf`` and ``recursor.yml`` files are found in the configuration directory the YAML file is used.
    A configuration using the old style syntax can be converted to a YAML configuration using the instructions in :doc:`appendices/yamlconversion`.
-   In a future release support for the "old-style" settings will be dropped.
+
+   Release 5.0.0 will install a default old-style ``recursor.conf`` files only.
+
+   With the release of version 5.1.0, packages will stop installing a default ``recursor.conf`` and start installing a default ``recursor.yml`` file if no existing ``recursor.conf`` is present.
+   In the absense of a ``recursor.yml`` file, an existing ``recursor.conf`` file will be accepted and used.
+
+   With the release of 5.2.0, the default will be to expect a ``recursor.yml`` file and reading of ``recursor.conf`` files will have to be enabled specifically by providing a command line option.
+
+   In a future release support for the "old-style" ``recursor.conf`` settings file will be dropped.
 
 
 YAML settings file

--- a/pdns/recursordist/settings/docs-old-preamble-in.rst
+++ b/pdns/recursordist/settings/docs-old-preamble-in.rst
@@ -6,7 +6,8 @@ The command line overrides the configuration file.
 .. note::
    Starting with version 5.0.0, :program:`Recursor` supports a new YAML syntax for configuration files.
    A configuration using the old style syntax can be converted to a YAML configuration using the instructions in :doc:`appendices/yamlconversion`.
-   In a future release support for the "old-style" settings will be dropped.
+   In a future release support for the "old-style" settings decribed here will be dropped.
+   See :doc:`yamlsettings` for details.
 
 .. note::
    Settings marked as ``Boolean`` can either be set to an empty value, which means **on**, or to ``no`` or ``off`` which means **off**.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This is the plan: in 5.0.0 use of YAML is completely optional. In 5.1.0 we are more insistent, e.g. by installing a default recursor.yml file for new installs. This release should also encourage admins to convert by loud log messages. In 5.2.0 old-style compatibility has to be enabled manually.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
