### PR TITLE
auth-4.8 for regression tests in recursor. updated sdig output format

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -486,7 +486,7 @@ jobs:
         sanitizers: [ubsan+asan, tsan]
         dist_name: [debian]
         dist_release_name: [bullseye]
-        pdns_repo_version: ['45']
+        pdns_repo_version: ['48']
     container:
       image: ghcr.io/powerdns/base-pdns-ci-image/debian-11-pdns-base:master
       env:

--- a/regression-tests.recursor/RPZ-Lua/expected_result
+++ b/regression-tests.recursor/RPZ-Lua/expected_result
@@ -1,10 +1,10 @@
 Reply to question for qname='www3.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	www3.example.net.	IN	CNAME	[ttl]	www2.example.net.
-0	www2.example.net.	IN	A	[ttl]	192.0.2.2
+0	www3.example.net.	[ttl]	IN	CNAME	www2.example.net.
+0	www2.example.net.	[ttl]	IN	A	192.0.2.2
 Reply to question for qname='android.marvin.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	android.marvin.example.net.	IN	A	[ttl]	192.0.2.5
+0	android.marvin.example.net.	[ttl]	IN	A	192.0.2.5
 Reply to question for qname='www5.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	www5.example.net.	IN	A	[ttl]	192.0.2.25
+0	www5.example.net.	[ttl]	IN	A	192.0.2.25

--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -21,11 +21,11 @@ $SDIG $nameserver 5301 capped-ttl.example.net a recurse 2>&1
 echo "==> defpol-with-ttl.example.net should use the default policy's TTL and not the zone one"
 $SDIG $nameserver 5301 defpol-with-ttl.example.net a recurse 2>&1
 echo "==> defpol-with-ttl-capped.example.net should use the default policy's TTL, but capped to maxTTL"
-$SDIG $nameserver 5301 defpol-with-ttl-capped.example.net a recurse 2>&1 | sed 's/\(0\tdefault.example.net.\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\115/'
+$SDIG $nameserver 5301 defpol-with-ttl-capped.example.net a recurse 2>&1 | sed 's/\(0\tdefault.example.net.\t\)\([0-9]\+\)/\115/'
 echo "==> defpol-without-ttl.example.net should use the zone's TTL"
-$SDIG $nameserver 5301 defpol-without-ttl.example.net a recurse 2>&1 | sed 's/\(0\tdefault.example.net.\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\115/'
+$SDIG $nameserver 5301 defpol-without-ttl.example.net a recurse 2>&1 | sed 's/\(0\tdefault.example.net.\t\)\([0-9]\+\)/\115/'
 echo "==> defpol-without-ttl-capped.example.net should use the zone's TTL but capped to maxTTL"
-$SDIG $nameserver 5301 defpol-without-ttl-capped.example.net a recurse 2>&1 | sed 's/\(0\tdefault.example.net.\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\115/'
+$SDIG $nameserver 5301 defpol-without-ttl-capped.example.net a recurse 2>&1 | sed 's/\(0\tdefault.example.net.\t\)\([0-9]\+\)/\115/'
 echo "==> unsupported.example.net has an unsupported target, should be ignored from the RPZ zone"
 $SDIG $nameserver 5301 unsupported.example.net a recurse 2>&1
 echo "==> unsupported2.example.net has an unsupported target, should be ignored from the RPZ zone"

--- a/regression-tests.recursor/RPZ/expected_result
+++ b/regression-tests.recursor/RPZ/expected_result
@@ -7,12 +7,12 @@ Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 ==> srv.arthur.example.net RPZ passthru
 Reply to question for qname='srv.arthur.example.net.', qtype=SRV
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	srv.arthur.example.net.	IN	SRV	15	0 100 389 server2.example.net.
+0	srv.arthur.example.net.	15	IN	SRV	0 100 389 server2.example.net.
 ==> www.example.net RPZ local data to www2.example.net
 Reply to question for qname='www.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	www.example.net.	IN	CNAME	7200	www2.example.net.
