### PR TITLE
Add a way to run pdnsutil using a debugger as part of the LMDB regression tests

### DIFF
--- a/regression-tests/backends/common
+++ b/regression-tests/backends/common
@@ -1,128 +1,128 @@
 start_master ()
 {
-	case $context in
-			bind*)
-				source ./backends/bind-master
-				;;
-			geoip*)
-				source ./backends/geoip-master
-				;;
-			gmysql*)
-				source ./backends/gmysql-master
-				;;
+        case $context in
+                        bind*)
+                                source ./backends/bind-master
+                                ;;
+                        geoip*)
+                                source ./backends/geoip-master
+                                ;;
+                        gmysql*)
+                                source ./backends/gmysql-master
+                                ;;
 
-			godbc_mssql*)
-				[ -z $GODBC_MSSQL_DSN ] && echo '$GODBC_MSSQL_DSN must be set' >&2 && exit 1
-				[ -z $GODBC_MSSQL_USERNAME ] && echo '$GODBC_MSSQL_USERNAME must be set' >&2 && exit 1
-				[ -z $GODBC_MSSQL_PASSWORD ] && echo '$GODBC_MSSQL_PASSWORD must be set' >&2 && exit 1
-				source ./backends/godbc_mssql-master
-				;;
+                        godbc_mssql*)
+                                [ -z $GODBC_MSSQL_DSN ] && echo '$GODBC_MSSQL_DSN must be set' >&2 && exit 1
+                                [ -z $GODBC_MSSQL_USERNAME ] && echo '$GODBC_MSSQL_USERNAME must be set' >&2 && exit 1
+                                [ -z $GODBC_MSSQL_PASSWORD ] && echo '$GODBC_MSSQL_PASSWORD must be set' >&2 && exit 1
+                                source ./backends/godbc_mssql-master
+                                ;;
 
-			godbc_sqlite3*)
-				[ -z $GODBC_SQLITE3_DSN ] && echo '$GODBC_SQLITE3_DSN must be set' >&2 && exit 1
-				source ./backends/godbc_sqlite3-master
-				;;
+                        godbc_sqlite3*)
+                                [ -z $GODBC_SQLITE3_DSN ] && echo '$GODBC_SQLITE3_DSN must be set' >&2 && exit 1
+                                source ./backends/godbc_sqlite3-master
+                                ;;
 
-			gpgsql*)
-				source ./backends/gpgsql-master
-				;;
+                        gpgsql*)
+                                source ./backends/gpgsql-master
+                                ;;
 
-			gsqlite3*)
-				source ./backends/gsqlite3-master
-				;;
+                        gsqlite3*)
+                                source ./backends/gsqlite3-master
+                                ;;
 
-			lmdb*)
-				source ./backends/lmdb-master
-				;;
+                        lmdb*)
+                                source ./backends/lmdb-master
+                                ;;
 
-			remote*)
-				source ./backends/remote-master
-				;;
+                        remote*)
+                                source ./backends/remote-master
+                                ;;
 
-			tinydns*)
-				source ./backends/tinydns-master
-				;;
+                        tinydns*)
+                                source ./backends/tinydns-master
+                                ;;
 
-			ldap*)
-				source ./backends/ldap-master
-				;;
+                        ldap*)
+                                source ./backends/ldap-master
+                                ;;
 
-			lua2*)
-				source ./backends/lua2-master
-				;;
+                        lua2*)
+                                source ./backends/lua2-master
+                                ;;
 
-			ext-nsd*)
-				source ./ext/nsd-master
-				;;
+                        ext-nsd*)
+                                source ./ext/nsd-master
+                                ;;
 
-			ext-bind*)
-				source ./ext/bind-master
-				;;
+                        ext-bind*)
+                                source ./ext/bind-master
+                                ;;
 
-			*)
-				nocontext=yes
-	esac
+                        *)
+                                nocontext=yes
+        esac
 
