### PR TITLE
pdnsutil check-zone: accept LUA A/AAAA as SVCB address targets

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1,3 +1,4 @@
+#include "dnsrecords.hh"
 #include <boost/smart_ptr/make_shared_array.hpp>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -250,7 +251,7 @@ static bool rectifyAllZones(DNSSECKeeper &dk, bool quiet = false)
   return result;
 }
 
-static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr)
+static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr) // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 {
   uint64_t numerrors=0, numwarnings=0;
 
@@ -376,6 +377,14 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, con
       tlsas.insert(rr.qname);
     if(rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) {
       addresses.insert(rr.qname);
+    }
+    if(rr.qtype.getCode() == QType::LUA) {
+      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(rr.qtype.getCode(), QClass::IN, rr.content));
+      auto luarec = std::dynamic_pointer_cast<LUARecordContent>(drc);
+      QType qtype = luarec->d_type;
+      if(qtype == QType::A || qtype == QType::AAAA) {
+        addresses.insert(rr.qname);
+      }
     }
     if(rr.qtype.getCode() == QType::A) {
       arecords.insert(rr.qname);


### PR DESCRIPTION
### Short description
Avoids `[Error] SVCB record svcb.example.com has a target sub.svcb.example.com that has neither address nor SVCB records.` when there is a valid LUA A or LUA AAAA at the target name.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master