### PR TITLE
docs: Add link to the fstrm FrameStream library

### DIFF
--- a/pdns/dnsdistdist/docs/reference/dnstap.rst
+++ b/pdns/dnsdistdist/docs/reference/dnstap.rst
@@ -22,9 +22,10 @@ To use FrameStream transport, :program:`dnsdist` must have been built with `libf
   :param string path: A local AF_UNIX socket path. Note that most platforms have a rather short limit on the length.
   :param table options: A table with key: value pairs with options.
 
-  The following options apply to the settings of the framestream library. Refer to the documentation of that
-  library for the default and allowed values for these options, as well as their exact descriptions.
-  For all these options, absence or a zero value has the effect of using the library-provided default value.
+  The following options apply to the settings of the `framestream library
+  <https://github.com/farsightsec/fstrm>`. Refer to the documentation of that library for the default and
+  allowed values for these options, as well as their exact descriptions. For all these options, absence or a
+  zero value has the effect of using the library-provided default value.
 
   * ``bufferHint=0``: unsigned
   * ``flushTimeout=0``: unsigned
@@ -45,9 +46,10 @@ To use FrameStream transport, :program:`dnsdist` must have been built with `libf
   :param string address: An IP:PORT combination where the logger will connect to.
   :param table options: A table with key: value pairs with options.
 
-  The following options apply to the settings of the framestream library. Refer to the documentation of that
-  library for the default and allowed values for these options, as well as their exact descriptions.
-  For all these options, absence or a zero value has the effect of using the library-provided default value.
+  The following options apply to the settings of the `framestream library
+  <https://github.com/farsightsec/fstrm>`. Refer to the documentation of that library for the default and
+  allowed values for these options, as well as their exact descriptions. For all these options, absence or a
+  zero value has the effect of using the library-provided default value.
 
   * ``bufferHint=0``: unsigned
   * ``flushTimeout=0``: unsigned

--- a/pdns/recursordist/docs/lua-config/protobuf.rst
+++ b/pdns/recursordist/docs/lua-config/protobuf.rst
@@ -140,9 +140,10 @@ The recursor must have been built with configure ``--enable-dnstap`` to make thi
   * ``logQueries=true``: bool - log outgoing queries
   * ``logResponses=true``: bool - log incoming responses
 
-  The following options apply to the settings of the framestream library. Refer to the documentation of that
-  library for the default values, exact description and allowable values for these options.
-  For all these options, absence or a zero value has the effect of using the library-provided default value.
+  The following options apply to the settings of the `framestream library
+  <https://github.com/farsightsec/fstrm>`. Refer to the documentation of that library for the default
+  values, exact description and allowable values for these options. For all these options, absence or a zero
+  value has the effect of using the library-provided default value.
 
   * ``bufferHint=0``: unsigned
   * ``flushTimeout=0``: unsigned
@@ -169,9 +170,10 @@ The recursor must have been built with configure ``--enable-dnstap`` to make thi
   * ``logNODs=true``: bool - log NODs
   * ``logUDRs=false``: bool - log UDRs
 
-  The following options apply to the settings of the framestream library. Refer to the documentation of that
-  library for the default values, exact description and allowable values for these options.
-  For all these options, absence or a zero value has the effect of using the library-provided default value.
+  The following options apply to the settings of the `framestream library
+  <https://github.com/farsightsec/fstrm>`. Refer to the documentation of that library for the default
+  values, exact description and allowable values for these options. For all these options, absence or a zero
+  value has the effect of using the library-provided default value.
 
   * ``bufferHint=0``: unsigned
   * ``flushTimeout=0``: unsigned


### PR DESCRIPTION
### Short description
I could not figure out which library to look at for the configuration values. @rgacogne helpfully pointed me in the right direction in #14510

Ideally we could link to more specific documentation, but as mentioned in #14510, it's not really easily linkable.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)