### PR TITLE
GH Actions: build and publish multi-platform images

### DIFF
--- a/.github/workflows/build-docker-images-dispatch.yml
+++ b/.github/workflows/build-docker-images-dispatch.yml
@@ -1,0 +1,90 @@
+---
+name: Trigger specific image build
+
+on:
+  workflow_dispatch:
+    inputs:
+      product:
+        required: true
+        description: Product to build
+        type: choice
+        options:
+        - auth
+        - recursor
+        - dnsdist
+      ref:
+        description: git branch or tag to checkout (e.g. rec-5.0.0-rc1)
+        type: string
+        default: master
+        required: false
+      platforms:
+        description: target platform(s)
+        type: string
+        default: linux/arm64/v8,linux/amd64
+        required: false
+      build-args:
+        description: build-time variables (e.g. DOCKER_FAKE_RELEASE=YES when building for tags)
+        type: string
+        default: ''
+        required: false
+      push:
+        description: push image to DockerHub
+        type: boolean
+        required: true
+
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+  actions: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-22.04
+    outputs:
+      image-tag: ${{ steps.get-image-tag.outputs.tag }}
+      image-name: ${{ steps.get-image-metadata.outputs.name }}
+      image-description: ${{ steps.get-image-metadata.outputs.description }}
+    steps:
+      - run: |
+          echo '${{ inputs.ref }}' | egrep -qq '^auth-.*|^rec-.*|^dnsdist-.*' && tag=$(echo '${{ inputs.ref }}' | cut -d '-' -f 2-)
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+        id: get-image-tag
+      - run: |
+          if $(echo '${{ inputs.ref }}' | egrep -qq '^auth-.*|^rec-.*|^dnsdist-.*'); then
+            echo "version=$(echo '${{ inputs.ref }}' | cut -d '-' -f 2 | awk -F'.' '{print $1$2}')" >> $GITHUB_ENV
+            echo "branch=$(echo '${{ inputs.ref }}' | cut -d '-' -f 2- | awk -F'.' '{print "v"$1"."$2".x"}')" >> $GITHUB_ENV
+          else
+            echo "version=$(echo '${{ inputs.ref }}' | tr '/' '-')" >> $GITHUB_ENV
+            echo "branch=${{ inputs.ref }}" >> $GITHUB_ENV
+          fi
+      - run: |
+          if $(echo '${{ inputs.product }}'| grep -qq auth); then
+            echo '${{ inputs.ref }}' | egrep -qq '^auth-.*' && description='PowerDNS Authoritative Server '$branch || description='EXPERIMENTAL pdns auth image'
+            echo "name=pdns-auth-$version" >> $GITHUB_OUTPUT
+          elif (echo '${{ inputs.product }}'| grep -qq recursor); then
+            echo '${{ inputs.ref }}' | egrep -qq '^rec-.*' && description='PowerDNS Recursor '$branch || description='EXPERIMENTAL pdns recursor image'
+            echo "name=pdns-recursor-$version" >> $GITHUB_OUTPUT
+          else
+            echo '${{ inputs.ref }}' | egrep -qq '^dnsdist-.*' && description='PowerDNS DNSDist '$branch || description='EXPERIMENTAL dnsdist image'
+            echo "name=dnsdist-$version" >> $GITHUB_OUTPUT
+          fi
+          echo "description=$description" >> $GITHUB_OUTPUT
+        id: get-image-metadata
+
+  call-build-docker-image:
+    uses: PowerDNS/pdns/.github/workflows/build-docker-images.yml@master
+    needs: prepare
+    with:
+      product: ${{ inputs.product }}
+      ref: ${{ inputs.ref }}
+      image-name: ${{ needs.prepare.outputs.image-name }}
+      image-tags: |-
+        latest
+        ${{ needs.prepare.outputs.image-tag }}
+      image-description: ${{ needs.prepare.outputs.image-description }}
+      platforms: ${{ inputs.platforms }}
+      build-args: ${{ inputs.build-args }}
+      push: ${{ inputs.push }}
+    secrets:
+      DOCKERHUB_ORGANIZATION_NAME: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-docker-images-tags.yml
+++ b/.github/workflows/build-docker-images-tags.yml
@@ -1,0 +1,91 @@
+---
+name: Build images for tags
+
+on:
+  push:
+    tags:
+    - 'auth-*'
+    - 'dnsdist-*'
+    - 'rec-*'
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-22.04
+    outputs:
+      image-name-suffix: ${{ steps.get-image-version.outputs.version }}
+      image-tag: ${{ steps.get-image-tag.outputs.tag }}
+      image-description-suffix: ${{ steps.get-image-description.outputs.description }}
+    steps:
+      - run: echo "version=$(echo '${{ github.ref_name }}' | cut -d '-' -f 2 | awk -F'.' '{print $1$2}')" >> $GITHUB_OUTPUT
+        id: get-image-version
+      - run: echo "tag=$(echo '${{ github.ref_name }}' | cut -d '-' -f 2-)" >> $GITHUB_OUTPUT
+        id: get-image-tag
+      - run: echo "description=$(echo '${{ github.ref_name }}' | cut -d '-' -f 2- | awk -F'.' '{print "v"$1"."$2".x"}')" >> $GITHUB_OUTPUT
+        id: get-image-description
+
+  call-build-image-auth:
+    uses: PowerDNS/pdns/.github/workflows/build-docker-images.yml@master
+    if: startsWith(github.ref_name, 'auth')
+    needs: prepare
+    with:
+      product: auth
+      ref: ${{ github.ref_name }}
+      image-name: pdns-auth-${{ needs.prepare.outputs.image-name-suffix }}
+      image-tags: |-
+        latest
+        ${{ needs.prepare.outputs.image-tag }}
+      image-description: 'PowerDNS Authoritative Server ${{ needs.prepare.outputs.image-description-suffix }}'
+      platforms: linux/amd64,linux/arm64/v8
+      build-args: |-
+        DOCKER_FAKE_RELEASE=YES
+      push: true
+    secrets:
+      DOCKERHUB_ORGANIZATION_NAME: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  call-build-image-recursor:
+    uses: PowerDNS/pdns/.github/workflows/build-docker-images.yml@master
+    if: startsWith(github.ref_name, 'rec')
+    needs: prepare
+    with:
+      product: recursor
+      ref: ${{ github.ref_name }}
+      image-name: pdns-recursor-${{ needs.prepare.outputs.image-name-suffix }}
+      image-tags: |-
+        latest
+        ${{ needs.prepare.outputs.image-tag }}
+      image-description: 'PowerDNS Recursor ${{ needs.prepare.outputs.image-description-suffix }}'
+      platforms: linux/amd64,linux/arm64/v8
+      build-args: |-
+        DOCKER_FAKE_RELEASE=YES
+      push: true
+    secrets:
+      DOCKERHUB_ORGANIZATION_NAME: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  call-build-image-dnsdist:
+    uses: PowerDNS/pdns/.github/workflows/build-docker-images.yml@master
+    if: startsWith(github.ref_name, 'dnsdist')
+    needs: prepare
+    with:
+      product: dnsdist
+      ref: ${{ github.ref_name }}
+      image-name: dnsdist-${{ needs.prepare.outputs.image-name-suffix }}
+      image-tags: |-
+        latest
+        ${{ needs.prepare.outputs.image-tag }}
+      image-description: 'PowerDNS DNSdist ${{ needs.prepare.outputs.image-description-suffix }}'
+      platforms: linux/amd64,linux/arm64/v8
+      build-args: |-
+        DOCKER_FAKE_RELEASE=YES
+      push: true
+    secrets:
+      DOCKERHUB_ORGANIZATION_NAME: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,162 @@
+---
+name: Build push and test docker images
+
+on:
+  workflow_call:
+    inputs:
+      product:
+        required: true
+        description: Product to build
+        type: string
+      ref:
+        description: git ref to checkout
+        type: string
+        default: master
+        required: false
+      image-name:
+        description: repository name for the requested image
+        type: string
+        required: true
+      image-tags:
+        description: tag for the requested image
+        type: string
+        required: true
+      image-description:
+        description: short description for the image repository
+        type: string
+        required: true
+      platforms:
+        description: target platform(s)
+        type: string
+        default: linux/arm64/v8,linux/amd64
+        required: false
+      build-args:
+        description: build-time variables
+        type: string
+        default: ''
+        required: false
+      push:
+        description: push image to DockerHub
+        type: boolean
+        required: true
+    secrets:
+      DOCKERHUB_ORGANIZATION_NAME:
+        required: true
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+  contents: read
+
+jobs:
+  validate-push-image:
+    name: Check only images built from tags and master are pushed
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          ref: ${{ inputs.ref }}
+      - name: validate reference only if image will be pushed
+        if: ${{ inputs.push }}
+        run: |
+          [[ "${{ inputs.ref }}" == "master" ]] || git describe --tags --exact-match
+
+  build:
+    name: build docker image for a product
+    runs-on: ubuntu-22.04
+    needs: validate-push-image
+    outputs:
+      image-digest: ${{ steps.build-image.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          ref: ${{ inputs.ref }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64/v8
+      - name: Set up Docker Buildx for multi-platform builds
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ inputs.platforms }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}
+          tags: ${{ inputs.image-tags }}
+      - name: Build and load powerdns product images
+        id: build-image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile-${{ inputs.product }}
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.push }}
+          sbom: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: ${{ inputs.build-args }}
+      - name: Update repo description
+        if: ${{ inputs.push }}
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}
+          short-description: ${{ inputs.image-description }}
+
+  test-uploaded-images:
+    name: test uploaded images
+    if: ${{ inputs.push }}
+    needs: build
+    runs-on: ${{ matrix.runner-os }}
+    strategy:
+      matrix:
+        runner-os:
+          - ubuntu-22.04
+          - ubicloud-standard-2-arm
+      fail-fast: false
+    steps:
+      - name: Check running image
+        if: ${{ ( matrix.runner-os == 'ubuntu-22.04' && contains(inputs.platforms, 'amd64') ) || ( matrix.runner-os == 'ubicloud-standard-2-arm' && contains(inputs.platforms, 'arm64') ) }}
+        run: |
+          image_name='${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}'
+          for tag in `echo '${{ inputs.image-tags }}' | tr '\n' ' '`; do
+            echo 'Testing: '${image_name}':'${tag};
+            # pdns-auth image returns a 134 exit code
+            docker run ${image_name}:${tag} --version || [ "$?" == "134" ]
+          done
+      - name: Check image digest matches
+        if: ${{ ( matrix.runner-os == 'ubuntu-22.04' && contains(inputs.platforms, 'amd64') ) || ( matrix.runner-os == 'ubicloud-standard-2-arm' && contains(inputs.platforms, 'arm64') ) }}
+        run: |
+          output_digest='${{ needs.build.outputs.image-digest }}'
+          image_name='${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}'
+          for tag in `echo '${{ inputs.image-tags }}' | tr '\n' ' '`; do
+            image_digest=$(docker inspect --format='{{index .RepoDigests 0}}' ${image_name}:${tag} | cut -d '@' -f 2)
+            [[ "${output_digest}" == "${image_digest}" ]] || \
+              ( echo "Image digest does not match => output_digest: "${output_digest}" - image_digest: "${image_digest} && exit 1 )
+          done
+      - name: Check SBOM and Provenance
+        if: ${{ ( matrix.runner-os == 'ubuntu-22.04' && contains(inputs.platforms, 'amd64') ) || ( matrix.runner-os == 'ubicloud-standard-2-arm' && contains(inputs.platforms, 'arm64') ) }}
+        run: |
+          image_name='${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}'
+          for tag in `echo '${{ inputs.image-tags }}' | tr '\n' ' '`; do
+            if $(echo '${{ inputs.platforms }}' | grep -qq ','); then
+              docker buildx imagetools inspect ${image_name}:${tag} --format "{{json .Provenance}}" | jq -e '."linux/'$(dpkg --print-architecture)'" | has("SLSA")'
+              docker buildx imagetools inspect ${image_name}:${tag} --format "{{json .SBOM}}" | jq -e '."linux/'$(dpkg --print-architecture)'" | has("SPDX")'
+            else
+              docker buildx imagetools inspect ${image_name}:${tag} --format "{{json .Provenance}}" | jq -e 'has("SLSA")'
+              docker buildx imagetools inspect ${image_name}:${tag} --format "{{json .SBOM}}" | jq -e 'has("SPDX")'
+            fi
+          done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,20 +7,56 @@ on:
 
 permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
   contents: read
