### PR TITLE
dnsdist: Make the max size of entries in the packet cache configurable

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -119,9 +119,10 @@ void DNSDistPacketCache::insertLocked(CacheShard& shard, std::unordered_map<uint
 
 void DNSDistPacketCache::insert(uint32_t key, const boost::optional<Netmask>& subnet, uint16_t queryFlags, bool dnssecOK, const DNSName& qname, uint16_t qtype, uint16_t qclass, const PacketBuffer& response, bool receivedOverUDP, uint8_t rcode, boost::optional<uint32_t> tempFailureTTL)
 {
-  if (response.size() < sizeof(dnsheader)) {
+  if (response.size() < sizeof(dnsheader) || response.size() > getMaximumEntrySize()) {
     return;
   }
+
   if (qtype == QType::AXFR || qtype == QType::IXFR) {
     return;
   }
@@ -619,4 +620,9 @@ std::set<ComboAddress> DNSDistPacketCache::getRecordsForDomain(const DNSName& do
   }
 
   return addresses;
+}
+
+void DNSDistPacketCache::setMaximumEntrySize(size_t maxSize)
+{
+  d_maximumEntrySize = maxSize;
 }

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -75,11 +75,13 @@ public:
     d_keepStaleData = keep;
   }
 
-
   void setECSParsingEnabled(bool enabled)
   {
     d_parseECS = enabled;
   }
+
+  void setMaximumEntrySize(size_t maxSize);
+  size_t getMaximumEntrySize() const { return d_maximumEntrySize; }
 
   uint32_t getKey(const DNSName::string_t& qname, size_t qnameWireLength, const PacketBuffer& packet, bool receivedOverUDP);
 
@@ -139,15 +141,16 @@ private:
   pdns::stat_t d_ttlTooShorts{0};
   pdns::stat_t d_cleanupCount{0};
 
-  size_t d_maxEntries;
-  uint32_t d_shardCount;
-  uint32_t d_maxTTL;
-  uint32_t d_tempFailureTTL;
-  uint32_t d_maxNegativeTTL;
-  uint32_t d_minTTL;
-  uint32_t d_staleTTL;
-  bool d_dontAge;
-  bool d_deferrableInsertLock;
+  const size_t d_maxEntries;
+  size_t d_maximumEntrySize{4096};
+  const uint32_t d_shardCount;
+  const uint32_t d_maxTTL;
+  const uint32_t d_tempFailureTTL;
+  const uint32_t d_maxNegativeTTL;
+  const uint32_t d_minTTL;
+  const uint32_t d_staleTTL;
+  const bool d_dontAge;
+  const bool d_deferrableInsertLock;
   bool d_parseECS;
   bool d_keepStaleData{false};
 };

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -1015,9 +1015,7 @@ void IncomingTCPConnectionState::handleIO()
             return;
           }
 
