### PR TITLE
dnsdist-1.9.x: Allow resetting `setWeightedBalancingFactor()` to zero

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2138,7 +2138,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
   luaCtx.writeFunction("setWeightedBalancingFactor", [](double factor) {
     setLuaSideEffect();
-    if (factor >= 1.0) {
+    if (factor >= 1.0 || factor == 0) {
       g_weightedBalancingFactor = factor;
     }
     else {

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -645,6 +645,9 @@ class TestRoutingWRandom(DNSDistTest):
     _config_params = ['_testServerPort', '_testServer2Port']
     _config_template = """
     setServerPolicy(wrandom)
+    setWeightedBalancingFactor(1.0)
+    -- this is the default, but let's ensure we can reset it to the initial value
+    setWeightedBalancingFactor(0)
     s1 = newServer{address="127.0.0.1:%s", weight=1}
     s1:setUp()
     s2 = newServer{address="127.0.0.1:%s", weight=2}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Zero is the initial value, but until now it was only possible to pass a value greater than or equal to 1.0 to `setWeightedBalancingFactor()` so it was not possible to reset it to the default value.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
