### PR TITLE
auth mssql CI: switch to 2022-CU12 image

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -423,7 +423,7 @@ jobs:
             env: {}
             ports: []
           - backend: godbc_mssql
-            image: mcr.microsoft.com/mssql/server:2017-GA-ubuntu
+            image: mcr.microsoft.com/mssql/server:2022-CU12-ubuntu-22.04
             env:
               ACCEPT_EULA: Y
               SA_PASSWORD: 'SAsa12%%-not-a-secret-password'


### PR DESCRIPTION
### Short description

https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240915.1 broke mssql.

https://github.com/microsoft/mssql-docker/issues/868 fits the kernel upgrade.

this commit switches from 2017-GA to 2022-CU12, which unbreaks the build

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master