### PR TITLE
rec: Backport 14384 to rec-5.1.x: keep Lua config as existing configs might use it 

### DIFF
--- a/builder-support/debian/recursor/debian-buster/pdns-recursor.maintscript
+++ b/builder-support/debian/recursor/debian-buster/pdns-recursor.maintscript
@@ -1,3 +1,4 @@
 # must support Ubuntu focal, with dpkg 1.19.7
-rm_conffile /etc/powerdns/recursor.lua 5.1~
+# Enable the line below once we fully moved to YAML configuration
+#rm_conffile /etc/powerdns/recursor.lua 5.1~
 

--- a/builder-support/debian/recursor/debian-buster/recursor.lua
+++ b/builder-support/debian/recursor/debian-buster/recursor.lua
@@ -1,0 +1,7 @@
+-- Debian default Lua configuration file for PowerDNS Recursor
+
+-- Load DNSSEC root keys from dns-root-data package.
+-- Note: If you provide your own Lua configuration file, consider
+-- running rootkeys.lua too.
+dofile("/usr/share/pdns-recursor/lua-config/rootkeys.lua")
+

--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -32,8 +32,12 @@ override_dh_auto_configure:
 		--enable-dnstap \
 		--enable-nod
 
+# Stop installing the Lua config files once we fully moved to YAML configuration
 override_dh_auto_install:
 	dh_auto_install
+	install -d debian/pdns-recursor/usr/share/pdns-recursor/lua-config
+	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
+	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	install -d debian/pdns-recursor/usr/share/pdns-recursor/snmp
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/snmp RECURSOR-MIB.txt
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist


### PR DESCRIPTION
(cherry picked from commit 6b2d9507dab4d64623bbca6fcd3bbd57ddebff8e)

Backport of #14384 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
