### PR TITLE
dnsdist-1.9.x: Backport "skip libxdp-devel for rhel8-aarch64"

### DIFF
--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -55,7 +55,7 @@ Requires(pre): shadow-utils
 BuildRequires: fstrm-devel
 %systemd_requires
 %endif
-%if 0%{?rhel} >= 8
+%if ( "%{_arch}" != "aarch64" && 0%{?rhel} >= 8 ) || ( "%{_arch}" == "aarch64" && 0%{?rhel} >= 9 )
 BuildRequires: libbpf-devel
 BuildRequires: libxdp-devel
 %endif


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The initial commit (7b070182728b4537489fcf33e6c382a93becb4a9) was added in https://github.com/PowerDNS/pdns/pull/14241 and needs to be backported to dnsdist-1.9.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
