### PR TITLE
rec: enable lsan in regression tests

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -565,7 +565,8 @@ jobs:
       image: "${{ needs.get-runner-container-image.outputs.id }}:${{ needs.get-runner-container-image.outputs.tag }}"
       env:
         UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp'
-        ASAN_OPTIONS: detect_leaks=0
+        ASAN_OPTIONS: ""
+        LSAN_OPTIONS: "suppressions=${{ env.REPO_HOME }}/pdns/recursordist/recursor-lsan.supp"
         TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ env.REPO_HOME }}/pdns/recursordist/recursor-tsan.supp"
       options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -2762,10 +2762,11 @@ static void usage()
 #endif
 #if __has_feature(address_sanitizer)
 #define __SANITIZE_ADDRESS__ 1
+#endif
+#endif
+
 #if defined(__SANITIZE_ADDRESS__) && defined(HAVE_LEAK_SANITIZER_INTERFACE)
 #include <sanitizer/lsan_interface.h>
-#endif
-#endif
 #endif
 
 #if defined(COVERAGE) || (defined(__SANITIZE_ADDRESS__) && defined(HAVE_LEAK_SANITIZER_INTERFACE))

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -51,10 +51,11 @@
 #endif
 #if __has_feature(address_sanitizer)
 #define __SANITIZE_ADDRESS__ 1
+#endif
+#endif
+
 #if defined(__SANITIZE_ADDRESS__) && defined(HAVE_LEAK_SANITIZER_INTERFACE)
 #include <sanitizer/lsan_interface.h>
-#endif
-#endif
 #endif
 
 std::pair<std::string, std::string> PrefixDashNumberCompare::prefixAndTrailingNum(const std::string& a)

--- a/pdns/recursordist/recursor-tsan.supp
+++ b/pdns/recursordist/recursor-tsan.supp
@@ -1,3 +1,5 @@
 # We don't care about stats for now
 race:doStats
 race:g_stats
+# Just calling _exit in th TSAN case
+signal:termIntHandler

--- a/pdns/recursordist/recursor-tsan.supp
+++ b/pdns/recursordist/recursor-tsan.supp
@@ -1,5 +1,5 @@
 # We don't care about stats for now
 race:doStats
 race:g_stats
-# Just calling _exit in th TSAN case
+# Just calling _exit in the TSAN case
 signal:termIntHandler

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -768,6 +768,7 @@ distributor-threads={threads}""".format(confdir=confdir,
                 print("kill...", p, file=sys.stderr)
                 p.kill()
                 p.wait()
+            return p
         except OSError as e:
             # There is a race-condition with the poll() and
             # kill() statements, when the process is dead on the
@@ -782,7 +783,9 @@ distributor-threads={threads}""".format(confdir=confdir,
 
     @classmethod
     def tearDownRecursor(cls):
-        cls.killProcess(cls._recursor)
+        p = cls.killProcess(cls._recursor)
+        if p.returncode != 0:
+            raise AssertionError('Process exited with return code %d' % (p.returncode))
 
     @classmethod
     def sendUDPQuery(cls, query, timeout=2.0, decode=True, fwparams=dict()):

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -784,7 +784,7 @@ distributor-threads={threads}""".format(confdir=confdir,
     @classmethod
     def tearDownRecursor(cls):
         p = cls.killProcess(cls._recursor)
-        if p.returncode != 0:
+        if p.returncode not in (0, -15):
             raise AssertionError('Process exited with return code %d' % (p.returncode))
 
     @classmethod

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -759,7 +759,7 @@ distributor-threads={threads}""".format(confdir=confdir,
             return
         try:
             p.terminate()
-            for count in range(10):
+            for count in range(100): # tsan can be slow
                 x = p.poll()
                 if x is not None:
                     break


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Mostly inspired by/copied from #14143. Same considerations wrt tsan apply. I tried calling `rec_control quit-nicely`, but that causes a race: the `rec_control` command finishes before rec has actually quit, so the kill code would be activated anyway, especially with tsan enabled quitting takes some time.

I' marking this a draft: 

- I see the occasional segfault in the dnstap nod tests. To be investigated.
- I need to double check that actual leaks in CI are detected (I did a local test already)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
