### PR TITLE
Fix compilation errors in `dnsproxy.cc` due to unused macro

### DIFF
--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -98,7 +98,7 @@ bool DNSProxy::completePacket(std::unique_ptr<DNSPacket>& reply, const DNSName& 
   string ECSOptionStr;
 
   if (reply->hasEDNSSubnet()) {
-    DLOG(g_log << "dnsproxy::completePacket: Parsed edns source: " << r->d_eso.source.toString() << ", scope: " << r->d_eso.scope.toString() << ", family = " << r->d_eso.scope.getNetwork().sin4.sin_family << endl);
+    DLOG(g_log << "dnsproxy::completePacket: Parsed edns source: " << reply->d_eso.source.toString() << ", scope: " << reply->d_eso.scope.toString() << ", family = " << reply->d_eso.scope.getNetwork().sin4.sin_family << endl);
     ECSOptionStr = makeEDNSSubnetOptsString(reply->d_eso);
     DLOG(g_log << "from dnsproxy::completePacket: Creating ECS option string " << makeHexDump(ECSOptionStr) << endl);
   }
@@ -272,7 +272,7 @@ void DNSProxy::mainloop()
         // update the EDNS options with info from the resolver - issue #5469
         // note that this relies on the ECS string encoder to use the source network, and only take the prefix length from scope
         iter->second.complete->d_eso.scope = packet.d_eso.scope;
-        DLOG(g_log << "from dnsproxy::mainLoop: updated EDNS options from resolver EDNS source: " << i->second.complete->d_eso.source.toString() << " EDNS scope: " << i->second.complete->d_eso.scope.toString() << endl);
+        DLOG(g_log << "from dnsproxy::mainLoop: updated EDNS options from resolver EDNS source: " << iter->second.complete->d_eso.source.toString() << " EDNS scope: " << iter->second.complete->d_eso.scope.toString() << endl);
 
         if (mdp.d_header.rcode == RCode::NoError) {
           for (const auto& answer : mdp.d_answers) {


### PR DESCRIPTION
### Short description
Some parts of `dnsproxy.cc` had compilation errors but were not used on CI because they were inside calls to logging macros.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)