### PR TITLE
Fix "unknown option" warnings on GCC and older Clang

### DIFF
--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -114,11 +114,13 @@ try
 
   Socket sock(g_dest.sin4.sin_family, SOCK_STREAM);
   int tmp=1;
-  if(setsockopt(sock.getHandle(),SOL_SOCKET,SO_REUSEADDR,(char*)&tmp,sizeof tmp)<0)
-    throw runtime_error("Unable to set socket reuse: "+stringerror());
+  if (setsockopt(sock.getHandle(), SOL_SOCKET, SO_REUSEADDR, &tmp, sizeof tmp) < 0) {
+    throw runtime_error("Unable to set socket reuse: " + stringerror());
+  }
 
-  if(g_tcpNoDelay && setsockopt(sock.getHandle(), IPPROTO_TCP, TCP_NODELAY,(char*)&tmp,sizeof tmp)<0)
-    throw runtime_error("Unable to set socket no delay: "+stringerror());
+  if (g_tcpNoDelay && setsockopt(sock.getHandle(), IPPROTO_TCP, TCP_NODELAY, &tmp, sizeof tmp) < 0) {
+    throw runtime_error("Unable to set socket no delay: " + stringerror());
+  }
 
   sock.connect(g_dest);
   uint16_t len = htons(packet.size());

--- a/pdns/histog.hh
+++ b/pdns/histog.hh
@@ -1,7 +1,9 @@
 #pragma once
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#if __clang_major__ >= 15
 #pragma GCC diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#endif
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
 #pragma GCC diagnostic pop


### PR DESCRIPTION
### Short description
```
[283/464] Compiling C++ object pdns/libdnstcpbench.a.p/dnstcpbench.cc.o
../pdns/dnstcpbench.cc:27:32: warning: unknown option after ‘#pragma GCC diagnostic’ kind [-Wpragmas]
   27 | #pragma GCC diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[291/464] Compiling C++ object pdns/libdnsscope.a.p/dnsscope.cc.o
In file included from ../pdns/dnsscope.cc:27:
../pdns/histog.hh:4:32: warning: unknown option after ‘#pragma GCC diagnostic’ kind [-Wpragmas]
    4 | #pragma GCC diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[305/464] Compiling C++ object pdns/libdnsbulktest.a.p/dnsbulktest.cc.o
../pdns/dnsbulktest.cc:27:32: warning: unknown option after ‘#pragma GCC diagnostic’ kind [-Wpragmas]
   27 | #pragma GCC diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)