### PR TITLE
dnsdist: Initialize DNSCrypt structures

### DIFF
--- a/pdns/dnsdistdist/dnscrypt.hh
+++ b/pdns/dnsdistdist/dnscrypt.hh
@@ -115,8 +115,8 @@ struct DNSCryptCertSignedData
   using ResolverPublicKeyType = std::array<unsigned char, DNSCRYPT_PROVIDER_PUBLIC_KEY_SIZE>;
   using ResolverPrivateKeyType = std::array<unsigned char, DNSCRYPT_PROVIDER_PRIVATE_KEY_SIZE>;
   using ClientMagicType = std::array<unsigned char, DNSCRYPT_CLIENT_MAGIC_SIZE>;
-  ResolverPublicKeyType resolverPK;
-  ClientMagicType clientMagic;
+  ResolverPublicKeyType resolverPK{};
+  ClientMagicType clientMagic{};
   uint32_t serial{0};
   uint32_t tsStart{0};
   uint32_t tsEnd{0};
@@ -148,10 +148,10 @@ public:
   using ESVersionType = std::array<unsigned char, 2>;
   using ProtocolMinorVersionType = std::array<unsigned char, 2>;
   using CertMagicType = std::array<unsigned char, DNSCRYPT_CERT_MAGIC_SIZE>;
-  CertMagicType magic;
-  ESVersionType esVersion;
-  ProtocolMinorVersionType protocolMinorVersion;
-  std::array<unsigned char, DNSCRYPT_SIGNATURE_SIZE> signature;
+  CertMagicType magic{};
+  ESVersionType esVersion{};
+  ProtocolMinorVersionType protocolMinorVersion{};
+  std::array<unsigned char, DNSCRYPT_SIGNATURE_SIZE> signature{};
   DNSCryptCertSignedData signedData;
 };
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
These are always properly initialized later in the code but Coverity is not convinced, and it's good practice to initialize them anyway.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
