### PR TITLE
rec: drop ref in mtasker when it is no longer needed

### DIFF
--- a/pdns/recursordist/mtasker.hh
+++ b/pdns/recursordist/mtasker.hh
@@ -181,7 +181,7 @@ private:
   size_t d_maxCachedStacks{0};
   int d_tid{0};
   int d_maxtid{0};
-  bool d_used{false}; // was d_eventkey consumed?
+  bool d_used{true}; // was d_eventkey consumed?
   enum waitstatusenum : int8_t
   {
     Error = -1,

--- a/pdns/recursordist/mtasker.hh
+++ b/pdns/recursordist/mtasker.hh
@@ -344,7 +344,7 @@ int MTasker<EventKey, EventVal, Cmp>::sendEvent(const EventKey& key, const Event
     d_waitval = *val;
   }
   d_tid = waiter->tid; // set tid
-  d_eventkey = std::move(waiter->key); // pass waitEvent the exact key it was woken for
+  d_eventkey = waiter->key; // pass waitEvent the exact key it was woken for
   d_used = false;
   auto userspace = std::move(waiter->context);
   d_waiters.erase(waiter); // removes the waitpoint
@@ -464,7 +464,7 @@ bool MTasker<Key, Val, Cmp>::schedule(const struct timeval& now)
     for (auto i = ttdindex.begin(); i != ttdindex.end();) {
       if (i->ttd.tv_sec && i->ttd < now) {
         d_waitstatus = TimeOut;
-        d_eventkey = std::move(i->key); // pass waitEvent the exact key it was woken for
+        d_eventkey = i->key; // pass waitEvent the exact key it was woken for
         d_used = false;
         auto ucontext = i->context;
         d_tid = i->tid;

--- a/pdns/recursordist/mtasker.hh
+++ b/pdns/recursordist/mtasker.hh
@@ -299,7 +299,7 @@ int MTasker<EventKey, EventVal, Cmp>::waitEvent(EventKey& key, EventVal* val, un
   d_threads[d_tid].dt.start();
 #endif
   if (val && d_waitstatus == Answer) {
-    *val = d_waitval;
+    *val = std::move(d_waitval);
   }
   d_tid = waiter.tid;
   if ((char*)&waiter < d_threads[d_tid].highestStackSeen) {

--- a/pdns/recursordist/mtasker.hh
+++ b/pdns/recursordist/mtasker.hh
@@ -305,7 +305,7 @@ int MTasker<EventKey, EventVal, Cmp>::waitEvent(EventKey& key, EventVal* val, un
   if ((char*)&waiter < d_threads[d_tid].highestStackSeen) {
     d_threads[d_tid].highestStackSeen = (char*)&waiter;
   }
-  key = d_eventkey;
+  key = std::move(d_eventkey);
   return d_waitstatus;
 }
 

--- a/pdns/recursordist/mtasker_context.hh
+++ b/pdns/recursordist/mtasker_context.hh
@@ -30,6 +30,8 @@ struct pdns_ucontext_t
   pdns_ucontext_t();
   pdns_ucontext_t(pdns_ucontext_t const&) = delete;
   pdns_ucontext_t& operator=(pdns_ucontext_t const&) = delete;
+  pdns_ucontext_t(pdns_ucontext_t &&) = delete;
+  pdns_ucontext_t& operator=(pdns_ucontext_t &&) = delete;
   ~pdns_ucontext_t();
 
   void* uc_mcontext;

--- a/pdns/recursordist/mtasker_context.hh
+++ b/pdns/recursordist/mtasker_context.hh
@@ -30,8 +30,8 @@ struct pdns_ucontext_t
   pdns_ucontext_t();
   pdns_ucontext_t(pdns_ucontext_t const&) = delete;
   pdns_ucontext_t& operator=(pdns_ucontext_t const&) = delete;
-  pdns_ucontext_t(pdns_ucontext_t &&) = delete;
-  pdns_ucontext_t& operator=(pdns_ucontext_t &&) = delete;
+  pdns_ucontext_t(pdns_ucontext_t&&) = delete;
+  pdns_ucontext_t& operator=(pdns_ucontext_t&&) = delete;
   ~pdns_ucontext_t();
 
   void* uc_mcontext;

--- a/pdns/recursordist/test-mtasker.cc
+++ b/pdns/recursordist/test-mtasker.cc
@@ -48,6 +48,84 @@ BOOST_AUTO_TEST_CASE(test_Simple)
   BOOST_CHECK_EQUAL(events.size(), 0U);
 }
 
+struct MTKey
+{
+  int key;
+  shared_ptr<int> ptr;
+
+  bool operator<(const MTKey& /* b */) const
+  {
+    // We don't want explicit PacketID compare here, but always via predicate class below
+    assert(0); // NOLINT: lib
+  }
+};
+
+struct MTKeyCompare
+{
+  bool operator()(const std::shared_ptr<MTKey>& lhs, const std::shared_ptr<MTKey>& rhs) const
+  {
+    return lhs->key < rhs->key;
+  }
+};
+
+using KeyMT_t = MTasker<std::shared_ptr<MTKey>, int, MTKeyCompare>;
+
+// Test the case of #14807
+static void doSomethingKey(void* ptr)
+{
+  auto* multiTasker = reinterpret_cast<KeyMT_t*>(ptr); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto key = std::make_shared<MTKey>();
+  key->key = 12;
+  key->ptr = std::make_shared<int>(13);
+  BOOST_CHECK_EQUAL(key.use_count(), 1U);
+  BOOST_CHECK_EQUAL(key->ptr.use_count(), 1U);
+  int value = 0;
+  if (multiTasker->waitEvent(key, &value) == 1) {
+    g_result = value;
+  }
+  BOOST_CHECK_EQUAL(key.use_count(), 1U);
+  BOOST_CHECK_EQUAL(key->key, 12);
+  BOOST_REQUIRE(key->ptr != nullptr);
+  BOOST_CHECK_EQUAL(key->ptr.use_count(), 1U);
+  BOOST_CHECK_EQUAL(*key->ptr, 13);
+}
+
+BOOST_AUTO_TEST_CASE(test_SharedPointer)
+{
+  g_result = 0;
+  KeyMT_t multiTasker;
+  multiTasker.makeThread(doSomethingKey, &multiTasker);
+  timeval now{};
+  gettimeofday(&now, nullptr);
+  bool first = true;
+  int value = 24;
+  auto key = std::make_shared<MTKey>();
+  key->key = 12;
+  key->ptr = std::make_shared<int>(1);
+  BOOST_CHECK_EQUAL(key->ptr.use_count(), 1U);
+  for (;;) {
+    while (multiTasker.schedule(now)) {
+    }
+
+    if (first) {
+      multiTasker.sendEvent(key, &value);
+      BOOST_CHECK_EQUAL(key.use_count(), 1U);
+      BOOST_CHECK_EQUAL(key->ptr.use_count(), 1U);
+      first = false;
+    }
+    if (multiTasker.noProcesses()) {
+      break;
+    }
+  }
+  BOOST_CHECK_EQUAL(g_result, value);
+  vector<std::shared_ptr<MTKey>> events;
+  multiTasker.getEvents(events);
+  BOOST_CHECK_EQUAL(events.size(), 0U);
+  BOOST_CHECK_EQUAL(key.use_count(), 1U);
+  BOOST_CHECK_EQUAL(key->ptr.use_count(), 1U);
+  BOOST_CHECK_EQUAL(*key->ptr, 1);
+}
+
 static const size_t stackSize = 8 * 1024;
 static const size_t headroom = 1536; // Decrease to hit stackoverflow
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

If we do not do that, only the next call of `sendEvent` will release
the shared pointer to the `TCPConnectionHandler` in `PacketID` as it overwrites `d_eventkey`. Same for `d_waitval`. This
might delay cleaning TCP objects up on not-so-busy threads.

Fixes https://github.com/PowerDNS/pdns/issues/13422, thought it can still take a while on idle recursors,
as the housekeeping function is not called often in those cases.

Added a simple mechanism to make sure `d_eventkey` is not used when it is not set yet or after being moved.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
