### PR TITLE
rec: Remove experimental warnings for YAML

### DIFF
--- a/pdns/recursordist/docs/appendices/example/conversion
+++ b/pdns/recursordist/docs/appendices/example/conversion
@@ -1,4 +1,3 @@
-# THIS IS A PROOF OF CONCEPT! STRUCTURE, TYPES AND NAMES ARE SUBJECT TO CHANGE
 # Start of converted recursor.yml based on recursor.conf
 dnssec:
   validation: validate

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -244,6 +244,9 @@ set-event-trace-enabled *NUM*
     Set logging of event trace messages, ``0`` = disabled, ``1`` = protobuf,
     ``2`` = log file, ``3`` = protobuf and log file.
 
+show-yaml [*FILE*]
+    Show Yaml representation of odl-style config.
+
 top-queries
     Shows the top-20 queries. Statistics are over the last
     'stats-ringbuffer-entries' queries.
@@ -337,9 +340,6 @@ wipe-cache *DOMAIN* [*DOMAIN*] [...]
 
 wipe-cache-typed *qtype* *DOMAIN* [*DOMAIN*] [...]
     Same as wipe-cache, but only wipe records of type *qtype*.
-
-show-yaml [*FILE*]
-    Show Yaml representation of config. EXPERIMENTAL.
 
 See also
 --------

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2091,6 +2091,7 @@ static RecursorControlChannel::Answer help()
           "set-carbon-server                set a carbon server for telemetry\n"
           "set-dnssec-log-bogus SETTING     enable (SETTING=yes) or disable (SETTING=no) logging of DNSSEC validation failures\n"
           "set-event-trace-enabled SETTING  set logging of event trace messages, 0 = disabled, 1 = protobuf, 2 = log file, 3 = both\n"
+          "show-yaml [file]                 show yaml config derived from old-style config\n"
           "trace-regex [regex file]         emit resolution trace for matching queries (no arguments clears tracing)\n"
           "top-largeanswer-remotes          show top remotes receiving large answers\n"
           "top-queries                      show top queries\n"
@@ -2106,8 +2107,7 @@ static RecursorControlChannel::Answer help()
           "unload-lua-script                unload Lua script\n"
           "version                          return Recursor version number\n"
           "wipe-cache domain0 [domain1] ..  wipe domain data from cache\n"
-          "wipe-cache-typed type domain0 [domain1] ..  wipe domain data with qtype from cache\n"
-          "show-yaml [file]                 EXPERIMENTAL command to show yaml config derived from old-style config\n"};
+          "wipe-cache-typed type domain0 [domain1] ..  wipe domain data with qtype from cache\n"};
 }
 
 template <typename T>

--- a/pdns/recursordist/rec_control.cc
+++ b/pdns/recursordist/rec_control.cc
@@ -202,7 +202,6 @@ static RecursorControlChannel::Answer showYAML(const std::string& path)
   try {
     std::string msg;
     auto converted = pdns::settings::rec::oldStyleSettingsFileToYaml(configName, true);
-    msg += "# THIS IS A PROOF OF CONCEPT! STRUCTURE, TYPES AND NAMES ARE SUBJECT TO CHANGE\n";
     msg += "# Start of converted recursor.yml based on " + configName + "\n";
     msg += converted;
     msg += "# Validation result: ";


### PR DESCRIPTION
YAML settings are no longer experimental, but still only used if a `recursor.yml` file is found in the config dir.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
