### PR TITLE
dnsdist: Add missing `stdexcept` include in `lmdb-safe.hh`

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -2,6 +2,7 @@
 
 #include "config.h"
 
+#include <stdexcept>
 #include <string_view>
 #include <lmdb.h>
 #include <map>
@@ -18,7 +19,6 @@
 #include <boost/range/detail/common.hpp>
 #include <cstdint>
 #include <netinet/in.h>
-#include <stdexcept>
 #endif
 
 using std::string_view;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue # -->

It was only included for non-dnsdist contexts, but `std::runtime_error` is used in all contexts and gcc version 14.2.1 20240910 (at least) is not happy about it:
```
In file included from ext/lmdb-safe/lmdb-safe.cc:2:
ext/lmdb-safe/lmdb-safe.hh: In member function ‘int MDBROTransactionImpl::get(MDB_dbi, const MDBInVal&, MDBOutVal&)’:
ext/lmdb-safe/lmdb-safe.hh:379:18: error: ‘runtime_error’ is not a member of ‘std’
  379 |       throw std::runtime_error("Attempt to use a closed RO transaction for get");
      |
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
