### PR TITLE
Fix ipv*hint=auto on lmdb backend

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1009,7 +1009,7 @@ static std::shared_ptr<DNSRecordContent> deserializeContentZR(uint16_t qtype, co
   if (qtype == QType::A && content.size() == 4) {
     return std::make_shared<ARecordContent>(*((uint32_t*)content.c_str()));
   }
-  return DNSRecordContent::deserialize(qname, qtype, content);
+  return DNSRecordContent::deserialize(qname, qtype, content, QClass::IN, true);
 }
 
 /* design. If you ask a question without a zone id, we lookup the best

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -80,7 +80,7 @@ void UnknownRecordContent::toPacket(DNSPacketWriter& pw) const
   pw.xfrBlob(string(d_record.begin(),d_record.end()));
 }
 
-shared_ptr<DNSRecordContent> DNSRecordContent::deserialize(const DNSName& qname, uint16_t qtype, const string& serialized, uint16_t qclass, bool trusted)
+shared_ptr<DNSRecordContent> DNSRecordContent::deserialize(const DNSName& qname, uint16_t qtype, const string& serialized, uint16_t qclass, bool internalRepresentation)
 {
   dnsheader dnsheader;
   memset(&dnsheader, 0, sizeof(dnsheader));
@@ -118,10 +118,11 @@ shared_ptr<DNSRecordContent> DNSRecordContent::deserialize(const DNSName& qname,
   dr.d_type = qtype;
   dr.d_name = qname;
   dr.d_clen = serialized.size();
-  PacketReader pr(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()), packet.size() - serialized.size() - sizeof(dnsrecordheader), trusted);
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): packet.data() is uint8_t *
+  PacketReader reader(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()), packet.size() - serialized.size() - sizeof(dnsrecordheader), internalRepresentation);
   /* needed to get the record boundaries right */
-  pr.getDnsrecordheader(drh);
-  auto content = DNSRecordContent::make(dr, pr, Opcode::Query);
+  reader.getDnsrecordheader(drh);
+  auto content = DNSRecordContent::make(dr, reader, Opcode::Query);
   return content;
 }
 
@@ -665,9 +666,10 @@ void PacketReader::xfrSvcParamKeyVals(set<SvcParam> &kvs) {
         xfrCAWithoutPort(key, addr);
         addresses.push_back(addr);
       }
-      // If there were no addresses, and the input comes from a trusted source,
-      // we can reasonably suppose this is the serialization of "auto".
-      bool doAuto{d_trusted && len == 0};
+      // If there were no addresses, and the input comes from internal
+      // representation, we can reasonably assume this is the serialization
+      // of "auto".
+      bool doAuto{d_internal && len == 0};
       auto param = SvcParam(key, std::move(addresses));
       param.setAutoHint(doAuto);
       kvs.insert(param);

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -68,8 +68,8 @@ class MOADNSParser;
 class PacketReader
 {
 public:
-  PacketReader(const std::string_view& content, uint16_t initialPos=sizeof(dnsheader))
-    : d_pos(initialPos), d_startrecordpos(initialPos), d_content(content)
+  PacketReader(const std::string_view& content, uint16_t initialPos=sizeof(dnsheader), bool trusted = false)
+    : d_pos(initialPos), d_startrecordpos(initialPos), d_content(content), d_trusted(trusted)
   {
     if(content.size() > std::numeric_limits<uint16_t>::max())
       throw std::out_of_range("packet too large");
@@ -186,6 +186,7 @@ private:
   uint16_t d_recordlen;      // ditto
   uint16_t not_used; // Aligns the whole class on 8-byte boundaries
   const std::string_view d_content;
+  bool d_trusted;
 };
 
 struct DNSRecord;
@@ -226,7 +227,7 @@ public:
   }
 
   // parse the content in wire format, possibly including compressed pointers pointing to the owner name
-  static shared_ptr<DNSRecordContent> deserialize(const DNSName& qname, uint16_t qtype, const string& serialized, uint16_t qclass=QClass::IN);
+  static shared_ptr<DNSRecordContent> deserialize(const DNSName& qname, uint16_t qtype, const string& serialized, uint16_t qclass=QClass::IN, bool trusted = false);
 
   void doRecordCheck(const struct DNSRecord&){}
 

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -68,8 +68,8 @@ class MOADNSParser;
 class PacketReader
 {
 public:
-  PacketReader(const std::string_view& content, uint16_t initialPos=sizeof(dnsheader), bool trusted = false)
-    : d_pos(initialPos), d_startrecordpos(initialPos), d_content(content), d_trusted(trusted)
+  PacketReader(const std::string_view& content, uint16_t initialPos=sizeof(dnsheader), bool internalRepresentation = false)
+    : d_pos(initialPos), d_startrecordpos(initialPos), d_content(content), d_internal(internalRepresentation)
   {
     if(content.size() > std::numeric_limits<uint16_t>::max())
       throw std::out_of_range("packet too large");
@@ -186,7 +186,7 @@ private:
   uint16_t d_recordlen;      // ditto
   uint16_t not_used; // Aligns the whole class on 8-byte boundaries
   const std::string_view d_content;
-  bool d_trusted;
+  bool d_internal;
 };
 
 struct DNSRecord;
@@ -226,8 +226,10 @@ public:
     return typeid(*this)==typeid(rhs) && this->getZoneRepresentation() == rhs.getZoneRepresentation();
   }
 
