### PR TITLE
Meson fix for `libdecaf` detection

### DIFF
--- a/meson/libdecaf/meson.build
+++ b/meson/libdecaf/meson.build
@@ -5,38 +5,52 @@ if not opt_libdecaf.disabled()
   dep_libdecaf = dependency('libdecaf', required: false)
 
   if not dep_libdecaf.found()
-    dep_libdecaf = cxx.find_library(
-      'decaf',
-      dirs: [
-        '/usr',
-        '/usr' / 'lib',
-        '/usr' / 'local',
-        '/usr' / 'local' / 'lib',
-      ],
-      required: opt_libdecaf
-    )
-  endif
+    all_lib_dirs = [
+      '/usr',
+      '/usr' / 'lib',
+      '/usr' / 'local',
+      '/usr' / 'local' / 'lib',
+    ]
 
-  if dep_libdecaf.found()
-    message('Libdecaf: Checking for header file')
-
-    include_dirs = include_directories(
+    all_include_dirs = [
       '/usr' / 'include',
       '/usr' / 'include' / 'decaf',
       '/usr' / 'local' / 'include',
       '/usr' / 'local' / 'include' / 'decaf',
-      is_system: true,
-    )
+    ]
 
-    cxx.has_header(
-      'decaf.hxx',
-      required: true,
-      include_directories: include_dirs,
+    fs = import('fs')
+
+    lib_dirs = []
+    foreach lib_dir: all_lib_dirs
+      if fs.is_dir(lib_dir)
+        lib_dirs += lib_dir
+      endif
+    endforeach
+
+    include_dirs = []
+    foreach include_dir: all_include_dirs
+      if fs.is_dir(include_dir)
+        include_dirs += include_dir
+      endif
+    endforeach
+    include_dirs = include_directories(include_dirs, is_system: true)
+
+    dep_libdecaf = cxx.find_library(
+      'decaf',
+      dirs: lib_dirs,
+      required: opt_libdecaf,
+      has_headers: [
+        'decaf.hxx',
+        'decaf' / 'spongerng.hxx',
+        'decaf' / 'eddsa.hxx',
+      ],
+      header_include_directories: include_dirs,
     )
 
     dep_libdecaf = declare_dependency(
-      include_directories: dir,
       dependencies: dep_libdecaf,
+      include_directories: include_dirs,
     )
   endif
 endif

--- a/meson/libdecaf/meson.build
+++ b/meson/libdecaf/meson.build
@@ -1,9 +1,6 @@
 opt_libdecaf = get_option('signers-libdecaf')
 dep_libdecaf = dependency('', required: false)
 
-found_header = false
-header_path = false
-
 if not opt_libdecaf.disabled()
   dep_libdecaf = dependency('libdecaf', required: false)
 
@@ -21,42 +18,28 @@ if not opt_libdecaf.disabled()
   endif
 
   if dep_libdecaf.found()
-    include_dirs = [
+    message('Libdecaf: Checking for header file')
+
+    include_dirs = include_directories(
       '/usr' / 'include',
       '/usr' / 'include' / 'decaf',
       '/usr' / 'local' / 'include',
       '/usr' / 'local' / 'include' / 'decaf',
-    ]
+      is_system: true,
+    )
 
-    do_break = false
-    foreach dirname: include_dirs
-      dir = include_directories(dirname, is_system: true)
+    cxx.has_header(
+      'decaf.hxx',
+      required: true,
+      include_directories: include_dirs,
+    )
 
-      header_path = dirname / 'decaf.hxx'
-      message('Libdecaf: Checking for ' + header_path)
-
-      found_header = cxx.has_header(
-        'decaf.hxx',
-        dependencies: dep_libdecaf,
-        required: false,
-        include_directories: dir,
-      )
-
-      if found_header
-        dep_libdecaf = declare_dependency(
-          include_directories: dir,
-          dependencies: dep_libdecaf,
-        )
-
-        break
-      endif
-    endforeach
+    dep_libdecaf = declare_dependency(
+      include_directories: dir,
+      dependencies: dep_libdecaf,
+    )
   endif
 endif
 
-conf.set('HAVE_LIBDECAF', dep_libdecaf.found() and found_header, description: 'libdecaf-based signers')
+conf.set('HAVE_LIBDECAF', dep_libdecaf.found(), description: 'libdecaf-based signers')
 summary('libdecaf', dep_libdecaf.found(), bool_yn: true, section: 'Crypto')
-
-if dep_libdecaf.found()
-  summary('libdecaf headers', header_path, bool_yn: true, section: 'Crypto')
-endif

--- a/meson/libdecaf/meson.build
+++ b/meson/libdecaf/meson.build
@@ -6,8 +6,18 @@ header_path = false
 
 if not opt_libdecaf.disabled()
   dep_libdecaf = dependency('libdecaf', required: false)
+
   if not dep_libdecaf.found()
-    dep_libdecaf = cxx.find_library('decaf', dirs: ['/usr', '/usr' / 'local'], required: opt_libdecaf)
+    dep_libdecaf = cxx.find_library(
+      'decaf',
+      dirs: [
+        '/usr',
+        '/usr' / 'lib',
+        '/usr' / 'local',
+        '/usr' / 'local' / 'lib',
+      ],
+      required: opt_libdecaf
+    )
   endif
 
   if dep_libdecaf.found()
@@ -15,7 +25,7 @@ if not opt_libdecaf.disabled()
       '/usr' / 'include',
       '/usr' / 'include' / 'decaf',
       '/usr' / 'local' / 'include',
-      '/usr' / 'local' / 'include' / 'decaf'
+      '/usr' / 'local' / 'include' / 'decaf',
     ]
 
     do_break = false
