### PR TITLE
Add and document a `localwho()` function for LUA records

### DIFF
--- a/.github/actions/spell-check/allow.txt
+++ b/.github/actions/spell-check/allow.txt
@@ -1825,6 +1825,7 @@ localdata
 localname
 localsock
 localstatedir
+localwho
 loctext
 locwild
 logaction

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -34,6 +34,8 @@ Client variables
   resolver. This is a :class:`ComboAddress`.
 ``who``
   IP address of requesting resolver as a :class:`ComboAddress`.
+``localwho``
+  IP address (including port) of socket on which the question arrived.
 
 Functions available
 -------------------

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1146,6 +1146,7 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
   lua.writeVariable("zone", zone);
   lua.writeVariable("zoneid", zoneid);
   lua.writeVariable("who", dnsp.getInnerRemote());
+  lua.writeVariable("localwho", dnsp.getLocal());
   lua.writeVariable("dh", (dnsheader*)&dnsp.d);
   lua.writeVariable("dnssecOK", dnsp.d_dnssecOk);
   lua.writeVariable("tcp", dnsp.d_tcp);


### PR DESCRIPTION
Add and document a `localwho()` function for LUA records

### Short description
This allows you to change your answer based on which address or port a query came in from.

Can be used like this:

```
berthub.eu	300	IN	LUA	A ";if(localwho:getPort() == 5300) then return '217.100.190.174'; else return '86.82.68.237'; end"
```

This, combined with some forwarding/iptables, means that queries that came in on 217.100.190.174 also get 217.100.190.174 as an answer. And same for 86.82.68.237. In this way you can do some simple DNS-based dual homing.

This code has been running in production for a few years already.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

