### PR TITLE
Enable doq and doh3 in dockerfile-dnsdist

### DIFF
--- a/Dockerfile-dnsdist
+++ b/Dockerfile-dnsdist
@@ -47,6 +47,12 @@ RUN mkdir /libh2o && cd /libh2o && \
       CFLAGS='-fPIC' cmake -DWITH_PICOTLS=off -DWITH_BUNDLED_SSL=off -DWITH_MRUBY=off -DCMAKE_INSTALL_PREFIX=/opt ./h2o-2.2.6-pdns2 && \
       make install
 
+RUN mkdir /quiche && cd /quiche && \
+    apt-get install -y libclang-dev && \
+    apt-get clean && \
+    /source/builder-support/helpers/install_rust.sh && \
+    /source/builder-support/helpers/install_quiche.sh
+
 RUN mkdir /build && \
     LUAVER=$([ -z "${NO_LUA_JIT##*$(dpkg --print-architecture)*}" ] && echo 'lua5.3' || echo 'luajit') && \
     ./configure \
@@ -59,10 +65,16 @@ RUN mkdir /build && \
       --enable-dns-over-https \
       --with-re2 \
       --with-h2o \
+      --enable-dns-over-quic \
+      --enable-dns-over-http3 \
+      --with-quiche \
       PKG_CONFIG_PATH=/opt/lib/pkgconfig && \
     make clean && \
     make $MAKEFLAGS install DESTDIR=/build && make clean && \
-    strip /build/usr/local/bin/*
+    strip /build/usr/local/bin/* &&\
+    mkdir -p /build/usr/lib/ && \
+    cp -rf /usr/lib/libdnsdist-quiche.so /build/usr/lib/
+
 RUN cd /tmp && mkdir /build/tmp/ && mkdir debian && \
     echo 'Source: docker-deps-for-pdns' > debian/control && \
     dpkg-shlibdeps /build/usr/local/bin/dnsdist && \


### PR DESCRIPTION
### Short description

This PR update the Dockerfile for dnsdist to enable DoQ and DoH3 as described in https://github.com/PowerDNS/pdns/issues/13669

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code (from dockerfile)
- [x] tested this code with generated local docker image only
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