@@ -34,7 +44,7 @@ if not opt_libdecaf.disabled()
 
       if found_header
         dep_libdecaf = declare_dependency(
-          compile_args: ['-I' + dirname],
+          include_directories: dir,
           dependencies: dep_libdecaf,
         )
 

--- a/meson/pgsql/meson.build
+++ b/meson/pgsql/meson.build
@@ -7,7 +7,7 @@ if get_option('module-gpgsql') != 'disabled'
     pg_config = find_program('pg_config', required: true)
 
     pg_includedir_res = run_command(pg_config, '--includedir', check: true)
-    pg_includedir = pg_includedir_res.stdout().strip()
+    pg_includedir = include_directories(pg_includedir_res.stdout().strip())
 
     # pg_cflags_res = run_command(pg_config, '--cflags', check: true)
     # pg_cflags = pg_cflags_res.stdout().strip().split()
@@ -30,7 +30,7 @@ if get_option('module-gpgsql') != 'disabled'
     dep_pgsql = declare_dependency(
       # compile_args: pg_cflags + pg_cppflags,
       # link_args: pg_ldflags,
-      compile_args: '-I' + pg_includedir,
+      include_directories: pg_includedir,
       link_args: ['-L' + pg_libdir, '-lpq'],
       version: pg_version,
     )


### PR DESCRIPTION
### Short description
This fixes `libdecaf` detection on Github runners. The library is installed in `/usr/local` and, when given custom directories to search in, meson doesn't add the `/lib` or `/include` postfix so we need to add those ourselves.

When given `/usr/local`, strace shows that meson searches for the library files in the given directories verbatim:
```
newfstatat(AT_FDCWD, "/usr/local/libdecaf.so", 0x7ffd8d377be0, 0) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/usr/local/decaf.so", 0x7ffd8d377be0, 0) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/usr/local/libdecaf.a", 0x7ffd8d377be0, 0) = -1 ENOENT (No such file or directory)
```

There's a tiny cleanup for the postgres backend.

*Do not merge until we've tested it again on the runner*.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)