### PR TITLE
GH Actions: remove rel/auth-4.6.x from daily/weekly builds

### DIFF
--- a/.github/workflows/build-and-test-all-releases-dispatch.yml
+++ b/.github/workflows/build-and-test-all-releases-dispatch.yml
@@ -40,13 +40,6 @@ jobs:
     with:
       branch-name: rel/auth-4.7.x
 
-  call-build-and-test-all-auth-46:
-    name: Call build-and-test-all rel/auth-4.6.x
-    if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
-    uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@rel/auth-4.6.x
-    with:
-      branch-name: rel/auth-4.6.x
-
   call-build-and-test-all-rec-50:
     name: Call build-and-test-all rel/rec-5.0.x
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}

--- a/.github/workflows/builder-releases-dispatch.yml
+++ b/.github/workflows/builder-releases-dispatch.yml
@@ -32,13 +32,6 @@ jobs:
     with:
       branch-name: rel/auth-4.7.x
 
-  call-builder-auth-46:
-    name: Call builder rel/auth-4.6.x
-    if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
-    uses: PowerDNS/pdns/.github/workflows/builder.yml@rel/auth-4.6.x
-    with:
-      branch-name: rel/auth-4.6.x
-
   call-builder-rec-50:
     name: Call builder rel/rec-5.0.x
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}


### PR DESCRIPTION
### Short description
Branch`rel/auth-4.6` is no longer maintained. This PR removes this branch from the scheduled workflows `build-and-test-all-releases-dispatch.yml` and `builder-releases-dispatch.yml`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
