### PR TITLE
CI: Enable verbose logging to catch errors within logging macros

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -466,6 +466,7 @@ def ci_auth_configure(c):
         "--enable-experimental-pkcs11",
         "--enable-experimental-gss-tsig",
         "--enable-remotebackend-zeromq",
+        "--enable-verbose-logging",
         "--with-lmdb=/usr",
         "--with-libdecaf" if os.getenv('DECAF_SUPPORT', 'no') == 'yes' else '',
         "--prefix=/opt/pdns-auth",
@@ -491,6 +492,7 @@ def ci_rec_configure(c):
         "--with-libcap",
         "--with-net-snmp",
         "--enable-dns-over-tls",
+        "--enable-verbose-logging",
         unittests,
     ])
     res = c.run(configure_cmd, warn=True)


### PR DESCRIPTION
### Short description
Compilation errors were not caught inside of calls to logging macros on master. This enables verbose logging in our CI to catch such errors.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)