### PR TITLE
clang-tidy: simplify some algorithms

### DIFF
--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -622,13 +622,6 @@ BOOST_DEFUN([Bind],
 [BOOST_FIND_HEADER([boost/bind.hpp])])
 
 
-# BOOST_CAST()
-# ------------
-# Look for Boost.Cast
-BOOST_DEFUN([Cast],
-[BOOST_FIND_HEADER([boost/cast.hpp])])
-
-
 # BOOST_CHRONO([PREFERRED-RT-OPT], [ERROR_ON_UNUSABLE])
 # --------------
 # Look for Boost.Chrono.
@@ -794,15 +787,6 @@ fi
 LIBS=$boost_context_save_LIBS
 LDFLAGS=$boost_context_save_LDFLAGS
 ])# BOOST_CONTEXT
-
-
-# BOOST_CONVERSION()
-# ------------------
-# Look for Boost.Conversion (cast / lexical_cast)
-BOOST_DEFUN([Conversion],
-[BOOST_FIND_HEADER([boost/cast.hpp])
-BOOST_FIND_HEADER([boost/lexical_cast.hpp])
-])# BOOST_CONVERSION
 
 
 # BOOST_COROUTINE([PREFERRED-RT-OPT], [ERROR_ON_UNUSABLE])

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -20,7 +20,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include "boost/lexical_cast.hpp"
 #include "boost/algorithm/string/join.hpp"
 #include "pdns/arguments.hh"
 

--- a/pdns/arguments.cc
+++ b/pdns/arguments.cc
@@ -111,7 +111,7 @@ bool ArgvMap::contains(const string& var, const string& val)
   vector<string> parts;
 
   stringtok(parts, param->second, ", \t");
-  return std::any_of(parts.begin(), parts.end(), [&](const std::string& str) { return str == val; });
+  return std::find(parts.begin(), parts.end(), val) != parts.end();
 }
 
 string ArgvMap::helpstring(string prefix)

--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -317,8 +317,7 @@ try
     pos=split.second.find('/');
     if(pos != string::npos) // alexa has whole urls in the list now.
       split.second.resize(pos);
-    if(find_if(split.second.begin(), split.second.end(), isalpha) == split.second.end())
-    {
+    if (std::none_of(split.second.begin(), split.second.end(), isalpha)) {
       continue; // this was an IP address
     }
     domains.push_back(TypedQuery(split.second, qtype));

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -28,8 +28,6 @@
 #include "dnsdist-cache.hh"
 #include "dnsdist-lua.hh"
 
-#include <boost/lexical_cast.hpp>
-
 void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
 {
   /* PacketCache */

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -812,11 +812,7 @@ SvcParam SVCBBaseRecordContent::getParam(const SvcParam::SvcParamKey &key) const
 }
 
 set<SvcParam>::const_iterator SVCBBaseRecordContent::getParamIt(const SvcParam::SvcParamKey &key) const {
-  auto p = std::find_if(d_params.begin(), d_params.end(),
-      [&key](const SvcParam &param) {
-        return param.getKey() == key;
-      });
-  return p;
+  return std::find(d_params.begin(), d_params.end(), key);
 }
 
 std::shared_ptr<SVCBBaseRecordContent> SVCBRecordContent::clone() const

--- a/pdns/svc-records.hh
+++ b/pdns/svc-records.hh
@@ -76,6 +76,11 @@ class SvcParam {
 
   bool operator< (const SvcParam &other) const;
 
+  bool operator==(const SvcParamKey& key) const
+  {
+    return key == d_key;
+  }
+
   SvcParamKey getKey() const {
     return d_key;
   }


### PR DESCRIPTION
Just a cleanup to prepare for C++20

I have:
- [ x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code

