### PR TITLE
dnsdist: Spoof a raw response for ANY queries

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -2497,11 +2497,11 @@ void setupLuaActions(LuaContext& luaCtx)
 
   luaCtx.writeFunction("SpoofRawAction", [](LuaTypeOrArrayOf<std::string> inp, boost::optional<responseParams_t> vars) {
       vector<string> raws;
-      if (auto str = boost::get<std::string>(&inp)) {
+      if (const auto* str = boost::get<std::string>(&inp)) {
         raws.push_back(*str);
       } else {
         const auto& vect = boost::get<LuaArray<std::string>>(inp);
-        for(const auto& raw: vect) {
+        for (const auto& raw: vect) {
           raws.push_back(raw.second);
         }
       }

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -2510,7 +2510,11 @@ void setupLuaActions(LuaContext& luaCtx)
       if (qtypeForAny > std::numeric_limits<uint16_t>::max()) {
         qtypeForAny = 0;
       }
-      auto ret = std::shared_ptr<DNSAction>(new SpoofAction(raws, qtypeForAny > 0 ? static_cast<uint16_t>(qtypeForAny) : std::optional<uint16_t>()));
+      std::optional<uint16_t> qtypeForAnyParam;
+      if (qtypeForAny > 0) {
+        qtypeForAnyParam = static_cast<uint16_t>(qtypeForAny);
+      }
+      auto ret = std::shared_ptr<DNSAction>(new SpoofAction(raws, qtypeForAnyParam));
       auto sa = std::dynamic_pointer_cast<SpoofAction>(ret);
       parseResponseConfig(vars, sa->d_responseConfig);
       checkAllParametersConsumed("SpoofRawAction", vars);

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -227,7 +227,7 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
     return true;
   });
 
-  luaCtx.registerFunction<void(DNSQuestion::*)(const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>&, boost::optional<uint16_t>)>("spoof", [](DNSQuestion& dq, const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>& response, boost::optional<uint16_t> typeForAny) {
+  luaCtx.registerFunction<void(DNSQuestion::*)(const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>&, boost::optional<uint16_t>)>("spoof", [](DNSQuestion& dnsQuestion, const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>& response, boost::optional<uint16_t> typeForAny) {
       if (response.type() == typeid(LuaArray<ComboAddress>)) {
           std::vector<ComboAddress> data;
           auto responses = boost::get<LuaArray<ComboAddress>>(response);
@@ -236,8 +236,8 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
             data.push_back(resp.second);
           }
           std::string result;
-          SpoofAction sa(data);
-          sa(&dq, &result);
+          SpoofAction tempSpoofAction(data);
+          tempSpoofAction(&dnsQuestion, &result);
 	  return;
       }
       if (response.type() == typeid(LuaArray<std::string>)) {
@@ -248,8 +248,8 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
             data.push_back(resp.second);
           }
           std::string result;
-          SpoofAction sa(data, typeForAny ? *typeForAny : std::optional<uint16_t>());
-          sa(&dq, &result);
+          SpoofAction tempSpoofAction(data, typeForAny ? *typeForAny : std::optional<uint16_t>());
+          tempSpoofAction(&dnsQuestion, &result);
 	  return;
       }
   });

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -227,7 +227,7 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
     return true;
   });
 
