### PR TITLE
fix register type race

### DIFF
--- a/modules/remotebackend/test-remotebackend-pipe.cc
+++ b/modules/remotebackend/test-remotebackend-pipe.cc
@@ -79,10 +79,7 @@ struct RemotebackendSetup
       ::arg().set("remote-connection-string") = "pipe:command=unittest_pipe.py";
       ::arg().set("remote-dnssec") = "yes";
       backendUnderTest = std::move(BackendMakers().all()[0]);
-      // load few record types to help out
-      SOARecordContent::report();
-      NSRecordContent::report();
-      ARecordContent::report();
+      reportAllTypes();
     }
     catch (PDNSException& ex) {
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);

--- a/modules/remotebackend/test-remotebackend-unix.cc
+++ b/modules/remotebackend/test-remotebackend-unix.cc
@@ -79,10 +79,7 @@ struct RemotebackendSetup
       ::arg().set("remote-connection-string") = "unix:path=/tmp/remotebackend.sock";
       ::arg().set("remote-dnssec") = "yes";
       backendUnderTest = std::move(BackendMakers().all()[0]);
-      // load few record types to help out
-      SOARecordContent::report();
-      NSRecordContent::report();
-      ARecordContent::report();
+      reportAllTypes();
     }
     catch (PDNSException& ex) {
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);

--- a/modules/remotebackend/test-remotebackend-zeromq.cc
+++ b/modules/remotebackend/test-remotebackend-zeromq.cc
@@ -81,10 +81,7 @@ struct RemotebackendSetup
       ::arg().set("remote-connection-string") = "zeromq:endpoint=ipc:///tmp/remotebackend.0";
       ::arg().set("remote-dnssec") = "yes";
       backendUnderTest = std::move(BackendMakers().all()[0]);
