### PR TITLE
rec: better fd count estimates and move default incoming.max_tcp_client to 1024 

### DIFF
--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -2677,7 +2677,7 @@ static void handleNewUDPQuestion(int fileDesc, FDMultiplexer::funcparam_t& /* va
   t_Counters.updateSnap(g_regressionTestMode);
 }
 
-void makeUDPServerSockets(deferredAdd_t& deferredAdds, Logr::log_t log)
+unsigned int makeUDPServerSockets(deferredAdd_t& deferredAdds, Logr::log_t log)
 {
   int one = 1;
   vector<string> localAddresses;
@@ -2769,6 +2769,7 @@ void makeUDPServerSockets(deferredAdd_t& deferredAdds, Logr::log_t log)
     SLOG(g_log << Logger::Info << "Listening for UDP queries on " << address.toStringWithPort() << endl,
          log->info(Logr::Info, "Listening for queries", "proto", Logging::Loggable("UDP"), "address", Logging::Loggable(address)));
   }
+  return localAddresses.size();
 }
 
 static bool trySendingQueryToWorker(unsigned int target, ThreadMSG* tmsg)

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -615,10 +615,10 @@ bool expectProxyProtocol(const ComboAddress& from, const ComboAddress& listenAdd
 void finishTCPReply(std::unique_ptr<DNSComboWriter>&, bool hadError, bool updateInFlight);
 void checkFastOpenSysctl(bool active, Logr::log_t);
 void checkTFOconnect(Logr::log_t);
-void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcpSockets, Logr::log_t);
+unsigned int makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcpSockets, Logr::log_t);
 void handleNewTCPQuestion(int fileDesc, FDMultiplexer::funcparam_t&);
 
-void makeUDPServerSockets(deferredAdd_t& deferredAdds, Logr::log_t);
+unsigned int makeUDPServerSockets(deferredAdd_t& deferredAdds, Logr::log_t);
 string doTraceRegex(FDWrapper file, vector<string>::const_iterator begin, vector<string>::const_iterator end);
 extern bool g_luaSettingsInYAML;
 void startLuaConfigDelayedThreads(const LuaConfigItems& luaConfig, uint64_t generation);

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -1085,7 +1085,7 @@ LWResult::Result arecvtcp(PacketBuffer& data, const size_t len, shared_ptr<TCPIO
   return LWResult::Result::Success;
 }
 
-void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcpSockets, Logr::log_t log)
+unsigned int makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcpSockets, Logr::log_t log)
 {
   vector<string> localAddresses;
   stringtok(localAddresses, ::arg()["local-address"], " ,");
@@ -1192,4 +1192,5 @@ void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcpSockets
     first = false;
 #endif
   }
+  return localAddresses.size();
 }

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -1656,11 +1656,12 @@ If :ref:`setting-qname-minimization` is enabled, the fallback code in case of a 
         'name' : 'max_tcp_clients',
         'section' : 'incoming',
         'type' : LType.Uint64,
-        'default' : '128',
+        'default' : '1024',
         'help' : 'Maximum number of simultaneous TCP clients',
         'doc' : '''
 Maximum number of simultaneous incoming TCP connections allowed.
  ''',
+        'versionchanged': ('5.2.0', 'Before 5.2.0 the default was 128.'),
     },
     {
         'name' : 'max_tcp_per_client',
@@ -1670,7 +1671,7 @@ Maximum number of simultaneous incoming TCP connections allowed.
         'help' : 'If set, maximum number of TCP sessions per client (IP address)',
         'doc' : '''
 Maximum number of simultaneous incoming TCP connections allowed per client (remote IP address).
- 0 means unlimited.
+0 means unlimited.
  ''',
     },
     {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Make a clear distinction between the various types of use of file descriptors. Some are static, some depend on the number of mthreads active, some on the number of posix threads.

As we already are reserving  max mthreads (2048) times workers (2 UDP + 1 TCP)) by default, I think we can bump max_tcp_clients  to 1024 without special precautions, apart from taking into account max_tcp_clients when computing the maximum number of FDs used. The current number already is > 6k. An extra 1k isn't that big of a deal. This number is then used to potentially reduce max mthreads.

I checked the numbers against the actual number seen on a running recursor, adding FDs for pipes and other assorted stuff which weren't included previously.

Fixes the last part of #14533.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
