### PR TITLE
dnsdist-1.9.x: Backport of 13927 - Fix annoying compiler warnings by introducing and switching to `pdns::UniqueFilePtr`

### DIFF
--- a/modules/pipebackend/coprocess.cc
+++ b/modules/pipebackend/coprocess.cc
@@ -233,7 +233,7 @@ UnixRemote::UnixRemote(const string& path)
   if (connect(d_fd, (struct sockaddr*)&remote, sizeof(remote)) < 0)
     unixDie("Unable to connect to remote '" + path + "' using UNIX domain socket");
 
-  d_fp = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(d_fd, "r"), fclose);
+  d_fp = pdns::UniqueFilePtr(fdopen(d_fd, "r"));
 }
 
 void UnixRemote::send(const string& line)

--- a/modules/pipebackend/coprocess.hh
+++ b/modules/pipebackend/coprocess.hh
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <string>
 
+#include "pdns/misc.hh"
 #include "pdns/namespaces.hh"
 
 class CoRemote
@@ -67,6 +68,6 @@ public:
 
 private:
   int d_fd;
-  std::unique_ptr<FILE, int (*)(FILE*)> d_fp{nullptr, fclose};
+  pdns::UniqueFilePtr d_fp{nullptr};
 };
 bool isUnixSocket(const string& fname);

--- a/modules/remotebackend/pipeconnector.cc
+++ b/modules/remotebackend/pipeconnector.cc
@@ -96,7 +96,7 @@ void PipeConnector::launch()
     setCloseOnExec(d_fd1[1]);
     close(d_fd2[1]);
     setCloseOnExec(d_fd2[0]);
-    if (!(d_fp = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(d_fd2[0], "r"), fclose))) {
+    if (!(d_fp = pdns::UniqueFilePtr(fdopen(d_fd2[0], "r")))) {
       throw PDNSException("Unable to associate a file pointer with pipe: " + stringerror());
     }
     if (d_timeout != 0) {

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -158,7 +158,7 @@ private:
   int d_fd1[2]{}, d_fd2[2]{};
   int d_pid;
   int d_timeout;
-  std::unique_ptr<FILE, int (*)(FILE*)> d_fp{nullptr, fclose};
+  pdns::UniqueFilePtr d_fp{nullptr};
 };
 
 class RemoteBackend : public DNSBackend

--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -497,7 +497,7 @@ uint64_t DNSDistPacketCache::dump(int fd)
           rcode = dh.rcode;
         }
 
-        fprintf(filePtr.get(), "%s %" PRId64 " %s ; rcode %" PRIu8 ", key %" PRIu32 ", length %" PRIu16 ", received over UDP %d, added %" PRId64 "\n", value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QType(value.qtype).toString().c_str(), rcode, entry.first, value.len, value.receivedOverUDP, static_cast<int64_t>(value.added));
+        fprintf(filePtr.get(), "%s %" PRId64 " %s ; rcode %" PRIu8 ", key %" PRIu32 ", length %" PRIu16 ", received over UDP %d, added %" PRId64 "\n", value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QType(value.qtype).toString().c_str(), rcode, entry.first, value.len, static_cast<int>(value.receivedOverUDP), static_cast<int64_t>(value.added));
       }
       catch(...) {
         fprintf(filePtr.get(), "; error printing '%s'\n", value.qname.empty() ? "EMPTY" : value.qname.toString().c_str());

--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -473,12 +473,12 @@ uint64_t DNSDistPacketCache::getEntriesCount()
 
 uint64_t DNSDistPacketCache::dump(int fd)
 {
-  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(dup(fd), "w"), fclose);
-  if (fp == nullptr) {
+  auto filePtr = pdns::UniqueFilePtr(fdopen(dup(fd), "w"));
+  if (filePtr == nullptr) {
     return 0;
   }
 
-  fprintf(fp.get(), "; dnsdist's packet cache dump follows\n;\n");
+  fprintf(filePtr.get(), "; dnsdist's packet cache dump follows\n;\n");
 
   uint64_t count = 0;
   time_t now = time(nullptr);
@@ -497,10 +497,10 @@ uint64_t DNSDistPacketCache::dump(int fd)
           rcode = dh.rcode;
         }
 
-        fprintf(fp.get(), "%s %" PRId64 " %s ; rcode %" PRIu8 ", key %" PRIu32 ", length %" PRIu16 ", received over UDP %d, added %" PRId64 "\n", value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QType(value.qtype).toString().c_str(), rcode, entry.first, value.len, value.receivedOverUDP, static_cast<int64_t>(value.added));
+        fprintf(filePtr.get(), "%s %" PRId64 " %s ; rcode %" PRIu8 ", key %" PRIu32 ", length %" PRIu16 ", received over UDP %d, added %" PRId64 "\n", value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QType(value.qtype).toString().c_str(), rcode, entry.first, value.len, value.receivedOverUDP, static_cast<int64_t>(value.added));
       }
       catch(...) {
-        fprintf(fp.get(), "; error printing '%s'\n", value.qname.empty() ? "EMPTY" : value.qname.toString().c_str());
+        fprintf(filePtr.get(), "; error printing '%s'\n", value.qname.empty() ? "EMPTY" : value.qname.toString().c_str());
       }
     }
   }

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -411,7 +411,7 @@ void setupLuaInspection(LuaContext& luaCtx)
       boost::optional<Netmask>  nm;
       boost::optional<DNSName> dn;
       int msec = -1;
