### PR TITLE
rec: fix regression test nod races and printlogs.py

### DIFF
--- a/regression-tests.recursor-dnssec/printlogs.py
+++ b/regression-tests.recursor-dnssec/printlogs.py
@@ -6,36 +6,41 @@ import os.path
 import glob
 
 e = xml.etree.ElementTree.parse('pytest.xml')
-root = e.getroot()
+testsuites = e.getroot()
 
-for child in root:
-    if len(child):
+for testsuite in testsuites:
+    if len(testsuite):
         getstdout = False
-        for elem in child:
-            if elem.tag in ["failure", "error"]:
-                cls = child.get("classname")
-                name = child.get("name")
-                if '_' not in cls or '.' not in cls:
-                    print('Unexpected classname %s; name %s' % (cls, name))
-                    getstdout = True
-                    continue
+        for testcase in testsuite:
+            cls = testcase.get("classname")
+            name = testcase.get("name")
+            if '_' not in cls or '.' not in cls:
+                print('Unexpected classname %s; name %s' % (cls, name))
+                getstdout = True
+                continue
 
-                confdirnames = [cls.split('_')[1].split('.')[0], cls.split('.')[1].split('Test')[0]]
-                for confdirname in confdirnames:
-                    confdir = os.path.join("configs", confdirname)
-                    recursorlog = os.path.join(confdir, "recursor.log")
-                    if os.path.exists(recursorlog):
-                        print("==============> %s <==============" % recursorlog)
-                        with open(recursorlog) as f:
-                            print(''.join(f.readlines()))
-                            authdirs = glob.glob(os.path.join(confdir, "auth-*"))
-                            for authdir in authdirs:
-                                authlog = os.path.join(authdir, "pdns.log")
-                                if os.path.exists(recursorlog):
-                                    print("==============> %s <==============" % authlog)
-                                    with open(authlog) as f:
-                                        print(''.join(f.readlines()))
-            if getstdout and elem.tag == 'system-out':
-                print("==============> STDOUT LOG FROM XML <==============")
-                print(elem.text)
-                print("==============> END STDOUT LOG FROM XML <==============")
+            confdirnames = [cls.split('_')[1].split('.')[0], cls.split('.')[1].split('Test')[0]]
+            found = False
+            for confdirname in confdirnames:
+                confdir = os.path.join("configs", confdirname)
+                recursorlog = os.path.join(confdir, "recursor.log")
+                if os.path.exists(recursorlog):
+                    found = True
+                    for elem in testcase:
+                        if elem.tag in ["failure", "error"]:
+                            print("==============> %s <==============" % recursorlog)
+                            with open(recursorlog) as f:
+                                print(''.join(f.readlines()))
+                                authdirs = glob.glob(os.path.join(confdir, "auth-*"))
+                                for authdir in authdirs:
+                                    authlog = os.path.join(authdir, "pdns.log")
+                                    if os.path.exists(recursorlog):
+                                        print("==============> %s <==============" % authlog)
+                                        with open(authlog) as f:
+                                            print(''.join(f.readlines()))
+            if not found and confdirnames[0] != 'Flags': 
+                print("%s not found, configdir does not mach expected pattern" % confdirnames)
+        if getstdout and elem.tag == 'system-out':
+            print("==============> STDOUT LOG FROM XML <==============")
+            print(elem.text)
+            print("==============> END STDOUT LOG FROM XML <==============")

--- a/regression-tests.recursor-dnssec/runtests
+++ b/regression-tests.recursor-dnssec/runtests
@@ -27,7 +27,7 @@ export PDNSUTIL=${PDNSUTIL:-${PWD}/../pdns/pdnsutil}
 export PDNSRECURSOR=${PDNSRECURSOR:-${PWD}/../pdns/recursordist/pdns_recursor}
 export RECCONTROL=${RECCONTROL:-${PWD}/../pdns/recursordist/rec_control}
 
