### PR TITLE
Rework the `QType` class

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -869,7 +869,7 @@ void Bind2Backend::doEmptyNonTerminals(std::shared_ptr<recordstorage_t>& records
   }
 
   DNSResourceRecord rr;
-  rr.qtype = "#0";
+  rr.qtype = QType::fromString("#0");
   rr.content = "";
   rr.ttl = 0;
   for (auto& nt : nonterm) {

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -237,7 +237,7 @@ bool GeoIPBackend::loadDomain(const YAML::Node& domain, std::uint32_t domainID, 
         }
         else {
           string qtype = boost::to_upper_copy(rec->first.as<string>());
-          rr.qtype = qtype;
+          rr.qtype = QType::fromString(qtype);
         }
         rr.has_weight = false;
         rr.weight = 100;

--- a/modules/ldapbackend/ldapbackend.cc
+++ b/modules/ldapbackend/ldapbackend.cc
@@ -180,7 +180,7 @@ void LdapBackend::extract_entry_results(const DNSName& domain, const DNSResult& 
       attrname = attribute.first;
       // extract qtype string from ldap attribute name by removing the 'Record' suffix.
       qstr = attrname.substr(0, attrname.length() - 6);
-      qt = toUpper(qstr);
+      qt = QType::fromString(qstr);
 
       for (const auto& value : attribute.second) {
         if (qtype != qt && qtype != QType::ANY) {

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -143,7 +143,7 @@ public:
           if (item.second.which() == 1)
             rec.qtype = QType(boost::get<int>(item.second));
           else if (item.second.which() == 3)
-            rec.qtype = boost::get<string>(item.second);
+            rec.qtype = QType::fromString(boost::get<string>(item.second));
           else if (item.second.which() == 4)
             rec.qtype = boost::get<QType>(item.second);
           else

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -312,7 +312,7 @@ bool PipeBackend::get(DNSResourceRecord& r)
           r.auth = true;
         }
         r.qname = DNSName(parts[1 + extraFields]);
-        r.qtype = parts[3 + extraFields];
+        r.qtype = QType::fromString(parts[3 + extraFields]);
         pdns::checked_stoi_into(r.ttl, parts[4 + extraFields]);
         pdns::checked_stoi_into(r.domain_id, parts[5 + extraFields]);
 

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -252,7 +252,7 @@ bool RemoteBackend::get(DNSResourceRecord& rr)
     return false;
   }
 
-  rr.qtype = stringFromJson(d_result["result"][d_index], "qtype");
+  rr.qtype = QType::fromString(stringFromJson(d_result["result"][d_index], "qtype"));
   rr.qname = DNSName(stringFromJson(d_result["result"][d_index], "qname"));
   rr.qclass = QClass::IN;
   rr.content = stringFromJson(d_result["result"][d_index], "content");
@@ -853,7 +853,7 @@ bool RemoteBackend::searchRecords(const string& pattern, size_t maxResults, vect
 
   for (const auto& row : answer["result"].array_items()) {
     DNSResourceRecord rr;
-    rr.qtype = stringFromJson(row, "qtype");
+    rr.qtype = QType::fromString(stringFromJson(row, "qtype"));
     rr.qname = DNSName(stringFromJson(row, "qname"));
     rr.qclass = QClass::IN;
     rr.content = stringFromJson(row, "content");

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -2283,7 +2283,7 @@ void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)
   else
     r.qname=DNSName(row[6]);
 
-  r.qtype=row[3];
+  r.qtype = QType::fromString(row[3]);
 
   if (d_upgradeContent && DNSRecordContent::isUnknownType(row[3]) && DNSRecordContent::isRegisteredType(r.qtype, r.qclass)) {
     r.content = DNSRecordContent::upgradeContent(r.qname, r.qtype, row[0]);
@@ -2324,7 +2324,7 @@ void GSQLBackend::extractComment(SSqlStatement::row_t& row, Comment& comment)
 {
   pdns::checked_stoi_into(comment.domain_id, row[0]);
   comment.qname = DNSName(row[1]);
-  comment.qtype = row[2];
+  comment.qtype = QType::fromString(row[2]);
   pdns::checked_stoi_into(comment.modified_at, row[3]);
   comment.account = std::move(row[4]);
   comment.content = std::move(row[5]);

--- a/pdns/dnsdistdist/dnsdist-lua-rules.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-rules.cc
@@ -544,7 +544,7 @@ void setupLuaRules(LuaContext& luaCtx)
     }
     else {
       string val = boost::get<string>(str);
-      qtype = QType::chartocode(val.c_str());
+      qtype = QType::fromString(val);
       if (qtype == 0) {
         throw std::runtime_error("Unable to convert '" + val + "' to a DNS type");
       }

--- a/pdns/dnsdistdist/dnsdist-rings.cc
+++ b/pdns/dnsdistdist/dnsdist-rings.cc
@@ -202,7 +202,7 @@ size_t Rings::loadFromFile(const std::string& filepath, const struct timespec& n
     /* skip ID */
     idx++;
     DNSName qname(parts.at(idx++));
-    QType qtype(QType::chartocode(parts.at(idx++).c_str()));
+    QType qtype(QType::fromString(parts.at(idx++)));
 
     if (isResponse) {
       insertResponse(when, from, qname, qtype.getCode(), 0, 0, dnsHeader, dest, protocol);

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -1583,7 +1583,7 @@ static void handleCacheManagement(const YaHTTP::Request& req, YaHTTP::Response& 
     return;
   }
   if (expungeType != req.getvars.end()) {
-    type = QType::chartocode(expungeType->second.c_str());
+    type = QType::fromString(expungeType->second);
   }
 
   std::shared_ptr<ServerPool> pool;

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -55,7 +55,7 @@ void AuthLua4::postPrepareContext() {
   d_lw->registerFunction<DNSPacket, void()>("clearRecords",[](DNSPacket &p){p.clearRecords();});
   d_lw->registerFunction<DNSPacket, void(DNSRecord&, bool)>("addRecord", [](DNSPacket &p, DNSRecord &dr, bool auth) { DNSZoneRecord dzr; dzr.dr = dr; dzr.auth = auth; p.addRecord(std::move(dzr)); });
   d_lw->registerFunction<DNSPacket, void(const vector<pair<unsigned int, DNSRecord> >&)>("addRecords", [](DNSPacket &p, const vector<pair<unsigned int, DNSRecord> >& records){ for(const auto &dr: records){ DNSZoneRecord dzr; dzr.dr = std::get<1>(dr); dzr.auth = true; p.addRecord(std::move(dzr)); }});
-  d_lw->registerFunction<DNSPacket, void(unsigned int, const DNSName&, const std::string&)>("setQuestion", [](DNSPacket &p, unsigned int opcode, const DNSName &name, const string &type){ QType qtype; qtype = type; p.setQuestion(static_cast<int>(opcode), name, static_cast<int>(qtype.getCode())); });
+  d_lw->registerFunction<DNSPacket, void(unsigned int, const DNSName&, const std::string&)>("setQuestion", [](DNSPacket &packet, unsigned int opcode, const DNSName &name, const string &type){ QType qtype; qtype = QType::fromString(type); packet.setQuestion(static_cast<int>(opcode), name, static_cast<int>(qtype.getCode())); });
   d_lw->registerFunction<DNSPacket, bool()>("isEmpty", [](DNSPacket &p){return p.isEmpty();});
   d_lw->registerFunction<DNSPacket, std::shared_ptr<DNSPacket>()>("replyPacket",[](DNSPacket& p){ return p.replyPacket();});
   d_lw->registerFunction<DNSPacket, bool()>("hasEDNSSubnet", [](DNSPacket &p){return p.hasEDNSSubnet();});
@@ -70,7 +70,7 @@ void AuthLua4::postPrepareContext() {
   d_lw->registerMember<DNSPacket, DNSName>("qdomainzone", [](const DNSPacket &p) -> DNSName { return p.qdomainzone; }, [](DNSPacket &p, const DNSName& name) { p.qdomainzone = name; });
 
   d_lw->registerMember<DNSPacket, std::string>("d_peer_principal", [](const DNSPacket &p) -> std::string { return p.d_peer_principal; }, [](DNSPacket &p, const std::string &princ) { p.d_peer_principal = princ; });
-  d_lw->registerMember<DNSPacket, const std::string>("qtype", [](const DNSPacket &p) ->  const std::string { return p.qtype.toString(); }, [](DNSPacket &p, const std::string &type) { p.qtype = type; });
+  d_lw->registerMember<DNSPacket, const std::string>("qtype", [](const DNSPacket &packet) -> std::string { return packet.qtype.toString(); }, [](DNSPacket &packet, const std::string &type) { packet.qtype = QType::fromString(type); });
 /* End of DNSPacket */
 
 

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -82,7 +82,7 @@ void BaseLua4::prepareContext() {
   d_lw->writeFunction("newDRR", [](const DNSName& qname, const string& qtype, const unsigned int ttl, const string& content, boost::optional<int> domain_id, boost::optional<int> auth){
     auto drr = DNSResourceRecord();
     drr.qname = qname;
-    drr.qtype = qtype;
+    drr.qtype = QType::fromString(qtype);
     drr.ttl = ttl;
     drr.setContent(content);
     if (domain_id)
@@ -177,7 +177,7 @@ void BaseLua4::prepareContext() {
   d_lw->registerFunction<bool(cas_t::*)(const ComboAddress&)>("check",[](const cas_t& cas, const ComboAddress&ca) { return cas.count(ca)>0; });
 
   // QType
-  d_lw->writeFunction("newQType", [](const string& s) { QType q; q = s; return q; });
+  d_lw->writeFunction("newQType", [](const string& newQType) { QType qType; qType = QType::fromString(newQType); return qType; });
   d_lw->registerFunction("getCode", &QType::getCode);
   d_lw->registerFunction("getName", &QType::toString);
   d_lw->registerEqFunction<bool(QType::*)(const QType&)>([](const QType& a, const QType& b){ return a == b;}); // operator overloading confuses LuaContext
@@ -216,7 +216,7 @@ void BaseLua4::prepareContext() {
   d_lw->registerFunction("match", (bool (NetmaskGroup::*)(const ComboAddress&) const)&NetmaskGroup::match);
 
   // DNSRecord
-  d_lw->writeFunction("newDR", [](const DNSName& name, const std::string& type, unsigned int ttl, const std::string& content, int place) { QType qtype; qtype = type; auto dr = DNSRecord(); dr.d_name = name; dr.d_type = qtype.getCode(); dr.d_ttl = ttl; dr.setContent(shared_ptr<DNSRecordContent>(DNSRecordContent::make(dr.d_type, QClass::IN, content))); dr.d_place = static_cast<DNSResourceRecord::Place>(place); return dr; });
+  d_lw->writeFunction("newDR", [](const DNSName& name, const std::string& type, unsigned int ttl, const std::string& content, int place) { QType qtype; qtype = QType::fromString(type); auto dnsRecord = DNSRecord(); dnsRecord.d_name = name; dnsRecord.d_type = qtype.getCode(); dnsRecord.d_ttl = ttl; dnsRecord.setContent(shared_ptr<DNSRecordContent>(DNSRecordContent::make(dnsRecord.d_type, QClass::IN, content))); dnsRecord.d_place = static_cast<DNSResourceRecord::Place>(place); return dnsRecord; });
   d_lw->registerMember("name", &DNSRecord::d_name);
   d_lw->registerMember("type", &DNSRecord::d_type);
   d_lw->registerMember("ttl", &DNSRecord::d_ttl);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1,4 +1,5 @@
 #include "dnsrecords.hh"
+#include "qtype.hh"
 #include <boost/smart_ptr/make_shared_array.hpp>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -1497,7 +1498,7 @@ static int createZone(const DNSName &zone, const DNSName& nsname) {
   rr.qname = zone;
   rr.auth = true;
   rr.ttl = ::arg().asNum("default-ttl");
-  rr.qtype = "SOA";
+  rr.qtype = QType::fromString("SOA");
 
   string soa = ::arg()["default-soa-content"];
   boost::replace_all(soa, "@", zone.toStringNoDot());
@@ -1735,9 +1736,9 @@ static int deleteRRSet(const std::string& zone_, const std::string& name_, const
   else
     name=DNSName(name_)+zone;
 
-  QType qt(QType::chartocode(type_.c_str()));
+  QType qType(QType::fromString(type_));
   di.backend->startTransaction(zone, -1);
-  di.backend->replaceRRSet(di.id, name, qt, vector<DNSResourceRecord>());
+  di.backend->replaceRRSet(di.id, name, qType, vector<DNSResourceRecord>());
   di.backend->commitTransaction();
   return EXIT_SUCCESS;
 }

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -20,41 +20,47 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
 
 #include "namespaces.hh"
+#include <cstdint>
 
-/** The QType class is meant to deal easily with the different kind of resource types, like 'A', 'NS',
- *  'CNAME' etcetera. These types have both a name and a number. This class can seamlessly move between
- *   them. Use it like this:
+/**
+ * The QType class is meant to be used to easily deal with the different kinds of resource
+ * types like 'A', 'NS' and 'CNAME'. These types have both a name and a number. This class
+ * can seamlessly convert between them. Use it like this:
 
 \code
-   QType t;
-   t="CNAME";
-   cout<<t.getCode()<<endl; // prints '5'
-   t=6;
-   cout<<t.toString()<<endl; // prints 'SOA'
+   QType qtype = QType::fromString("CNAME");
+   cout << qtype.getCode() << endl; // prints '5'
+   qtype = QType(6);
+   cout << qtype.toString() << endl; // prints 'SOA'
 \endcode
-
 */
 
 class QType
 {
 public:
-  QType(uint16_t qtype = 0) : code(qtype) {}
-  QType &operator=(const char *);
-  QType &operator=(const string &);
+  constexpr QType(uint16_t code = 0) :
+    qtype(code) {}
 
-  operator uint16_t() const {
-    return code;
+  static auto fromString(const string&) -> QType;
+
+  operator uint16_t() const
+  {
+    return qtype;
   }
 
-  const string toString() const;
-  uint16_t getCode() const
+  auto operator=(std::string& value) -> QType&
   {
-    return code;
+    *this = QType::fromString(value);
+    return *this;
+  }
+
+  [[nodiscard]] string toString() const;
+
+  [[nodiscard]] uint16_t getCode() const
+  {
+    return qtype;
   }
 
   /**
@@ -63,31 +69,31 @@ public:
    * This does not presume that we have an implemented a content representation for this type,
    * for that please see DNSRecordContent::isRegisteredType().
    */
-  bool isSupportedType() const;
+  [[nodiscard]] bool isSupportedType() const;
+
   /**
    * \brief Whether the type is either a QTYPE or Meta-Type as defined by rfc6895 section 3.1.
    *
    * Note that ANY is 255 and falls outside the range.
    */
-  bool isMetadataType() const;
+  [[nodiscard]] bool isMetadataType() const;
 
-  static uint16_t chartocode(const char* p);
-
-  enum typeenum : uint16_t {
+  enum QTypeEnum : uint16_t
+  {
     ENT = 0,
-    A = 1,
-    NS = 2,
+    A = 1,                      // NOLINT(readability-identifier-length)
+    NS = 2,                     // NOLINT(readability-identifier-length)
     CNAME = 5,
     SOA = 6,
-    MB = 7,
-    MG = 8,
-    MR = 9,
+    MB = 7,                     // NOLINT(readability-identifier-length)
+    MG = 8,                     // NOLINT(readability-identifier-length)
+    MR = 9,                     // NOLINT(readability-identifier-length)
     PTR = 12,
     HINFO = 13,
     MINFO = 14,
-    MX = 15,
+    MX = 15,                    // NOLINT(readability-identifier-length)
     TXT = 16,
-    RP = 17,
+    RP = 17,                    // NOLINT(readability-identifier-length)
     AFSDB = 18,
     SIG = 24,
     KEY = 25,
@@ -95,13 +101,13 @@ public:
     LOC = 29,
     SRV = 33,
     NAPTR = 35,
-    KX = 36,
+    KX = 36,                    // NOLINT(readability-identifier-length)
     CERT = 37,
-    A6 = 38,
+    A6 = 38,                    // NOLINT(readability-identifier-length)
     DNAME = 39,
     OPT = 41,
     APL = 42,
-    DS = 43,
+    DS = 43,                    // NOLINT(readability-identifier-length)
     SSHFP = 44,
     IPSECKEY = 45,
     RRSIG = 46,
@@ -124,7 +130,7 @@ public:
     NID = 104,
     L32 = 105,
     L64 = 106,
-    LP = 107,
+    LP = 107,                   // NOLINT(readability-identifier-length)
     EUI48 = 108,
     EUI64 = 109,
     TKEY = 249,
@@ -140,29 +146,32 @@ public:
     ADDR = 65400,
 #if !defined(RECURSOR)
     ALIAS = 65401,
-    LUA = 65402
+    LUA = 65402,
 #endif
   };
 
-  const static uint16_t rfc6895MetaLowerBound = 128;
-  const static uint16_t rfc6895MetaUpperBound = 254; // Note 255: ANY is not included
-  const static uint16_t rfc6895Reserved = 65535;
+  static const uint16_t rfc6895MetaLowerBound = 128;
+  static const uint16_t rfc6895MetaUpperBound = 254; // Note 255: ANY is not included
+  static const uint16_t rfc6895Reserved = 65535;
 
-  const static map<const string, uint16_t> names;
-  const static map<uint16_t, const string> numbers;
+  static const map<const string, uint16_t> names;
+  static const map<uint16_t, const string> numbers;
 
 private:
-
-  uint16_t code;
+  uint16_t qtype;
 };
 
 // Define hash function on QType. See https://en.cppreference.com/w/cpp/utility/hash
-namespace std {
-  template<> struct hash<QType> {
-    std::size_t operator()(QType qtype) const noexcept {
-      return std::hash<uint16_t>{}(qtype.getCode());
-    }
-  };
+namespace std
+{
+template <>
+struct hash<QType>
+{
+  std::size_t operator()(QType qtype) const noexcept
+  {
+    return std::hash<uint16_t>{}(qtype.getCode());
+  }
+};
 }
 
 inline std::ostream& operator<<(std::ostream& stream, const QType& qtype)
@@ -171,24 +180,29 @@ inline std::ostream& operator<<(std::ostream& stream, const QType& qtype)
 }
 
 // Used by e.g. boost multi-index
-inline size_t hash_value(const QType qtype) {
+inline size_t hash_value(const QType qtype)
+{
   return qtype.getCode();
 }
 
 struct QClass
 {
-  constexpr QClass(uint16_t code = 0) : qclass(code) {}
+  constexpr QClass(uint16_t code = 0) :
+    qclass(code) {}
 
-  constexpr operator uint16_t() const {
-    return qclass;
-  }
-  constexpr uint16_t getCode() const
+  constexpr operator uint16_t() const
   {
     return qclass;
   }
-  const std::string toString() const;
 
-  static const QClass IN;
+  [[nodiscard]] constexpr uint16_t getCode() const
+  {
+    return qclass;
+  }
+
+  [[nodiscard]] std::string toString() const;
+
+  static const QClass IN; // NOLINT(readability-identifier-length)
   static const QClass CHAOS;
   static const QClass NONE;
   static const QClass ANY;
@@ -197,12 +211,12 @@ private:
   uint16_t qclass;
 };
 
-constexpr QClass QClass::IN(1);
+constexpr QClass QClass::IN(1); // NOLINT(readability-identifier-length)
 constexpr QClass QClass::CHAOS(3);
 constexpr QClass QClass::NONE(254);
 constexpr QClass QClass::ANY(255);
 
-inline std::ostream& operator<<(std::ostream& s, QClass qclass)
+inline std::ostream& operator<<(std::ostream& stream, QClass qclass)
 {
-  return s << qclass.toString();
+  return stream << qclass.toString();
 }

--- a/pdns/recursordist/rec-lua-conf.cc
+++ b/pdns/recursordist/rec-lua-conf.cc
@@ -216,7 +216,7 @@ static void parseProtobufOptions(const boost::optional<protobufOptions_t>& vars,
         qtype = std::stoul(type);
       }
       catch (const std::exception& ex) {
-        qtype = QType::chartocode(type.c_str());
+        qtype = QType::fromString(type);
         if (qtype == 0) {
           throw std::runtime_error("Unknown QType '" + type + "' in protobuf's export types");
         }

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2350,7 +2350,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int socket, cons
     if (begin == end) {
       return {1, "Need a qtype\n"};
     }
-    uint16_t qtype = QType::chartocode(begin->c_str());
+    uint16_t qtype = QType::fromString(*begin);
     if (qtype == 0) {
       return {1, "Unknown qtype " + *begin + "\n"};
     }

--- a/pdns/recursordist/settings/cxxsupport.cc
+++ b/pdns/recursordist/settings/cxxsupport.cc
@@ -1095,7 +1095,7 @@ void fromRustToLuaConfig(const pdns::rust::settings::rec::ProtobufServer& pbServ
   exp.enabled = true;
   exp.exportTypes.clear();
   for (const auto& type : pbServer.exportTypes) {
-    exp.exportTypes.emplace(QType::chartocode(std::string(type).c_str()));
+    exp.exportTypes.emplace(QType::fromString(std::string(type)));
   }
   for (const auto& server : pbServer.servers) {
     exp.servers.emplace_back(std::string(server));
@@ -1253,10 +1253,10 @@ void fromRustToLuaConfig(const rust::Vec<pdns::rust::settings::rec::SortList>& s
 void fromRustToLuaConfig(const rust::Vec<pdns::rust::settings::rec::AllowedAdditionalQType>& alloweds, std::map<QType, std::pair<std::set<QType>, AdditionalMode>>& lua)
 {
   for (const auto& allowed : alloweds) {
-    QType qtype(QType::chartocode(std::string(allowed.qtype).c_str()));
+    QType qtype = QType::fromString(std::string(allowed.qtype));
     std::set<QType> set;
     for (const auto& target : allowed.targets) {
-      set.emplace(QType::chartocode(std::string(target).c_str()));
+      set.emplace(QType::fromString(std::string(target)));
     }
     AdditionalMode mode = AdditionalMode::CacheOnlyRequireAuth;
     mode = cvtAdditional(std::string(allowed.mode));
@@ -1384,7 +1384,7 @@ pdns::settings::rec::YamlSettingsStatus pdns::settings::rec::tryReadYAML(const s
 uint16_t pdns::rust::settings::rec::qTypeStringToCode(::rust::Str str)
 {
   std::string tmp(str.data(), str.length());
-  return QType::chartocode(tmp.c_str());
+  return QType::fromString(std::string(tmp));
 }
 
 bool pdns::rust::settings::rec::isValidHostname(::rust::Str str)

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -851,7 +851,7 @@ bool SyncRes::doSpecialNamesResolve(const DNSName& qname, const QType qtype, con
   static const DNSName negativetrustanchorserver("negativetrustanchor.server.");
 
   bool handled = false;
-  vector<pair<QType::typeenum, string>> answers;
+  vector<pair<QType::QTypeEnum, string>> answers;
 
   if ((qname == arpa || qname == ip6_arpa) && qclass == QClass::IN) {
     handled = true;

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -479,7 +479,7 @@ static void apiServerCacheFlush(HttpRequest* req, HttpResponse* resp)
   bool subtree = req->getvars.count("subtree") > 0 && req->getvars["subtree"] == "true";
   uint16_t qtype = 0xffff;
   if (req->getvars.count("type") != 0) {
-    qtype = QType::chartocode(req->getvars["type"].c_str());
+    qtype = QType::fromString(req->getvars["type"]);
   }
 
   struct WipeCacheResult res = wipeCaches(canon, subtree, qtype);

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -45,8 +45,8 @@ BOOST_AUTO_TEST_SUITE(test_dnsrecords_cc)
 
 BOOST_AUTO_TEST_CASE(test_record_types) {
   // tuple contains <type, user value, zone representation, line value, broken>
-  typedef boost::tuple<QType::typeenum, std::string, std::string, std::string, broken_marker> case_t;
-  typedef std::list<case_t> cases_t;
+  using case_t = boost::tuple<QType::QTypeEnum, std::string, std::string, std::string, broken_marker>;
+  using cases_t = std::list<case_t>;
   MRRecordContent::report();
   IPSECKEYRecordContent::report();
   KXRecordContent::report();
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
      (CASE_S(QType::CAA, "0 issue \"aaaaaaa\"", "\x00\x05\x69\x73\x73\x75\x65\x61\x61\x61\x61\x61\x61\x61"))
      (CASE_S(QType::CAA, "0 issue \"aaaaaaa.aaa\"", "\x00\x05\x69\x73\x73\x75\x65\x61\x61\x61\x61\x61\x61\x61\x2e\x61\x61\x61"))
      (CASE_S(QType::DLV, "20642 8 2 04443abe7e94c3985196beae5d548c727b044dda5151e60d7cd76a9fd931d00e", "\x50\xa2\x08\x02\x04\x44\x3a\xbe\x7e\x94\xc3\x98\x51\x96\xbe\xae\x5d\x54\x8c\x72\x7b\x04\x4d\xda\x51\x51\xe6\x0d\x7c\xd7\x6a\x9f\xd9\x31\xd0\x0e"))
-     (CASE_S((QType::typeenum)65226,"\\# 3 414243","\x41\x42\x43"))
+     (CASE_S((QType::QTypeEnum)65226,"\\# 3 414243","\x41\x42\x43"))
 
 ;
 
@@ -349,8 +349,8 @@ BOOST_AUTO_TEST_CASE(test_record_types_bad_values) {
   enum class case_type_t { zone, wire };
 
   // qtype, value, zone/wire format, broken
-  typedef boost::tuple<const QType::typeenum, const std::string, case_type_t, broken_marker> case_t;
-  typedef std::list<case_t> cases_t;
+  using case_t = boost::tuple<const QType::QTypeEnum, const std::string, case_type_t, broken_marker>;
+  using cases_t = std::list<case_t>;
 
 #define ZONE_CASE(type, input) case_t(type, BINARY(input), case_type_t::zone, broken_marker::WORKING)
 #define WIRE_CASE(type, input) case_t(type, BINARY(input), case_type_t::wire, broken_marker::WORKING)
@@ -471,27 +471,27 @@ BOOST_AUTO_TEST_CASE(test_opt_record_out) {
 // special record test, because Unknown record types are the worst
 BOOST_AUTO_TEST_CASE(test_unknown_records_in) {
 
-  auto validUnknown = DNSRecordContent::make(static_cast<QType::typeenum>(65534), QClass::IN, "\\# 1 42");
+  auto validUnknown = DNSRecordContent::make(static_cast<QType::QTypeEnum>(65534), QClass::IN, "\\# 1 42");
 
   // we need at least two parts
-  BOOST_CHECK_THROW(auto notEnoughPartsUnknown = DNSRecordContent::make(static_cast<QType::typeenum>(65534), QClass::IN, "\\#"), MOADNSException);
+  BOOST_CHECK_THROW(auto notEnoughPartsUnknown = DNSRecordContent::make(static_cast<QType::QTypeEnum>(65534), QClass::IN, "\\#"), MOADNSException);
 
   // two parts are OK when the RDATA size is 0, not OK otherwise
-  auto validEmptyUnknown = DNSRecordContent::make(static_cast<QType::typeenum>(65534), QClass::IN, "\\# 0");
-  BOOST_CHECK_THROW(auto twoPartsNotZeroUnknown = DNSRecordContent::make(static_cast<QType::typeenum>(65534), QClass::IN, "\\# 1"), MOADNSException);
+  auto validEmptyUnknown = DNSRecordContent::make(static_cast<QType::QTypeEnum>(65534), QClass::IN, "\\# 0");
+  BOOST_CHECK_THROW(auto twoPartsNotZeroUnknown = DNSRecordContent::make(static_cast<QType::QTypeEnum>(65534), QClass::IN, "\\# 1"), MOADNSException);
 
   // the first part has to be "\#"
-  BOOST_CHECK_THROW(auto invalidFirstPartUnknown = DNSRecordContent::make(static_cast<QType::typeenum>(65534), QClass::IN, "\\$ 0"), MOADNSException);
+  BOOST_CHECK_THROW(auto invalidFirstPartUnknown = DNSRecordContent::make(static_cast<QType::QTypeEnum>(65534), QClass::IN, "\\$ 0"), MOADNSException);
 
   // RDATA length is not even
-  BOOST_CHECK_THROW(auto unevenUnknown = DNSRecordContent::make(static_cast<QType::typeenum>(65534), QClass::IN, "\\# 1 A"), MOADNSException);
+  BOOST_CHECK_THROW(auto unevenUnknown = DNSRecordContent::make(static_cast<QType::QTypeEnum>(65534), QClass::IN, "\\# 1 A"), MOADNSException);
 
   // RDATA length is not equal to the expected size
-  BOOST_CHECK_THROW(auto wrongRDATASizeUnknown = DNSRecordContent::make(static_cast<QType::typeenum>(65534), QClass::IN, "\\# 2 AA"), MOADNSException);
+  BOOST_CHECK_THROW(auto wrongRDATASizeUnknown = DNSRecordContent::make(static_cast<QType::QTypeEnum>(65534), QClass::IN, "\\# 2 AA"), MOADNSException);
 
   // RDATA is invalid (invalid hex value)
   try {
-    auto invalidRDATAUnknown = DNSRecordContent::make(static_cast<QType::typeenum>(65534), QClass::IN, "\\# 1 JJ");
+    auto invalidRDATAUnknown = DNSRecordContent::make(static_cast<QType::QTypeEnum>(65534), QClass::IN, "\\# 1 JJ");
     // we should not reach that code
     BOOST_CHECK(false);
     // but if we do let's see what we got (likely what was left over on the stack)
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_records_types) {
     auto nsecContent = std::dynamic_pointer_cast<NSECRecordContent>(validNSEC);
     BOOST_REQUIRE(nsecContent);
 
-    for (const auto type : { QType::A, QType::MX, QType::RRSIG, QType::NSEC, static_cast<QType::typeenum>(1234) }) {
+    for (const auto type : { QType::A, QType::MX, QType::RRSIG, QType::NSEC, static_cast<QType::QTypeEnum>(1234) }) {
       BOOST_CHECK(nsecContent->isSet(type));
     }
     BOOST_CHECK_EQUAL(nsecContent->isSet(QType::NSEC3), false);
@@ -648,7 +648,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_records_types) {
     auto nsec3Content = std::dynamic_pointer_cast<NSEC3RecordContent>(validNSEC3);
     BOOST_REQUIRE(nsec3Content);
 
-    for (const auto type : { QType::A, QType::MX, QType::RRSIG, QType::NSEC3, static_cast<QType::typeenum>(1234), static_cast<QType::typeenum>(65535) }) {
+    for (const auto type : { QType::A, QType::MX, QType::RRSIG, QType::NSEC3, static_cast<QType::QTypeEnum>(1234), static_cast<QType::QTypeEnum>(65535) }) {
       BOOST_CHECK(nsec3Content->isSet(type));
     }
     BOOST_CHECK_EQUAL(nsec3Content->isSet(QType::NSEC), false);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -457,7 +457,7 @@ static void fillZone(UeberBackend& backend, const DNSName& zonename, HttpRespons
           qType = QType::ANY;
         }
         else {
-          qType = req->getvars["rrset_type"];
+          qType = QType::fromString(req->getvars["rrset_type"]);
         }
         domainInfo.backend->lookup(qType, DNSName(req->getvars["rrset_name"]), static_cast<int>(domainInfo.id));
       }
@@ -1908,7 +1908,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
         DNSName qname = apiNameToDNSName(stringFromJson(rrset, "name"));
         apiCheckQNameAllowedCharacters(qname.toString());
         QType qtype;
-        qtype = stringFromJson(rrset, "type");
+        qtype = QType::fromString(stringFromJson(rrset, "type"));
         if (qtype.getCode() == 0) {
           throw ApiException("RRset " + qname.toString() + " IN " + stringFromJson(rrset, "type") + ": unknown type given");
         }
@@ -2124,7 +2124,7 @@ static void apiServerZoneDetailPUT(HttpRequest* req, HttpResponse* resp)
         DNSName qname = apiNameToDNSName(stringFromJson(rrset, "name"));
         apiCheckQNameAllowedCharacters(qname.toString());
         QType qtype;
-        qtype = stringFromJson(rrset, "type");
+        qtype = QType::fromString(stringFromJson(rrset, "type"));
         if (qtype.getCode() == 0) {
           throw ApiException("RRset " + qname.toString() + " IN " + stringFromJson(rrset, "type") + ": unknown type given");
         }
@@ -2337,7 +2337,7 @@ static void patchZone(UeberBackend& backend, const DNSName& zonename, DomainInfo
       DNSName qname = apiNameToDNSName(stringFromJson(rrset, "name"));
       apiCheckQNameAllowedCharacters(qname.toString());
       QType qtype;
-      qtype = stringFromJson(rrset, "type");
+      qtype = QType::fromString(stringFromJson(rrset, "type"));
       if (qtype.getCode() == 0) {
         throw ApiException("RRset " + qname.toString() + " IN " + stringFromJson(rrset, "type") + ": unknown type given");
       }


### PR DESCRIPTION
### Short description
This adds `QType::fromString()` which does error checking and throws exceptions when invalid input is provided.

Cleans up the anti-pattern that was previously there where you could only construct a `QType` object from a string by assigning to a dummy one. Also removes access to internals like `chartocode` which was being used all around in place of that anti-pattern.

I haven't tried to build dnsdist and the recursor with this change and I'll wait until tomorrow for the CI to give me feedback.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)