### PR TITLE
dnsdist-1.9.x: Backport of 14247: autoconf: allow prerelease systemd versions

### DIFF
--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -134,7 +134,7 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
           AC_PATH_PROG([SYSTEMCTL], [systemctl], [no])
           AS_IF([test "$SYSTEMCTL" = "no"],
             [AC_MSG_ERROR([systemctl not found])], [
-              _systemd_version=`${SYSTEMCTL} --version|head -1 |cut -d" " -f 2`
+              _systemd_version=`${SYSTEMCTL} --version|head -1 | tr ".~" "  " | cut -d" " -f 2`
               if test $_systemd_version -ge 183; then
                  systemd_private_tmp=y
               fi


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14247 to dnsdist-1.9.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
