### PR TITLE
Do shuffle TCP responses except *XFRs

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -279,7 +279,7 @@ void DNSPacket::wrapup(bool throwsOnTruncation)
     });
   static bool mustNotShuffle = ::arg().mustDo("no-shuffle");
 
-  if(!d_tcp && !mustNotShuffle) {
+  if(!d_xfr && !mustNotShuffle) {
     pdns::shuffle(d_rrs);
   }
   d_wrapped=true;
@@ -453,6 +453,7 @@ std::unique_ptr<DNSPacket> DNSPacket::replyPacket() const
   r->d_haveednscookie = d_haveednscookie;
   r->d_ednsversion = 0;
   r->d_ednsrcode = 0;
+  r->d_xfr = d_xfr;
 
   if(d_tsigkeyname.countLabels()) {
     r->d_tsigkeyname = d_tsigkeyname;

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -157,7 +157,8 @@ public:
   uint16_t qclass{QClass::IN};  //!< class of the question - should always be INternet 2
   QType qtype;  //!< type of the question 2
 
-  bool d_tcp{false};
+  bool d_tcp{false}; // whether DNS packet is using TCP (false when UDP)
+  bool d_xfr{false}; // whether DNS packet is a zone transfer, either AXFR or IXFR
   bool d_dnssecOk{false};
   bool d_havetsig{false};
 

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -367,11 +367,13 @@ void TCPNameserver::doConnection(int fd)
         S.inc("tcp-cookie-queries");
 
       if(packet->qtype.getCode()==QType::AXFR) {
+        packet->d_xfr=true;
         doAXFR(packet->qdomain, packet, fd);
         continue;
       }
 
       if(packet->qtype.getCode()==QType::IXFR) {
+        packet->d_xfr=true;
         doIXFR(packet, fd);
         continue;
       }


### PR DESCRIPTION
### Short description
Currently, TCP responses are not shuffled.

It seems the heuristics way back in 2005 was "when it's TCP, it's probably a zone transfer", which might have made sense back then, but not in 2024.

Fixes #13003 in the way it was suggested in the github discussion.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)