### PR TITLE
Add clarification on backend writer guide

### DIFF
--- a/docs/appendices/backend-writers-guide.rst
+++ b/docs/appendices/backend-writers-guide.rst
@@ -905,6 +905,7 @@ In order for a backend to support DNSSEC, quite a few number of additional opera
 .. cpp:function:: virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after)
 
   Asks the names before and after qname for NSEC and NSEC3. The qname will be hashed when using NSEC3. Care must be taken to handle wrap-around when qname is the first or last in the ordered list of zone names.
+  Please note that in case the requested name is present in the zone, it should be returned as the "before" name.
 
 .. cpp:function:: virtual bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype=QType::ANY)
 


### PR DESCRIPTION
For `getBeforeAndAfterNamesAbsolute()`, in case of proof of non existence for a type (and not the name), the requested name should be returned, **not** the name before it.

### Short description
This is a small addition to the Backend writers’ guide

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
