### PR TITLE
GH Actions - misc-dailies: set python-version 3.11 for complying with pip pinning

### DIFF
--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
       - run: inv install-clang
       - run: inv install-auth-build-deps
@@ -80,6 +83,9 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
       - run: inv install-clang
       - run: inv install-dnsdist-build-deps --skipXDP
@@ -112,6 +118,9 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
       - run: inv install-clang
       - run: inv install-rec-build-deps


### PR DESCRIPTION
### Short description
Set python-version 3.11 for complying with pip pinning in `misc-dailies.yml`.

Fixes an error in the CI for pip packages not being pinned: [https://github.com/PowerDNS/pdns/actions/runs/9395185097/job/25874138446](https://github.com/PowerDNS/pdns/actions/runs/9395185097/job/25874138446)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
