### PR TITLE
rec: allow out-of-tree builds

### DIFF
--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -1,7 +1,7 @@
-JSON11_LIBS = $(top_srcdir)/ext/json11/libjson11.la
-PROBDS_LIBS = $(top_srcdir)/ext/probds/libprobds.la
-ARC4RANDOM_LIBS = $(top_srcdir)/ext/arc4random/libarc4random.la
-RUST_LIBS = $(top_srcdir)/settings/rust/libsettings.a $(LIBDL)
+JSON11_LIBS = $(top_builddir)/ext/json11/libjson11.la
+PROBDS_LIBS = $(top_builddir)/ext/probds/libprobds.la
+ARC4RANDOM_LIBS = $(top_builddir)/ext/arc4random/libarc4random.la
+RUST_LIBS = $(top_builddir)/settings/rust/libsettings.a $(LIBDL)
 
 AM_CPPFLAGS = $(LUA_CFLAGS) $(YAHTTP_CFLAGS) $(BOOST_CPPFLAGS) $(LIBSODIUM_CFLAGS) $(NET_SNMP_CFLAGS) $(LIBCAP_CFLAGS) $(SANITIZER_FLAGS) -O3 -Wall -pthread -DSYSCONFDIR=\"${sysconfdir}\" $(SYSTEMD_CFLAGS)
 
@@ -12,6 +12,8 @@ endif
 AM_CPPFLAGS += \
 	-I$(top_srcdir)/ext/json11 \
 	-I$(top_srcdir)/ext/protozero/include \
+	-I$(top_srcdir)/settings \
+	-I$(top_builddir)/settings \
 	$(YAHTTP_CFLAGS) \
 	$(LIBCRYPTO_INCLUDES) \
 	-DBOOST_CONTAINER_USE_STD_EXCEPTIONS
@@ -41,8 +43,9 @@ BUILT_SOURCES=htmlfiles.h \
 CLEANFILES = htmlfiles.h \
 	recursor.conf-dist recursor.yml-dist
 
-htmlfiles.h: incfiles html/* html/js/*
-	./incfiles > $@
+htmlfiles.h: incfiles ${srcdir}/html/* ${srcdir}/html/js/*
+	$(AM_V_GEN)$(srcdir)/incfiles > $@.tmp
+	@mv $@.tmp $@
 
 # We explicitly build settings in two steps, as settings modifies files in the settings/rust subdir
 SUBDIRS=ext settings settings/rust
@@ -525,7 +528,7 @@ $(srcdir)/effective_tld_names.dat:
 	$(curl_verbose)if ! curl -s -S https://publicsuffix.org/list/public_suffix_list.dat > $@; then rm -f $@; exit 1; fi
 
 pubsuffix.cc: $(srcdir)/effective_tld_names.dat
-	$(AM_V_GEN)./mkpubsuffixcc
+	$(srcdir)/mkpubsuffixcc $< $@
 
 ## Config file
 sysconf_DATA = recursor.conf-dist recursor.yml-dist
@@ -545,13 +548,13 @@ dist_man_MANS=$(MANPAGES)
 if HAVE_VENV
 if !HAVE_MANPAGES
 $(MANPAGES): %: docs/manpages/%.rst .venv
-	.venv/bin/python -msphinx -b man docs . $<
+	$(builddir)/.venv/bin/python -msphinx -b man "$(srcdir)/docs" "$(builddir)" $<
 endif # if !HAVE_MANPAGES
 
 .venv: docs/requirements.txt
 	$(PYTHON) -m venv .venv
 	.venv/bin/pip install -U pip setuptools setuptools-git wheel
-	.venv/bin/pip install -r docs/requirements.txt
+	.venv/bin/pip install -r ${top_srcdir}/docs/requirements.txt
 
 html-docs: docs/** .venv
 	.venv/bin/python -msphinx -b html docs html-docs

--- a/pdns/recursordist/mkpubsuffixcc
+++ b/pdns/recursordist/mkpubsuffixcc
@@ -1,8 +1,12 @@
 #!/bin/sh
-
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 effective_tld_names.dat pubsuffix.cc"
+  exit 1
+fi
+set -e
 (echo "const char* g_pubsuffix[]={"; 
-	for a in $(grep -v "//" effective_tld_names.dat  | grep \\. | egrep "^[.0-9a-z-]*$")
+	for a in $(grep -v "//" "$1" | grep \\. | egrep "^[.0-9a-z-]*$")
 	do 
 		echo \"$a\",
 	done 
-echo "0};") > pubsuffix.cc
+echo "0};") > "$2"

--- a/pdns/recursordist/settings/Makefile.am
+++ b/pdns/recursordist/settings/Makefile.am
@@ -23,7 +23,7 @@ BUILT_SOURCES=cxxsettings-generated.cc rust/src/lib.rs
 # Use patterns to avoid having two instances of generate run simultaneously, a well-known hack for GNU make
 cxxsettings-generated%cc rust/src/lib%rs: table.py generate.py rust-preamble-in.rs rust-bridge-in.rs docs-old-preamble-in.rst docs-new-preamble-in.rst
 	$(MAKE) -C rust clean
-	$(PYTHON) generate.py
+	(cd ${srcdir} && $(PYTHON) generate.py)
 
 clean-local:
 	rm -f cxxsettings-generated.cc rust/src/lib.rs

--- a/pdns/recursordist/settings/rust/Makefile.am
+++ b/pdns/recursordist/settings/rust/Makefile.am
@@ -11,7 +11,7 @@ EXTRA_DIST = \
 
 # should actually end up in a target specific dir...
 libsettings.a lib.rs.h: src/bridge.rs src/lib.rs src/helpers.rs Cargo.toml Cargo.lock build.rs
-	SYSCONFDIR=$(sysconfdir) NODCACHEDIRNOD=$(localstatedir)/nod NODCACHEDIRUDR=$(localstatedir)/udr $(CARGO) build --release $(RUST_TARGET)
+	SYSCONFDIR=$(sysconfdir) NODCACHEDIRNOD=$(localstatedir)/nod NODCACHEDIRUDR=$(localstatedir)/udr $(CARGO) build --release $(RUST_TARGET) --target-dir=$(builddir)/target --manifest-path ${srcdir}/Cargo.toml
 	cp target/$(RUSTC_TARGET_ARCH)/release/libsettings.a libsettings.a
 	cp target/$(RUSTC_TARGET_ARCH)/cxxbridge/settings/src/lib.rs.h lib.rs.h
 	cp target/$(RUSTC_TARGET_ARCH)/cxxbridge/rust/cxx.h cxx.h


### PR DESCRIPTION
### Short description
Allow building recursor with autoconf in a separate build dir.

The codegen for the rust parts is not 100% clean: it writes two files into the srcdir. But it does build.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
