### PR TITLE
gh actions - misc-dailies workflow: add feature option to ci-rec-configure task

### DIFF
--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -118,7 +118,7 @@ jobs:
       - run: inv coverity-clang-configure
       - run: inv ci-autoconf
         working-directory: ./pdns/recursordist/
-      - run: inv ci-rec-configure
+      - run: inv ci-rec-configure full
         working-directory: ./pdns/recursordist/
       - run: inv coverity-make
         working-directory: ./pdns/recursordist/


### PR DESCRIPTION
### Short description

Add option feature (full) to ci-rec-configure in the misc-dailies workflow. Required since [this change](https://github.com/PowerDNS/pdns/commit/dc46a0283a5f36dcd4747cfd868087e0800ada75)

Example of a failed run: [https://github.com/PowerDNS/pdns/actions/runs/8353894551/job/22866345611](https://github.com/PowerDNS/pdns/actions/runs/8353894551/job/22866345611)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
