### PR TITLE
GH Actions: force CI failure if there are binaries present in a Pull Request

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -250,7 +250,7 @@ jobs:
 
   check-clang-tidy:
     needs: analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Check whether clang-tidy succeeded
     steps:
       - run: |
@@ -266,3 +266,14 @@ jobs:
             echo "::error::Rec clang-tidy failed"
             exit 1
           fi
+
+  check-for-binaries:
+    runs-on: ubuntu-22.04
+    name: Force failure in case there are binaries present in a pull request
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - run: if [[ "$(file -i --dereference $(git diff --name-only HEAD^..HEAD) | grep binary | grep -v 'image/' | grep -v 'inode/x-empty')" != "" ]]; then exit 1; fi


### PR DESCRIPTION
### Short description

Force CI failure if there are binaries present in a Pull Request.

The original request comes from this [pull request](https://github.com/PowerDNS/pdns/pull/13221)

This is an example of a failure in the CodeQL workflow when a binary file is added to a PR: [here](https://github.com/romeroalx/pdns/actions/runs/7182275016/job/19558412138)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
