### PR TITLE
auth: Informative logging from error/warn to notice/info

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -1067,7 +1067,7 @@ static int guardian(int argc, char** argv)
       }
       newargv[n] = nullptr;
 
-      g_log << Logger::Error << "Guardian is launching an instance" << endl;
+      g_log << Logger::Info << "Guardian is launching an instance" << endl;
       close(g_fd1[1]);
       fclose(g_fp); // this closes g_fd2[0] for us
 
@@ -1391,11 +1391,11 @@ int main(int argc, char** argv)
     }
 
     if (isGuarded(argv)) {
-      g_log << Logger::Warning << "This is a guarded instance of pdns" << endl;
+      g_log << Logger::Info << "This is a guarded instance of pdns" << endl;
       s_dynListener = std::make_unique<DynListener>(); // listens on stdin
     }
     else {
-      g_log << Logger::Warning << "This is a standalone pdns" << endl;
+      g_log << Logger::Info << "This is a standalone pdns" << endl;
 
       if (::arg().mustDo("control-console"))
         s_dynListener = std::make_unique<DynListener>();

--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -170,14 +170,14 @@ template<class Answer, class Question, class Backend>MultiThreadDistributor<Answ
     d_receivers.push_back(std::move(receiver));
   }
 
-  g_log<<Logger::Warning<<"About to create "<<numberOfThreads<<" backend threads for UDP"<<endl;
+  g_log<<Logger::Info<<"About to create "<<numberOfThreads<<" backend threads for UDP"<<endl;
 
   for (int distributorIdx = 0; distributorIdx < numberOfThreads; distributorIdx++) {
     std::thread t([=](){distribute(distributorIdx);});
     t.detach();
     Utility::usleep(50000); // we've overloaded mysql in the past :-)
   }
-  g_log<<Logger::Warning<<"Done launching threads, ready to distribute questions"<<endl;
+  g_log<<Logger::Info<<"Done launching threads, ready to distribute questions"<<endl;
 }
 
 

--- a/pdns/dynlistener.cc
+++ b/pdns/dynlistener.cc
@@ -142,7 +142,7 @@ void DynListener::listenOnUnixDomain(const string& fname)
   
   listen(d_s, 10);
   
-  g_log<<Logger::Warning<<"Listening on controlsocket in '"<<fname<<"'"<<endl;
+  g_log<<Logger::Info<<"Listening on controlsocket in '"<<fname<<"'"<<endl;
   d_nonlocal=true;
 }
 
@@ -156,12 +156,12 @@ void DynListener::listenOnTCP(const ComboAddress& local)
   listen(d_s, 10);
 
   d_socketaddress=local;
-  g_log<<Logger::Warning<<"Listening on controlsocket on '"<<local.toStringWithPort()<<"'"<<endl;
+  g_log<<Logger::Info<<"Listening on controlsocket on '"<<local.toStringWithPort()<<"'"<<endl;
   d_nonlocal=true;
 
   if(!::arg()["tcp-control-range"].empty()) {
     d_tcprange.toMasks(::arg()["tcp-control-range"]);
-    g_log<<Logger::Warning<<"Only allowing TCP control from: "<<d_tcprange.toString()<<endl;
+    g_log<<Logger::Info<<"Only allowing TCP control from: "<<d_tcprange.toString()<<endl;
   }
 }
 

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -166,7 +166,7 @@ void UDPNameserver::bindAddresses()
     pfd.events = POLLIN;
     pfd.revents = 0;
     d_rfds.push_back(pfd);
-    g_log<<Logger::Error<<"UDP server bound to "<<locala.toStringWithPort()<<endl;
+    g_log<<Logger::Info<<"UDP server bound to "<<locala.toStringWithPort()<<endl;
   }
 }
 

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -82,7 +82,7 @@ LockGuarded<std::map<ComboAddress,size_t,ComboAddress::addressOnlyLessThan>> TCP
 
 void TCPNameserver::go()
 {
-  g_log<<Logger::Error<<"Creating backend connection for TCP"<<endl;
+  g_log<<Logger::Info<<"Creating backend connection for TCP"<<endl;
   s_P.lock()->reset();
   try {
     *(s_P.lock()) = make_unique<PacketHandler>();
@@ -594,7 +594,7 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
   if(q->d_dnssecOk)
     outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
 
-  g_log<<Logger::Warning<<logPrefix<<"transfer initiated"<<endl;
+  g_log<<Logger::Notice<<logPrefix<<"transfer initiated"<<endl;
 
   // determine if zone exists and AXFR is allowed using existing backend before spawning a new backend.
   SOAData sd;
@@ -1215,7 +1215,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock)
     }
   }
 
