### PR TITLE
rec: fix coverity 1564914 (afaiks harmless)

### DIFF
--- a/pdns/recursordist/rec-xfr.hh
+++ b/pdns/recursordist/rec-xfr.hh
@@ -48,8 +48,8 @@ struct ZoneXFRParams
   TSIGTriplet tsigtriplet;
   size_t maxReceivedMBytes{0};
   size_t zoneSizeHint{0};
-  size_t zoneIdx;
-  uint32_t refreshFromConf;
+  size_t zoneIdx{0};
+  uint32_t refreshFromConf{0};
   uint16_t xfrTimeout{20};
 };
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

The coverity report is about zoneIdx, but it is always initialized in rec-main.cc before being used. Still having no initialized fields is better in general.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
