### PR TITLE
dnsdist-1.9.x: Backport of #14078 - Use the correct source IP for outgoing QUIC datagrams

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -163,14 +163,25 @@ static constexpr size_t s_maxUDPResponsePacketSize{4096U};
 static size_t const s_initialUDPPacketBufferSize = s_maxUDPResponsePacketSize + DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE;
 static_assert(s_initialUDPPacketBufferSize <= UINT16_MAX, "Packet size should fit in a uint16_t");
 
-static ssize_t sendfromto(int sock, const PacketBuffer& buffer, const ComboAddress& from, const ComboAddress& dest)
+static void sendfromto(int sock, const PacketBuffer& buffer, const ComboAddress& from, const ComboAddress& dest)
 {
   const int flags = 0;
   if (from.sin4.sin_family == 0) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return sendto(sock, buffer.data(), buffer.size(), flags, reinterpret_cast<const struct sockaddr*>(&dest), dest.getSocklen());
+    auto ret = sendto(sock, buffer.data(), buffer.size(), flags, reinterpret_cast<const struct sockaddr*>(&dest), dest.getSocklen());
+    if (ret == -1) {
+      int error = errno;
+      vinfolog("Error sending UDP response to %s: %s", dest.toStringWithPort(), stringerror(error));
+    }
+    return;
   }
-  return sendMsgWithOptions(sock, buffer.data(), buffer.size(), &dest, &from, 0, 0);
+
+  try {
+    sendMsgWithOptions(sock, buffer.data(), buffer.size(), &dest, &from, 0, 0);
+  }
+  catch (const std::exception& exp) {
+    vinfolog("Error sending UDP response from %s to %s: %s", from.toStringWithPort(), dest.toStringWithPort(), exp.what());
+  }
 }
 
 static void truncateTC(PacketBuffer& packet, size_t maximumSize, unsigned int qnameWireLength)
@@ -210,13 +221,9 @@ struct DelayedPacket
   PacketBuffer packet;
   ComboAddress destination;
   ComboAddress origDest;
-  void operator()()
+  void operator()() const
   {
-    ssize_t res = sendfromto(fd, packet, origDest, destination);
-    if (res == -1) {
-      int err = errno;
-      vinfolog("Error sending delayed response to %s: %s", destination.toStringWithPort(), strerror(err));
-    }
+    sendfromto(fd, packet, origDest, destination);
   }
 };
 
@@ -654,12 +661,8 @@ bool sendUDPResponse(int origFD, const PacketBuffer& response, const int delayMs
     return true;
   }
 #endif /* DISABLE_DELAY_PIPE */
-  ssize_t res = sendfromto(origFD, response, origDest, origRemote);
-  if (res == -1) {
-    int err = errno;
-    vinfolog("Error sending response to %s: %s", origRemote.toStringWithPort(), stringerror(err));
-  }
-
+  // NOLINTNEXTLINE(readability-suspicious-call-argument)
+  sendfromto(origFD, response, origDest, origRemote);
   return true;
 }
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -163,31 +163,14 @@ static constexpr size_t s_maxUDPResponsePacketSize{4096U};
 static size_t const s_initialUDPPacketBufferSize = s_maxUDPResponsePacketSize + DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE;
 static_assert(s_initialUDPPacketBufferSize <= UINT16_MAX, "Packet size should fit in a uint16_t");
 
-static ssize_t sendfromto(int sock, const void* data, size_t len, int flags, const ComboAddress& from, const ComboAddress& to)
+static ssize_t sendfromto(int sock, const PacketBuffer& buffer, const ComboAddress& from, const ComboAddress& dest)
 {
+  const int flags = 0;
   if (from.sin4.sin_family == 0) {
-    return sendto(sock, data, len, flags, reinterpret_cast<const struct sockaddr*>(&to), to.getSocklen());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return sendto(sock, buffer.data(), buffer.size(), flags, reinterpret_cast<const struct sockaddr*>(&dest), dest.getSocklen());
   }
-  struct msghdr msgh;
-  struct iovec iov;
-  cmsgbuf_aligned cbuf;
-
-  /* Set up iov and msgh structures. */
-  memset(&msgh, 0, sizeof(struct msghdr));
-  iov.iov_base = const_cast<void*>(data);
-  iov.iov_len = len;
-  msgh.msg_iov = &iov;
-  msgh.msg_iovlen = 1;
-  msgh.msg_name = (struct sockaddr*)&to;
-  msgh.msg_namelen = to.getSocklen();
-
-  if (from.sin4.sin_family) {
-    addCMsgSrcAddr(&msgh, &cbuf, &from, 0);
-  }
-  else {
-    msgh.msg_control=nullptr;
-  }
-  return sendmsg(sock, &msgh, flags);
+  return sendMsgWithOptions(sock, buffer.data(), buffer.size(), &dest, &from, 0, 0);
 }
 
 static void truncateTC(PacketBuffer& packet, size_t maximumSize, unsigned int qnameWireLength)
