### PR TITLE
rec: use shared NOD (and/or UDR) DB, to avoid multiple copies in memory and on disk

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -821,12 +821,14 @@ struct FDWrapper
     return d_fd;
   }
 
-  void reset()
+  int reset()
   {
+    int ret = 0;
     if (d_fd != -1) {
-      ::close(d_fd);
+      ret = close(d_fd);
       d_fd = -1;
     }
+    return ret;
   }
 
 private:

--- a/pdns/recursordist/nod.cc
+++ b/pdns/recursordist/nod.cc
@@ -43,7 +43,7 @@ std::mutex PersistentSBF::d_cachedir_mutex;
 void PersistentSBF::remove_tmp_files(const filesystem::path& path, std::lock_guard<std::mutex>& /* lock */)
 {
   Regex file_regex(d_prefix + ".*\\." + bf_suffix + "\\..{8}$");
-  for (const auto& file : filesystem::directory_iterator (path)) {
+  for (const auto& file : filesystem::directory_iterator(path)) {
     if (filesystem::is_regular_file(file.path()) && file_regex.match(file.path().filename().string())) {
       filesystem::remove(file);
     }
@@ -67,11 +67,11 @@ bool PersistentSBF::init(bool ignore_pid)
         filesystem::path newest_file;
         std::time_t newest_time = 0;
         Regex file_regex(d_prefix + ".*\\." + bf_suffix + "$");
-        for (const auto& file : filesystem::directory_iterator (path)) {
+        for (const auto& file : filesystem::directory_iterator(path)) {
           if (filesystem::is_regular_file(file.path()) && file_regex.match(file.path().filename().string())) {
             if (ignore_pid || (file.path().filename().string().find(std::to_string(getpid())) == std::string::npos)) {
               // look for the newest file matching the regex
-              if (last_write_time(file.path()) > newest_time) { 
+              if (last_write_time(file.path()) > newest_time) {
                 newest_time = last_write_time(file.path());
                 newest_file = file.path();
               }
@@ -204,8 +204,6 @@ bool NODDB::isNewDomain(const std::string& domain)
 bool NODDB::isNewDomain(const DNSName& dname)
 {
   std::string dname_lc = dname.toDNSStringLC();
-  // The only time this should block is when snapshotting from the
-  // housekeeping thread
   // the result is always the inverse of what is returned by the SBF
   return !d_psbf.testAndAdd(dname_lc);
 }

--- a/pdns/recursordist/nod.cc
+++ b/pdns/recursordist/nod.cc
@@ -50,11 +50,11 @@ void PersistentSBF::remove_tmp_files(const filesystem::path& path, std::lock_gua
   }
 }
 
-// This looks for an old (per-thread) snapshot. The first one it finds,
-// it restores from that. Then immediately snapshots with the current thread id,// before removing the old snapshot
-// In this way, we can have per-thread SBFs, but still snapshot and restore.
-// The mutex has to be static because we can't have multiple (i.e. per-thread)
-// instances iterating and writing to the cache dir at the same time
+// This looks for the newest (per-thread) snapshot it can find and it restores from that. Then
+// immediately snapshots with the current thread id, before removing the old snapshot.
+// In this way, we can have per-thread SBFs, but still snapshot and restore.  The mutex has to be
+// static because we can't have multiple (i.e. per-thread) instances iterating and writing to the
+// cache dir at the same time
 bool PersistentSBF::init(bool ignore_pid)
 {
   auto log = g_slog->withName("nod");

--- a/pdns/recursordist/nod.hh
+++ b/pdns/recursordist/nod.hh
@@ -55,13 +55,11 @@ public:
   bool snapshotCurrent(std::thread::id tid); // Write the current file out to disk
   void add(const std::string& data)
   {
-    // The only time this should block is when snapshotting
     d_sbf.lock()->add(data);
   }
   bool test(const std::string& data) { return d_sbf.lock()->test(data); }
   bool testAndAdd(const std::string& data)
   {
-    // The only time this should block is when snapshotting
     return d_sbf.lock()->testAndAdd(data);
   }
 

--- a/pdns/recursordist/nod.hh
+++ b/pdns/recursordist/nod.hh
@@ -33,7 +33,7 @@ namespace nod
 const float c_fp_rate = 0.01;
 const size_t c_num_cells = 67108864;
 const uint8_t c_num_dec = 10;
-  const unsigned int snapshot_interval_default = 30; // XXX 600;
+const unsigned int snapshot_interval_default = 600;
 const std::string bf_suffix = "bf";
 const std::string sbf_prefix = "sbf";
 

--- a/pdns/recursordist/nod.hh
+++ b/pdns/recursordist/nod.hh
@@ -33,7 +33,7 @@ namespace nod
 const float c_fp_rate = 0.01;
 const size_t c_num_cells = 67108864;
 const uint8_t c_num_dec = 10;
-const unsigned int snapshot_interval_default = 600;
+  const unsigned int snapshot_interval_default = 30; // XXX 600;
 const std::string bf_suffix = "bf";
 const std::string sbf_prefix = "sbf";
 
@@ -96,15 +96,11 @@ public:
   void setSnapshotInterval(unsigned int secs) { d_snapshot_interval = secs; }
   void setCacheDir(const std::string& cachedir) { d_psbf.setCacheDir(cachedir); }
   bool snapshotCurrent(std::thread::id tid) { return d_psbf.snapshotCurrent(tid); }
-  static void startHousekeepingThread(const std::shared_ptr<NODDB>& noddbp, std::thread::id tid)
-  {
-    noddbp->housekeepingThread(tid);
-  }
+  void housekeepingThread(std::thread::id tid);
 
 private:
   PersistentSBF d_psbf;
   unsigned int d_snapshot_interval{snapshot_interval_default}; // Number seconds between snapshots
-  void housekeepingThread(std::thread::id tid);
 };
 
 class UniqueResponseDB
@@ -123,15 +119,11 @@ public:
   void setSnapshotInterval(unsigned int secs) { d_snapshot_interval = secs; }
   void setCacheDir(const std::string& cachedir) { d_psbf.setCacheDir(cachedir); }
   bool snapshotCurrent(std::thread::id tid) { return d_psbf.snapshotCurrent(tid); }
-  static void startHousekeepingThread(const std::shared_ptr<UniqueResponseDB>& udrdbp, std::thread::id tid)
-  {
-    udrdbp->housekeepingThread(tid);
-  }
+  void housekeepingThread(std::thread::id tid);
 
 private:
   PersistentSBF d_psbf;
   unsigned int d_snapshot_interval{snapshot_interval_default}; // Number seconds between snapshots
-  void housekeepingThread(std::thread::id tid);
 };
 
 }

--- a/pdns/recursordist/nod.hh
+++ b/pdns/recursordist/nod.hh
@@ -69,7 +69,10 @@ private:
   LockGuarded<bf::stableBF> d_sbf; // Stable Bloom Filter
   std::string d_cachedir;
   std::string d_prefix = sbf_prefix;
-  static std::mutex d_cachedir_mutex; // One mutex for all instances of this class
+  // One mutex for all instances of this class, used to avoid multiple init() calls happening
+  // simulateneously.  The snapshot code is thread safe wrt file operations, so it does not need to
+  // acquire this mutex, assuming the init() code never runs simulatenously with the snapshot code.
+  static std::mutex d_cachedir_mutex;
 };
 
 class NODDB

--- a/pdns/recursordist/nod.hh
+++ b/pdns/recursordist/nod.hh
@@ -77,8 +77,7 @@ private:
 class NODDB
 {
 public:
-  NODDB() :
-    d_psbf{} {}
+  NODDB() = default;
   NODDB(uint32_t num_cells) :
     d_psbf{num_cells} {}
   // Set ignore_pid to true if you don't mind loading files
@@ -97,7 +96,7 @@ public:
   void setSnapshotInterval(unsigned int secs) { d_snapshot_interval = secs; }
   void setCacheDir(const std::string& cachedir) { d_psbf.setCacheDir(cachedir); }
   bool snapshotCurrent(std::thread::id tid) { return d_psbf.snapshotCurrent(tid); }
-  static void startHousekeepingThread(std::shared_ptr<NODDB> noddbp, std::thread::id tid)
+  static void startHousekeepingThread(const std::shared_ptr<NODDB>& noddbp, std::thread::id tid)
   {
     noddbp->housekeepingThread(tid);
   }
@@ -111,8 +110,7 @@ private:
 class UniqueResponseDB
 {
 public:
-  UniqueResponseDB() :
-    d_psbf{} {}
+  UniqueResponseDB() = default;
   UniqueResponseDB(uint32_t num_cells) :
     d_psbf{num_cells} {}
   bool init(bool ignore_pid = false)
@@ -125,7 +123,7 @@ public:
   void setSnapshotInterval(unsigned int secs) { d_snapshot_interval = secs; }
   void setCacheDir(const std::string& cachedir) { d_psbf.setCacheDir(cachedir); }
   bool snapshotCurrent(std::thread::id tid) { return d_psbf.snapshotCurrent(tid); }
-  static void startHousekeepingThread(std::shared_ptr<UniqueResponseDB> udrdbp, std::thread::id tid)
+  static void startHousekeepingThread(const std::shared_ptr<UniqueResponseDB>& udrdbp, std::thread::id tid)
   {
     udrdbp->housekeepingThread(tid);
   }

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -603,7 +603,7 @@ static bool nodCheckNewDomain(Logr::log_t nodlogger, const DNSName& dname)
   // First check the (sub)domain isn't ignored for NOD purposes
   if (!g_nodDomainWL.check(dname)) {
     // Now check the NODDB (note this is probabilistic so can have FNs/FPs)
-    if (t_nodDBp && t_nodDBp->isNewDomain(dname)) {
+    if (g_nodDBp && g_nodDBp->isNewDomain(dname)) {
       if (g_nodLog) {
         // This should probably log to a dedicated log file
         SLOG(g_log << Logger::Notice << "Newly observed domain nod=" << dname << endl,
@@ -644,7 +644,7 @@ static bool udrCheckUniqueDNSRecord(Logr::log_t nodlogger, const DNSName& dname,
     // Create a string that represent a triplet of (qname, qtype and RR[type, name, content])
     std::stringstream strStream;
     strStream << dname.toDNSStringLC() << ":" << qtype << ":" << qtype << ":" << record.d_type << ":" << record.d_name.toDNSStringLC() << ":" << record.getContent()->getZoneRepresentation();
-    if (t_udrDBp && t_udrDBp->isUniqueResponse(strStream.str())) {
+    if (g_udrDBp && g_udrDBp->isUniqueResponse(strStream.str())) {
       if (g_udrLog) {
         // This should also probably log to a dedicated file.
         SLOG(g_log << Logger::Notice << "Unique response observed: qname=" << dname << " qtype=" << QType(qtype) << " rrtype=" << QType(record.d_type) << " rrname=" << record.d_name << " rrcontent=" << record.getContent()->getZoneRepresentation() << endl,

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -796,10 +796,13 @@ static void setupNODThread(Logr::log_t log)
            log->info(Logr::Error, "Could not initialize domain tracking"));
       _exit(1);
     }
-    std::thread thread([tid = std::this_thread::get_id()]() {
-      g_nodDBp->housekeepingThread(tid);
-    });
-    thread.detach();
+    if (::arg().asNum("new-domain-db-snapshot-interval") > 0) {
+      g_nodDBp->setSnapshotInterval(::arg().asNum("new-domain-db-snapshot-interval"));
+      std::thread thread([tid = std::this_thread::get_id()]() {
+        g_nodDBp->housekeepingThread(tid);
+      });
+      thread.detach();
+    }
   }
   if (g_udrEnabled) {
     uint32_t num_cells = ::arg().asNum("unique-response-db-size");
@@ -817,10 +820,13 @@ static void setupNODThread(Logr::log_t log)
            log->info(Logr::Error, "Could not initialize unique response tracking"));
       _exit(1);
     }
-    std::thread thread([tid = std::this_thread::get_id()]() {
-      g_udrDBp->housekeepingThread(tid);
-    });
-    thread.detach();
+    if (::arg().asNum("new-domain-db-snapshot-interval") > 0) {
+      g_udrDBp->setSnapshotInterval(::arg().asNum("new-domain-db-snapshot-interval"));
+      std::thread thread([tid = std::this_thread::get_id()]() {
+        g_udrDBp->housekeepingThread(tid);
+      });
+      thread.detach();
+    }
   }
 }
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -79,8 +79,8 @@ std::string g_nod_pbtag;
 bool g_udrEnabled;
 bool g_udrLog;
 std::string g_udr_pbtag;
-thread_local std::shared_ptr<nod::NODDB> t_nodDBp;
-thread_local std::shared_ptr<nod::UniqueResponseDB> t_udrDBp;
+std::unique_ptr<nod::NODDB> g_nodDBp;
+std::unique_ptr<nod::UniqueResponseDB> g_udrDBp;
 #endif /* NOD_ENABLED */
 
 std::atomic<bool> statsWanted;
@@ -782,40 +782,44 @@ static void setupNODThread(Logr::log_t log)
 {
   if (g_nodEnabled) {
     uint32_t num_cells = ::arg().asNum("new-domain-db-size");
-    t_nodDBp = std::make_shared<nod::NODDB>(num_cells);
+    g_nodDBp = std::make_unique<nod::NODDB>(num_cells);
     try {
-      t_nodDBp->setCacheDir(::arg()["new-domain-history-dir"]);
+      g_nodDBp->setCacheDir(::arg()["new-domain-history-dir"]);
     }
     catch (const PDNSException& e) {
       SLOG(g_log << Logger::Error << "new-domain-history-dir (" << ::arg()["new-domain-history-dir"] << ") is not readable or does not exist" << endl,
            log->error(Logr::Error, e.reason, "new-domain-history-dir is not readable or does not exists", "dir", Logging::Loggable(::arg()["new-domain-history-dir"])));
       _exit(1);
     }
-    if (!t_nodDBp->init()) {
+    if (!g_nodDBp->init()) {
       SLOG(g_log << Logger::Error << "Could not initialize domain tracking" << endl,
            log->info(Logr::Error, "Could not initialize domain tracking"));
       _exit(1);
     }
-    std::thread thread(nod::NODDB::startHousekeepingThread, t_nodDBp, std::this_thread::get_id());
+    std::thread thread([tid = std::this_thread::get_id()]() {
+      g_nodDBp->housekeepingThread(tid);
+    });
     thread.detach();
   }
   if (g_udrEnabled) {
     uint32_t num_cells = ::arg().asNum("unique-response-db-size");
-    t_udrDBp = std::make_shared<nod::UniqueResponseDB>(num_cells);
+    g_udrDBp = std::make_unique<nod::UniqueResponseDB>(num_cells);
     try {
-      t_udrDBp->setCacheDir(::arg()["unique-response-history-dir"]);
+      g_udrDBp->setCacheDir(::arg()["unique-response-history-dir"]);
     }
     catch (const PDNSException& e) {
       SLOG(g_log << Logger::Error << "unique-response-history-dir (" << ::arg()["unique-response-history-dir"] << ") is not readable or does not exist" << endl,
            log->info(Logr::Error, "unique-response-history-dir is not readable or does not exist", "dir", Logging::Loggable(::arg()["unique-response-history-dir"])));
       _exit(1);
     }
-    if (!t_udrDBp->init()) {
+    if (!g_udrDBp->init()) {
       SLOG(g_log << Logger::Error << "Could not initialize unique response tracking" << endl,
            log->info(Logr::Error, "Could not initialize unique response tracking"));
       _exit(1);
     }
-    std::thread thread(nod::UniqueResponseDB::startHousekeepingThread, t_udrDBp, std::this_thread::get_id());
+    std::thread thread([tid = std::this_thread::get_id()]() {
+      g_udrDBp->housekeepingThread(tid);
+    });
     thread.detach();
   }
 }
@@ -2253,6 +2257,10 @@ static int serviceMain(Logr::log_t log)
     return ret;
   }
 
+#ifdef NOD_ENABLED
+  setupNODThread(log);
+#endif /* NOD_ENABLED */
+
   return RecThreadInfo::runThreads(log);
 }
 
@@ -2728,12 +2736,6 @@ static void recursorThread()
              log->info(Logr::Debug, "Done priming cache with root hints"));
       }
     }
-
-#ifdef NOD_ENABLED
-    if (threadInfo.isWorker()) {
-      setupNODThread(log);
-    }
-#endif /* NOD_ENABLED */
 
     /* the listener threads handle TCP queries */
     if (threadInfo.isWorker() || threadInfo.isListener()) {

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -247,8 +247,8 @@ extern std::string g_nod_pbtag;
 extern bool g_udrEnabled;
 extern bool g_udrLog;
 extern std::string g_udr_pbtag;
-extern thread_local std::shared_ptr<nod::NODDB> t_nodDBp;
-extern thread_local std::shared_ptr<nod::UniqueResponseDB> t_udrDBp;
+extern std::unique_ptr<nod::NODDB> g_nodDBp;
+extern std::unique_ptr<nod::UniqueResponseDB> g_udrDBp;
 #endif
 
 struct ProtobufServersInfo

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -1738,6 +1738,19 @@ from this directory.
     'versionadded': '4.2.0'
     },
     {
+        'name' : 'db_snapshot_interval',
+        'section' : 'nod',
+        'oldname' : 'new-domain-db-snapshot-interval',
+        'type' : LType.Uint64,
+        'default' : '600',
+        'help' : 'Interval (in seconds) to write the NOD and UDR DB snapshots',
+        'doc' : '''
+Interval (in seconds) to write the NOD and UDR DB snapshots.
+Set to zero to disable snapshot writing.',
+ ''',
+        'versionadded': '5.1.0'
+    },
+    {
         'name' : 'whitelist',
         'section' : 'nod',
         'oldname' : 'new-domain-whitelist',

--- a/pdns/recursordist/stable-bloom.hh
+++ b/pdns/recursordist/stable-bloom.hh
@@ -29,6 +29,7 @@
 #include <boost/dynamic_bitset.hpp>
 #include "misc.hh"
 #include "noinitvector.hh"
+#include "views.hh"
 #include "ext/probds/murmur3.h"
 
 namespace bf
@@ -40,119 +41,139 @@ namespace bf
 class stableBF
 {
 public:
-  stableBF(float fp_rate, uint32_t num_cells, uint8_t p) :
+  stableBF(float fp_rate, uint32_t num_cells, uint8_t pArg) :
     d_k(optimalK(fp_rate)),
     d_num_cells(num_cells),
-    d_p(p),
+    d_p(pArg),
     d_cells(num_cells),
     d_gen(std::random_device()()),
-    d_dis(0, num_cells) {}
-  stableBF(uint8_t k, uint32_t num_cells, uint8_t p, const std::string& bitstr) :
-    d_k(k),
+    d_dis(0, static_cast<int>(num_cells)) {}
+  stableBF(uint8_t kArg, uint32_t num_cells, uint8_t pArg, const std::string& bitstr) :
+    d_k(kArg),
     d_num_cells(num_cells),
-    d_p(p),
+    d_p(pArg),
     d_cells(bitstr),
     d_gen(std::random_device()()),
-    d_dis(0, num_cells) {}
+    d_dis(0, static_cast<int>(num_cells)) {}
+
   void add(const std::string& data)
   {
     decrement();
     auto hashes = hash(data);
-    for (auto& i : hashes) {
-      d_cells.set(i % d_num_cells);
+    for (auto& hash : hashes) {
+      d_cells.set(hash % d_num_cells);
     }
   }
-  bool test(const std::string& data) const
+
+  [[nodiscard]] bool test(const std::string& data) const
   {
     auto hashes = hash(data);
-    for (auto& i : hashes) {
-      if (d_cells.test(i % d_num_cells) == false)
+    for (auto& hash : hashes) { // NOLINT(readability-use-anyofallof) not more clear IMO
+      if (!d_cells.test(hash % d_num_cells)) {
         return false;
+      }
     }
     return true;
   }
+
   bool testAndAdd(const std::string& data)
   {
     auto hashes = hash(data);
     bool retval = true;
-    for (auto& i : hashes) {
-      if (d_cells.test(i % d_num_cells) == false) {
+    for (auto& hash : hashes) {
+      if (!d_cells.test(hash % d_num_cells)) {
         retval = false;
         break;
       }
     }
     decrement();
-    for (auto& i : hashes) {
-      d_cells.set(i % d_num_cells);
+    for (auto& hash : hashes) {
+      d_cells.set(hash % d_num_cells);
     }
     return retval;
   }
-  void dump(std::ostream& os)
+
+  void dump(std::ostream& ostr)
   {
-    os.write((char*)&d_k, sizeof(d_k));
+    ostr.write(charPtr(&d_k), sizeof(d_k));
     uint32_t nint = htonl(d_num_cells);
-    os.write((char*)&nint, sizeof(nint));
-    os.write((char*)&d_p, sizeof(d_p));
+    ostr.write(charPtr(&nint), sizeof(nint));
+    ostr.write(charPtr(&d_p), sizeof(d_p));
     std::string temp_str;
     boost::to_string(d_cells, temp_str);
-    uint32_t bitstr_length = htonl((uint32_t)temp_str.length());
-    os.write((char*)&bitstr_length, sizeof(bitstr_length));
-    os.write((char*)temp_str.c_str(), temp_str.length());
-    if (os.fail()) {
+    uint32_t bitstr_length = htonl(static_cast<uint32_t>(temp_str.length()));
+    ostr.write(charPtr(&bitstr_length), sizeof(bitstr_length));
+    ostr.write(charPtr(temp_str.c_str()), static_cast<std::streamsize>(temp_str.length()));
+    if (ostr.fail()) {
       throw std::runtime_error("SBF: Failed to dump");
     }
   }
-  void restore(std::istream& is)
+
+  void restore(std::istream& istr)
   {
-    uint8_t k, p;
-    uint32_t num_cells, bitstr_len;
-    is.read((char*)&k, sizeof(k));
-    if (is.fail()) {
+    uint8_t kValue{};
+    istr.read(charPtr(&kValue), sizeof(kValue));
+    if (istr.fail()) {
       throw std::runtime_error("SBF: read failed (file too short?)");
     }
-    is.read((char*)&num_cells, sizeof(num_cells));
-    if (is.fail()) {
+    uint32_t num_cells{};
+    istr.read(charPtr(&num_cells), sizeof(num_cells));
+    if (istr.fail()) {
       throw std::runtime_error("SBF: read failed (file too short?)");
     }
     num_cells = ntohl(num_cells);
-    is.read((char*)&p, sizeof(p));
-    if (is.fail()) {
+    uint8_t pValue{};
+    istr.read(charPtr(&pValue), sizeof(pValue));
+    if (istr.fail()) {
       throw std::runtime_error("SBF: read failed (file too short?)");
     }
-    is.read((char*)&bitstr_len, sizeof(bitstr_len));
-    if (is.fail()) {
+    uint32_t bitstr_len{};
+    istr.read(charPtr(&bitstr_len), sizeof(bitstr_len));
+    if (istr.fail()) {
       throw std::runtime_error("SBF: read failed (file too short?)");
     }
     bitstr_len = ntohl(bitstr_len);
     if (bitstr_len > 2 * 64 * 1024 * 1024U) { // twice the current size
       throw std::runtime_error("SBF: read failed (bitstr_len too big)");
     }
-    auto bitcstr = std::make_unique<char[]>(bitstr_len);
-    is.read(bitcstr.get(), bitstr_len);
-    if (is.fail()) {
+    auto bitcstr = NoInitVector<char>(bitstr_len);
+    istr.read(bitcstr.data(), bitstr_len);
+    if (istr.fail()) {
       throw std::runtime_error("SBF: read failed (file too short?)");
     }
-    std::string bitstr(bitcstr.get(), bitstr_len);
-    stableBF tempbf(k, num_cells, p, bitstr);
+    const std::string bitstr(bitcstr.data(), bitstr_len);
+    stableBF tempbf(kValue, num_cells, pValue, bitstr);
     swap(tempbf);
   }
 
 private:
-  unsigned int optimalK(float fp_rate)
+  static const char* charPtr(const void* ptr)
   {
-    return std::ceil(std::log2(1 / fp_rate));
+    return static_cast<const char*>(ptr);
   }
+
+  static char* charPtr(void* ptr)
+  {
+    return static_cast<char*>(ptr);
+  }
+
+  static unsigned int optimalK(float fp_rate)
+  {
+    return std::ceil(std::log2(1.0 / fp_rate));
+  }
+
   void decrement()
   {
     // Choose a random cell then decrement the next p-1
     // The stable bloom algorithm described in the paper says
     // to choose p independent positions, but that is much slower
     // and this shouldn't change the properties of the SBF
-    size_t r = d_dis(d_gen);
+    size_t randomValue = d_dis(d_gen);
     for (uint64_t i = 0; i < d_p; ++i) {
-      d_cells.reset((r + i) % d_num_cells);
+      d_cells.reset((randomValue + i) % d_num_cells);
     }
   }
+
   void swap(stableBF& rhs)
   {
     std::swap(d_k, rhs.d_k);
@@ -160,29 +181,32 @@ private:
     std::swap(d_p, rhs.d_p);
     d_cells.swap(rhs.d_cells);
   }
+
   // This is a double hash implementation returning an array of
   // k hashes
-  std::vector<uint32_t> hash(const std::string& data) const
+  [[nodiscard]] std::vector<uint32_t> hash(const std::string& data) const
   {
-    uint32_t h1, h2;
+    uint32_t hash1{};
+    uint32_t hash2{};
     // MurmurHash3 assumes the data is uint32_t aligned, so fixup if needed
     // It does handle string lengths that are not a multiple of sizeof(uint32_t) correctly
-    if (reinterpret_cast<uintptr_t>(data.data()) % sizeof(uint32_t) != 0) {
-      NoInitVector<uint32_t> x((data.length() / sizeof(uint32_t)) + 1);
-      memcpy(x.data(), data.data(), data.length());
-      MurmurHash3_x86_32(x.data(), data.length(), 1, &h1);
-      MurmurHash3_x86_32(x.data(), data.length(), 2, &h2);
+    if (reinterpret_cast<uintptr_t>(data.data()) % sizeof(uint32_t) != 0) { // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+      NoInitVector<uint32_t> vec((data.length() / sizeof(uint32_t)) + 1);
+      memcpy(vec.data(), data.data(), data.length());
+      MurmurHash3_x86_32(vec.data(), static_cast<int>(data.length()), 1, &hash1);
+      MurmurHash3_x86_32(vec.data(), static_cast<int>(data.length()), 2, &hash2);
     }
     else {
-      MurmurHash3_x86_32(data.data(), data.length(), 1, &h1);
-      MurmurHash3_x86_32(data.data(), data.length(), 2, &h2);
+      MurmurHash3_x86_32(data.data(), static_cast<int>(data.length()), 1, &hash1);
+      MurmurHash3_x86_32(data.data(), static_cast<int>(data.length()), 2, &hash2);
     }
     std::vector<uint32_t> ret_hashes(d_k);
     for (size_t i = 0; i < d_k; ++i) {
-      ret_hashes[i] = h1 + i * h2;
+      ret_hashes[i] = hash1 + i * hash2;
     }
     return ret_hashes;
   }
+
   uint8_t d_k;
   uint32_t d_num_cells;
   uint8_t d_p;

--- a/pdns/recursordist/stable-bloom.hh
+++ b/pdns/recursordist/stable-bloom.hh
@@ -29,7 +29,6 @@
 #include <boost/dynamic_bitset.hpp>
 #include "misc.hh"
 #include "noinitvector.hh"
-#include "views.hh"
 #include "ext/probds/murmur3.h"
 
 namespace bf


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This modified the threading model of the NOD/UDR subsystem. We now use a single DB, which has the big advantage that there's way less memory and disk storage used. Also, multiple threads will not report the same name, as they base their decision on the same data.

This PR also cleans up the code and introduces a setting to set the interval for the writing snapshots to disk (0 means switch the disk based snapshot mechanism off).

As a bonus the code to select the newest snap actually does what's promised. Existing code picked the oldest snap, unless I'm very confused, so please do a review for that commit with good attention to detail.

Ideally it should be confirmed that lock contention is not  an issue here. I do not expect given the number we have seen for the record cache (packet cache hits do not call into the NOD code). 

There might be a way to reduce potential lock contention even more: only call the NOD/UDR code if the answer was produced using outgoing queries (i.e. a non-record cache hit). If the answer is coming straight out of the record cache, it will not contain new data. This may not be true however if the cache refresh mechanism is used, so beware!

Tagging @neilcook, for some reason I cannot add him as reviewer.

Fixes #13677

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