-LIBFAKETIME_DEFAULT=/usr/lib/x86_64-linux-gnu/faketime/libfaketimeMT.so.1 # ubuntu default
+LIBFAKETIME_DEFAULT=/usr/lib/$(arch)-linux-gnu/faketime/libfaketimeMT.so.1 # ubuntu default
 LIBAUTHBIND_DEFAULT=/usr/lib/authbind/libauthbind.so.1
 if [ $(uname -s) = "Darwin" ]; then
   # macOS is not /really/ supported here; it works for some tests, and then you might need sudo.

--- a/regression-tests.recursor-dnssec/test_Additionals.py
+++ b/regression-tests.recursor-dnssec/test_Additionals.py
@@ -2,7 +2,7 @@ import dns
 import os
 from recursortests import RecursorTest
 
-class testAdditionalsDefault(RecursorTest):
+class AdditionalsDefaultTest(RecursorTest):
     _confdir = 'AdditionalsDefault'
 
     _config_template = """
@@ -40,7 +40,7 @@ class testAdditionalsDefault(RecursorTest):
         self.assertRRsetInAdditional(res, adds1)
         self.assertRRsetInAdditional(res, adds2)
 
-class testAdditionalsResolveImmediately(RecursorTest):
+class AdditionalsResolveImmediatelyTest(RecursorTest):
     _confdir = 'AdditionalsResolveImmediately'
     _config_template = """
     dnssec=validate
@@ -102,7 +102,7 @@ class testAdditionalsResolveImmediately(RecursorTest):
         self.assertRRsetInAdditional(res, adds7)
         self.assertMatchingRRSIGInAdditional(res, adds7)
 
-class testAdditionalsResolveCacheOnly(RecursorTest):
+class AdditionalsResolveCacheOnlyTest(RecursorTest):
     _confdir = 'AdditionalsResolveCacheOnly'
     _config_template = """
     dnssec=validate

--- a/regression-tests.recursor-dnssec/test_ECS.py
+++ b/regression-tests.recursor-dnssec/test_ECS.py
@@ -116,7 +116,7 @@ ecs-add-for=0.0.0.0/0
     def tearDownClass(cls):
         cls.tearDownRecursor()
 
-class testNoECS(ECSTest):
+class NoECSTest(ECSTest):
     _confdir = 'NoECS'
 
     _config_template = """edns-subnet-allow-list=
@@ -141,7 +141,7 @@ forward-zones=ecs-echo.example=%s.21
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected)
 
-class testIncomingNoECS(ECSTest):
+class IncomingNoECSTest(ECSTest):
     _confdir = 'IncomingNoECS'
 
     _config_template = """edns-subnet-allow-list=
@@ -169,7 +169,7 @@ forward-zones=ecs-echo.example=%s.21
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected, scopeZeroResponse=True)
 
-class testECSByName(ECSTest):
+class ECSByNameTest(ECSTest):
     _confdir = 'ECSByName'
 
     _config_template = """edns-subnet-allow-list=ecs-echo.example.
@@ -200,7 +200,7 @@ forward-zones=ecs-echo.example=%s.21
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected)
 
-class testECSByNameLarger(ECSTest):
+class ECSByNameLargerTest(ECSTest):
     _confdir = 'ECSByNameLarger'
 
     _config_template = """edns-subnet-allow-list=ecs-echo.example.
@@ -234,8 +234,8 @@ ecs-ipv6-cache-bits=128
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected)
 
-class testECSByNameSmaller(ECSTest):
-    _confdir = 'ECSByNameLarger'
+class ECSByNameSmallerTest(ECSTest):
+    _confdir = 'ECSByNameSmaller'
 
     _config_template = """edns-subnet-allow-list=ecs-echo.example.
 ecs-ipv4-bits=16
@@ -261,8 +261,8 @@ forward-zones=ecs-echo.example=%s.21
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected)
 
-class testIncomingECSByName(ECSTest):
-    _confdir = 'ECSIncomingByName'
+class IncomingECSByNameTest(ECSTest):
+    _confdir = 'IncomingECSByName'
 
     _config_template = """edns-subnet-allow-list=ecs-echo.example.
 use-incoming-edns-subnet=yes
@@ -301,8 +301,8 @@ ecs-ipv6-cache-bits=128
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected, ttlECS)
 
-class testIncomingECSByNameLarger(ECSTest):
-    _confdir = 'ECSIncomingByNameLarger'
+class IncomingECSByNameLargerTest(ECSTest):
+    _confdir = 'IncomingECSByNameLarger'
 
     _config_template = """edns-subnet-allow-list=ecs-echo.example.
 use-incoming-edns-subnet=yes
