### PR TITLE
Auth/meson: Don't fail if compiler doesn't support `trivial-auto-var-init`

### DIFF
--- a/meson/auto-var-init/meson.build
+++ b/meson/auto-var-init/meson.build
@@ -2,12 +2,12 @@ auto_var_init = get_option('auto-var-init')
 
 if auto_var_init != 'disabled'
   arg = '-ftrivial-auto-var-init=' + auto_var_init
-  if not cxx.has_argument(arg)
-    error('Compiler does not support ' + arg + ', which is needed for automatic variable initialization')
-    subdir_done()
+  if cxx.has_argument(arg)
+    add_project_arguments(arg, language: ['c', 'cpp'])
+  else
+    warning('Compiler does not support ' + arg + ', which is needed for automatic variable initialization')
+    auto_var_init = 'unsupported by compiler'
   endif
-
-  add_project_arguments(arg, language: ['c', 'cpp'])
 endif
 
 summary('Auto Var Init', auto_var_init, section: 'Configuration')


### PR DESCRIPTION
### Short description
Auth/meson: Don't fail if compiler doesn't support `trivial-auto-var-init`.
This will issue a warning instead and print out a summary line that the compiler doesn't support it.

This should fix the issue here: https://github.com/PowerDNS/pdns/actions/runs/9309740577/job/25625817149

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)