### PR TITLE
auth API: reject priority element in record, closes #12657

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -49,6 +49,13 @@ Various custom queries have been renamed.
 
 Also, ``get-all-domains-query`` got an extra column for a zone's catalog assignment.
 
+API changes
+~~~~~~~~~~~
+
+A long time ago (in version 3.4.2), the ``priority`` field was removed from record content in the HTTP API.
+Starting with 4.9, API calls containing a ``priority`` field are actively rejected.
+This makes it easier for users to detect they are attempting to use a very old API client.
+
 any version to 4.8.x
 --------------------
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -591,6 +591,9 @@ static void gatherRecords(const Json& container, const DNSName& qname, const QTy
   const auto& items = container["records"].array_items();
   for (const auto& record : items) {
     string content = stringFromJson(record, "content");
+    if (record.object_items().count("priority") > 0) {
+      throw std::runtime_error("`priority` element is not allowed in record");
+    }
     resourceRecord.disabled = false;
     if (!record["disabled"].is_null()) {
       resourceRecord.disabled = boolFromJson(record, "disabled");


### PR DESCRIPTION
### Short description
This should make outdated API clients notice failure earlier and/or more clearly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master