### PR TITLE
Pin pysnmp version for rec and dnsdist regression tests

### DIFF
--- a/regression-tests.dnsdist/requirements.txt
+++ b/regression-tests.dnsdist/requirements.txt
@@ -5,7 +5,7 @@ libnacl>=1.4.3,<1.7
 requests>=2.1.0
 protobuf>=3.0
 pyasn1==0.4.8
-pysnmp>=4.3.4
+pysnmp>=5,<6
 future>=0.17.1
 pycurl>=7.43.0
 lmdb>=0.95

--- a/regression-tests.recursor-dnssec/requirements.txt
+++ b/regression-tests.recursor-dnssec/requirements.txt
@@ -3,6 +3,6 @@ pytest
 protobuf>=2.5; sys_platform != 'darwin'
 protobuf>=3.0; sys_platform == 'darwin'
 pyasn1==0.4.8
-pysnmp>=4.3.4
+pysnmp>=5,<6
 requests>=2.1.0
 Twisted>0.15.0


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

There also seems to be a race in both a rec and ad dnsdist test that quite often pops up.
Specifically in rec `test_RecDnstap.DNSTapLogNODTest` and in dnsdist `TestAsyncFFI.testTruncation` (calling a destructor from a signal handler does not look safe:
```
==4264==ERROR: AddressSanitizer: SEGV on unknown address 0x7ff514006688 (pc 0x7ff517bea27b bp 0x000000000000 sp 0x7ffdd6e39180 T0)
  ==4264==The signal is caused by a WRITE memory access.
      #0 0x7ff517bea27b  (/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0x1527b)
      #1 0x7ff517be9d25  (/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0x14d25)
      #2 0x7ff517bf05e7  (/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0x1b5e7)
      #3 0x55ab38c7300b in LuaContext::~LuaContext() /__w/pdns/pdns/pdns/dnsdistdist/dnsdist-0.0.0-git1/./ext/luawrapper/include/LuaContext.hpp:174:9
      #4 0x55ab39f002db in sigTermHandler(int) /__w/pdns/pdns/pdns/dnsdistdist/dnsdist-0.0.0-git1/dnsdist.cc:2794:5
      #5 0x7ff51645504f  (/lib/x86_64-linux-gnu/libc.so.6+0x3c04f)
      #6 0x7ff51649ee93  (/lib/x86_64-linux-gnu/libc.so.6+0x85e93)
      #7 0x7ff5164a3c22  (/lib/x86_64-linux-gnu/libc.so.6+0x8ac22)
      #8 0x7ff5167cf516 in std::thread::join() (/lib/x86_64-linux-gnu/libstdc++.so.6+0xd4516)
      #9 0x55ab39eff09e in main /__w/pdns/pdns/pdns/dnsdistdist/dnsdist-0.0.0-git1/dnsdist.cc:3535:20
      #10 0x7ff516440249  (/lib/x86_64-linux-gnu/libc.so.6+0x27249)
      #11 0x7ff516440304 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x27304)
      #12 0x55ab38967f60 in _start (/opt/dnsdist/bin/dnsdist+0x12e2f60)
```

Attempts at reproducing the rec failure locally did not succeed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
