### PR TITLE
rec: on rhel and debian install recursor.yml default file, but only for new installs

### DIFF
--- a/builder-support/debian/recursor/debian-buster/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-buster/pdns-recursor.postinst
@@ -5,6 +5,9 @@ case "$1" in
   configure)
     addgroup --system pdns
     adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ ! -e /etc/powerdns/recursor.conf -a ! -e /etc/powerdns/recursor.yml ]; then
+      cp /etc/powerdns/recursor.yml-dist /etc/powerdns/recursor.yml
+    fi
   ;;
 
   *)

--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -41,15 +41,15 @@ override_dh_auto_install:
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/snmp RECURSOR-MIB.txt
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.yml-dist
-	./pdns_recursor --no-config --config=default | sed \
-		-e 's!^# config-dir=.*!config-dir=/etc/powerdns!' \
-		-e 's!^# hint-file=.*!&\nhint-file=/usr/share/dns/root.hints!' \
-		-e 's!^# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
-		-e 's!^# local-address=.*!local-address=127.0.0.1!' \
-		-e 's!^# lua-config-file=.*!lua-config-file=/etc/powerdns/recursor.lua!' \
-		-e 's!^# quiet=.*!quiet=yes!' \
-		-e '/^# version-string=.*/d' \
-		> debian/pdns-recursor/etc/powerdns/recursor.conf
+	dir=$$(mktemp -d) && touch "$$dir/recursor.yml" && ./pdns_recursor --config-dir="$$dir" --config=default 2> /dev/null | sed \
+		-e 's!^#\(.*config_dir: \).*!\1/etc/powerdns!' \
+		-e 's!^#\(.*hint_file: \).*!\1/usr/share/dns/root.hints!' \
+		-e 's!^#\(.*include_dir: \).*!\1/etc/powerdns/recursor.d!' \
+		-e 's!^#\(.*local_address: \).*\1!127.0.0.1!' \
+		-e 's!^#\(.*lua_config_file: \).*!\1/etc/powerdns/recursor.lua!' \
+		-e 's!^#\(.*quiet: \)=.*!\1=true!' \
+		-e '/^#.*version_string:.*/d' \
+		> debian/pdns-recursor/etc/powerdns/recursor.yml-dist
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -80,7 +80,7 @@ make %{?_smp_mflags} check || (cat test-suite.log && false)
 %install
 make install DESTDIR=%{buildroot}
 
-%{__mv} %{buildroot}%{_sysconfdir}/%{name}/recursor.conf{-dist,}
+#%{__mv} %{buildroot}%{_sysconfdir}/%{name}/recursor.conf{-dist,}
 %{__mkdir} %{buildroot}%{_sysconfdir}/%{name}/recursor.d
 
 # change user and group to pdns-recursor and add default include-dir
@@ -88,7 +88,7 @@ sed -i \
     -e 's/# setuid=/setuid=pdns-recursor/' \
     -e 's/# setgid=/setgid=pdns-recursor/' \
     -e 's!# include-dir=.*!&\ninclude-dir=%{_sysconfdir}/%{name}/recursor.d!' \
-    %{buildroot}%{_sysconfdir}/%{name}/recursor.conf
+    %{buildroot}%{_sysconfdir}/%{name}/recursor.yml-dist
 
 # The EL7 and 8 systemd actually supports %t, but its version number is older than that, so we do use seperate runtime dirs, but don't rely on RUNTIME_DIRECTORY
 %if 0%{?rhel} < 9
@@ -106,6 +106,9 @@ getent passwd pdns-recursor > /dev/null || \
 exit 0
 
 %post
+if [ ! -e %{_sysconfdir}/%{name}/recursor.conf -a ! -e %{_sysconfdir}/%{name}/recursor.yml ]; then
+    cp %{_sysconfdir}/%{name}/recursor.yml-dist %{_sysconfdir}/%{name}/recursor.yml
+fi
 systemctl daemon-reload ||:
 %systemd_post %{name}.service
 
@@ -124,6 +127,6 @@ systemctl daemon-reload ||:
 %{_unitdir}/pdns-recursor@.service
 %dir %{_sysconfdir}/%{name}
 %dir %{_sysconfdir}/%{name}/recursor.d
-%config(noreplace) %{_sysconfdir}/%{name}/recursor.conf
+#%config(noreplace) %{_sysconfdir}/%{name}/recursor.conf
 %config %{_sysconfdir}/%{name}/recursor.yml-dist
 %doc README

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -41,7 +41,7 @@ BUILT_SOURCES=htmlfiles.h \
 	dnslabeltext.cc
 
 CLEANFILES = htmlfiles.h \
-	recursor.conf-dist recursor.yml-dist
+	recursor.yml-dist
 
 htmlfiles.h: incfiles ${srcdir}/html/* ${srcdir}/html/js/*
 	$(AM_V_GEN)$(srcdir)/incfiles > $@.tmp
@@ -531,10 +531,7 @@ pubsuffix.cc: $(srcdir)/effective_tld_names.dat
 	$(srcdir)/mkpubsuffixcc $< $@
 
 ## Config file
-sysconf_DATA = recursor.conf-dist recursor.yml-dist
-
-recursor.conf-dist: pdns_recursor
-	$(AM_V_GEN)./pdns_recursor --config=default > $@
+sysconf_DATA = recursor.yml-dist
 
 recursor.yml-dist: pdns_recursor
 	dir=$$(mktemp -d) && touch "$$dir/recursor.yml" && ./pdns_recursor --config-dir="$$dir" --config=default 2> /dev/null > $@ && rm "$$dir/recursor.yml" && rmdir "$$dir"


### PR DESCRIPTION
So only if no existing recursor.conf and no recursor.yml was found. This allows:

- new installes to have a default .yml file.
- existing .conf install to be untouched
- existing .yml installs to be left untouched

This needs careful review from somebody familiar with packaging do's and don't s.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
