### PR TITLE
Meson: Move modules handling to `modules/` dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -669,43 +669,7 @@ if dep_cdb.found()
   )
 endif
 
-# Modules
-all_modules = [
-  'bind',
-  'pipe',
-  'gmysql',
-  'godbc',
-  'gpgsql',
-  'gsqlite3',
-  'ldap',
-  'lua2',
-  'remote',
-  'tinydns',
-  'geoip',
-  'lmdb',
-]
-
-selected_modules = []
-selected_dyn_modules = []
-dep_modules = []
-foreach module_name: all_modules
-  module_backend_name = module_name + 'backend'
-  module_opt = get_option('module-' + module_name)
-
-  if module_opt == 'disabled'
-    continue
-  elif module_opt == 'static'
-    selected_modules += module_name
-  else
-    selected_dyn_modules += module_name
-  endif
-
-  subdir('modules' / module_backend_name)
-  dep_modules += get_variable('dep_' + module_backend_name)
-endforeach
-
-conf.set_quoted('PDNS_MODULES', ' '.join(selected_modules), description: 'Built-in modules')
-conf.set_quoted('PDNS_DYN_MODULES', ' '.join(selected_dyn_modules), description: 'Loadable modules')
+subdir('modules')
 
 # Generate config.h
 config_h = configure_file(configuration: conf, output: 'config.h')

--- a/modules/bindbackend/meson.build
+++ b/modules/bindbackend/meson.build
@@ -1,33 +1,14 @@
-sources = [
+module_sources = files(
   'bindbackend2.cc',
   'binddnssec.cc',
-]
+)
 
