### PR TITLE
dnsdist-1.9.x: Backport 14005 - Release incoming TCP connection right away on backend failure

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -608,7 +608,7 @@ void TCPConnectionToBackend::notifyAllQueriesFailed(const struct timeval& now, F
   try {
     if (d_state == State::sendingQueryToBackend) {
       increaseCounters(d_currentQuery.d_query.d_idstate.cs);
-      auto sender = d_currentQuery.d_sender;
+      auto sender = std::move(d_currentQuery.d_sender);
       if (sender->active()) {
         TCPResponse response(std::move(d_currentQuery.d_query));
         sender->notifyIOError(now, std::move(response));
@@ -617,7 +617,7 @@ void TCPConnectionToBackend::notifyAllQueriesFailed(const struct timeval& now, F
 
     for (auto& query : pendingQueries) {
       increaseCounters(query.d_query.d_idstate.cs);
-      auto sender = query.d_sender;
+      auto sender = std::move(query.d_sender);
       if (sender->active()) {
         TCPResponse response(std::move(query.d_query));
         sender->notifyIOError(now, std::move(response));
@@ -626,7 +626,7 @@ void TCPConnectionToBackend::notifyAllQueriesFailed(const struct timeval& now, F
 
     for (auto& response : pendingResponses) {
       increaseCounters(response.second.d_query.d_idstate.cs);
-      auto sender = response.second.d_sender;
+      auto sender = std::move(response.second.d_sender);
       if (sender->active()) {
         TCPResponse tresp(std::move(response.second.d_query));
         sender->notifyIOError(now, std::move(tresp));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14005 to rel/dnsdist-1.9.x.

We used to keep a shared pointer to the incoming TCP connection around in `TCPConnectionToBackend::d_currentQuery.d_sender` even after all queries sent to the backend failed, which prevented the incoming TCP connection from being closed as soon as it should have.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
