### PR TITLE
rec: Backport 13984 to rec-4.8.x: Correctly count NSEC3s considered when chasing the closest encloser

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -783,7 +783,6 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
   DNSName closestEncloser(qname);
   bool found = false;
   if (needWildcardProof) {
-    nsec3sConsidered = 0;
     /* We now need to look for a NSEC3 covering the closest (provable) encloser
        RFC 5155 section-7.2.1
        RFC 7129 section-5.5
@@ -791,6 +790,7 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
     LOG("Now looking for the closest encloser for "<<qname<<endl);
 
     while (!found && closestEncloser.chopOff() && closestEncloser.countLabels() >= numberOfLabelsOfParentZone) {
+      nsec3sConsidered = 0;
 
       for(const auto& validset : validrrsets) {
         if(validset.first.second==QType::NSEC3) {


### PR DESCRIPTION
We need to count the number of NSEC3s that are present in the response, not the number of times we have to consider possible NSEC3s when looking for the NSEC3 closest encloser, label by label.

(cherry picked from commit c4f4d09654bde9d389e83f0bc8eadc6b665e9de9)

Backport of #13984 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
