### PR TITLE
auth: allow turning off across-zone resolving

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -785,6 +785,23 @@ the server will return NODATA for A/AAAA queries for such names.
   In PowerDNS Authoritative Server 4.0.x, this setting did not exist and
   ALIAS was always expanded.
 
+.. _setting-resolve-across-zones:
+
+``resolve-across-zones``
+------------------------
+
+.. versionadded:: 5.0.0
+
+-  Boolean
+-  Default: yes
+
+If this is enabled, CNAME records and other referrals will be resolved as long as their targets exist in any local backend.
+Can be disabled to allow for different authorities managing zones in the same server instance.
+
+Referrals not available in local backends are never resolved.
+SVCB referrals are never resolved across zones.
+ALIAS is not impacted by this setting.
+
 .. _setting-forward-dnsupdate:
 
 ``forward-dnsupdate``

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -309,6 +309,7 @@ static void declareArguments()
 
   ::arg().setSwitch("expand-alias", "Expand ALIAS records") = "no";
   ::arg().set("outgoing-axfr-expand-alias", "Expand ALIAS records during outgoing AXFR") = "no";
+  ::arg().setSwitch("resolve-across-zones", "Resolve CNAME targets and other referrals across local zones") = "yes";
   ::arg().setSwitch("8bit-dns", "Allow 8bit dns queries") = "no";
 #ifdef HAVE_LUA_RECORDS
   ::arg().setSwitch("enable-lua-records", "Process LUA records for all zones (metadata overrides this)") = "no";

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1517,6 +1517,12 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
       return r;
     }
 
