### PR TITLE
dnsdist setTicketsKeyAddedHook(): adjust type of the key to fix potential truncate

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-hooks.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-hooks.cc
@@ -7,7 +7,7 @@
 namespace dnsdist::lua::hooks
 {
 using MaintenanceCallback = std::function<void()>;
-using TicketsKeyAddedHook = std::function<void(const char*, size_t)>;
+using TicketsKeyAddedHook = std::function<void(const std::string&, size_t)>;
 
 static LockGuarded<std::vector<MaintenanceCallback>> s_maintenanceHooks;
 
@@ -35,7 +35,7 @@ static void setTicketsKeyAddedHook(const LuaContext& context, const TicketsKeyAd
   TLSCtx::setTicketsKeyAddedHook([hook](const std::string& key) {
     try {
       auto lua = g_lua.lock();
-      hook(key.c_str(), key.size());
+      hook(key, key.size());
     }
     catch (const std::exception& exp) {
       warnlog("Error calling the Lua hook after new tickets key has been added: %s", exp.what());


### PR DESCRIPTION
The key received on the lua side might be truncated if it contains the null char. By changing the type of the prototype, the lua wrapper uses the `key.size()` method to evaluate the actual size.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
