### PR TITLE
rec: Backport 13720 to rec-5.0.x: update submodule pdns-builder for removing fakeroot usage

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.debian-trixie
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-trixie
@@ -13,8 +13,7 @@ FROM arm64v8/debian:trixie as dist-base
 
 ARG BUILDER_CACHE_BUSTER=
 ARG APT_URL
-RUN apt-get update && apt-get -y dist-upgrade && \
-    apt-get install -y fakeroot
+RUN apt-get update && apt-get -y dist-upgrade
 
 @INCLUDE Dockerfile.debbuild-prepare
 


### PR DESCRIPTION
### Short description
Update submodule pdns-builder for removing fakeroot usage.

CI runs currently failing when building `rel/rec-5.0.x` on `ubuntu-noble`: [https://github.com/PowerDNS/pdns/actions/runs/8226664556/job/22493416295](https://github.com/PowerDNS/pdns/actions/runs/8226664556/job/22493416295)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
