### PR TITLE
pdnsutil check-zone: make LUA records optional

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -378,6 +378,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, con
     if(rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) {
       addresses.insert(rr.qname);
     }
+#ifdef HAVE_LUA_RECORDS
     if(rr.qtype.getCode() == QType::LUA) {
       shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(rr.qtype.getCode(), QClass::IN, rr.content));
       auto luarec = std::dynamic_pointer_cast<LUARecordContent>(drc);
@@ -386,6 +387,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, con
         addresses.insert(rr.qname);
       }
     }
+#endif
     if(rr.qtype.getCode() == QType::A) {
       arecords.insert(rr.qname);
     }


### PR DESCRIPTION
Merge #14011 added checking for LUA records to checkZone(), but LUA records depend on --enable-lua-records and the change causes a build error without.

I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
