### PR TITLE
clang-analyzer: fix null pointer deref

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -942,10 +942,12 @@ void PacketHandler::addNSEC(DNSPacket& /* p */, std::unique_ptr<DNSPacket>& r, c
   DLOG(g_log<<"addNSEC() mode="<<mode<<" auth="<<d_sd.qname<<" target="<<target<<" wildcard="<<wildcard<<endl);
 
   if (d_sd.db == nullptr) {
-    if(!B.getSOAUncached(d_sd.qname, d_sd)) {
-      DLOG(g_log<<"Could not get SOA for domain"<<endl);
-      return;
-    }
+    return;
+  }
+
+  if (!B.getSOAUncached(d_sd.qname, d_sd)) {
+    DLOG(g_log << "Could not get SOA for domain" << endl);
+    return;
   }
 
   DNSName before,after;


### PR DESCRIPTION
I have:
- [x ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x ] compiled this code