@@ -333,8 +333,8 @@ ecs-ipv6-cache-bits=128
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected, ttlECS)
 
-class testIncomingECSByNameSmaller(ECSTest):
-    _confdir = 'ECSIncomingByNameSmaller'
+class IncomingECSByNameSmallerTest(ECSTest):
+    _confdir = 'IncomingECSByNameSmaller'
 
     _config_template = """edns-subnet-allow-list=ecs-echo.example.
 use-incoming-edns-subnet=yes
@@ -364,8 +364,8 @@ ecs-ipv6-cache-bits=128
         self.sendECSQuery(query, expected, ttlECS)
 
 @unittest.skipIf(not have_ipv6(), "No IPv6")
-class testIncomingECSByNameV6(ECSTest):
-    _confdir = 'ECSIncomingByNameV6'
+class IncomingECSByNameV6Test(ECSTest):
+    _confdir = 'IncomingECSByNameV6'
 
     _config_template = """edns-subnet-allow-list=ecs-echo.example.
 use-incoming-edns-subnet=yes
@@ -397,7 +397,7 @@ forward-zones=ecs-echo.example=[::1]:53000
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected, ttlECS)
 
-class testECSNameMismatch(ECSTest):
+class ECSNameMismatchTest(ECSTest):
     _confdir = 'ECSNameMismatch'
 
     _config_template = """edns-subnet-allow-list=not-the-right-name.example.
@@ -422,7 +422,7 @@ forward-zones=ecs-echo.example=%s.21
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected)
 
-class testECSByIP(ECSTest):
+class ECSByIPTest(ECSTest):
     _confdir = 'ECSByIP'
 
     _config_template = """edns-subnet-allow-list=%s.21
@@ -448,8 +448,8 @@ forward-zones=ecs-echo.example=%s.21
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected)
 
-class testIncomingECSByIP(ECSTest):
-    _confdir = 'ECSIncomingByIP'
+class IncomingECSByIPTest(ECSTest):
+    _confdir = 'IncomingECSByIP'
 
     _config_template = """edns-subnet-allow-list=%s.21
 use-incoming-edns-subnet=yes
@@ -488,7 +488,7 @@ ecs-ipv6-cache-bits=128
 
         self.sendECSQuery(query, expected)
 
-class testECSIPMismatch(ECSTest):
+class ECSIPMismatchTest(ECSTest):
     _confdir = 'ECSIPMismatch'
 
     _config_template = """edns-subnet-allow-list=192.0.2.1
@@ -514,8 +514,8 @@ forward-zones=ecs-echo.example=%s.21
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected)
 
-class testECSWithProxyProtocoldRecursorTest(ECSTest):
-    _confdir = 'ECSWithProxyProtocol'
+class ECSWithProxyProtocolRecursorTest(ECSTest):
+    _confdir = 'ECSWithProxyProtocolRecursor'
     _config_template = """
     ecs-add-for=2001:db8::1/128
     edns-subnet-allow-list=ecs-echo.example.
@@ -535,7 +535,7 @@ class testECSWithProxyProtocoldRecursorTest(ECSTest):
             self.assertRcodeEqual(res, dns.rcode.NOERROR)
             self.assertRRsetInAnswer(res, expected)
 
-class testTooLargeToAddZeroScope(RecursorTest):
+class TooLargeToAddZeroScopeTest(RecursorTest):
 
     _confdir = 'TooLargeToAddZeroScope'
     _config_template = """
@@ -573,7 +573,7 @@ dnssec=validate
 
     @classmethod
     def generateRecursorConfig(cls, confdir):
-        super(testTooLargeToAddZeroScope, cls).generateRecursorConfig(confdir)
+        super(TooLargeToAddZeroScopeTest, cls).generateRecursorConfig(confdir)
 
     def testTooLarge(self):
         qname = 'toolarge.ecs.'

