### PR TITLE
auth-4.8.x: Backport 13679 - Update upload-artifact and download-artifact to version 4

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -82,7 +82,7 @@ jobs:
       - run: ccache -s
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Store the binaries
-        uses: actions/upload-artifact@v3 # this takes 30 seconds, maybe we want to tar
+        uses: actions/upload-artifact@v4 # this takes 30 seconds, maybe we want to tar
         with:
           name: pdns-auth-${{ env.normalized-branch-name }}
           path: /opt/pdns-auth
@@ -129,7 +129,7 @@ jobs:
           ref: ${{ inputs.branch-name }}
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pdns-auth-${{ env.normalized-branch-name }}
           path: /opt/pdns-auth
@@ -241,7 +241,7 @@ jobs:
           ref: ${{ inputs.branch-name }}
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pdns-auth-${{ env.normalized-branch-name }}
           path: /opt/pdns-auth
@@ -268,7 +268,7 @@ jobs:
           ref: ${{ inputs.branch-name }}
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pdns-auth-${{ env.normalized-branch-name }}
           path: /opt/pdns-auth

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -32,7 +32,7 @@ jobs:
       clang-tidy-auth-failed: ${{ steps.clang-tidy-annotations.outputs.failed }}
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: recursive
@@ -122,7 +122,7 @@ jobs:
           --restart always
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: recursive
@@ -234,7 +234,7 @@ jobs:
           --restart always
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: recursive
@@ -261,7 +261,7 @@ jobs:
       ASAN_OPTIONS: detect_leaks=0
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: recursive
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: recursive
@@ -316,7 +316,7 @@ jobs:
         run: "sudo apt-get update && sudo apt-get install jq jc"
       - name: Fail job if any of the previous jobs failed
         run: "for i in `echo '${{ toJSON(needs) }}' | jq -r '.[].result'`; do if [[ $i == 'failure' ]]; then echo '${{ toJSON(needs) }}'; exit 1; fi; done;"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: recursive

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -43,7 +43,7 @@ jobs:
           echo "stamp=$(/bin/date +%s)" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: let GitHub cache our ccache data
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.ccache
           key: auth-ccache-${{ steps.get-stamp.outputs.stamp }}

--- a/.github/workflows/builder-dispatch.yml
+++ b/.github/workflows/builder-dispatch.yml
@@ -58,7 +58,7 @@ jobs:
         os: ${{fromJson(needs.prepare.outputs.oslist)}}
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # for correct version numbers
           submodules: recursive

--- a/.github/workflows/builder-dispatch.yml
+++ b/.github/workflows/builder-dispatch.yml
@@ -69,7 +69,7 @@ jobs:
         run: 'echo ::set-output name=version::$(readlink builder/tmp/latest)'
         id: getversion
       - name: Upload packages as GH artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.inputs.product }}-${{ matrix.os }}-${{ steps.getversion.outputs.version }}
           path: built_pkgs/

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -33,7 +33,7 @@ jobs:
           - amazon-2023
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # for correct version numbers
           submodules: recursive

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -45,7 +45,7 @@ jobs:
           echo "version=$(readlink builder/tmp/latest)" >> $GITHUB_OUTPUT
         id: getversion
       - name: Upload packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.product }}-${{ matrix.os }}-${{ steps.getversion.outputs.version }}
           path: built_pkgs/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -14,7 +14,7 @@ jobs:
     # on a ubuntu-20.04 VM
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: recursive

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,7 +20,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: artifacts

--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ vars.SCHEDULED_MISC_DAILIES }}
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 5
         submodules: recursive

--- a/.github/workflows/secpoll.yml
+++ b/.github/workflows/secpoll.yml
@@ -14,7 +14,7 @@ jobs:
     # on a ubuntu-20.04 VM
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: recursive


### PR DESCRIPTION
### Short description
Backport #13679: Update upload/download artifact actions to v4.

As cited in the deprecation notice ([https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)), these actions cannot be used from the end of January 2025:

> "Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of `actions/upload-artifact` or `actions/download-artifact`"

As part of this PR, #13539 and #13725 are also backported for updating to v4 `actions/checkout` and `action/cache`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