@@ -229,7 +212,7 @@ struct DelayedPacket
   ComboAddress origDest;
   void operator()()
   {
-    ssize_t res = sendfromto(fd, packet.data(), packet.size(), 0, origDest, destination);
+    ssize_t res = sendfromto(fd, packet, origDest, destination);
     if (res == -1) {
       int err = errno;
       vinfolog("Error sending delayed response to %s: %s", destination.toStringWithPort(), strerror(err));
@@ -671,7 +654,7 @@ bool sendUDPResponse(int origFD, const PacketBuffer& response, const int delayMs
     return true;
   }
 #endif /* DISABLE_DELAY_PIPE */
-  ssize_t res = sendfromto(origFD, response.data(), response.size(), 0, origDest, origRemote);
+  ssize_t res = sendfromto(origFD, response, origDest, origRemote);
   if (res == -1) {
     int err = errno;
     vinfolog("Error sending response to %s: %s", origRemote.toStringWithPort(), stringerror(err));

--- a/pdns/dnsdistdist/doq-common.cc
+++ b/pdns/dnsdistdist/doq-common.cc
@@ -126,7 +126,18 @@ std::optional<PacketBuffer> validateToken(const PacketBuffer& token, const Combo
   }
 }
 
-void handleStatelessRetry(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, uint32_t version, PacketBuffer& buffer)
+static ssize_t sendFromTo(Socket& sock, const ComboAddress& peer, const ComboAddress& local, PacketBuffer& buffer)
+{
+  const int flags = 0;
+  if (local.sin4.sin_family == 0) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return sendto(sock.getHandle(), buffer.data(), buffer.size(), flags, reinterpret_cast<const struct sockaddr*>(&peer), peer.getSocklen());
+  }
+
+  return sendMsgWithOptions(sock.getHandle(), buffer.data(), buffer.size(), &peer, &local, 0, 0);
+}
+
+void handleStatelessRetry(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, const ComboAddress& localAddr, uint32_t version, PacketBuffer& buffer)
 {
   auto newServerConnID = getCID();
   if (!newServerConnID) {
@@ -148,11 +159,11 @@ void handleStatelessRetry(Socket& sock, const PacketBuffer& clientConnID, const 
     return;
   }
 
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  sock.sendTo(reinterpret_cast<const char*>(buffer.data()), static_cast<size_t>(written), peer);
+  buffer.resize(static_cast<size_t>(written));
+  sendFromTo(sock, peer, localAddr, buffer);
 }
 
-void handleVersionNegociation(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, PacketBuffer& buffer)
+void handleVersionNegociation(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, const ComboAddress& localAddr, PacketBuffer& buffer)
 {
   buffer.resize(MAX_DATAGRAM_SIZE);
 
@@ -164,11 +175,12 @@ void handleVersionNegociation(Socket& sock, const PacketBuffer& clientConnID, co
     DEBUGLOG("failed to create vneg packet " << written);
     return;
   }
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  sock.sendTo(reinterpret_cast<const char*>(buffer.data()), static_cast<size_t>(written), peer);
+
+  buffer.resize(static_cast<size_t>(written));
+  sendFromTo(sock, peer, localAddr, buffer);
 }
 
-void flushEgress(Socket& sock, QuicheConnection& conn, const ComboAddress& peer, PacketBuffer& buffer)
+void flushEgress(Socket& sock, QuicheConnection& conn, const ComboAddress& peer, const ComboAddress& localAddr, PacketBuffer& buffer)
 {
   buffer.resize(MAX_DATAGRAM_SIZE);
   quiche_send_info send_info;
@@ -183,8 +195,8 @@ void flushEgress(Socket& sock, QuicheConnection& conn, const ComboAddress& peer,
       return;
     }
     // FIXME pacing (as send_info.at should tell us when to send the packet) ?
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    sock.sendTo(reinterpret_cast<const char*>(buffer.data()), static_cast<size_t>(written), peer);
+    buffer.resize(static_cast<size_t>(written));
+    sendFromTo(sock, peer, localAddr, buffer);
   }
 }
 
@@ -256,6 +268,51 @@ void configureQuiche(QuicheConfig& config, const QuicheParams& params, bool isHT
     fillRandom(resetToken, 16);
     quiche_config_set_stateless_reset_token(config.get(), resetToken.data());
   }
+}
+
+bool recvAsync(Socket& socket, PacketBuffer& buffer, ComboAddress& clientAddr, ComboAddress& localAddr)
+{
+  msghdr msgh{};
+  iovec iov{};
+  /* used by HarvestDestinationAddress */
+  cmsgbuf_aligned cbuf;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  fillMSGHdr(&msgh, &iov, &cbuf, sizeof(cbuf), reinterpret_cast<char*>(&buffer.at(0)), buffer.size(), &clientAddr);
+
+  ssize_t got = recvmsg(socket.getHandle(), &msgh, 0);
+  if (got < 0) {
+    int error = errno;
+    if (error != EAGAIN) {
+      throw NetworkError("Error in recvmsg: " + stringerror(error));
+    }
+    return false;
+  }
+
+  if ((msgh.msg_flags & MSG_TRUNC) != 0) {
+    return false;
+  }
+
+  buffer.resize(static_cast<size_t>(got));
+
+  if (HarvestDestinationAddress(&msgh, &localAddr)) {
+    /* so it turns out that sometimes the kernel lies to us:
+       the address is set to 0.0.0.0:0 which makes our sendfromto() use
+       the wrong address. In that case it's better to let the kernel
+       do the work by itself and use sendto() instead.
+       This is indicated by setting the family to 0 which is acted upon
+       in sendUDPResponse() and DelayedPacket::().
+    */
+    const ComboAddress bogusV4("0.0.0.0:0");
+    const ComboAddress bogusV6("[::]:0");
+    if ((localAddr.sin4.sin_family == AF_INET && localAddr == bogusV4) || (localAddr.sin4.sin_family == AF_INET6 && localAddr == bogusV6)) {
+      localAddr.sin4.sin_family = 0;
+    }
+  }
+  else {
+    localAddr.sin4.sin_family = 0;
+  }
+
+  return !buffer.empty();
 }
 
 };

