### PR TITLE
auth web: make request/response timeout configurable

### DIFF
--- a/docs/http-api/index.rst
+++ b/docs/http-api/index.rst
@@ -20,6 +20,7 @@ The following webserver related configuration items are available:
 * :ref:`setting-webserver-port`: Port to bind the webserver to.
 * :ref:`setting-webserver-allow-from`: Netmasks that are allowed to connect to the webserver
 * :ref:`setting-webserver-max-bodysize`: Maximum request/response body size in megabytes
+* :ref:`setting-webserver-connection-timeout`: Request/response timeout in seconds
 
 
 Metrics Endpoint

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -2038,6 +2038,17 @@ The value between the hooks is a UUID that is generated for each request. This c
 
 Maximum request/response body size in megabytes.
 
+.. _setting-webserver-connection-timeout:
+
+``webserver-connection-timeout``
+--------------------------------
+.. versionadded:: 4.8.5
+
+-  Integer
+-  Default: 5
+
+Request/response timeout in seconds.
+
 .. _setting-webserver-password:
 
 ``webserver-password``

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -244,6 +244,7 @@ static void declareArguments()
   ::arg().set("webserver-allow-from", "Webserver/API access is only allowed from these subnets") = "127.0.0.1,::1";
   ::arg().set("webserver-loglevel", "Amount of logging in the webserver (none, normal, detailed)") = "normal";
   ::arg().set("webserver-max-bodysize", "Webserver/API maximum request/response body size in megabytes") = "2";
+  ::arg().set("webserver-connection-timeout", "Webserver/API request/response timeout in seconds") = "5";
   ::arg().setSwitch("webserver-hash-plaintext-credentials", "Whether to hash passwords and api keys supplied in plaintext, to prevent keeping the plaintext version in memory at runtime") = "no";
 
   ::arg().setSwitch("query-logging", "Hint backends that queries should be logged") = "no";

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -520,7 +520,7 @@ void WebServer::serveConnection(const std::shared_ptr<Socket>& client) const {
     YaHTTP::AsyncRequestLoader yarl;
     yarl.initialize(&req);
     req.max_request_size=d_maxbodysize;
-    int timeout = 5;
+    int timeout = d_connectiontimeout;
     client->setNonBlocking();
 
     try {
@@ -588,7 +588,8 @@ WebServer::WebServer(string listenaddress, int port) :
   d_listenaddress(std::move(listenaddress)),
   d_port(port),
   d_server(nullptr),
-  d_maxbodysize(2*1024*1024)
+  d_maxbodysize(2*1024*1024),
+  d_connectiontimeout(5)
 {
     YaHTTP::Router::Map("OPTIONS", "/<*url>", [](YaHTTP::Request *req, YaHTTP::Response *resp) {
       // look for url in routes

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -212,6 +212,10 @@ public:
     d_maxbodysize = s * 1024 * 1024;
   }
 
+  void setConnectionTimeout(int t) { // in seconds
+    d_connectiontimeout = t;
+  }
+
   void setACL(const NetmaskGroup &nmg) {
     d_acl = nmg;
   }
@@ -285,6 +289,7 @@ protected:
   std::unique_ptr<CredentialsHolder> d_webserverPassword{nullptr};
 
   ssize_t d_maxbodysize; // in bytes
+  int d_connectiontimeout; // in seconds
 
   NetmaskGroup d_acl;
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -117,6 +117,7 @@ AuthWebServer::AuthWebServer() :
     d_ws->setACL(acl);
 
     d_ws->setMaxBodySize(::arg().asNum("webserver-max-bodysize"));
+    d_ws->setConnectionTimeout(::arg().asNum("webserver-connection-timeout"));
 
     d_ws->bind();
   }


### PR DESCRIPTION
### Short description
In the REST API, make the timeout for reading requests and writing responses configurable.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
