### PR TITLE
GH actions: use arm64 Ubicloud runners only if a variable is defined at repository level

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -116,20 +116,39 @@ jobs:
           repository: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}
           short-description: ${{ inputs.image-description }}
 
-  test-uploaded-images:
-    name: test uploaded images
+  prepare-test-runner-os-list:
+    name: generate runner list
     if: ${{ inputs.push }}
     needs: build
+    runs-on: ubuntu-22.04
+    outputs:
+      runnerlist: ${{ steps.get-runnerlist.outputs.runnerlist }}
+      skiptests: ${{ steps.get-runnerlist.outputs.skiptests }}
+    steps:
+      - run: sudo apt-get update && sudo apt-get -y install jo
+      - id: get-runnerlist
+        run: |
+          runner_os=()
+          [[ -n "${{ contains(inputs.platforms, 'amd64') && 'ubuntu-22.04' || '' }}" ]] && runner_os+=('ubuntu-22.04')
+          [[ -n "${{ vars.ARM64_USE_UBICLOUD == '1' && contains(inputs.platforms, 'arm64') || '' }}" ]] && runner_os+=('ubicloud-standard-2-arm')
+          echo "runnerlist=$(jo -a ${runner_os[@]})" >> "$GITHUB_OUTPUT"
+          # Skip tests if no runner is suitable for running them. Set a default runner to avoid CI failure
+          if [[ -z "${runner_os[@]}" ]]; then
+            echo "runnerlist=$(jo -a ubuntu-22.04)" >> "$GITHUB_OUTPUT"
+            echo "skiptests=1" >> "$GITHUB_OUTPUT"
+          fi
+
+  test-uploaded-images:
+    name: test uploaded images
+    if: ${{ inputs.push && ! needs.prepare-test-runner-os-list.outputs.skiptests }}
+    needs: [build, prepare-test-runner-os-list]
     runs-on: ${{ matrix.runner-os }}
     strategy:
       matrix:
-        runner-os:
-          - ubuntu-22.04
-          - ubicloud-standard-2-arm
+        runner-os: ${{ fromJson(needs.prepare-test-runner-os-list.outputs.runnerlist )}}
       fail-fast: false
     steps:
       - name: Check running image
-        if: ${{ ( matrix.runner-os == 'ubuntu-22.04' && contains(inputs.platforms, 'amd64') ) || ( matrix.runner-os == 'ubicloud-standard-2-arm' && contains(inputs.platforms, 'arm64') ) }}
         run: |
           image_name='${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}'
           for tag in `echo '${{ inputs.image-tags }}' | tr '\n' ' '`; do
@@ -138,7 +157,6 @@ jobs:
             docker run ${image_name}:${tag} --version || [ "$?" == "134" ]
           done
       - name: Check image digest matches
-        if: ${{ ( matrix.runner-os == 'ubuntu-22.04' && contains(inputs.platforms, 'amd64') ) || ( matrix.runner-os == 'ubicloud-standard-2-arm' && contains(inputs.platforms, 'arm64') ) }}
         run: |
           output_digest='${{ needs.build.outputs.image-digest }}'
           image_name='${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}'
@@ -148,7 +166,6 @@ jobs:
               ( echo "Image digest does not match => output_digest: "${output_digest}" - image_digest: "${image_digest} && exit 1 )
           done
       - name: Check SBOM and Provenance
-        if: ${{ ( matrix.runner-os == 'ubuntu-22.04' && contains(inputs.platforms, 'amd64') ) || ( matrix.runner-os == 'ubicloud-standard-2-arm' && contains(inputs.platforms, 'arm64') ) }}
         run: |
           image_name='${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}'
           for tag in `echo '${{ inputs.image-tags }}' | tr '\n' ' '`; do

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -47,10 +47,12 @@ permissions: # least privileges, see https://docs.github.com/en/actions/using-wo
 
 jobs:
   prepare:
-    name: generate OS list
+    name: generate OS runner and arch list
     runs-on: ubuntu-22.04
     outputs:
       oslist: ${{ steps.get-oslist.outputs.oslist }}
+      runnerlist: ${{ steps.get-runnerlist.outputs.runnerlist }}
+      archlist: ${{ steps.get-archlist.outputs.archlist }}
     steps:
       # instead of jo, we could use jq here, which avoids running apt, and thus would be faster.
       # but, as this whole workflow needs at least 30 minutes to run, I prefer spending a few seconds here
@@ -58,6 +60,11 @@ jobs:
       - run: sudo apt-get update && sudo apt-get -y install jo
       - id: get-oslist
         run: echo "oslist=$(jo -a ${{ inputs.os }})" >> "$GITHUB_OUTPUT"
