### PR TITLE
rec: avoid duplicated waiter ids for chained requests

### DIFF
--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -484,7 +484,7 @@ static LWResult::Result asyncresolve(const ComboAddress& address, const DNSName&
       return ret;
     }
 
-    if (queryfd == -1) {
+    if (queryfd <= -1) {
       *chained = true;
     }
 

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -777,7 +777,7 @@ struct PacketID
   PacketBuffer inMSG; // they'll go here
   PacketBuffer outMSG; // the outgoing message that needs to be sent
 
-  using chain_t = set<uint16_t>;
+  using chain_t = set<std::pair<int, uint16_t>>;
   mutable chain_t authReqChain;
   shared_ptr<TCPIOHandler> tcphandler{nullptr};
   timeval creationTime{};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes #14624 

The whole of the chaining mechanism could use some tests. The unit testing framework is not really suited to do that. I'd have to think on a regression test approach, will be added later. Therefore draft atm.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
