### PR TITLE
tec: Backport 13588 to rec 5.0.x: fix handling of RUNTIME_DIRETCORY and NOD dirs

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -872,6 +872,8 @@ noaction
 noad
 noall
 nocookie
+NODCACHEDIRNOD
+NODCACHEDIRUDR
 noedns
 noerrors
 NOLOCK

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -23,7 +23,7 @@ AM_CXXFLAGS = \
 
 if NOD_ENABLED
 AM_CXXFLAGS += \
-	-DNODCACHEDIR=\"$(nodcachedir)\"
+	-DNODCACHEDIRNOD=\"$(nodcachedir)/nod\" -DNODCACHEDIRUDR=\"$(nodcachedir)/udr\"
 endif
 
 if FSTRM

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -21,10 +21,8 @@ AM_CXXFLAGS = \
 	-DPKGLIBDIR=\"$(pkglibdir)\" \
 	-DLOCALSTATEDIR=\"$(socketdir)\"
 
-if NOD_ENABLED
 AM_CXXFLAGS += \
 	-DNODCACHEDIRNOD=\"$(nodcachedir)/nod\" -DNODCACHEDIRUDR=\"$(nodcachedir)/udr\"
-endif
 
 if FSTRM
 AM_CPPFLAGS += \

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2940,6 +2940,13 @@ static void handleRuntimeDefaults(Logr::log_t log)
   }
 
   if (::arg()["socket-dir"].empty()) {
+    auto* runtimeDir = getenv("RUNTIME_DIRECTORY"); // NOLINT(concurrency-mt-unsafe,cppcoreguidelines-pro-type-vararg)
+    if (runtimeDir != nullptr) {
+      ::arg().set("socket-dir") = runtimeDir;
+    }
+  }
+
+  if (::arg()["socket-dir"].empty()) {
     if (::arg()["chroot"].empty()) {
       ::arg().set("socket-dir") = std::string(LOCALSTATEDIR) + "/pdns-recursor";
     }

--- a/pdns/recursordist/settings/generate.py
+++ b/pdns/recursordist/settings/generate.py
@@ -205,6 +205,9 @@ def quote(arg):
     """Return a quoted string"""
     return '"' + arg + '"'
 
+def isEnvVar(name):
+    return name in ('SYSCONFDIR', 'NODCACHEDIRNOD', 'NODCACHEDIRUDR')
+
 def gen_cxx_defineoldsettings(file, entries):
     """Generate C++ code to declare old-style settings"""
     file.write('void pdns::settings::rec::defineOldStyleSettings()\n{\n')
@@ -221,7 +224,7 @@ def gen_cxx_defineoldsettings(file, entries):
         elif entry['type'] == LType.Command:
             file.write(f"  ::arg().setCmd({oldname}, {helptxt});\n")
         else:
-            cxxdef = 'SYSCONFDIR' if entry['default'] == 'SYSCONFDIR' else quote(entry['default'])
+            cxxdef = entry['default'] if isEnvVar(entry['default']) else quote(entry['default'])
             file.write(f"  ::arg().set({oldname}, {helptxt}) = {cxxdef};\n")
     file.write('}\n\n')
 
@@ -415,7 +418,8 @@ def gen_rust_default_functions(entry, name, rust_type):
         return gen_rust_authzonevec_default_functions(name)
     ret = f'// DEFAULT HANDLING for {name}\n'
     ret += f'fn default_value_{name}() -> {rust_type} {{\n'
-    rustdef = 'env!("SYSCONFDIR")' if entry['default'] == 'SYSCONFDIR' else quote(entry['default'])
+    defvalue = entry['default']
+    rustdef = f'env!("{defvalue}")' if isEnvVar(defvalue) else quote(defvalue)
     ret += f"    String::from({rustdef})\n"
     ret += '}\n'
     if rust_type == 'String':

--- a/pdns/recursordist/settings/rust/Makefile.am
+++ b/pdns/recursordist/settings/rust/Makefile.am
@@ -11,7 +11,7 @@ EXTRA_DIST = \
 
 # should actually end up in a target specific dir...
 libsettings.a lib.rs.h: src/bridge.rs src/lib.rs src/helpers.rs Cargo.toml Cargo.lock build.rs
-	SYSCONFDIR=$(sysconfdir) $(CARGO) build --release $(RUST_TARGET)
+	SYSCONFDIR=$(sysconfdir) NODCACHEDIRNOD=$(localstatedir)/nod NODCACHEDIRUDR=$(localstatedir)/udr $(CARGO) build --release $(RUST_TARGET)
 	cp target/$(RUSTC_TARGET_ARCH)/release/libsettings.a libsettings.a
 	cp target/$(RUSTC_TARGET_ARCH)/cxxbridge/settings/src/lib.rs.h lib.rs.h
 	cp target/$(RUSTC_TARGET_ARCH)/cxxbridge/rust/cxx.h cxx.h

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -393,6 +393,7 @@ EMPTY?  '''
         'section' : 'recursor',
         'type' : LType.String,
         'default' : 'SYSCONFDIR',
+        'docdefault': 'Determined by distribution',
         'help' : 'Location of configuration directory (recursor.conf or recursor.yml)',
         'doc' : '''
 Location of configuration directory (where ``recursor.conf`` or ``recursor.yml`` is stored).
@@ -1716,6 +1717,7 @@ have no effect unless you remove the existing files.
         'oldname' : 'new-domain-history-dir',
         'type' : LType.String,
         'default' : 'NODCACHEDIRNOD',
+        'docdefault': 'Determined by distribution',
         'help' : 'Persist new domain tracking data here to persist between restarts',
         'doc' : '''
 This setting controls which directory is used to store the on-disk
@@ -2358,7 +2360,7 @@ Where to store the control socket and pidfile.
 The default depends on ``LOCALSTATEDIR`` or the ``--with-socketdir`` setting when building (usually ``/var/run`` or ``/run``).
 
 When using :ref:`setting-chroot` the default becomes ``/``.
-Defaults to the ``RUNTIME_DIRECTORY`` environment variable when that variable has a value (e.g. under systemd).
+The default value is overruled by the ``RUNTIME_DIRECTORY`` environment variable when that variable has a value (e.g. under systemd).
  ''',
     },
     {
@@ -2822,6 +2824,7 @@ have no effect unless you remove the existing files.
         'section' : 'nod',
         'type' : LType.String,
         'default' : 'NODCACHEDIRUDR',
+        'docdefault': 'Determined by distribution',
         'help' : 'Persist unique response tracking data here to persist between restarts',
         'doc' : '''
 This setting controls which directory is used to store the on-disk

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -1715,7 +1715,7 @@ have no effect unless you remove the existing files.
         'section' : 'nod',
         'oldname' : 'new-domain-history-dir',
         'type' : LType.String,
-        'default' : '/usr/local/var/lib/pdns-recursor/nod',
+        'default' : 'NODCACHEDIRNOD',
         'help' : 'Persist new domain tracking data here to persist between restarts',
         'doc' : '''
 This setting controls which directory is used to store the on-disk
@@ -2358,6 +2358,7 @@ Where to store the control socket and pidfile.
 The default depends on ``LOCALSTATEDIR`` or the ``--with-socketdir`` setting when building (usually ``/var/run`` or ``/run``).
 
 When using :ref:`setting-chroot` the default becomes ``/``.
+Defaults to the ``RUNTIME_DIRECTORY`` environment variable when that variable has a value (e.g. under systemd).
  ''',
     },
     {
@@ -2820,7 +2821,7 @@ have no effect unless you remove the existing files.
         'name' : 'unique_response_history_dir',
         'section' : 'nod',
         'type' : LType.String,
-        'default' : '/usr/local/var/lib/pdns-recursor/udr',
+        'default' : 'NODCACHEDIRUDR',
         'help' : 'Persist unique response tracking data here to persist between restarts',
         'doc' : '''
 This setting controls which directory is used to store the on-disk


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #13588 and #13612 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