-	if [ "$nocontext" == "yes" ]
-	then
-		echo unknown context $context
-		: > passed_tests
-		echo 'unknown-context-'"$context" > failed_tests
-		./toxml $context
-		exit
-	fi
+        if [ "$nocontext" == "yes" ]
+        then
+                echo unknown context $context
+                : > passed_tests
+                echo 'unknown-context-'"$context" > failed_tests
+                ./toxml $context
+                exit
+        fi
 }
 
 start_slave ()
 {
-	skipreasons="$skipreasons presigned nodyndns"
+        skipreasons="$skipreasons presigned nodyndns"
 
-	case $presignedcontext in
-		bind*)
-			source ./backends/bind-slave
-			;;
+        case $presignedcontext in
+                bind*)
+                        source ./backends/bind-slave
+                        ;;
 
-		gmysql*)
-			source ./backends/gmysql-slave
-			;;
+                gmysql*)
+                        source ./backends/gmysql-slave
+                        ;;
 
-		godbc_mssql*)
-			[ -z $GODBC_MSSQL2_DSN ] && echo '$GODBC_MSSQL2_DSN must be set' >&2 && exit 1
-			[ -z $GODBC_MSSQL2_USERNAME ] && echo '$GODBC_MSSQL2_USERNAME must be set' >&2 && exit 1
-			[ -z $GODBC_MSSQL2_PASSWORD ] && echo '$GODBC_MSSQL2_PASSWORD must be set' >&2 && exit 1
-			source ./backends/godbc_mssql-slave
-			;;
+                godbc_mssql*)
+                        [ -z $GODBC_MSSQL2_DSN ] && echo '$GODBC_MSSQL2_DSN must be set' >&2 && exit 1
+                        [ -z $GODBC_MSSQL2_USERNAME ] && echo '$GODBC_MSSQL2_USERNAME must be set' >&2 && exit 1
+                        [ -z $GODBC_MSSQL2_PASSWORD ] && echo '$GODBC_MSSQL2_PASSWORD must be set' >&2 && exit 1
+                        source ./backends/godbc_mssql-slave
+                        ;;
 
-		gpgsql*)
-		source ./backends/gpgsql-slave
-			;;
+                gpgsql*)
+                source ./backends/gpgsql-slave
+                        ;;
 
-		gsqlite3*)
-			source ./backends/gsqlite3-slave
-			;;
+                gsqlite3*)
+                        source ./backends/gsqlite3-slave
+                        ;;
 
-		lmdb*)
-			source ./backends/lmdb-slave
-			;;
+                lmdb*)
+                        source ./backends/lmdb-slave
+                        ;;
 
-		ext-bind*)
-			source ./ext/bind-slave
-			;;
+                ext-bind*)
+                        source ./ext/bind-slave
+                        ;;
 
-		ext-nsd*)
-			source ./ext/nsd-slave
-			;;
+                ext-nsd*)
+                        source ./ext/nsd-slave
+                        ;;
 
-		*)
-			nocontext=yes
-	esac
+                *)
+                        nocontext=yes
+        esac
 
-	if [ "$nocontext" == "yes" ]
-	then
-		echo unknown presigned context $presignedcontext
-		: > passed_tests
-		echo 'unknown-presigned-context-'"$presignedcontext" > failed_tests
-		./toxml $context
-		exit
-	fi
+        if [ "$nocontext" == "yes" ]
+        then
+                echo unknown presigned context $presignedcontext
+                : > passed_tests
+                echo 'unknown-presigned-context-'"$presignedcontext" > failed_tests
+                ./toxml $context
+                exit
+        fi
 }

