### PR TITLE
Backport 13692 to rec 5.0.x: GH Actions - Fix builder workflow for Debian Trixie

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.debian-trixie
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-trixie
@@ -13,7 +13,8 @@ FROM arm64v8/debian:trixie as dist-base
 
 ARG BUILDER_CACHE_BUSTER=
 ARG APT_URL
-RUN apt-get update && apt-get -y dist-upgrade
+RUN apt-get update && apt-get -y dist-upgrade && \
+    apt-get install -y fakeroot
 
 @INCLUDE Dockerfile.debbuild-prepare
 


### PR DESCRIPTION
### Short description

The package `fakeroot` is not present by default with the `Debian Trixie` docker image.

This package is used by the script `builder/helpers/build-debs.sh` during the `build` job of the `builder` workflow.

An example of a [failed run](https://github.com/PowerDNS/pdns/actions/runs/7469424676/job/20326514735#step:3:4233)

Already merged in [Master](https://github.com/PowerDNS/pdns/pull/13692). 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
