### PR TITLE
rec: use a more generous timeout for a test using external servers

### DIFF
--- a/regression-tests.recursor-dnssec/test_SimpleDoT.py
+++ b/regression-tests.recursor-dnssec/test_SimpleDoT.py
@@ -35,7 +35,8 @@ devonly-regression-test-mode
         query = dns.message.make_query('dot-test-target.powerdns.org', 'TXT', want_dnssec=True)
         query.flags |= dns.flags.AD
 
-        res = self.sendUDPQuery(query)
+        # As this test uses external servers, be a more generous wrt timeouts than the default 2.0s
+        res = self.sendUDPQuery(query, timeout=5.0)
 
         self.assertMessageIsAuthenticated(res)
         self.assertRRsetInAnswer(res, expected)


### PR DESCRIPTION
Other tests using external servers already use 5s

Should fix #14829 in many cases.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
