### PR TITLE
rec: introduce command to set aggressive NSEC cache size

### DIFF
--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -48,6 +48,11 @@ public:
   {
   }
 
+  void setMaxEntries(uint64_t number)
+  {
+    d_maxEntries = number;
+  }
+
   static bool nsec3Disabled()
   {
     return s_maxNSEC3CommonPrefix == 0;

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <atomic>
 #include <boost/utility.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -162,7 +163,7 @@ private:
   pdns::stat_t d_nsecWildcardHits{0};
   pdns::stat_t d_nsec3WildcardHits{0};
   pdns::stat_t d_entriesCount{0};
-  uint64_t d_maxEntries{0};
+  std::atomic<uint64_t> d_maxEntries{0};
 };
 
 extern std::unique_ptr<AggressiveNSECCache> g_aggressiveNSECCache;

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -231,7 +231,7 @@ set-max-aggr-nsec-cache-size *NUM*
     Change the maximum number of entries in the NSEC aggressive cache. If the
     cache is disabled by setting its size to 0 in the config, the cache size
     cannot be set by this command. Setting the size to 0 by this command still
-    keeps the cache, but makes it mostly ineffective as it emptied periodically.
+    keeps the cache, but makes it mostly ineffective as it is emptied periodically.
 
 set-max-cache-entries *NUM*
     Change the maximum number of entries in the DNS cache.  If reduced, the

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -227,6 +227,12 @@ set-dnssec-log-bogus *SETTING*
 set-ecs-minimum-ttl *NUM*
     Set ecs-minimum-ttl-override to *NUM*.
 
+set-max-aggr-nsec-cache-size *NUM*
+    Change the maximum number of entries in the NSEC aggressive cache. If the
+    cache is disabled by setting its size to 0 in the config, the cache size
+    cannot be set by this command. Setting the size to 0 by this command still
+    keeps the cache, but makes it mostly ineffective as it emptied periodically.
+
 set-max-cache-entries *NUM*
     Change the maximum number of entries in the DNS cache.  If reduced, the
     cache size will start shrinking to this number as part of the normal

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2104,7 +2104,7 @@ static RecursorControlChannel::Answer help()
           "reload-lua-config [filename]     (re)load Lua configuration file\n"
           "reload-zones                     reload all auth and forward zones\n"
           "set-ecs-minimum-ttl value        set ecs-minimum-ttl-override\n"
-          "set-max-aggr-nsec-cache-size     set new maximum aggressive NSEC cache size\n"
+          "set-max-aggr-nsec-cache-size value set new maximum aggressive NSEC cache size\n"
           "set-max-cache-entries value      set new maximum record cache size\n"
           "set-max-packetcache-entries val  set new maximum packet cache size\n"
           "set-minimum-ttl value            set minimum-ttl-override\n"

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -888,6 +888,25 @@ static string setMaxPacketCacheEntries(T begin, T end)
   }
 }
 
+template <typename T>
+static RecursorControlChannel::Answer setAggrNSECCacheSize(T begin, T end)
+{
+  if (end - begin != 1) {
+    return {1, "Need to supply new aggressive NSEC cache size\n"};
+  }
+  if (!g_aggressiveNSECCache) {
+    return {1, "Aggressive NSEC cache is disabled by startup config\n"};
+  }
+  try {
+    auto newmax = pdns::checked_stoi<uint64_t>(*begin);
+    g_aggressiveNSECCache->setMaxEntries(newmax);
+    return {0, "New aggressive NSEC cache size: " + std::to_string(newmax) + "\n"};
+  }
+  catch (const std::exception& e) {
+    return {1, "Error parsing the new aggressive NSEC cache size: " + std::string(e.what()) + "\n"};
+  }
+}
+
 static uint64_t getSysTimeMsec()
 {
   struct rusage ru;
@@ -2085,7 +2104,8 @@ static RecursorControlChannel::Answer help()
           "reload-lua-config [filename]     (re)load Lua configuration file\n"
           "reload-zones                     reload all auth and forward zones\n"
           "set-ecs-minimum-ttl value        set ecs-minimum-ttl-override\n"
-          "set-max-cache-entries value      set new maximum cache size\n"
+          "set-max-aggr-nsec-cache-size     set new maximum aggressive NSEC cache size\n"
+          "set-max-cache-entries value      set new maximum record cache size\n"
           "set-max-packetcache-entries val  set new maximum packet cache size\n"
           "set-minimum-ttl value            set minimum-ttl-override\n"
           "set-carbon-server                set a carbon server for telemetry\n"
@@ -2364,6 +2384,9 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int socket, cons
   }
   if (cmd == "list-dnssec-algos") {
     return {0, DNSCryptoKeyEngine::listSupportedAlgoNames()};
+  }
+  if (cmd == "set-aggr-nsec-cache-size") {
+    return setAggrNSECCacheSize(begin, end);
   }
 
   return {1, "Unknown command '" + cmd + "', try 'help'\n"};


### PR DESCRIPTION
To avoid race conditions creating and destroying the cache, we do not allow setting the cache size if it is not enabled from startup. Also, setting the cache size to 0 with this command does not disable the cache, it just makes it mostly ineffective (entries can still appear in it and get used until the purge task is run). 

Fixes #13265.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