-0	www2.example.net.	IN	A	15	192.0.2.2
+0	www.example.net.	7200	IN	CNAME	www2.example.net.
+0	www2.example.net.	15	IN	A	192.0.2.2
 ==> www4.example.net RPZ IP trigger action, dropped
 ==> trillian.example.net NXDOMAIN
 Reply to question for qname='trillian.example.net.', qtype=A
@@ -20,8 +20,8 @@ Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 ==> www.trillian.example.net has no RPZ policy attached, so lookup should succeed
 Reply to question for qname='www.trillian.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	www.trillian.example.net.	IN	CNAME	15	www3.arthur.example.net.
-0	www3.arthur.example.net.	IN	A	15	192.0.2.6
+0	www.trillian.example.net.	15	IN	CNAME	www3.arthur.example.net.
+0	www3.arthur.example.net.	15	IN	A	192.0.2.6
 ==> www.hijackme.example.net is served on ns.hijackme.example.net, which should be NXDOMAIN
 Reply to question for qname='www.hijackme.example.net.', qtype=A
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
@@ -31,42 +31,42 @@ Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 ==> capped-ttl.example.net TTL exceeds the maximum TTL for the zone
 Reply to question for qname='capped-ttl.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	capped-ttl.example.net.	IN	A	5	192.0.2.35
+0	capped-ttl.example.net.	5	IN	A	192.0.2.35
 ==> defpol-with-ttl.example.net should use the default policy's TTL and not the zone one
 Reply to question for qname='defpol-with-ttl.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	defpol-with-ttl.example.net.	IN	CNAME	10	default.example.net.
-0	default.example.net.	IN	A	15	192.0.2.42
+0	defpol-with-ttl.example.net.	10	IN	CNAME	default.example.net.
+0	default.example.net.	15	IN	A	192.0.2.42
 ==> defpol-with-ttl-capped.example.net should use the default policy's TTL, but capped to maxTTL
 Reply to question for qname='defpol-with-ttl-capped.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	defpol-with-ttl-capped.example.net.	IN	CNAME	20	default.example.net.
-0	default.example.net.	IN	A	15	192.0.2.42
+0	defpol-with-ttl-capped.example.net.	20	IN	CNAME	default.example.net.
+0	default.example.net.	15	IN	A	192.0.2.42
 ==> defpol-without-ttl.example.net should use the zone's TTL
 Reply to question for qname='defpol-without-ttl.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	defpol-without-ttl.example.net.	IN	CNAME	7200	default.example.net.
-0	default.example.net.	IN	A	15	192.0.2.42
+0	defpol-without-ttl.example.net.	7200	IN	CNAME	default.example.net.
+0	default.example.net.	15	IN	A	192.0.2.42
 ==> defpol-without-ttl-capped.example.net should use the zone's TTL but capped to maxTTL
 Reply to question for qname='defpol-without-ttl-capped.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	defpol-without-ttl-capped.example.net.	IN	CNAME	50	default.example.net.
-0	default.example.net.	IN	A	15	192.0.2.42
+0	defpol-without-ttl-capped.example.net.	50	IN	CNAME	default.example.net.
+0	default.example.net.	15	IN	A	192.0.2.42
 ==> unsupported.example.net has an unsupported target, should be ignored from the RPZ zone
 Reply to question for qname='unsupported.example.net.', qtype=A
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-1	example.net.	IN	SOA	15	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+1	example.net.	15	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
 ==> unsupported2.example.net has an unsupported target, should be ignored from the RPZ zone
 Reply to question for qname='unsupported2.example.net.', qtype=A
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-1	example.net.	IN	SOA	15	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+1	example.net.	15	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
 ==> not-rpz.example.net is _not_ an RPZ target and should be processed
 Reply to question for qname='not-rpz.example.net.', qtype=A
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	not-rpz.example.net.	IN	CNAME	5	rpz-not.com.
-1	.	IN	SOA	15	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+0	not-rpz.example.net.	5	IN	CNAME	rpz-not.com.
+1	.	15	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
 ==> echo-me.wildcard-target.example.net is an RPZ wildcard target
 Reply to question for qname='echo-me.wildcard-target.example.net.', qtype=A
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	echo-me.wildcard-target.example.net.	IN	CNAME	7200	echo-me.wildcard-target.example.net.walled-garden.example.net.
-1	example.net.	IN	SOA	15	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+0	echo-me.wildcard-target.example.net.	7200	IN	CNAME	echo-me.wildcard-target.example.net.walled-garden.example.net.
+1	example.net.	15	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300

