### PR TITLE
re: followup to 14796: also call stop hook in 1 thread case

### DIFF
--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -356,7 +356,6 @@ int RecThreadInfo::runThreads(Logr::log_t log)
         ret = tInfo.exitCode;
       }
     }
-    runStartStopLua(false, log);
   }
   return ret;
 }
@@ -2390,8 +2389,9 @@ static int serviceMain(Logr::log_t log)
 #endif /* NOD_ENABLED */
 
   runStartStopLua(true, log);
-
-  return RecThreadInfo::runThreads(log);
+  ret = RecThreadInfo::runThreads(log);
+  runStartStopLua(false, log);
+  return ret;
 }
 
 static void handlePipeRequest(int fileDesc, FDMultiplexer::funcparam_t& /* var */)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

The stop hook was not called in the threads=1 case. This looks better from a symmetry point of view as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
