### PR TITLE
rec: generate metrics files (also) where meson expects them

### DIFF
--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -274,7 +274,7 @@ py = import('python')
 python = py.find_installation('python3', required: true)
 
 metricfiles = custom_target(
-  command: [python, '@INPUT0@', '@SOURCE_ROOT@'],
+  command: [python, '@INPUT0@', '@SOURCE_ROOT@', '@BUILD_ROOT@'],
   input: metric_sources,
   output: [
           'rec-metrics-gen.h',


### PR DESCRIPTION
This avoids unnecessary regeneration of files. Generating into the src dir as we do is a bit rough, but the moment we drop autotools it will not be needed anymore.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
