### PR TITLE
dnsdist-1.9.x: Backport of #13906 - Fix first IPv6 console connection being rejected

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -1033,6 +1033,11 @@ void controlThread(std::shared_ptr<Socket> acceptFD, ComboAddress local)
   {
     setThreadName("dnsdist/control");
     ComboAddress client;
+    // make sure that the family matches the one from the listening IP,
+    // so that getSocklen() returns the correct size later, otherwise
+    // the first IPv6 console connection might get refused
+    client.sin4.sin_family = local.sin4.sin_family;
+
     int sock{-1};
     auto localACL = g_consoleACL.getLocal();
     infolog("Accepting control connections on %s", local.toStringWithPort());

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -816,15 +816,15 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         return result.decode('UTF-8')
 
     @classmethod
-    def sendConsoleCommand(cls, command, timeout=5.0):
+    def sendConsoleCommand(cls, command, timeout=5.0, IPv6=False):
         ourNonce = libnacl.utils.rand_nonce()
         theirNonce = None
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock = socket.socket(socket.AF_INET if not IPv6 else socket.AF_INET6, socket.SOCK_STREAM)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         if timeout:
             sock.settimeout(timeout)
 
-        sock.connect(("127.0.0.1", cls._consolePort))
+        sock.connect(("::1", cls._consolePort, 0, 0) if IPv6 else ("127.0.0.1", cls._consolePort))
         sock.send(ourNonce)
         theirNonce = sock.recv(len(ourNonce))
         if len(theirNonce) != len(ourNonce):

--- a/regression-tests.dnsdist/test_Console.py
+++ b/regression-tests.dnsdist/test_Console.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import base64
 import dns
+import os
 import socket
 import time
 from dnsdisttests import DNSDistTest
@@ -22,6 +23,27 @@ class TestConsoleAllowed(DNSDistTest):
         Console: Allowed
         """
         version = self.sendConsoleCommand('showVersion()')
+        self.assertTrue(version.startswith('dnsdist '))
+
+class TestConsoleAllowedV6(DNSDistTest):
+
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
+
+    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
+    _config_template = """
+    setKey("%s")
+    controlSocket("[::1]:%s")
+    newServer{address="127.0.0.1:%d"}
+    """
+
+    def testConsoleAllowed(self):
+        """
+        Console: Allowed IPv6
+        """
+        if 'SKIP_IPV6_TESTS' in os.environ:
+            raise unittest.SkipTest('IPv6 tests are disabled')
+        version = self.sendConsoleCommand('showVersion()', IPv6=True)
         self.assertTrue(version.startswith('dnsdist '))
 
 class TestConsoleNotAllowed(DNSDistTest):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #13906 to 1.9.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
