### PR TITLE
dnsdist: Optimize the DoQ packet handling path

### DIFF
--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -813,7 +813,7 @@ static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientStat
     if (!sock.recvFromAsync(buffer, client) || buffer.empty()) {
       return;
     }
-    DEBUGLOG("Received DoH3 datagram of size "<<buffer.size()<<" from "<<client.toStringWithPort());
+    DEBUGLOG("Received DoH3 datagram of size " << buffer.size() << " from " << client.toStringWithPort());
 
     uint32_t version{0};
     uint8_t type{0};

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -805,6 +805,104 @@ static void processH3Events(ClientState& clientState, DOH3Frontend& frontend, H3
   }
 }
 
+static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientState, Socket& sock)
+{
+  DEBUGLOG("Received datagram");
+  std::string bufferStr;
+  ComboAddress client;
+  sock.recvFrom(bufferStr, client);
+
+  uint32_t version{0};
+  uint8_t type{0};
+  std::array<uint8_t, QUICHE_MAX_CONN_ID_LEN> scid{};
+  size_t scid_len = scid.size();
+  std::array<uint8_t, QUICHE_MAX_CONN_ID_LEN> dcid{};
+  size_t dcid_len = dcid.size();
+  std::array<uint8_t, MAX_TOKEN_LEN> token{};
+  size_t token_len = token.size();
+
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto res = quiche_header_info(reinterpret_cast<const uint8_t*>(bufferStr.data()), bufferStr.size(), LOCAL_CONN_ID_LEN,
+                                &version, &type,
+                                scid.data(), &scid_len,
+                                dcid.data(), &dcid_len,
+                                token.data(), &token_len);
+  if (res != 0) {
+    DEBUGLOG("Error in quiche_header_info: " << res);
+    return;
+  }
+
+  // destination connection ID, will have to be sent as original destination connection ID
+  PacketBuffer serverConnID(dcid.begin(), dcid.begin() + dcid_len);
+  // source connection ID, will have to be sent as destination connection ID
+  PacketBuffer clientConnID(scid.begin(), scid.begin() + scid_len);
+  auto conn = getConnection(frontend.d_server_config->d_connections, serverConnID);
+
+  if (!conn) {
+    DEBUGLOG("Connection not found");
+    if (!quiche_version_is_supported(version)) {
+      DEBUGLOG("Unsupported version");
+      ++frontend.d_doh3UnsupportedVersionErrors;
+      handleVersionNegociation(sock, clientConnID, serverConnID, client);
+      return;
+    }
+
+    if (token_len == 0) {
+      /* stateless retry */
+      DEBUGLOG("No token received");
+      handleStatelessRetry(sock, clientConnID, serverConnID, client, version);
+      return;
+    }
+
+    PacketBuffer tokenBuf(token.begin(), token.begin() + token_len);
+    auto originalDestinationID = validateToken(tokenBuf, client);
+    if (!originalDestinationID) {
+      ++frontend.d_doh3InvalidTokensReceived;
+      DEBUGLOG("Discarding invalid token");
+      return;
+    }
+
+    DEBUGLOG("Creating a new connection");
+    conn = createConnection(*frontend.d_server_config, serverConnID, *originalDestinationID, clientState.local, client);
+    if (!conn) {
+      return;
+    }
+  }
+  DEBUGLOG("Connection found");
+  quiche_recv_info recv_info = {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    reinterpret_cast<struct sockaddr*>(&client),
+    client.getSocklen(),
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    reinterpret_cast<struct sockaddr*>(&clientState.local),
+    clientState.local.getSocklen(),
+  };
+
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto done = quiche_conn_recv(conn->get().d_conn.get(), reinterpret_cast<uint8_t*>(bufferStr.data()), bufferStr.size(), &recv_info);
+  if (done < 0) {
+    return;
+  }
+
+  if (quiche_conn_is_established(conn->get().d_conn.get())) {
+    DEBUGLOG("Connection is established");
+
+    if (!conn->get().d_http3) {
+      conn->get().d_http3 = QuicheHTTP3Connection(quiche_h3_conn_new_with_transport(conn->get().d_conn.get(), frontend.d_server_config->http3config.get()),
+                                                  quiche_h3_conn_free);
+      if (!conn->get().d_http3) {
+        return;
+      }
+      DEBUGLOG("Successfully created HTTP/3 connection");
+    }
+
+    processH3Events(clientState, frontend, conn->get(), client, serverConnID);
+  }
+  else {
+    DEBUGLOG("Connection not established");
+  }
+}
+
 // this is the entrypoint from dnsdist.cc
 void doh3Thread(ClientState* clientState)
 {
@@ -828,100 +926,7 @@ void doh3Thread(ClientState* clientState)
       mplexer->getAvailableFDs(readyFDs, 500);
 
       if (std::find(readyFDs.begin(), readyFDs.end(), sock.getHandle()) != readyFDs.end()) {
-        DEBUGLOG("Received datagram");
-        std::string bufferStr;
-        ComboAddress client;
-        sock.recvFrom(bufferStr, client);
-
-        uint32_t version{0};
-        uint8_t type{0};
-        std::array<uint8_t, QUICHE_MAX_CONN_ID_LEN> scid{};
-        size_t scid_len = scid.size();
-        std::array<uint8_t, QUICHE_MAX_CONN_ID_LEN> dcid{};
-        size_t dcid_len = dcid.size();
-        std::array<uint8_t, MAX_TOKEN_LEN> token{};
-        size_t token_len = token.size();
-
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        auto res = quiche_header_info(reinterpret_cast<const uint8_t*>(bufferStr.data()), bufferStr.size(), LOCAL_CONN_ID_LEN,
-                                      &version, &type,
-                                      scid.data(), &scid_len,
-                                      dcid.data(), &dcid_len,
-                                      token.data(), &token_len);
-        if (res != 0) {
-          DEBUGLOG("Error in quiche_header_info: " << res);
-          continue;
-        }
-
-        // destination connection ID, will have to be sent as original destination connection ID
-        PacketBuffer serverConnID(dcid.begin(), dcid.begin() + dcid_len);
-        // source connection ID, will have to be sent as destination connection ID
-        PacketBuffer clientConnID(scid.begin(), scid.begin() + scid_len);
-        auto conn = getConnection(frontend->d_server_config->d_connections, serverConnID);
-
-        if (!conn) {
-          DEBUGLOG("Connection not found");
-          if (!quiche_version_is_supported(version)) {
-            DEBUGLOG("Unsupported version");
-            ++frontend->d_doh3UnsupportedVersionErrors;
-            handleVersionNegociation(sock, clientConnID, serverConnID, client);
-            continue;
-          }
-
-          if (token_len == 0) {
-            /* stateless retry */
-            DEBUGLOG("No token received");
-            handleStatelessRetry(sock, clientConnID, serverConnID, client, version);
-            continue;
-          }
-
-          PacketBuffer tokenBuf(token.begin(), token.begin() + token_len);
-          auto originalDestinationID = validateToken(tokenBuf, client);
-          if (!originalDestinationID) {
-            ++frontend->d_doh3InvalidTokensReceived;
-            DEBUGLOG("Discarding invalid token");
-            continue;
-          }
-
-          DEBUGLOG("Creating a new connection");
-          conn = createConnection(*frontend->d_server_config, serverConnID, *originalDestinationID, clientState->local, client);
-          if (!conn) {
-            continue;
-          }
-        }
-        DEBUGLOG("Connection found");
-        quiche_recv_info recv_info = {
-          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-          reinterpret_cast<struct sockaddr*>(&client),
-          client.getSocklen(),
-          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-          reinterpret_cast<struct sockaddr*>(&clientState->local),
-          clientState->local.getSocklen(),
-        };
-
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        auto done = quiche_conn_recv(conn->get().d_conn.get(), reinterpret_cast<uint8_t*>(bufferStr.data()), bufferStr.size(), &recv_info);
-        if (done < 0) {
-          continue;
-        }
-
-        if (quiche_conn_is_established(conn->get().d_conn.get())) {
-          DEBUGLOG("Connection is established");
-
-          if (!conn->get().d_http3) {
-            conn->get().d_http3 = QuicheHTTP3Connection(quiche_h3_conn_new_with_transport(conn->get().d_conn.get(), frontend->d_server_config->http3config.get()),
-                                                        quiche_h3_conn_free);
-            if (!conn->get().d_http3) {
-              continue;
-            }
-            DEBUGLOG("Successfully created HTTP/3 connection");
-          }
-
-          processH3Events(*clientState, *frontend, conn->get(), client, serverConnID);
-        }
-        else {
-          DEBUGLOG("Connection not established");
-        }
+        handleSocketReadable(*frontend, *clientState, sock);
       }
 
       if (std::find(readyFDs.begin(), readyFDs.end(), responseReceiverFD) != readyFDs.end()) {

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -805,15 +805,15 @@ static void processH3Events(ClientState& clientState, DOH3Frontend& frontend, H3
   }
 }
 
-static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientState, Socket& sock)
+static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientState, Socket& sock, PacketBuffer& buffer)
 {
   while (true) {
-    DEBUGLOG("Received datagram");
-    std::string bufferStr;
     ComboAddress client;
-    if (!sock.recvFromAsync(bufferStr, client) || bufferStr.size() == 0) {
+    buffer.resize(4096);
+    if (!sock.recvFromAsync(buffer, client) || buffer.size() == 0) {
       return;
     }
+    DEBUGLOG("Received DoH3 datagram of size "<<buffer.size()<<" from "<<client.toStringWithPort());
 
     uint32_t version{0};
     uint8_t type{0};
@@ -824,8 +824,7 @@ static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientStat
     std::array<uint8_t, MAX_TOKEN_LEN> token{};
     size_t token_len = token.size();
 
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    auto res = quiche_header_info(reinterpret_cast<const uint8_t*>(bufferStr.data()), bufferStr.size(), LOCAL_CONN_ID_LEN,
+    auto res = quiche_header_info(buffer.data(), buffer.size(), LOCAL_CONN_ID_LEN,
                                   &version, &type,
                                   scid.data(), &scid_len,
                                   dcid.data(), &dcid_len,
@@ -881,8 +880,7 @@ static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientStat
       clientState.local.getSocklen(),
     };
 
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    auto done = quiche_conn_recv(conn->get().d_conn.get(), reinterpret_cast<uint8_t*>(bufferStr.data()), bufferStr.size(), &recv_info);
+    auto done = quiche_conn_recv(conn->get().d_conn.get(), buffer.data(), buffer.size(), &recv_info);
     if (done < 0) {
       continue;
     }
@@ -927,13 +925,14 @@ void doh3Thread(ClientState* clientState)
     mplexer->addReadFD(sock.getHandle(), [](int, FDMultiplexer::funcparam_t&) {});
     mplexer->addReadFD(responseReceiverFD, [](int, FDMultiplexer::funcparam_t&) {});
     std::vector<int> readyFDs;
+    PacketBuffer buffer(4096);
     while (true) {
       readyFDs.clear();
       mplexer->getAvailableFDs(readyFDs, 500);
 
       try {
         if (std::find(readyFDs.begin(), readyFDs.end(), sock.getHandle()) != readyFDs.end()) {
-          handleSocketReadable(*frontend, *clientState, sock);
+          handleSocketReadable(*frontend, *clientState, sock, buffer);
         }
 
         if (std::find(readyFDs.begin(), readyFDs.end(), responseReceiverFD) != readyFDs.end()) {
@@ -953,7 +952,7 @@ void doh3Thread(ClientState* clientState)
             quiche_conn_stats(conn->second.d_conn.get(), &stats);
             quiche_conn_path_stats(conn->second.d_conn.get(), 0, &path_stats);
 
-            DEBUGLOG("Connection closed, recv=" << stats.recv << " sent=" << stats.sent << " lost=" << stats.lost << " rtt=" << path_stats.rtt << "ns cwnd=" << path_stats.cwnd);
+            DEBUGLOG("Connection (DoH3) closed, recv=" << stats.recv << " sent=" << stats.sent << " lost=" << stats.lost << " rtt=" << path_stats.rtt << "ns cwnd=" << path_stats.cwnd);
 #endif
             conn = frontend->d_server_config->d_connections.erase(conn);
           }

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -885,7 +885,7 @@ static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientStat
       continue;
     }
 
-    if (quiche_conn_is_established(conn->get().d_conn.get())) {
+    if (quiche_conn_is_established(conn->get().d_conn.get()) || quiche_conn_is_in_early_data(conn->get().d_conn.get())) {
       DEBUGLOG("Connection is established");
 
       if (!conn->get().d_http3) {

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -810,7 +810,7 @@ static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientStat
   while (true) {
     ComboAddress client;
     buffer.resize(4096);
-    if (!sock.recvFromAsync(buffer, client) || buffer.size() == 0) {
+    if (!sock.recvFromAsync(buffer, client) || buffer.empty()) {
       return;
     }
     DEBUGLOG("Received DoH3 datagram of size "<<buffer.size()<<" from "<<client.toStringWithPort());

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -898,6 +898,8 @@ static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientStat
       }
 
       processH3Events(clientState, frontend, conn->get(), client, serverConnID);
+
+      flushEgress(sock, conn->get().d_conn, client);
     }
     else {
       DEBUGLOG("Connection not established");

--- a/pdns/dnsdistdist/doq-common.hh
+++ b/pdns/dnsdistdist/doq-common.hh
@@ -81,9 +81,9 @@ void fillRandom(PacketBuffer& buffer, size_t size);
 std::optional<PacketBuffer> getCID();
 PacketBuffer mintToken(const PacketBuffer& dcid, const ComboAddress& peer);
 std::optional<PacketBuffer> validateToken(const PacketBuffer& token, const ComboAddress& peer);
-void handleStatelessRetry(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, uint32_t version);
-void handleVersionNegociation(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer);
-void flushEgress(Socket& sock, QuicheConnection& conn, const ComboAddress& peer);
+void handleStatelessRetry(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, uint32_t version, PacketBuffer& buffer);
+void handleVersionNegociation(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, PacketBuffer& buffer);
+void flushEgress(Socket& sock, QuicheConnection& conn, const ComboAddress& peer, PacketBuffer& buffer);
 void configureQuiche(QuicheConfig& config, const QuicheParams& params);
 
 };

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -634,7 +634,7 @@ static void handleSocketReadable(DOQFrontend& frontend, ClientState& clientState
     if (!sock.recvFromAsync(buffer, client) || buffer.empty()) {
       return;
     }
-    DEBUGLOG("Received DoQ datagram of size "<<buffer.size()<<" from "<<client.toStringWithPort());
+    DEBUGLOG("Received DoQ datagram of size " << buffer.size() << " from " << client.toStringWithPort());
 
     uint32_t version{0};
     uint8_t type{0};

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -628,93 +628,97 @@ static void handleReadableStream(DOQFrontend& frontend, ClientState& clientState
 
 static void handleSocketReadable(DOQFrontend& frontend, ClientState& clientState, Socket& sock)
 {
-  DEBUGLOG("Received datagram");
-  std::string bufferStr;
-  ComboAddress client;
-  sock.recvFrom(bufferStr, client);
-
-  uint32_t version{0};
-  uint8_t type{0};
-  std::array<uint8_t, QUICHE_MAX_CONN_ID_LEN> scid{};
-  size_t scid_len = scid.size();
-  std::array<uint8_t, QUICHE_MAX_CONN_ID_LEN> dcid{};
-  size_t dcid_len = dcid.size();
-  std::array<uint8_t, MAX_TOKEN_LEN> token{};
-  size_t token_len = token.size();
-
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  auto res = quiche_header_info(reinterpret_cast<const uint8_t*>(bufferStr.data()), bufferStr.size(), LOCAL_CONN_ID_LEN,
-                                &version, &type,
-                                scid.data(), &scid_len,
-                                dcid.data(), &dcid_len,
-                                token.data(), &token_len);
-  if (res != 0) {
-    DEBUGLOG("Error in quiche_header_info: " << res);
-    return;
-  }
-
-  // destination connection ID, will have to be sent as original destination connection ID
-  PacketBuffer serverConnID(dcid.begin(), dcid.begin() + dcid_len);
-  // source connection ID, will have to be sent as destination connection ID
-  PacketBuffer clientConnID(scid.begin(), scid.begin() + scid_len);
-  auto conn = getConnection(frontend.d_server_config->d_connections, serverConnID);
-
-  if (!conn) {
-    DEBUGLOG("Connection not found");
-    if (!quiche_version_is_supported(version)) {
-      DEBUGLOG("Unsupported version");
-      ++frontend.d_doqUnsupportedVersionErrors;
-      handleVersionNegociation(sock, clientConnID, serverConnID, client);
+  while (true) {
+    DEBUGLOG("Received datagram");
+    std::string bufferStr;
+    ComboAddress client;
+    if (!sock.recvFromAsync(bufferStr, client) || bufferStr.size() == 0) {
       return;
     }
 
-    if (token_len == 0) {
-      /* stateless retry */
-      DEBUGLOG("No token received");
-      handleStatelessRetry(sock, clientConnID, serverConnID, client, version);
-      return;
+    uint32_t version{0};
+    uint8_t type{0};
+    std::array<uint8_t, QUICHE_MAX_CONN_ID_LEN> scid{};
+    size_t scid_len = scid.size();
+    std::array<uint8_t, QUICHE_MAX_CONN_ID_LEN> dcid{};
+    size_t dcid_len = dcid.size();
+    std::array<uint8_t, MAX_TOKEN_LEN> token{};
+    size_t token_len = token.size();
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto res = quiche_header_info(reinterpret_cast<const uint8_t*>(bufferStr.data()), bufferStr.size(), LOCAL_CONN_ID_LEN,
+                                  &version, &type,
+                                  scid.data(), &scid_len,
+                                  dcid.data(), &dcid_len,
+                                  token.data(), &token_len);
+    if (res != 0) {
+      DEBUGLOG("Error in quiche_header_info: " << res);
+      continue;
     }
 
-    PacketBuffer tokenBuf(token.begin(), token.begin() + token_len);
-    auto originalDestinationID = validateToken(tokenBuf, client);
-    if (!originalDestinationID) {
-      ++frontend.d_doqInvalidTokensReceived;
-      DEBUGLOG("Discarding invalid token");
-      return;
-    }
+    // destination connection ID, will have to be sent as original destination connection ID
+    PacketBuffer serverConnID(dcid.begin(), dcid.begin() + dcid_len);
+    // source connection ID, will have to be sent as destination connection ID
+    PacketBuffer clientConnID(scid.begin(), scid.begin() + scid_len);
+    auto conn = getConnection(frontend.d_server_config->d_connections, serverConnID);
 
-    DEBUGLOG("Creating a new connection");
-    conn = createConnection(*frontend.d_server_config, serverConnID, *originalDestinationID, clientState.local, client);
     if (!conn) {
-      return;
+      DEBUGLOG("Connection not found");
+      if (!quiche_version_is_supported(version)) {
+        DEBUGLOG("Unsupported version");
+        ++frontend.d_doqUnsupportedVersionErrors;
+        handleVersionNegociation(sock, clientConnID, serverConnID, client);
+        continue;
+      }
+
+      if (token_len == 0) {
+        /* stateless retry */
+        DEBUGLOG("No token received");
+        handleStatelessRetry(sock, clientConnID, serverConnID, client, version);
+        continue;
+      }
+
+      PacketBuffer tokenBuf(token.begin(), token.begin() + token_len);
+      auto originalDestinationID = validateToken(tokenBuf, client);
+      if (!originalDestinationID) {
+        ++frontend.d_doqInvalidTokensReceived;
+        DEBUGLOG("Discarding invalid token");
+        continue;
+      }
+
+      DEBUGLOG("Creating a new connection");
+      conn = createConnection(*frontend.d_server_config, serverConnID, *originalDestinationID, clientState.local, client);
+      if (!conn) {
+        continue;
+      }
     }
-  }
-  DEBUGLOG("Connection found");
-  quiche_recv_info recv_info = {
+    DEBUGLOG("Connection found");
+    quiche_recv_info recv_info = {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      reinterpret_cast<struct sockaddr*>(&client),
+      client.getSocklen(),
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      reinterpret_cast<struct sockaddr*>(&clientState.local),
+      clientState.local.getSocklen(),
+    };
+
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    reinterpret_cast<struct sockaddr*>(&client),
-    client.getSocklen(),
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    reinterpret_cast<struct sockaddr*>(&clientState.local),
-    clientState.local.getSocklen(),
-  };
-
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  auto done = quiche_conn_recv(conn->get().d_conn.get(), reinterpret_cast<uint8_t*>(bufferStr.data()), bufferStr.size(), &recv_info);
-  if (done < 0) {
-    return;
-  }
-
-  if (quiche_conn_is_established(conn->get().d_conn.get())) {
-    auto readable = std::unique_ptr<quiche_stream_iter, decltype(&quiche_stream_iter_free)>(quiche_conn_readable(conn->get().d_conn.get()), quiche_stream_iter_free);
-
-    uint64_t streamID = 0;
-    while (quiche_stream_iter_next(readable.get(), &streamID)) {
-      handleReadableStream(frontend, clientState, *conn, streamID, client, serverConnID);
+    auto done = quiche_conn_recv(conn->get().d_conn.get(), reinterpret_cast<uint8_t*>(bufferStr.data()), bufferStr.size(), &recv_info);
+    if (done < 0) {
+      continue;
     }
-  }
-  else {
-    DEBUGLOG("Connection not established");
+
+    if (quiche_conn_is_established(conn->get().d_conn.get())) {
+      auto readable = std::unique_ptr<quiche_stream_iter, decltype(&quiche_stream_iter_free)>(quiche_conn_readable(conn->get().d_conn.get()), quiche_stream_iter_free);
+
+      uint64_t streamID = 0;
+      while (quiche_stream_iter_next(readable.get(), &streamID)) {
+        handleReadableStream(frontend, clientState, *conn, streamID, client, serverConnID);
+      }
+    }
+    else {
+      DEBUGLOG("Connection not established");
+    }
   }
 }
 
@@ -730,50 +734,60 @@ void doqThread(ClientState* clientState)
     setThreadName("dnsdist/doq");
 
     Socket sock(clientState->udpFD);
+    sock.setNonBlocking();
 
     auto mplexer = std::unique_ptr<FDMultiplexer>(FDMultiplexer::getMultiplexerSilent());
 
     auto responseReceiverFD = frontend->d_server_config->d_responseReceiver.getDescriptor();
     mplexer->addReadFD(sock.getHandle(), [](int, FDMultiplexer::funcparam_t&) {});
     mplexer->addReadFD(responseReceiverFD, [](int, FDMultiplexer::funcparam_t&) {});
+    std::vector<int> readyFDs;
     while (true) {
-      std::vector<int> readyFDs;
+      readyFDs.clear();
       mplexer->getAvailableFDs(readyFDs, 500);
 
-      if (std::find(readyFDs.begin(), readyFDs.end(), sock.getHandle()) != readyFDs.end()) {
-        handleSocketReadable(*frontend, *clientState, sock);
-      }
+      try {
+        if (std::find(readyFDs.begin(), readyFDs.end(), sock.getHandle()) != readyFDs.end()) {
+          handleSocketReadable(*frontend, *clientState, sock);
+        }
 
-      if (std::find(readyFDs.begin(), readyFDs.end(), responseReceiverFD) != readyFDs.end()) {
-        flushResponses(frontend->d_server_config->d_responseReceiver);
-      }
+        if (std::find(readyFDs.begin(), readyFDs.end(), responseReceiverFD) != readyFDs.end()) {
+          flushResponses(frontend->d_server_config->d_responseReceiver);
+        }
 
-      for (auto conn = frontend->d_server_config->d_connections.begin(); conn != frontend->d_server_config->d_connections.end();) {
-        quiche_conn_on_timeout(conn->second.d_conn.get());
+        for (auto conn = frontend->d_server_config->d_connections.begin(); conn != frontend->d_server_config->d_connections.end();) {
+          quiche_conn_on_timeout(conn->second.d_conn.get());
 
-        flushEgress(sock, conn->second.d_conn, conn->second.d_peer);
+          flushEgress(sock, conn->second.d_conn, conn->second.d_peer);
 
-        if (quiche_conn_is_closed(conn->second.d_conn.get())) {
+          if (quiche_conn_is_closed(conn->second.d_conn.get())) {
 #ifdef DEBUGLOG_ENABLED
-          quiche_stats stats;
-          quiche_path_stats path_stats;
+            quiche_stats stats;
+            quiche_path_stats path_stats;
 
-          quiche_conn_stats(conn->second.d_conn.get(), &stats);
-          quiche_conn_path_stats(conn->second.d_conn.get(), 0, &path_stats);
+            quiche_conn_stats(conn->second.d_conn.get(), &stats);
+            quiche_conn_path_stats(conn->second.d_conn.get(), 0, &path_stats);
 
-          DEBUGLOG("Connection closed, recv=" << stats.recv << " sent=" << stats.sent << " lost=" << stats.lost << " rtt=" << path_stats.rtt << "ns cwnd=" << path_stats.cwnd);
+            DEBUGLOG("Connection closed, recv=" << stats.recv << " sent=" << stats.sent << " lost=" << stats.lost << " rtt=" << path_stats.rtt << "ns cwnd=" << path_stats.cwnd);
 #endif
-          conn = frontend->d_server_config->d_connections.erase(conn);
+            conn = frontend->d_server_config->d_connections.erase(conn);
+          }
+          else {
+            flushStalledResponses(conn->second);
+            ++conn;
+          }
         }
-        else {
-          flushStalledResponses(conn->second);
-          ++conn;
-        }
+      }
+      catch (const std::exception& exp) {
+        vinfolog("Caught exception in the main DoQ thread: %s", exp.what());
+      }
+      catch (...) {
+        vinfolog("Unknown exception in the main DoQ thread");
       }
     }
   }
   catch (const std::exception& e) {
-    DEBUGLOG("Caught fatal error: " << e.what());
+    DEBUGLOG("Caught fatal error in the main DoQ thread: " << e.what());
   }
 }
 

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -713,6 +713,8 @@ static void handleSocketReadable(DOQFrontend& frontend, ClientState& clientState
       while (quiche_stream_iter_next(readable.get(), &streamID)) {
         handleReadableStream(frontend, clientState, *conn, streamID, client, serverConnID);
       }
+
+      flushEgress(sock, conn->get().d_conn, client);
     }
     else {
       DEBUGLOG("Connection not established");

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -593,7 +593,7 @@ static void handleReadableStream(DOQFrontend& frontend, ClientState& clientState
       streamBuffer.resize(existingLength);
       return;
     }
-    else if (received < 0) {
+    if (received < 0) {
       ++dnsdist::metrics::g_stats.nonCompliantQueries;
       ++clientState.nonCompliantQueries;
       quiche_conn_stream_shutdown(conn.d_conn.get(), streamID, QUICHE_SHUTDOWN_WRITE, static_cast<uint64_t>(DOQ_Error_Codes::DOQ_PROTOCOL_ERROR));
@@ -631,7 +631,7 @@ static void handleSocketReadable(DOQFrontend& frontend, ClientState& clientState
   while (true) {
     ComboAddress client;
     buffer.resize(4096);
-    if (!sock.recvFromAsync(buffer, client) || buffer.size() == 0) {
+    if (!sock.recvFromAsync(buffer, client) || buffer.empty()) {
       return;
     }
     DEBUGLOG("Received DoQ datagram of size "<<buffer.size()<<" from "<<client.toStringWithPort());

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -706,7 +706,7 @@ static void handleSocketReadable(DOQFrontend& frontend, ClientState& clientState
       continue;
     }
 
-    if (quiche_conn_is_established(conn->get().d_conn.get())) {
+    if (quiche_conn_is_established(conn->get().d_conn.get()) || quiche_conn_is_in_early_data(conn->get().d_conn.get())) {
       auto readable = std::unique_ptr<quiche_stream_iter, decltype(&quiche_stream_iter_free)>(quiche_conn_readable(conn->get().d_conn.get()), quiche_stream_iter_free);
 
       uint64_t streamID = 0;

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -387,7 +387,7 @@ std::unique_ptr<Socket> s_socket = nullptr;
 static void receiveFromReference()
 try
 {
-  string packet;
+  PacketBuffer packet;
   ComboAddress remote;
   int res=waitForData(s_socket->getHandle(), g_timeoutMsec/1000, 1000*(g_timeoutMsec%1000));
 
@@ -397,7 +397,8 @@ try
   while (s_socket->recvFromAsync(packet, remote)) {
     try {
       s_weanswers++;
-      MOADNSParser mdp(false, packet.c_str(), packet.length());
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      MOADNSParser mdp(false, reinterpret_cast<const char*>(packet.data()), packet.size());
       if(!mdp.d_header.qr) {
         cout<<"Received a question from our reference nameserver!"<<endl;
         continue;

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -394,7 +394,7 @@ try
   if(res < 0 || res==0)
     return;
 
-  while(s_socket->recvFromAsync(packet)) {
+  while (s_socket->recvFromAsync(packet, remote)) {
     try {
       s_weanswers++;
       MOADNSParser mdp(false, packet.c_str(), packet.length());

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -184,19 +184,16 @@ public:
     dgram.assign(d_buffer, 0, static_cast<size_t>(bytes));
   }
 
-  bool recvFromAsync(string &dgram)
+  bool recvFromAsync(string& dgram, ComboAddress& remote)
   {
-    struct sockaddr_in remote;
     socklen_t remlen = sizeof(remote);
-    ssize_t bytes;
     d_buffer.resize(s_buflen);
-    if((bytes=recvfrom(d_socket, &d_buffer[0], s_buflen, 0, reinterpret_cast<sockaddr *>(&remote), &remlen))<0) {
-      if(errno!=EAGAIN) {
-        throw NetworkError("After async recvfrom: "+stringerror());
+    const auto bytes = recvfrom(d_socket, d_buffer.data(), s_buflen, 0, reinterpret_cast<sockaddr *>(&remote), &remlen);
+    if (bytes < 0) {
+      if (errno != EAGAIN) {
+        throw NetworkError("After async recvfrom: " + stringerror());
       }
-      else {
-        return false;
-      }
+      return false;
     }
     dgram.assign(d_buffer, 0, static_cast<size_t>(bytes));
     return true;

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -38,9 +38,9 @@
 #include <boost/utility.hpp>
 #include <csignal>
 #include "namespaces.hh"
+#include "noinitvector.hh"
 
-
-typedef int ProtocolType; //!< Supported protocol types
+using ProtocolType = int; //!< Supported protocol types
 
 //! Representation of a Socket and many of the Berkeley functions available
 class Socket : public boost::noncopyable
@@ -173,54 +173,64 @@ public:
   /** For datagram sockets, receive a datagram and learn where it came from
       \param dgram Will be filled with the datagram
       \param ep Will be filled with the origin of the datagram */
-  void recvFrom(string &dgram, ComboAddress &ep)
-  {
-    socklen_t remlen = sizeof(ep);
-    ssize_t bytes;
-    d_buffer.resize(s_buflen);
-    if((bytes=recvfrom(d_socket, &d_buffer[0], s_buflen, 0, reinterpret_cast<sockaddr *>(&ep) , &remlen)) <0)
-      throw NetworkError("After recvfrom: "+stringerror());
-
-    dgram.assign(d_buffer, 0, static_cast<size_t>(bytes));
-  }
-
-  bool recvFromAsync(string& dgram, ComboAddress& remote)
+  void recvFrom(string &dgram, ComboAddress& remote)
   {
     socklen_t remlen = sizeof(remote);
-    d_buffer.resize(s_buflen);
-    const auto bytes = recvfrom(d_socket, d_buffer.data(), s_buflen, 0, reinterpret_cast<sockaddr *>(&remote), &remlen);
+    if (dgram.size() < s_buflen) {
+      dgram.resize(s_buflen);
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto bytes = recvfrom(d_socket, dgram.data(), dgram.size(), 0, reinterpret_cast<sockaddr *>(&remote) , &remlen);
+    if (bytes < 0) {
+      throw NetworkError("After recvfrom: " + stringerror());
+    }
+    dgram.resize(static_cast<size_t>(bytes));
+  }
+
+  bool recvFromAsync(PacketBuffer& dgram, ComboAddress& remote)
+  {
+    socklen_t remlen = sizeof(remote);
+    if (dgram.size() < s_buflen) {
+      dgram.resize(s_buflen);
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto bytes = recvfrom(d_socket, dgram.data(), dgram.size(), 0, reinterpret_cast<sockaddr *>(&remote), &remlen);
     if (bytes < 0) {
       if (errno != EAGAIN) {
         throw NetworkError("After async recvfrom: " + stringerror());
       }
-      return false;
+      else {
+        return false;
+      }
     }
-    dgram.assign(d_buffer, 0, static_cast<size_t>(bytes));
+    dgram.resize(static_cast<size_t>(bytes));
     return true;
   }
 
-
   //! For datagram sockets, send a datagram to a destination
-  void sendTo(const char* msg, size_t len, const ComboAddress &ep)
+  void sendTo(const char* msg, size_t len, const ComboAddress& remote)
   {
-    if(sendto(d_socket, msg, len, 0, reinterpret_cast<const sockaddr *>(&ep), ep.getSocklen())<0)
-      throw NetworkError("After sendto: "+stringerror());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    if (sendto(d_socket, msg, len, 0, reinterpret_cast<const sockaddr *>(&remote), remote.getSocklen()) < 0) {
+      throw NetworkError("After sendto: " + stringerror());
+    }
   }
 
   //! For connected datagram sockets, send a datagram
   void send(const std::string& msg)
   {
-    if(::send(d_socket, msg.c_str(), msg.size(), 0)<0)
+    if (::send(d_socket, msg.data(), msg.size(), 0) < 0) {
       throw NetworkError("After send: "+stringerror());
+    }
   }
 
 
   /** For datagram sockets, send a datagram to a destination
       \param dgram The datagram
-      \param ep The intended destination of the datagram */
-  void sendTo(const string &dgram, const ComboAddress &ep)
+      \param remote The intended destination of the datagram */
+  void sendTo(const string& dgram, const ComboAddress& remote)
   {
-    sendTo(dgram.c_str(), dgram.length(), ep);
+    sendTo(dgram.data(), dgram.length(), remote);
   }
 
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
By reading as many UDP datagrams as possible from the socket when it becomes readable, processing as many DoQ events as possible in one go, and preventing a few allocations and copies.

I do get very nice results with this pull request and increasing the rmem and wmem buffers (which quic-go appears to do by default):

![latency](https://github.com/PowerDNS/pdns/assets/1086257/495703ea-a1b7-4ff5-9ef1-4703792bc961)

And even better on a longer-run, as the cost of establishing the QUIC connections is amortized (60 seconds run vs 20 seconds for the previous one above):

![latency](https://github.com/PowerDNS/pdns/assets/1086257/d18ba4f4-3b92-4a61-b818-d837b42bb35f)

Might help with https://github.com/PowerDNS/pdns/issues/13631 even though I believe https://github.com/PowerDNS/pdns/pull/13664 might very well be as big a win.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