--- a/regression-tests.recursor-dnssec/test_EDNSPadding.py
+++ b/regression-tests.recursor-dnssec/test_EDNSPadding.py
@@ -9,6 +9,8 @@ from recursortests import RecursorTest
 
 class RecursorEDNSPaddingTest(RecursorTest):
 
+    _confdir = 'RecursorEDNSPadding'
+
     @classmethod
     def setUpClass(cls):
         cls.setUpSockets()
@@ -209,7 +211,7 @@ packetcache-ttl=60
 
 class PaddingNotAllowedAlwaysTest(RecursorEDNSPaddingTest):
 
-    _confdir = 'PaddingAlwaysNotAllowed'
+    _confdir = 'PaddingNotAllowedAlways'
     _config_template = """edns-padding-from=127.0.0.2
 edns-padding-mode=always
 edns-padding-tag=7830
@@ -299,7 +301,7 @@ class PaddingAllowedAlwaysSameTagTest(RecursorEDNSPaddingTest):
     # we use the default tag (0) for padded responses, which will cause
     # the same packet cache entry (with padding ) to be returned to a client
     # not allowed by the edns-padding-from list
-    _confdir = 'PaddingAlwaysSameTag'
+    _confdir = 'PaddingAllowedAlwaysSameTag'
     _config_template = """edns-padding-from=127.0.0.1
 edns-padding-mode=always
 edns-padding-tag=0

--- a/regression-tests.recursor-dnssec/test_Flags.py
+++ b/regression-tests.recursor-dnssec/test_Flags.py
@@ -5,7 +5,7 @@ import dns
 from recursortests import RecursorTest
 
 
-class TestFlags(RecursorTest):
+class FlagsTest(RecursorTest):
     _confdir = 'Flags'
     _config_template = """dnssec=%s"""
     _config_params = ['_dnssec_setting']

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -11,7 +11,7 @@ from twisted.internet import reactor
 from recursortests import RecursorTest
 
 class GettagRecursorTest(RecursorTest):
-    _confdir = 'LuaGettag'
+    _confdir = 'GettagRecursor'
     _config_template = """
     log-common-errors=yes
     gettag-needs-edns-options=yes
@@ -209,7 +209,7 @@ class GettagRecursorTest(RecursorTest):
         self.assertResponseMatches(query, expected, res)
 
 class GettagRecursorDistributesQueriesTest(GettagRecursorTest):
-    _confdir = 'LuaGettagDistributes'
+    _confdir = 'GettagRecursorDistributesQueries'
     _config_template = """
     log-common-errors=yes
     gettag-needs-edns-options=yes
@@ -247,7 +247,7 @@ class UDPHooksResponder(DatagramProtocol):
         self.transport.write(response.to_wire(), address)
 
 class LuaHooksRecursorTest(RecursorTest):
-    _confdir = 'LuaHooks'
+    _confdir = 'LuaHooksRecursor'
     _config_template = """
 forward-zones=luahooks.example=%s.23
 log-common-errors=yes
@@ -446,7 +446,7 @@ quiet=no
             self.assertRcodeEqual(res, dns.rcode.NOERROR)
 
 class LuaHooksRecursorDistributesTest(LuaHooksRecursorTest):
-    _confdir = 'LuaHooksDistributes'
+    _confdir = 'LuaHooksRecursorDistributes'
     _config_template = """
 forward-zones=luahooks.example=%s.23
 log-common-errors=yes
@@ -458,7 +458,7 @@ quiet=no
 class LuaDNS64Test(RecursorTest):
     """Tests the dq.followupAction("getFakeAAAARecords")"""
 
-    _confdir = 'lua-dns64'
+    _confdir = 'LuaDNS64'
     _config_template = """
     """
     _lua_dns_script_file = """
@@ -519,7 +519,7 @@ class GettagFFIDNS64Test(RecursorTest):
        - DNS64 should kick in, generating an AAAA
     """
 
-    _confdir = 'gettagffi-rpz-dns64'
+    _confdir = 'GettagFFIDNS64'
     _config_template = """
     dns64-prefix=64:ff9b::/96
     """