-          /* allocate a bit more memory to be able to spoof the content, get an answer from the cache
-             or to add ECS without allocating a new buffer */
-          d_buffer.resize(std::max(d_querySize + static_cast<size_t>(512), s_maxPacketCacheEntrySize));
+          d_buffer.resize(d_querySize);
           d_currentPos = 0;
         }
         else {

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1134,7 +1134,6 @@ extern bool g_addEDNSToSelfGeneratedResponses;
 
 extern std::set<std::string> g_capabilitiesToRetain;
 static const uint16_t s_udpIncomingBufferSize{1500}; // don't accept UDP queries larger than this value
-static const size_t s_maxPacketCacheEntrySize{4096}; // don't cache responses larger than this value
 
 enum class ProcessQueryResult : uint8_t { Drop, SendAnswer, PassToBackend, Asynchronous };
 ProcessQueryResult processQuery(DNSQuestion& dq, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend);

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -41,6 +41,7 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
     size_t maxNegativeTTL = 3600;
     size_t staleTTL = 60;
     size_t numberOfShards = 20;
+    size_t maxEntrySize{0};
     bool dontAge = false;
     bool deferrableInsertLock = true;
     bool ecsParsing = false;
@@ -59,6 +60,7 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
     getOptionalValue<size_t>(vars, "staleTTL", staleTTL);
     getOptionalValue<size_t>(vars, "temporaryFailureTTL", tempFailTTL);
     getOptionalValue<bool>(vars, "cookieHashing", cookieHashing);
+    getOptionalValue<size_t>(vars, "maximumEntrySize", maxEntrySize);
 
     if (getOptionalValue<decltype(skipOptions)>(vars, "skipOptions", skipOptions) > 0) {
       for (const auto& option : skipOptions) {
@@ -87,6 +89,9 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
 
     res->setKeepStaleData(keepStaleData);
     res->setSkippedOptions(optionsToSkip);
+    if (maxEntrySize >= sizeof(dnsheader)) {
+      res->setMaximumEntrySize(maxEntrySize);
+    }
 
     return res;
   });

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -226,7 +226,7 @@ protected:
 class TCPConnectionToBackend : public ConnectionToBackend
 {
 public:
-  TCPConnectionToBackend(const std::shared_ptr<DownstreamState>& ds, std::unique_ptr<FDMultiplexer>& mplexer, const struct timeval& now, std::string&& /* proxyProtocolPayload*, unused but there to match the HTTP2 connections, so we can use the same templated connections manager class */): ConnectionToBackend(ds, mplexer, now), d_responseBuffer(s_maxPacketCacheEntrySize)
+  TCPConnectionToBackend(const std::shared_ptr<DownstreamState>& ds, std::unique_ptr<FDMultiplexer>& mplexer, const struct timeval& now, std::string&& /* proxyProtocolPayload*, unused but there to match the HTTP2 connections, so we can use the same templated connections manager class */): ConnectionToBackend(ds, mplexer, now), d_responseBuffer(512)
   {
   }
 

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -30,7 +30,7 @@ public:
   enum class QueryProcessingResult : uint8_t { Forwarded, TooSmall, InvalidHeaders, Dropped, SelfAnswered, NoBackend, Asynchronous };
   enum class ProxyProtocolResult : uint8_t { Reading, Done, Error };
 
-  IncomingTCPConnectionState(ConnectionInfo&& ci, TCPClientThreadData& threadData, const struct timeval& now): d_buffer(s_maxPacketCacheEntrySize), d_ci(std::move(ci)), d_handler(d_ci.fd, timeval{g_tcpRecvTimeout,0}, d_ci.cs->tlsFrontend ? d_ci.cs->tlsFrontend->getContext() : (d_ci.cs->dohFrontend ? d_ci.cs->dohFrontend->d_tlsContext.getContext() : nullptr), now.tv_sec), d_connectionStartTime(now), d_ioState(make_unique<IOStateHandler>(*threadData.mplexer, d_ci.fd)), d_threadData(threadData), d_creatorThreadID(std::this_thread::get_id())
+  IncomingTCPConnectionState(ConnectionInfo&& ci, TCPClientThreadData& threadData, const struct timeval& now): d_buffer(sizeof(uint16_t)), d_ci(std::move(ci)), d_handler(d_ci.fd, timeval{g_tcpRecvTimeout,0}, d_ci.cs->tlsFrontend ? d_ci.cs->tlsFrontend->getContext() : (d_ci.cs->dohFrontend ? d_ci.cs->dohFrontend->d_tlsContext.getContext() : nullptr), now.tv_sec), d_connectionStartTime(now), d_ioState(make_unique<IOStateHandler>(*threadData.mplexer, d_ci.fd)), d_threadData(threadData), d_creatorThreadID(std::this_thread::get_id())
   {
     d_origDest.reset();
     d_origDest.sin4.sin_family = d_ci.remote.sin4.sin_family;

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -916,6 +916,9 @@ See :doc:`../guides/cache` for a how to.
   .. versionchanged:: 1.7.0
     ``skipOptions`` parameter added.
 
+  .. versionchanged:: 1.9.0
+    ``maximumEntrySize`` parameter added.
+
   Creates a new :class:`PacketCache` with the settings specified.
 
   :param int maxEntries: The maximum number of entries in this cache
@@ -934,6 +937,7 @@ See :doc:`../guides/cache` for a how to.
   * ``temporaryFailureTTL=60``: int - On a SERVFAIL or REFUSED from the backend, cache for this amount of seconds..
   * ``cookieHashing=false``: bool - If true, EDNS Cookie values will be hashed, resulting in separate entries for different cookies in the packet cache. This is required if the backend is sending answers with EDNS Cookies, otherwise a client might receive an answer with the wrong cookie.
   * ``skipOptions={}``: Extra list of EDNS option codes to skip when hashing the packet (if ``cookieHashing`` above is false, EDNS cookie option number will be added to this list internally).
+  * ``maximumEntrySize=4096``: int - The maximum size, in bytes, of a DNS packet that can be inserted into the packet cache. Default is 4096 bytes, which was the fixed size before 1.9.0, and is also a hard limit for UDP responses.
 
 .. class:: PacketCache
 

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSharded) {
       pwR.getHeader()->id = pwQ.getHeader()->id;
       pwR.startRecord(ids.qname, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
       ComboAddress v6addr("2001:db8::1");
-      pwR.xfrIP6(std::string(reinterpret_cast<const char*>(v6addr.sin6.sin6_addr.s6_addr), 16));
+      pwR.xfrCAWithoutPort(6, v6addr);
       pwR.commit();
 
       uint32_t key = 0;
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheTCP) {
     pwR.getHeader()->id = pwQ.getHeader()->id;
     pwR.startRecord(a, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
     ComboAddress v6addr("2001:db8::1");
-    pwR.xfrIP6(std::string(reinterpret_cast<const char*>(v6addr.sin6.sin6_addr.s6_addr), 16));
+    pwR.xfrCAWithoutPort(6, v6addr);
     pwR.commit();
 
     {

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -55,17 +55,17 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
 
       uint32_t key = 0;
       boost::optional<Netmask> subnet;
-      DNSQuestion dq(ids, query);
-      bool found = PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      DNSQuestion dnsQuestion(ids, query);
+      bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
       BOOST_CHECK_EQUAL(found, false);
       BOOST_CHECK(!subnet);
 
-      PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, receivedOverUDP, 0, boost::none);
+      PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, receivedOverUDP, 0, boost::none);
 
-      found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+      found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
       if (found == true) {
-        BOOST_CHECK_EQUAL(dq.getData().size(), response.size());
-        int match = memcmp(dq.getData().data(), response.data(), dq.getData().size());
+        BOOST_CHECK_EQUAL(dnsQuestion.getData().size(), response.size());
+        int match = memcmp(dnsQuestion.getData().data(), response.data(), dnsQuestion.getData().size());
         BOOST_CHECK_EQUAL(match, 0);
         BOOST_CHECK(!subnet);
       }
@@ -86,8 +86,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
       pwQ.getHeader()->rd = 1;
       uint32_t key = 0;
       boost::optional<Netmask> subnet;
-      DNSQuestion dq(ids, query);
-      bool found = PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      DNSQuestion dnsQuestion(ids, query);
+      bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
       if (found == true) {
         auto removed = PC.expungeByName(ids.qname);
         BOOST_CHECK_EQUAL(removed, 1U);
@@ -105,8 +105,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
       pwQ.getHeader()->rd = 1;
       uint32_t key = 0;
       boost::optional<Netmask> subnet;
-      DNSQuestion dq(ids, query);
-      if (PC.get(dq, pwQ.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP)) {
+      DNSQuestion dnsQuestion(ids, query);
+      if (PC.get(dnsQuestion, pwQ.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP)) {
         matches++;
       }
     }
@@ -160,23 +160,23 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSharded) {
       pwR.getHeader()->qr = 1;
       pwR.getHeader()->id = pwQ.getHeader()->id;
       pwR.startRecord(ids.qname, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
-      ComboAddress v6("2001:db8::1");
-      pwR.xfrIP6(std::string(reinterpret_cast<const char*>(v6.sin6.sin6_addr.s6_addr), 16));
+      ComboAddress v6addr("2001:db8::1");
+      pwR.xfrIP6(std::string(reinterpret_cast<const char*>(v6addr.sin6.sin6_addr.s6_addr), 16));
       pwR.commit();
 
       uint32_t key = 0;
       boost::optional<Netmask> subnet;
-      DNSQuestion dq(ids, query);
-      bool found = PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      DNSQuestion dnsQuestion(ids, query);
+      bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
       BOOST_CHECK_EQUAL(found, false);
       BOOST_CHECK(!subnet);
 
-      PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::AAAA, QClass::IN, response, receivedOverUDP, 0, boost::none);
+      PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::AAAA, QClass::IN, response, receivedOverUDP, 0, boost::none);
 
-      found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+      found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
       if (found == true) {
-        BOOST_CHECK_EQUAL(dq.getData().size(), response.size());
-        int match = memcmp(dq.getData().data(), response.data(), dq.getData().size());
+        BOOST_CHECK_EQUAL(dnsQuestion.getData().size(), response.size());
+        int match = memcmp(dnsQuestion.getData().data(), response.data(), dnsQuestion.getData().size());
         BOOST_CHECK_EQUAL(match, 0);
         BOOST_CHECK(!subnet);
       }
@@ -197,8 +197,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSharded) {
       pwQ.getHeader()->rd = 1;
       uint32_t key = 0;
       boost::optional<Netmask> subnet;
-      DNSQuestion dq(ids, query);
-      if (PC.get(dq, pwQ.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP)) {
+      DNSQuestion dnsQuestion(ids, query);
+      if (PC.get(dnsQuestion, pwQ.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP)) {
         matches++;
       }
     }
@@ -255,21 +255,21 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheTCP) {
     pwR.getHeader()->qr = 1;
     pwR.getHeader()->id = pwQ.getHeader()->id;
     pwR.startRecord(a, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
-    ComboAddress v6("2001:db8::1");
-    pwR.xfrIP6(std::string(reinterpret_cast<const char*>(v6.sin6.sin6_addr.s6_addr), 16));
+    ComboAddress v6addr("2001:db8::1");
+    pwR.xfrIP6(std::string(reinterpret_cast<const char*>(v6addr.sin6.sin6_addr.s6_addr), 16));
     pwR.commit();
 
     {
       /* UDP */
       uint32_t key = 0;
       boost::optional<Netmask> subnet;
-      DNSQuestion dq(ids, query);
-      bool found = PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      DNSQuestion dnsQuestion(ids, query);
+      bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
       BOOST_CHECK_EQUAL(found, false);
       BOOST_CHECK(!subnet);
 
-      PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
-      found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+      PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
+      found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
       BOOST_CHECK_EQUAL(found, true);
       BOOST_CHECK(!subnet);
     }
@@ -279,13 +279,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheTCP) {
       uint32_t key = 0;
       boost::optional<Netmask> subnet;
       ids.protocol = dnsdist::Protocol::DoTCP;
-      DNSQuestion dq(ids, query);
-      bool found = PC.get(dq, 0, &key, subnet, dnssecOK, !receivedOverUDP);
+      DNSQuestion dnsQuestion(ids, query);
+      bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, !receivedOverUDP);
       BOOST_CHECK_EQUAL(found, false);
       BOOST_CHECK(!subnet);
 
-      PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, boost::none);
-      found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
+      PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, boost::none);
+      found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
       BOOST_CHECK_EQUAL(found, true);
       BOOST_CHECK(!subnet);
     }
@@ -325,20 +325,20 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheServFailTTL) {
 
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
-    DNSQuestion dq(ids, query);
-    bool found = PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
     // Insert with failure-TTL of 0 (-> should not enter cache).
-    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, receivedOverUDP, RCode::ServFail, boost::optional<uint32_t>(0));
-    found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, receivedOverUDP, RCode::ServFail, boost::optional<uint32_t>(0));
+    found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
     // Insert with failure-TTL non-zero (-> should enter cache).
