### PR TITLE
Add ARM64 tests to repo script

### DIFF
--- a/build-scripts/docker/repo-test/README.md
+++ b/build-scripts/docker/repo-test/README.md
@@ -10,6 +10,11 @@ To see the supported releases do `./generate-repo-files.py --help`.
 This tool is mainly used internally to test releases but might be useful
 for others.
 
+## Known Issues
+
+- `--test-aarch64` really only makes sense if the test script is running on
+  another platform (and so far we've assumed `x86_64` to be the default)
+
 ## Dependencies
 
 - Python 3

--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -58,6 +58,8 @@ def init_argparser():
                         help='always show output from running a container')
     parser.add_argument('--test', action='store_true',
                         help='test the release')
+    parser.add_argument('--test-aarch64', action='store_true',
+                        help='test the release for ARM64')
     parser.add_argument('--verbose', action='store_true',
                         help='verbose output')
     parser.add_argument('--version', action='store_true',
@@ -111,7 +113,7 @@ def write_list_file (os, os_version, release):
     tpl = g_env.get_template('pdns-list.jinja2')
 
     if os in ['debian', 'ubuntu']:
-        arch = ' [arch=amd64] '
+        arch = ' [arch=amd64,arm64] '
     else:
         arch = ' '
 
@@ -170,7 +172,7 @@ def write_release_files (release):
 
 # Test Release Functions
 
-def build (dockerfile):
+def build (dockerfile, arch='x86_64'):
     # Maybe create `determine_tag` function.
     if len(str(dockerfile)) <= len(g_dockerfile):
         print('Unable to determine tag for {}'.format(dockerfile))
@@ -179,9 +181,16 @@ def build (dockerfile):
     print('Building Docker image using {}...'.format(dockerfile))
     if g_verbose:
         print('  - tag = {}'.format(tag))
-    cp = subprocess.run(['docker', 'build', '--no-cache', '--pull', '--file',
-                         dockerfile, '--tag', tag, '.'],
-                        capture_output=not(g_verbose))
+    if arch == 'x86_64':
+        cp = subprocess.run(['docker', 'build', '--no-cache', '--pull',
+                             '--file', dockerfile, '--tag', tag, '.'],
+                            capture_output=not(g_verbose))
+    # not very subtle
+    elif arch == 'aarch64':
+        cp = subprocess.run(['docker', 'build', '--platform', 'linux/arm64/v8',
+                             '--no-cache', '--pull', '--file', dockerfile,
+                             '--tag', tag, '.'],
+                            capture_output=not(g_verbose))
     # FIXME write failed output to log
     if cp.returncode != 0:
         print('Error building {}: {}'.format(tag, repr(cp.returncode)))
@@ -189,14 +198,20 @@ def build (dockerfile):
     return ( tag, cp.returncode )
 
 
-def run (tag):
+def run (tag, arch='x86_64'):
     if g_run_output:
         capture_run_output = False
     else:
         capture_run_output = not(g_verbose)
     print('Running Docker container tagged {}...'.format(tag))
-    cp = subprocess.run(['docker', 'run', tag],
-                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if arch == 'x86_64':
+        cp = subprocess.run(['docker', 'run', tag],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    # not very subtle
+    elif arch == 'aarch64':
+        cp = subprocess.run(['docker', 'run', '--platform', 'linux/arm64/v8',
+                             tag],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     version = re.search(r'(PowerDNS Authoritative Server|PowerDNS Recursor|' +
                         r'dnsdist) (\d+\.\d+\.\d+(-\w+)?)',
                         cp.stdout.decode())
@@ -224,17 +239,22 @@ def collect_dockerfiles (release):
     return files
 
 
-def test_release (release):
+def test_release (release, arch='x86_64'):
     # sorted because we want determinism
     dockerfiles = sorted(collect_dockerfiles(release))
     failed_builds = []
     failed_runs = []
     returned_versions = []
-    print('=== testing {} ==='.format(release))
+    print('=== testing {} ({}) ==='.format(release, arch))
     for df in dockerfiles:
+        if arch == 'aarch64' and str(df).endswith('centos-7'):
+            continue
+        if arch == 'aarch64' and not release in ['rec-51', 'rec-master',
+                                                 'dnsdist-19', 'dnsdist-master']:
+            continue
         if g_verbose:
             print('--- {} ---'.format(df))
-        (tag, returncode) = build(df)
+        (tag, returncode) = build(df, arch)
         if returncode != 0:
             print('Skipping running {} due to build error: {}'
                   .format(df, returncode))
@@ -243,7 +263,7 @@ def test_release (release):
             print('Skipping running {} due to undetermined tag.'.format(df))
             failed_builds.append((str(df), returncode))
         else:
-            (returncode, return_version) = run(tag)
+            (returncode, return_version) = run(tag, arch)
             # for some reason 99 is returned on `cmd --version` :shrug:
             # (not sure if this is true since using `stdout=PIPE...`)
             if returncode != 0 and returncode != 99:
@@ -286,3 +306,6 @@ write_release_files(args.release)
 
 if args.test:
     test_release(args.release)
+
+if args.test_aarch64:
+    test_release(args.release, 'aarch64')

--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -112,16 +112,10 @@ def write_dockerfile (os, os_version, release):
 def write_list_file (os, os_version, release):
     tpl = g_env.get_template('pdns-list.jinja2')
 
-    if os in ['debian', 'ubuntu']:
-        arch = ' [arch=amd64,arm64] '
-    else:
-        arch = ' '
-
     f = open('pdns.list.{}.{}-{}'.format(release, os, os_version), 'w')
     f.write(tpl.render({ "os": os,
                          "os_version": os_version,
-                         "release": release,
-                         "arch": arch }))
+                         "release": release }))
     f.close()
 
 

--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -243,7 +243,7 @@ def test_release (release, arch='x86_64'):
     for df in dockerfiles:
         if arch == 'aarch64' and str(df).endswith('centos-7'):
             continue
-        if arch == 'aarch64' and not release in ['rec-51', 'rec-master',
+        if arch == 'aarch64' and not release in ['rec-49', 'rec-50', 'rec-51', 'rec-master',
                                                  'dnsdist-19', 'dnsdist-master']:
             continue
         if g_verbose:

--- a/build-scripts/docker/repo-test/templates/pdns-list.jinja2
+++ b/build-scripts/docker/repo-test/templates/pdns-list.jinja2
@@ -1,2 +1,1 @@
-deb {{- arch -}} http://repo.powerdns.com/{{ os }} {{ os_version }}-{{ release }} main
-
+deb http://repo.powerdns.com/{{ os }} {{ os_version }}-{{ release }} main


### PR DESCRIPTION
### Short description

This PR adds tests for the ARM64 repos to the "repo test script".

These have already been tested for a few releases.

### Checklist

I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)