### PR TITLE
Fix documentation typos

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1446,6 +1446,7 @@ unistd
 unitialized
 unixodbc
 unixtime
+unparsable
 unparseable
 UNPRIV
 unpublishdomainkey

--- a/docs/backends/ldap.rst
+++ b/docs/backends/ldap.rst
@@ -175,7 +175,7 @@ information.
 
 -  ``simple``: Search the requested domain by comparing the
    associatedDomain attributes with the domain string in the question.
--  ``tree``: Search entires by translating the domain string into a LDAP
+-  ``tree``: Search entries by translating the domain string into a LDAP
    dn. Your LDAP tree must be designed in the same way as the DNS LDAP
    tree. The question for "myhost.linuxnetworks.de" would translate into
    "dc=myhost,dc=linuxnetworks,dc=de,ou=hosts=..." and the entry where

--- a/docs/changelog/4.1.rst
+++ b/docs/changelog/4.1.rst
@@ -488,7 +488,7 @@ Changelogs for 4.1.x
     :pullreq: 6555
     :tickets: 6396
 
-    Report unparseable data in stoul invalid_argument exception
+    Report unparsable data in stoul invalid_argument exception
 
   .. change::
     :tags: Improvements

--- a/docs/changelog/4.2.rst
+++ b/docs/changelog/4.2.rst
@@ -1455,7 +1455,7 @@ Changelogs for 4.2.x
     :tags: Bug Fixes
     :pullreq: 6396
 
-    Report unparseable data in stoul ``invalid_argument`` exception.
+    Report unparsable data in stoul ``invalid_argument`` exception.
 
   .. change::
     :tags: New Features, Tools

--- a/docs/changelog/pre-4.0.rst
+++ b/docs/changelog/pre-4.0.rst
@@ -1443,7 +1443,7 @@ Other changes
    parameters for pdnssec.
 -  `commit 2f2b014 <https://github.com/PowerDNS/pdns/commit/2f2b014>`__:
    apply variant of code in `ticket
-   714 <https://github.com/PowerDNS/pdns/issues/714>`__ so we can lauch
+   714 <https://github.com/PowerDNS/pdns/issues/714>`__ so we can launch
    pipe backend scripts with parameters, plus add experimental code that
    if pipe-command is a unix domain socket, we use that.
 -  `commit 9566683 <https://github.com/PowerDNS/pdns/commit/9566683>`__:
@@ -4749,7 +4749,7 @@ Improvements
    fact only made things worse.
 -  LDAP backend updates from its author Norbert Sendetzky. Reverse
    lookups should work now too.
--  An error message about unparseable packets did not include the
+-  An error message about unparsable packets did not include the
    originating IP address (fixed by Mark Bergsma)
 -  PowerDNS can now be started via path resolution while running with a
    guardian. Suggested by Maurice Nonnekes.

--- a/docs/lua-records/index.rst
+++ b/docs/lua-records/index.rst
@@ -6,7 +6,7 @@ PowerDNS Authoritative Server version 4.2 and later support dynamic DNS
 records.
 
 These records contain small snippets of configuration that enable dynamic
-behaviour based on requester IP address, requester's EDNS Client Subnet,
+behaviour based on requestor IP address, requestor's EDNS Client Subnet,
 server availability or other factors.
 
 Capabilities range from very simple to highly advanced multi-pool
@@ -66,7 +66,7 @@ Another example using :func:`pickclosest`::
     www    IN    LUA    A    "pickclosest({'192.0.2.1','192.0.2.2','198.51.100.1'})"
 
 This uses the GeoIP backend to find indications of the geographical location of
-the requester and the listed IP addresses. It will return with one of the closest
+the requestor and the listed IP addresses. It will return with one of the closest
 addresses.
 
 :func:`pickclosest` and :func:`ifportup` can be combined as follows::

--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -148,7 +148,7 @@ respective domain to allow immediate freshness checks for this domain.
   ``/etc`` and ``/home``, possibly being unable to write AXFR'd zones.
 
 PowerDNS also reacts to notifies by immediately checking if the zone has
-updated and if so, retransfering it.
+updated and if so, retransferring it.
 
 All backends which implement this feature must make sure that they can
 handle transactions so as to not leave the zone in a half updated state.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -2038,7 +2038,7 @@ When set to "detailed", all information about the request and response are logge
 The value between the hooks is a UUID that is generated for each request. This can be used to find all lines related to a single request.
 
 .. note::
