### PR TITLE
rec: better error message in case of syntax errors in defaults defined in table.py

### DIFF
--- a/pdns/recursordist/settings/generate.py
+++ b/pdns/recursordist/settings/generate.py
@@ -405,7 +405,8 @@ def gen_rust_vec_default_functions(name, typeName, defvalue):
     """Generate Rust code for the default handling of a vector for typeName"""
     ret = f'// DEFAULT HANDLING for {name}\n'
     ret += f'fn default_value_{name}() -> Vec<recsettings::{typeName}> {{\n'
-    ret += f'    let deserialized: Vec<recsettings::{typeName}> = serde_yaml::from_str({quote(defvalue)}).unwrap();\n'
+    ret += f'    let msg = "default value defined for `{name}\' should be valid YAML";'
+    ret += f'    let deserialized: Vec<recsettings::{typeName}> = serde_yaml::from_str({quote(defvalue)}).expect(&msg);\n'
     ret += f'    deserialized\n'
     ret += '}\n'
     ret += f'fn default_value_equal_{name}(value: &Vec<recsettings::{typeName}>)'


### PR DESCRIPTION
With this the error message from #14525 becomes:

```
thread '<unnamed>' panicked at src/lib.rs:2394:347:
default value defined for `dnssec_trustanchors' should be valid YAML: Error(".[0]: invalid type: sequence, expected field identifier", line: 1, column: 103)
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
