### PR TITLE
pdnsutil edit-zone: Emit the updated SOA serial

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1338,6 +1338,7 @@ static int editZone(const DNSName &zone, const PDNSColors& col) {
 
             changed[{dr.d_name, dr.d_type}]+=str.str();
             grouped[{dr.d_name, dr.d_type}].at(0) = dr;
+            cout<<endl<<"SOA serial for zone "<<zone<<" set to "<<sd.serial;
           }
           break;
         case 'q':


### PR DESCRIPTION
After a change to a zone pdnsutil offers to increase the serial. Similar to `pdnsutil increase-serial` inform the user about the actual value of the new serial if the increase was agreed to.

To check for the change to be flushed out to the secondaries it is useful to know that serial. So emitting it without me having to ask for it is a nice service.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
