### PR TITLE
Fix vector list formatting in `ws-auth.cc`

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -960,7 +960,8 @@ static bool isValidMetadataKind(const string& kind, bool readonly)
     "SLAVE-RENOTIFY",
     "SOA-EDIT",
     "TSIG-ALLOW-AXFR",
-    "TSIG-ALLOW-DNSUPDATE"};
+    "TSIG-ALLOW-DNSUPDATE",
+  };
 
   // the following options do not allow modifications via API
   static vector<string> protectedOptions{
@@ -970,7 +971,8 @@ static bool isValidMetadataKind(const string& kind, bool readonly)
     "NSEC3PARAM",
     "PRESIGNED",
     "LUA-AXFR-SCRIPT",
-    "TSIG-ALLOW-AXFR"};
+    "TSIG-ALLOW-AXFR",
+  };
 
   if (kind.find("X-") == 0) {
     return true;


### PR DESCRIPTION
### Short description
When using a comma after the last element, `clang-format` is forced to put the closing brace on a separate line. This also improves the readability of future diffs.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