-      // load few record types to help out
-      SOARecordContent::report();
-      NSRecordContent::report();
-      ARecordContent::report();
+      reportAllTypes();
     }
     catch (PDNSException& ex) {
       BOOST_TEST_MESSAGE("Cannot start remotebackend: " << ex.reason);

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -1210,6 +1210,7 @@ int main(int argc, char** argv)
 {
   versionSetProduct(ProductAuthoritative);
   reportAllTypes(); // init MOADNSParser
+  DNSRecordContent::lock();
 
   g_programname = "pdns";
   g_starttime = time(nullptr);

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -1210,7 +1210,6 @@ int main(int argc, char** argv)
 {
   versionSetProduct(ProductAuthoritative);
   reportAllTypes(); // init MOADNSParser
-  DNSRecordContent::lock();
 
   g_programname = "pdns";
   g_starttime = time(nullptr);

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -27,6 +27,8 @@
 #include "namespaces.hh"
 #include "noinitvector.hh"
 
+bool DNSRecordContent::d_locked{false};
+
 UnknownRecordContent::UnknownRecordContent(const string& zone)
 {
   // parse the input

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -27,7 +27,7 @@
 #include "namespaces.hh"
 #include "noinitvector.hh"
 
-bool DNSRecordContent::d_locked{false};
+std::atomic<bool> DNSRecordContent::d_locked{false};
 
 UnknownRecordContent::UnknownRecordContent(const string& zone)
 {
@@ -80,7 +80,7 @@ void UnknownRecordContent::toPacket(DNSPacketWriter& pw) const
   pw.xfrBlob(string(d_record.begin(),d_record.end()));
 }
 
-shared_ptr<DNSRecordContent> DNSRecordContent::deserialize(const DNSName& qname, uint16_t qtype, const string& serialized)
+shared_ptr<DNSRecordContent> DNSRecordContent::deserialize(const DNSName& qname, uint16_t qtype, const string& serialized, uint16_t qclass)
 {
   dnsheader dnsheader;
   memset(&dnsheader, 0, sizeof(dnsheader));
@@ -102,7 +102,7 @@ shared_ptr<DNSRecordContent> DNSRecordContent::deserialize(const DNSName& qname,
 
   struct dnsrecordheader drh;
   drh.d_type=htons(qtype);
-  drh.d_class=htons(QClass::IN);
+  drh.d_class=htons(qclass);
   drh.d_ttl=0;
   drh.d_clen=htons(serialized.size());
 
@@ -114,7 +114,7 @@ shared_ptr<DNSRecordContent> DNSRecordContent::deserialize(const DNSName& qname,
   }
 
   DNSRecord dr;
-  dr.d_class = QClass::IN;
+  dr.d_class = qclass;
   dr.d_type = qtype;
   dr.d_name = qname;
   dr.d_clen = serialized.size();

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -234,6 +234,7 @@ public:
 
   static void regist(uint16_t cl, uint16_t ty, makerfunc_t* f, zmakerfunc_t* z, const char* name)
   {
+    assert(!d_locked);
     if(f)
       getTypemap()[pair(cl,ty)]=f;
     if(z)
@@ -245,6 +246,7 @@ public:
 
   static void unregist(uint16_t cl, uint16_t ty)
   {
+    assert(!d_locked);
     auto key = pair(cl, ty);
     getTypemap().erase(key);
     getZmakermap().erase(key);
@@ -284,6 +286,11 @@ public:
 
   virtual uint16_t getType() const = 0;
 
+  static void lock()
+  {
+    d_locked = true;
+  }
+
 protected:
   typedef std::map<std::pair<uint16_t, uint16_t>, makerfunc_t* > typemap_t;
   typedef std::map<std::pair<uint16_t, uint16_t>, zmakerfunc_t* > zmakermap_t;
@@ -293,6 +300,7 @@ protected:
   static t2namemap_t& getT2Namemap();
   static n2typemap_t& getN2Typemap();
   static zmakermap_t& getZmakermap();
+  static bool d_locked;
 };
 
 struct DNSRecord

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -234,7 +234,7 @@ public:
 
   static void regist(uint16_t cl, uint16_t ty, makerfunc_t* f, zmakerfunc_t* z, const char* name)
   {
-    assert(!d_locked);
+    assert(!d_locked); // NOLINT: it's the API
     if(f)
       getTypemap()[pair(cl,ty)]=f;
     if(z)
@@ -242,14 +242,6 @@ public:
 
     getT2Namemap().emplace(pair(cl, ty), name);
     getN2Typemap().emplace(name, pair(cl, ty));
-  }
-
-  static void unregist(uint16_t cl, uint16_t ty)
-  {
-    assert(!d_locked);
-    auto key = pair(cl, ty);
-    getTypemap().erase(key);
-    getZmakermap().erase(key);
   }
 
   static bool isUnknownType(const string& name)

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -458,8 +458,9 @@ boilerplate_conv(LP,
                  conv.xfrName(d_fqdn, false);)
 
 /* EUI48 start */
-void EUI48RecordContent::report()
+void EUI48RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
+  (void)guard;
   regist(1, QType::EUI48, &make, &make, "EUI48");
 }
 std::shared_ptr<DNSRecordContent> EUI48RecordContent::make(const DNSRecord &dr, PacketReader& pr)
@@ -502,8 +503,9 @@ string EUI48RecordContent::getZoneRepresentation(bool /* noDot */) const
 
 /* EUI64 start */
 
-void EUI64RecordContent::report()
+void EUI64RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
+  (void)guard;
   regist(1, QType::EUI64, &make, &make, "EUI64");
 }
 std::shared_ptr<DNSRecordContent> EUI64RecordContent::make(const DNSRecord &dr, PacketReader& pr)
@@ -548,8 +550,9 @@ string EUI64RecordContent::getZoneRepresentation(bool /* noDot */) const
 
 /* APL start */
 /* https://tools.ietf.org/html/rfc3123 */
-void APLRecordContent::report()
+void APLRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
+  (void)guard;
   regist(1, QType::APL, &make, &make, "APL");
 }
 
@@ -906,85 +909,91 @@ bool getEDNSOpts(const MOADNSParser& mdp, EDNSOpts* eo)
   return false;
 }
 
-void reportBasicTypes()
+static void reportBasicTypes(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
-  ARecordContent::report();
-  AAAARecordContent::report();
-  NSRecordContent::report();
-  CNAMERecordContent::report();
-  MXRecordContent::report();
-  SOARecordContent::report();
-  SRVRecordContent::report();
-  PTRRecordContent::report();
+  ARecordContent::report(guard);
+  AAAARecordContent::report(guard);
+  NSRecordContent::report(guard);
+  CNAMERecordContent::report(guard);
+  MXRecordContent::report(guard);
+  SOARecordContent::report(guard);
+  SRVRecordContent::report(guard);
+  PTRRecordContent::report(guard);
   DNSRecordContent::regist(QClass::CHAOS, QType::TXT, &TXTRecordContent::make, &TXTRecordContent::make, "TXT");
-  TXTRecordContent::report();
+  TXTRecordContent::report(guard);
 #ifdef HAVE_LUA_RECORDS
-  LUARecordContent::report();
+  LUARecordContent::report(guard);
 #endif
   DNSRecordContent::regist(QClass::IN, QType::ANY, nullptr, nullptr, "ANY");
   DNSRecordContent::regist(QClass::IN, QType::AXFR, nullptr, nullptr, "AXFR");
   DNSRecordContent::regist(QClass::IN, QType::IXFR, nullptr, nullptr, "IXFR");
 }
 
-void reportOtherTypes()
+static void reportOtherTypes(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
-   MBRecordContent::report();
-   MGRecordContent::report();
-   MRRecordContent::report();
-   AFSDBRecordContent::report();
-   DNAMERecordContent::report();
+   MBRecordContent::report(guard);
+   MGRecordContent::report(guard);
+   MRRecordContent::report(guard);
+   AFSDBRecordContent::report(guard);
+   DNAMERecordContent::report(guard);
 #if !defined(RECURSOR)
-   ALIASRecordContent::report();
+   ALIASRecordContent::report(guard);
 #endif
-   SPFRecordContent::report();
-   NAPTRRecordContent::report();
-   KXRecordContent::report();
-   LOCRecordContent::report();
-   ENTRecordContent::report();
-   HINFORecordContent::report();
-   RPRecordContent::report();
-   KEYRecordContent::report();
-   DNSKEYRecordContent::report();
-   DHCIDRecordContent::report();
-   CDNSKEYRecordContent::report();
-   RKEYRecordContent::report();
-   RRSIGRecordContent::report();
-   DSRecordContent::report();
-   CDSRecordContent::report();
-   SSHFPRecordContent::report();
-   CERTRecordContent::report();
-   NSECRecordContent::report();
-   NSEC3RecordContent::report();
-   NSEC3PARAMRecordContent::report();
-   TLSARecordContent::report();
-   SMIMEARecordContent::report();
-   OPENPGPKEYRecordContent::report();
-   SVCBRecordContent::report();
-   HTTPSRecordContent::report();
-   DLVRecordContent::report();
+   SPFRecordContent::report(guard);
+   NAPTRRecordContent::report(guard);
+   KXRecordContent::report(guard);
+   LOCRecordContent::report(guard);
+   ENTRecordContent::report(guard);
+   HINFORecordContent::report(guard);
+   RPRecordContent::report(guard);
+   KEYRecordContent::report(guard);
+   DNSKEYRecordContent::report(guard);
+   DHCIDRecordContent::report(guard);
+   CDNSKEYRecordContent::report(guard);
+   RKEYRecordContent::report(guard);
+   RRSIGRecordContent::report(guard);
+   DSRecordContent::report(guard);
+   CDSRecordContent::report(guard);
+   SSHFPRecordContent::report(guard);
+   CERTRecordContent::report(guard);
+   NSECRecordContent::report(guard);
+   NSEC3RecordContent::report(guard);
+   NSEC3PARAMRecordContent::report(guard);
+   TLSARecordContent::report(guard);
+   SMIMEARecordContent::report(guard);
+   OPENPGPKEYRecordContent::report(guard);
+   SVCBRecordContent::report(guard);
+   HTTPSRecordContent::report(guard);
+   DLVRecordContent::report(guard);
    DNSRecordContent::regist(QClass::ANY, QType::TSIG, &TSIGRecordContent::make, &TSIGRecordContent::make, "TSIG");
    DNSRecordContent::regist(QClass::ANY, QType::TKEY, &TKEYRecordContent::make, &TKEYRecordContent::make, "TKEY");
-   //TSIGRecordContent::report();
-   OPTRecordContent::report();
-   EUI48RecordContent::report();
-   EUI64RecordContent::report();
-   MINFORecordContent::report();
-   URIRecordContent::report();
-   CAARecordContent::report();
-   APLRecordContent::report();
-   IPSECKEYRecordContent::report();
-   CSYNCRecordContent::report();
-   NIDRecordContent::report();
-   L32RecordContent::report();
-   L64RecordContent::report();
-   LPRecordContent::report();
-   ZONEMDRecordContent::report();
+   //TSIGRecordContent::report(guard);
+   OPTRecordContent::report(guard);
+   EUI48RecordContent::report(guard);
+   EUI64RecordContent::report(guard);
+   MINFORecordContent::report(guard);
+   URIRecordContent::report(guard);
+   CAARecordContent::report(guard);
+   APLRecordContent::report(guard);
+   IPSECKEYRecordContent::report(guard);
+   CSYNCRecordContent::report(guard);
+   NIDRecordContent::report(guard);
+   L32RecordContent::report(guard);
+   L64RecordContent::report(guard);
+   LPRecordContent::report(guard);
+   ZONEMDRecordContent::report(guard);
 }
+
+struct ReportIsOnlyCallableByReportAllTypes
+{
+};
 
 void reportAllTypes()
 {
-  reportBasicTypes();
-  reportOtherTypes();
+  ReportIsOnlyCallableByReportAllTypes guard;
+  reportBasicTypes(guard);
+  reportOtherTypes(guard);
+  DNSRecordContent::lock();
 }
 
 ComboAddress getAddr(const DNSRecord& dr, uint16_t defport)

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -458,9 +458,8 @@ boilerplate_conv(LP,
                  conv.xfrName(d_fqdn, false);)
 
 /* EUI48 start */
-void EUI48RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
+void EUI48RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)
 {
-  (void)guard;
   regist(1, QType::EUI48, &make, &make, "EUI48");
 }
 std::shared_ptr<DNSRecordContent> EUI48RecordContent::make(const DNSRecord &dr, PacketReader& pr)
@@ -503,9 +502,8 @@ string EUI48RecordContent::getZoneRepresentation(bool /* noDot */) const
 
 /* EUI64 start */
 
-void EUI64RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
+void EUI64RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)
 {
-  (void)guard;
   regist(1, QType::EUI64, &make, &make, "EUI64");
 }
 std::shared_ptr<DNSRecordContent> EUI64RecordContent::make(const DNSRecord &dr, PacketReader& pr)
@@ -550,9 +548,8 @@ string EUI64RecordContent::getZoneRepresentation(bool /* noDot */) const
 
 /* APL start */
 /* https://tools.ietf.org/html/rfc3123 */
-void APLRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
+void APLRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)
 {
-  (void)guard;
   regist(1, QType::APL, &make, &make, "APL");
 }
 

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -37,7 +37,6 @@
 #define includeboilerplate(RNAME)   RNAME##RecordContent(const DNSRecord& dr, PacketReader& pr); \
   RNAME##RecordContent(const string& zoneData);                                                  \
   static void report(void);                                                                      \
