### PR TITLE
Fix country()/countryCode() mixup in example Lua Record documentation

### DIFF
--- a/docs/lua-records/index.rst
+++ b/docs/lua-records/index.rst
@@ -78,7 +78,7 @@ This will pick from the viable IP addresses the one deemed closest to the user.
 
 LUA records can also contain more complex code, for example::
 
-    www    IN    LUA    A    ";if countryCode('US') then return {'192.0.2.1','192.0.2.2','198.51.100.1'} else return '192.0.2.2' end"
+    www    IN    LUA    A    ";if country('US') then return {'192.0.2.1','192.0.2.2','198.51.100.1'} else return '192.0.2.2' end"
 
 As you can see you can return both single string value or array of strings.
 


### PR DESCRIPTION
### Short description
There is a mixup between the country() function and the countryCode() function in one of the example Lua Records in the PowerDNS Authoritative server documentation.

The country() function returns true if the country code for the query source IP address matches the country code passed to the function.
The countryCode() function doesn't take any arguments and just returns the country code of the query source IP address.

For this example, we're checking if the country for the query source IP address is "US" and expecting a true/false response for evaluation in the if statement, so country() is the correct function to use.
Alternatively, this would be something like "if countryCode() == 'US' then return...".

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
