### PR TITLE
dnsdist: Backport 14486 to dnsdist 1.8.x: pin pysnmp to version 5 for regression tests

### DIFF
--- a/regression-tests.dnsdist/requirements.txt
+++ b/regression-tests.dnsdist/requirements.txt
@@ -4,7 +4,7 @@ libnacl>=1.4.3,<1.7
 requests>=2.1.0
 protobuf>=3.0
 pyasn1==0.4.8
-pysnmp>=4.3.4
+pysnmp>=5,<6
 future>=0.17.1
 pycurl>=7.43.0
 lmdb>=0.95

--- a/regression-tests.recursor-dnssec/requirements.txt
+++ b/regression-tests.recursor-dnssec/requirements.txt
@@ -3,6 +3,6 @@ nose>=1.3.7
 protobuf>=2.5; sys_platform != 'darwin'
 protobuf>=3.0; sys_platform == 'darwin'
 pyasn1==0.4.8
-pysnmp>=4.3.4
+pysnmp>=5,<6
 requests>=2.1.0
 Twisted>0.15.0


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

BAckport of #14486 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
