### PR TITLE
Updated upgrading guide to add a note the DNSSEC defaults changed in version 4.5.0

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -153,6 +153,7 @@ Changed defaults
 - The default value of the :ref:`setting-max-nsec3-iterations` option has been changed from ``500`` to ``100``.
 - The default value of the ``timeout`` parameter for :func:`ifportup` and :func:`ifurlup` functions has been changed from ``1`` to ``2`` seconds.
 - The default value of the new :ref:`setting-zone-cache-refresh-interval` option is ``300``.
+- The default mode for DNSSEC  from :ref:`process-no-validate` to :ref:`process`
 
 Zone cache
 ~~~~~~~~~~


### PR DESCRIPTION
### Short description
The [Upgrading guide](https://doc.powerdns.com/recursor/upgrade.html) to add a note the DNSSEC defaults changed in version 4.5.0.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