-    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, receivedOverUDP, RCode::ServFail, boost::optional<uint32_t>(300));
-    found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, a, QType::A, QClass::IN, response, receivedOverUDP, RCode::ServFail, boost::optional<uint32_t>(300));
+    found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_CHECK(!subnet);
   }
@@ -381,19 +381,19 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheNoDataTTL) {
 
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
-    DNSQuestion dq(ids, query);
-    bool found = PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, name, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
-    found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, name, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
+    found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_CHECK(!subnet);
 
     sleep(2);
     /* it should have expired by now */
-    found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
   }
@@ -436,19 +436,19 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheNXDomainTTL) {
 
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
-    DNSQuestion dq(ids, query);
-    bool found = PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, name, QType::A, QClass::IN, response, receivedOverUDP, RCode::NXDomain, boost::none);
-    found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, name, QType::A, QClass::IN, response, receivedOverUDP, RCode::NXDomain, boost::none);
+    found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_CHECK(!subnet);
 
     sleep(2);
     /* it should have expired by now */
-    found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
   }
@@ -490,20 +490,20 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheTruncated) {
 
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
-    DNSQuestion dq(ids, query);
-    bool found = PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NXDomain, boost::none);
+    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NXDomain, boost::none);
 
     bool allowTruncated = true;
-    found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true, allowTruncated);
+    found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true, allowTruncated);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_CHECK(!subnet);
 
     allowTruncated = false;
