### PR TITLE
auth: added a new config for direct queries of dnskey signature

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -295,6 +295,7 @@ static void declareArguments()
 
   ::arg().setSwitch("traceback-handler", "Enable the traceback handler (Linux only)") = "yes";
   ::arg().setSwitch("direct-dnskey", "Fetch DNSKEY, CDS and CDNSKEY RRs from backend during DNSKEY or CDS/CDNSKEY synthesis") = "no";
+  ::arg().setSwitch("direct-dnskey-signature", "Fetch signature of DNSKEY RRs from backend directly") = "no";
   ::arg().set("default-ksk-algorithm", "Default KSK algorithm") = "ecdsa256";
   ::arg().set("default-ksk-size", "Default KSK size (0 means default)") = "0";
   ::arg().set("default-zsk-algorithm", "Default ZSK algorithm") = "";

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -151,7 +151,7 @@ static void addSignature(DNSSECKeeper& dk, UeberBackend& db, const DNSName& sign
   if(toSign.empty())
     return;
   vector<RRSIGRecordContent> rrcs;
-  if(dk.isPresigned(signer)) {
+  if(dk.isPresigned(signer) || (::arg().mustDo("direct-dnskey-signature") && signQType == QType::DNSKEY)) {
     //cerr<<"Doing presignatures"<<endl;
     dk.getPreRRSIGs(db, outsigned, origTTL, packet); // does it all
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Addresses the feature request that I made on Issue #14372.

Added a new setting called `direct-dnskey-signature`, which allows for the direct retrieval of DNSKEY signature from the backend.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