--- a/regression-tests.recursor/answer-in-local-auth/command
+++ b/regression-tests.recursor/answer-in-local-auth/command
@@ -1,1 +1,1 @@
-cleandig service.box.answer-cname-in-local.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig service.box.answer-cname-in-local.example.net. A | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/answer-in-local-auth/expected_result
+++ b/regression-tests.recursor/answer-in-local-auth/expected_result
@@ -1,5 +1,5 @@
-0	pfs.global.box.answer-cname-in-local.example.net.	IN	CNAME	3600	vip-reunion.pfsbox.answer-cname-in-local.example.net.
-0	service.box.answer-cname-in-local.example.net.	IN	CNAME	3600	pfs.global.box.answer-cname-in-local.example.net.
-0	vip-reunion.pfsbox.answer-cname-in-local.example.net.	IN	A	3600	10.1.1.1
+0	pfs.global.box.answer-cname-in-local.example.net.	3600	IN	CNAME	vip-reunion.pfsbox.answer-cname-in-local.example.net.
+0	service.box.answer-cname-in-local.example.net.	3600	IN	CNAME	pfs.global.box.answer-cname-in-local.example.net.
+0	vip-reunion.pfsbox.answer-cname-in-local.example.net.	3600	IN	A	10.1.1.1
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='service.box.answer-cname-in-local.example.net.', qtype=A

--- a/regression-tests.recursor/auth-zone-cname-wildcard/command
+++ b/regression-tests.recursor/auth-zone-cname-wildcard/command
@@ -1,2 +1,2 @@
-cleandig host1.something.auth-zone.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
-cleandig host1.something.auth-zone.example.net. AAAA | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig host1.something.auth-zone.example.net. A | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
+cleandig host1.something.auth-zone.example.net. AAAA | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/auth-zone-cname-wildcard/expected_result
+++ b/regression-tests.recursor/auth-zone-cname-wildcard/expected_result
@@ -1,8 +1,8 @@
-0	host1.auth-zone.example.net.	IN	A	3600	127.0.0.55
-0	host1.something.auth-zone.example.net.	IN	CNAME	3600	host1.auth-zone.example.net.
+0	host1.auth-zone.example.net.	3600	IN	A	127.0.0.55
+0	host1.something.auth-zone.example.net.	3600	IN	CNAME	host1.auth-zone.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='host1.something.auth-zone.example.net.', qtype=A
-0	host1.auth-zone.example.net.	IN	AAAA	3600	2001:db8::1:45ba
-0	host1.something.auth-zone.example.net.	IN	CNAME	3600	host1.auth-zone.example.net.
+0	host1.auth-zone.example.net.	3600	IN	AAAA	2001:db8::1:45ba
+0	host1.something.auth-zone.example.net.	3600	IN	CNAME	host1.auth-zone.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='host1.something.auth-zone.example.net.', qtype=AAAA

--- a/regression-tests.recursor/auth-zone-delegation/command
+++ b/regression-tests.recursor/auth-zone-delegation/command
@@ -1,2 +1,2 @@
-cleandig www.france.auth-zone.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
-cleandig france.auth-zone.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig www.france.auth-zone.example.net. A | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
+cleandig france.auth-zone.example.net. A | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/auth-zone-delegation/expected_result
+++ b/regression-tests.recursor/auth-zone-delegation/expected_result
@@ -1,6 +1,6 @@
-0	www.france.auth-zone.example.net.	IN	A	3600	192.0.2.23
+0	www.france.auth-zone.example.net.	3600	IN	A	192.0.2.23
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='www.france.auth-zone.example.net.', qtype=A
-0	france.auth-zone.example.net.	IN	A	3600	192.0.2.223
+0	france.auth-zone.example.net.	3600	IN	A	192.0.2.223
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='france.auth-zone.example.net.', qtype=A