-    found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true, allowTruncated);
+    found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true, allowTruncated);
     BOOST_CHECK_EQUAL(found, false);
 }
   catch(const PDNSException& e) {
@@ -540,8 +540,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize) {
     pwR.getHeader()->qr = 1;
     pwR.getHeader()->id = queryID;
     pwR.startRecord(ids.qname, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
-    ComboAddress v6("2001:db8::1");
-    pwR.xfrCAWithoutPort(6, v6);
+    ComboAddress v6addr("2001:db8::1");
+    pwR.xfrCAWithoutPort(6, v6addr);
     pwR.commit();
   }
 
@@ -552,13 +552,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize) {
     /* UDP */
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
-    DNSQuestion dq(ids, query);
-    bool found = packetCache.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
-    found = packetCache.get(dq, queryID, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
+    found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_CHECK(!subnet);
   }
@@ -568,13 +568,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize) {
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
     ids.protocol = dnsdist::Protocol::DoTCP;
-    DNSQuestion dq(ids, query);
-    bool found = packetCache.get(dq, 0, &key, subnet, dnssecOK, !receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, !receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, boost::none);
-    found = packetCache.get(dq, queryID, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
+    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, boost::none);
+    found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_CHECK(!subnet);
   }
@@ -586,13 +586,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize) {
     /* UDP */
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
-    DNSQuestion dq(ids, query);
-    bool found = packetCache.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
-    found = packetCache.get(dq, queryID, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
+    found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, false);
   }
 
