### PR TITLE
auth: Fix a construction ordering issue between `StatBag` and `Logger`

### DIFF
--- a/modules/remotebackend/test-remotebackend-http.cc
+++ b/modules/remotebackend/test-remotebackend-http.cc
@@ -32,12 +32,10 @@
 #include "pdns/logger.hh"
 #include "pdns/arguments.hh"
 #include "pdns/json.hh"
-#include "pdns/statbag.hh"
 #include "pdns/auth-packetcache.hh"
 #include "pdns/auth-querycache.hh"
 #include "pdns/auth-zonecache.hh"
 
-StatBag S;
 AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;

--- a/modules/remotebackend/test-remotebackend-json.cc
+++ b/modules/remotebackend/test-remotebackend-json.cc
@@ -30,12 +30,10 @@
 #include "pdns/logger.hh"
 #include "pdns/arguments.hh"
 #include "pdns/json.hh"
-#include "pdns/statbag.hh"
 #include "pdns/auth-packetcache.hh"
 #include "pdns/auth-querycache.hh"
 #include "pdns/auth-zonecache.hh"
 
-StatBag S;
 AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;

--- a/modules/remotebackend/test-remotebackend-pipe.cc
+++ b/modules/remotebackend/test-remotebackend-pipe.cc
@@ -42,12 +42,10 @@
 #include "pdns/arguments.hh"
 #include "pdns/dnsrecords.hh"
 #include "pdns/json.hh"
-#include "pdns/statbag.hh"
 #include "pdns/auth-packetcache.hh"
 #include "pdns/auth-querycache.hh"
 #include "pdns/auth-zonecache.hh"
 
-StatBag S;
 AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;

--- a/modules/remotebackend/test-remotebackend-post.cc
+++ b/modules/remotebackend/test-remotebackend-post.cc
@@ -30,12 +30,10 @@
 #include "pdns/logger.hh"
 #include "pdns/arguments.hh"
 #include "pdns/json.hh"
-#include "pdns/statbag.hh"
 #include "pdns/auth-packetcache.hh"
 #include "pdns/auth-querycache.hh"
 #include "pdns/auth-zonecache.hh"
 
-StatBag S;
 AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;

--- a/modules/remotebackend/test-remotebackend-unix.cc
+++ b/modules/remotebackend/test-remotebackend-unix.cc
@@ -42,12 +42,10 @@
 #include "pdns/arguments.hh"
 #include "pdns/dnsrecords.hh"
 #include "pdns/json.hh"
-#include "pdns/statbag.hh"
 #include "pdns/auth-packetcache.hh"
 #include "pdns/auth-querycache.hh"
 #include "pdns/auth-zonecache.hh"
 
-StatBag S;
 AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;

--- a/modules/remotebackend/test-remotebackend-zeromq.cc
+++ b/modules/remotebackend/test-remotebackend-zeromq.cc
@@ -41,12 +41,10 @@
 #include "pdns/arguments.hh"
 #include "pdns/dnsrecords.hh"
 #include "pdns/json.hh"
-#include "pdns/statbag.hh"
 #include "pdns/auth-packetcache.hh"
 #include "pdns/auth-querycache.hh"
 #include "pdns/auth-zonecache.hh"
 
-StatBag S;
 AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;

--- a/pdns/auth-carbon.cc
+++ b/pdns/auth-carbon.cc
@@ -36,7 +36,6 @@ void carbonDumpThread()
 try
 {
   setThreadName("pdns/carbonDump");
-  extern StatBag S;
 
   string namespace_name=arg()["carbon-namespace"];
   string hostname=arg()["carbon-ourname"];
@@ -60,11 +59,11 @@ try
     }
 
     string msg;
-    vector<string> entries = S.getEntries();
+    vector<string> entries = StatBag::getStatBag().getEntries();
     ostringstream str;
     time_t now=time(nullptr);
     for(const string& entry : entries) {
-      str<<namespace_name<<'.'<<hostname<<'.'<<instance_name<<'.'<<entry<<' '<<S.read(entry)<<' '<<now<<"\r\n";
+      str<<namespace_name<<'.'<<hostname<<'.'<<instance_name<<'.'<<entry<<' '<<StatBag::getStatBag().read(entry)<<' '<<now<<"\r\n";
     }
     msg = str.str();
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -116,7 +116,6 @@ bool g_doGssTSIG;
 typedef Distributor<DNSPacket, DNSPacket, PacketHandler> DNSDistributor;
 
 ArgvMap theArg;