-  static void unreport(void);                                                                    \
   static std::shared_ptr<DNSRecordContent> make(const DNSRecord &dr, PacketReader& pr);          \
   static std::shared_ptr<DNSRecordContent> make(const string& zonedata);                         \
   string getZoneRepresentation(bool noDot=false) const override;                                 \
@@ -1012,11 +1011,6 @@ void RNAME##RecordContent::report(void)                                         
 {                                                                                                  \
   regist(1, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);              \
   regist(254, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);            \
-}                                                                                                  \
-void RNAME##RecordContent::unreport(void)                                                          \
-{                                                                                                  \
-  unregist(1, QType::RNAME);                                                                              \
-  unregist(254, QType::RNAME);                                                                            \
 }                                                                                                  \
                                                                                                    \
 RNAME##RecordContent::RNAME##RecordContent(const string& zoneData)                                 \

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -1009,9 +1009,8 @@ void RNAME##RecordContent::toPacket(DNSPacketWriter& pw) const                  
   this->xfrPacket(pw);                                                                             \
 }                                                                                                  \
                                                                                                    \
-void RNAME##RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)               \
+void RNAME##RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)        \
 {                                                                                                  \
-  (void)guard;                                                                                     \
   regist(1, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);       \
   regist(254, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);     \
 }                                                                                                  \

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -34,9 +34,11 @@
 #include "iputils.hh"
 #include "svc-records.hh"
 
