### PR TITLE
dnsdist: Release failed TCP backend connections more quickly

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -146,6 +146,13 @@ void TCPConnectionToBackend::release(){
   if (d_ioState) {
     d_ioState.reset();
   }
+
+  auto shared = std::dynamic_pointer_cast<TCPConnectionToBackend>(shared_from_this());
+  if (!willBeReusable(true)) {
+    /* remove ourselves from the connection cache, this might mean that our
+       reference count drops to zero after that, so we need to be careful */
+    t_downstreamTCPConnectionsManager.removeDownstreamConnection(shared);
+  }
 }
 
 static uint32_t getSerialFromRawSOAContent(const std::vector<uint8_t>& raw)

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -3620,8 +3620,8 @@ BOOST_FIXTURE_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR, TestFixture)
     g_tcpRecvTimeout = 2;
 
     /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
-    /* we have one connection to clear, no proxy protocol */
-    BOOST_CHECK_EQUAL(IncomingTCPConnectionState::clearAllDownstreamConnections(), 1U);
+    /* we have no connection to clear, because there was a timeout! */
+    BOOST_CHECK_EQUAL(IncomingTCPConnectionState::clearAllDownstreamConnections(), 0U);
   }
 
   {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
After a timeout we cannot reuse the TCP connection to the backend anyway, so let's release it immediately.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
