### PR TITLE
rec: make valgrind build and testrunner run work again

### DIFF
--- a/pdns/recursordist/mtasker.hh
+++ b/pdns/recursordist/mtasker.hh
@@ -373,8 +373,7 @@ std::shared_ptr<pdns_ucontext_t> MTasker<Key, Val, Cmp>::getUContext()
   ucontext->uc_link = &d_kernel; // come back to kernel after dying
 
 #ifdef PDNS_USE_VALGRIND
-  uc->valgrind_id = VALGRIND_STACK_REGISTER(&uc->uc_stack[0],
-                                            &uc->uc_stack[uc->uc_stack.size() - 1]);
+  ucontext->valgrind_id = VALGRIND_STACK_REGISTER(&ucontext->uc_stack[0], &ucontext->uc_stack[ucontext->uc_stack.size() - 1]);
 #endif /* PDNS_USE_VALGRIND */
 
   return ucontext;

--- a/pdns/recursordist/test-rec-tcounters_cc.cc
+++ b/pdns/recursordist/test-rec-tcounters_cc.cc
@@ -76,6 +76,7 @@ BOOST_AUTO_TEST_CASE(update_fast)
       BOOST_CHECK_EQUAL(counts.uint64Count[0], counts.uint64Count[1]);
       auto avg = counts.at(rec::DoubleWAvgCounter::avgLatencyUsec).avg;
       BOOST_CHECK(avg == 0.0 || (avg >= 1.1 && avg <= 2.2));
+      std::this_thread::yield(); // needed, as otherwise the updates to done might not be spotted under valgrind
     }
   });
   thread1.join();

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -215,6 +215,7 @@ void initSR(bool debug)
 
   g_dnssecmode = DNSSECMode::Off;
   g_maxNSEC3Iterations = 2500;
+  g_signatureInceptionSkew = 60;
 
   g_aggressiveNSECCache.reset();
   AggressiveNSECCache::s_maxNSEC3CommonPrefix = AggressiveNSECCache::s_default_maxNSEC3CommonPrefix;


### PR DESCRIPTION
The testrunner run becomes very slow, a non-zero inception skew is needed.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