+struct ReportIsOnlyCallableByReportAllTypes;
+
 #define includeboilerplate(RNAME)   RNAME##RecordContent(const DNSRecord& dr, PacketReader& pr); \
   RNAME##RecordContent(const string& zoneData);                                                  \
-  static void report(void);                                                                      \
+  static void report(const ReportIsOnlyCallableByReportAllTypes& guard);                         \
   static std::shared_ptr<DNSRecordContent> make(const DNSRecord &dr, PacketReader& pr);          \
   static std::shared_ptr<DNSRecordContent> make(const string& zonedata);                         \
   string getZoneRepresentation(bool noDot=false) const override;                                 \
@@ -700,7 +702,7 @@ private:
 class NSECRecordContent : public DNSRecordContent
 {
 public:
-  static void report();
+  static void report(const ReportIsOnlyCallableByReportAllTypes& guard);
   NSECRecordContent() = default;
   NSECRecordContent(const string& content, const DNSName& zone=DNSName());
 
@@ -737,7 +739,7 @@ private:
 class NSEC3RecordContent : public DNSRecordContent
 {
 public:
-  static void report();
+  static void report(const ReportIsOnlyCallableByReportAllTypes& guard);
   NSEC3RecordContent() = default;
   NSEC3RecordContent(const string& content, const DNSName& zone=DNSName());
 
@@ -783,7 +785,7 @@ private:
 class CSYNCRecordContent : public DNSRecordContent
 {
 public:
-  static void report();
+  static void report(const ReportIsOnlyCallableByReportAllTypes& guard);
   CSYNCRecordContent() = default;
   CSYNCRecordContent(const string& content, const DNSName& zone=DNSName());
 
@@ -811,7 +813,7 @@ private:
 class NSEC3PARAMRecordContent : public DNSRecordContent
 {
 public:
-  static void report();
+  static void report(const ReportIsOnlyCallableByReportAllTypes& guard);
   NSEC3PARAMRecordContent() = default;
   NSEC3PARAMRecordContent(const string& content, const DNSName& zone=DNSName());
 
@@ -835,7 +837,7 @@ public:
 class LOCRecordContent : public DNSRecordContent
 {
 public:
-  static void report();
+  static void report(const ReportIsOnlyCallableByReportAllTypes& guard);
   LOCRecordContent() = default;
   LOCRecordContent(const string& content, const string& zone="");
 
@@ -899,7 +901,7 @@ class EUI48RecordContent : public DNSRecordContent
 {
 public:
   EUI48RecordContent() = default;
-  static void report();
+  static void report(const ReportIsOnlyCallableByReportAllTypes& guard);
   static std::shared_ptr<DNSRecordContent> make(const DNSRecord &dr, PacketReader& pr);
   static std::shared_ptr<DNSRecordContent> make(const string& zone); // FIXME400: DNSName& zone?
   string getZoneRepresentation(bool noDot=false) const override;
@@ -914,7 +916,7 @@ class EUI64RecordContent : public DNSRecordContent
 {
 public:
   EUI64RecordContent() = default;
-  static void report();
+  static void report(const ReportIsOnlyCallableByReportAllTypes& guard);
   static std::shared_ptr<DNSRecordContent> make(const DNSRecord &dr, PacketReader& pr);
   static std::shared_ptr<DNSRecordContent> make(const string& zone); // FIXME400: DNSName& zone?
   string getZoneRepresentation(bool noDot=false) const override;
@@ -1007,10 +1009,11 @@ void RNAME##RecordContent::toPacket(DNSPacketWriter& pw) const                  
   this->xfrPacket(pw);                                                                             \
 }                                                                                                  \
                                                                                                    \
-void RNAME##RecordContent::report(void)                                                            \
+void RNAME##RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)               \
 {                                                                                                  \
-  regist(1, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);              \
-  regist(254, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);            \
+  (void)guard;                                                                                     \
+  regist(1, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);       \
+  regist(254, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);     \
 }                                                                                                  \
                                                                                                    \
 RNAME##RecordContent::RNAME##RecordContent(const string& zoneData)                                 \
@@ -1060,8 +1063,6 @@ struct EDNSOpts
 
 class MOADNSParser;
 bool getEDNSOpts(const MOADNSParser& mdp, EDNSOpts* eo);
-void reportBasicTypes();
-void reportOtherTypes();
 void reportAllTypes();
 ComboAddress getAddr(const DNSRecord& dr, uint16_t defport=0);
 void checkHostnameCorrectness(const DNSResourceRecord& rr);

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -225,7 +225,8 @@ try
   typedef vector<pair<time_t, LiveCounts> > pcounts_t;
   pcounts_t pcounts;
   const uint16_t port = g_vm["port"].as<uint16_t>();
-  OPTRecordContent::report();
+
+  reportAllTypes();
 
   for(unsigned int fno=0; fno < files.size(); ++fno) {
     PcapPacketReader pr(files[fno]);

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -164,9 +164,8 @@ string NSECBitmap::getZoneRepresentation() const
   return ret;
 }
 
-void NSECRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
+void NSECRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)
 {
-  (void)guard;
   regist(1, 47, &make, &make, "NSEC");
 }
 
@@ -214,9 +213,8 @@ string NSECRecordContent::getZoneRepresentation(bool /* noDot */) const
 
 ////// begin of NSEC3
 
-void NSEC3RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
+void NSEC3RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)
 {
-  (void)guard;
   regist(1, 50, &make, &make, "NSEC3");
 }
 
@@ -288,9 +286,8 @@ string NSEC3RecordContent::getZoneRepresentation(bool /* noDot */) const
 }
 
 
-void NSEC3PARAMRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
+void NSEC3PARAMRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)
 {
-  (void)guard;
   regist(1, 51, &make, &make, "NSEC3PARAM");
   regist(254, 51, &make, &make, "NSEC3PARAM");
 }
@@ -346,9 +343,8 @@ string NSEC3PARAMRecordContent::getZoneRepresentation(bool /* noDot */) const
 
 ////// begin of CSYNC
 
-void CSYNCRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
+void CSYNCRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)
 {
-  (void)guard;
   regist(1, 62, &make, &make, "CSYNC");
 }
 

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -164,8 +164,9 @@ string NSECBitmap::getZoneRepresentation() const
   return ret;
 }
 
