### PR TITLE
FDWrapper: Do not try to close negative file descriptors

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -803,7 +803,7 @@ struct FDWrapper
 
   FDWrapper& operator=(FDWrapper&& rhs) noexcept
   {
-    if (d_fd != -1) {
+    if (d_fd >= 0) {
       close(d_fd);
     }
     d_fd = rhs.d_fd;
@@ -824,7 +824,7 @@ struct FDWrapper
   int reset()
   {
     int ret = 0;
-    if (d_fd != -1) {
+    if (d_fd >= 0) {
       ret = close(d_fd);
       d_fd = -1;
     }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -826,8 +826,8 @@ struct FDWrapper
     int ret = 0;
     if (d_fd >= 0) {
       ret = close(d_fd);
-      d_fd = -1;
     }
+    d_fd = -1;
     return ret;
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It turns out that some of the BPF helper functions return a negative `errno` value in case of failure, and since we wrap the return value into a `FDWrapper` right away this led to a warning from Valgrind about trying to close an invalid file descriptor.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