--- a/regression-tests.recursor/auth-zones/command
+++ b/regression-tests.recursor/auth-zones/command
@@ -1,7 +1,7 @@
-cleandig host1.auth-zone.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
-cleandig host1.auth-zone.example.net. AAAA | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
-cleandig host2.auth-zone.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
-cleandig host3.auth-zone.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
-cleandig you-are.wild.auth-zone.example.net. TXT | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig host1.auth-zone.example.net. A | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
+cleandig host1.auth-zone.example.net. AAAA | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
+cleandig host2.auth-zone.example.net. A | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
+cleandig host3.auth-zone.example.net. A | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
+cleandig you-are.wild.auth-zone.example.net. TXT | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 # Non-existing QTYPE at the apex
-cleandig auth-zone.example.net. TXT | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig auth-zone.example.net. TXT | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/auth-zones/expected_result
+++ b/regression-tests.recursor/auth-zones/expected_result
@@ -1,20 +1,20 @@
-0	host1.auth-zone.example.net.	IN	A	3600	127.0.0.55
+0	host1.auth-zone.example.net.	3600	IN	A	127.0.0.55
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='host1.auth-zone.example.net.', qtype=A
-0	host1.auth-zone.example.net.	IN	AAAA	3600	2001:db8::1:45ba
+0	host1.auth-zone.example.net.	3600	IN	AAAA	2001:db8::1:45ba
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='host1.auth-zone.example.net.', qtype=AAAA
-0	host1.another-auth-zone.example.net.	IN	A	3600	127.0.0.56
-0	host2.auth-zone.example.net.	IN	CNAME	3600	host1.another-auth-zone.example.net.
+0	host1.another-auth-zone.example.net.	3600	IN	A	127.0.0.56
+0	host2.auth-zone.example.net.	3600	IN	CNAME	host1.another-auth-zone.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='host2.auth-zone.example.net.', qtype=A
-0	host1.not-auth-zone.example.net.	IN	A	3600	127.0.0.57
-0	host3.auth-zone.example.net.	IN	CNAME	3600	host1.not-auth-zone.example.net.
+0	host1.not-auth-zone.example.net.	3600	IN	A	127.0.0.57
+0	host3.auth-zone.example.net.	3600	IN	CNAME	host1.not-auth-zone.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='host3.auth-zone.example.net.', qtype=A
-0	you-are.wild.auth-zone.example.net.	IN	TXT	3600	"Hi there!"
+0	you-are.wild.auth-zone.example.net.	3600	IN	TXT	"Hi there!"
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='you-are.wild.auth-zone.example.net.', qtype=TXT
-1	auth-zone.example.net.	IN	SOA	3600	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+1	auth-zone.example.net.	3600	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='auth-zone.example.net.', qtype=TXT

--- a/regression-tests.recursor/cache-recursorcache-forward/command
+++ b/regression-tests.recursor/cache-recursorcache-forward/command
@@ -1,4 +1,4 @@
 #!/bin/bash
 $SDIG $nameserver 5302 www.arthur.example.net a recurse
 sleep 3
-$SDIG $nameserver 5302 www.arthur.example.net a recurse | sed 's/\(.*\tIN\tA\t\)\(11\)/\112/'
+$SDIG $nameserver 5302 www.arthur.example.net a recurse | sed 's/\(.*\t\)\(11\tIN\)/\112\tIN/'

--- a/regression-tests.recursor/cache-recursorcache-forward/expected_result
+++ b/regression-tests.recursor/cache-recursorcache-forward/expected_result
@@ -1,6 +1,6 @@
 Reply to question for qname='www.arthur.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	www.arthur.example.net.	IN	A	15	192.0.2.2
+0	www.arthur.example.net.	15	IN	A	192.0.2.2
 Reply to question for qname='www.arthur.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	www.arthur.example.net.	IN	A	12	192.0.2.2
