### PR TITLE
Cleanup read2n and mark unixDie as [[noreturn]]

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -95,24 +95,26 @@ size_t writen2(int fileDesc, const void *buf, size_t count)
   return count;
 }
 
-size_t readn2(int fd, void* buffer, size_t len)
+size_t readn2(int fileDesc, void* buffer, size_t len)
 {
-  size_t pos=0;
-  ssize_t res;
-  for(;;) {
-    res = read(fd, (char*)buffer + pos, len - pos);
-    if(res == 0)
+  size_t pos = 0;
+
+  for (;;) {
+    auto res = read(fileDesc, static_cast<char *>(buffer) + pos, len - pos); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic): it's the API
+    if (res == 0) {
       throw runtime_error("EOF while reading message");
-    if(res < 0) {
-      if (errno == EAGAIN)
+    }
+    if (res < 0) {
+      if (errno == EAGAIN) {
         throw std::runtime_error("used readn2 on non-blocking socket, got EAGAIN");
-      else
-        unixDie("failed in readn2");
+      }
+      unixDie("failed in readn2");
     }
 
-    pos+=(size_t)res;
-    if(pos == len)
+    pos += static_cast<size_t>(res);
+    if (pos == len) {
       break;
+    }
   }
   return len;
 }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -167,7 +167,7 @@ vstringtok (Container &container, string const &in,
 
 size_t writen2(int fd, const void *buf, size_t count);
 inline size_t writen2(int fd, const std::string &s) { return writen2(fd, s.data(), s.size()); }
-size_t readn2(int fd, void* buffer, size_t len);
+size_t readn2(int fileDesc, void* buffer, size_t len);
 size_t readn2WithTimeout(int fd, void* buffer, size_t len, const struct timeval& idleTimeout, const struct timeval& totalTimeout={0,0}, bool allowIncomplete=false);
 size_t writen2WithTimeout(int fd, const void * buffer, size_t len, const struct timeval& timeout);
 
@@ -319,9 +319,9 @@ inline double getTime()
   return now.tv_sec+now.tv_usec/1000000.0;
 }
 
-inline void unixDie(const string &why)
+[[noreturn]] inline void unixDie(const string &why)
 {
-  throw runtime_error(why+": "+stringerror());
+  throw runtime_error(why + ": " + stringerror(errno));
 }
 
 string makeHexDump(const string& str);


### PR DESCRIPTION
It might even be the case that this (marking `unixDie` as `[[noreturn]]`) makes Coverity realize pos does not overflow.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
