### PR TITLE
rec: log vm.max_map_count possibly being too low and log a few exceptions (with rate limiting)

### DIFF
--- a/pdns/devpollmplexer.cc
+++ b/pdns/devpollmplexer.cc
@@ -140,9 +140,8 @@ void DevPollFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
 
 int DevPollFDMultiplexer::run(struct timeval* now, int timeout)
 {
-  if (d_inrun) {
-    throw FDMultiplexerException("FDMultiplexer::run() is not reentrant!\n");
-  }
+  InRun guard(d_inrun);
+
   std::vector<struct pollfd> fds(d_readCallbacks.size() + d_writeCallbacks.size());
   struct dvpoll dvp;
   dvp.dp_nfds = d_readCallbacks.size() + d_writeCallbacks.size();
@@ -160,7 +159,6 @@ int DevPollFDMultiplexer::run(struct timeval* now, int timeout)
     return 0;
   }
 
-  d_inrun = true;
   int count = 0;
   for (int n = 0; n < ret; ++n) {
     if ((fds.at(n).revents & POLLIN) || (fds.at(n).revents & POLLERR) || (fds.at(n).revents & POLLHUP)) {
@@ -180,7 +178,6 @@ int DevPollFDMultiplexer::run(struct timeval* now, int timeout)
     }
   }
 
-  d_inrun = false;
   return count;
 }
 

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -166,9 +166,7 @@ void KqueueFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
 
 int KqueueFDMultiplexer::run(struct timeval* now, int timeout)
 {
-  if (d_inrun) {
-    throw FDMultiplexerException("FDMultiplexer::run() is not reentrant!\n");
-  }
+  InRun guard(d_inrun);
 
   struct timespec ts;
   ts.tv_sec = timeout / 1000;
@@ -186,8 +184,6 @@ int KqueueFDMultiplexer::run(struct timeval* now, int timeout)
     return 0;
   }
 
-  d_inrun = true;
-
   for (int n = 0; n < ret; ++n) {
     if (d_kevents[n].filter == EVFILT_READ) {
       const auto& iter = d_readCallbacks.find(d_kevents[n].ident);
@@ -204,7 +200,6 @@ int KqueueFDMultiplexer::run(struct timeval* now, int timeout)
     }
   }
 
-  d_inrun = false;
   return ret;
 }
 

--- a/pdns/mplexer.hh
+++ b/pdns/mplexer.hh
@@ -81,6 +81,25 @@ public:
      minimum value of maxEventsHint and s_maxevents, to reduce memory usage. */
   static FDMultiplexer* getMultiplexerSilent(unsigned int maxEventsHint = s_maxevents);
 
+  struct InRun {
+    InRun(const InRun&) = delete;
+    InRun(InRun&&) = delete;
+    InRun& operator=(const InRun&) = delete;
+    InRun& operator=(InRun&&) = delete;
+    InRun(bool& ref) :
+      d_inrun(ref)
+    {
+      if (d_inrun) {
+        throw FDMultiplexerException("FDMultiplexer::run() is not reentrant!");
+      }
+      d_inrun = true;
+    }
+    ~InRun() {
+      d_inrun = false;
+    }
+    bool& d_inrun;
+  };
+
   /* tv will be updated to 'now' before run returns */
   /* timeout is in ms, 0 will return immediately, -1 will block until at
      least one descriptor is ready */

--- a/pdns/mplexer.hh
+++ b/pdns/mplexer.hh
@@ -81,7 +81,8 @@ public:
      minimum value of maxEventsHint and s_maxevents, to reduce memory usage. */
   static FDMultiplexer* getMultiplexerSilent(unsigned int maxEventsHint = s_maxevents);
 
-  struct InRun {
+  struct InRun
+  {
     InRun(const InRun&) = delete;
     InRun(InRun&&) = delete;
     InRun& operator=(const InRun&) = delete;
@@ -94,7 +95,8 @@ public:
       }
       d_inrun = true;
     }
