### PR TITLE
snmp-agent: Move net-snmp headers out of our headers

### DIFF
--- a/pdns/dnsdistdist/dnsdist-snmp.cc
+++ b/pdns/dnsdistdist/dnsdist-snmp.cc
@@ -9,6 +9,14 @@ std::unique_ptr<DNSDistSNMPAgent> g_snmpAgent{nullptr};
 
 #ifdef HAVE_NET_SNMP
 
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/definitions.h>
+#include <net-snmp/types.h>
+#include <net-snmp/utilities.h>
+#include <net-snmp/config_api.h>
+#include <net-snmp/agent/net-snmp-agent-includes.h>
+#undef INET6 /* SRSLY? */
+
 #define DNSDIST_OID 1, 3, 6, 1, 4, 1, 43315, 3
 #define DNSDIST_STATS_OID DNSDIST_OID, 1
 #define DNSDIST_STATS_TABLE_OID DNSDIST_OID, 2
@@ -387,12 +395,9 @@ bool DNSDistSNMPAgent::sendBackendStatusChangeTrap(const DownstreamState& dss)
   const string backendStatus = dss.getStatus();
   netsnmp_variable_list* varList = nullptr;
 
-  snmp_varlist_add_variable(&varList,
-                            snmpTrapOID.data(),
-                            snmpTrapOID.size(),
-                            ASN_OBJECT_ID,
-                            backendStatusChangeTrapOID.data(),
-                            backendStatusChangeTrapOID.size() * sizeof(oid));
+  addSNMPTrapOID(&varList,
+                 backendStatusChangeTrapOID.data(),
+                 backendStatusChangeTrapOID.size() * sizeof(oid));
 
   snmp_varlist_add_variable(&varList,
                             backendNameOID.data(),
@@ -426,12 +431,9 @@ bool DNSDistSNMPAgent::sendCustomTrap(const std::string& reason)
 #ifdef HAVE_NET_SNMP
   netsnmp_variable_list* varList = nullptr;
 
-  snmp_varlist_add_variable(&varList,
-                            snmpTrapOID.data(),
-                            snmpTrapOID.size(),
-                            ASN_OBJECT_ID,
-                            customTrapOID.data(),
-                            customTrapOID.size() * sizeof(oid));
+  addSNMPTrapOID(&varList,
+                 customTrapOID.data(),
+                 customTrapOID.size() * sizeof(oid));
 
   snmp_varlist_add_variable(&varList,
                             trapReasonOID.data(),
@@ -462,12 +464,9 @@ bool DNSDistSNMPAgent::sendDNSTrap(const DNSQuestion& dnsQuestion, const std::st
 
   netsnmp_variable_list* varList = nullptr;
 
-  snmp_varlist_add_variable(&varList,
-                            snmpTrapOID.data(),
-                            snmpTrapOID.size(),
-                            ASN_OBJECT_ID,
-                            actionTrapOID.data(),
-                            actionTrapOID.size() * sizeof(oid));
+  addSNMPTrapOID(&varList,
+                 actionTrapOID.data(),
+                 actionTrapOID.size() * sizeof(oid));
 
   snmp_varlist_add_variable(&varList,
                             socketFamilyOID.data(),

--- a/pdns/recursordist/rec-snmp.cc
+++ b/pdns/recursordist/rec-snmp.cc
@@ -30,6 +30,14 @@
 
 #ifdef HAVE_NET_SNMP
 
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/definitions.h>
+#include <net-snmp/types.h>
+#include <net-snmp/utilities.h>
+#include <net-snmp/config_api.h>
+#include <net-snmp/agent/net-snmp-agent-includes.h>
+#undef INET6 /* SRSLY? */
+
 #define RECURSOR_OID 1, 3, 6, 1, 4, 1, 43315, 2
 #define RECURSOR_STATS_OID RECURSOR_OID, 1
 #define RECURSOR_TRAPS_OID RECURSOR_OID, 10, 0
@@ -277,12 +285,9 @@ bool RecursorSNMPAgent::sendCustomTrap([[maybe_unused]] const std::string& reaso
 #ifdef HAVE_NET_SNMP
   netsnmp_variable_list* varList = nullptr;
 
-  snmp_varlist_add_variable(&varList,
-                            snmpTrapOID.data(),
-                            snmpTrapOID.size(),
-                            ASN_OBJECT_ID,
-                            customTrapOID.data(),
-                            customTrapOID.size() * sizeof(oid));
+  addSNMPTrapOID(&varList,
+                 customTrapOID.data(),
+                 customTrapOID.size() * sizeof(oid));
 
   snmp_varlist_add_variable(&varList,
                             trapReasonOID.data(),

--- a/pdns/snmp-agent.cc
+++ b/pdns/snmp-agent.cc
@@ -9,6 +9,14 @@
 
 #ifdef HAVE_NET_SNMP
 
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/definitions.h>
+#include <net-snmp/types.h>
+#include <net-snmp/utilities.h>
+#include <net-snmp/config_api.h>
+#include <net-snmp/agent/net-snmp-agent-includes.h>
+#undef INET6 /* SRSLY? */
+
 #ifndef HAVE_SNMP_SELECT_INFO2
 /* that's terrible, because it means we are going to have trouble with large
    FD numbers at some point.. */
@@ -25,7 +33,7 @@
 # include <net-snmp/library/large_fd_set.h>
 #endif
 
-const std::array<oid, 11> SNMPAgent::snmpTrapOID = { 1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0 };
+static const std::array<oid, 11> s_snmpTrapOID = { 1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0 };
 
 int SNMPAgent::setCounter64Value(netsnmp_request_info* request,
                                  uint64_t value)
@@ -38,6 +46,16 @@ int SNMPAgent::setCounter64Value(netsnmp_request_info* request,
                            &val64,
                            sizeof(val64));
   return SNMP_ERR_NOERROR;
+}
+
+void SNMPAgent::addSNMPTrapOID(netsnmp_variable_list** varList, const void* value, size_t len)
+{
+  snmp_varlist_add_variable(varList,
+                            s_snmpTrapOID.data(),
+                            s_snmpTrapOID.size(),
+                            ASN_OBJECT_ID,
+                            value,
+                            len);
 }
 
 bool SNMPAgent::sendTrap(pdns::channel::Sender<netsnmp_variable_list, void(*)(netsnmp_variable_list*)>& sender,

--- a/pdns/snmp-agent.hh
+++ b/pdns/snmp-agent.hh
@@ -5,18 +5,11 @@
 #include <thread>
 #include <unistd.h>
 
-#ifdef HAVE_NET_SNMP
-#include <net-snmp/net-snmp-config.h>
-#include <net-snmp/definitions.h>
-#include <net-snmp/types.h>
-#include <net-snmp/utilities.h>
-#include <net-snmp/config_api.h>
-#include <net-snmp/agent/net-snmp-agent-includes.h>
-#undef INET6 /* SRSLY? */
-#endif /* HAVE_NET_SNMP */
-
 #include "mplexer.hh"
 #include "channel.hh"
+
+typedef struct netsnmp_request_info_s netsnmp_request_info;
+typedef struct variable_list netsnmp_variable_list;
 
 class SNMPAgent
 {
@@ -40,8 +33,7 @@ public:
 #endif /* HAVE_NET_SNMP */
 protected:
 #ifdef HAVE_NET_SNMP
-  /* OID for snmpTrapOID.0 */
-  static const std::array<oid, 11> snmpTrapOID;
+  static void addSNMPTrapOID(netsnmp_variable_list** varList, const void* value, size_t len);
 
   static bool sendTrap(pdns::channel::Sender<netsnmp_variable_list, void(*)(netsnmp_variable_list*)>& sender,
                        netsnmp_variable_list* varList);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The net-snmp headers are unfortunately defining things that we do not want, like `INET6` and `HAVE_LIBSSL`, so it's better for us not to include them from our headers.

Hopefully closes https://github.com/PowerDNS/pdns/issues/11204

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

