### PR TITLE
YaHTTP: Fix a non-virtual destructor warning in the `HTTPBase` class

### DIFF
--- a/ext/yahttp/yahttp/reqresp.hpp
+++ b/ext/yahttp/yahttp/reqresp.hpp
@@ -98,6 +98,7 @@ namespace YaHTTP {
     HTTPBase() {
       HTTPBase::initialize();
     };
+    virtual ~HTTPBase() = default;
 
     virtual void initialize() {
       kind = 0;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`g++` 14.2.1's `-Wnon-virtual-dtor` complains:
```
‘class YaHTTP::HTTPBase’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
