### PR TITLE
Dockerfile.rpmsbom:  fix grep syntax for authoritative on rhel>7

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.rpmsbom
+++ b/builder-support/dockerfiles/Dockerfile.rpmsbom
@@ -25,7 +25,7 @@ RUN cd /pdns/builder-support/helpers/; \
 @IF [ -n "$M_authoritative$M_all" ]
 RUN cd /pdns/builder-support/helpers/ && \
     if ! $(grep -q 'release 7' /etc/redhat-release); then \
-      for pkg in $(dnf list installed 'pdns*' | grep -E ^'pdns' | grep -vF '-debuginfo-' | cut -d. -f1); do \
+      for pkg in $(dnf list installed 'pdns*' | grep -E ^'pdns' | grep -vE '\-debuginfo|\-debugsource' | cut -d. -f1); do \
         python3 generate-sbom-dnf.py /dist/${pkg}-${BUILDER_VERSION}-${BUILDER_TARGET}.cyclonedx.json ${pkg}; \
       done; \
     fi


### PR DESCRIPTION
### Short description
Fix grep syntax in Dockerfile.rpmsbom. Currently shows the following error when building authoritative on `rhel>7`:

```
#48 [dist 6/6] RUN cd /pdns/builder-support/helpers/ &&     if ! $(grep -q 'release 7' /etc/redhat-release); then       for pkg in $(dnf list installed 'pdns*' | grep -E ^'pdns' | grep -vF '-debuginfo-' | cut -d. -f1); do         python3 generate-sbom-dnf.py /dist/${pkg}-4.8.0-alpha0.4469.testgeneratesbom.g177712258-el-8.cyclonedx.json ${pkg};       done;     fi
#48 0.208 grep: invalid argument 'ebuginfo-' for '--directories'
#48 0.208 Valid arguments are:
#48 0.208   - 'read'
#48 0.208   - 'recurse'
#48 0.208   - 'skip'
#48 0.208 Usage: grep [OPTION]... PATTERN [FILE]...
#48 0.208 Try 'grep --help' for more information.
#48 DONE 0.5s
```

Fix tested here: [https://github.com/romeroalx/pdns/actions/runs/8464846371](https://github.com/romeroalx/pdns/actions/runs/8464846371)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
