### PR TITLE
dnsdist-1.9.x: Backport of 14128 - Reply to HTTP/2 PING frames immediately

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -922,6 +922,9 @@ int IncomingHTTP2Connection::on_frame_recv_callback(nghttp2_session* session, co
       return NGHTTP2_ERR_CALLBACK_FAILURE;
     }
   }
+  else if (frame->hd.type == NGHTTP2_PING) {
+    conn->d_needFlush = true;
+  }
 
   return 0;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #14128 to dnsdist-1.9.x

We usually buffer a bit to avoid sending a lot of small data chunks on the wire (or to the kernel anyway), but for `HTTP/2 PING` frames that are not followed by anything else calling for a response, this causes an issue as these frames are designed to measure the latency between a client and a server, and are used by HTTP/2 proxies to ensure that a connection can be reused.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
