### PR TITLE
dnsdist: add elapsed time to dq object

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
@@ -168,6 +168,10 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
     return dnsQuestion.ids.queryRealTime.getStartTime();
   });
 
+  luaCtx.registerFunction<double (DNSQuestion::*)() const>("getElapsedUs", [](const DNSQuestion& dnsQuestion) {
+    return dnsQuestion.ids.queryRealTime.udiff();
+  });
+
   luaCtx.registerFunction<void (DNSQuestion::*)(std::string)>("sendTrap", [](const DNSQuestion& dnsQuestion, boost::optional<std::string> reason) {
 #ifdef HAVE_NET_SNMP
     if (g_snmpAgent != nullptr && dnsdist::configuration::getCurrentRuntimeConfiguration().d_snmpTrapsEnabled) {
@@ -493,6 +497,10 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
 
   luaCtx.registerFunction<timespec (DNSResponse::*)() const>("getQueryTime", [](const DNSResponse& dnsResponse) {
     return dnsResponse.ids.queryRealTime.getStartTime();
+  });
+
+  luaCtx.registerFunction<double (DNSResponse::*)() const>("getElapsedUs", [](const DNSResponse& dnsResponse) {
+    return dnsResponse.ids.queryRealTime.udiff();
   });
 
   luaCtx.registerFunction<void (DNSResponse::*)(std::string)>("sendTrap", [](const DNSResponse& dnsResponse, boost::optional<std::string> reason) {

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -131,6 +131,14 @@ This state can be modified from the various hooks.
 
     :returns: A table of EDNSOptionView objects, indexed on the ECS Option code
 
+  .. method:: DNSQuestion::getElapsedUs -> double
+
+     .. versionadded:: 2.0.0
+
+     Return the amount of time that has elapsed since the query was received.
+
+     :returns: A double indicating elapsed time in microseconds
+
   .. method:: DNSQuestion:getHTTPHeaders() -> table
 
     .. versionadded:: 1.4.0


### PR DESCRIPTION
### Short description
FFI seems to have this already.

Not sure if there is a reason not to include it in the normal Lua bindings?

Use case: want to easily check how much time has been spent so far, to decide if query should be replayed or not. 

```Lua
function result(dq)
        warnlog("query elapsed time is " .. dq:getElapsedUs() .. " us")
 
        return DNSResponseAction.None
end
 

addAction(AllRule(), LuaAction(result))
addResponseAction(AllRule(),LuaResponseAction(result))

addLocal("127.0.0.1:5454")
newServer({address="8.8.8.8"})
```

```
query elapsed time is 69.56 us
query elapsed time is 34759.856 us
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
