### PR TITLE
Various cleanups and fixes

### DIFF
--- a/modules/remotebackend/test-remotebackend-http.cc
+++ b/modules/remotebackend/test-remotebackend-http.cc
@@ -55,7 +55,10 @@ public:
 
 std::unique_ptr<DNSBackend> backendUnderTest;
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE unit
 

--- a/modules/remotebackend/test-remotebackend-json.cc
+++ b/modules/remotebackend/test-remotebackend-json.cc
@@ -53,7 +53,10 @@ public:
 
 std::unique_ptr<DNSBackend> backendUnderTest;
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE unit
 

--- a/modules/remotebackend/test-remotebackend-pipe.cc
+++ b/modules/remotebackend/test-remotebackend-pipe.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE unit
 

--- a/modules/remotebackend/test-remotebackend-post.cc
+++ b/modules/remotebackend/test-remotebackend-post.cc
@@ -53,7 +53,10 @@ public:
 
 std::unique_ptr<DNSBackend> backendUnderTest;
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE unit
 

--- a/modules/remotebackend/test-remotebackend-unix.cc
+++ b/modules/remotebackend/test-remotebackend-unix.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE unit
 

--- a/modules/remotebackend/test-remotebackend-zeromq.cc
+++ b/modules/remotebackend/test-remotebackend-zeromq.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE unit
 

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -167,7 +167,6 @@ static void sendPackets(const vector<std::unique_ptr<Socket>>& sockets, const ve
     cmsgbuf_aligned cbuf;
   };
   vector<unique_ptr<Unit> > units;
