### PR TITLE
auth tests: abort if runtests is used incorrectly

### DIFF
--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+if [ -z "$testsdir" ]; then
+  echo "Incorrect usage. You probably want ./start-test-stop help"
+  exit 1
+fi
+
 PATH=.:$PATH:/usr/sbin
 MAKE=${MAKE:-make}
 


### PR DESCRIPTION
### Short description
Abort if `./regresstion-tests/runtests` is called directly.

I tend to do this because I misremember that I should use `start-test-stop help` instead.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
