### PR TITLE
dnsdist: Clarify server status documentation

### DIFF
--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -808,7 +808,7 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
     Returns the up status of the server.
     Result is based on the administrative status of the server (as set by either :meth:`Server:setDown` or :meth:`Server:setUp`).
-    If no administrative status is set (see :meth:`Server.setAuto`), result is based on :attr:`Server.upStatus`
+    If no administrative status is set (see :meth:`Server:setAuto`), result is based on :attr:`Server.upStatus`
 
     :returns: true when the server is up, false otherwise
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -806,7 +806,9 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
   .. method:: Server:isUp() -> bool
 
-    Returns the up status of the server
+    Returns the up status of the server.
+    Result is based on the administrative status of the server (as set by either :meth:`Server:setDown` or :meth:`Server:setUp`).
+    If no administrative status is set, result is based on :attr:`Server.upStatus`
 
     :returns: true when the server is up, false otherwise
 
@@ -825,7 +827,7 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
   .. method:: Server:setDown()
 
-    Set the server in a ``DOWN`` state.
+    Administratively set the server in a ``DOWN`` state.
     The server will not receive queries and the health checks are disabled.
 
   .. method:: Server:setLazyAuto([status])
@@ -846,7 +848,7 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
   .. method:: Server:setUp()
 
-    Set the server in an ``UP`` state.
+    Administratively set the server in an ``UP`` state.
     This server will still receive queries and health checks are disabled
 
   Apart from the functions, a :class:`Server` object has these attributes:
@@ -857,7 +859,7 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
   .. attribute:: Server.upStatus
 
-    Whether or not this server is up or down
+    Whether or not this server is ``up`` (true) or ``down`` (false) based on the last known state of heatlh-checks.
 
   .. attribute:: Server.order
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -859,7 +859,7 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
   .. attribute:: Server.upStatus
 
-    Whether or not this server is ``up`` (true) or ``down`` (false) based on the last known state of heatlh-checks.
+    Whether or not this server is ``up`` (true) or ``down`` (false) based on the last known state of health-checks.
 
   .. attribute:: Server.order
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -808,7 +808,7 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
     Returns the up status of the server.
     Result is based on the administrative status of the server (as set by either :meth:`Server:setDown` or :meth:`Server:setUp`).
-    If no administrative status is set, result is based on :attr:`Server.upStatus`
+    If no administrative status is set (see :meth:`Server.setAuto`), result is based on :attr:`Server.upStatus`
 
     :returns: true when the server is up, false otherwise
 


### PR DESCRIPTION
### Short description
Detail return values  for `Server:isUp()` method and `Server.upStatus` attribute to clarify behavior related to the server being administratively set UP or DOWN.

Closes #14217

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
