### PR TITLE
Fix the LMDB backend not finding symbols in `pdns-auth` and `pdns-auth-util`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -106,6 +106,15 @@ libpdns_gettime = declare_dependency(
   )
 )
 
+libpdns_uuidutils = declare_dependency(
+  link_whole: static_library(
+    'pdns-uuidutils',
+    src_dir / 'uuid-utils.cc',
+    src_dir / 'uuid-utils.hh',
+    dependencies: dep_rt,
+  )
+)
+
 if get_option('module-lmdb') != 'disabled'
   subdir('ext' / 'lmdb-safe')
 endif
@@ -623,8 +632,6 @@ common_sources += files(
   src_dir / 'unix_semaphore.cc',
   src_dir / 'unix_utility.cc',
   src_dir / 'utility.hh',
-  src_dir / 'uuid-utils.cc',
-  src_dir / 'uuid-utils.hh',
   src_dir / 'validate.hh',
   src_dir / 'version.cc',
   src_dir / 'version.hh',
@@ -690,6 +697,7 @@ tools = {
   },
   'pdns-auth-util': {
     'main': src_dir / 'pdnsutil.cc',
+    'export-dynamic': true,
     'files-extra': libpdns_bind_dnssec_schema_gen,
     'deps-extra': [
       dep_modules,
@@ -983,6 +991,7 @@ foreach tool, info: tools
       dependencies: [
         deps,
         libpdns_common,
+        libpdns_uuidutils,
         deps_extra,
       ],
     )

--- a/modules/lmdbbackend/meson.build
+++ b/modules/lmdbbackend/meson.build
@@ -6,4 +6,4 @@ module_extras = files(
   'lmdbbackend.hh',
 )
 
-module_deps = [deps, dep_lmdb_safe, dep_lmdb, dep_boost_serialization]
+module_deps = [deps, dep_lmdb_safe, dep_lmdb, dep_boost_serialization, dep_systemd]


### PR DESCRIPTION
### Short description
Fix the LMDB backend not finding symbols in `pdns-auth` and `pdns-auth-util`. This ended up being much simpler than the original route I had taken of doing lots of refactoring. I went down the wrong path because I was under the impression that some of those missing symbols were missing in the module itself and not in the executable that is loading the module (e.g. `pdns-auth` or `pdns-auth-util`).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)