### PR TITLE
dnsdist: also handle EHOSTUNREACH as a case for reconnecting the socket

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1255,7 +1255,7 @@ ssize_t udpClientSendRequestToBackend(const std::shared_ptr<DownstreamState>& ba
        because it's not using the same socket.
     */
     if (!healthCheck) {
-      if (savederrno == EINVAL || savederrno == ENODEV || savederrno == ENETUNREACH || savederrno == EBADF) {
+      if (savederrno == EINVAL || savederrno == ENODEV || savederrno == ENETUNREACH || savederrno == EHOSTUNREACH || savederrno == EBADF) {
         backend->reconnect();
       }
       backend->reportTimeoutOrError();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Refer to #13945 for details

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

On macOS:

```
prio="Debug" msg="Got query for www.apple.com|A from 127.0.0.1:57298, relayed to [2620:fe::fe]:53"
prio="Debug" msg="Got answer from [2620:fe::fe]:53, relayed to 127.0.0.1:57298 (UDP), took 17783 us"

Disable v6 here

prio="Debug" msg="Got query for www.apple.com|A from 127.0.0.1:51308, relayed to [2620:fe::fe]:53"
prio="Debug" msg="Error sending request to backend [2620:fe::fe]:53: No route to host"
prio="Info" msg="Error connecting to new server with address [2620:fe::fe]:53: connecting socket to [2620:fe::fe]:53: No route to host"
prio="Debug" msg="Backend [2620:fe::fe]:53 reached the lazy health-check threshold (50% out of 20%, looking at sample of 2 items with 1 failures), moving to Potential Failure state"
prio="Debug" msg="Backend [2620:fe::fe]:53 is in potential failure state, next check in 30 seconds"
prio="Info" msg="Error checking the health of backend [2620:fe::fe]:53: connecting to [2620:fe::fe]:53: No route to host"
prio="Debug" msg="Backend [2620:fe::fe]:53 failed its health-check, moving from Potential failure to Failed"
prio="Debug" msg="Backend [2620:fe::fe]:53 is in failed state, next check in 30 seconds"
prio="Info" msg="Marking downstream [2620:fe::fe]:53 as 'down'"
prio="Debug" msg="Dropped query for www.apple.com|A from 127.0.0.1:59998, no downstream server available"
prio="Debug" msg="Dropped query for www.apple.com|A from 127.0.0.1:57524, no downstream server available"
prio="Debug" msg="Sending health-check query for [2620:fe::fe]:53 which is still in the Failed state"
prio="Debug" msg="Backend [2620:fe::fe]:53 is in failed state, next check in 30 seconds"
prio="Info" msg="Error checking the health of backend [2620:fe::fe]:53: connecting to [2620:fe::fe]:53: No route to host"
prio="Debug" msg="Dropped query for www.apple.com|A from 127.0.0.1:63101, no downstream server available"
prio="Debug" msg="Dropped query for www.apple.com|A from 127.0.0.1:63502, no downstream server available"
prio="Debug" msg="Dropped query for www.apple.com|A from 127.0.0.1:54787, no downstream server available"

Re-enable v6:

prio="Debug" msg="Sending health-check query for [2620:fe::fe]:53 which is still in the Failed state"
prio="Debug" msg="Backend [2620:fe::fe]:53 is in failed state, next check in 30 seconds"
prio="Debug" msg="Backend [2620:fe::fe]:53 had 1 successful checks, moving to Healthy"
prio="Info" msg="Marking downstream [2620:fe::fe]:53 as 'up'"
prio="Debug" msg="Got query for www.apple.com|A from 127.0.0.1:54090, relayed to [2620:fe::fe]:53"
prio="Debug" msg="Got answer from [2620:fe::fe]:53, relayed to 127.0.0.1:54090 (UDP), took 161804 us"
```