### PR TITLE
rec: also look for __res_query symbol

### DIFF
--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -43,7 +43,7 @@ AC_SUBST([LIBDL], [$lt_cv_dlopen_libs])
 
 PDNS_CHECK_OS
 PDNS_CHECK_NETWORK_LIBS
-AC_SEARCH_LIBS([res_query], [resolv])
+AC_SEARCH_LIBS([res_query], [resolv], [], [AC_SEARCH_LIBS([__res_query], [resolv])])
 # macOS uses an alternative name internally
 AC_SEARCH_LIBS([res_9_query], [resolv])
 PTHREAD_SET_NAME


### PR DESCRIPTION
### Short description
This should avoid build failure on GNU Libc systems from before `res_query` moved into libc proper.

Tested on el7, testing all others in https://github.com/Habbie/pdns/actions/runs/8434779315

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
