### PR TITLE
DNSName: correct len and offset types

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -137,8 +137,8 @@ void DNSName::packetParser(const char* qpos, size_t len, size_t offset, bool unc
       labellen &= (~0xc0);
       size_t newpos = (labellen << 8) + *(const unsigned char*)pos;
 
-      if(newpos < offset) {
-        if(newpos < static_cast<size_t>(minOffset)) {
+      if (newpos < offset) {
+        if (newpos < minOffset) {
           throw std::range_error("Invalid label position during decompression ("+std::to_string(newpos)+ " < "+std::to_string(minOffset)+")");
         }
         if (++depth > 100) {

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -99,8 +99,7 @@ DNSName::DNSName(const std::string_view sw)
   }
 }
 
-
-DNSName::DNSName(const char* pos, int len, int offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, uint16_t minOffset)
+DNSName::DNSName(const char* pos, size_t len, size_t offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, uint16_t minOffset)
 {
   if (offset >= len)
     throw std::range_error("Trying to read past the end of the buffer ("+std::to_string(offset)+ " >= "+std::to_string(len)+")");
@@ -115,7 +114,7 @@ DNSName::DNSName(const char* pos, int len, int offset, bool uncompress, uint16_t
 }
 
 // this should be the __only__ dns name parser in PowerDNS.
-void DNSName::packetParser(const char* qpos, int len, int offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset)
+void DNSName::packetParser(const char* qpos, size_t len, size_t offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset)
 {
   const unsigned char* pos=(const unsigned char*)qpos;
   unsigned char labellen;
@@ -123,7 +122,7 @@ void DNSName::packetParser(const char* qpos, int len, int offset, bool uncompres
 
   if (offset >= len)
     throw std::range_error("Trying to read past the end of the buffer ("+std::to_string(offset)+ " >= "+std::to_string(len)+")");
-  if (offset < (int) minOffset)
+  if (offset < static_cast<size_t>(minOffset))
     throw std::range_error("Trying to read before the beginning of the buffer ("+std::to_string(offset)+ " < "+std::to_string(minOffset)+")");
 
   const unsigned char* end = pos + len;
@@ -134,10 +133,10 @@ void DNSName::packetParser(const char* qpos, int len, int offset, bool uncompres
         throw std::range_error("Found compressed label, instructed not to follow");
 
       labellen &= (~0xc0);
-      int newpos = (labellen << 8) + *(const unsigned char*)pos;
+      size_t newpos = (labellen << 8) + *(const unsigned char*)pos;
 
       if(newpos < offset) {
-        if(newpos < (int) minOffset)
+        if(newpos < static_cast<size_t>(minOffset))
           throw std::range_error("Invalid label position during decompression ("+std::to_string(newpos)+ " < "+std::to_string(minOffset)+")");
         if (++depth > 100)
           throw std::range_error("Abort label decompression after 100 redirects");

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -161,13 +161,13 @@ void DNSName::packetParser(const char* qpos, size_t len, size_t offset, bool unc
     }
     pos+=labellen;
   }
-  if(d_storage.empty()) {
+  if (d_storage.empty()) {
     d_storage.append(1, (char)0); // we just parsed the root
   }
-  if(consumed) {
+  if (consumed != nullptr) {
     *consumed = pos - opos - offset;
   }
-  if(qtype) {
+  if (qtype != nullptr) {
     if (pos + 2 > end) {
       throw std::range_error("Trying to read qtype past the end of the buffer ("+std::to_string((pos - opos) + 2)+ " > "+std::to_string(len)+")");
     }

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -100,7 +100,7 @@ public:
   DNSName(DNSName&& a) = default;
 
   explicit DNSName(std::string_view sw); //!< Constructs from a human formatted, escaped presentation
-  DNSName(const char* p, int len, int offset, bool uncompress, uint16_t* qtype = nullptr, uint16_t* qclass = nullptr, unsigned int* consumed = nullptr, uint16_t minOffset = 0); //!< Construct from a DNS Packet, taking the first question if offset=12. If supplied, consumed is set to the number of bytes consumed from the packet, which will not be equal to the wire length of the resulting name in case of compression.
+  DNSName(const char* p, size_t len, size_t offset, bool uncompress, uint16_t* qtype = nullptr, uint16_t* qclass = nullptr, unsigned int* consumed = nullptr, uint16_t minOffset = 0); //!< Construct from a DNS Packet, taking the first question if offset=12. If supplied, consumed is set to the number of bytes consumed from the packet, which will not be equal to the wire length of the resulting name in case of compression.
 
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name? Note that name.isPartOf(name).
   inline bool operator==(const DNSName& rhs) const; //!< DNS-native comparison (case insensitive) - empty compares to empty
@@ -216,7 +216,7 @@ public:
 private:
   string_t d_storage;
 
-  void packetParser(const char* p, int len, int offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset);
+  void packetParser(const char* p, size_t len, size_t offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset);
   static void appendEscapedLabel(std::string& appendTo, const char* orig, size_t len);
   static std::string unescapeLabel(const std::string& orig);
   static void throwSafeRangeError(const std::string& msg, const char* buf, size_t length);

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -216,7 +216,7 @@ public:
 private:
   string_t d_storage;
 
-  void packetParser(const char* p, size_t len, size_t offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset);
+  void packetParser(const char* qpos, size_t len, size_t offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset);
   static void appendEscapedLabel(std::string& appendTo, const char* orig, size_t len);
   static std::string unescapeLabel(const std::string& orig);
   static void throwSafeRangeError(const std::string& msg, const char* buf, size_t length);


### PR DESCRIPTION
### Short description
This PR ~format `dnsname.{hh,cc}` files and~ corrects the type of `len` and `offset` arguments from `int` to `size_t`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