-void NSECRecordContent::report()
+void NSECRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
+  (void)guard;
   regist(1, 47, &make, &make, "NSEC");
 }
 
@@ -213,8 +214,9 @@ string NSECRecordContent::getZoneRepresentation(bool /* noDot */) const
 
 ////// begin of NSEC3
 
-void NSEC3RecordContent::report()
+void NSEC3RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
+  (void)guard;
   regist(1, 50, &make, &make, "NSEC3");
 }
 
@@ -286,8 +288,9 @@ string NSEC3RecordContent::getZoneRepresentation(bool /* noDot */) const
 }
 
 
-void NSEC3PARAMRecordContent::report()
+void NSEC3PARAMRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
+  (void)guard;
   regist(1, 51, &make, &make, "NSEC3PARAM");
   regist(254, 51, &make, &make, "NSEC3PARAM");
 }
@@ -343,8 +346,9 @@ string NSEC3PARAMRecordContent::getZoneRepresentation(bool /* noDot */) const
 
 ////// begin of CSYNC
 
-void CSYNCRecordContent::report()
+void CSYNCRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
+  (void)guard;
   regist(1, 62, &make, &make, "CSYNC");
 }
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -3154,7 +3154,6 @@ int main(int argc, char** argv)
   g_argv = argv;
   versionSetProduct(ProductRecursor);
   reportAllTypes();
