### PR TITLE
Docker: Only print config if debug flag is set

### DIFF
--- a/Docker-README.md
+++ b/Docker-README.md
@@ -19,15 +19,16 @@ Other data involved in the Docker build process can be found at https://github.c
 
 The images are ready to run with limited functionality.
 At container startup, the startup.py wrapper (from the dockerdata directory linked above) checks for `PDNS_RECURSOR_API_KEY` / `PDNS_AUTH_API_KEY` / `DNSDIST_API_KEY` environment variables for the product you are running.
-If such a variable is found, `/etc/powerdns-api.conf` or `/etc/dnsdist-api.conf` is written, enabling the webserver in all products, and the dnsdist console.
+If such a variable is found, `/etc/powerdns/recursor.d/_api.conf` / `/etc/powerdns/pdns.d/_api.conf` / `/etc/dnsdist/conf.d/_api.conf` is written, enabling the webserver in all products, and the dnsdist console.
 For the dnsdist console, make sure that your API key is in a format suitable for the console (use `makeKey()`).
 
 The default configs shipped in the image (see dockerdata above) parse all files in `/etc/powerdns/pdns.d` / `/etc/powerdns/recursor.d` / `/etc/dnsdist/conf.d`.
-The image also ships a symlink to the API config file inside those `.d` dirs.
 For Auth and Recursor, extra configuration can be passed on the command line, or via a volume mount into `/etc/powerdns` or the `.d` dir.
 For dnsdist, only the volume mount is applicable.
 
-If you want to volume mount a config, but also take the keys from the environment, please take care to include the same `X-api.conf` symlink in your `.d` directory.
+If you want to volume mount a config, but also take the keys from the environment, please take care to include the same `_api.conf` file in your `.d` directory.
+
+If you want to read the configuration for debugging purposes, you can run the containers with the `DEBUG_CONFIG` environment variable set to `'yes'`). This will print the full config on startup. Please keep in mind that this also includes credentials, therefore this setting should never be used in production environments. 
 
 # Auth and databases
 

--- a/Docker-README.md
+++ b/Docker-README.md
@@ -28,7 +28,8 @@ For dnsdist, only the volume mount is applicable.
 
 If you want to volume mount a config, but also take the keys from the environment, please take care to include the same `_api.conf` file in your `.d` directory.
 
-If you want to read the configuration for debugging purposes, you can run the containers with the `DEBUG_CONFIG` environment variable set to `'yes'`). This will print the full config on startup. Please keep in mind that this also includes credentials, therefore this setting should never be used in production environments. 
+If you want to read the configuration for debugging purposes, you can run the containers with the `DEBUG_CONFIG` environment variable set to `'yes'`.
+This will print the full config on startup. Please keep in mind that this also includes credentials, therefore this setting should never be used in production environments.
 
 # Auth and databases
 

--- a/dockerdata/startup.py
+++ b/dockerdata/startup.py
@@ -45,13 +45,16 @@ setConsoleACL('0.0.0.0/0')
     templateroot = '/etc/dnsdist/templates.d'
     templatedestination = '/etc/dnsdist/conf.d'
 
+debug = os.getenv("DEBUG_CONFIG", 'no').lower() == 'yes'
+
 apikey = os.getenv(apienvvar)
 if apikey is not None:
     webserver_conf = jinja2.Template(apiconftemplate).render(apikey=apikey)
     conffile = os.path.join(templatedestination, '_api.conf')
     with open(conffile, 'w') as f:
         f.write(webserver_conf)
-    print("Created {} with content:\n{}\n".format(conffile, webserver_conf))
+    if debug:
+        print("Created {} with content:\n{}\n".format(conffile, webserver_conf))
 
 templates = os.getenv('TEMPLATE_FILES')
 if templates is not None:
@@ -63,6 +66,7 @@ if templates is not None:
         target = os.path.join(templatedestination, templateFile + '.conf')
         with open(target, 'w') as f:
             f.write(rendered)
-        print("Created {} with content:\n{}\n".format(target, rendered))
+        if debug:
+            print("Created {} with content:\n{}\n".format(target, rendered))
 
 os.execv(program, [program]+args+sys.argv[1:])


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This changes the default behavior of Auth, Recursor and dnsdist containers to only print their configuration on startup if the environment variable `DEBUG_CONFIG` is set to `'yes'`. Per default, the env variable is not set.

I also added an explanation to the Docker README and additionally adjusted parts that seemed to be outdated.

Fix for #13838

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

