### PR TITLE
dnsdist-1.9.x: Backport 14037 - Fix "C++ One Definition Rule" warnings in XSK

### DIFF
--- a/pdns/xsk.cc
+++ b/pdns/xsk.cc
@@ -29,15 +29,6 @@
 #include <cstring>
 #include <fcntl.h>
 #include <iterator>
-#include <linux/bpf.h>
-#include <linux/if_ether.h>
-#include <linux/if_link.h>
-#include <linux/if_xdp.h>
-#include <linux/ip.h>
-#include <linux/ipv6.h>
-#include <linux/tcp.h>
-#include <linux/types.h>
-#include <linux/udp.h>
 #include <net/if.h>
 #include <net/if_arp.h>
 #include <netinet/in.h>
@@ -60,6 +51,21 @@ extern "C"
 
 #include "gettime.hh"
 #include "xsk.hh"
+
+/* we need to include the linux specific headers AFTER the regular
+   ones, because it then detects that some types have already been
+   defined (sockaddr_in6 for example) and does not attempt to
+   re-define them, which otherwise breaks the C++ One Definition Rule
+*/
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/if_link.h>
+#include <linux/if_xdp.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+#include <linux/types.h>
+#include <linux/udp.h>
 
 #ifdef DEBUG_UMEM
 namespace


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #14037 to rel/dnsdist-1.9.x.

It turns out we need to include the linux specific headers AFTER the regular ones, because it then detects that some types have already been defined (`sockaddr_in6` for example) and does not attempt to re-define them, which otherwise breaks the C++ One Definition Rule

(cherry picked from commit 679360ad842c60e38f4009cecac6e1422c747889)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
