### PR TITLE
Update dns.cc: Avoid compile error: implicit instantiation of undefined template 'std::char_traits<unsigned char>'

### DIFF
--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -108,16 +108,16 @@ uint32_t hashQuestion(const uint8_t* packet, uint16_t packet_len, uint32_t init,
     ok = false;
     return init;
   }
-  // C++ 17 does not have std::u8string_view
-  std::basic_string_view<uint8_t> name(packet + sizeof(dnsheader), packet_len - sizeof(dnsheader));
-  std::basic_string_view<uint8_t>::size_type len = 0;
+  // C++ 17 does not have std::u8string_view, nor std::basic_string_view<uint8_t>
+  std::basic_string_view<char> name(reinterpret_cast<const char*>(packet) + sizeof(dnsheader), packet_len - sizeof(dnsheader));
+  std::basic_string_view<char>::size_type len = 0;
 
   while (len < name.length()) {
     uint8_t labellen = name[len++];
     if (labellen == 0) {
       ok = true;
       // len is name.length() at max as it was < before the increment
-      return burtleCI(name.data(), len, init);
+      return burtleCI(reinterpret_cast<const uint8_t*>(name.data()), len, init);
     }
     len += labellen;
   }


### PR DESCRIPTION

### Short description

With at least `clang-18` there is a warning:

```
In file included from dns.cc:25:
In file included from ./dns.hh:23:
In file included from ./qtype.hh:27:
In file included from ./namespaces.hh:24:
In file included from /usr/include/boost/optional.hpp:15:
In file included from /usr/include/boost/optional/optional.hpp:36:
In file included from /usr/include/boost/throw_exception.hpp:21:
In file included from /usr/include/boost/exception/exception.hpp:9:
In file included from /usr/include/boost/assert/source_location.hpp:13:
In file included from /usr/local/bin/../include/c++/v1/string:622:
/usr/local/bin/../include/c++/v1/string_view:294:45: error: implicit instantiation of undefined template 'std::char_traits<unsigned char>'
  294 |     static_assert((is_same<_CharT, typename traits_type::char_type>::value),
      |                                             ^
dns.cc:112:35: note: in instantiation of template class 'std::basic_string_view<unsigned char>' requested here
  112 |   std::basic_string_view<uint8_t> name(packet + sizeof(dnsheader), packet_len - sizeof(dnsheader));
      |                                   ^
/usr/local/bin/../include/c++/v1/__string/char_traits.h:42:8: note: template is declared here
   42 | struct char_traits;
      |        ^
```

Fix it.

Reference: https://en.cppreference.com/w/cpp/string/basic_string_view

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code