### PR TITLE
auth: on OpenBSD, try harder to send on a non-blocking socket

### DIFF
--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -233,8 +233,10 @@ void UDPNameserver::send(DNSPacket& p)
   if(buffer.length() > p.getMaxReplyLen()) {
     g_log<<Logger::Error<<"Weird, trying to send a message that needs truncation, "<< buffer.length()<<" > "<<p.getMaxReplyLen()<<". Question was for "<<p.qdomain<<"|"<<p.qtype.toString()<<endl;
   }
-  if(sendmsg(p.getSocket(), &msgh, 0) < 0)
-    g_log<<Logger::Error<<"Error sending reply with sendmsg (socket="<<p.getSocket()<<", dest="<<p.d_remote.toStringWithPort()<<"): "<<stringerror()<<endl;
+  if (sendOnNBSocket(p.getSocket(), &msgh) < 0) {
+    int err = errno;
+    g_log<<Logger::Error<<"Error sending reply with sendmsg (socket="<<p.getSocket()<<", dest="<<p.d_remote.toStringWithPort()<<"): "<<stringerror(err)<<endl;
+  }
 }
 
 bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)


### PR DESCRIPTION
Should fix #13857 in many cases, though you can still argue this is a OpenBSD bug (or at least an undesirable difference between other systems and OpenBSD).

See also #9633

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