-      std::unique_ptr<FILE, decltype(&fclose)> outputFile{nullptr, fclose};
+      pdns::UniqueFilePtr outputFile{nullptr};
 
       if (options) {
         std::string outputFileName;
@@ -421,7 +421,7 @@ void setupLuaInspection(LuaContext& luaCtx)
             g_outputBuffer = "Error opening dump file for writing: " + stringerror() + "\n";
             return;
           }
-          outputFile = std::unique_ptr<FILE, decltype(&fclose)>(fdopen(fd, "w"), fclose);
+          outputFile = pdns::UniqueFilePtr(fdopen(fd, "w"));
           if (outputFile == nullptr) {
             g_outputBuffer = "Error opening dump file for writing: " + stringerror() + "\n";
             close(fd);

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -160,7 +160,7 @@ public:
 
   std::map<int, std::string> d_ocspResponses;
   std::unique_ptr<OpenSSLTLSTicketKeysRing> d_ticketKeys{nullptr};
-  std::unique_ptr<FILE, int(*)(FILE*)> d_keyLogFile{nullptr, fclose};
+  pdns::UniqueFilePtr d_keyLogFile{nullptr};
   ClientState* d_cs{nullptr};
   time_t d_ticketsKeyRotationDelay{0};
 

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -160,6 +160,7 @@ public:
 
   std::map<int, std::string> d_ocspResponses;
   std::unique_ptr<OpenSSLTLSTicketKeysRing> d_ticketKeys{nullptr};
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   pdns::UniqueFilePtr d_keyLogFile{nullptr};
   ClientState* d_cs{nullptr};
   time_t d_ticketsKeyRotationDelay{0};

--- a/pdns/dnspcap.cc
+++ b/pdns/dnspcap.cc
@@ -235,8 +235,7 @@ PcapPacketWriter::PcapPacketWriter(const string& fname, const PcapPacketReader& 
 
 PcapPacketWriter::PcapPacketWriter(const string& fname) : d_fname(fname)
 {
-  d_fp = pdns::UniqueFilePtr(fopen(fname.c_str(),"w"));
-
+  d_fp = pdns::openFileForWriting(fname, 0600, true, false);
   if (!d_fp) {
     unixDie("Unable to open file");
   }

--- a/pdns/dnspcap.cc
+++ b/pdns/dnspcap.cc
@@ -30,7 +30,7 @@
 #include "namespaces.hh"
 PcapPacketReader::PcapPacketReader(const string& fname) : d_fname(fname)
 {
-  d_fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(fname.c_str(), "r"), fclose);
+  d_fp = pdns::UniqueFilePtr(fopen(fname.c_str(), "r"));
   if (!d_fp) {
     unixDie("Unable to open file " + fname);
   }
@@ -235,7 +235,7 @@ PcapPacketWriter::PcapPacketWriter(const string& fname, const PcapPacketReader& 
 
 PcapPacketWriter::PcapPacketWriter(const string& fname) : d_fname(fname)
 {
-  d_fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(fname.c_str(),"w"), fclose);
+  d_fp = pdns::UniqueFilePtr(fopen(fname.c_str(),"w"));
 
   if (!d_fp) {
     unixDie("Unable to open file");

--- a/pdns/dnspcap.hh
+++ b/pdns/dnspcap.hh
@@ -87,7 +87,7 @@ public:
     }
   };
 
-  PcapPacketReader(const string& fname); 
+  PcapPacketReader(const string& fname);
 
   template<typename T>
   void checkedFread(T* ptr)
@@ -118,17 +118,17 @@ public:
   char *d_buffer;
   size_t d_bufsize;
 private:
-  std::unique_ptr<FILE, int(*)(FILE*)> d_fp{nullptr, fclose};
+  pdns::UniqueFilePtr d_fp{nullptr};
   string d_fname;
   unsigned int d_skipMediaHeader;
 };
 
 class PcapPacketWriter
 {
-public: 
+public:
   PcapPacketWriter(const string& fname, const PcapPacketReader& ppr);
   PcapPacketWriter(const string& fname);
-  
+
   void write();
   void setPPR(const PcapPacketReader& ppr) { d_ppr = &ppr; }
 
@@ -136,6 +136,6 @@ private:
   string d_fname;
   const PcapPacketReader* d_ppr{nullptr};
 
-  std::unique_ptr<FILE, int(*)(FILE*)> d_fp{nullptr, fclose};
+  pdns::UniqueFilePtr d_fp{nullptr};
   bool d_first{true};
-}; 
+};

--- a/pdns/dnspcap2protobuf.cc
+++ b/pdns/dnspcap2protobuf.cc
@@ -63,9 +63,11 @@ try {
 
   PcapPacketReader pr(argv[1]);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): it's argv..
   auto filePtr = pdns::openFileForWriting(argv[2], 0600, true, false);
   if (!filePtr) {
     auto error = errno;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): it's argv..
     cerr<<"Error opening output file "<<argv[2]<<": "<<stringerror(error)<<endl;
     exit(EXIT_FAILURE);
   }

