### PR TITLE
dnsdist: Enable memory leaks detection during regression tests in CI

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -655,7 +655,7 @@ jobs:
       env:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         # Disabling (intercept_send=0) the custom send wrappers for ASAN and TSAN because they cause the tools to report a race that doesn't exist on actual implementations of send(), see https://github.com/google/sanitizers/issues/1498
-        ASAN_OPTIONS: detect_leaks=0:intercept_send=0
+        ASAN_OPTIONS: intercept_send=0
         TSAN_OPTIONS: "halt_on_error=1:intercept_send=0:suppressions=${{ env.REPO_HOME }}/pdns/dnsdistdist/dnsdist-tsan.supp"
         # IncludeDir tests are disabled because of a weird interaction between TSAN and these tests which ever only happens on GH actions
         SKIP_INCLUDEDIR_TESTS: yes

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -656,6 +656,7 @@ jobs:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         # Disabling (intercept_send=0) the custom send wrappers for ASAN and TSAN because they cause the tools to report a race that doesn't exist on actual implementations of send(), see https://github.com/google/sanitizers/issues/1498
         ASAN_OPTIONS: intercept_send=0
+        LSAN_OPTIONS: "suppressions=${{ env.REPO_HOME }}/pdns/dnsdistdist/dnsdist-lsan.supp"
         TSAN_OPTIONS: "halt_on_error=1:intercept_send=0:suppressions=${{ env.REPO_HOME }}/pdns/dnsdistdist/dnsdist-tsan.supp"
         # IncludeDir tests are disabled because of a weird interaction between TSAN and these tests which ever only happens on GH actions
         SKIP_INCLUDEDIR_TESTS: yes

--- a/m4/pdns_enable_sanitizers.m4
+++ b/m4/pdns_enable_sanitizers.m4
@@ -78,6 +78,10 @@ AC_DEFUN([PDNS_ENABLE_ASAN], [
             [#include <sanitizer/common_interface_defs.h>]
           )]
         )
+        AC_CHECK_HEADERS([sanitizer/lsan_interface.h],
+          AC_DEFINE([HAVE_LEAK_SANITIZER_INTERFACE], [1], [Define if LSAN interface is available.]),
+         []
+        )
       ],
       [AC_MSG_ERROR([Cannot enable AddressSanitizer])]
     )
@@ -120,6 +124,10 @@ AC_DEFUN([PDNS_ENABLE_LSAN], [
     gl_COMPILER_OPTION_IF([-fsanitize=leak],
       [SANITIZER_FLAGS="-fsanitize=leak $SANITIZER_FLAGS"],
       [AC_MSG_ERROR([Cannot enable LeakSanitizer])]
+    )
+    AC_CHECK_HEADERS([sanitizer/lsan_interface.h],
+      AC_DEFINE([HAVE_LEAK_SANITIZER_INTERFACE], [1], [Define if LSAN interface is available.]),
+      []
     )
   ])
   AC_SUBST([SANITIZER_FLAGS])
@@ -164,4 +172,3 @@ AC_DEFUN([PDNS_ENABLE_MSAN], [
   ])
   AC_SUBST([SANITIZER_FLAGS])
 ])
-

--- a/pdns/dnsdistdist/dnsdist-lsan.supp
+++ b/pdns/dnsdistdist/dnsdist-lsan.supp
@@ -1,0 +1,2 @@
+# h2o
+leak:create_socket

--- a/pdns/dnsdistdist/dnsdist-lsan.supp
+++ b/pdns/dnsdistdist/dnsdist-lsan.supp
@@ -1,2 +1,2 @@
-# h2o
-leak:create_socket
+# it's hard to clean up the per-thread Lua load-balancing policies on exit
+leak:setupLuaLoadBalancingContext

--- a/pdns/dnsdistdist/dnsdist-lua-network.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-network.cc
@@ -41,6 +41,11 @@ NetworkListener::NetworkListener() :
 NetworkListener::~NetworkListener()
 {
   d_data->d_exiting = true;
+
+  /* wake up the listening thread */
+  for (const auto& socket : d_data->d_sockets) {
+    shutdown(socket.second.getHandle(), SHUT_RD);
+  }
 }
 
 void NetworkListener::readCB(int desc, FDMultiplexer::funcparam_t& param)

--- a/pdns/dnsdistdist/dnsdist-tsan.supp
+++ b/pdns/dnsdistdist/dnsdist-tsan.supp
@@ -22,3 +22,4 @@ race:carbonDumpThread
 # can still be looking at the existing socket descriptors.
 # Actually writing to these is protected by a mutex, though.
 race:DownstreamState::reconnect
+signal:sigTermHandler

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -2810,9 +2810,14 @@ static void sigTermHandler([[maybe_unused]] int sig)
   std::cout << "Exiting on user request" << std::endl;
 #endif /* __SANITIZE_THREAD__ */
 #if defined(__SANITIZE_ADDRESS__) && defined(HAVE_LEAK_SANITIZER_INTERFACE)
