### PR TITLE
dnsdist: add the ability to load a given TLS tickets key

### DIFF
--- a/pdns/dnsdistdist/dnsdist-doh-common.cc
+++ b/pdns/dnsdistdist/dnsdist-doh-common.cc
@@ -99,6 +99,11 @@ void DOHFrontend::loadTicketsKeys(const std::string& keyFile)
   return d_tlsContext.loadTicketsKeys(keyFile);
 }
 
+void DOHFrontend::loadTicketsKey(const std::string& key)
+{
+  return d_tlsContext.loadTicketsKey(key);
+}
+
 void DOHFrontend::handleTicketsKeyRotation()
 {
 }

--- a/pdns/dnsdistdist/dnsdist-doh-common.hh
+++ b/pdns/dnsdistdist/dnsdist-doh-common.hh
@@ -166,6 +166,10 @@ struct DOHFrontend
   {
   }
 
+  virtual void loadTicketsKey(const std::string& /* key */)
+  {
+  }
+
   virtual void handleTicketsKeyRotation()
   {
   }
@@ -187,6 +191,7 @@ struct DOHFrontend
 
   virtual void rotateTicketsKey(time_t now);
   virtual void loadTicketsKeys(const std::string& keyFile);
+  virtual void loadTicketsKey(const std::string& key);
   virtual void handleTicketsKeyRotation();
   virtual std::string getNextTicketsKeyRotation() const;
   virtual size_t getTicketsKeysCount();

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3002,14 +3002,14 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       }
       try {
 #ifdef HAVE_DNS_OVER_TLS
-       if (frontend->tlsFrontend) {
-         frontend->tlsFrontend->loadTicketsKey(key);
-       }
+        if (frontend->tlsFrontend) {
+          frontend->tlsFrontend->loadTicketsKey(key);
+        }
 #endif /* HAVE_DNS_OVER_TLS */
 #ifdef HAVE_DNS_OVER_HTTPS
-       if (frontend->dohFrontend) {
-         frontend->dohFrontend->loadTicketsKey(key);
-       }
+        if (frontend->dohFrontend) {
+          frontend->dohFrontend->loadTicketsKey(key);
+        }
 #endif /* HAVE_DNS_OVER_HTTPS */
       }
       catch (const std::exception& e) {
@@ -3017,7 +3017,6 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       }
     }
   });