-StatBag S; //!< Statistics are gathered across PDNS via the StatBag class S
 AuthPacketCache PC; //!< This is the main PacketCache, shared across all threads
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;
@@ -401,101 +400,102 @@ static uint64_t getSendLatency(const std::string& /* str */)
 
 static void declareStats()
 {
-  S.declare("udp-queries", "Number of UDP queries received");
-  S.declare("udp-do-queries", "Number of UDP queries received with DO bit");
-  S.declare("udp-cookie-queries", "Number of UDP queries received with the COOKIE EDNS option");
-  S.declare("udp-answers", "Number of answers sent out over UDP");
-  S.declare("udp-answers-bytes", "Total size of answers sent out over UDP");
-  S.declare("udp4-answers-bytes", "Total size of answers sent out over UDPv4");
-  S.declare("udp6-answers-bytes", "Total size of answers sent out over UDPv6");
+  auto& theStatBag = StatBag::getStatBag();
+  theStatBag.declare("udp-queries", "Number of UDP queries received");
+  theStatBag.declare("udp-do-queries", "Number of UDP queries received with DO bit");
+  theStatBag.declare("udp-cookie-queries", "Number of UDP queries received with the COOKIE EDNS option");
+  theStatBag.declare("udp-answers", "Number of answers sent out over UDP");
+  theStatBag.declare("udp-answers-bytes", "Total size of answers sent out over UDP");
+  theStatBag.declare("udp4-answers-bytes", "Total size of answers sent out over UDPv4");
+  theStatBag.declare("udp6-answers-bytes", "Total size of answers sent out over UDPv6");
 
-  S.declare("udp4-answers", "Number of IPv4 answers sent out over UDP");
-  S.declare("udp4-queries", "Number of IPv4 UDP queries received");
-  S.declare("udp6-answers", "Number of IPv6 answers sent out over UDP");
-  S.declare("udp6-queries", "Number of IPv6 UDP queries received");
-  S.declare("overload-drops", "Queries dropped because backends overloaded");
+  theStatBag.declare("udp4-answers", "Number of IPv4 answers sent out over UDP");
+  theStatBag.declare("udp4-queries", "Number of IPv4 UDP queries received");
+  theStatBag.declare("udp6-answers", "Number of IPv6 answers sent out over UDP");
+  theStatBag.declare("udp6-queries", "Number of IPv6 UDP queries received");
+  theStatBag.declare("overload-drops", "Queries dropped because backends overloaded");
 
-  S.declare("rd-queries", "Number of recursion desired questions");
-  S.declare("recursion-unanswered", "Number of packets unanswered by configured recursor");
-  S.declare("recursing-answers", "Number of recursive answers sent out");
-  S.declare("recursing-questions", "Number of questions sent to recursor");
-  S.declare("corrupt-packets", "Number of corrupt packets received");
-  S.declare("signatures", "Number of DNSSEC signatures made");
-  S.declare("tcp-queries", "Number of TCP queries received");
-  S.declare("tcp-cookie-queries", "Number of TCP queries received with the COOKIE option");
-  S.declare("tcp-answers", "Number of answers sent out over TCP");
-  S.declare("tcp-answers-bytes", "Total size of answers sent out over TCP");
-  S.declare("tcp4-answers-bytes", "Total size of answers sent out over TCPv4");
-  S.declare("tcp6-answers-bytes", "Total size of answers sent out over TCPv6");
+  theStatBag.declare("rd-queries", "Number of recursion desired questions");
+  theStatBag.declare("recursion-unanswered", "Number of packets unanswered by configured recursor");
+  theStatBag.declare("recursing-answers", "Number of recursive answers sent out");
+  theStatBag.declare("recursing-questions", "Number of questions sent to recursor");
+  theStatBag.declare("corrupt-packets", "Number of corrupt packets received");
+  theStatBag.declare("signatures", "Number of DNSSEC signatures made");
+  theStatBag.declare("tcp-queries", "Number of TCP queries received");
+  theStatBag.declare("tcp-cookie-queries", "Number of TCP queries received with the COOKIE option");
+  theStatBag.declare("tcp-answers", "Number of answers sent out over TCP");
+  theStatBag.declare("tcp-answers-bytes", "Total size of answers sent out over TCP");
+  theStatBag.declare("tcp4-answers-bytes", "Total size of answers sent out over TCPv4");
+  theStatBag.declare("tcp6-answers-bytes", "Total size of answers sent out over TCPv6");
 
-  S.declare("tcp4-queries", "Number of IPv4 TCP queries received");
-  S.declare("tcp4-answers", "Number of IPv4 answers sent out over TCP");
+  theStatBag.declare("tcp4-queries", "Number of IPv4 TCP queries received");
+  theStatBag.declare("tcp4-answers", "Number of IPv4 answers sent out over TCP");
 
-  S.declare("tcp6-queries", "Number of IPv6 TCP queries received");
-  S.declare("tcp6-answers", "Number of IPv6 answers sent out over TCP");
+  theStatBag.declare("tcp6-queries", "Number of IPv6 TCP queries received");
+  theStatBag.declare("tcp6-answers", "Number of IPv6 answers sent out over TCP");
 
-  S.declare("open-tcp-connections", "Number of currently open TCP connections", getTCPConnectionCount, StatType::gauge);
+  theStatBag.declare("open-tcp-connections", "Number of currently open TCP connections", getTCPConnectionCount, StatType::gauge);
 
-  S.declare("qsize-q", "Number of questions waiting for database attention", getQCount, StatType::gauge);
+  theStatBag.declare("qsize-q", "Number of questions waiting for database attention", getQCount, StatType::gauge);
 
-  S.declare("dnsupdate-queries", "DNS update packets received.");
-  S.declare("dnsupdate-answers", "DNS update packets successfully answered.");
-  S.declare("dnsupdate-refused", "DNS update packets that are refused.");
-  S.declare("dnsupdate-changes", "DNS update changes to records in total.");
+  theStatBag.declare("dnsupdate-queries", "DNS update packets received.");
+  theStatBag.declare("dnsupdate-answers", "DNS update packets successfully answered.");
+  theStatBag.declare("dnsupdate-refused", "DNS update packets that are refused.");
+  theStatBag.declare("dnsupdate-changes", "DNS update changes to records in total.");
 
-  S.declare("incoming-notifications", "NOTIFY packets received.");
+  theStatBag.declare("incoming-notifications", "NOTIFY packets received.");
 
-  S.declare("uptime", "Uptime of process in seconds", uptimeOfProcess, StatType::counter);
-  S.declare("real-memory-usage", "Actual unique use of memory in bytes (approx)", getRealMemoryUsage, StatType::gauge);
-  S.declare("special-memory-usage", "Actual unique use of memory in bytes (approx)", getSpecialMemoryUsage, StatType::gauge);
-  S.declare("fd-usage", "Number of open filedescriptors", getOpenFileDescriptors, StatType::gauge);
+  theStatBag.declare("uptime", "Uptime of process in seconds", uptimeOfProcess, StatType::counter);
+  theStatBag.declare("real-memory-usage", "Actual unique use of memory in bytes (approx)", getRealMemoryUsage, StatType::gauge);
+  theStatBag.declare("special-memory-usage", "Actual unique use of memory in bytes (approx)", getSpecialMemoryUsage, StatType::gauge);
+  theStatBag.declare("fd-usage", "Number of open filedescriptors", getOpenFileDescriptors, StatType::gauge);
 #ifdef __linux__
-  S.declare("udp-recvbuf-errors", "UDP 'recvbuf' errors", udpErrorStats, StatType::counter);
-  S.declare("udp-sndbuf-errors", "UDP 'sndbuf' errors", udpErrorStats, StatType::counter);
-  S.declare("udp-noport-errors", "UDP 'noport' errors", udpErrorStats, StatType::counter);
-  S.declare("udp-in-errors", "UDP 'in' errors", udpErrorStats, StatType::counter);
-  S.declare("udp-in-csum-errors", "UDP 'in checksum' errors", udpErrorStats, StatType::counter);
-  S.declare("udp6-in-errors", "UDP 'in' errors over IPv6", udp6ErrorStats, StatType::counter);
-  S.declare("udp6-recvbuf-errors", "UDP 'recvbuf' errors over IPv6", udp6ErrorStats, StatType::counter);
-  S.declare("udp6-sndbuf-errors", "UDP 'sndbuf' errors over IPv6", udp6ErrorStats, StatType::counter);
-  S.declare("udp6-noport-errors", "UDP 'noport' errors over IPv6", udp6ErrorStats, StatType::counter);
-  S.declare("udp6-in-csum-errors", "UDP 'in checksum' errors over IPv6", udp6ErrorStats, StatType::counter);
+  theStatBag.declare("udp-recvbuf-errors", "UDP 'recvbuf' errors", udpErrorStats, StatType::counter);
+  theStatBag.declare("udp-sndbuf-errors", "UDP 'sndbuf' errors", udpErrorStats, StatType::counter);
+  theStatBag.declare("udp-noport-errors", "UDP 'noport' errors", udpErrorStats, StatType::counter);
+  theStatBag.declare("udp-in-errors", "UDP 'in' errors", udpErrorStats, StatType::counter);
+  theStatBag.declare("udp-in-csum-errors", "UDP 'in checksum' errors", udpErrorStats, StatType::counter);
+  theStatBag.declare("udp6-in-errors", "UDP 'in' errors over IPv6", udp6ErrorStats, StatType::counter);
+  theStatBag.declare("udp6-recvbuf-errors", "UDP 'recvbuf' errors over IPv6", udp6ErrorStats, StatType::counter);
+  theStatBag.declare("udp6-sndbuf-errors", "UDP 'sndbuf' errors over IPv6", udp6ErrorStats, StatType::counter);
+  theStatBag.declare("udp6-noport-errors", "UDP 'noport' errors over IPv6", udp6ErrorStats, StatType::counter);
+  theStatBag.declare("udp6-in-csum-errors", "UDP 'in checksum' errors over IPv6", udp6ErrorStats, StatType::counter);
 #endif
 
-  S.declare("sys-msec", "Number of msec spent in system time", getSysUserTimeMsec, StatType::counter);
-  S.declare("user-msec", "Number of msec spent in user time", getSysUserTimeMsec, StatType::counter);
+  theStatBag.declare("sys-msec", "Number of msec spent in system time", getSysUserTimeMsec, StatType::counter);
+  theStatBag.declare("user-msec", "Number of msec spent in user time", getSysUserTimeMsec, StatType::counter);
 
 #ifdef __linux__
-  S.declare("cpu-iowait", "Time spent waiting for I/O to complete by the whole system, in units of USER_HZ", getCPUIOWait, StatType::counter);
-  S.declare("cpu-steal", "Stolen time, which is the time spent by the whole system in other operating systems when running in a virtualized environment, in units of USER_HZ", getCPUSteal, StatType::counter);
+  theStatBag.declare("cpu-iowait", "Time spent waiting for I/O to complete by the whole system, in units of USER_HZ", getCPUIOWait, StatType::counter);
+  theStatBag.declare("cpu-steal", "Stolen time, which is the time spent by the whole system in other operating systems when running in a virtualized environment, in units of USER_HZ", getCPUSteal, StatType::counter);
 #endif
 
-  S.declare("meta-cache-size", "Number of entries in the metadata cache", DNSSECKeeper::dbdnssecCacheSizes, StatType::gauge);
-  S.declare("key-cache-size", "Number of entries in the key cache", DNSSECKeeper::dbdnssecCacheSizes, StatType::gauge);
-  S.declare("signature-cache-size", "Number of entries in the signature cache", signatureCacheSize, StatType::gauge);
+  theStatBag.declare("meta-cache-size", "Number of entries in the metadata cache", DNSSECKeeper::dbdnssecCacheSizes, StatType::gauge);
+  theStatBag.declare("key-cache-size", "Number of entries in the key cache", DNSSECKeeper::dbdnssecCacheSizes, StatType::gauge);
+  theStatBag.declare("signature-cache-size", "Number of entries in the signature cache", signatureCacheSize, StatType::gauge);
 
-  S.declare("nxdomain-packets", "Number of times an NXDOMAIN packet was sent out");
-  S.declare("noerror-packets", "Number of times a NOERROR packet was sent out");
-  S.declare("servfail-packets", "Number of times a server-failed packet was sent out");
-  S.declare("unauth-packets", "Number of times a zone we are not auth for was queried");
-  S.declare("latency", "Average number of microseconds needed to answer a question", getLatency, StatType::gauge);
-  S.declare("receive-latency", "Average number of microseconds needed to receive a query", getReceiveLatency, StatType::gauge);
-  S.declare("cache-latency", "Average number of microseconds needed for a packet cache lookup", getCacheLatency, StatType::gauge);
-  S.declare("backend-latency", "Average number of microseconds needed for a backend lookup", getBackendLatency, StatType::gauge);
-  S.declare("send-latency", "Average number of microseconds needed to send the answer", getSendLatency, StatType::gauge);
-  S.declare("timedout-packets", "Number of packets which weren't answered within timeout set");
-  S.declare("security-status", "Security status based on regular polling", StatType::gauge);
-  S.declare(
+  theStatBag.declare("nxdomain-packets", "Number of times an NXDOMAIN packet was sent out");
+  theStatBag.declare("noerror-packets", "Number of times a NOERROR packet was sent out");
+  theStatBag.declare("servfail-packets", "Number of times a server-failed packet was sent out");
+  theStatBag.declare("unauth-packets", "Number of times a zone we are not auth for was queried");
+  theStatBag.declare("latency", "Average number of microseconds needed to answer a question", getLatency, StatType::gauge);
+  theStatBag.declare("receive-latency", "Average number of microseconds needed to receive a query", getReceiveLatency, StatType::gauge);
+  theStatBag.declare("cache-latency", "Average number of microseconds needed for a packet cache lookup", getCacheLatency, StatType::gauge);
+  theStatBag.declare("backend-latency", "Average number of microseconds needed for a backend lookup", getBackendLatency, StatType::gauge);
+  theStatBag.declare("send-latency", "Average number of microseconds needed to send the answer", getSendLatency, StatType::gauge);
+  theStatBag.declare("timedout-packets", "Number of packets which weren't answered within timeout set");
+  theStatBag.declare("security-status", "Security status based on regular polling", StatType::gauge);
+  theStatBag.declare(
     "xfr-queue", "Size of the queue of zones to be XFRd", [](const string&) { return Communicator.getSuckRequestsWaiting(); }, StatType::gauge);
-  S.declareDNSNameQTypeRing("queries", "UDP Queries Received");
-  S.declareDNSNameQTypeRing("nxdomain-queries", "Queries for nonexistent records within existent zones");
-  S.declareDNSNameQTypeRing("noerror-queries", "Queries for existing records, but for type we don't have");
-  S.declareDNSNameQTypeRing("servfail-queries", "Queries that could not be answered due to backend errors");
-  S.declareDNSNameQTypeRing("unauth-queries", "Queries for zones that we are not authoritative for");
-  S.declareRing("logmessages", "Log Messages");
-  S.declareComboRing("remotes", "Remote server IP addresses");
-  S.declareComboRing("remotes-unauth", "Remote hosts querying zones for which we are not auth");
-  S.declareComboRing("remotes-corrupt", "Remote hosts sending corrupt packets");
+  theStatBag.declareDNSNameQTypeRing("queries", "UDP Queries Received");
+  theStatBag.declareDNSNameQTypeRing("nxdomain-queries", "Queries for nonexistent records within existent zones");
+  theStatBag.declareDNSNameQTypeRing("noerror-queries", "Queries for existing records, but for type we don't have");
+  theStatBag.declareDNSNameQTypeRing("servfail-queries", "Queries that could not be answered due to backend errors");
+  theStatBag.declareDNSNameQTypeRing("unauth-queries", "Queries for zones that we are not authoritative for");
+  theStatBag.declareRing("logmessages", "Log Messages");
+  theStatBag.declareComboRing("remotes", "Remote server IP addresses");
+  theStatBag.declareComboRing("remotes-unauth", "Remote hosts querying zones for which we are not auth");
+  theStatBag.declareComboRing("remotes-corrupt", "Remote hosts sending corrupt packets");
 }
 
 static int isGuarded(char** argv)
@@ -537,14 +537,14 @@ try {
   DNSPacket question(true);
   DNSPacket cached(false);
 
-  AtomicCounter& numreceived = *S.getPointer("udp-queries");
-  AtomicCounter& numreceiveddo = *S.getPointer("udp-do-queries");
-  AtomicCounter& numreceivedcookie = *S.getPointer("udp-cookie-queries");
+  AtomicCounter& numreceived = *StatBag::getStatBag().getPointer("udp-queries");
+  AtomicCounter& numreceiveddo = *StatBag::getStatBag().getPointer("udp-do-queries");
+  AtomicCounter& numreceivedcookie = *StatBag::getStatBag().getPointer("udp-cookie-queries");
 
-  AtomicCounter& numreceived4 = *S.getPointer("udp4-queries");
+  AtomicCounter& numreceived4 = *StatBag::getStatBag().getPointer("udp4-queries");
 
-  AtomicCounter& numreceived6 = *S.getPointer("udp6-queries");
-  AtomicCounter& overloadDrops = *S.getPointer("overload-drops");
+  AtomicCounter& numreceived6 = *StatBag::getStatBag().getPointer("udp6-queries");
+  AtomicCounter& overloadDrops = *StatBag::getStatBag().getPointer("overload-drops");
 
   int diff, start;
   bool logDNSQueries = ::arg().mustDo("log-dns-queries");
@@ -600,8 +600,8 @@ try {
       if (question.d.qr)
         continue;
 
-      S.ringAccount("queries", question.qdomain, question.qtype);
-      S.ringAccount("remotes", question.getInnerRemote());
+      StatBag::getStatBag().ringAccount("queries", question.qdomain, question.qtype);
+      StatBag::getStatBag().ringAccount("remotes", question.getInnerRemote());
       if (logDNSQueries) {
         g_log << Logger::Notice << "Remote " << question.getRemoteString() << " wants '" << question.qdomain << "|" << question.qtype << "', do = " << question.d_dnssecOk << ", bufsize = " << question.getMaxReplyLen();
         if (question.d_ednsRawPacketSizeLimit > 0 && question.getMaxReplyLen() != (unsigned int)question.d_ednsRawPacketSizeLimit)
@@ -1483,7 +1483,7 @@ int main(int argc, char** argv)
     g_log << Logger::Error << "Invalid value '" << ::arg()["default-catalog-zone"] << "' for default-catalog-zone: " << e.what() << endl;
     exit(1);
   }
-  S.blacklist("special-memory-usage");
+  StatBag::getStatBag().blacklist("special-memory-usage");
 
   DLOG(g_log << Logger::Warning << "Verbose logging in effect" << endl);
 

--- a/pdns/auth-main.hh
+++ b/pdns/auth-main.hh
@@ -31,13 +31,11 @@
 #include "dnsproxy.hh"
 #include "dynlistener.hh"
 #include "nameserver.hh"
-#include "statbag.hh"
 #include "tcpreceiver.hh"
 #include "dnsseckeeper.hh"
 
 extern time_t g_starttime;
 extern ArgvMap theArg;
-extern StatBag S; //!< Statistics are gathered across PDNS via the StatBag class S
 extern AuthPacketCache PC; //!< This is the main PacketCache, shared across all threads
 extern AuthQueryCache QC;
 extern std::unique_ptr<DNSProxy> DP;

--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -26,21 +26,20 @@
 #include "logger.hh"
 #include "statbag.hh"
 #include "cachecleaner.hh"
-extern StatBag S;
 
 const unsigned int AuthPacketCache::s_mincleaninterval, AuthPacketCache::s_maxcleaninterval;
 
 AuthPacketCache::AuthPacketCache(size_t mapsCount): d_maps(mapsCount), d_lastclean(time(nullptr))
 {
-  S.declare("packetcache-hit", "Number of hits on the packet cache");
-  S.declare("packetcache-miss", "Number of misses on the packet cache");
-  S.declare("packetcache-size", "Number of entries in the packet cache", StatType::gauge);
-  S.declare("deferred-packetcache-inserts","Amount of packet cache inserts that were deferred because of maintenance");
-  S.declare("deferred-packetcache-lookup","Amount of packet cache lookups that were deferred because of maintenance");
+  StatBag::getStatBag().declare("packetcache-hit", "Number of hits on the packet cache");
+  StatBag::getStatBag().declare("packetcache-miss", "Number of misses on the packet cache");
+  StatBag::getStatBag().declare("packetcache-size", "Number of entries in the packet cache", StatType::gauge);
+  StatBag::getStatBag().declare("deferred-packetcache-inserts","Amount of packet cache inserts that were deferred because of maintenance");
+  StatBag::getStatBag().declare("deferred-packetcache-lookup","Amount of packet cache lookups that were deferred because of maintenance");
 
-  d_statnumhit=S.getPointer("packetcache-hit");
-  d_statnummiss=S.getPointer("packetcache-miss");
-  d_statnumentries=S.getPointer("packetcache-size");
+  d_statnumhit=StatBag::getStatBag().getPointer("packetcache-hit");
+  d_statnummiss=StatBag::getStatBag().getPointer("packetcache-miss");
+  d_statnumentries=StatBag::getStatBag().getPointer("packetcache-size");
 }
 
 void AuthPacketCache::MapCombo::reserve(size_t numberOfEntries)
@@ -69,7 +68,7 @@ bool AuthPacketCache::get(DNSPacket& p, DNSPacket& cached)
   {
     auto map = mc.d_map.try_read_lock();
     if (!map.owns_lock()) {
-      S.inc("deferred-packetcache-lookup");
+      StatBag::getStatBag().inc("deferred-packetcache-lookup");
       return false;
     }
 
@@ -135,7 +134,7 @@ void AuthPacketCache::insert(DNSPacket& q, DNSPacket& r, unsigned int maxTTL)
   {
     auto map = mc.d_map.try_write_lock();
     if (!map.owns_lock()) {
-      S.inc("deferred-packetcache-inserts");
+      StatBag::getStatBag().inc("deferred-packetcache-inserts");
       return;
     }
 

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -27,21 +27,20 @@
 #include "logger.hh"
 #include "statbag.hh"
 #include "cachecleaner.hh"
-extern StatBag S;
 
 const unsigned int AuthQueryCache::s_mincleaninterval, AuthQueryCache::s_maxcleaninterval;
 
 AuthQueryCache::AuthQueryCache(size_t mapsCount): d_maps(mapsCount), d_lastclean(time(nullptr))
 {
-  S.declare("query-cache-hit","Number of hits on the query cache");
-  S.declare("query-cache-miss","Number of misses on the query cache");
-  S.declare("query-cache-size", "Number of entries in the query cache", StatType::gauge);
-  S.declare("deferred-cache-inserts","Amount of cache inserts that were deferred because of maintenance");
-  S.declare("deferred-cache-lookup","Amount of cache lookups that were deferred because of maintenance");
+  StatBag::getStatBag().declare("query-cache-hit","Number of hits on the query cache");
+  StatBag::getStatBag().declare("query-cache-miss","Number of misses on the query cache");
+  StatBag::getStatBag().declare("query-cache-size", "Number of entries in the query cache", StatType::gauge);
+  StatBag::getStatBag().declare("deferred-cache-inserts","Amount of cache inserts that were deferred because of maintenance");
+  StatBag::getStatBag().declare("deferred-cache-lookup","Amount of cache lookups that were deferred because of maintenance");
 
-  d_statnumhit=S.getPointer("query-cache-hit");
-  d_statnummiss=S.getPointer("query-cache-miss");
-  d_statnumentries=S.getPointer("query-cache-size");
+  d_statnumhit=StatBag::getStatBag().getPointer("query-cache-hit");
+  d_statnummiss=StatBag::getStatBag().getPointer("query-cache-miss");
+  d_statnumentries=StatBag::getStatBag().getPointer("query-cache-size");
 }
 
 void AuthQueryCache::MapCombo::reserve(size_t numberOfEntries)
@@ -62,7 +61,7 @@ bool AuthQueryCache::getEntry(const DNSName &qname, const QType& qtype, vector<D
   {
     auto map = mc.d_map.try_read_lock();
     if (!map.owns_lock()) {
-      S.inc("deferred-cache-lookup");
+      StatBag::getStatBag().inc("deferred-cache-lookup");
       return false;
     }
 
@@ -90,7 +89,7 @@ void AuthQueryCache::insert(const DNSName &qname, const QType& qtype, vector<DNS
   {
     auto map = mc.d_map.try_write_lock();
     if (!map.owns_lock()) {
-      S.inc("deferred-cache-inserts"); 
+      StatBag::getStatBag().inc("deferred-cache-inserts"); 
       return;
     }
 

--- a/pdns/auth-zonecache.cc
+++ b/pdns/auth-zonecache.cc
@@ -28,18 +28,17 @@
 #include "statbag.hh"
 #include "arguments.hh"
 #include "cachecleaner.hh"
-extern StatBag S;
 
 AuthZoneCache::AuthZoneCache(size_t mapsCount) :
   d_maps(mapsCount)
 {
-  S.declare("zone-cache-hit", "Number of zone cache hits");
-  S.declare("zone-cache-miss", "Number of zone cache misses");
-  S.declare("zone-cache-size", "Number of entries in the zone cache", StatType::gauge);
+  StatBag::getStatBag().declare("zone-cache-hit", "Number of zone cache hits");
+  StatBag::getStatBag().declare("zone-cache-miss", "Number of zone cache misses");
+  StatBag::getStatBag().declare("zone-cache-size", "Number of entries in the zone cache", StatType::gauge);
 
-  d_statnumhit = S.getPointer("zone-cache-hit");
-  d_statnummiss = S.getPointer("zone-cache-miss");
-  d_statnumentries = S.getPointer("zone-cache-size");
+  d_statnumhit = StatBag::getStatBag().getPointer("zone-cache-hit");
+  d_statnummiss = StatBag::getStatBag().getPointer("zone-cache-miss");
+  d_statnumentries = StatBag::getStatBag().getPointer("zone-cache-size");
 }
 
 bool AuthZoneCache::getEntry(const DNSName& zone, int& zoneId)

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -40,12 +40,9 @@
 #include "ednssubnet.hh"
 #include "misc.hh"
 #include "sstuff.hh"
-#include "statbag.hh"
 
 using std::thread;
 using std::unique_ptr;
-
-StatBag S;
 
 static std::atomic<unsigned int> g_recvcounter, g_recvbytes;
 static volatile bool g_done;

--- a/pdns/comfun.cc
+++ b/pdns/comfun.cc
@@ -30,7 +30,7 @@
 #include <deque>
 #include "inflighter.cc"
 //#include "malloctrace.hh"
-StatBag S;
+
 bool g_quiet;
 std::unique_ptr<ofstream> g_powerdns;
 std::atomic<unsigned int> g_count;

--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -41,8 +41,6 @@
 #include "statbag.hh"
 #include "gss_context.hh"
 
-extern StatBag S;
-
 /** the Distributor template class enables you to multithread slow question/answer 
     processes. 
     
@@ -201,7 +199,7 @@ template<class Answer, class Question, class Backend>void MultiThreadDistributor
       auto questionData = std::move(*tempQD);
       std::unique_ptr<Answer> a = nullptr;
       if (queuetimeout && questionData->Q.d_dt.udiff() > queuetimeout * 1000) {
-        S.inc("timedout-packets");
+        StatBag::getStatBag().inc("timedout-packets");
         continue;
       }
 
@@ -222,8 +220,8 @@ retry:
           a = questionData->Q.replyPacket();
 
           a->setRcode(RCode::ServFail);
-          S.inc("servfail-packets");
-          S.ringAccount("servfail-queries", questionData->Q.qdomain, questionData->Q.qtype);
+          StatBag::getStatBag().inc("servfail-packets");
+          StatBag::getStatBag().ringAccount("servfail-queries", questionData->Q.qdomain, questionData->Q.qtype);
         } else {
           g_log<<Logger::Notice<<"Backend error (retry once): "<<e.reason<<endl;
           goto retry;
@@ -236,8 +234,8 @@ retry:
           a = questionData->Q.replyPacket();
 
           a->setRcode(RCode::ServFail);
-          S.inc("servfail-packets");
-          S.ringAccount("servfail-queries", questionData->Q.qdomain, questionData->Q.qtype);
+          StatBag::getStatBag().inc("servfail-packets");
+          StatBag::getStatBag().ringAccount("servfail-queries", questionData->Q.qdomain, questionData->Q.qtype);
         } else {
           g_log<<Logger::Warning<<"Caught unknown exception in Distributor thread "<<std::this_thread::get_id()<<" (retry once)"<<endl;
           goto retry;
@@ -289,8 +287,8 @@ retry:
       a=q.replyPacket();
 
       a->setRcode(RCode::ServFail);
-      S.inc("servfail-packets");
-      S.ringAccount("servfail-queries", q.qdomain, q.qtype);
+      StatBag::getStatBag().inc("servfail-packets");
+      StatBag::getStatBag().ringAccount("servfail-queries", q.qdomain, q.qtype);
     } else {
       g_log<<Logger::Notice<<"Backend error (retry once): "<<e.reason<<endl;
       goto retry;
@@ -303,8 +301,8 @@ retry:
       a=q.replyPacket();
 
       a->setRcode(RCode::ServFail);
-      S.inc("servfail-packets");
-      S.ringAccount("servfail-queries", q.qdomain, q.qtype);
+      StatBag::getStatBag().inc("servfail-packets");
+      StatBag::getStatBag().ringAccount("servfail-queries", q.qdomain, q.qtype);
     } else {
       g_log<<Logger::Warning<<"Caught unknown exception in Distributor thread "<<std::this_thread::get_id()<<" (retry once)"<<endl;
       goto retry;

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -36,8 +36,6 @@
 #include "dns.hh"
 #include "statbag.hh"
 
-extern StatBag S;
-
 // this has to be somewhere central, and not in a file that requires Lua
 // this is so the geoipbackend can set this pointer if loaded for lua-record.cc
 std::function<std::string(const std::string&, int)> g_getGeo;
@@ -233,7 +231,7 @@ vector<std::unique_ptr<DNSBackend>> BackendMakerClass::all(bool metadataOnly)
 bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd)
 {
   this->lookup(QType(QType::SOA),domain,-1);
-  S.inc("backend-queries");
+  StatBag::getStatBag().inc("backend-queries");
 
   DNSResourceRecord rr;
   int hits=0;

--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -46,8 +46,6 @@ namespace po = boost::program_options;
 
 po::variables_map g_vm;
 
-StatBag S;
-
 ArgvMap &arg()
 {
   static ArgvMap theArg;

--- a/pdns/dnsdemog.cc
+++ b/pdns/dnsdemog.cc
@@ -23,7 +23,6 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "statbag.hh"
 #include "dnspcap.hh"
 #include "dnsparser.hh"
 #include <map>
@@ -33,8 +32,6 @@
 #include "anadns.hh"
 
 #include "namespaces.hh"
-
-StatBag S;
 
 struct Entry
 {

--- a/pdns/dnsgram.cc
+++ b/pdns/dnsgram.cc
@@ -23,7 +23,6 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "statbag.hh"
 #include "dnspcap.hh"
 #include "dnsrecords.hh"
 #include "dnsparser.hh"
@@ -34,9 +33,6 @@
 #include "anadns.hh"
 
 #include "namespaces.hh"
-#include "namespaces.hh"
-
-StatBag S;
 
 static struct tm* pdns_localtime_r(const uint32_t* then, struct tm* tm)
 {

--- a/pdns/dnspcap2calidns.cc
+++ b/pdns/dnspcap2calidns.cc
@@ -31,9 +31,6 @@
 #include "dnspcap.hh"
 #include "dnsparser.hh"
 
-#include "statbag.hh"
-StatBag S;
-
 static void usage()
 {
   cerr<<"This program reads DNS queries from a PCAP file and outputs them in the calidns format."<<endl;

--- a/pdns/dnspcap2protobuf.cc
+++ b/pdns/dnspcap2protobuf.cc
@@ -32,9 +32,6 @@
 #include "protozero.hh"
 #include "uuid-utils.hh"
 
-#include "statbag.hh"
-StatBag S;
-
 static void usage()
 {
   cerr<<"This program reads DNS queries and responses from a PCAP file and stores them into our protobuf format."<<endl;

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -38,13 +38,11 @@
 #include "arguments.hh"
 #include "threadname.hh"
 
-extern StatBag S;
-
 DNSProxy::DNSProxy(const string &remote): d_xor(dns_random_uint16())
 {
-  d_resanswers=S.getPointer("recursing-answers");
-  d_resquestions=S.getPointer("recursing-questions");
-  d_udpanswers=S.getPointer("udp-answers");
+  d_resanswers=StatBag::getStatBag().getPointer("recursing-answers");
+  d_resquestions=StatBag::getStatBag().getPointer("recursing-questions");
+  d_udpanswers=StatBag::getStatBag().getPointer("udp-answers");
 
   vector<string> addresses;
   stringtok(addresses, remote, " ,\t");
@@ -176,7 +174,7 @@ int DNSProxy::getID_locked(map_t& conntrack)
           i->second.remote.toStringWithPort()<<" with internal id "<<n<<
           " was not answered by backend within timeout, reusing id"<<endl;
 	i->second.complete.reset();
-	S.inc("recursion-unanswered");
+	StatBag::getStatBag().inc("recursion-unanswered");
       }
       return n;
     }

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -63,7 +63,6 @@ What to do with timeouts. We keep around at most 65536 outstanding answers.
 #include "config.h"
 #endif
 #include <bitset>
-#include "statbag.hh"
 #include "dnspcap.hh"
 #include "sstuff.hh"
 #include "anadns.hh"
@@ -85,7 +84,6 @@ What to do with timeouts. We keep around at most 65536 outstanding answers.
 using namespace ::boost::multi_index;
 #include "namespaces.hh"
 
-StatBag S;
 bool g_quiet=true;
 int g_timeoutMsec=0;
 

--- a/pdns/dnsscan.cc
+++ b/pdns/dnsscan.cc
@@ -23,7 +23,6 @@
 #include "config.h"
 #endif
 #include <bitset>
-#include "statbag.hh"
 #include "dnspcap.hh"
 #include "sstuff.hh"
 #include "anadns.hh"
@@ -41,8 +40,6 @@
 
 #include "namespaces.hh"
 using namespace ::boost::multi_index;
-#include "namespaces.hh"
-StatBag S;
 
 static void usage() {
   cerr<<"syntax: dnsscan INFILE ..."<<endl;

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -27,7 +27,6 @@
 #include "histog.hh"
 #endif
 
-#include "statbag.hh"
 #include "dnspcap.hh"
 #include "dnsparser.hh"
 #include "dnsname.hh"
@@ -53,9 +52,6 @@ ArgvMap& arg()
   static ArgvMap theArg;
   return theArg;
 }
-StatBag S;
-
-
 
 struct QuestionData
 {

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -62,7 +62,7 @@ static std::string getLookupKeyFromPublicKey(const std::string& pubKey)
 
 static void fillOutRRSIG(DNSSECPrivateKey& dpk, const DNSName& signQName, RRSIGRecordContent& rrc, const sortedRecords_t& toSign)
 {
-  if (!g_signatureCount) {
+  if (g_signatureCount == nullptr) {
     g_signatureCount = StatBag::getStatBag().getPointer("signatures");
   }
 

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -31,7 +31,6 @@
 #include "lock.hh"
 #include "arguments.hh"
 #include "statbag.hh"
-extern StatBag S;
 
 typedef map<pair<string, string>, string> signaturecache_t;
 static SharedLockGuarded<signaturecache_t> g_signatures;
@@ -63,8 +62,9 @@ static std::string getLookupKeyFromPublicKey(const std::string& pubKey)
 
 static void fillOutRRSIG(DNSSECPrivateKey& dpk, const DNSName& signQName, RRSIGRecordContent& rrc, const sortedRecords_t& toSign)
 {
-  if(!g_signatureCount)
-    g_signatureCount = S.getPointer("signatures");
+  if (!g_signatureCount) {
+    g_signatureCount = StatBag::getStatBag().getPointer("signatures");
+  }
 
   DNSKEYRecordContent drc = dpk.getDNSKEY();
   const std::shared_ptr<DNSCryptoKeyEngine>& rc = dpk.getKey();

--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -38,14 +38,12 @@
 #include "misc.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
-#include "statbag.hh"
 #include "threadname.hh"
 #include <netinet/tcp.h>
 #include <boost/array.hpp>
 #include <boost/program_options.hpp>
 
 
-StatBag S;
 namespace po = boost::program_options;
 
 po::variables_map g_vm;

--- a/pdns/dnswasher.cc
+++ b/pdns/dnswasher.cc
@@ -39,8 +39,6 @@ otherwise, obfuscate the response IP address
 #endif
 
 #include "namespaces.hh"
-#include "statbag.hh"
-StatBag S;
 
 #ifdef HAVE_IPCIPHER
 #include "dnspcap.hh"

--- a/pdns/dumresp.cc
+++ b/pdns/dumresp.cc
@@ -24,11 +24,9 @@
 #endif
 #include "iputils.hh"
 #include "sstuff.hh"
-#include "statbag.hh"
 #include <atomic>
 #include <sys/mman.h>
 #include <thread>
-StatBag S;
 
 static std::atomic<uint64_t>* g_counter;
 

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -92,15 +92,14 @@ string DLPingHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid *
 string DLShowHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
 {
   try {
-    extern StatBag S;
     string ret("Wrong number of parameters");
     if (parts.size() == 2) {
       if (parts[1] == "*")
-        ret = S.directory();
+        ret = StatBag::getStatBag().directory();
       else if (parts[1].length() && parts[1][parts[1].length() - 1 ] == '*')
-        ret = S.directory(parts[1].substr(0, parts[1].length() - 1));
+        ret = StatBag::getStatBag().directory(parts[1].substr(0, parts[1].length() - 1));
       else
-        ret = S.getValueStr(parts[1]);
+        ret = StatBag::getStatBag().getValueStr(parts[1]);
     }
 
     return ret;
@@ -202,9 +201,8 @@ string DLRSizesHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid
 
 string DLRemotesHandler(const vector<string>& /* parts */, Utility::pid_t /* ppid */)
 {
-  extern StatBag S;
   typedef vector<pair<string, unsigned int> > totals_t;
-  totals_t totals = S.getRing("remotes");
+  totals_t totals = StatBag::getStatBag().getRing("remotes");
   string ret;
   boost::format fmt("%s\t%d\n");
   for(totals_t::value_type& val :  totals) {

--- a/pdns/dynlistener.cc
+++ b/pdns/dynlistener.cc
@@ -52,10 +52,7 @@
 #include "dynlistener.hh"
 #include "dnspacket.hh"
 #include "logger.hh"
-#include "statbag.hh"
 #include "threadname.hh"
-
-extern StatBag S;
 
 DynListener::g_funkdb_t DynListener::s_funcdb;
 DynListener::g_funk_t* DynListener::s_restfunc;

--- a/pdns/dynloader.cc
+++ b/pdns/dynloader.cc
@@ -40,7 +40,6 @@
 #include "misc.hh"
 #include "dynmessenger.hh"
 #include "arguments.hh"
-#include "statbag.hh"
 #include "misc.hh"
 #include "namespaces.hh"
 
@@ -49,8 +48,6 @@ ArgvMap &arg()
   static ArgvMap arg;
   return arg;
 }
-
-StatBag S;
 
 int main(int argc, char **argv)
 {

--- a/pdns/fuzz_moadnsparser.cc
+++ b/pdns/fuzz_moadnsparser.cc
@@ -22,9 +22,6 @@
 
 #include "dnsparser.hh"
 #include "dnsrecords.hh"
-#include "statbag.hh"
-
-StatBag S;
 
 static void init()
 {

--- a/pdns/fuzz_packetcache.cc
+++ b/pdns/fuzz_packetcache.cc
@@ -21,9 +21,6 @@
  */
 
 #include "packetcache.hh"
-#include "statbag.hh"
-
-StatBag S;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
 

--- a/pdns/fuzz_zoneparsertng.cc
+++ b/pdns/fuzz_zoneparsertng.cc
@@ -23,10 +23,7 @@
 #include "dnsname.hh"
 #include "dnsparser.hh"
 #include "dnsrecords.hh"
-#include "statbag.hh"
 #include "zoneparser-tng.hh"
-
-StatBag S;
 
 static void init()
 {

--- a/pdns/inflighter.cc
+++ b/pdns/inflighter.cc
@@ -33,7 +33,6 @@
 #include <sys/time.h>
 #include <time.h>
 #include "iputils.hh"
-#include "statbag.hh"
 #include <sys/socket.h>
 
 #include "namespaces.hh"
@@ -184,8 +183,6 @@ template<typename Container, typename SendReceive> bool Inflighter<Container, Se
 }
 
 #if 0
-StatBag S;
-
 struct SendReceive
 {
   typedef int Identifier;

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -55,8 +55,6 @@
 
 /* BEGIN Needed because of deeper dependencies */
 #include "arguments.hh"
-#include "statbag.hh"
-StatBag S;
 
 ArgvMap &arg()
 {

--- a/pdns/ixplore.cc
+++ b/pdns/ixplore.cc
@@ -27,7 +27,6 @@
 
 #include "misc.hh"
 #include "dnsrecords.hh"
-#include "statbag.hh"
 #include "base32.hh"
 #include "dnssecinfra.hh"
 
@@ -38,7 +37,6 @@
 #include <fstream>
 #include "ixfr.hh"
 #include "ixfrutils.hh"
-StatBag S;
 
 ArgvMap &arg()
 {

--- a/pdns/kvresp.cc
+++ b/pdns/kvresp.cc
@@ -24,13 +24,10 @@
 #endif
 #include "iputils.hh"
 #include "sstuff.hh"
-#include "statbag.hh"
 
 /* This tool REALLY wants to be rewritten in Python, by ahu does not speak it very well.
    What it does is provide answers to queries from the Lua generic UDP Question/Answer
    stuff in kv-example-script.lua */
-
-StatBag S;
 
 int main(int argc, char** argv)
 try

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -31,7 +31,6 @@
 #include "misc.hh"
 #ifndef RECURSOR
 #include "statbag.hh"
-extern StatBag S;
 #endif
 #include "namespaces.hh"
 
@@ -131,7 +130,7 @@ void Logger::log(const string& msg, Urgency u) noexcept
 #ifndef RECURSOR
   if (mustAccount) {
     try {
-      S.ringAccount("logmessages", msg);
+      StatBag::getStatBag().ringAccount("logmessages", msg);
     }
     catch (const runtime_error& e) {
       cerr << e.what() << endl;

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -45,8 +45,6 @@
 
 #include "namespaces.hh"
 
-extern StatBag S;
-
 /** \mainpage 
     PowerDNS is a very versatile nameserver that can answer questions from different backends. To implement your
     own backend, see the documentation for the DNSBackend class.
@@ -79,7 +77,7 @@ extern StatBag S;
     asking this question. If so, the entire Distributor is shunted, and the answer is sent back *directly*, within a few microseconds.
 
     \section misc Miscellaneous
-    Configuration details are available via the ArgvMap instance arg. Statistics are created by making calls to the StatBag object called S. 
+    Configuration details are available via the ArgvMap instance arg. Statistics are created by making calls to the StatBag object. 
     These statistics are made available via the UeberBackend on the same socket that is used for dynamic module commands.
 
     \section Main Main 
@@ -240,7 +238,6 @@ void UDPNameserver::send(DNSPacket& p)
 bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
 {
   ComboAddress remote;
-  extern StatBag S;
   ssize_t len=-1;
   Utility::sock_t sock=-1;
 
@@ -313,8 +310,8 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
     buffer.resize(len);
     ssize_t used = parseProxyHeader(buffer, proxyProto, psource, pdestination, tcp, ppvalues);
     if (used <= 0 || (size_t) used > g_proxyProtocolMaximumSize || (len - used) > DNSPacket::s_udpTruncationThreshold) {
-      S.inc("corrupt-packets");
-      S.ringAccount("remotes-corrupt", packet.d_remote);
+      StatBag::getStatBag().inc("corrupt-packets");
+      StatBag::getStatBag().ringAccount("remotes-corrupt", packet.d_remote);
       return false;
     }
     buffer.erase(0, used);
@@ -326,8 +323,8 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
   }
 
   if(packet.parse(&buffer.at(0), (size_t) len)<0) {
-    S.inc("corrupt-packets");
-    S.ringAccount("remotes-corrupt", packet.getInnerRemote());
+    StatBag::getStatBag().inc("corrupt-packets");
+    StatBag::getStatBag().ringAccount("remotes-corrupt", packet.getInnerRemote());
 
     return false; // unable to parse
   }

--- a/pdns/notify.cc
+++ b/pdns/notify.cc
@@ -35,7 +35,6 @@
 #include <boost/multi_index/key_extractors.hpp>
 
 #include "mplexer.hh"
-#include "statbag.hh"
 #include "arguments.hh"
 #include "version.hh"
 #include "namespaces.hh"
@@ -44,7 +43,6 @@ using namespace ::boost::multi_index;
 namespace po = boost::program_options;
 po::variables_map g_vm;
 
-StatBag S;
 ArgvMap &arg()
 {
   static ArgvMap arg;

--- a/pdns/nproxy.cc
+++ b/pdns/nproxy.cc
@@ -40,15 +40,12 @@
 #include <unistd.h>
 #include "dnsrecords.hh"
 #include "mplexer.hh"
-#include "statbag.hh"
 
 #include "namespaces.hh"
 using namespace ::boost::multi_index;
 
 namespace po = boost::program_options;
 po::variables_map g_vm;
-
-StatBag S;
 
 FDMultiplexer* g_fdm;
 int g_pdnssocket;

--- a/pdns/nsec3dig.cc
+++ b/pdns/nsec3dig.cc
@@ -27,16 +27,12 @@
 #include "misc.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
-#include "statbag.hh"
 #include "base32.hh"
 #include "dnssecinfra.hh"
 
-
-StatBag S;
-
-typedef std::pair<string,string> nsec3;
-typedef set<nsec3> nsec3set;
-typedef map<string, int> nsec3types;
+using nsec3 = std::pair<string,string>;
+using nsec3set = std::set<nsec3>;
+using nsec3types = std::map<std::string, int>;
 
 static string nsec3Hash(const DNSName &qname, const string &salt, unsigned int iters)
 {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -44,7 +44,6 @@
 #include "bind-dnssec.schema.sqlite3.sql.h"
 #endif
 
-StatBag S;
 AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;
@@ -134,7 +133,7 @@ static void loadMainConfig(const std::string& configdir)
 
   //cerr<<"Backend: "<<::arg()["launch"]<<", '" << ::arg()["gmysql-dbname"] <<"'" <<endl;
 
-  S.declare("qsize-q","Number of questions waiting for database attention");
+  StatBag::getStatBag().declare("qsize-q","Number of questions waiting for database attention");
 
   ::arg().set("max-cache-entries", "Maximum number of cache entries")="1000000";
   ::arg().set("cache-ttl","Seconds to store packets in the PacketCache")="20";
@@ -226,7 +225,7 @@ static void dbBench(const std::string& fname)
   }
   cout<<0.001*dt.udiff()/n<<" millisecond/lookup"<<endl;
   cout<<"Retrieved "<<hits<<" records, did "<<misses<<" queries which should have no match"<<endl;
-  cout<<"Packet cache reports: "<<S.read("query-cache-hit")<<" hits (should be 0) and "<<S.read("query-cache-miss") <<" misses"<<endl;
+  cout<<"Packet cache reports: "<<StatBag::getStatBag().read("query-cache-hit")<<" hits (should be 0) and "<<StatBag::getStatBag().read("query-cache-miss") <<" misses"<<endl;
 }
 
 static bool rectifyAllZones(DNSSECKeeper &dk, bool quiet = false)

--- a/pdns/responsestats-auth.cc
+++ b/pdns/responsestats-auth.cc
@@ -2,38 +2,37 @@
 #include "dnspacket.hh"
 #include "statbag.hh"
 
-extern StatBag S;
 /**
  *  Function that creates all the stats
  *  when udpOrTCP is true, it is udp
  */
 void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP, bool last) const {
   const string& buf=p.getString();
-  static AtomicCounter &udpnumanswered=*S.getPointer("udp-answers");
-  static AtomicCounter &udpnumanswered4=*S.getPointer("udp4-answers");
-  static AtomicCounter &udpnumanswered6=*S.getPointer("udp6-answers");
-  static AtomicCounter &udpbytesanswered=*S.getPointer("udp-answers-bytes");
-  static AtomicCounter &udpbytesanswered4=*S.getPointer("udp4-answers-bytes");
-  static AtomicCounter &udpbytesanswered6=*S.getPointer("udp6-answers-bytes");
-  static AtomicCounter &tcpnumanswered=*S.getPointer("tcp-answers");
-  static AtomicCounter &tcpnumanswered4=*S.getPointer("tcp4-answers");
-  static AtomicCounter &tcpnumanswered6=*S.getPointer("tcp6-answers");
-  static AtomicCounter &tcpbytesanswered=*S.getPointer("tcp-answers-bytes");
-  static AtomicCounter &tcpbytesanswered4=*S.getPointer("tcp4-answers-bytes");
-  static AtomicCounter &tcpbytesanswered6=*S.getPointer("tcp6-answers-bytes");
+  static AtomicCounter &udpnumanswered=*StatBag::getStatBag().getPointer("udp-answers");
+  static AtomicCounter &udpnumanswered4=*StatBag::getStatBag().getPointer("udp4-answers");
+  static AtomicCounter &udpnumanswered6=*StatBag::getStatBag().getPointer("udp6-answers");
+  static AtomicCounter &udpbytesanswered=*StatBag::getStatBag().getPointer("udp-answers-bytes");
+  static AtomicCounter &udpbytesanswered4=*StatBag::getStatBag().getPointer("udp4-answers-bytes");
+  static AtomicCounter &udpbytesanswered6=*StatBag::getStatBag().getPointer("udp6-answers-bytes");
+  static AtomicCounter &tcpnumanswered=*StatBag::getStatBag().getPointer("tcp-answers");
+  static AtomicCounter &tcpnumanswered4=*StatBag::getStatBag().getPointer("tcp4-answers");
+  static AtomicCounter &tcpnumanswered6=*StatBag::getStatBag().getPointer("tcp6-answers");
+  static AtomicCounter &tcpbytesanswered=*StatBag::getStatBag().getPointer("tcp-answers-bytes");
+  static AtomicCounter &tcpbytesanswered4=*StatBag::getStatBag().getPointer("tcp4-answers-bytes");
+  static AtomicCounter &tcpbytesanswered6=*StatBag::getStatBag().getPointer("tcp6-answers-bytes");
 
   ComboAddress accountremote = p.d_remote;
   if (p.d_inner_remote) accountremote = *p.d_inner_remote;
 
   if(p.d.aa) {
     if (p.d.rcode==RCode::NXDomain) {
-      S.inc("nxdomain-packets");
-      S.ringAccount("nxdomain-queries", p.qdomain, p.qtype);
+      StatBag::getStatBag().inc("nxdomain-packets");
+      StatBag::getStatBag().ringAccount("nxdomain-queries", p.qdomain, p.qtype);
     }
   } else if (p.d.rcode == RCode::Refused) {
-    S.inc("unauth-packets");
-    S.ringAccount("unauth-queries", p.qdomain, p.qtype);
-    S.ringAccount("remotes-unauth", accountremote);
+    StatBag::getStatBag().inc("unauth-packets");
+    StatBag::getStatBag().ringAccount("unauth-queries", p.qdomain, p.qtype);
+    StatBag::getStatBag().ringAccount("remotes-unauth", accountremote);
   }
 
   if (udpOrTCP) { // udp

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -21,7 +21,6 @@
 #include "gss_context.hh"
 #include "auth-main.hh"
 
-extern StatBag S;
 extern CommunicatorClass Communicator;
 
 std::mutex PacketHandler::s_rfc2136lock;
@@ -981,7 +980,7 @@ int PacketHandler::processUpdate(DNSPacket& p) {
         return RCode::ServFail;
       }
 
-      S.deposit("dnsupdate-changes", changedRecords);
+      StatBag::getStatBag().deposit("dnsupdate-changes", changedRecords);
 
       d_dk.clearMetaCache(di.zone);
       // Purge the records!

--- a/pdns/saxfr.cc
+++ b/pdns/saxfr.cc
@@ -7,14 +7,11 @@
 #include "misc.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
-#include "statbag.hh"
 #include "base32.hh"
 #include "dnssecinfra.hh"
 
 #include "dns_random.hh"
 #include "gss_context.hh"
-
-StatBag S;
 
 int main(int argc, char** argv)
 try

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -10,7 +10,6 @@
 #include "misc.hh"
 #include "proxy-protocol.hh"
 #include "sstuff.hh"
-#include "statbag.hh"
 #include <boost/array.hpp>
 
 #ifdef HAVE_LIBCURL
@@ -18,8 +17,6 @@
 #endif
 
 #include "tcpiohandler.hh"
-
-StatBag S;
 
 // Vars below used by tcpiohandler.cc
 bool g_verbose = true;

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -24,8 +24,6 @@
 
 string g_security_message;
 
-extern StatBag S;
-
 /** Do an actual secpoll for the current version
  * @param first bool that tells if this is the first secpoll run since startup
  */
@@ -47,7 +45,7 @@ void doSecPoll(bool first)
   boost::replace_all(query, "+", "_");
   boost::replace_all(query, "~", "_");
 
-  int security_status = std::stoi(S.getValueStr("security-status"));
+  int security_status = std::stoi(StatBag::getStatBag().getValueStr("security-status"));
 
   vector<DNSRecord> ret;
   int res = stubDoResolve(DNSName(query), QType::TXT, ret);
@@ -62,13 +60,13 @@ void doSecPoll(bool first)
   try {
     processSecPoll(res, ret, security_status, security_message);
   } catch(const PDNSException &pe) {
-    S.set("security-status", security_status);
+    StatBag::getStatBag().set("security-status", security_status);
     g_log<<Logger::Warning<<"Failed to retrieve security status update for '" + pkgv + "' on '"+ query + "': "<<pe.reason<<endl;
     return;
   }
 
 
-  S.set("security-status", security_status);
+  StatBag::getStatBag().set("security-status", security_status);
   g_security_message = security_message;
 
   if(security_status == 1 && first) {

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -22,7 +22,6 @@
 #ifndef RECURSOR
 #include "statbag.hh"
 #include "base64.hh"
-StatBag S;
 #endif
 
 volatile bool g_ret; // make sure the optimizer does not get too smart
@@ -893,7 +892,7 @@ struct StatRingDNSNameQTypeToStringTest
   string getName() const { return "StatRing test with DNSName and QType to string"; }
 
   void operator()() const {
-    S.ringAccount("testring", d_name.toLogString()+"/"+d_type.toString());
+    StatBag::getStatBag().ringAccount("testring", d_name.toLogString()+"/"+d_type.toString());
   };
 
   DNSName d_name;
@@ -907,7 +906,7 @@ struct StatRingDNSNameQTypeTest
   string getName() const { return "StatRing test with DNSName and QType"; }
 
   void operator()() const {
-    S.ringAccount("testringdnsname", d_name, d_type);
+    StatBag::getStatBag().ringAccount("testringdnsname", d_name, d_type);
   };
 
   DNSName d_name;
@@ -1321,12 +1320,12 @@ int main()
 #endif
 
 #ifndef RECURSOR
-    S.doRings();
+    StatBag::getStatBag().doRings();
 
-    S.declareRing("testring", "Just some ring where we'll account things");
+    StatBag::getStatBag().declareRing("testring", "Just some ring where we'll account things");
     doRun(StatRingDNSNameQTypeToStringTest(DNSName("example.com"), QType(1)));
 
-    S.declareDNSNameQTypeRing("testringdnsname", "Just some ring where we'll account things");
+    StatBag::getStatBag().declareDNSNameQTypeRing("testringdnsname", "Just some ring where we'll account things");
     doRun(StatRingDNSNameQTypeTest(DNSName("example.com"), QType(1)));
 #endif
 

--- a/pdns/statbag.cc
+++ b/pdns/statbag.cc
@@ -36,10 +36,16 @@
 
 #include "namespaces.hh"
 
-StatBag::StatBag()
+StatBag& StatBag::getStatBag()
 {
-  d_doRings=false;
-  d_allowRedeclare=false;
+  static StatBag theGlobalStatBag;
+  return theGlobalStatBag;
+}
+
+// only set this true during tests, never in production code
+void StatBag::setAllowRedeclare(bool allow)
+{
+  d_allowRedeclare = allow;
 }
 
 void StatBag::exists(const string &key)
@@ -164,10 +170,6 @@ AtomicCounter *StatBag::getPointer(const string &key)
 {
   exists(key);
   return d_stats[key].get();
-}
-
-StatBag::~StatBag()
-{
 }
 
 template<typename T, typename Comp>

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -76,15 +76,17 @@ class StatBag
   typedef std::function<uint64_t(const std::string&)> func_t;
   typedef map<string, func_t> funcstats_t;
   funcstats_t d_funcstats;
-  bool d_doRings;
+  bool d_doRings{false};
+  bool d_allowRedeclare{false}; // only set this true during tests, never in production code
 
   std::set<string> d_blacklist;
 
   void registerRingStats(const string& name);
 
 public:
-  StatBag(); //!< Naked constructor. You need to declare keys before this class becomes useful
-  ~StatBag();
+  static StatBag& getStatBag();
+
+  StatBag() = default; //!< Naked constructor. You need to declare keys before this class becomes useful
   void declare(const string &key, const string &descrip="", StatType statType=StatType::counter); //!< Before you can store or access a key, you need to declare it
   void declare(const string &key, const string &descrip, func_t func, StatType statType); //!< Before you can store or access a key, you need to declare it
 
@@ -149,8 +151,7 @@ public:
   AtomicCounter *getPointer(const string &key); //!< get a direct pointer to the value behind a key. Use this for high performance increments
   string getValueStr(const string &key); //!< read a value behind a key, and return it as a string
   void blacklist(const string &str);
-
-  bool d_allowRedeclare; // only set this true during tests, never in production code
+  void setAllowRedeclare(bool allow); // only set this true during tests, never in production code
 };
 
 inline void StatBag::deposit(const string &key, int value)

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -144,7 +144,7 @@ public:
   string getDescrip(const string &item); //!< Returns the description of this datum/item
   StatType getStatType(const string &item); //!< Returns the stats type for the metrics endpoint
   void exists(const string &key); //!< call this function to throw an exception in case a key does not exist
-  inline void deposit(const string &key, int value); //!< increment the statistics behind this key by value amount
+  inline void deposit(const string &key, unsigned int value); //!< increment the statistics behind this key by value amount
   inline void inc(const string &key); //!< increase this key's value by one
   void set(const string &key, unsigned long value); //!< set this key's value
   unsigned long read(const string &key); //!< read the value behind this key
@@ -154,7 +154,7 @@ public:
   void setAllowRedeclare(bool allow); // only set this true during tests, never in production code
 };
 
-inline void StatBag::deposit(const string &key, int value)
+inline void StatBag::deposit(const string &key, unsigned int value)
 {
   exists(key);
 

--- a/pdns/stubquery.cc
+++ b/pdns/stubquery.cc
@@ -5,9 +5,6 @@
 #include "dnsrecords.hh"
 #include "dns_random.hh"
 #include "stubresolver.hh"
-#include "statbag.hh"
-
-StatBag S;
 
 ArgvMap &arg()
 {

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -63,7 +63,6 @@
 #include "gss_context.hh"
 #include "pdnsexception.hh"
 extern AuthPacketCache PC;
-extern StatBag S;
 
 /**
 \file tcpreceiver.cc
@@ -346,11 +345,11 @@ void TCPNameserver::doConnection(int fd)
       }
 
       getQuestion(fd, mesg.get(), pktlen, remote, remainingTime);
-      S.inc("tcp-queries");
+      StatBag::getStatBag().inc("tcp-queries");
       if (accountremote.sin4.sin_family == AF_INET6)
-        S.inc("tcp6-queries");
+        StatBag::getStatBag().inc("tcp6-queries");
       else
-        S.inc("tcp4-queries");
+        StatBag::getStatBag().inc("tcp4-queries");
 
       packet=make_unique<DNSPacket>(true);
       packet->setRemote(&remote);
@@ -364,7 +363,7 @@ void TCPNameserver::doConnection(int fd)
         break;
 
       if (packet->hasEDNSCookie())
-        S.inc("tcp-cookie-queries");
+        StatBag::getStatBag().inc("tcp-cookie-queries");
 
       if(packet->qtype.getCode()==QType::AXFR) {
         doAXFR(packet->qdomain, packet, fd);

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -48,8 +48,8 @@ BOOST_AUTO_TEST_CASE(test_distributor_basic) {
   ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";
   ::arg().set("queue-limit","Maximum number of milliseconds to queue a query")="1500";
-  S.declare("servfail-packets","Number of times a server-failed packet was sent out");
-  S.declare("timedout-packets", "timedout-packets");
+  StatBag::getStatBag().declare("servfail-packets","Number of times a server-failed packet was sent out");
+  StatBag::getStatBag().declare("timedout-packets", "timedout-packets");
 
   auto d=Distributor<DNSPacket, Question, Backend>::Create(2);
 
@@ -82,8 +82,8 @@ BOOST_AUTO_TEST_CASE(test_distributor_queue) {
   ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="1000";
   ::arg().set("queue-limit","Maximum number of milliseconds to queue a query")="1500";
-  S.declare("servfail-packets","Number of times a server-failed packet was sent out");
-  S.declare("timedout-packets", "timedout-packets");
+  StatBag::getStatBag().declare("servfail-packets","Number of times a server-failed packet was sent out");
+  StatBag::getStatBag().declare("timedout-packets", "timedout-packets");
 
   auto d=Distributor<DNSPacket, Question, BackendSlow>::Create(2);
 
@@ -135,8 +135,8 @@ BOOST_AUTO_TEST_CASE(test_distributor_dies) {
   ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";
   ::arg().set("queue-limit","Maximum number of milliseconds to queue a query")="1500";
-  S.declare("servfail-packets","Number of times a server-failed packet was sent out");
-  S.declare("timedout-packets", "timedout-packets");
+  StatBag::getStatBag().declare("servfail-packets","Number of times a server-failed packet was sent out");
+  StatBag::getStatBag().declare("timedout-packets", "timedout-packets");
 
   auto d=Distributor<DNSPacket, Question, BackendDies>::Create(10);
 

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -17,8 +17,6 @@
 #include <utility>
 #include <thread>
 
-extern StatBag S;
-
 BOOST_AUTO_TEST_SUITE(test_packetcache_cc)
 
 BOOST_AUTO_TEST_CASE(test_AuthQueryCacheSimple) {
@@ -118,8 +116,8 @@ BOOST_AUTO_TEST_CASE(test_QueryCacheThreaded) {
     }
     manglers.clear();
 
-    BOOST_CHECK_EQUAL(QC.size() + S.read("deferred-cache-inserts"), 400000U);
-    BOOST_CHECK_SMALL(1.0*S.read("deferred-cache-inserts"), 10000.0);
+    BOOST_CHECK_EQUAL(QC.size() + StatBag::getStatBag().read("deferred-cache-inserts"), 400000U);
+    BOOST_CHECK_SMALL(1.0*StatBag::getStatBag().read("deferred-cache-inserts"), 10000.0);
 
     std::vector<std::thread> readers;
     for (int i=0; i < 4; ++i) {
@@ -131,8 +129,8 @@ BOOST_AUTO_TEST_CASE(test_QueryCacheThreaded) {
     }
     readers.clear();
 
-    BOOST_CHECK(S.read("deferred-cache-inserts") + S.read("deferred-cache-lookup") >= g_QCmissing);
-    //    BOOST_CHECK_EQUAL(S.read("deferred-cache-lookup"), 0); // cache cleaning invalidates this
+    BOOST_CHECK(StatBag::getStatBag().read("deferred-cache-inserts") + StatBag::getStatBag().read("deferred-cache-lookup") >= g_QCmissing);
+    //    BOOST_CHECK_EQUAL(StatBag::getStatBag().read("deferred-cache-lookup"), 0); // cache cleaning invalidates this
   }
   catch(PDNSException& e) {
     cerr<<"Had error: "<<e.reason<<endl;
@@ -220,9 +218,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheThreaded) {
     }
     manglers.clear();
 
-    BOOST_CHECK_EQUAL(PC.size() + S.read("deferred-packetcache-inserts"), 400000UL);
-    BOOST_CHECK_EQUAL(S.read("deferred-packetcache-lookup"), 0UL);
-    BOOST_CHECK_SMALL(1.0*S.read("deferred-packetcache-inserts"), 10000.0);
+    BOOST_CHECK_EQUAL(PC.size() + StatBag::getStatBag().read("deferred-packetcache-inserts"), 400000UL);
+    BOOST_CHECK_EQUAL(StatBag::getStatBag().read("deferred-packetcache-lookup"), 0UL);
+    BOOST_CHECK_SMALL(1.0*StatBag::getStatBag().read("deferred-packetcache-inserts"), 10000.0);
 
     std::vector<std::thread> readers;
     for (int i=0; i < 4; ++i) {
@@ -235,16 +233,16 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheThreaded) {
     readers.clear();
 
 /*
-    cerr<<"Misses: "<<S.read("packetcache-miss")<<endl;
-    cerr<<"Hits: "<<S.read("packetcache-hit")<<endl;
-    cerr<<"Deferred inserts: "<<S.read("deferred-packetcache-inserts")<<endl;
-    cerr<<"Deferred lookups: "<<S.read("deferred-packetcache-lookup")<<endl;
+    cerr<<"Misses: "<<StatBag::getStatBag().read("packetcache-miss")<<endl;
+    cerr<<"Hits: "<<StatBag::getStatBag().read("packetcache-hit")<<endl;
+    cerr<<"Deferred inserts: "<<StatBag::getStatBag().read("deferred-packetcache-inserts")<<endl;
+    cerr<<"Deferred lookups: "<<StatBag::getStatBag().read("deferred-packetcache-lookup")<<endl;
     cerr<<g_PCmissing<<endl;
     cerr<<PC.size()<<endl;
 */
 
-    BOOST_CHECK_EQUAL(g_PCmissing + S.read("packetcache-hit"), 400000UL);
-    BOOST_CHECK_EQUAL(S.read("deferred-packetcache-inserts") + S.read("deferred-packetcache-lookup"), g_PCmissing);
+    BOOST_CHECK_EQUAL(g_PCmissing + StatBag::getStatBag().read("packetcache-hit"), 400000UL);
+    BOOST_CHECK_EQUAL(StatBag::getStatBag().read("deferred-packetcache-inserts") + StatBag::getStatBag().read("deferred-packetcache-lookup"), g_PCmissing);
   }
   catch(PDNSException& e) {
     cerr<<"Had error: "<<e.reason<<endl;

--- a/pdns/testrunner.cc
+++ b/pdns/testrunner.cc
@@ -13,7 +13,6 @@
 #include "auth-zonecache.hh"
 #include "statbag.hh"
 
-StatBag S;
 AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;
@@ -34,6 +33,6 @@ static bool init_unit_test()
 // entry point:
 int main(int argc, char* argv[])
 {
-  S.d_allowRedeclare = true;
+  StatBag::getStatBag().setAllowRedeclare(true);
   return boost::unit_test::unit_test_main(&init_unit_test, argc, argv);
 }

--- a/pdns/tsig-tests.cc
+++ b/pdns/tsig-tests.cc
@@ -7,7 +7,6 @@
 #include "misc.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
-#include "statbag.hh"
 #include "digests.hh"
 #include "base64.hh"
 #include "dnssecinfra.hh"
@@ -15,8 +14,6 @@
 #include "arguments.hh"
 #include "dns_random.hh"
 #include "query-local-address.hh"
-
-StatBag S;
 
 ArgvMap& arg()
 {

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -47,8 +47,6 @@
 #include "logger.hh"
 #include "statbag.hh"
 
-extern StatBag S;
-
 LockGuarded<vector<UeberBackend*>> UeberBackend::d_instances;
 
 // initially we are blocked
@@ -110,8 +108,8 @@ void UeberBackend::go()
     s_doANYLookupsOnly = true;
   }
 
-  S.declare("backend-queries", "Number of queries sent to the backend(s)");
-  s_backendQueries = S.getPointer("backend-queries");
+  StatBag::getStatBag().declare("backend-queries", "Number of queries sent to the backend(s)");
+  s_backendQueries = StatBag::getStatBag().getPointer("backend-queries");
 
   {
     std::unique_lock<std::mutex> l(d_mut);

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -46,10 +46,6 @@
 
 using json11::Json;
 
-#ifndef RECURSOR
-extern StatBag S;
-#endif
-
 #ifndef HAVE_STRCASESTR
 
 /*
@@ -276,9 +272,9 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp) {
 #ifndef RECURSOR
   if (!req->getvars.count("includerings") ||
        req->getvars["includerings"] != "false") {
-    for(const auto& ringName : S.listRings()) {
+    for(const auto& ringName : StatBag::getStatBag().listRings()) {
       Json::array values;
-      const auto& ring = S.getRing(ringName);
+      const auto& ring = StatBag::getStatBag().getRing(ringName);
       for(const auto& item : ring) {
         if (item.second == 0)
           continue;
@@ -292,7 +288,7 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp) {
       doc.push_back(Json::object {
         { "type", "RingStatisticItem" },
         { "name", ringName },
-        { "size", std::to_string(S.getRingSize(ringName)) },
+        { "size", std::to_string(StatBag::getStatBag().getRingSize(ringName)) },
         { "value", values },
       });
     }

--- a/pdns/ws-auth.hh
+++ b/pdns/ws-auth.hh
@@ -32,9 +32,9 @@ class Ewma
 {
 public:
   Ewma() : d_last(0), d_10(0), d_5(0), d_1(0), d_max(0){dt.set();}
-  void submit(int val) 
+  void submit(unsigned int val)
   {
-    int rate=val-d_last;
+    auto rate=val-d_last;
     double difft=dt.udiff()/1000000.0;
     dt.set();
     
@@ -45,25 +45,25 @@ public:
       
     d_last=val;
   }
-  double get10()
+  double get10() const
   {
     return d_10;
   }
-  double get5()
+  double get5() const
   {
     return d_5;
   }
-  double get1()
+  double get1() const
   {
     return d_1;
   }
-  double getMax()
+  double getMax() const
   {
     return d_max;
   }
 private:
   DTime dt;
-  int d_last;
+  unsigned int d_last;
   double d_10, d_5, d_1, d_max;
 };
 

--- a/pdns/zone2json.cc
+++ b/pdns/zone2json.cc
@@ -50,7 +50,6 @@
 
 using namespace json11;
 
-StatBag S;
 static int g_numRecords;
 
 static Json::object emitRecord(const DNSName &DNSqname, const string &qtype, const string &ocontent, int ttl)
@@ -109,7 +108,7 @@ try
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print the version");
 
-    S.declare("logmessages");
+    StatBag::getStatBag().declare("logmessages");
 
     string namedfile="";
     string zonefile="";

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -32,7 +32,6 @@
 #include <stdio.h>
 #include "arguments.hh"
 #include "bindparserclasses.hh"
-#include "statbag.hh"
 #include "dnsrecords.hh"
 #include "misc.hh"
 #include "dns.hh"
@@ -42,7 +41,6 @@ using std::map;
 using std::string;
 using std::vector;
 
-StatBag S;
 ArgvMap args;
 bool g_dnsttl;
 bool g_pdnsinfo;

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -46,10 +46,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-
-
-StatBag S;
-
 enum dbmode_t {MYSQL, POSTGRES, SQLITE};
 static dbmode_t g_mode;
 static bool g_intransaction;
@@ -219,7 +215,7 @@ try
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print the version");
 
-    S.declare("logmessages");
+    StatBag::getStatBag().declare("logmessages");
 
     string namedfile="";
     string zonefile="";


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
By turning the global `StatBag` into a singleton.

Reported by Coverity as CID 1524949: Initialization or destruction ordering is unspecified.

This is only a draft because turning `StatBag` into a singleton might not be the way we want to tackle this. It's the only way I found that did not require an awful lot of refactoring in various places, but hopefully someone will get a better idea :)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
