### PR TITLE
dnsdist: Fix a race in the XSK/AF_XDP backend handling code

### DIFF
--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -905,10 +905,10 @@ void DownstreamState::registerXsk(std::vector<std::shared_ptr<XskSocket>>& xsks)
   d_config.sourceMACAddr = d_xskSockets.at(0)->getSourceMACAddress();
 
   for (auto& xsk : d_xskSockets) {
-    auto xskInfo = XskWorker::create();
+    auto xskInfo = XskWorker::create(XskWorker::Type::Bidirectional);
     d_xskInfos.push_back(xskInfo);
     xsk->addWorker(xskInfo);
-    xskInfo->sharedEmptyFrameOffset = xsk->sharedEmptyFrameOffset;
+    xskInfo->setSharedFrames(xsk->sharedEmptyFrameOffset);
   }
   reconnect(false);
 }

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -905,10 +905,9 @@ void DownstreamState::registerXsk(std::vector<std::shared_ptr<XskSocket>>& xsks)
   d_config.sourceMACAddr = d_xskSockets.at(0)->getSourceMACAddress();
 
   for (auto& xsk : d_xskSockets) {
-    auto xskInfo = XskWorker::create(XskWorker::Type::Bidirectional);
+    auto xskInfo = XskWorker::create(XskWorker::Type::Bidirectional, xsk->sharedEmptyFrameOffset);
     d_xskInfos.push_back(xskInfo);
     xsk->addWorker(xskInfo);
-    xskInfo->setSharedFrames(xsk->sharedEmptyFrameOffset);
   }
   reconnect(false);
 }

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -816,12 +816,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       std::shared_ptr<XskSocket> socket;
       parseXskVars(vars, socket);
       if (socket) {
-        udpCS->xskInfo = XskWorker::create(XskWorker::Type::Bidirectional);
-        udpCS->xskInfo->setSharedFrames(socket->sharedEmptyFrameOffset);
+        udpCS->xskInfo = XskWorker::create(XskWorker::Type::Bidirectional, socket->sharedEmptyFrameOffset);
         socket->addWorker(udpCS->xskInfo);
         socket->addWorkerRoute(udpCS->xskInfo, loc);
-        udpCS->xskInfoResponder = XskWorker::create(XskWorker::Type::OutgoingOnly);
-        udpCS->xskInfoResponder->setSharedFrames(socket->sharedEmptyFrameOffset);
+        udpCS->xskInfoResponder = XskWorker::create(XskWorker::Type::OutgoingOnly, socket->sharedEmptyFrameOffset);
         socket->addWorker(udpCS->xskInfoResponder);
         vinfolog("Enabling XSK in %s mode for incoming UDP packets to %s", socket->getXDPMode(), loc.toStringWithPort());
       }
@@ -874,12 +872,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       std::shared_ptr<XskSocket> socket;
       parseXskVars(vars, socket);
       if (socket) {
-        udpCS->xskInfo = XskWorker::create(XskWorker::Type::Bidirectional);
-        udpCS->xskInfo->setSharedFrames(socket->sharedEmptyFrameOffset);
+        udpCS->xskInfo = XskWorker::create(XskWorker::Type::Bidirectional, socket->sharedEmptyFrameOffset);
         socket->addWorker(udpCS->xskInfo);
         socket->addWorkerRoute(udpCS->xskInfo, loc);
-        udpCS->xskInfoResponder = XskWorker::create(XskWorker::Type::OutgoingOnly);
-        udpCS->xskInfoResponder->setSharedFrames(socket->sharedEmptyFrameOffset);
+        udpCS->xskInfoResponder = XskWorker::create(XskWorker::Type::OutgoingOnly, socket->sharedEmptyFrameOffset);
         socket->addWorker(udpCS->xskInfoResponder);
         vinfolog("Enabling XSK in %s mode for incoming UDP packets to %s", socket->getXDPMode(), loc.toStringWithPort());
       }

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -816,10 +816,13 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       std::shared_ptr<XskSocket> socket;
       parseXskVars(vars, socket);
       if (socket) {
-        udpCS->xskInfo = XskWorker::create();
-        udpCS->xskInfo->sharedEmptyFrameOffset = socket->sharedEmptyFrameOffset;
+        udpCS->xskInfo = XskWorker::create(XskWorker::Type::Bidirectional);
+        udpCS->xskInfo->setSharedFrames(socket->sharedEmptyFrameOffset);
         socket->addWorker(udpCS->xskInfo);
         socket->addWorkerRoute(udpCS->xskInfo, loc);
+        udpCS->xskInfoResponder = XskWorker::create(XskWorker::Type::OutgoingOnly);
+        udpCS->xskInfoResponder->setSharedFrames(socket->sharedEmptyFrameOffset);
+        socket->addWorker(udpCS->xskInfoResponder);
         vinfolog("Enabling XSK in %s mode for incoming UDP packets to %s", socket->getXDPMode(), loc.toStringWithPort());
       }
 #endif /* HAVE_XSK */
