### PR TITLE
[bugfix] Reject hexadecimal blobs with odd number of characters

### DIFF
--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -546,8 +546,7 @@ static void HEXDecode(const char* begin, const char* end, string& out)
     }
   }
   if(mode)
-    out.append(1, (char) val);
-
+    throw RecordTextException("Hexadecimal blob with odd number of characters");
 }
 
 void RecordTextReader::xfrHexBlob(string& val, bool keepReading)

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -584,6 +584,9 @@ BOOST_AUTO_TEST_CASE(test_nsec_records_in) {
 
     BOOST_CHECK_THROW(MOADNSParser failParser(false, reinterpret_cast<const char*>(packet.data()), packet.size()-1), MOADNSException);
   }
+
+  // Invalid length of the NSEC3 hex blob
+  BOOST_CHECK_THROW(DNSRecordContent::make(QType::NSEC3PARAM, QClass::IN, "1 0 12 abcde"), RecordTextException);
 }
 
 BOOST_AUTO_TEST_CASE(test_nsec_records_types) {


### PR DESCRIPTION
### Short description

Until about 2011, hexadecimal input as ascii strings were required to have an even number of characters, in order to make a correct number of bytes. Then changes were made to allow whitespace in these strings, or a dangling single hex char was accepted as the high-order part of a complete byte, i.e. "ABCDE" would be parsed as "ABCDE0".

This PR brings back the exception which used to be raised for an odd number of meaningful characters, but does not change the rest of the logic (i.e. you can still write "AB_CD_EF" if you want).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
