### PR TITLE
Rec: add setting to exclude specific listen socket addresses from requiring proxy protocol

### DIFF
--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -17,7 +17,7 @@ Changed settings
 New Settings
 ^^^^^^^^^^^^
 
-- The :ref:`setting-proxy-protocol-exceptions` has been added. It allows to exclude specific listen addresses from requiring th e Proxy Protocol.
+- The :ref:`setting-proxy-protocol-exceptions` has been added. It allows to exclude specific listen addresses from requiring the Proxy Protocol.
 
 5.0.2 to 5.0.3, 4.9.3 to 4.9.4 and 4.8.6 to 4.8.7
 -------------------------------------------------

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -14,8 +14,10 @@ Changed settings
 
 - Disabling :ref:`setting-structured-logging` is no longer supported.
 
-Changed Settings
-^^^^^^^^^^^^^^^^
+New Settings
+^^^^^^^^^^^^
+
+- The :ref:`setting-proxy-protocol-exceptions` has been added. It allows to exclude specific listen addresses from requiring th e Proxy Protocol.
 
 5.0.2 to 5.0.3, 4.9.3 to 4.9.4 and 4.8.6 to 4.8.7
 -------------------------------------------------

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -88,6 +88,7 @@ std::atomic<bool> statsWanted;
 uint32_t g_disthashseed;
 bool g_useIncomingECS;
 NetmaskGroup g_proxyProtocolACL;
+std::set<ComboAddress> g_proxyProtocolExceptions;
 boost::optional<ComboAddress> g_dns64Prefix{boost::none};
 DNSName g_dns64PrefixReverse;
 std::shared_ptr<SyncRes::domainmap_t> g_initialDomainMap; // new threads needs this to be setup
@@ -2119,6 +2120,14 @@ static int serviceMain(Logr::log_t log)
   }
 
   g_proxyProtocolACL.toMasks(::arg()["proxy-protocol-from"]);
+  {
+    std::vector<std::string> vec;
+    stringtok(vec, ::arg()["proxy-protocol-exceptions"], ", ");
+    for (const auto& sockAddrStr: vec) {
+      ComboAddress sockAddr(sockAddrStr, 53);
+      g_proxyProtocolExceptions.emplace(sockAddr);
+    }
+  }
   g_proxyProtocolMaximumSize = ::arg().asNum("proxy-protocol-maximum-size");
 
   ret = initDNS64(log);

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2123,7 +2123,7 @@ static int serviceMain(Logr::log_t log)
   {
     std::vector<std::string> vec;
     stringtok(vec, ::arg()["proxy-protocol-exceptions"], ", ");
-    for (const auto& sockAddrStr: vec) {
+    for (const auto& sockAddrStr : vec) {
       ComboAddress sockAddr(sockAddrStr, 53);
       g_proxyProtocolExceptions.emplace(sockAddr);
     }

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -221,6 +221,7 @@ extern boost::optional<ComboAddress> g_dns64Prefix;
 extern DNSName g_dns64PrefixReverse;
 extern uint64_t g_latencyStatSize;
 extern NetmaskGroup g_proxyProtocolACL;
+extern std::set<ComboAddress> g_proxyProtocolExceptions;
 extern std::atomic<bool> g_statsWanted;
 extern uint32_t g_disthashseed;
 extern int g_argc;
@@ -610,7 +611,7 @@ void protobufLogResponse(const struct dnsheader* header, LocalStateHolder<LuaCon
                          const std::unordered_set<std::string>& policyTags);
 void requestWipeCaches(const DNSName& canon);
 void startDoResolve(void*);
-bool expectProxyProtocol(const ComboAddress& from);
+bool expectProxyProtocol(const ComboAddress& from, const ComboAddress& listenAddress);
 void finishTCPReply(std::unique_ptr<DNSComboWriter>&, bool hadError, bool updateInFlight);
 void checkFastOpenSysctl(bool active, Logr::log_t);
 void checkTFOconnect(Logr::log_t);

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -2072,7 +2072,7 @@ The dnsdist docs have `more information about the PROXY protocol <https://dnsdis
         'help' : 'A Proxy Protocol header should not be used for these listen addresses.',
         'doc' : '''
 If set, clients sending from an address in :ref:`setting-proxy-protocol-from` to a address:port listed here are excluded from using the Proxy Protocol.
-If not port is specified, port 53 is assumed.
+If no port is specified, port 53 is assumed.
 This is typically used to provide an easy to use address and port to send debug queries to.
  ''',
         'versionadded' : '5.1.0',

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -2065,6 +2065,19 @@ The dnsdist docs have `more information about the PROXY protocol <https://dnsdis
         'versionchanged' : ('5.0.4', 'YAML settings only: previously this was defined as a string instead of a sequence')
     },
     {
+        'name' : 'proxy_protocol_exceptions',
+        'section' : 'incoming',
+        'type' : LType.ListSocketAddresses,
+        'default' : '',
+        'help' : 'A Proxy Protocol header should not be used for these listen addresses.',
+        'doc' : '''
+If set, clients sending from an address in :ref:`setting-proxy-protocol-from` to a address:port listed here are excluded from using the Proxy Protocol.
+If not port is specified, port 53 is assumed.
+This is typically used to provide an easy to use address and port to send debug queries to.
+ ''',
+        'versionadded' : '5.1.0',
+    },
+    {
         'name' : 'proxy_protocol_maximum_size',
         'section' : 'incoming',
         'type' : LType.Uint64,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes #13948

I had to move the code that retrieves the local address up to be able to check the exception for both UDP and TCP. This part of the change should be reviewed extra carefully to not have bad side-effects.
Potentially an extra syscall is done before dropping a connection/packet. 

You can use this as follows:

```yaml
incoming:
  listen:
    - 0.0.0.0:5301
    - 0.0.0.0:5302
    - '[::]:5301'
  proxy_protocol_from: [127.0.0.1]
  proxy_protocol_exceptions: [127.0.0.1:5302]
```
Has the effect that queries _to_ `127.0.0.1:5302` will not require proxy protocol, while queries _to_ `127.0.0.1:5301` will. Note that `proxy_protocol_from` talks about remote addresses/subnets, while `proxy_protocol_exceptions` talks about local addresses. I hope I made that clear in the docs.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
