### PR TITLE
rec: allow recursor.conf file to contain YAML to ease transition to YAML config

### DIFF
--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -41,14 +41,14 @@ override_dh_auto_install:
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/snmp RECURSOR-MIB.txt
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.yml-dist
-	./pdns_recursor --no-config --config=default | sed \
-		-e 's!^# config-dir=.*!config-dir=/etc/powerdns!' \
-		-e 's!^# hint-file=.*!&\nhint-file=/usr/share/dns/root.hints!' \
-		-e 's!^# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
-		-e 's!^# local-address=.*!local-address=127.0.0.1!' \
-		-e 's!^# lua-config-file=.*!lua-config-file=/etc/powerdns/recursor.lua!' \
-		-e 's!^# quiet=.*!quiet=yes!' \
-		-e '/^# version-string=.*/d' \
+	dir=$$(mktemp -d) && touch "$$dir/recursor.yml" && ./pdns_recursor --config-dir="$$dir" --config=default 2> /dev/null | sed \
+		-e 's!^#\(.*config_dir: \).*!\1/etc/powerdns!' \
+		-e 's!^#\(.*hint_file: \).*!\1/usr/share/dns/root.hints!' \
+		-e 's!^#\(.*include_dir: \).*!\1/etc/powerdns/recursor.d!' \
+		-e 's!^#\(.*local_address: \).*\1!127.0.0.1!' \
+		-e 's!^#\(.*lua_config_file: \).*!\1/etc/powerdns/recursor.lua!' \
+		-e 's!^#\(.*quiet: \)=.*!\1=true!' \
+		-e '/^#.*version_string:.*/d' \
 		> debian/pdns-recursor/etc/powerdns/recursor.conf
 
 override_dh_auto_test:

--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -41,15 +41,20 @@ override_dh_auto_install:
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/snmp RECURSOR-MIB.txt
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.yml-dist
-	dir=$$(mktemp -d) && touch "$$dir/recursor.yml" && ./pdns_recursor --config-dir="$$dir" --config=default 2> /dev/null | sed \
-		-e 's!^#\(.*config_dir: \).*!\1/etc/powerdns!' \
-		-e 's!^#\(.*hint_file: \).*!\1/usr/share/dns/root.hints!' \
-		-e 's!^#\(.*include_dir: \).*!\1/etc/powerdns/recursor.d!' \
-		-e 's!^#\(.*local_address: \).*\1!127.0.0.1!' \
-		-e 's!^#\(.*lua_config_file: \).*!\1/etc/powerdns/recursor.lua!' \
-		-e 's!^#\(.*quiet: \)=.*!\1=true!' \
-		-e '/^#.*version_string:.*/d' \
-		> debian/pdns-recursor/etc/powerdns/recursor.conf
+	@echo "\
+	dnssec:\n\
+	  # validation: process\n\
+	recursor:\n\
+	  hint_file: /usr/share/dns/root.hints\n\
+	  include_dir: /etc/powerdns/recursor.d\n\
+	  lua_config_file: /etc/powerdns/recursor.lua\n\
+	incoming:\n\
+	 # listen:\n\
+	 # - 127.0.0.1\n\
+	outgoing:\n\
+	 # source_address:\n\
+	 # - 0.0.0.0\n\
+	" > debian/pdns-recursor/etc/powerdns/recursor.conf
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -81,15 +81,23 @@ make %{?_smp_mflags} check || (cat test-suite.log && false)
 %install
 make install DESTDIR=%{buildroot}
 
-%{__cp} %{buildroot}%{_sysconfdir}/%{name}/recursor.{yml-dist,conf}
 %{__mkdir} %{buildroot}%{_sysconfdir}/%{name}/recursor.d
 
 # change user and group to pdns-recursor and add default include-dir
-sed -i \
-    -e 's/# \(.*setuid: \).*/\1pdns-recursor/' \
-    -e 's/# \(.*setgid: \).*/\1pdns-recursor/' \
-    -e 's!# \(.*include_dir: \).*!\1%{_sysconfdir}/%{name}/recursor.d!' \
-    %{buildroot}%{_sysconfdir}/%{name}/recursor.conf
+cat << EOF > %{buildroot}%{_sysconfdir}/%{name}/recursor.conf
+dnssec:
+  # validation: process
+recursor:
+  include_dir: %{_sysconfdir}/%{name}/recursor.d
+  setuid: pdns-recursor
+  setgid: pdns-recursor
+incoming:
+  # listen:
+  # - 127.0.0.1
+outgoing:
+  # source_address:
+  # - 0.0.0.0
+EOF
 
 %{__install } -d %{buildroot}/%{_sharedstatedir}/%{name}
 

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -81,14 +81,14 @@ make %{?_smp_mflags} check || (cat test-suite.log && false)
 %install
 make install DESTDIR=%{buildroot}
 
-%{__mv} %{buildroot}%{_sysconfdir}/%{name}/recursor.conf{-dist,}
+%{__cp} %{buildroot}%{_sysconfdir}/%{name}/recursor.{yml-dist,conf}
 %{__mkdir} %{buildroot}%{_sysconfdir}/%{name}/recursor.d
 
 # change user and group to pdns-recursor and add default include-dir
 sed -i \
