### PR TITLE
dnsdist-1.8.x: Add a `DNSHeader:getTC()` Lua binding

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -192,8 +192,12 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
       return (bool)dh.cd;
     });
 
-    luaCtx.registerFunction<uint16_t(dnsheader::*)()const>("getID", [](const dnsheader& dh) {
+  luaCtx.registerFunction<uint16_t(dnsheader::*)()const>("getID", [](const dnsheader& dh) {
       return ntohs(dh.id);
+    });
+
+  luaCtx.registerFunction<bool(dnsheader::*)()const>("getTC", [](const dnsheader& dh) {
+      return (bool)dh.tc;
     });
 
   luaCtx.registerFunction<void(dnsheader::*)(bool)>("setTC", [](dnsheader& dh, bool v) {

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -504,7 +504,7 @@ DNSHeader (``dh``) object
 
     Get recursion desired flag.
 
-  .. method:: DNSHeader:getTC() -> int
+  .. method:: DNSHeader:getTC() -> bool
 
     .. versionadded:: 1.8.1
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -504,6 +504,12 @@ DNSHeader (``dh``) object
 
     Get recursion desired flag.
 
+  .. method:: DNSHeader:getTC() -> int
+
+    .. versionadded:: 1.8.1
+
+    Get the TC flag.
+
   .. method:: DNSHeader:setAA(aa)
 
     Set authoritative answer flag.

--- a/regression-tests.dnsdist/test_Lua.py
+++ b/regression-tests.dnsdist/test_Lua.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import base64
+import dns
 import time
 import unittest
 from dnsdisttests import DNSDistTest
@@ -40,3 +41,55 @@ class TestLuaThread(DNSDistTest):
         time.sleep(3)
         count2 = self.sendConsoleCommand('counter')
         self.assertTrue(count2 > count1)
+
+class TestLuaDNSHeaderBindings(DNSDistTest):
+    _config_template = """
+    newServer{address="127.0.0.1:%s"}
+
+    function checkTCSet(dq)
+      local tc = dq.dh:getTC()
+      if not tc then
+        return DNSAction.Spoof, 'tc-not-set.check-tc.lua-dnsheaders.tests.powerdns.com.'
+      end
+      return DNSAction.Allow
+    end
+
+    addAction('check-tc.lua-dnsheaders.tests.powerdns.com.', LuaAction(checkTCSet))
+    """
+
+    def testLuaGetTC(self):
+        """
+        LuaDNSHeaders: TC
+        """
+        name = 'notset.check-tc.lua-dnsheaders.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.CNAME,
+                                    'tc-not-set.check-tc.lua-dnsheaders.tests.powerdns.com.')
+        response.answer.append(rrset)
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (_, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertEqual(response, receivedResponse)
+
+        name = 'set.check-tc.lua-dnsheaders.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+        query.flags |= dns.flags.TC
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #13135 to rel/dnsdist-1.8.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
