### PR TITLE
ixfrdist: use IPV6_V6ONLY on listening sockets, closes #13878

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -8,6 +8,15 @@ Please upgrade to the PowerDNS Authoritative Server 4.0.0 from 3.4.2+.
 See the `3.X <https://doc.powerdns.com/3/authoritative/upgrading/>`__
 upgrade notes if your version is older than 3.4.2.
 
+4.9.0 to 5.0.0/master
+--------------
+
+ixfrdist IPv6 support
+^^^^^^^^^^^^^^^^^^^^^
+
+``ixfrdist`` now binds listening sockets with `IPV6_V6ONLY set`, which means that ``[::]`` no longer accepts IPv4 connections.
+If you want to listen on both IPv4 and IPv6, you need to add a line with ``0.0.0.0`` to the ``listen`` section of your ixfrdist configuration.
+
 4.8.0 to 4.9.0
 --------------
 

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -1621,6 +1621,11 @@ static std::optional<IXFRDistConfiguration> parseConfiguration(int argc, char** 
           int s = SSocket(addr.sin4.sin_family, stype, 0);
           setNonBlocking(s);
           setReuseAddr(s);
+          if (addr.isIPv6()) {
+            int one = 1;
+            (void)setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one));
+          }
+
           SBind(s, addr);
           if (stype == SOCK_STREAM) {
             SListen(s, 30); // TODO make this configurable


### PR DESCRIPTION
### Short description
This avoids getting IPv6-mapped v4 sources, which confused the NOTIFY and acl handlers.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master