### PR TITLE
Fix compile error on OPENSSL_VERSION_MAJOR < 3

### DIFF
--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -100,11 +100,12 @@ public:
 #if OPENSSL_VERSION_MAJOR >= 3
   int encrypt(unsigned char keyName[TLS_TICKETS_KEY_NAME_SIZE], unsigned char* iv, EVP_CIPHER_CTX* ectx, EVP_MAC_CTX* hctx) const;
   bool decrypt(const unsigned char* iv, EVP_CIPHER_CTX* ectx, EVP_MAC_CTX* hctx) const;
-  [[nodiscard]] std::string content() const;
 #else
   int encrypt(unsigned char keyName[TLS_TICKETS_KEY_NAME_SIZE], unsigned char* iv, EVP_CIPHER_CTX* ectx, HMAC_CTX* hctx) const;
   bool decrypt(const unsigned char* iv, EVP_CIPHER_CTX* ectx, HMAC_CTX* hctx) const;
 #endif
+
+  [[nodiscard]] std::string content() const;
 
 private:
   unsigned char d_name[TLS_TICKETS_KEY_NAME_SIZE];


### PR DESCRIPTION
`../pdns/libssl.cc:637:28: error: no member named 'content' in 'OpenSSLTLSTicketKey'`

Followup to #14327 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
