### PR TITLE
dnsdist-1.9.x: Backport 14570 - Return a valid unix timestamp for Dynamic Block's `until`

### DIFF
--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -956,7 +956,14 @@ void setupLuaInspection(LuaContext& luaCtx)
   /* DynBlock object accessors */
   luaCtx.registerMember("reason", &DynBlock::reason);
   luaCtx.registerMember("domain", &DynBlock::domain);
-  luaCtx.registerMember("until", &DynBlock::until);
+  luaCtx.registerMember<DynBlock, timespec>(
+    "until", [](const DynBlock& block) {
+      timespec nowMonotonic{};
+      gettime(&nowMonotonic);
+      timespec nowRealTime{};
+      gettime(&nowRealTime, true);
+      nowRealTime.tv_sec += (block.until.tv_sec - nowMonotonic.tv_sec);
+      return nowRealTime; }, [](DynBlock& block, [[maybe_unused]] timespec until) {});
   luaCtx.registerMember<DynBlock, unsigned int>("blocks", [](const DynBlock& block) { return block.blocks.load(); }, [](DynBlock& block, [[maybe_unused]] unsigned int blocks) { });
   luaCtx.registerMember("action", &DynBlock::action);
   luaCtx.registerMember("warning", &DynBlock::warning);

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -962,7 +962,21 @@ void setupLuaInspection(LuaContext& luaCtx)
       gettime(&nowMonotonic);
       timespec nowRealTime{};
       gettime(&nowRealTime, true);
-      nowRealTime.tv_sec += (block.until.tv_sec - nowMonotonic.tv_sec);
+
+      auto seconds = block.until.tv_sec - nowMonotonic.tv_sec;
+      auto nseconds = block.until.tv_nsec - nowMonotonic.tv_nsec;
+      if (nseconds < 0) {
+        seconds -= 1;
+        nseconds += 1000000000;
+      }
+
+      nowRealTime.tv_sec += seconds;
+      nowRealTime.tv_nsec += nseconds;
+      if (nowRealTime.tv_nsec > 1000000000) {
+        nowRealTime.tv_sec += 1;
+        nowRealTime.tv_nsec -= 1000000000;
+      }
+
       return nowRealTime; }, [](DynBlock& block, [[maybe_unused]] timespec until) {});
   luaCtx.registerMember<DynBlock, unsigned int>("blocks", [](const DynBlock& block) { return block.blocks.load(); }, [](DynBlock& block, [[maybe_unused]] unsigned int blocks) { });
   luaCtx.registerMember("action", &DynBlock::action);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14570 to dnsdist-1.9.x.

We internally use a timestamp obtained via `CLOCK_MONOTONIC` which is quite useless to an external observer, so convert it to a normal unix timestamp in the Lua accessor.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