-  int ret;
 
   for(const auto& p : packets) {
     count++;
@@ -179,11 +178,14 @@ static void sendPackets(const vector<std::unique_ptr<Socket>>& sockets, const ve
     }
 
     fillMSGHdr(&u.msgh, &u.iov, nullptr, 0, (char*)&(*p)[0], p->size(), &dest);
-    if((ret=sendmsg(sockets[count % sockets.size()]->getHandle(),
-		    &u.msgh, 0)))
-      if(ret < 0)
-	      unixDie("sendmsg");
 
+    auto socketHandle = sockets[count % sockets.size()]->getHandle();
+    ssize_t sendmsgRet = sendmsg(socketHandle, &u.msgh, 0);
+    if (sendmsgRet != 0) {
+      if (sendmsgRet < 0) {
+        unixDie("sendmsg");
+      }
+    }
 
     if(!(count%burst)) {
       nBursts++;

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -72,7 +72,7 @@ static void recvThread(const std::shared_ptr<std::vector<std::unique_ptr<Socket>
 
   int err;
 
-#if HAVE_RECVMMSG
+#ifdef HAVE_RECVMMSG
   vector<struct mmsghdr> buf(100);
   for(auto& m : buf) {
     cmsgbuf_aligned *cbuf = new cmsgbuf_aligned;
@@ -96,7 +96,7 @@ static void recvThread(const std::shared_ptr<std::vector<std::unique_ptr<Socket>
 
     for(auto &pfd : fds) {
       if (pfd.revents & POLLIN) {
-#if HAVE_RECVMMSG
+#ifdef HAVE_RECVMMSG
         if ((err=recvmmsg(pfd.fd, &buf[0], buf.size(), MSG_WAITFORONE, 0)) < 0 ) {
           if(errno != EAGAIN)
             unixDie("recvmmsg");
@@ -384,7 +384,7 @@ try
   struct sched_param param;
   param.sched_priority=99;
 
-#if HAVE_SCHED_SETSCHEDULER
+#ifdef HAVE_SCHED_SETSCHEDULER
   if(sched_setscheduler(0, SCHED_FIFO, &param) < 0) {
     if (!g_quiet) {
       cerr<<"Unable to set SCHED_FIFO: "<<stringerror()<<endl;

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -179,12 +179,12 @@ static void sendPackets(const vector<std::unique_ptr<Socket>>& sockets, const ve
     }
 
     fillMSGHdr(&u.msgh, &u.iov, nullptr, 0, (char*)&(*p)[0], p->size(), &dest);
-    if((ret=sendmsg(sockets[count % sockets.size()]->getHandle(), 
+    if((ret=sendmsg(sockets[count % sockets.size()]->getHandle(),
 		    &u.msgh, 0)))
       if(ret < 0)
 	      unixDie("sendmsg");
-    
-    
+
+
     if(!(count%burst)) {
       nBursts++;
       // Calculate the time in nsec we need to sleep to the next burst.
@@ -264,11 +264,11 @@ void parseQueryFile(const std::string& queryFile, vector<std::shared_ptr<vector<
   We then move the 1000 unique queries to the 'known' pool.
 
   For the next second, say 20000 qps, we know we are going to need 2000 new queries,
-  so we take 2000 from the unknown pool. Then we need 18000 cache hits. We can get 1000 from 
+  so we take 2000 from the unknown pool. Then we need 18000 cache hits. We can get 1000 from
   the known pool, leaving us down 17000. Or, we have 3000 in total now and we need 2000. We simply
   repeat the 3000 mix we have ~7 times. The 2000 can now go to the known pool too.
 
-  For the next second, say 30000 qps, we'll need 3000 cache misses, which we get from 
+  For the next second, say 30000 qps, we'll need 3000 cache misses, which we get from
   the unknown pool. To this we add 3000 queries from the known pool. Next up we repeat this batch 5
   times.
 
@@ -400,7 +400,7 @@ try
   if (!g_quiet) {
     cout<<"Generated "<<unknown.size()<<" ready to use queries"<<endl;
   }
-  
+
   auto sockets = std::make_shared<std::vector<std::unique_ptr<Socket>>>();
   ComboAddress dest;
   try {
@@ -489,13 +489,13 @@ try
     dt.set();
 
     sendPackets(*sockets, toSend, qps, dest, ecsRange);
-    
+
     const auto udiff = dt.udiffNoReset();
     const auto realqps=toSend.size()/(udiff/1000000.0);
     if (!g_quiet) {
       cout<<"Achieved "<<realqps<<" qps over "<< udiff/1000000.0<<" seconds"<<endl;
     }
-    
+
     usleep(50000);
     const auto received = g_recvcounter.load();
     const auto udiffReceived = dt.udiff();

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -3,7 +3,10 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #include <decaf.hxx>
+#pragma GCC diagnostic pop
 #include <decaf/eddsa.hxx>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -5,7 +5,10 @@
 #endif
 #include <decaf.hxx>
 #include <decaf/eddsa.hxx>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <decaf/spongerng.hxx>
+#pragma GCC diagnostic pop
 #include "dnsseckeeper.hh"
 
 #include "dnssecinfra.hh"

--- a/pdns/dnsdistdist/test-connectionmanagement_hh.cc
+++ b/pdns/dnsdistdist/test-connectionmanagement_hh.cc
@@ -1,5 +1,7 @@
-
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-delaypipe_hh.cc
+++ b/pdns/dnsdistdist/test-delaypipe_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
+++ b/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/test-dnsdist-dnsparser.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistasync.cc
+++ b/pdns/dnsdistdist/test-dnsdistasync.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistbackend_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistbackend_cc.cc
@@ -1,5 +1,8 @@
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
+++ b/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
@@ -1,5 +1,8 @@
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistedns.cc
+++ b/pdns/dnsdistdist/test-dnsdistedns.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistkvs_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistkvs_cc.cc
@@ -1,5 +1,8 @@
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
@@ -1,5 +1,8 @@
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistluanetwork.cc
+++ b/pdns/dnsdistdist/test-dnsdistluanetwork.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2-in_cc.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistnghttp2_cc.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdistrings_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrings_cc.cc
@@ -1,5 +1,8 @@
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <thread>

--- a/pdns/dnsdistdist/test-dnsdistrules_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrules_cc.cc
@@ -1,5 +1,8 @@
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <thread>

--- a/pdns/dnsdistdist/test-dnsdistsvc_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistsvc_cc.cc
@@ -1,5 +1,8 @@
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/dnsdistdist/testrunner.cc
+++ b/pdns/dnsdistdist/testrunner.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE unit
 

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -23,7 +23,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#if HAVE_BOOST_GE_148
+#ifdef HAVE_BOOST_GE_148
 #include "histog.hh"
 #endif
 
@@ -139,7 +139,7 @@ try
     ("rd", po::value<bool>(), "If set to true, only process RD packets, to false only non-RD, unset: both")
     ("ipv4", po::value<bool>()->default_value(true), "Process IPv4 packets")
     ("ipv6", po::value<bool>()->default_value(true), "Process IPv6 packets")
-#if HAVE_BOOST_GE_148
+#ifdef HAVE_BOOST_GE_148
     ("log-histogram", "Write a log-histogram to file 'log-histogram'")
     ("full-histogram", po::value<double>(), "Write a log-histogram to file 'full-histogram' with this millisecond bin size")
 #endif
@@ -472,7 +472,7 @@ try
   cout.precision(4);
   sum=0;
 
-#if HAVE_BOOST_GE_148
+#ifdef HAVE_BOOST_GE_148
   if(g_vm.count("log-histogram")) {
     string fname = g_vm["stats-dir"].as<string>()+"/log-histogram";
     ofstream loglog(fname);

--- a/pdns/histog.hh
+++ b/pdns/histog.hh
@@ -1,10 +1,10 @@
 #pragma once
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 #include <vector>
 #include <fstream>

--- a/pdns/histog.hh
+++ b/pdns/histog.hh
@@ -45,13 +45,13 @@ std::vector<LogHistogramBin> createLogHistogram(const T& bins)
       break;
     sum += c.second;
     bincount += c.second;
-      
+
     acc(c.first/1000.0, ba::weight=c.second);
     for(unsigned int i=0; i < c.second; ++i)
       cumulstats(c.first/1000.0, ba::weight=1); // "weighted" does not work for median
     if(sum > percentiles.front() * totcumul / 100.0) {
       ret.push_back({100.0-percentiles.front(), (double)c.first/1000.0, ba::mean(acc), ba::median(acc), sqrt(ba::variance(acc)), bincount, ba::mean(cumulstats), ba::median(cumulstats)});
-      
+
       percentiles.pop_front();
       acc=decltype(acc)();
       bincount=0;
@@ -81,8 +81,8 @@ void writeLogHistogramFile(const T& bins, std::ostream& out)
 #	'log-histogram' using 1:7 with linespoints title 'Cumulative median latency')"<<"\n";
 
   out<<"# slow-percentile usec-latency-mean usec-latency-max usec-latency-median usec-latency-stddev usec-latency-cumul usec-latency-median-cumul num-queries\n";
-  
-  
+
+
   for(const auto& e : vec) {
     out<<e.percentile<<" "<<e.latAverage<<" "<<e.latLimit<<" "<<e.latMedian<<" "<<e.latStddev<<" "<<e.cumulLatAverage<<" "<<e.cumulLatMedian<<" "<<e.count<<"\n";
   }

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -939,7 +939,7 @@ std::pair<std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)>, std::vector<std::st
   /* load certificate and private key */
   for (const auto& pair : config.d_certKeyPairs) {
     if (!pair.d_key) {
-#if defined(HAVE_SSL_CTX_USE_CERT_AND_KEY) && HAVE_SSL_CTX_USE_CERT_AND_KEY == 1
+#if defined(HAVE_SSL_CTX_USE_CERT_AND_KEY) && defined(HAVE_SSL_CTX_USE_CERT_AND_KEY)
       // If no separate key is given, treat it as a pkcs12 file
       auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(pair.d_cert.c_str(), "r"), fclose);
       if (!fp) {

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "aggressive_nsec.hh"

--- a/pdns/recursordist/test-ednsoptions_cc.cc
+++ b/pdns/recursordist/test-ednsoptions_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/recursordist/test-filterpo_cc.cc
+++ b/pdns/recursordist/test-filterpo_cc.cc
@@ -1,5 +1,8 @@
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/recursordist/test-histogram_hh.cc
+++ b/pdns/recursordist/test-histogram_hh.cc
@@ -20,7 +20,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/recursordist/test-mtasker.cc
+++ b/pdns/recursordist/test-mtasker.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 

--- a/pdns/recursordist/test-nod_cc.cc
+++ b/pdns/recursordist/test-nod_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 #include "nod.hh"

--- a/pdns/recursordist/test-rec-taskqueue.cc
+++ b/pdns/recursordist/test-rec-taskqueue.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include <stdio.h>

--- a/pdns/recursordist/test-rec-tcounters_cc.cc
+++ b/pdns/recursordist/test-rec-tcounters_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/recursordist/test-rec-zonetocache.cc
+++ b/pdns/recursordist/test-rec-zonetocache.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include <stdio.h>

--- a/pdns/recursordist/test-recpacketcache_cc.cc
+++ b/pdns/recursordist/test-recpacketcache_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/recursordist/test-reczones-helpers.cc
+++ b/pdns/recursordist/test-reczones-helpers.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include <cstdio>

--- a/pdns/recursordist/test-secpoll_cc.cc
+++ b/pdns/recursordist/test-secpoll_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/recursordist/test-settings.cc
+++ b/pdns/recursordist/test-settings.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include <memory>

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "aggressive_nsec.hh"

--- a/pdns/recursordist/test-syncres_cc1.cc
+++ b/pdns/recursordist/test-syncres_cc1.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/test-syncres_cc10.cc
+++ b/pdns/recursordist/test-syncres_cc10.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/test-syncres_cc2.cc
+++ b/pdns/recursordist/test-syncres_cc2.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/test-syncres_cc3.cc
+++ b/pdns/recursordist/test-syncres_cc3.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/test-syncres_cc5.cc
+++ b/pdns/recursordist/test-syncres_cc5.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/test-syncres_cc6.cc
+++ b/pdns/recursordist/test-syncres_cc6.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/test-syncres_cc7.cc
+++ b/pdns/recursordist/test-syncres_cc7.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/test-syncres_cc9.cc
+++ b/pdns/recursordist/test-syncres_cc9.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"

--- a/pdns/recursordist/testrunner.cc
+++ b/pdns/recursordist/testrunner.cc
@@ -19,7 +19,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -133,7 +133,7 @@ public:
 #endif
     }
     else {
-#if (OPENSSL_VERSION_NUMBER >= 0x1010000fL) && HAVE_SSL_SET_HOSTFLAGS // grrr libressl
+#if (OPENSSL_VERSION_NUMBER >= 0x1010000fL) && defined(HAVE_SSL_SET_HOSTFLAGS) // grrr libressl
       SSL_set_hostflags(d_conn.get(), X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
       if (SSL_set1_host(d_conn.get(), d_hostname.c_str()) != 1) {
         throw std::runtime_error("Error setting TLS hostname for certificate validation");
@@ -1110,7 +1110,7 @@ public:
     gnutls_handshake_set_timeout(d_conn.get(),  timeout.tv_sec * 1000 + timeout.tv_usec / 1000);
     gnutls_record_set_timeout(d_conn.get(),  timeout.tv_sec * 1000 + timeout.tv_usec / 1000);
 
-#if HAVE_GNUTLS_SESSION_SET_VERIFY_CERT
+#ifdef HAVE_GNUTLS_SESSION_SET_VERIFY_CERT
     if (validateCerts && !d_host.empty()) {
       gnutls_session_set_verify_cert(d_conn.get(), d_host.c_str(), GNUTLS_VERIFY_ALLOW_UNSORTED_CHAIN);
       rc = gnutls_server_name_set(d_conn.get(), GNUTLS_NAME_DNS, d_host.c_str(), d_host.size());
@@ -1258,7 +1258,7 @@ public:
       else if (gnutls_error_is_fatal(ret) || ret == GNUTLS_E_WARNING_ALERT_RECEIVED) {
         if (d_client) {
           std::string error;
-#if HAVE_GNUTLS_SESSION_GET_VERIFY_CERT_STATUS
+#ifdef HAVE_GNUTLS_SESSION_GET_VERIFY_CERT_STATUS
           if (ret == GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR) {
             gnutls_datum_t out;
             if (gnutls_certificate_verification_status_print(gnutls_session_get_verify_cert_status(d_conn.get()), gnutls_certificate_type_get(d_conn.get()), &out, 0) == 0) {

--- a/pdns/test-arguments_cc.cc
+++ b/pdns/test-arguments_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-auth-zonecache_cc.cc
+++ b/pdns/test-auth-zonecache_cc.cc
@@ -1,4 +1,3 @@
-
 /*
     PowerDNS Versatile Database Driven Nameserver
     Copyright (C) 2021  PowerDNS.COM BV
@@ -21,7 +20,10 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-base32_cc.cc
+++ b/pdns/test-base32_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-base64_cc.cc
+++ b/pdns/test-base64_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-bindparser_cc.cc
+++ b/pdns/test-bindparser_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-channel.cc
+++ b/pdns/test-channel.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/test-communicator_hh.cc
+++ b/pdns/test-communicator_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-credentials_cc.cc
+++ b/pdns/test-credentials_cc.cc
@@ -1,5 +1,8 @@
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/algorithm/string.hpp>

--- a/pdns/test-digests_hh.cc
+++ b/pdns/test-digests_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-dnscrypt_cc.cc
+++ b/pdns/test-dnscrypt_cc.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #include <boost/test/unit_test.hpp>
 
 #include <cmath>

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -23,10 +23,10 @@ BOOST_AUTO_TEST_SUITE(test_dnsname_cc)
 BOOST_AUTO_TEST_CASE(test_basic) {
   DNSName aroot("a.root-servers.net"), broot("b.root-servers.net");
   BOOST_CHECK(aroot < broot);
-  BOOST_CHECK(!(broot < aroot));  
+  BOOST_CHECK(!(broot < aroot));
   BOOST_CHECK(aroot.canonCompare(broot));
-  BOOST_CHECK(!broot.canonCompare(aroot));  
-  
+  BOOST_CHECK(!broot.canonCompare(aroot));
+
 
   string before("www.ds9a.nl.");
   DNSName b(before);
@@ -112,14 +112,14 @@ BOOST_AUTO_TEST_CASE(test_basic) {
     DNSName name;
     BOOST_CHECK(name.empty());
   }
-  
+
   { // empty() root
     DNSName name(".");
     BOOST_CHECK(!name.empty());
-    
+
     DNSName rootnodot("");
     BOOST_CHECK_EQUAL(name, rootnodot);
-    
+
     string empty;
     DNSName rootnodot2(empty);
     BOOST_CHECK_EQUAL(rootnodot2, name);
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(test_basic) {
   left.appendRawLabel("com");
 
   BOOST_CHECK( left == DNSName("WwW.Ds9A.Nl.com."));
-  
+
   DNSName unset;
 
   unset.appendRawLabel("www");
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(test_empty) {
   BOOST_CHECK(!empty.isWildcard());
   BOOST_CHECK_EQUAL(empty, empty);
   BOOST_CHECK(!(empty < empty));
-  
+
   DNSName root(".");
   BOOST_CHECK(empty < root);
 
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(test_empty) {
 
 BOOST_AUTO_TEST_CASE(test_specials) {
   DNSName root(".");
-  
+
   BOOST_CHECK(root.isRoot());
   BOOST_CHECK(root != DNSName());
 
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(test_chopping) {
 BOOST_AUTO_TEST_CASE(test_Append) {
   DNSName dn("www."), powerdns("powerdns.com.");
   DNSName tot=dn+powerdns;
-  
+
   BOOST_CHECK_EQUAL(tot.toString(), "www.powerdns.com.");
   BOOST_CHECK(tot == DNSName("www.powerdns.com."));
 
@@ -284,14 +284,14 @@ BOOST_AUTO_TEST_CASE(test_packetCompress) {
   aaaa.toPacket(dpw);
   dpw.commit();
   string str((const char*)&packet[0], (const char*)&packet[0] + packet.size());
-  size_t pos = 0; 
+  size_t pos = 0;
   int count=0;
   while((pos = str.find("ds9a", pos)) != string::npos) {
     ++pos;
     ++count;
   }
   BOOST_CHECK_EQUAL(count, 1);
-  pos = 0; 
+  pos = 0;
   count=0;
   while((pos = str.find("powerdns", pos)) != string::npos) {
     ++pos;
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(test_packetCompressLong) {
   dpw.commit();
   DNSName roundtrip((char*)&packet[0], packet.size(), 12, false);
   BOOST_CHECK_EQUAL(loopback,roundtrip);
-  
+
   packet.clear();
   DNSName longer("1.2.3.4.5.6.7.8.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa");
   DNSPacketWriter dpw2(packet, longer, QType::PTR);
@@ -350,26 +350,26 @@ BOOST_AUTO_TEST_CASE(test_PacketParse) {
 BOOST_AUTO_TEST_CASE(test_hash) {
   DNSName a("wwW.Ds9A.Nl"), b("www.ds9a.nl");
   BOOST_CHECK_EQUAL(a.hash(), b.hash());
-  
+
   vector<uint32_t> counts(1500);
- 
+
   for(unsigned int n=0; n < 100000; ++n) {
     DNSName dn(std::to_string(n)+"."+std::to_string(n*2)+"ds9a.nl");
     DNSName dn2(std::to_string(n)+"."+std::to_string(n*2)+"Ds9a.nL");
     BOOST_CHECK_EQUAL(dn.hash(), dn2.hash());
     counts[dn.hash() % counts.size()]++;
   }
-  
+
   double sum = std::accumulate(std::begin(counts), std::end(counts), 0.0);
   double m =  sum / counts.size();
-  
+
   double accum = 0.0;
   std::for_each (std::begin(counts), std::end(counts), [&](const double d) {
       accum += (d - m) * (d - m);
   });
-      
+
   double stdev = sqrt(accum / (counts.size()-1));
-  BOOST_CHECK(stdev < 10);      
+  BOOST_CHECK(stdev < 10);
 }
 
 BOOST_AUTO_TEST_CASE(test_hashContainer) {
@@ -455,7 +455,7 @@ BOOST_AUTO_TEST_CASE(test_packetParse) {
   vector<unsigned char> packet;
   reportBasicTypes();
   DNSPacketWriter dpw(packet, DNSName("www.ds9a.nl."), QType::AAAA);
-  
+
   uint16_t qtype, qclass;
   DNSName dn((char*)&packet[0], packet.size(), 12, false, &qtype, &qclass);
   BOOST_CHECK_EQUAL(dn.toString(), "www.ds9a.nl.");
@@ -479,15 +479,15 @@ BOOST_AUTO_TEST_CASE(test_packetParse) {
      content name */
 
   DNSName dn2((char*)&packet[0], packet.size(), 12+13+4, true, &qtype, &qclass);
-  BOOST_CHECK_EQUAL(dn2.toString(), "ds9a.nl."); 
+  BOOST_CHECK_EQUAL(dn2.toString(), "ds9a.nl.");
   BOOST_CHECK(qtype == QType::NS);
   BOOST_CHECK_EQUAL(qclass, 1);
 
   DNSName dn3((char*)&packet[0], packet.size(), 12+13+4+2 + 4 + 4 + 2, true);
-  BOOST_CHECK_EQUAL(dn3.toString(), "ns1.powerdns.com."); 
+  BOOST_CHECK_EQUAL(dn3.toString(), "ns1.powerdns.com.");
   try {
     DNSName dn4((char*)&packet[0], packet.size(), 12+13+4, false); // compressed, should fail
-    BOOST_CHECK(0); 
+    BOOST_CHECK(0);
   }
   catch(...){}
 }
@@ -720,7 +720,7 @@ BOOST_AUTO_TEST_CASE(test_compare_canonical) {
 
   vector<DNSName> vec;
   for(const char* b : {"bert.com.", "alpha.nl.", "articles.xxx.",
-	"Aleph1.powerdns.com.", "ZOMG.powerdns.com.", "aaa.XXX.", "yyy.XXX.", 
+	"Aleph1.powerdns.com.", "ZOMG.powerdns.com.", "aaa.XXX.", "yyy.XXX.",
 	"test.powerdns.com.", "\\128.com"}) {
     vec.push_back(DNSName(b));
   }
@@ -739,7 +739,7 @@ BOOST_AUTO_TEST_CASE(test_compare_canonical) {
 	"yyy.XXX."})
     right.push_back(DNSName(b));
 
-  
+
   BOOST_CHECK(vec==right);
 }
 

--- a/pdns/test-dnsparser_cc.cc
+++ b/pdns/test-dnsparser_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-dnsparser_cc.cc
+++ b/pdns/test-dnsparser_cc.cc
@@ -610,7 +610,7 @@ BOOST_AUTO_TEST_CASE(test_clearDNSPacketUnsafeRecordTypes) {
     // MX is unsafe, but we asked to remove it
     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 1, QType::A), 1);
     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 1, QType::AAAA), 0);
-    BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 3, QType::A), 1); 
+    BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 3, QType::A), 1);
     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 3, QType::MX), 0);
   }
 

--- a/pdns/test-dnsparser_hh.cc
+++ b/pdns/test-dnsparser_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-dnsrecordcontent.cc
+++ b/pdns/test-dnsrecordcontent.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/test-dnswriter_cc.cc
+++ b/pdns/test-dnswriter_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-ednscookie_cc.cc
+++ b/pdns/test-ednscookie_cc.cc
@@ -19,7 +19,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-ipcrypt_cc.cc
+++ b/pdns/test-ipcrypt_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/test-ixfr_cc.cc
+++ b/pdns/test-ixfr_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-lock_hh.cc
+++ b/pdns/test-lock_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-lua_auth4_cc.cc
+++ b/pdns/test-lua_auth4_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-luawrapper.cc
+++ b/pdns/test-luawrapper.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-mplexer.cc
+++ b/pdns/test-mplexer.cc
@@ -1,5 +1,7 @@
-
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <thread>

--- a/pdns/test-nameserver_cc.cc
+++ b/pdns/test-nameserver_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-nameserver_cc.cc
+++ b/pdns/test-nameserver_cc.cc
@@ -25,11 +25,11 @@ BOOST_AUTO_TEST_CASE(test_AddressIsUs4) {
   ComboAddress Remote("192.168.255.255", 53);
 
   g_localaddresses.push_back(ComboAddress("0.0.0.0", 53));
-    
+
   BOOST_CHECK_EQUAL(AddressIsUs(local1), true);
 //  BOOST_CHECK_EQUAL(AddressIsUs(local2), false);
   BOOST_CHECK_EQUAL(AddressIsUs(Remote), false);
-  
+
   g_localaddresses.clear();
   g_localaddresses.push_back(ComboAddress("192.168.255.255", 53));
   BOOST_CHECK_EQUAL(AddressIsUs(Remote), true);
@@ -42,10 +42,10 @@ BOOST_AUTO_TEST_CASE(test_AddressIsUs6) {
   ComboAddress local2("127.0.0.2", 53);
   ComboAddress local3("::1", 53);
   ComboAddress Remote("192.168.255.255", 53);
-  
+
   g_localaddresses.clear();
   g_localaddresses.push_back(ComboAddress("::", 53));
-  
+
   BOOST_CHECK_EQUAL(AddressIsUs(local1), true);
 //  BOOST_CHECK_EQUAL(AddressIsUs(local2), false);
   if(!getenv("PDNS_TEST_NO_IPV6")) BOOST_CHECK_EQUAL(AddressIsUs(local3), true);

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-packetcache_hh.cc
+++ b/pdns/test-packetcache_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-proxy_protocol_cc.cc
+++ b/pdns/test-proxy_protocol_cc.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #include <boost/test/unit_test.hpp>
 
 #include "iputils.hh"

--- a/pdns/test-rcpgenerator_cc.cc
+++ b/pdns/test-rcpgenerator_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-rcpgenerator_cc.cc
+++ b/pdns/test-rcpgenerator_cc.cc
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(test_xfrIP6) {
         loopback6.append(15, 0);
         loopback6.append(1,1);
         BOOST_CHECK_EQUAL(makeHexDump(rawIPv6), makeHexDump(loopback6));
-        
+
         RecordTextReader rtr2("2a01:4f8:d12:1880::5");
         rtr2.xfrIP6(rawIPv6);
         string ip6("\x2a\x01\x04\xf8\x0d\x12\x18\x80\x00\x00\x00\x00\x00\x00\x00\x05", 16);

--- a/pdns/test-sha_hh.cc
+++ b/pdns/test-sha_hh.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/test-sha_hh.cc
+++ b/pdns/test-sha_hh.cc
@@ -28,40 +28,40 @@ BOOST_AUTO_TEST_CASE(test_sha1) {
    cases_t cases = list_of
       (case_t("abc", "a9 99 3e 36 47 06 81 6a ba 3e 25 71 78 50 c2 6c 9c d0 d8 9d "))
       (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "84 98 3e 44 1c 3b d2 6e ba ae 4a a1 f9 51 29 e5 e5 46 70 f1 "));
-   
+
    for(case_t& val :  cases) {
       BOOST_CHECK_EQUAL(makeHexDump(pdns_sha1sum(val.get<0>())), val.get<1>());
    }
 }
 
 BOOST_AUTO_TEST_CASE(test_sha256) {
-   cases_t cases = list_of 
-      (case_t("abc", "ba 78 16 bf 8f 01 cf ea 41 41 40 de 5d ae 22 23 b0 03 61 a3 96 17 7a 9c b4 10 ff 61 f2 00 15 ad ")) 
-      (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "24 8d 6a 61 d2 06 38 b8 e5 c0 26 93 0c 3e 60 39 a3 3c e4 59 64 ff 21 67 f6 ec ed d4 19 db 06 c1 ")); 
+   cases_t cases = list_of
+      (case_t("abc", "ba 78 16 bf 8f 01 cf ea 41 41 40 de 5d ae 22 23 b0 03 61 a3 96 17 7a 9c b4 10 ff 61 f2 00 15 ad "))
+      (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "24 8d 6a 61 d2 06 38 b8 e5 c0 26 93 0c 3e 60 39 a3 3c e4 59 64 ff 21 67 f6 ec ed d4 19 db 06 c1 "));
 
-   for(case_t& val :  cases) { 
+   for(case_t& val :  cases) {
       BOOST_CHECK_EQUAL(makeHexDump(pdns_sha256sum(val.get<0>())), val.get<1>());
-   } 
+   }
 }
 
 BOOST_AUTO_TEST_CASE(test_sha384) {
-   cases_t cases = list_of 
-      (case_t("abc", "cb 00 75 3f 45 a3 5e 8b b5 a0 3d 69 9a c6 50 07 27 2c 32 ab 0e de d1 63 1a 8b 60 5a 43 ff 5b ed 80 86 07 2b a1 e7 cc 23 58 ba ec a1 34 c8 25 a7 ")) 
-      (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "33 91 fd dd fc 8d c7 39 37 07 a6 5b 1b 47 09 39 7c f8 b1 d1 62 af 05 ab fe 8f 45 0d e5 f3 6b c6 b0 45 5a 85 20 bc 4e 6f 5f e9 5b 1f e3 c8 45 2b ")); 
+   cases_t cases = list_of
+      (case_t("abc", "cb 00 75 3f 45 a3 5e 8b b5 a0 3d 69 9a c6 50 07 27 2c 32 ab 0e de d1 63 1a 8b 60 5a 43 ff 5b ed 80 86 07 2b a1 e7 cc 23 58 ba ec a1 34 c8 25 a7 "))
+      (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "33 91 fd dd fc 8d c7 39 37 07 a6 5b 1b 47 09 39 7c f8 b1 d1 62 af 05 ab fe 8f 45 0d e5 f3 6b c6 b0 45 5a 85 20 bc 4e 6f 5f e9 5b 1f e3 c8 45 2b "));
 
-   for(case_t& val :  cases) { 
+   for(case_t& val :  cases) {
       BOOST_CHECK_EQUAL(makeHexDump(pdns_sha384sum(val.get<0>())), val.get<1>());
-   } 
+   }
 }
 
 BOOST_AUTO_TEST_CASE(test_sha512) {
-   cases_t cases = list_of 
-      (case_t("abc", "dd af 35 a1 93 61 7a ba cc 41 73 49 ae 20 41 31 12 e6 fa 4e 89 a9 7e a2 0a 9e ee e6 4b 55 d3 9a 21 92 99 2a 27 4f c1 a8 36 ba 3c 23 a3 fe eb bd 45 4d 44 23 64 3c e8 0e 2a 9a c9 4f a5 4c a4 9f ")) 
-      (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "20 4a 8f c6 dd a8 2f 0a 0c ed 7b eb 8e 08 a4 16 57 c1 6e f4 68 b2 28 a8 27 9b e3 31 a7 03 c3 35 96 fd 15 c1 3b 1b 07 f9 aa 1d 3b ea 57 78 9c a0 31 ad 85 c7 a7 1d d7 03 54 ec 63 12 38 ca 34 45 ")); 
+   cases_t cases = list_of
+      (case_t("abc", "dd af 35 a1 93 61 7a ba cc 41 73 49 ae 20 41 31 12 e6 fa 4e 89 a9 7e a2 0a 9e ee e6 4b 55 d3 9a 21 92 99 2a 27 4f c1 a8 36 ba 3c 23 a3 fe eb bd 45 4d 44 23 64 3c e8 0e 2a 9a c9 4f a5 4c a4 9f "))
+      (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "20 4a 8f c6 dd a8 2f 0a 0c ed 7b eb 8e 08 a4 16 57 c1 6e f4 68 b2 28 a8 27 9b e3 31 a7 03 c3 35 96 fd 15 c1 3b 1b 07 f9 aa 1d 3b ea 57 78 9c a0 31 ad 85 c7 a7 1d d7 03 54 ec 63 12 38 ca 34 45 "));
 
-   for(case_t& val :  cases) { 
+   for(case_t& val :  cases) {
       BOOST_CHECK_EQUAL(makeHexDump(pdns_sha512sum(val.get<0>())), val.get<1>());
-   } 
+   }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-sholder_hh.cc
+++ b/pdns/test-sholder_hh.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/test-statbag_cc.cc
+++ b/pdns/test-statbag_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-statbag_cc.cc
+++ b/pdns/test-statbag_cc.cc
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(test_StatBagBasic) {
   s.declare("c", "description");
   s.inc("a");
   BOOST_CHECK_EQUAL(s.read("a"), 1UL);
-  
+
   unsigned long n;
   for(n=0; n < 1000000; ++n)
     s.inc("b");
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_StatBagBasic) {
   manglers.clear();
 
   BOOST_CHECK_EQUAL(s.read("c"), 4000000U);
- 
+
   s.set("c", 0);
 
   for (int i=0; i < 4; ++i) {
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(test_StatBagBasic) {
   s.inc("c");
   BOOST_CHECK_EQUAL(s.read("c"), (1ULL<<31) +1 );
 
-#ifdef UINTPTR_MAX  
+#ifdef UINTPTR_MAX
 #if UINTPTR_MAX > 0xffffffffULL
     BOOST_CHECK_EQUAL(sizeof(AtomicCounterInner), 8U);
     s.set("c", 1ULL<<33);
@@ -111,4 +111,3 @@ BOOST_AUTO_TEST_CASE(test_StatBagBasic) {
 
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/pdns/test-svc_records_cc.cc
+++ b/pdns/test-svc_records_cc.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/test-trusted-notification-proxy_cc.cc
+++ b/pdns/test-trusted-notification-proxy_cc.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #include <boost/test/unit_test.hpp>
 #include "trusted-notification-proxy.hh"
 

--- a/pdns/test-tsig.cc
+++ b/pdns/test-tsig.cc
@@ -21,7 +21,10 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #ifdef HAVE_CONFIG_H

--- a/pdns/test-webserver_cc.cc
+++ b/pdns/test-webserver_cc.cc
@@ -1,4 +1,7 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>

--- a/pdns/test-zonemd_cc.cc
+++ b/pdns/test-zonemd_cc.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #include <boost/test/unit_test.hpp>
 
 #include "zonemd.hh"

--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -1,5 +1,9 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
+
 #define BOOST_TEST_NO_MAIN
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/testrunner.cc
+++ b/pdns/testrunner.cc
@@ -1,4 +1,6 @@
+#ifndef BOOST_TEST_DYN_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -24,7 +24,10 @@
 #include <string>
 #include <list>
 #include <boost/utility.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #include <yahttp/yahttp.hpp>
+#pragma GCC diagnostic pop
 
 #include "json11.hpp"
 


### PR DESCRIPTION
### Short description

Best viewed on a per-commit basis.

- Fix some uses of `#if` instead of `#ifdef`.
- Silence some warnings when including header files that we don't really control or want to clean up (e.g. `ext/`).
- Don't redefine `BOOST_TEST_DYN_LINK` if it's already passed on the command-line because `gcc` warns about it. Meson passes it on the cmdline so it doesn't need to be redefined in the test file.
- And of course whitespace cleanups.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)