### PR TITLE
dnsdist: Use atomic variables for the per-protocol latencies

### DIFF
--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -64,9 +64,6 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint)
         else if (const auto& adval = std::get_if<pdns::stat_t_trait<double>*>(&entry.d_value)) {
           str << (*adval)->load();
         }
-        else if (const auto& dval = std::get_if<double*>(&entry.d_value)) {
-          str << **dval;
-        }
         else if (const auto& func = std::get_if<dnsdist::metrics::Stats::statfunction_t>(&entry.d_value)) {
           str << (*func)(entry.d_name);
         }

--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -61,7 +61,7 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint)
         if (const auto& val = std::get_if<pdns::stat_t*>(&entry.d_value)) {
           str << (*val)->load();
         }
-        else if (const auto& adval = std::get_if<pdns::stat_t_trait<double>*>(&entry.d_value)) {
+        else if (const auto& adval = std::get_if<pdns::stat_double_t*>(&entry.d_value)) {
           str << (*adval)->load();
         }
         else if (const auto& func = std::get_if<dnsdist::metrics::Stats::statfunction_t>(&entry.d_value)) {

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -817,9 +817,6 @@ void setupLuaInspection(LuaContext& luaCtx)
       else if (const auto& adval = std::get_if<pdns::stat_t_trait<double>*>(&entry.d_value)) {
         second = (flt % (*adval)->load()).str();
       }
-      else if (const auto& dval = std::get_if<double*>(&entry.d_value)) {
-        second = (flt % (**dval)).str();
-      }
       else if (const auto& func = std::get_if<dnsdist::metrics::Stats::statfunction_t>(&entry.d_value)) {
         second = std::to_string((*func)(entry.d_name));
       }

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -814,7 +814,7 @@ void setupLuaInspection(LuaContext& luaCtx)
       if (const auto& val = std::get_if<pdns::stat_t*>(&entry.d_value)) {
         second = std::to_string((*val)->load());
       }
-      else if (const auto& adval = std::get_if<pdns::stat_t_trait<double>*>(&entry.d_value)) {
+      else if (const auto& adval = std::get_if<pdns::stat_double_t*>(&entry.d_value)) {
         second = (flt % (*adval)->load()).str();
       }
       else if (const auto& func = std::get_if<dnsdist::metrics::Stats::statfunction_t>(&entry.d_value)) {

--- a/pdns/dnsdistdist/dnsdist-metrics.cc
+++ b/pdns/dnsdistdist/dnsdist-metrics.cc
@@ -64,7 +64,7 @@ struct MutableGauge
   }
   ~MutableGauge() = default;
 
-  mutable pdns::stat_t_trait<double> d_value{0};
+  mutable pdns::stat_double_t d_value{0};
 };
 
 static SharedLockGuarded<std::map<std::string, MutableCounter, std::less<>>> s_customCounters;

--- a/pdns/dnsdistdist/dnsdist-metrics.hh
+++ b/pdns/dnsdistdist/dnsdist-metrics.hh
@@ -81,14 +81,14 @@ struct Stats
   stat_t tcpQueryPipeFull{0};
   stat_t tcpCrossProtocolQueryPipeFull{0};
   stat_t tcpCrossProtocolResponsePipeFull{0};
-  pdns::stat_t_trait<double> latencyAvg100{0}, latencyAvg1000{0}, latencyAvg10000{0}, latencyAvg1000000{0};
-  pdns::stat_t_trait<double> latencyTCPAvg100{0}, latencyTCPAvg1000{0}, latencyTCPAvg10000{0}, latencyTCPAvg1000000{0};
-  pdns::stat_t_trait<double> latencyDoTAvg100{0}, latencyDoTAvg1000{0}, latencyDoTAvg10000{0}, latencyDoTAvg1000000{0};
-  pdns::stat_t_trait<double> latencyDoHAvg100{0}, latencyDoHAvg1000{0}, latencyDoHAvg10000{0}, latencyDoHAvg1000000{0};
-  pdns::stat_t_trait<double> latencyDoQAvg100{0}, latencyDoQAvg1000{0}, latencyDoQAvg10000{0}, latencyDoQAvg1000000{0};
-  pdns::stat_t_trait<double> latencyDoH3Avg100{0}, latencyDoH3Avg1000{0}, latencyDoH3Avg10000{0}, latencyDoH3Avg1000000{0};
+  pdns::stat_double_t latencyAvg100{0}, latencyAvg1000{0}, latencyAvg10000{0}, latencyAvg1000000{0};
+  pdns::stat_double_t latencyTCPAvg100{0}, latencyTCPAvg1000{0}, latencyTCPAvg10000{0}, latencyTCPAvg1000000{0};
+  pdns::stat_double_t latencyDoTAvg100{0}, latencyDoTAvg1000{0}, latencyDoTAvg10000{0}, latencyDoTAvg1000000{0};
+  pdns::stat_double_t latencyDoHAvg100{0}, latencyDoHAvg1000{0}, latencyDoHAvg10000{0}, latencyDoHAvg1000000{0};
+  pdns::stat_double_t latencyDoQAvg100{0}, latencyDoQAvg1000{0}, latencyDoQAvg10000{0}, latencyDoQAvg1000000{0};
+  pdns::stat_double_t latencyDoH3Avg100{0}, latencyDoH3Avg1000{0}, latencyDoH3Avg10000{0}, latencyDoH3Avg1000000{0};
   using statfunction_t = std::function<uint64_t(const std::string&)>;
-  using entry_t = std::variant<stat_t*, pdns::stat_t_trait<double>*, statfunction_t>;
+  using entry_t = std::variant<stat_t*, pdns::stat_double_t*, statfunction_t>;
   struct EntryPair
   {
     std::string d_name;

--- a/pdns/dnsdistdist/dnsdist-metrics.hh
+++ b/pdns/dnsdistdist/dnsdist-metrics.hh
@@ -81,14 +81,14 @@ struct Stats
   stat_t tcpQueryPipeFull{0};
   stat_t tcpCrossProtocolQueryPipeFull{0};
   stat_t tcpCrossProtocolResponsePipeFull{0};
-  double latencyAvg100{0}, latencyAvg1000{0}, latencyAvg10000{0}, latencyAvg1000000{0};
-  double latencyTCPAvg100{0}, latencyTCPAvg1000{0}, latencyTCPAvg10000{0}, latencyTCPAvg1000000{0};
-  double latencyDoTAvg100{0}, latencyDoTAvg1000{0}, latencyDoTAvg10000{0}, latencyDoTAvg1000000{0};
-  double latencyDoHAvg100{0}, latencyDoHAvg1000{0}, latencyDoHAvg10000{0}, latencyDoHAvg1000000{0};
-  double latencyDoQAvg100{0}, latencyDoQAvg1000{0}, latencyDoQAvg10000{0}, latencyDoQAvg1000000{0};
-  double latencyDoH3Avg100{0}, latencyDoH3Avg1000{0}, latencyDoH3Avg10000{0}, latencyDoH3Avg1000000{0};
+  pdns::stat_t_trait<double> latencyAvg100{0}, latencyAvg1000{0}, latencyAvg10000{0}, latencyAvg1000000{0};
+  pdns::stat_t_trait<double> latencyTCPAvg100{0}, latencyTCPAvg1000{0}, latencyTCPAvg10000{0}, latencyTCPAvg1000000{0};
+  pdns::stat_t_trait<double> latencyDoTAvg100{0}, latencyDoTAvg1000{0}, latencyDoTAvg10000{0}, latencyDoTAvg1000000{0};
+  pdns::stat_t_trait<double> latencyDoHAvg100{0}, latencyDoHAvg1000{0}, latencyDoHAvg10000{0}, latencyDoHAvg1000000{0};
+  pdns::stat_t_trait<double> latencyDoQAvg100{0}, latencyDoQAvg1000{0}, latencyDoQAvg10000{0}, latencyDoQAvg1000000{0};
+  pdns::stat_t_trait<double> latencyDoH3Avg100{0}, latencyDoH3Avg1000{0}, latencyDoH3Avg10000{0}, latencyDoH3Avg1000000{0};
   using statfunction_t = std::function<uint64_t(const std::string&)>;
-  using entry_t = std::variant<stat_t*, pdns::stat_t_trait<double>*, double*, statfunction_t>;
+  using entry_t = std::variant<stat_t*, pdns::stat_t_trait<double>*, statfunction_t>;
   struct EntryPair
   {
     std::string d_name;

--- a/pdns/dnsdistdist/dnsdist-snmp.cc
+++ b/pdns/dnsdistdist/dnsdist-snmp.cc
@@ -140,7 +140,7 @@ static int handleFloatStats(netsnmp_mib_handler* handler,
     return SNMP_ERR_GENERR;
   }
 
-  if (const auto& val = std::get_if<pdns::stat_t_trait<double>*>(&stIt->second)) {
+  if (const auto& val = std::get_if<pdns::stat_double_t*>(&stIt->second)) {
     std::string str(std::to_string((*val)->load()));
     snmp_set_var_typed_value(requests->requestvb,
                              ASN_OCTET_STR,
@@ -152,7 +152,7 @@ static int handleFloatStats(netsnmp_mib_handler* handler,
   return SNMP_ERR_GENERR;
 }
 
-static void registerFloatStat(const char* name, const OIDStat& statOID, pdns::stat_t_trait<double>* ptr)
+static void registerFloatStat(const char* name, const OIDStat& statOID, pdns::stat_double_t* ptr)
 {
   if (statOID.size() != OID_LENGTH(queriesOID)) {
     errlog("Invalid OID for SNMP Float statistic %s", name);

--- a/pdns/dnsdistdist/dnsdist-snmp.cc
+++ b/pdns/dnsdistdist/dnsdist-snmp.cc
@@ -140,8 +140,8 @@ static int handleFloatStats(netsnmp_mib_handler* handler,
     return SNMP_ERR_GENERR;
   }
 
-  if (const auto& val = std::get_if<double*>(&stIt->second)) {
-    std::string str(std::to_string(**val));
+  if (const auto& val = std::get_if<pdns::stat_t_trait<double>*>(&stIt->second)) {
+    std::string str(std::to_string((*val)->load()));
     snmp_set_var_typed_value(requests->requestvb,
                              ASN_OCTET_STR,
                              str.c_str(),
@@ -152,7 +152,7 @@ static int handleFloatStats(netsnmp_mib_handler* handler,
   return SNMP_ERR_GENERR;
 }
 
-static void registerFloatStat(const char* name, const OIDStat& statOID, double* ptr)
+static void registerFloatStat(const char* name, const OIDStat& statOID, pdns::stat_t_trait<double>* ptr)
 {
   if (statOID.size() != OID_LENGTH(queriesOID)) {
     errlog("Invalid OID for SNMP Float statistic %s", name);

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -515,9 +515,6 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
       else if (const auto& adval = std::get_if<pdns::stat_t_trait<double>*>(&entry.d_value)) {
         output << (*adval)->load();
       }
-      else if (const auto& dval = std::get_if<double*>(&entry.d_value)) {
-        output << **dval;
-      }
       else if (const auto& func = std::get_if<dnsdist::metrics::Stats::statfunction_t>(&entry.d_value)) {
         output << (*func)(entry.d_name);
       }
@@ -934,9 +931,6 @@ static void addStatsToJSONObject(Json::object& obj)
     }
     else if (const auto& adval = std::get_if<pdns::stat_t_trait<double>*>(&entry.d_value)) {
       obj.emplace(entry.d_name, (*adval)->load());
-    }
-    else if (const auto& dval = std::get_if<double*>(&entry.d_value)) {
-      obj.emplace(entry.d_name, (**dval));
     }
     else if (const auto& func = std::get_if<dnsdist::metrics::Stats::statfunction_t>(&entry.d_value)) {
       obj.emplace(entry.d_name, (double)(*func)(entry.d_name));
@@ -1406,12 +1400,6 @@ static void handleStatsOnly(const YaHTTP::Request& req, YaHTTP::Response& resp)
           {"type", "StatisticItem"},
           {"name", item.d_name},
           {"value", (*adval)->load()}});
-      }
-      else if (const auto& dval = std::get_if<double*>(&item.d_value)) {
-        doc.emplace_back(Json::object{
-          {"type", "StatisticItem"},
-          {"name", item.d_name},
-          {"value", (**dval)}});
       }
       else if (const auto& func = std::get_if<dnsdist::metrics::Stats::statfunction_t>(&item.d_value)) {
         doc.emplace_back(Json::object{

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -512,7 +512,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
       if (const auto& val = std::get_if<pdns::stat_t*>(&entry.d_value)) {
         output << (*val)->load();
       }
-      else if (const auto& adval = std::get_if<pdns::stat_t_trait<double>*>(&entry.d_value)) {
+      else if (const auto& adval = std::get_if<pdns::stat_double_t*>(&entry.d_value)) {
         output << (*adval)->load();
       }
       else if (const auto& func = std::get_if<dnsdist::metrics::Stats::statfunction_t>(&entry.d_value)) {
@@ -929,7 +929,7 @@ static void addStatsToJSONObject(Json::object& obj)
     if (const auto& val = std::get_if<pdns::stat_t*>(&entry.d_value)) {
       obj.emplace(entry.d_name, (double)(*val)->load());
     }
-    else if (const auto& adval = std::get_if<pdns::stat_t_trait<double>*>(&entry.d_value)) {
+    else if (const auto& adval = std::get_if<pdns::stat_double_t*>(&entry.d_value)) {
       obj.emplace(entry.d_name, (*adval)->load());
     }
     else if (const auto& func = std::get_if<dnsdist::metrics::Stats::statfunction_t>(&entry.d_value)) {
@@ -1395,7 +1395,7 @@ static void handleStatsOnly(const YaHTTP::Request& req, YaHTTP::Response& resp)
           {"name", item.d_name},
           {"value", (double)(*val)->load()}});
       }
-      else if (const auto& adval = std::get_if<pdns::stat_t_trait<double>*>(&item.d_value)) {
+      else if (const auto& adval = std::get_if<pdns::stat_double_t*>(&item.d_value)) {
         doc.emplace_back(Json::object{
           {"type", "StatisticItem"},
           {"name", item.d_name},

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -187,8 +187,8 @@ static std::unique_ptr<DelayPipe<DelayedPacket>> g_delay{nullptr};
 
 static void doLatencyStats(dnsdist::Protocol protocol, double udiff)
 {
-  constexpr auto doAvg = [](double& var, double n, double weight) {
-    var = (weight - 1) * var / weight + n / weight;
+  constexpr auto doAvg = [](pdns::stat_t_trait<double>& var, double n, double weight) {
+    var.store((weight - 1) * var.load() / weight + n / weight);
   };
 
   if (protocol == dnsdist::Protocol::DoUDP || protocol == dnsdist::Protocol::DNSCryptUDP) {

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -187,7 +187,7 @@ static std::unique_ptr<DelayPipe<DelayedPacket>> g_delay{nullptr};
 
 static void doLatencyStats(dnsdist::Protocol protocol, double udiff)
 {
-  constexpr auto doAvg = [](pdns::stat_t_trait<double>& var, double n, double weight) {
+  constexpr auto doAvg = [](pdns::stat_double_t& var, double n, double weight) {
     var.store((weight - 1) * var.load() / weight + n / weight);
   };
 

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -345,9 +345,9 @@ struct ClientState
   stat_t tls12queries{0}; // valid DNS queries received via TLSv1.2
   stat_t tls13queries{0}; // valid DNS queries received via TLSv1.3
   stat_t tlsUnknownqueries{0}; // valid DNS queries received via unknown TLS version
-  pdns::stat_t_trait<double> tcpAvgQueriesPerConnection{0.0};
+  pdns::stat_double_t tcpAvgQueriesPerConnection{0.0};
   /* in ms */
-  pdns::stat_t_trait<double> tcpAvgConnectionDuration{0.0};
+  pdns::stat_double_t tcpAvgConnectionDuration{0.0};
   std::set<int> cpus;
   std::string interface;
   ComboAddress local;
@@ -655,11 +655,11 @@ struct DownstreamState : public std::enable_shared_from_this<DownstreamState>
   stat_t tcpReusedConnections{0};
   stat_t tcpNewConnections{0};
   stat_t tlsResumptions{0};
-  pdns::stat_t_trait<double> tcpAvgQueriesPerConnection{0.0};
+  pdns::stat_double_t tcpAvgQueriesPerConnection{0.0};
   /* in ms */
-  pdns::stat_t_trait<double> tcpAvgConnectionDuration{0.0};
-  pdns::stat_t_trait<double> queryLoad{0.0};
-  pdns::stat_t_trait<double> dropRate{0.0};
+  pdns::stat_double_t tcpAvgConnectionDuration{0.0};
+  pdns::stat_double_t queryLoad{0.0};
+  pdns::stat_double_t dropRate{0.0};
 
   SharedLockGuarded<std::vector<unsigned int>> hashes;
   LockGuarded<std::unique_ptr<FDMultiplexer>> mplexer{nullptr};

--- a/pdns/stat_t.hh
+++ b/pdns/stat_t.hh
@@ -87,17 +87,17 @@ namespace pdns {
     }
     typename std::aligned_storage_t<sizeof(atomic_t), CPU_LEVEL1_DCACHE_LINESIZE> counter;
   };
-
-  using stat_t = stat_t_trait<uint64_t>;
-  using stat32_t = stat_t_trait<uint32_t>;
-  using stat16_t = stat_t_trait<uint16_t>;
 }
 #else
 namespace pdns {
-  using stat_t = std::atomic<uint64_t>;
-  using stat32_t = std::atomic<uint32_t>;
-  using stat16_t = std::atomic<uint16_t>;
   template <class T>
   using stat_t_trait = std::atomic<T>;
 }
 #endif
+
+namespace pdns {
+  using stat_t = stat_t_trait<uint64_t>;
+  using stat32_t = stat_t_trait<uint32_t>;
+  using stat16_t = stat_t_trait<uint16_t>;
+  using stat_double_t = stat_t_trait<double>;
+}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #

While we do not care about a race in the sense that it's OK if we miss/overwrite a value from time to time, we still need to prevent an interleaved write from two threads which could technically result in a garbage value. Using atomics also makes it easier for TSAN to understand what's going on.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