-  DNSRecordContent::lock();
 
   int ret = EXIT_SUCCESS;
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -3153,8 +3153,8 @@ int main(int argc, char** argv)
   g_argc = argc;
   g_argv = argv;
   versionSetProduct(ProductRecursor);
-  reportBasicTypes();
-  reportOtherTypes();
+  reportAllTypes();
+  DNSRecordContent::lock();
 
   int ret = EXIT_SUCCESS;
 

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -570,9 +570,6 @@ std::tuple<std::shared_ptr<SyncRes::domainmap_t>, std::shared_ptr<notifyset_t>> 
 {
   auto log = g_slog->withName("config");
 
-  TXTRecordContent::report();
-  OPTRecordContent::report();
-
   auto newMap = std::make_shared<SyncRes::domainmap_t>();
   auto newSet = std::make_shared<notifyset_t>();
 

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -156,8 +156,9 @@ latlon2ul(const char **latlonstrptr, int *which)
   return (retval);
 }
 
-void LOCRecordContent::report()
+void LOCRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
 {
+  (void)guard;
   regist(1, QType::LOC, &make, &make, "LOC");
   regist(254, QType::LOC, &make, &make, "LOC");
 }

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -156,9 +156,8 @@ latlon2ul(const char **latlonstrptr, int *which)
   return (retval);
 }
 
