### PR TITLE
dnsdist: adapt unit test to avoid race on OpenBSD

### DIFF
--- a/pdns/dnsdistdist/test-dnsdistasync.cc
+++ b/pdns/dnsdistdist/test-dnsdistasync.cc
@@ -135,7 +135,10 @@ BOOST_AUTO_TEST_CASE(test_TimeoutFailClose)
   // the event should be triggered after 10 ms, but we have seen
   // many spurious failures on our CI, likely because the box is
   // overloaded, so sleep for up to 100 ms to be sure
-  for (size_t counter = 0; !holder->empty() && counter < 10; counter++) {
+  for (size_t counter = 0; counter < 10; counter++) {
+    if (holder->empty() && sender->errorRaised.load()) {
+      break;
+    }
     usleep(10000);
   }
 
@@ -168,7 +171,10 @@ BOOST_AUTO_TEST_CASE(test_AddingExpiredEvent)
   // but we have seen many spurious failures on our CI,
   // likely because the box is overloaded, so sleep for up to
   // 100 ms to be sure
-  for (size_t counter = 0; !holder->empty() && counter < 10; counter++) {
+  for (size_t counter = 0; counter < 10; counter++) {
+    if (holder->empty() && sender->errorRaised.load()) {
+      break;
+    }
     usleep(10000);
   }
 


### PR DESCRIPTION
It looks like OpenBSD has different thread scheduler behaviour, and it can take a while for the error condition to be set.

Note that executing the loop more times does not work, as the `holder->empty()` condition is wat terminates the loop from what I have observed. But it still takes a while for the error condition to get set. Increasing the individual `usleeps` is what made this work reliable on OpenBSD/arm64.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