-  luaCtx.registerFunction<void(DNSQuestion::*)(const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>& response)>("spoof", [](DNSQuestion& dq, const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>& response) {
+  luaCtx.registerFunction<void(DNSQuestion::*)(const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>&, boost::optional<uint16_t>)>("spoof", [](DNSQuestion& dq, const boost::variant<LuaArray<ComboAddress>, LuaArray<std::string>>& response, boost::optional<uint16_t> typeForAny) {
       if (response.type() == typeid(LuaArray<ComboAddress>)) {
           std::vector<ComboAddress> data;
           auto responses = boost::get<LuaArray<ComboAddress>>(response);
@@ -248,7 +248,7 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
             data.push_back(resp.second);
           }
           std::string result;
-          SpoofAction sa(data);
+          SpoofAction sa(data, typeForAny ? *typeForAny : std::optional<uint16_t>());
           sa(&dq, &result);
 	  return;
       }

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -62,7 +62,7 @@ public:
   {
   }
 
-  SpoofAction(const vector<std::string>& raws): d_rawResponses(raws)
+  SpoofAction(const vector<std::string>& raws, std::optional<uint16_t> typeForAny): d_rawResponses(raws), d_rawTypeForAny(typeForAny)
   {
   }
 
@@ -93,6 +93,7 @@ private:
   std::vector<std::string> d_rawResponses;
   PacketBuffer d_raw;
   DNSName d_cname;
+  std::optional<uint16_t> d_rawTypeForAny{};
 };
 
 class LimitTTLResponseAction : public DNSResponseAction, public boost::noncopyable

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -863,7 +863,7 @@ static void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent,
   if (raw) {
     std::vector<std::string> raws;
     stringtok(raws, spoofContent, ",");
-    SpoofAction sa(raws);
+    SpoofAction sa(raws, std::nullopt);
     sa(&dq, &result);
   }
   else {

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -863,8 +863,8 @@ static void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent,
   if (raw) {
     std::vector<std::string> raws;
     stringtok(raws, spoofContent, ",");
-    SpoofAction sa(raws, std::nullopt);
-    sa(&dq, &result);
+    SpoofAction tempSpoofAction(raws, std::nullopt);
+    tempSpoofAction(&dq, &result);
   }
   else {
     std::vector<std::string> addrs;
@@ -873,13 +873,13 @@ static void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent,
     if (addrs.size() == 1) {
       try {
         ComboAddress spoofAddr(spoofContent);
-        SpoofAction sa({spoofAddr});
-        sa(&dq, &result);
+        SpoofAction tempSpoofAction({spoofAddr});
+        tempSpoofAction(&dq, &result);
       }
       catch(const PDNSException &e) {
         DNSName cname(spoofContent);
-        SpoofAction sa(cname); // CNAME then
-        sa(&dq, &result);
+        SpoofAction tempSpoofAction(cname); // CNAME then
+        tempSpoofAction(&dq, &result);
       }
     } else {
       std::vector<ComboAddress> cas;
@@ -890,8 +890,8 @@ static void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent,
         catch (...) {
         }
       }
-      SpoofAction sa(cas);
-      sa(&dq, &result);
+      SpoofAction tempSpoofAction(cas);
+      tempSpoofAction(&dq, &result);
     }
   }
 }
@@ -900,8 +900,8 @@ static void spoofPacketFromString(DNSQuestion& dq, const string& spoofContent)
 {
   string result;
 
-  SpoofAction sa(spoofContent.c_str(), spoofContent.size());
-  sa(&dq, &result);
+  SpoofAction tempSpoofAction(spoofContent.c_str(), spoofContent.size());
+  tempSpoofAction(&dq, &result);
 }
 
 bool processRulesResult(const DNSAction::Action& action, DNSQuestion& dq, std::string& ruleresult, bool& drop)

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -588,8 +588,8 @@ void dnsdist_ffi_dnsquestion_send_trap(dnsdist_ffi_dnsquestion_t* dq, const char
 void dnsdist_ffi_dnsquestion_spoof_packet(dnsdist_ffi_dnsquestion_t* dq, const char* raw, size_t len)
 {
   std::string result;
-  SpoofAction sa(raw, len);
-  sa(dq->dq, &result);
+  SpoofAction tempSpoofAction(raw, len);
+  tempSpoofAction(dq->dq, &result);
 }
 
 void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_raw_value_t* values, size_t valuesCount)
@@ -602,8 +602,8 @@ void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dq, const dnsd
   }
 
   std::string result;
-  SpoofAction sa(data, std::nullopt);
-  sa(dq->dq, &result);
+  SpoofAction tempSpoofAction(data, std::nullopt);
+  tempSpoofAction(dq->dq, &result);
 }
 
 void dnsdist_ffi_dnsquestion_spoof_addrs(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_raw_value_t* values, size_t valuesCount)
@@ -631,8 +631,8 @@ void dnsdist_ffi_dnsquestion_spoof_addrs(dnsdist_ffi_dnsquestion_t* dq, const dn
   }
 
   std::string result;
