### PR TITLE
Auth feature: RFC9615 (authenticated DNSSEC bootstrapping)

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -62,6 +62,7 @@ Atlassian
 Atomia
 aton
 Authoritativedoc
+authsignal
 authzone
 autobuilt
 autocalculation
@@ -909,6 +910,7 @@ Novell
 nproxy
 NPTL
 NSes
+nshost
 NSID
 nsis
 nsl
@@ -960,6 +962,7 @@ oraclebackend
 ordername
 orsn
 Oservers
+oskar
 otherdomain
 otherpool
 othervariant

--- a/docs/domainmetadata.rst
+++ b/docs/domainmetadata.rst
@@ -197,6 +197,21 @@ see the :doc:`guides/kskrollcdnskey`.
 
 Global defaults for these values can be set via :ref:`setting-default-publish-cdnskey` and :ref:`setting-default-publish-cds`.
 
+.. _metadata-signaling-zone:
+
+SIGNALING-ZONE
+--------------
+.. versionadded:: 5.0.0
+
+If set to 1 (and the zone is signed and uses NSEC3 narrow mode), this setting will make
+PowerDNS synthesize CDS/CDNSKEY records obtained from other zones served on the same
+nameserver, in accordance with :rfc:`9615`.
+
+Typically, this metadata does not need to be set manually; instead, you can use
+``pdnsutil set-signaling-zone $zone``. This command not only configures this metadata but
+also takes care of the other preconditions needed to properly set up a signaling zone.
+For details, see :ref:`dnssec-bootstrapping`.
+
 .. _metadata-slave-renotify:
 
 SLAVE-RENOTIFY

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -575,8 +575,12 @@ Configure a delay to send out notifications, no delay by default.
 -  Boolean
 -  Default: no
 