-    ~InRun() {
+    ~InRun()
+    {
       d_inrun = false;
     }
     bool& d_inrun;

--- a/pdns/pollmplexer.cc
+++ b/pdns/pollmplexer.cc
@@ -122,9 +122,7 @@ void PollFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
 
 int PollFDMultiplexer::run(struct timeval* now, int timeout)
 {
-  if (d_inrun) {
-    throw FDMultiplexerException("FDMultiplexer::run() is not reentrant!\n");
-  }
+  InRun guard(d_inrun);
 
   auto pollfds = preparePollFD();
   if (pollfds.empty()) {
@@ -139,7 +137,6 @@ int PollFDMultiplexer::run(struct timeval* now, int timeout)
     throw FDMultiplexerException("poll returned error: " + stringerror());
   }
 
-  d_inrun = true;
   int count = 0;
   for (const auto& pollfd : pollfds) {
     if (pollfd.revents & POLLIN || pollfd.revents & POLLERR || pollfd.revents & POLLHUP) {
@@ -159,7 +156,6 @@ int PollFDMultiplexer::run(struct timeval* now, int timeout)
     }
   }
 
-  d_inrun = false;
   return count;
 }
 

--- a/pdns/portsmplexer.cc
+++ b/pdns/portsmplexer.cc
@@ -147,9 +147,7 @@ void PortsFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
 
 int PortsFDMultiplexer::run(struct timeval* now, int timeout)
 {
-  if (d_inrun) {
-    throw FDMultiplexerException("FDMultiplexer::run() is not reentrant!\n");
-  }
+  InRun guard(d_inrun);
 
   struct timespec timeoutspec;
   timeoutspec.tv_sec = timeout / 1000;
@@ -177,7 +175,6 @@ int PortsFDMultiplexer::run(struct timeval* now, int timeout)
     return 0;
   }
 
-  d_inrun = true;
   int count = 0;
   for (unsigned int n = 0; n < numevents; ++n) {
     if (d_pevents[n].portev_events & POLLIN || d_pevents[n].portev_events & POLLERR || d_pevents[n].portev_events & POLLHUP) {
@@ -202,7 +199,6 @@ int PortsFDMultiplexer::run(struct timeval* now, int timeout)
     }
   }
 
-  d_inrun = false;
   return count;
 }
 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -169,6 +169,7 @@ pdns_recursor_SOURCES = \
 	pubsuffixloader.cc \
 	qtype.hh qtype.cc \
 	query-local-address.hh query-local-address.cc \
+	ratelimitedlog.hh \
 	rcpgenerator.cc rcpgenerator.hh \
 	rec-carbon.cc \
 	rec-eventtrace.cc rec-eventtrace.hh \
@@ -307,6 +308,7 @@ testrunner_SOURCES = \
 	pollmplexer.cc \
 	qtype.cc qtype.hh \
 	query-local-address.hh query-local-address.cc \
+	ratelimitedlog.hh \
 	rcpgenerator.cc \
 	rec-eventtrace.cc rec-eventtrace.hh \
 	rec-responsestats.hh rec-responsestats.cc \

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -23,6 +23,7 @@ Changed settings
 - The :ref:`setting-max-qperq` default value has been lowered to 50, and the qname-minimization special case has been removed.
 - Disabling :ref:`setting-structured-logging` is no longer supported.
 - The :ref:`setting-structured-logging-backend` setting has gained the possibility to request JSON formatted output of structured logging information.
+- The :ref:`setting-max-mthreads` setting will be adjusted to a lower value if the value of ``sysctl vm.max_map_count`` is too low to support the maximum number of mthread stacks. In this case :program:`Recursor` logs an error message including the suggested value of ``vm.max_map_count`` to not cause lowering of :ref:`setting-max-mthreads`.
 
 5.0.4 to 5.0.5
 --------------