@@ -572,7 +572,7 @@ dns64.test.powerdns.com.zone.rpz. 60 IN A 192.0.2.42
 class PDNSRandomTest(RecursorTest):
     """Tests if pdnsrandom works"""
 
-    _confdir = 'pdnsrandom'
+    _confdir = 'PDNSRandom'
     _config_template = """
     """
     _lua_dns_script_file = """
@@ -600,7 +600,7 @@ class PDNSRandomTest(RecursorTest):
 class PDNSFeaturesTest(RecursorTest):
     """Tests if pdns_features works"""
 
-    _confdir = 'pdnsfeatures'
+    _confdir = 'PDNSFeatures'
     _config_template = """
     """
     _lua_dns_script_file = """
@@ -628,7 +628,7 @@ class PDNSFeaturesTest(RecursorTest):
 class PDNSGeneratingAnswerFromGettagTest(RecursorTest):
     """Tests that we can generate answers from gettag"""
 
-    _confdir = 'gettaganswers'
+    _confdir = 'PDNSGeneratingAnswerFromGettag'
     _config_template = """
     """
     _lua_dns_script_file = """
@@ -685,7 +685,7 @@ class PDNSGeneratingAnswerFromGettagTest(RecursorTest):
 class PDNSValidationStatesTest(RecursorTest):
     """Tests that we have access to the validation states from Lua"""
 
-    _confdir = 'validation-states-from-lua'
+    _confdir = 'PDNSValidationStates'
     _config_template = """
 dnssec=validate
 """
@@ -751,7 +751,7 @@ class PolicyEventFilterOnFollowUpTest(RecursorTest):
     """Tests the interaction between RPZ and followup queries (dns64, followCNAME)
     """
 
-    _confdir = 'policyeventfilter-followup'
+    _confdir = 'PolicyEventFilterOnFollowUp'
     _config_template = """
     """
     _lua_config_file = """
@@ -802,7 +802,7 @@ class PolicyEventFilterOnFollowUpWithNativeDNS64Test(RecursorTest):
     """Tests the interaction between followup queries and native dns64
     """
 
-    _confdir = 'policyeventfilter-followup-dns64'
+    _confdir = 'PolicyEventFilterOnFollowUpWithNativeDNS64'
     _config_template = """
     dns64-prefix=1234::/96
     """
@@ -838,7 +838,7 @@ class PolicyEventFilterOnFollowUpWithNativeDNS64Test(RecursorTest):
 class LuaPostResolveFFITest(RecursorTest):
     """Tests postresolve_ffi interface"""
 
-    _confdir = 'LuaPostResolveFFITest'
+    _confdir = 'LuaPostResolveFFI'
     _config_template = """
     """
     _lua_dns_script_file = """

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -386,7 +386,7 @@ class ProtobufProxyMappingTest(TestRecursorProtobuf):
     This test makes sure that we correctly export queries and response over protobuf with a proxyMapping
     """
 
-    _confdir = 'ProtobufProxyMappingTest'
+    _confdir = 'ProtobufProxyMapping'
     _config_template = """
     auth-zones=example=configs/%s/example.zone
     allow-from=3.4.5.0/24
@@ -424,7 +424,7 @@ class ProtobufProxyMappingLogMappedTest(TestRecursorProtobuf):
     This test makes sure that we correctly export queries and response over protobuf.
     """
 
-    _confdir = 'ProtobufProxyMappingLogMappedTest'
+    _confdir = 'ProtobufProxyMappingLogMapped'
     _config_template = """
     auth-zones=example=configs/%s/example.zone
     allow-from=3.4.5.0/0"
@@ -643,7 +643,7 @@ class OutgoingProtobufWithECSMappingTest(TestRecursorProtobuf):
     that the recursor at least connects to the protobuf server.
     """
 
