### PR TITLE
rec: Backport 14373 to rec 5.0.x:  Remove potential double SOA records if the target of a dns64 name is NODATA

### DIFF
--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -764,18 +764,18 @@ int getFakeAAAARecords(const DNSName& qname, ComboAddress prefix, vector<DNSReco
     // Remove double SOA records
     std::set<DNSName> seenSOAs;
     ret.erase(std::remove_if(
-                             ret.begin(),
-                             ret.end(),
-                             [&seenSOAs](DNSRecord& record) {
-                               if (record.d_type == QType::SOA) {
-                                 if (seenSOAs.count(record.d_name) > 0) {
-                                   // We've had this SOA before, remove it
-                                   return true;
-                                 }
-                                 seenSOAs.insert(record.d_name);
-                               }
-                               return false;
-                             }),
+                ret.begin(),
+                ret.end(),
+                [&seenSOAs](DNSRecord& record) {
+                  if (record.d_type == QType::SOA) {
+                    if (seenSOAs.count(record.d_name) > 0) {
+                      // We've had this SOA before, remove it
+                      return true;
+                    }
+                    seenSOAs.insert(record.d_name);
+                  }
+                  return false;
+                }),
               ret.end());
   }
   t_Counters.at(rec::Counter::dns64prefixanswers)++;

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -760,6 +760,24 @@ int getFakeAAAARecords(const DNSName& qname, ComboAddress prefix, vector<DNSReco
                 }),
               ret.end());
   }
+  else {
+    // Remove double SOA records
+    std::set<DNSName> seenSOAs;
+    ret.erase(std::remove_if(
+                             ret.begin(),
+                             ret.end(),
+                             [&seenSOAs](DNSRecord& record) {
+                               if (record.d_type == QType::SOA) {
+                                 if (seenSOAs.count(record.d_name) > 0) {
+                                   // We've had this SOA before, remove it
+                                   return true;
+                                 }
+                                 seenSOAs.insert(record.d_name);
+                               }
+                               return false;
+                             }),
+              ret.end());
+  }
   t_Counters.at(rec::Counter::dns64prefixanswers)++;
   return rcode;
 }

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -805,7 +805,7 @@ distributor-threads={threads}""".format(confdir=confdir,
         return message
 
     @classmethod
-    def sendTCPQuery(cls, query, timeout=2.0):
+    def sendTCPQuery(cls, query, timeout=2.0, decode=True, fwparams=dict()):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if timeout:
             sock.settimeout(timeout)
@@ -831,7 +831,9 @@ distributor-threads={threads}""".format(confdir=confdir,
 
         message = None
         if data:
-            message = dns.message.from_wire(data)
+            if not decode:
+                return data
+            message = dns.message.from_wire(data, **fwparams)
         return message
 
     @classmethod


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #14373 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