-
 
   luaCtx.registerFunction<void (std::shared_ptr<DOHFrontend>::*)(const LuaArray<std::shared_ptr<DOHResponseMapEntry>>&)>("setResponsesMap", [](const std::shared_ptr<DOHFrontend>& frontend, const LuaArray<std::shared_ptr<DOHResponseMapEntry>>& map) {
     if (frontend != nullptr) {

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -2990,6 +2990,12 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
+  luaCtx.registerFunction<void (std::shared_ptr<DOHFrontend>::*)(const std::string&)>("loadTicketsKey", [](const std::shared_ptr<DOHFrontend>& frontend, const std::string& key) {
+    if (frontend != nullptr) {
+      frontend->loadTicketsKey(key);
+    }
+  });
+
   luaCtx.registerFunction<void (std::shared_ptr<DOHFrontend>::*)(const LuaArray<std::shared_ptr<DOHResponseMapEntry>>&)>("setResponsesMap", [](const std::shared_ptr<DOHFrontend>& frontend, const LuaArray<std::shared_ptr<DOHResponseMapEntry>>& map) {
     if (frontend != nullptr) {
       auto newMap = std::make_shared<std::vector<std::shared_ptr<DOHResponseMapEntry>>>();
@@ -3220,6 +3226,16 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     auto ctx = frontend->getContext();
     if (ctx) {
       ctx->loadTicketsKeys(file);
+    }
+  });
+
+  luaCtx.registerFunction<void (std::shared_ptr<TLSFrontend>::*)(const std::string&)>("loadTicketsKey", [](std::shared_ptr<TLSFrontend>& frontend, const std::string& key) {
+    if (frontend == nullptr) {
+      return;
+    }
+    auto ctx = frontend->getContext();
+    if (ctx) {
+      ctx->loadTicketsKey(key);
     }
   });
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -2363,7 +2363,7 @@ DOHFrontend
 
   .. method:: DOHFrontend:loadTicketsKey(key)
 
-     Replace the current TLS tickets key with a given one.
+     Load a new TLS tickets key.
 
      :param str key: the new raw TLS tickets key to load.
 
@@ -2548,7 +2548,7 @@ TLSFrontend
 
   .. method:: TLSFrontend:loadTicketsKey(key)
 
-     Replace the current TLS tickets key with a given one.
+     Load a new TLS tickets key.
 
     :param str key: the new raw TLS tickets key to load.
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -52,6 +52,12 @@ Global configuration
 
   :param str path: The directory to load configuration files from. Each file must end in ``.conf``.
 
+.. function:: loadTicketsKey(key)
+
+  Load the given TLS tickets key on all compatible frontends (DOH and TLS).
+
+  :param str key: The new raw TLS tickets key to use.
+
 .. function:: reloadAllCertificates()
 
   .. versionadded:: 1.4.0
@@ -2355,6 +2361,12 @@ DOHFrontend
 
     :param str ticketsKeysFile: The path to a file from where TLS tickets keys should be loaded.
 
+  .. method:: DOHFrontend:loadTicketsKey(key)
+
+     Replace the current TLS tickets key with a given one.
+
+     :param str key: the new raw TLS tickets key to load.
+
   .. method:: DOHFrontend:reloadCertificates()
 
      Reload the current TLS certificate and key pairs.
@@ -2533,6 +2545,12 @@ TLSFrontend
      See :doc:`../advanced/tls-sessions-management` for more information.
 
     :param str ticketsKeysFile: The path to a file from where TLS tickets keys should be loaded.
+
+  .. method:: TLSFrontend:loadTicketsKey(key)
+
+     Replace the current TLS tickets key with a given one.
+
+    :param str key: the new raw TLS tickets key to load.
 
   .. method:: TLSFrontend:reloadCertificates()
 

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -688,6 +688,22 @@ void OpenSSLTLSTicketKeysRing::loadTicketsKeys(const std::string& keyFile)
   file.close();
 }
 
+void OpenSSLTLSTicketKeysRing::loadTicketsKey(const std::string& key)
+{
+  bool keyLoaded = false;
+  try {
+    auto newKey = std::make_shared<OpenSSLTLSTicketKey>(key);
+    addKey(std::move(newKey));
+    keyLoaded = true;
+  }
+  catch (const std::exception& e) {
+    /* if we haven't been able to load at least one key, fail */
+    if (!keyLoaded) {
+      throw;
+    }
+  }
+}
+
 void OpenSSLTLSTicketKeysRing::rotateTicketsKey(time_t /* now */)
 {
   auto newKey = std::make_shared<OpenSSLTLSTicketKey>();
@@ -723,6 +739,25 @@ OpenSSLTLSTicketKey::OpenSSLTLSTicketKey(std::ifstream& file)
   if (file.fail()) {
     throw std::runtime_error("Unable to load a ticket key from the OpenSSL tickets key file");
   }
+#ifdef HAVE_LIBSODIUM
+  sodium_mlock(d_name, sizeof(d_name));
+  sodium_mlock(d_cipherKey, sizeof(d_cipherKey));
+  sodium_mlock(d_hmacKey, sizeof(d_hmacKey));
+#endif /* HAVE_LIBSODIUM */
+}
+
+OpenSSLTLSTicketKey::OpenSSLTLSTicketKey(const std::string& key)
+{
+  if (key.size() != (sizeof(d_name) + sizeof(d_cipherKey) + sizeof(d_hmacKey))) {
+    throw std::runtime_error("Unable to load a ticket key from given data");
+  }
+  size_t from = 0;
+  memcpy(d_name, &key.at(from), sizeof(d_name));
+  from += sizeof(d_name);
+  memcpy(d_cipherKey, &key.at(from), sizeof(d_cipherKey));
+  from += sizeof(d_cipherKey);
+  memcpy(d_hmacKey, &key.at(from), sizeof(d_hmacKey));
+
 #ifdef HAVE_LIBSODIUM
   sodium_mlock(d_name, sizeof(d_name));
   sodium_mlock(d_cipherKey, sizeof(d_cipherKey));

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -93,6 +93,7 @@ class OpenSSLTLSTicketKey
 public:
   OpenSSLTLSTicketKey();
   OpenSSLTLSTicketKey(std::ifstream& file);
+  OpenSSLTLSTicketKey(const std::string& key);
   ~OpenSSLTLSTicketKey();
 
   bool nameMatches(const unsigned char name[TLS_TICKETS_KEY_NAME_SIZE]) const;
@@ -122,6 +123,7 @@ public:
   std::shared_ptr<OpenSSLTLSTicketKey> getDecryptionKey(unsigned char name[TLS_TICKETS_KEY_NAME_SIZE], bool& activeKey);
   size_t getKeysCount();
   void loadTicketsKeys(const std::string& keyFile);
+  void loadTicketsKey(const std::string& key);
   void rotateTicketsKey(time_t now);
 
 private:

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -889,6 +889,15 @@ public:
     }
   }
 
+  void loadTicketsKey(const std::string& key) final
+  {
+    d_feContext->d_ticketKeys.loadTicketsKey(key);
+
+    if (d_ticketsKeyRotationDelay > 0) {
+      d_ticketsKeyNextRotation = time(nullptr) + d_ticketsKeyRotationDelay;
+    }
+  }
+
   size_t getTicketsKeysCount() override
   {
     return d_feContext->d_ticketKeys.getKeysCount();
@@ -993,7 +1002,24 @@ public:
     safe_memory_lock(d_key.data, d_key.size);
   }
 
-  GnuTLSTicketsKey(const std::string& keyFile)
+  GnuTLSTicketsKey(const std::string& key)
+  {
+    /* to be sure we are loading the correct amount of data, which
+       may change between versions, let's generate a correct key first */
+    if (gnutls_session_ticket_key_generate(&d_key) != GNUTLS_E_SUCCESS) {
+      throw std::runtime_error("Error generating tickets key (before parsing key file) for TLS context");
+    }
+
+    safe_memory_lock(d_key.data, d_key.size);
+    if (key.size() != d_key.size) {
+      safe_memory_release(d_key.data, d_key.size);
+      gnutls_free(d_key.data);
+      d_key.data = nullptr;
+      throw std::runtime_error("Invalid GnuTLS ticket key size");
+    }
+    memcpy(d_key.data, key.data(), key.size());
+  }
+  GnuTLSTicketsKey(std::ifstream& file)
   {
     /* to be sure we are loading the correct amount of data, which
        may change between versions, let's generate a correct key first */
@@ -1004,17 +1030,17 @@ public:
     safe_memory_lock(d_key.data, d_key.size);
 
     try {
-      ifstream file(keyFile);
       file.read(reinterpret_cast<char*>(d_key.data), d_key.size);
 
       if (file.fail()) {
-        file.close();
-        throw std::runtime_error("Invalid GnuTLS tickets key file " + keyFile);
+        throw std::runtime_error("Invalid GnuTLS tickets key file");
       }
 
-      file.close();
     }
     catch (const std::exception& e) {
+      safe_memory_release(d_key.data, d_key.size);
+      gnutls_free(d_key.data);
+      d_key.data = nullptr;
       safe_memory_release(d_key.data, d_key.size);
       gnutls_free(d_key.data);
       d_key.data = nullptr;
@@ -1804,14 +1830,26 @@ public:
     auto newKey = std::make_shared<GnuTLSTicketsKey>();
     addTicketsKey(now, std::move(newKey));
   }
-  void loadTicketsKeys(const std::string& file) final
+  void loadTicketsKey(const std::string& key) final
   {
     if (!d_enableTickets) {
       return;
     }
 
+    auto newKey = std::make_shared<GnuTLSTicketsKey>(key);
+    addTicketsKey(time(nullptr), std::move(newKey));
+  }
+
+  void loadTicketsKeys(const std::string& keyFile) final
+  {
+    if (!d_enableTickets) {
+      return;
+    }
+
+    std::ifstream file(keyFile);
     auto newKey = std::make_shared<GnuTLSTicketsKey>(file);
     addTicketsKey(time(nullptr), std::move(newKey));
+    file.close();
   }
 
   size_t getTicketsKeysCount() override

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -1041,9 +1041,6 @@ public:
       safe_memory_release(d_key.data, d_key.size);
       gnutls_free(d_key.data);
       d_key.data = nullptr;
-      safe_memory_release(d_key.data, d_key.size);
-      gnutls_free(d_key.data);
-      d_key.data = nullptr;
       throw;
     }
   }

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -81,6 +81,10 @@ public:
   {
     throw std::runtime_error("This TLS backend does not have the capability to load a tickets key from a file");
   }
+  virtual void loadTicketsKey(const std::string& /* key */)
+  {
+    throw std::runtime_error("This TLS backend does not have the capability to load a ticket key");
+  }
   void handleTicketsKeyRotation(time_t now)
   {
     if (d_ticketsKeyRotationDelay != 0 && now > d_ticketsKeyNextRotation) {
@@ -160,6 +164,13 @@ public:
   {
     if (d_ctx != nullptr) {
       d_ctx->loadTicketsKeys(file);
+    }
+  }
+
+  void loadTicketsKey(const std::string& key)
+  {
+    if (d_ctx != nullptr) {
+      d_ctx->loadTicketsKey(key);
     }
   }
 

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -6,6 +6,9 @@ import ssl
 import subprocess
 import time
 import unittest
+import random
+import string
+
 from dnsdisttests import DNSDistTest, pickAvailablePort
 
 class TLSTests(object):
@@ -517,7 +520,7 @@ class TestPKCSTLSCertificate(DNSDistTest, TLSTests):
         cls.startDNSDist()
         cls.setUpSockets()
 
-class TestTLSTicketsKeyAddedCallback(DNSDistTest):
+class TestOpenSSLTLSTicketsKeyCallback(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
 
@@ -536,20 +539,67 @@ class TestTLSTicketsKeyAddedCallback(DNSDistTest):
     newServer{address="127.0.0.1:%s"}
     addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
 
-    callbackCalled = 0
-    function keyAddedCallback(key, keyLen)
-      callbackCalled = keyLen
-    end
+    lastKey = ""
+    lastKeyLen = 0
 
+    function keyAddedCallback(key, keyLen)
+      lastKey = key
+      lastKeyLen = keyLen
+    end
+    setTicketsKeyAddedHook(keyAddedCallback)
     """
 
-    def testLuaThreadCounter(self):
+    def testSetTicketsKey(self):
         """
-        LuaThread: Test the lua newThread interface
+        TLSTicketsKey: test setting new key and the key added hook
         """
-        self.sendConsoleCommand('setTicketsKeyAddedHook(keyAddedCallback)');
-        called = self.sendConsoleCommand('callbackCalled')
-        self.assertEqual(int(called), 0)
-        self.sendConsoleCommand("getTLSFrontend(0):rotateTicketsKey()")
-        called = self.sendConsoleCommand('callbackCalled')
-        self.assertGreater(int(called), 0)
+
+        newKey = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(80))
+        print("about to send command: `{}`".format("getTLSFrontend(0):setTicketsKey(\"{}\")".format(newKey)))
+        self.sendConsoleCommand("getTLSFrontend(0):loadTicketsKey(\"{}\")".format(newKey))
+        keyLen = self.sendConsoleCommand('lastKeyLen')
+        self.assertEqual(int(keyLen), 80)
+        lastKey = self.sendConsoleCommand('lastKey')
+        self.assertEqual(newKey, lastKey.strip())
+
+class TestGnuTLSTLSTicketsKeyCallback(DNSDistTest):
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
+
+    _serverKey = 'server.key'
+    _serverCert = 'server.chain'
+    _serverName = 'tls.tests.dnsdist.org'
+    _caCert = 'ca.pem'
+    _tlsServerPort = pickAvailablePort()
+    _numberOfKeys = 5
+
+    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey']
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%s")
+
+    newServer{address="127.0.0.1:%s"}
+    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="gnutls" })
+
+    lastKey = ""
+    lastKeyLen = 0
+
+    function keyAddedCallback(key, keyLen)
+      lastKey = key
+      lastKeyLen = keyLen
+    end
+    setTicketsKeyAddedHook(keyAddedCallback)
+    """
+
+    def testSetTicketsKey(self):
+        """
+        TLSTicketsKey: test setting new key and the key added hook
+        """
+
+        newKey = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(64))
+        print("about to send command: `{}`".format("getTLSFrontend(0):setTicketsKey(\"{}\")".format(newKey)))
+        self.sendConsoleCommand("getTLSFrontend(0):loadTicketsKey(\"{}\")".format(newKey))
+        keyLen = self.sendConsoleCommand('lastKeyLen')
+        self.assertEqual(int(keyLen), 64)
+        lastKey = self.sendConsoleCommand('lastKey')
+        self.assertEqual(newKey, lastKey.strip())

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -555,7 +555,6 @@ class TestOpenSSLTLSTicketsKeyCallback(DNSDistTest):
         """
 
         newKey = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(80))
-        print("about to send command: `{}`".format("getTLSFrontend(0):setTicketsKey(\"{}\")".format(newKey)))
         self.sendConsoleCommand("getTLSFrontend(0):loadTicketsKey(\"{}\")".format(newKey))
         keyLen = self.sendConsoleCommand('lastKeyLen')
         self.assertEqual(int(keyLen), 80)
@@ -597,7 +596,6 @@ class TestGnuTLSTLSTicketsKeyCallback(DNSDistTest):
         """
 
         newKey = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(64))
-        print("about to send command: `{}`".format("getTLSFrontend(0):setTicketsKey(\"{}\")".format(newKey)))
         self.sendConsoleCommand("getTLSFrontend(0):loadTicketsKey(\"{}\")".format(newKey))
         keyLen = self.sendConsoleCommand('lastKeyLen')
         self.assertEqual(int(keyLen), 64)


### PR DESCRIPTION
### Short description
This adds the ability to load a given TLS tickets key on DOH and TLS frontends.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
