### PR TITLE
dnsdist: Get rid of `assert()`

### DIFF
--- a/pdns/ednsoptions.cc
+++ b/pdns/ednsoptions.cc
@@ -45,12 +45,14 @@ bool getNextEDNSOption(const char* data, size_t dataLen, uint16_t& optionCode, u
 /* extract the position (relative to the optRR pointer!) and size of a specific EDNS0 option from a pointer on the beginning rdLen of the OPT RR */
 int getEDNSOption(const char* optRR, const size_t len, uint16_t wantedOption, size_t* optionValuePosition, size_t * optionValueSize)
 {
-  assert(optRR != nullptr);
-  assert(optionValuePosition != nullptr);
-  assert(optionValueSize != nullptr);
-  size_t pos = 0;
-  if (len < DNS_RDLENGTH_SIZE)
+  if (optRR == nullptr || optionValuePosition == nullptr || optionValueSize == nullptr) {
     return EINVAL;
+  }
+
+  size_t pos = 0;
+  if (len < DNS_RDLENGTH_SIZE) {
+    return EINVAL;
+  }
 
   const uint16_t rdLen = (((unsigned char) optRR[pos]) * 256) + ((unsigned char) optRR[pos+1]);
   size_t rdPos = 0;
@@ -94,10 +96,10 @@ int getEDNSOption(const char* optRR, const size_t len, uint16_t wantedOption, si
 /* extract all EDNS0 options from a pointer on the beginning rdLen of the OPT RR */
 int getEDNSOptions(const char* optRR, const size_t len, EDNSOptionViewMap& options)
 {
-  assert(optRR != nullptr);
   size_t pos = 0;
-  if (len < DNS_RDLENGTH_SIZE)
+  if (optRR == nullptr || len < DNS_RDLENGTH_SIZE) {
     return EINVAL;
+  }
 
   const uint16_t rdLen = (((unsigned char) optRR[pos]) * 256) + ((unsigned char) optRR[pos+1]);
   size_t rdPos = 0;

--- a/pdns/ipcipher.cc
+++ b/pdns/ipcipher.cc
@@ -77,7 +77,9 @@ static ComboAddress encryptCA6(const ComboAddress& address, const std::string& k
   const auto inSize = sizeof(address.sin6.sin6_addr.s6_addr);
   static_assert(inSize == 16, "We disable padding and so we must assume a data size of 16 bytes");
   const auto blockSize = EVP_CIPHER_get_block_size(aes128cbc.get());
-  assert(blockSize == 16);
+  if (blockSize != 16) {
+    throw pdns::OpenSSL::error("encryptCA6: unexpected block size");
+  }
   EVP_CIPHER_CTX_set_padding(ctx.get(), 0);
 
   int updateLen = 0;
@@ -94,7 +96,9 @@ static ComboAddress encryptCA6(const ComboAddress& address, const std::string& k
     throw pdns::OpenSSL::error("encryptCA6: Could not finalize address encryption");
   }
 
-  assert(updateLen + finalLen == inSize);
+  if ((updateLen + finalLen) != inSize) {
+    throw pdns::OpenSSL::error("encryptCA6: unexpected final size");
+  }
 #else
   AES_KEY wctx;
   AES_set_encrypt_key((const unsigned char*)key.c_str(), 128, &wctx);
@@ -130,7 +134,9 @@ static ComboAddress decryptCA6(const ComboAddress& address, const std::string& k
   const auto inSize = sizeof(address.sin6.sin6_addr.s6_addr);
   static_assert(inSize == 16, "We disable padding and so we must assume a data size of 16 bytes");
   const auto blockSize = EVP_CIPHER_get_block_size(aes128cbc.get());
-  assert(blockSize == 16);
+  if (blockSize != 16) {
+    throw pdns::OpenSSL::error("decryptCA6: unexpected block size");
+  }
   EVP_CIPHER_CTX_set_padding(ctx.get(), 0);
 
   int updateLen = 0;
@@ -147,7 +153,9 @@ static ComboAddress decryptCA6(const ComboAddress& address, const std::string& k
     throw pdns::OpenSSL::error("decryptCA6: Could not finalize address decryption");
   }
 
-  assert(updateLen + finalLen == inSize);
+  if ((updateLen + finalLen) != inSize) {
+    throw pdns::OpenSSL::error("decryptCA6: unexpected final size");
+  }
 #else
   AES_KEY wctx;
   AES_set_decrypt_key((const unsigned char*)key.c_str(), 128, &wctx);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
PowerDNS Security Advisory 2024-03 has made it clear that some of them that have been designed to break during testing might break in production, as we compile with `NDEBUG` unset.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
