### PR TITLE
dnsdist-1.9-x: Backport 14006 - FDWrapper: Do not try to close negative file descriptors

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -803,7 +803,7 @@ struct FDWrapper
 
   FDWrapper& operator=(FDWrapper&& rhs) noexcept
   {
-    if (d_fd != -1) {
+    if (d_fd >= 0) {
       close(d_fd);
     }
     d_fd = rhs.d_fd;
@@ -823,7 +823,7 @@ struct FDWrapper
 
   void reset()
   {
-    if (d_fd != -1) {
+    if (d_fd >= 0) {
       ::close(d_fd);
       d_fd = -1;
     }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -824,9 +824,9 @@ struct FDWrapper
   void reset()
   {
     if (d_fd >= 0) {
-      ::close(d_fd);
-      d_fd = -1;
+      close(d_fd);
     }
+    d_fd = -1;
   }
 
 private:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #14006 to rel/dnsdist-1.9-x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
