### PR TITLE
dnsdist-1.9.x: Backport #14636 - Fix handling of proxy protocol payload outside of TLS for DoT

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -908,6 +908,9 @@ IncomingTCPConnectionState::ProxyProtocolResult IncomingTCPConnectionState::hand
           d_proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>(std::move(proxyProtocolValues));
         }
 
+        d_currentPos = 0;
+        d_proxyProtocolNeed = 0;
+        d_buffer.clear();
         return ProxyProtocolResult::Done;
       }
     }
@@ -1090,15 +1093,14 @@ void IncomingTCPConnectionState::handleIO()
       if (!d_lastIOBlocked && d_state == State::readingProxyProtocolHeader) {
         auto status = handleProxyProtocolPayload();
         if (status == ProxyProtocolResult::Done) {
+          d_buffer.resize(sizeof(uint16_t));
+
           if (isProxyPayloadOutsideTLS()) {
             d_state = State::doingHandshake;
             iostate = handleHandshake(now);
           }
           else {
             d_state = State::readingQuerySize;
-            d_buffer.resize(sizeof(uint16_t));
-            d_currentPos = 0;
-            d_proxyProtocolNeed = 0;
           }
         }
         else if (status == ProxyProtocolResult::Error) {

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -400,9 +400,6 @@ void IncomingHTTP2Connection::handleIO()
           }
         }
         else {
-          d_currentPos = 0;
-          d_proxyProtocolNeed = 0;
-          d_buffer.clear();
           d_state = State::waitingForQuery;
           handleConnectionReady();
         }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #14636 to dnsdist-1.9.x.

After reading the proxy protocol payload from the I/O buffer we were clearing the buffer but failed to properly reset the position, leading to an exception when trying to read the DNS payload after processing the TLS handshake:

```
Got an exception while handling (reading) TCP query from 127.0.0.1:59426: Calling tryRead() with a too small buffer (2) for a read of 18446744073709551566 bytes starting at 52
```

The huge value comes from the fact that the position (52 here) is larger than the size of the buffer (2 at this point to read the size of the incoming DNS payload), leading to an unsigned underflow. The code is properly detecting that the value makes no sense in this context, but the connection is then dropped because we cannot recover.

It turns out we had a end-to-end test for the "proxy protocol outside of TLS" case but only over incoming DoH, and the DoH case avoids this specific issue because the buffer is always properly resized, and the position updated.

(cherry picked from commit 4931fb28f7bc6e8905d3298003dead7c32f4d090)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
