### PR TITLE
rec: allow_no_rd - document cache contents on root on startup pertaining to dig +trace

### DIFF
--- a/pdns/recursordist/docs/appendices/FAQ.rst
+++ b/pdns/recursordist/docs/appendices/FAQ.rst
@@ -87,6 +87,6 @@ For example, in the default setup the root name servers are called ``[a-m].root-
 This is needed to correctly determine zone cuts to be able to decide if the ``.root-servers.net`` domain is DNSSEC protected. Newer versions solve this by querying the needed information top-down.
 
 Starting with version 5.0.0, enabling :ref:`allow-no-rd` allows for queries without the recursion desired bit to be answered from cache.
-Older versions of the ``dig`` program provided by ISC do not set the RD bit causing it to sometimes fail to perform a ``+trace`` when asking a freshly restarted :program:`Recursor` despite the :ref:`allow-no-rd` option being set.
+Older versions of the ``dig`` program provided by ISC do not set the RD bit on the initial ``+trace`` query causing it to sometimes fail to perform a ``+trace`` when asking a freshly restarted :program:`Recursor` despite the :ref:`allow-no-rd` option being set.
 This is because there is a short while after restarting that the cache has no authoritative data on the root, so it will answer with an NODATA (NOERROR and no answer records) in that period for RD=0 queries asking for the root name servers.
 For ``dig`` this has been fixed in `BIND 9.15.1 <https://gitlab.isc.org/isc-projects/bind9/-/issues/1028>` by setting the RD bit.

--- a/pdns/recursordist/docs/appendices/FAQ.rst
+++ b/pdns/recursordist/docs/appendices/FAQ.rst
@@ -86,3 +86,7 @@ With versions older than 4.8, there is another detail: after refreshing the root
 For example, in the default setup the root name servers are called ``[a-m].root-servers.net``, so the :program:`Recursor` will resolve the name servers of the ``.net`` domain.
 This is needed to correctly determine zone cuts to be able to decide if the ``.root-servers.net`` domain is DNSSEC protected. Newer versions solve this by querying the needed information top-down.
 
+Starting with version 5.0.0, enabling :ref:`allow-no-rd` allows for queries without the recursion desired bit to be answered from cache.
+Older versions of the ``dig`` program provided by BIND do not set the RD bit causing it to sometimes fail to perform a ``+trace`` when asking a freshly restarted :program:`Recursor` despite the :ref:`allow-no-rd` option being set.
+This is because there is a short while after restarting that the cache has no authoritative data on the root, so it will answer with an NODATA (NOERROR and no answer records) in that period for RD=0 queries.
+For ``dig`` this has been fixed in `BIND 9.15.1 <https://gitlab.isc.org/isc-projects/bind9/-/issues/1028>` by setting the RD bit.

--- a/pdns/recursordist/docs/appendices/FAQ.rst
+++ b/pdns/recursordist/docs/appendices/FAQ.rst
@@ -88,5 +88,5 @@ This is needed to correctly determine zone cuts to be able to decide if the ``.r
 
 Starting with version 5.0.0, enabling :ref:`allow-no-rd` allows for queries without the recursion desired bit to be answered from cache.
 Older versions of the ``dig`` program provided by ISC do not set the RD bit causing it to sometimes fail to perform a ``+trace`` when asking a freshly restarted :program:`Recursor` despite the :ref:`allow-no-rd` option being set.
-This is because there is a short while after restarting that the cache has no authoritative data on the root, so it will answer with an NODATA (NOERROR and no answer records) in that period for RD=0 queries.
+This is because there is a short while after restarting that the cache has no authoritative data on the root, so it will answer with an NODATA (NOERROR and no answer records) in that period for RD=0 queries asking for the root name servers.
 For ``dig`` this has been fixed in `BIND 9.15.1 <https://gitlab.isc.org/isc-projects/bind9/-/issues/1028>` by setting the RD bit.

--- a/pdns/recursordist/docs/appendices/FAQ.rst
+++ b/pdns/recursordist/docs/appendices/FAQ.rst
@@ -87,6 +87,6 @@ For example, in the default setup the root name servers are called ``[a-m].root-
 This is needed to correctly determine zone cuts to be able to decide if the ``.root-servers.net`` domain is DNSSEC protected. Newer versions solve this by querying the needed information top-down.
 
 Starting with version 5.0.0, enabling :ref:`allow-no-rd` allows for queries without the recursion desired bit to be answered from cache.
-Older versions of the ``dig`` program provided by BIND do not set the RD bit causing it to sometimes fail to perform a ``+trace`` when asking a freshly restarted :program:`Recursor` despite the :ref:`allow-no-rd` option being set.
+Older versions of the ``dig`` program provided by ISC do not set the RD bit causing it to sometimes fail to perform a ``+trace`` when asking a freshly restarted :program:`Recursor` despite the :ref:`allow-no-rd` option being set.
 This is because there is a short while after restarting that the cache has no authoritative data on the root, so it will answer with an NODATA (NOERROR and no answer records) in that period for RD=0 queries.
 For ``dig`` this has been fixed in `BIND 9.15.1 <https://gitlab.isc.org/isc-projects/bind9/-/issues/1028>` by setting the RD bit.

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -203,6 +203,10 @@ Like :ref:`setting-allow-notify-from`, except reading a sequence of `Subnet`_ fr
         'doc' : '''
 Allow ``no recursion desired (RD=0) queries`` to query cache contents.
 If not set (the default), these queries are answered with rcode ``Refused``.
+
+Note that there is a short while after restarting that the cache has no authoritative data on the root,
+so it will answer with an NODATA (NOERROR and no answer records) in that period for RD=0 queries
+affecting for example older versions of dig when using its +trace option.
  ''',
     'versionadded': '5.0.0'
     },

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -205,8 +205,8 @@ Allow ``no recursion desired (RD=0) queries`` to query cache contents.
 If not set (the default), these queries are answered with rcode ``Refused``.
 
 Note that there is a short while after restarting that the cache has no authoritative data on the root,
-so it will answer with an NODATA (NOERROR and no answer records) in that period for RD=0 queries
-affecting for example older versions of dig when using its +trace option.
+so it will answer with an NODATA (NOERROR and no answer records) in that period for RD=0 queries.
+This affects for example older versions of dig when using its +trace option causing it to fail.
  ''',
     'versionadded': '5.0.0'
     },

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -203,10 +203,6 @@ Like :ref:`setting-allow-notify-from`, except reading a sequence of `Subnet`_ fr
         'doc' : '''
 Allow ``no recursion desired (RD=0) queries`` to query cache contents.
 If not set (the default), these queries are answered with rcode ``Refused``.
-
-Note that there is a short while after restarting that the cache has no authoritative data on the root,
-so it will answer with an NODATA (NOERROR and no answer records) in that period for RD=0 queries.
-This affects for example older versions of dig when using its +trace option causing it to fail.
  ''',
     'versionadded': '5.0.0'
     },


### PR DESCRIPTION
### Short description
As discussed in https://github.com/PowerDNS/pdns/issues/14263 the behavior of the recursor is as expected but as older versions of dig +trace use RD=0 queries and fail when no data is returned i thought it best to document this.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