+0	www.arthur.example.net.	12	IN	A	192.0.2.2

--- a/regression-tests.recursor/cname-to-a-nxdomain/command
+++ b/regression-tests.recursor/cname-to-a-nxdomain/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig www-a.prefect.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig www-a.prefect.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/cname-to-a-nxdomain/expected_result
+++ b/regression-tests.recursor/cname-to-a-nxdomain/expected_result
@@ -1,4 +1,4 @@
-0	www-a.prefect.example.net.	IN	CNAME	3600	www-a-2.prefect.example.net.
-1	prefect.example.net.	IN	SOA	3600	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+0	www-a.prefect.example.net.	3600	IN	CNAME	www-a-2.prefect.example.net.
+1	prefect.example.net.	3600	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='www-a.prefect.example.net.', qtype=A

--- a/regression-tests.recursor/cross-zone-cname-bogus-nxdomain/command
+++ b/regression-tests.recursor/cross-zone-cname-bogus-nxdomain/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig www.trillian.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig www.trillian.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/cross-zone-cname-bogus-nxdomain/expected_result
+++ b/regression-tests.recursor/cross-zone-cname-bogus-nxdomain/expected_result
@@ -1,4 +1,4 @@
-0	www.trillian.example.net.	IN	CNAME	3600	www3.arthur.example.net.
-0	www3.arthur.example.net.	IN	A	3600	192.0.2.6
+0	www.trillian.example.net.	3600	IN	CNAME	www3.arthur.example.net.
+0	www3.arthur.example.net.	3600	IN	A	192.0.2.6
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='www.trillian.example.net.', qtype=A

--- a/regression-tests.recursor/direct-cname-to-nxdomain/command
+++ b/regression-tests.recursor/direct-cname-to-nxdomain/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig www-a.prefect.example.net cname | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig www-a.prefect.example.net cname | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/direct-cname-to-nxdomain/expected_result
+++ b/regression-tests.recursor/direct-cname-to-nxdomain/expected_result
@@ -1,3 +1,3 @@
-0	www-a.prefect.example.net.	IN	CNAME	3600	www-a-2.prefect.example.net.
+0	www-a.prefect.example.net.	3600	IN	CNAME	www-a-2.prefect.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='www-a.prefect.example.net.', qtype=CNAME

--- a/regression-tests.recursor/direct-cname/command
+++ b/regression-tests.recursor/direct-cname/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig www-d.prefect.example.net cname | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig www-d.prefect.example.net cname | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/direct-cname/expected_result
+++ b/regression-tests.recursor/direct-cname/expected_result
@@ -1,3 +1,3 @@
-0	www-d.prefect.example.net.	IN	CNAME	3600	www.arthur.example.net.
+0	www-d.prefect.example.net.	3600	IN	CNAME	www.arthur.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='www-d.prefect.example.net.', qtype=CNAME

--- a/regression-tests.recursor/ghost-1/command
+++ b/regression-tests.recursor/ghost-1/command
@@ -1,13 +1,13 @@
 #!/bin/sh
 . vars
 rm -f configs/$PREFIX.17/drop-1
-cleandig a.www.1.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig a.www.1.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 sleep 8
 touch configs/$PREFIX.17/drop-1
-cleandig b.www.1.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig b.www.1.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 sleep 5
-cleandig c.www.1.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig c.www.1.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 sleep 5
-cleandig d.www.1.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig d.www.1.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 sleep 5
-cleandig e.www.1.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig e.www.1.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/ghost-1/expected_result
+++ b/regression-tests.recursor/ghost-1/expected_result
@@ -1,15 +1,15 @@
-0	a.www.1.ghost.example.net.	IN	A	3600	192.0.2.7
+0	a.www.1.ghost.example.net.	3600	IN	A	192.0.2.7
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='a.www.1.ghost.example.net.', qtype=A
-0	b.www.1.ghost.example.net.	IN	A	3600	192.0.2.7
+0	b.www.1.ghost.example.net.	3600	IN	A	192.0.2.7
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='b.www.1.ghost.example.net.', qtype=A
-0	c.www.1.ghost.example.net.	IN	A	3600	192.0.2.7
+0	c.www.1.ghost.example.net.	3600	IN	A	192.0.2.7
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='c.www.1.ghost.example.net.', qtype=A
-1	ghost.example.net.	IN	SOA	3600	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+1	ghost.example.net.	3600	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='d.www.1.ghost.example.net.', qtype=A
-1	ghost.example.net.	IN	SOA	3600	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+1	ghost.example.net.	3600	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='e.www.1.ghost.example.net.', qtype=A

