### PR TITLE
dnsdist: Fix a race in the async regression tests

### DIFF
--- a/regression-tests.dnsdist/test_Async.py
+++ b/regression-tests.dnsdist/test_Async.py
@@ -6,6 +6,7 @@ import sys
 import threading
 import unittest
 import dns
+import dns.message
 import doqclient
 
 from dnsdisttests import DNSDistTest, pickAvailablePort
@@ -459,8 +460,8 @@ class TestAsyncFFI(DNSDistTest, AsyncTests):
       end
     end
 
-    local asyncResponderEndpoint = newNetworkEndpoint('%s')
-    local listener = newNetworkListener()
+    asyncResponderEndpoint = newNetworkEndpoint('%s')
+    listener = newNetworkListener()
     listener:addUnixListeningEndpoint('%s', 0, gotAsyncResponse)
     listener:start()
 
@@ -588,8 +589,8 @@ class TestAsyncLua(DNSDistTest, AsyncTests):
       end
     end
 
-    local asyncResponderEndpoint = newNetworkEndpoint('%s')
-    local listener = newNetworkListener()
+    asyncResponderEndpoint = newNetworkEndpoint('%s')
+    listener = newNetworkListener()
     listener:addUnixListeningEndpoint('%s', 0, gotAsyncResponse)
     listener:start()
 


### PR DESCRIPTION
### Short description

We need to make sure the listener is alive during the duration of the test, and not destroyed by the garbage collector.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