-    _confdir = 'OutgoingProtobuffWithECSMapping'
+    _confdir = 'OutgoingProtobufWithECSMapping'
     _config_template = """
     # Switch off QName Minimization, it generates much more protobuf messages
     # (or make the test much more smart!)
@@ -1532,7 +1532,7 @@ class ProtobufMetaFFITest(TestRecursorProtobuf):
     """
     This test makes sure that we can correctly add extra meta fields (FFI version).
     """
-    _confdir = 'ProtobufMetaFFITest'
+    _confdir = 'ProtobufMetaFFI'
     _config_template = """
 auth-zones=example=configs/%s/example.zone""" % _confdir
     _lua_config_file = """

--- a/regression-tests.recursor-dnssec/test_RDFlag.py
+++ b/regression-tests.recursor-dnssec/test_RDFlag.py
@@ -2,8 +2,8 @@ import dns
 import os
 from recursortests import RecursorTest
 
-class testRDNotAllowed(RecursorTest):
-    _confdir = 'RDFlagNotAllowed'
+class RDNotAllowedTest(RecursorTest):
+    _confdir = 'RDNotAllowed'
 
     _config_template = """
 """
@@ -17,8 +17,8 @@ class testRDNotAllowed(RecursorTest):
         self.assertRcodeEqual(res, dns.rcode.REFUSED)
         self.assertAnswerEmpty(res)
 
-class testRDAllowed(RecursorTest):
-    _confdir = 'RDFlagAllowed'
+class RDAllowedTest(RecursorTest):
+    _confdir = 'RDAllowed'
 
     _config_template = """
     disable-packetcache=yes

--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -387,7 +387,7 @@ class RPZXFRRecursorTest(RPZRecursorTest):
     -- The first server is a bogus one, to test that we correctly fail over to the second one
     rpzMaster({'127.0.0.1:9999', '127.0.0.1:%d'}, 'zone.rpz.', { refresh=1, includeSOA=true})
     """ % (rpzServerPort)
-    _confdir = 'RPZXFR'
+    _confdir = 'RPZXFRRecursor'
     _wsPort = 8042
     _wsTimeout = 2
     _wsPassword = 'secretpassword'
@@ -564,7 +564,7 @@ class RPZFileRecursorTest(RPZRecursorTest):
     This test makes sure that we correctly load RPZ zones from a file
     """
 
-    _confdir = 'RPZFile'
+    _confdir = 'RPZFileRecursor'
     _lua_config_file = """
     rpzFile('configs/%s/zone.rpz', { policyName="zone.rpz.", includeSOA=true })
     """ % (_confdir)
@@ -618,7 +618,7 @@ class RPZFileDefaultPolRecursorTest(RPZRecursorTest):
     This test makes sure that we correctly load RPZ zones from a file with a default policy
     """
 
-    _confdir = 'RPZFileDefaultPolicy'
+    _confdir = 'RPZFileDefaultPolRecursor'
     _lua_config_file = """
     rpzFile('configs/%s/zone.rpz', { policyName="zone.rpz.", defpol=Policy.NoAction })
     """ % (_confdir)
@@ -671,7 +671,7 @@ class RPZFileDefaultPolNotOverrideLocalRecursorTest(RPZRecursorTest):
     This test makes sure that we correctly load RPZ zones from a file with a default policy, not overriding local data entries
     """
 
-    _confdir = 'RPZFileDefaultPolicyNotOverrideLocal'
+    _confdir = 'RPZFileDefaultPolNotOverrideLocalRecursor'
     _lua_config_file = """
     rpzFile('configs/%s/zone.rpz', { policyName="zone.rpz.", defpol=Policy.NoAction, defpolOverrideLocalData=false })
     """ % (_confdir)
@@ -775,7 +775,7 @@ class RPZOrderingPrecedenceRecursorTest(RPZRecursorTest):
     This test makes sure that the recursor respects the RPZ ordering precedence rules
     """
 
-    _confdir = 'RPZOrderingPrecedence'
+    _confdir = 'RPZOrderingPrecedenceRecursor'
     _lua_config_file = """
     rpzFile('configs/%s/zone.rpz', { policyName="zone.rpz."})
     rpzFile('configs/%s/zone2.rpz', { policyName="zone2.rpz."})
@@ -1040,7 +1040,7 @@ class RPZFileModByLuaRecursorTest(RPZRecursorTest):
     This test makes sure that we correctly load RPZ zones from a file while being modified by Lua callbacks
     """
 