+    if (retargetcount > 0 && !d_doResolveAcrossZones && !target.isPartOf(r->qdomainzone)) {
+      // We are following a retarget outside the initial zone (and do not need to check getAuth to know this). Config asked us not to do that.
+      // This is a performance optimization, the generic case is checked after getAuth below.
+      goto sendit;  // NOLINT(cppcoreguidelines-avoid-goto)
+    }
+
     if(!B.getAuth(target, p.qtype, &d_sd)) {
       DLOG(g_log<<Logger::Error<<"We have no authority over zone '"<<target<<"'"<<endl);
       if(!retargetcount) {

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -70,6 +70,7 @@ PacketHandler::PacketHandler():B(g_programname), d_dk(&B)
   ++s_count;
   d_doDNAME=::arg().mustDo("dname-processing");
   d_doExpandALIAS = ::arg().mustDo("expand-alias");
+  d_doResolveAcrossZones = ::arg().mustDo("resolve-across-zones");
   d_logDNSDetails= ::arg().mustDo("log-dns-details");
   string fname= ::arg()["lua-prequery-script"];
 
@@ -1526,11 +1527,16 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
     }
     DLOG(g_log<<Logger::Error<<"We have authority, zone='"<<d_sd.qname<<"', id="<<d_sd.domain_id<<endl);
 
+    if (retargetcount == 0) {
+      r->qdomainzone = d_sd.qname;
+    } else if (!d_doResolveAcrossZones && r->qdomainzone != d_sd.qname) {
+      // We are following a retarget outside the initial zone. Config asked us not to do that.
+      goto sendit;  // NOLINT(cppcoreguidelines-avoid-goto)
+    }
+
     authSet.insert(d_sd.qname);
     d_dnssec=(p.d_dnssecOk && d_dk.isSecuredZone(d_sd.qname));
     doSigs |= d_dnssec;
-
-    if(!retargetcount) r->qdomainzone=d_sd.qname;
 
     if(d_sd.qname==p.qdomain) {
       if(!d_dk.isPresigned(d_sd.qname)) {

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -114,6 +114,7 @@ private:
   bool d_logDNSDetails;
   bool d_doDNAME;
   bool d_doExpandALIAS;
+  bool d_doResolveAcrossZones;
   bool d_dnssec{false};
   SOAData d_sd;
   std::unique_ptr<AuthLua4> d_pdl;

--- a/regression-tests.auth-py/authtests.py
+++ b/regression-tests.auth-py/authtests.py
@@ -440,7 +440,7 @@ options {
                 self.assertEqual(ans, rrset, "'%s' != '%s'" % (ans.to_text(), rrset.to_text()))
                 found = True
 
-        if not found :
+        if not found:
             raise AssertionError("RRset not found in answer\n\n%s" % ret)
 
     def assertRRsetInAdditional(self, msg, rrset):
@@ -464,7 +464,7 @@ options {
                 self.assertEqual(ans, rrset, "'%s' != '%s'" % (ans.to_text(), rrset.to_text()))
                 found = True
 
-        if not found :
+        if not found:
             raise AssertionError("RRset not found in answer\n\n%s" % ret)
 
     def sortRRsets(self, rrsets):

--- a/regression-tests.auth-py/test_ResolveAcrossZones.py
+++ b/regression-tests.auth-py/test_ResolveAcrossZones.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import dns
+
+from authtests import AuthTest
+
+
+class CrossZoneResolveBase(AuthTest):
+    _config_template = """
+any-to-tcp=no
+launch=bind
+edns-subnet-processing=yes
+"""
+    target_otherzone_ip = "192.0.2.2"
+    target_subzone_ip = "192.0.2.3"
+    _zones = {
+        "example.org": """
+example.org.                 3600 IN SOA   {soa}
+example.org.                 3600 IN NS    ns1.example.org.
+example.org.                 3600 IN NS    ns2.example.org.
+ns1.example.org.             3600 IN A     {prefix}.10
+ns2.example.org.             3600 IN A     {prefix}.11
+subzone.example.org.         3600 IN NS    ns1.example.org.
+subzone.example.org.         3600 IN NS    ns2.example.org.
+cname-otherzone.example.org. 3600 IN CNAME target.example.com.
+cname-subzone.example.org.   3600 IN CNAME target.subzone.example.org.
+        """,
+        "subzone.example.org": """
+subzone.example.org.         3600 IN SOA   {soa}
+target.subzone.example.org.  3600 IN A     """
+        + target_subzone_ip,
+        "example.com": """
+example.com.                 3600 IN SOA   {soa}
+example.com.                 3600 IN NS    ns1.example.com.
+example.com.                 3600 IN NS    ns2.example.com.
+ns1.example.com.             3600 IN A     {prefix}.10
+ns2.example.com.             3600 IN A     {prefix}.11
+target.example.com.          3600 IN A     """
+        + target_otherzone_ip,
+    }
+
+
+class TestCrossZoneResolveOff(CrossZoneResolveBase):
+    _config_template = (
+        CrossZoneResolveBase._config_template
+        + """
+resolve-across-zones=no
+"""
+    )
+
+    def impl_cname_only_test(self, qname, target):
+        expected_cname = dns.rrset.from_text(
+            qname, 0, dns.rdataclass.IN, "CNAME", target
+        )
+        query = dns.message.make_query(qname, "A")
+        res = self.sendUDPQuery(query)
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        assert res.answer == [expected_cname]
+        assert res.additional == []
+
+    def testCNAMEOtherZone(self):
+        self.impl_cname_only_test("cname-otherzone.example.org.", "target.example.com.")
+
+    def testCNAMESubZone(self):
+        self.impl_cname_only_test(
+            "cname-subzone.example.org.", "target.subzone.example.org."
+        )
+
+
+class TestCrossZoneResolveOn(CrossZoneResolveBase):
+    _config_template = (
+        CrossZoneResolveBase._config_template
+        + """
+resolve-across-zones=yes
+"""
+    )
+
+    def impl_cname_and_target_test(self, qname, target, target_ip):
+        expected_cname = dns.rrset.from_text(
+            qname, 0, dns.rdataclass.IN, "CNAME", target
+        )
+        expected_target = dns.rrset.from_text(
+            target, 0, dns.rdataclass.IN, "A", target_ip
+        )
+        query = dns.message.make_query(qname, "A")
+        res = self.sendUDPQuery(query)
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        assert res.answer == [expected_cname, expected_target]
+        assert res.additional == []
+
+    def testCNAMEOtherZone(self):
+        self.impl_cname_and_target_test(
+            "cname-otherzone.example.org.",
+            "target.example.com.",
+            self.target_otherzone_ip,
+        )
+
+    def testCNAMESubZone(self):
+        self.impl_cname_and_target_test(
+            "cname-subzone.example.org.",
+            "target.subzone.example.org.",
+            self.target_subzone_ip,
+        )


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Addresses #10017. Introduces new setting `resolve-across-zones`. Default is the unchanged behaviour.

Turning off the new setting causes CNAME targets to not be followed across (local) zones. Also, queries that could be answered by following a local delegation are similarly not resolved.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
