### PR TITLE
dnsdist: Handle a non-existent default pool when removing a server

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -736,8 +736,14 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
                          for (const string& poolName : server->d_config.pools) {
                            removeServerFromPool(poolName, server);
                          }
-                         /* the server might also be in the default pool */
-                         removeServerFromPool("", server);
+
+                         try {
+                           /* the server might also be in the default pool */
+                           removeServerFromPool("", server);
+                         }
+                         catch (const std::out_of_range& exp) {
+                           /* but the default pool might not exist yet, this is fine */
+                         }
 
                          dnsdist::configuration::updateRuntimeConfiguration([&server](dnsdist::configuration::RuntimeConfiguration& config) {
                            config.d_backends.erase(std::remove(config.d_backends.begin(), config.d_backends.end(), server), config.d_backends.end());

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -3349,6 +3349,9 @@ int main(int argc, char** argv)
 
     dnsdist::g_asyncHolder = std::make_unique<dnsdist::AsynchronousHolder>();
 
+    /* create the default pool no matter what */
+    createPoolIfNotExists("");
+
     setupLua(*(g_lua.lock()), false, false, cmdLine.config);
 
     setupPools();
@@ -3454,9 +3457,6 @@ int main(int argc, char** argv)
       std::thread webServerThread(dnsdist::webserver::WebserverThread, std::move(listeningSockets.d_webServerSocket));
       webServerThread.detach();
     }
-
-    /* create the default pool no matter what */
-    createPoolIfNotExists("");
 
     for (const auto& backend : dnsdist::configuration::getCurrentRuntimeConfiguration().d_backends) {
       if (backend->connected) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If the server has not been added to the default pool, and is removed before the configuration has been fully parsed, the default pool might not exist yet.
Also create the default pool earlier, before parsing the configuration, so that we don't trip over its absence in a different place.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
