### PR TITLE
dnsdist-1.8.x: Fix the removal of the last rule by name or UUID

### DIFF
--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -132,7 +132,7 @@ static void rmRule(GlobalStateHolder<vector<T> > *someRuleActions, boost::varian
       const auto uuid = getUniqueID(*str);
       auto removeIt = std::remove_if(rules.begin(),
                                      rules.end(),
-                                     [uuid](const T& rule) { return rule.d_id == uuid; });
+                                     [&uuid](const T& rule) { return rule.d_id == uuid; });
       if (removeIt == rules.end()) {
         g_outputBuffer = "Error: no rule matched\n";
         return;

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -130,23 +130,27 @@ static void rmRule(GlobalStateHolder<vector<T> > *someRuleActions, boost::varian
   if (auto str = boost::get<std::string>(&id)) {
     try {
       const auto uuid = getUniqueID(*str);
-      if (rules.erase(std::remove_if(rules.begin(),
+      auto removeIt = std::remove_if(rules.begin(),
                                      rules.end(),
-                                     [uuid](const T& a) { return a.d_id == uuid; }),
-                      rules.end()) == rules.end()) {
+                                     [uuid](const T& rule) { return rule.d_id == uuid; });
+      if (removeIt == rules.end()) {
         g_outputBuffer = "Error: no rule matched\n";
         return;
       }
+      rules.erase(removeIt,
+                  rules.end());
     }
     catch (const std::runtime_error& e) {
       /* it was not an UUID, let's see if it was a name instead */
-      if (rules.erase(std::remove_if(rules.begin(),
+      auto removeIt = std::remove_if(rules.begin(),
                                      rules.end(),
-                                     [&str](const T& a) { return a.d_name == *str; }),
-                      rules.end()) == rules.end()) {
+                                     [&str](const T& rule) { return rule.d_name == *str; });
+      if (removeIt == rules.end()) {
         g_outputBuffer = "Error: no rule matched\n";
         return;
       }
+      rules.erase(removeIt,
+                  rules.end());
     }
   }
   else if (auto pos = boost::get<unsigned int>(&id)) {

--- a/regression-tests.dnsdist/test_RulesActions.py
+++ b/regression-tests.dnsdist/test_RulesActions.py
@@ -1309,6 +1309,46 @@ class TestSetRules(DNSDistTest):
             self.assertTrue(receivedResponse)
             self.assertEqual(expectedResponse, receivedResponse)
 
+class TestRmRules(DNSDistTest):
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
+    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%s"}
+    addAction(AllRule(), SpoofAction("192.0.2.1"), {name='myFirstRule', uuid='090736ca-2fb6-41e7-a836-58efaca3d71e'})
+    addAction(AllRule(), SpoofAction("192.0.2.1"), {name='mySecondRule'})
+    addResponseAction(AllRule(), AllowResponseAction(), {name='myFirstResponseRule', uuid='745a03b5-89e0-4eee-a6bf-c9700b0d31f0'})
+    addResponseAction(AllRule(), AllowResponseAction(), {name='mySecondResponseRule'})
+    """
+
+    def testRmRules(self):
+        """
+        Advanced: Remove rules
+        """
+        lines = self.sendConsoleCommand("showRules({showUUIDs=true})").splitlines()
+        self.assertEqual(len(lines), 3)
+        self.assertIn('myFirstRule', lines[1])
+        self.assertIn('mySecondRule', lines[2])
+        self.assertIn('090736ca-2fb6-41e7-a836-58efaca3d71e', lines[1])
+
+        lines = self.sendConsoleCommand("showResponseRules({showUUIDs=true})").splitlines()
+        self.assertEqual(len(lines), 3)
+        self.assertIn('myFirstResponseRule', lines[1])
+        self.assertIn('mySecondResponseRule', lines[2])
+        self.assertIn('745a03b5-89e0-4eee-a6bf-c9700b0d31f0', lines[1])
+
+        self.sendConsoleCommand("rmRule('090736ca-2fb6-41e7-a836-58efaca3d71e')")
+        self.sendConsoleCommand("rmRule('mySecondRule')")
+        lines = self.sendConsoleCommand("showRules({showUUIDs=true})").splitlines()
+        self.assertEqual(len(lines), 1)
+
+        self.sendConsoleCommand("rmResponseRule('745a03b5-89e0-4eee-a6bf-c9700b0d31f0')")
+        self.sendConsoleCommand("rmResponseRule('mySecondResponseRule')")
+        lines = self.sendConsoleCommand("showResponseRules({showUUIDs=true})").splitlines()
+        self.assertEqual(len(lines), 1)
+
 class TestAdvancedContinueAction(DNSDistTest):
 
     _config_template = """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #13488 to rel/dnsdist-1.8.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
