### PR TITLE
rec: fix serial number inconsistency for RPZ dumpfiles

### DIFF
--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -272,6 +272,10 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord>>> getIXFRDeltas(const ComboAddr
           // we are up to date
           return ret;
         }
+        if(soaRecord->d_st.serial < getRR<SOARecordContent>(oursr)->d_st.serial) {
+          // we have a higher SOA than the auth? Should not happen, but what can we do?
+          throw std::runtime_error("Our serial is higher than remote one for zone '" + zone.toLogString() + "' from primary '" + primary.toStringWithPort() + "': ours " + std::to_string(getRR<SOARecordContent>(oursr)->d_st.serial) + " theirs " + std::to_string(soaRecord->d_st.serial));
+        }
         primarySOA = std::move(soaRecord);
         ++primarySOACount;
       } else if (r.d_type == QType::SOA) {

--- a/pdns/recursordist/filterpo.hh
+++ b/pdns/recursordist/filterpo.hh
@@ -374,6 +374,10 @@ public:
     {
       return d_serial;
     }
+    [[nodiscard]] const DNSRecord& getSOA() const
+    {
+      return d_zoneData->d_soa;
+    }
 
     [[nodiscard]] size_t size() const
     {

--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -432,7 +432,7 @@ e 3600 IN A 192.0.2.42
             # if the above call did not throw an exception the SOA has the right owner, continue
             soa = zone.get_soa()
             if soa.serial == serial and soa.mname == dns.name.from_text('ns.zone.rpz.'):
-                return # we foiund what we expected
+                return # we found what we expected
             attempts = attempts + incr
             time.sleep(incr)
         raise AssertionError("Waited %d seconds for the dumpfile to be updated to %d but the serial is still %d" % (timeout, serial, soa.serial))


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

There is a double bookkeeping going on for RPZs. An RPZ has an internal serial number, but also stores a SOA, which has its own serial. #14471 attempted to dump the real SOA into the dumpFile, but it was only partially correct. Consequence is that after a restart or `rec_control reload-lua-config` rec would present an older than previous serial (read from the dumpFile) to the auth server, which in most cases would respond with a full zone. After that the serial would be right, only the dumpFile would contain the wrong serial.

This adds consistency checking, a regression test and as an extra also gives a better error message if our serial is *higher* than the auths one. Previously we would report an exception that the auth has closed the connection.

Fixes #14857

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
