### PR TITLE
rec: fix version changed for incoming.edns_padding_from and incoming.proxy_protocol_from

### DIFF
--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -871,7 +871,7 @@ Lower this if you experience timeouts.
 List of netmasks (proxy IP in case of proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses, provided that :ref:`setting-edns-padding-mode` applies.
  ''',
         'versionadded' : '4.5.0',
-        'versionchanged' : ('5.0.4', 'YAML settings only: previously this was defined as a string instead of a sequence')
+        'versionchanged' : ('5.0.5', 'YAML settings only: previously this was defined as a string instead of a sequence')
     },
     {
         'name' : 'edns_padding_mode',
@@ -2062,7 +2062,7 @@ Note that once a Proxy Protocol header has been received, the source address fro
 The dnsdist docs have `more information about the PROXY protocol <https://dnsdist.org/advanced/passing-source-address.html#proxy-protocol>`_.
  ''',
         'versionadded' : '4.4.0',
-        'versionchanged' : ('5.0.4', 'YAML settings only: previously this was defined as a string instead of a sequence')
+        'versionchanged' : ('5.0.5', 'YAML settings only: previously this was defined as a string instead of a sequence')
     },
     {
         'name' : 'proxy_protocol_exceptions',


### PR DESCRIPTION
Due to the in-between 5.0.4 release these changes were moved to 5.0.5

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