-    _confdir = 'RPZFileModByLua'
+    _confdir = 'RPZFileModByLuaRecursor'
     _lua_dns_script_file = """
     function preresolve(dq)
       if dq.qname:equal('zmod.example.') then

--- a/regression-tests.recursor-dnssec/test_RPZIncomplete.py
+++ b/regression-tests.recursor-dnssec/test_RPZIncomplete.py
@@ -129,7 +129,7 @@ class RPZIncompleteRecursorTest(RecursorTest):
     _wsTimeout = 2
     _wsPassword = 'secretpassword'
     _apiKey = 'secretapikey'
-    _confdir = 'RPZIncomplete'
+    _confdir = 'RPZIncompleteRecursor'
     _auth_zones = {
         '8': {'threads': 1,
               'zones': ['ROOT']},
@@ -179,7 +179,7 @@ class RPZXFRIncompleteRecursorTest(RPZIncompleteRecursorTest):
     -- The first server is a bogus one, to test that we correctly fail over to the second one
     rpzMaster({'127.0.0.1:9999', '127.0.0.1:%d'}, 'zone.rpz.', { refresh=1 })
     """ % (badrpzServerPort)
-    _confdir = 'RPZXFRIncomplete'
+    _confdir = 'RPZXFRIncompleteRecursor'
     _wsPort = 8042
     _wsTimeout = 2
     _wsPassword = 'secretpassword'

--- a/regression-tests.recursor-dnssec/test_ReadTrustAnchorsFromFile.py
+++ b/regression-tests.recursor-dnssec/test_ReadTrustAnchorsFromFile.py
@@ -4,8 +4,8 @@ import subprocess
 from recursortests import RecursorTest
 
 
-class testReadTrustAnchorsFromFile(RecursorTest):
-    _confdir = 'ReadTAsFromFile'
+class ReadTrustAnchorsFromFileTest(RecursorTest):
+    _confdir = 'ReadTrustAnchorsFromFile'
 
     _config_template = """dnssec=validate"""
     _lua_config_file = """clearTA()

--- a/regression-tests.recursor-dnssec/test_RecDnstap.py
+++ b/regression-tests.recursor-dnssec/test_RecDnstap.py
@@ -4,6 +4,7 @@ import socket
 import struct
 import sys
 import threading
+import time
 import dns
 import dnstap_pb2
 from unittest import SkipTest
@@ -330,6 +331,7 @@ dnstapFrameStreamServer({"%s"}, {logQueries=false})
         self.assertNotEqual(res, None)
 
         # We don't expect anything
+        time.sleep(1)
         self.assertTrue(DNSTapServerParameters.queue.empty())
 
 class DNSTapLogNODTest(TestRecursorDNSTap):
@@ -368,7 +370,7 @@ dnstapNODFrameStreamServer({"%s"})
         return dnstap
 
     def testA(self):
-        name = 'www.example.org.'
+        name = 'types.example.'
         query = dns.message.make_query(name, 'A', want_dnssec=True)
         query.flags |= dns.flags.RD
         res = self.sendUDPQuery(query)

--- a/regression-tests.recursor-dnssec/test_RecDnstap.py
+++ b/regression-tests.recursor-dnssec/test_RecDnstap.py
@@ -341,7 +341,7 @@ class DNSTapLogNODTest(TestRecursorDNSTap):
     that the recursor at least connects to the DNSTap server.
     """
 
-    _confdir = 'DNSTapLogNODQueries'
+    _confdir = 'DNSTapLogNOD'
     _config_template = """
 new-domain-tracking=yes
 new-domain-history-dir=configs/%s/nod
@@ -385,7 +385,7 @@ dnstapNODFrameStreamServer({"%s"})
 
 class DNSTapLogUDRTest(TestRecursorDNSTap):
 
-    _confdir = 'DNSTapLogUDRResponses'
+    _confdir = 'DNSTapLogUDR'
     _config_template = """
 new-domain-tracking=yes
 new-domain-history-dir=configs/%s/nod
