### PR TITLE
dnsdist: Fix `DynBlockRulesGroup:removeRange`'s version in the docs

### DIFF
--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1823,7 +1823,7 @@ faster than the existing rules.
 
   .. method:: DynBlockRulesGroup:removeRange(netmasks)
 
-    .. versionadded:: 1.9.0
+    .. versionadded:: 1.8.3
 
     Remove a previously included or excluded range. The range should be an exact match of the existing entry to remove.
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

