### PR TITLE
builder: add centos-10-stream target

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -37,6 +37,7 @@ jobs:
         os:
           - el-8
           - centos-9-stream
+          - centos-10-stream
           - ubuntu-noble
           - ubuntu-oracular
           - debian-bookworm

--- a/builder-support/dockerfiles/Dockerfile.target.centos-10-stream
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-10-stream
@@ -1,0 +1,19 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+# This defines the distribution base layer
+# Put only the bare minimum of common commands here, without dev tools
+FROM quay.io/centos/centos:stream10 as dist-base
+
+ARG BUILDER_CACHE_BUSTER=
+
+RUN touch /var/lib/rpm/* && dnf install -y epel-release && \
+    dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled crb
+
+# Do the actual rpm build
+@INCLUDE Dockerfile.rpmbuild
+
+# Do a test install and verify
+# Can be skipped with skippackagetest=1 in the environment
+@EXEC [ "$skippackagetest" = "" ] && include Dockerfile.rpmtest

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -119,7 +119,7 @@ export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/opt/lib64/pkgconfig
   -Dre2=enabled \
   -Ddns-over-quic=enabled \
   -Ddns-over-http3=enabled \
-%if "%{_arch}" == "aarch64" || 0%{?amzn2023}
+%if ( "%{_arch}" == "aarch64" && 0%{?rhel} == 8 ) || 0%{?amzn2023}
   -Dxsk=disabled \
 %endif
   -Debpf=enabled \


### PR DESCRIPTION
### Short description

Update: now that all deps are available, this PR has become nice and small and simple. `--version` output from the three products is identical to the EL9 build. Rémi noticed eBPF missing in dnsdist, but that's true for EL9 too and he'll fix that separately.

I will test this on aarch64 before removing the Draft status.

~~~
this is hacked up instead of done nicely.
Once EPEL10 becomes available, we can re-enable sodium, re2, etc. and do this nicely, and then start building it periodically to prepare us for RHEL10 (next year I think)

only tested for dnsdist
~~~

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
