### PR TITLE
auth api: flush all caches when flushing

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2331,6 +2331,7 @@ static void patchZone(UeberBackend& B, const DNSName& zonename, DomainInfo& di, 
 
   di.backend->commitTransaction();
 
+  DNSSECKeeper::clearCaches(zonename);
   purgeAuthCaches(zonename.toString() + "$");
 
   resp->body = "";
@@ -2459,6 +2460,7 @@ static void apiServerCacheFlush(HttpRequest* req, HttpResponse* resp) {
     }
   }
 
+  DNSSECKeeper::clearCaches(canon);
   // purge entire zone from cache, not just zone-level records.
   uint64_t count = purgeAuthCaches(canon.toString() + "$");
   resp->setJsonBody(Json::object {


### PR DESCRIPTION

### Short description
So far we never flushed the DNSSEC caches, except when DELETEing a domain. However clearly some operations can affect the DNSSEC settings, and then the caches should go.

Also do this for the flush API, to be consistent, and for users writing to the DNSSEC settings/data externally.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

