### PR TITLE
Don't include openssl/engine.h if it's not going to be used

### DIFF
--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -12,8 +12,10 @@
 #include <pthread.h>
 
 #include <openssl/conf.h>
+#if OPENSSL_VERSION_MAJOR < 3 || !defined(HAVE_TLS_PROVIDERS)
 #ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
+#endif
 #endif
 #include <openssl/err.h>
 #ifndef DISABLE_OCSP_STAPLING


### PR DESCRIPTION
### Short description
If you specify ` --enable-tls-providers` it's possible to build without openssl engine support. However, currently `openssl/engine.h` is still included. This PR changes that

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