--- a/regression-tests/backends/lmdb-master
+++ b/regression-tests/backends/lmdb-master
@@ -11,9 +11,9 @@ __EOF__
         for zone in $(grep 'zone ' named.conf  | cut -f2 -d\" | grep -v '^nztest.com$')
         do
             if [ "$zone" = "." ]; then
-                        $PDNSUTIL --config-dir=. --config-name=lmdb load-zone $zone zones/ROOT
+                        $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb load-zone $zone zones/ROOT
             else
-                        $PDNSUTIL --config-dir=. --config-name=lmdb load-zone $zone zones/$zone
+                        $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb load-zone $zone zones/$zone
             fi
             if [ $context != lmdb-nodnssec ]
             then
@@ -21,51 +21,51 @@ __EOF__
                 then
                     if [ $context = lmdb-nsec3 ]
                     then
-                        $PDNSUTIL --config-dir=. --config-name=lmdb set-nsec3 $zone "1 0 1 abcd" 2>&1
+                        $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-nsec3 $zone "1 0 1 abcd" 2>&1
                     elif [ $context =  lmdb-nsec3-optout ]
                     then
-                        $PDNSUTIL --config-dir=. --config-name=lmdb set-nsec3 $zone "1 1 1 abcd" 2>&1
+                        $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-nsec3 $zone "1 1 1 abcd" 2>&1
                     elif [ $context = lmdb-nsec3-narrow ]
                     then
-                        $PDNSUTIL --config-dir=. --config-name=lmdb set-nsec3 $zone '1 1 1 abcd' narrow 2>&1
+                        $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-nsec3 $zone '1 1 1 abcd' narrow 2>&1
                     fi
                     securezone $zone lmdb
                     if [ $zone = hiddencryptokeys.org ]
                     then
-                        keyid=$($PDNSUTIL --config-dir=. --config-name=lmdb list-keys $zone | grep hiddencryptokeys.org | awk '{ print $7 }')
-                        $PDNSUTIL --config-dir=. --config-name=lmdb unpublish-zone-key $zone $keyid
+                        keyid=$($RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb list-keys $zone | grep hiddencryptokeys.org | awk '{ print $7 }')
+                        $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb unpublish-zone-key $zone $keyid
                     fi
                     if [ $zone = cryptokeys.org ]
                     then
-                        $PDNSUTIL --config-dir=. --config-name=lmdb add-zone-key $zone zsk 384 active unpublished ecdsa384
-                        $PDNSUTIL --config-dir=. --config-name=lmdb add-zone-key $zone zsk 2048 inactive published rsasha512
-                        $PDNSUTIL --config-dir=. --config-name=lmdb add-zone-key $zone zsk 2048 inactive unpublished rsasha256
+                        $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb add-zone-key $zone zsk 384 active unpublished ecdsa384
+                        $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb add-zone-key $zone zsk 2048 inactive published rsasha512
+                        $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb add-zone-key $zone zsk 2048 inactive unpublished rsasha256
                     fi
                 fi
             else
-                $PDNSUTIL --config-dir=. --config-name=lmdb rectify-zone $zone 2>&1
+                $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb rectify-zone $zone 2>&1
             fi
             if [ "$zone" = "tsig.com" ]; then
-                $PDNSUTIL --config-dir=. --config-name=lmdb import-tsig-key test $ALGORITHM $KEY
-                $PDNSUTIL --config-dir=. --config-name=lmdb activate-tsig-key tsig.com test primary
+                $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb import-tsig-key test $ALGORITHM $KEY
+                $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb activate-tsig-key tsig.com test primary
             fi
         done
 
         # setup catalog zone
 
-        if ! $PDNSUTIL --config-dir=. --config-name=lmdb list-all-zones | grep '^.$' # detect root tests
+        if ! $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb list-all-zones | grep '^.$' # detect root tests
         then
             for zone in $(grep 'zone ' named.conf  | cut -f2 -d\" | grep -v '^nztest.com$')
             do
-                $PDNSUTIL --config-dir=. --config-name=lmdb set-kind $zone master
-                $PDNSUTIL --config-dir=. --config-name=lmdb set-catalog $zone catalog.invalid
+                $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-kind $zone master
+                $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-catalog $zone catalog.invalid
             done
 
-            $PDNSUTIL --config-dir=. --config-name=lmdb load-zone catalog.invalid zones/catalog.invalid
-            $PDNSUTIL --config-dir=. --config-name=lmdb set-kind catalog.invalid producer
+            $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb load-zone catalog.invalid zones/catalog.invalid
+            $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-kind catalog.invalid producer
 
-            $PDNSUTIL --config-dir=. --config-name=lmdb set-options-json test.com '{"producer":{"coo":"other-catalog.invalid","unique":"123"}}'
-            $PDNSUTIL --config-dir=. --config-name=lmdb set-options-json tsig.com '{"producer":{"group":["pdns-group-x","pdns-group-y"]}}'
+            $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-options-json test.com '{"producer":{"coo":"other-catalog.invalid","unique":"123"}}'
+            $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-options-json tsig.com '{"producer":{"group":["pdns-group-x","pdns-group-y"]}}'
         fi
 
         $RUNWRAPPER $PDNS --loglevel=7 --daemon=no --local-address=$address --local-port=$port --config-dir=. \

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -57,7 +57,7 @@ for arg; do
     esac
 done; unset -v arg
 if [ "$_show_help" -eq 1 ]; then
-	grep -v '^#' << '__EOF__'
+        grep -v '^#' << '__EOF__'
 
 Usage: ./start-test-stop <port> [<context>] [wait|nowait] [<cachettl>] [<specifictest>]
 
@@ -93,7 +93,7 @@ lua2 lua2-dnssec lua2-nsec3 lua2-nsec3-narrow
 
 * Specifictest can be used to run only one single test.
 __EOF__
-	exit
+        exit
 fi
 unset -v _show_help
 
@@ -103,129 +103,129 @@ source ../regression-tests/common
 
 bindwait ()
 {
-	check_process
-	configname=$1
-	domcount=$(grep -c ^zone named.conf)
-	if [ ! -x $PDNSCONTROL ]
-	then
-		echo "No pdns_control found"
-		exit
-	fi
-	loopcount=0
+        check_process
+        configname=$1
+        domcount=$(grep -c ^zone named.conf)
+        if [ ! -x $PDNSCONTROL ]
+        then
+                echo "No pdns_control found"
+                exit
+        fi
+        loopcount=0
 
-	while [ $loopcount -lt 20 ]
-	do
-		sleep 5
-		done=$( ($PDNSCONTROL --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
-		if [ $done = $domcount ]
-		then
-			return
-		fi
-		let loopcount=loopcount+1
-	done
+        while [ $loopcount -lt 20 ]
+        do
+                sleep 5
+                done=$( ($PDNSCONTROL --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
+                if [ $done = $domcount ]
+                then
+                        return
+                fi
+                let loopcount=loopcount+1
+        done
 
-	if [ $done != $domcount ]
-	then
-		echo "Domain parsing failed" >> failed_tests
-	fi
+        if [ $done != $domcount ]
+        then
+                echo "Domain parsing failed" >> failed_tests
+        fi
 }
 
 securezone ()
 {
-	local zone=$1
-	local configname=$2
+        local zone=$1
+        local configname=$2
 
-	if [ -n "$configname" ]
-	then
-		configname="--config-name=$configname"
-	fi
-	if [ "${zone: 0:16}" = "secure-delegated" ]
-	then
-		$PDNSUTIL --config-dir=. $configname import-zone-key $zone $zone.private ksk 2>&1
-		$PDNSUTIL --config-dir=. $configname add-zone-key $zone rsasha256 1024 zsk active 2>&1
-		$PDNSUTIL --config-dir=. $configname rectify-zone $zone 2>&1
-		$PDNSUTIL --config-dir=. $configname set-publish-cds $zone 2>&1
-		$PDNSUTIL --config-dir=. $configname set-publish-cdnskey $zone 2>&1
-	else
-		# check if PKCS#11 should be used
-		if [ "$pkcs11" -eq 1 ]; then
-			if [ "$slot" == "" ]; then
-				slot=0
-			else
-				slot=$((slot+1))
-			fi
-			label=pdnstest-${EPOCHSECONDS}-${slot}
-			softhsm2-util --delete-token --label $label 2> /dev/null || true
-			softhsm2-util --init-token --label $label --free --pin 1234 --so-pin 1234
-			kid=`$PDNSUTIL --config-dir=. $configname hsm assign $zone ecdsa256 ksk softhsm2 $label 1234 $label 2>&1 | grep softhsm | awk '{ print $NF }'`
-			$PDNSUTIL --config-dir=. $configname hsm create-key $zone $kid
-			$PDNSUTIL --config-dir=. $configname rectify-zone $zone 2>&1
-		else
-			$PDNSUTIL --config-dir=. $configname secure-zone $zone 2>&1
-		fi
-		if [ "${zone: 0:20}" = "cdnskey-cds-test.com" ]; then
-			$PDNSUTIL --config-dir=. $configname set-publish-cds $zone 2>&1
-			$PDNSUTIL --config-dir=. $configname set-publish-cdnskey $zone 2>&1
-		fi
-		if [ "$zone" = "dnssec-parent.com" ]; then
-			$PDNSUTIL --config-dir=. $configname set-publish-cds $zone 0 2>&1
-			$PDNSUTIL --config-dir=. $configname set-publish-cdnskey $zone delete 2>&1
-		fi
-	fi
+        if [ -n "$configname" ]
+        then
+                configname="--config-name=$configname"
+        fi
+        if [ "${zone: 0:16}" = "secure-delegated" ]
+        then
+                $PDNSUTIL --config-dir=. $configname import-zone-key $zone $zone.private ksk 2>&1
+                $PDNSUTIL --config-dir=. $configname add-zone-key $zone rsasha256 1024 zsk active 2>&1
+                $PDNSUTIL --config-dir=. $configname rectify-zone $zone 2>&1
+                $PDNSUTIL --config-dir=. $configname set-publish-cds $zone 2>&1
+                $PDNSUTIL --config-dir=. $configname set-publish-cdnskey $zone 2>&1
+        else
+                # check if PKCS#11 should be used
+                if [ "$pkcs11" -eq 1 ]; then
+                        if [ "$slot" == "" ]; then
+                                slot=0
+                        else
+                                slot=$((slot+1))
+                        fi
+                        label=pdnstest-${EPOCHSECONDS}-${slot}
+                        softhsm2-util --delete-token --label $label 2> /dev/null || true
+                        softhsm2-util --init-token --label $label --free --pin 1234 --so-pin 1234
+                        kid=`$PDNSUTIL --config-dir=. $configname hsm assign $zone ecdsa256 ksk softhsm2 $label 1234 $label 2>&1 | grep softhsm | awk '{ print $NF }'`
+                        $PDNSUTIL --config-dir=. $configname hsm create-key $zone $kid
+                        $PDNSUTIL --config-dir=. $configname rectify-zone $zone 2>&1
+                else
+                        $PDNSUTIL --config-dir=. $configname secure-zone $zone 2>&1
+                fi
+                if [ "${zone: 0:20}" = "cdnskey-cds-test.com" ]; then
+                        $PDNSUTIL --config-dir=. $configname set-publish-cds $zone 2>&1
+                        $PDNSUTIL --config-dir=. $configname set-publish-cdnskey $zone 2>&1
+                fi
+                if [ "$zone" = "dnssec-parent.com" ]; then
+                        $PDNSUTIL --config-dir=. $configname set-publish-cds $zone 0 2>&1
+                        $PDNSUTIL --config-dir=. $configname set-publish-cdnskey $zone delete 2>&1
+                fi
+        fi
 }
 
 kill_process ()
 {
-	set +e
-	trap - EXIT INT TERM
+        set +e
+        trap - EXIT INT TERM
 
-	if [ $1 -gt 1 ]
-	then
-		echo "exitvalue$1" >> failed_tests
-		./toxml
-		./totar
-	fi
+        if [ $1 -gt 1 ]
+        then
+                echo "exitvalue$1" >> failed_tests
+                ./toxml
+                ./totar
+        fi
 
-	pids=$(cat pdns*.pid)
+        pids=$(cat pdns*.pid)
 
-	if [ -n "$pids" ]
-	then
-		kill $pids
-		# make sure they die.
-		loopcount=0
-		done=0
-		while [ $loopcount -lt 10 ] && [ $done -eq 0 ]
-		do
-			done=1
-			for pid in $pids
-			do
-				kill -0 $pid > /dev/null 2>&1
-				if [ $? -eq 0 ];
-				then
-					done=0
-				fi
-			done
-			let loopcount=loopcount+1
-			sleep 1
-		done
+        if [ -n "$pids" ]
+        then
+                kill $pids
+                # make sure they die.
+                loopcount=0
+                done=0
+                while [ $loopcount -lt 10 ] && [ $done -eq 0 ]
+                do
+                        done=1
+                        for pid in $pids
+                        do
+                                kill -0 $pid > /dev/null 2>&1
+                                if [ $? -eq 0 ];
+                                then
+                                        done=0
+                                fi
+                        done
+                        let loopcount=loopcount+1
+                        sleep 1
+                done
 
-		kill -9 $pids
-	fi
+                kill -9 $pids
+        fi
 
-	rm pdns*.pid
-	exit $1
+        rm pdns*.pid
+        exit $1
 }
 
 if [ ! -x $PDNS ]
  then
-	echo "$PDNS is not executable binary"
-	exit
+        echo "$PDNS is not executable binary"
+        exit
 fi
 
 if [ ! -x $PDNS2 ]
 then
-	echo "$PDNS2 is not executable binary"
-	exit
+        echo "$PDNS2 is not executable binary"
+        exit
 fi
 
 address="${PDNS_LISTEN_ADDR:-127.0.0.1}"
@@ -250,10 +250,10 @@ done
 # Copy original zones because the test might modify them (well only the dyndns stuff, but let's make this work for others as well)
 for zone in $(grep 'zone ' named.conf  | cut -f2 -d\")
 do
-	if [ -f zones/$zone.orig ]
-	then
-		cp -f zones/$zone.orig zones/$zone
-	fi
+        if [ -f zones/$zone.orig ]
+        then
+                cp -f zones/$zone.orig zones/$zone
+        fi
 done
 
 rm -f pdns*.pid
@@ -265,21 +265,21 @@ both=no
 
 if [[ "$context" =~ .+-presigned.* ]]
 then
-	presigned=yes
-	port=$((port-100))
-	eval "$(echo "$context" | sed -r 's/(.+)(-presigned)(-(.*))?/context=\1 presignedcontext=\4/')"
-	if [ -z "$presignedcontext" ]
-	then
-		presignedcontext=$context
-	fi
+        presigned=yes
+        port=$((port-100))
+        eval "$(echo "$context" | sed -r 's/(.+)(-presigned)(-(.*))?/context=\1 presignedcontext=\4/')"
+        if [ -z "$presignedcontext" ]
+        then
+                presignedcontext=$context
+        fi
 fi
 
 if [ "${context: -5}" = "-both" ]
 then
-	both=yes
-	port=$((port-100))
-	context=${context%-both}
-	presignedcontext=$context
+        both=yes
+        port=$((port-100))
+        context=${context%-both}
+        presignedcontext=$context
 fi
 
 optout=0
@@ -287,7 +287,7 @@ pkcs11=0
 
 if [ "${context: -13}" = "-nsec3-optout" ]
 then
-	optout=1
+        optout=1
 fi
 
 if [ "${context: -7}" = "-pkcs11" ]
@@ -311,30 +311,30 @@ source backends/common
 start_master
 
 if [ "$skiplua" == "1" ]; then
-	skipreasons="$skipreasons nolua"
+        skipreasons="$skipreasons nolua"
 fi
 
 check_process
 
 dotests () {
-	nameserver=127.0.0.1 ./runtests $spectest
-	./toxml
-	./totar
+        nameserver=127.0.0.1 ./runtests $spectest
+        ./toxml
+        ./totar
 
-	cat ./trustedkeys
+        cat ./trustedkeys
 
-	if [ -s "./failed_tests" ]
-	then
-		for t in `cat failed_tests`
-		do
-			echo -e "\n\n$t"
-			cat ${testsdir}/$t/diff
-		done
-		if [ "${!1}" -eq 0 ]
-		then
-			eval "$1=1"
-		fi
-	fi
+        if [ -s "./failed_tests" ]
+        then
+                for t in `cat failed_tests`
+                do
+                        echo -e "\n\n$t"
+                        cat ${testsdir}/$t/diff
+                done
+                if [ "${!1}" -eq 0 ]
+                then
+                        eval "$1=1"
+                fi
+        fi
 }
 
 ## TODO: give sdig a timeout
@@ -354,25 +354,25 @@ sleep 2
 
 if [ $presigned = no ] || [ $both = yes ]
 then
-	dotests RETVAL
+        dotests RETVAL
 fi
 
 if [ $presigned = yes ] || [ $both = yes ]
 then
-	start_slave
+        start_slave
 
-	export port
-	export context
-	export skipreasons
-	export backend
+        export port
+        export context
+        export skipreasons
+        export backend
 
-	dotests RETVAL
+        dotests RETVAL
 fi
 
 if [ "$wait" = "wait" ]
 then
-	echo tests done! push enter to terminate instance
-	read l
+        echo tests done! push enter to terminate instance
+        read l
 fi
 
 trap "kill_process $RETVAL" EXIT


### PR DESCRIPTION
### Short description
Convenient to set $RUNWRAPPER_PDNSUTIL to "gdb -q --args" or something.
Bare pdns has $RUNWRAPPER for that

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