-  The webserver logs these line on the NOTICE level. The :ref:`setting-loglevel` seting must be 5 or higher for these lines to end up in the log.
+  The webserver logs these line on the NOTICE level. The :ref:`setting-loglevel` setting must be 5 or higher for these lines to end up in the log.
 
 .. _setting-webserver-max-bodysize:
 

--- a/pdns/dnsdistdist/docs/advanced/passing-source-address.rst
+++ b/pdns/dnsdistdist/docs/advanced/passing-source-address.rst
@@ -35,7 +35,7 @@ Both the PowerDNS Authoritative Server and the Recursor can parse PROXYv2 header
 
   proxy-protocol-from=192.0.2.2
 
-For more informations, see the `authoritative server's documentation <https://doc.powerdns.com/authoritative/settings.html#proxy-protocol-from>`_ or the `recursor's documentation <https://docs.powerdns.com/recursor/settings.html#proxy-protocol-from>`_.
+For more information, see the `authoritative server's documentation <https://doc.powerdns.com/authoritative/settings.html#proxy-protocol-from>`_ or the `recursor's documentation <https://docs.powerdns.com/recursor/settings.html#proxy-protocol-from>`_.
 
 From clients to dnsdist
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/pdns/dnsdistdist/docs/advanced/tuning.rst
+++ b/pdns/dnsdistdist/docs/advanced/tuning.rst
@@ -34,7 +34,7 @@ To be able to use more CPU cores for UDP queries processing, it is possible to u
 Note that this require ``SO_REUSEPORT`` support in the underlying operating system (added for example in Linux 3.9).
 Please also be aware that doing so will increase lock contention and might not therefore scale linearly, as discussed below.
 
-Another possibility is to use the reuseport option to run several dnsdist processes in parallel on the same host, thus avoiding the lock contention issue at the cost of having to deal with the fact that the different processes will not share informations, like statistics or DDoS offenders.
+Another possibility is to use the reuseport option to run several dnsdist processes in parallel on the same host, thus avoiding the lock contention issue at the cost of having to deal with the fact that the different processes will not share information, like statistics or DDoS offenders.
 
 The UDP threads handling the responses from the backends do not use a lot of CPU, but if needed it is also possible to add the same backend several times to the dnsdist configuration to distribute the load over several responder threads::
 

--- a/pdns/dnsdistdist/docs/changelog.rst
+++ b/pdns/dnsdistdist/docs/changelog.rst
@@ -5399,7 +5399,7 @@ Changelog
     :tags: Improvements
     :pullreq: 6637
 
-    Don't copy unitialized values of SuffixMatchTree
+    Don't copy uninitialized values of SuffixMatchTree
 
   .. change::
     :tags: Improvements

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1530,7 +1530,7 @@ Dynamic Blocks
   :param int clientIPMask: The network mask to apply to the address. Default is 32 for IPv4, 128 for IPv6.
   :param int clientIPPortMask: The port mask to use to specify a range of ports to match, when the clients are behind a CG-NAT.
 
-  Please see the documentation for :func:`setDynBlocksAction` to confirm which actions are supported by the action paramater.
+  Please see the documentation for :func:`setDynBlocksAction` to confirm which actions are supported by the action parameter.
 
 .. function:: addDynBlocks(addresses, message[, seconds=10[, action]])
 
@@ -1543,7 +1543,7 @@ Dynamic Blocks
   :param int seconds: The number of seconds this block to expire
   :param int action: The action to take when the dynamic block matches, see :ref:`DNSAction <DNSAction>`. (default to DNSAction.None, meaning the one set with :func:`setDynBlocksAction` is used)
 
-  Please see the documentation for :func:`setDynBlocksAction` to confirm which actions are supported by the action paramater.
+  Please see the documentation for :func:`setDynBlocksAction` to confirm which actions are supported by the action parameter.
 
 .. function:: clearDynBlocks()
 

--- a/pdns/recursordist/docs/changelog/4.3.rst
+++ b/pdns/recursordist/docs/changelog/4.3.rst
@@ -681,7 +681,7 @@ Changelogs for 4.3.x
     :pullreq: 8047
     :tickets: 8008
 
-    Another time sensistive test fixed with a fixednow construct.
+    Another time sensitive test fixed with a fixednow construct.
 
   .. change::
     :tags: New Features

--- a/pdns/recursordist/docs/changelog/5.0.rst
+++ b/pdns/recursordist/docs/changelog/5.0.rst
@@ -83,7 +83,7 @@ Before upgrading, it is advised to read the :doc:`../upgrade`.
     :pullreq: 14222
     :tickets: 14185
 
