### PR TITLE
dnsdist: Clean up the Lua objects before exiting

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2525,8 +2525,8 @@ static void usage()
 #ifdef COVERAGE
 static void cleanupLuaObjects()
 {
-  /* when our coverage mode is enabled, we need to make
-     that the Lua objects destroyed before the Lua contexts. */
+  /* when our coverage mode is enabled, we need to make sure
+     that the Lua objects are destroyed before the Lua contexts. */
   g_ruleactions.setState({});
   g_respruleactions.setState({});
   g_cachehitrespruleactions.setState({});
@@ -3215,6 +3215,7 @@ int main(int argc, char** argv)
       errlog("Fatal pdns error: %s", ae.reason);
     }
 #ifdef COVERAGE
+    cleanupLuaObjects();
     exit(EXIT_FAILURE);
 #else
     _exit(EXIT_FAILURE);
@@ -3224,6 +3225,7 @@ int main(int argc, char** argv)
   {
     errlog("Fatal error: %s", e.what());
 #ifdef COVERAGE
+    cleanupLuaObjects();
     exit(EXIT_FAILURE);
 #else
     _exit(EXIT_FAILURE);
@@ -3233,6 +3235,7 @@ int main(int argc, char** argv)
   {
     errlog("Fatal pdns error: %s", ae.reason);
 #ifdef COVERAGE
+    cleanupLuaObjects();
     exit(EXIT_FAILURE);
 #else
     _exit(EXIT_FAILURE);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When code coverage is enabled, we try to call `exit()` instead of our usual use of `_exit()` to get more accurate coverage. It does however trigger a race condition between the destruction of Lua objects and the Lua context(s) they belong to, so we try to explicitly clean up the objects before calling `exit()`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
