### PR TITLE
dnsdist: Fix two broken Lua directives

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -910,10 +910,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     {"setWeightedBalancingFactor", [](dnsdist::configuration::ImmutableConfiguration& config, double newValue) { config.d_weightedBalancingFactor = newValue; }, 1.0},
   };
 
-  for (const auto& item : booleanConfigItems) {
+  for (const auto& item : booleanImmutableConfigItems) {
     luaCtx.writeFunction(item.name, [&item](bool value) {
       try {
-        dnsdist::configuration::updateRuntimeConfiguration([value, &item](dnsdist::configuration::RuntimeConfiguration& config) {
+        dnsdist::configuration::updateImmutableConfiguration([value, &item](dnsdist::configuration::ImmutableConfiguration& config) {
           item.mutator(config, value);
         });
       }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #14036 

These two directives were no longer recognized on master:
- `setRandomizedIdsOverUDP`
- `setRandomizedOutgoingSockets`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
