### PR TITLE
GH workflow for building packages: change name so target isn't chopped off

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -67,7 +67,7 @@ jobs:
 
   build:
     needs: prepare
-    name: ${{ inputs.product }} (${{ inputs.ref }}) on ${{ matrix.runner-os }} for ${{ matrix.os }}
+    name: for ${{ matrix.os }} ${{ inputs.product }} (${{ inputs.ref }}) on ${{ matrix.runner-os }}
     runs-on: ${{ matrix.runner-os }}
     strategy:
       matrix:


### PR DESCRIPTION
When I'm running this workflow by hand I'm mostly interested in results of specific builds. But the part of the name that varies is at the end, and chopped of in te tree view. so it requires extra clicking to see which build failed. This moves the target platform part to the from of the displayed name.


![Screenshot 2024-12-05 at 10-22-07 Trigger specific package build · PowerDNS_pdns@5eae153](https://github.com/user-attachments/assets/98267a2d-899b-4a86-b505-e81d3533f7ab)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master


