### PR TITLE
libssl: Enable OpenSSL engine support for DNSdist only

### DIFF
--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -13,6 +13,7 @@
 #include <openssl/conf.h>
 #if defined(DNSDIST) && (OPENSSL_VERSION_MAJOR < 3 || !defined(HAVE_TLS_PROVIDERS))
 #ifndef OPENSSL_NO_ENGINE
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage): used by the preprocessor below
 #define DNSDIST_ENABLE_LIBSSL_ENGINE 1
 #include <openssl/engine.h>
 #endif


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Engine support is not used by the recursor or the authoritative server's tools (`sdig`) so there is no need to enable it for them, especially since it has now been deprecated for a while and trigger compilation warnings.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
