### PR TITLE
Add dnsdist documentation example for using DoH behind nginx

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -531,6 +531,7 @@ gpgsqlbackend
 gprof
 gpsqlbackend
 grepq
+grpcs
 GSQ
 gsql
 gsqlite
@@ -1009,7 +1010,6 @@ otherdomain
 otherpool
 ourname
 ourserial
-ourtime
 outpacket
 outputbuffer
 outqueries

--- a/pdns/dnsdistdist/docs/guides/dns-over-https.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-https.rst
@@ -80,8 +80,8 @@ For nginx in particular, a possible work-around is to use the `grpc_pass <http:/
   location /dns-query {
     set $upstream_app dnsdist;
     set $upstream_port 443;
-    set $upstream_proto grpc;
-    grpc_pass grpcs://$upstream_app:$upstream_port;
+    set $upstream_proto grpcs;
+    grpc_pass $upstream_proto://$upstream_app:$upstream_port;
 
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/pdns/dnsdistdist/docs/guides/dns-over-https.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-https.rst
@@ -74,7 +74,26 @@ preferred library for incoming DoH support, because ``h2o`` has unfortunately re
 (see https://github.com/h2o/h2o/issues/3230). While we took great care to make the migration as painless as possible, ``h2o`` supported HTTP/1 while ``nghttp2``
 does not. This is not an issue for actual DNS over HTTPS clients that support HTTP/2, but might be one in setups running dnsdist behind a reverse-proxy that
 does not support HTTP/2, like nginx. We do not plan on implementing HTTP/1, and recommend using HTTP/2 between the reverse-proxy and dnsdist for performance reasons.
-For nginx in particular, a possible work-around is to use the `grpc_pass <http://nginx.org/r/grpc_pass>`_ directive as suggested in their `bug tracker <https://trac.nginx.org/nginx/ticket/1875>`_.
+
+For nginx in particular, a possible work-around is to use the `grpc_pass <http://nginx.org/r/grpc_pass>`_ directive as suggested in their `bug tracker <https://trac.nginx.org/nginx/ticket/1875>`_ e.g.::
+
+  location /dns-query {
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app dnsdist;
+    set $upstream_port 443;
+    set $upstream_proto grpc;
+    grpc_pass grpcs://$upstream_app:$upstream_port;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Protocol $scheme;
+    proxy_set_header Range $http_range;
+    proxy_set_header If-Range $http_if_range;
+  }
 
 Internal design
 ^^^^^^^^^^^^^^^

--- a/pdns/dnsdistdist/docs/guides/dns-over-https.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-https.rst
@@ -78,8 +78,6 @@ does not support HTTP/2, like nginx. We do not plan on implementing HTTP/1, and 
 For nginx in particular, a possible work-around is to use the `grpc_pass <http://nginx.org/r/grpc_pass>`_ directive as suggested in their `bug tracker <https://trac.nginx.org/nginx/ticket/1875>`_ e.g.::
 
   location /dns-query {
-    include /config/nginx/proxy.conf;
-    include /config/nginx/resolver.conf;
     set $upstream_app dnsdist;
     set $upstream_port 443;
     set $upstream_proto grpc;


### PR DESCRIPTION
### Short description
This small documentation change updates dnsdist with an example nginx configuration, for running DoH with the grpc_pass directive. Closes #14815 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
