### PR TITLE
dnsdist: Fix a small race in the NetworkListener

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-network.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-network.hh
@@ -42,7 +42,7 @@ public:
 
   using EndpointID = uint16_t;
   using NetworkDatagramCB = std::function<void(EndpointID endpoint, std::string&& dgram, const std::string& from)>;
-  bool addUnixListeningEndpoint(const std::string& path, EndpointID id, NetworkDatagramCB cb);
+  bool addUnixListeningEndpoint(const std::string& path, EndpointID endpointID, NetworkDatagramCB callback);
   void start();
   void runOnce(timeval& now, uint32_t timeout);
 

--- a/pdns/dnsdistdist/dnsdist-lua-network.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-network.hh
@@ -34,16 +34,32 @@ class NetworkListener
 {
 public:
   NetworkListener();
+  NetworkListener(const NetworkListener&) = delete;
+  NetworkListener(NetworkListener&&) = delete;
+  NetworkListener& operator=(const NetworkListener&) = delete;
+  NetworkListener& operator=(NetworkListener&&) = delete;
+  ~NetworkListener();
 
   using EndpointID = uint16_t;
   using NetworkDatagramCB = std::function<void(EndpointID endpoint, std::string&& dgram, const std::string& from)>;
   bool addUnixListeningEndpoint(const std::string& path, EndpointID id, NetworkDatagramCB cb);
   void start();
-  void runOnce(struct timeval& now, uint32_t timeout);
+  void runOnce(timeval& now, uint32_t timeout);
 
 private:
+  struct ListenerData
+  {
+    ListenerData();
+
+    std::unique_ptr<FDMultiplexer> d_mplexer;
+    std::unordered_map<std::string, Socket> d_sockets;
+    std::atomic<bool> d_running{false};
+    std::atomic<bool> d_exiting{false};
+  };
+
   static void readCB(int desc, FDMultiplexer::funcparam_t& param);
-  void mainThread();
+  static void mainThread(std::shared_ptr<ListenerData>& data);
+  static void runOnce(ListenerData& data, timeval& now, uint32_t timeout);
 
   struct CBData
   {
@@ -51,9 +67,7 @@ private:
     EndpointID d_endpoint;
   };
 
-  std::unique_ptr<FDMultiplexer> d_mplexer;
-  std::unordered_map<std::string, Socket> d_sockets;
-  std::atomic<bool> d_running{false};
+  std::shared_ptr<ListenerData> d_data;
 };
 
 class NetworkEndpoint


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The main thread needs to be able to access the data even if the NetworkListener object has been destroyed first, which usually only happens when DNSdist is exiting, but could also happen earlier if the Lua handle is garbage collected (see #13583).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
