### PR TITLE
YaHTTP: Enforce max # of request fields and max request line size

### DIFF
--- a/ext/yahttp/yahttp/utility.hpp
+++ b/ext/yahttp/yahttp/utility.hpp
@@ -1,4 +1,13 @@
 #pragma once
+
+#ifndef YAHTTP_MAX_REQUEST_LINE_SIZE
+#define YAHTTP_MAX_REQUEST_LINE_SIZE 8192
+#endif
+
+#ifndef YAHTTP_MAX_REQUEST_FIELDS
+#define YAHTTP_MAX_REQUEST_FIELDS 100
+#endif
+
 namespace YaHTTP {
   static const char *MONTHS[] = {0,"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec",0}; //<! List of months 
   static const char *DAYS[] = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat",0}; //<! List of days
@@ -364,7 +373,10 @@ namespace YaHTTP {
        }
     }; //<! static HTTP codes to text mappings
 
-    static strstr_map_t parseUrlParameters(std::string parameters) {
+    static strstr_map_t parseUrlParameters(const std::string& parameters) {
+      if (parameters.size() > YAHTTP_MAX_REQUEST_LINE_SIZE) {
+        return {};
+      }
       std::string::size_type pos = 0;
       strstr_map_t parameter_map;
       while (pos != std::string::npos) {
@@ -390,11 +402,12 @@ namespace YaHTTP {
           // no parameters at all
           break;
         }
-        key = decodeURL(key);
-        value = decodeURL(value);
-        parameter_map[key] = std::move(value);
+        parameter_map[decodeURL(key)] = decodeURL(value);
         if (nextpos == std::string::npos) {
           // no more parameters left
+          break;
+        }
+        if (parameter_map.size() >= YAHTTP_MAX_REQUEST_FIELDS) {
           break;
         }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The default values, 8192 bytes for the maximum request line size and 100 fields, are taken from the default settings of Apache HTTPd:
- https://httpd.apache.org/docs/2.2/mod/core.html#limitrequestline
- https://httpd.apache.org/docs/2.2/mod/core.html#limitrequestfields

Reported by OSS-Fuzz as a timeout in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67993

Since our web endpoint is behind an ACL and/or authentication this should not have any security impact.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
