### PR TITLE
rec ci: also build a rec with all optional stuff disabled

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -115,6 +115,10 @@ jobs:
     strategy:
       matrix:
         sanitizers: [ubsan+asan, tsan]
+        features: [least, full]
+        exclude:
+          - sanitizers: tsan
+            features: least
     container:
       image: ghcr.io/powerdns/base-pdns-ci-image/debian-12-pdns-base:master
       env:
@@ -156,17 +160,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ccache
-          key: recursor-${{ matrix.sanitizers }}-ccache-${{ steps.get-stamp.outputs.stamp }}
-          restore-keys: recursor-${{ matrix.sanitizers }}-ccache-
+          key: recursor-${{ matrix.features }}-${{ matrix.sanitizers }}-ccache-${{ steps.get-stamp.outputs.stamp }}
+          restore-keys: recursor-${{ matrix.features }}-${{ matrix.sanitizers }}-ccache-
       - run: inv ci-install-rust ${{ env.REPO_HOME }}
         working-directory: ./pdns/recursordist/
       - run: inv ci-autoconf
         working-directory: ./pdns/recursordist/
-      - run: inv ci-rec-configure
+      - run: inv ci-rec-configure ${{ matrix.features }}
         working-directory: ./pdns/recursordist/
       - run: inv ci-make-distdir
         working-directory: ./pdns/recursordist/
-      - run: inv ci-rec-configure
+      - run: inv ci-rec-configure ${{ matrix.features }}
       - run: inv ci-rec-make-bear
       - run: inv ci-rec-run-unit-tests
       - run: inv generate-coverage-info ./testrunner $GITHUB_WORKSPACE
@@ -175,7 +179,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: rec-unit-${{ matrix.sanitizers }}
+          flag-name: rec-unit-${{ matrix.features }}-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
@@ -185,7 +189,7 @@ jobs:
       - name: Store the binaries
         uses: actions/upload-artifact@v4 # this takes 30 seconds, maybe we want to tar
         with:
-          name: pdns-recursor-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          name: pdns-recursor-${{ matrix.features }}-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
           path: /opt/pdns-recursor
           retention-days: 1
 
@@ -573,7 +577,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-recursor-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          name: pdns-recursor-full-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
           path: /opt/pdns-recursor
       - run: inv apt-fresh
       - run: inv add-auth-repo  ${{ matrix.dist_name }} ${{ matrix.dist_release_name }} ${{ matrix.pdns_repo_version }}
@@ -586,7 +590,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: rec-api
+          flag-name: rec-api-full-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
@@ -630,7 +634,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-recursor-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          name: pdns-recursor-full-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
           path: /opt/pdns-recursor
       - run: inv apt-fresh
       - run: inv add-auth-repo ${{ matrix.dist_name }} ${{ matrix.dist_release_name }} ${{ matrix.pdns_repo_version }}
@@ -643,7 +647,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: rec-regression
+          flag-name: rec-regression-full-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
@@ -687,7 +691,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-recursor-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          name: pdns-recursor-full-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
           path: /opt/pdns-recursor
       - run: inv install-clang-runtime
       - run: inv install-rec-bulk-deps
@@ -698,7 +702,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: rec-regression-bulk
+          flag-name: rec-regression-bulk-full-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -212,7 +212,7 @@ jobs:
       if: matrix.product == 'rec'
       working-directory: ./pdns/recursordist/
       run: |
-        inv ci-rec-configure
+        inv ci-rec-configure full
     - name: Build rec
       if: matrix.product == 'rec'
       working-directory: ./pdns/recursordist/

--- a/tasks.py
+++ b/tasks.py
@@ -490,20 +490,40 @@ def ci_auth_configure(c):
 
 
 @task
-def ci_rec_configure(c):
+def ci_rec_configure(c, features):
     unittests = get_unit_tests()
 
-    configure_cmd = " ".join([
-        get_base_configure_cmd(),
-        "--enable-nod",
-        "--prefix=/opt/pdns-recursor",
-        "--with-lua=luajit",
-        "--with-libcap",
-        "--with-net-snmp",
-        "--enable-dns-over-tls",
-        "--enable-verbose-logging",
-        unittests,
-    ])
+    if features == 'full':
+        configure_cmd = " ".join([
+            get_base_configure_cmd(),
+            "--prefix=/opt/pdns-recursor",
+            "--enable-option-checking",
+            "--enable-verbose-logging",
+            "--enable-dns-over-tls",
+            "--enable-nod",
+            "--with-libcap",
+            "--with-lua=luajit",
+            "--with-net-snmp",
+            unittests,
+        ])
+    else:
+        configure_cmd = " ".join([
+            get_base_configure_cmd(),
+            "--prefix=/opt/pdns-recursor",
+            "--enable-option-checking",
+            "--enable-verbose-logging",
+            "--disable-dns-over-tls",
+            "--disable-dnstap",
+            "--disable-nod",
+            "--disable-systemd",
+            "--with-lua=luajit",
+            "--without-libcap",
+            "--without-libcurl",
+            "--without-libdecaf",
+            "--without-libsodium",
+            "--without-net-snmp",
+            unittests,
+        ])
     res = c.run(configure_cmd, warn=True)
     if res.exited != 0:
         c.run('cat config.log')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

When working on stuff related to optional features it is easy to miss e.g. an `#ifdef`, so also build with basically all optional stuff disabled. Approach stolen from the dnsdist case.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
