### PR TITLE
Revert "gh actions: wo issue 9491 - actions/runner-images"

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -41,23 +41,11 @@ jobs:
         SANITIZERS: asan+ubsan
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     defaults:
       run:
         working-directory: ./pdns-${{ env.BUILDER_VERSION }}
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -125,23 +113,11 @@ jobs:
         SANITIZERS: ${{ matrix.sanitizers }}
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     defaults:
       run:
         working-directory: ./pdns/recursordist/pdns-recursor-${{ env.BUILDER_VERSION }}
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -210,23 +186,11 @@ jobs:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
         FUZZING_TARGETS: yes
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     defaults:
       run:
         working-directory: ./pdns/dnsdistdist/dnsdist-${{ env.BUILDER_VERSION }}
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -289,7 +253,7 @@ jobs:
         ASAN_OPTIONS: detect_leaks=0
         TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ env.REPO_HOME }}/pdns/dnsdistdist/dnsdist-tsan.supp"
         AUTH_BACKEND_IP_ADDR: "172.17.0.1"
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     strategy:
       matrix:
         include:
@@ -316,18 +280,6 @@ jobs:
         options: >-
           --restart always
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -365,7 +317,7 @@ jobs:
         LDAPHOST: ldap://ldapserver/
         ODBCINI: /github/home/.odbc.ini
         AUTH_BACKEND_IP_ADDR: "172.17.0.1"
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     strategy:
       matrix:
         include:
@@ -452,18 +404,6 @@ jobs:
         options: >-
           --restart always
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -498,20 +438,8 @@ jobs:
       env:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         ASAN_OPTIONS: detect_leaks=0
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -552,20 +480,8 @@ jobs:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         ASAN_OPTIONS: detect_leaks=0
         TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ env.REPO_HOME }}/pdns/recursordist/recursor-tsan.supp"
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -608,20 +524,8 @@ jobs:
         UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp'
         ASAN_OPTIONS: detect_leaks=0
         TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ env.REPO_HOME }}/pdns/recursordist/recursor-tsan.supp"
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       # - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v4
         with:
@@ -666,20 +570,8 @@ jobs:
         UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp'
         ASAN_OPTIONS: detect_leaks=0
         TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ env.REPO_HOME }}/pdns/recursordist/recursor-tsan.supp"
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -724,18 +616,6 @@ jobs:
         COVERAGE: yes
       options: --sysctl net.ipv6.conf.all.disable_ipv6=0 --privileged
     steps:
-      # workaround issue 9491 repo actions/runner-images
-      - name: get runner image version
-        id: runner-image-version
-        run: |
-          echo "image-version=$(echo $ImageVersion)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: modify number of bits to use for aslr entropy
-        if: ${{ steps.runner-image-version.outputs.ImageVersion }} == '20240310.1.0'
-        run: |
-          sudo sysctl -a | grep vm.mmap.rnd
-          sudo sysctl -w vm.mmap_rnd_bits=28
-        working-directory: .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5


### PR DESCRIPTION
This reverts commit e0bf314e472d0c1d4bc1ff82d97cabf87be1e929.

The workaround done in #13907 is no longer needed. 

Currently, this workaround is being applied to all runners independent from the runner image version. To actually apply the fix to only a specific version, the following changes should be applied in a new PR: [commit](https://github.com/romeroalx/pdns/commit/a06785722c7a7b002f6ebe4de3eb0c848d9b8e93). However, it seems is no longer needed as the current images already have in place the fix done by GitHub (check [here](https://github.com/actions/runner-images?tab=readme-ov-file#available-images))


### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
