### PR TITLE
rec: rng and entropy-source are not longer processed

### DIFF
--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -949,6 +949,8 @@ This is used for generating random numbers which are very hard to predict.
 Generally on UNIX platforms, this source will be ``/dev/urandom``, which will always supply random numbers, even if entropy is lacking.
 Change to ``/dev/random`` if PowerDNS should block waiting for enough entropy to arrive.
  ''',
+        'skip-yaml': True,
+        'versionchanged': ('4.9.0', 'This setting is no longer used.'),
     },
     {
         'name' : 'etc_hosts_file',
@@ -2139,6 +2141,8 @@ Specify which random number generator to use. Permissible choices are
  - urandom - Use ``/dev/urandom``
  - kiss - Use simple settable deterministic RNG. **FOR TESTING PURPOSES ONLY!**
  ''',
+        'skip-yaml': True,
+        'versionchanged': ('4.9.0', 'This setting is no longer used.')
     },
     {
         'name' : 'root_nx_trust',


### PR DESCRIPTION
This is true since the move to `arc4random()`.

Remove them from YAML settings and mention the fact in old-style

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
