### PR TITLE
dnsname: Optimize parsing of uncompressed labels

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -363,7 +363,7 @@ void DNSName::makeUsRelative(const DNSName& zone)
 {
   if (isPartOf(zone)) {
     d_storage.erase(d_storage.size()-zone.d_storage.size());
-    d_storage.append(1, (char)0); // put back the trailing 0
+    d_storage.append(1, static_cast<char>(0)); // put back the trailing 0
   }
   else {
     clear();
@@ -429,14 +429,14 @@ void DNSName::appendRawLabel(const char* start, unsigned int length)
 
   if (d_storage.empty()) {
     d_storage.reserve(1 + length + 1);
-    d_storage.append(1, (char)length);
+    d_storage.append(1, static_cast<char>(length));
   }
   else {
     d_storage.reserve(d_storage.size() + length + 1);
-    *d_storage.rbegin()=(char)length;
+    *d_storage.rbegin() = static_cast<char>(length);
   }
   d_storage.append(start, length);
-  d_storage.append(1, (char)0);
+  d_storage.append(1, static_cast<char>(0));
 }
 
 void DNSName::prependRawLabel(const std::string& label)
@@ -450,13 +450,13 @@ void DNSName::prependRawLabel(const std::string& label)
 
   if (d_storage.empty()) {
     d_storage.reserve(1 + label.size() + 1);
-    d_storage.append(1, (char)0);
+    d_storage.append(1, static_cast<char>(0));
   }
   else {
     d_storage.reserve(d_storage.size() + 1 + label.size());
   }
 
-  string_t prep(1, (char)label.size());
+  string_t prep(1, static_cast<char>(label.size()));
   prep.append(label.c_str(), label.size());
   d_storage = prep+d_storage;
 }
@@ -564,7 +564,7 @@ void DNSName::appendEscapedLabel(std::string& appendTo, const char* orig, size_t
       appendTo+="\\\\";
     }
     else if (p > 0x20 && p < 0x7f) {
-      appendTo.append(1, (char)p);
+      appendTo.append(1, static_cast<char>(p));
     }
     else {
       char buf[] = "000";

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -168,7 +168,6 @@ size_t DNSName::parsePacketUncompressed(const UnsignedCharView& view, size_t pos
     if (existingSize > 0) {
       // remove the last label count, we are about to override it */
       --existingSize;
-      d_storage.resize(existingSize);
     }
     d_storage.reserve(existingSize + totalLength + 1);
     d_storage.resize(existingSize + totalLength);

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -161,7 +161,7 @@ size_t DNSName::parsePacketUncompressed(const UnsignedCharView& view, size_t pos
     pos += labellen;
     totalLength += 1 + labellen;
   }
-  while (labellen != 0 && pos < view.size());
+  while (pos < view.size());
 
   if (totalLength != 0) {
     auto existingSize = d_storage.size();

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -217,6 +217,7 @@ private:
   string_t d_storage;
 
   void packetParser(const char* qpos, size_t len, size_t offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset);
+  const unsigned char* parsePacketUncompressed(const unsigned char* start, const unsigned char* pos, const unsigned char* end, bool uncompress);
   static void appendEscapedLabel(std::string& appendTo, const char* orig, size_t len);
   static std::string unescapeLabel(const std::string& orig);
   static void throwSafeRangeError(const std::string& msg, const char* buf, size_t length);

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -216,8 +216,28 @@ public:
 private:
   string_t d_storage;
 
+  class UnsignedCharView
+  {
+  public:
+    UnsignedCharView(const char* data_, size_t size_): view(data_, size_)
+    {
+    }
+    const unsigned char& at(std::string_view::size_type pos) const
+    {
+      return reinterpret_cast<const unsigned char&>(view.at(pos));
+    }
+
+    size_t size() const
+    {
+      return view.size();
+    }
+
+  private:
+    std::string_view view;
+  };
+
   void packetParser(const char* qpos, size_t len, size_t offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset);
-  const unsigned char* parsePacketUncompressed(const unsigned char* start, const unsigned char* pos, const unsigned char* end, bool uncompress);
+  size_t parsePacketUncompressed(const UnsignedCharView& view, size_t position, bool uncompress);
   static void appendEscapedLabel(std::string& appendTo, const char* orig, size_t len);
   static std::string unescapeLabel(const std::string& orig);
   static void throwSafeRangeError(const std::string& msg, const char* buf, size_t length);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

The gist of this change is to stop allocating and copying per label when parsing DNSNames from the wire format, as long as we do not encounter a compression pointer, so that we only allocate and copy once for as many labels as possible.

This has a noticeable impact in some of our speedtest results:

| Test | Before | After |
| --- | --- | --- |
| 'parse 'empty-query'' | 7282032.6 runs/s, 0.14 us/run | 13519722.8 runs/s, 0.07 us/run |
| 'parse 'empty-query' bare' | 7512588.4 runs/s, 0.13 us/run | 14421770.5 runs/s, 0.07 us/run |
| 'parse 'typical-referral' bare | 917539.2 runs/s, 1.09 us/run | 1151581.7 runs/s, 0.87 us/run |
| 'parse 'typical-referral'' | 626927.3 runs/s, 1.60 us/run | 711754.3 runs/s, 1.40 us/run |

The improvement is quite clear when the number of labels increases:

| Number of labels | Before | After |
| --- | --- | --- |
| 1 | 16280173.9 runs/s, 0.06 us/run | 15798338.6 runs/s, 0.06 us/run |
| 2 | 11591389.8 runs/s, 0.09 us/run | 15677266.9 runs/s, 0.06 us/run |
| 3 | 9008087.9 runs/s, 0.11 us/run | 14705491.1 runs/s, 0.07 us/run |
| 4 | 7391707.9 runs/s, 0.14 us/run | 14368828.1 runs/s, 0.07 us/run |
| 5 | 6172025.9 runs/s, 0.16 us/run | 14326900.3 runs/s, 0.07 us/run |
| 6 | 5396152.4 runs/s, 0.19 us/run | 13585892.7 runs/s, 0.07 us/run |
| 7 | 4763488.4 runs/s, 0.21 us/run | 12824105.9 runs/s, 0.08 us/run |
| 8 | 4323804.8 runs/s, 0.23 us/run | 12494736.6 runs/s, 0.08 us/run |
| 9 | 3877356.8 runs/s, 0.26 us/run | 12308737.6 runs/s, 0.08 us/run |
| ... | ... | ... |
| 127 | 360564.0 runs/s, 2.77 us/run | 2782692.4 runs/s, 0.36 us/run |

I also tested the change in dnsdist, and I see a ~5% decrease of CPU usage when processing a lot of incoming queries served from the packet cache.

It is still always a bit scary to touch this code, so reviews are welcome! :)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

