### PR TITLE
pdns/docs: pin version of pip package typing-extensions

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -13,3 +13,4 @@ pyyaml==6.0.1
 packaging==24.0
 setuptools-scm==8.0.3 # setup-requires for sphinxcontrib-openapi
 pbr # setup-requires for sphinxcontrib-fulltoc
+typing-extensions==4.12

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -331,10 +331,12 @@ tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via setuptools-scm
-typing-extensions==4.11.0 \
-    --hash=sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0 \
-    --hash=sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a
-    # via setuptools-scm
+typing-extensions==4.12.0 \
+    --hash=sha256:8cbcdc8606ebcb0d95453ad7dc5065e6237b6aa230a31e81d0f440c30fed5fd8 \
+    --hash=sha256:b349c66bea9016ac22978d800cfff206d5f9816951f12a7d0ec5578b0a819594
+    # via
+    #   -r requirements.in
+    #   setuptools-scm
 urllib3==2.0.7 \
     --hash=sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84 \
     --hash=sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e


### PR DESCRIPTION
### Short description
Our package `sphinxcontrib-openapi` has a `setup_requires` dependency for `setuptools-scm`, which in turn requires a not-fixed version of `typing-extensions`

There is a new version of typing extensions that makes our validation that we are only pulling the hashed pip dependencies: [https://github.com/PowerDNS/pdns/actions/runs/9221618822](https://github.com/PowerDNS/pdns/actions/runs/9221618822)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
