### PR TITLE
docs - pip pinning: set pbr version to 6.1.0

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -12,4 +12,4 @@ jinja2<3.1.0
 pyyaml==6.0.1
 packaging==24.1
 setuptools-scm==8.0.3 # setup-requires for sphinxcontrib-openapi
-pbr # setup-requires for sphinxcontrib-fulltoc
+pbr==6.1.0 # setup-requires for sphinxcontrib-fulltoc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -191,9 +191,9 @@ packaging==24.1 \
     #   -r requirements.in
     #   setuptools-scm
     #   sphinx
-pbr==6.0.0 \
-    --hash=sha256:4a7317d5e3b17a3dccb6a8cfe67dab65b20551404c52c8ed41279fa4f0cb4cda \
-    --hash=sha256:d1377122a5a00e2f940ee482999518efe16d745d423a670c27773dfbc3c9a7d9
+pbr==6.1.0 \
+    --hash=sha256:788183e382e3d1d7707db08978239965e8b9e4e5ed42669bf4758186734d5f24 \
+    --hash=sha256:a776ae228892d8013649c0aeccbb3d5f99ee15e005a4cbb7e61d55a067b28a2a
     # via -r requirements.in
 pygments==2.15.1 \
     --hash=sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c \


### PR DESCRIPTION
### Short description

One of the external dependencies for building docs, the `pip` package `sphinxcontrib-fulltoc` has a not-pinned setup-requirement dependency with the package `pbr`. This makes us update our list of pinned pulled packages each time a new version comes up.

The package version is being explicitly set to `6.1.0` in this PR because otherwise, the tool that generates the list (`pip-compile --generate-hashes requirements.in`) will not include a dependency that is already satisfied. 

**NOTE**: the execution of the tool requires Python 3.11, which is the version used in the CI. Any other Python version would end up with a different list and errors when running the workflows

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
