### PR TITLE
dnsdist: Fix issues with the balancing factors

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lbpolicies.cc
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.cc
@@ -87,7 +87,7 @@ template <class T> static std::shared_ptr<DownstreamState> getValRandom(const Se
   int sum = 0;
 
   size_t usableServers = 0;
-  const auto weightedBalancingFactor = dnsdist::configuration::getImmutableConfiguration().d_consistentHashBalancingFactor;
+  const auto weightedBalancingFactor = dnsdist::configuration::getImmutableConfiguration().d_weightedBalancingFactor;
   for (const auto& d : servers) {      // w=1, w=10 -> 1, 11
     if (d.second->isUp() && (weightedBalancingFactor == 0 || (static_cast<double>(d.second->outstanding.load()) <= (targetLoad * d.second->d_config.d_weight)))) {
       // Don't overflow sum when adding high weights
@@ -121,7 +121,7 @@ static shared_ptr<DownstreamState> valrandom(const unsigned int val, const Serve
 {
   using ValRandomType = int;
   double targetLoad = std::numeric_limits<double>::max();
-  const auto weightedBalancingFactor = dnsdist::configuration::getImmutableConfiguration().d_consistentHashBalancingFactor;
+  const auto weightedBalancingFactor = dnsdist::configuration::getImmutableConfiguration().d_weightedBalancingFactor;
   if (weightedBalancingFactor > 0) {
     /* we start with one, representing the query we are currently handling */
     double currentLoad = 1;

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -903,7 +903,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   {
     const std::string name;
     const std::function<void(dnsdist::configuration::ImmutableConfiguration& config, double value)> mutator;
-    const double maximumValue{1.0};
+    const double minimumValue{1.0};
   };
   static const std::vector<DoubleImmutableConfigurationItems> doubleImmutableConfigItems{
     {"setConsistentHashingBalancingFactor", [](dnsdist::configuration::ImmutableConfiguration& config, double newValue) { config.d_consistentHashBalancingFactor = newValue; }, 1.0},
@@ -940,7 +940,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   }
   for (const auto& item : doubleImmutableConfigItems) {
     luaCtx.writeFunction(item.name, [&item](double value) {
-      if (value > item.maximumValue) {
+      if (value != 0 && value < item.minimumValue) {
         g_outputBuffer = "Invalid value passed to " + item.name + "()!\n";
         errlog("Invalid value passed to %s()!", item.name);
         return;

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -599,9 +599,9 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
                 self.assertEqual(receivedResponse, response)
 
         # 4 queries should made it through, 2 UDP and 2 TCP
-        for k,v in self._responsesCounter.items():
-            print(k)
-            print(v)
+        #for k,v in self._responsesCounter.items():
+        #    print(k)
+        #    print(v)
 
         if 'UDP Responder' in self._responsesCounter:
             self.assertEqual(self._responsesCounter['UDP Responder'], 0)
@@ -807,6 +807,168 @@ class TestRoutingHighValueWRandom(DNSDistTest):
             self.assertEqual(self._responsesCounter['UDP Responder 2'], numberOfQueries - self._responsesCounter['UDP Responder'])
         if 'TCP Responder 2' in self._responsesCounter:
             self.assertEqual(self._responsesCounter['TCP Responder 2'], numberOfQueries - self._responsesCounter['TCP Responder'])
+
+class TestRoutingWHashed(DNSDistTest):
+
+    _testServer2Port = pickAvailablePort()
+    _config_params = ['_testServerPort', '_testServer2Port']
+    _config_template = """
+    setServerPolicy(whashed)
+    setWeightedBalancingFactor(1.5)
+    -- this is the default, but let's ensure we can reset it to the initial value
+    setWeightedBalancingFactor(0)
+    s1 = newServer{address="127.0.0.1:%s", weight=1}
+    s1:setUp()
+    s2 = newServer{address="127.0.0.1:%s", weight=1}
+    s2:setUp()
+    """
+
+    @classmethod
+    def startResponders(cls):
+        print("Launching responders..")
+        cls._UDPResponder = threading.Thread(name='UDP Responder', target=cls.UDPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue])
+        cls._UDPResponder.daemon = True
+        cls._UDPResponder.start()
+        cls._UDPResponder2 = threading.Thread(name='UDP Responder 2', target=cls.UDPResponder, args=[cls._testServer2Port, cls._toResponderQueue, cls._fromResponderQueue])
+        cls._UDPResponder2.daemon = True
+        cls._UDPResponder2.start()
+
+        cls._TCPResponder = threading.Thread(name='TCP Responder', target=cls.TCPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue])
+        cls._TCPResponder.daemon = True
+        cls._TCPResponder.start()
+
+        cls._TCPResponder2 = threading.Thread(name='TCP Responder 2', target=cls.TCPResponder, args=[cls._testServer2Port, cls._toResponderQueue, cls._fromResponderQueue])
+        cls._TCPResponder2.daemon = True
+        cls._TCPResponder2.start()
+
+    def testHashed(self):
+        """
+        Routing: WHashed
+
+        Send 100 A queries to "<num>.whashed.routing.tests.powerdns.com.",
+        check that dnsdist routes at least 25% to each backend (hashing
+        will not be perfect, especially with so few datapoints, but still).
+        """
+        numberOfQueries = 100
+        suffix = 'whashed.routing.tests.powerdns.com.'
+
+        # the counter is shared for UDP and TCP,
+        # so we need to do UDP then TCP to have a clean count
+        for idx in range(numberOfQueries):
+            name = str(idx) + '.udp.' + suffix
+            query = dns.message.make_query(name, 'A', 'IN')
+            response = dns.message.make_response(query)
+            rrset = dns.rrset.from_text(name,
+                                        60,
+                                        dns.rdataclass.IN,
+                                        dns.rdatatype.A,
+                                        '192.0.2.1')
+            response.answer.append(rrset)
+            (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
+
+        for idx in range(numberOfQueries):
+            name = str(idx) + '.tcp.' + suffix
+            query = dns.message.make_query(name, 'A', 'IN')
+            response = dns.message.make_response(query)
+            rrset = dns.rrset.from_text(name,
+                                        60,
+                                        dns.rdataclass.IN,
+                                        dns.rdatatype.A,
+                                        '192.0.2.1')
+            response.answer.append(rrset)
+            (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
+
+        self.assertGreater(self._responsesCounter['UDP Responder'], numberOfQueries * 0.25)
+        self.assertGreater(self._responsesCounter['TCP Responder'], numberOfQueries * 0.25)
+        self.assertGreater(self._responsesCounter['UDP Responder 2'], numberOfQueries * 0.25)
+        self.assertGreater(self._responsesCounter['TCP Responder 2'], numberOfQueries * 0.25)
+
+class TestRoutingCHashed(DNSDistTest):
+
+    _testServer2Port = pickAvailablePort()
+    _config_params = ['_testServerPort', '_testServer2Port']
+    _config_template = """
+    setServerPolicy(chashed)
+    setConsistentHashingBalancingFactor(1.5)
+    -- this is the default, but let's ensure we can reset it to the initial value
+    setConsistentHashingBalancingFactor(0)
+    s1 = newServer{address="127.0.0.1:%s", weight=1000}
+    s1:setUp()
+    s2 = newServer{address="127.0.0.1:%s", weight=1000}
+    s2:setUp()
+    """
+
+    @classmethod
+    def startResponders(cls):
+        print("Launching responders..")
+        cls._UDPResponder = threading.Thread(name='UDP Responder', target=cls.UDPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue])
+        cls._UDPResponder.daemon = True
+        cls._UDPResponder.start()
+        cls._UDPResponder2 = threading.Thread(name='UDP Responder 2', target=cls.UDPResponder, args=[cls._testServer2Port, cls._toResponderQueue, cls._fromResponderQueue])
+        cls._UDPResponder2.daemon = True
+        cls._UDPResponder2.start()
+
+        cls._TCPResponder = threading.Thread(name='TCP Responder', target=cls.TCPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue])
+        cls._TCPResponder.daemon = True
+        cls._TCPResponder.start()
+
+        cls._TCPResponder2 = threading.Thread(name='TCP Responder 2', target=cls.TCPResponder, args=[cls._testServer2Port, cls._toResponderQueue, cls._fromResponderQueue])
+        cls._TCPResponder2.daemon = True
+        cls._TCPResponder2.start()
+
+    def testHashed(self):
+        """
+        Routing: CHashed
+
+        Send 100 A queries to "<num>.chashed.routing.tests.powerdns.com.",
+        check that dnsdist routes at least 25% to each backend (hashing
+        will not be perfect, especially with so few datapoints, but still).
+        """
+        numberOfQueries = 100
+        suffix = 'chashed.routing.tests.powerdns.com.'
+
+        # the counter is shared for UDP and TCP,
+        # so we need to do UDP then TCP to have a clean count
+        for idx in range(numberOfQueries):
+            name = str(idx) + '.udp.' + suffix
+            query = dns.message.make_query(name, 'A', 'IN')
+            response = dns.message.make_response(query)
+            rrset = dns.rrset.from_text(name,
+                                        60,
+                                        dns.rdataclass.IN,
+                                        dns.rdatatype.A,
+                                        '192.0.2.1')
+            response.answer.append(rrset)
+            (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
+
+        for idx in range(numberOfQueries):
+            name = str(idx) + '.tcp.' + suffix
+            query = dns.message.make_query(name, 'A', 'IN')
+            response = dns.message.make_response(query)
+            rrset = dns.rrset.from_text(name,
+                                        60,
+                                        dns.rdataclass.IN,
+                                        dns.rdatatype.A,
+                                        '192.0.2.1')
+            response.answer.append(rrset)
+            (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
+
+        self.assertGreater(self._responsesCounter['UDP Responder'], numberOfQueries * 0.25)
+        self.assertGreater(self._responsesCounter['TCP Responder'], numberOfQueries * 0.25)
+        self.assertGreater(self._responsesCounter['UDP Responder 2'], numberOfQueries * 0.25)
+        self.assertGreater(self._responsesCounter['TCP Responder 2'], numberOfQueries * 0.25)
 
 class TestRoutingLuaFFILBNoServer(DNSDistTest):
 

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -650,6 +650,9 @@ class TestRoutingWRandom(DNSDistTest):
     _config_params = ['_testServerPort', '_testServer2Port']
     _config_template = """
     setServerPolicy(wrandom)
+    setWeightedBalancingFactor(1.5)
+    -- this is the default, but let's ensure we can reset it to the initial value
+    setWeightedBalancingFactor(0)
     s1 = newServer{address="127.0.0.1:%s", weight=1}
     s1:setUp()
     s2 = newServer{address="127.0.0.1:%s", weight=2}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The first issue was introduced during the configuration refactoring, and caused `whashed` and `wrandom` to use the wrong internal setting for bounded-loads.
The second issue is the same than the one fixed in #14929: "Zero is the initial value, but until now it was only possible to pass a value greater than or equal to 1.0 to `setWeightedBalancingFactor()` so it was not possible to reset it to the default value". The actual check was also wrong since the refactoring.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
