### PR TITLE
auth dnsproxy: document network ought to be trusted

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1541,6 +1541,8 @@ Number of receiver (listening) threads to start. See :doc:`performance`.
 
 Recursive DNS server to use for ALIAS lookups and the internal stub resolver. Only one address can be given.
 
+It is assumed that the specified recursive DNS server, and the network path to it, are trusted.
+
 Examples::
 
   resolver=127.0.0.1


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

We are reusing the source UDP port for a very long time. Cannot have people interfere or try to attack us with this design.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
