### PR TITLE
auth: Use smart pointers in the remote backend unit tests

### DIFF
--- a/modules/remotebackend/test-remotebackend-http.cc
+++ b/modules/remotebackend/test-remotebackend-http.cc
@@ -75,7 +75,7 @@ struct RemotebackendSetup
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
-      new RemoteLoader();
+      auto loader = std::make_unique<RemoteLoader>();
       BackendMakers().launch("remote");
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "http:url=http://localhost:62434/dns";

--- a/modules/remotebackend/test-remotebackend-json.cc
+++ b/modules/remotebackend/test-remotebackend-json.cc
@@ -73,7 +73,7 @@ struct RemotebackendSetup
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
-      new RemoteLoader();
+      auto loader = std::make_unique<RemoteLoader>();
       BackendMakers().launch("remote");
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "http:url=http://localhost:62434/dns/endpoint.json,post=1,post_json=1";

--- a/modules/remotebackend/test-remotebackend-pipe.cc
+++ b/modules/remotebackend/test-remotebackend-pipe.cc
@@ -73,7 +73,7 @@ struct RemotebackendSetup
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
-      new RemoteLoader();
+      auto loader = std::make_unique<RemoteLoader>();
       BackendMakers().launch("remote");
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "pipe:command=unittest_pipe.py";

--- a/modules/remotebackend/test-remotebackend-post.cc
+++ b/modules/remotebackend/test-remotebackend-post.cc
@@ -73,7 +73,7 @@ struct RemotebackendSetup
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
-      new RemoteLoader();
+      auto loader = std::make_unique<RemoteLoader>();
       BackendMakers().launch("remote");
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "http:url=http://localhost:62434/dns,post=1";

--- a/modules/remotebackend/test-remotebackend-unix.cc
+++ b/modules/remotebackend/test-remotebackend-unix.cc
@@ -73,7 +73,7 @@ struct RemotebackendSetup
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
-      new RemoteLoader();
+      auto loader = std::make_unique<RemoteLoader>();
       BackendMakers().launch("remote");
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "unix:path=/tmp/remotebackend.sock";

--- a/modules/remotebackend/test-remotebackend-zeromq.cc
+++ b/modules/remotebackend/test-remotebackend-zeromq.cc
@@ -75,7 +75,7 @@ struct RemotebackendSetup
     try {
       // setup minimum arguments
       ::arg().set("module-dir") = "./.libs";
-      new RemoteLoader();
+      auto loader = std::make_unique<RemoteLoader>();
       BackendMakers().launch("remote");
       // then get us a instance of it
       ::arg().set("remote-connection-string") = "zeromq:endpoint=ipc:///tmp/remotebackend.0";


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR gets rid of LeakSanitizer warnings like this one:
```
Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x652dca6a1e12 in operator new(unsigned long) (/pdns/modules/remotebackend/remotebackend_http.test+0x1b8e12) (BuildId: f9ff2ecf3bf5e1000f1bb0cd8950e4cb9244f2e3)
    #1 0x652dca6a622a in RemotebackendSetup::RemotebackendSetup() /pdns/modules/remotebackend/test-remotebackend-http.cc:78:7
    #2 0x652dca6a5e1b in boost::unit_test::ut_detail::global_configuration_impl<RemotebackendSetup>::test_start(unsigned long, unsigned long) /usr/include/boost/test/tree/global_fixture.hpp:91:40

SUMMARY: AddressSanitizer: 1 byte(s) leaked in 1 allocation(s).
FAIL remotebackend_http.test (exit status: 1)
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)