-void LOCRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& guard)
+void LOCRecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)
 {
-  (void)guard;
   regist(1, QType::LOC, &make, &make, "LOC");
   regist(254, QType::LOC, &make, &make, "LOC");
 }

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -265,7 +265,6 @@ BOOST_AUTO_TEST_CASE(test_Append) {
 }
 
 BOOST_AUTO_TEST_CASE(test_packetCompress) {
-  reportBasicTypes();
   vector<unsigned char> packet;
   DNSPacketWriter dpw(packet, DNSName("www.ds9a.nl."), QType::AAAA);
   dpw.startRecord(DNSName("ds9a.nl"), QType::SOA);
@@ -302,7 +301,6 @@ BOOST_AUTO_TEST_CASE(test_packetCompress) {
 }
 
 BOOST_AUTO_TEST_CASE(test_packetCompressLong) {
-  reportBasicTypes();
   vector<unsigned char> packet;
   DNSName loopback("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa");
   DNSPacketWriter dpw(packet, loopback, QType::PTR);
@@ -330,7 +328,6 @@ BOOST_AUTO_TEST_CASE(test_packetCompressLong) {
 
 BOOST_AUTO_TEST_CASE(test_PacketParse) {
   vector<unsigned char> packet;
-  reportBasicTypes();
   DNSName root(".");
   DNSPacketWriter dpw1(packet, g_rootdnsname, QType::AAAA);
   DNSName p((char*)&packet[0], packet.size(), 12, false);
@@ -393,7 +390,6 @@ BOOST_AUTO_TEST_CASE(test_hashContainer) {
 
 BOOST_AUTO_TEST_CASE(test_QuestionHash) {
   vector<unsigned char> packet(sizeof(dnsheader));
-  reportBasicTypes();
 
   bool ok;
   // A return init case
@@ -453,7 +449,6 @@ BOOST_AUTO_TEST_CASE(test_QuestionHash) {
 
 BOOST_AUTO_TEST_CASE(test_packetParse) {
   vector<unsigned char> packet;
-  reportBasicTypes();
   DNSPacketWriter dpw(packet, DNSName("www.ds9a.nl."), QType::AAAA);
 
   uint16_t qtype, qclass;

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -47,12 +47,6 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
   // tuple contains <type, user value, zone representation, line value, broken>
   typedef boost::tuple<QType::typeenum, std::string, std::string, std::string, broken_marker> case_t;
   typedef std::list<case_t> cases_t;
-  MRRecordContent::report();
-  IPSECKEYRecordContent::report();
-  KXRecordContent::report();
-  DHCIDRecordContent::report();
-  TSIGRecordContent::report();
-  TKEYRecordContent::report();
 
 // NB!!! WHEN ADDING A TEST MAKE SURE YOU PUT IT NEXT TO ITS KIND
 // TO MAKE SURE TEST NUMBERING DOES NOT BREAK
@@ -305,8 +299,12 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
    BOOST_TEST_MESSAGE("Checking record type " << q.toString() << " test #" << n);
    try {
       std::string recData;
-      auto rec = DNSRecordContent::make(q.getCode(), 1, inval);
-      BOOST_CHECK_MESSAGE(rec != NULL, "make( " << q.getCode() << ", 1, " << inval << ") should not return NULL");
+      uint16_t qclass = QClass::IN;
+      if (q.getCode() == QType::TSIG || q.getCode() == QType::TKEY) {
+        qclass = QClass::ANY;
+      }
+      auto rec = DNSRecordContent::make(q.getCode(), qclass, inval);
+      BOOST_CHECK_MESSAGE(rec != nullptr, "make( " << q.getCode() << ", " << qclass << ", " << inval << ") should not return NULL");
       if (rec == NULL) continue;
       // now verify the record (note that this will be same as *zone* value (except for certain QTypes)
 
@@ -325,7 +323,7 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
       }
       recData = rec->serialize(DNSName("rec.test"));
 
-      std::shared_ptr<DNSRecordContent> rec2 = DNSRecordContent::deserialize(DNSName("rec.test"),q.getCode(),recData);
+      auto rec2 = DNSRecordContent::deserialize(DNSName("rec.test"), q.getCode(), recData, qclass);
       BOOST_CHECK_MESSAGE(rec2 != NULL, "deserialize(rec.test, " << q.getCode() << ", recData) should not return NULL");
       if (rec2 == NULL) continue;
       // now verify the zone representation (here it can be different!)
@@ -434,7 +432,6 @@ BOOST_AUTO_TEST_CASE(test_opt_record_in) {
 
   // test that nsid gets parsed into system
   std::string packet("\xf0\x01\x01\x00\x00\x01\x00\x01\x00\x00\x00\x01\x03www\x08powerdns\x03""com\x00\x00\x01\x00\x01\x03www\x08powerdns\x03""com\x00\x00\x01\x00\x01\x00\x00\x00\x10\x00\x04\x7f\x00\x00\x01\x00\x00\x29\x05\x00\x00\x00\x00\x00\x00\x0c\x00\x03\x00\x08powerdns",89);
-  OPTRecordContent::report();
 
   MOADNSParser mdp(true, (char*)&*packet.begin(), (unsigned int)packet.size());
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -344,8 +344,6 @@ static void checkRR(const SignerParams& signer)
   /* values taken from rfc8080 for ed25519 and ed448, rfc5933 for gost */
   DNSName qname(dpk.getAlgorithm() == DNSSECKeeper::ECCGOST ? "www.example.net." : "example.com.");
 
-  reportBasicTypes();
-
   RRSIGRecordContent rrc;
   uint32_t expire = 1440021600;
   uint32_t inception = 1438207200;

--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -21,8 +21,6 @@
 BOOST_AUTO_TEST_SUITE(test_zoneparser_tng_cc)
 
 BOOST_AUTO_TEST_CASE(test_tng_record_types) {
-  reportAllTypes();
-
   std::ostringstream pathbuf;
   const char* p = std::getenv("SRCDIR");
   if(!p)
@@ -57,8 +55,6 @@ BOOST_AUTO_TEST_CASE(test_tng_record_types) {
 }
 
 BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
-  reportAllTypes();
-
   std::ostringstream pathbuf;
   const char* p = std::getenv("SRCDIR");
   if(!p)
@@ -219,8 +215,6 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
 }
 
 BOOST_AUTO_TEST_CASE(test_tng_upgrade) {
-  reportAllTypes();
-
   ZoneParserTNG zp(std::vector<std::string>({"foo.test. 86400 IN TYPE1 \\# 4 c0000304"}), DNSName("test"), true);
   DNSResourceRecord rr;
   zp.get(rr);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Actually seen in recursor, but auth could also have it in theory.

The issue is that you cannot call type register functions while the rest of the threads are doing their work. The actual fix is in `reczones.cc`, but also guard against this happening in other places (for both rec and auth), and while there remove the unused `unregist` function.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
