### PR TITLE
rec: avoid duplicate object files in meson build

### DIFF
--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -251,7 +251,6 @@ dep_htmlfiles = declare_dependency(
 deps = [
   dep_pdns,
   dep_no_config_in_source,
-  dep_settings,
   dep_rust_settings,
   dep_boost,
   dep_boost_context,
@@ -359,6 +358,7 @@ librec_common = declare_dependency(
     config_h,
     dependencies: [
       deps,
+      dep_settings_ch,
       librec_dnslabeltext,
     ],
   )
@@ -491,8 +491,6 @@ if get_option('unit-tests')
     }
   }
 endif
-
-
 
 man_pages = []
 foreach tool, info: tools

--- a/pdns/recursordist/settings/meson.build
+++ b/pdns/recursordist/settings/meson.build
@@ -19,11 +19,17 @@ settings = custom_target(
   output: generated,
 )
 
-dep_settings = declare_dependency(
+# librec_common depends on this, so the sources get linked
+dep_settings_ch = declare_dependency(
   sources: [settings, 'cxxsupport.cc'],
   include_directories: [include_directories('.'), ]
 )
 
-subdir('rust')
+# The rust parts depend on this, no sources listed, which avoid duplicates object files
+# In turn deps (defined in the main meson.build file, includes dep_rust_settings)
+dep_settings = declare_dependency(
+  include_directories: [include_directories('.'), ]
+)
 
+subdir('rust')
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Rearrange dependencies so that we don't get multiple object files for `cxx-generated.o`, but just a single one that gets linked into `librec_common`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
