### PR TITLE
LuaWrapper: Throw instead of asserting for null objects

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1155,7 +1155,6 @@ private:
             std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             throw ExecutionErrorException{"Calling method " + functionName + " on a NULL object of type " + typeid(TObject).name()};
           }
-          std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
           return function(*obj, std::forward<TOtherParams>(rest)...);
         });
 
@@ -1165,7 +1164,6 @@ private:
             std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             throw ExecutionErrorException{"Calling method " + functionName + " on a NULL object of type " + typeid(TObject).name()};
           }
-          std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
           return function(*obj, std::forward<TOtherParams>(rest)...);
         });
     }
@@ -1181,7 +1179,6 @@ private:
             std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             throw ExecutionErrorException{"Calling method " + functionName + " on a NULL object of type " + typeid(TObject).name()};
           }
-          std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
           return function(*obj, std::forward<TOtherParams>(rest)...);
         });
 
@@ -1191,7 +1188,6 @@ private:
             std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             throw ExecutionErrorException{"Calling method " + functionName + " on a NULL object of type " + typeid(TObject).name()};
           }
-          std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
           return function(*obj, std::forward<TOtherParams>(rest)...);
         });
     }
@@ -1237,7 +1233,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             return readFunction(*object);
         });
 
@@ -1247,7 +1242,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             return readFunction(*object);
         });
 
@@ -1257,7 +1251,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             return readFunction(*object);
         });
 
@@ -1267,7 +1260,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             return readFunction(*object);
         });
     }
@@ -1286,7 +1278,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             writeFunction_(*object, value);
         });
 
@@ -1295,7 +1286,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             writeFunction_(*object, value);
         });
     }
@@ -1327,7 +1317,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             return readFunction(*object, name);
         });
 
@@ -1337,7 +1326,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             return readFunction(*object, name);
         });
 
@@ -1347,7 +1335,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             return readFunction(*object, name);
         });
 
@@ -1357,7 +1344,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             return readFunction(*object, name);
         });
     }
@@ -1376,7 +1362,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             writeFunction_(*object, name, value);
         });
 
@@ -1385,7 +1370,6 @@ private:
               std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
               throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
             }
-            std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             writeFunction_(*object, name, value);
         });
     }

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1149,10 +1149,20 @@ private:
         setTable<TRetValue(TObject&, TOtherParams...)>(mState, Registry, &typeid(TObject), 0, functionName, function);
         
         checkTypeRegistration(mState, &typeid(TObject*));
-        setTable<TRetValue(TObject*, TOtherParams...)>(mState, Registry, &typeid(TObject*), 0, functionName, [=](TObject* obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
-        
+        setTable<TRetValue(TObject*, TOtherParams...)>(mState, Registry, &typeid(TObject*), 0, functionName, [=](TObject* obj, TOtherParams... rest) {
+          if (obj == nullptr) {
+            throw ExecutionErrorException{"Calling method " + functionName + " on a NULL object of type " + typeid(TObject).name()};
+          }
+          return function(*obj, std::forward<TOtherParams>(rest)...);
+        });
+
         checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject>));
-        setTable<TRetValue(std::shared_ptr<TObject>, TOtherParams...)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 0, functionName, [=](const std::shared_ptr<TObject>& obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
+        setTable<TRetValue(std::shared_ptr<TObject>, TOtherParams...)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 0, functionName, [=](const std::shared_ptr<TObject>& obj, TOtherParams... rest) {
+          if (obj == nullptr) {
+            throw ExecutionErrorException{"Calling method " + functionName + " on a NULL object of type " + typeid(TObject).name()};
+          }
+          return function(*obj, std::forward<TOtherParams>(rest)...);
+        });
     }
     
     template<typename TFunctionType, typename TRetValue, typename TObject, typename... TOtherParams>
@@ -1161,10 +1171,20 @@ private:
         registerFunctionImpl(functionName, function, tag<TObject>{}, fTypeTag);
 
         checkTypeRegistration(mState, &typeid(TObject const*));
