### PR TITLE
rec: Backport 14049 to rec-4.8.x: do not count RRSIGs using unsupported algorithms toward RRSIGs limit

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -1022,6 +1022,9 @@ vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t
     }
 
     vState ede = vState::Indeterminate;
+    if (!DNSCryptoKeyEngine::isAlgorithmSupported(signature->d_algorithm)) {
+        continue;
+    }
     if (!checkSignatureInceptionAndExpiry(name, now, signature, ede)) {
       if (isRRSIGIncepted(now, signature)) {
         noneIncepted = false;
@@ -1151,7 +1154,7 @@ bool haveNegativeTrustAnchor(const map<DNSName,std::string>& negAnchors, const D
   return true;
 }
 
-vState validateDNSKeysAgainstDS(time_t now, const DNSName& zone, const dsmap_t& dsmap, const skeyset_t& tkeys, const sortedRecords_t& toSign, const vector<shared_ptr<RRSIGRecordContent> >& sigs, skeyset_t& validkeys, pdns::validation::ValidationContext& context)
+vState validateDNSKeysAgainstDS(time_t now, const DNSName& zone, const dsmap_t& dsmap, const skeyset_t& tkeys, const sortedRecords_t& toSign, const vector<shared_ptr<RRSIGRecordContent> >& sigs, skeyset_t& validkeys, pdns::validation::ValidationContext& context) // NOLINT(readability-function-cognitive-complexity): FIXME
 {
   /*
    * Check all DNSKEY records against all DS records and place all DNSKEY records
@@ -1217,6 +1220,9 @@ vState validateDNSKeysAgainstDS(time_t now, const DNSName& zone, const dsmap_t& 
     // whole set
     uint16_t signaturesConsidered = 0;
     for (const auto& sig : sigs) {
+      if (!DNSCryptoKeyEngine::isAlgorithmSupported(sig->d_algorithm)) {
+        continue;
+      }
       if (!checkSignatureInceptionAndExpiry(zone, now, sig, ede)) {
         continue;
       }


### PR DESCRIPTION

(cherry picked from commit 834660b5c62fe7a8bcf93b0182f26fbfa5464ecc)

Backport of #14049 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
