### PR TITLE
GH Actions - rel/dnsdist-1.7.x: make `build-and-test-all` and `builder` workflows reusable from other branches

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -37,7 +37,7 @@ jobs:
           echo "stamp=$(/bin/date +%s)" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: let GitHub cache our ccache data
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.ccache
           key: dnsdist-${{ matrix.sanitizers }}-ccache-${{ steps.get-stamp.outputs.stamp }}

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -4,6 +4,13 @@ name: 'Build and test everything'
 on:
   push:
   pull_request:
+  workflow_call:
+    inputs:
+      branch-name:
+        description: 'Checkout to a specific branch'
+        required: true
+        default: ''
+        type: string
   schedule:
     - cron: '0 22 * * 3'
 
@@ -31,6 +38,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+          ref: ${{ inputs.branch-name }}
       - name: get timestamp for cache
         id: get-stamp
         run: |
@@ -52,10 +60,11 @@ jobs:
       - run: inv ci-dnsdist-run-unit-tests
       - run: inv ci-make-install
       - run: ccache -s
+      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Store the binaries
         uses: actions/upload-artifact@v3 # this takes 30 seconds, maybe we want to tar
         with:
-          name: dnsdist-${{ matrix.sanitizers }}
+          name: dnsdist-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
           path: /opt/dnsdist
           retention-days: 1
 
@@ -78,10 +87,12 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+          ref: ${{ inputs.branch-name }}
+      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v3
         with:
-          name: dnsdist-${{ matrix.sanitizers }}
+          name: dnsdist-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
           path: /opt/dnsdist
       - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
       - run: inv install-clang-runtime
@@ -102,6 +113,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+          ref: ${{ inputs.branch-name }}
       - name: Install yq
         run: sudo wget https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
       - name: Get full list of jobs for this workflow

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -53,7 +53,7 @@ jobs:
       - run: inv ci-make-install
       - run: ccache -s
       - name: Store the binaries
-        uses: actions/upload-artifact@v2 # this takes 30 seconds, maybe we want to tar
+        uses: actions/upload-artifact@v3 # this takes 30 seconds, maybe we want to tar
         with:
           name: dnsdist-${{ matrix.sanitizers }}
           path: /opt/dnsdist

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ./pdns/dnsdistdist/
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: recursive
@@ -74,7 +74,7 @@ jobs:
       SKIP_INCLUDEDIR_TESTS: yes
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: recursive
@@ -94,7 +94,11 @@ jobs:
       - test-dnsdist-regression
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - name: Install jq and yq
+        run: "sudo snap install jq yq"
+      - name: Fail job if any of the previous jobs failed
+        run: "for i in `echo '${{ toJSON(needs) }}' | jq '.[].result' | tr -d '\"'`; do if [[ $i == 'failure' ]]; then echo '${{ toJSON(needs) }}'; exit 1; fi; done;"
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: recursive

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -26,7 +26,8 @@ jobs:
       run:
         working-directory: ./pdns/dnsdistdist/
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
+      - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 5
           submodules: recursive
@@ -72,7 +73,8 @@ jobs:
       # IncludeDir tests are disabled because of a weird interaction between TSAN and these tests which ever only happens on GH actions
       SKIP_INCLUDEDIR_TESTS: yes
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
+      - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 5
           submodules: recursive

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -103,6 +103,7 @@ jobs:
     needs:
       - build-dnsdist
       - test-dnsdist-regression
+    if: success() || failure()
     runs-on: ubuntu-20.04
     steps:
       - name: Install jq and yq
@@ -114,13 +115,11 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
-      - name: Install yq
-        run: sudo wget https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
-      - name: Get full list of jobs for this workflow
-        run: yq e '.jobs | keys' .github/workflows/build-and-test-all.yml | grep -v '^- collect' | sort | tee /tmp/workflow-jobs-list.yml
-      - name: Get list of jobs the collect job depends on
-        run: yq e '.jobs.collect.needs | ... comments=""' .github/workflows/build-and-test-all.yml | sort | tee /tmp/workflow-collect-dependencies.yml
-      - name: Diff them
-        run: diff -u /tmp/workflow-jobs-list.yml /tmp/workflow-collect-dependencies.yml
+      - name: Get list of jobs in the workflow
+        run: "yq e '.jobs | keys' .github/workflows/build-and-test-all.yml | awk '{print $2}' | grep -v collect | sort | tee /tmp/workflow-jobs-list.yml"
+      - name: Get list of prerequisite jobs
+        run: "echo '${{ toJSON(needs) }}' | jq 'keys | .[]' | tr -d '\"' | sort | tee /tmp/workflow-needs-list.yml"
+      - name: Fail if there is a job missing on the needs list
+        run: "if ! diff -q /tmp/workflow-jobs-list.yml /tmp/workflow-needs-list.yml; then exit 1; fi"
 
 # FIXME: if we can make upload/download-artifact fasts, running unit tests outside of build can let regression tests start earlier

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
       - name: Fetch the binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: dnsdist-${{ matrix.sanitizers }}
           path: /opt/dnsdist

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -34,7 +34,8 @@ jobs:
       # this builds packages and runs our unit test (make check)
       - run: builder/build.sh -v -m ${{ matrix.product }} ${{ matrix.os }}
       - name: Get version number