-extras = [
+module_extras = files(
   'bindbackend2.hh',
 
   # TODO These should be packaged up some other way (and avoid product_source_dir)
   product_source_dir / 'pdns' / 'bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql',
   product_source_dir / 'pdns' / 'bind-dnssec.schema.sqlite3.sql',
-]
-
-module_deps = [deps]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: [
-    module_deps,
-    libpdns_bindparser,
-  ],
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_deps = [deps]

--- a/modules/geoipbackend/meson.build
+++ b/modules/geoipbackend/meson.build
@@ -1,29 +1,13 @@
-sources = [
+module_sources = files(
   'geoipbackend.cc',
   'geoipinterface-dat.cc',
   'geoipinterface-mmdb.cc',
   'geoipinterface.cc',
-]
-
-extras = [
-  'geoipbackend.hh',
-  'geoipinterface.hh',
-]
-
-module_deps = [deps, dep_geoip, dep_mmdb, dep_yaml_cpp]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_extras = files(
+  'geoipbackend.hh',
+  'geoipinterface.hh',
+)
+
+module_deps = [deps, dep_geoip, dep_mmdb, dep_yaml_cpp]

--- a/modules/gmysqlbackend/meson.build
+++ b/modules/gmysqlbackend/meson.build
@@ -1,9 +1,9 @@
-sources = [
+module_sources = files(
   'gmysqlbackend.cc',
   'smysql.cc',
-]
+)
 
-extras = [
+module_extras = files(
   'gmysqlbackend.hh',
   'smysql.hh',
 
@@ -15,22 +15,6 @@ extras = [
   '4.2.0_to_4.3.0_schema.mysql.sql',
   '4.3.0_to_4.7.0_schema.mysql.sql',
   'schema.mysql.sql',
-]
-
-module_deps = [deps, dep_mysql]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_deps = [deps, dep_mysql]

--- a/modules/godbcbackend/meson.build
+++ b/modules/godbcbackend/meson.build
@@ -1,9 +1,9 @@
-sources = [
+module_sources = files(
   'godbcbackend.cc',
   'sodbc.cc',
-]
+)
 
-extras = [
+module_extras = files(
   'godbcbackend.hh',
   'sodbc.hh',
 
@@ -11,22 +11,6 @@ extras = [
   '4.0.0_to_4.2.0_schema.mssql.sql',
   '4.2.0_to_4.3.0_schema.mssql.sql',
   '4.3.0_to_4.7.0_schema.mssql.sql',
-]
-
-module_deps = [deps, dep_odbc]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_deps = [deps, dep_odbc]

--- a/modules/gpgsqlbackend/meson.build
+++ b/modules/gpgsqlbackend/meson.build
@@ -1,9 +1,9 @@
-sources = [
+module_sources = files(
   'gpgsqlbackend.cc',
   'spgsql.cc',
-]
+)
 
-extras = [
+module_extras = files(
   'gpgsqlbackend.hh',
   'spgsql.hh',
 
@@ -14,22 +14,6 @@ extras = [
   '4.1.0_to_4.2.0_schema.pgsql.sql',
   '4.2.0_to_4.3.0_schema.pgsql.sql',
   '4.3.0_to_4.7.0_schema.pgsql.sql',
-]
-
-module_deps = [deps, dep_pgsql]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_deps = [deps, dep_pgsql]

--- a/modules/gsqlite3backend/meson.build
+++ b/modules/gsqlite3backend/meson.build
@@ -1,8 +1,8 @@
-sources = [
+module_sources = files(
   'gsqlite3backend.cc',
-]
+)
 
-extras = [
+module_extras = files(
   'gsqlite3backend.hh',
 
   'dnssec-3.x_to_3.4.0_schema.sqlite3.sql',
@@ -13,22 +13,6 @@ extras = [
   '4.3.0_to_4.3.1_schema.sqlite3.sql',
   '4.3.1_to_4.7.0_schema.sqlite3.sql',
   'schema.sqlite3.sql',
-]
-
-module_deps = [deps, dep_sqlite3]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_deps = [deps, dep_sqlite3]

--- a/modules/ldapbackend/meson.build
+++ b/modules/ldapbackend/meson.build
@@ -1,13 +1,13 @@
-sources = [
+module_sources = files(
   'ldapauthenticator.cc',
   'ldapbackend.cc',
   'ldaputils.cc',
   'native.cc',
   'powerldap.cc',
   'primary.cc',
-]
+)
 
-extras = [
+module_extras = files(
   'exceptions.hh',
   'ldapauthenticator.hh',
   'ldapauthenticator_p.hh',
@@ -18,22 +18,6 @@ extras = [
 
   'dnsdomain2.schema',
   'pdns-domaininfo.schema',
-]
-
-module_deps = [deps, dep_ldap]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_deps = [deps, dep_ldap]

--- a/modules/lmdbbackend/meson.build
+++ b/modules/lmdbbackend/meson.build
@@ -1,25 +1,9 @@
-sources = [
+module_sources = files(
   'lmdbbackend.cc',
-]
-
-extras = [
-  'lmdbbackend.hh',
-]
-
-module_deps = [deps, dep_lmdb_safe, dep_lmdb, dep_boost_serialization]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_extras = files(
+  'lmdbbackend.hh',
+)
+
+module_deps = [deps, dep_lmdb_safe, dep_lmdb, dep_boost_serialization]

--- a/modules/lua2backend/meson.build
+++ b/modules/lua2backend/meson.build
@@ -1,27 +1,11 @@
-sources = [
+module_sources = files(
   'lua2api2.cc',
   'lua2backend.cc',
-]
-
-extras = [
-  'lua2backend.hh',
-  'lua2api2.hh',
-]
-
-module_deps = [deps]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_extras = files(
+  'lua2backend.hh',
+  'lua2api2.hh',
+)
+
+module_deps = [deps]

--- a/modules/meson.build
+++ b/modules/meson.build
@@ -1,0 +1,54 @@
+# Modules
+all_modules = [
+  'bind',
+  'pipe',
+  'gmysql',
+  'godbc',
+  'gpgsql',
+  'gsqlite3',
+  'ldap',
+  'lua2',
+  'remote',
+  'tinydns',
+  'geoip',
+  'lmdb',
+]
+
+selected_modules = []
+selected_dyn_modules = []
+dep_modules = []
+foreach module_name: all_modules
+  module_backend_name = module_name + 'backend'
+  module_dep_name = 'dep_' + module_backend_name
+  module_lib_name = 'module_' + module_backend_name + '_lib'
+  module_opt = get_option('module-' + module_name)
+
+  if module_opt == 'disabled'
+    continue
+  endif
+
+  subdir(module_backend_name)
+
+  module_lib = static_library(
+    module_backend_name,
+    sources: module_sources,
+    dependencies: module_deps,
+    extra_files: module_extras,
+  )
+
+  set_variable(module_lib_name, declare_dependency(link_whole: module_lib))
+
+  set_variable(module_dep_name, dependency('', required: false))
+  if module_opt == 'static'
+    set_variable(module_dep_name, get_variable(module_lib_name))
+    selected_modules += module_name
+  else
+    shared_module(module_backend_name, link_whole: module_lib, name_suffix: 'so')
+    selected_dyn_modules += module_name
+  endif
+
+  dep_modules += get_variable(module_dep_name)
+endforeach
+
+conf.set_quoted('PDNS_MODULES', ' '.join(selected_modules), description: 'Built-in modules')
+conf.set_quoted('PDNS_DYN_MODULES', ' '.join(selected_dyn_modules), description: 'Loadable modules')

--- a/modules/pipebackend/meson.build
+++ b/modules/pipebackend/meson.build
@@ -1,29 +1,13 @@
-sources = [
+module_sources = files(
   'coprocess.cc',
   'pipebackend.cc',
-]
+)
 
-extras = [
+module_extras = files(
   'coprocess.hh',
   'pipebackend.hh',
 
   'backend.pl',
-]
-
-module_deps = [deps]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_deps = [deps]

--- a/modules/remotebackend/meson.build
+++ b/modules/remotebackend/meson.build
@@ -1,4 +1,4 @@
-sources = files(
+module_sources = files(
   'httpconnector.cc',
   'pipeconnector.cc',
   'remotebackend.cc',
@@ -6,30 +6,13 @@ sources = files(
   'zmqconnector.cc',
 )
 
-extras = files(
+module_extras = files(
   'remotebackend.hh',
 )
 
 module_deps = [deps, dep_zeromq]
 
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
-)
-
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
-
 if get_option('unit-tests-backends')
-  module_remotebackend_lib = declare_dependency(link_whole: lib)
   module_remotebackend_testrunner = files('testrunner.sh')[0]
 
   module_remotebackend_test_sources_common = files(

--- a/modules/tinydnsbackend/meson.build
+++ b/modules/tinydnsbackend/meson.build
@@ -1,25 +1,9 @@
-sources = [
+module_sources = files(
   'tinydnsbackend.cc',
-]
-
-extras = [
-  'tinydnsbackend.hh',
-]
-
-module_deps = [deps, dep_cdb, libpdns_cdb]
-
-lib = static_library(
-  module_backend_name,
-  sources,
-  dependencies: module_deps,
-  extra_files: extras,
 )
 
-dep_name = 'dep_' + module_backend_name
-set_variable(dep_name, dependency('', required: false))
-if module_opt == 'static'
-  dep = declare_dependency(link_whole: lib)
-  set_variable(dep_name, dep)
-else
-  shared_module(module_backend_name, link_whole: lib, name_suffix: 'so')
-endif
+module_extras = files(
+  'tinydnsbackend.hh',
+)
+
+module_deps = [deps, dep_cdb, libpdns_cdb]


### PR DESCRIPTION
### Short description
This simplifies the handling of modules, and puts the backend file artifacts in a directory similar to how autotools did it, this helps simplify adapting the regression tests harness to support our Meson builds.

All the files that are `modules/*backend/meson.build` were changed the same way: The library creation was removed from there and the source and extra files variable were renamed to `module_sources` and `module_extras`.

Then the handling of modules was moved from the top-level `meson.build` into `modules/meson.build` and made a bit more generic to handle the creation of library artifacts for each backend there.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)