--- a/pdns/recursordist/ratelimitedlog.hh
+++ b/pdns/recursordist/ratelimitedlog.hh
@@ -1,0 +1,95 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "logger.hh"
+#include "logging.hh"
+
+namespace pdns
+{
+class RateLimitedLog
+{
+public:
+  RateLimitedLog(time_t arg = 60) :
+    d_period(arg) {}
+
+  [[nodiscard]] uint32_t getCount() const
+  {
+    return d_count;
+  }
+
+  template <typename... Args>
+  void log(Logr::log_t slog, const string& msg, const Args&... args)
+  {
+    uint32_t count{};
+    if (doLog(count)) {
+      SLOG(g_log << Logger::Error << msg << " created an exception" << endl,
+           slog->info(Logr::Error, msg + " created an exception",
+                      "ratelimitingSkipped", Logging::Loggable(count),
+                      "exception", Logging::Loggable("other"), args...));
+    };
+  }
+  template <typename... Args>
+  void log(Logr::log_t slog, const string& msg, const std::exception& stdException, const Args&... args)
+  {
+    uint32_t count{};
+    if (doLog(count)) {
+      SLOG(g_log << Logger::Error << msg << " created an exception: " << except.what() << endl,
+           slog->error(Logr::Error, stdException.what(), msg + " created an exception",
+                       "ratelimitingSkipped", Logging::Loggable(count),
+                       "exception", Logging::Loggable("std::exception"), args...));
+    }
+  }
+
+  template <typename... Args>
+  void log(Logr::log_t slog, const string& msg, const PDNSException& pdnsException, const Args&... args)
+  {
+    uint32_t count{};
+    if (doLog(count)) {
+      SLOG(g_log << Logger::Error << msg << " created an PDNSException: " << except.reason << endl,
+           slog->error(Logr::Error, pdnsException.reason, msg + " created an exception",
+                       "ratelimitingSkipped", Logging::Loggable(count),
+                       "exception", Logging::Loggable("PDNSException"), args...));
+    }
+  }
+
+private:
+  [[nodiscard]] bool doLog(uint32_t& count)
+  {
+    std::lock_guard lock(d_mutex);
+    time_t now = time(nullptr);
+    if (d_last + d_period < now) {
+      d_last = now;
+      count = d_count;
+      d_count = 0;
+      return true;
+    }
+    count = d_count;
+    d_count++;
+    return false;
+  }
+  std::mutex d_mutex;
+  time_t d_last{0};
+  const time_t d_period;
+  uint32_t d_count{0};
+};
+}

