### PR TITLE
dnsdist: Fall back to libcrypto for authenticated encryption

### DIFF
--- a/.github/actions/spell-check/allow.txt
+++ b/.github/actions/spell-check/allow.txt
@@ -3335,7 +3335,6 @@ sockname
 sockowner
 socktype
 sodbc
-sodcrypto
 sodiumsigners
 sokolov
 somedata

--- a/.not-formatted
+++ b/.not-formatted
@@ -225,8 +225,6 @@
 ./pdns/sillyrecords.cc
 ./pdns/snmp-agent.cc
 ./pdns/snmp-agent.hh
-./pdns/sodcrypto.cc
-./pdns/sodcrypto.hh
 ./pdns/sortlist.cc
 ./pdns/sortlist.hh
 ./pdns/speedtest.cc

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -58,39 +58,40 @@ static ConcurrentConnectionManager s_connManager(100);
 class ConsoleConnection
 {
 public:
-  ConsoleConnection(const ComboAddress& client, FDWrapper&& fd): d_client(client), d_fd(std::move(fd))
+  ConsoleConnection(const ComboAddress& client, FDWrapper&& fileDesc): d_client(client), d_fileDesc(std::move(fileDesc))
   {
     if (!s_connManager.registerConnection()) {
       throw std::runtime_error("Too many concurrent console connections");
     }
   }
-  ConsoleConnection(ConsoleConnection&& rhs): d_client(rhs.d_client), d_fd(std::move(rhs.d_fd))
+  ConsoleConnection(ConsoleConnection&& rhs) noexcept: d_client(rhs.d_client), d_fileDesc(std::move(rhs.d_fileDesc))
   {
   }
 
   ConsoleConnection(const ConsoleConnection&) = delete;
   ConsoleConnection& operator=(const ConsoleConnection&) = delete;
+  ConsoleConnection& operator=(ConsoleConnection&&) = delete;
 
   ~ConsoleConnection()
   {
-    if (d_fd.getHandle() != -1) {
+    if (d_fileDesc.getHandle() != -1) {
       s_connManager.releaseConnection();
     }
   }
 
-  int getFD() const
+  [[nodiscard]] int getFD() const
   {
-    return d_fd.getHandle();
+    return d_fileDesc.getHandle();
   }
 
-  const ComboAddress& getClient() const
+  [[nodiscard]] const ComboAddress& getClient() const
   {
     return d_client;
   }
 
 private:
   ComboAddress d_client;
-  FDWrapper d_fd;
+  FDWrapper d_fileDesc;
 };
 
 void setConsoleMaximumConcurrentConnections(size_t max)
@@ -101,10 +102,11 @@ void setConsoleMaximumConcurrentConnections(size_t max)
 // MUST BE CALLED UNDER A LOCK - right now the LuaLock
 static void feedConfigDelta(const std::string& line)
 {
-  if(line.empty())
+  if (line.empty()) {
     return;
-  struct timeval now;
-  gettimeofday(&now, 0);
+  }
+  timeval now{};
+  gettimeofday(&now, nullptr);
   g_confDelta.emplace_back(now, line);
 }
 
@@ -113,18 +115,22 @@ static string historyFile(const bool &ignoreHOME = false)
 {
   string ret;
 
-  struct passwd pwd;
-  struct passwd *result;
-  char buf[16384];
-  getpwuid_r(geteuid(), &pwd, buf, sizeof(buf), &result);
+  passwd pwd{};
+  passwd *result{nullptr};
+  std::array<char, 16384> buf{};
+  getpwuid_r(geteuid(), &pwd, buf.data(), buf.size(), &result);
 
+  // NOLINTNEXTLINE(concurrency-mt-unsafe): we are not modifying the environment
   const char *homedir = getenv("HOME");
-  if (result)
+  if (result != nullptr) {
     ret = string(pwd.pw_dir);
-  if (homedir && !ignoreHOME) // $HOME overrides what the OS tells us
+  }
+  if (homedir != nullptr && !ignoreHOME) { // $HOME overrides what the OS tells us
     ret = string(homedir);
-  if (ret.empty())
+  }
+  if (ret.empty()) {
     ret = "."; // CWD if nothing works..
+  }
   ret.append("/.dnsdist_history");
   return ret;
 }
@@ -136,11 +142,11 @@ enum class ConsoleCommandResult : uint8_t {
   TooLarge
 };
 
-static ConsoleCommandResult getMsgLen32(int fd, uint32_t* len)
+static ConsoleCommandResult getMsgLen32(int fileDesc, uint32_t* len)
 {
   try {
-    uint32_t raw;
-    size_t ret = readn2(fd, &raw, sizeof(raw));
+    uint32_t raw{0};
+    size_t ret = readn2(fileDesc, &raw, sizeof(raw));
 
     if (ret != sizeof raw) {
       return ConsoleCommandResult::ConnectionClosed;
@@ -158,12 +164,12 @@ static ConsoleCommandResult getMsgLen32(int fd, uint32_t* len)
   }
 }
 
-static bool putMsgLen32(int fd, uint32_t len)
+static bool putMsgLen32(int fileDesc, uint32_t len)
 {
   try
   {
     uint32_t raw = htonl(len);
-    size_t ret = writen2(fd, &raw, sizeof raw);
+    size_t ret = writen2(fileDesc, &raw, sizeof raw);
     return ret == sizeof raw;
   }
   catch(...) {
@@ -171,7 +177,7 @@ static bool putMsgLen32(int fd, uint32_t len)
   }
 }
 
-static ConsoleCommandResult sendMessageToServer(int fd, const std::string& line, dnsdist::crypto::authenticated::Nonce& readingNonce, dnsdist::crypto::authenticated::Nonce& writingNonce, const bool outputEmptyLine)
+static ConsoleCommandResult sendMessageToServer(int fileDesc, const std::string& line, dnsdist::crypto::authenticated::Nonce& readingNonce, dnsdist::crypto::authenticated::Nonce& writingNonce, const bool outputEmptyLine)
 {
   string msg = dnsdist::crypto::authenticated::encryptSym(line, g_consoleKey, writingNonce);
   const auto msgLen = msg.length();
@@ -180,19 +186,19 @@ static ConsoleCommandResult sendMessageToServer(int fd, const std::string& line,
     return ConsoleCommandResult::TooLarge;
   }
 
-  putMsgLen32(fd, static_cast<uint32_t>(msgLen));
+  putMsgLen32(fileDesc, static_cast<uint32_t>(msgLen));
 
   if (!msg.empty()) {
-    writen2(fd, msg);
+    writen2(fileDesc, msg);
   }
 
-  uint32_t len;
-  auto commandResult = getMsgLen32(fd, &len);
+  uint32_t len{0};
+  auto commandResult = getMsgLen32(fileDesc, &len);
   if (commandResult == ConsoleCommandResult::ConnectionClosed) {
     cout << "Connection closed by the server." << endl;
     return commandResult;
   }
-  else if (commandResult == ConsoleCommandResult::TooLarge) {
+  if (commandResult == ConsoleCommandResult::TooLarge) {
     cerr << "Received a console message whose length (" << len << ") is exceeding the allowed one (" << g_consoleOutputMsgMaxSize << "), closing that connection" << endl;
     return commandResult;
   }
@@ -207,7 +213,7 @@ static ConsoleCommandResult sendMessageToServer(int fd, const std::string& line,
 
   msg.clear();
   msg.resize(len);
-  readn2(fd, msg.data(), len);
+  readn2(fileDesc, msg.data(), len);
   msg = dnsdist::crypto::authenticated::decryptSym(msg, g_consoleKey, readingNonce);
   cout << msg;
   cout.flush();
@@ -226,35 +232,38 @@ void doClient(ComboAddress server, const std::string& command)
     cout<<"Connecting to "<<server.toStringWithPort()<<endl;
   }
 
-  auto fd = FDWrapper(socket(server.sin4.sin_family, SOCK_STREAM, 0));
-  if (fd.getHandle() < 0) {
+  auto fileDesc = FDWrapper(socket(server.sin4.sin_family, SOCK_STREAM, 0));
+  if (fileDesc.getHandle() < 0) {
     cerr<<"Unable to connect to "<<server.toStringWithPort()<<endl;
     return;
   }
-  SConnect(fd.getHandle(), server);
-  setTCPNoDelay(fd.getHandle());
-  dnsdist::crypto::authenticated::Nonce theirs, ours, readingNonce, writingNonce;
+  SConnect(fileDesc.getHandle(), server);
+  setTCPNoDelay(fileDesc.getHandle());
+  dnsdist::crypto::authenticated::Nonce theirs;
+  dnsdist::crypto::authenticated::Nonce ours;
+  dnsdist::crypto::authenticated::Nonce readingNonce;
+  dnsdist::crypto::authenticated::Nonce writingNonce;
   ours.init();
 
-  writen2(fd.getHandle(), ours.value.data(), ours.value.size());
-  readn2(fd.getHandle(), theirs.value.data(), theirs.value.size());
+  writen2(fileDesc.getHandle(), ours.value.data(), ours.value.size());
+  readn2(fileDesc.getHandle(), theirs.value.data(), theirs.value.size());
   readingNonce.merge(ours, theirs);
   writingNonce.merge(theirs, ours);
 
   /* try sending an empty message, the server should send an empty
      one back. If it closes the connection instead, we are probably
      having a key mismatch issue. */
-  auto commandResult = sendMessageToServer(fd.getHandle(), "", readingNonce, writingNonce, false);
+  auto commandResult = sendMessageToServer(fileDesc.getHandle(), "", readingNonce, writingNonce, false);
   if (commandResult == ConsoleCommandResult::ConnectionClosed) {
     cerr<<"The server closed the connection right away, likely indicating a key mismatch. Please check your setKey() directive."<<endl;
     return;
   }
-  else if (commandResult == ConsoleCommandResult::TooLarge) {
+  if (commandResult == ConsoleCommandResult::TooLarge) {
     return;
   }
 
   if (!command.empty()) {
-    sendMessageToServer(fd.getHandle(), command, readingNonce, writingNonce, false);
+    sendMessageToServer(fileDesc.getHandle(), command, readingNonce, writingNonce, false);
     return;
   }
 
@@ -272,7 +281,7 @@ void doClient(ComboAddress server, const std::string& command)
   for (;;) {
     char* sline = readline("> ");
     rl_bind_key('\t',rl_complete);
-    if (!sline) {
+    if (sline == nullptr) {
       break;
     }
 
@@ -283,6 +292,7 @@ void doClient(ComboAddress server, const std::string& command)
       history.flush();
     }
     lastline = line;
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory): readline
     free(sline);
 
     if (line == "quit") {
@@ -297,7 +307,7 @@ void doClient(ComboAddress server, const std::string& command)
       continue;
     }
 
-    commandResult = sendMessageToServer(fd.getHandle(), line, readingNonce, writingNonce, true);
+    commandResult = sendMessageToServer(fileDesc.getHandle(), line, readingNonce, writingNonce, true);
     if (commandResult != ConsoleCommandResult::Valid) {
       break;
     }
@@ -312,7 +322,7 @@ static std::optional<std::string> getNextConsoleLine(ofstream& history, std::str
 {
   char* sline = readline("> ");
   rl_bind_key('\t', rl_complete);
-  if (!sline) {
+  if (sline == nullptr) {
     return std::nullopt;
   }
 
@@ -324,6 +334,7 @@ static std::optional<std::string> getNextConsoleLine(ofstream& history, std::str
   }
 
   lastline = line;
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory): readline
   free(sline);
 
   return line;
@@ -390,25 +401,26 @@ void doConsole()
             >
           >(withReturn ? ("return "+*line) : *line);
         if (ret) {
-          if (const auto dsValue = boost::get<shared_ptr<DownstreamState>>(&*ret)) {
+          if (const auto* dsValue = boost::get<shared_ptr<DownstreamState>>(&*ret)) {
             if (*dsValue) {
               cout<<(*dsValue)->getName()<<endl;
             }
           }
-          else if (const auto csValue = boost::get<ClientState*>(&*ret)) {
-            if (*csValue) {
+          else if (const auto* csValue = boost::get<ClientState*>(&*ret)) {
+            if (*csValue != nullptr) {
               cout<<(*csValue)->local.toStringWithPort()<<endl;
             }
           }
-          else if (const auto strValue = boost::get<string>(&*ret)) {
+          else if (const auto* strValue = boost::get<string>(&*ret)) {
             cout<<*strValue<<endl;
           }
-          else if (const auto um = boost::get<std::unordered_map<string, double> >(&*ret)) {
+          else if (const auto* mapValue = boost::get<std::unordered_map<string, double> >(&*ret)) {
             using namespace json11;
-            Json::object o;
-            for(const auto& v : *um)
-              o[v.first]=v.second;
-            Json out = o;
+            Json::object obj;
+            for (const auto& value : *mapValue) {
+              obj[value.first] = value.second;
+            }
+            Json out = obj;
             cout<<out.dump()<<endl;
           }
         }
@@ -422,7 +434,8 @@ void doConsole()
       }
       catch (const LuaContext::SyntaxErrorException&) {
         if (withReturn) {
-          withReturn=false;
+          withReturn = false;
+          // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
           goto retry;
         }
         throw;
@@ -433,7 +446,7 @@ void doConsole()
       // tried to return something we don't understand
     }
     catch (const LuaContext::ExecutionErrorException& e) {
-      if (!strcmp(e.what(), "invalid key to 'next'")) {
+      if (strcmp(e.what(), "invalid key to 'next'") == 0) {
         std::cerr<<"Error parsing parameters, did you forget parameter name?";
       }
       else {
@@ -464,22 +477,22 @@ void doConsole()
 const std::vector<ConsoleKeyword> g_consoleKeywords{
   /* keyword, function, parameters, description */
   { "addACL", true, "netmask", "add to the ACL set who can use this server" },
-  { "addAction", true, "DNS rule, DNS action [, {uuid=\"UUID\", name=\"name\"}]", "add a rule" },
+  { "addAction", true, R"(DNS rule, DNS action [, {uuid="UUID", name="name"}])", "add a rule" },
   { "addBPFFilterDynBlocks", true, "addresses, dynbpf[[, seconds=10], msg]", "This is the eBPF equivalent of addDynBlocks(), blocking a set of addresses for (optionally) a number of seconds, using an eBPF dynamic filter" },
   { "addCapabilitiesToRetain", true, "capability or list of capabilities", "Linux capabilities to retain after startup, like CAP_BPF" },
   { "addConsoleACL", true, "netmask", "add a netmask to the console ACL" },
-  { "addDNSCryptBind", true, "\"127.0.0.1:8443\", \"provider name\", \"/path/to/resolver.cert\", \"/path/to/resolver.key\", {reusePort=false, tcpFastOpenQueueSize=0, interface=\"\", cpus={}}", "listen to incoming DNSCrypt queries on 127.0.0.1 port 8443, with a provider name of `provider name`, using a resolver certificate and associated key stored respectively in the `resolver.cert` and `resolver.key` files. The fifth optional parameter is a table of parameters" },
+  { "addDNSCryptBind", true, R"('127.0.0.1:8443", "provider name", "/path/to/resolver.cert", "/path/to/resolver.key", {reusePort=false, tcpFastOpenQueueSize=0, interface="", cpus={}})", "listen to incoming DNSCrypt queries on 127.0.0.1 port 8443, with a provider name of `provider name`, using a resolver certificate and associated key stored respectively in the `resolver.cert` and `resolver.key` files. The fifth optional parameter is a table of parameters" },
   { "addDOHLocal", true, "addr, certFile, keyFile [, urls [, vars]]", "listen to incoming DNS over HTTPS queries on the specified address using the specified certificate and key. The last two parameters are tables" },
   { "addDOH3Local", true, "addr, certFile, keyFile [, vars]", "listen to incoming DNS over HTTP/3 queries on the specified address using the specified certificate and key. The last parameter is a table" },
   { "addDOQLocal", true, "addr, certFile, keyFile [, vars]", "listen to incoming DNS over QUIC queries on the specified address using the specified certificate and key. The last parameter is a table" },
   { "addDynamicBlock", true, "address, message[, action [, seconds [, clientIPMask [, clientIPPortMask]]]]", "block the supplied address with message `msg`, for `seconds` seconds (10 by default), applying `action` (default to the one set with `setDynBlocksAction()`)" },
   { "addDynBlocks", true, "addresses, message[, seconds[, action]]", "block the set of addresses with message `msg`, for `seconds` seconds (10 by default), applying `action` (default to the one set with `setDynBlocksAction()`)" },
   { "addDynBlockSMT", true, "names, message[, seconds [, action]]", "block the set of names with message `msg`, for `seconds` seconds (10 by default), applying `action` (default to the one set with `setDynBlocksAction()`)" },
-  { "addLocal", true, "addr [, {doTCP=true, reusePort=false, tcpFastOpenQueueSize=0, interface=\"\", cpus={}}]", "add `addr` to the list of addresses we listen on" },
-  { "addCacheHitResponseAction", true, "DNS rule, DNS response action [, {uuid=\"UUID\", name=\"name\"}}]", "add a cache hit response rule" },
-  { "addCacheInsertedResponseAction", true, "DNS rule, DNS response action [, {uuid=\"UUID\", name=\"name\"}}]", "add a cache inserted response rule" },
-  { "addResponseAction", true, "DNS rule, DNS response action [, {uuid=\"UUID\", name=\"name\"}}]", "add a response rule" },
-  { "addSelfAnsweredResponseAction", true, "DNS rule, DNS response action [, {uuid=\"UUID\", name=\"name\"}}]", "add a self-answered response rule" },
+  { "addLocal", true, R"(addr [, {doTCP=true, reusePort=false, tcpFastOpenQueueSize=0, interface="", cpus={}}])", "add `addr` to the list of addresses we listen on" },
+  { "addCacheHitResponseAction", true, R"(DNS rule, DNS response action [, {uuid="UUID", name="name"}}])", "add a cache hit response rule" },
+  { "addCacheInsertedResponseAction", true, R"(DNS rule, DNS response action [, {uuid="UUID", name="name"}}])", "add a cache inserted response rule" },
+  { "addResponseAction", true, R"(DNS rule, DNS response action [, {uuid="UUID", name="name"}}])", "add a response rule" },
+  { "addSelfAnsweredResponseAction", true, R"(DNS rule, DNS response action [, {uuid="UUID", name="name"}}])", "add a self-answered response rule" },
   { "addTLSLocal", true, "addr, certFile(s), keyFile(s) [,params]", "listen to incoming DNS over TLS queries on the specified address using the specified certificate (or list of) and key (or list of). The last parameter is a table" },
   { "AllowAction", true, "", "let these packets go through" },
   { "AllowResponseAction", true, "", "let these packets go through" },
@@ -517,8 +530,8 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "exceedServFails", true, "rate, seconds", "get set of addresses that exceed `rate` servfails/s over `seconds` seconds" },
   { "firstAvailable", false, "", "picks the server with the lowest `order` that has not exceeded its QPS limit" },
   { "fixupCase", true, "bool", "if set (default to no), rewrite the first qname of the question part of the answer to match the one from the query. It is only useful when you have a downstream server that messes up the case of the question qname in the answer" },
-  { "generateDNSCryptCertificate", true, "\"/path/to/providerPrivate.key\", \"/path/to/resolver.cert\", \"/path/to/resolver.key\", serial, validFrom, validUntil", "generate a new resolver private key and related certificate, valid from the `validFrom` timestamp until the `validUntil` one, signed with the provider private key" },
-  { "generateDNSCryptProviderKeys", true, "\"/path/to/providerPublic.key\", \"/path/to/providerPrivate.key\"", "generate a new provider keypair" },
+  { "generateDNSCryptCertificate", true, R"("/path/to/providerPrivate.key", "/path/to/resolver.cert", "/path/to/resolver.key", serial, validFrom, validUntil)", "generate a new resolver private key and related certificate, valid from the `validFrom` timestamp until the `validUntil` one, signed with the provider private key" },
+  { "generateDNSCryptProviderKeys", true, R"("/path/to/providerPublic.key", "/path/to/providerPrivate.key")", "generate a new provider keypair" },
   { "getAction", true, "n", "Returns the Action associated with rule n" },
   { "getBind", true, "n", "returns the listener at index n" },
   { "getBindCount", true, "", "returns the number of listeners all kinds" },
@@ -558,7 +571,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "getTLSFrontend", true, "n", "returns the TLS frontend with index n" },
   { "getTLSFrontendCount", true, "", "returns the number of DoT listeners" },
   { "getVerbose", true, "", "get whether log messages at the verbose level will be logged" },
-  { "grepq", true, "Netmask|DNS Name|100ms|{\"::1\", \"powerdns.com\", \"100ms\"} [, n] [,options]", "shows the last n queries and responses matching the specified client address or range (Netmask), or the specified DNS Name, or slower than 100ms" },
+  { "grepq", true, R"(Netmask|DNS Name|100ms|{"::1", "powerdns.com", "100ms"} [, n] [,options])", "shows the last n queries and responses matching the specified client address or range (Netmask), or the specified DNS Name, or slower than 100ms" },
   { "hashPassword", true, "password [, workFactor]", "Returns a hashed and salted version of the supplied password, usable with 'setWebserverConfig()'"},
   { "HTTPHeaderRule", true, "name, regex", "matches DoH queries with a HTTP header 'name' whose content matches the regular expression 'regex'"},
   { "HTTPPathRegexRule", true, "regex", "matches DoH queries whose HTTP path matches 'regex'"},
@@ -627,8 +640,8 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "newPacketCache", true, "maxEntries[, maxTTL=86400, minTTL=0, temporaryFailureTTL=60, staleTTL=60, dontAge=false, numberOfShards=1, deferrableInsertLock=true, options={}]", "return a new Packet Cache" },
   { "newQPSLimiter", true, "rate, burst", "configure a QPS limiter with that rate and that burst capacity" },
   { "newRemoteLogger", true, "address:port [, timeout=2, maxQueuedEntries=100, reconnectWaitTime=1]", "create a Remote Logger object, to use with `RemoteLogAction()` and `RemoteLogResponseAction()`" },
-  { "newRuleAction", true, "DNS rule, DNS action [, {uuid=\"UUID\", name=\"name\"}]", "return a pair of DNS Rule and DNS Action, to be used with `setRules()`" },
-  { "newServer", true, "{address=\"ip:port\", qps=1000, order=1, weight=10, pool=\"abuse\", retries=5, tcpConnectTimeout=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName=\"a.root-servers.net.\", checkType=\"A\", maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source=\"address|interface name|address@interface\", sockets=1, reconnectOnUp=false}", "instantiate a server" },
+  { "newRuleAction", true, R"(DNS rule, DNS action [, {uuid="UUID", name="name"}])", "return a pair of DNS Rule and DNS Action, to be used with `setRules()`" },
+  { "newServer", true, R"({address="ip:port", qps=1000, order=1, weight=10, pool="abuse", retries=5, tcpConnectTimeout=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName="a.root-servers.net.", checkType="A", maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source="address|interface name|address@interface", sockets=1, reconnectOnUp=false})", "instantiate a server" },
   { "newServerPolicy", true, "name, function", "create a policy object from a Lua function" },
   { "newSuffixMatchNode", true, "", "returns a new SuffixMatchNode" },
   { "newSVCRecordParameters", true, "priority, target, mandatoryParams, alpns, noDefaultAlpn [, port [, ech [, ipv4hints [, ipv6hints [, additionalParameters ]]]]]", "return a new SVCRecordParameters object, to use with SpoofSVCAction" },
@@ -640,7 +653,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "PoolAction", true, "poolname [, stop]", "set the packet into the specified pool" },
   { "PoolAvailableRule", true, "poolname", "Check whether a pool has any servers available to handle queries" },
   { "PoolOutstandingRule", true, "poolname, limit", "Check whether a pool has outstanding queries above limit" },
-  { "printDNSCryptProviderFingerprint", true, "\"/path/to/providerPublic.key\"", "display the fingerprint of the provided resolver public key" },
+  { "printDNSCryptProviderFingerprint", true, R"("/path/to/providerPublic.key")", "display the fingerprint of the provided resolver public key" },
   { "ProbaRule", true, "probability", "Matches queries with a given probability. 1.0 means always" },
   { "ProxyProtocolValueRule", true, "type [, value]", "matches queries with a specified Proxy Protocol TLV value of that type, optionally matching the content of the option as well" },
   { "QClassRule", true, "qclass", "Matches queries with the specified qclass. class can be specified as an integer or as one of the built-in DNSClass" },
@@ -693,7 +706,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "setECSSourcePrefixV4", true, "prefix-length", "the EDNS Client Subnet prefix-length used for IPv4 queries" },
   { "setECSSourcePrefixV6", true, "prefix-length", "the EDNS Client Subnet prefix-length used for IPv6 queries" },
   { "setKey", true, "key", "set access key to that key" },
-  { "setLocal", true, "addr [, {doTCP=true, reusePort=false, tcpFastOpenQueueSize=0, interface=\"\", cpus={}}]", "reset the list of addresses we listen on to this address" },
+  { "setLocal", true, R"(addr [, {doTCP=true, reusePort=false, tcpFastOpenQueueSize=0, interface="", cpus={}}])", "reset the list of addresses we listen on to this address" },
   { "setMaxCachedDoHConnectionsPerDownstream", true, "max", "Set the maximum number of inactive DoH connections to a backend cached by each worker DoH thread" },
   { "setMaxCachedTCPConnectionsPerDownstream", true, "max", "Set the maximum number of inactive TCP connections to a backend cached by each worker TCP thread" },
   { "setMaxTCPClientThreads", true, "n", "set the maximum of TCP client threads, handling TCP connections" },
@@ -827,17 +840,17 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
 extern "C" {
 static char* my_generator(const char* text, int state)
 {
-  string t(text);
+  string textStr(text);
   /* to keep it readable, we try to keep only 4 keywords per line
      and to start a new line when the first letter changes */
   static int s_counter = 0;
-  int counter=0;
-  if (!state) {
+  int counter = 0;
+  if (state == 0) {
     s_counter = 0;
   }
 
   for (const auto& keyword : g_consoleKeywords) {
-    if (boost::starts_with(keyword.name, t) && counter++ == s_counter)  {
+    if (boost::starts_with(keyword.name, textStr) && counter++ == s_counter)  {
       std::string value(keyword.name);
       s_counter++;
       if (keyword.function) {
@@ -849,14 +862,15 @@ static char* my_generator(const char* text, int state)
       return strdup(value.c_str());
     }
   }
-  return 0;
+  return nullptr;
 }
 
 char** my_completion( const char * text , int start,  int end)
 {
-  char **matches=0;
+  char **matches = nullptr;
   if (start == 0) {
-    matches = rl_completion_matches ((char*)text, &my_generator);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast): readline
+    matches = rl_completion_matches (const_cast<char*>(text), &my_generator);
   }
 
   // skip default filename completion.
@@ -875,7 +889,10 @@ static void controlClientThread(ConsoleConnection&& conn)
 
     setTCPNoDelay(conn.getFD());
 
-    dnsdist::crypto::authenticated::Nonce theirs, ours, readingNonce, writingNonce;
+    dnsdist::crypto::authenticated::Nonce theirs;
+    dnsdist::crypto::authenticated::Nonce ours;
+    dnsdist::crypto::authenticated::Nonce readingNonce;
+    dnsdist::crypto::authenticated::Nonce writingNonce;
     ours.init();
     readn2(conn.getFD(), theirs.value.data(), theirs.value.size());
     writen2(conn.getFD(), ours.value.data(), ours.value.size());
@@ -883,7 +900,7 @@ static void controlClientThread(ConsoleConnection&& conn)
     writingNonce.merge(theirs, ours);
 
     for (;;) {
-      uint32_t len;
+      uint32_t len{0};
       if (getMsgLen32(conn.getFD(), &len) != ConsoleCommandResult::Valid) {
         break;
       }
@@ -922,30 +939,30 @@ static void controlClientThread(ConsoleConnection&& conn)
             >(withReturn ? ("return "+line) : line);
 
           if (ret) {
-            if (const auto dsValue = boost::get<shared_ptr<DownstreamState>>(&*ret)) {
+            if (const auto* dsValue = boost::get<shared_ptr<DownstreamState>>(&*ret)) {
               if (*dsValue) {
                 response = (*dsValue)->getName()+"\n";
               } else {
                 response = "";
               }
             }
-            else if (const auto csValue = boost::get<ClientState*>(&*ret)) {
-              if (*csValue) {
+            else if (const auto* csValue = boost::get<ClientState*>(&*ret)) {
+              if (*csValue != nullptr) {
                 response = (*csValue)->local.toStringWithPort()+"\n";
               } else {
                 response = "";
               }
             }
-            else if (const auto strValue = boost::get<string>(&*ret)) {
+            else if (const auto* strValue = boost::get<string>(&*ret)) {
               response = *strValue+"\n";
             }
-            else if (const auto um = boost::get<std::unordered_map<string, double> >(&*ret)) {
+            else if (const auto* mapValue = boost::get<std::unordered_map<string, double> >(&*ret)) {
               using namespace json11;
-              Json::object o;
-              for(const auto& v : *um) {
-                o[v.first] = v.second;
+              Json::object obj;
+              for (const auto& value : *mapValue) {
+                obj[value.first] = value.second;
               }
-              Json out = o;
+              Json out = obj;
               response = out.dump()+"\n";
             }
           }
@@ -957,8 +974,9 @@ static void controlClientThread(ConsoleConnection&& conn)
           }
         }
         catch (const LuaContext::SyntaxErrorException&) {
-          if(withReturn) {
-            withReturn=false;
+          if (withReturn) {
+            withReturn = false;
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
             goto retry;
           }
           throw;
@@ -969,7 +987,7 @@ static void controlClientThread(ConsoleConnection&& conn)
         // tried to return something we don't understand
       }
       catch (const LuaContext::ExecutionErrorException& e) {
-        if (!strcmp(e.what(),"invalid key to 'next'")) {
+        if (strcmp(e.what(),"invalid key to 'next'") == 0) {
           response = "Error: Parsing function parameters, did you forget parameter name?";
         }
         else {
@@ -1003,18 +1021,18 @@ static void controlClientThread(ConsoleConnection&& conn)
   }
 }
 
-void controlThread(int fd, ComboAddress local)
+// NOLINTNEXTLINE(performance-unnecessary-value-param): this is thread
+void controlThread(std::shared_ptr<Socket> acceptFD, ComboAddress local)
 {
-  FDWrapper acceptFD(fd);
   try
   {
     setThreadName("dnsdist/control");
     ComboAddress client;
-    int sock;
+    int sock{-1};
     auto localACL = g_consoleACL.getLocal();
     infolog("Accepting control connections on %s", local.toStringWithPort());
 
-    while ((sock = SAccept(acceptFD.getHandle(), client)) >= 0) {
+    while ((sock = SAccept(acceptFD->getHandle(), client)) >= 0) {
 
       FDWrapper socket(sock);
       if (!dnsdist::crypto::authenticated::isValidKey(g_consoleKey)) {
@@ -1033,8 +1051,8 @@ void controlThread(int fd, ComboAddress local)
           warnlog("Got control connection from %s", client.toStringWithPort());
         }
 
-        std::thread t(controlClientThread, std::move(conn));
-        t.detach();
+        std::thread clientThread(controlClientThread, std::move(conn));
+        clientThread.detach();
       }
       catch (const std::exception& e) {
         infolog("Control connection died: %s", e.what());

--- a/pdns/dnsdist-console.hh
+++ b/pdns/dnsdist-console.hh
@@ -55,7 +55,7 @@ extern uint32_t g_consoleOutputMsgMaxSize;
 
 void doClient(ComboAddress server, const std::string& command);
 void doConsole();
-void controlThread(int fd, ComboAddress local);
+void controlThread(std::shared_ptr<Socket> acceptFD, ComboAddress local);
 void clearConsoleHistory();
 
 void setConsoleMaximumConcurrentConnections(size_t max);

--- a/pdns/dnsdist-console.hh
+++ b/pdns/dnsdist-console.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "config.h"
+#include "sstuff.hh"
 
 #ifndef DISABLE_COMPLETION
 struct ConsoleKeyword {

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -52,6 +52,7 @@
 #include "dnsdist-cache.hh"
 #include "dnsdist-carbon.hh"
 #include "dnsdist-console.hh"
+#include "dnsdist-crypto.hh"
 #include "dnsdist-discovery.hh"
 #include "dnsdist-dnsparser.hh"
 #include "dnsdist-dynblocks.hh"
@@ -80,7 +81,6 @@
 #include "gettime.hh"
 #include "lock.hh"
 #include "misc.hh"
-#include "sodcrypto.hh"
 #include "sstuff.hh"
 #include "threadname.hh"
 
@@ -2499,7 +2499,7 @@ static void usage()
   cout<<"-c,--client           Operate as a client, connect to dnsdist. This reads\n";
   cout<<"                      controlSocket from your configuration file, but also\n";
   cout<<"                      accepts an IP:PORT argument\n";
-#ifdef HAVE_LIBSODIUM
+#if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBCRYPTO)
   cout<<"-k,--setkey KEY       Use KEY for encrypted communication to dnsdist. This\n";
   cout<<"                      is similar to setting setKey in the configuration file.\n";
   cout<<"                      NOTE: this will leak this key in your shell's history\n";
@@ -2722,14 +2722,14 @@ static void parseParameters(int argc, char** argv, ComboAddress& clientAddress)
       g_ACL.modify([optstring](NetmaskGroup& nmg) { nmg.addMask(optstring); });
       break;
     case 'k':
-#ifdef HAVE_LIBSODIUM
+#if defined HAVE_LIBSODIUM || defined(HAVE_LIBCRYPTO)
       if (B64Decode(string(optarg), g_consoleKey) < 0) {
         cerr<<"Unable to decode key '"<<optarg<<"'."<<endl;
         // NOLINTNEXTLINE(concurrency-mt-unsafe): only one thread at this point
         exit(EXIT_FAILURE);
       }
 #else
-      cerr<<"dnsdist has been built without libsodium, -k/--setkey is unsupported."<<endl;
+      cerr<<"dnsdist has been built without libsodium or libcrypto, -k/--setkey is unsupported."<<endl;
       // NOLINTNEXTLINE(concurrency-mt-unsafe): only one thread at this point
       exit(EXIT_FAILURE);
 #endif
@@ -3081,7 +3081,7 @@ int main(int argc, char** argv)
       infolog("Console ACL allowing connections from: %s", acls.c_str());
     }
 
-#ifdef HAVE_LIBSODIUM
+#if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBCRYPTO)
     if (g_consoleEnabled && g_consoleKey.empty()) {
       warnlog("Warning, the console has been enabled via 'controlSocket()' but no key has been set with 'setKey()' so all connections will fail until a key has been set");
     }

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -151,6 +151,7 @@ dnsdist_SOURCES = \
 	dnsdist-carbon.cc dnsdist-carbon.hh \
 	dnsdist-concurrent-connections.hh \
 	dnsdist-console.cc dnsdist-console.hh \
+	dnsdist-crypto.cc dnsdist-crypto.hh \
 	dnsdist-discovery.cc dnsdist-discovery.hh \
 	dnsdist-dnscrypt.cc \
 	dnsdist-dnsparser.cc dnsdist-dnsparser.hh \
@@ -245,7 +246,6 @@ dnsdist_SOURCES = \
 	remote_logger.cc remote_logger.hh \
 	sholder.hh \
 	snmp-agent.cc snmp-agent.hh \
-	sodcrypto.cc sodcrypto.hh \
 	sstuff.hh \
 	stat_t.hh \
 	statnode.cc statnode.hh \
@@ -271,6 +271,7 @@ testrunner_SOURCES = \
 	dnsdist-backoff.hh \
 	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-concurrent-connections.hh \
+	dnsdist-crypto.cc dnsdist-crypto.hh \
 	dnsdist-dnsparser.cc dnsdist-dnsparser.hh \
 	dnsdist-doh-common.cc dnsdist-doh-common.hh \
 	dnsdist-downstream-connection.hh \
@@ -324,7 +325,6 @@ testrunner_SOURCES = \
 	proxy-protocol.cc proxy-protocol.hh \
 	qtype.cc qtype.hh \
 	sholder.hh \
-	sodcrypto.cc \
 	sstuff.hh \
 	stat_t.hh \
 	statnode.cc statnode.hh \

--- a/pdns/dnsdistdist/dnsdist-crypto.cc
+++ b/pdns/dnsdistdist/dnsdist-crypto.cc
@@ -328,7 +328,8 @@ bool isValidKey(const std::string& key)
 
 #include <cinttypes>
 
-namespace anonpdns {
+namespace anonpdns
+{
 static char B64Decode1(char cInChar)
 {
   // The incoming character will be A-Z, a-z, 0-9, +, /, or =.
@@ -340,7 +341,7 @@ static char B64Decode1(char cInChar)
   //
   // To do that, we'll play some tricks...
   unsigned char iIndex = '\0';
-  switch ( cInChar ) {
+  switch (cInChar) {
   case '+':
     iIndex = 62;
     break;
@@ -362,13 +363,13 @@ static char B64Decode1(char cInChar)
     // so we check for numerals first, then capital letters,
     // and finally small letters.
     iIndex = '9' - cInChar;
-    if ( iIndex > 0x3F ) {
+    if (iIndex > 0x3F) {
       // Not from '0' to '9'...
       iIndex = 'Z' - cInChar;
-      if ( iIndex > 0x3F ) {
+      if (iIndex > 0x3F) {
         // Not from 'A' to 'Z'...
         iIndex = 'z' - cInChar;
-        if ( iIndex > 0x3F ) {
+        if (iIndex > 0x3F) {
           // Invalid character...cannot
           // decode!
           iIndex = 0x80; // set the high bit
@@ -396,31 +397,26 @@ static char B64Decode1(char cInChar)
 
 static inline char B64Encode1(unsigned char uc)
 {
-  if (uc < 26)
-    {
-      return 'A'+uc;
-    }
-  if (uc < 52)
-    {
-      return 'a'+(uc-26);
-    }
-  if (uc < 62)
-    {
-      return '0'+(uc-52);
-    }
-  if (uc == 62)
-    {
-      return '+';
-    }
+  if (uc < 26) {
+    return 'A' + uc;
+  }
+  if (uc < 52) {
+    return 'a' + (uc - 26);
+  }
+  if (uc < 62) {
+    return '0' + (uc - 52);
+  }
+  if (uc == 62) {
+    return '+';
+  }
   return '/';
 };
-
-
 
 }
 using namespace anonpdns;
 
-template<typename Container> int B64Decode(const std::string& strInput, Container& strOutput)
+template <typename Container>
+int B64Decode(const std::string& strInput, Container& strOutput)
 {
   // Set up a decoding buffer
   long cBuf = 0;
@@ -442,16 +438,16 @@ template<typename Container> int B64Decode(const std::string& strInput, Containe
   int iInSize = strInput.size();
   unsigned char cChar = '\0';
   uint8_t pad = 0;
-  while ( iInNum < iInSize ) {
+  while (iInNum < iInSize) {
     // Fill the decode buffer with 4 groups of 6 bits
     cBuf = 0; // clear
     pad = 0;
-    for ( iBitGroup = 0; iBitGroup < 4; ++iBitGroup ) {
-      if ( iInNum < iInSize ) {
+    for (iBitGroup = 0; iBitGroup < 4; ++iBitGroup) {
+      if (iInNum < iInSize) {
         // Decode a character
-       if(strInput.at(iInNum)=='=')
-         pad++;
-        while(isspace(strInput.at(iInNum)))
+        if (strInput.at(iInNum) == '=')
+          pad++;
+        while (isspace(strInput.at(iInNum)))
           iInNum++;
         cChar = B64Decode1(strInput.at(iInNum++));
 
@@ -462,11 +458,11 @@ template<typename Container> int B64Decode(const std::string& strInput, Containe
       } // else
 
       // Check for valid decode
-      if ( cChar > 0x7F )
+      if (cChar > 0x7F)
         return -1;
 
       // Adjust the bits
-      switch ( iBitGroup ) {
+      switch (iBitGroup) {
       case 0:
         // The first group is copied into
         // the least significant 6 bits of
@@ -492,17 +488,17 @@ template<typename Container> int B64Decode(const std::string& strInput, Containe
     // may have been padding, so those padded bytes
     // are actually ignored.
 #if BYTE_ORDER == BIG_ENDIAN
-    strOutput.push_back(pBuf[sizeof(long)-3]);
-    strOutput.push_back(pBuf[sizeof(long)-2]);
-    strOutput.push_back(pBuf[sizeof(long)-1]);
+    strOutput.push_back(pBuf[sizeof(long) - 3]);
+    strOutput.push_back(pBuf[sizeof(long) - 2]);
+    strOutput.push_back(pBuf[sizeof(long) - 1]);
 #else
     strOutput.push_back(pBuf[2]);
     strOutput.push_back(pBuf[1]);
     strOutput.push_back(pBuf[0]);
 #endif
   } // while
-  if(pad)
-    strOutput.resize(strOutput.size()-pad);
+  if (pad)
+    strOutput.resize(strOutput.size() - pad);
 
   return 1;
 }
@@ -517,53 +513,44 @@ Copyright 2001-2002 Randy Charles Morin
 The Encode static method takes an array of 8-bit values and returns a base-64 stream.
 */
 
-
-std::string Base64Encode (const std::string& vby)
+std::string Base64Encode(const std::string& vby)
 {
   std::string retval;
-  if (vby.size () == 0)
-    {
-      return retval;
+  if (vby.size() == 0) {
+    return retval;
+  };
+  for (unsigned int i = 0; i < vby.size(); i += 3) {
+    unsigned char by1 = 0, by2 = 0, by3 = 0;
+    by1 = vby[i];
+    if (i + 1 < vby.size()) {
+      by2 = vby[i + 1];
     };
-  for (unsigned int i = 0; i < vby.size (); i += 3)
-    {
-      unsigned char by1 = 0, by2 = 0, by3 = 0;
-      by1 = vby[i];
-      if (i + 1 < vby.size ())
-        {
-          by2 = vby[i + 1];
-        };
-      if (i + 2 < vby.size ())
-        {
-          by3 = vby[i + 2];
-        }
-      unsigned char by4 = 0, by5 = 0, by6 = 0, by7 = 0;
-      by4 = by1 >> 2;
-      by5 = ((by1 & 0x3) << 4) | (by2 >> 4);
-      by6 = ((by2 & 0xf) << 2) | (by3 >> 6);
-      by7 = by3 & 0x3f;
-      retval += B64Encode1 (by4);
-      retval += B64Encode1 (by5);
-      if (i + 1 < vby.size ())
-        {
-          retval += B64Encode1 (by6);
-        }
-      else
-        {
-          retval += "=";
-        };
-      if (i + 2 < vby.size ())
-        {
-          retval += B64Encode1 (by7);
-        }
-      else
-        {
-          retval += "=";
-        };
-      /*      if ((i % (76 / 4 * 3)) == 0)
-        {
-          retval += "\r\n";
-          }*/
+    if (i + 2 < vby.size()) {
+      by3 = vby[i + 2];
+    }
+    unsigned char by4 = 0, by5 = 0, by6 = 0, by7 = 0;
+    by4 = by1 >> 2;
+    by5 = ((by1 & 0x3) << 4) | (by2 >> 4);
+    by6 = ((by2 & 0xf) << 2) | (by3 >> 6);
+    by7 = by3 & 0x3f;
+    retval += B64Encode1(by4);
+    retval += B64Encode1(by5);
+    if (i + 1 < vby.size()) {
+      retval += B64Encode1(by6);
+    }
+    else {
+      retval += "=";
     };
+    if (i + 2 < vby.size()) {
+      retval += B64Encode1(by7);
+    }
+    else {
+      retval += "=";
+    };
+    /*      if ((i % (76 / 4 * 3)) == 0)
+      {
+        retval += "\r\n";
+        }*/
+  };
   return retval;
 };

--- a/pdns/dnsdistdist/docs/guides/console.rst
+++ b/pdns/dnsdistdist/docs/guides/console.rst
@@ -11,9 +11,9 @@ The console can be enabled with :func:`controlSocket`:
 
   controlSocket('192.0.2.53:5199')
 
-Enabling the console without encryption enabled is not recommended. Note that encryption requires building dnsdist with libsodium support enabled.
+Enabling the console without encryption enabled is not recommended. Note that encryption requires building dnsdist with either libsodium or libcrypto support enabled.
 
-Once you have a libsodium-enabled dnsdist, the first step to enable encryption is to generate a key with :func:`makeKey`::
+Once you have a console-enabled dnsdist, the first step to enable encryption is to generate a key with :func:`makeKey`::
 
   $ ./dnsdist -l 127.0.0.1:5300
   [..]

--- a/pdns/dnsdistdist/docs/manpages/dnsdist.1.rst
+++ b/pdns/dnsdistdist/docs/manpages/dnsdist.1.rst
@@ -58,7 +58,7 @@ Options
                                        that is used on the server (set with **setKey()**). Note that this
                                        will leak the key into your shell's history and into the systems
                                        running process list. Only available when dnsdist is compiled with
-                                       libsodium support.
+                                       libsodium or libcrypto support.
 -e, --execute <command>                Connect to dnsdist and execute *command*.
 -h, --help                             Display a helpful message and exit.
 -l, --local <address>                  Bind to *address*, Supply as many addresses (using multiple

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -28,7 +28,6 @@
 #include "dolog.hh"
 #include "iputils.hh"
 #include "misc.hh"
-#include "sodcrypto.hh"
 #include "sstuff.hh"
 #include "threadname.hh"
 #include "base64.hh"

--- a/pdns/dnsdistdist/doq-common.hh
+++ b/pdns/dnsdistdist/doq-common.hh
@@ -32,9 +32,9 @@
 
 #include "dolog.hh"
 #include "noinitvector.hh"
-#include "sodcrypto.hh"
 #include "sstuff.hh"
 #include "libssl.hh"
+#include "dnsdist-crypto.hh"
 
 namespace dnsdist::doq
 {
@@ -71,7 +71,7 @@ enum class DOQ_Error_Codes : uint64_t
   DOQ_UNSPECIFIED_ERROR = 5
 };
 
-static constexpr size_t MAX_TOKEN_LEN = dnsdist::crypto::authenticated::getEncryptedSize(std::tuple_size<decltype(SodiumNonce::value)>{} /* nonce */ + sizeof(uint64_t) /* TTD */ + 16 /* IPv6 */ + QUICHE_MAX_CONN_ID_LEN);
+static constexpr size_t MAX_TOKEN_LEN = dnsdist::crypto::authenticated::getEncryptedSize(std::tuple_size<decltype(dnsdist::crypto::authenticated::Nonce::value)>{} /* nonce */ + sizeof(uint64_t) /* TTD */ + 16 /* IPv6 */ + QUICHE_MAX_CONN_ID_LEN);
 static constexpr size_t MAX_DATAGRAM_SIZE = 1200;
 static constexpr size_t LOCAL_CONN_ID_LEN = 16;
 static constexpr std::array<uint8_t, 4> DOQ_ALPN{'\x03', 'd', 'o', 'q'};

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -28,7 +28,6 @@
 #include "dolog.hh"
 #include "iputils.hh"
 #include "misc.hh"
-#include "sodcrypto.hh"
 #include "sstuff.hh"
 #include "threadname.hh"
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to fall back to plain-text for console communications when libsodium was not available, which was not great. Now that we are also using the authenticated encryption module to secure our QUIC tokens, let's fall back to OpenSSL's Chacha20 Poly 1305 implementation instead.
Note that, unfortunately, both implementations are not compatible so the console communication format will be different depending on whether libsodium is available. I believe this is still better than plain-text :)

I'm renaming `sodcrypto.cc` and `sodcrypto.hh` in the process and GitHub is unfortunately not handling that very well, so it might be easier to review the diff in a different tool, sorry about that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
