### PR TITLE
dnsdist: Prevent a race when calling `registerWebHandler` at runtime

### DIFF
--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -1716,18 +1716,20 @@ static void handleRings(const YaHTTP::Request& req, YaHTTP::Response& resp)
   resp.headers["Content-Type"] = "application/json";
 }
 
-static std::unordered_map<std::string, std::function<void(const YaHTTP::Request&, YaHTTP::Response&)>> s_webHandlers;
+using WebHandler = std::function<void(const YaHTTP::Request&, YaHTTP::Response&)>;
+static SharedLockGuarded<std::unordered_map<std::string, WebHandler>> s_webHandlers;
 
-void registerWebHandler(const std::string& endpoint, std::function<void(const YaHTTP::Request&, YaHTTP::Response&)> handler);
+void registerWebHandler(const std::string& endpoint, WebHandler handler);
 
-void registerWebHandler(const std::string& endpoint, std::function<void(const YaHTTP::Request&, YaHTTP::Response&)> handler)
+void registerWebHandler(const std::string& endpoint, WebHandler handler)
 {
-  s_webHandlers[endpoint] = std::move(handler);
+  auto handlers = s_webHandlers.write_lock();
+  (*handlers)[endpoint] = std::move(handler);
 }
 
 void clearWebHandlers()
 {
-  s_webHandlers.clear();
+  s_webHandlers.write_lock()->clear();
 }
 
 #ifndef DISABLE_BUILTIN_HTML
@@ -1866,9 +1868,17 @@ static void connectionThread(WebClientConnection&& conn)
       resp.status = 405;
     }
     else {
-      const auto webHandlersIt = s_webHandlers.find(req.url.path);
-      if (webHandlersIt != s_webHandlers.end()) {
-        webHandlersIt->second(req, resp);
+      WebHandler handler;
+      {
+        auto handlers = s_webHandlers.read_lock();
+        const auto webHandlersIt = handlers->find(req.url.path);
+        if (webHandlersIt != handlers->end()) {
+          handler = webHandlersIt->second;
+        }
+      }
+
+      if (handler) {
+        handler(req, resp);
       }
       else {
         resp.status = 404;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

The `registerWebHandler()` Lua method can be used to tie a custom Lua function to an HTTP endpoint. This function was clearly not intended to be used at runtime but this was never enforced, so let's prevent a race condition by wrapping the internal web handlers map in a lock.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
