### PR TITLE
Cleanups to lmdb source files

### DIFF
--- a/.not-formatted
+++ b/.not-formatted
@@ -1,6 +1,5 @@
 ./ext/lmdb-safe/lmdb-safe.cc
 ./ext/lmdb-safe/lmdb-safe.hh
-./ext/lmdb-safe/lmdb-typed.cc
 ./ext/lmdb-safe/lmdb-typed.hh
 ./ext/probds/murmur3.cc
 ./pdns/anadns.hh

--- a/ext/lmdb-safe/lmdb-typed.cc
+++ b/ext/lmdb-safe/lmdb-typed.cc
@@ -4,9 +4,10 @@
 unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi)
 {
   auto cursor = txn->getRWCursor(dbi);
-  MDBOutVal maxidval, maxcontent;
+  MDBOutVal maxidval{};
+  MDBOutVal maxcontent{};
   unsigned int maxid{0};
-  if (!cursor.get(maxidval, maxcontent, MDB_LAST)) {
+  if (cursor.get(maxidval, maxcontent, MDB_LAST) == 0) {
     maxid = maxidval.getNoStripHeader<unsigned int>();
   }
   return maxid;
@@ -15,15 +16,16 @@ unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi)
 unsigned int MDBGetRandomID(MDBRWTransaction& txn, MDBDbi& dbi)
 {
   auto cursor = txn->getRWCursor(dbi);
-  unsigned int id;
+  unsigned int newID = 0;
   for (int attempts = 0; attempts < 20; attempts++) {
-    MDBOutVal key, content;
+    MDBOutVal key{};
+    MDBOutVal content{};
 
     // dns_random generates a random number in [0..signed_int_max-1]. We add 1 to avoid 0 and allow type_max.
     // 0 is avoided because the put() interface uses it to mean "please allocate a number for me"
-    id = dns_random(std::numeric_limits<signed int>::max()) + 1;
-    if (cursor.find(MDBInVal(id), key, content)) {
-      return id;
+    newID = dns_random(std::numeric_limits<signed int>::max()) + 1;
+    if (cursor.find(MDBInVal(newID), key, content) != 0) {
+      return newID;
     }
   }
   throw std::runtime_error("MDBGetRandomID() could not assign an unused random ID");

--- a/ext/lmdb-safe/lmdb-typed.cc
+++ b/ext/lmdb-safe/lmdb-typed.cc
@@ -6,7 +6,7 @@ unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi)
   auto cursor = txn->getRWCursor(dbi);
   MDBOutVal maxidval, maxcontent;
   unsigned int maxid{0};
-  if(!cursor.get(maxidval, maxcontent, MDB_LAST)) {
+  if (!cursor.get(maxidval, maxcontent, MDB_LAST)) {
     maxid = maxidval.getNoStripHeader<unsigned int>();
   }
   return maxid;
@@ -16,13 +16,13 @@ unsigned int MDBGetRandomID(MDBRWTransaction& txn, MDBDbi& dbi)
 {
   auto cursor = txn->getRWCursor(dbi);
   unsigned int id;
-  for(int attempts=0; attempts<20; attempts++) {
+  for (int attempts = 0; attempts < 20; attempts++) {
     MDBOutVal key, content;
 
     // dns_random generates a random number in [0..signed_int_max-1]. We add 1 to avoid 0 and allow type_max.
     // 0 is avoided because the put() interface uses it to mean "please allocate a number for me"
     id = dns_random(std::numeric_limits<signed int>::max()) + 1;
-    if(cursor.find(MDBInVal(id), key, content)) {
+    if (cursor.find(MDBInVal(id), key, content)) {
       return id;
     }
   }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -918,12 +918,14 @@ std::string serializeToBuffer(const LMDBBackend::LMDBResourceRecord& value)
   buffer.reserve(sizeof(len) + len + sizeof(value.ttl) + sizeof(value.auth) + sizeof(value.disabled) + sizeof(value.ordername));
 
   // Store the size of the resource record.
+  buffer.resize(sizeof(len));
   std::memcpy(&buffer.at(0), &len, sizeof(len));
 
   // Store the contents of the resource record.
   buffer += value.content;
 
   // The few other things.
+  buffer.resize(buffer.size() + sizeof(value.ttl));
   std::memcpy(&buffer.at(sizeof(len) + len), &value.ttl, sizeof(value.ttl));
   buffer.append(1, (char)value.auth);
   buffer.append(1, (char)value.disabled);

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1327,7 +1327,7 @@ bool LMDBBackend::deleteDomain(const DNSName& domain)
 
   abortTransaction();
 
-  LMDBIDvec idvec;
+  LmdbIdVec idvec;
 
   if (!d_handle_dups) {
     // get domain id
@@ -1352,7 +1352,7 @@ bool LMDBBackend::deleteDomain(const DNSName& domain)
 
     { // Remove metadata
       auto txn = d_tmeta->getRWTransaction();
-      LMDBIDvec ids;
+      LmdbIdVec ids;
 
       txn.get_multi<0>(domain, ids);
 
@@ -1365,7 +1365,7 @@ bool LMDBBackend::deleteDomain(const DNSName& domain)
 
     { // Remove cryptokeys
       auto txn = d_tkdb->getRWTransaction();
-      LMDBIDvec ids;
+      LmdbIdVec ids;
       txn.get_multi<0>(domain, ids);
 
       for (auto _id : ids) {
@@ -1909,7 +1909,7 @@ bool LMDBBackend::getAllDomainMetadata(const DNSName& name, std::map<std::string
 {
   meta.clear();
   auto txn = d_tmeta->getROTransaction();
-  LMDBIDvec ids;
+  LmdbIdVec ids;
   txn.get_multi<0>(name, ids);
 
   DomainMeta dm;
@@ -1926,7 +1926,7 @@ bool LMDBBackend::setDomainMetadata(const DNSName& name, const std::string& kind
 {
   auto txn = d_tmeta->getRWTransaction();
 
-  LMDBIDvec ids;
+  LmdbIdVec ids;
   txn.get_multi<0>(name, ids);
 
   DomainMeta dmeta;
@@ -1950,7 +1950,7 @@ bool LMDBBackend::setDomainMetadata(const DNSName& name, const std::string& kind
 bool LMDBBackend::getDomainKeys(const DNSName& name, std::vector<KeyData>& keys)
 {
   auto txn = d_tkdb->getROTransaction();
-  LMDBIDvec ids;
+  LmdbIdVec ids;
   txn.get_multi<0>(name, ids);
 
   KeyDataDB key;
@@ -2567,7 +2567,7 @@ bool LMDBBackend::updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& inse
 bool LMDBBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& content)
 {
   auto txn = d_ttsig->getROTransaction();
-  LMDBIDvec ids;
+  LmdbIdVec ids;
   txn.get_multi<0>(name, ids);
 
   TSIGKey key;
@@ -2588,7 +2588,7 @@ bool LMDBBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, cons
 {
   auto txn = d_ttsig->getRWTransaction();
 
-  LMDBIDvec ids;
+  LmdbIdVec ids;
   txn.get_multi<0>(name, ids);
 
   TSIGKey key;
@@ -2614,7 +2614,7 @@ bool LMDBBackend::deleteTSIGKey(const DNSName& name)
 {
   auto txn = d_ttsig->getRWTransaction();
 
-  LMDBIDvec ids;
+  LmdbIdVec ids;
   txn.get_multi<0>(name, ids);
 
   TSIGKey key;
@@ -2698,7 +2698,7 @@ string LMDBBackend::directBackendCmd(const string& query)
 
           auto id = iter.getID();
 
-          LMDBIDvec ids;
+          LmdbIdVec ids;
           txn.get_multi<0>(di.zone, ids);
 
           if (ids.size() != 1) {

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -798,7 +798,7 @@ namespace serialization
       ar& std::string();
     }
     else {
-      ar& g.toDNSStringLC();
+      ar & g.toDNSStringLC();
     }
   }
 
@@ -806,7 +806,7 @@ namespace serialization
   void load(Archive& ar, DNSName& g, const unsigned int /* version */)
   {
     string tmp;
-    ar& tmp;
+    ar & tmp;
     if (tmp.empty()) {
       g = DNSName();
     }
@@ -818,44 +818,44 @@ namespace serialization
   template <class Archive>
   void save(Archive& ar, const QType& g, const unsigned int /* version */)
   {
-    ar& g.getCode();
+    ar & g.getCode();
   }
 
   template <class Archive>
   void load(Archive& ar, QType& g, const unsigned int /* version */)
   {
     uint16_t tmp;
-    ar& tmp;
+    ar & tmp;
     g = QType(tmp);
   }
 
   template <class Archive>
   void save(Archive& ar, const DomainInfo& g, const unsigned int /* version */)
   {
-    ar& g.zone;
-    ar& g.last_check;
-    ar& g.account;
-    ar& g.primaries;
-    ar& g.id;
-    ar& g.notified_serial;
-    ar& g.kind;
-    ar& g.options;
-    ar& g.catalog;
+    ar & g.zone;
+    ar & g.last_check;
+    ar & g.account;
+    ar & g.primaries;
+    ar & g.id;
+    ar & g.notified_serial;
+    ar & g.kind;
+    ar & g.options;
+    ar & g.catalog;
   }
 
   template <class Archive>
   void load(Archive& ar, DomainInfo& g, const unsigned int version)
   {
-    ar& g.zone;
-    ar& g.last_check;
-    ar& g.account;
-    ar& g.primaries;
-    ar& g.id;
-    ar& g.notified_serial;
-    ar& g.kind;
+    ar & g.zone;
+    ar & g.last_check;
+    ar & g.account;
+    ar & g.primaries;
+    ar & g.id;
+    ar & g.notified_serial;
+    ar & g.kind;
     if (version >= 1) {
-      ar& g.options;
-      ar& g.catalog;
+      ar & g.options;
+      ar & g.catalog;
     }
     else {
       g.options.clear();
@@ -866,21 +866,21 @@ namespace serialization
   template <class Archive>
   void serialize(Archive& ar, LMDBBackend::DomainMeta& g, const unsigned int /* version */)
   {
-    ar& g.domain& g.key& g.value;
+    ar & g.domain & g.key & g.value;
   }
 
   template <class Archive>
   void save(Archive& ar, const LMDBBackend::KeyDataDB& g, const unsigned int /* version */)
   {
-    ar& g.domain& g.content& g.flags& g.active& g.published;
+    ar & g.domain & g.content & g.flags & g.active & g.published;
   }
 
   template <class Archive>
   void load(Archive& ar, LMDBBackend::KeyDataDB& g, const unsigned int version)
   {
-    ar& g.domain& g.content& g.flags& g.active;
+    ar & g.domain & g.content & g.flags & g.active;
     if (version >= 1) {
-      ar& g.published;
+      ar & g.published;
     }
     else {
       g.published = true;
@@ -890,9 +890,9 @@ namespace serialization
   template <class Archive>
   void serialize(Archive& ar, TSIGKey& g, const unsigned int /* version */)
   {
-    ar& g.name;
-    ar& g.algorithm; // this is the ordername
-    ar& g.key;
+    ar & g.name;
+    ar & g.algorithm; // this is the ordername
+    ar & g.key;
   }
 
 } // namespace serialization
@@ -2087,8 +2087,8 @@ bool LMDBBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qna
 
     for (;;) {
       if (co.getDomainID(key.getNoStripHeader<StringView>()) != id) {
-        //cout<<"Last record also not part of this zone!"<<endl;
-        // this implies something is wrong in the database, nothing we can do
+        // cout<<"Last record also not part of this zone!"<<endl;
+        //  this implies something is wrong in the database, nothing we can do
         return false;
       }
 
@@ -2185,8 +2185,8 @@ bool LMDBBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qna
 
         for (;;) {
           if (co.getDomainID(key.getNoStripHeader<StringView>()) != id) {
-            //cout<<"Last record also not part of this zone!"<<endl;
-            // this implies something is wrong in the database, nothing we can do
+            // cout<<"Last record also not part of this zone!"<<endl;
+            //  this implies something is wrong in the database, nothing we can do
             return false;
           }
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -918,15 +918,15 @@ std::string serializeToBuffer(const LMDBBackend::LMDBResourceRecord& value)
   buffer.reserve(sizeof(len) + len + sizeof(value.ttl) + sizeof(value.auth) + sizeof(value.disabled) + sizeof(value.ordername));
 
   // Store the size of the resource record.
-  buffer.resize(sizeof(len));
-  std::memcpy(&buffer.at(0), &len, sizeof(len));
+  // NOLINTNEXTLINE.
+  buffer.assign((const char*)&len, sizeof(len));
 
   // Store the contents of the resource record.
   buffer += value.content;
 
   // The few other things.
-  buffer.resize(buffer.size() + sizeof(value.ttl));
-  std::memcpy(&buffer.at(sizeof(len) + len), &value.ttl, sizeof(value.ttl));
+  // NOLINTNEXTLINE.
+  buffer.append((const char*)&value.ttl, sizeof(value.ttl));
   buffer.append(1, (char)value.auth);
   buffer.append(1, (char)value.disabled);
   buffer.append(1, (char)value.ordername);

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -957,19 +957,19 @@ static inline size_t deserializeRRFromBuffer(const string_view& str, LMDBBackend
 }
 
 template <>
-void deserializeFromBuffer(const string_view& str, LMDBBackend::LMDBResourceRecord& lrr)
+void deserializeFromBuffer(const string_view& buffer, LMDBBackend::LMDBResourceRecord& value)
 {
-  deserializeRRFromBuffer(str, lrr);
+  deserializeRRFromBuffer(buffer, value);
 }
 
 template <>
-void deserializeFromBuffer(const string_view& str, vector<LMDBBackend::LMDBResourceRecord>& lrrs)
+void deserializeFromBuffer(const string_view& buffer, vector<LMDBBackend::LMDBResourceRecord>& value)
 {
-  auto str_copy = str;
+  auto str_copy = buffer;
   while (str_copy.size() >= 9) { // minimum length for a record is 10
     LMDBBackend::LMDBResourceRecord lrr;
     auto rrLength = deserializeRRFromBuffer(str_copy, lrr);
-    lrrs.emplace_back(lrr);
+    value.emplace_back(lrr);
     str_copy.remove_prefix(rrLength);
   }
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -798,7 +798,7 @@ namespace serialization
       ar& std::string();
     }
     else {
-      ar & g.toDNSStringLC();
+      ar& g.toDNSStringLC();
     }
   }
 
@@ -806,7 +806,7 @@ namespace serialization
   void load(Archive& ar, DNSName& g, const unsigned int /* version */)
   {
     string tmp;
-    ar & tmp;
+    ar& tmp;
     if (tmp.empty()) {
       g = DNSName();
     }
@@ -818,44 +818,44 @@ namespace serialization
   template <class Archive>
   void save(Archive& ar, const QType& g, const unsigned int /* version */)
   {
-    ar & g.getCode();
+    ar& g.getCode();
   }
 
   template <class Archive>
   void load(Archive& ar, QType& g, const unsigned int /* version */)
   {
     uint16_t tmp;
-    ar & tmp;
+    ar& tmp;
     g = QType(tmp);
   }
 
   template <class Archive>
   void save(Archive& ar, const DomainInfo& g, const unsigned int /* version */)
   {
-    ar & g.zone;
-    ar & g.last_check;
-    ar & g.account;
-    ar & g.primaries;
-    ar & g.id;
-    ar & g.notified_serial;
-    ar & g.kind;
-    ar & g.options;
-    ar & g.catalog;
+    ar& g.zone;
+    ar& g.last_check;
+    ar& g.account;
+    ar& g.primaries;
+    ar& g.id;
+    ar& g.notified_serial;
+    ar& g.kind;
+    ar& g.options;
+    ar& g.catalog;
   }
 
   template <class Archive>
   void load(Archive& ar, DomainInfo& g, const unsigned int version)
   {
-    ar & g.zone;
-    ar & g.last_check;
-    ar & g.account;
-    ar & g.primaries;
-    ar & g.id;
-    ar & g.notified_serial;
-    ar & g.kind;
+    ar& g.zone;
+    ar& g.last_check;
+    ar& g.account;
+    ar& g.primaries;
+    ar& g.id;
+    ar& g.notified_serial;
+    ar& g.kind;
     if (version >= 1) {
-      ar & g.options;
-      ar & g.catalog;
+      ar& g.options;
+      ar& g.catalog;
     }
     else {
       g.options.clear();
@@ -866,21 +866,21 @@ namespace serialization
   template <class Archive>
   void serialize(Archive& ar, LMDBBackend::DomainMeta& g, const unsigned int /* version */)
   {
-    ar & g.domain & g.key & g.value;
+    ar& g.domain& g.key& g.value;
   }
 
   template <class Archive>
   void save(Archive& ar, const LMDBBackend::KeyDataDB& g, const unsigned int /* version */)
   {
-    ar & g.domain & g.content & g.flags & g.active & g.published;
+    ar& g.domain& g.content& g.flags& g.active& g.published;
   }
 
   template <class Archive>
   void load(Archive& ar, LMDBBackend::KeyDataDB& g, const unsigned int version)
   {
-    ar & g.domain & g.content & g.flags & g.active;
+    ar& g.domain& g.content& g.flags& g.active;
     if (version >= 1) {
-      ar & g.published;
+      ar& g.published;
     }
     else {
       g.published = true;
@@ -890,9 +890,9 @@ namespace serialization
   template <class Archive>
   void serialize(Archive& ar, TSIGKey& g, const unsigned int /* version */)
   {
-    ar & g.name;
-    ar & g.algorithm; // this is the ordername
-    ar & g.key;
+    ar& g.name;
+    ar& g.algorithm; // this is the ordername
+    ar& g.key;
   }
 
 } // namespace serialization

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -30,7 +30,6 @@ std::string keyConv(const T& t)
   /* www.ds9a.nl -> nl0ds9a0www0
      root -> 0   <- we need this to keep lmdb happy
      nl -> nl0
-     
   */
   if (t.empty()) {
     throw std::out_of_range(std::string(__PRETTY_FUNCTION__) + " Attempt to serialize an unset dnsname");


### PR DESCRIPTION
### Short description
Some cleanup to lmdb source files, the 128-bit IDs branch is getting more complicated so I want to merge commits that can be made independent:

- Formatting and lint cleanups
- Rewrite serToString and serFromString (and rename them to serializeToBuffer and deserializeFromBuffer). The rewrites fix issues with casts and memory copies.
- Rename the LMDBIDVec
- Clean up source code comments

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
