### PR TITLE
auth: encapsulate lookup()-cleanup

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -439,7 +439,7 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
             }
           }
           catch (std::exception &e) {
-            while (B.get(rr)) ;                 // don't leave DB handle in bad state
+            B.lookupEnd();                 // don't leave DB handle in bad state
 
             throw;
           }
@@ -465,7 +465,7 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
     B.lookup(QType(QType::ANY), subdomain, d_sd.domain_id, &p);
     if (B.get(rr)) {
       DLOG(g_log<<"No wildcard match, ancestor exists"<<endl);
-      while (B.get(rr)) ;
+      B.lookupEnd();
       break;
     }
     wildcard=subdomain;
@@ -501,7 +501,7 @@ DNSName PacketHandler::doAdditionalServiceProcessing(const DNSName &firstTarget,
           break;
         }
         default:
-          while (B.get(rr)) ;              // don't leave DB handle in bad state
+          B.lookupEnd();              // don't leave DB handle in bad state
 
           throw PDNSException("Unknown type (" + QType(qtype).toString() + ") for additional service processing");
       }
@@ -1623,7 +1623,7 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
             }
           }
           catch(std::exception &e) {
-            while (B.get(rr)) ;              // don't leave DB handle in bad state
+            B.lookupEnd();              // don't leave DB handle in bad state
 
             r=p.replyPacket();
             r->setRcode(RCode::ServFail);

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -801,6 +801,20 @@ bool UeberBackend::get(DNSZoneRecord& resourceRecord)
   return false;
 }
 
+void UeberBackend::lookupEnd()
+{
+  if (!d_negcached && !d_cached) {
+    DNSZoneRecord zoneRecord;
+    while (d_handle.get(zoneRecord)) {
+      // Read all answers so the backends will close any database handles they might have allocated.
+      // One day this could be optimized.
+    }
+  }
+
+  d_answers.clear();
+  d_cached = d_negcached = false;
+}
+
 // TSIG
 //
 bool UeberBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content)

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -94,12 +94,15 @@ public:
   };
 
   void lookup(const QType& qtype, const DNSName& qname, int zoneId, DNSPacket* pkt_p = nullptr);
+  /** Read a single record from a lookup(...) result. */
+  bool get(DNSZoneRecord& resourceRecord);
+  /** Close state created by lookup(...). */
+  void lookupEnd();
 
   /** Determines if we are authoritative for a zone, and at what level */
   bool getAuth(const DNSName& target, const QType& qtype, SOAData* soaData, bool cachedOk = true);
   /** Load SOA info from backends, ignoring the cache.*/
   bool getSOAUncached(const DNSName& domain, SOAData& soaData);
-  bool get(DNSZoneRecord& resourceRecord);
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled);
 
   void getUnfreshSecondaryInfos(vector<DomainInfo>* domains);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Encapsulate this pattern into a new function:
```
while (B.get(rr)) ;      // don't leave DB handle in bad state
```

I've tentatively called the function `lookupEnd`.

This is a tiny improvement and probably opens a can of clang-tidy worms. I'll preemptively say that a solution which would instead remove the need to explicitly call this would be better, but that can still come.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
