### PR TITLE
dnsdist: Fix "C++ One Definition Rule" warnings in XSK

### DIFF
--- a/pdns/xsk.cc
+++ b/pdns/xsk.cc
@@ -29,15 +29,6 @@
 #include <cstring>
 #include <fcntl.h>
 #include <iterator>
-#include <linux/bpf.h>
-#include <linux/if_ether.h>
-#include <linux/if_link.h>
-#include <linux/if_xdp.h>
-#include <linux/ip.h>
-#include <linux/ipv6.h>
-#include <linux/tcp.h>
-#include <linux/types.h>
-#include <linux/udp.h>
 #include <net/if.h>
 #include <net/if_arp.h>
 #include <netinet/in.h>
@@ -60,6 +51,21 @@ extern "C"
 
 #include "gettime.hh"
 #include "xsk.hh"
+
+/* we need to include the linux specific headers AFTER the regular
+   ones, because it then detects that some types have already been
+   defined (sockaddr_in6 for example) and does not attempt to
+   re-define them, which otherwise breaks the C++ One Definition Rule
+*/
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/if_link.h>
+#include <linux/if_xdp.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+#include <linux/types.h>
+#include <linux/udp.h>
 
 #ifdef DEBUG_UMEM
 namespace


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It turns out we need to include the linux specific headers AFTER the regular ones, because it then detects that some types have already been defined (`sockaddr_in6` for example) and does not attempt to re-define them, which otherwise breaks the C++ One Definition Rule.
I thought I fixed all of these in 1.9.2 but compiling with `g++` instead of `clang++` brought a remaining one that this PR fixes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
