### PR TITLE
dnsdist-1.8.x: Skip our BADVERS regression test on broken Python versions

### DIFF
--- a/regression-tests.dnsdist/test_RulesActions.py
+++ b/regression-tests.dnsdist/test_RulesActions.py
@@ -2,6 +2,7 @@
 import base64
 from datetime import datetime, timedelta
 import os
+import sys
 import time
 import unittest
 import dns
@@ -1195,6 +1196,9 @@ class TestAdvancedEDNSVersionRule(DNSDistTest):
         """
         Advanced: A question with ECS version larger than 0 yields BADVERS
         """
+
+        if sys.version_info >= (3, 11) and sys.version_info < (3, 12):
+            raise unittest.SkipTest("Test skipped, see https://github.com/PowerDNS/pdns/pull/12912")
 
         name = 'ednsversionrule.advanced.tests.powerdns.com.'
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #13314 to rel/dnsdist-1.8.x.

See https://github.com/PowerDNS/pdns/pull/12912 for the longer explanation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
