### PR TITLE
rec: implement rfc6303 special zones (mostly v6 reverse mappings)

### DIFF
--- a/pdns/recursordist/reczones-helpers.cc
+++ b/pdns/recursordist/reczones-helpers.cc
@@ -270,6 +270,17 @@ void makePartialIPZone(SyncRes::domainmap_t& newMap,
   addToDomainMap(newMap, std::move(ad), dr.d_name, log, true, true);
 }
 
+void makePartialIP6Zone(SyncRes::domainmap_t& newMap,
+                        const std::string& name,
+                        Logr::log_t log)
+{
+  DNSRecord dnsRecord;
+  dnsRecord.d_name = DNSName(name);
+  SyncRes::AuthDomain authDomain = makeSOAAndNSNodes(dnsRecord, DNSName("localhost."));
+
+  addToDomainMap(newMap, std::move(authDomain), dnsRecord.d_name, log, true, true);
+}
+
 void addForwardAndReverseLookupEntries(SyncRes::domainmap_t& newMap,
                                        const std::string& searchSuffix,
                                        const std::vector<std::string>& parts,

--- a/pdns/recursordist/reczones-helpers.hh
+++ b/pdns/recursordist/reczones-helpers.hh
@@ -45,6 +45,9 @@ bool parseEtcHostsLine(std::vector<std::string>& parts, std::string& line);
 void makePartialIPZone(SyncRes::domainmap_t& newMap,
                        std::initializer_list<const char*> labels,
                        Logr::log_t log);
+void makePartialIP6Zone(SyncRes::domainmap_t& newMap,
+                        const std::string& name,
+                        Logr::log_t log);
 
 void addForwardAndReverseLookupEntries(SyncRes::domainmap_t& newMap,
                                        const std::string& searchSuffix,

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -200,7 +200,7 @@ string reloadZoneConfiguration(bool yaml)
         ::arg().preParseFile(filename, "allow-notify-for-file", ::arg()["allow-notify-for-file"]);
         ::arg().preParseFile(filename, "export-etc-hosts", ::arg()["export-etc-hosts"]);
         ::arg().preParseFile(filename, "serve-rfc1918", ::arg()["serve-rfc1918"]);
-        ::arg().preParseFile(filename, "serve-rfc1918", ::arg()["serve-rfc6303"]);
+        ::arg().preParseFile(filename, "serve-rfc6303", ::arg()["serve-rfc6303"]);
       }
     }
     // Process command line args potentially overriding what we read from config files

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -516,6 +516,9 @@ static void processServeRFC6303(std::shared_ptr<SyncRes::domainmap_t>& newMap, L
   if (!::arg().mustDo("serve-rfc6303")) {
     return;
   }
+  if (!::arg().mustDo("serve-rfc1918")) {
+    return;
+  }
   SLOG(g_log << Logger::Warning << "Inserting rfc 6303 private space zones" << endl,
        log->info(Logr::Notice, "Inserting rfc 6303 private space zones"));
   // Section 4.2

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -2395,7 +2395,7 @@ Individual parts of these zones can still be loaded or forwarded.
 This makes the server authoritatively aware of the zones in RFC 6303 not covered by RFC 1918.
 Individual parts of these zones can still be loaded or forwarded.
 ''',
-        'versionadded': ['5.1.x', '5.2.0'],
+        'versionadded': ['5.1.3', '5.2.0'],
     },
     {
         'name' : 'serve_stale_extensions',

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -2386,6 +2386,18 @@ Individual parts of these zones can still be loaded or forwarded.
  ''',
     },
     {
+        'name' : 'serve_rfc6303',
+        'section' : 'recursor',
+        'type' : LType.Bool,
+        'default' : 'true',
+        'help' : 'If we should be authoritative for RFC 6303 private IP space',
+        'doc' : '''
+This makes the server authoritatively aware of the zones in RFC 6303 not covered by RFC 1918.
+Individual parts of these zones can still be loaded or forwarded.
+''',
+        'versionadded': ['5.1.x', '5.2.0'],
+    },
+    {
         'name' : 'serve_stale_extensions',
         'section' : 'recordcache',
         'type' : LType.Uint64,

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -2394,6 +2394,7 @@ Individual parts of these zones can still be loaded or forwarded.
         'doc' : '''
 This makes the server authoritatively aware of the zones in RFC 6303 not covered by RFC 1918.
 Individual parts of these zones can still be loaded or forwarded.
+:ref:`setting-serve-rfc1918` must be enabled for this option to take effect.
 ''',
         'versionadded': ['5.1.3', '5.2.0'],
     },

--- a/regression-tests.recursor-dnssec/test_DNS64.py
+++ b/regression-tests.recursor-dnssec/test_DNS64.py
@@ -7,6 +7,7 @@ class DNS64Test(RecursorTest):
 
     _confdir = 'DNS64'
     _config_template = """
+    serve-rfc6303=no
     auth-zones=example.dns64=configs/%s/example.dns64.zone
     auth-zones+=in-addr.arpa=configs/%s/in-addr.arpa.zone
     auth-zones+=ip6.arpa=configs/%s/ip6.arpa.zone


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Guarded by a `recursor.serve_rfc6303` setting, default `true`.

Requested by @neilcook 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
