### PR TITLE
remotebackend: Fix http request of replaceRRSet

### DIFF
--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -95,14 +95,12 @@ std::string HTTPConnector::buildMemberListArgs(const std::string& prefix, const 
   std::stringstream stream;
 
   for (const auto& pair : args.object_items()) {
+    stream << prefix << "[" << YaHTTP::Utility::encodeURL(pair.first, false) << "]=";
     if (pair.second.is_bool()) {
       stream << (pair.second.bool_value() ? "1" : "0");
     }
-    else if (pair.second.is_null()) {
-      stream << prefix << "[" << YaHTTP::Utility::encodeURL(pair.first, false) << "]=";
-    }
-    else {
-      stream << prefix << "[" << YaHTTP::Utility::encodeURL(pair.first, false) << "]=" << YaHTTP::Utility::encodeURL(HTTPConnector::asString(pair.second), false);
+    else if (!pair.second.is_null()) {
+      stream << YaHTTP::Utility::encodeURL(HTTPConnector::asString(pair.second), false);
     }
     stream << "&";
   }
@@ -183,9 +181,9 @@ void HTTPConnector::restful_requestbuilder(const std::string& method, const Json
   else if (method == "replaceRRSet") {
     std::stringstream ss2;
     for (size_t index = 0; index < parameters["rrset"].array_items().size(); index++) {
-      ss2 << buildMemberListArgs("rrset[" + std::to_string(index) + "]", parameters["rrset"][index]);
+      ss2 << buildMemberListArgs("rrset[" + std::to_string(index) + "]", parameters["rrset"][index]) << "&";
     }
-    req.body = ss2.str();
+    req.body = ss2.str().substr(0, ss2.str().size() - 1); // remove trailing &
     req.headers["content-type"] = "application/x-www-form-urlencoded; charset=utf-8";
     req.headers["content-length"] = std::to_string(req.body.size());
     verb = "PATCH";


### PR DESCRIPTION
Add missing field name of "auth" and ampersand between records.

### Short description
Use `pdnsutil` to add following RR set to an auth server with remote backend and HTTP connector:
```
foo.example.com. 100 IN TXT "foo"
foo.example.com. 100 IN TXT "bar"
```
The backend HTTP server will receive `replaceRRSet` request body like:
`1&rrset[0][content]=%22foo%22&rrset[0][qclass]=1&rrset[0][qname]=foo%2eexample%2ecom%2e&rrset[0][qtype]=TXT&rrset[0][ttl]=1001&rrset[1][content]=%22bar%22&rrset[1][qclass]=1&rrset[1][qname]=foo%2eexample%2ecom%2e&rrset[1][qtype]=TXT&rrset[1][ttl]=100`.

The field name of "auth" (`rrset[0][auth]`, `rrset[1][auth]`) and the ampersand between the two RRs (`1001`) are missing.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
