### PR TITLE
rec: notify_allowed should be processed for forward_zones and forward_zones_recurse

### DIFF
--- a/pdns/recursordist/settings/docs-new-preamble-in.rst
+++ b/pdns/recursordist/settings/docs-new-preamble-in.rst
@@ -160,7 +160,7 @@ A forward zone is defined as:
     - Socket Address
     - ...
   recurse: Boolean, default false
-  allow_notify:  Boolean, default false
+  allow_notify: Boolean, default false
 
 An example of a ``forward_zones`` entry, which consists of a sequence of `Forward Zone`_ entries:
 

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -1084,6 +1084,7 @@ To prevent this, add a Negative Trust Anchor (NTA) for this zone in the :ref:`se
 If this forwarded zone is signed, instead of adding NTA, add the DS record to the :ref:`setting-lua-config-file`.
 See the :doc:`dnssec` information.
  ''',
+        'versionchanged' : ('5.2.0',  'Zones having ``notify_allowed`` set will be added to :ref:`setting-yaml-incoming.allow_notify_for`.')
     },
     {
         'name' : 'forward_zones_file',

--- a/regression-tests.recursor-dnssec/test_Notify.py
+++ b/regression-tests.recursor-dnssec/test_Notify.py
@@ -20,18 +20,25 @@ class NotifyTest(RecursorTest):
     _wsPassword = 'secretpassword'
     _apiKey = 'secretapikey'
     _config_template = """
-    disable-packetcache=yes
-    auth-zones=example=configs/%s/example.zone
-    allow-notify-from=127.0.0.1
-    allow-notify-for=example
-    quiet=no
-    loglevel=9
-    webserver=yes
-    webserver-port=%d
-    webserver-address=127.0.0.1
-    webserver-password=%s
-    api-key=%s
-    """ % (_confdir, _wsPort, _wsPassword, _apiKey)
+packetcache:
+    disable: true
+recursor:
+    auth_zones:
+    - zone: example
+      file: configs/%s/example.zone
+incoming:
+    allow_notify_from: [127.0.0.1]
+    allow_notify_for: ['example']
+logging:
+    quiet: false
+    loglevel: 9
+webservice:
+    webserver: true
+    port: %d
+    address: 127.0.0.1
+    password: %s
+    api_key: %s
+""" % (_confdir, _wsPort, _wsPassword, _apiKey)
 
     @classmethod
     def generateRecursorConfig(cls, confdir):
@@ -46,7 +53,7 @@ d 3600 IN A 192.0.2.42
 e 3600 IN A 192.0.2.42
 f 3600 IN CNAME f            ; CNAME loop: dirty trick to get a ServFail in an authzone
 """.format(soa=cls._SOA))
-        super(NotifyTest, cls).generateRecursorConfig(confdir)
+        super(NotifyTest, cls).generateRecursorYamlConfig(confdir)
 
     def checkRecordCacheMetrics(self, expectedHits, expectedMisses):
         headers = {'x-api-key': self._apiKey}


### PR DESCRIPTION
Until now AuthZones did not have the field at all, and for ForwardZones it was only processed if reading from a forward_zones_file.

A slight drawback is the thing mentioned in the comment: the zones will be shown in `allow_notify_for` if you
run `pdns_recursor --config`, while they aren't actually there in any config file.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
