### PR TITLE
dnsdist: syslog should be enabled by default

### DIFF
--- a/pdns/dnsdistdist/dolog.cc
+++ b/pdns/dnsdistdist/dolog.cc
@@ -32,7 +32,7 @@ std::string LoggingConfiguration::s_structuredLevelPrefix{"prio"};
 LoggingConfiguration::TimeFormat LoggingConfiguration::s_structuredTimeFormat{LoggingConfiguration::TimeFormat::Numeric};
 bool LoggingConfiguration::s_structuredLogging{false};
 bool LoggingConfiguration::s_logTimestamps{false};
-bool LoggingConfiguration::s_syslog{false};
+bool LoggingConfiguration::s_syslog{true};
 
 namespace
 {


### PR DESCRIPTION
Regression introduced with the logging refactoring of dnsdist.

See rel/dnsdist-1.8.x: https://github.com/PowerDNS/pdns/blob/4d5bb67a2a75f9d88894e7dfc42bbbebfda297b0/pdns/dnsdist.cc#L103

In master and 1.9.x the newly intrdoduced `LoggingConfiguration::s_syslog` is inited to `false`.

This does not matter using the default systemd unit file as it disables syslog:
```
ExecStart=@bindir@/dnsdist --supervised --disable-syslog
```
but it does matter for non-systemd cases.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
