### PR TITLE
dnsdist: stop using makeRule, update Qname to QName so links should work

### DIFF
--- a/pdns/dnsdistdist/docs/advanced/axfr.rst
+++ b/pdns/dnsdistdist/docs/advanced/axfr.rst
@@ -21,7 +21,7 @@ The first issue can be solved by routing SOA, AXFR and IXFR requests explicitly 
 The second one might require allowing AXFR/IXFR from the :program:`dnsdist` source address
 and moving the source address check to :program:`dnsdist`'s side::
 
-  addAction(AndRule({OrRule({QTypeRule(DNSQType.AXFR), QTypeRule(DNSQType.IXFR)}), NotRule(makeRule("192.168.1.0/24"))}), RCodeAction(DNSRCode.REFUSED))
+  addAction(AndRule({OrRule({QTypeRule(DNSQType.AXFR), QTypeRule(DNSQType.IXFR)}), NotRule(NetmaskGroupRule("192.168.1.0/24"))}), RCodeAction(DNSRCode.REFUSED))
 
 .. versionchanged:: 1.4.0
   Before 1.4.0, the QTypes were in the ``dnsdist`` namespace. Use ``dnsdist.AXFR`` and ``dnsdist.IXFR`` in these versions.
@@ -55,7 +55,7 @@ and not the primary's one. One way to fix this issue is to allow NOTIFY from the
 address on the secondary side (for example with PowerDNS's `trusted-notification-proxy`) and move the address
 check to :program:`dnsdist`'s side::
 
-  addAction(AndRule({OpcodeRule(DNSOpcode.Notify), NotRule(makeRule("192.168.1.0/24"))}), RCodeAction(DNSRCode.REFUSED))
+  addAction(AndRule({OpcodeRule(DNSOpcode.Notify), NotRule(NetmaskGroupRule("192.168.1.0/24"))}), RCodeAction(DNSRCode.REFUSED))
 
 .. versionchanged:: 1.4.0
   Before 1.4.0, the RCodes were in the ``dnsdist`` namespace. Use ``dnsdist.REFUSED`` in these versions.

--- a/pdns/dnsdistdist/docs/advanced/ebpf.rst
+++ b/pdns/dnsdistdist/docs/advanced/ebpf.rst
@@ -43,7 +43,7 @@ The :meth:`BPFFilter:blockQName` method can be used to block queries based on th
 Using the 255 (ANY) qtype will block all queries for the qname, regardless of the qtype.
 Contrary to source address filtering, qname filtering only works over UDP. TCP qname filtering can be done the usual way::
 
-  addAction(AndRule({TCPRule(true), makeRule("evildomain.com")}), DropAction())
+  addAction(AndRule({TCPRule(true), QNameSuffixRule("evildomain.com")}), DropAction())
 
 The :meth:`BPFFilter:attachToAllBinds` method attaches the filter to every existing bind at runtime. It cannot use at configuration time. The :func:`setDefaultBPFFilter()` should be used at configuration time.
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -266,7 +266,7 @@ This state can be modified from the various hooks.
         dq:setContent(raw)
         return DNSAction.Allow
       end
-      addAction(AndRule({QTypeRule(DNSQType.A), makeRule('custom.async.tests.powerdns.com')}), LuaAction(replaceQueryPayload))
+      addAction(AndRule({QTypeRule(DNSQType.A), QNameSuffixRule('custom.async.tests.powerdns.com')}), LuaAction(replaceQueryPayload))
 
     :param string data: The raw DNS payload
 

--- a/pdns/dnsdistdist/docs/reference/rules-management.rst
+++ b/pdns/dnsdistdist/docs/reference/rules-management.rst
@@ -587,7 +587,7 @@ Convenience Functions
 .. function:: makeRule(rule)
 
   .. versionchanged:: 1.9.0
-    This function is deprecated, please use :func:`NetmaskGroupRule` or :func:`QnameSuffixRule` instead
+    This function is deprecated, please use :func:`NetmaskGroupRule` or :func:`QNameSuffixRule` instead
 
   Make a :func:`NetmaskGroupRule` or a :func:`SuffixMatchNodeRule`, depending on how it is called.
   The `rule` parameter can be a string, or a list of strings, that should contain either:


### PR DESCRIPTION
### Short description

update docs to use non-deprecated examples

### Checklist

- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
