### PR TITLE
Do not include a stray pdns dir in the recursor artifacts

### DIFF
--- a/builder-support/post-build
+++ b/builder-support/post-build
@@ -17,6 +17,9 @@ if ! $tar --version | grep -q GNU; then
     exit 1
 fi
 
+# pdns (auth) is handled seperately, it needs a special find condition which is hard to do with
+# vars, as we don't want the asterisks to expand prematurely. So repeat the body of the loop below
+# with a find condition for pdns to exclude accidentally matching pdns-recursor*.
 for prog in pdns-recursor dnsdist; do
   if [ $(find ${SRCDIR}/dist -name "${prog}*" 2>/dev/null | wc -l) -ne 0 ]; then
     dst=${DESTDIR}/${prog}/${BUILDER_VERSION}

--- a/builder-support/post-build
+++ b/builder-support/post-build
@@ -17,15 +17,20 @@ if ! $tar --version | grep -q GNU; then
     exit 1
 fi
 
-for prog in pdns-recursor dnsdist pdns; do
+for prog in pdns-recursor dnsdist; do
   if [ $(find ${SRCDIR}/dist -name "${prog}*" 2>/dev/null | wc -l) -ne 0 ]; then
     dst=${DESTDIR}/${prog}/${BUILDER_VERSION}
     mkdir -p ${dst}
     cp ${BUILDER_TMP}/${BUILDER_VERSION}/sdist/${prog}*.tar.bz2 ${dst}
-    if [ "${prog}" = "pdns" ]; then
-      rm -f ${dst}/pdns-recursor*
-    fi
     tardirname=${prog}-${BUILDER_VERSION}-${BUILDER_TARGET}
     "$tar" -cjf ${dst}/${tardirname}.tar.bz2 --transform="s,.*/,${tardirname}/,g"  $(find ${SRCDIR} -type f)
   fi
 done
+prog=pdns
+if [ $(find ${SRCDIR}/dist -name 'pdns*' -a ! -name 'pdns-recursor*' 2>/dev/null | wc -l) -ne 0 ]; then
+  dst=${DESTDIR}/${prog}/${BUILDER_VERSION}
+  mkdir -p ${dst}
+  cp ${BUILDER_TMP}/${BUILDER_VERSION}/sdist/${prog}*.tar.bz2 ${dst}
+  tardirname=${prog}-${BUILDER_VERSION}-${BUILDER_TARGET}
+  "$tar" -cjf ${dst}/${tardirname}.tar.bz2 --transform="s,.*/,${tardirname}/,g"  $(find ${SRCDIR} -type f)
+fi


### PR DESCRIPTION
This is caused by pdns-recursor matching pdns*, which is intended to select auth files only.
Not terribly happy with the code duplication, but we would end up in quoting hell otherwise.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
