### PR TITLE
dnf sbom: use same logic for our version number too

### DIFF
--- a/builder-support/helpers/generate-sbom-dnf.py
+++ b/builder-support/helpers/generate-sbom-dnf.py
@@ -45,9 +45,9 @@ def addDependencyToSBOM(sbom, appInfos, pkg):
     bomRef = 'lib:' + pkg.name
     component = { 'name': pkg.name, 'bom-ref': bomRef, 'type': 'library'}
     if pkg.release:
-        component['version'] = (pkg.version if pkg.epoch == 0 else str(pkg.epoch) + ':' + pkg.version) + '-' + pkg.release
+        component['version'] = (pkg.version if pkg.epoch == 0 else str(pkg.epoch) + ':' + pkg.version) + '-' + pkg.release + '.' + pkg.arch
     else:
-        component['version'] = (pkg.version if pkg.epoch == 0 else str(pkg.epoch) + ':' + pkg.version)
+        component['version'] = (pkg.version if pkg.epoch == 0 else str(pkg.epoch) + ':' + pkg.version) + '.' + pkg.arch
     if hasattr(pkg, 'vendor') and pkg.vendor is not None:
         component['supplier'] = {'name': pkg.vendor}
     if hasattr(pkg, 'publisher') and pkg.publisher is not None:
@@ -134,9 +134,9 @@ def generateSBOM(packageName, additionalDeps):
     component = { 'name': appName, 'bom-ref': 'pkg:' + appName, 'type': 'application'}
 
     if appInfos.release:
-        component['version'] = (appInfos.version if appInfos.epoch == 0 else str(appInfos.epoch) + ':' + appInfos.version) + '-' + appInfos.release
+        component['version'] = (appInfos.version if appInfos.epoch == 0 else str(appInfos.epoch) + ':' + appInfos.version) + '-' + appInfos.release + '.' + appInfos.arch
     else:
-        component['version'] = (appInfos.version if appInfos.epoch == 0 else str(appInfos.epoch) + ':' + appInfos.version)
+        component['version'] = (appInfos.version if appInfos.epoch == 0 else str(appInfos.epoch) + ':' + appInfos.version) + '.' + appInfos.arch
 
     component['supplier'] = {'name': appInfos.vendor if appInfos.vendor != '<NULL>' else 'PowerDNS.COM BV', 'url': ['https://www.powerdns.com']}
     component['licenses'] = [{'license': {'id': licenseToSPDXIdentifier(appInfos.license)}}]

--- a/builder-support/helpers/generate-sbom-dnf.py
+++ b/builder-support/helpers/generate-sbom-dnf.py
@@ -132,7 +132,12 @@ def generateSBOM(packageName, additionalDeps):
     appName = packageName
     appInfos = getPackageInformations(pkgDB, packageName)
     component = { 'name': appName, 'bom-ref': 'pkg:' + appName, 'type': 'application'}
-    component['version'] = appInfos.version
+
+    if appInfos.release:
+        component['version'] = (appInfos.version if appInfos.epoch == 0 else str(appInfos.epoch) + ':' + appInfos.version) + '-' + appInfos.release
+    else:
+        component['version'] = (appInfos.version if appInfos.epoch == 0 else str(appInfos.epoch) + ':' + appInfos.version)
+
     component['supplier'] = {'name': appInfos.vendor if appInfos.vendor != '<NULL>' else 'PowerDNS.COM BV', 'url': ['https://www.powerdns.com']}
     component['licenses'] = [{'license': {'id': licenseToSPDXIdentifier(appInfos.license)}}]
     depRelations['pkg:' + appName] = []


### PR DESCRIPTION
### Short description
this turns `4.8.0` into `4.8.0-0.beta1.authnodynnoso.3731.g201e03656.1pdns.el8`, which is what `rpm -qa` also prints (except we leave out `pdns-` in front and `.x86_64` at the tail)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master