### PR TITLE
auth: deprecate output of SHA1, GOST hashes

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2031,7 +2031,7 @@ static int setZoneKind(const DNSName& zone, const DomainInfo::DomainKind kind)
   return EXIT_SUCCESS;
 }
 
-static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = false)
+static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = false) // NOLINT(readability-function-cognitive-complexity)
 {
   UeberBackend B("default");
   DomainInfo di;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2174,12 +2174,14 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
         cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;
       }
       cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA256).getZoneRepresentation() << " ; ( SHA256 digest )" << endl;
-      try {
-        string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
-        cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( GOST R 34.11-94 digest )" << endl;
+      if (g_verbose) {
+        try {
+          string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
+          cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( GOST R 34.11-94 digest )" << endl;
+        }
+        catch(...)
+        {}
       }
-      catch(...)
-      {}
       try {
         string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA384).getZoneRepresentation();
         cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( SHA-384 digest )" << endl;
@@ -2227,12 +2229,14 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
           cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;
         }
         cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA256).getZoneRepresentation() << " ; ( SHA256 digest )" << endl;
-        try {
-          string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
-          cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( GOST R 34.11-94 digest )" << endl;
+        if (g_verbose) {
+          try {
+            string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
+            cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( GOST R 34.11-94 digest )" << endl;
+          }
+          catch(...)
+          {}
         }
-        catch(...)
-        {}
         try {
           string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA384).getZoneRepresentation();
           cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( SHA-384 digest )" << endl;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2031,7 +2031,7 @@ static int setZoneKind(const DNSName& zone, const DomainInfo::DomainKind kind)
   return EXIT_SUCCESS;
 }
 
-static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = false) // NOLINT(readability-function-cognitive-complexity)
+static bool showZone(DNSSECKeeper& dnsseckeeper, const DNSName& zone, bool exportDS = false) // NOLINT(readability-function-cognitive-complexity)
 {
   UeberBackend B("default");
   DomainInfo di;
@@ -2081,7 +2081,7 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
     }
   }
 
-  if(!dk.isSecuredZone(zone)) {
+  if(!dnsseckeeper.isSecuredZone(zone)) {
     auto &outstream = (exportDS ? cerr : cout);
     outstream << "Zone is not actively secured" << endl;
     if (exportDS) {
@@ -2093,9 +2093,9 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
 
   NSEC3PARAMRecordContent ns3pr;
   bool narrow = false;
-  bool haveNSEC3=dk.getNSEC3PARAM(zone, &ns3pr, &narrow);
+  bool haveNSEC3=dnsseckeeper.getNSEC3PARAM(zone, &ns3pr, &narrow);
 
-  DNSSECKeeper::keyset_t keyset=dk.getKeys(zone);
+  DNSSECKeeper::keyset_t keyset=dnsseckeeper.getKeys(zone);
 
   if (!exportDS) {
     std::vector<std::string> meta;
@@ -2124,7 +2124,7 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
 
   }
 
-  if (dk.isPresigned(zone)) {
+  if (dnsseckeeper.isPresigned(zone)) {
     if (!exportDS) {
       cout <<"Zone is presigned"<<endl;
     }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1287,7 +1287,7 @@ static void apiZoneCryptokeysExport(const DNSName& zonename, int64_t inquireKeyI
     if (value.second.keyType == DNSSECKeeper::KSK || value.second.keyType == DNSSECKeeper::CSK) {
       Json::array cdses;
       Json::array dses;
-      for (const uint8_t keyid : {DNSSECKeeper::DIGEST_SHA1, DNSSECKeeper::DIGEST_SHA256, DNSSECKeeper::DIGEST_GOST, DNSSECKeeper::DIGEST_SHA384}) {
+      for (const uint8_t keyid : {DNSSECKeeper::DIGEST_SHA256, DNSSECKeeper::DIGEST_SHA384}) {
         try {
           string dsRecordContent = makeDSFromDNSKey(zonename, value.first.getDNSKEY(), keyid).getZoneRepresentation();
 


### PR DESCRIPTION
### Short description

https://datatracker.ietf.org/doc/html/rfc8624#section-3.3

```
   | Number | Mnemonics       | DNSSEC Delegation | DNSSEC Validation |
   +--------+-----------------+-------------------+-------------------+
   | 0      | NULL (CDS only) | MUST NOT [*]      | MUST NOT [*]      |
   | 1      | SHA-1           | MUST NOT          | MUST              |
   | 2      | SHA-256         | MUST              | MUST              |
   | 3      | GOST R 34.11-94 | MUST NOT          | MAY               |
   | 4      | SHA-384         | MAY               | RECOMMENDED       |
```

closes #13950


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master