### PR TITLE
auth: allow building in separate build directory

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -62,14 +62,14 @@ endif # if !HAVE_MANPAGES
 mans/.complete: manpages := $(addprefix manpages/,$(addsuffix .rst,$(MANPAGES_DIST)))
 mans/.complete: .venv
 	rm -rf "$(@D).tmp"
-	.venv/bin/python -msphinx -b man . "$(@D).tmp" $(manpages) && rm -rf "$(@D)" && mv "$(@D).tmp" "$(@D)"
+	(cd "${srcdir}" && $(CURDIR)/.venv/bin/python -msphinx -b man . "$(CURDIR)/$(@D).tmp" $(manpages)) && rm -rf "$(@D)" && mv "$(@D).tmp" "$(@D)"
 	touch "$@"
 	rm -rf "$(@D).tmp"
 
 .venv: requirements.txt
 	$(PYTHON) -m venv .venv
 	.venv/bin/pip install -U pip setuptools setuptools-git wheel
-	.venv/bin/pip install -r requirements.txt
+	.venv/bin/pip install -r ${srcdir}/requirements.txt
 
 .NOTPARALLEL: \
 	all-docs \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -96,15 +96,15 @@ endif
 
 # use a $(wildcard) wrapper here to allow build to proceed if output
 # file is present but input file is not (e.g. in a dist tarball)
-api-swagger.yaml: $(wildcard ../docs/http-api/swagger/authoritative-api-swagger.yaml)
+api-swagger.yaml: $(wildcard ${srcdir}/../docs/http-api/swagger/authoritative-api-swagger.yaml)
 	cp $< $@
 
 if HAVE_VENV
 api-swagger.json: api-swagger.yaml requirements.txt
 	$(PYTHON) -m venv .venv
 	.venv/bin/pip install -U pip setuptools setuptools-git wheel
-	.venv/bin/pip install -r requirements.txt
-	.venv/bin/python convert-yaml-to-json.py $< $@
+	.venv/bin/pip install -r ${srcdir}/requirements.txt
+	.venv/bin/python ${srcdir}/convert-yaml-to-json.py $< $@
 else # if HAVE_VENV
 if !HAVE_API_SWAGGER_JSON
 api-swagger.json:
@@ -114,7 +114,8 @@ endif
 endif
 
 apidocfiles.h: api-swagger.yaml api-swagger.json
-	./incfiles $^ > $@
+	$(AM_V_GEN)$(srcdir)/incfiles $^ > $@.tmp
+	@mv $@.tmp $@
 
 sysconf_DATA = pdns.conf-dist
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This allows building at least the auth in a mostly default configuration like
this:

```
mkdir build && cd build && \
autoreconf --install --force --verbose .. && \
../configure ...
```

This is useful because not all IDEs \*cough\* editors like in-tree builds, for performance or other reasons.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
