### PR TITLE
dnsdist: Fix a user-after-move in the dynamic rules SMT code

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dynblocks.cc
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.cc
@@ -311,7 +311,8 @@ bool addOrRefreshBlockSMT(SuffixMatchTree<DynBlock>& blocks, const timespec& now
   if (!beQuiet && (got == nullptr || expired)) {
     warnlog("Inserting dynamic block for %s for %d seconds: %s", dblock.domain, dblock.until.tv_sec - now.tv_sec, dblock.reason);
   }
-  blocks.add(dblock.domain, std::move(dblock));
+  auto domain = dblock.domain;
+  blocks.add(domain, std::move(dblock));
   return true;
 }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Introduced in 099e95eee273937d666255dc7ebe510d717b4a07 (#14182), spotted by Coverity. Needs to be backported if we decide to backport #14182.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
