### PR TITLE
dnsdist: Fix handling of proxy protocol payload outside of TLS for DoT

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -401,9 +401,6 @@ void IncomingHTTP2Connection::handleIO()
           }
         }
         else {
-          d_currentPos = 0;
-          d_proxyProtocolNeed = 0;
-          d_buffer.clear();
           d_state = State::waitingForQuery;
           handleConnectionReady();
         }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue # -->
After reading the proxy protocol payload from the I/O buffer we were clearing the buffer but failed to properly reset the position, leading to an exception when trying to read the DNS payload after processing the TLS handshake:

```
Got an exception while handling (reading) TCP query from 127.0.0.1:59426: Calling tryRead() with a too small buffer (2) for a read of 18446744073709551566 bytes starting at 52
```

The huge value comes from the fact that the position (52 here) is larger than the size of the buffer (2 at this point to read the size of the incoming DNS payload), leading to an unsigned underflow. The code is properly detecting that the value makes no sense in this context, but the connection is then dropped because we cannot recover.

It turns out we had a end-to-end test for the "proxy protocol outside of TLS" case but only over incoming DoH, and the DoH case avoids this specific issue because the buffer is always properly resized, and the position updated. This PR adds a test for the DoT case as well.

Fixes https://github.com/PowerDNS/pdns/discussions/14631.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

