### PR TITLE
auth: do not disable ns records at apex in consumer zones

### DIFF
--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -331,6 +331,9 @@ static bool catalogProcess(const DomainInfo& di, vector<DNSResourceRecord>& rrs,
         hasSOA = true;
         continue;
       }
+      if (rr.qtype == QType::NS) {
+        continue;
+      }
     }
 
     else if (rr.qname == DNSName("version") + di.zone && rr.qtype == QType::TXT) {


### PR DESCRIPTION
### Short description
Fixes re-notify for consumer zones.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
