### PR TITLE
Update overload-queue-length and overload-drops documentation

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -236,7 +236,7 @@ Number of currently open TCP connections
 
 overload-drops
 ^^^^^^^^^^^^^^
-Number of questions dropped because backends overloaded
+Number of questions dropped because backends overloaded (backends are overloaded if they have more queries outstanding then the value of :ref:`setting-overload-queue-length`)
 
 .. _stat-packetcache-hit:
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -236,7 +236,7 @@ Number of currently open TCP connections
 
 overload-drops
 ^^^^^^^^^^^^^^
-Number of questions dropped because backends overloaded (backends are overloaded if they have more queries outstanding then the value of :ref:`setting-overload-queue-length`)
+Number of questions dropped because backends overloaded (backends are overloaded if they have more outstanding queries than the value of :ref:`setting-overload-queue-length`)
 
 .. _stat-packetcache-hit:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1369,7 +1369,8 @@ Secondary name servers.
 -  Default: 0 (disabled)
 
 If this many packets are waiting for database attention, answer any new
-questions strictly from the packet cache.
+questions strictly from the packet cache. Packets not in the cache will
+be dropped, and :ref:`_stat-overload-drops` will be incremented.
 
 .. _setting-prevent-self-notification:
 


### PR DESCRIPTION
It wasn't clear to be what overload-queue-length did until I looked at the code.  This is a documentation only update
