### PR TITLE
auth web: Backport 14218 to auth-4.8.x: make request/response timeout configurable

### DIFF
--- a/docs/http-api/index.rst
+++ b/docs/http-api/index.rst
@@ -20,6 +20,7 @@ The following webserver related configuration items are available:
 * :ref:`setting-webserver-port`: Port to bind the webserver to.
 * :ref:`setting-webserver-allow-from`: Netmasks that are allowed to connect to the webserver
 * :ref:`setting-webserver-max-bodysize`: Maximum request/response body size in megabytes
+* :ref:`setting-webserver-connection-timeout`: Request/response timeout in seconds
 
 
 Metrics Endpoint

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1953,6 +1953,17 @@ The value between the hooks is a UUID that is generated for each request. This c
 
 Maximum request/response body size in megabytes.
 
+.. _setting-webserver-connection-timeout:
+
+``webserver-connection-timeout``
+--------------------------------
+.. versionadded:: 4.8.5
+
+-  Integer
+-  Default: 5
+
+Request/response timeout in seconds.
+
 .. _setting-webserver-password:
 
 ``webserver-password``

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -242,6 +242,7 @@ static void declareArguments()
   ::arg().set("webserver-allow-from", "Webserver/API access is only allowed from these subnets") = "127.0.0.1,::1";
   ::arg().set("webserver-loglevel", "Amount of logging in the webserver (none, normal, detailed)") = "normal";
   ::arg().set("webserver-max-bodysize", "Webserver/API maximum request/response body size in megabytes") = "2";
+  ::arg().set("webserver-connection-timeout", "Webserver/API request/response timeout in seconds") = "5";
   ::arg().setSwitch("webserver-hash-plaintext-credentials", "Whether to hash passwords and api keys supplied in plaintext, to prevent keeping the plaintext version in memory at runtime") = "no";
 
   ::arg().setSwitch("query-logging", "Hint backends that queries should be logged") = "no";

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -530,7 +530,7 @@ void WebServer::serveConnection(const std::shared_ptr<Socket>& client) const {
     YaHTTP::AsyncRequestLoader yarl;
     yarl.initialize(&req);
     req.max_request_size=d_maxbodysize;
-    int timeout = 5;
+    int timeout = d_connectiontimeout;
     client->setNonBlocking();
 
     try {
@@ -598,7 +598,8 @@ WebServer::WebServer(string listenaddress, int port) :
   d_listenaddress(std::move(listenaddress)),
   d_port(port),
   d_server(nullptr),
-  d_maxbodysize(2*1024*1024)
+  d_maxbodysize(2*1024*1024),
+  d_connectiontimeout(5)
 {
 }
 

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -209,6 +209,10 @@ public:
     d_maxbodysize = s * 1024 * 1024;
   }
 
+  void setConnectionTimeout(int t) { // in seconds
+    d_connectiontimeout = t;
+  }
+
   void setACL(const NetmaskGroup &nmg) {
     d_acl = nmg;
   }
@@ -282,6 +286,7 @@ protected:
   std::unique_ptr<CredentialsHolder> d_webserverPassword{nullptr};
 
   ssize_t d_maxbodysize; // in bytes
+  int d_connectiontimeout; // in seconds
 
   NetmaskGroup d_acl;
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -80,6 +80,7 @@ AuthWebServer::AuthWebServer() :
     d_ws->setACL(acl);
 
     d_ws->setMaxBodySize(::arg().asNum("webserver-max-bodysize"));
+    d_ws->setConnectionTimeout(::arg().asNum("webserver-connection-timeout"));
 
     d_ws->bind();
   }


### PR DESCRIPTION
### Short description
In the REST API, make the timeout for reading requests and writing responses configurable.

Backport of #14218

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] checked that this code was merged to master
