### PR TITLE
dnsdist: dump more packet cache

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -556,6 +556,7 @@ fuzz_target_dnsdistcache_SOURCES = \
 	dns.cc dns.hh \
 	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-configuration.cc dnsdist-configuration.hh \
+	dnsdist-crypto.cc dnsdist-crypto.hh \
 	dnsdist-dnsparser.cc dnsdist-dnsparser.hh \
 	dnsdist-dnsquestion.cc \
 	dnsdist-ecs.cc dnsdist-ecs.hh \

--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -511,10 +511,10 @@ uint64_t DNSDistPacketCache::dump(int fileDesc, bool rawResponse)
         fprintf(filePtr.get(), "%s %" PRId64 " %s %s ; ecs %s, rcode %" PRIu8 ", key %" PRIu32 ", length %" PRIu16 ", received over UDP %d, added %" PRId64 ", dnssecOK %d, raw query flags %" PRIu16, value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QClass(value.qclass).toString().c_str(), QType(value.qtype).toString().c_str(), value.subnet ? value.subnet.get().toString().c_str() : "empty", rcode, entry.first, value.len, value.receivedOverUDP ? 1 : 0, static_cast<int64_t>(value.added), value.dnssecOK ? 1 : 0, value.queryFlags);
 
         if (rawResponse) {
-	  std::string rawDataResponse = Base64Encode(value.value);
-	  fprintf(filePtr.get(), ", base64response %s", rawDataResponse.c_str());
-	}
-	fprintf(filePtr.get(), "\n");
+          std::string rawDataResponse = Base64Encode(value.value);
+          fprintf(filePtr.get(), ", base64response %s", rawDataResponse.c_str());
+        }
+        fprintf(filePtr.get(), "\n");
       }
       catch (...) {
         fprintf(filePtr.get(), "; error printing '%s'\n", value.qname.empty() ? "EMPTY" : value.qname.toString().c_str());

--- a/pdns/dnsdistdist/dnsdist-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-cache.hh
@@ -55,7 +55,7 @@ public:
   uint64_t getTTLTooShorts() const { return d_ttlTooShorts.load(); }
   uint64_t getCleanupCount() const { return d_cleanupCount.load(); }
   uint64_t getEntriesCount();
-  uint64_t dump(int fileDesc);
+  uint64_t dump(int fileDesc, bool fullResponse = false);
 
   /* get the list of domains (qnames) that contains the given address in an A or AAAA record */
   std::set<DNSName> getDomainsContainingRecords(const ComboAddress& addr);

--- a/pdns/dnsdistdist/dnsdist-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-cache.hh
@@ -55,7 +55,7 @@ public:
   uint64_t getTTLTooShorts() const { return d_ttlTooShorts.load(); }
   uint64_t getCleanupCount() const { return d_cleanupCount.load(); }
   uint64_t getEntriesCount();
-  uint64_t dump(int fileDesc, bool fullResponse = false);
+  uint64_t dump(int fileDesc, bool rawResponse = false);
 
   /* get the list of domains (qnames) that contains the given address in an A or AAAA record */
   std::set<DNSName> getDomainsContainingRecords(const ComboAddress& addr);

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -202,7 +202,7 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
       return results;
     });
 
-  luaCtx.registerFunction<void(std::shared_ptr<DNSDistPacketCache>::*)(const std::string& fname)const>("dump", [](const std::shared_ptr<DNSDistPacketCache>& cache, const std::string& fname) {
+  luaCtx.registerFunction<void(std::shared_ptr<DNSDistPacketCache>::*)(const std::string& fname, boost::optional<bool> rawResponse)const>("dump", [](const std::shared_ptr<DNSDistPacketCache>& cache, const std::string& fname, boost::optional<bool> rawResponse) {
       if (cache) {
 
         int fd = open(fname.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0660);
@@ -213,7 +213,7 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
 
         uint64_t records = 0;
         try {
-          records = cache->dump(fd);
+          records = cache->dump(fd, rawResponse? *rawResponse : false);
         }
         catch (const std::exception& e) {
           close(fd);

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1009,7 +1009,7 @@ See :doc:`../guides/cache` for a how to.
     .. versionchanged:: 2.0.0
       ``rawResponse`` added
 
-    Dump a summary of the cache entries to a file.
+    Dump a summary of the cache entries to a file. The raw response packet can be decoded by passing it to ``sdig``: ``echo [base64 encoded packet] | openssl base64 -d | sdig stdin 0 . A``
 
     :param str fname: The path to a file where the cache summary should be dumped. Note that if the target file already exists, it will not be overwritten.
     :param bool rawResponse: Dump the raw packet response encoded with base64.

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1004,11 +1004,15 @@ See :doc:`../guides/cache` for a how to.
 
   Represents a cache that can be part of :class:`ServerPool`.
 
-  .. method:: PacketCache:dump(fname)
+  .. method:: PacketCache:dump(fname [, rawResponse=false])
+
+    .. versionchanged:: 2.0.0
+      ``rawResponse`` added
 
     Dump a summary of the cache entries to a file.
 
     :param str fname: The path to a file where the cache summary should be dumped. Note that if the target file already exists, it will not be overwritten.
+    :param bool rawResponse: Dump the raw packet response encoded with base64.
 
   .. method:: PacketCache:expunge(n)
 


### PR DESCRIPTION
Idea from #14649

### Short description
Include more readily accessible info from the packet cache.

Potentially need to change documentation to remove 'summary of the cache', or make the full packet stuff an optional argument. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)