+  actions: read
 
 jobs:
-  build:
-    name: docker build
+  call-build-image-auth:
+    uses: PowerDNS/pdns/.github/workflows/build-docker-images.yml@master
     if: ${{ vars.SCHEDULED_DOCKER }}
-    # on a ubuntu-20.04 VM
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        product: ['auth', 'recursor', 'dnsdist']
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 5
-          submodules: recursive
-      # this builds packages and runs our unit test (make check)
-      - run: docker build --rm -t powerdns-${{ matrix.product }} -f Dockerfile-${{ matrix.product }} .
+    with:
+      product: auth
+      ref: ${{ github.ref_name }}
+      image-name: pdns-auth-master
+      image-tags: |-
+        latest
+      image-description: 'EXPERIMENTAL pdns auth image'
+      platforms: linux/amd64,linux/arm64/v8
+      push: true
+    secrets:
+      DOCKERHUB_ORGANIZATION_NAME: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  call-build-image-recursor:
+    uses: PowerDNS/pdns/.github/workflows/build-docker-images.yml@master
+    if: ${{ vars.SCHEDULED_DOCKER }}
+    with:
+      product: recursor
+      ref: ${{ github.ref_name }}
+      image-name: pdns-recursor-master
+      image-tags: |-
+        latest
+      image-description: 'EXPERIMENTAL pdns recursor image'
+      platforms: linux/amd64,linux/arm64/v8
+      push: true
+    secrets:
+      DOCKERHUB_ORGANIZATION_NAME: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  call-build-image-dnsdist:
+    uses: PowerDNS/pdns/.github/workflows/build-docker-images.yml@master
+    if: ${{ vars.SCHEDULED_DOCKER }}
+    with:
+      product: dnsdist
+      ref: ${{ github.ref_name }}
+      image-name: dnsdist-master
+      image-tags: |-
+        latest
+      image-description: 'EXPERIMENTAL dnsdist image'
+      platforms: linux/amd64,linux/arm64/v8
+      push: true
+    secrets:
+      DOCKERHUB_ORGANIZATION_NAME: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -46,6 +46,7 @@ RUN if [ "${DOCKER_FAKE_RELEASE}" = "YES" ]; then \
 # simplify repeated -C calls with SUBDIRS?
 RUN mkdir /build && \
     LUAVER=$([ -z "${NO_LUA_JIT##*$(dpkg --print-architecture)*}" ] && echo 'lua5.3' || echo 'luajit') && \
