### PR TITLE
dnsdist: Set the DNS over HTTP/3 default port to 443

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2606,7 +2606,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     if (!loadTLSCertificateAndKeys("addDOH3Local", frontend->d_quicheParams.d_tlsConfig.d_certKeyPairs, certFiles, keyFiles)) {
       return;
     }
-    frontend->d_local = ComboAddress(addr, 853);
+    frontend->d_local = ComboAddress(addr, 443);
 
     bool reusePort = false;
     int tcpFastOpenQueueSize = 0;

--- a/pdns/dnsdistdist/docs/guides/dns-over-http3.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-http3.rst
@@ -12,7 +12,7 @@ Adding a listen port for DNS-over-HTTP/3 can be done with the :func:`addDOH3Loca
 
   addDOH3Local('2001:db8:1:f00::1', '/etc/ssl/certs/example.com.pem', '/etc/ssl/private/example.com.key')
 
-This will make :program:`dnsdist` listen on [2001:db8:1:f00::1]:853 on UDP, and will use the provided certificate and key to serve incoming DoH3 connections.
+This will make :program:`dnsdist` listen on [2001:db8:1:f00::1]:443 on UDP, and will use the provided certificate and key to serve incoming DoH3 connections.
 
 The fourth parameter, if present, indicates various options. For instance, you can change the congestion control algorithm used. An example is::
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -183,7 +183,7 @@ Listen Sockets
   Listen on the specified address and UDP port for incoming DNS over HTTP3 connections, presenting the specified X.509 certificate.
 
   :param str address: The IP Address with an optional port to listen on.
-                      The default port is 853.
+                      The default port is 443.
   :param str certFile(s): The path to a X.509 certificate file in PEM format, a list of paths to such files, or a TLSCertificate object.
   :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones. Ignored if ``certFile`` contains TLSCertificate objects.
   :param table options: A table with key: value pairs with listen options.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixes https://github.com/PowerDNS/pdns/issues/13639

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
