### PR TITLE
dnsdist: Handle Quiche >= 0.22.0

### DIFF
--- a/pdns/dnsdistdist/m4/pdns_with_quiche.m4
+++ b/pdns/dnsdistdist/m4/pdns_with_quiche.m4
@@ -10,10 +10,17 @@ AC_DEFUN([PDNS_WITH_QUICHE], [
 
   AS_IF([test "x$with_quiche" != "xno"], [
     AS_IF([test "x$with_quiche" = "xyes" -o "x$with_quiche" = "xauto"], [
-      PKG_CHECK_MODULES([QUICHE], [quiche >= 0.15.0], [
+      PKG_CHECK_MODULES([QUICHE], [quiche >= 0.22.0], [
         [HAVE_QUICHE=1]
         AC_DEFINE([HAVE_QUICHE], [1], [Define to 1 if you have quiche])
-      ], [ : ])
+        AC_DEFINE([HAVE_QUICHE_STREAM_ERROR_CODES], [1], [Define to 1 if the Quiche API includes error code in quiche_conn_stream_recv and quiche_conn_stream_send])
+      ], [
+        # Quiche is older than 0.22.0, or no Quiche at all
+        PKG_CHECK_MODULES([QUICHE], [quiche >= 0.15.0], [
+          [HAVE_QUICHE=1]
+          AC_DEFINE([HAVE_QUICHE], [1], [Define to 1 if you have quiche])
+        ], [ : ])
+      ])
     ])
   ])
   AM_CONDITIONAL([HAVE_QUICHE], [test "x$QUICHE_LIBS" != "x"])


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Quiche broke its existing API in 0.22.0: https://github.com/cloudflare/quiche/pull/1726 
This pull request adds m4 code to detect whether the Quiche version we are building against is `>= 0.22.0`, and if it is defines `HAVE_QUICHE_STREAM_ERROR_CODES` which is later used by the code using Quiche to know which version of the API to use.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
