### PR TITLE
rec: Backport 14766 to rec 5.1.x: bump SNMP ignore from buster to bookworm after buildbot VM upgrade 

### DIFF
--- a/build-scripts/test-recursor
+++ b/build-scripts/test-recursor
@@ -17,7 +17,7 @@ fi
 set -x
 
 EXTRA_ARG=""
-if [ $PWD = /srv/buildbot-worker/test-rec-debian-buster/build ]; then
+if [ $PWD = /srv/buildbot-worker/test-rec-debian-bookworm/build ]; then
     EXTRA_ARG=--ignore=test_SNMP.py
 fi
 


### PR DESCRIPTION
(cherry picked from commit 32ac2627fad9d398756c6ec05ae423eec22eff7e)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
