### PR TITLE
`pdnsutil`: Add `backend-lookup` subcommand

### DIFF
--- a/contrib/_pdnsutil.zsh_completion
+++ b/contrib/_pdnsutil.zsh_completion
@@ -19,7 +19,7 @@
             'list-autoprimaries:List all autoprimaries'
             'add-zone-key:Add a ZSK or KSK to zone and specify algo&bits'
             'backend-cmd:Perform one or more backend commands'
-            'backend-lookup:Perform a backend record filtering lookup'
+            'backend-lookup:Perform a backend record lookup'
             'b2b-migrate:Move all data from one backend to another'
             'bench-db:Bench database backend with queries, one zone per line'
             'check-zone:Check a zone for correctness'

--- a/contrib/_pdnsutil.zsh_completion
+++ b/contrib/_pdnsutil.zsh_completion
@@ -19,6 +19,7 @@
             'list-autoprimaries:List all autoprimaries'
             'add-zone-key:Add a ZSK or KSK to zone and specify algo&bits'
             'backend-cmd:Perform one or more backend commands'
+            'backend-lookup:Perform a backend record filtering lookup'
             'b2b-migrate:Move all data from one backend to another'
             'bench-db:Bench database backend with queries, one zone per line'
             'check-zone:Check a zone for correctness'

