### PR TITLE
The recursor cache needs to check stale when updating the ns type cache.

### DIFF
--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -581,7 +581,7 @@ void MemRecursorCache::replace(time_t now, const DNSName& qname, const QType qty
   // for an auth to keep a "ghost" zone alive forever, even after the delegation is gone from
   // the parent
   // BUT make sure that we CAN refresh the root
-  if (cacheEntry.d_auth && auth && qtype == QType::NS && !isNew && !qname.isRoot()) {
+  if (cacheEntry.d_auth && auth && qtype == QType::NS && !isNew && !qname.isRoot() && cacheEntry.d_servedStale == 0) {
     maxTTD = cacheEntry.d_ttd;
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When an NS record already exists in the recursor cache and the NS record is replaced again, the **TTD** setting of the NS record should check the **stale** flag of CacheEntry. Otherwise, the **TTL of the NS** cache will always be **s_serveStaleExtensionPeriod(30s)**. Then the new NS cache will expires quickly, causing delays in iterative DNS resolution
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
