### PR TITLE
rec: Backport 14247 to rec 5.0.x: autoconf: allow prerelease systemd versions

### DIFF
--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -134,7 +134,7 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
           AC_PATH_PROG([SYSTEMCTL], [systemctl], [no])
           AS_IF([test "$SYSTEMCTL" = "no"],
             [AC_MSG_ERROR([systemctl not found])], [
-              _systemd_version=`${SYSTEMCTL} --version|head -1 |cut -d" " -f 2`
+              _systemd_version=`${SYSTEMCTL} --version|head -1 | tr ".~" "  " | cut -d" " -f 2`
               if test $_systemd_version -ge 183; then
                  systemd_private_tmp=y
               fi


### PR DESCRIPTION
For example 256~rc3. Also preemptively support versions like 252.2.

(cherry picked from commit 81e3f38b1909956e228077e4677c34f469ea9835)

Backport of #14247 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
