### PR TITLE
docs/migration: Fix reference to zone2sql(1) manpage

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -112,7 +112,7 @@ For backends supporting slave operation, there is also an option to keep
 slave zones as slaves, and not convert them to native operation.
 
 ``zone2sql`` can generate SQL for nearly all the Generic SQL backends.
-See `its manpage <manpages/zone2sql.1>` for more information.
+See :doc:`its manpage <manpages/zone2sql.1>` for more information.
 
 An example call to ``zone2sql`` could be:
 


### PR DESCRIPTION
Without :doc: the sentence is rendered as

	See its manpage <manpages/zone2sql.1> for more information.

in the html output as can currently be seen on
https://doc.powerdns.com/authoritative/migration.html#migration-zone2sql . Adding :doc: makes this a proper link.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [-] included documentation (including possible behaviour changes)
- [-] documented the code
- [-] added or modified regression test(s)
- [-] added or modified unit test(s)
