### PR TITLE
rec: Backport 14132 to rec-4.8.x: gh actions - build-and-test-all: use ubuntu-22.04 runners

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -164,7 +164,7 @@ jobs:
       - test-recursor-regression
       - test-recursor-bulk
     if: success() || failure()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install jq and yq
         run: "sudo snap install jq yq"


### PR DESCRIPTION
### Short description
Backports #14132 to `rel/rec-4.8.x`: Use `ubuntu-22.04` as runner-os for the `build-and-test-all` workflow.

**UPDATE:**
Partially back-ported: only for `collect` job. Some dependencies in the `build-and-test-all` workflow are not available on `ubuntu-22.04` and will require too many changes.

Required by #14094 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
