### PR TITLE
dnsdist-1.8.x: Refactor the exponential back-off timer code

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -138,6 +138,7 @@ dnsdist_SOURCES = \
 	dnscrypt.cc dnscrypt.hh \
 	dnsdist-async.cc dnsdist-async.hh \
 	dnsdist-backend.cc \
+	dnsdist-backoff.hh \
 	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-carbon.cc dnsdist-carbon.hh \
 	dnsdist-concurrent-connections.hh \
@@ -250,6 +251,7 @@ testrunner_SOURCES = \
 	dnscrypt.cc dnscrypt.hh \
 	dnsdist-async.cc dnsdist-async.hh \
 	dnsdist-backend.cc \
+	dnsdist-backoff.hh \
 	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-concurrent-connections.hh \
 	dnsdist-dnsparser.cc dnsdist-dnsparser.hh \
@@ -316,6 +318,7 @@ testrunner_SOURCES = \
 	test-dnsdist_cc.cc \
 	test-dnsdistasync.cc \
 	test-dnsdistbackend_cc.cc \
+	test-dnsdistbackoff.cc \
 	test-dnsdistdynblocks_hh.cc \
 	test-dnsdistkvs_cc.cc \
 	test-dnsdistlbpolicies_cc.cc \

--- a/pdns/dnsdistdist/dnsdist-backoff.hh
+++ b/pdns/dnsdistdist/dnsdist-backoff.hh
@@ -1,0 +1,44 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+class ExponentialBackOffTimer
+{
+public:
+  ExponentialBackOffTimer(unsigned int maxBackOff) :
+    d_maxBackOff(maxBackOff)
+  {
+  }
+
+  unsigned int get(size_t consecutiveFailures) const
+  {
+    unsigned int backOff = d_maxBackOff;
+    if (consecutiveFailures <= 31) {
+      backOff = 1U << consecutiveFailures;
+      backOff = std::min(d_maxBackOff, backOff);
+    }
+    return backOff;
+  }
+
+private:
+  const unsigned int d_maxBackOff;
+};

--- a/pdns/dnsdistdist/test-dnsdistbackoff.cc
+++ b/pdns/dnsdistdist/test-dnsdistbackoff.cc
@@ -1,0 +1,58 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include "dnsdist-backoff.hh"
+
+BOOST_AUTO_TEST_SUITE(dnsdistbackoff)
+
+BOOST_AUTO_TEST_CASE(test_ExponentialBackOffTimer)
+{
+  const unsigned int maxBackOff = 10 * 60;
+  const ExponentialBackOffTimer ebot(maxBackOff);
+  const std::vector<std::pair<size_t, unsigned int>> testVector{
+    {0U, 1U},
+    {1U, 2U},
+    {2U, 4U},
+    {3U, 8U},
+    {4U, 16U},
+    {5U, 32U},
+    {6U, 64U},
+    {7U, 128U},
+    {8U, 256U},
+    {9U, 512U},
+    {10U, maxBackOff}};
+  for (const auto& entry : testVector) {
+    BOOST_CHECK_EQUAL(ebot.get(entry.first), entry.second);
+  }
+
+  /* the behaviour is identical after 32 but let's go to 1024 to be safe */
+  for (size_t consecutiveFailures = testVector.size(); consecutiveFailures < 1024; consecutiveFailures++) {
+    BOOST_CHECK_EQUAL(ebot.get(consecutiveFailures), maxBackOff);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The existing code could overflow in some cases, leading to a potentially endless busy-loop.

Backport of #13520 to rel/dnsdist-1.8.x.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