@@ -601,13 +601,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize) {
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
     ids.protocol = dnsdist::Protocol::DoTCP;
-    DNSQuestion dq(ids, query);
-    bool found = packetCache.get(dq, 0, &key, subnet, dnssecOK, !receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, !receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, boost::none);
-    found = packetCache.get(dq, queryID, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
+    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, boost::none);
+    found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, false);
   }
 
@@ -622,8 +622,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize) {
     pwR.getHeader()->id = queryID;
     for (size_t idx = 0; idx < 1000; idx++) {
       pwR.startRecord(ids.qname, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
-      ComboAddress v6("2001:db8::1");
-      pwR.xfrCAWithoutPort(6, v6);
+      ComboAddress v6addr("2001:db8::1");
+      pwR.xfrCAWithoutPort(6, v6addr);
     }
     pwR.commit();
   }
@@ -635,13 +635,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize) {
     /* UDP */
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
-    DNSQuestion dq(ids, query);
-    bool found = packetCache.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
-    found = packetCache.get(dq, queryID, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
+    found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, true);
   }
 
@@ -650,13 +650,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize) {
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
     ids.protocol = dnsdist::Protocol::DoTCP;
-    DNSQuestion dq(ids, query);
-    bool found = packetCache.get(dq, 0, &key, subnet, dnssecOK, !receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, !receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, boost::none);
-    found = packetCache.get(dq, queryID, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
+    packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, boost::none);
+    found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, true);
   }
 }