-Read additional DNSKEY, CDS and CDNSKEY records from the records table/your BIND zonefile. If not
-set, DNSKEY, CDS and CDNSKEY records in the zonefiles are ignored.
+Read additional DNSKEY records from the records table/your BIND zonefile and use both when
+preparing responses. If not set, such records in the zonefiles are ignored.
+
+When automatic CDS and CDNSKEY publication (see :ref:`metadata-publish-cdnskey-publish-cds`)
+is enabled, this also applies to those types. If not set, such records are only considered
+when automatic publication is turned off.
 
 .. _setting-direct-dnskey-signature:
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -395,6 +395,13 @@ bool DNSSECKeeper::checkNSEC3PARAM(const NSEC3PARAMRecordContent& ns3p, string& 
 
 bool DNSSECKeeper::setNSEC3PARAM(const ZoneName& zname, const NSEC3PARAMRecordContent& ns3p, const bool& narrow)
 {
+  if (auto wirelength = zname.operator const DNSName&().wirelength(); wirelength > 222) {
+    throw runtime_error("Cannot enable NSEC3 for zone '" + zname.toLogString() + "' as it is too long (" + std::to_string(wirelength) + " bytes, maximum is 222 bytes)");
+  }
+  if(ns3p.d_algorithm != 1) {
+    throw runtime_error("NSEC3PARAM algorithm set to '" + std::to_string(ns3p.d_algorithm) + "', but '1' is the only valid value");
+  }
+
   if (d_keymetadb->inTransaction()) {
     d_metaUpdate = true;
   }

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -85,6 +85,17 @@ bool DNSSECKeeper::isPresigned(const ZoneName& name, bool useCache)
   return meta=="1";
 }
 
+bool DNSSECKeeper::isSignalingZone(const ZoneName& name, bool useCache)
+{
+  string meta;
+  if (useCache) {
+    getFromMeta(name, "SIGNALING-ZONE", meta);
+  }
+  else {
+    getFromMetaNoCache(name, "SIGNALING-ZONE", meta);
+  }
+  return meta=="1";
+}
 
 bool DNSSECKeeper::addKey(const ZoneName& name, bool setSEPBit, int algorithm, int64_t& keyId, int bits, bool active, bool published)
 {

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -213,6 +213,7 @@ public:
   bool isPresigned(const ZoneName& zname, bool useCache=true);
   bool setPresigned(const ZoneName& zname);
   bool unsetPresigned(const ZoneName& zname);
+  bool isSignalingZone(const ZoneName& zname, bool useCache=true);
   bool setPublishCDNSKEY(const ZoneName& zname, bool deleteAlg);
   void getPublishCDNSKEY(const ZoneName& zname, std::string& value);
   bool unsetPublishCDNSKEY(const ZoneName& zname);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1382,6 +1382,7 @@ bool PacketHandler::tryAuthSignal(DNSPacket& p, std::unique_ptr<DNSPacket>& r, D
   // Insert synthetic response
   bool haveOne = false;
   bool autoPublish = !d_dk.isPresigned(zone);
+  std::string val;
   if(p.qtype.getCode() == QType::CDS) {
     d_dk.getPublishCDS(zone, val);
     autoPublish &= !val.empty();

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1342,6 +1342,9 @@ void PacketHandler::completeANYRecords(DNSPacket& p, std::unique_ptr<DNSPacket>&
 
 bool PacketHandler::tryAuthSignal(DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target) {
   DLOG(g_log<<Logger::Warning<<"Let's try authenticated DNSSEC bootstrapping (RFC 9615) ..."<<endl);
+  if(d_sd.zonename.operator const DNSName&().getRawLabel(0) != "_signal" || !d_dk.isSignalingZone(d_sd.zonename)) {
+    return false;
+  }
 
   // Check that we're doing online signing in narrow mode (as we don't know next owner names)
   if(!d_dk.isSecuredZone(d_sd.zonename) || d_dk.isPresigned(d_sd.zonename)) {

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1342,7 +1342,7 @@ void PacketHandler::completeANYRecords(DNSPacket& p, std::unique_ptr<DNSPacket>&
 
 bool PacketHandler::tryAuthSignal(DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target) {
   DLOG(g_log<<Logger::Warning<<"Let's try authenticated DNSSEC bootstrapping (RFC 9615) ..."<<endl);
-  if(d_sd.zonename.operator const DNSName&().getRawLabel(0) != "_signal" || !d_dk.isSignalingZone(d_sd.zonename)) {
+  if(d_sd.zonename.operator const DNSName&().countLabels() == 0 || d_sd.zonename.operator const DNSName&().getRawLabel(0) != "_signal" || !d_dk.isSignalingZone(d_sd.zonename)) {
     return false;
   }
 
@@ -1358,7 +1358,7 @@ bool PacketHandler::tryAuthSignal(DNSPacket& p, std::unique_ptr<DNSPacket>& r, D
   }
 
   // Check for prefix mismatch
-  if(target.getRawLabel(0) != "_dsboot") {
+  if(target.countLabels() == 0 || target.getRawLabel(0) != "_dsboot") {
     makeNOError(p, r, target, DNSName(), 0); // could be ENT
     return true;
   }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -755,7 +755,7 @@ void PacketHandler::emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name,
   r->addRecord(std::move(rr));
 }
 
-void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRecordContent& ns3prc, const DNSName& name, const string& namehash, const string& nexthash, int mode)
+void PacketHandler::emitNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRecordContent& ns3prc, const DNSName& name, const string& namehash, const string& nexthash, int mode)
 {
   NSEC3RecordContent n3rc;
   n3rc.d_algorithm = ns3prc.d_algorithm;
@@ -786,6 +786,13 @@ void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRec
             break;
           }
         }
+      }
+    } else if(mode == 6) {
+      if (p.qtype.getCode() != QType::CDS) {
+        n3rc.set(QType::CDS);
+      }
+      if (p.qtype.getCode() != QType::CDNSKEY) {
+        n3rc.set(QType::CDNSKEY);
       }
     }
 
@@ -854,6 +861,7 @@ void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRec
    mode 3 = Wildcard Answer Responses
    mode 4 = Name Error Responses
    mode 5 = Direct NSEC request
+   mode 6 = Authenticated DNSSEC bootstrapping (RFC 9615)
 */
 void PacketHandler::addNSECX(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName& target, const DNSName& wildcard, int mode)
 {
@@ -955,7 +963,7 @@ void PacketHandler::addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const 
 
     if (!after.empty()) {
       DLOG(g_log<<"Done calling for matching, hashed: '"<<toBase32Hex(hashed)<<"' before='"<<toBase32Hex(before)<<"', after='"<<toBase32Hex(after)<<"'"<<endl);
-      emitNSEC3(r, ns3rc, unhashed, before, after, mode);
+      emitNSEC3(p, r, ns3rc, unhashed, before, after, mode);
     }
   }
 
@@ -972,7 +980,7 @@ void PacketHandler::addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const 
 
     getNSEC3Hashes(narrow, hashed, true, unhashed, before, after);
     DLOG(g_log<<"Done calling for covering, hashed: '"<<toBase32Hex(hashed)<<"' before='"<<toBase32Hex(before)<<"', after='"<<toBase32Hex(after)<<"'"<<endl);
-    emitNSEC3( r, ns3rc, unhashed, before, after, mode);
+    emitNSEC3(p, r, ns3rc, unhashed, before, after, mode);
   }
 
   // wildcard denial
@@ -984,7 +992,7 @@ void PacketHandler::addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const 
 
     getNSEC3Hashes(narrow, hashed, (mode != 2), unhashed, before, after);
     DLOG(g_log<<"Done calling for '*', hashed: '"<<toBase32Hex(hashed)<<"' before='"<<toBase32Hex(before)<<"', after='"<<toBase32Hex(after)<<"'"<<endl);
-    emitNSEC3( r, ns3rc, unhashed, before, after, mode);
+    emitNSEC3(p, r, ns3rc, unhashed, before, after, mode);
   }
 }
 
@@ -1330,6 +1338,59 @@ void PacketHandler::completeANYRecords(DNSPacket& p, std::unique_ptr<DNSPacket>&
     }
     addNSEC3PARAM(p, r);
   }
+}
+
+bool PacketHandler::tryAuthSignal(DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target) {
+  DLOG(g_log<<Logger::Warning<<"Let's try authenticated DNSSEC bootstrapping (RFC 9615) ..."<<endl);
+
+  // Check for prefix mismatch
+  if(target.getRawLabel(0) != "_dsboot") {
+    makeNOError(p, r, target, DNSName(), 0); // could be ENT
+    return true;
+  }
+
+  // Check for qtype match
+  if(!(p.qtype.getCode() == QType::CDS || p.qtype.getCode() == QType::CDNSKEY)) {
+    // We don't know at this point whether CDS/CDNSKEY exist, so let's add both to DoE type map
+    makeNOError(p, r, target, DNSName(), 6);
+    return true;
+  }
+
+  // Extract target zone name and fetch zone
+  SOAData zone_sd;
+  ZoneName zone = ZoneName(target.makeRelative(d_sd.zonename));
+  zone.chopOff();
+  // Zone must exist, but need not be secured (could be using front-sign setup)
+  if(!B.getAuth(zone, p.qtype, &zone_sd, p.getRealRemote()) || zone_sd.zonename != zone) {
+    return false; // Bootstrap target zone unknown, NXDOMAIN at _dsboot is OK
+  }
+
+  // Insert synthetic response
+  bool haveOne = false;
+  bool autoPublish = !d_dk.isPresigned(zone);
+  if(p.qtype.getCode() == QType::CDS) {
+    d_dk.getPublishCDS(zone, val);
+    autoPublish &= !val.empty();
+    if(autoPublish)
+      haveOne = addCDS(p, r, zone_sd);
+  } else if(p.qtype.getCode() == QType::CDNSKEY) {
+    d_dk.getPublishCDNSKEY(zone, val);
+    autoPublish &= !val.empty();
+    if(autoPublish)
+      haveOne = addCDNSKEY(p, r, zone_sd);
+  }
+  if(!autoPublish) {
+      DNSZoneRecord rr;
+      B.lookup(p.qtype.getCode(), DNSName(zone), zone_sd.domain_id, &p);
+      while(B.get(rr)) {
+        rr.dr.d_name = p.qdomain;
+        r->addRecord(std::move(rr));
+        haveOne=true;
+      }
+    }
+  if(!haveOne)
+    makeNOError(p, r, target, DNSName(), 6); // other type might exist
+  return true;
 }
 
 bool PacketHandler::tryDNAME(DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target)
