### PR TITLE
dnsdist-1.9.x: Backport 13999 - Fix DNS over HTTP connections/queries counters with `nghttp2`

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -347,6 +347,9 @@ void IncomingHTTP2Connection::handleIO()
     }
 
     if (d_state == State::starting) {
+      if (d_ci.cs != nullptr && d_ci.cs->dohFrontend != nullptr) {
+        ++d_ci.cs->dohFrontend->d_httpconnects;
+      }
       if (d_ci.cs != nullptr && d_ci.cs->d_enableProxyProtocol && isProxyPayloadOutsideTLS() && expectProxyProtocolFrom(d_ci.remote)) {
         d_state = State::readingProxyProtocolHeader;
         d_buffer.resize(s_proxyProtocolMinimumHeaderSize);

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -272,6 +272,11 @@ bool IncomingHTTP2Connection::checkALPN()
     return true;
   }
 
+  constexpr std::array<uint8_t, 8> http11ALPN{'h','t','t','p','/','1','.','1'};
+  if (protocols.size() == http11ALPN.size() && memcmp(protocols.data(), http11ALPN.data(), http11ALPN.size()) == 0) {
+    ++d_ci.cs->dohFrontend->d_http1Stats.d_nbQueries;
+  }
+
   const std::string data("HTTP/1.1 400 Bad Request\r\nConnection: Close\r\n\r\n<html><body>This server implements RFC 8484 - DNS Queries over HTTP, and requires HTTP/2 in accordance with section 5.2 of the RFC.</body></html>\r\n");
   d_out.insert(d_out.end(), data.begin(), data.end());
   writeToSocket(false);

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -272,7 +272,7 @@ bool IncomingHTTP2Connection::checkALPN()
     return true;
   }
 
-  constexpr std::array<uint8_t, 8> http11ALPN{'h','t','t','p','/','1','.','1'};
+  constexpr std::array<uint8_t, 8> http11ALPN{'h', 't', 't', 'p', '/', '1', '.', '1'};
   if (protocols.size() == http11ALPN.size() && memcmp(protocols.data(), http11ALPN.data(), http11ALPN.size()) == 0) {
     ++d_ci.cs->dohFrontend->d_http1Stats.d_nbQueries;
   }

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -838,7 +838,7 @@ JSON Objects
   :property integer error-responses: Number of HTTP responses sent with a non-200 code
   :property integer get-queries: Number of DoH queries received via the GET HTTP method
   :property integer http-connects: Number of DoH TCP connections established to this frontend
-  :property integer http1-queries: Number of DoH queries received over HTTP/1
+  :property integer http1-queries: Number of DoH queries received over HTTP/1 (or connection attempts with a HTTP/1.1 ALPN when the nghttp2 provider is used)
   :property integer http1-x00-responses: Number of DoH responses sent, over HTTP/1, per response code (200, 400, 403, 500, 502)
   :property integer http1-other-responses: Number of DoH responses sent, over HTTP/1, with another response code
   :property integer http2-queries: Number of DoH queries received over HTTP/2

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -11,7 +11,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <h2o.h>
-//#include <h2o/http1.h>
 #include <h2o/http2.h>
 
 #include <openssl/err.h>


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #13999 to rel/dnsdist-1.9.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