-  auto lock = g_lua.lock();
-  cleanupLuaObjects();
-  *lock = LuaContext();
+  if (dnsdist::g_asyncHolder) {
+    dnsdist::g_asyncHolder->stop();
+  }
+  {
+    auto lock = g_lua.lock();
+    cleanupLuaObjects();
+    *lock = LuaContext();
+  }
   __lsan_do_leak_check();
 #endif /* __SANITIZE_ADDRESS__ && HAVE_LEAK_SANITIZER_INTERFACE */
   _exit(EXIT_SUCCESS);

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -2753,7 +2753,22 @@ static void usage()
   cout << "-V,--version          Show dnsdist version information and exit\n";
 }
 
-#ifdef COVERAGE
+/* g++ defines __SANITIZE_THREAD__
+   clang++ supports the nice __has_feature(thread_sanitizer),
+   let's merge them */
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define __SANITIZE_THREAD__ 1
+#endif
+#if __has_feature(address_sanitizer)
+#define __SANITIZE_ADDRESS__ 1
+#if defined(__SANITIZE_ADDRESS__) && defined(HAVE_LEAK_SANITIZER_INTERFACE)
+#include <sanitizer/lsan_interface.h>
+#endif
+#endif
+#endif
+
+#if defined(COVERAGE) || (defined(__SANITIZE_ADDRESS__) && defined(HAVE_LEAK_SANITIZER_INTERFACE))
 static void cleanupLuaObjects()
 {
   /* when our coverage mode is enabled, we need to make sure
@@ -2770,24 +2785,16 @@ static void cleanupLuaObjects()
   clearWebHandlers();
   dnsdist::lua::hooks::clearMaintenanceHooks();
 }
+#endif /* defined(COVERAGE) || (defined(__SANITIZE_ADDRESS__) && defined(HAVE_LEAK_SANITIZER_INTERFACE)) */
 
+#if defined(COVERAGE)
 static void sigTermHandler(int)
 {
   cleanupLuaObjects();
   pdns::coverage::dumpCoverageData();
   _exit(EXIT_SUCCESS);
 }
-#else /* COVERAGE */
-
-/* g++ defines __SANITIZE_THREAD__
-   clang++ supports the nice __has_feature(thread_sanitizer),
-   let's merge them */
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-#define __SANITIZE_THREAD__ 1
-#endif
-#endif
-
+#else
 static void sigTermHandler([[maybe_unused]] int sig)
 {
 #if !defined(__SANITIZE_THREAD__)
@@ -2802,7 +2809,12 @@ static void sigTermHandler([[maybe_unused]] int sig)
   }
   std::cout << "Exiting on user request" << std::endl;
 #endif /* __SANITIZE_THREAD__ */
-
+#if defined(__SANITIZE_ADDRESS__) && defined(HAVE_LEAK_SANITIZER_INTERFACE)
+  auto lock = g_lua.lock();
+  cleanupLuaObjects();
+  *lock = LuaContext();
+  __lsan_do_leak_check();
+#endif /* __SANITIZE_ADDRESS__ && HAVE_LEAK_SANITIZER_INTERFACE */
   _exit(EXIT_SUCCESS);
 }
 #endif /* COVERAGE */

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -215,6 +215,8 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                 print("kill...", p, file=sys.stderr)
                 p.kill()
                 p.wait()
+            if p.returncode != 0:
+              raise AssertionError('Process exited with return code %d' % (p.returncode))
         except OSError as e:
             # There is a race-condition with the poll() and
             # kill() statements, when the process is dead on the

--- a/regression-tests.dnsdist/test_Async.py
+++ b/regression-tests.dnsdist/test_Async.py
@@ -510,6 +510,11 @@ class TestAsyncFFI(DNSDistTest, AsyncTests):
       return DNSResponseAction.Allow
     end
 
+    function atExit()
+      listener = nil
+      collectgarbage()
+    end
+
     -- this only matters for tests actually reaching the backend
     addAction('tcp-only.async.tests.powerdns.com', PoolAction('tcp-only', false))
     addAction('cache.async.tests.powerdns.com', PoolAction('cache', false))
@@ -616,6 +621,11 @@ class TestAsyncLua(DNSDistTest, AsyncTests):
       asyncResponderEndpoint:send(buffer)
 
       return DNSResponseAction.Allow
+    end
+
+    function atExit()
+      listener = nil
+      collectgarbage()
     end
 
     -- this only matters for tests actually reaching the backend

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -352,6 +352,11 @@ class TestRoutingLuaFFIPerThreadRoundRobinLB(RoundRobinTest, DNSDistTest):
     s1:setUp()
     s2 = newServer{address="127.0.0.1:%s"}
     s2:setUp()
+
+    function atExit()
+      setServerPolicy(leastOutstanding)
+      collectgarbage()
+    end
     """
 
     @classmethod


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
I realized that, since we are already using Address Sanitizer during these tests, we get Leak Sanitizer almost for free. Enabling it means that we would detect memory leaks in the code paths that are covered by these tests, which is nice.

To make it work I had to:
- remove `detect_leaks=0` from `ASAN_OPTIONS`  in our CI
- detect and fail on a non-zero return code when dnsdist is terminated
- detect when LSAN is enabled, and then:
  - clean up a few objects that were allocated only once at startup and never freed
  - implement an `atExit` `Lua` callback for some objects allocated from our `Lua` code
  - tell `TSAN` to stop worrying about what happens in the `TERM` signal handler: we are only calling `_exit` which POSIX defines as async-signal-safe, but somehow `TSAN` was not happy, setting the exit code to `66|

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