-        setTable<TRetValue(TObject const*, TOtherParams...)>(mState, Registry, &typeid(TObject const*), 0, functionName, [=](TObject const* obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
-        
+        setTable<TRetValue(TObject const*, TOtherParams...)>(mState, Registry, &typeid(TObject const*), 0, functionName, [=](TObject const* obj, TOtherParams... rest) {
+          if (obj == nullptr) {
+            throw ExecutionErrorException{"Calling method " + functionName + " on a NULL object of type " + typeid(TObject).name()};
+          }
+          return function(*obj, std::forward<TOtherParams>(rest)...);
+        });
+
         checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject const>));
-        setTable<TRetValue(std::shared_ptr<TObject const>, TOtherParams...)>(mState, Registry, &typeid(std::shared_ptr<TObject const>), 0, functionName, [=](const std::shared_ptr<TObject const>& obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
+        setTable<TRetValue(std::shared_ptr<TObject const>, TOtherParams...)>(mState, Registry, &typeid(std::shared_ptr<TObject const>), 0, functionName, [=](const std::shared_ptr<TObject const>& obj, TOtherParams... rest) {
+          if (obj == nullptr) {
+            throw ExecutionErrorException{"Calling method " + functionName + " on a NULL object of type " + typeid(TObject).name()};
+          }
+          return function(*obj, std::forward<TOtherParams>(rest)...);
+        });
     }
 
     template<typename TFunctionType, typename TRetValue, typename TObject, typename... TOtherParams>
@@ -1196,33 +1216,41 @@ private:
     void registerMemberImpl(const std::string& name, TReadFunction readFunction)
     {
         static_assert(std::is_class<TObject>::value || std::is_pointer<TObject>::value, "registerMember can only be called on a class or a pointer");
-        
+
         checkTypeRegistration(mState, &typeid(TObject));
         setTable<TVarType (TObject&)>(mState, Registry, &typeid(TObject), 1, name, [readFunction](TObject const& object) {
             return readFunction(object);
         });
-        
+
         checkTypeRegistration(mState, &typeid(TObject*));
-        setTable<TVarType (TObject*)>(mState, Registry, &typeid(TObject*), 1, name, [readFunction](TObject const* object) {
-            assert(object);
+        setTable<TVarType (TObject*)>(mState, Registry, &typeid(TObject*), 1, name, [readFunction,name](TObject const* object) {
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             return readFunction(*object);
         });
-        
+
         checkTypeRegistration(mState, &typeid(TObject const*));
-        setTable<TVarType (TObject const*)>(mState, Registry, &typeid(TObject const*), 1, name, [readFunction](TObject const* object) {
-            assert(object);
+        setTable<TVarType (TObject const*)>(mState, Registry, &typeid(TObject const*), 1, name, [readFunction,name](TObject const* object) {
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             return readFunction(*object);
         });
-        
+
         checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject>));
-        setTable<TVarType (std::shared_ptr<TObject>)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 1, name, [readFunction](const std::shared_ptr<TObject>& object) {
-            assert(object);
+        setTable<TVarType (std::shared_ptr<TObject>)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 1, name, [readFunction,name](const std::shared_ptr<TObject>& object) {
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             return readFunction(*object);
         });
-        
+
         checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject const>));
-        setTable<TVarType (std::shared_ptr<TObject const>)>(mState, Registry, &typeid(std::shared_ptr<TObject const>), 1, name, [readFunction](const std::shared_ptr<TObject const>& object) {
-            assert(object);
+        setTable<TVarType (std::shared_ptr<TObject const>)>(mState, Registry, &typeid(std::shared_ptr<TObject const>), 1, name, [readFunction,name](const std::shared_ptr<TObject const>& object) {
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             return readFunction(*object);
         });
     }
@@ -1235,14 +1263,18 @@ private:
         setTable<void (TObject&, TVarType)>(mState, Registry, &typeid(TObject), 4, name, [writeFunction_](TObject& object, const TVarType& value) {
             writeFunction_(object, value);
         });
-        
-        setTable<void (TObject*, TVarType)>(mState, Registry, &typeid(TObject*), 4, name, [writeFunction_](TObject* object, const TVarType& value) {
-            assert(object);
+
+        setTable<void (TObject*, TVarType)>(mState, Registry, &typeid(TObject*), 4, name, [writeFunction_,name](TObject* object, const TVarType& value) {
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             writeFunction_(*object, value);
         });
-        
-        setTable<void (std::shared_ptr<TObject>, TVarType)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 4, name, [writeFunction_](std::shared_ptr<TObject> object, const TVarType& value) {
-            assert(object);
+
+        setTable<void (std::shared_ptr<TObject>, TVarType)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 4, name, [writeFunction_,name](std::shared_ptr<TObject> object, const TVarType& value) {
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             writeFunction_(*object, value);
         });
     }
@@ -1267,28 +1299,36 @@ private:
         setTable<TVarType (TObject const&, std::string)>(mState, Registry, &typeid(TObject), 2, [readFunction](TObject const& object, const std::string& name) {
             return readFunction(object, name);
         });
-        
+
         checkTypeRegistration(mState, &typeid(TObject*));
         setTable<TVarType (TObject*, std::string)>(mState, Registry, &typeid(TObject*), 2, [readFunction](TObject const* object, const std::string& name) {
-            assert(object);
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             return readFunction(*object, name);
         });
-        
+
         checkTypeRegistration(mState, &typeid(TObject const*));
         setTable<TVarType (TObject const*, std::string)>(mState, Registry, &typeid(TObject const*), 2, [readFunction](TObject const* object, const std::string& name) {
-            assert(object);
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             return readFunction(*object, name);
         });
-        
+
         checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject>));
         setTable<TVarType (std::shared_ptr<TObject>, std::string)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 2, [readFunction](const std::shared_ptr<TObject>& object, const std::string& name) {
-            assert(object);
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             return readFunction(*object, name);
         });
-        
+
         checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject const>));
         setTable<TVarType (std::shared_ptr<TObject const>, std::string)>(mState, Registry, &typeid(std::shared_ptr<TObject const>), 2, [readFunction](const std::shared_ptr<TObject const>& object, const std::string& name) {
-            assert(object);
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             return readFunction(*object, name);
         });
     }
