### PR TITLE
regression-tests.auth-py: remove duplicate method

### DIFF
--- a/regression-tests.auth-py/authtests.py
+++ b/regression-tests.auth-py/authtests.py
@@ -250,10 +250,6 @@ options {
         pass
 
     @classmethod
-    def tearDownClass(cls):
-        cls.tearDownAuth()
-
-    @classmethod
     def killProcess(cls, p):
         # Don't try to kill it if it's already dead
         if p.poll() is not None:


### PR DESCRIPTION
### Short description
PR removed duplicate `tearDownClass` method. one located at line [244](https://github.com/PowerDNS/pdns/blob/51c26d140a95d07ca25ed787cc9b2f470d9b7570/regression-tests.auth-py/authtests.py#L244) while the other one located at line [253](https://github.com/PowerDNS/pdns/blob/51c26d140a95d07ca25ed787cc9b2f470d9b7570/regression-tests.auth-py/authtests.py#L253).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