+    apt-get install -y lib${LUAVER}-*dev && \
     ./configure \
       --with-lua=${LUAVER} \
       --sysconfdir=/etc/powerdns \

--- a/Dockerfile-dnsdist
+++ b/Dockerfile-dnsdist
@@ -55,6 +55,7 @@ RUN mkdir /quiche && cd /quiche && \
 
 RUN mkdir /build && \
     LUAVER=$([ -z "${NO_LUA_JIT##*$(dpkg --print-architecture)*}" ] && echo 'lua5.3' || echo 'luajit') && \
+    apt-get install -y lib${LUAVER}-*dev && \
     ./configure \
       --with-lua=${LUAVER} \
       LDFLAGS=-rdynamic \

--- a/Dockerfile-recursor
+++ b/Dockerfile-recursor
@@ -54,6 +54,7 @@ RUN if [ "${DOCKER_FAKE_RELEASE}" = "YES" ]; then \
 
 RUN mkdir /build && \
     LUAVER=$([ -z "${NO_LUA_JIT##*$(dpkg --print-architecture)*}" ] && echo 'lua5.3' || echo 'luajit') && \
+    apt-get install -y lib${LUAVER}-*dev && \
     ./configure \
       --with-lua=${LUAVER} \
       LDFLAGS=-rdynamic \


### PR DESCRIPTION
### Short description

This PR enables building amd64 and arm64 images and pushing them to DockerHub. It also tests that the images are properly uploaded and that attestations are included.

For this purpose:

- The workflow `build-docker-images.yml` performs the actual process of building, pushing, and testing. Can only be triggered on `workflow_call` events.
- The workflow `docker.yml` has been updated to daily build and push images from `master`.
- The workflow `build-docker-images-tags.yml` triggers the whole process on new tags.
- The workflow `build-docker-images-dispatch.yml` enables triggering manually the process of building images

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
