### PR TITLE
autoconf: allow prerelease systemd versions

### DIFF
--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -134,7 +134,7 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
           AC_PATH_PROG([SYSTEMCTL], [systemctl], [no])
           AS_IF([test "$SYSTEMCTL" = "no"],
             [AC_MSG_ERROR([systemctl not found])], [
-              _systemd_version=`${SYSTEMCTL} --version|head -1 |cut -d" " -f 2`
+              _systemd_version=`${SYSTEMCTL} --version|head -1 | tr ".~" "  " | cut -d" " -f 2`
               if test $_systemd_version -ge 183; then
                  systemd_private_tmp=y
               fi


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Support systemd prerelease versions, like example 256~rc3. Also preemptively support versions like 252.2.

Without this, configure prints:
```
./configure: line 21310: test: 256~rc3: integer expression expected
...
```

And I assume it turns off the newer features.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
