### PR TITLE
auth docs: set catalog member to primary

### DIFF
--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -101,6 +101,7 @@ In the example below ``example.com`` is the member and ``catalog.example`` is th
 .. code-block:: shell
 
   pdnsutil set-catalog example.com catalog.example
+  pdnsutil set-kind example.com primary
 
 Setting catalog values is supported in the :doc:`API <http-api/zone>`, by setting the ``catalog`` property in the zone properties.
 Setting the catalog to an empty ``""`` removes the member zone from the catalog it is in.


### PR DESCRIPTION
### Short description
In the example about assigning members to a producer zone, the example.com zone should have its kind (type) set to primary, as native zones are not included in the catalog.

`pdnsutil set-catalog` does not change the type to primary, so we also have to run `pdnsutil set-kind`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

