### PR TITLE
configure.ac fixup: do not require bash

### DIFF
--- a/m4/pdns_d_fortify_source.m4
+++ b/m4/pdns_d_fortify_source.m4
@@ -28,13 +28,13 @@ AC_DEFUN([AC_CC_D_FORTIFY_SOURCE],[
   AS_IF([test "x$enable_fortify_source" != "xno"], [
 
     dnl Auto means the highest version we support, which is currently 3
-    AS_IF([test "x$enable_fortify_source" == "xauto"],
+    AS_IF([test "$enable_fortify_source" = "auto"],
       [enable_fortify_source=3],
       []
     )
 
     dnl If 3 is not supported, we try to fallback to 2
-    AS_IF([test "x$enable_fortify_source" == "x3"], [
+    AS_IF([test "$enable_fortify_source" = "3"], [
       gl_COMPILER_OPTION_IF([-D_FORTIFY_SOURCE=3], [
         CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 $CFLAGS"
         CXXFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 $CXXFLAGS"
@@ -42,14 +42,14 @@ AC_DEFUN([AC_CC_D_FORTIFY_SOURCE],[
     ])
 
     dnl If 2 is not supported, we try to fallback to 1
-    AS_IF([test "x$enable_fortify_source" == "x2"], [
+    AS_IF([test "$enable_fortify_source" = "2"], [
       gl_COMPILER_OPTION_IF([-D_FORTIFY_SOURCE=2], [
         CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $CFLAGS"
         CXXFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $CXXFLAGS"
       ], [enable_fortify_source=1])
     ])
 
-    AS_IF([test "x$enable_fortify_source" == "x1"], [
+    AS_IF([test "$enable_fortify_source" = "1"], [
       gl_COMPILER_OPTION_IF([-D_FORTIFY_SOURCE=1], [
         CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 $CFLAGS"
         CXXFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 $CXXFLAGS"

--- a/m4/pdns_enable_lto.m4
+++ b/m4/pdns_enable_lto.m4
@@ -5,10 +5,10 @@ AC_DEFUN([PDNS_ENABLE_LTO],[
     [enable_lto=no]
   )
 
-  AS_IF([test "x$enable_lto" != "xno"], [
+  AS_IF([test "$enable_lto" != "no"], [
 
     dnl If thin is not supported, we try to fallback to auto
-    AS_IF([test "x$enable_lto" == "xthin"], [
+    AS_IF([test "$enable_lto" = "thin"], [
       gl_COMPILER_OPTION_IF([-flto=thin], [
         CFLAGS="-flto=thin $CFLAGS"
         CXXFLAGS="-flto=thin $CXXFLAGS"
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_ENABLE_LTO],[
     ])
 
     dnl If auto is not supported, we try to fallback -flto
-    AS_IF([test "x$enable_lto" == "xauto"], [
+    AS_IF([test "$enable_lto" = "auto"], [
       gl_COMPILER_OPTION_IF([-flto=auto], [
         CFLAGS="-flto=auto $CFLAGS"
         CXXFLAGS="-flto=auto $CXXFLAGS"
@@ -25,7 +25,7 @@ AC_DEFUN([PDNS_ENABLE_LTO],[
       ], [enable_lto=yes])
     ])
 
-    AS_IF([test "x$enable_lto" == "xyes"], [
+    AS_IF([test "$enable_lto" = "yes"], [
       gl_COMPILER_OPTION_IF([-flto], [
         CFLAGS="-flto $CFLAGS"
         CXXFLAGS="-flto $CXXFLAGS"

--- a/m4/pdns_with_postgresql.m4
+++ b/m4/pdns_with_postgresql.m4
@@ -1,7 +1,7 @@
 dnl
 dnl Attempt to detect the flags we need for the Postgresql client libraries
 dnl First, use pkg-config
-dnl If that yields no results, use (optionally find) pg_config and use it to 
+dnl If that yields no results, use (optionally find) pg_config and use it to
 dnl determine the CFLAGS and LIBS
 dnl
 AC_DEFUN([PDNS_WITH_POSTGRESQL], [
@@ -10,21 +10,21 @@ AC_DEFUN([PDNS_WITH_POSTGRESQL], [
     [AS_HELP_STRING([--with-pg-config=<path>], [path to pg_config])
   ], [
     PG_CONFIG="$withval"
-    AS_IF([test "x$PG_CONFIG" = "xyes" -o ! -x "$PG_CONFIG"], [
+    AS_IF([test "$PG_CONFIG" = "yes" -o ! -x "$PG_CONFIG"], [
       AC_MSG_ERROR([--with-pg-config must provide a valid path to the pg_config executable])
     ])
   ])
 
-  AS_IF([test "x$PG_CONFIG" = "x"], [
+  AS_IF([test -z "$PG_CONFIG"], [
     PKG_CHECK_MODULES([PGSQL], [libpq], [ : ], [ : ])
   ])
 
-  AS_IF([test "x$PG_CONFIG" != "x" -o "x$PGSQL_LIBS" = "x"], [
+  AS_IF([test -n "$PG_CONFIG" -o -z "$PGSQL_LIBS"], [
     dnl Either a path was provided, or pkg-config failed to produce a result
-    AS_IF([test "x$PG_CONFIG" == "x"], [
+    AS_IF([test -z "$PG_CONFIG"], [
       AC_PATH_PROG([PG_CONFIG], [pg_config])
     ])
-    AS_IF([test "x$PG_CONFIG" == "x"], [
+    AS_IF([test -z "$PG_CONFIG"], [
       AC_MSG_ERROR([Can not find pg_config, use --with-pg-config to specify the path to pg_config])
     ])
     PGSQL_LIBS="-L$($PG_CONFIG --libdir) -lpq"


### PR DESCRIPTION
- configure: remove broken bashism

  In a configure check that was carefully written for pre-unix-wars versions of the bourne shell, some code which was only valid using GNU bash was included.
  
  The `==` operator is a bash-specific alias for `=`. It behaves exactly the same, except more confusing. It contains no added functionality, other than making an otherwise /bin/sh compatible script only work when /bin/sh is a symlink to /bin/bash.

- configure: remove useless multi-step check for cdb

  cdb doesn't provide a pkg-config file. Debian patches one in, but theirs is broken and provides no functionality which isn't already covered by checking if -lcdb works.
  
  The compile test is already needed in the general case, provides more accurate results even on Debian, and avoids running commands that cannot work on non-Debian systems.