@@ -429,7 +429,7 @@ dnstapNODFrameStreamServer({"%s"}, {logNODs=false, logUDRs=true})
 
 class DNSTapLogNODUDRTest(TestRecursorDNSTap):
 
-    _confdir = 'DNSTapLogNODUDRs'
+    _confdir = 'DNSTapLogNODUDR'
     _config_template = """
 new-domain-tracking=yes
 new-domain-history-dir=configs/%s/nod

--- a/regression-tests.recursor-dnssec/test_RootNXTrust.py
+++ b/regression-tests.recursor-dnssec/test_RootNXTrust.py
@@ -33,7 +33,7 @@ class RootNXTrustRecursorTest(RecursorTest):
             if outgoing1 == outgoing2:
                 break
 
-class testRootNXTrustDisabled(RootNXTrustRecursorTest):
+class RootNXTrustDisabledTest(RootNXTrustRecursorTest):
     _confdir = 'RootNXTrustDisabled'
     _wsPort = 8042
     _wsTimeout = 2
@@ -86,7 +86,7 @@ extended-resolution-errors
         self.assertEqual(res.edns, 0)
         self.assertEqual(len(res.options), 0)
 
-class testRootNXTrustEnabled(RootNXTrustRecursorTest):
+class RootNXTrustEnabledTest(RootNXTrustRecursorTest):
     _confdir = 'RootNXTrustEnabled'
     _wsPort = 8042
     _wsTimeout = 2

--- a/regression-tests.recursor-dnssec/test_TTL.py
+++ b/regression-tests.recursor-dnssec/test_TTL.py
@@ -2,7 +2,7 @@ import dns
 import os
 from recursortests import RecursorTest
 
-class testBogusMaxTTL(RecursorTest):
+class BogusMaxTTLTest(RecursorTest):
     _confdir = 'BogusMaxTTL'
 
     _config_template = """dnssec=validate

--- a/regression-tests.recursor-dnssec/test_TrustAnchors.py
+++ b/regression-tests.recursor-dnssec/test_TrustAnchors.py
@@ -2,7 +2,7 @@ import dns
 from recursortests import RecursorTest
 
 
-class testTrustAnchorsEnabled(RecursorTest):
+class TrustAnchorsEnabledTest(RecursorTest):
     """This test will do a query for "trustanchor.server CH TXT" and hopes to get
     a proper answer"""
 
@@ -42,7 +42,7 @@ addNTA("example.com", "some reason")
         self.assertRRsetInAnswer(result, expected)
 
 
-class testTrustAnchorsDisabled(RecursorTest):
+class TrustAnchorsDisabledTest(RecursorTest):
     """This test will do a query for "trustanchor.server CH TXT" and hopes to get
     a proper answer"""
 


### PR DESCRIPTION
This fixes (at least locally) a race occasionally seen in the regression tests:

A test might finish "too early". In that case not all workers are fully setup yet, and leak sanitizer crashes due to a stack out of bounds.

One case fixed by introducing a sleep (for a test to see if the dnstap queue is empty), and one actually querying an existing out-of-band domain, which was enough for me to get all threads properly setup. Previously it would check a domain and get connnection refused, as this test does not setup auths at all. The assumption is that that causes a "too fast exit" of rec.

Log before fix:
```
  test_RecDnstap.py:274: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  cls = <class 'test_RecDnstap.DNSTapLogNODTest'>
  
      @classmethod
      def tearDownRecursor(cls):
          p = cls.killProcess(cls._recursor)
          if p.returncode not in (0, -15):
  >           raise AssertionError('Process exited with return code %d' % (p.returncode))
  E           AssertionError: Process exited with return code 1
  
  recursortests.py:788: AssertionError
```
Corresponding `recursor.log` snippet:
```
Tracer caught signal 11: addr=0x7f60365ff000 pc=0x562fa9c9d8fa sp=0x7f6030a00d40
==62680==LeakSanitizer has encountered a fatal error.
==62680==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
```

Additionally, fix `printlogs.py` and rename a few classes/confdirs so that the names are what `printlogs` expects. And don't hardcode the arch (I have switched to testing on aarch64 linux often),

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