@@ -1301,14 +1341,18 @@ private:
         setTable<void (TObject&, std::string, TVarType)>(mState, Registry, &typeid(TObject), 5, [writeFunction_](TObject& object, const std::string& name, const TVarType& value) {
             writeFunction_(object, name, value);
         });
-        
+
         setTable<void (TObject*, std::string, TVarType)>(mState, Registry, &typeid(TObject*), 2, [writeFunction_](TObject* object, const std::string& name, const TVarType& value) {
-            assert(object);
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             writeFunction_(*object, name, value);
         });
-        
+
         setTable<void (std::shared_ptr<TObject>, std::string, TVarType)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 2, [writeFunction_](const std::shared_ptr<TObject>& object, const std::string& name, const TVarType& value) {
-            assert(object);
+            if (object == nullptr) {
+              throw ExecutionErrorException{"Accessing attribute " + name + " on a NULL object of type " + typeid(TObject).name()};
+            }
             writeFunction_(*object, name, value);
         });
     }

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1589,7 +1589,6 @@ private:
 
         template<typename TType2>
         static PushedObject push(lua_State* state, TType2&& value) noexcept {
-          std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
             // this function is called when lua's garbage collector wants to destroy our object
             // we simply call its destructor
             const auto garbageCallbackFunction = [](lua_State* lua) -> int {
@@ -2340,7 +2339,6 @@ struct LuaContext::Pusher<TReturnType (TParameters...)>
     static auto push(lua_State* state, TFunctionObject fn) noexcept
         -> typename std::enable_if<!boost::has_trivial_destructor<TFunctionObject>::value, PushedObject>::type
     {
-      std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
         // TODO: is_move_constructible not supported by some compilers
         //static_assert(std::is_move_constructible<TFunctionObject>::value, "The function object must be move-constructible");
 
@@ -2429,7 +2427,6 @@ struct LuaContext::Pusher<TReturnType (TParameters...)>
     static auto push(lua_State* state, TReturnType (*fn)(TParameters...)) noexcept
         -> PushedObject
     {
-      std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
         // when the lua script calls the thing we will push on the stack, we want "fn" to be executed
         // since "fn" doesn't need to be destroyed, we simply push it on the stack
 
@@ -2453,7 +2450,6 @@ struct LuaContext::Pusher<TReturnType (TParameters...)>
     static auto push(lua_State* state, TReturnType (&fn)(TParameters...)) noexcept
         -> PushedObject
     {
-      std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
         return push(state, &fn);
     }
 
@@ -2541,7 +2537,6 @@ struct LuaContext::Pusher<TReturnType (*)(TParameters...)>
 
     template<typename TType>
     static PushedObject push(lua_State* state, TType value) noexcept {
-      std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
         return SubPusher::push(state, value);
     }
 };
@@ -2558,7 +2553,6 @@ struct LuaContext::Pusher<TReturnType (&)(TParameters...)>
 
     template<typename TType>
     static PushedObject push(lua_State* state, TType value) noexcept {
-      std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
         return SubPusher::push(state, value);
     }
 };
@@ -2574,7 +2568,6 @@ struct LuaContext::Pusher<std::function<TReturnType (TParameters...)>>
     static const int maxSize = SubPusher::maxSize;
 
     static PushedObject push(lua_State* state, const std::function<TReturnType (TParameters...)>& value) noexcept {
-      std::cerr<<__PRETTY_FUNCTION__<<" "<<__LINE__<<std::endl;
         return SubPusher::push(state, value);
     }
 };

--- a/regression-tests.dnsdist/test_Lua.py
+++ b/regression-tests.dnsdist/test_Lua.py
@@ -93,3 +93,19 @@ class TestLuaDNSHeaderBindings(DNSDistTest):
             receivedQuery.id = query.id
             self.assertEqual(query, receivedQuery)
             self.assertEqual(response, receivedResponse)
+
+class TestLuaCallingMethodOnInvalidObject(DNSDistTest):
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
+
+    _config_params = ['_consoleKeyB64', '_consolePort']
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%s")
+    """
+
+    def testLuaCallingMethodOnInvalidObject(self):
+        # calling setUp() method on an invalid server should not crash
+        wrongID = '0BAD1DEA-0000-0000-0000-123456789ABC'
+        for _ in range(2):
+            self.sendConsoleCommand(f"getServer('{wrongID}'):setUp()")


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
LuaWrapper used to throw when a NULL object was passed to a method
or accessor binding. Unfortunately it is not always possible from
the Lua side to ensure that a userdata object is not a NULL one,
so terminating the process on such an error is not nice.

For example in dnsdist, this turns calling the `setUp` method on
an invalid (NULL) backend `DownstreamState` from:
```
dnsdist: ./ext/luawrapper/include/LuaContext.hpp:1155: auto LuaContext::registerFunctionImpl(const std::string &, std::_Mem_fn<void (DownstreamState::*)()>, tag<DownstreamState>, tag<void ()>)::(anonymous class)::operator()(const std::shared_ptr<TObject> &, TOtherParams...) const: Assertion `obj' failed.
Aborted (core dumped)
```
to:
```
Error: [string "a = getServer("..."]:1: Caught exception: Calling method setUp on a NULL object of type 15DownstreamState
stack traceback:
	[C]: in function 'setUp'
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