--- a/contrib/pdnsutil.bash_completion.d
+++ b/contrib/pdnsutil.bash_completion.d
@@ -15,7 +15,7 @@ have pdnsutil && {
   _pdnsutil_helper_local_() {
     local cur prev cmd
 
-    local _PDNSUTIL_ALL_CMDS="activate-tsig-key activate-zone-key add-record add-supermaster add-zone-key backend-cmd b2b-migrate bench-db change-slave-zone-master
+    local _PDNSUTIL_ALL_CMDS="activate-tsig-key activate-zone-key add-record add-supermaster add-zone-key backend-cmd backend-lookup b2b-migrate bench-db change-slave-zone-master
                               check-zone check-all-zones clear-zone create-bind-db create-slave-zone create-zone deactivate-tsig-key deactivate-zone-key delete-rrset
                               delete-tsig-key delete-zone disable-dnssec edit-zone export-zone-dnskey export-zone-key generate-tsig-key generate-zone-key get-meta
                               hash-zone-record increase-serial import-tsig-key import-zone-key load-zone list-algorithms list-keys list-zone list-all-zones

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -283,7 +283,7 @@ backend-cmd *BACKEND* *CMD* [*CMD...*]
     Send a text command to a backend for execution. GSQL backends will
     take SQL commands, other backends may take different things. Be
     careful!
-backend-lookup *BACKEND* *NAME* *TYPE* *CLIENT-IP-SUBNET*
+backend-lookup *BACKEND* *NAME* [*TYPE* [*CLIENT-IP-SUBNET*]]
     Perform a backend record filtering lookup.
 bench-db [*FILE*]
     Perform a benchmark of the backend-database.

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -283,6 +283,8 @@ backend-cmd *BACKEND* *CMD* [*CMD...*]
     Send a text command to a backend for execution. GSQL backends will
     take SQL commands, other backends may take different things. Be
     careful!
+backend-lookup *BACKEND* *NAME* *TYPE* *CLIENT-IP-SUBNET*
+    Perform a backend record filtering lookup.
 bench-db [*FILE*]
     Perform a benchmark of the backend-database.
     *FILE* can be a file with a list, one per line, of zone names to use for this.

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -284,7 +284,7 @@ backend-cmd *BACKEND* *CMD* [*CMD...*]
     take SQL commands, other backends may take different things. Be
     careful!
 backend-lookup *BACKEND* *NAME* [*TYPE* [*CLIENT-IP-SUBNET*]]
-    Perform a backend record filtering lookup.
+    Perform a backend record lookup.
 bench-db [*FILE*]
     Perform a benchmark of the backend-database.
     *FILE* can be a file with a list, one per line, of zone names to use for this.

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -704,6 +704,11 @@ bool DNSPacket::hasValidEDNSCookie() const
   return d_ednscookievalid;
 }
 
+void DNSPacket::setRealRemote(const Netmask& netmask) {
+  d_eso.source = netmask;
+  d_haveednssubnet = true;
+}
+
 Netmask DNSPacket::getRealRemote() const
 {
   return d_haveednssubnet ? d_eso.source : Netmask{getInnerRemote()};

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -65,6 +65,7 @@ public:
   ComboAddress getRemote() const;
   ComboAddress getInnerRemote() const; // for proxy protocol
   Netmask getRealRemote() const;
+  void setRealRemote(const Netmask& netmask);
   ComboAddress getLocal() const
   {
     ComboAddress ca;

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -97,7 +97,7 @@ public:
 
   void clearRecords(); //!< when building a packet, wipe all previously added records (clears 'rrs')
 
-  /** Add a DNSZoneRecord to this packet. A DNSPacket (as does a DNS Packet) has 4 kinds of resource records. Questions, 
+  /** Add a DNSZoneRecord to this packet. A DNSPacket (as does a DNS Packet) has 4 kinds of resource records. Questions,
       Answers, Authority and Additional. See RFC 1034 and 1035 for details. You can specify where a record needs to go in the
       DNSZoneRecord d_place field */
   void addRecord(DNSZoneRecord&&);  // adds to 'rrs'
@@ -169,7 +169,7 @@ public:
   vector<DNSZoneRecord>& getRRS() { return d_rrs; }
   bool checkForCorrectTSIG(UeberBackend* B, DNSName* keyname, string* secret, TSIGRecordContent* trc) const;
 
-  static uint16_t s_udpTruncationThreshold; 
+  static uint16_t s_udpTruncationThreshold;
   static bool s_doEDNSSubnetProcessing;
   static bool s_doEDNSCookieProcessing;
   static string s_EDNSCookieKey;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -4257,8 +4257,9 @@ try
     DNSName name{cmds.at(2)};
 
     DNSPacket queryPacket(true);
+    Netmask clientNetmask;
     if (cmds.size() > 4) {
-      Netmask clientNetmask(cmds.at(4));
+      clientNetmask = cmds.at(4);
       queryPacket.setRealRemote(clientNetmask);
     }
 
@@ -4267,7 +4268,12 @@ try
     bool found = false;
     DNSZoneRecord resultZoneRecord;
     while (matchingBackend->get(resultZoneRecord)) {
-      cout << resultZoneRecord.dr.d_name.toString() << "\t" << std::to_string(resultZoneRecord.dr.d_ttl) << "\t" << QClass(resultZoneRecord.dr.d_class).toString() << "\t" << DNSRecordContent::NumberToType(resultZoneRecord.dr.d_type, resultZoneRecord.dr.d_class) << "\t" << resultZoneRecord.dr.getContent()->getZoneRepresentation() << endl;
+      cout << resultZoneRecord.dr.d_name.toString() << "\t" << std::to_string(resultZoneRecord.dr.d_ttl) << "\t" << QClass(resultZoneRecord.dr.d_class).toString() << "\t" << DNSRecordContent::NumberToType(resultZoneRecord.dr.d_type, resultZoneRecord.dr.d_class) << "\t" << resultZoneRecord.dr.getContent()->getZoneRepresentation();
+      if (resultZoneRecord.scopeMask > 0) {
+        clientNetmask.setBits(resultZoneRecord.scopeMask);
+        cout << "\t" << "; " << clientNetmask.toString();
+      }
+      cout << endl;
       found = true;
     }
     if (!found) {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -4262,7 +4262,7 @@ try
     bool found = false;
     DNSZoneRecord resultZoneRecord;
     while (matchingBackend->get(resultZoneRecord)) {
-      cout << resultZoneRecord.dr.d_name.toString() << "\t" << resultZoneRecord.dr.getContent()->getZoneRepresentation() << "\t" << std::to_string(resultZoneRecord.dr.d_ttl) << "\t" << QClass(resultZoneRecord.dr.d_class).toString() << "\t" << DNSRecordContent::NumberToType(resultZoneRecord.dr.d_type, resultZoneRecord.dr.d_class) << "\t" << endl;
+      cout << resultZoneRecord.dr.d_name.toString() << "\t" << std::to_string(resultZoneRecord.dr.d_ttl) << "\t" << QClass(resultZoneRecord.dr.d_class).toString() << "\t" << DNSRecordContent::NumberToType(resultZoneRecord.dr.d_type, resultZoneRecord.dr.d_class) << "\t" << resultZoneRecord.dr.getContent()->getZoneRepresentation() << endl;
       found = true;
     }
     if (!found) {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -4249,7 +4249,7 @@ try
     }
 
     QType type;
-    type = cmds.at(3);
+    type = DNSRecordContent::TypeToNumber(cmds.at(3));
 
     DNSName name{cmds.at(2)};
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2569,8 +2569,8 @@ try
     cout << "]" << endl;
     cout << "                                   Add a ZSK or KSK to zone and specify algo&bits" << endl;
     cout << "backend-cmd BACKEND CMD [CMD..]    Perform one or more backend commands" << endl;
-    cout << "backend-lookup BACKEND NAME TYPE CLIENT-IP" << endl;
-    cout << "                                   Perform a backend lookup of NAME, TYPE and CLIENT-IP" << endl;
+    cout << "backend-lookup BACKEND NAME [[TYPE] CLIENT-IP-SUBNET]" << endl;
+    cout << "                                   Perform a backend lookup of NAME, TYPE and CLIENT-IP-SUBNET" << endl;
     cout << "b2b-migrate OLD NEW                Move all data from one backend to another" << endl;
     cout << "bench-db [filename]                Bench database backend with queries, one zone per line" << endl;
     cout << "check-zone ZONE                    Check a zone for correctness" << endl;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1,6 +1,7 @@
 #include "dnsname.hh"
 #include "dnsparser.hh"
 #include "dnsrecords.hh"
+#include "qtype.hh"
 #include <boost/smart_ptr/make_shared_array.hpp>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -4230,8 +4231,8 @@ try
     return 0;
   }
   else if (cmds.at(0) == "backend-lookup") {
-    if (cmds.size() < 5) {
-      cerr << "Usage: backend-lookup BACKEND NAME TYPE CLIENT-IP-SUBNET" << endl;
+    if (cmds.size() < 3) {
+      cerr << "Usage: backend-lookup BACKEND NAME [TYPE [CLIENT-IP-SUBNET]]" << endl;
       return 1;
     }
 
@@ -4248,14 +4249,18 @@ try
       return 1;
     }
 
-    QType type;
-    type = DNSRecordContent::TypeToNumber(cmds.at(3));
+    QType type = QType::ANY;
+    if (cmds.size() > 3) {
+      type = DNSRecordContent::TypeToNumber(cmds.at(3));
+    }
 
     DNSName name{cmds.at(2)};
 
     DNSPacket queryPacket(true);
-    Netmask clientNetmask(cmds.at(4));
-    queryPacket.setRealRemote(clientNetmask);
+    if (cmds.size() > 4) {
+      Netmask clientNetmask(cmds.at(4));
+      queryPacket.setRealRemote(clientNetmask);
+    }
 
     matchingBackend->lookup(type, name, -1, &queryPacket);
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -4277,7 +4277,11 @@ try
       found = true;
     }
     if (!found) {
-      cerr << "Backend found 0 zone record results" << endl;
+      cerr << "Backend found 0 zone record results";
+      if (type != QType::ANY) {
+        cerr << "- maybe retry with type ANY?";
+      }
+      cerr << endl;
       return 1;
     }
 


### PR DESCRIPTION
### Short description
This can be used to lookup records from a backend using some filtering like type and client subnet.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)