### PR TITLE
dnsdist-1.9.x: Backport of 14255: Add a Lua FFI function to set proxy protocol values

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -178,6 +178,7 @@ typedef struct dnsdist_ffi_proxy_protocol_value {
 
 size_t dnsdist_ffi_generate_proxy_protocol_payload(size_t addrSize, const void* srcAddr, const void* dstAddr, uint16_t srcPort, uint16_t dstPort, bool tcp, size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, size_t outSize) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi_dnsquestion_t* dq, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, const size_t outSize) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_add_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values) __attribute__ ((visibility ("default")));
 
 typedef struct dnsdist_ffi_domain_list_t dnsdist_ffi_domain_list_t;
 typedef struct dnsdist_ffi_address_list_t dnsdist_ffi_address_list_t;

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1097,11 +1097,11 @@ bool dnsdist_ffi_dnsquestion_add_proxy_protocol_values(dnsdist_ffi_dnsquestion_t
   if (!dnsQuestion->dq->proxyProtocolValues) {
     dnsQuestion->dq->proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>();
   }
-  if (valuesCount > 0) {
-    dnsQuestion->dq->proxyProtocolValues->reserve(dnsQuestion->dq->proxyProtocolValues->size() + valuesCount);
-    for (size_t idx = 0; idx < valuesCount; idx++) {
-      dnsQuestion->dq->proxyProtocolValues->push_back({ std::string(values[idx].value, values[idx].size), values[idx].type });
-    }
+
+  dnsQuestion->dq->proxyProtocolValues->reserve(dnsQuestion->dq->proxyProtocolValues->size() + valuesCount);
+  for (size_t idx = 0; idx < valuesCount; idx++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): the Lua FFI API is a C API..
+    dnsQuestion->dq->proxyProtocolValues->push_back({ std::string(values[idx].value, values[idx].size), values[idx].type });
   }
 
   return true;

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1088,6 +1088,25 @@ size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi
   return payload.size();
 }
 
+bool dnsdist_ffi_dnsquestion_add_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values)
+{
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || values == nullptr || valuesCount == 0) {
+    return false;
+  }
+
+  if (!dnsQuestion->dq->proxyProtocolValues) {
+    dnsQuestion->dq->proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>();
+  }
+  if (valuesCount > 0) {
+    dnsQuestion->dq->proxyProtocolValues->reserve(dnsQuestion->dq->proxyProtocolValues->size() + valuesCount);
+    for (size_t idx = 0; idx < valuesCount; idx++) {
+      dnsQuestion->dq->proxyProtocolValues->push_back({ std::string(values[idx].value, values[idx].size), values[idx].type });
+    }
+  }
+
+  return true;
+}
+
 struct dnsdist_ffi_domain_list_t
 {
   std::vector<std::string> d_domains;

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -594,8 +594,8 @@ BOOST_AUTO_TEST_CASE(test_ProxyProtocolQuery)
   pwQ.getHeader()->rd = 1;
   pwQ.getHeader()->id = htons(42);
 
-  DNSQuestion dq(ids, query);
-  dnsdist_ffi_dnsquestion_t lightDQ(&dq);
+  DNSQuestion dnsQuestion(ids, query);
+  dnsdist_ffi_dnsquestion_t lightDQ(&dnsQuestion);
 
   std::vector<dnsdist_ffi_proxy_protocol_value> values;
   values.push_back({"test-value", 10U, 1U});
@@ -618,11 +618,11 @@ BOOST_AUTO_TEST_CASE(test_ProxyProtocolQuery)
   {
     auto added = dnsdist_ffi_dnsquestion_add_proxy_protocol_values(&lightDQ, values.size(), values.data());
     BOOST_CHECK_EQUAL(added, true);
-    BOOST_REQUIRE(dq.proxyProtocolValues != nullptr);
-    BOOST_REQUIRE_EQUAL(dq.proxyProtocolValues->size(), values.size());
-    BOOST_CHECK_EQUAL(dq.proxyProtocolValues->at(0).type, values.at(0).type);
-    BOOST_REQUIRE_EQUAL(dq.proxyProtocolValues->at(0).content.size(), values.at(0).size);
-    BOOST_CHECK_EQUAL(memcmp(dq.proxyProtocolValues->at(0).content.data(), values.at(0).value, values.at(0).size), 0);
+    BOOST_REQUIRE(dnsQuestion.proxyProtocolValues != nullptr);
+    BOOST_REQUIRE_EQUAL(dnsQuestion.proxyProtocolValues->size(), values.size());
+    BOOST_CHECK_EQUAL(dnsQuestion.proxyProtocolValues->at(0).type, values.at(0).type);
+    BOOST_REQUIRE_EQUAL(dnsQuestion.proxyProtocolValues->at(0).content.size(), values.at(0).size);
+    BOOST_CHECK_EQUAL(memcmp(dnsQuestion.proxyProtocolValues->at(0).content.data(), values.at(0).value, values.at(0).size), 0);
   }
 }
 

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -579,6 +579,53 @@ BOOST_AUTO_TEST_CASE(test_ProxyProtocol)
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_ProxyProtocolQuery)
+{
+  InternalQueryState ids;
+  ids.origRemote = ComboAddress("192.0.2.1:4242");
+  ids.origDest = ComboAddress("192.0.2.255:53");
+  ids.qtype = QType::A;
+  ids.qclass = QClass::IN;
+  ids.protocol = dnsdist::Protocol::DoUDP;
+  ids.qname = DNSName("www.powerdns.com.");
+  ids.queryRealTime.start();
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, ids.qname, QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+  pwQ.getHeader()->id = htons(42);
+
+  DNSQuestion dq(ids, query);
+  dnsdist_ffi_dnsquestion_t lightDQ(&dq);
+
+  std::vector<dnsdist_ffi_proxy_protocol_value> values;
+  values.push_back({"test-value", 10U, 1U});
+
+  {
+    auto added = dnsdist_ffi_dnsquestion_add_proxy_protocol_values(nullptr, values.size(), values.data());
+    BOOST_CHECK_EQUAL(added, false);
+  }
+
+  {
+    auto added = dnsdist_ffi_dnsquestion_add_proxy_protocol_values(&lightDQ, 0, values.data());
+    BOOST_CHECK_EQUAL(added, false);
+  }
+
+  {
+    auto added = dnsdist_ffi_dnsquestion_add_proxy_protocol_values(&lightDQ, values.size(), nullptr);
+    BOOST_CHECK_EQUAL(added, false);
+  }
+
+  {
+    auto added = dnsdist_ffi_dnsquestion_add_proxy_protocol_values(&lightDQ, values.size(), values.data());
+    BOOST_CHECK_EQUAL(added, true);
+    BOOST_REQUIRE(dq.proxyProtocolValues != nullptr);
+    BOOST_REQUIRE_EQUAL(dq.proxyProtocolValues->size(), values.size());
+    BOOST_CHECK_EQUAL(dq.proxyProtocolValues->at(0).type, values.at(0).type);
+    BOOST_REQUIRE_EQUAL(dq.proxyProtocolValues->at(0).content.size(), values.at(0).size);
+    BOOST_CHECK_EQUAL(memcmp(dq.proxyProtocolValues->at(0).content.data(), values.at(0).value, values.at(0).size), 0);
+  }
+}
+
 BOOST_AUTO_TEST_CASE(test_PacketOverlay)
 {
   const DNSName target("powerdns.com.");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14255 to dnsdist-1.9.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
