### PR TITLE
dnsdist-1.9.x: Backport of 13914 - Fix XSK-enabled check when reconnecting a backend

### DIFF
--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -101,7 +101,7 @@ bool DownstreamState::reconnect(bool initialAttempt)
         (*mplexer.lock())->removeReadFD(fd);
       }
 #ifdef HAVE_XSK
-      if (d_xskInfos.empty()) {
+      if (!d_xskInfos.empty()) {
         removeXSKDestination(fd);
       }
 #endif /* HAVE_XSK */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #13914 to 1.9.x: 

The check was reverted, meaning that we did not properly remove an address:port from the XSK map when reconnecting a backend, and actually tried to remove an entry from a non-existing map when XSK is compiled in but not enabled, triggering a:
```
Error getting the XSK destination addresses map path '/sys/fs/bpf/dnsdist/xsk-destinations-v4'
```
message.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
