### PR TITLE
GH Actions -  Coveralls: avoid CI failure when upload fails

### DIFF
--- a/.github/workflows/build-and-test-all-releases-dispatch.yml
+++ b/.github/workflows/build-and-test-all-releases-dispatch.yml
@@ -12,7 +12,6 @@ permissions: # least privileges, see https://docs.github.com/en/actions/using-wo
 
 jobs:
   call-build-and-test-all-master-debian-11:
-    name: Call build-and-test-all master using debian 11 as docker runner image
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@master
     with:
@@ -20,56 +19,48 @@ jobs:
       runner-docker-image-name: base-pdns-ci-image/debian-11-pdns-base
 
   call-build-and-test-all-auth-49:
-    name: Call build-and-test-all rel/auth-4.9.x
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@rel/auth-4.9.x
     with:
       branch-name: rel/auth-4.9.x
 
   call-build-and-test-all-auth-48:
-    name: Call build-and-test-all rel/auth-4.8.x
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@rel/auth-4.8.x
     with:
       branch-name: rel/auth-4.8.x
 
   call-build-and-test-all-auth-47:
-    name: Call build-and-test-all rel/auth-4.7.x
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@rel/auth-4.7.x
     with:
       branch-name: rel/auth-4.7.x
 
   call-build-and-test-all-rec-51:
-    name: Call build-and-test-all rel/rec-5.1.x
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@rel/rec-5.1.x
     with:
       branch-name: rel/rec-5.1.x
 
   call-build-and-test-all-rec-50:
-    name: Call build-and-test-all rel/rec-5.0.x
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@rel/rec-5.0.x
     with:
       branch-name: rel/rec-5.0.x
 
   call-build-and-test-all-rec-49:
-    name: Call build-and-test-all rel/rec-4.9.x
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@rel/rec-4.9.x
     with:
       branch-name: rel/rec-4.9.x
 
   call-build-and-test-all-dnsdist-19:
-    name: Call build-and-test-all rel/dnsdist-1.9.x
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@rel/dnsdist-1.9.x
     with:
       branch-name: rel/dnsdist-1.9.x
 
   call-build-and-test-all-dnsdist-18:
-    name: Call build-and-test-all rel/dnsdist-1.8.x
     if: ${{ vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
     uses: PowerDNS/pdns/.github/workflows/build-and-test-all.yml@rel/dnsdist-1.8.x
     with:

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -120,6 +120,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
       - run: inv ci-auth-install ${{ matrix.build_option }}
       - run: ccache -s
       - if: ${{ matrix.builder != 'meson' }}
@@ -195,6 +196,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
       - run: inv ci-make-install
       - run: ccache -s
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
@@ -271,6 +273,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
       - run: inv ci-make-install
       - run: ccache -s
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
@@ -345,6 +348,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   test-auth-backend:
     needs:
@@ -471,6 +475,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   test-ixfrdist:
     needs:
@@ -508,6 +513,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   test-recursor-api:
     needs:
@@ -553,6 +559,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   test-recursor-regression:
     needs:
@@ -600,6 +607,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   test-recursor-bulk:
     name: 'test rec *mini* bulk'
@@ -645,6 +653,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   test-dnsdist-regression:
     needs:
@@ -692,6 +701,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   swagger-syntax-check:
     if: ${{ !github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
@@ -732,6 +742,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
+          fail-on-error: false
       - name: Install jq and jc
         run: "sudo apt-get update && sudo apt-get install jq jc"
       - name: Fail job if any of the previous jobs failed

--- a/.github/workflows/builder-releases-dispatch.yml
+++ b/.github/workflows/builder-releases-dispatch.yml
@@ -12,56 +12,48 @@ permissions: # least privileges, see https://docs.github.com/en/actions/using-wo
 
 jobs:
   call-builder-auth-49:
-    name: Call builder rel/auth-4.9.x
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
     uses: PowerDNS/pdns/.github/workflows/builder.yml@rel/auth-4.9.x
     with:
       branch-name: rel/auth-4.9.x
 
   call-builder-auth-48:
-    name: Call builder rel/auth-4.8.x
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
     uses: PowerDNS/pdns/.github/workflows/builder.yml@rel/auth-4.8.x
     with:
       branch-name: rel/auth-4.8.x
 
   call-builder-auth-47:
-    name: Call builder rel/auth-4.7.x
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
     uses: PowerDNS/pdns/.github/workflows/builder.yml@rel/auth-4.7.x
     with:
       branch-name: rel/auth-4.7.x
 
   call-builder-rec-51:
-    name: Call builder rel/rec-5.1.x
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
     uses: PowerDNS/pdns/.github/workflows/builder.yml@rel/rec-5.1.x
     with:
       branch-name: rel/rec-5.1.x
 
   call-builder-rec-50:
-    name: Call builder rel/rec-5.0.x
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
     uses: PowerDNS/pdns/.github/workflows/builder.yml@rel/rec-5.0.x
     with:
       branch-name: rel/rec-5.0.x
 
   call-builder-rec-49:
-    name: Call builder rel/rec-4.9.x
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
     uses: PowerDNS/pdns/.github/workflows/builder.yml@rel/rec-4.9.x
     with:
       branch-name: rel/rec-4.9.x
 
   call-builder-dnsdist-19:
-    name: Call builder rel/dnsdist-1.9.x
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
     uses: PowerDNS/pdns/.github/workflows/builder.yml@rel/dnsdist-1.9.x
     with:
       branch-name: rel/dnsdist-1.9.x
 
   call-builder-dnsdist-18:
-    name: Call builder rel/dnsdist-1.8.x
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
     uses: PowerDNS/pdns/.github/workflows/builder.yml@rel/dnsdist-1.8.x
     with:


### PR DESCRIPTION
### Short description
Avoid CI failures related to Coveralls when upload fails due to any errors.

Simplification of calls for workflows `build-and-test-all-releases-dispatch.yml` and `builder-releases-dispatch.yml` to improve readability.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