-  SpoofAction sa(data);
-  sa(dq->dq, &result);
+  SpoofAction tempSpoofAction(data);
+  tempSpoofAction(dq->dq, &result);
 }
 
 void dnsdist_ffi_dnsquestion_set_max_returned_ttl(dnsdist_ffi_dnsquestion_t* dq, uint32_t max)

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -602,7 +602,7 @@ void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dq, const dnsd
   }
 
   std::string result;
-  SpoofAction sa(data);
+  SpoofAction sa(data, std::nullopt);
   sa(dq->dq, &result);
 }
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -362,9 +362,12 @@ This state can be modified from the various hooks.
     :param string tail: The new data
     :returns: true if the operation succeeded, false otherwise
 
-  .. method:: DNSQuestion:spoof(ip|ips|raw|raws)
+  .. method:: DNSQuestion:spoof(ip|ips|raw|raws [, typeForAny])
 
     .. versionadded:: 1.6.0
+
+    .. versionchanged:: 1.9.0
+      Optional parameter ``typeForAny`` added.
 
     Forge a response with the specified record data as raw bytes. If you specify list of raws (it is assumed they match the query type), all will get spoofed in.
 
@@ -372,6 +375,7 @@ This state can be modified from the various hooks.
     :param table ComboAddresses ips: The `ComboAddress`es to be spoofed, e.g. `{ newCA("192.0.2.1"), newCA("192.0.2.2") }`.
     :param string raw: The raw string to be spoofed, e.g. `"\\192\\000\\002\\001"`.
     :param table raws: The raw strings to be spoofed, e.g. `{ "\\192\\000\\002\\001", "\\192\\000\\002\\002" }`.
+    :param int typeForAny: The type to use for raw responses when the requested type is ``ANY``, as using ``ANY` for the type of the response record would not make sense.
 
   .. method:: DNSQuestion:suspend(asyncID, queryID, timeoutMS) -> bool
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1792,6 +1792,9 @@ The following actions exist.
   .. versionchanged:: 1.6.0
     Up to 1.6.0, it was only possible to spoof one answer.
 
+  .. versionchanged:: 1.9.0
+    Added the optional parameter ``typeForAny``.
+
   Forge a response with the specified raw bytes as record data.
 
   .. code-block:: Lua
@@ -1802,6 +1805,8 @@ The following actions exist.
     addAction(AndRule({QNameRule('raw-srv.powerdns.com.'), QTypeRule(DNSQType.SRV)}), SpoofRawAction("\000\000\000\000\255\255\003srv\008powerdns\003com\000", { aa=true, ttl=3600 }))
     -- select reverse queries for '127.0.0.1' and answer with 'localhost'
     addAction(AndRule({QNameRule('1.0.0.127.in-addr.arpa.'), QTypeRule(DNSQType.PTR)}), SpoofRawAction("\009localhost\000"))
+    -- rfc8482: Providing Minimal-Sized Responses to DNS Queries That Have QTYPE=ANY via HINFO of value "rfc8482"
+    addAction(QTypeRule(DNSQType.ANY), SpoofRawAction("\007rfc\056\052\056\050\000", { typeForAny=DNSQType.HINFO }))
 
   :func:`DNSName:toDNSString` is convenient for converting names to wire format for passing to ``SpoofRawAction``.
 
@@ -1828,6 +1833,7 @@ The following actions exist.
   * ``ad``: bool - Set the AD bit to this value (true means the bit is set, false means it's cleared). Default is to clear it.
   * ``ra``: bool - Set the RA bit to this value (true means the bit is set, false means it's cleared). Default is to copy the value of the RD bit from the incoming query.
   * ``ttl``: int - The TTL of the record.
+  * ``typeForAny``: int - The record type to use when responding to queries of type ``ANY``, as using ``ANY`` for the type of the response record would not make sense.
 
 .. function:: SpoofSVCAction(svcParams [, options])
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds the ability to spoof a raw response for ``ANY`` queries, as it would not make sense to use ``ANY`` for the type of the response record.

Closes https://github.com/PowerDNS/pdns/issues/13559

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