-        run: 'echo ::set-output name=version::$(readlink builder/tmp/latest)'
+        run: |
+          echo "version=$(readlink builder/tmp/latest)" >> $GITHUB_OUTPUT
         id: getversion
       - name: Upload packages
         uses: actions/upload-artifact@v3

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -27,7 +27,7 @@ jobs:
           - ubuntu-jammy
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # for correct version numbers
           submodules: recursive

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -2,6 +2,13 @@
 name: 'Test package building for specific distributions'
 
 on:
+  workflow_call:
+    inputs:
+      branch-name:
+        description: 'Checkout to a specific branch'
+        required: true
+        default: ''
+        type: string
   schedule:
     - cron: '0 1 * * *'
 
@@ -31,6 +38,7 @@ jobs:
         with:
           fetch-depth: 0  # for correct version numbers
           submodules: recursive
+          ref: ${{ inputs.branch-name }}
       # this builds packages and runs our unit test (make check)
       - run: builder/build.sh -v -m ${{ matrix.product }} ${{ matrix.os }}
       - name: Get version number

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -37,7 +37,7 @@ jobs:
         run: 'echo ::set-output name=version::$(readlink builder/tmp/latest)'
         id: getversion
       - name: Upload packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.product }}-${{ matrix.os }}-${{ steps.getversion.outputs.version }}
           path: built_pkgs/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
         fetch-depth: 2
 
     # Python is required for building the Authoritative server
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         product: ['dnsdist']
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: recursive

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -14,7 +14,7 @@ jobs:
     # on a ubuntu-20.04 VM
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: recursive

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,7 +20,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: artifacts

--- a/.github/workflows/secpoll.yml
+++ b/.github/workflows/secpoll.yml
@@ -14,7 +14,7 @@ jobs:
     # on a ubuntu-20.04 VM
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: recursive

--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -20,12 +20,12 @@ jobs:
     steps:
     - name: checkout-merge
       if: "contains(github.event_name, 'pull_request')"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: refs/pull/${{github.event.pull_request.number}}/merge
     - name: checkout
       if: ${{ github.event_name == 'push' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: check-spelling/check-spelling@v0.0.19
       id: spelling
       with:

--- a/build-scripts/gh-actions-setup-inv
+++ b/build-scripts/gh-actions-setup-inv
@@ -1,4 +1,10 @@
 #!/bin/bash -x
+sudo sh -c "cat > /usr/sbin/policy-rc.d << EOF
+#!/bin/sh
+exit 101
+EOF
+"
+sudo chmod 755 /usr/sbin/policy-rc.d
 sudo apt-get update
 # FIXME: Avoid GRUB related errors due to runner image configuration by removing it.
 sudo dpkg --purge --force-all grub-efi-amd64-signed && sudo dpkg --purge --force-all shim-signed


### PR DESCRIPTION
### Short description

Make `build-and-test-all` and `builder` workflows reusable from other branches.

Backport changes for deprecated actions.

This PR is a pre-requisite for scheduling the workflows `build-and-test-all` and `builder` from the `master` branch.

The following branches will be triggered from `master`:

- `auth/4.8.x`. Already merged: [https://github.com/PowerDNS/pdns/pull/13534](https://github.com/PowerDNS/pdns/pull/13534)
- `auth/4.7.x`
- `auth/4.6.x`
- `rec/5.0.x`
- `rec/4.9.x`
- `rec/4.8.x`
- `dnsdist/1.8.x`
- `dnsdist/1.7.x`

Example of a run for the `builder` workflow, per release/branch: [link](https://github.com/romeroalx/pdns/actions/runs/7113662407)

Same example for the `build-and-test-all` workflow: [link](https://github.com/romeroalx/pdns/actions/runs/7113662409)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
