### PR TITLE
CI: Run the daily package building workflow only if requested

### DIFF
--- a/.github/workflows/build-packages-daily-master.yml
+++ b/.github/workflows/build-packages-daily-master.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   call-build-packages-auth:
+    if: ${{ vars.SCHEDULED_PACKAGES_DAILY }}
     uses: PowerDNS/pdns/.github/workflows/build-packages.yml@master
     with:
       is_release: 'NO'
@@ -23,6 +24,7 @@ jobs:
       DOWNLOADS_AUTOBUILT_HOSTKEY: ${{ secrets.DOWNLOADS_AUTOBUILT_HOSTKEY }}
 
   call-build-packages-dnsdist:
+    if: ${{ vars.SCHEDULED_PACKAGES_DAILY }}
     uses: PowerDNS/pdns/.github/workflows/build-packages.yml@master
     with:
       is_release: 'NO'
@@ -34,6 +36,7 @@ jobs:
       DOWNLOADS_AUTOBUILT_HOSTKEY: ${{ secrets.DOWNLOADS_AUTOBUILT_HOSTKEY }}
 
   call-build-packages-rec:
+    if: ${{ vars.SCHEDULED_PACKAGES_DAILY }}
     uses: PowerDNS/pdns/.github/workflows/build-packages.yml@master
     with:
       is_release: 'NO'


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
After this commit, the `build-packages-daily-master` workflow will only be executed on repositories that have a `SCHEDULED_PACKAGES_DAILY` variable set to a non-negative value.
I added the variable to the PowerDNS/pdns repository already.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

