### PR TITLE
dns.cc: use pdns::views::UnsignedCharView

### DIFF
--- a/pdns/views.hh
+++ b/pdns/views.hh
@@ -33,19 +33,37 @@ public:
     view(data_, size_)
   {
   }
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): No unsigned char view in C++17
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast): No unsigned char view in C++17
   UnsignedCharView(const unsigned char* data_, size_t size_) :
     view(reinterpret_cast<const char*>(data_), size_)
   {
   }
-  const unsigned char& at(std::string_view::size_type pos) const
+  using size_type = std::string_view::size_type;
+
+  [[nodiscard]] const unsigned char& at(size_type pos) const
   {
     return reinterpret_cast<const unsigned char&>(view.at(pos));
   }
 
-  size_t size() const
+  [[nodiscard]] const unsigned char& operator[](size_type pos) const
+  {
+    return reinterpret_cast<const unsigned char&>(view[pos]);
+  }
+
+  [[nodiscard]] const unsigned char* data() const
+  {
+    return reinterpret_cast<const unsigned char*>(view.data());
+  }
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast): No unsigned char view in C++17
+
+  [[nodiscard]] size_t size() const
   {
     return view.size();
+  }
+
+  [[nodiscard]] size_t length() const
+  {
+    return view.length();
   }
 
 private:


### PR DESCRIPTION
Includes minor cleanup and additions to make UnsignedCharView usable for this use case. Supersedes #14356
Fixes
```
/usr/include/c++/v1/__fwd/string_view.h:22:41: warning: 'char_traits<unsigned char>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 19, so please migrate off of it. [-Wdeprecated-declarations]
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