-    Report error and adjust max-mthreads when linux map limit (vm.max_map_count) is too low to accomodate resource usage under load.
+    Report error and adjust max-mthreads when linux map limit (vm.max_map_count) is too low to accommodate resource usage under load.
 
 .. changelog::
    :version: 5.0.5

--- a/pdns/recursordist/docs/running.rst
+++ b/pdns/recursordist/docs/running.rst
@@ -56,7 +56,7 @@ To log only info messages, use ``local0.=info``
 
 Cache Management
 ----------------
-Sometimes a domain fails to resolve due to an error on the domain owner's end, or records for your own domain have updated and you want your users to immediatly see them without waiting for the TTL to expire.
+Sometimes a domain fails to resolve due to an error on the domain owner's end, or records for your own domain have updated and you want your users to immediately see them without waiting for the TTL to expire.
 The :doc:`rec_control <manpages/rec_control.1>` tool can be used to selectively wipe the cache.
 
 To wipe all records for the exact name 'www.example.com'::

--- a/pdns/recursordist/settings/docs-new-preamble-in.rst
+++ b/pdns/recursordist/settings/docs-new-preamble-in.rst
@@ -12,11 +12,11 @@ Settings on the command line are processed after the file-based settings are pro
 
    Release 5.0.0 will install a default old-style ``recursor.conf`` file.
 
-   Starting with version 5.1.0, in the absense of a ``recursor.yml`` file, an existing ``recursor.conf`` will be processed as YAML,
+   Starting with version 5.1.0, in the absence of a ``recursor.yml`` file, an existing ``recursor.conf`` will be processed as YAML,
    if that fails, it will be processed as old-style configuration.
    Packages will stop installing a old-style ``recursor.conf`` file and start installing a default ``recursor.conf`` file containing YAML syntax.
 
-   With the release of 5.2.0, the default will be to expect a YAML configuation file and reading of old-style ``recursor.conf`` files will have to be enabled specifically by providing a command line option.
+   With the release of 5.2.0, the default will be to expect a YAML configuration file and reading of old-style ``recursor.conf`` files will have to be enabled specifically by providing a command line option.
 
    In a future release support for the "old-style" ``recursor.conf`` settings file will be dropped.
 
@@ -138,7 +138,7 @@ If no prefix length is specified, ``/32`` or ``/128`` is assumed, indicating a s
 Subnets can also be prefixed with a ``!``, specifying negation.
 This can be used to deny addresses from a previously allowed range.
 
-For example, ``alow-from`` takes a sequence of subnets:
+For example, ``allow-from`` takes a sequence of subnets:
 
 .. code-block:: yaml
 
@@ -408,7 +408,7 @@ As of version 5.1.0, a ZoneToCache entry is defined as
    tsig:
      name: name of key
      algo: algorithm
-     secret: Base64 endcoded secret
+     secret: Base64 encoded secret
    refreshPeriod: 86400
    retryOnErrorPeriod: 60
    maxReceivedMBytes: 0 Zero mean no restrcition
@@ -430,7 +430,7 @@ An example of an ``zonetocaches`` entry, which is a sequence of `ZoneToCache`_:
 
 AllowedAdditionalQType
 ^^^^^^^^^^^^^^^^^^^^^^
-As of version 5.1.0, an allowed addtional qtype entry is defined as:
+As of version 5.1.0, an allowed additional qtype entry is defined as:
 
 .. code-block:: yaml
 

--- a/pdns/recursordist/settings/docs-old-preamble-in.rst
+++ b/pdns/recursordist/settings/docs-old-preamble-in.rst
@@ -6,7 +6,7 @@ The command line overrides the configuration file.
 .. note::
    Starting with version 5.0.0, :program:`Recursor` supports a new YAML syntax for configuration files.
    A configuration using the old style syntax can be converted to a YAML configuration using the instructions in :doc:`appendices/yamlconversion`.
-   In a future release support for the "old-style" settings decribed here will be dropped.
+   In a future release support for the "old-style" settings described here will be dropped.
    See :doc:`yamlsettings` for details.
 
 .. note::


### PR DESCRIPTION
### Short description

Identified and fixed typos / spelling issues identified by the [typos](https://github.com/crate-ci/typos) tool. I tried to leave all the British-english spellings in place, as that seems to be the convention here.

It might be a good idea to add the typos tool to CI, at least for documentation. It did have a lot of false positives that would need to be added to an exemption list. If you're interested in this, let me know and I can send a PR.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)