### PR TITLE
dnsdist: Update Quiche to 0.22.0 (in our packages)

### DIFF
--- a/builder-support/helpers/install_quiche.sh
+++ b/builder-support/helpers/install_quiche.sh
@@ -26,6 +26,9 @@ echo $0: Checking that the hash of ${QUICHE_TARBALL} is ${QUICHE_TARBALL_HASH}
 echo "${QUICHE_TARBALL_HASH}"  "${QUICHE_TARBALL}" | sha256sum -c -
 tar xf "${QUICHE_TARBALL}"
 cd "quiche-${QUICHE_VERSION}"
+# Disable SONAME in the quiche shared library, we do not intend this library to be used by anyone else and it makes things more complicated since we rename it to libdnsdist-quiche
+sed -i 's/ffi = \["dep:cdylib-link-lines"\]/ffi = \[\]/' quiche/Cargo.toml
+sed -i 's,cdylib_link_lines::metabuild();,//cdylib_link_lines::metabuild();,' quiche/src/build.rs
 RUST_BACKTRACE=1 cargo build --release --no-default-features --features ffi,boringssl-boring-crate --package quiche
 
 install -m644 quiche/include/quiche.h "${INSTALL_PREFIX}"/include

--- a/builder-support/helpers/quiche.json
+++ b/builder-support/helpers/quiche.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "BSD-2-Clause",
   "publisher": "https://github.com/cloudflare/quiche",
-  "SHA256SUM": "ca0f953c34e1549930cfd44deac5e8a6d9e6c3c3df01e5a2d9bcf6d07246b6a4"
+  "SHA256SUM": "0af8744b07038ee4af8cdb94dd4c11f1a730001944a0ef2f3f03e63715b15268"
 }

--- a/tasks.py
+++ b/tasks.py
@@ -1059,6 +1059,9 @@ def ci_build_and_install_quiche(c, repo):
     c.run(f'echo {quiche_hash}"  "quiche-{quiche_version}.tar.gz | sha256sum -c -')
     c.run(f'tar xf quiche-{quiche_version}.tar.gz')
     with c.cd(f'quiche-{quiche_version}'):
+        # Disable SONAME in the quiche shared library, we do not intend this library to be used by anyone else and it makes things more complicated since we rename it to libdnsdist-quiche
+        c.run('sed -i \'s/ffi = \["dep:cdylib-link-lines"\]/ffi = \[\]/\' quiche/Cargo.toml')
+        c.run('sed -i \'s,cdylib_link_lines::metabuild();,//cdylib_link_lines::metabuild();,\' quiche/src/build.rs')
         c.run('cargo build --release --no-default-features --features ffi,boringssl-boring-crate --package quiche')
         # cannot use c.sudo() inside a cd() context, see https://github.com/pyinvoke/invoke/issues/687
         c.run('sudo install -Dm644 quiche/include/quiche.h /usr/include')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since 0.22.0 Quiche sets a proper `SONAME`, see cloudflare/quiche#1769
but it does not matter in our case since we install the Quiche library in such a way (libdnsdist-quiche.so)
that we are the only user, and it will always be updated with DNSdist. Keeping it makes our life significantly harder
since several packaging tools look a the `SONAME`, so this PR reverts this change.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