-  g_log<<Logger::Warning<<logPrefix<<"transfer initiated with serial "<<serial<<endl;
+  g_log<<Logger::Notice<<logPrefix<<"transfer initiated with serial "<<serial<<endl;
 
   // determine if zone exists, XFR is allowed, and if IXFR can proceed using existing backend before spawning a new backend.
   SOAData sd;
@@ -1369,7 +1369,7 @@ TCPNameserver::TCPNameserver()
     }
 
     listen(s, 128);
-    g_log<<Logger::Error<<"TCP server bound to "<<local.toStringWithPort()<<endl;
+    g_log<<Logger::Info<<"TCP server bound to "<<local.toStringWithPort()<<endl;
     d_sockets.push_back(s);
     struct pollfd pfd;
     memset(&pfd, 0, sizeof(pfd));

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -61,7 +61,7 @@ AtomicCounter* UeberBackend::s_backendQueries = nullptr;
 //! Loads a module and reports it to all UeberBackend threads
 bool UeberBackend::loadmodule(const string& name)
 {
-  g_log << Logger::Warning << "Loading '" << name << "'" << endl;
+  g_log << Logger::Info << "Loading '" << name << "'" << endl;
 
   void* dlib = dlopen(name.c_str(), RTLD_NOW);
 

--- a/pdns/version.cc
+++ b/pdns/version.cc
@@ -70,15 +70,15 @@ string productTypeApiType() {
 
 void showProductVersion()
 {
-  g_log<<Logger::Warning<<productName()<<" "<< VERSION << " (C) "
+  g_log<<Logger::Notice<<productName()<<" "<< VERSION << " (C) "
     "PowerDNS.COM BV" << endl;
-  g_log<<Logger::Warning<<"Using "<<(sizeof(unsigned long)*8)<<"-bits mode. "
+  g_log<<Logger::Notice<<"Using "<<(sizeof(unsigned long)*8)<<"-bits mode. "
     "Built using " << compilerVersion()
 #ifndef REPRODUCIBLE
     <<" on " __DATE__ " " __TIME__ " by " BUILD_HOST
 #endif
     <<"."<< endl;
-  g_log<<Logger::Warning<<"PowerDNS comes with ABSOLUTELY NO WARRANTY. "
+  g_log<<Logger::Notice<<"PowerDNS comes with ABSOLUTELY NO WARRANTY. "
     "This is free software, and you are welcome to redistribute it "
     "according to the terms of the GPL version 2." << endl;
 }

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -626,7 +626,7 @@ void WebServer::bind()
 {
   try {
     d_server = createServer();
-    SLOG(g_log<<Logger::Warning<<d_logprefix<<"Listening for HTTP requests on "<<d_server->d_local.toStringWithPort()<<endl,
+    SLOG(g_log<<Logger::Info<<d_logprefix<<"Listening for HTTP requests on "<<d_server->d_local.toStringWithPort()<<endl,
          d_slog->info(Logr::Info, "Listening for HTTP requests", "address", Logging::Loggable(d_server->d_local)));
   }
   catch(NetworkError &e) {


### PR DESCRIPTION
### Short description
Auth 4.9 parameter `loglevel-show` exposes some informative messages are logged as `Warning` or `Error`. This PR lowers the level of several informative messages in an attempt to keep `Warning` and `Error` levels for events that users should act upon.

Note: This is not an exhaustive audit of all logging statements, only a specific few which I ran into as a user.
Note: The default `loglevel` is `Warning`, so in a deployment with default logging these messages would be discarded as a result of this PR

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