-  // parse the content in wire format, possibly including compressed pointers pointing to the owner name
-  static shared_ptr<DNSRecordContent> deserialize(const DNSName& qname, uint16_t qtype, const string& serialized, uint16_t qclass=QClass::IN, bool trusted = false);
+  // parse the content in wire format, possibly including compressed pointers pointing to the owner name.
+  // internalRepresentation is set when the data comes from an internal source,
+  // such as the LMDB backend.
+  static shared_ptr<DNSRecordContent> deserialize(const DNSName& qname, uint16_t qtype, const string& serialized, uint16_t qclass=QClass::IN, bool internalRepresentation = false);
 
   void doRecordCheck(const struct DNSRecord&){}
 

--- a/regression-tests.auth-py/test_SVCB.py
+++ b/regression-tests.auth-py/test_SVCB.py
@@ -1,10 +1,23 @@
 from authtests import AuthTest
 import dns
+import os
+import subprocess
 
+class SVCBRecordsBase(AuthTest):
+    # Copied from AuthTest, without the bind-config and bind-dnssec fields.
+    _config_template_default = """
+module-dir={PDNS_MODULE_DIR}
+daemon=no
+socket-dir={confdir}
+cache-ttl=0
+negquery-cache-ttl=0
+query-cache-ttl=0
+log-dns-queries=yes
+log-dns-details=yes
+loglevel=9
+distributor-threads=1"""
 
-class TestSVCBRecords(AuthTest):
     _config_template = """
-launch=bind
 svc-autohints
 """
 
