### PR TITLE
auth docs: fix invalid reference

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1406,7 +1406,7 @@ Secondary name servers.
 
 If this many packets are waiting for database attention, answer any new
 questions strictly from the packet cache. Packets not in the cache will
-be dropped, and :ref:`_stat-overload-drops` will be incremented.
+be dropped, and :ref:`stat-overload-drops` will be incremented.
 
 .. _setting-prevent-self-notification:
 


### PR DESCRIPTION

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes this warning from sphinx:

```
docs/settings.rst:1407: WARNING: undefined label: _stat-overload-drops (if the link has no caption the label must precede a section header)
```


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
