### PR TITLE
Remove unused pip packages from gh-actions-setup

### DIFF
--- a/build-scripts/gh-actions-setup-inv
+++ b/build-scripts/gh-actions-setup-inv
@@ -11,7 +11,4 @@ sudo dpkg --purge --force-all grub-efi-amd64-signed && sudo dpkg --purge --force
 sudo dpkg --purge --force-all firefox
 sudo apt-get autoremove
 sudo apt-get -qq -y --allow-downgrades dist-upgrade
-sudo apt-get -qq -y --no-install-recommends install python3-pip
-sudo pip3 install git+https://github.com/pyinvoke/invoke@faa5728a6f76199a3da1750ed952e7efee17c1da
-sudo pip3 install gitpython
-sudo pip3 install unidiff
+sudo apt-get -qq -y --no-install-recommends install python3-pip python3-invoke

--- a/build-scripts/gh-actions-setup-inv-no-dist-upgrade
+++ b/build-scripts/gh-actions-setup-inv-no-dist-upgrade
@@ -7,5 +7,3 @@ EOF
 sudo chmod 755 /usr/sbin/policy-rc.d
 sudo apt-get update
 sudo apt-get -qq -y --no-install-recommends install python3-pip python3-invoke
-sudo pip3 install gitpython
-sudo pip3 install unidiff

--- a/tasks.py
+++ b/tasks.py
@@ -152,7 +152,6 @@ doc_deps_pdf = [
 
 @task
 def apt_fresh(c):
-    c.sudo('sed -i \'s/azure\.//\' /etc/apt/sources.list')
     c.sudo('apt-get update')
     c.sudo('apt-get -y --allow-downgrades dist-upgrade')
 


### PR DESCRIPTION
### Short description
Clang-tidy checks were moved to the CodeQL workflow [here](https://github.com/PowerDNS/pdns/pull/13414). This PR removes its dependencies from `build-scripts/gh-actions-setup-inv` and `build-scripts/gh-actions-setup-inv-no-dist-upgrade`.

In addition, the attempt to remove the Azure APT repository from `sources.list` is also cleaned. This only made sense when `build-and-test-all.yml` tests were executed directly on the GitHub workers. No longer needed as they now run on Docker containers.

This PR enables building also Debian Bookworm as the base image for the `build-and-test-all.yml` workflow.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