@@ -691,10 +691,10 @@ static void threadMangler(unsigned int offset)
 
       uint32_t key = 0;
       boost::optional<Netmask> subnet;
-      DNSQuestion dq(ids, query);
-      g_PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      DNSQuestion dnsQuestion(ids, query);
+      g_PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
 
-      g_PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, boost::none);
+      g_PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, boost::none);
     }
   }
   catch(PDNSException& e) {
@@ -724,8 +724,8 @@ static void threadReader(unsigned int offset)
 
       uint32_t key = 0;
       boost::optional<Netmask> subnet;
-      DNSQuestion dq(ids, query);
-      bool found = g_PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      DNSQuestion dnsQuestion(ids, query);
+      bool found = g_PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
       if (!found) {
 	g_missing++;
       }
@@ -802,8 +802,8 @@ BOOST_AUTO_TEST_CASE(test_PCCollision) {
 
     ComboAddress remote("192.0.2.1");
     ids.queryRealTime.start();
-    DNSQuestion dq(ids, query);
-    bool found = PC.get(dq, 0, &key, subnetOut, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = PC.get(dnsQuestion, 0, &key, subnetOut, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_REQUIRE(subnetOut);
     BOOST_CHECK_EQUAL(subnetOut->toString(), opt.source.toString());
@@ -813,8 +813,8 @@ BOOST_AUTO_TEST_CASE(test_PCCollision) {
     pwR.getHeader()->rd = 1;
     pwR.getHeader()->id = qid;
     pwR.startRecord(ids.qname, ids.qtype, 100, QClass::IN, DNSResourceRecord::ANSWER);
-    ComboAddress v6("::1");
-    pwR.xfrCAWithoutPort(6, v6);
+    ComboAddress v6addr("::1");
+    pwR.xfrCAWithoutPort(6, v6addr);
     pwR.commit();
     pwR.addOpt(512, 0, 0, ednsOptions);
     pwR.commit();
@@ -822,7 +822,7 @@ BOOST_AUTO_TEST_CASE(test_PCCollision) {
     PC.insert(key, subnetOut, *(getFlagsFromDNSHeader(pwR.getHeader())), dnssecOK, ids.qname, ids.qtype, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
     BOOST_CHECK_EQUAL(PC.getSize(), 1U);
 
-    found = PC.get(dq, 0, &key, subnetOut, dnssecOK, receivedOverUDP);
+    found = PC.get(dnsQuestion, 0, &key, subnetOut, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_REQUIRE(subnetOut);
     BOOST_CHECK_EQUAL(subnetOut->toString(), opt.source.toString());
@@ -844,8 +844,8 @@ BOOST_AUTO_TEST_CASE(test_PCCollision) {
 
     ComboAddress remote("192.0.2.1");
     ids.queryRealTime.start();
-    DNSQuestion dq(ids, query);
-    bool found = PC.get(dq, 0, &secondKey, subnetOut, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = PC.get(dnsQuestion, 0, &secondKey, subnetOut, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK_EQUAL(secondKey, key);
     BOOST_REQUIRE(subnetOut);
@@ -923,8 +923,8 @@ BOOST_AUTO_TEST_CASE(test_PCDNSSECCollision) {
     ComboAddress remote("192.0.2.1");
     ids.queryRealTime.start();
     ids.origRemote = remote;
-    DNSQuestion dq(ids, query);
-    bool found = PC.get(dq, 0, &key, subnetOut, true, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = PC.get(dnsQuestion, 0, &key, subnetOut, true, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
 
     PacketBuffer response;
@@ -932,8 +932,8 @@ BOOST_AUTO_TEST_CASE(test_PCDNSSECCollision) {
     pwR.getHeader()->rd = 1;
     pwR.getHeader()->id = qid;
     pwR.startRecord(ids.qname, ids.qtype, 100, QClass::IN, DNSResourceRecord::ANSWER);
-    ComboAddress v6("::1");
-    pwR.xfrCAWithoutPort(6, v6);
+    ComboAddress v6addr("::1");
+    pwR.xfrCAWithoutPort(6, v6addr);
     pwR.commit();
     pwR.addOpt(512, 0, EDNS_HEADER_FLAG_DO);
     pwR.commit();
@@ -941,10 +941,10 @@ BOOST_AUTO_TEST_CASE(test_PCDNSSECCollision) {
     PC.insert(key, subnetOut, *(getFlagsFromDNSHeader(pwR.getHeader())), /* DNSSEC OK is set */ true, ids.qname, ids.qtype, QClass::IN, response, receivedOverUDP, RCode::NoError, boost::none);
     BOOST_CHECK_EQUAL(PC.getSize(), 1U);
 
-    found = PC.get(dq, 0, &key, subnetOut, false, receivedOverUDP);
+    found = PC.get(dnsQuestion, 0, &key, subnetOut, false, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
 
-    found = PC.get(dq, 0, &key, subnetOut, true, receivedOverUDP);
+    found = PC.get(dnsQuestion, 0, &key, subnetOut, true, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, true);
   }
 
@@ -1221,13 +1221,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheXFR) {
 
     uint32_t key = 0;
     boost::optional<Netmask> subnet;
-    DNSQuestion dq(ids, query);
-    bool found = PC.get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    DNSQuestion dnsQuestion(ids, query);
+    bool found = PC.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, ids.qtype, ids.qclass, response, receivedOverUDP, 0, boost::none);
-    found = PC.get(dq, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    PC.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, ids.qtype, ids.qclass, response, receivedOverUDP, 0, boost::none);
+    found = PC.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
     BOOST_CHECK_EQUAL(found, false);
   }
 }

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -2936,12 +2936,6 @@ class TestCachingOfVeryLargeAnswers(DNSDistTest):
         query = dns.message.make_query(name, 'TXT', 'IN')
         response = dns.message.make_response(query)
         # we prepare a large answer
-        #         for i in range(44):
-        #             if len(content) > 0:
-        #                 content = content + ', '
-        #             content = content + (str(i)*50)
-        #         # pad up to 4096
-        #         content = content + 'A'*42
         content = ''
         for i in range(31):
             if len(content) > 0:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It used to be set to 4096 bytes, which is also a hard limit for UDP responses anyway, because of the internal buffer size, but the limit can now be raised for responses received over TCP (including DoT and DoH).

Since the existing value was used to determine the initial size of TCP buffers, these are also updated:
- the default buffer size for incoming TCP connections is now 2 bytes: no need to waste a lot of memory for incoming connections until we got at least one query
- the default buffer size for outgoing connection is now 512 bytes: it should be enough for a fair percentage of responses

This PR is based on top of https://github.com/PowerDNS/pdns/pull/13536 and will need to be rebased, so the first commit can be ignored for now.

Closes https://github.com/PowerDNS/pdns/issues/11563.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)