@@ -1854,6 +1915,9 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
     } catch (const std::range_error &e) {
       // We couldn't make a CNAME.....
       state.r->setRcode(RCode::YXDomain);
+      return true;
+    }
+    if(tryAuthSignal(pkt, state.r, state.target)) {
       return true;
     }
 

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -124,7 +124,7 @@ bool PacketHandler::addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r)
 {
   return addCDNSKEY(p, r, d_sd);
 }
-bool PacketHandler::addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, SOAData &sd)
+bool PacketHandler::addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, SOAData &sd) // NOLINT(readability-identifier-length)
 {
   string publishCDNSKEY;
   d_dk.getPublishCDNSKEY(sd.zonename,publishCDNSKEY);
@@ -755,7 +755,7 @@ void PacketHandler::emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name,
   r->addRecord(std::move(rr));
 }
 
-void PacketHandler::emitNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRecordContent& ns3prc, const DNSName& name, const string& namehash, const string& nexthash, int mode)
+void PacketHandler::emitNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRecordContent& ns3prc, const DNSName& name, const string& namehash, const string& nexthash, int mode) // NOLINT(readability-identifier-length)
 {
   NSEC3RecordContent n3rc;
   n3rc.d_algorithm = ns3prc.d_algorithm;
@@ -1340,7 +1340,8 @@ void PacketHandler::completeANYRecords(DNSPacket& p, std::unique_ptr<DNSPacket>&
   }
 }
 
