### PR TITLE
rec: periodic stats cleanup and fix of outqueries-per-query to not be a percentage

### DIFF
--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -2117,8 +2117,6 @@ bool checkForCacheHit(bool qnameParsed, unsigned int tag, const string& data,
       }
     }
 
-    t_Counters.at(rec::Counter::packetCacheHits)++;
-    t_Counters.at(rec::Counter::syncresqueries)++; // XXX
     if (response.length() >= sizeof(struct dnsheader)) {
       dnsheader_aligned dh_aligned(response.data());
       ageDNSPacket(response, age, dh_aligned);

--- a/pdns/recursordist/rec-tcounters.hh
+++ b/pdns/recursordist/rec-tcounters.hh
@@ -37,7 +37,6 @@ namespace rec
 // Simple counters
 enum class Counter : uint8_t
 {
-  syncresqueries,
   outgoingtimeouts,
   outgoing4timeouts,
   outgoing6timeouts,
@@ -79,7 +78,6 @@ enum class Counter : uint8_t
   ednsPingMismatches,
   noPingOutQueries,
   noEdnsOutQueries,
-  packetCacheHits,
   noPacketError,
   ignoredCount,
   emptyQueriesCount,

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -764,7 +764,6 @@ bool SyncRes::addAdditionals(QType qtype, vector<DNSRecord>& ret, unsigned int d
 int SyncRes::beginResolve(const DNSName& qname, const QType qtype, QClass qclass, vector<DNSRecord>& ret, unsigned int depth)
 {
   d_eventTrace.add(RecEventTrace::SyncRes);
-  t_Counters.at(rec::Counter::syncresqueries)++;
   d_wasVariable = false;
   d_wasOutOfBand = false;
   d_cutStates.clear();


### PR DESCRIPTION
Also
    - cleans up two TCounters that where unused and/or redundant.
    - group the log lines more naturally
    - print doubles with two decimal places

Needs an upgrade guide entry for `outqueries-per-query`.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
