### PR TITLE
dnsdist-1.9.x: Backport 14569 - Fix EDNS flags confusion when editing the OPT header

### DIFF
--- a/pdns/dnsdist-ecs.cc
+++ b/pdns/dnsdist-ecs.cc
@@ -252,7 +252,7 @@ bool slowRewriteEDNSOptionInQueryWithRecords(const PacketBuffer& initialPacket, 
       /* addOrReplaceEDNSOption will set it to false if there is already an existing option */
       optionAdded = true;
       addOrReplaceEDNSOption(options, optionToReplace, optionAdded, overrideExisting, newOptionContent);
-      pw.addOpt(ah.d_class, edns0.extRCode, edns0.extFlags, options, edns0.version);
+      pw.addOpt(ah.d_class, edns0.extRCode, ntohs(edns0.extFlags), options, edns0.version);
     }
   }
 

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -2261,7 +2261,7 @@ BOOST_AUTO_TEST_CASE(test_setEDNSOption)
   BOOST_REQUIRE(getEDNS0Record(dq.getData(), edns0));
   BOOST_CHECK_EQUAL(edns0.version, 0U);
   BOOST_CHECK_EQUAL(edns0.extRCode, 0U);
-  BOOST_CHECK_EQUAL(edns0.extFlags, EDNS_HEADER_FLAG_DO);
+  BOOST_CHECK_EQUAL(ntohs(edns0.extFlags), EDNS_HEADER_FLAG_DO);
 
   BOOST_REQUIRE(parseEDNSOptions(dq));
   BOOST_REQUIRE(dq.ednsOptions != nullptr);

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -862,11 +862,13 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     def checkMessageEDNSWithoutOptions(self, expected, received):
         self.assertEqual(expected, received)
         self.assertEqual(received.edns, 0)
+        self.assertEqual(expected.ednsflags, received.ednsflags)
         self.assertEqual(expected.payload, received.payload)
 
     def checkMessageEDNSWithoutECS(self, expected, received, withCookies=0):
         self.assertEqual(expected, received)
         self.assertEqual(received.edns, 0)
+        self.assertEqual(expected.ednsflags, received.ednsflags)
         self.assertEqual(expected.payload, received.payload)
         self.assertEqual(len(received.options), withCookies)
         if withCookies:
@@ -879,6 +881,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     def checkMessageEDNSWithECS(self, expected, received, additionalOptions=0):
         self.assertEqual(expected, received)
         self.assertEqual(received.edns, 0)
+        self.assertEqual(expected.ednsflags, received.ednsflags)
         self.assertEqual(expected.payload, received.payload)
         self.assertEqual(len(received.options), 1 + additionalOptions)
         hasECS = False
@@ -894,6 +897,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     def checkMessageEDNS(self, expected, received):
         self.assertEqual(expected, received)
         self.assertEqual(received.edns, 0)
+        self.assertEqual(expected.ednsflags, received.ednsflags)
         self.assertEqual(expected.payload, received.payload)
         self.assertEqual(len(expected.options), len(received.options))
         self.compareOptions(expected.options, received.options)

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -184,6 +184,7 @@ class DOHTests(object):
         query.id = 0
         response = dns.message.make_response(query)
         response.use_edns(edns=True, payload=4096, options=[rewrittenEcso])
+        response.want_dnssec(True)
         rrset = dns.rrset.from_text(name,
                                     3600,
                                     dns.rdataclass.IN,
@@ -899,9 +900,10 @@ class DOHAddingECSTests(object):
         rewrittenEcso = clientsubnetoption.ClientSubnetOption('127.0.0.0', 24)
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=512, options=[ecso], want_dnssec=True)
         query.id = 0
-        expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=512, options=[rewrittenEcso])
+        expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=512, options=[rewrittenEcso], want_dnssec=True)
         response = dns.message.make_response(query)
         response.use_edns(edns=True, payload=4096, options=[rewrittenEcso])
+        response.want_dnssec(True)
         rrset = dns.rrset.from_text(name,
                                     3600,
                                     dns.rdataclass.IN,

--- a/regression-tests.dnsdist/test_EDNSSelfGenerated.py
+++ b/regression-tests.dnsdist/test_EDNSSelfGenerated.py
@@ -145,6 +145,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, want_dnssec=True)
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query, our_payload=1042)
+        expectedResponse.want_dnssec(True)
         expectedResponse.set_rcode(dns.rcode.REFUSED)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -159,6 +160,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
         # dnsdist sets RA = RD for TC responses
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query, our_payload=1042)
+        expectedResponse.want_dnssec(True)
         expectedResponse.flags |= dns.flags.TC
 
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
@@ -169,6 +171,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
         name = 'edns-do.lua.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, want_dnssec=True)
         expectedResponse = dns.message.make_response(query, our_payload=1042)
+        expectedResponse.want_dnssec(True)
         expectedResponse.set_rcode(dns.rcode.NXDOMAIN)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -183,6 +186,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
         # dnsdist set RA = RD for spoofed responses
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query, our_payload=1042)
+        expectedResponse.want_dnssec(True)
         expectedResponse.answer.append(dns.rrset.from_text(name,
                                                            60,
                                                            dns.rdataclass.IN,
@@ -206,6 +210,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query, our_payload=1042)
         expectedResponse.set_rcode(dns.rcode.REFUSED)
+        expectedResponse.want_dnssec(True)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
@@ -219,6 +224,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
         # dnsdist sets RA = RD for TC responses
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query, our_payload=1042)
+        expectedResponse.want_dnssec(True)
         expectedResponse.flags |= dns.flags.TC
 
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
@@ -229,6 +235,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
         name = 'edns-options.lua.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, options=[ecso], payload=512, want_dnssec=True)
         expectedResponse = dns.message.make_response(query, our_payload=1042)
+        expectedResponse.want_dnssec(True)
         expectedResponse.set_rcode(dns.rcode.NXDOMAIN)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -243,6 +250,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
         # dnsdist set RA = RD for spoofed responses
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query, our_payload=1042)
+        expectedResponse.want_dnssec(True)
         expectedResponse.answer.append(dns.rrset.from_text(name,
                                                            60,
                                                            dns.rdataclass.IN,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #14569 to dnsdist-1.9.x

We used to wrongly reverse the byte-ordering of the existing EDNS flags when editing the OPT header, for example when setting an extended DNS error status.

(cherry picked from commit 010521a0197091642bbc654b2b371b462fa73033)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