+      - id: get-runnerlist
+        run: echo "runnerlist=$(jo -a ubuntu-22.04 ${{ vars.ARM64_USE_UBICLOUD == '1' && 'ubicloud-standard-2-arm' || '' }})" >> "$GITHUB_OUTPUT"
+      - id: get-archlist
+        run: echo "archlist=$(jo -a  x86_64 ${{ vars.ARM64_USE_UBICLOUD == '1' && 'aarch64' || '' }})" >> "$GITHUB_OUTPUT"
+
   build:
     needs: prepare
     name: ${{ inputs.product }} (${{ inputs.ref }}) on ${{ matrix.runner-os }} for ${{ matrix.os }}
@@ -65,9 +72,7 @@ jobs:
     strategy:
       matrix:
         os: ${{fromJson(needs.prepare.outputs.oslist)}}
-        runner-os:
-          - ubuntu-22.04
-          - ubicloud-standard-2-arm
+        runner-os: ${{ fromJson(needs.prepare.outputs.runnerlist )}}
         exclude:
           - os: el-7
             runner-os: ubicloud-standard-2-arm
@@ -167,7 +172,7 @@ jobs:
       - name: Get list of OS inputs
         run: |
           for os in ${{ inputs.os }}; do
-            for architecture in x86_64 aarch64; do
+            for architecture in x86_64 ${{ vars.ARM64_USE_UBICLOUD == '1' && 'aarch64' || '' }}; do
               [[ "$os" != "el-7" || "$architecture" != "aarch64"  ]] && echo "\"pkghashes-$os-$architecture\"" | tee -a /tmp/os-inputs.txt
             done
           done
@@ -182,7 +187,7 @@ jobs:
     strategy:
       matrix:
         os: ${{fromJson(needs.prepare.outputs.oslist)}}
-        architecture: ['x86_64', 'aarch64']
+        architecture: ${{ fromJson(needs.prepare.outputs.archlist )}}
         exclude:
           - os: el-7
             architecture: aarch64
@@ -218,7 +223,7 @@ jobs:
     strategy:
       matrix:
         os: ${{fromJson(needs.prepare.outputs.oslist)}}
-        architecture: ['x86_64', 'aarch64']
+        architecture: ${{ fromJson(needs.prepare.outputs.archlist )}}
         exclude:
           - os: el-7
             architecture: aarch64

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -16,9 +16,20 @@ permissions: # least privileges, see https://docs.github.com/en/actions/using-wo
   contents: read
 
 jobs:
+  prepare:
+    name: generate runner list
+    runs-on: ubuntu-22.04
+    outputs:
+      runnerlist: ${{ steps.get-runnerlist.outputs.runnerlist }}
+    steps:
+      - run: sudo apt-get update && sudo apt-get -y install jo
+      - id: get-runnerlist
+        run: echo "runnerlist=$(jo -a ubuntu-22.04 ${{ vars.ARM64_USE_UBICLOUD == '1' && 'ubicloud-standard-2-arm' || '' }})" >> "$GITHUB_OUTPUT"
+
   build:
     name: build.sh
     if: ${{ vars.SCHEDULED_JOBS_BUILDER }}
+    needs: prepare
     runs-on: ${{ matrix.runner-os }}
     strategy:
       matrix:
@@ -33,9 +44,7 @@ jobs:
           - debian-bookworm
           - debian-trixie
           - amazon-2023
-        runner-os:
-          - ubuntu-22.04
-          - ubicloud-standard-2-arm
+        runner-os: ${{ fromJson(needs.prepare.outputs.runnerlist )}}
         exclude:
           - os: el-7
             runner-os: ubicloud-standard-2-arm


### PR DESCRIPTION
### Short description
Use the variable `ARM64_USE_UBICLOUD='1'` to enable using arm64 runners on Ubicloud when building images or packages. This avoids errors when running these workflows on forks.

**NOTE**: Please add the variable `ARM64_USE_UBICLOUD='1'` into the repository configuration before merging.

Test build packages with arm64 runners not available (variable unset):
- Builder: [https://github.com/romeroalx/pdns/actions/runs/11404844261](https://github.com/romeroalx/pdns/actions/runs/11404844261)
- Build packages: [https://github.com/romeroalx/pdns/actions/runs/11404844315](https://github.com/romeroalx/pdns/actions/runs/11404844315)

Test build packages with arm64 runners available (`ARM64_USE_UBICLOUD='1'):
- Builder: [https://github.com/romeroalx/pdns/actions/runs/11407238715](https://github.com/romeroalx/pdns/actions/runs/11407238715)
- Build packages: [https://github.com/romeroalx/pdns/actions/runs/11407238797](https://github.com/romeroalx/pdns/actions/runs/11407238797)

Test build images multi-platform, amd64 only, and arm64 only: [https://github.com/romeroalx/pdns/actions/runs/11416688159](https://github.com/romeroalx/pdns/actions/runs/11416688159)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
