### PR TITLE
Finally fix the clang-tidy issues.

### DIFF
--- a/.clang-tidy.bugs
+++ b/.clang-tidy.bugs
@@ -1,17 +1,18 @@
 ---
 FormatStyle: none
-HeaderFileExtensions:
-  - h
-  - hh
-  - hpp
-ImplementationFileExtensions:
-  - c
-  - cc
-  - cpp
+# Older (pre 19) versions of clang-tidy do not grok these
+# HeaderFileExtensions:
+#  - h
+#  - hh
+#  - hpp
+#ImplementationFileExtensions:
+#  - c
+#  - cc
+#  - cpp
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 Checks: |
-  'clang-diagnostic-*,clang-analyzer-*,bugprone-*,concurrency-*,-modernize-use-trailing-return-type,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-performance-avoid-endl'
+  clang-diagnostic-*,clang-analyzer-*,bugprone-*,concurrency-*,-modernize-use-trailing-return-type,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-performance-avoid-endl
 # yamllint disable rule:line-length
 CheckOptions:
   - key: bugprone-string-constructor.LargeLengthThreshold

--- a/.clang-tidy.full
+++ b/.clang-tidy.full
@@ -1,17 +1,18 @@
 ---
-FormatStyle: none
-HeaderFileExtensions:
-  - h
-  - hh
-  - hpp
-ImplementationFileExtensions:
-  - c
-  - cc
-  - cpp
+FormatStyle: non
+# Older (pre 19) versions of clang-tidy do not grok these
+#HeaderFileExtensions:
+#  - h
+#  - hh
+#  - hpp
+#ImplementationFileExtensions:
+#  - c
+#  - cc
+#  - cpp
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 Checks: |
-  'clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,bugprone-*,concurrency-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-type-union-access,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-avoid-do-while,-cppcoreguidelines-avoid-const-or-ref-data-members,-performance-avoid-endl'
+  clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,bugprone-*,concurrency-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-type-union-access,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-avoid-do-while,-cppcoreguidelines-avoid-const-or-ref-data-members,-performance-avoid-endl
 # yamllint disable rule:line-length
 CheckOptions:
   - key: readability-suspicious-call-argument.PrefixSimilarAbove


### PR DESCRIPTION
Root cause was the slightly different parsing or the Checks: line, newer version handle the single quotes differently. Also remove two entries that are not present on older clang-tidy implementations.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
