### PR TITLE
Meson fix: `lmdb-safe` needs gettime

### DIFF
--- a/ext/lmdb-safe/meson.build
+++ b/ext/lmdb-safe/meson.build
@@ -6,7 +6,12 @@ lib_lmdb_safe = static_library(
     'lmdb-safe.hh',
     'lmdb-typed.hh',
   ],
-  dependencies: [dep_pdns, dep_lmdb, dep_boost_serialization],
+  dependencies: [
+    dep_pdns,
+    dep_lmdb,
+    dep_boost_serialization,
+    libpdns_gettime,
+  ],
 )
 
 dep_lmdb_safe = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,16 @@ subdir('ext' / 'json11')
 subdir('ext' / 'luawrapper')
 subdir('ext' / 'protozero')
 subdir('ext' / 'yahttp')
+
+libpdns_gettime = declare_dependency(
+  link_whole: static_library(
+    'pdns-gettime',
+    src_dir / 'gettime.cc',
+    src_dir / 'gettime.hh',
+    dependencies: dep_rt,
+  )
+)
+
 if get_option('module-lmdb') != 'disabled'
   subdir('ext' / 'lmdb-safe')
 endif
@@ -322,15 +332,6 @@ if dep_sqlite3.found()
     )
   )
 endif
-
-libpdns_gettime = declare_dependency(
-  link_whole: static_library(
-    'pdns-gettime',
-    src_dir / 'gettime.cc',
-    src_dir / 'gettime.hh',
-    dependencies: dep_rt,
-  )
-)
 
 libpdns_signers_openssl = declare_dependency(
   link_whole: static_library(


### PR DESCRIPTION
### Short description
`lmdb-safe` needs gettime.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)