### PR TITLE
rec: regression test markers

### DIFF
--- a/regression-tests.recursor-dnssec/pytest.ini
+++ b/regression-tests.recursor-dnssec/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers = 
+    external: uses external web servers
+    unreliable_on_gh: test is fine when run locally, but shows issues on GitHub

--- a/regression-tests.recursor-dnssec/runtests
+++ b/regression-tests.recursor-dnssec/runtests
@@ -61,9 +61,13 @@ if ! "$PDNSRECURSOR" --version 2>&1 | grep Features | grep -q dnstap-framestream
   export NODNSTAPTESTS=1
 fi
 
+# Run with -m 'not external' to skip test that require external connectivity
+# Run with -m 'not unreliable_on_gh' to skip tests that are unreliable on GitHUb
+# Run with -m 'not (external or unreliable_on_gh)' to skip both categories
+
 # LIBFAKETIME is only added to LD_PRELOAD by the pyton code when needed
 if [ "${LIBASAN}" != "" -o "${LIBAUTHBIND}" != "" ]; then
-LD_PRELOAD="${LIBASAN} ${LIBAUTHBIND}" pytest --ignore=test_WellKnown.py --junitxml=pytest.xml $@
+LD_PRELOAD="${LIBASAN} ${LIBAUTHBIND}" pytest --junitxml=pytest.xml "$@"
 else
-pytest --ignore=test_WellKnown.py  --junitxml=pytest.xml $@
+pytest --junitxml=pytest.xml "$@"
 fi

--- a/regression-tests.recursor-dnssec/test_Chain.py
+++ b/regression-tests.recursor-dnssec/test_Chain.py
@@ -1,3 +1,4 @@
+import pytest
 import dns
 import os
 import time
@@ -23,6 +24,7 @@ class ChainTest(RecursorTest):
     api-key=%s
 """ % (_wsPort, _wsPassword, _apiKey)
 
+    @pytest.mark.unreliable_on_gh
     def testBasic(self):
         """
         Tests the case of #14624. Sending many equal requests could lead to ServFail because of clashing

--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -83,6 +83,7 @@ extended-resolution-errors=yes
 
         super(ExtendedErrorsTest, cls).generateRecursorConfig(confdir)
 
+    @pytest.mark.external
     def testNotIncepted(self):
         qname = 'signotincepted.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -96,6 +97,7 @@ extended-resolution-errors=yes
             self.assertEqual(res.options[0].otype, 15)
             self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(8, b''))
 
+    @pytest.mark.external
     def testExpired(self):
         qname = 'sigexpired.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -109,6 +111,7 @@ extended-resolution-errors=yes
             self.assertEqual(res.options[0].otype, 15)
             self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(7, b''))
 
+    @pytest.mark.external
     def testAllExpired(self):
         qname = 'servfail.nl.'
         query = dns.message.make_query(qname, 'AAAA', want_dnssec=True)
@@ -122,6 +125,7 @@ extended-resolution-errors=yes
             self.assertEqual(res.options[0].otype, 15)
             self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(6, b''))
 
+    @pytest.mark.external
     def testBogus(self):
         qname = 'bogussig.ok.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -135,6 +139,7 @@ extended-resolution-errors=yes
             self.assertEqual(res.options[0].otype, 15)
             self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(6, b''))
 
+    @pytest.mark.external
     def testMissingRRSIG(self):
         qname = 'brokendnssec.net.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)
@@ -236,6 +241,7 @@ extended-resolution-errors=no
     def generateRecursorConfig(cls, confdir):
         super(NoExtendedErrorsTest, cls).generateRecursorConfig(confdir)
 
+    @pytest.mark.external
     def testNotIncepted(self):
         qname = 'signotincepted.bad-dnssec.wb.sidnlabs.nl.'
         query = dns.message.make_query(qname, 'A', want_dnssec=True)

--- a/regression-tests.recursor-dnssec/test_SimpleDoT.py
+++ b/regression-tests.recursor-dnssec/test_SimpleDoT.py
@@ -1,3 +1,4 @@
+import pytest
 import dns
 import os
 import subprocess
@@ -30,6 +31,7 @@ devonly-regression-test-mode
         cls.generateRecursorConfig(confdir)
         cls.startRecursor(confdir, cls._recursorPort)
 
+    @pytest.mark.external
     def testTXT(self):
         expected = dns.rrset.from_text('dot-test-target.powerdns.org.', 0, dns.rdataclass.IN, 'TXT', 'https://github.com/PowerDNS/pdns/pull/12825')
         query = dns.message.make_query('dot-test-target.powerdns.org', 'TXT', want_dnssec=True)

--- a/regression-tests.recursor-dnssec/test_SimpleForwardOverDoT.py
+++ b/regression-tests.recursor-dnssec/test_SimpleForwardOverDoT.py
@@ -1,3 +1,4 @@
+import pytest
 import dns
 import os
 import subprocess
@@ -27,6 +28,7 @@ devonly-regression-test-mode
         cls.generateRecursorConfig(confdir)
         cls.startRecursor(confdir, cls._recursorPort)
 
+    @pytest.mark.external
     def testA(self):
         expected = dns.rrset.from_text('dns.google.', 0, dns.rdataclass.IN, 'A', '8.8.8.8', '8.8.4.4')
         query = dns.message.make_query('dns.google', 'A', want_dnssec=True)

--- a/regression-tests.recursor-dnssec/test_WellKnown.py
+++ b/regression-tests.recursor-dnssec/test_WellKnown.py
@@ -1,7 +1,9 @@
+import pytest
 import dns
 from recursortests import RecursorTest
 
-class TestWellKnown(RecursorTest):
+@pytest.mark.external
+class WellKnownTest(RecursorTest):
     _auths_zones = None
     _confdir = 'WellKnown'
     _roothints = None


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Add `pytest` markers to

- tests that need external connectivity
- a test that has been shown to be unreliable on GH but fine elsewhere (`test_Chain.py`).
- get rid of the special status of `test_WellKnown.py`

This opens up a structured way to disable some tests on GH (if the intermittent failures become too annoying), while they are still being run locally and by buildbot.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
