### PR TITLE
dnsdist/docs: pin version of pip package typing-extensions

### DIFF
--- a/pdns/dnsdistdist/docs/requirements.in
+++ b/pdns/dnsdistdist/docs/requirements.in
@@ -10,3 +10,4 @@ sphinxcontrib-fulltoc
 docutils!=0.15,<0.18
 jinja2<3.1.0
 alabaster==0.7.13
+typing-extensions==4.12

--- a/pdns/dnsdistdist/docs/requirements.txt
+++ b/pdns/dnsdistdist/docs/requirements.txt
@@ -257,6 +257,10 @@ sphinxcontrib-websupport==1.2.4 \
     --hash=sha256:4edf0223a0685a7c485ae5a156b6f529ba1ee481a1417817935b20bde1956232 \
     --hash=sha256:6fc9287dfc823fe9aa432463edd6cea47fa9ebbf488d7f289b322ffcfca075c7
     # via sphinx
+typing-extensions==4.12.0 \
+    --hash=sha256:8cbcdc8606ebcb0d95453ad7dc5065e6237b6aa230a31e81d0f440c30fed5fd8 \
+    --hash=sha256:b349c66bea9016ac22978d800cfff206d5f9816951f12a7d0ec5578b0a819594
+    # via -r requirements.in
 urllib3==2.2.0 \
     --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20 \
     --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Similar to https://github.com/PowerDNS/pdns/pull/14237 but for dnsdist

Our package `sphinxcontrib-openapi` has a `setup_requires` dependency for `setuptools-scm`, which in turn requires a not-fixed version of `typing-extensions`.

There is a new version of typing extensions that makes our validation that we are only pulling the hashed pip dependencies: https://github.com/PowerDNS/pdns/actions/runs/9347956398

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
