### PR TITLE
Add supervisor to Auth container image

### DIFF
--- a/Docker-README.md
+++ b/Docker-README.md
@@ -58,3 +58,21 @@ There are multiple ways of dealing with these restrictions if you encounter them
     * Auth & Recursor: `local-address` and/or `local-port`
 
 Note: Docker Engine 20.10.0 (released december 2020) removed the need to set the `NET_BIND_SERVICE` capability when attempting to bind to a privileged port.
+
+## Auth and Supervisord
+
+The auth image uses `tini` as init process to run auth via the startup.py wrapper. However, it also has `supervisord` available for special use cases. Example scenarios for using `supervisord` include:
+
+* Running multiple processes (ie: auth + ixfrdist) within the same container - Generally not advisable, but has benefits in some cases
+* Allowing restarts of processes within a container without having the entire container restart - Primarily has benefits in Kubernetes where you could have a process (ixfrdist for example) restart when a mounted configmap containing the process' configuration is observed to be modified.
+
+To use `supervisord` as within Kubernetes, you can configure the container with the following:
+
+```yaml
+command: ["supervisord"]
+args:
+  - "--configuration"
+  - "/path/to/supervisord.conf"
+```
+
+In the above example `/path/to/supervisord.conf` is the path where a configmap containing your supervisord configuration is mounted. Further details about `supervisord` and how to configure it can be found here: http://supervisord.org/configuration.html

--- a/Docker-README.md
+++ b/Docker-README.md
@@ -75,4 +75,5 @@ args:
   - "/path/to/supervisord.conf"
 ```
 
-In the above example `/path/to/supervisord.conf` is the path where a configmap containing your supervisord configuration is mounted. Further details about `supervisord` and how to configure it can be found here: http://supervisord.org/configuration.html
+In the above example `/path/to/supervisord.conf` is the path where a configmap containing your supervisord configuration is mounted.
+Further details about `supervisord` and how to configure it can be found here: http://supervisord.org/configuration.html

--- a/Docker-README.md
+++ b/Docker-README.md
@@ -64,9 +64,9 @@ Note: Docker Engine 20.10.0 (released december 2020) removed the need to set the
 The auth image uses `tini` as init process to run auth via the startup.py wrapper. However, it also has `supervisord` available for special use cases. Example scenarios for using `supervisord` include:
 
 * Running multiple processes (ie: auth + ixfrdist) within the same container - Generally not advisable, but has benefits in some cases
-* Allowing restarts of processes within a container without having the entire container restart - Primarily has benefits in Kubernetes where you could have a process (ixfrdist for example) restart when a mounted configmap containing the process' configuration is observed to be modified.
+* Allowing restarts of processes within a container without having the entire container restart - Primarily has benefits in Kubernetes where you could have a process (ixfrdist for example) restart when a script/agent detects changes in a mounted configmap containing the process' configuration.
 
-To use `supervisord` as within Kubernetes, you can configure the container with the following:
+To use `supervisord` within Kubernetes, you can configure the container with the following:
 
 ```yaml
 command: ["supervisord"]

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -72,8 +72,8 @@ FROM debian:11-slim
 RUN apt-get update && apt-get -y dist-upgrade && apt-get clean
 
 # Ensure python3 and jinja2 is present (for startup script), and sqlite3 (for db schema), and tini (for signal management),
-#   and vim (for pdnsutil edit-zone) 
-RUN apt-get install -y python3 python3-jinja2 sqlite3 tini libcap2-bin vim-tiny && apt-get clean
+#   and vim (for pdnsutil edit-zone) , and supervisor (for special use cases requiring advanced process management)
+RUN apt-get install -y python3 python3-jinja2 sqlite3 tini libcap2-bin vim-tiny supervisor && apt-get clean
 
 # Output from builder
 COPY --from=builder /build /


### PR DESCRIPTION
### Short description
This PR adds `supervisor` to the Auth container image. Tini is still in place as default init process, but supervisor can be used for scenarios where more advanced process management has benefits.

Scenarios where this might be beneficial include:
- Running multiple processes (ie: auth + ixfrdist) within a single container
- Kubernetes: Automating restarts of a process (ie: ixfrdist) within a container when a mounted configmap containing the process' configuration is observed to have been changed (without restarting the container itself) 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
