### PR TITLE
auth: add a configurable delay for notifications

### DIFF
--- a/.not-formatted
+++ b/.not-formatted
@@ -26,8 +26,6 @@
 ./pdns/cdb.hh
 ./pdns/comfun.cc
 ./pdns/comment.hh
-./pdns/communicator.cc
-./pdns/communicator.hh
 ./pdns/dbdnsseckeeper.cc
 ./pdns/delaypipe.cc
 ./pdns/delaypipe.hh

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -547,6 +547,16 @@ to enable DNSSEC. Must be one of:
 The default keysize for the ZSK generated with :doc:`pdnsutil secure-zone <dnssec/pdnsutil>`.
 Only relevant for algorithms with non-fixed keysizes (like RSA).
 
+.. _setting-delay-notifications:
+
+``delay-notifications``
+-----------------------
+
+-  Integer
+-  Default: 0 (no delay, send them directly)
+
+Configure a delay to send out notifications, no delay by default.
+
 .. _setting-direct-dnskey:
 
 ``direct-dnskey``
@@ -1051,7 +1061,7 @@ Setting this to any value less than or equal to 0 will set no limit.
 
 .. deprecated:: 4.5.0
   Renamed to :ref:`setting-primary`.
- 
+
 -  Boolean
 -  Default: no
 
@@ -1858,11 +1868,11 @@ Enable for testing PowerDNS upgrades, without changing stored records.
 Enable for upgrading record content on secondaries, or when using the API (see :doc:`upgrade notes <../upgrading>`).
 Disable after record contents have been upgraded.
 
-This option is supported by the bind and Generic SQL backends. 
+This option is supported by the bind and Generic SQL backends.
 
 .. note::
   When using a generic SQL backend, records with an unknown record type (see :doc:`../appendices/types`) can be identified with the following SQL query::
-  
+
       SELECT * from records where type like 'TYPE%';
 
 .. _setting-version-string:
@@ -1956,7 +1966,7 @@ When set to "detailed", all information about the request and response are logge
   [webserver] e235780e-a5cf-415e-9326-9d33383e739e   Content-Length: 49
   [webserver] e235780e-a5cf-415e-9326-9d33383e739e   Content-Type: text/html; charset=utf-8
   [webserver] e235780e-a5cf-415e-9326-9d33383e739e   Server: PowerDNS/0.0.15896.0.gaba8bab3ab
-  [webserver] e235780e-a5cf-415e-9326-9d33383e739e  Full body: 
+  [webserver] e235780e-a5cf-415e-9326-9d33383e739e  Full body:
   [webserver] e235780e-a5cf-415e-9326-9d33383e739e   <!html><title>Not Found</title><h1>Not Found</h1>
   [webserver] e235780e-a5cf-415e-9326-9d33383e739e 127.0.0.1:55376 "GET /api/v1/servers/localhost/bla HTTP/1.1" 404 196
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -228,6 +228,7 @@ static void declareArguments()
   ::arg().setSwitch("prevent-self-notification", "Don't send notifications to what we think is ourself") = "yes";
   ::arg().setSwitch("any-to-tcp", "Answer ANY queries with tc=1, shunting to TCP") = "yes";
   ::arg().setSwitch("edns-subnet-processing", "If we should act on EDNS Subnet options") = "no";
+  ::arg().set("delay-notifications", "Configure a delay to send out notifications, no delay by default") = "0";
 
   ::arg().set("edns-cookie-secret", "When set, set a server cookie when responding to a query with a Client cookie (in hex)") = "";
 
@@ -326,6 +327,7 @@ static void declareArguments()
   ::arg().set("rng", "Specify the random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.") = "auto";
 
   ::arg().set("default-catalog-zone", "Catalog zone to assign newly created primary zones (via the API) to") = "";
+
 #ifdef ENABLE_GSS_TSIG
   ::arg().setSwitch("enable-gss-tsig", "Enable GSS TSIG processing") = "no";
 #endif

--- a/pdns/auth-primarycommunicator.cc
+++ b/pdns/auth-primarycommunicator.cc
@@ -75,7 +75,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
 
       for (const auto& ip : ips) {
         g_log << Logger::Notice << "Queued notification of domain '" << di.zone << "' to " << ip << endl;
-        d_nq.add(di.zone, ip);
+        d_nq.add(di.zone, ip, d_delayNotifications);
         hasQueuedItem = true;
       }
     }
