### PR TITLE
rec: make sure the record cache has sane paramers for each unit test

### DIFF
--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -61,6 +61,8 @@ void MemRecursorCache::resetStaticsForTests()
   SyncRes::s_refresh_ttlperc = 0;
   SyncRes::s_locked_ttlperc = 0;
   SyncRes::s_minimumTTL = 0;
+  s_maxRRSetSize = 256;
+  s_limitQTypeAny = true;
 }
 
 MemRecursorCache::MemRecursorCache(size_t mapsCount) :

--- a/pdns/recursordist/test-reczones-helpers.cc
+++ b/pdns/recursordist/test-reczones-helpers.cc
@@ -272,7 +272,7 @@ const std::string hints = ". 3600 IN NS ns.\n"
 
 BOOST_AUTO_TEST_CASE(test_UserHints)
 {
-
+  MemRecursorCache::resetStaticsForTests();
   g_recCache = make_unique<MemRecursorCache>();
 
   ::arg().set("max-generate-steps") = "0";

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -142,9 +142,7 @@ void initSR(bool debug)
   }
 
   RecursorPacketCache::s_refresh_ttlperc = 0;
-  MemRecursorCache::s_maxServedStaleExtensions = 0;
-  MemRecursorCache::s_maxRRSetSize = 100;
-  MemRecursorCache::s_limitQTypeAny = true;
+  MemRecursorCache::resetStaticsForTests();
   NegCache::s_maxServedStaleExtensions = 0;
   g_recCache = std::make_unique<MemRecursorCache>();
   g_negCache = std::make_unique<NegCache>();


### PR DESCRIPTION
In particluar if a specific test was run that would set the maximum RRSET very low, the reczones_helpers/test_UserHints test would fail.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