@@ -39,7 +52,7 @@ auto-aaaa.example.org.       3600 IN AAAA 2001:db8::80
         """,
     }
 
-    def testWithoutAlias(self):
+    def impl_testWithoutAlias(self):
         query = dns.message.make_query('www.example.org', 'HTTPS')
         res = self.sendUDPQuery(query)
         expected_ans = dns.rrset.from_text(
@@ -50,7 +63,7 @@ auto-aaaa.example.org.       3600 IN AAAA 2001:db8::80
         self.assertRRsetInAnswer(res, expected_ans)
         self.assertEqual(len(res.additional), 2)
 
-    def testWithAlias(self):
+    def impl_testWithAlias(self):
         """
         Ensure additional processing happens for HTTPS AliasMode
         """
@@ -70,7 +83,7 @@ auto-aaaa.example.org.       3600 IN AAAA 2001:db8::80
         self.assertRRsetInAdditional(res, expected_addl)
         self.assertEqual(len(res.additional), 3)
 
-    def testWithMissingA(self):
+    def impl_testWithMissingA(self):
         """
         Ensure PowerDNS removes the ipv4hint if there's no A record
         """
@@ -84,7 +97,7 @@ auto-aaaa.example.org.       3600 IN AAAA 2001:db8::80
         self.assertRRsetInAnswer(res, expected_ans)
         self.assertEqual(len(res.additional), 1)
 
-    def testWithMissingAAAA(self):
+    def impl_testWithMissingAAAA(self):
         """
         Ensure PowerDNS removes the ipv6hint if there's no AAAA record
         """
@@ -98,7 +111,7 @@ auto-aaaa.example.org.       3600 IN AAAA 2001:db8::80
         self.assertRRsetInAnswer(res, expected_ans)
         self.assertEqual(len(res.additional), 1)
 
-    def testNoAuto(self):
+    def impl_testNoAuto(self):
         """
         Ensure we send the actual hints, not generated ones
         """
@@ -113,7 +126,7 @@ auto-aaaa.example.org.       3600 IN AAAA 2001:db8::80
         self.assertRRsetInAnswer(res, expected_ans)
         self.assertEqual(len(res.additional), 2)
 
-    def testAutoA(self):
+    def impl_testAutoA(self):
         """
         Ensure we send a generated A hint, but keep the existing AAAA hint
         """
@@ -128,7 +141,7 @@ auto-aaaa.example.org.       3600 IN AAAA 2001:db8::80
         self.assertRRsetInAnswer(res, expected_ans)
         self.assertEqual(len(res.additional), 2)
 
-    def testAutoAAAA(self):
+    def impl_testAutoAAAA(self):
         """
         Ensure we send a generated AAAA hint, but keep the existing A hint
         """
@@ -142,3 +155,128 @@ auto-aaaa.example.org.       3600 IN AAAA 2001:db8::80
         print(res)
         self.assertRRsetInAnswer(res, expected_ans)
         self.assertEqual(len(res.additional), 2)
+
+class TestSVCBRecordsBind(SVCBRecordsBase):
+    _config_template_default = (
+        SVCBRecordsBase._config_template_default
+        + """
+bind-config={confdir}/named.conf
+bind-dnssec-db={bind_dnssec_db}
+"""
+    )
+
+    _config_template = (
+        SVCBRecordsBase._config_template
+        + """
+launch=bind
+"""
+    )
+
+    def testWithoutAlias(self):
+        self.impl_testWithoutAlias()
+
+    def testWithAlias(self):
+        """
+        Ensure additional processing happens for HTTPS AliasMode
+        """
+        self.impl_testWithAlias()
+
+    def testWithMissingA(self):
+        """
+        Ensure PowerDNS removes the ipv4hint if there's no A record
+        """
+        self.impl_testWithMissingA()
+
+    def testWithMissingAAAA(self):
+        """
+        Ensure PowerDNS removes the ipv6hint if there's no AAAA record
+        """
+        self.impl_testWithMissingAAAA()
+
+    def testNoAuto(self):
+        """
+        Ensure we send the actual hints, not generated ones
+        """
+        self.impl_testNoAuto()
+
+    def testAutoA(self):
+        """
+        Ensure we send a generated A hint, but keep the existing AAAA hint
+        """
+        self.impl_testAutoA()
+
+    def testAutoAAAA(self):
+        """
+        Ensure we send a generated AAAA hint, but keep the existing A hint
+        """
+        self.impl_testAutoAAAA()
+
+class TestSVCBRecordsLMDB(SVCBRecordsBase):
+    _config_template = (
+        SVCBRecordsBase._config_template
+        + """
+launch=lmdb
+"""
+    )
+
+    @classmethod
+    def generateAllAuthConfig(cls, confdir):
+        # This is very similar to AuthTest.generateAllAuthConfig,
+        # but for lmdb backend, we ignore auth keys but need to load-zone
+        # into lmdb storage.
+        cls.generateAuthConfig(confdir)
+
+        for zonename, zonecontent in cls._zones.items():
+            cls.generateAuthZone(confdir,
+                                 zonename,
+                                 zonecontent)
+            pdnsutilCmd = [os.environ['PDNSUTIL'],
+                           '--config-dir=%s' % confdir,
+                           'load-zone',
+                           zonename,
+                           os.path.join(confdir, '%s.zone' % zonename)]
+
+            print(' '.join(pdnsutilCmd))
+            try:
+                subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as e:
+                raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
+
+    def testWithoutAlias(self):
+        self.impl_testWithoutAlias()
+
+    def testWithAlias(self):
+        """
+        Ensure additional processing happens for HTTPS AliasMode
+        """
+        self.impl_testWithAlias()
+
+    def testWithMissingA(self):
+        """
+        Ensure PowerDNS removes the ipv4hint if there's no A record
+        """
+        self.impl_testWithMissingA()
+
+    def testWithMissingAAAA(self):
+        """
+        Ensure PowerDNS removes the ipv6hint if there's no AAAA record
+        """
+        self.impl_testWithMissingAAAA()
+
+    def testNoAuto(self):
+        """
+        Ensure we send the actual hints, not generated ones
+        """
+        self.impl_testNoAuto()
+
+    def testAutoA(self):
+        """
+        Ensure we send a generated A hint, but keep the existing AAAA hint
+        """
+        self.impl_testAutoA()
+
+    def testAutoAAAA(self):
+        """
+        Ensure we send a generated AAAA hint, but keep the existing A hint
+        """
+        self.impl_testAutoAAAA()


### PR DESCRIPTION
### Short description

This is an attempt to fix #12653. When using LMDB as backend, DNS records are serialized using `GenericDNSPacketWriter<>::xfrSvcParamKeyVals`, which writes no value in the "auto" case. Thus, when reading back with `PacketReader::xfrSvcParamKeyVals`, we should handle an empty value as the absent serialization of "auto".

Note that this does not change the way data is serialized, so there should be no interoperability problem caused by this.

- [x] TODO: add tests to demonstrate this

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
