### PR TITLE
systemd service: restart less agressively but still quicker

### DIFF
--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -13,10 +13,8 @@ User=@service_user@
 Group=@service_group@
 SyslogIdentifier=dnsdist
 Type=notify
-Restart=on-failure
-RestartSec=2
+Restart=on-abnormal
 TimeoutStopSec=5
-StartLimitInterval=0
 
 # Tuning
 TasksMax=8192

--- a/pdns/ixfrdist.service.in
+++ b/pdns/ixfrdist.service.in
@@ -9,9 +9,7 @@ After=network-online.target time-sync.target
 [Service]
 Type=simple
 ExecStart=@bindir@/ixfrdist
-Restart=on-failure
-RestartSec=1
-StartLimitInterval=0
+Restart=on-abnormal
 
 # Sandboxing
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID

--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -11,9 +11,7 @@ SyslogIdentifier=pdns_server
 User=@service_user@
 Group=@service_group@
 Type=notify
-Restart=on-failure
-RestartSec=1
-StartLimitInterval=0
+Restart=on-abnormal
 RuntimeDirectory=pdns
 
 # Sandboxing

--- a/pdns/recursordist/pdns-recursor.service.in
+++ b/pdns/recursordist/pdns-recursor.service.in
@@ -10,8 +10,7 @@ ExecStart=@sbindir@/pdns_recursor --daemon=no --write-pid=no --disable-syslog --
 User=@service_user@
 Group=@service_group@
 Type=notify
-Restart=on-failure
-StartLimitInterval=0
+Restart=on-abnormal
 RuntimeDirectory=pdns-recursor
 SyslogIdentifier=pdns-recursor
 


### PR DESCRIPTION
If a service fails to start because it's not properly configured (e.g. directly after installation) the existing settings make the daemons restart in a loop. Each start logs several lines to the journal which quickly results in older but probably still relevant logs of other serives being rotated out.

Dropping RestartSec makes systemd use the default of 100ms. So a restart happens quicker. With dropping StartLimitInterval=0 systemd applies some ratelimiting and (by default) only starts the service 5 times per 10s.

Replacing Restart=on-failure by Restart=on-abnormal makes systemd not restart the service if the daemon process exits with a non-zero exit code. It's still restarted when the process exits by a signal (other than SIGHUP, SIGINT, SIGTERM or SIGPIPE).

Debian-Bug: https://bugs.debian.org/1055529

### Short description
I'm well aware that these settings are very much depending on personal preferences. But IMHO this is another hint that pdns should stick to system defaults and let the administrator fine tune the settings if needed. The motivation to change these settings came from installing the Debian package which in my case resulted in an annoying restart loop. See the linked Debian bug report. The Debian maintainer asked me to forward this issue upstream; here it is.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] tested this code