@@ -871,10 +874,13 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       std::shared_ptr<XskSocket> socket;
       parseXskVars(vars, socket);
       if (socket) {
-        udpCS->xskInfo = XskWorker::create();
-        udpCS->xskInfo->sharedEmptyFrameOffset = socket->sharedEmptyFrameOffset;
+        udpCS->xskInfo = XskWorker::create(XskWorker::Type::Bidirectional);
+        udpCS->xskInfo->setSharedFrames(socket->sharedEmptyFrameOffset);
         socket->addWorker(udpCS->xskInfo);
         socket->addWorkerRoute(udpCS->xskInfo, loc);
+        udpCS->xskInfoResponder = XskWorker::create(XskWorker::Type::OutgoingOnly);
+        udpCS->xskInfoResponder->setSharedFrames(socket->sharedEmptyFrameOffset);
+        socket->addWorker(udpCS->xskInfoResponder);
         vinfolog("Enabling XSK in %s mode for incoming UDP packets to %s", socket->getXDPMode(), loc.toStringWithPort());
       }
 #endif /* HAVE_XSK */

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -852,9 +852,9 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
             continue;
           }
 
-          if (processResponderPacket(dss, response, *localRespRuleActions, *localCacheInsertedRespRuleActions, std::move(*ids)) && ids->isXSK() && ids->cs->xskInfo) {
+          if (processResponderPacket(dss, response, *localRespRuleActions, *localCacheInsertedRespRuleActions, std::move(*ids)) && ids->isXSK() && ids->cs->xskInfoResponder) {
 #ifdef HAVE_XSK
-            auto& xskInfo = ids->cs->xskInfo;
+            auto& xskInfo = ids->cs->xskInfoResponder;
             auto xskPacket = xskInfo->getEmptyFrame();
             if (!xskPacket) {
               continue;

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -565,6 +565,7 @@ struct ClientState
   std::shared_ptr<DOH3Frontend> doh3Frontend{nullptr};
   std::shared_ptr<BPFFilter> d_filter{nullptr};
   std::shared_ptr<XskWorker> xskInfo{nullptr};
+  std::shared_ptr<XskWorker> xskInfoResponder{nullptr};
   size_t d_maxInFlightQueriesPerConn{1};
   size_t d_tcpConcurrentConnectionsLimit{0};
   int udpFD{-1};

--- a/pdns/xsk.cc
+++ b/pdns/xsk.cc
@@ -87,15 +87,16 @@ LockGuarded<std::map<std::pair<void*, uint64_t>, UmemEntryStatus>> s_umems;
 void checkUmemIntegrity(const char* function, int line, std::shared_ptr<LockGuarded<vector<uint64_t>>> vect, uint64_t offset, const std::set<UmemEntryStatus::Status>& validStatuses, UmemEntryStatus::Status newStatus)
 {
   auto umems = s_umems.lock();
-  if (validStatuses.count(umems->at({vect.get(), offset}).status) == 0) {
-    std::cerr << "UMEM integrity check failed at " << function << ": " << line << ": status of " << (void*)vect.get() << ", " << offset << " is " << static_cast<int>(umems->at({vect.get(), offset}).status) << ", expected: ";
+  auto& umemState = umems->at({vect.get(), offset});
+  if (validStatuses.count(umemState.status) == 0) {
+    std::cerr << "UMEM integrity check failed at " << function << ": " << line << ": status of " << (void*)vect.get() << ", " << offset << " is " << static_cast<int>(umemState.status) << ", expected: ";
     for (const auto status : validStatuses) {
       std::cerr << static_cast<int>(status) << " ";
     }
     std::cerr << std::endl;
     abort();
   }
-  (*umems)[{vect.get(), offset}].status = newStatus;
+  umemState.status = newStatus;
 }
 }
 #endif /* DEBUG_UMEM */

--- a/pdns/xsk.cc
+++ b/pdns/xsk.cc
@@ -88,7 +88,7 @@ void checkUmemIntegrity(const char* function, int line, std::shared_ptr<LockGuar
 {
   auto umems = s_umems.lock();
   if (validStatuses.count(umems->at({vect.get(), offset}).status) == 0) {
-    std::cerr << "UMEM integrity check failed at " << function << ": " << line << ": status of "<<(void*)vect.get()<<", "<<offset<<" is " << static_cast<int>(umems->at({vect.get(), offset}).status) << ", expected: ";
+    std::cerr << "UMEM integrity check failed at " << function << ": " << line << ": status of " << (void*)vect.get() << ", " << offset << " is " << static_cast<int>(umems->at({vect.get(), offset}).status) << ", expected: ";
     for (const auto status : validStatuses) {
       std::cerr << static_cast<int>(status) << " ";
     }
@@ -918,7 +918,7 @@ void XskPacket::rewrite() noexcept
     /* needed to get the correct checksum */
     setIPv4Header(ipHeader);
     setUDPHeader(udpHeader);
-    //udpHeader.check = tcp_udp_v4_checksum(&ipHeader);
+    // udpHeader.check = tcp_udp_v4_checksum(&ipHeader);
     rewriteIpv4Header(&ipHeader, getFrameLen());
     setIPv4Header(ipHeader);
     setUDPHeader(udpHeader);

--- a/pdns/xsk.cc
+++ b/pdns/xsk.cc
@@ -860,8 +860,8 @@ void XskWorker::notify(int desc)
   }
 }
 
-XskWorker::XskWorker(XskWorker::Type type) :
-  d_type(type), workerWaker(createEventfd()), xskSocketWaker(createEventfd())
+XskWorker::XskWorker(XskWorker::Type type, const std::shared_ptr<LockGuarded<std::vector<uint64_t>>>& frames) :
+  d_sharedEmptyFrameOffset(frames), d_type(type), workerWaker(createEventfd()), xskSocketWaker(createEventfd())
 {
 }
 
@@ -1134,9 +1134,9 @@ void XskWorker::notifyXskSocket() const
   notify(xskSocketWaker);
 }
 
-std::shared_ptr<XskWorker> XskWorker::create(Type type)
+std::shared_ptr<XskWorker> XskWorker::create(Type type, const std::shared_ptr<LockGuarded<std::vector<uint64_t>>>& frames)
 {
-  return std::make_shared<XskWorker>(type);
+  return std::make_shared<XskWorker>(type, frames);
 }
 
 void XskSocket::addWorker(std::shared_ptr<XskWorker> worker)
@@ -1158,11 +1158,6 @@ void XskSocket::addWorkerRoute(const std::shared_ptr<XskWorker>& worker, const C
 void XskSocket::removeWorkerRoute(const ComboAddress& dest)
 {
   d_workerRoutes.lock()->erase(dest);
-}
-
-void XskWorker::setSharedFrames(std::shared_ptr<LockGuarded<vector<uint64_t>>>& frames)
-{
-  d_sharedEmptyFrameOffset = frames;
 }
 
 void XskWorker::setUmemBufBase(uint8_t* base)

--- a/pdns/xsk.hh
+++ b/pdns/xsk.hh
@@ -275,7 +275,11 @@ bool operator<(const XskPacket& lhs, const XskPacket& rhs) noexcept;
 class XskWorker
 {
 public:
-  enum class Type : uint8_t { OutgoingOnly, Bidirectional};
+  enum class Type : uint8_t
+  {
+    OutgoingOnly,
+    Bidirectional
+  };
 
 private:
   using XskPacketRing = boost::lockfree::spsc_queue<XskPacket, boost::lockfree::capacity<XSK_RING_CONS__DEFAULT_NUM_DESCS * 2>>;

--- a/pdns/xsk.hh
+++ b/pdns/xsk.hh
@@ -305,10 +305,9 @@ public:
 
   static int createEventfd();
   static void notify(int desc);
-  static std::shared_ptr<XskWorker> create(Type);
+  static std::shared_ptr<XskWorker> create(Type type, const std::shared_ptr<LockGuarded<std::vector<uint64_t>>>& frames);
 
-  XskWorker(Type);
-  void setSharedFrames(std::shared_ptr<LockGuarded<vector<uint64_t>>>& frames);
+  XskWorker(Type type, const std::shared_ptr<LockGuarded<std::vector<uint64_t>>>& frames);
   void setUmemBufBase(uint8_t* base);
   void pushToProcessingQueue(XskPacket& packet);
   void pushToSendQueue(XskPacket& packet);

--- a/pdns/xsk.hh
+++ b/pdns/xsk.hh
@@ -192,8 +192,10 @@ class XskPacket
 public:
   enum Flags : uint32_t
   {
+    /* whether the payload has been modified */
     UPDATE = 1 << 0,
     DELAY = 1 << 1,
+    /* whether the headers have already been updated */
     REWRITE = 1 << 2
   };
 
@@ -234,6 +236,7 @@ private:
   void setIPv6Header(const ipv6hdr& ipv6Header) noexcept;
   [[nodiscard]] udphdr getUDPHeader() const noexcept;
   void setUDPHeader(const udphdr& udpHeader) noexcept;
+  /* exchange the source and destination addresses (ethernet and IP) */
   void changeDirectAndUpdateChecksum() noexcept;
 
   constexpr static uint8_t DefaultTTL = 64;
@@ -250,10 +253,13 @@ public:
   [[nodiscard]] PacketBuffer cloneHeaderToPacketBuffer() const;
   void setAddr(const ComboAddress& from_, MACAddr fromMAC, const ComboAddress& to_, MACAddr toMAC) noexcept;
   bool setPayload(const PacketBuffer& buf);
+  /* rewrite the headers, usually after setAddr() and setPayload() have been called */
   void rewrite() noexcept;
   void setHeader(PacketBuffer& buf);
   XskPacket(uint8_t* frame, size_t dataSize, size_t frameSize);
   void addDelay(int relativeMilliseconds) noexcept;
+  /* if the payload have been updated, and the headers have not been rewritten, exchange the source
+     and destination addresses (ethernet and IP) and rewrite the headers */
   void updatePacket() noexcept;
   // parse IP and UDP payloads
   bool parse(bool fromSetHeader);

--- a/pdns/xsk.hh
+++ b/pdns/xsk.hh
@@ -298,8 +298,6 @@ public:
   uint8_t* umemBufBase{nullptr};
   // list of frames that are shared with the XskRouter
   std::shared_ptr<LockGuarded<vector<uint64_t>>> sharedEmptyFrameOffset;
-  // list of frames that we own, used to generate new packets (health-check)
-  vector<uint64_t> uniqueEmptyFrameOffset;
   const size_t frameSize{XskSocket::getFrameSize()};
   FDWrapper workerWaker;
   FDWrapper xskSocketWaker;
@@ -319,10 +317,7 @@ public:
   void cleanWorkerNotification() const noexcept;
   void cleanSocketNotification() const noexcept;
   [[nodiscard]] uint64_t frameOffset(const XskPacket& packet) const noexcept;
-  // reap empty umem entry from sharedEmptyFrameOffset into uniqueEmptyFrameOffset
-  void fillUniqueEmptyOffset();
-  // look for an empty umem entry in uniqueEmptyFrameOffset
-  // then sharedEmptyFrameOffset if needed
+  // get an empty umem entry from sharedEmptyFrameOffset
   std::optional<XskPacket> getEmptyFrame();
 };
 std::vector<pollfd> getPollFdsForWorker(XskWorker& info);


### PR DESCRIPTION
### Short description

For performance reasons we used to keep a local list of available frames in our `XskWorker` object, like we are doing in the `XskSocket` one, to avoid having to go to the shared list which is protected by a lock. Unfortunately, while it works well for the `XskSocket` because it is accessed by a single `XskRouter` thread, the `XskWorker` object can be accessed by multiple threads at once: `XskResponderThread`, `responderThread`, `XskClientThread` and `XskRouter`. Most of the time these threads do not acquire nor release frames to the local list, but `responderThread` does acquire one when a response frame is punted to the regular networking stack, and all of them release frames when an unexpected condition occurs, for example when a queue is full. This leads to memory corruption and to a crash.

This commit gets rid of the local list of frames in the `XskWorker` object, acquiring and releasing them to the shared list instead, since performance in these cases is likely not as critical. If it turns out to be too slow, we can look into caching a few frames in a thread-local list, but then we need to be careful not to hold on them indefinitely which might be tricky.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
