### PR TITLE
dnsdist-1.8.x: Fix a race in the Async unit tests

### DIFF
--- a/pdns/dnsdistdist/test-dnsdistasync.cc
+++ b/pdns/dnsdistdist/test-dnsdistasync.cc
@@ -49,7 +49,7 @@ public:
     errorRaised = true;
   }
 
-  bool errorRaised{false};
+  std::atomic<bool> errorRaised{false};
 };
 
 struct DummyCrossProtocolQuery : public CrossProtocolQuery
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_TimeoutFailClose)
   usleep(20000);
 
   BOOST_CHECK(holder->empty());
-  BOOST_CHECK(sender->errorRaised);
+  BOOST_CHECK(sender->errorRaised.load());
 
   holder->stop();
 }
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(test_AddingExpiredEvent)
   usleep(20000);
 
   BOOST_CHECK(holder->empty());
-  BOOST_CHECK(sender->errorRaised);
+  BOOST_CHECK(sender->errorRaised.load());
 
   holder->stop();
 }


### PR DESCRIPTION
### Short description
Backport of #13304 to rel/dnsdist-1.8.x.

We used to set the `errorRaised` variable from the `AsynchronousHolder` thread then check its value from the main thread, which is correctly reported as TSAN as a data race. We do know that we have waited enough, and that otherwise it's fine to fail, but TSAN cannot know that. Switching to a `std::atomic<bool>` fixes it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