--- a/regression-tests.recursor/ghost-2/command
+++ b/regression-tests.recursor/ghost-2/command
@@ -1,13 +1,13 @@
 #!/bin/sh
 . vars
 rm -f configs/$PREFIX.17/drop-2
-cleandig a.www.2.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig a.www.2.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 sleep 8
 touch configs/$PREFIX.17/drop-2
-cleandig b.www.2.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig b.www.2.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 sleep 5
-cleandig c.www.2.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig c.www.2.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 sleep 5
-cleandig d.www.2.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig d.www.2.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 sleep 5
-cleandig e.www.2.ghost.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig e.www.2.ghost.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/ghost-2/expected_result
+++ b/regression-tests.recursor/ghost-2/expected_result
@@ -1,15 +1,15 @@
-0	a.www.2.ghost.example.net.	IN	A	3600	192.0.2.8
+0	a.www.2.ghost.example.net.	3600	IN	A	192.0.2.8
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='a.www.2.ghost.example.net.', qtype=A
-0	b.www.2.ghost.example.net.	IN	A	3600	192.0.2.8
+0	b.www.2.ghost.example.net.	3600	IN	A	192.0.2.8
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='b.www.2.ghost.example.net.', qtype=A
-0	c.www.2.ghost.example.net.	IN	A	3600	192.0.2.8
+0	c.www.2.ghost.example.net.	3600	IN	A	192.0.2.8
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='c.www.2.ghost.example.net.', qtype=A
-1	ghost.example.net.	IN	SOA	3600	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+1	ghost.example.net.	3600	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='d.www.2.ghost.example.net.', qtype=A
-1	ghost.example.net.	IN	SOA	3600	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+1	ghost.example.net.	3600	IN	SOA	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='e.www.2.ghost.example.net.', qtype=A

--- a/regression-tests.recursor/hijack-1/command
+++ b/regression-tests.recursor/hijack-1/command
@@ -1,5 +1,5 @@
 #!/bin/sh
 . vars
-cleandig hijacker.example.net ns | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
-cleandig www.hijackme.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig hijacker.example.net ns | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
+cleandig www.hijackme.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
 sleep 5

--- a/regression-tests.recursor/hijack-1/expected_result
+++ b/regression-tests.recursor/hijack-1/expected_result
@@ -1,6 +1,6 @@
-0	hijacker.example.net.	IN	NS	3600	ns.hijackme.example.net.
+0	hijacker.example.net.	3600	IN	NS	ns.hijackme.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='hijacker.example.net.', qtype=NS
-0	www.hijackme.example.net.	IN	A	3600	192.0.2.20
+0	www.hijackme.example.net.	3600	IN	A	192.0.2.20
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='www.hijackme.example.net.', qtype=A

--- a/regression-tests.recursor/in-zone-cname-bogus-nxdomain/command
+++ b/regression-tests.recursor/in-zone-cname-bogus-nxdomain/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig www.marvin.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig www.marvin.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/in-zone-cname-bogus-nxdomain/expected_result
+++ b/regression-tests.recursor/in-zone-cname-bogus-nxdomain/expected_result
@@ -1,4 +1,4 @@
-0	android.marvin.example.net.	IN	A	3600	192.0.2.5
-0	www.marvin.example.net.	IN	CNAME	3600	android.marvin.example.net.
+0	android.marvin.example.net.	3600	IN	A	192.0.2.5
+0	www.marvin.example.net.	3600	IN	CNAME	android.marvin.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='www.marvin.example.net.', qtype=A

