### PR TITLE
dnsdist-1.9.x: Backport 14664 - Add a FFI accessor to incoming proxy protocol values

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -179,6 +179,8 @@ typedef struct dnsdist_ffi_proxy_protocol_value {
 size_t dnsdist_ffi_generate_proxy_protocol_payload(size_t addrSize, const void* srcAddr, const void* dstAddr, uint16_t srcPort, uint16_t dstPort, bool tcp, size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, size_t outSize) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi_dnsquestion_t* dq, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, const size_t outSize) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsquestion_add_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values) __attribute__ ((visibility ("default")));
+// returns the length of the resulting 'out' array. 'out' is not set if the length is 0. Note that the return value will get invalidated as soon as a new value is added via dnsdist_ffi_dnsquestion_add_proxy_protocol_values().
+size_t dnsdist_ffi_dnsquestion_get_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_proxy_protocol_value_t** out) __attribute__((visibility("default")));
 
 typedef struct dnsdist_ffi_domain_list_t dnsdist_ffi_domain_list_t;
 typedef struct dnsdist_ffi_address_list_t dnsdist_ffi_address_list_t;

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1112,9 +1112,12 @@ bool dnsdist_ffi_dnsquestion_add_proxy_protocol_values(dnsdist_ffi_dnsquestion_t
 
 size_t dnsdist_ffi_dnsquestion_get_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_proxy_protocol_value_t** out)
 {
-  size_t count = 0;
-  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || out == nullptr || !dnsQuestion->dq->proxyProtocolValues) {
-    return count;
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || !dnsQuestion->dq->proxyProtocolValues) {
+    return 0;
+  }
+
+  if (out == nullptr) {
+    return dnsQuestion->proxyProtocolValuesVect->size();
   }
 
   dnsQuestion->proxyProtocolValuesVect = std::make_unique<std::vector<dnsdist_ffi_proxy_protocol_value_t>>(dnsQuestion->dq->proxyProtocolValues->size());
@@ -1124,11 +1127,10 @@ size_t dnsdist_ffi_dnsquestion_get_proxy_protocol_values(dnsdist_ffi_dnsquestion
     targetEntry.size = entry.content.size();
     targetEntry.value = entry.content.data();
     targetEntry.type = entry.type;
-    ++count;
   }
 
   *out = dnsQuestion->proxyProtocolValuesVect->data();
-  return count;
+  return dnsQuestion->proxyProtocolValuesVect->size();
 }
 
 struct dnsdist_ffi_domain_list_t

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1110,6 +1110,27 @@ bool dnsdist_ffi_dnsquestion_add_proxy_protocol_values(dnsdist_ffi_dnsquestion_t
   return true;
 }
 
+size_t dnsdist_ffi_dnsquestion_get_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_proxy_protocol_value_t** out)
+{
+  size_t count = 0;
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || out == nullptr || !dnsQuestion->dq->proxyProtocolValues) {
+    return count;
+  }
+
+  dnsQuestion->proxyProtocolValuesVect = std::make_unique<std::vector<dnsdist_ffi_proxy_protocol_value_t>>(dnsQuestion->dq->proxyProtocolValues->size());
+  for (size_t counter = 0; counter < dnsQuestion->dq->proxyProtocolValues->size(); ++counter) {
+    const auto& entry = dnsQuestion->dq->proxyProtocolValues->at(counter);
+    auto& targetEntry = dnsQuestion->proxyProtocolValuesVect->at(counter);
+    targetEntry.size = entry.content.size();
+    targetEntry.value = entry.content.data();
+    targetEntry.type = entry.type;
+    ++count;
+  }
+
+  *out = dnsQuestion->proxyProtocolValuesVect->data();
+  return count;
+}
+
 struct dnsdist_ffi_domain_list_t
 {
   std::vector<std::string> d_domains;

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.hh
@@ -56,6 +56,7 @@ struct dnsdist_ffi_dnsquestion_t
   std::unique_ptr<std::vector<dnsdist_ffi_ednsoption_t>> ednsOptionsVect;
   std::unique_ptr<std::vector<dnsdist_ffi_http_header_t>> httpHeadersVect;
   std::unique_ptr<std::vector<dnsdist_ffi_tag_t>> tagsVect;
+  std::unique_ptr<std::vector<dnsdist_ffi_proxy_protocol_value_t>> proxyProtocolValuesVect;
   std::unique_ptr<std::unordered_map<std::string, std::string>> httpHeaders;
 };
 

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -626,6 +626,59 @@ BOOST_AUTO_TEST_CASE(test_ProxyProtocolQuery)
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_ProxyProtocolIncoming)
+{
+  InternalQueryState ids;
+  ids.origRemote = ComboAddress("192.0.2.1:4242");
+  ids.origDest = ComboAddress("192.0.2.255:53");
+  ids.qtype = QType::A;
+  ids.qclass = QClass::IN;
+  ids.protocol = dnsdist::Protocol::DoUDP;
+  ids.qname = DNSName("www.powerdns.com.");
+  ids.queryRealTime.start();
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, ids.qname, QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+  pwQ.getHeader()->id = htons(42);
+
+  DNSQuestion dnsQuestion(ids, query);
+  dnsdist_ffi_dnsquestion_t lightDQ(&dnsQuestion);
+
+  {
+    /* invalid dq */
+    const dnsdist_ffi_proxy_protocol_value_t* out = nullptr;
+    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_proxy_protocol_values(nullptr, &out), 0U);
+  }
+  {
+    /* invalid pointer */
+    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_proxy_protocol_values(&lightDQ, nullptr), 0U);
+  }
+  {
+    /* no proxy protocol values */
+    const dnsdist_ffi_proxy_protocol_value_t* out = nullptr;
+    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_proxy_protocol_values(&lightDQ, &out), 0U);
+  }
+
+  {
+    /* add some proxy protocol TLV values */
+    dnsQuestion.proxyProtocolValues = std::make_unique<std::vector<ProxyProtocolValue>>();
+    dnsQuestion.proxyProtocolValues->emplace_back(ProxyProtocolValue{"foo", 42});
+    dnsQuestion.proxyProtocolValues->emplace_back(ProxyProtocolValue{"bar", 255});
+    dnsQuestion.proxyProtocolValues->emplace_back(ProxyProtocolValue{"", 0});
+    const dnsdist_ffi_proxy_protocol_value_t* out = nullptr;
+    auto count = dnsdist_ffi_dnsquestion_get_proxy_protocol_values(&lightDQ, &out);
+    BOOST_REQUIRE_EQUAL(count, 3U);
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic): sorry, this is a C API
+    BOOST_CHECK_EQUAL(out[0].type, 42U);
+    BOOST_CHECK_EQUAL(out[0].value, "foo");
+    BOOST_CHECK_EQUAL(out[1].type, 255U);
+    BOOST_CHECK_EQUAL(out[1].value, "bar");
+    BOOST_CHECK_EQUAL(out[2].type, 0U);
+    BOOST_CHECK_EQUAL(out[2].value, "");
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic): sorry, this is a C API
+  }
+}
+
 BOOST_AUTO_TEST_CASE(test_PacketOverlay)
 {
   const DNSName target("powerdns.com.");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14664 to rel/dnsdist-1.9.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
