### PR TITLE
Update pdnsutil.bash_completion.d

### DIFF
--- a/contrib/pdnsutil.bash_completion.d
+++ b/contrib/pdnsutil.bash_completion.d
@@ -17,13 +17,14 @@ then
   _pdnsutil_helper_local_() {
     local cur prev cmd
 
-    local _PDNSUTIL_ALL_CMDS="activate-tsig-key activate-zone-key add-record add-autoprimary add-zone-key backend-cmd backend-lookup b2b-migrate bench-db change-secondary-zone-master
-                              check-zone check-all-zones clear-zone create-bind-db create-secondary-zone create-zone deactivate-tsig-key deactivate-zone-key delete-rrset
-                              delete-tsig-key delete-zone disable-dnssec edit-zone export-zone-dnskey export-zone-key generate-tsig-key generate-zone-key get-meta
-                              hash-zone-record increase-serial import-tsig-key import-zone-key load-zone list-algorithms list-keys list-zone list-all-zones
-                              list-tsig-keys rectify-zone rectify-all-zones remove-zone-key replace-rrset secure-all-zones secure-zone set-kind set-nsec3 set-presigned
-                              set-publish-cdnskey set-publish-cds set-meta show-zone unset-nsec3 unset-presigned unset-publish-cdnskey unset-publish-cds test-schema
-                              import-zone-key-pem export-zone-key-pem list-member-zones"
+    local _PDNSUTIL_ALL_CMDS="activate-tsig-key activate-zone-key add-record add-autoprimary remove-autoprimary list-autoprimaries add-zone-key backend-cmd b2b-migrate bench-db
+                              check-zone check-all-zones clear-zone create-bind-db create-secondary-zone change-secondary-zone-primary create-zone deactivate-tsig-key
+                              deactivate-zone-key delete-rrset delete-tsig-key delete-zone disable-dnssec edit-zone export-zone-dnskey export-zone-ds export-zone-key
+                              export-zone-key-pem generate-tsig-key generate-zone-key get-meta hash-password hash-zone-record hsm hsm increase-serial import-tsig-key
+                              import-zone-key import-zone-key-pem ipdecrypt ipencrypt load-zone list-algorithms list-keys list-zone list-all-zones list-member-zones
+                              list-tsig-keys publish-zone-key rectify-zone rectify-all-zones remove-zone-key replace-rrset secure-all-zones secure-zone set-kind set-options-json
+                              set-option set-catalog set-account set-nsec3 set-presigned set-publish-cdnskey set-publish-cds add-meta set-meta show-zone unpublish-zone-key
+                              unset-nsec3 unset-presigned unset-publish-cdnskey unset-publish-cds test-schema raw-lua-from-content zonemd-verify-file lmdb-get-backend-version"
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/contrib/pdnsutil.bash_completion.d
+++ b/contrib/pdnsutil.bash_completion.d
@@ -10,13 +10,15 @@
 # pdnsutil YOUNAMEIT <TAB> - completes to available zones, might be expensive with many (>10000) zones
 #
 
-have pdnsutil && {
+which pdnsutil >/dev/null 2>&1
 
+if [ "${?}" -eq 0 ]
+then
   _pdnsutil_helper_local_() {
     local cur prev cmd
 
-    local _PDNSUTIL_ALL_CMDS="activate-tsig-key activate-zone-key add-record add-supermaster add-zone-key backend-cmd backend-lookup b2b-migrate bench-db change-slave-zone-master
-                              check-zone check-all-zones clear-zone create-bind-db create-slave-zone create-zone deactivate-tsig-key deactivate-zone-key delete-rrset
+    local _PDNSUTIL_ALL_CMDS="activate-tsig-key activate-zone-key add-record add-autoprimary add-zone-key backend-cmd backend-lookup b2b-migrate bench-db change-secondary-zone-master
+                              check-zone check-all-zones clear-zone create-bind-db create-secondary-zone create-zone deactivate-tsig-key deactivate-zone-key delete-rrset
                               delete-tsig-key delete-zone disable-dnssec edit-zone export-zone-dnskey export-zone-key generate-tsig-key generate-zone-key get-meta
                               hash-zone-record increase-serial import-tsig-key import-zone-key load-zone list-algorithms list-keys list-zone list-all-zones
                               list-tsig-keys rectify-zone rectify-all-zones remove-zone-key replace-rrset secure-all-zones secure-zone set-kind set-nsec3 set-presigned
@@ -42,4 +44,4 @@ have pdnsutil && {
   }
 
   complete -o default -F _pdnsutil_helper_local_ pdnsutil
-}
+fi


### PR DESCRIPTION
### Short description
- Removed dependency to the `have` command, which isn't available by default on Debian 12 (Bookworm)
- Updated the completion list to have the new names 'primary' and 'secondary' instead of the old ones 'master' and 'slave'

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
