### PR TITLE
rec: Don't enter wildcard qnames into the cache in the ZoneToCache function

### DIFF
--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -403,6 +403,9 @@ void ZoneData::ZoneToCache(const RecZoneToCache::Config& config)
   d_now = time(nullptr);
   for (const auto& [key, v] : d_all) {
     const auto& [qname, qtype] = key;
+    if (qname.isWildcard()) {
+      continue;
+    }
     switch (qtype) {
     case QType::NSEC:
     case QType::NSEC3:


### PR DESCRIPTION
In the record cache, a wildcard has no meaning, it will only match a literal '*'. No need for backport AFAIKS, as it does not prevent queries matching a wildcard in the auth to be processed by rec (either the query is sent to the auth if no match was found in the record cache, or it is matched by the record cache against a previously received record from the auth).

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
