### PR TITLE
rec: document outgoing querycounts better, including a small fix

### DIFF
--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -170,7 +170,7 @@ number of answers synthesized from NSEC entries and wildcards by the NSEC3 aggre
 
 all-outqueries
 ^^^^^^^^^^^^^^
-counts the number of outgoing UDP queries since starting
+counts the number of outgoing queries since starting, this includes UDP, TCP, DoT queries both over IPv4 and IPv6
 
 answers-slow
 ^^^^^^^^^^^^
@@ -458,7 +458,7 @@ number of outgoing queries dropped because of   :ref:`setting-dont-query` settin
 
 dot-outqueries
 ^^^^^^^^^^^^^^
-counts the number of outgoing DoT queries since starting
+counts the number of outgoing DoT queries since starting, both using IPv4 and IPv6
 
 qname-min-fallback-success
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -513,11 +513,11 @@ counts the number of non-query packets received   on server sockets that should 
 
 ipv6-outqueries
 ^^^^^^^^^^^^^^^
-number of outgoing queries over IPv6
+number of outgoing queries over IPv6 using UDP, since version 5.0.0 also including TCP and DoT
 
 ipv6-questions
 ^^^^^^^^^^^^^^
-counts all end-user initiated queries with the RD   bit set, received over IPv6 UDP
+counts all client initiated queries using IPv6
 
 maintenance-usec
 ^^^^^^^^^^^^^^^^
@@ -760,7 +760,7 @@ counts the number of currently active TCP/IP clients
 
 tcp-outqueries
 ^^^^^^^^^^^^^^
-counts the number of outgoing TCP queries since   starting
+counts the number of outgoing TCP queries since starting, both using IPv4 and IPV6
 
 tcp-questions
 ^^^^^^^^^^^^^

--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -468,9 +468,6 @@ static LWResult::Result asyncresolve(const ComboAddress& address, const DNSName&
 
   if (!doTCP) {
     int queryfd;
-    if (address.sin4.sin_family == AF_INET6) {
-      t_Counters.at(rec::Counter::ipv6queries)++;
-    }
 
     ret = asendto(vpacket.data(), vpacket.size(), 0, address, qid, domain, type, weWantEDNSSubnet, &queryfd);
 

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -616,6 +616,7 @@ private:
   bool addAdditionals(QType qtype, vector<DNSRecord>& ret, unsigned int depth);
 
   bool doDoTtoAuth(const DNSName& ns) const;
+  void updateQueryCounts(const string& prefix, const DNSName& qname, const ComboAddress& address, bool doTCP, bool doDoT);
   int doResolveAt(NsSet& nameservers, DNSName auth, bool flawedNSSet, const DNSName& qname, QType qtype, vector<DNSRecord>& ret,
                   unsigned int depth, const string& prefix, set<GetBestNSAnswer>& beenthere, Context& context, StopAtDelegation* stopAtDelegation,
                   std::map<DNSName, std::vector<ComboAddress>>* fallback);

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -616,7 +616,7 @@ static void serveStuff(HttpRequest* req, HttpResponse* resp)
 const std::map<std::string, MetricDefinition> MetricDefinitionStorage::d_metrics = {
   {"all-outqueries",
    MetricDefinition(PrometheusMetricType::counter,
-                    "Number of outgoing UDP queries since starting")},
+                    "Number of outgoing queries since starting")},
 
   {"answers-slow",
    MetricDefinition(PrometheusMetricType::counter,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes #13463

There are also two behaviour changes: previously v6 queries over TCP or DoT were not counted in `ipv6-outqueries`, and queries were counted even when a Lua `preoutquery` hook would have prevented them.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
