### PR TITLE
rec: Fix a dangling reference in Lua's UDP Query Response callback

### DIFF
--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -746,7 +746,7 @@ bool RecursorLua4::genhook(const luacall_t& func, DNSQuestion& dq, int& ret) con
         PacketBuffer p = GenUDPQueryResponse(dq.udpQueryDest, dq.udpQuery);
         dq.udpAnswer = std::string(reinterpret_cast<const char*>(p.data()), p.size());
         // coverity[auto_causes_copy] not copying produces a dangling ref
-        const auto cbFunc = d_lw->readVariable<boost::optional<luacall_t>&>(dq.udpCallback).get_value_or(nullptr);
+        const auto cbFunc = d_lw->readVariable<boost::optional<luacall_t>>(dq.udpCallback).get_value_or(nullptr);
         if (!cbFunc) {
           SLOG(g_log << Logger::Error << "Attempted callback for Lua UDP Query/Response which could not be found" << endl,
                g_slog->withName("lua")->info(Logr::Error, "Attempted callback for Lua UDP Query/Response which could not be found"));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This fixes the recently recurring errors happening in our CI in these tests:
```
FAILED test_Lua.py::LuaHooksRecursorTest::testPreResolve - TypeError: msg is not a dns.message.Message but a <class 'NoneType'>
FAILED test_Lua.py::LuaHooksRecursorTest::testVanillaNXD - ConnectionRefusedError: [Errno 111] Connection refused
FAILED test_Lua.py::LuaHooksRecursorDistributesTest::testPreResolve - TypeError: msg is not a dns.message.Message but a <class 'NoneType'>
FAILED test_Lua.py::LuaHooksRecursorDistributesTest::testVanillaNXD - ConnectionRefusedError: [Errno 111] Connection refused
```
The recursor was crashing because it was calling a Lua callback which no longer existed at this point.

Introduced in 50bd111e3c78e2cc8c2aa916a1f9fc22699f1f60
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