--- a/pdns/dnspcap2protobuf.cc
+++ b/pdns/dnspcap2protobuf.cc
@@ -63,8 +63,8 @@ try {
 
   PcapPacketReader pr(argv[1]);
 
-  auto fp = pdns::UniqueFilePtr(fopen(argv[2], "w"));
-  if (!fp) {
+  auto filePtr = pdns::UniqueFilePtr(fopen(argv[2], "w"));
+  if (!filePtr) {
     cerr<<"Error opening output file "<<argv[2]<<": "<<stringerror()<<endl;
     exit(EXIT_FAILURE);
   }
@@ -150,8 +150,8 @@ try {
       }
 
       uint16_t mlen = htons(pbBuffer.length());
-      fwrite(&mlen, 1, sizeof(mlen), fp.get());
-      fwrite(pbBuffer.c_str(), 1, pbBuffer.length(), fp.get());
+      fwrite(&mlen, 1, sizeof(mlen), filePtr.get());
+      fwrite(pbBuffer.c_str(), 1, pbBuffer.length(), filePtr.get());
     }
   }
   catch (const std::exception& e) {

--- a/pdns/dnspcap2protobuf.cc
+++ b/pdns/dnspcap2protobuf.cc
@@ -63,7 +63,7 @@ try {
 
   PcapPacketReader pr(argv[1]);
 
-  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(argv[2], "w"), fclose);
+  auto fp = pdns::UniqueFilePtr(fopen(argv[2], "w"));
   if (!fp) {
     cerr<<"Error opening output file "<<argv[2]<<": "<<stringerror()<<endl;
     exit(EXIT_FAILURE);

--- a/pdns/dnspcap2protobuf.cc
+++ b/pdns/dnspcap2protobuf.cc
@@ -63,9 +63,10 @@ try {
 
   PcapPacketReader pr(argv[1]);
 
-  auto filePtr = pdns::UniqueFilePtr(fopen(argv[2], "w"));
+  auto filePtr = pdns::openFileForWriting(argv[2], 0600, true, false);
   if (!filePtr) {
-    cerr<<"Error opening output file "<<argv[2]<<": "<<stringerror()<<endl;
+    auto error = errno;
+    cerr<<"Error opening output file "<<argv[2]<<": "<<stringerror(error)<<endl;
     exit(EXIT_FAILURE);
   }
 

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -53,15 +53,15 @@ using namespace boost::assign;
 std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCFile(DNSKEYRecordContent& drc, const char* fname)
 {
   string sline, isc;
-  auto fp = pdns::UniqueFilePtr(fopen(fname, "r"));
-  if(!fp) {
+  auto filePtr = pdns::UniqueFilePtr(fopen(fname, "r"));
+  if(!filePtr) {
     throw runtime_error("Unable to read file '"+string(fname)+"' for generating DNS Private Key");
   }
 
-  while(stringfgets(fp.get(), sline)) {
+  while(stringfgets(filePtr.get(), sline)) {
     isc += sline;
   }
-  fp.reset();
+  filePtr.reset();
 
   auto dke = makeFromISCString(drc, isc);
   auto checkKeyErrors = std::vector<std::string>{};

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -53,7 +53,7 @@ using namespace boost::assign;
 std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCFile(DNSKEYRecordContent& drc, const char* fname)
 {
   string sline, isc;
-  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(fname, "r"), fclose);
+  auto fp = pdns::UniqueFilePtr(fopen(fname, "r"));
   if(!fp) {
     throw runtime_error("Unable to read file '"+string(fname)+"' for generating DNS Private Key");
   }

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -66,7 +66,7 @@ class DNSCryptoKeyEngine
     void createFromPEMString(DNSKEYRecordContent& drc, const std::string& contents)
     {
       // NOLINTNEXTLINE(*-cast): POSIX APIs.
-      unique_ptr<std::FILE, decltype(&std::fclose)> inputFile{fmemopen(const_cast<char*>(contents.data()), contents.length(), "r"), &std::fclose};
+      pdns::UniqueFilePtr inputFile{fmemopen(const_cast<char*>(contents.data()), contents.length(), "r")};
       createFromPEMFile(drc, *inputFile);
     }
 
@@ -89,7 +89,7 @@ class DNSCryptoKeyEngine
 
       std::string output{};
       output.resize(buflen);
-      unique_ptr<std::FILE, decltype(&std::fclose)> outputFile{fmemopen(output.data(), output.length() - 1, "w"), &std::fclose};
+      pdns::UniqueFilePtr outputFile{fmemopen(output.data(), output.length() - 1, "w")};
       convertToPEMFile(*outputFile);
       std::fflush(outputFile.get());
       output.resize(std::ftell(outputFile.get()));

--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -262,12 +262,12 @@ try
   std::vector<std::thread> workers;
   workers.reserve(numworkers);
 
-  std::unique_ptr<FILE, int(*)(FILE*)> fp{nullptr, fclose};
+  pdns::UniqueFilePtr fp{nullptr};
   if (!g_vm.count("file")) {
-    fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(0, "r"), fclose);
+    fp = pdns::UniqueFilePtr(fdopen(0, "r"));
   }
   else {
-    fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(g_vm["file"].as<string>().c_str(), "r"), fclose);
+    fp = pdns::UniqueFilePtr(fopen(g_vm["file"].as<string>().c_str(), "r"));
     if (!fp) {
       unixDie("Unable to open "+g_vm["file"].as<string>()+" for input");
     }

--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -262,24 +262,24 @@ try
   std::vector<std::thread> workers;
   workers.reserve(numworkers);
 
-  pdns::UniqueFilePtr fp{nullptr};
+  pdns::UniqueFilePtr filePtr{nullptr};
   if (!g_vm.count("file")) {
-    fp = pdns::UniqueFilePtr(fdopen(0, "r"));
+    filePtr = pdns::UniqueFilePtr(fdopen(0, "r"));
   }
   else {
-    fp = pdns::UniqueFilePtr(fopen(g_vm["file"].as<string>().c_str(), "r"));
-    if (!fp) {
+    filePtr = pdns::UniqueFilePtr(fopen(g_vm["file"].as<string>().c_str(), "r"));
+    if (!filePtr) {
       unixDie("Unable to open "+g_vm["file"].as<string>()+" for input");
     }
   }
   pair<string, string> q;
   string line;
-  while(stringfgets(fp.get(), line)) {
+  while(stringfgets(filePtr.get(), line)) {
     boost::trim_right(line);
     q=splitField(line, ' ');
     g_queries.push_back(BenchQuery(q.first, DNSRecordContent::TypeToNumber(q.second)));
   }
-  fp.reset();
+  filePtr.reset();
 
   for (unsigned int n = 0; n < numworkers; ++n) {
     workers.push_back(std::thread(worker));

--- a/pdns/ixfrutils.cc
+++ b/pdns/ixfrutils.cc
@@ -134,7 +134,7 @@ void writeZoneToDisk(const records_t& records, const DNSName& zone, const std::s
   /* ensure that the partial zone file will only be accessible by the current user, not even
      by other users in the same group, and certainly not by other users. */
   umask(S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
-  auto filePtr = std::unique_ptr<FILE, int(*)(FILE*)>(fopen((fname+".partial").c_str(), "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fopen((fname+".partial").c_str(), "w"));
   if (!filePtr) {
     throw runtime_error("Unable to open file '"+fname+".partial' for writing: "+stringerror());
   }

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -1040,7 +1040,8 @@ static void libssl_key_log_file_callback(const SSL* ssl, const char* line)
     return;
   }
 
-  auto filePtr = reinterpret_cast<FILE*>(SSL_CTX_get_ex_data(sslCtx, s_keyLogIndex));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): OpenSSL's API
+  auto* filePtr = reinterpret_cast<FILE*>(SSL_CTX_get_ex_data(sslCtx, s_keyLogIndex));
   if (filePtr == nullptr) {
     return;
   }

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -1040,13 +1040,13 @@ static void libssl_key_log_file_callback(const SSL* ssl, const char* line)
     return;
   }
 
-  auto fp = reinterpret_cast<FILE*>(SSL_CTX_get_ex_data(sslCtx, s_keyLogIndex));
-  if (fp == nullptr) {
+  auto filePtr = reinterpret_cast<FILE*>(SSL_CTX_get_ex_data(sslCtx, s_keyLogIndex));
+  if (filePtr == nullptr) {
     return;
   }
 
-  fprintf(fp, "%s\n", line);
-  fflush(fp);
+  fprintf(filePtr, "%s\n", line);
+  fflush(filePtr);
 }
 #endif /* HAVE_SSL_CTX_SET_KEYLOG_CALLBACK */
 

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -471,23 +471,23 @@ bool libssl_generate_ocsp_response(const std::string& certFile, const std::strin
 {
   const EVP_MD* rmd = EVP_sha256();
 
-  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(certFile.c_str(), "r"), fclose);
-  if (!fp) {
+  auto filePtr = pdns::UniqueFilePtr(fopen(certFile.c_str(), "r"));
+  if (!filePtr) {
     throw std::runtime_error("Unable to open '" + certFile + "' when loading the certificate to generate an OCSP response");
   }
-  auto cert = std::unique_ptr<X509, void(*)(X509*)>(PEM_read_X509_AUX(fp.get(), nullptr, nullptr, nullptr), X509_free);
+  auto cert = std::unique_ptr<X509, void(*)(X509*)>(PEM_read_X509_AUX(filePtr.get(), nullptr, nullptr, nullptr), X509_free);
 
-  fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(caCert.c_str(), "r"), fclose);
-  if (!fp) {
+  filePtr = pdns::UniqueFilePtr(fopen(caCert.c_str(), "r"));
+  if (!filePtr) {
     throw std::runtime_error("Unable to open '" + caCert + "' when loading the issuer certificate to generate an OCSP response");
   }
-  auto issuer = std::unique_ptr<X509, void(*)(X509*)>(PEM_read_X509_AUX(fp.get(), nullptr, nullptr, nullptr), X509_free);
-  fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(caKey.c_str(), "r"), fclose);
-  if (!fp) {
+  auto issuer = std::unique_ptr<X509, void(*)(X509*)>(PEM_read_X509_AUX(filePtr.get(), nullptr, nullptr, nullptr), X509_free);
+  filePtr = pdns::UniqueFilePtr(fopen(caKey.c_str(), "r"));
+  if (!filePtr) {
     throw std::runtime_error("Unable to open '" + caKey + "' when loading the issuer key to generate an OCSP response");
   }
-  auto issuerKey = std::unique_ptr<EVP_PKEY, void(*)(EVP_PKEY*)>(PEM_read_PrivateKey(fp.get(), nullptr, nullptr, nullptr), EVP_PKEY_free);
-  fp.reset();
+  auto issuerKey = std::unique_ptr<EVP_PKEY, void(*)(EVP_PKEY*)>(PEM_read_PrivateKey(filePtr.get(), nullptr, nullptr, nullptr), EVP_PKEY_free);
+  filePtr.reset();
 
   auto bs = std::unique_ptr<OCSP_BASICRESP, void(*)(OCSP_BASICRESP*)>(OCSP_BASICRESP_new(), OCSP_BASICRESP_free);
   auto thisupd = std::unique_ptr<ASN1_TIME, void(*)(ASN1_TIME*)>(X509_gmtime_adj(nullptr, 0), ASN1_TIME_free);
@@ -939,11 +939,11 @@ std::pair<std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)>, std::vector<std::st
     if (!pair.d_key) {
 #if defined(HAVE_SSL_CTX_USE_CERT_AND_KEY)
       // If no separate key is given, treat it as a pkcs12 file
-      auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(pair.d_cert.c_str(), "r"), fclose);
-      if (!fp) {
+      auto filePtr = pdns::UniqueFilePtr(fopen(pair.d_cert.c_str(), "r"));
+      if (!filePtr) {
         throw std::runtime_error("Unable to open file " + pair.d_cert);
       }
-      auto p12 = std::unique_ptr<PKCS12, void(*)(PKCS12*)>(d2i_PKCS12_fp(fp.get(), nullptr), PKCS12_free);
+      auto p12 = std::unique_ptr<PKCS12, void(*)(PKCS12*)>(d2i_PKCS12_fp(filePtr.get(), nullptr), PKCS12_free);
       if (!p12) {
         throw std::runtime_error("Unable to open PKCS12 file " + pair.d_cert);
       }
@@ -1050,26 +1050,26 @@ static void libssl_key_log_file_callback(const SSL* ssl, const char* line)
 }
 #endif /* HAVE_SSL_CTX_SET_KEYLOG_CALLBACK */
 
-std::unique_ptr<FILE, int(*)(FILE*)> libssl_set_key_log_file(std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)>& ctx, const std::string& logFile)
+pdns::UniqueFilePtr libssl_set_key_log_file(std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)>& ctx, const std::string& logFile)
 {
 #ifdef HAVE_SSL_CTX_SET_KEYLOG_CALLBACK
   int fd = open(logFile.c_str(),  O_WRONLY | O_CREAT | O_APPEND, 0600);
   if (fd == -1) {
     unixDie("Error opening TLS log file '" + logFile + "'");
   }
-  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(fd, "a"), fclose);
-  if (!fp) {
+  auto filePtr = pdns::UniqueFilePtr(fdopen(fd, "a"));
+  if (!filePtr) {
     int error = errno; // close might clobber errno
     close(fd);
     throw std::runtime_error("Error opening TLS log file '" + logFile + "': " + stringerror(error));
   }
 
-  SSL_CTX_set_ex_data(ctx.get(), s_keyLogIndex, fp.get());
+  SSL_CTX_set_ex_data(ctx.get(), s_keyLogIndex, filePtr.get());
   SSL_CTX_set_keylog_callback(ctx.get(), &libssl_key_log_file_callback);
 
-  return fp;
+  return filePtr;
 #else
-  return std::unique_ptr<FILE, int(*)(FILE*)>(nullptr, fclose);
+  return {};
 #endif /* HAVE_SSL_CTX_SET_KEYLOG_CALLBACK */
 }
 

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -12,6 +12,7 @@
 #include "config.h"
 #include "circular_buffer.hh"
 #include "lock.hh"
+#include "misc.hh"
 
 enum class LibsslTLSVersion : uint8_t { Unknown, TLS10, TLS11, TLS12, TLS13 };
 
@@ -154,7 +155,7 @@ bool libssl_set_min_tls_version(std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)
 std::pair<std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)>, std::vector<std::string>> libssl_init_server_context(const TLSConfig& config,
                                                                                                             std::map<int, std::string>& ocspResponses);
 
-std::unique_ptr<FILE, int(*)(FILE*)> libssl_set_key_log_file(std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)>& ctx, const std::string& logFile);
+pdns::UniqueFilePtr libssl_set_key_log_file(std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)>& ctx, const std::string& logFile);
 
 /* called in a client context, if the client advertised more than one ALPN values and the server returned more than one as well, to select the one to use. */
 #ifndef DISABLE_NPN

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1789,14 +1789,14 @@ UniqueFilePtr openFileForWriting(const std::string& filePath, mode_t permissions
   }
   int fileDesc = open(filePath.c_str(), flags, permissions);
   if (fileDesc == -1) {
-    return UniqueFilePtr(nullptr);
+    return {};
   }
   auto filePtr = pdns::UniqueFilePtr(fdopen(fileDesc, appendIfExists ? "a" : "w"));
   if (!filePtr) {
     auto error = errno;
     close(fileDesc);
     errno = error;
-    return UniqueFilePtr(nullptr);
+    return {};
   }
   return filePtr;
 }

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1753,7 +1753,7 @@ namespace pdns
 {
 struct CloseDirDeleter
 {
-  void operator()(DIR* dir) {
+  void operator()(DIR* dir) const noexcept {
     closedir(dir);
   }
 };

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -861,11 +861,11 @@ bool stringfgets(FILE* fp, std::string& line)
 bool readFileIfThere(const char* fname, std::string* line)
 {
   line->clear();
-  auto fp = pdns::UniqueFilePtr(fopen(fname, "r"));
-  if (!fp) {
+  auto filePtr = pdns::UniqueFilePtr(fopen(fname, "r"));
+  if (!filePtr) {
     return false;
   }
-  return stringfgets(fp.get(), *line);
+  return stringfgets(filePtr.get(), *line);
 }
 
 Regex::Regex(const string &expr)

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -846,7 +846,7 @@ struct FilePtrDeleter
      - we avoid the annoying "ignoring attributes on template argument ‘int (*)(FILE*)’"
        warning from the compiler, which is there because fclose is tagged as __nonnull((1))
   */
-  void operator()(FILE* filePtr) {
+  void operator()(FILE* filePtr) const noexcept {
     fclose(filePtr);
   }
 };

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -836,4 +836,20 @@ private:
 namespace pdns
 {
 [[nodiscard]] std::optional<std::string> visit_directory(const std::string& directory, const std::function<bool(ino_t inodeNumber, const std::string_view& name)>& visitor);
+
+struct FilePtrDeleter
+{
+  /* using a deleter instead of decltype(&fclose) has two big advantages:
+     - the deleter is included in the type and does not have to be passed
+       when creating a new object (easier to use, less memory usage, in theory
+       better inlining)
+     - we avoid the annoying "ignoring attributes on template argument ‘int (*)(FILE*)’"
+       warning from the compiler, which is there because fclose is tagged as __nonnull((1))
+  */
+  void operator()(FILE* filePtr) {
+    fclose(filePtr);
+  }
+};
+
+using UniqueFilePtr = std::unique_ptr<FILE, FilePtrDeleter>;
 }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -852,4 +852,6 @@ struct FilePtrDeleter
 };
 
 using UniqueFilePtr = std::unique_ptr<FILE, FilePtrDeleter>;
+
+UniqueFilePtr openFileForWriting(const std::string& filePath, mode_t permissions, bool mustNotExist = true, bool appendIfExists = false);
 }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3527,14 +3527,14 @@ try
     const auto algorithm = pdns::checked_stoi<unsigned int>(cmds.at(3));
 
     errno = 0;
-    pdns::UniqueFilePtr fp{std::fopen(filename.c_str(), "r")};
-    if (fp == nullptr) {
+    pdns::UniqueFilePtr filePtr{std::fopen(filename.c_str(), "r")};
+    if (filePtr == nullptr) {
       auto errMsg = pdns::getMessageFromErrno(errno);
       throw runtime_error("Failed to open PEM file `" + filename + "`: " + errMsg);
     }
 
     DNSKEYRecordContent drc;
-    shared_ptr<DNSCryptoKeyEngine> key{DNSCryptoKeyEngine::makeFromPEMFile(drc, algorithm, *fp, filename)};
+    shared_ptr<DNSCryptoKeyEngine> key{DNSCryptoKeyEngine::makeFromPEMFile(drc, algorithm, *filePtr, filename)};
     if (!key) {
       cerr << "Could not convert key from PEM to internal format" << endl;
       return 1;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3527,7 +3527,7 @@ try
     const auto algorithm = pdns::checked_stoi<unsigned int>(cmds.at(3));
 
     errno = 0;
-    std::unique_ptr<std::FILE, decltype(&std::fclose)> fp{std::fopen(filename.c_str(), "r"), &std::fclose};
+    pdns::UniqueFilePtr fp{std::fopen(filename.c_str(), "r")};
     if (fp == nullptr) {
       auto errMsg = pdns::getMessageFromErrno(errno);
       throw runtime_error("Failed to open PEM file `" + filename + "`: " + errMsg);

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -901,7 +901,7 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
   return true;
 }
 
-size_t AggressiveNSECCache::dumpToFile(std::unique_ptr<FILE, int (*)(FILE*)>& fp, const struct timeval& now)
+size_t AggressiveNSECCache::dumpToFile(pdns::UniqueFilePtr& fp, const struct timeval& now)
 {
   size_t ret = 0;
 

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -93,7 +93,7 @@ public:
   static bool isSmallCoveringNSEC3(const DNSName& owner, const std::string& nextHash);
 
   void prune(time_t now);
-  size_t dumpToFile(pdns::UniqueFilePtr& fp, const struct timeval& now);
+  size_t dumpToFile(pdns::UniqueFilePtr& filePtr, const struct timeval& now);
 
 private:
   struct ZoneEntry

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -93,7 +93,7 @@ public:
   static bool isSmallCoveringNSEC3(const DNSName& owner, const std::string& nextHash);
 
   void prune(time_t now);
-  size_t dumpToFile(std::unique_ptr<FILE, int (*)(FILE*)>& fp, const struct timeval& now);
+  size_t dumpToFile(pdns::UniqueFilePtr& fp, const struct timeval& now);
 
 private:
   struct ZoneEntry

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -286,7 +286,7 @@ size_t NegCache::doDump(int fd, size_t maxCacheEntries, time_t now)
   if (newfd == -1) {
     return 0;
   }
-  auto fp = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto fp = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!fp) {
     close(newfd);
     return 0;

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -858,7 +858,7 @@ static void dumpTrace(const string& trace, const timeval& timev)
     return;
   }
   setNonBlocking(traceFd);
-  auto filep = std::unique_ptr<FILE, decltype(&fclose)>(fdopen(traceFd, "a"), &fclose);
+  auto filep = pdns::UniqueFilePtr(fdopen(traceFd, "a"));
   if (!filep) {
     int err = errno;
     SLOG(g_log << Logger::Error << "Could not write to trace file: " << stringerror(err) << endl,

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -326,15 +326,15 @@ static uint64_t dumpAggressiveNSECCache(int fd)
   if (newfd == -1) {
     return 0;
   }
-  auto fp = pdns::UniqueFilePtr(fdopen(newfd, "w"));
-  if (!fp) {
+  auto filePtr = pdns::UniqueFilePtr(fdopen(newfd, "w"));
+  if (!filePtr) {
     return 0;
   }
-  fprintf(fp.get(), "; aggressive NSEC cache dump follows\n;\n");
+  fprintf(filePtr.get(), "; aggressive NSEC cache dump follows\n;\n");
 
   struct timeval now;
   Utility::gettimeofday(&now, nullptr);
-  return g_aggressiveNSECCache->dumpToFile(fp, now);
+  return g_aggressiveNSECCache->dumpToFile(filePtr, now);
 }
 
 static uint64_t* pleaseDumpEDNSMap(int fd)
@@ -480,13 +480,13 @@ static RecursorControlChannel::Answer doDumpRPZ(int s, T begin, T end)
     return {1, "No RPZ zone named " + zoneName + "\n"};
   }
 
-  auto fp = pdns::UniqueFilePtr(fdopen(fdw, "w"));
-  if (!fp) {
+  auto filePtr = pdns::UniqueFilePtr(fdopen(fdw, "w"));
+  if (!filePtr) {
     int err = errno;
     return {1, "converting file descriptor: " + stringerror(err) + "\n"};
   }
 
-  zone->dump(fp.get());
+  zone->dump(filePtr.get());
 
   return {0, "done\n"};
 }

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -326,7 +326,7 @@ static uint64_t dumpAggressiveNSECCache(int fd)
   if (newfd == -1) {
     return 0;
   }
-  auto fp = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto fp = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!fp) {
     return 0;
   }
@@ -480,7 +480,7 @@ static RecursorControlChannel::Answer doDumpRPZ(int s, T begin, T end)
     return {1, "No RPZ zone named " + zoneName + "\n"};
   }
 
-  auto fp = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(fdw, "w"), fclose);
+  auto fp = pdns::UniqueFilePtr(fdopen(fdw, "w"));
   if (!fp) {
     int err = errno;
     return {1, "converting file descriptor: " + stringerror(err) + "\n"};

--- a/pdns/recursordist/recpacketcache.cc
+++ b/pdns/recursordist/recpacketcache.cc
@@ -264,7 +264,7 @@ uint64_t RecursorPacketCache::doDump(int file)
   if (fdupped == -1) {
     return 0;
   }
-  auto filePtr = std::unique_ptr<FILE, decltype(&fclose)>(fdopen(fdupped, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(fdupped, "w"));
   if (!filePtr) {
     close(fdupped);
     return 0;

--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -777,7 +777,7 @@ uint64_t MemRecursorCache::doDump(int fileDesc, size_t maxCacheEntries)
   if (newfd == -1) {
     return 0;
   }
-  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!filePtr) { // dup probably failed
     close(newfd);
     return 0;

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -361,7 +361,7 @@ static void processForwardZonesFile(shared_ptr<SyncRes::domainmap_t>& newMap, sh
   else {
     SLOG(g_log << Logger::Warning << "Reading zone forwarding information from '" << filename << "'" << endl,
          log->info(Logr::Notice, "Reading zone forwarding information", "file", Logging::Loggable(filename)));
-    auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fopen(filename.c_str(), "r"), fclose);
+    auto filePtr = pdns::UniqueFilePtr(fopen(filename.c_str(), "r"));
     if (!filePtr) {
       int err = errno;
       throw PDNSException("Error opening forward-zones-file '" + filename + "': " + stringerror(err));
@@ -508,7 +508,7 @@ static void processAllowNotifyForFile(shared_ptr<notifyset_t>& newSet, Logr::log
   else {
     SLOG(g_log << Logger::Warning << "Reading NOTIFY-allowed zones from '" << filename << "'" << endl,
          log->info(Logr::Notice, "Reading NOTIFY-allowed zones from file", "file", Logging::Loggable(filename)));
-    auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fopen(filename.c_str(), "r"), fclose);
+    auto filePtr = pdns::UniqueFilePtr(fopen(filename.c_str(), "r"));
     if (!filePtr) {
       throw PDNSException("Error opening allow-notify-for-file '" + filename + "': " + stringerror());
     }

--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -363,8 +363,8 @@ static bool dumpZoneToDisk(Logr::log_t logger, const DNSName& zoneName, const st
     return false;
   }
 
-  auto fp = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(fd, "w+"), fclose);
-  if (!fp) {
+  auto filePtr = pdns::UniqueFilePtr(fdopen(fileDesc, "w+"));
+  if (!filePtr) {
     int err = errno;
     close(fd);
     SLOG(g_log << Logger::Warning << "Unable to open a file pointer to dump the content of the RPZ zone " << zoneName << endl,

--- a/pdns/recursordist/settings/cxxsupport.cc
+++ b/pdns/recursordist/settings/cxxsupport.cc
@@ -58,7 +58,7 @@
 
 void pdns::settings::rec::oldStyleForwardsFileToBridgeStruct(const std::string& file, ::rust::Vec<ForwardZone>& vec)
 {
-  auto filePtr = std::unique_ptr<FILE, decltype(&fclose)>(fopen(file.c_str(), "r"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fopen(file.c_str(), "r"));
   if (!filePtr) {
     throw PDNSException("Error opening forward-zones-file '" + file + "': " + stringerror());
   }

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -1160,7 +1160,7 @@ uint64_t SyncRes::doEDNSDump(int fileDesc)
   if (newfd == -1) {
     return 0;
   }
-  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!filePtr) {
     close(newfd);
     return 0;
@@ -1212,7 +1212,7 @@ uint64_t SyncRes::doDumpNSSpeeds(int fileDesc)
   if (newfd == -1) {
     return 0;
   }
-  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!filePtr) {
     close(newfd);
     return 0;
@@ -1293,7 +1293,7 @@ uint64_t SyncRes::doDumpThrottleMap(int fileDesc)
   if (newfd == -1) {
     return 0;
   }
-  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!filePtr) {
     close(newfd);
     return 0;
@@ -1340,7 +1340,7 @@ uint64_t SyncRes::doDumpFailedServers(int fileDesc)
   if (newfd == -1) {
     return 0;
   }
-  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!filePtr) {
     close(newfd);
     return 0;
@@ -1380,7 +1380,7 @@ uint64_t SyncRes::doDumpNonResolvingNS(int fileDesc)
   if (newfd == -1) {
     return 0;
   }
-  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!filePtr) {
     close(newfd);
     return 0;
@@ -1420,7 +1420,7 @@ uint64_t SyncRes::doDumpSavedParentNSSets(int fileDesc)
   if (newfd == -1) {
     return 0;
   }
-  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!filePtr) {
     close(newfd);
     return 0;
@@ -1465,7 +1465,7 @@ uint64_t SyncRes::doDumpDoTProbeMap(int fileDesc)
   if (newfd == -1) {
     return 0;
   }
-  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(newfd, "w"));
   if (!filePtr) {
     close(newfd);
     return 0;

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -1265,7 +1265,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_dump)
 
   BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3U);
 
-  auto filePtr = std::unique_ptr<FILE, int (*)(FILE*)>(tmpfile(), fclose);
+  auto filePtr = pdns::UniqueFilePtr(tmpfile());
   if (!filePtr) {
     BOOST_FAIL("Temporary file could not be opened");
   }

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -525,9 +525,10 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile)
   cache.add(genNegCacheEntry(DNSName("www1.powerdns.com"), DNSName("powerdns.com"), now));
   cache.add(genNegCacheEntry(DNSName("www2.powerdns.com"), DNSName("powerdns.com"), now));
 
-  auto fp = std::unique_ptr<FILE, int (*)(FILE*)>(tmpfile(), fclose);
-  if (!fp)
+  auto fp = pdns::UniqueFilePtr(tmpfile());
+  if (!fp) {
     BOOST_FAIL("Temporary file could not be opened");
+  }
 
   cache.doDump(fileno(fp.get()), 0, now.tv_sec);
 

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -525,20 +525,20 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile)
   cache.add(genNegCacheEntry(DNSName("www1.powerdns.com"), DNSName("powerdns.com"), now));
   cache.add(genNegCacheEntry(DNSName("www2.powerdns.com"), DNSName("powerdns.com"), now));
 
-  auto fp = pdns::UniqueFilePtr(tmpfile());
-  if (!fp) {
+  auto filePtr = pdns::UniqueFilePtr(tmpfile());
+  if (!filePtr) {
     BOOST_FAIL("Temporary file could not be opened");
   }
 
-  cache.doDump(fileno(fp.get()), 0, now.tv_sec);
+  cache.doDump(fileno(filePtr.get()), 0, now.tv_sec);
 
-  rewind(fp.get());
+  rewind(filePtr.get());
   char* line = nullptr;
   size_t len = 0;
   ssize_t read;
 
   for (auto str : expected) {
-    read = getline(&line, &len, fp.get());
+    read = getline(&line, &len, filePtr.get());
     if (read == -1)
       BOOST_FAIL("Unable to read a line from the temp file");
     // The clock might have ticked so the 600 becomes 599

--- a/pdns/recursordist/test-rpzloader_cc.cc
+++ b/pdns/recursordist/test-rpzloader_cc.cc
@@ -45,7 +45,7 @@ static string makeFile(const string& lines)
   std::array<char, 20> temp{"/tmp/rpzXXXXXXXXXX"};
   int fileDesc = mkstemp(temp.data());
   BOOST_REQUIRE(fileDesc > 0);
-  auto filePtr = std::unique_ptr<FILE, decltype(&fclose)>(fdopen(fileDesc, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(fileDesc, "w"));
   BOOST_REQUIRE(filePtr);
   size_t written = fwrite(lines.data(), 1, lines.length(), filePtr.get());
   BOOST_REQUIRE(written == lines.length());

--- a/pdns/recursordist/test-settings.cc
+++ b/pdns/recursordist/test-settings.cc
@@ -256,7 +256,7 @@ example1.com= 1.2.3.4, 5.6.7.8; 8.9.0.1
   std::string temp("/tmp/test-settingsXXXXXXXXXX");
   int fileDesc = mkstemp(temp.data());
   BOOST_REQUIRE(fileDesc > 0);
-  auto filePtr = std::unique_ptr<FILE, decltype(&fclose)>(fdopen(fileDesc, "w"), fclose);
+  auto filePtr = pdns::UniqueFilePtr(fdopen(fileDesc, "w"));
   BOOST_REQUIRE(filePtr != nullptr);
   size_t written = fwrite(fileContent.data(), 1, fileContent.length(), filePtr.get());
   BOOST_REQUIRE(written == fileContent.length());

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -52,7 +52,7 @@ public:
   OpenSSLTLSTicketKeysRing d_ticketKeys;
   std::map<int, std::string> d_ocspResponses;
   std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> d_tlsCtx{nullptr, SSL_CTX_free};
-  std::unique_ptr<FILE, int(*)(FILE*)> d_keyLogFile{nullptr, fclose};
+  pdns::UniqueFilePtr d_keyLogFile{nullptr};
 };
 
 class OpenSSLSession : public TLSSession


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #13927 to 1.9.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
