### PR TITLE
meson: don't assume libdecaf is present when declaring dependency

### DIFF
--- a/meson/libdecaf/meson.build
+++ b/meson/libdecaf/meson.build
@@ -48,10 +48,12 @@ if not opt_libdecaf.disabled()
       header_include_directories: include_dirs,
     )
 
-    dep_libdecaf = declare_dependency(
-      dependencies: dep_libdecaf,
-      include_directories: include_dirs,
-    )
+    if dep_libdecaf.found()
+      dep_libdecaf = declare_dependency(
+        dependencies: dep_libdecaf,
+        include_directories: include_dirs,
+      )
+    endif
   endif
 endif
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes the build in case libdecaf is not available at all for me (tested on macOS and OpenBSD)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