-bool PacketHandler::tryAuthSignal(DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target) {
+bool PacketHandler::tryAuthSignal(DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target) // NOLINT(readability-identifier-length)
+{
   DLOG(g_log<<Logger::Warning<<"Let's try authenticated DNSSEC bootstrapping (RFC 9615) ..."<<endl);
   if(d_sd.zonename.operator const DNSName&().countLabels() == 0 || d_sd.zonename.operator const DNSName&().getRawLabel(0) != "_signal" || !d_dk.isSignalingZone(d_sd.zonename)) {
     return false;
@@ -1386,25 +1387,28 @@ bool PacketHandler::tryAuthSignal(DNSPacket& p, std::unique_ptr<DNSPacket>& r, D
   if(p.qtype.getCode() == QType::CDS) {
     d_dk.getPublishCDS(zone, val);
     autoPublish &= !val.empty();
-    if(autoPublish)
+    if(autoPublish) {
       haveOne = addCDS(p, r, zone_sd);
+    }
   } else if(p.qtype.getCode() == QType::CDNSKEY) {
     d_dk.getPublishCDNSKEY(zone, val);
     autoPublish &= !val.empty();
-    if(autoPublish)
+    if(autoPublish) {
       haveOne = addCDNSKEY(p, r, zone_sd);
+    }
   }
   if(!autoPublish) {
-      DNSZoneRecord rr;
+      DNSZoneRecord rec;
       B.lookup(p.qtype.getCode(), DNSName(zone), zone_sd.domain_id, &p);
-      while(B.get(rr)) {
-        rr.dr.d_name = p.qdomain;
-        r->addRecord(std::move(rr));
+      while(B.get(rec)) {
+        rec.dr.d_name = p.qdomain;
+        r->addRecord(std::move(rec));
         haveOne=true;
       }
     }
-  if(!haveOne)
+  if(!haveOne) {
     makeNOError(p, r, target, DNSName(), 6); // other type might exist
+  }
   return true;
 }
 

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -89,7 +89,7 @@ private:
   bool getNSEC3Hashes(bool narrow, const std::string& hashed, bool decrement, DNSName& unhashed, std::string& before, std::string& after, int mode=0);
   void addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName &target, const DNSName &wildcard, const NSEC3PARAMRecordContent& nsec3param, bool narrow, int mode);
   void emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name, const DNSName& next, int mode);
-  void emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRecordContent &ns3rc, const DNSName& unhashed, const string& begin, const string& end, int mode);
+  void emitNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRecordContent &ns3rc, const DNSName& unhashed, const string& begin, const string& end, int mode);
   int processUpdate(DNSPacket& p);
   int forwardPacket(const string &msgPrefix, const DNSPacket& p, const DomainInfo& di);
   uint performUpdate(const string &msgPrefix, const DNSRecord *rr, DomainInfo *di, bool isPresigned, bool* narrow, bool* haveNSEC3, NSEC3PARAMRecordContent *ns3pr, bool *updatedSerial);
