### PR TITLE
gh actions: Fix CI - `issue 9491` on repository `actions/runner-images`

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -41,11 +41,23 @@ jobs:
         SANITIZERS: asan+ubsan
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     defaults:
       run:
         working-directory: ./pdns-${{ env.BUILDER_VERSION }}
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -110,11 +122,23 @@ jobs:
         SANITIZERS: ${{ matrix.sanitizers }}
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     defaults:
       run:
         working-directory: ./pdns/recursordist/pdns-recursor-${{ env.BUILDER_VERSION }}
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -184,11 +208,23 @@ jobs:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
         FUZZING_TARGETS: yes
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     defaults:
       run:
         working-directory: ./pdns/dnsdistdist/dnsdist-${{ env.BUILDER_VERSION }}
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -251,7 +287,7 @@ jobs:
         ASAN_OPTIONS: detect_leaks=0
         TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ env.REPO_HOME }}/pdns/dnsdistdist/dnsdist-tsan.supp"
         AUTH_BACKEND_IP_ADDR: "172.17.0.1"
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     strategy:
       matrix:
         include:
@@ -278,6 +314,18 @@ jobs:
         options: >-
           --restart always
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -315,7 +363,7 @@ jobs:
         LDAPHOST: ldap://ldapserver/
         ODBCINI: /github/home/.odbc.ini
         AUTH_BACKEND_IP_ADDR: "172.17.0.1"
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     strategy:
       matrix:
         include:
@@ -402,6 +450,18 @@ jobs:
         options: >-
           --restart always
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -436,8 +496,20 @@ jobs:
       env:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         ASAN_OPTIONS: detect_leaks=0
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -478,8 +550,20 @@ jobs:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         ASAN_OPTIONS: detect_leaks=0
         TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ env.REPO_HOME }}/pdns/recursordist/recursor-tsan.supp"
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -522,8 +606,20 @@ jobs:
         UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp'
         ASAN_OPTIONS: detect_leaks=0
         TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ env.REPO_HOME }}/pdns/recursordist/recursor-tsan.supp"
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       # - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v4
         with:
@@ -568,8 +664,20 @@ jobs:
         UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp'
         ASAN_OPTIONS: detect_leaks=0
         TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ env.REPO_HOME }}/pdns/recursordist/recursor-tsan.supp"
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -614,6 +722,18 @@ jobs:
         COVERAGE: yes
       options: --sysctl net.ipv6.conf.all.disable_ipv6=0 --privileged
     steps:
+      # workaround issue 9491 repo actions/runner-images
+      - name: get runner image version
+        id: runner-image-version
+        run: |
+          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: modify number of bits to use for aslr entropy
+        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
+        run: |
+          sudo sysctl -a | grep vm.mmap.rnd
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5


### PR DESCRIPTION
### Short description

Github runners with the latest `ubuntu-22.04` image version are using a 32-bit entropy value, which is not compatible with the LLVM installed by default on these runners. This affects the `build-and-test-all.yml` workflow (even tough tests are run on containers on top of the GH runners).

This change should be reverted once the issue is solved. This issue can be tracked [here](https://github.com/actions/runner-images/issues/9491)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
