### PR TITLE
dnsdist-1.9.x: Backport 14070 - Fix DNS over plain HTTP broken by `reloadAllCertificates()`

### DIFF
--- a/pdns/dnsdistdist/dnsdist-doh-common.cc
+++ b/pdns/dnsdistdist/dnsdist-doh-common.cc
@@ -115,7 +115,9 @@ size_t DOHFrontend::getTicketsKeysCount()
 
 void DOHFrontend::reloadCertificates()
 {
-  d_tlsContext.setupTLS();
+  if (isHTTPS()) {
+    d_tlsContext.setupTLS();
+  }
 }
 
 void DOHFrontend::setup()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14070 to rel/dnsdist-1.9.x

This was introduced in 1.9.0, with the use of the `nghttp2` library for incoming DNS over HTTP(S).
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