-    -e 's/# setuid=/setuid=pdns-recursor/' \
-    -e 's/# setgid=/setgid=pdns-recursor/' \
-    -e 's!# include-dir=.*!&\ninclude-dir=%{_sysconfdir}/%{name}/recursor.d!' \
+    -e 's/# \(.*setuid: \).*/\1pdns-recursor/' \
+    -e 's/# \(.*setgid: \).*/\1pdns-recursor/' \
+    -e 's!# \(.*include_dir: \).*!\1%{_sysconfdir}/%{name}/recursor.d!' \
     %{buildroot}%{_sysconfdir}/%{name}/recursor.conf
 
 %{__install } -d %{buildroot}/%{_sharedstatedir}/%{name}

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -42,7 +42,7 @@ BUILT_SOURCES=htmlfiles.h \
 	dnslabeltext.cc
 
 CLEANFILES = htmlfiles.h \
-	recursor.conf-dist recursor.yml-dist
+	recursor.yml-dist
 
 htmlfiles.h: incfiles ${srcdir}/html/* ${srcdir}/html/js/*
 	$(AM_V_GEN)$(srcdir)/incfiles > $@.tmp
@@ -552,10 +552,7 @@ pubsuffix.cc: $(srcdir)/effective_tld_names.dat
 	$(srcdir)/mkpubsuffixcc $< $@
 
 ## Config file
-sysconf_DATA = recursor.conf-dist recursor.yml-dist
-
-recursor.conf-dist: pdns_recursor
-	$(AM_V_GEN)./pdns_recursor --config=default > $@
+sysconf_DATA = recursor.yml-dist
 
 recursor.yml-dist: pdns_recursor
 	dir=$$(mktemp -d) && touch "$$dir/recursor.yml" && ./pdns_recursor --config-dir="$$dir" --config=default 2> /dev/null > $@ && rm "$$dir/recursor.yml" && rmdir "$$dir"

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -193,6 +193,7 @@ extern std::unique_ptr<RecursorPacketCache> g_packetCache;
 using RemoteLoggerStats_t = std::unordered_map<std::string, RemoteLoggerInterface::Stats>;
 
 extern bool g_yamlSettings;
+extern string g_yamlSettingsSuffix;
 extern bool g_logCommonErrors;
 extern size_t g_proxyProtocolMaximumSize;
 extern std::atomic<bool> g_quiet;

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -35,8 +35,10 @@
 #include "settings/cxxsettings.hh"
 #include "rec-system-resolve.hh"
 
+// XXX consider including rec-main.hh?
 extern int g_argc;
 extern char** g_argv;
+extern string g_yamlSettingsSuffix;
 
 bool primeHints(time_t now)
 {
@@ -147,7 +149,7 @@ string reloadZoneConfiguration(bool yaml)
          log->info(Logr::Notice, "Reloading zones, purging data from cache"));
 
     if (yaml) {
-      configname += ".yml";
+      configname += g_yamlSettingsSuffix;
       string msg;
       pdns::rust::settings::rec::Recursorsettings settings;
       // XXX Does ::arg()["include-dir"] have the right value, i.e. potentially overriden by command line?

--- a/pdns/recursordist/settings/docs-new-preamble-in.rst
+++ b/pdns/recursordist/settings/docs-new-preamble-in.rst
@@ -10,12 +10,13 @@ Settings on the command line are processed after the file-based settings are pro
    If both ``recursor.conf`` and ``recursor.yml`` files are found in the configuration directory the YAML file is used.
    A configuration using the old style syntax can be converted to a YAML configuration using the instructions in :doc:`appendices/yamlconversion`.
 
-   Release 5.0.0 will install a default old-style ``recursor.conf`` files only.
+   Release 5.0.0 will install a default old-style ``recursor.conf`` file.
 
-   With the release of version 5.1.0, packages will stop installing a default ``recursor.conf`` and start installing a default ``recursor.yml`` file if no existing ``recursor.conf`` is present.
-   In the absense of a ``recursor.yml`` file, an existing ``recursor.conf`` file will be accepted and used.
+   Starting with version 5.1.0, in the absense of a ``recursor.yml`` file, an existing ``recursor.conf`` will be processed as YAML,
+   if that fails, it will be processed as old-style configuration.
+   Packages will stop installing a old-style ``recursor.conf`` file and start installing a default ``recursor.conf`` file containing YAML syntax.
 
-   With the release of 5.2.0, the default will be to expect a ``recursor.yml`` file and reading of ``recursor.conf`` files will have to be enabled specifically by providing a command line option.
+   With the release of 5.2.0, the default will be to expect a YAML configuation file and reading of old-style ``recursor.conf`` files will have to be enabled specifically by providing a command line option.
 
    In a future release support for the "old-style" ``recursor.conf`` settings file will be dropped.
 


### PR DESCRIPTION
This should allow us to work around the packaging issues discussed in #13935. The idea is that modify the parsing so that .conf files also *may* contain YAML.

The search for a config file then becomes:

1. Try reading `recuror.yml` if it exists. If valid, done. If it is invalid punt.
2. Try reading `recursor.conf` as YAML. If it is valid, done.
3. If it is invalid, try to read as old-style.

This means that the status of `recursor.conf` as a config file in the packaging meta data does not need to change.

This allows us to install a default YAML config into `recursor.conf` for new installs. Of course we leave `recursor.conf` alone for existing installs.

This is a draft. I will add docs and packaging changes after this is deemed the way to proceed.

@zeha could you check if this approach is acceptable? In an ideal world, we should do fully automated conversion, but I do not see that happening, due to all kinds of real world constraints. Thanks.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
