### PR TITLE
rec: do not add UDR field to outgoingProtobuf answer messages

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -139,7 +139,7 @@ class PDNSPBConnHandler(object):
             if response.HasField('queryTimeSec'):
                 datestr = datetime.datetime.fromtimestamp(response.queryTimeSec).strftime('%Y-%m-%d %H:%M:%S')
                 if response.HasField('queryTimeUsec'):
-                    datestr = datestr + '.' + str(response.queryTimeUsec)
+                    datestr = datestr + '.' + ("%06d" % response.queryTimeUsec)
                 print("- Query time: %s" % (datestr))
 
             policystr = ''
@@ -166,12 +166,12 @@ class PDNSPBConnHandler(object):
             for rr in response.rrs:
                 rrclass = 1
                 rdatastr = ''
-                rrudr = 0
+                rrudr = 'N/A'
                 if rr.HasField('class'):
                     rrclass = getattr(rr, 'class')
                 rrtype = rr.type
                 if rr.HasField('udr'):
-                    rrudr = rr.udr
+                    rrudr = str(rr.udr)
                 if (rrclass == 1 or rrclass == 255) and rr.HasField('rdata'):
                     if rrtype == 1:
                         rdatastr = socket.inet_ntop(socket.AF_INET, rr.rdata)
@@ -180,7 +180,7 @@ class PDNSPBConnHandler(object):
                     elif rrtype == 28:
                         rdatastr = socket.inet_ntop(socket.AF_INET6, rr.rdata)
 
-                print("\t - %d, %d, %s, %d, %s, %d" % (rrclass,
+                print("\t - %d, %d, %s, %d, %s, %s" % (rrclass,
                                                    rrtype,
                                                    rr.name,
                                                    rr.ttl,
@@ -190,7 +190,7 @@ class PDNSPBConnHandler(object):
     def printSummary(self, msg, typestr):
         datestr = datetime.datetime.fromtimestamp(msg.timeSec).strftime('%Y-%m-%d %H:%M:%S')
         if msg.HasField('timeUsec'):
-            datestr = datestr + '.' + str(msg.timeUsec)
+            datestr = datestr + '.' + ("%06d" % msg.timeUsec)
         ipfromstr = 'N/A'
         iptostr = 'N/A'
         toportstr = ''
@@ -241,14 +241,14 @@ class PDNSPBConnHandler(object):
         if msg.HasField('requestorId'):
             requestorId = msg.requestorId
 
-        nod = 0
+        nod = 'N/A';
         if msg.HasField('newlyObservedDomain'):
-            nod = msg.newlyObservedDomain
+            nod = str(msg.newlyObservedDomain)
 
         workerId = 'N/A'
         if msg.HasField('workerId'):
            workerId = str(msg.workerId)
- 
+
         pcCacheHit = 'N/A'
         if msg.HasField('packetCacheHit'):
            pcCacheHit = str(msg.packetCacheHit)
@@ -256,10 +256,9 @@ class PDNSPBConnHandler(object):
         outgoingQs = 'N/A'
         if msg.HasField('outgoingQueries'):
            outgoingQs = str(msg.outgoingQueries)
-	
 
         print('[%s] %s of size %d: %s%s%s -> %s%s(%s) id: %d uuid: %s%s '
-                  'requestorid: %s deviceid: %s devicename: %s serverid: %s nod: %d workerId: %s pcCacheHit: %s outgoingQueries: %s' % (datestr,
+                  'requestorid: %s deviceid: %s devicename: %s serverid: %s nod: %s workerId: %s pcCacheHit: %s outgoingQueries: %s' % (datestr,
                                                     typestr,
                                                     msg.inBytes,
                                                     ipfromstr,

--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -270,7 +270,7 @@ static void logIncomingResponse(const std::shared_ptr<std::vector<std::unique_pt
   }
 
   for (const auto& record : records) {
-    m.addRR(record, exportTypes, false);
+    m.addRR(record, exportTypes, std::nullopt);
   }
   m.commitResponse();
 

--- a/pdns/recursordist/rec-protozero.cc
+++ b/pdns/recursordist/rec-protozero.cc
@@ -24,7 +24,7 @@
 #include "rec-protozero.hh"
 #include <variant>
 
-void pdns::ProtoZero::RecMessage::addRR(const DNSRecord& record, const std::set<uint16_t>& exportTypes, [[maybe_unused]] bool udr)
+void pdns::ProtoZero::RecMessage::addRR(const DNSRecord& record, const std::set<uint16_t>& exportTypes, [[maybe_unused]] std::optional<bool> udr)
 {
   if (record.d_place != DNSResourceRecord::ANSWER || record.d_class != QClass::IN) {
     return;
@@ -150,12 +150,14 @@ void pdns::ProtoZero::RecMessage::addRR(const DNSRecord& record, const std::set<
     break;
   }
 #ifdef NOD_ENABLED
-  pbf_rr.add_bool(static_cast<protozero::pbf_tag_type>(pdns::ProtoZero::Message::RRField::udr), udr);
-  pbf_rr.commit();
+  if (udr) {
+    pbf_rr.add_bool(static_cast<protozero::pbf_tag_type>(pdns::ProtoZero::Message::RRField::udr), *udr);
+    pbf_rr.commit();
 
-  // Save the offset of the byte containing the just added bool. We can do this since
-  // we know a bit about how protobuf's encoding works.
-  offsets.push_back(d_rspbuf.length() - 1);
+    // Save the offset of the byte containing the just added bool. We can do this since
+    // we know a bit about how protobuf's encoding works.
+    offsets.push_back(d_rspbuf.length() - 1);
+  }
 #endif
 }
 

--- a/pdns/recursordist/rec-protozero.hh
+++ b/pdns/recursordist/rec-protozero.hh
@@ -109,7 +109,7 @@ namespace ProtoZero
 
     // DNSResponse related fields below
 
-    void addRR(const DNSRecord& record, const std::set<uint16_t>& exportTypes, bool udr);
+    void addRR(const DNSRecord& record, const std::set<uint16_t>& exportTypes, std::optional<bool> udr);
 
     void setAppliedPolicyType(const DNSFilterEngine::PolicyType type)
     {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

As noted by @johnhtodd 

UDR field is optional, and is not determined yet at the point where the outgoingProtobuf message is created.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