--- a/pdns/dnsdistdist/doq-common.hh
+++ b/pdns/dnsdistdist/doq-common.hh
@@ -92,10 +92,11 @@ void fillRandom(PacketBuffer& buffer, size_t size);
 std::optional<PacketBuffer> getCID();
 PacketBuffer mintToken(const PacketBuffer& dcid, const ComboAddress& peer);
 std::optional<PacketBuffer> validateToken(const PacketBuffer& token, const ComboAddress& peer);
-void handleStatelessRetry(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, uint32_t version, PacketBuffer& buffer);
-void handleVersionNegociation(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, PacketBuffer& buffer);
-void flushEgress(Socket& sock, QuicheConnection& conn, const ComboAddress& peer, PacketBuffer& buffer);
+void handleStatelessRetry(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, const ComboAddress& localAddr, uint32_t version, PacketBuffer& buffer);
+void handleVersionNegociation(Socket& sock, const PacketBuffer& clientConnID, const PacketBuffer& serverConnID, const ComboAddress& peer, const ComboAddress& localAddr, PacketBuffer& buffer);
+void flushEgress(Socket& sock, QuicheConnection& conn, const ComboAddress& peer, const ComboAddress& localAddr, PacketBuffer& buffer);
 void configureQuiche(QuicheConfig& config, const QuicheParams& params, bool isHTTP);
+bool recvAsync(Socket& socket, PacketBuffer& buffer, ComboAddress& clientAddr, ComboAddress& localAddr);
 
 };
 

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1736,7 +1736,7 @@ bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destinat
 bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv);
 void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, cmsgbuf_aligned* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr);
 int sendOnNBSocket(int fd, const struct msghdr *msgh);