--- a/regression-tests.recursor/lame-noerror/command
+++ b/regression-tests.recursor/lame-noerror/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig www.ford.example.net A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig www.ford.example.net A | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/simple-a/command
+++ b/regression-tests.recursor/simple-a/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig www.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig www.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/simple-a/expected_result
+++ b/regression-tests.recursor/simple-a/expected_result
@@ -1,3 +1,3 @@
-0	www.example.net.	IN	A	3600	192.0.2.1
+0	www.example.net.	3600	IN	A	192.0.2.1
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='www.example.net.', qtype=A

--- a/regression-tests.recursor/simple-cname-to-a/command
+++ b/regression-tests.recursor/simple-cname-to-a/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig www-d.prefect.example.net a | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig www-d.prefect.example.net a | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/simple-cname-to-a/expected_result
+++ b/regression-tests.recursor/simple-cname-to-a/expected_result
@@ -1,4 +1,4 @@
-0	www-d.prefect.example.net.	IN	CNAME	3600	www.arthur.example.net.
-0	www.arthur.example.net.	IN	A	3600	192.0.2.2
+0	www-d.prefect.example.net.	3600	IN	CNAME	www.arthur.example.net.
+0	www.arthur.example.net.	3600	IN	A	192.0.2.2
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='www-d.prefect.example.net.', qtype=A

--- a/regression-tests.recursor/simple-rawtypes/command
+++ b/regression-tests.recursor/simple-rawtypes/command
@@ -1,4 +1,4 @@
 #!/bin/sh
-cleandig srv.arthur.example.net srv | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
-cleandig rp.arthur.example.net rp | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
-cleandig type1234.arthur.example.net TYPE1234 | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig srv.arthur.example.net srv | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
+cleandig rp.arthur.example.net rp | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'
+cleandig type1234.arthur.example.net TYPE1234 | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/simple-rawtypes/expected_result
+++ b/regression-tests.recursor/simple-rawtypes/expected_result
@@ -1,9 +1,9 @@
-0	srv.arthur.example.net.	IN	SRV	3600	0 100 389 server2.example.net.
+0	srv.arthur.example.net.	3600	IN	SRV	0 100 389 server2.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='srv.arthur.example.net.', qtype=SRV
-0	rp.arthur.example.net.	IN	RP	3600	ahu.ds9a.nl. counter.arthur.example.net.
+0	rp.arthur.example.net.	3600	IN	RP	ahu.ds9a.nl. counter.arthur.example.net.
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='rp.arthur.example.net.', qtype=RP
-0	type1234.arthur.example.net.	IN	TYPE1234	3600	\# 2 4142
+0	type1234.arthur.example.net.	3600	IN	TYPE1234	\# 2 4142
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='type1234.arthur.example.net.', qtype=TYPE1234

--- a/regression-tests.recursor/truncate-empty/command
+++ b/regression-tests.recursor/truncate-empty/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig big.arthur.example.net txt | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig big.arthur.example.net txt | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/txt-escaping/command
+++ b/regression-tests.recursor/txt-escaping/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-cleandig weirdtxt.example.net txt | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig weirdtxt.example.net txt | sed 's/\(.*\t\)\([0-9]\+\tIN\)/\13600\tIN/'

--- a/regression-tests.recursor/txt-escaping/expected_result
+++ b/regression-tests.recursor/txt-escaping/expected_result
@@ -1,3 +1,3 @@
-0	weirdtxt.example.net.	IN	TXT	3600	"x\014x"
+0	weirdtxt.example.net.	3600	IN	TXT	"x\014x"
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='weirdtxt.example.net.', qtype=TXT


### PR DESCRIPTION
### Short description
Change the `auth` repository version used for the `recursor`'s regression tests to 4.8.

`sdig` output format changes in 4.8 as described in this [PR](https://github.com/PowerDNS/pdns/pull/11858).

This PR enables upgrading the docker base image in `build-and-test-all.yml` from Debian Bullseye to Bookworm.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
