### PR TITLE
auth: Wrap SSql pointers in a unique pointer earlier

### DIFF
--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -52,17 +52,17 @@ gMySQLBackend::gMySQLBackend(const string& mode, const string& suffix) :
 
 void gMySQLBackend::reconnect()
 {
-  setDB(new SMySQL(getArg("dbname"),
-                   getArg("host"),
-                   getArgAsNum("port"),
-                   getArg("socket"),
-                   getArg("user"),
-                   getArg("password"),
-                   getArg("group"),
-                   mustDo("innodb-read-committed"),
-                   getArgAsNum("timeout"),
-                   mustDo("thread-cleanup"),
-                   mustDo("ssl")));
+  setDB(std::unique_ptr<SSql>(new SMySQL(getArg("dbname"),
+                                         getArg("host"),
+                                         getArgAsNum("port"),
+                                         getArg("socket"),
+                                         getArg("user"),
+                                         getArg("password"),
+                                         getArg("group"),
+                                         mustDo("innodb-read-committed"),
+                                         getArgAsNum("timeout"),
+                                         mustDo("thread-cleanup"),
+                                         mustDo("ssl"))));
   allocateStatements();
 }
 

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -38,7 +38,7 @@ gODBCBackend::gODBCBackend(const std::string& mode, const std::string& suffix) :
   GSQLBackend(mode, suffix)
 {
   try {
-    setDB(new SODBC(getArg("datasource"), getArg("username"), getArg("password")));
+    setDB(std::unique_ptr<SSql>(new SODBC(getArg("datasource"), getArg("username"), getArg("password"))));
   }
   catch (SSqlException& e) {
     g_log << Logger::Error << mode << " Connection failed: " << e.txtReason() << std::endl;

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -40,13 +40,13 @@ gPgSQLBackend::gPgSQLBackend(const string& mode, const string& suffix) :
   GSQLBackend(mode, suffix)
 {
   try {
-    setDB(new SPgSQL(getArg("dbname"),
-                     getArg("host"),
-                     getArg("port"),
-                     getArg("user"),
-                     getArg("password"),
-                     getArg("extra-connection-parameters"),
-                     mustDo("prepared-statements")));
+    setDB(std::unique_ptr<SSql>(new SPgSQL(getArg("dbname"),
+                                           getArg("host"),
+                                           getArg("port"),
+                                           getArg("user"),
+                                           getArg("password"),
+                                           getArg("extra-connection-parameters"),
+                                           mustDo("prepared-statements"))));
   }
 
   catch (SSqlException& e) {

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -43,15 +43,15 @@ gSQLite3Backend::gSQLite3Backend(const std::string& mode, const std::string& suf
   GSQLBackend(mode, suffix)
 {
   try {
-    SSQLite3* ptr = new SSQLite3(getArg("database"), getArg("pragma-journal-mode"));
-    setDB(ptr);
-    allocateStatements();
+    auto ptr = std::unique_ptr<SSql>(new SSQLite3(getArg("database"), getArg("pragma-journal-mode")));
     if (!getArg("pragma-synchronous").empty()) {
       ptr->execute("PRAGMA synchronous=" + getArg("pragma-synchronous"));
     }
     if (mustDo("pragma-foreign-keys")) {
       ptr->execute("PRAGMA foreign_keys = 1");
     }
+    setDB(std::move(ptr));
+    allocateStatements();
   }
   catch (SSqlException& e) {
     g_log << Logger::Error << mode << ": connection failed: " << e.txtReason() << std::endl;

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -42,10 +42,10 @@ public:
     d_db.reset();
   }
 
-  void setDB(SSql *db)
+  void setDB(std::unique_ptr<SSql>&& database)
   {
     freeStatements();
-    d_db=std::unique_ptr<SSql>(db);
+    d_db = std::move(database);
     if (d_db) {
       d_db->setLog(::arg().mustDo("query-logging"));
     }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Using a unique pointer from the beginning makes the ownership of the pointer more clear, and prevents leaking the database connection and associated memory if an exception is raised right away.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