-size_t sendMsgWithOptions(int fd, const void* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags);
+size_t sendMsgWithOptions(int socketDesc, const void* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags);
 
 /* requires a non-blocking, connected TCP socket */
 bool isTCPSocketUsable(int sock);

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1736,7 +1736,7 @@ bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destinat
 bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv);
 void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, cmsgbuf_aligned* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr);
 int sendOnNBSocket(int fd, const struct msghdr *msgh);
-size_t sendMsgWithOptions(int fd, const char* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags);
+size_t sendMsgWithOptions(int fd, const void* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags);
 
 /* requires a non-blocking, connected TCP socket */
 bool isTCPSocketUsable(int sock);

--- a/regression-tests.dnsdist/quictests.py
+++ b/regression-tests.dnsdist/quictests.py
@@ -170,6 +170,28 @@ class QUICWithCacheTests(object):
 
         self.assertEqual(total, 1)
 
+class QUICGetLocalAddressOnAnyBindTests(object):
+
+    def testGetLocalAddressOnAnyBind(self):
+        """
+        QUIC: Return CNAME containing the local address for an ANY bind
+        """
+        name = 'local-address-any.quic.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.CNAME,
+                                    'address-was-127-0-0-1.local-address-any.advanced.tests.powerdns.com.')
+        response.answer.append(rrset)
+
+        (_, receivedResponse) = self.sendQUICQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
 class QUICXFRTests(object):
 
     def testXFR(self):

--- a/regression-tests.dnsdist/test_DOQ.py
+++ b/regression-tests.dnsdist/test_DOQ.py
@@ -6,7 +6,7 @@ import clientsubnetoption
 from dnsdisttests import DNSDistTest
 from dnsdisttests import pickAvailablePort
 from doqclient import quic_bogus_query
-from quictests import QUICTests, QUICWithCacheTests, QUICACLTests, QUICXFRTests
+from quictests import QUICTests, QUICWithCacheTests, QUICACLTests, QUICGetLocalAddressOnAnyBindTests, QUICXFRTests
 import doqclient
 from doqclient import quic_query
 
@@ -162,3 +162,32 @@ class TestDOQCertificateReloading(DNSDistTest):
         (_, secondSerial) = quic_query(query, '127.0.0.1', 0.5, self._doqServerPort, verify=self._caCert, server_hostname=self._serverName)
         # check that the serial is different
         self.assertNotEqual(serial, secondSerial)
+
+class TestDOQGetLocalAddressOnAnyBind(QUICGetLocalAddressOnAnyBindTests, DNSDistTest):
+    _serverKey = 'server.key'
+    _serverCert = 'server.chain'
+    _serverName = 'tls.tests.dnsdist.org'
+    _caCert = 'ca.pem'
+    _doqServerPort = pickAvailablePort()
+    _config_template = """
+    function answerBasedOnLocalAddress(dq)
+      local dest = tostring(dq.localaddr)
+      local i, j = string.find(dest, "[0-9.]+")
+      local addr = string.sub(dest, i, j)
+      local dashAddr = string.gsub(addr, "[.]", "-")
+      return DNSAction.Spoof, "address-was-"..dashAddr..".local-address-any.advanced.tests.powerdns.com."
+    end
+    addAction("local-address-any.quic.tests.powerdns.com.", LuaAction(answerBasedOnLocalAddress))
+    newServer{address="127.0.0.1:%s"}
+    addDOQLocal("0.0.0.0:%d", "%s", "%s")
+    addDOQLocal("[::]:%d", "%s", "%s")
+    """
+    _config_params = ['_testServerPort', '_doqServerPort','_serverCert', '_serverKey', '_doqServerPort','_serverCert', '_serverKey']
+    _acl = ['127.0.0.1/32', '::1/128']
+    _skipListeningOnCL = True
+
+    def getQUICConnection(self):
+        return self.getDOQConnection(self._doqServerPort, self._caCert)
+
+    def sendQUICQuery(self, query, response=None, useQueue=True, connection=None):
+        return self.sendDOQQuery(self._doqServerPort, query, response=response, caFile=self._caCert, useQueue=useQueue, serverName=self._serverName, connection=connection)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14078 to rel/dnsdist-1.9.x

And expose the correct destination IP to Lua.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
