### PR TITLE
Auth/Meson: Fix man-page generation

### DIFF
--- a/docs/generate-man-pages.py
+++ b/docs/generate-man-pages.py
@@ -30,7 +30,7 @@ def main():
     # Install some stuff into the venv.
     requirements_file = source_root.joinpath(args.requirements_file)
     pip = venv_directory.joinpath("bin").joinpath("pip")
-    subprocess.run([pip, "install", "-U", "pip", "setuptools-git", "wheel"])
+    subprocess.run([pip, "install", "-U", "pip", "setuptools", "wheel"])
     subprocess.run([pip, "install", "-r", requirements_file])
 
     # Run sphinx to generate the man-pages.

--- a/meson.build
+++ b/meson.build
@@ -1017,7 +1017,7 @@ if python.found()
     'man-pages',
     command: [
       python,
-      docs_dir / 'generate-man-pages.py',
+      product_source_dir / docs_dir / 'generate-man-pages.py',
       '--venv-name', 'venv-auth-man-pages',
       '--requirements-file', docs_dir / 'requirements.txt',
       '--source-directory', docs_dir,


### PR DESCRIPTION
### Short description
This gets man-pages to get built using meson. There was an issue that `pip install` expected a hash for `setuptools` from the requirements file (which included hashes for everything and caused to pip to run with `--require-hashes`). I am not entirely sure why we used `setuptools-git`, so switching that to the non-git version fixed it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
