### PR TITLE
dnsdist: Add a new query rules chain triggered after a cache miss

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rule-chains.cc
+++ b/pdns/dnsdistdist/dnsdist-rule-chains.cc
@@ -24,7 +24,8 @@
 
 namespace dnsdist::rules
 {
-GlobalStateHolder<std::vector<RuleAction>> g_ruleactions;
+GlobalStateHolder<std::vector<RuleAction>> s_ruleActions;
+GlobalStateHolder<std::vector<RuleAction>> s_cacheMissRuleActions;
 GlobalStateHolder<std::vector<ResponseRuleAction>> s_respruleactions;
 GlobalStateHolder<std::vector<ResponseRuleAction>> s_cachehitrespruleactions;
 GlobalStateHolder<std::vector<ResponseRuleAction>> s_selfansweredrespruleactions;
@@ -45,5 +46,20 @@ const std::vector<ResponseRuleChainDescription>& getResponseRuleChains()
 GlobalStateHolder<std::vector<ResponseRuleAction>>& getResponseRuleChainHolder(ResponseRuleChain chain)
 {
   return s_responseRuleChains.at(static_cast<size_t>(chain)).holder;
+}
+
+static const std::vector<RuleChainDescription> s_ruleChains{
+  {"", "rules", s_ruleActions},
+  {"CacheMiss", "cache-miss-rules", s_cacheMissRuleActions},
+};
+
+const std::vector<RuleChainDescription>& getRuleChains()
+{
+  return s_ruleChains;
+}
+
+GlobalStateHolder<std::vector<RuleAction>>& getRuleChainHolder(RuleChain chain)
+{
+  return s_ruleChains.at(static_cast<size_t>(chain)).holder;
 }
 }

