### PR TITLE
rec: add AUTHORITY section records received for the recursive forwarding case

### DIFF
--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -4890,7 +4890,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
        return the corresponding NSEC/NSEC3 records from the AUTHORITY section
        proving that the exact name did not exist.
        Except if this is a NODATA answer because then we will gather the NXNSEC records later */
-    else if (gatherWildcardProof && !negindic && (rec.d_type == QType::RRSIG || rec.d_type == QType::NSEC || rec.d_type == QType::NSEC3) && rec.d_place == DNSResourceRecord::AUTHORITY) {
+    else if ((sendRDQuery || gatherWildcardProof) && !negindic && (rec.d_type == QType::RRSIG || rec.d_type == QType::NSEC || rec.d_type == QType::NSEC3) && rec.d_place == DNSResourceRecord::AUTHORITY) {
       ret.push_back(rec); // enjoy your DNSSEC
     }
     // for ANY answers we *must* have an authoritative answer, unless we are forwarding recursively


### PR DESCRIPTION

Tentative fix of #13817

This needs test and a thorough review.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master

With this PR the testcase of the Issue becomes:

```
$ mydig test.drijf.net +dnssec

; <<>> DiG 9.18.24 <<>> +retry -p 5301 @127.0.0.1 test.drijf.net +dnssec
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 42215
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 4, AUTHORITY: 2, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags: do; udp: 512
;; QUESTION SECTION:
;test.drijf.net.                        IN      A

;; ANSWER SECTION:
test.drijf.net.         60      IN      CNAME   r.sub.m6k.nl.
r.sub.m6k.nl.           60      IN      A       1.2.3.4
test.drijf.net.         60      IN      RRSIG   CNAME 13 3 60 20240229000000 20240208000000 39531 drijf.net. QVMKGQFKRswf9KLHzRnPEtYkv/7F9M/IvtukVJMY2BteO/YseCrfTLH6 DrsmOZBUeN0KFPF/czCKrpVA1tbsgw==
r.sub.m6k.nl.           60      IN      RRSIG   A 13 3 60 20240229000000 20240208000000 53536 m6k.nl. fp7jqKSVbRDTkm/IXXGwlBkdMS7YWUCphe6VCvGKQp66AwkoL4cL9fB1 t5RFJ+KAhKTg6uZfduvL17Nwd8eA3g==

;; AUTHORITY SECTION:
*.sub.m6k.nl.           60      IN      NSEC    test.m6k.nl. A RRSIG NSEC
*.sub.m6k.nl.           60      IN      RRSIG   NSEC 13 3 60 20240229000000 20240208000000 53536 m6k.nl. ppsy1KZR0QlVoubaoDUK1aHpJFjL1/6LK/30nGqnb+4vuRG0RbJ+J7M9 z6Nejg+xeY0O/Y1FqlvrqsJqWLrLfA==

;; Query time: 176 msec
;; SERVER: 127.0.0.1#5301(127.0.0.1) (UDP)
;; WHEN: Wed Feb 21 12:15:59 CET 2024
;; MSG SIZE  rcvd: 429
```
