### PR TITLE
regression-tests.auth-py: allow running with meson, and on macOS

### DIFF
--- a/regression-tests.auth-py/authtests.py
+++ b/regression-tests.auth-py/authtests.py
@@ -27,7 +27,7 @@ class AuthTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     _config_params = []
 
     _config_template_default = """
-module-dir=../regression-tests/modules
+module-dir={PDNS_MODULE_DIR}
 daemon=no
 bind-config={confdir}/named.conf
 bind-dnssec-db={bind_dnssec_db}
@@ -75,6 +75,7 @@ PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
     _auths = {}
 
     _PREFIX = os.environ['PREFIX']
+    _PDNS_MODULE_DIR = os.environ['PDNS_MODULE_DIR']
 
 
     @classmethod
@@ -116,7 +117,9 @@ options {
         with open(os.path.join(confdir, 'pdns.conf'), 'w') as pdnsconf:
             pdnsconf.write(cls._config_template_default.format(
                 confdir=confdir, prefix=cls._PREFIX,
-                bind_dnssec_db=bind_dnssec_db))
+                bind_dnssec_db=bind_dnssec_db,
+                PDNS_MODULE_DIR=cls._PDNS_MODULE_DIR,
+            ))
             pdnsconf.write(cls._config_template % params)
 
         os.system("sqlite3 ./configs/auth/powerdns.sqlite < ../modules/gsqlite3backend/schema.sqlite3.sql")

--- a/regression-tests.auth-py/authtests.py
+++ b/regression-tests.auth-py/authtests.py
@@ -69,8 +69,10 @@ PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
         """,
     }
 
-    _auth_cmd = ['authbind',
-                 os.environ['PDNS']]
+    _auth_cmd = [os.environ['PDNS']]
+    if sys.platform != 'darwin':
+        _auth_cmd = ['authbind'] + _auth_cmd
+
     _auth_env = {}
     _auths = {}
 

--- a/regression-tests.auth-py/runtests
+++ b/regression-tests.auth-py/runtests
@@ -14,9 +14,20 @@ mkdir -p configs
 
 [ -f ./vars ] && . ./vars
 
-export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
-export PDNSUTIL=${PDNSUTIL:-${PWD}/../pdns/pdnsutil}
-export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
+if [ -z "$PDNS_BUILD_PATH" ]; then
+  # PDNS_BUILD_PATH is unset or empty. Assume an autotools build.
+  PDNS_BUILD_PATH=.
+
+  export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
+  export PDNSUTIL=${PDNSUTIL:-${PWD}/../pdns/pdnsutil}
+  export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
+  export PDNS_MODULE_DIR=${PDNS_MODULE_DIR:-${PWD}/modules}
+else
+  export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns-auth}
+  export PDNSUTIL=${PDNSUTIL:-$PDNS_BUILD_PATH/pdns-auth-util}
+  export PDNSCONTROL=${PDNSCONTROL:-$PDNS_BUILD_PATH/pdns-auth-control}
+  export PDNS_MODULE_DIR=${PDNS_MODULE_DIR:-$PDNS_BUILD_PATH/modules}
+fi
 
 export PREFIX=127.0.0
 

--- a/regression-tests.auth-py/test_GSSTSIG.py
+++ b/regression-tests.auth-py/test_GSSTSIG.py
@@ -8,7 +8,7 @@ from authtests import AuthTest
 
 class GSSTSIGBase(AuthTest):
     _config_template_default = """
-module-dir=../regression-tests/modules
+module-dir={PDNS_MODULE_DIR}
 daemon=no
 socket-dir={confdir}
 cache-ttl=0


### PR DESCRIPTION
### Short description

Support `$PDNS_BUILD_PATH` like in `regression-tests`. Avoid passing the autoconf-only `module-dir` and instead assume modules are in `$PDNS_BUILD_PATH/modules`.

Avoid `authbind` on macOS, where it is not necessary and absent.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