--- a/pdns/recursordist/ratelimitedlog.hh
+++ b/pdns/recursordist/ratelimitedlog.hh
@@ -50,7 +50,7 @@ public:
   {
     uint32_t count{};
     if (doLog(count)) {
-      SLOG(g_log << Logger::Error << msg << " created an exception: " << except.what() << endl,
+      SLOG(g_log << Logger::Error << msg << " created an exception: " << stdException.what() << endl,
            slog->error(Logr::Error, stdException.what(), msg + " created an exception",
                        "ratelimitingSkipped", Logging::Loggable(count),
                        "exception", Logging::Loggable("std::exception"), args...));
@@ -62,7 +62,7 @@ public:
   {
     uint32_t count{};
     if (doLog(count)) {
-      SLOG(g_log << Logger::Error << msg << " created an PDNSException: " << except.reason << endl,
+      SLOG(g_log << Logger::Error << msg << " created an PDNSException: " << pdnsException.reason << endl,
            slog->error(Logr::Error, pdnsException.reason, msg + " created an exception",
                        "ratelimitingSkipped", Logging::Loggable(count),
                        "exception", Logging::Loggable("PDNSException"), args...));

--- a/pdns/recursordist/ratelimitedlog.hh
+++ b/pdns/recursordist/ratelimitedlog.hh
@@ -86,7 +86,8 @@ private:
   }
   const time_t d_period;
 
-  struct LockedObject {
+  struct LockedObject
+  {
     time_t d_last{0};
     uint32_t d_count{0};
   };

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -932,6 +932,24 @@ static void checkLinuxIPv6Limits([[maybe_unused]] Logr::log_t log)
 #endif
 }
 
+static void checkLinuxMapCountLimits([[maybe_unused]] Logr::log_t log)
+{
+#ifdef __linux__
+  string line;
+  if (readFileIfThere("/proc/sys/vm/max_map_count", &line)) {
+    auto lim = std::stoull(line);
+    // mthread stack use 3 maps per stack (2 guard pages + stack itself). Multiple by 4 for extra allowance.
+    // Also add 2 for handler and task threads.
+    auto mapsNeeded = 4ULL * g_maxMThreads * (RecThreadInfo::numTCPWorkers() + RecThreadInfo::numUDPWorkers() + 2);
+    if (lim < mapsNeeded) {
+      SLOG(g_log << Logger::Error << "sysctl kern.max_map_count= <" << mapsNeeded << ", this may cause 'bad_alloc' exceptions" << endl,
+           log->info(Logr::Error, "sysctl kern.max_map_count < mapsNeeded, this may cause 'bad_alloc' exceptions",
+                     "kern.max_map_count", Logging::Loggable(lim), "mapsNeeded", Logging::Loggable(mapsNeeded)));
+    }
+  }
+#endif
+}
+
 static void checkOrFixFDS(Logr::log_t log)
 {
   unsigned int availFDs = getFilenumLimit();
@@ -2192,6 +2210,8 @@ static int serviceMain(Logr::log_t log)
   }
 
   g_maxMThreads = ::arg().asNum("max-mthreads");
+
+  checkLinuxMapCountLimits(log);
 
   int64_t maxInFlight = ::arg().asNum("max-concurrent-requests-per-tcp-connection");
   if (maxInFlight < 1 || maxInFlight > USHRT_MAX || maxInFlight >= g_maxMThreads) {

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -946,7 +946,7 @@ static void checkOrFixLinuxMapCountLimits([[maybe_unused]] Logr::log_t log)
     auto workers = RecThreadInfo::numTCPWorkers() + RecThreadInfo::numUDPWorkers() + 2;
     auto mapsNeeded = 4ULL * g_maxMThreads * workers;
     if (lim < mapsNeeded) {
-      g_maxMThreads = lim / (4 * workers);
+      g_maxMThreads = static_cast<unsigned int>(lim / (4ULL * workers));
       SLOG(g_log << Logger::Error << "sysctl vm.max_map_count= <" << mapsNeeded << ", this may cause 'bad_alloc' exceptions; adjusting max-mthreads to " << g_maxMThreads << endl,
            log->info(Logr::Error, "sysctl vm.max_map_count < mapsNeeded, this may cause 'bad_alloc' exceptions, adjusting max-mthreads",
                      "kern.max_map_count", Logging::Loggable(lim), "mapsNeeded", Logging::Loggable(mapsNeeded),

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -949,7 +949,7 @@ static void checkOrFixLinuxMapCountLimits([[maybe_unused]] Logr::log_t log)
       g_maxMThreads = static_cast<unsigned int>(lim / (4ULL * workers));
       SLOG(g_log << Logger::Error << "sysctl vm.max_map_count= <" << mapsNeeded << ", this may cause 'bad_alloc' exceptions; adjusting max-mthreads to " << g_maxMThreads << endl,
            log->info(Logr::Error, "sysctl vm.max_map_count < mapsNeeded, this may cause 'bad_alloc' exceptions, adjusting max-mthreads",
-                     "kern.max_map_count", Logging::Loggable(lim), "mapsNeeded", Logging::Loggable(mapsNeeded),
+                     "vm.max_map_count", Logging::Loggable(lim), "mapsNeeded", Logging::Loggable(mapsNeeded),
                      "max-mthreads", Logging::Loggable(g_maxMThreads)));
     }
   }

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2343,17 +2343,17 @@ static void handlePipeRequest(int fileDesc, FDMultiplexer::funcparam_t& /* var *
   try {
     resp = tmsg->func();
   }
-  catch (std::exception& e) {
-    if (g_logCommonErrors) {
-      SLOG(g_log << Logger::Error << "PIPE function we executed created exception: " << e.what() << endl, // but what if they wanted an answer.. we send 0
-           g_slog->withName("runtime")->error(Logr::Error, e.what(), "PIPE function we executed created exception", "exception", Logging::Loggable("std::exception")));
-    }
+  catch (const PDNSException& e) {
+    SLOG(g_log << Logger::Error << "PIPE function we executed created PDNS exception: " << e.reason << endl, // but what if they wanted an answer.. we send 0
+         g_slog->withName("runtime")->error(Logr::Error, e.reason, "PIPE function we executed created exception", "exception", Logging::Loggable("PDNSException")));
   }
-  catch (PDNSException& e) {
-    if (g_logCommonErrors) {
-      SLOG(g_log << Logger::Error << "PIPE function we executed created PDNS exception: " << e.reason << endl, // but what if they wanted an answer.. we send 0
-           g_slog->withName("runtime")->error(Logr::Error, e.reason, "PIPE function we executed created exception", "exception", Logging::Loggable("PDNSException")));
-    }
+  catch (const std::exception& e) {
+    SLOG(g_log << Logger::Error << "PIPE function we executed created exception: " << e.what() << endl, // but what if they wanted an answer.. we send 0
+         g_slog->withName("runtime")->error(Logr::Error, e.what(), "PIPE function we executed created exception", "exception", Logging::Loggable("std::exception")));
+  }
+  catch (...) {
+    SLOG(g_log << Logger::Error << "PIPE function we executed created another exception" << endl, // but what if they wanted an answer.. we send 0
+         g_slog->withName("runtime")->info(Logr::Error, "PIPE function we executed created another exception"));
   }
   if (tmsg->wantAnswer) {
     if (write(RecThreadInfo::self().getPipes().writeFromThread, &resp, sizeof(resp)) != sizeof(resp)) {
@@ -2712,62 +2712,72 @@ static void recLoop()
   auto& threadInfo = RecThreadInfo::self();
 
   while (!RecursorControlChannel::stop) {
-    while (g_multiTasker->schedule(g_now)) {
-      ; // MTasker letting the mthreads do their thing
-    }
-
-    // Use primes, it avoid not being scheduled in cases where the counter has a regular pattern.
-    // We want to call handler thread often, it gets scheduled about 2 times per second
-    if (((threadInfo.isHandler() || threadInfo.isTaskThread()) && s_counter % 11 == 0) || s_counter % 499 == 0) {
-      struct timeval start
-      {
-      };
-      Utility::gettimeofday(&start);
-      g_multiTasker->makeThread(houseKeeping, nullptr);
-      if (!threadInfo.isTaskThread()) {
-        struct timeval stop
-        {
-        };
-        Utility::gettimeofday(&stop);
-        t_Counters.at(rec::Counter::maintenanceUsec) += uSec(stop - start);
-        ++t_Counters.at(rec::Counter::maintenanceCalls);
+    try {
+      while (g_multiTasker->schedule(g_now)) {
+        ; // MTasker letting the mthreads do their thing
       }
-    }
 
-    if (s_counter % 55 == 0) {
-      auto expired = t_fdm->getTimeouts(g_now);
-
-      for (const auto& exp : expired) {
-        auto conn = boost::any_cast<shared_ptr<TCPConnection>>(exp.second);
-        if (g_logCommonErrors) {
-          SLOG(g_log << Logger::Warning << "Timeout from remote TCP client " << conn->d_remote.toStringWithPort() << endl,
-               g_slogtcpin->info(Logr::Warning, "Timeout from remote TCP client", "remote", Logging::Loggable(conn->d_remote)));
+      // Use primes, it avoid not being scheduled in cases where the counter has a regular pattern.
+      // We want to call handler thread often, it gets scheduled about 2 times per second
+      if (((threadInfo.isHandler() || threadInfo.isTaskThread()) && s_counter % 11 == 0) || s_counter % 499 == 0) {
+        timeval start{};
+        Utility::gettimeofday(&start);
+        g_multiTasker->makeThread(houseKeeping, nullptr);
+        if (!threadInfo.isTaskThread()) {
+          timeval stop{};
+          Utility::gettimeofday(&stop);
+          t_Counters.at(rec::Counter::maintenanceUsec) += uSec(stop - start);
+          ++t_Counters.at(rec::Counter::maintenanceCalls);
         }
-        t_fdm->removeReadFD(exp.first);
       }
+
+      if (s_counter % 55 == 0) {
+        auto expired = t_fdm->getTimeouts(g_now);
+
+        for (const auto& exp : expired) {
+          auto conn = boost::any_cast<shared_ptr<TCPConnection>>(exp.second);
+          if (g_logCommonErrors) {
+            SLOG(g_log << Logger::Warning << "Timeout from remote TCP client " << conn->d_remote.toStringWithPort() << endl,
+                 g_slogtcpin->info(Logr::Warning, "Timeout from remote TCP client", "remote", Logging::Loggable(conn->d_remote)));
+          }
+          t_fdm->removeReadFD(exp.first);
+        }
+      }
+
+      s_counter++;
+
+      if (threadInfo.isHandler()) {
+        if (statsWanted || (s_statisticsInterval > 0 && (g_now.tv_sec - last_stat) >= s_statisticsInterval)) {
+          doStats();
+          last_stat = g_now.tv_sec;
+        }
+
+        Utility::gettimeofday(&g_now, nullptr);
+
+        if ((g_now.tv_sec - last_carbon) >= carbonInterval) {
+          g_multiTasker->makeThread(doCarbonDump, nullptr);
+          last_carbon = g_now.tv_sec;
+        }
+      }
+      runLuaMaintenance(threadInfo, last_lua_maintenance, luaMaintenanceInterval);
+
+      t_fdm->run(&g_now);
+      // 'run' updates g_now for us
+
+      runTCPMaintenance(threadInfo, listenOnTCP, maxTcpClients);
     }
-
-    s_counter++;
-
-    if (threadInfo.isHandler()) {
-      if (statsWanted || (s_statisticsInterval > 0 && (g_now.tv_sec - last_stat) >= s_statisticsInterval)) {
-        doStats();
-        last_stat = g_now.tv_sec;
-      }
-
-      Utility::gettimeofday(&g_now, nullptr);
-
-      if ((g_now.tv_sec - last_carbon) >= carbonInterval) {
-        g_multiTasker->makeThread(doCarbonDump, nullptr);
-        last_carbon = g_now.tv_sec;
-      }
+    catch (const PDNSException& ae) {
+      SLOG(g_log << Logger::Error << "PDNSException in recLoop: " << ae.reason << endl,
+           g_slog->withName("runtime")->error(Logr::Error, ae.reason, "Exception in recLoop", "exception", Logging::Loggable("PDNSException")));
     }
-    runLuaMaintenance(threadInfo, last_lua_maintenance, luaMaintenanceInterval);
-
-    t_fdm->run(&g_now);
-    // 'run' updates g_now for us
-
-    runTCPMaintenance(threadInfo, listenOnTCP, maxTcpClients);
+    catch (const std::exception& e) {
+      SLOG(g_log << Logger::Error << "Exception in recLoop: " << e.what() << endl,
+           g_slog->withName("runtime")->error(Logr::Error, e.what(), "Exception in recLoop", "exception", Logging::Loggable("std::exception")));
+    }
+    catch (...) {
+      SLOG(g_log << Logger::Error << "Any other exception in recLoop: " << endl,
+           g_slog->withName("runtime")->info(Logr::Error, "Exception in recLoop"));
+    }
   }
 }
 
@@ -2915,11 +2925,11 @@ static void recursorThread()
 
     recLoop();
   }
-  catch (PDNSException& ae) {
+  catch (const PDNSException& ae) {
     SLOG(g_log << Logger::Error << "Exception: " << ae.reason << endl,
          log->error(Logr::Error, ae.reason, "Exception in RecursorThread", "exception", Logging::Loggable("PDNSException")));
   }
-  catch (std::exception& e) {
+  catch (const std::exception& e) {
     SLOG(g_log << Logger::Error << "STL Exception: " << e.what() << endl,
          log->error(Logr::Error, e.what(), "Exception in RecursorThread", "exception", Logging::Loggable("std::exception")));
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

- Warn when `vm.max_map_count` is dangerously low and adjust `max-mthreads` accordingly
- Fix a few cases where lack of logging could hide bad errors.
- Don't let recursorthead die on exceptions for the pdns-distributes-queries=no case
- Use rate limited logging for the logging in these cases

Not that the rate limited logging is not very smart, it throws all logging calls in one basket.

You might want to see part of the diff with whitespace ignored, it boils down to indenting changes due to an introduce try/catch block.

Fixes the logging part of #14180 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
