### PR TITLE
dnsdist-1.9.x: Backport 14562 - Fix build with boost 1.86.0

### DIFF
--- a/pdns/uuid-utils.cc
+++ b/pdns/uuid-utils.cc
@@ -30,6 +30,7 @@
 #endif /* BOOST_PENDING_INTEGER_LOG2_HPP */
 #endif /* BOOST_VERSION */
 
+#include <boost/random/mersenne_twister.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
 // The default of:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue # -->

Backport of #14562 to dnsdist-1.9.x.

Boost 1.86.0 changes seem to no longer indirectly include header which causes build to fail with:
```
uuid-utils.cc:38:58:
error: 'random' is not a class, namespace, or enumeration
```

boost/random/mersenne_twister.hpp has been available since Boost 1.21.2

(cherry picked from commit eed56000b1d68ac083b8e8bea4ff0ea30a1579c4)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
