### PR TITLE
Fix warning about pointer with non-zero offset being freed

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1,4 +1,3 @@
-
 #include <boost/smart_ptr/make_shared_array.hpp>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -12,6 +11,7 @@
 #include "statbag.hh"
 #include "base32.hh"
 #include "base64.hh"
+#include "dns.hh"
 
 #include <boost/program_options.hpp>
 #include <boost/assign/std/vector.hpp>
@@ -925,7 +925,7 @@ static int increaseSerial(const DNSName& zone, DNSSECKeeper &dk)
 
   sd.db->startTransaction(zone, -1);
 
-  if (!sd.db->replaceRRSet(sd.domain_id, zone, rr.qtype, vector<DNSResourceRecord>(1, rr))) {
+  if (!sd.db->replaceRRSet(sd.domain_id, zone, rr.qtype, {rr})) {
    sd.db->abortTransaction();
    cerr<<"Backend did not replace SOA record. Backend might not support this operation."<<endl;
    return -1;


### PR DESCRIPTION
### Short description
```
In file included from /usr/include/c++/13.2.1/x86_64-pc-linux-gnu/bits/c++allocator.h:33,
                 from /usr/include/c++/13.2.1/bits/allocator.h:46,
                 from /usr/include/c++/13.2.1/memory:65,
                 from /usr/include/boost/smart_ptr/detail/sp_counted_impl.hpp:35,
                 from /usr/include/boost/smart_ptr/detail/shared_count.hpp:27,
                 from /usr/include/boost/smart_ptr/shared_ptr.hpp:18,
                 from /usr/include/boost/smart_ptr/allocate_shared_array.hpp:15,
                 from /usr/include/boost/smart_ptr/make_shared_array.hpp:13,
                 from ../pdns/pdnsutil.cc:2:
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = DNSResourceRecord]’,
    inlined from ‘static void std::allocator_traits<std::allocator<_Tp1> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = DNSResourceRecord]’ at /usr/include/c++/13.2.1/bits/alloc_traits.h:516:23,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = DNSResourceRecord; _Alloc = std::allocator<DNSResourceRecord>]’ at /usr/include/c++/13.2.1/bits/stl_vector.h:387:19,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = DNSResourceRecord; _Alloc = std::allocator<DNSResourceRecord>]’ at /usr/include/c++/13.2.1/bits/stl_vector.h:366:15,
    inlined from ‘std::vector<_Tp, _Alloc>::~vector() [with _Tp = DNSResourceRecord; _Alloc = std::allocator<DNSResourceRecord>]’ at /usr/include/c++/13.2.1/bits/stl_vector.h:735:7,
    inlined from ‘int increaseSerial(const DNSName&, DNSSECKeeper&)’ at ../pdns/pdnsutil.cc:928:58:
/usr/include/c++/13.2.1/bits/new_allocator.h:168:33: warning: ‘void operator delete(void*, std::size_t)’ called on pointer ‘<unknown>’ with nonzero offset 136 [-Wfree-nonheap-object]
  168 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                 ^
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = DNSResourceRecord]’,
    inlined from ‘static _Tp* std::allocator_traits<std::allocator<_Tp1> >::allocate(allocator_type&, size_type) [with _Tp = DNSResourceRecord]’ at /usr/include/c++/13.2.1/bits/alloc_traits.h:482:28,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = DNSResourceRecord; _Alloc = std::allocator<DNSResourceRecord>]’ at /usr/include/c++/13.2.1/bits/stl_vector.h:378:33,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = DNSResourceRecord; _Alloc = std::allocator<DNSResourceRecord>]’ at /usr/include/c++/13.2.1/bits/stl_vector.h:375:7,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_create_storage(std::size_t) [with _Tp = DNSResourceRecord; _Alloc = std::allocator<DNSResourceRecord>]’ at /usr/include/c++/13.2.1/bits/stl_vector.h:395:44,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::_Vector_base(std::size_t, const allocator_type&) [with _Tp = DNSResourceRecord; _Alloc = std::allocator<DNSResourceRecord>]’ at /usr/include/c++/13.2.1/bits/stl_vector.h:332:26,
    inlined from ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = DNSResourceRecord; _Alloc = std::allocator<DNSResourceRecord>]’ at /usr/include/c++/13.2.1/bits/stl_vector.h:568:47,
    inlined from ‘int increaseSerial(const DNSName&, DNSSECKeeper&)’ at ../pdns/pdnsutil.cc:928:58:
/usr/include/c++/13.2.1/bits/new_allocator.h:147:55: note: returned from ‘void* operator new(std::size_t)’
  147 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                                       ^
```

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)