### PR TITLE
dnsdist-1.9.x: Backport of 14281: Edit the systemd unit file, `CAP_BPF` is no longer enough

### DIFF
--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -25,10 +25,10 @@ LimitNOFILE=16384
 # LimitMEMLOCK=infinity
 
 # Sandboxing
-# Note: adding CAP_SYS_ADMIN (or CAP_BPF for Linux >= 5.8) is required to use eBPF support,
+# Note: adding CAP_SYS_ADMIN is required to use eBPF support,
 # and CAP_NET_RAW to be able to set the source interface to contact a backend
 # If an AppArmor policy is in use, it might have to be updated to allow dnsdist to keep the
-# capability: adding a 'capability bpf,' (for CAP_BPF) line to the policy is usually enough.
+# capability: adding a 'capability sys_admin,' line to the policy is usually enough.
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 LockPersonality=true


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14281 to dnsdist-1.9.x

We used to be able to use only `CAP_BPF` since kernel 5.8, but the eBPF verifier has been made more strict a few versions later and we now require `CAP_SYS_ADMIN` again.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