@@ -98,7 +98,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
       g_log << Logger::Notice << "Queued also-notification of domain '" << di.zone << "' to " << caIp.toStringWithPort() << endl;
       if (!ips.count(caIp.toStringWithPort())) {
         ips.insert(caIp.toStringWithPort());
-        d_nq.add(di.zone, caIp.toStringWithPort());
+        d_nq.add(di.zone, caIp.toStringWithPort(), d_delayNotifications);
       }
       hasQueuedItem = true;
     }

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -100,6 +100,11 @@ void CommunicatorClass::go()
 
   d_preventSelfNotification = ::arg().mustDo("prevent-self-notification");
 
+  auto delay = ::arg().asNum("delay-notifications");
+  if (delay > 0) {
+    d_delayNotifications = static_cast<time_t>(delay);
+  }
+
   try {
     d_onlyNotify.toMasks(::arg()["only-notify"]);
   }

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -43,7 +43,7 @@
 void CommunicatorClass::retrievalLoopThread()
 {
   setThreadName("pdns/comm-retre");
-  for(;;) {
+  for (;;) {
     d_suck_sem.wait();
     SuckRequest sr;
     {
@@ -53,8 +53,8 @@ void CommunicatorClass::retrievalLoopThread()
       }
 
       auto firstItem = data->d_suckdomains.begin();
-        
-      sr=*firstItem;
+
+      sr = *firstItem;
       data->d_suckdomains.erase(firstItem);
       if (data->d_suckdomains.empty()) {
         data->d_sorthelper = 0;
@@ -64,17 +64,17 @@ void CommunicatorClass::retrievalLoopThread()
   }
 }
 
-void CommunicatorClass::loadArgsIntoSet(const char *listname, set<string> &listset)
+void CommunicatorClass::loadArgsIntoSet(const char* listname, set<string>& listset)
 {
   vector<string> parts;
   stringtok(parts, ::arg()[listname], ", \t");
-  for (const auto & part : parts) {
+  for (const auto& part : parts) {
     try {
       ComboAddress caIp(part, 53);
       listset.insert(caIp.toStringWithPort());
     }
-    catch(PDNSException &e) {
-      g_log<<Logger::Error<<"Unparseable IP in "<<listname<<". Error: "<<e.reason<<endl;
+    catch (PDNSException& e) {
+      g_log << Logger::Error << "Unparseable IP in " << listname << ". Error: " << e.reason << endl;
       _exit(1);
     }
   }
@@ -83,18 +83,18 @@ void CommunicatorClass::loadArgsIntoSet(const char *listname, set<string> &lists
 void CommunicatorClass::go()
 {
   try {
-    PacketHandler::s_allowNotifyFrom.toMasks(::arg()["allow-notify-from"] );
+    PacketHandler::s_allowNotifyFrom.toMasks(::arg()["allow-notify-from"]);
   }
-  catch(PDNSException &e) {
-    g_log<<Logger::Error<<"Unparseable IP in allow-notify-from. Error: "<<e.reason<<endl;
+  catch (PDNSException& e) {
+    g_log << Logger::Error << "Unparseable IP in allow-notify-from. Error: " << e.reason << endl;
     _exit(1);
   }
 
-  std::thread mainT([this](){mainloop();});
+  std::thread mainT([this]() { mainloop(); });
   mainT.detach();
 
-  for(int n=0; n < ::arg().asNum("retrieval-threads", 1); ++n) {
-    std::thread retrieve([this](){retrievalLoopThread();});
+  for (int n = 0; n < ::arg().asNum("retrieval-threads", 1); ++n) {
+    std::thread retrieve([this]() { retrievalLoopThread(); });
     retrieve.detach();
   }
 
@@ -108,8 +108,8 @@ void CommunicatorClass::go()
   try {
     d_onlyNotify.toMasks(::arg()["only-notify"]);
   }
-  catch(PDNSException &e) {
-    g_log<<Logger::Error<<"Unparseable IP in only-notify. Error: "<<e.reason<<endl;
+  catch (PDNSException& e) {
+    g_log << Logger::Error << "Unparseable IP in only-notify. Error: " << e.reason << endl;
     _exit(1);
   }
 
@@ -122,7 +122,7 @@ void CommunicatorClass::mainloop()
 {
   try {
     setThreadName("pdns/comm-main");
-    signal(SIGPIPE,SIG_IGN);
+    signal(SIGPIPE, SIG_IGN);
     g_log << Logger::Warning << "Primary/secondary communicator launching" << endl;
 
     d_tickinterval = ::arg().asNum("xfr-cycle-interval");
@@ -133,17 +133,17 @@ void CommunicatorClass::mainloop()
 
     makeNotifySockets();
 
-    for(;;) {
+    for (;;) {
       secondaryRefresh(&P);
       primaryUpdateCheck(&P);
       doNotifications(&P); // this processes any notification acknowledgements and actually send out our own notifications
 
       next = time(nullptr) + d_tickinterval;
 
-      while(time(nullptr) < next) {
-        rc=d_any_sem.tryWait();
+      while (time(nullptr) < next) {
+        rc = d_any_sem.tryWait();
 
-        if(rc) {
+        if (rc) {
           bool extraSecondaryRefresh = false;
           Utility::sleep(1);
           {
@@ -166,17 +166,16 @@ void CommunicatorClass::mainloop()
       }
     }
   }
-  catch(PDNSException &ae) {
-    g_log<<Logger::Error<<"Exiting because communicator thread died with error: "<<ae.reason<<endl;
+  catch (PDNSException& ae) {
+    g_log << Logger::Error << "Exiting because communicator thread died with error: " << ae.reason << endl;
     Utility::sleep(1);
     _exit(1);
   }
-  catch(std::exception &e) {
-    g_log<<Logger::Error<<"Exiting because communicator thread died with STL error: "<<e.what()<<endl;
+  catch (std::exception& e) {
+    g_log << Logger::Error << "Exiting because communicator thread died with STL error: " << e.what() << endl;
     _exit(1);
   }
-  catch( ... )
-  {
+  catch (...) {
     g_log << Logger::Error << "Exiting because communicator caught unknown exception." << endl;
     _exit(1);
   }

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -93,7 +93,7 @@ void CommunicatorClass::go()
   std::thread mainT([this]() { mainloop(); });
   mainT.detach();
 
-  for (int n = 0; n < ::arg().asNum("retrieval-threads", 1); ++n) {
+  for (int nthreads = 0; nthreads < ::arg().asNum("retrieval-threads", 1); ++nthreads) {
     std::thread retrieve([this]() { retrievalLoopThread(); });
     retrieve.detach();
   }
@@ -143,7 +143,7 @@ void CommunicatorClass::mainloop()
       while (time(nullptr) < next) {
         rc = d_any_sem.tryWait();
 
-        if (rc) {
+        if (rc != 0) {
           bool extraSecondaryRefresh = false;
           Utility::sleep(1);
           {

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -68,7 +68,7 @@ typedef UniQueue::index<IDTag>::type domains_by_name_t;
 class NotificationQueue
 {
 public:
-  void add(const DNSName &domain, const string &ip)
+  void add(const DNSName &domain, const string &ip, time_t delay = 0)
   {
     const ComboAddress caIp(ip);
 
@@ -77,7 +77,7 @@ public:
     nr.ip       = caIp.toStringWithPort();
     nr.attempts = 0;
     nr.id       = dns_random_uint16();
-    nr.next     = time(0);
+    nr.next     = time(nullptr) + delay;
 
     d_nqueue.push_back(nr);
   }
@@ -195,6 +195,7 @@ private:
   time_t d_tickinterval;
   bool d_secondarieschanged;
   bool d_preventSelfNotification;
+  time_t d_delayNotifications{0};
 
   struct Data
   {

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -46,7 +46,14 @@ struct SuckRequest
   DNSName domain;
   ComboAddress primary;
   bool force;
-  enum RequestPriority : uint8_t { PdnsControl, Api, Notify, SerialRefresh, SignaturesRefresh };
+  enum RequestPriority : uint8_t
+  {
+    PdnsControl,
+    Api,
+    Notify,
+    SerialRefresh,
+    SignaturesRefresh
+  };
   std::pair<RequestPriority, uint64_t> priorityAndOrder;
   bool operator<(const SuckRequest& b) const
   {
@@ -54,30 +61,31 @@ struct SuckRequest
   }
 };
 
-struct IDTag{};
+struct IDTag
+{
+};
 
 typedef multi_index_container<
   SuckRequest,
   indexed_by<
-    ordered_unique<member<SuckRequest,std::pair<SuckRequest::RequestPriority,uint64_t>,&SuckRequest::priorityAndOrder>>,
-    ordered_unique<tag<IDTag>, identity<SuckRequest> >
-  >
-> UniQueue;
+    ordered_unique<member<SuckRequest, std::pair<SuckRequest::RequestPriority, uint64_t>, &SuckRequest::priorityAndOrder>>,
+    ordered_unique<tag<IDTag>, identity<SuckRequest>>>>
+  UniQueue;
 typedef UniQueue::index<IDTag>::type domains_by_name_t;
 
 class NotificationQueue
 {
 public:
-  void add(const DNSName &domain, const string &ip, time_t delay = 0)
+  void add(const DNSName& domain, const string& ip, time_t delay = 0)
   {
     const ComboAddress caIp(ip);
 
     NotificationRequest nr;
-    nr.domain   = domain;
-    nr.ip       = caIp.toStringWithPort();
+    nr.domain = domain;
+    nr.ip = caIp.toStringWithPort();
     nr.attempts = 0;
-    nr.id       = dns_random_uint16();
-    nr.next     = time(nullptr) + delay;
+    nr.id = dns_random_uint16();
+    nr.next = time(nullptr) + delay;
 
     d_nqueue.push_back(nr);
   }
@@ -94,19 +102,19 @@ public:
     return false;
   }
 
-  bool getOne(DNSName &domain, string &ip, uint16_t *id, bool &purged)
+  bool getOne(DNSName& domain, string& ip, uint16_t* id, bool& purged)
   {
-    for(d_nqueue_t::iterator i=d_nqueue.begin();i!=d_nqueue.end();++i)
-      if(i->next <= time(0)) {
+    for (d_nqueue_t::iterator i = d_nqueue.begin(); i != d_nqueue.end(); ++i)
+      if (i->next <= time(0)) {
         i->attempts++;
-        purged=false;
-        i->next=time(0)+1+(1<<i->attempts);
-        domain=i->domain;
-        ip=i->ip;
-        *id=i->id;
-        purged=false;
-        if(i->attempts>4) {
-          purged=true;
+        purged = false;
+        i->next = time(0) + 1 + (1 << i->attempts);
+        domain = i->domain;
+        ip = i->ip;
+        *id = i->id;
+        purged = false;
+        if (i->attempts > 4) {
+          purged = true;
           d_nqueue.erase(i);
         }
         return true;
@@ -116,10 +124,10 @@ public:
 
   time_t earliest()
   {
-    time_t early=std::numeric_limits<time_t>::max() - 1;
-    for(d_nqueue_t::const_iterator i=d_nqueue.begin();i!=d_nqueue.end();++i)
-      early=min(early,i->next);
-    return early-time(0);
+    time_t early = std::numeric_limits<time_t>::max() - 1;
+    for (d_nqueue_t::const_iterator i = d_nqueue.begin(); i != d_nqueue.end(); ++i)
+      early = min(early, i->next);
+    return early - time(0);
   }
 
   void dump();
@@ -136,7 +144,6 @@ private:
 
   typedef std::list<NotificationRequest> d_nqueue_t;
   d_nqueue_t d_nqueue;
-
 };
 
 struct ZoneStatus;
@@ -149,36 +156,36 @@ class CommunicatorClass
 public:
   CommunicatorClass()
   {
-    d_tickinterval=60;
+    d_tickinterval = 60;
     d_secondarieschanged = true;
     d_nsock4 = -1;
     d_nsock6 = -1;
     d_preventSelfNotification = false;
   }
-  time_t doNotifications(PacketHandler *P);
+  time_t doNotifications(PacketHandler* P);
   void go();
 
-
-  void drillHole(const DNSName &domain, const string &ip);
-  bool justNotified(const DNSName &domain, const string &ip);
+  void drillHole(const DNSName& domain, const string& ip);
+  bool justNotified(const DNSName& domain, const string& ip);
   void addSuckRequest(const DNSName& domain, const ComboAddress& primary, SuckRequest::RequestPriority, bool force = false);
   void addSecondaryCheckRequest(const DomainInfo& di, const ComboAddress& remote);
   void addTryAutoPrimaryRequest(const DNSPacket& p);
-  void notify(const DNSName &domain, const string &ip);
+  void notify(const DNSName& domain, const string& ip);
   void mainloop();
   void retrievalLoopThread();
-  void sendNotification(int sock, const DNSName &domain, const ComboAddress& remote, uint16_t id, UeberBackend* B);
-  bool notifyDomain(const DNSName &domain, UeberBackend* B);
-  vector<pair<DNSName, ComboAddress> > getSuckRequests();
+  void sendNotification(int sock, const DNSName& domain, const ComboAddress& remote, uint16_t id, UeberBackend* B);
+  bool notifyDomain(const DNSName& domain, UeberBackend* B);
+  vector<pair<DNSName, ComboAddress>> getSuckRequests();
   size_t getSuckRequestsWaiting();
+
 private:
-  void loadArgsIntoSet(const char *listname, set<string> &listset);
+  void loadArgsIntoSet(const char* listname, set<string>& listset);
   void makeNotifySockets();
   void queueNotifyDomain(const DomainInfo& di, UeberBackend* B);
   int d_nsock4, d_nsock6;
-  LockGuarded<map<pair<DNSName,string>,time_t>> d_holes;
+  LockGuarded<map<pair<DNSName, string>, time_t>> d_holes;
 
-  void suck(const DNSName &domain, const ComboAddress& remote, bool force=false);
+  void suck(const DNSName& domain, const ComboAddress& remote, bool force = false);
   void ixfrSuck(const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, ZoneStatus& zs, vector<DNSRecord>* axfr);
 
   void secondaryRefresh(PacketHandler* P);
@@ -204,8 +211,10 @@ private:
     set<DNSName> d_inprogress;
 
     set<DomainInfo> d_tocheck;
-    struct cmp {
-      bool operator()(const DNSPacket& a, const DNSPacket& b) const {
+    struct cmp
+    {
+      bool operator()(const DNSPacket& a, const DNSPacket& b) const
+      {
         return a.qdomain < b.qdomain;
       };
     };
@@ -222,7 +231,8 @@ private:
 
   struct RemoveSentinel
   {
-    explicit RemoveSentinel(const DNSName& dn, CommunicatorClass* cc) : d_dn(dn), d_cc(cc)
+    explicit RemoveSentinel(const DNSName& dn, CommunicatorClass* cc) :
+      d_dn(dn), d_cc(cc)
     {}
 
     ~RemoveSentinel()
@@ -230,31 +240,30 @@ private:
       try {
         d_cc->d_data.lock()->d_inprogress.erase(d_dn);
       }
-      catch(...) {
+      catch (...) {
       }
     }
     DNSName d_dn;
     CommunicatorClass* d_cc;
-};
-
+  };
 };
 
 // class that one day might be more than a function to help you get IP addresses for a nameserver
 class FindNS
 {
 public:
-  vector<string> lookup(const DNSName &name, UeberBackend *b)
+  vector<string> lookup(const DNSName& name, UeberBackend* b)
   {
     vector<string> addresses;
 
     this->resolve_name(&addresses, name);
 
-    if(b) {
-        b->lookup(QType(QType::ANY),name,-1);
-        DNSZoneRecord rr;
-        while(b->get(rr))
-          if(rr.dr.d_type == QType::A || rr.dr.d_type==QType::AAAA)
-            addresses.push_back(rr.dr.getContent()->getZoneRepresentation());   // SOL if you have a CNAME for an NS
+    if (b) {
+      b->lookup(QType(QType::ANY), name, -1);
+      DNSZoneRecord rr;
+      while (b->get(rr))
+        if (rr.dr.d_type == QType::A || rr.dr.d_type == QType::AAAA)
+          addresses.push_back(rr.dr.getContent()->getZoneRepresentation()); // SOL if you have a CNAME for an NS
     }
     return addresses;
   }
@@ -266,18 +275,18 @@ private:
     struct addrinfo hints;
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_DGRAM; // otherwise we get everything in triplicate (!)
-    for(int n = 0; n < 2; ++n) {
+    for (int n = 0; n < 2; ++n) {
       hints.ai_family = n ? AF_INET : AF_INET6;
       ComboAddress remote;
       remote.sin4.sin_family = AF_INET6;
-      if(!getaddrinfo(name.toString().c_str(), 0, &hints, &res)) {
+      if (!getaddrinfo(name.toString().c_str(), 0, &hints, &res)) {
         struct addrinfo* address = res;
         do {
           if (address->ai_addrlen <= sizeof(remote)) {
             remote.setSockaddr(address->ai_addr, address->ai_addrlen);
             addresses->push_back(remote.toString());
           }
-        } while((address = address->ai_next));
+        } while ((address = address->ai_next));
         freeaddrinfo(res);
       }
     }


### PR DESCRIPTION
### Short description
Adds a configurable `delay-notifications` parameter to delay notifications.

Fix #12785 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
