### PR TITLE
rec: Backport 13813 to rec 4.9.x: dnspython's API changed wrt NSID, apply (version dependent) fix in regression test

### DIFF
--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -83,7 +83,7 @@ extended-resolution-errors=yes
 
         super(ExtendedErrorsRecursorTest, cls).generateRecursorConfig(confdir)
 
-    @unittest.skip(reason="sidnlabs no longer serves thiss until further notice")
+    @unittest.skip(reason="sidnlabs no longer serves this until further notice")
     def testNotIncepted(self):
         qname = 'signotincepted.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -97,7 +97,7 @@ extended-resolution-errors=yes
             self.assertEqual(res.options[0].otype, 15)
             self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(8, b''))
 
-    @unittest.skip(reason="sidnlabs no longer serves thiss until further notice")
+    @unittest.skip(reason="sidnlabs no longer serves this until further notice")
     def testExpired(self):
         qname = 'sigexpired.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -124,7 +124,7 @@ extended-resolution-errors=yes
             self.assertEqual(res.options[0].otype, 15)
             self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(6, b''))
 
-    @unittest.skip(reason="sidnlabs no longer serves thiss until further notice")
+    @unittest.skip(reason="sidnlabs no longer serves this until further notice")
     def testBogus(self):
         qname = 'bogussig.ok.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -239,7 +239,7 @@ extended-resolution-errors=no
     def generateRecursorConfig(cls, confdir):
         super(NoExtendedErrorsRecursorTest, cls).generateRecursorConfig(confdir)
 
-    @unittest.skip(reason="sidnlabs no longer serves thiss until further notice")
+    @unittest.skip(reason="sidnlabs no longer serves this until further notice")
     def testNotIncepted(self):
         qname = 'signotincepted.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)

--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -1,7 +1,7 @@
 import dns
 import os
 import extendederrors
-import pytest
+import unittest
 
 from recursortests import RecursorTest
 
@@ -83,7 +83,7 @@ extended-resolution-errors=yes
 
         super(ExtendedErrorsRecursorTest, cls).generateRecursorConfig(confdir)
 
-    @pytest.mark.skip(reason="sidnlabs no longer serves thiss until further notice")
+    @unittest.skip(reason="sidnlabs no longer serves thiss until further notice")
     def testNotIncepted(self):
         qname = 'signotincepted.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -97,7 +97,7 @@ extended-resolution-errors=yes
             self.assertEqual(res.options[0].otype, 15)
             self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(8, b''))
 
-    @pytest.mark.skip(reason="sidnlabs no longer serves thiss until further notice")
+    @unittest.skip(reason="sidnlabs no longer serves thiss until further notice")
     def testExpired(self):
         qname = 'sigexpired.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -124,7 +124,7 @@ extended-resolution-errors=yes
             self.assertEqual(res.options[0].otype, 15)
             self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(6, b''))
 
-    @pytest.mark.skip(reason="sidnlabs no longer serves thiss until further notice")
+    @unittest.skip(reason="sidnlabs no longer serves thiss until further notice")
     def testBogus(self):
         qname = 'bogussig.ok.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -239,7 +239,7 @@ extended-resolution-errors=no
     def generateRecursorConfig(cls, confdir):
         super(NoExtendedErrorsRecursorTest, cls).generateRecursorConfig(confdir)
 
-    @pytest.mark.skip(reason="sidnlabs no longer serves thiss until further notice")
+    @unittest.skip(reason="sidnlabs no longer serves thiss until further notice")
     def testNotIncepted(self):
         qname = 'signotincepted.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)

--- a/regression-tests.recursor-dnssec/test_ServerNames.py
+++ b/regression-tests.recursor-dnssec/test_ServerNames.py
@@ -108,7 +108,10 @@ version-string=%s
         response = self.sendUDPQuery(query)
 
         self.assertEqual(len(response.options), 1)
-        self.assertEqual(response.options[0].data, self._servername.encode('ascii'))
+        if dns.version.MAJOR < 2 or (dns.version.MAJOR == 2 and dns.version.MINOR < 6):
+            self.assertEqual(response.options[0].data, self._servername.encode('ascii'))
+        else:
+            self.assertEqual(response.options[0].to_text(), 'NSID ' + self._servername)
 
     def testNSIDTCP(self):
         """
@@ -119,4 +122,7 @@ version-string=%s
         response = self.sendTCPQuery(query)
 
         self.assertEqual(len(response.options), 1)
-        self.assertEqual(response.options[0].data, self._servername.encode('ascii'))
+        if dns.version.MAJOR < 2 or (dns.version.MAJOR == 2 and dns.version.MINOR < 6):
+            self.assertEqual(response.options[0].data, self._servername.encode('ascii'))
+        else:
+            self.assertEqual(response.options[0].to_text(), 'NSID ' + self._servername)


### PR DESCRIPTION
Backport of #13813 

See https://dnspython.readthedocs.io/en/stable/whatsnew.html 2.6.0 2nd bullet

(cherry picked from commit e1ea89984da1c10850dd0cb4e7d4d7ee501e078d)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
