### PR TITLE
auth dnsproxy: fix build on s390x

### DIFF
--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -240,10 +240,11 @@ void DNSProxy::mainloop()
       memcpy(&dHead, &buffer[0], sizeof(dHead));
       {
         auto conntrack = d_conntrack.lock();
-#if BYTE_ORDER == BIG_ENDIAN
-        // this is needed because spoof ID down below does not respect the native byteorder
-        d.id = (256 * (uint16_t)buffer[1]) + (uint16_t)buffer[0];
-#endif
+        if (BYTE_ORDER == BIG_ENDIAN) {
+          // this is needed because spoof ID down below does not respect the native byteorder
+          dHead.id = (256 * (uint16_t)buffer[1]) + (uint16_t)buffer[0];
+        }
+
         auto iter = conntrack->find(dHead.id ^ d_xor);
         if (iter == conntrack->end()) {
           g_log << Logger::Error << "Discarding untracked packet from recursor backend with id " << (dHead.id ^ d_xor) << ". Conntrack table size=" << conntrack->size() << endl;


### PR DESCRIPTION
### Short description

```
dnsproxy.cc: In member function ‘void DNSProxy::mainloop()’:
dnsproxy.cc:245:9: error: ‘d’ was not declared in this scope
  245 |         d.id = (256 * (uint16_t)buffer[1]) + (uint16_t)buffer[0];
      |         ^
```

https://buildd.debian.org/status/fetch.php?pkg=pdns&arch=s390x&ver=4.9.0-1&stamp=1712324826&raw=0


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
