### PR TITLE
rec: Backport 14132 to rec-4.9.x: gh actions - build-and-test-all: use ubuntu-22.04 runners

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -26,7 +26,7 @@ jobs:
   build-recursor:
     name: build recursor
     if: ${{ !github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         sanitizers: [ubsan+asan, tsan]
@@ -95,7 +95,7 @@ jobs:
 
   test-recursor-api:
     needs: build-recursor
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         sanitizers: [ubsan+asan, tsan]
@@ -129,7 +129,7 @@ jobs:
 
   test-recursor-regression:
     needs: build-recursor
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         sanitizers: [ubsan+asan, tsan]
@@ -165,7 +165,7 @@ jobs:
   test-recursor-bulk:
     name: 'test rec *mini* bulk'
     needs: build-recursor
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         sanitizers: [ubsan+asan, tsan]
@@ -197,7 +197,7 @@ jobs:
 
   check-clang-tidy:
     needs: [build-recursor]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Check whether clang-tidy succeeded
     steps:
       - run: |
@@ -213,7 +213,7 @@ jobs:
       - test-recursor-bulk
       - check-clang-tidy
     if: success() || failure()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install jq and yq
         run: "sudo snap install jq yq"


### PR DESCRIPTION
### Short description
Backports #14132 to `rel/rec-4.9.x`: Use `ubuntu-22.04` as runner-os for the `build-and-test-all` workflow.

Required by #14092 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
