### PR TITLE
Allow setting notify_allowed in Recursor API for forwarded zones

### DIFF
--- a/pdns/recursordist/docs/http-api/zone.rst
+++ b/pdns/recursordist/docs/http-api/zone.rst
@@ -22,6 +22,7 @@ Comments are per-RRset.
   :property [RRSet] rrsets: RRSets in this zone
   :property [str] servers: For zones of type "Forwarded", addresses to send the queries to
   :property bool recursion_desired: For zones of type "Forwarded", Whether or not the RD bit should be set in the query
+  :property bool notify_allowed: For zones of type "Forwarded", Whether or not to permit incoming NOTIFY to wipe cache for the domain
 
 To properly process new zones, the following conditions must
 be true:

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -808,9 +808,8 @@ bool isAllowNotifyForZone(DNSName qname)
     return false;
   }
 
-  notifyset_t::const_iterator ret;
   do {
-    ret = t_allowNotifyFor->find(qname);
+    auto ret = t_allowNotifyFor->find(qname);
     if (ret != t_allowNotifyFor->end()) {
       return true;
     }

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -214,6 +214,7 @@ static void fillZone(const DNSName& zonename, HttpResponse* resp)
     {"kind", zone.d_servers.empty() ? "Native" : "Forwarded"},
     {"servers", servers},
     {"recursion_desired", zone.d_servers.empty() ? false : zone.d_rdForward},
+    {"notify_allowed", isAllowNotifyForZone(zonename)},
     {"records", records}};
 
   resp->setJsonBody(doc);

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -232,6 +232,7 @@ static void doCreateZone(const Json& document)
   string singleIPTarget = document["single_target_ip"].string_value();
   string kind = toUpper(stringFromJson(document, "kind"));
   bool rdFlag = boolFromJson(document, "recursion_desired");
+  bool notifyAllowed = boolFromJson(document, "notify_allowed", false);
   string confbasename = "zone-" + apiZoneNameToId(zone);
 
   const string yamlAPiZonesFile = ::arg()["api-config-dir"] + "/apizones";
@@ -280,7 +281,7 @@ static void doCreateZone(const Json& document)
       pdns::rust::settings::rec::ForwardZone forward;
       forward.zone = zonename;
       forward.recurse = rdFlag;
-      forward.notify_allowed = false;
+      forward.notify_allowed = notifyAllowed;
       for (const auto& value : document["servers"].array_items()) {
         forward.forwarders.emplace_back(value.string_value());
       }
@@ -308,11 +309,12 @@ static void doCreateZone(const Json& document)
         throw ApiException("Need at least one upstream server when forwarding");
       }
 
+      const string notifyAllowedConfig = notifyAllowed ? "\nallow-notify-for+=" + zonename : "";
       if (rdFlag) {
-        apiWriteConfigFile(confbasename, "forward-zones-recurse+=" + zonename + "=" + serverlist);
+        apiWriteConfigFile(confbasename, "forward-zones-recurse+=" + zonename + "=" + serverlist + notifyAllowedConfig);
       }
       else {
-        apiWriteConfigFile(confbasename, "forward-zones+=" + zonename + "=" + serverlist);
+        apiWriteConfigFile(confbasename, "forward-zones+=" + zonename + "=" + serverlist + notifyAllowedConfig);
       }
     }
   }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -2555,7 +2555,7 @@ class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):
 @unittest.skipIf(not is_recursor(), "Not applicable")
 class RecursorZones(ApiTestCase):
 
-    def create_zone(self, name=None, kind=None, rd=False, servers=None):
+    def create_zone(self, name=None, kind=None, rd=False, servers=None, notify_allowed=False):
         if name is None:
             name = unique_zone_name()
         if servers is None:
@@ -2564,7 +2564,8 @@ class RecursorZones(ApiTestCase):
             'name': name,
             'kind': kind,
             'servers': servers,
-            'recursion_desired': rd
+            'recursion_desired': rd,
+            'notify_allowed': notify_allowed
         }
         r = self.session.post(
             self.url("/api/v1/servers/localhost/zones"),
@@ -2595,6 +2596,13 @@ class RecursorZones(ApiTestCase):
 
     def test_create_forwarded_zone(self):
         payload, data = self.create_zone(kind='Forwarded', rd=False, servers=['8.8.8.8'])
+        # return values are normalized
+        payload['servers'][0] += ':53'
+        for k in payload.keys():
+            self.assertEqual(data[k], payload[k])
+
+    def test_create_forwarded_zone_notify_allowed(self):
+        payload, data = self.create_zone(kind='Forwarded', rd=False, servers=['8.8.8.8'], notify_allowed=True)
         # return values are normalized
         payload['servers'][0] += ':53'
         for k in payload.keys():


### PR DESCRIPTION
Closes #14116

### Short description
Allows setting `notify_allowed` when adding forwarded zones through the Recursor API.  This works with the new YAML settings and the old-style settings.  If `notify_allowed` is not sent or is set to false, the behavior is unchanged.  If `notify_allowed` is set to true the Recursor will allow NOTIFY to clear cache for the given zone.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
