### PR TITLE
Fix type qualifier warning

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -132,7 +132,7 @@ static int readnWithTimeout(int fd, void* buffer, unsigned int n, unsigned int i
     if (totalTimeout) {
       time_t now = time(nullptr);
       const auto elapsed = now - start;
-      if (elapsed >= static_cast<decltype(elapsed)>(remainingTotal)) {
+      if (elapsed >= static_cast<time_t>(remainingTotal)) {
         throw NetworkError("Timeout while reading data");
       }
       start = now;


### PR DESCRIPTION
### Short description
Fixes a small type qualifier warning:
```
[199/464] Compiling C++ object pdns/libpdns-tcpreceiver.cc.a.p/tcpreceiver.cc.o
../pdns/tcpreceiver.cc: In function ‘int readnWithTimeout(int, void*, unsigned int, unsigned int, bool, unsigned int)’:
../pdns/tcpreceiver.cc:135:22: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
  135 |       if (elapsed >= static_cast<decltype(elapsed)>(remainingTotal)) {
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)