@@ -101,6 +101,7 @@ private:
   void makeNOError(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName& target, const DNSName& wildcard, int mode);
   vector<DNSZoneRecord> getBestReferralNS(DNSPacket& p, const DNSName &target);
   void getBestDNAMESynth(DNSPacket& p, DNSName &target, vector<DNSZoneRecord> &ret);
+  bool tryAuthSignal(DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target);
   bool tryDNAME(DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target);
   bool tryReferral(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName &target, bool retargeted);
 

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -89,7 +89,7 @@ private:
   bool getNSEC3Hashes(bool narrow, const std::string& hashed, bool decrement, DNSName& unhashed, std::string& before, std::string& after, int mode=0);
   void addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName &target, const DNSName &wildcard, const NSEC3PARAMRecordContent& nsec3param, bool narrow, int mode);
   void emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name, const DNSName& next, int mode);
-  void emitNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRecordContent &ns3rc, const DNSName& unhashed, const string& begin, const string& end, int mode);
+  void emitNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRecordContent &ns3prc, const DNSName& name, const string& namehash, const string& nexthash, int mode);
   int processUpdate(DNSPacket& p);
   int forwardPacket(const string &msgPrefix, const DNSPacket& p, const DomainInfo& di);
   uint performUpdate(const string &msgPrefix, const DNSRecord *rr, DomainInfo *di, bool isPresigned, bool* narrow, bool* haveNSEC3, NSEC3PARAMRecordContent *ns3pr, bool *updatedSerial);

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -74,7 +74,9 @@ private:
   void addRootReferral(DNSPacket& r);
   int doChaosRequest(const DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target) const;
   bool addDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r);
+  bool addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, SOAData &sd);
   bool addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r);
+  bool addCDS(DNSPacket& p, std::unique_ptr<DNSPacket>& r, SOAData &sd);
   bool addCDS(DNSPacket& p, std::unique_ptr<DNSPacket>& r);
   bool addNSEC3PARAM(const DNSPacket& p, std::unique_ptr<DNSPacket>& r);
   void doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPacket>& r);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -4249,11 +4249,14 @@ static int setMeta(vector<string>& cmds, const std::string_view synopsis)
   const static std::array<string, 7> multiMetaWhitelist = {"ALLOW-AXFR-FROM", "ALLOW-DNSUPDATE-FROM",
     "ALSO-NOTIFY", "TSIG-ALLOW-AXFR", "TSIG-ALLOW-DNSUPDATE", "GSS-ALLOW-AXFR-PRINCIPAL",
     "PUBLISH-CDS"};
