### PR TITLE
dnsdist-1.9.x: Backport 14104 - Fix a crash in incoming DoH with nghttp2

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -116,6 +116,10 @@ private:
   /* Whether we have data that we want to write to the socket,
      but the socket is full. */
   bool d_pendingWrite{false};
+  /* Whether we are currently inside the readHTTPData function,
+     which is not reentrant and could be called from itself via
+     the nghttp2 callbacks */
+  bool d_inReadFunction{false};
 };
 
 class NGHTTP2Headers


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14104 to rel/dnsdist-1.9.x

This fixes an issue in the code dealing with incoming DNS over HTTPS queries with the nghttp2 provider. In some rare cases, if the incoming query is forwarded to the backend over TCP and the response comes back immediately (the `read()` call done just after the `write()` call sending the query must succeed and yield a complete response), the processing of the response might end up calling `IncomingHTTP2Connection::readHTTPData()` down the line, via the `nghttp2` callbacks, while we were already inside this function. This does not actually work because `nghttp2_session_mem_recv` is not reentrant, so the internal state of the `nghttp2_session` object might become inconsistent and trigger an assertion, for example:
```
nghttp2_session.c:6854: nghttp2_session_mem_recv2: Assertion `iframe->state == NGHTTP2_IB_IGN_ALL' failed.
```

This results in a call to `abort()` and very unlikely to be exploitable, because there is no memory corruption occurring. It would also be quite difficult for an attacker to trigger the conditions leading to this event remotely.

Reported by Daniel Stirnimann from Switch and Stephane Bortzmeyer, many thanks to them.

(cherry picked from commit a4d82c53f714211462ae4da2e16fb13dec51ba05)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
