### PR TITLE
dnsdist-1.9.x: Backport 14575 - Handle a non-existent default pool when removing a server

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -738,8 +738,13 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
                          for (const string& poolName : server->d_config.pools) {
                            removeServerFromPool(localPools, poolName, server);
                          }
-                         /* the server might also be in the default pool */
-                         removeServerFromPool(localPools, "", server);
+                         try {
+                           /* the server might also be in the default pool */
+                           removeServerFromPool(localPools, "", server);
+                         }
+                         catch (const std::out_of_range& exp) {
+                           /* but the default pool might not exist yet, this is fine */
+                         }
                          g_pools.setState(localPools);
                          states.erase(remove(states.begin(), states.end(), server), states.end());
                          g_dstates.setState(states);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -3270,6 +3270,13 @@ int main(int argc, char** argv)
 
     dnsdist::g_asyncHolder = std::make_unique<dnsdist::AsynchronousHolder>();
 
+    /* create the default pool no matter what */
+    {
+      auto localPools = g_pools.getCopy();
+      createPoolIfNotExists(localPools, "");
+      g_pools.setState(localPools);
+    }
+
     auto todo = setupLua(*(g_lua.lock()), false, false, g_cmdLine.config);
 
     setupPools();
@@ -3355,8 +3362,6 @@ int main(int argc, char** argv)
     }
 
     auto localPools = g_pools.getCopy();
-    /* create the default pool no matter what */
-    createPoolIfNotExists(localPools, "");
     if (!g_cmdLine.remotes.empty()) {
       for (const auto& address : g_cmdLine.remotes) {
         DownstreamState::Config config;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14575 to dnsdist-1.9.x.

If the server has not been added to the default pool, and is removed before the configuration has been fully parsed, the default pool might not exist yet.
Also create the default pool earlier, before parsing the configuration, so that we don't trip over its absence in a different place.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