-  bool clobber = true;
-  if (cmds.at(0) == "add-meta") {
-    clobber = false;
-    if (find(multiMetaWhitelist.begin(), multiMetaWhitelist.end(), kind) == multiMetaWhitelist.end() && kind.find("X-") != 0) {
+  bool clobber = (cmds.at(0) != "add-meta");
+  if (find(multiMetaWhitelist.begin(), multiMetaWhitelist.end(), kind) == multiMetaWhitelist.end() && kind.find("X-") != 0) {
+    if(!clobber) {
       cerr<<"Refusing to add metadata to single-value metadata "<<kind<<endl;
+      return 1;
+    }
+    if(cmds.size() > 4) {
+      cerr<<"Refusing to set several metadata to single-value metadata "<<kind<<endl;
       return 1;
     }
   }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3717,7 +3717,7 @@ static int setSignalingZone(vector<string>& cmds, const std::string_view synopsi
   }
 
   // pdnsutil set-meta $zone SIGNALING-ZONE 1
-  if(addOrSetMeta(zone, "SIGNALING-ZONE", {"1"}, true)) {
+  if(addOrSetMeta(zone, "SIGNALING-ZONE", {"1"}, true) != 0) {
     cerr<<"Cannot set meta for zone " << zone << endl;
     return 1;
   }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3681,7 +3681,7 @@ static int setSignalingZone(vector<string>& cmds, const std::string_view synopsi
 
   ZoneName zone(cmds.at(1));
 
-  if(zone.operator const DNSName&().getRawLabel(0) != "_signal") {
+  if(zone.operator const DNSName&().countLabels() == 0 || zone.operator const DNSName&().getRawLabel(0) != "_signal") {
     cerr << "Signaling zone's first label must be '_signal': " << zone << endl;
     return 1;
   }
@@ -5115,7 +5115,7 @@ static const std::unordered_map<std::string, commandDispatcher> commands{
   {"set-signaling-zone", {true, setSignalingZone, GROUP_CDNSKEY,
    "set-signaling-zone ZONE",
    "\tConfigure zone for RFC 9615 DNSSEC bootstrapping\n"
-   "(zone name must begin with _signal.)"}},
+   "\t(zone name must begin with _signal.)"}},
   {"show-zone", {true, showZone, GROUP_DNSSEC,
    "show-zone ZONE",
    "\tShow DNSSEC (public) key details about a zone"}},

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3595,16 +3595,14 @@ static int setNsec3(vector<string>& cmds, const std::string_view synopsis)
 
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   ZoneName zone(cmds.at(1));
-  if (auto wirelength = zone.operator const DNSName&().wirelength(); wirelength > 222) {
-    cerr<<"Cannot enable NSEC3 for " << zone << " as it is too long (" << wirelength << " bytes, maximum is 222 bytes)"<<endl;
-    return 1;
+  try {
+    if (! dk.setNSEC3PARAM(zone, ns3pr, narrow)) {
+      cerr<<"Cannot set NSEC3 param for " << zone << endl;
+      return 1;
+    }
   }
-  if(ns3pr.d_algorithm != 1) {
-    cerr<<"NSEC3PARAM algorithm set to '"<<std::to_string(ns3pr.d_algorithm)<<"', but '1' is the only valid value"<<endl;
-    return EXIT_FAILURE;
-  }
-  if (! dk.setNSEC3PARAM(zone, ns3pr, narrow)) {
-    cerr<<"Cannot set NSEC3 param for " << zone << endl;
+  catch (const runtime_error& err) {
+    cerr << err.what() << endl;
     return 1;
   }
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -969,6 +969,7 @@ static bool isValidMetadataKind(const string& kind, bool readonly)
     {"PRESIGNED", true},
     {"PUBLISH-CDNSKEY", false},
     {"PUBLISH-CDS", false},
+    {"SIGNALING-ZONE", false},
     {"SLAVE-RENOTIFY", false},
     {"SOA-EDIT", true},
     {"SOA-EDIT-DNSUPDATE", false},

--- a/regression-tests.auth-py/test_AuthSignal.py
+++ b/regression-tests.auth-py/test_AuthSignal.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+import dns
+import os
+
+import pytest
+from authtests import AuthTest
+
+
+class TestAuthSignal(AuthTest):
+    _backend = 'gsqlite3'
+
+    _config_template_default = """
+module-dir={PDNS_MODULE_DIR}
+daemon=no
+socket-dir={confdir}
+cache-ttl=0
+negquery-cache-ttl=0
+query-cache-ttl=0
+log-dns-queries=yes
+log-dns-details=yes
+loglevel=9
+distributor-threads=1"""
+
+    _config_template = """
+launch=gsqlite3
+gsqlite3-database=configs/auth/powerdns.sqlite
+gsqlite3-pragma-foreign-keys=yes
+gsqlite3-dnssec=yes
+"""
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.signaling_domain = dns.name.from_text('_signal.ns1.example.net')
+        cls.signaling_prefix = dns.name.from_text('_dsboot.cds-cdnskey.test').relativize(dns.name.root)
+        cls.signaling_qname = cls.signaling_prefix.concatenate(cls.signaling_domain)
+
+        os.system("$PDNSUTIL --config-dir=configs/auth create-zone _signal.ns1.example.net")
+        os.system("$PDNSUTIL --config-dir=configs/auth set-signaling-zone _signal.ns1.example.net")
+        query = dns.message.make_query('_signal.ns1.example.net', 'DNSKEY')
+        res = cls.sendUDPQuery(query)
+        cls.signaling_keytag = dns.dnssec.key_id(res.answer[0][0])
+
+        os.system("$PDNSUTIL --config-dir=configs/auth create-zone cds-cdnskey.test")
+        os.system("$PDNSUTIL --config-dir=configs/auth secure-zone cds-cdnskey.test")
+        os.system("$PDNSUTIL --config-dir=configs/auth set-publish-cds cds-cdnskey.test 2 4")
+        os.system("$PDNSUTIL --config-dir=configs/auth set-publish-cdnskey cds-cdnskey.test")
+
+    def _signalingQuery(self, rdtype):
+        query = dns.message.make_query('cds-cdnskey.test', rdtype)
+        res1 = self.sendUDPQuery(query)
+
+        query = dns.message.make_query(self.signaling_qname, rdtype, use_edns=True, want_dnssec=True)
+        res2 = self.sendUDPQuery(query)
+
+        return res1, res2
+
+    def _testSignalingRRset(self, rdtype):
+        res1, res2 = self._signalingQuery(rdtype)
+
+        # Ensure no error in response
+        self.assertRcodeEqual(res1, dns.rcode.NOERROR)
+        self.assertRcodeEqual(res2, dns.rcode.NOERROR)
+
+        # Ensure that signaling rdata were taken from the corresponding zone
+        rrset1 = res1.answer[0]
+        rrset2 = res2.find_rrset(dns.message.ANSWER, self.signaling_qname, rdclass=dns.rdataclass.IN, rdtype=rdtype)
+        self.assertEqual(rrset1.to_rdataset(), rrset2.to_rdataset())
+
+        # ... and signed by the signaling zone
+        rrsig_correct = any(rrset.rdtype == dns.rdatatype.RRSIG and rrset.covers == rdtype and rrset[0].key_tag == self.signaling_keytag for rrset in res2.answer)
+        self.assertTrue(rrsig_correct, f"RRSIG({rdtype}) with proper keytag not found")
+
+    def testSignalingCDSQuery(self):
+        self._testSignalingRRset(dns.rdatatype.CDS)
+
+    def testSignalingCDNSKEYQuery(self):
+        self._testSignalingRRset(dns.rdatatype.CDNSKEY)
+
+    def testSignalingQueryNoSignal(self):
+        os.system("$PDNSUTIL --config-dir=configs/auth create-zone no-signaling.test")
+        os.system("$PDNSUTIL --config-dir=configs/auth secure-zone no-signaling.test")
+
+        signaling_prefix = dns.name.from_text('_dsboot.no-signaling.test').relativize(dns.name.root)
+        qname = signaling_prefix.concatenate(self.signaling_domain)
+        for rdtype, nsec3windows in {
+            dns.rdatatype.CDS: ((0, b'\x00\x00\x00\x00\x00\x02\x00\x08'),),  # RRSIG CDNSKEY
+            dns.rdatatype.CDNSKEY: ((0, b'\x00\x00\x00\x00\x00\x02\x00\x10'),)  # RRSIG CDS
+        }.items():
+            query = dns.message.make_query(qname, rdtype, use_edns=True, want_dnssec=True)
+            res = self.sendUDPQuery(query)
+
+            # Verify that signaling RRset is not there
+            self.assertRcodeEqual(res, dns.rcode.NOERROR)
+            with self.assertRaises(KeyError):
+                res.find_rrset(dns.message.ANSWER, qname, rdclass=dns.rdataclass.IN, rdtype=rdtype)
+
+            # Verify that NSEC3 is present but does not disprove the other signaling record type
+            nsec3_present = any(rrset.rdtype == dns.rdatatype.NSEC3 for rrset in res.authority)
+            self.assertTrue(nsec3_present)
+            for rrset in res.authority:
+                if rrset.rdtype == dns.rdatatype.NSEC3:
+                    self.assertEqual(rrset.to_rdataset()[0].windows, nsec3windows)
+
+    def testSignalingQueryNXDOMAIN(self):
+        signaling_prefix = dns.name.from_text('_dsboot.othername.test').relativize(dns.name.root)
+        qname = signaling_prefix.concatenate(self.signaling_domain)
+        for rdtype in (dns.rdatatype.CDS, dns.rdatatype.CDNSKEY):
+            query = dns.message.make_query(qname, rdtype, use_edns=True, want_dnssec=True)
+            res = self.sendUDPQuery(query)
+
+            # Expect NXDOMAIN for signaling records of zones we don't serve
+            self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)


### PR DESCRIPTION
### Short description
Implements [RFC9615](https://datatracker.ietf.org/doc/rfc9615/). We'd like to replace our LUA-based implementation at desec.io with this for about 50k zones.

Implementation:
- Introduce `SIGNALING-ZONE` metadata. Zones with this setting will synthesize bootstrapping records.
- Signaling zone needs to use narrow-mode online signing (because neighboring owner names are not known at signing time).
- Usage:
  ```sh
      export nshost=ns1.example.net
      pdnsutil create-zone _signal.$nshost $nshost  # create NS record too
      pdnsutil secure-zone _signal.$nshost
      pdnsutil set-nsec3 _signal.$nshost "1 0 0 -" narrow
      pdnsutil rectify-zone _signal.$nshost
      pdnsutil set-meta _signal.$nshost SIGNALING-ZONE 1
  ```

Questions / tasks:
- [x] Should we create `pdnsutil set-signaling-zone` which would run the last 4 commands above? That way users wouldn't have to worry about NSEC3 mode etc. The `SIGNALING-ZONE` metadata makes sense only with this specific config, so no flexibility would be lost.
- [x] I included a test that looks for proper CDS synthesis, but did not manage to deal with the fact that record contents change. How can this be done?
- [ ] ~I added a few `skip.*` files to the test so that it only runs in the proper context(s). Not sure if I did this right.~
- [x] Will also include a CDNSKEY test.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