--- a/pdns/dnsdistdist/dnsdist-rule-chains.hh
+++ b/pdns/dnsdistdist/dnsdist-rule-chains.hh
@@ -34,15 +34,6 @@ class DNSResponseAction;
 
 namespace dnsdist::rules
 {
-enum class ResponseRuleChain : uint8_t
-{
-  ResponseRules = 0,
-  CacheHitResponseRules = 1,
-  CacheInsertedResponseRules = 2,
-  SelfAnsweredResponseRules = 3,
-  ResponseRuleChainsCount = 4
-};
-
 struct RuleAction
 {
   std::shared_ptr<DNSRule> d_rule;
@@ -51,6 +42,22 @@ struct RuleAction
   boost::uuids::uuid d_id;
   uint64_t d_creationOrder;
 };
+
+struct RuleChainDescription
+{
+  std::string prefix;
+  std::string metricName;
+  GlobalStateHolder<std::vector<RuleAction>>& holder;
+};
+
+enum class RuleChain : uint8_t
+{
+  Rules = 0,
+  CacheMissRules = 1,
+};
+
+const std::vector<RuleChainDescription>& getRuleChains();
+GlobalStateHolder<std::vector<RuleAction>>& getRuleChainHolder(RuleChain chain);
 
 struct ResponseRuleAction
 {
@@ -61,14 +68,20 @@ struct ResponseRuleAction
   uint64_t d_creationOrder;
 };
 
+enum class ResponseRuleChain : uint8_t
+{
+  ResponseRules = 0,
+  CacheHitResponseRules = 1,
+  CacheInsertedResponseRules = 2,
+  SelfAnsweredResponseRules = 3,
+};
+
 struct ResponseRuleChainDescription
 {
   std::string prefix;
   std::string metricName;
   GlobalStateHolder<std::vector<ResponseRuleAction>>& holder;
 };
-
-extern GlobalStateHolder<std::vector<RuleAction>> g_ruleactions;
 
 const std::vector<ResponseRuleChainDescription>& getResponseRuleChains();
 GlobalStateHolder<std::vector<ResponseRuleAction>>& getResponseRuleChainHolder(ResponseRuleChain chain);

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1050,7 +1050,28 @@ bool processRulesResult(const DNSAction::Action& action, DNSQuestion& dnsQuestio
   return false;
 }
 
-static bool applyRulesToQuery(LocalHolders& holders, DNSQuestion& dnsQuestion, const struct timespec& now)
+static bool applyRulesChainToQuery(const std::vector<dnsdist::rules::RuleAction>& rules, DNSQuestion& dnsQuestion)
+{
+  DNSAction::Action action = DNSAction::Action::None;
+  string ruleresult;
+  bool drop = false;
+
+  for (const auto& rule : rules) {
+    if (!rule.d_rule->matches(&dnsQuestion)) {
+      continue;
+    }
+
+    rule.d_rule->d_matches++;
+    action = (*rule.d_action)(&dnsQuestion, &ruleresult);
+    if (processRulesResult(action, dnsQuestion, ruleresult, drop)) {
+      break;
+    }
+  }
+
+  return !drop;
+}
+
+static bool applyRulesToQuery(LocalHolders& holders, DNSQuestion& dnsQuestion, const timespec& now)
 {
   if (g_rings.shouldRecordQueries()) {
     g_rings.insertQuery(now, dnsQuestion.ids.origRemote, dnsQuestion.ids.qname, dnsQuestion.ids.qtype, dnsQuestion.getData().size(), *dnsQuestion.getHeader(), dnsQuestion.getProtocol());
@@ -1211,20 +1232,7 @@ static bool applyRulesToQuery(LocalHolders& holders, DNSQuestion& dnsQuestion, c
   }
 #endif /* DISABLE_DYNBLOCKS */
 
-  DNSAction::Action action = DNSAction::Action::None;
-  string ruleresult;
-  bool drop = false;
-  for (const auto& rule : *holders.ruleactions) {
-    if (rule.d_rule->matches(&dnsQuestion)) {
-      rule.d_rule->d_matches++;
-      action = (*rule.d_action)(&dnsQuestion, &ruleresult);
-      if (processRulesResult(action, dnsQuestion, ruleresult, drop)) {
-        break;
-      }
-    }
-  }
-
-  return !drop;
+  return applyRulesChainToQuery(*holders.ruleactions, dnsQuestion);
 }
 
 ssize_t udpClientSendRequestToBackend(const std::shared_ptr<DownstreamState>& backend, const int socketDesc, const PacketBuffer& request, bool healthCheck)
@@ -1413,39 +1421,49 @@ static bool prepareOutgoingResponse(LocalHolders& holders, const ClientState& cl
   return true;
 }
 
+static ProcessQueryResult handleQueryTurnedIntoSelfAnsweredResponse(DNSQuestion& dnsQuestion, LocalHolders& holders)
+{
+  fixUpQueryTurnedResponse(dnsQuestion, dnsQuestion.ids.origFlags);
+
+  if (!prepareOutgoingResponse(holders, *dnsQuestion.ids.cs, dnsQuestion, false)) {
+    return ProcessQueryResult::Drop;
+  }
+
+  const auto rcode = dnsQuestion.getHeader()->rcode;
+  if (rcode == RCode::NXDomain) {
+    ++dnsdist::metrics::g_stats.ruleNXDomain;
+  }
+  else if (rcode == RCode::Refused) {
+    ++dnsdist::metrics::g_stats.ruleRefused;
+  }
+  else if (rcode == RCode::ServFail) {
+    ++dnsdist::metrics::g_stats.ruleServFail;
+  }
+
+  ++dnsdist::metrics::g_stats.selfAnswered;
+  ++dnsQuestion.ids.cs->responses;
+  return ProcessQueryResult::SendAnswer;
+}
+
+static void selectBackendForOutgoingQuery(DNSQuestion& dnsQuestion, const std::shared_ptr<ServerPool>& serverPool, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend)
+{
+  std::shared_ptr<ServerPolicy> poolPolicy = serverPool->policy;
+  const auto& policy = poolPolicy != nullptr ? *poolPolicy : *(holders.policy);
+  const auto servers = serverPool->getServers();
+  selectedBackend = policy.getSelectedBackend(*servers, dnsQuestion);
+}
+
 ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend)
 {
   const uint16_t queryId = ntohs(dnsQuestion.getHeader()->id);
 
   try {
     if (dnsQuestion.getHeader()->qr) { // something turned it into a response
-      fixUpQueryTurnedResponse(dnsQuestion, dnsQuestion.ids.origFlags);
-
-      if (!prepareOutgoingResponse(holders, *dnsQuestion.ids.cs, dnsQuestion, false)) {
-        return ProcessQueryResult::Drop;
-      }
-
-      const auto rcode = dnsQuestion.getHeader()->rcode;
-      if (rcode == RCode::NXDomain) {
-        ++dnsdist::metrics::g_stats.ruleNXDomain;
-      }
-      else if (rcode == RCode::Refused) {
-        ++dnsdist::metrics::g_stats.ruleRefused;
-      }
-      else if (rcode == RCode::ServFail) {
-        ++dnsdist::metrics::g_stats.ruleServFail;
-      }
-
-      ++dnsdist::metrics::g_stats.selfAnswered;
-      ++dnsQuestion.ids.cs->responses;
-      return ProcessQueryResult::SendAnswer;
+      return handleQueryTurnedIntoSelfAnsweredResponse(dnsQuestion, holders);
     }
     std::shared_ptr<ServerPool> serverPool = getPool(*holders.pools, dnsQuestion.ids.poolName);
-    std::shared_ptr<ServerPolicy> poolPolicy = serverPool->policy;
     dnsQuestion.ids.packetCache = serverPool->packetCache;
-    const auto& policy = poolPolicy != nullptr ? *poolPolicy : *(holders.policy);
-    const auto servers = serverPool->getServers();
-    selectedBackend = policy.getSelectedBackend(*servers, dnsQuestion);
+    selectBackendForOutgoingQuery(dnsQuestion, serverPool, holders, selectedBackend);
 
     uint32_t allowExpired = selectedBackend ? 0 : g_staleCacheEntriesTTL;
 
@@ -1524,6 +1542,21 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, LocalHolders
       vinfolog("Packet cache miss for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size());
 
       ++dnsdist::metrics::g_stats.cacheMisses;
+
+      const auto existingPool = dnsQuestion.ids.poolName;
+      if (!applyRulesChainToQuery(*holders.cacheMissRuleActions, dnsQuestion)) {
+        return ProcessQueryResult::Drop;
+      }
+      if (dnsQuestion.getHeader()->qr) { // something turned it into a response
+        return handleQueryTurnedIntoSelfAnsweredResponse(dnsQuestion, holders);
+      }
+      /* let's be nice and allow the selection of a different pool,
+         but no second cache-lookup for you */
+      if (dnsQuestion.ids.poolName != existingPool) {
+        serverPool = getPool(*holders.pools, dnsQuestion.ids.poolName);
+        dnsQuestion.ids.packetCache = serverPool->packetCache;
+        selectBackendForOutgoingQuery(dnsQuestion, serverPool, holders, selectedBackend);
+      }
     }
 
     if (!selectedBackend) {
@@ -2740,7 +2773,9 @@ static void cleanupLuaObjects()
 {
   /* when our coverage mode is enabled, we need to make sure
      that the Lua objects are destroyed before the Lua contexts. */
-  dnsdist::rules::g_ruleactions.setState({});
+  for (const auto& chain : dnsdist::rules::getRuleChains()) {
+    chain.holder.setState({});
+  }
   for (const auto& chain : dnsdist::rules::getResponseRuleChains()) {
     chain.holder.setState({});
   }

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -1225,13 +1225,14 @@ enum class ProcessQueryResult : uint8_t
 struct LocalHolders
 {
   LocalHolders() :
-    acl(g_ACL.getLocal()), policy(g_policy.getLocal()), ruleactions(dnsdist::rules::g_ruleactions.getLocal()), cacheHitRespRuleactions(dnsdist::rules::getResponseRuleChainHolder(dnsdist::rules::ResponseRuleChain::CacheHitResponseRules).getLocal()), cacheInsertedRespRuleActions(dnsdist::rules::getResponseRuleChainHolder(dnsdist::rules::ResponseRuleChain::CacheInsertedResponseRules).getLocal()), selfAnsweredRespRuleactions(dnsdist::rules::getResponseRuleChainHolder(dnsdist::rules::ResponseRuleChain::SelfAnsweredResponseRules).getLocal()), servers(g_dstates.getLocal()), dynNMGBlock(g_dynblockNMG.getLocal()), dynSMTBlock(g_dynblockSMT.getLocal()), pools(g_pools.getLocal())
+    acl(g_ACL.getLocal()), policy(g_policy.getLocal()), ruleactions(dnsdist::rules::getRuleChainHolder(dnsdist::rules::RuleChain::Rules).getLocal()), cacheMissRuleActions(dnsdist::rules::getRuleChainHolder(dnsdist::rules::RuleChain::CacheMissRules).getLocal()), cacheHitRespRuleactions(dnsdist::rules::getResponseRuleChainHolder(dnsdist::rules::ResponseRuleChain::CacheHitResponseRules).getLocal()), cacheInsertedRespRuleActions(dnsdist::rules::getResponseRuleChainHolder(dnsdist::rules::ResponseRuleChain::CacheInsertedResponseRules).getLocal()), selfAnsweredRespRuleactions(dnsdist::rules::getResponseRuleChainHolder(dnsdist::rules::ResponseRuleChain::SelfAnsweredResponseRules).getLocal()), servers(g_dstates.getLocal()), dynNMGBlock(g_dynblockNMG.getLocal()), dynSMTBlock(g_dynblockSMT.getLocal()), pools(g_pools.getLocal())
   {
   }
 
   LocalStateHolder<NetmaskGroup> acl;
   LocalStateHolder<ServerPolicy> policy;
   LocalStateHolder<vector<dnsdist::rules::RuleAction>> ruleactions;
+  LocalStateHolder<vector<dnsdist::rules::RuleAction>> cacheMissRuleActions;
   LocalStateHolder<vector<dnsdist::rules::ResponseRuleAction>> cacheHitRespRuleactions;
   LocalStateHolder<vector<dnsdist::rules::ResponseRuleAction>> cacheInsertedRespRuleActions;
   LocalStateHolder<vector<dnsdist::rules::ResponseRuleAction>> selfAnsweredRespRuleactions;

--- a/pdns/dnsdistdist/docs/reference/rules-management.rst
+++ b/pdns/dnsdistdist/docs/reference/rules-management.rst
@@ -36,51 +36,11 @@ For Rules related to the incoming query:
 
   :param int n: The rule number
 
-.. function:: getCacheHitResponseRule(selector) -> DNSDistResponseRuleAction
-
-  .. versionadded:: 1.9.0
-
-  Return the cache-hit response rule corresponding to the selector, if any.
-  The selector can be the position of the rule in the list, as an integer,
-  its name as a string or its UUID as a string as well.
-
-  :param int or str selector: The position in the list, name or UUID of the rule to return.
-
-.. function:: getCacheInsertedResponseRule(selector) -> DNSDistResponseRuleAction
-
-  .. versionadded:: 1.9.0
-
-  Return the cache-inserted response rule corresponding to the selector, if any.
-  The selector can be the position of the rule in the list, as an integer,
-  its name as a string or its UUID as a string as well.
-
-  :param int or str selector: The position in the list, name or UUID of the rule to return.
-
-.. function:: getResponseRule(selector) -> DNSDistResponseRuleAction
-
-  .. versionadded:: 1.9.0
-
-  Return the response rule corresponding to the selector, if any.
-  The selector can be the position of the rule in the list, as an integer,
-  its name as a string or its UUID as a string as well.
-
-  :param int or str selector: The position in the list, name or UUID of the rule to return.
-
 .. function:: getRule(selector) -> DNSDistRuleAction
 
   .. versionadded:: 1.9.0
 
   Return the rule corresponding to the selector, if any.
-  The selector can be the position of the rule in the list, as an integer,
-  its name as a string or its UUID as a string as well.
-
-  :param int or str selector: The position in the list, name or UUID of the rule to return.
-
-.. function:: getSelfAnsweredResponseRule(selector) -> DNSDistResponseRuleAction
-
-  .. versionadded:: 1.9.0
-
-  Return the self-answered response rule corresponding to the selector, if any.
   The selector can be the position of the rule in the list, as an integer,
   its name as a string or its UUID as a string as well.
 
@@ -99,22 +59,6 @@ For Rules related to the incoming query:
   .. versionadded:: 1.6.0
 
   This function moves the last rule to the first position. Before 1.6.0 this was handled by :func:`topRule`.
-
-.. function:: newRuleAction(rule, action[, options])
-
-  .. versionchanged:: 1.6.0
-    Added ``name`` to the ``options``.
-
-  Return a pair of DNS Rule and DNS Action, to be used with :func:`setRules`.
-
-  :param Rule rule: A Rule (see :doc:`selectors`)
-  :param Action action: The Action (see :doc:`actions`) to apply to the matched traffic
-  :param table options: A table with key: value pairs with options.
-
-  Options:
-
-  * ``uuid``: string - UUID to assign to the new rule. By default a random UUID is generated for each rule.
-  * ``name``: string - Name to assign to the new rule.
 
 .. function:: setRules(rules)
 
@@ -149,6 +93,103 @@ For Rules related to the incoming query:
 
   :param int id: The position of the rule to remove if ``id`` is numerical, its UUID or name otherwise
 
+Cache misses
+------------
+
+For Rules related to the incoming query after a cache miss:
+
+.. warning::
+  While all selectors and actions are available, some actions will no longer be honored at
+  this point. For example changing the backend pool will not trigger a second cache-lookup.
+  Switching from a backend pool that has EDNS Client Subnet enabled to one that doesn't
+  will result in the EDNS Client Subnet corresponding to the initial server pool to be
+  added to the query.
+
+.. function:: addCacheMissAction(DNSrule, action [, options])
+
+  .. versionadded:: 1.10
+
+  Add a Rule and Action to the existing cache miss rules.
+  If a string (or list of) is passed as the first parameter instead of a :class:`DNSRule`, it behaves as if the string or list of strings was passed to :func:`NetmaskGroupRule` or :func:`SuffixMatchNodeRule`.
+
+  :param DNSrule rule: A :class:`DNSRule`, e.g. an :func:`AllRule`, or a compounded bunch of rules using e.g. :func:`AndRule`.
+  :param action: The action to take
+  :param table options: A table with key: value pairs with options.
+
+  Options:
+
+  * ``uuid``: string - UUID to assign to the new rule. By default a random UUID is generated for each rule.
+  * ``name``: string - Name to assign to the new rule.
+
+.. function:: clearCacheMissRules()
+
+  .. versionadded:: 1.10
+
+  Remove all current cache miss rules.
+
+.. function:: getCacheMissAction(n) -> DNSDistRuleAction
+
+  .. versionadded:: 1.10
+
+  Returns the :class:`DNSDistRuleAction` associated with cache miss rule ``n``.
+
+  :param int n: The rule number
+
+.. function:: getCacheMissRule(selector) -> DNSDistRuleAction
+
+  .. versionadded:: 1.10
+
+  Return the cache miss rule corresponding to the selector, if any.
+  The selector can be the position of the rule in the list, as an integer,
+  its name as a string or its UUID as a string as well.
+
+  :param int or str selector: The position in the list, name or UUID of the rule to return.
+
+.. function:: mvCacheMissRule(from, to)
+
+  .. versionadded:: 1.10
+
+  Move cache miss rule ``from`` to a position where it is in front of ``to``.
+  ``to`` can be one larger than the largest rule, in which case the rule will be moved to the last position.
+
+  :param int from: Rule number to move
+  :param int to: Location to more the Rule to
+
+.. function:: mvCacheMissRuleToTop()
+
+  .. versionadded:: 1.10
+
+  This function moves the last cache miss rule to the first position.
+
+.. function:: setCacheMissRules(rules)
+
+  .. versionadded:: 1.10
+
+  Replace the current cache miss rules with the supplied list of pairs of DNS Rules and DNS Actions (see :func:`newRuleAction`)
+
+  :param [RuleAction] rules: A list of RuleActions
+
+.. function:: showCacheMissRules([options])
+
+  .. versionadded:: 1.10
+
+  Show all defined cache miss rules for queries, optionally displaying their UUIDs.
+
+  :param table options: A table with key: value pairs with display options.
+
+  Options:
+
+  * ``showUUIDs=false``: bool - Whether to display the UUIDs, defaults to false.
+  * ``truncateRuleWidth=-1``: int - Truncate rules output to ``truncateRuleWidth`` size. Defaults to ``-1`` to display the full rule.
+
+.. function:: rmCacheMissRule(id)
+
+  .. versionadded:: 1.10
+
+  Remove rule ``id``.
+
+  :param int id: The position of the cache miss rule to remove if ``id`` is numerical, its UUID or name otherwise
+
 Responses
 ---------
 
@@ -173,6 +214,22 @@ For Rules related to responses:
 
   * ``uuid``: string - UUID to assign to the new rule. By default a random UUID is generated for each rule.
   * ``name``: string - Name to assign to the new rule.
+
+.. function:: clearResponseRules()
+
+  .. versionadded:: 1.10
+
+  Remove all current response rules.
+
+.. function:: getResponseRule(selector) -> DNSDistResponseRuleAction
+
+  .. versionadded:: 1.9.0
+
+  Return the response rule corresponding to the selector, if any.
+  The selector can be the position of the rule in the list, as an integer,
+  its name as a string or its UUID as a string as well.
+
+  :param int or str selector: The position in the list, name or UUID of the rule to return.
 
 .. function:: mvResponseRule(from, to)
 
@@ -240,6 +297,22 @@ Functions for manipulating Cache Hit Response Rules:
   * ``uuid``: string - UUID to assign to the new rule. By default a random UUID is generated for each rule.
   * ``name``: string - Name to assign to the new rule.
 
+.. function:: clearCacheHitResponseRules()
+
+  .. versionadded:: 1.10
+
+  Remove all current cache-hit response rules.
+
+.. function:: getCacheHitResponseRule(selector) -> DNSDistResponseRuleAction
+
+  .. versionadded:: 1.9.0
+
+  Return the cache-hit response rule corresponding to the selector, if any.
+  The selector can be the position of the rule in the list, as an integer,
+  its name as a string or its UUID as a string as well.
+
+  :param int or str selector: The position in the list, name or UUID of the rule to return.
+
 .. function:: mvCacheHitResponseRule(from, to)
 
   Move cache hit response rule ``from`` to a position where it is in front of ``to``.
@@ -303,6 +376,22 @@ Functions for manipulating Cache Inserted Response Rules:
   * ``uuid``: string - UUID to assign to the new rule. By default a random UUID is generated for each rule.
   * ``name``: string - Name to assign to the new rule.
 
+.. function:: clearCacheInsertedResponseRules()
+
+  .. versionadded:: 1.10
+
+  Remove all current cache-inserted response rules.
+
+.. function:: getCacheInsertedResponseRule(selector) -> DNSDistResponseRuleAction
+
+  .. versionadded:: 1.9.0
+
+  Return the cache-inserted response rule corresponding to the selector, if any.
+  The selector can be the position of the rule in the list, as an integer,
+  its name as a string or its UUID as a string as well.
+
+  :param int or str selector: The position in the list, name or UUID of the rule to return.
+
 .. function:: mvCacheInsertedResponseRule(from, to)
 
   .. versionadded:: 1.8.0
@@ -362,6 +451,22 @@ Functions for manipulating Self-Answered Response Rules:
 
   * ``uuid``: string - UUID to assign to the new rule. By default a random UUID is generated for each rule.
   * ``name``: string - Name to assign to the new rule.
+
+.. function:: clearSelfAnsweredResponseRules()
+
+  .. versionadded:: 1.10
+
+  Remove all current self-answered response rules.
+
+.. function:: getSelfAnsweredResponseRule(selector) -> DNSDistResponseRuleAction
+
+  .. versionadded:: 1.9.0
+
+  Return the self-answered response rule corresponding to the selector, if any.
+  The selector can be the position of the rule in the list, as an integer,
+  its name as a string or its UUID as a string as well.
+
+  :param int or str selector: The position in the list, name or UUID of the rule to return.
 
 .. function:: mvSelfAnsweredResponseRule(from, to)
 
@@ -425,3 +530,19 @@ Convenience Functions
   ``makeRule("0.0.0.0/0")`` will for example match all IPv4 traffic, ``makeRule({"be","nl","lu"})`` will match all Benelux DNS traffic.
 
   :param string rule: A string, or list of strings, to convert to a rule.
+
+.. function:: newRuleAction(rule, action[, options])
+
+  .. versionchanged:: 1.6.0
+    Added ``name`` to the ``options``.
+
+  Return a pair of DNS Rule and DNS Action, to be used with :func:`setRules`.
+
+  :param Rule rule: A Rule (see :doc:`selectors`)
+  :param Action action: The Action (see :doc:`actions`) to apply to the matched traffic
+  :param table options: A table with key: value pairs with options.
+
+  Options:
+
+  * ``uuid``: string - UUID to assign to the new rule. By default a random UUID is generated for each rule.
+  * ``name``: string - Name to assign to the new rule.

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -35,7 +35,6 @@
 #include "dnsdist-tcp-upstream.hh"
 
 GlobalStateHolder<NetmaskGroup> g_ACL;
-GlobalStateHolder<std::vector<dnsdist::rules::RuleAction> > g_ruleactions;
 GlobalStateHolder<servers_t> g_dstates;
 
 QueryCount g_qcount;

--- a/regression-tests.dnsdist/test_CacheMissActions.py
+++ b/regression-tests.dnsdist/test_CacheMissActions.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+import base64
+import time
+import dns
+from dnsdisttests import DNSDistTest, pickAvailablePort
+
+class TestCacheMissSelfAnswered(DNSDistTest):
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
+    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
+
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%d")
+    newServer{address="127.0.0.1:%d"}
+
+    pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
+    getPool(""):setCache(pc)
+    -- this does not really make sense on its own, but we might want
+    -- to refuse queries for a domain under attack if the anwer is not cached
+    addCacheMissAction(SuffixMatchNodeRule("refused.cache-miss.tests.powerdns.com."), RCodeAction(DNSRCode.REFUSED), {name="myFirstRule"})
+    """
+
+    def testRefusedWhenNotCached(self):
+        """
+        CacheMiss: Refused when not in cache
+        """
+        # check that the rule is in place
+        lines = self.sendConsoleCommand('showCacheMissRules()').splitlines()
+        self.assertEqual(len(lines), 2)
+        self.assertIn('myFirstRule', lines[1])
+
+        name = 'refused.cache-miss.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AAAA', 'IN')
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertTrue(receivedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
+
+        # now we remove the rule
+        self.sendConsoleCommand('clearCacheMissRules()')
+        lines = self.sendConsoleCommand('showCacheMissRules()').splitlines()
+        self.assertEqual(len(lines), 1)
+
+        # get a response inserted into the cache
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.AAAA,
+                                    '2001:db8::1')
+        response.answer.append(rrset)
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response=response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
+
+        # add the rule back
+        self.sendConsoleCommand('addCacheMissAction(SuffixMatchNodeRule("refused.cache-miss.tests.powerdns.com."), RCodeAction(DNSRCode.REFUSED), {name="myFirstRule"})')
+        lines = self.sendConsoleCommand('showCacheMissRules()').splitlines()
+        self.assertEqual(len(lines), 2)
+        self.assertIn('myFirstRule', lines[1])
+
+        # and check that we do get the cached response
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertTrue(receivedResponse)
+        self.assertEqual(receivedResponse, response)
+
+class TestCacheMissGoToADifferentPool(DNSDistTest):
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
+    _testServer2Port = pickAvailablePort()
+    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_testServer2Port']
+
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%d")
+
+    newServer{address="127.0.0.1:%d", pool="slow", name="slow"}
+    newServer{address="127.0.0.1:%d", pool="initial", name="initial"}
+
+    pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
+    getPool("initial"):setCache(pc)
+    getPool("slow"):setCache(pc)
+
+    addAction(AllRule(), PoolAction("initial"))
+    -- this does not really make sense on its own, but we might want
+    -- to route queries for a domain under attack to a different pool
+    -- of 'best-effort' servers if the anwer is not cached
+    addCacheMissAction(SuffixMatchNodeRule("routed-to-slow.cache-miss.tests.powerdns.com."), PoolAction("slow"))
+    """
+
+    def testRoutedToSlowWhenNotCached(self):
+        """
+        CacheMiss: Routed to a different pool when not in cache
+        """
+        name = 'routed-to-slow.cache-miss.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AAAA', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.AAAA,
+                                    '2001:db8::1')
+        response.answer.append(rrset)
+
+        # first query goes to the 'slow' server
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response=response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
+
+        # the second one is a cache-hit
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertTrue(receivedResponse)
+        self.assertEqual(receivedResponse, response)
+
+        backendLines = self.sendConsoleCommand('showServers()').splitlines(False)
+        self.assertEqual(len(backendLines), 4)
+        for line in backendLines:
+            if line.startswith('#') or line.startswith('All'):
+                continue
+            tokens = line.split()
+            self.assertEqual(len(tokens), 15)
+            pool = tokens[13]
+            queries = int(tokens[9])
+            if pool == 'slow':
+                self.assertEqual(queries, 1)
+            else:
+                self.assertEqual(queries, 0)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This new chain of rules allows postponing the decision of what to do with the query to after a cache-lookup has been done. This is particularly useful when dealing with abuse: we might want to allow cache hits to be processed normally since they are cheap while dropping/refusing/routing to a different pool queries that result in a cache miss.

Closes https://github.com/PowerDNS/pdns/issues/5760 and is the first step to implement https://github.com/PowerDNS/pdns/issues/13750

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
