### PR TITLE
rec: do not count RRSIGs using unsupported algorithms towards RRSIGs limit

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -1022,6 +1022,9 @@ vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t
     }
 
     vState ede = vState::Indeterminate;
+    if (!DNSCryptoKeyEngine::isAlgorithmSupported(signature->d_algorithm)) {
+        continue;
+    }
     if (!checkSignatureInceptionAndExpiry(name, now, *signature, ede, log)) {
       if (isRRSIGIncepted(now, *signature)) {
         noneIncepted = false;
@@ -1127,7 +1130,7 @@ bool haveNegativeTrustAnchor(const map<DNSName,std::string>& negAnchors, const D
   return true;
 }
 
-vState validateDNSKeysAgainstDS(time_t now, const DNSName& zone, const dsmap_t& dsmap, const skeyset_t& tkeys, const sortedRecords_t& toSign, const vector<shared_ptr<const RRSIGRecordContent> >& sigs, skeyset_t& validkeys, const OptLog& log, pdns::validation::ValidationContext& context)
+vState validateDNSKeysAgainstDS(time_t now, const DNSName& zone, const dsmap_t& dsmap, const skeyset_t& tkeys, const sortedRecords_t& toSign, const vector<shared_ptr<const RRSIGRecordContent> >& sigs, skeyset_t& validkeys, const OptLog& log, pdns::validation::ValidationContext& context) // NOLINT(readability-function-cognitive-complexity): FIXME
 {
   /*
    * Check all DNSKEY records against all DS records and place all DNSKEY records
@@ -1194,6 +1197,9 @@ vState validateDNSKeysAgainstDS(time_t now, const DNSName& zone, const dsmap_t& 
     // whole set
     uint16_t signaturesConsidered = 0;
     for (const auto& sig : sigs) {
+      if (!DNSCryptoKeyEngine::isAlgorithmSupported(sig->d_algorithm)) {
+        continue;
+      }
       if (!checkSignatureInceptionAndExpiry(zone, now, *sig, ede, log)) {
         continue;
       }


### PR DESCRIPTION
I don't think we should count RRSIGs with unsupported algos towards the RRSIG limit, just like expired RRSIGs are skipped.

I found two places where the RRSIG's limit is increased if we're encountering unsupported algo's.

In `validateWithKeySet` the `checkSignatureWithKey` call currently returns `false` because `DNSCryptoKeyEngine::makeFromPublicKeyString` fails for unsupported algorithms. We must check earlier, as otherwise the counter is already increased. It does not look lik `ede` set is passed to the caller here. 

In `validateDNSKeysAgainstDS` we have a similar case. The `ede` does not seem to get used if an unsupported algo is encountered.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
