### PR TITLE
auth: Add setting to make TSIG required for DNS updates

### DIFF
--- a/docs/dnsupdate.rst
+++ b/docs/dnsupdate.rst
@@ -46,6 +46,13 @@ combination with the ``ALLOW-DNSUPDATE-FROM`` :doc:`domain metadata <domainmetad
 zone. Setting a range here and in ``ALLOW-DNSUPDATE-FROM`` enables updates
 from either address range.
 
+``dnsupdate-require-tsig``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A setting to require DNS updates to be signed by a valid TSIG signature.
+The default is no, which means zones without TSIG keys can be updated by
+unauthenticated agents operating from an allowed address range.
+
 ``forward-dnsupdate``
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -152,6 +159,7 @@ both requirements need to be satisfied before an update will be accepted.
 By default, an update can add, update or delete any resource records in
 the zone.  See :ref:`dnsupdate-update-policy` for finer-grained
 control of what an update is allowed to do.
+Use :ref:`setting-dnsupdate-require-tsig` to disallow unsigned updates.
 
 .. _metadata-forward-dnsupdate:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -654,6 +654,16 @@ caching.
 
 Enable/Disable DNS update (RFC2136) support. See :doc:`dnsupdate` for more.
 
+.. _setting-dnsupdate-require-tsig:
+
+``dnsupdate-require-tsig``
+-------------
+
+-  Boolean
+-  Default: no
+
+Requires DNS updates to be signed by a valid TSIG signature even if the zone has no associated keys.
+
 .. _setting-do-ipv6-additional-processing:
 
 ``do-ipv6-additional-processing``

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -161,6 +161,7 @@ static void declareArguments()
   ::arg().setSwitch("dnsupdate", "Enable/Disable DNS update (RFC2136) support. Default is no.") = "no";
   ::arg().setSwitch("write-pid", "Write a PID file") = "yes";
   ::arg().set("allow-dnsupdate-from", "A global setting to allow DNS updates from these IP ranges.") = "127.0.0.0/8,::1";
+  ::arg().setSwitch("dnsupdate-require-tsig", "Require TSIG secured DNS updates. Default is no.") = "no";
   ::arg().set("proxy-protocol-from", "A Proxy Protocol header is only allowed from these subnets, and is mandatory then too.") = "";
   ::arg().set("proxy-protocol-maximum-size", "The maximum size of a proxy protocol payload, including the TLV values") = "512";
   ::arg().setSwitch("send-signed-notify", "Send TSIG secured NOTIFY if TSIG key is configured for a zone") = "yes";

--- a/pdns/gss_context.hh
+++ b/pdns/gss_context.hh
@@ -160,7 +160,7 @@ public:
 
 private:
 #ifdef ENABLE_GSS_TSIG
-  OM_uint32 d_maj, d_min;
+  OM_uint32 d_maj{0}, d_min{0};
   gss_name_t d_name;
 #endif
 }; // GssName

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -661,7 +661,7 @@ int PacketHandler::forwardPacket(const string &msgPrefix, const DNSPacket& p, co
 
 }
 
-int PacketHandler::processUpdate(DNSPacket& p) {
+int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-cognitive-complexity)
   if (! ::arg().mustDo("dnsupdate"))
     return RCode::Refused;
 

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -726,6 +726,9 @@ int PacketHandler::processUpdate(DNSPacket& p) {
         g_log<<Logger::Error<<msgPrefix<<"TSIG key ("<<inputkey<<") required, but no matching key found in domainmetadata, tried "<<tsigKeys.size()<<". Sending REFUSED"<<endl;
         return RCode::Refused;
       }
+    } else if(::arg().mustDo("dnsupdate-require-tsig")) {
+      g_log<<Logger::Error<<msgPrefix<<"TSIG key required, but domain is not secured with TSIG. Sending REFUSED"<<endl;
+      return RCode::Refused;
     }
 
     if (tsigKeys.size() == 0 && p.d_havetsig)

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -661,11 +661,11 @@ int PacketHandler::forwardPacket(const string &msgPrefix, const DNSPacket& p, co
 
 }
 
-int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-cognitive-complexity)
+int PacketHandler::processUpdate(DNSPacket& packet) { // NOLINT(readability-function-cognitive-complexity)
   if (! ::arg().mustDo("dnsupdate"))
     return RCode::Refused;
 
-  string msgPrefix="UPDATE (" + std::to_string(p.d.id) + ") from " + p.getRemoteString() + " for " + p.qdomain.toLogString() + ": ";
+  string msgPrefix="UPDATE (" + std::to_string(packet.d.id) + ") from " + packet.getRemoteString() + " for " + packet.qdomain.toLogString() + ": ";
   g_log<<Logger::Info<<msgPrefix<<"Processing started."<<endl;
 
   // if there is policy, we delegate all checks to it
@@ -673,7 +673,7 @@ int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-
 
     // Check permissions - IP based
     vector<string> allowedRanges;
-    B.getDomainMetadata(p.qdomain, "ALLOW-DNSUPDATE-FROM", allowedRanges);
+    B.getDomainMetadata(packet.qdomain, "ALLOW-DNSUPDATE-FROM", allowedRanges);
     if (! ::arg()["allow-dnsupdate-from"].empty())
       stringtok(allowedRanges, ::arg()["allow-dnsupdate-from"], ", \t" );
 
@@ -682,7 +682,7 @@ int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-
       ng.addMask(i);
     }
 
-    if ( ! ng.match(p.getInnerRemote())) {
+    if ( ! ng.match(packet.getInnerRemote())) {
       g_log<<Logger::Error<<msgPrefix<<"Remote not listed in allow-dnsupdate-from or domainmetadata. Sending REFUSED"<<endl;
       return RCode::Refused;
     }
@@ -690,20 +690,20 @@ int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-
 
     // Check permissions - TSIG based.
     vector<string> tsigKeys;
-    B.getDomainMetadata(p.qdomain, "TSIG-ALLOW-DNSUPDATE", tsigKeys);
+    B.getDomainMetadata(packet.qdomain, "TSIG-ALLOW-DNSUPDATE", tsigKeys);
     if (tsigKeys.size() > 0) {
       bool validKey = false;
 
       TSIGRecordContent trc;
       DNSName inputkey;
       string message;
-      if (! p.getTSIGDetails(&trc,  &inputkey)) {
+      if (! packet.getTSIGDetails(&trc,  &inputkey)) {
         g_log<<Logger::Error<<msgPrefix<<"TSIG key required, but packet does not contain key. Sending REFUSED"<<endl;
         return RCode::Refused;
       }
 #ifdef ENABLE_GSS_TSIG
-      if (g_doGssTSIG && p.d_tsig_algo == TSIG_GSS) {
-        GssName inputname(p.d_peer_principal); // match against principal since GSS requires that
+      if (g_doGssTSIG && packet.d_tsig_algo == TSIG_GSS) {
+        GssName inputname(packet.d_peer_principal); // match against principal since GSS requires that
         for(const auto& key: tsigKeys) {
           if (inputname.match(key)) {
             validKey = true;
@@ -731,7 +731,7 @@ int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-
       return RCode::Refused;
     }
 
-    if (tsigKeys.size() == 0 && p.d_havetsig)
+    if (tsigKeys.size() == 0 && packet.d_havetsig)
       g_log<<Logger::Warning<<msgPrefix<<"TSIG is provided, but domain is not secured with TSIG. Processing continues"<<endl;
 
   }
@@ -739,31 +739,31 @@ int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-
   // RFC2136 uses the same DNS Header and Message as defined in RFC1035.
   // This means we can use the MOADNSParser to parse the incoming packet. The result is that we have some different
   // variable names during the use of our MOADNSParser.
-  MOADNSParser mdp(false, p.getString());
+  MOADNSParser mdp(false, packet.getString());
   if (mdp.d_header.qdcount != 1) {
     g_log<<Logger::Warning<<msgPrefix<<"Zone Count is not 1, sending FormErr"<<endl;
     return RCode::FormErr;
   }
 
-  if (p.qtype.getCode() != QType::SOA) { // RFC2136 2.3 - ZTYPE must be SOA
+  if (packet.qtype.getCode() != QType::SOA) { // RFC2136 2.3 - ZTYPE must be SOA
     g_log<<Logger::Warning<<msgPrefix<<"Query ZTYPE is not SOA, sending FormErr"<<endl;
     return RCode::FormErr;
   }
 
-  if (p.qclass != QClass::IN) {
+  if (packet.qclass != QClass::IN) {
     g_log<<Logger::Warning<<msgPrefix<<"Class is not IN, sending NotAuth"<<endl;
     return RCode::NotAuth;
   }
 
   DomainInfo di;
   di.backend=nullptr;
-  if(!B.getDomainInfo(p.qdomain, di) || !di.backend) {
-    g_log<<Logger::Error<<msgPrefix<<"Can't determine backend for domain '"<<p.qdomain<<"' (or backend does not support DNS update operation)"<<endl;
+  if(!B.getDomainInfo(packet.qdomain, di) || !di.backend) {
+    g_log<<Logger::Error<<msgPrefix<<"Can't determine backend for domain '"<<packet.qdomain<<"' (or backend does not support DNS update operation)"<<endl;
     return RCode::NotAuth;
   }
 
   if (di.kind == DomainInfo::Secondary)
-    return forwardPacket(msgPrefix, p, di);
+    return forwardPacket(msgPrefix, packet, di);
 
   // Check if all the records provided are within the zone
   for(const auto & answer : mdp.d_answers) {
@@ -782,8 +782,8 @@ int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-
 
   std::lock_guard<std::mutex> l(s_rfc2136lock); //TODO: i think this lock can be per zone, not for everything
   g_log<<Logger::Info<<msgPrefix<<"starting transaction."<<endl;
-  if (!di.backend->startTransaction(p.qdomain, -1)) { // Not giving the domain_id means that we do not delete the existing records.
-    g_log<<Logger::Error<<msgPrefix<<"Backend for domain "<<p.qdomain<<" does not support transaction. Can't do Update packet."<<endl;
+  if (!di.backend->startTransaction(packet.qdomain, -1)) { // Not giving the domain_id means that we do not delete the existing records.
+    g_log<<Logger::Error<<msgPrefix<<"Backend for domain "<<packet.qdomain<<" does not support transaction. Can't do Update packet."<<endl;
     return RCode::NotImp;
   }
 
@@ -904,7 +904,7 @@ int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-
       if (rr->d_place == DNSResourceRecord::AUTHORITY) {
         /* see if it's permitted by policy */
         if (this->d_update_policy_lua != nullptr) {
-          if (this->d_update_policy_lua->updatePolicy(rr->d_name, QType(rr->d_type), di.zone, p) == false) {
+          if (this->d_update_policy_lua->updatePolicy(rr->d_name, QType(rr->d_type), di.zone, packet) == false) {
             g_log<<Logger::Warning<<msgPrefix<<"Refusing update for " << rr->d_name << "/" << QType(rr->d_type).toString() << ": Not permitted by policy"<<endl;
             continue;
           } else {
@@ -995,7 +995,7 @@ int PacketHandler::processUpdate(DNSPacket& p) { // NOLINT(readability-function-
       // Notify secondaries
       if (di.kind == DomainInfo::Primary) {
         vector<string> notify;
-        B.getDomainMetadata(p.qdomain, "NOTIFY-DNSUPDATE", notify);
+        B.getDomainMetadata(packet.qdomain, "NOTIFY-DNSUPDATE", notify);
         if (!notify.empty() && notify.front() == "1") {
           Communicator.notifyDomain(di.zone, &B);
         }

--- a/regression-tests.auth-py/test_GSSTSIG.py
+++ b/regression-tests.auth-py/test_GSSTSIG.py
@@ -27,6 +27,7 @@ gsqlite3-dnssec=yes
 enable-gss-tsig=yes
 allow-dnsupdate-from=0.0.0.0/0
 dnsupdate=yes
+dnsupdate-require-tsig=no
 """
     _auth_env = {'KRB5_CONFIG' : './kerberos-client/krb5.conf',
                  'KRB5_KTNAME' : './kerberos-client/kt.keytab'
@@ -54,10 +55,13 @@ dnsupdate=yes
         ret = subprocess.run(["kinit", "-Vt", "./kerberos-client/kt.keytab", user], env=self._auth_env)
         self.assertEqual(ret.returncode, 0)
 
-    def nsupdate(self, commands, expected=0):
+    def nsupdate(self, commands, expected=0, unauth=False):
         full = "server 127.0.0.1 %s\n" % self._authPort
         full += commands + "\nsend\nquit\n"
-        ret = subprocess.run(["nsupdate", "-g"], input=full, env=self._auth_env, capture_output=True, text=True)
+        if unauth:
+            ret = subprocess.run(["nsupdate"], input=full, capture_output=True, text=True)
+        else:
+            ret = subprocess.run(["nsupdate", "-g"], input=full, env=self._auth_env, capture_output=True, text=True)
         self.assertEqual(ret.returncode, expected)
 
     def checkInDB(self, zone, record):
@@ -132,4 +136,70 @@ lua-dnsupdate-policy-script=kerberos-client/update-policy.lua
         self.kinit("testuser1")
         self.nsupdate("add inserted13.wrongacceptor.net 10 A 1.2.3.13", 2)
         self.checkNotInDB('wrongacceptor.net', 'inserted13.wrongacceptor.net')
+
+class TestUnauthTSIG(GSSTSIGBase):
+
+    _config_template = """
+launch=gsqlite3
+gsqlite3-database=configs/auth/powerdns.sqlite
+gsqlite3-pragma-foreign-keys=yes
+gsqlite3-dnssec=yes
+enable-gss-tsig=no
+allow-dnsupdate-from=0.0.0.0/0
+dnsupdate=yes
+"""
+    def testNoAcceptor(self):
+        self.checkNotInDB('noacceptor.net', 'inserted20.noacceptor.net')
+        self.nsupdate("add inserted20.noacceptor.net 10 A 1.2.3.3", 0, True)
+        self.checkInDB('noacceptor.net', 'inserted20.noacceptor.net')
+
+class TestAuthTSIG(GSSTSIGBase):
+
+    _config_template = """
+launch=gsqlite3
+gsqlite3-database=configs/auth/powerdns.sqlite
+gsqlite3-pragma-foreign-keys=yes
+gsqlite3-dnssec=yes
+enable-gss-tsig=no
+allow-dnsupdate-from=0.0.0.0/0
+dnsupdate=yes
+dnsupdate-require-tsig=yes
+"""
+    def testNoAcceptor(self):
+        self.nsupdate("add inserted30.noacceptor.net 10 A 1.2.3.3", 2, True)
+        self.checkNotInDB('noacceptor.net', 'inserted30.noacceptor.net')
+
+class TestBasicRequiredGSSTSIG(GSSTSIGBase):
+
+    _config_template = """
+launch=gsqlite3
+gsqlite3-database=configs/auth/powerdns.sqlite
+gsqlite3-pragma-foreign-keys=yes
+gsqlite3-dnssec=yes
+enable-gss-tsig=yes
+allow-dnsupdate-from=0.0.0.0/0
+dnsupdate=yes
+dnsupdate-require-tsig=yes
+"""
+    def testAllowedUpdate(self):
+        self.checkNotInDB('example.net', 'inserted40.example.net')
+        self.kinit("testuser1")
+        self.nsupdate("add inserted40.example.net 10 A 1.2.3.1")
+        self.checkInDB('example.net', '^inserted40.example.net.*10.*IN.*A.*1.2.3.1$')
+
+    def testDisallowedUpdate(self):
+        self.kinit("testuser2")
+        self.nsupdate("add inserted41.example.net 10 A 1.2.3.2", 2)
+        self.checkNotInDB('example.net', 'inserted41.example.net')
+
+    def testNoAcceptor(self):
+        self.kinit("testuser1")
+        self.nsupdate("add inserted42.noacceptor.net 10 A 1.2.3.3", 2)
+        self.checkNotInDB('noacceptor.net', 'inserted42.noacceptor.net')
+
+    def testWrongAcceptor(self):
+        self.kinit("testuser1")
+        self.nsupdate("add inserted43.wrongacceptor.net 10 A 1.2.3.4", 2)
+        self.checkNotInDB('wrongacceptor.net', 'inserted43.wrongacceptor.net')
+
 


### PR DESCRIPTION
### Short description
Closes #12234 by adding the proposed `dnsupdate-require-tsig` setting.

Not ideal perhaps, but backwards compatible, which is nice. Adding to `test_GSSTSIG.py` is a bit iffy considering it's not GSS related but it is convenient.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)

