### PR TITLE
regression-tests.auth-py: actually test ALIAS AAAA cases

### DIFF
--- a/regression-tests.auth-py/test_ALIAS.py
+++ b/regression-tests.auth-py/test_ALIAS.py
@@ -194,10 +194,10 @@ subnetwrong.example.org.     3600 IN ALIAS subnetwrong.example.com.
 
         ecso = clientsubnetoption.ClientSubnetOption('2001:db8:db6:db5::', 64)
         ecso2 = clientsubnetoption.ClientSubnetOption('2001:db8:db6:db5::', 64, 48)
-        query = dns.message.make_query('subnet.example.org', 'A', use_edns=True, options=[ecso])
+        query = dns.message.make_query('subnet.example.org', 'AAAA', use_edns=True, options=[ecso])
         res = self.sendUDPQuery(query)
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertAnyRRsetInAnswer(res, expected_a)
+        self.assertAnyRRsetInAnswer(res, expected_aaaa)
         self.assertEqual(res.options[0], ecso2)
 
     def testECSWrong(self):
@@ -218,10 +218,10 @@ subnetwrong.example.org.     3600 IN ALIAS subnetwrong.example.com.
 
         ecso = clientsubnetoption.ClientSubnetOption('2001:db8:db6:db5::', 64)
         ecso2 = clientsubnetoption.ClientSubnetOption('2001:db8:db6:db5::', 64, 48)
-        query = dns.message.make_query('subnetwrong.example.org', 'A', use_edns=True, options=[ecso])
+        query = dns.message.make_query('subnetwrong.example.org', 'AAAA', use_edns=True, options=[ecso])
         res = self.sendUDPQuery(query)
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertAnyRRsetInAnswer(res, expected_a)
+        self.assertAnyRRsetInAnswer(res, expected_aaaa)
         self.assertEqual(res.options[0], ecso2)
 
     def testECSNone(self):
@@ -242,10 +242,10 @@ subnetwrong.example.org.     3600 IN ALIAS subnetwrong.example.com.
 
         ecso = clientsubnetoption.ClientSubnetOption('2001:db8:db6:db5::', 64)
         ecso2 = clientsubnetoption.ClientSubnetOption('2001:db8:db6:db5::', 64, 0)
-        query = dns.message.make_query('noerror.example.org', 'A', use_edns=True, options=[ecso])
+        query = dns.message.make_query('noerror.example.org', 'AAAA', use_edns=True, options=[ecso])
         res = self.sendUDPQuery(query)
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertAnyRRsetInAnswer(res, expected_a)
+        self.assertAnyRRsetInAnswer(res, expected_aaaa)
         self.assertEqual(res.options[0], ecso2)
 
 class AliasUDPResponder(DatagramProtocol):


### PR DESCRIPTION
### Short description

`expected_aaaa` is unused in these tests, use it.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
