### PR TITLE
GH Actions: fix builds for ubuntu noble. Remove pkg usrmerge

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-noble
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-noble
@@ -14,6 +14,8 @@ FROM arm64v8/ubuntu:noble as dist-base
 ARG BUILDER_CACHE_BUSTER=
 ARG APT_URL
 RUN apt-get update && apt-get -y dist-upgrade
+# FIXME: Package usrmerge missing sha256 str
+RUN apt-get purge -y usrmerge
 
 @INCLUDE Dockerfile.debbuild-prepare
 


### PR DESCRIPTION
### Short description
The latest Ubuntu Noble docker image includes a package `usrmerge` version that lacks the sha256sum in its metadata, which provokes a failure in our provenance script.

As a workaround, this package is removed until it is fixed for the distro.

This fix has been tested in the following [run](https://github.com/romeroalx/pdns/actions/runs/7749148036)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
