### PR TITLE
pdns: allow empty string in version-string

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -288,7 +288,7 @@ int PacketHandler::doChaosRequest(const DNSPacket& p, std::unique_ptr<DNSPacket>
       // modes: full, powerdns only, anonymous or custom
       const static string mode=::arg()["version-string"];
       string content;
-      if(mode.empty() || mode=="full")
+      if(mode=="full")
         content=fullVersionString();
       else if(mode=="powerdns")
         content="Served by PowerDNS - https://www.powerdns.com/";


### PR DESCRIPTION
### Short description

This change allow an empty string to be returned to CHAOS version.bind request. version-string by default is set to "full" through pdns/auth-main.cc declareArguments(), however does not allow an empty string to be returned as PowerDNS Recursor does.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
