### PR TITLE
auth: followup to 14370: add boost depedendency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -111,7 +111,7 @@ libpdns_uuidutils = declare_dependency(
     'pdns-uuidutils',
     src_dir / 'uuid-utils.cc',
     src_dir / 'uuid-utils.hh',
-    dependencies: [dep_rt, dep_boost, ],
+    dependencies: [dep_rt, dep_boost],
   )
 )
 

--- a/meson.build
+++ b/meson.build
@@ -111,7 +111,7 @@ libpdns_uuidutils = declare_dependency(
     'pdns-uuidutils',
     src_dir / 'uuid-utils.cc',
     src_dir / 'uuid-utils.hh',
-    dependencies: dep_rt,
+    dependencies: [dep_rt, dep_boost, ],
   )
 )
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Avoids on FreebSD and macOS:
```
In file included from ../pdns/uuid-utils.cc:23:
../pdns/uuid-utils.hh:24:10: fatal error: 'boost/uuid/uuid.hpp' file not found
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
