### PR TITLE
dnsdist: Fix a crash in the Downstream TCP handler

### DIFF
--- a/pdns/dnsdistdist/dnsdist-downstream-connection.hh
+++ b/pdns/dnsdistdist/dnsdist-downstream-connection.hh
@@ -203,7 +203,7 @@ public:
 
     if (backendIt->second.d_idles.size() >= s_maxIdleConnectionsPerDownstream) {
       auto old = backendIt->second.d_idles.template get<SequencedTag>().back();
-      old->release();
+      old->release(false);
       backendIt->second.d_idles.template get<SequencedTag>().pop_back();
     }
 
@@ -231,7 +231,7 @@ protected:
 
       if (entry->isIdle() && entry->getLastDataReceivedTime() < idleCutOff) {
         /* idle for too long */
-        (*connIt)->release();
+        (*connIt)->release(false);
         connIt = sidx.erase(connIt);
         continue;
       }
@@ -242,7 +242,7 @@ protected:
       }
 
       if (entry->isIdle()) {
-        (*connIt)->release();
+        (*connIt)->release(false);
       }
       connIt = sidx.erase(connIt);
     }

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -70,8 +70,9 @@ public:
   bool reachedMaxConcurrentQueries() const override;
   bool reachedMaxStreamID() const override;
   bool isIdle() const override;
-  void release() override
+  void release(bool removeFromCache) override
   {
+    (void)removeFromCache;
   }
 
 private:

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -119,7 +119,7 @@ public:
   virtual bool reachedMaxStreamID() const = 0;
   virtual bool reachedMaxConcurrentQueries() const = 0;
   virtual bool isIdle() const = 0;
-  virtual void release() = 0;
+  virtual void release(bool removeFromCache) = 0;
   virtual void stopIO()
   {
   }
@@ -256,7 +256,7 @@ public:
 
   void queueQuery(std::shared_ptr<TCPQuerySender>& sender, TCPQuery&& query) override;
   void handleTimeout(const struct timeval& now, bool write) override;
-  void release() override;
+  void release(bool removeFromCache) override;
 
   std::string toString() const override
   {

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -342,7 +342,7 @@ void IncomingTCPConnectionState::terminateClientConnection()
      we don't care about the ones still waiting for responses */
   for (auto& backend : d_ownedConnectionsToBackend) {
     for (auto& conn : backend.second) {
-      conn->release();
+      conn->release(true);
     }
   }
   d_ownedConnectionsToBackend.clear();
@@ -475,7 +475,7 @@ void IncomingTCPConnectionState::handleResponse(const struct timeval& now, TCPRe
         for (auto it = list.begin(); it != list.end(); ++it) {
           if (*it == response.d_connection) {
             try {
-              response.d_connection->release();
+              response.d_connection->release(true);
             }
             catch (const std::exception& e) {
               vinfolog("Error releasing connection: %s", e.what());

--- a/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
+++ b/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
@@ -71,7 +71,7 @@ public:
   {
   }
 
-  void release()
+  void release(bool removeFomCache)
   {
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When we are looking for an existing TCP connection to a backend to reuse, we routinely (every 60s by default) clean up existing connections from the cache.
7b5f590ee72fecf54c0c40b24e98ba03a406af53 removes a connection from the cache more aggressively when it has failed, but I did not notice that the same function might be called from the cache cleaning algorithm. It caused the cache cleanup function to call this function which in turns tried to remove the connection from the same cache, invalidating the iterator of the cache algorithm, and causing a crash when the function returned.

Better fix than https://github.com/PowerDNS/pdns/pull/14039 for master, and likely for 1.9.x after more testing.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
