### PR TITLE
ci: Enable LeakSanitizer during dnsdist and recursor unit tests

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -122,7 +122,6 @@ jobs:
     container:
       image: ghcr.io/powerdns/base-pdns-ci-image/debian-12-pdns-base:master
       env:
-        ASAN_OPTIONS: detect_leaks=0
         SANITIZERS: ${{ matrix.sanitizers }}
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
@@ -207,7 +206,6 @@ jobs:
     container:
       image: ghcr.io/powerdns/base-pdns-ci-image/debian-12-pdns-base:master
       env:
-        ASAN_OPTIONS: detect_leaks=0
         SANITIZERS: ${{ matrix.sanitizers }}
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We need to fix some one-time allocations in the authoritative server that are reported as leaked memory before we can enable it for the authoritative server as well. See:
- https://github.com/PowerDNS/pdns/pull/14028
- https://github.com/PowerDNS/pdns/pull/14029

<strike>There is also a leak in the remotebackend unit tests that I will investigate after https://github.com/PowerDNS/pdns/pull/13960 has been merged. Fixed by https://github.com/PowerDNS/pdns/pull/14033</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
