### PR TITLE
dnsdist: add support for labels on custom metrics

### DIFF
--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -57,6 +57,11 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint)
     {
       auto entries = dnsdist::metrics::g_stats.entries.read_lock();
       for (const auto& entry : *entries) {
+        // Skip non-empty labels, since labels are not supported in Carbon
+        if (!entry.d_labels.empty()) {
+          continue;
+        }
+
         str << namespace_name << "." << hostname << "." << instance_name << "." << entry.d_name << ' ';
         if (const auto& val = std::get_if<pdns::stat_t*>(&entry.d_value)) {
           str << (*val)->load();

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1811,7 +1811,8 @@ bool dnsdist_ffi_metric_declare(const char* name, size_t nameLen, const char* ty
 
 void dnsdist_ffi_metric_inc(const char* metricName, size_t metricNameLen)
 {
-  auto result = dnsdist::metrics::incrementCustomCounter(std::string_view(metricName, metricNameLen), 1U);
+  // TODO: add labels?
+  auto result = dnsdist::metrics::incrementCustomCounter(std::string_view(metricName, metricNameLen), 1U, {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
   }
@@ -1819,7 +1820,8 @@ void dnsdist_ffi_metric_inc(const char* metricName, size_t metricNameLen)
 
 void dnsdist_ffi_metric_inc_by(const char* metricName, size_t metricNameLen, uint64_t value)
 {
-  auto result = dnsdist::metrics::incrementCustomCounter(std::string_view(metricName, metricNameLen), value);
+  // TODO: add labels?
+  auto result = dnsdist::metrics::incrementCustomCounter(std::string_view(metricName, metricNameLen), value, {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
   }
@@ -1827,7 +1829,8 @@ void dnsdist_ffi_metric_inc_by(const char* metricName, size_t metricNameLen, uin
 
 void dnsdist_ffi_metric_dec(const char* metricName, size_t metricNameLen)
 {
-  auto result = dnsdist::metrics::decrementCustomCounter(std::string_view(metricName, metricNameLen), 1U);
+  // TODO: add labels?
+  auto result = dnsdist::metrics::decrementCustomCounter(std::string_view(metricName, metricNameLen), 1U, {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
   }
@@ -1835,7 +1838,8 @@ void dnsdist_ffi_metric_dec(const char* metricName, size_t metricNameLen)
 
 void dnsdist_ffi_metric_set(const char* metricName, size_t metricNameLen, double value)
 {
-  auto result = dnsdist::metrics::setCustomGauge(std::string_view(metricName, metricNameLen), value);
+  // TODO: add labels?
+  auto result = dnsdist::metrics::setCustomGauge(std::string_view(metricName, metricNameLen), value, {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
   }
@@ -1843,7 +1847,8 @@ void dnsdist_ffi_metric_set(const char* metricName, size_t metricNameLen, double
 
 double dnsdist_ffi_metric_get(const char* metricName, size_t metricNameLen, bool isCounter)
 {
-  auto result = dnsdist::metrics::getCustomMetric(std::string_view(metricName, metricNameLen));
+  // TODO: add labels?
+  auto result = dnsdist::metrics::getCustomMetric(std::string_view(metricName, metricNameLen), {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return 0.;
   }

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1805,7 +1805,8 @@ bool dnsdist_ffi_metric_declare(const char* name, size_t nameLen, const char* ty
   if (name == nullptr || nameLen == 0 || type == nullptr || description == nullptr) {
     return false;
   }
-  auto result = dnsdist::metrics::declareCustomMetric(name, type, description, customName != nullptr ? std::optional<std::string>(customName) : std::nullopt);
+  // TODO: add labels options?
+  auto result = dnsdist::metrics::declareCustomMetric(name, type, description, customName != nullptr ? std::optional<std::string>(customName) : std::nullopt, false);
   return !result;
 }
 

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1056,6 +1056,7 @@ size_t dnsdist_ffi_generate_proxy_protocol_payload(const size_t addrSize, const 
     if (valuesCount > 0) {
       valuesVect.reserve(valuesCount);
       for (size_t idx = 0; idx < valuesCount; idx++) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         valuesVect.push_back({std::string(values[idx].value, values[idx].size), values[idx].type});
       }
     }
@@ -1085,6 +1086,7 @@ size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi
   if (valuesCount > 0) {
     valuesVect.reserve(valuesCount);
     for (size_t idx = 0; idx < valuesCount; idx++) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       valuesVect.push_back({std::string(values[idx].value, values[idx].size), values[idx].type});
     }
   }

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1806,14 +1806,12 @@ bool dnsdist_ffi_metric_declare(const char* name, size_t nameLen, const char* ty
   if (name == nullptr || nameLen == 0 || type == nullptr || description == nullptr) {
     return false;
   }
-  // TODO: add labels options?
   auto result = dnsdist::metrics::declareCustomMetric(name, type, description, customName != nullptr ? std::optional<std::string>(customName) : std::nullopt, false);
   return !result;
 }
 
 void dnsdist_ffi_metric_inc(const char* metricName, size_t metricNameLen)
 {
-  // TODO: add labels?
   auto result = dnsdist::metrics::incrementCustomCounter(std::string_view(metricName, metricNameLen), 1U, {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
@@ -1822,7 +1820,6 @@ void dnsdist_ffi_metric_inc(const char* metricName, size_t metricNameLen)
 
 void dnsdist_ffi_metric_inc_by(const char* metricName, size_t metricNameLen, uint64_t value)
 {
-  // TODO: add labels?
   auto result = dnsdist::metrics::incrementCustomCounter(std::string_view(metricName, metricNameLen), value, {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
@@ -1831,7 +1828,6 @@ void dnsdist_ffi_metric_inc_by(const char* metricName, size_t metricNameLen, uin
 
 void dnsdist_ffi_metric_dec(const char* metricName, size_t metricNameLen)
 {
-  // TODO: add labels?
   auto result = dnsdist::metrics::decrementCustomCounter(std::string_view(metricName, metricNameLen), 1U, {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
@@ -1840,7 +1836,6 @@ void dnsdist_ffi_metric_dec(const char* metricName, size_t metricNameLen)
 
 void dnsdist_ffi_metric_set(const char* metricName, size_t metricNameLen, double value)
 {
-  // TODO: add labels?
   auto result = dnsdist::metrics::setCustomGauge(std::string_view(metricName, metricNameLen), value, {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return;
@@ -1849,7 +1844,6 @@ void dnsdist_ffi_metric_set(const char* metricName, size_t metricNameLen, double
 
 double dnsdist_ffi_metric_get(const char* metricName, size_t metricNameLen, bool isCounter)
 {
-  // TODO: add labels?
   auto result = dnsdist::metrics::getCustomMetric(std::string_view(metricName, metricNameLen), {});
   if (std::get_if<dnsdist::metrics::Error>(&result) != nullptr) {
     return 0.;

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -260,7 +260,7 @@ void dnsdist_ffi_dnsquestion_get_sni(const dnsdist_ffi_dnsquestion_t* dq, const 
 
 const char* dnsdist_ffi_dnsquestion_get_tag(const dnsdist_ffi_dnsquestion_t* dq, const char* label)
 {
-  const char * result = nullptr;
+  const char* result = nullptr;
 
   if (dq != nullptr && dq->dq != nullptr && dq->dq->ids.qTag != nullptr) {
     const auto it = dq->dq->ids.qTag->find(label);
@@ -455,7 +455,6 @@ size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dq, cons
     entry.value = tag.second.c_str();
     ++pos;
   }
-
 
   if (!dq->tagsVect->empty()) {
     *out = dq->tagsVect->data();
@@ -1007,7 +1006,7 @@ static constexpr char s_lua_ffi_code[] = R"FFICodeContent(
   ffi.cdef[[
 )FFICodeContent"
 #include "dnsdist-lua-ffi-interface.inc"
-R"FFICodeContent(
+                                         R"FFICodeContent(
   ]]
 
 )FFICodeContent";
@@ -1057,7 +1056,7 @@ size_t dnsdist_ffi_generate_proxy_protocol_payload(const size_t addrSize, const 
     if (valuesCount > 0) {
       valuesVect.reserve(valuesCount);
       for (size_t idx = 0; idx < valuesCount; idx++) {
-        valuesVect.push_back({ std::string(values[idx].value, values[idx].size), values[idx].type });
+        valuesVect.push_back({std::string(values[idx].value, values[idx].size), values[idx].type});
       }
     }
 
@@ -1086,7 +1085,7 @@ size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi
   if (valuesCount > 0) {
     valuesVect.reserve(valuesCount);
     for (size_t idx = 0; idx < valuesCount; idx++) {
-      valuesVect.push_back({ std::string(values[idx].value, values[idx].size), values[idx].type });
+      valuesVect.push_back({std::string(values[idx].value, values[idx].size), values[idx].type});
     }
   }
 
@@ -1113,7 +1112,7 @@ bool dnsdist_ffi_dnsquestion_add_proxy_protocol_values(dnsdist_ffi_dnsquestion_t
   dnsQuestion->dq->proxyProtocolValues->reserve(dnsQuestion->dq->proxyProtocolValues->size() + valuesCount);
   for (size_t idx = 0; idx < valuesCount; idx++) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): the Lua FFI API is a C API..
-    dnsQuestion->dq->proxyProtocolValues->push_back({ std::string(values[idx].value, values[idx].size), values[idx].type });
+    dnsQuestion->dq->proxyProtocolValues->push_back({std::string(values[idx].value, values[idx].size), values[idx].type});
   }
 
   return true;
@@ -1146,7 +1145,8 @@ struct dnsdist_ffi_domain_list_t
 {
   std::vector<std::string> d_domains;
 };
-struct dnsdist_ffi_address_list_t {
+struct dnsdist_ffi_address_list_t
+{
   std::vector<std::string> d_addresses;
 };
 
@@ -1476,7 +1476,8 @@ void dnsdist_ffi_ring_entry_list_free(dnsdist_ffi_ring_entry_list_t* list)
   delete list;
 }
 
-template<typename T> static void addRingEntryToList(std::unique_ptr<dnsdist_ffi_ring_entry_list_t>& list, const struct timespec& now, const T& entry)
+template <typename T>
+static void addRingEntryToList(std::unique_ptr<dnsdist_ffi_ring_entry_list_t>& list, const struct timespec& now, const T& entry)
 {
   auto age = DiffTime(entry.when, now);
 

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.hh
@@ -23,27 +23,31 @@
 
 #include "dnsdist.hh"
 
-extern "C" {
+extern "C"
+{
 #include "dnsdist-lua-ffi-interface.h"
 }
 
 #include "ext/luawrapper/include/LuaContext.hpp"
 
 // dnsdist_ffi_dnsquestion_t is a lightuserdata
-template<>
-struct LuaContext::Pusher<dnsdist_ffi_dnsquestion_t*> {
-    static const int minSize = 1;
-    static const int maxSize = 1;
+template <>
+struct LuaContext::Pusher<dnsdist_ffi_dnsquestion_t*>
+{
+  static const int minSize = 1;
+  static const int maxSize = 1;
 
-    static PushedObject push(lua_State* state, dnsdist_ffi_dnsquestion_t* ptr) noexcept {
-        lua_pushlightuserdata(state, ptr);
-        return PushedObject{state, 1};
-    }
+  static PushedObject push(lua_State* state, dnsdist_ffi_dnsquestion_t* ptr) noexcept
+  {
+    lua_pushlightuserdata(state, ptr);
+    return PushedObject{state, 1};
+  }
 };
 
 struct dnsdist_ffi_dnsquestion_t
 {
-  dnsdist_ffi_dnsquestion_t(DNSQuestion* dq_): dq(dq_)
+  dnsdist_ffi_dnsquestion_t(DNSQuestion* dq_) :
+    dq(dq_)
   {
   }
 
@@ -63,20 +67,23 @@ struct dnsdist_ffi_dnsquestion_t
 };
 
 // dnsdist_ffi_dnsresponse_t is a lightuserdata
-template<>
-struct LuaContext::Pusher<dnsdist_ffi_dnsresponse_t*> {
-    static const int minSize = 1;
-    static const int maxSize = 1;
+template <>
+struct LuaContext::Pusher<dnsdist_ffi_dnsresponse_t*>
+{
+  static const int minSize = 1;
+  static const int maxSize = 1;
 
-    static PushedObject push(lua_State* state, dnsdist_ffi_dnsresponse_t* ptr) noexcept {
-        lua_pushlightuserdata(state, ptr);
-        return PushedObject{state, 1};
-    }
+  static PushedObject push(lua_State* state, dnsdist_ffi_dnsresponse_t* ptr) noexcept
+  {
+    lua_pushlightuserdata(state, ptr);
+    return PushedObject{state, 1};
+  }
 };
 
 struct dnsdist_ffi_dnsresponse_t
 {
-  dnsdist_ffi_dnsresponse_t(DNSResponse* dr_): dr(dr_)
+  dnsdist_ffi_dnsresponse_t(DNSResponse* dr_) :
+    dr(dr_)
   {
   }
 
@@ -85,20 +92,23 @@ struct dnsdist_ffi_dnsresponse_t
 };
 
 // dnsdist_ffi_server_t is a lightuserdata
-template<>
-struct LuaContext::Pusher<dnsdist_ffi_server_t*> {
-    static const int minSize = 1;
-    static const int maxSize = 1;
+template <>
+struct LuaContext::Pusher<dnsdist_ffi_server_t*>
+{
+  static const int minSize = 1;
+  static const int maxSize = 1;
 
-    static PushedObject push(lua_State* state, dnsdist_ffi_server_t* ptr) noexcept {
-        lua_pushlightuserdata(state, ptr);
-        return PushedObject{state, 1};
-    }
+  static PushedObject push(lua_State* state, dnsdist_ffi_server_t* ptr) noexcept
+  {
+    lua_pushlightuserdata(state, ptr);
+    return PushedObject{state, 1};
+  }
 };
 
 struct dnsdist_ffi_server_t
 {
-  dnsdist_ffi_server_t(const std::shared_ptr<DownstreamState>& server_): server(server_)
+  dnsdist_ffi_server_t(const std::shared_ptr<DownstreamState>& server_) :
+    server(server_)
   {
   }
 
@@ -106,23 +116,26 @@ struct dnsdist_ffi_server_t
 };
 
 // dnsdist_ffi_servers_list_t is a lightuserdata
-template<>
-struct LuaContext::Pusher<dnsdist_ffi_servers_list_t*> {
-    static const int minSize = 1;
-    static const int maxSize = 1;
+template <>
+struct LuaContext::Pusher<dnsdist_ffi_servers_list_t*>
+{
+  static const int minSize = 1;
+  static const int maxSize = 1;
 
-    static PushedObject push(lua_State* state, dnsdist_ffi_servers_list_t* ptr) noexcept {
-        lua_pushlightuserdata(state, ptr);
-        return PushedObject{state, 1};
-    }
+  static PushedObject push(lua_State* state, dnsdist_ffi_servers_list_t* ptr) noexcept
+  {
+    lua_pushlightuserdata(state, ptr);
+    return PushedObject{state, 1};
+  }
 };
 
 struct dnsdist_ffi_servers_list_t
 {
-  dnsdist_ffi_servers_list_t(const ServerPolicy::NumberedServerVector& servers_): servers(servers_)
+  dnsdist_ffi_servers_list_t(const ServerPolicy::NumberedServerVector& servers_) :
+    servers(servers_)
   {
     ffiServers.reserve(servers.size());
-    for (const auto& server: servers) {
+    for (const auto& server : servers) {
       ffiServers.push_back(dnsdist_ffi_server_t(server.second));
     }
   }
@@ -132,20 +145,23 @@ struct dnsdist_ffi_servers_list_t
 };
 
 // dnsdist_ffi_network_message_t is a lightuserdata
-template<>
-struct LuaContext::Pusher<dnsdist_ffi_network_message_t*> {
-    static const int minSize = 1;
-    static const int maxSize = 1;
+template <>
+struct LuaContext::Pusher<dnsdist_ffi_network_message_t*>
+{
+  static const int minSize = 1;
+  static const int maxSize = 1;
 
-    static PushedObject push(lua_State* state, dnsdist_ffi_network_message_t* ptr) noexcept {
-        lua_pushlightuserdata(state, ptr);
-        return PushedObject{state, 1};
-    }
+  static PushedObject push(lua_State* state, dnsdist_ffi_network_message_t* ptr) noexcept
+  {
+    lua_pushlightuserdata(state, ptr);
+    return PushedObject{state, 1};
+  }
 };
 
 struct dnsdist_ffi_network_message_t
 {
-  dnsdist_ffi_network_message_t(const std::string& payload_ ,const std::string& from_, uint16_t endpointID_): payload(payload_), from(from_), endpointID(endpointID_)
+  dnsdist_ffi_network_message_t(const std::string& payload_, const std::string& from_, uint16_t endpointID_) :
+    payload(payload_), from(from_), endpointID(endpointID_)
   {
   }
 

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -85,6 +85,8 @@
 
 using std::thread;
 
+using update_metric_opts_t = LuaAssociativeTable<boost::variant<uint64_t, double, LuaAssociativeTable<std::string>>>;
+
 static boost::tribool s_noLuaSideEffect;
 
 /* this is a best effort way to prevent logging calls with no side-effects in the output of delta()
@@ -3419,8 +3421,20 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return true;
   });
-  luaCtx.writeFunction("incMetric", [](const std::string& name, boost::optional<uint64_t> step) {
-    auto result = dnsdist::metrics::incrementCustomCounter(name, step ? *step : 1);
+  luaCtx.writeFunction("incMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, boost::optional<update_metric_opts_t>>> opts) {
+    auto incOpts = opts.get_value_or(1);
+    uint64_t step = 1;
+    std::unordered_map<std::string, std::string> labels;
+    if (auto* custom_step = boost::get<uint64_t>(&incOpts)) {
+      step = *custom_step;
+    }
+    else {
+      boost::optional<update_metric_opts_t> vars = boost::get<boost::optional<update_metric_opts_t>>(incOpts);
+      getOptionalValue<uint64_t>(vars, "step", step);
+      getOptionalValue<LuaAssociativeTable<std::string>>(vars, "labels", labels);
+      checkAllParametersConsumed("incMetric", vars);
+    }
+    auto result = dnsdist::metrics::incrementCustomCounter(name, step, labels);
     if (const auto* errorStr = std::get_if<dnsdist::metrics::Error>(&result)) {
       g_outputBuffer = *errorStr + "'\n";
       errlog("Error in incMetric: %s", *errorStr);
@@ -3428,8 +3442,20 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return std::get<uint64_t>(result);
   });
-  luaCtx.writeFunction("decMetric", [](const std::string& name, boost::optional<uint64_t> step) {
-    auto result = dnsdist::metrics::decrementCustomCounter(name, step ? *step : 1);
+  luaCtx.writeFunction("decMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, boost::optional<update_metric_opts_t>>> opts) {
+    auto decOpts = opts.get_value_or(1);
+    uint64_t step = 1;
+    std::unordered_map<std::string, std::string> labels;
+    if (auto custom_step = boost::get<uint64_t>(&decOpts)) {
+      step = *custom_step;
+    }
+    else {
+      boost::optional<update_metric_opts_t> vars = boost::get<boost::optional<update_metric_opts_t>>(decOpts);
+      getOptionalValue<uint64_t>(vars, "step", step);
+      getOptionalValue<LuaAssociativeTable<std::string>>(vars, "labels", labels);
+      checkAllParametersConsumed("decMetric", vars);
+    }
+    auto result = dnsdist::metrics::decrementCustomCounter(name, step, labels);
     if (const auto* errorStr = std::get_if<dnsdist::metrics::Error>(&result)) {
       g_outputBuffer = *errorStr + "'\n";
       errlog("Error in decMetric: %s", *errorStr);
@@ -3437,8 +3463,13 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return std::get<uint64_t>(result);
   });
-  luaCtx.writeFunction("setMetric", [](const std::string& name, const double value) -> double {
-    auto result = dnsdist::metrics::setCustomGauge(name, value);
+  luaCtx.writeFunction("setMetric", [](const std::string& name, const double value, boost::optional<update_metric_opts_t> opts) -> double {
+    std::unordered_map<std::string, std::string> labels;
+    if (opts) {
+      getOptionalValue<LuaAssociativeTable<std::string>>(opts, "labels", labels);
+    }
+    checkAllParametersConsumed("setMetric", opts);
+    auto result = dnsdist::metrics::setCustomGauge(name, value, labels);
     if (const auto* errorStr = std::get_if<dnsdist::metrics::Error>(&result)) {
       g_outputBuffer = *errorStr + "'\n";
       errlog("Error in setMetric: %s", *errorStr);
@@ -3446,8 +3477,13 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return std::get<double>(result);
   });
-  luaCtx.writeFunction("getMetric", [](const std::string& name) {
-    auto result = dnsdist::metrics::getCustomMetric(name);
+  luaCtx.writeFunction("getMetric", [](const std::string& name, boost::optional<update_metric_opts_t> opts) {
+    std::unordered_map<std::string, std::string> labels;
+    if (opts) {
+      getOptionalValue<LuaAssociativeTable<std::string>>(opts, "labels", labels);
+    }
+    checkAllParametersConsumed("getMetric", opts);
+    auto result = dnsdist::metrics::getCustomMetric(name, labels);
     if (const auto* errorStr = std::get_if<dnsdist::metrics::Error>(&result)) {
       g_outputBuffer = *errorStr + "'\n";
       errlog("Error in getMetric: %s", *errorStr);

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3436,6 +3436,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return true;
   });
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   luaCtx.writeFunction("incMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, update_metric_opts_t>> opts) {
     auto incOpts = opts.get_value_or(1);
     uint64_t step = 1;
@@ -3457,6 +3458,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return std::get<uint64_t>(result);
   });
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   luaCtx.writeFunction("decMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, update_metric_opts_t>> opts) {
     auto decOpts = opts.get_value_or(1);
     uint64_t step = 1;

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -886,29 +886,28 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     const std::function<void(dnsdist::configuration::ImmutableConfiguration& config, uint64_t value)> mutator;
     const size_t maximumValue{std::numeric_limits<uint64_t>::max()};
   };
-  static const std::vector<UnsignedIntegerImmutableConfigurationItems> unsignedIntegerImmutableConfigItems
-  {
+  static const std::vector<UnsignedIntegerImmutableConfigurationItems> unsignedIntegerImmutableConfigItems{
     {"setMaxTCPQueuedConnections", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPQueuedConnections = newValue; }, std::numeric_limits<uint16_t>::max()},
-      {"setMaxTCPClientThreads", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPClientThreads = newValue; }, std::numeric_limits<uint16_t>::max()},
-      {"setMaxTCPConnectionsPerClient", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPConnectionsPerClient = newValue; }, std::numeric_limits<uint64_t>::max()},
-      {"setTCPInternalPipeBufferSize", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpInternalPipeBufferSize = newValue; }, std::numeric_limits<uint64_t>::max()},
-      {"setMaxCachedTCPConnectionsPerDownstream", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPMaxIdlePerBackend = newValue; }, std::numeric_limits<uint16_t>::max()},
-      {"setTCPDownstreamCleanupInterval", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPCleanupInterval = newValue; }, std::numeric_limits<uint32_t>::max()},
-      {"setTCPDownstreamMaxIdleTime", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPMaxIdleTime = newValue; }, std::numeric_limits<uint16_t>::max()},
+    {"setMaxTCPClientThreads", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPClientThreads = newValue; }, std::numeric_limits<uint16_t>::max()},
+    {"setMaxTCPConnectionsPerClient", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPConnectionsPerClient = newValue; }, std::numeric_limits<uint64_t>::max()},
+    {"setTCPInternalPipeBufferSize", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpInternalPipeBufferSize = newValue; }, std::numeric_limits<uint64_t>::max()},
+    {"setMaxCachedTCPConnectionsPerDownstream", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPMaxIdlePerBackend = newValue; }, std::numeric_limits<uint16_t>::max()},
+    {"setTCPDownstreamCleanupInterval", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPCleanupInterval = newValue; }, std::numeric_limits<uint32_t>::max()},
+    {"setTCPDownstreamMaxIdleTime", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPMaxIdleTime = newValue; }, std::numeric_limits<uint16_t>::max()},
 #if defined(HAVE_DNS_OVER_HTTPS) && defined(HAVE_NGHTTP2)
-      {"setOutgoingDoHWorkerThreads", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHWorkers = newValue; }, std::numeric_limits<uint16_t>::max()},
-      {"setMaxIdleDoHConnectionsPerDownstream", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHMaxIdlePerBackend = newValue; }, std::numeric_limits<uint16_t>::max()},
-      {"setDoHDownstreamCleanupInterval", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHCleanupInterval = newValue; }, std::numeric_limits<uint32_t>::max()},
-      {"setDoHDownstreamMaxIdleTime", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHMaxIdleTime = newValue; }, std::numeric_limits<uint16_t>::max()},
+    {"setOutgoingDoHWorkerThreads", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHWorkers = newValue; }, std::numeric_limits<uint16_t>::max()},
+    {"setMaxIdleDoHConnectionsPerDownstream", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHMaxIdlePerBackend = newValue; }, std::numeric_limits<uint16_t>::max()},
+    {"setDoHDownstreamCleanupInterval", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHCleanupInterval = newValue; }, std::numeric_limits<uint32_t>::max()},
+    {"setDoHDownstreamMaxIdleTime", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHMaxIdleTime = newValue; }, std::numeric_limits<uint16_t>::max()},
 #endif /* HAVE_DNS_OVER_HTTPS && HAVE_NGHTTP2 */
-      {"setMaxUDPOutstanding", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxUDPOutstanding = newValue; }, std::numeric_limits<uint16_t>::max()},
-      {"setWHashedPertubation", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_hashPerturbation = newValue; }, std::numeric_limits<uint32_t>::max()},
+    {"setMaxUDPOutstanding", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxUDPOutstanding = newValue; }, std::numeric_limits<uint16_t>::max()},
+    {"setWHashedPertubation", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_hashPerturbation = newValue; }, std::numeric_limits<uint32_t>::max()},
 #ifndef DISABLE_RECVMMSG
-      {"setUDPMultipleMessagesVectorSize", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_udpVectorSize = newValue; }, std::numeric_limits<uint32_t>::max()},
+    {"setUDPMultipleMessagesVectorSize", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_udpVectorSize = newValue; }, std::numeric_limits<uint32_t>::max()},
 #endif /* DISABLE_RECVMMSG */
-      {"setUDPTimeout", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_udpTimeout = newValue; }, std::numeric_limits<uint8_t>::max()},
-      {"setConsoleMaximumConcurrentConnections", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_consoleMaxConcurrentConnections = newValue; }, std::numeric_limits<uint32_t>::max()},
-      {"setRingBuffersLockRetries", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_ringsNbLockTries = newValue; }, std::numeric_limits<uint64_t>::max()},
+    {"setUDPTimeout", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_udpTimeout = newValue; }, std::numeric_limits<uint8_t>::max()},
+    {"setConsoleMaximumConcurrentConnections", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_consoleMaxConcurrentConnections = newValue; }, std::numeric_limits<uint32_t>::max()},
+    {"setRingBuffersLockRetries", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_ringsNbLockTries = newValue; }, std::numeric_limits<uint64_t>::max()},
   };
 
   struct DoubleImmutableConfigurationItems
@@ -1267,7 +1266,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
   luaCtx.writeFunction("getPoolServers", [](const string& pool) {
-    //coverity[auto_causes_copy]
+    // coverity[auto_causes_copy]
     const auto poolServers = getDownstreamCandidates(pool);
     return *poolServers;
   });
@@ -1603,7 +1602,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       g_outputBuffer = "Crypto failed..\n";
     }
 #else
-      g_outputBuffer = "Crypto not available.\n";
+    g_outputBuffer = "Crypto not available.\n";
 #endif
   });
 
@@ -1876,9 +1875,9 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       //             1        2         3                4
       ret << (fmt % "Name" % "Cache" % "ServerPolicy" % "Servers") << endl;
 
-      //coverity[auto_causes_copy]
+      // coverity[auto_causes_copy]
       const auto defaultPolicyName = dnsdist::configuration::getCurrentRuntimeConfiguration().d_lbPolicy->getName();
-      //coverity[auto_causes_copy]
+      // coverity[auto_causes_copy]
       const auto pools = dnsdist::configuration::getCurrentRuntimeConfiguration().d_pools;
       for (const auto& entry : pools) {
         const string& name = entry.first;
@@ -2461,7 +2460,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #ifdef HAVE_NGHTTP2
       frontend->d_library = "nghttp2";
 #else /* HAVE_NGHTTP2 */
-        frontend->d_library = "h2o";
+      frontend->d_library = "h2o";
 #endif /* HAVE_NGHTTP2 */
     }
     if (frontend->d_library == "h2o") {
@@ -2470,8 +2469,8 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       // we _really_ need to set it again, as we just replaced the generic frontend by a new one
       frontend->d_library = "h2o";
 #else /* HAVE_LIBH2OEVLOOP */
-        errlog("DOH bind %s is configured to use libh2o but the library is not available", addr);
-        return;
+      errlog("DOH bind %s is configured to use libh2o but the library is not available", addr);
+      return;
 #endif /* HAVE_LIBH2OEVLOOP */
     }
     else if (frontend->d_library == "nghttp2") {
@@ -2588,7 +2587,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #ifdef HAVE_LIBSSL
         const std::string provider("openssl");
 #else
-          const std::string provider("gnutls");
+        const std::string provider("gnutls");
 #endif
         vinfolog("Loading default TLS provider '%s'", provider);
       }
@@ -2609,7 +2608,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       config.d_frontends.push_back(std::move(clientState));
     });
 #else /* HAVE_DNS_OVER_HTTPS */
-      throw std::runtime_error("addDOHLocal() called but DNS over HTTPS support is not present!");
+    throw std::runtime_error("addDOHLocal() called but DNS over HTTPS support is not present!");
 #endif /* HAVE_DNS_OVER_HTTPS */
   });
 
@@ -2686,7 +2685,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       config.d_frontends.push_back(std::move(clientState));
     });
 #else
-      throw std::runtime_error("addDOH3Local() called but DNS over HTTP/3 support is not present!");
+    throw std::runtime_error("addDOH3Local() called but DNS over HTTP/3 support is not present!");
 #endif
   });
 
@@ -2763,7 +2762,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       config.d_frontends.push_back(std::move(clientState));
     });
 #else
-      throw std::runtime_error("addDOQLocal() called but DNS over QUIC support is not present!");
+    throw std::runtime_error("addDOQLocal() called but DNS over QUIC support is not present!");
 #endif
   });
 
@@ -2786,7 +2785,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-      g_outputBuffer = "DNS over QUIC support is not present!\n";
+    g_outputBuffer = "DNS over QUIC support is not present!\n";
 #endif
   });
 
@@ -2845,7 +2844,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-      g_outputBuffer = "DNS over HTTPS support is not present!\n";
+    g_outputBuffer = "DNS over HTTPS support is not present!\n";
 #endif
   });
 
@@ -2868,7 +2867,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-      g_outputBuffer = "DNS over HTTP3 support is not present!\n";
+    g_outputBuffer = "DNS over HTTP3 support is not present!\n";
 #endif
   });
 
@@ -2938,7 +2937,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-      g_outputBuffer = "DNS over HTTPS support is not present!\n";
+    g_outputBuffer = "DNS over HTTPS support is not present!\n";
 #endif
   });
 
@@ -3117,7 +3116,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #ifdef HAVE_LIBSSL
         const std::string provider("openssl");
 #else
-          const std::string provider("gnutls");
+        const std::string provider("gnutls");
 #endif
         vinfolog("Loading default TLS provider '%s'", provider);
       }
@@ -3143,7 +3142,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       g_outputBuffer = "Error: " + string(e.what()) + "\n";
     }
 #else
-      throw std::runtime_error("addTLSLocal() called but DNS over TLS support is not present!");
+    throw std::runtime_error("addTLSLocal() called but DNS over TLS support is not present!");
 #endif
   });
 
@@ -3167,7 +3166,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-      g_outputBuffer = "DNS over TLS support is not present!\n";
+    g_outputBuffer = "DNS over TLS support is not present!\n";
 #endif
   });
 

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3412,7 +3412,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     newThread.detach();
   });
 
-  luaCtx.writeFunction("declareMetric", [](const std::string& name, const std::string& type, const std::string& description, boost::optional<boost::variant<std::string, boost::optional<declare_metric_opts_t>>> opts) {
+  luaCtx.writeFunction("declareMetric", [](const std::string& name, const std::string& type, const std::string& description, boost::optional<boost::variant<std::string, declare_metric_opts_t>> opts) {
     bool withLabels = false;
     std::optional<std::string> customName = std::nullopt;
     if (opts) {
@@ -3421,7 +3421,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         customName = std::optional(*optCustomName);
       }
       if (!customName) {
-        boost::optional<declare_metric_opts_t> vars = boost::get<boost::optional<declare_metric_opts_t>>(opts.get());
+        boost::optional<declare_metric_opts_t> vars = {boost::get<declare_metric_opts_t>(opts.get())};
         getOptionalValue<std::string>(vars, "customName", customName);
         getOptionalValue<bool>(vars, "withLabels", withLabels);
         checkAllParametersConsumed("declareMetric", vars);
@@ -3435,7 +3435,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return true;
   });
-  luaCtx.writeFunction("incMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, boost::optional<update_metric_opts_t>>> opts) {
+  luaCtx.writeFunction("incMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, update_metric_opts_t>> opts) {
     auto incOpts = opts.get_value_or(1);
     uint64_t step = 1;
     std::unordered_map<std::string, std::string> labels;
@@ -3443,7 +3443,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       step = *custom_step;
     }
     else {
-      boost::optional<update_metric_opts_t> vars = boost::get<boost::optional<update_metric_opts_t>>(incOpts);
+      boost::optional<update_metric_opts_t> vars = {boost::get<update_metric_opts_t>(incOpts)};
       getOptionalValue<uint64_t>(vars, "step", step);
       getOptionalValue<LuaAssociativeTable<std::string>>(vars, "labels", labels);
       checkAllParametersConsumed("incMetric", vars);
@@ -3456,7 +3456,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return std::get<uint64_t>(result);
   });
-  luaCtx.writeFunction("decMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, boost::optional<update_metric_opts_t>>> opts) {
+  luaCtx.writeFunction("decMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, update_metric_opts_t>> opts) {
     auto decOpts = opts.get_value_or(1);
     uint64_t step = 1;
     std::unordered_map<std::string, std::string> labels;
@@ -3464,7 +3464,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       step = *custom_step;
     }
     else {
-      boost::optional<update_metric_opts_t> vars = boost::get<boost::optional<update_metric_opts_t>>(decOpts);
+      boost::optional<update_metric_opts_t> vars = {boost::get<update_metric_opts_t>(decOpts)};
       getOptionalValue<uint64_t>(vars, "step", step);
       getOptionalValue<LuaAssociativeTable<std::string>>(vars, "labels", labels);
       checkAllParametersConsumed("decMetric", vars);

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -886,28 +886,29 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     const std::function<void(dnsdist::configuration::ImmutableConfiguration& config, uint64_t value)> mutator;
     const size_t maximumValue{std::numeric_limits<uint64_t>::max()};
   };
-  static const std::vector<UnsignedIntegerImmutableConfigurationItems> unsignedIntegerImmutableConfigItems{
+  static const std::vector<UnsignedIntegerImmutableConfigurationItems> unsignedIntegerImmutableConfigItems
+  {
     {"setMaxTCPQueuedConnections", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPQueuedConnections = newValue; }, std::numeric_limits<uint16_t>::max()},
-    {"setMaxTCPClientThreads", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPClientThreads = newValue; }, std::numeric_limits<uint16_t>::max()},
-    {"setMaxTCPConnectionsPerClient", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPConnectionsPerClient = newValue; }, std::numeric_limits<uint64_t>::max()},
-    {"setTCPInternalPipeBufferSize", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpInternalPipeBufferSize = newValue; }, std::numeric_limits<uint64_t>::max()},
-    {"setMaxCachedTCPConnectionsPerDownstream", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPMaxIdlePerBackend = newValue; }, std::numeric_limits<uint16_t>::max()},
-    {"setTCPDownstreamCleanupInterval", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPCleanupInterval = newValue; }, std::numeric_limits<uint32_t>::max()},
-    {"setTCPDownstreamMaxIdleTime", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPMaxIdleTime = newValue; }, std::numeric_limits<uint16_t>::max()},
+      {"setMaxTCPClientThreads", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPClientThreads = newValue; }, std::numeric_limits<uint16_t>::max()},
+      {"setMaxTCPConnectionsPerClient", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPConnectionsPerClient = newValue; }, std::numeric_limits<uint64_t>::max()},
+      {"setTCPInternalPipeBufferSize", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpInternalPipeBufferSize = newValue; }, std::numeric_limits<uint64_t>::max()},
+      {"setMaxCachedTCPConnectionsPerDownstream", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPMaxIdlePerBackend = newValue; }, std::numeric_limits<uint16_t>::max()},
+      {"setTCPDownstreamCleanupInterval", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPCleanupInterval = newValue; }, std::numeric_limits<uint32_t>::max()},
+      {"setTCPDownstreamMaxIdleTime", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingTCPMaxIdleTime = newValue; }, std::numeric_limits<uint16_t>::max()},
 #if defined(HAVE_DNS_OVER_HTTPS) && defined(HAVE_NGHTTP2)
-    {"setOutgoingDoHWorkerThreads", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHWorkers = newValue; }, std::numeric_limits<uint16_t>::max()},
-    {"setMaxIdleDoHConnectionsPerDownstream", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHMaxIdlePerBackend = newValue; }, std::numeric_limits<uint16_t>::max()},
-    {"setDoHDownstreamCleanupInterval", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHCleanupInterval = newValue; }, std::numeric_limits<uint32_t>::max()},
-    {"setDoHDownstreamMaxIdleTime", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHMaxIdleTime = newValue; }, std::numeric_limits<uint16_t>::max()},
+      {"setOutgoingDoHWorkerThreads", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHWorkers = newValue; }, std::numeric_limits<uint16_t>::max()},
+      {"setMaxIdleDoHConnectionsPerDownstream", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHMaxIdlePerBackend = newValue; }, std::numeric_limits<uint16_t>::max()},
+      {"setDoHDownstreamCleanupInterval", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHCleanupInterval = newValue; }, std::numeric_limits<uint32_t>::max()},
+      {"setDoHDownstreamMaxIdleTime", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_outgoingDoHMaxIdleTime = newValue; }, std::numeric_limits<uint16_t>::max()},
 #endif /* HAVE_DNS_OVER_HTTPS && HAVE_NGHTTP2 */
-    {"setMaxUDPOutstanding", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxUDPOutstanding = newValue; }, std::numeric_limits<uint16_t>::max()},
-    {"setWHashedPertubation", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_hashPerturbation = newValue; }, std::numeric_limits<uint32_t>::max()},
+      {"setMaxUDPOutstanding", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxUDPOutstanding = newValue; }, std::numeric_limits<uint16_t>::max()},
+      {"setWHashedPertubation", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_hashPerturbation = newValue; }, std::numeric_limits<uint32_t>::max()},
 #ifndef DISABLE_RECVMMSG
-    {"setUDPMultipleMessagesVectorSize", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_udpVectorSize = newValue; }, std::numeric_limits<uint32_t>::max()},
+      {"setUDPMultipleMessagesVectorSize", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_udpVectorSize = newValue; }, std::numeric_limits<uint32_t>::max()},
 #endif /* DISABLE_RECVMMSG */
-    {"setUDPTimeout", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_udpTimeout = newValue; }, std::numeric_limits<uint8_t>::max()},
-    {"setConsoleMaximumConcurrentConnections", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_consoleMaxConcurrentConnections = newValue; }, std::numeric_limits<uint32_t>::max()},
-    {"setRingBuffersLockRetries", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_ringsNbLockTries = newValue; }, std::numeric_limits<uint64_t>::max()},
+      {"setUDPTimeout", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_udpTimeout = newValue; }, std::numeric_limits<uint8_t>::max()},
+      {"setConsoleMaximumConcurrentConnections", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_consoleMaxConcurrentConnections = newValue; }, std::numeric_limits<uint32_t>::max()},
+      {"setRingBuffersLockRetries", [](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_ringsNbLockTries = newValue; }, std::numeric_limits<uint64_t>::max()},
   };
 
   struct DoubleImmutableConfigurationItems
@@ -1602,7 +1603,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       g_outputBuffer = "Crypto failed..\n";
     }
 #else
-    g_outputBuffer = "Crypto not available.\n";
+      g_outputBuffer = "Crypto not available.\n";
 #endif
   });
 
@@ -2460,7 +2461,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #ifdef HAVE_NGHTTP2
       frontend->d_library = "nghttp2";
 #else /* HAVE_NGHTTP2 */
-      frontend->d_library = "h2o";
+        frontend->d_library = "h2o";
 #endif /* HAVE_NGHTTP2 */
     }
     if (frontend->d_library == "h2o") {
@@ -2469,8 +2470,8 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       // we _really_ need to set it again, as we just replaced the generic frontend by a new one
       frontend->d_library = "h2o";
 #else /* HAVE_LIBH2OEVLOOP */
-      errlog("DOH bind %s is configured to use libh2o but the library is not available", addr);
-      return;
+        errlog("DOH bind %s is configured to use libh2o but the library is not available", addr);
+        return;
 #endif /* HAVE_LIBH2OEVLOOP */
     }
     else if (frontend->d_library == "nghttp2") {
@@ -2587,7 +2588,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #ifdef HAVE_LIBSSL
         const std::string provider("openssl");
 #else
-        const std::string provider("gnutls");
+          const std::string provider("gnutls");
 #endif
         vinfolog("Loading default TLS provider '%s'", provider);
       }
@@ -2608,7 +2609,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       config.d_frontends.push_back(std::move(clientState));
     });
 #else /* HAVE_DNS_OVER_HTTPS */
-    throw std::runtime_error("addDOHLocal() called but DNS over HTTPS support is not present!");
+      throw std::runtime_error("addDOHLocal() called but DNS over HTTPS support is not present!");
 #endif /* HAVE_DNS_OVER_HTTPS */
   });
 
@@ -2685,7 +2686,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       config.d_frontends.push_back(std::move(clientState));
     });
 #else
-    throw std::runtime_error("addDOH3Local() called but DNS over HTTP/3 support is not present!");
+      throw std::runtime_error("addDOH3Local() called but DNS over HTTP/3 support is not present!");
 #endif
   });
 
@@ -2762,7 +2763,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       config.d_frontends.push_back(std::move(clientState));
     });
 #else
-    throw std::runtime_error("addDOQLocal() called but DNS over QUIC support is not present!");
+      throw std::runtime_error("addDOQLocal() called but DNS over QUIC support is not present!");
 #endif
   });
 
@@ -2785,7 +2786,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-    g_outputBuffer = "DNS over QUIC support is not present!\n";
+      g_outputBuffer = "DNS over QUIC support is not present!\n";
 #endif
   });
 
@@ -2844,7 +2845,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-    g_outputBuffer = "DNS over HTTPS support is not present!\n";
+      g_outputBuffer = "DNS over HTTPS support is not present!\n";
 #endif
   });
 
@@ -2867,7 +2868,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-    g_outputBuffer = "DNS over HTTP3 support is not present!\n";
+      g_outputBuffer = "DNS over HTTP3 support is not present!\n";
 #endif
   });
 
@@ -2937,7 +2938,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-    g_outputBuffer = "DNS over HTTPS support is not present!\n";
+      g_outputBuffer = "DNS over HTTPS support is not present!\n";
 #endif
   });
 
@@ -3116,7 +3117,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #ifdef HAVE_LIBSSL
         const std::string provider("openssl");
 #else
-        const std::string provider("gnutls");
+          const std::string provider("gnutls");
 #endif
         vinfolog("Loading default TLS provider '%s'", provider);
       }
@@ -3142,7 +3143,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       g_outputBuffer = "Error: " + string(e.what()) + "\n";
     }
 #else
-    throw std::runtime_error("addTLSLocal() called but DNS over TLS support is not present!");
+      throw std::runtime_error("addTLSLocal() called but DNS over TLS support is not present!");
 #endif
   });
 
@@ -3166,7 +3167,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       throw;
     }
 #else
-    g_outputBuffer = "DNS over TLS support is not present!\n";
+      g_outputBuffer = "DNS over TLS support is not present!\n";
 #endif
   });
 

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3413,12 +3413,12 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     newThread.detach();
   });
 
-  luaCtx.writeFunction("declareMetric", [](const std::string& name, const std::string& type, const std::string& description, boost::optional<boost::variant<std::string, declare_metric_opts_t>> opts) {
+  luaCtx.writeFunction("declareMetric", [](const std::string& name, const std::string& type, const std::string& description, const boost::optional<boost::variant<std::string, declare_metric_opts_t>>& opts) {
     bool withLabels = false;
     std::optional<std::string> customName = std::nullopt;
     if (opts) {
       auto* optCustomName = boost::get<std::string>(&opts.get());
-      if (optCustomName) {
+      if (optCustomName != nullptr) {
         customName = std::optional(*optCustomName);
       }
       if (!customName) {
@@ -3436,7 +3436,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return true;
   });
-  luaCtx.writeFunction("incMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, update_metric_opts_t>> opts) {
+  luaCtx.writeFunction("incMetric", [](const std::string& name, const boost::optional<boost::variant<uint64_t, update_metric_opts_t>>& opts) {
     auto incOpts = opts.get_value_or(1);
     uint64_t step = 1;
     std::unordered_map<std::string, std::string> labels;
@@ -3457,11 +3457,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return std::get<uint64_t>(result);
   });
-  luaCtx.writeFunction("decMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, update_metric_opts_t>> opts) {
+  luaCtx.writeFunction("decMetric", [](const std::string& name, const boost::optional<boost::variant<uint64_t, update_metric_opts_t>>& opts) {
     auto decOpts = opts.get_value_or(1);
     uint64_t step = 1;
     std::unordered_map<std::string, std::string> labels;
-    if (auto custom_step = boost::get<uint64_t>(&decOpts)) {
+    if (auto* custom_step = boost::get<uint64_t>(&decOpts)) {
       step = *custom_step;
     }
     else {

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3413,7 +3413,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     newThread.detach();
   });
 
-  luaCtx.writeFunction("declareMetric", [](const std::string& name, const std::string& type, const std::string& description, const boost::optional<boost::variant<std::string, declare_metric_opts_t>>& opts) {
+  luaCtx.writeFunction("declareMetric", [](const std::string& name, const std::string& type, const std::string& description, boost::optional<boost::variant<std::string, declare_metric_opts_t>> opts) {
     bool withLabels = false;
     std::optional<std::string> customName = std::nullopt;
     if (opts) {
@@ -3436,7 +3436,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return true;
   });
-  luaCtx.writeFunction("incMetric", [](const std::string& name, const boost::optional<boost::variant<uint64_t, update_metric_opts_t>>& opts) {
+  luaCtx.writeFunction("incMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, update_metric_opts_t>> opts) {
     auto incOpts = opts.get_value_or(1);
     uint64_t step = 1;
     std::unordered_map<std::string, std::string> labels;
@@ -3457,7 +3457,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
     return std::get<uint64_t>(result);
   });
-  luaCtx.writeFunction("decMetric", [](const std::string& name, const boost::optional<boost::variant<uint64_t, update_metric_opts_t>>& opts) {
+  luaCtx.writeFunction("decMetric", [](const std::string& name, boost::optional<boost::variant<uint64_t, update_metric_opts_t>> opts) {
     auto decOpts = opts.get_value_or(1);
     uint64_t step = 1;
     std::unordered_map<std::string, std::string> labels;

--- a/pdns/dnsdistdist/dnsdist-metrics.cc
+++ b/pdns/dnsdistdist/dnsdist-metrics.cc
@@ -227,7 +227,8 @@ static string prometheusLabelValueEscape(const string& value)
 
 static std::string generateCombinationOfLabels(const std::unordered_map<std::string, std::string>& labels)
 {
-  return std::accumulate(labels.begin(), labels.end(), std::string(), [](const std::string& acc, const std::pair<std::string, std::string>& l) {
+  auto ordered = std::map(labels.begin(), labels.end());
+  return std::accumulate(ordered.begin(), ordered.end(), std::string(), [](const std::string& acc, const std::pair<std::string, std::string>& l) {
     return acc + (acc.empty() ? std::string() : ",") + l.first + "=" + "\"" + prometheusLabelValueEscape(l.second) + "\"";
   });
 }

--- a/pdns/dnsdistdist/dnsdist-metrics.cc
+++ b/pdns/dnsdistdist/dnsdist-metrics.cc
@@ -19,6 +19,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#include <boost/algorithm/string/join.hpp>
+#include <numeric>
 #include <regex>
 
 #include "dnsdist-metrics.hh"
@@ -67,100 +69,100 @@ struct MutableGauge
   mutable pdns::stat_double_t d_value{0};
 };
 
-static SharedLockGuarded<std::map<std::string, MutableCounter, std::less<>>> s_customCounters;
-static SharedLockGuarded<std::map<std::string, MutableGauge, std::less<>>> s_customGauges;
+static SharedLockGuarded<std::map<std::string, std::map<std::string, MutableCounter>, std::less<>>> s_customCounters;
+static SharedLockGuarded<std::map<std::string, std::map<std::string, MutableGauge>, std::less<>>> s_customGauges;
 
 Stats::Stats() :
-  entries{std::vector<EntryPair>{
-    {"responses", &responses},
-    {"servfail-responses", &servfailResponses},
-    {"queries", &queries},
-    {"frontend-nxdomain", &frontendNXDomain},
-    {"frontend-servfail", &frontendServFail},
-    {"frontend-noerror", &frontendNoError},
-    {"acl-drops", &aclDrops},
-    {"rule-drop", &ruleDrop},
-    {"rule-nxdomain", &ruleNXDomain},
-    {"rule-refused", &ruleRefused},
-    {"rule-servfail", &ruleServFail},
-    {"rule-truncated", &ruleTruncated},
-    {"self-answered", &selfAnswered},
-    {"downstream-timeouts", &downstreamTimeouts},
-    {"downstream-send-errors", &downstreamSendErrors},
-    {"trunc-failures", &truncFail},
-    {"no-policy", &noPolicy},
-    {"latency0-1", &latency0_1},
-    {"latency1-10", &latency1_10},
-    {"latency10-50", &latency10_50},
-    {"latency50-100", &latency50_100},
-    {"latency100-1000", &latency100_1000},
-    {"latency-slow", &latencySlow},
-    {"latency-avg100", &latencyAvg100},
-    {"latency-avg1000", &latencyAvg1000},
-    {"latency-avg10000", &latencyAvg10000},
-    {"latency-avg1000000", &latencyAvg1000000},
-    {"latency-tcp-avg100", &latencyTCPAvg100},
-    {"latency-tcp-avg1000", &latencyTCPAvg1000},
-    {"latency-tcp-avg10000", &latencyTCPAvg10000},
-    {"latency-tcp-avg1000000", &latencyTCPAvg1000000},
-    {"latency-dot-avg100", &latencyDoTAvg100},
-    {"latency-dot-avg1000", &latencyDoTAvg1000},
-    {"latency-dot-avg10000", &latencyDoTAvg10000},
-    {"latency-dot-avg1000000", &latencyDoTAvg1000000},
-    {"latency-doh-avg100", &latencyDoHAvg100},
-    {"latency-doh-avg1000", &latencyDoHAvg1000},
-    {"latency-doh-avg10000", &latencyDoHAvg10000},
-    {"latency-doh-avg1000000", &latencyDoHAvg1000000},
-    {"latency-doq-avg100", &latencyDoQAvg100},
-    {"latency-doq-avg1000", &latencyDoQAvg1000},
-    {"latency-doq-avg10000", &latencyDoQAvg10000},
-    {"latency-doq-avg1000000", &latencyDoQAvg1000000},
-    {"latency-doh3-avg100", &latencyDoH3Avg100},
-    {"latency-doh3-avg1000", &latencyDoH3Avg1000},
-    {"latency-doh3-avg10000", &latencyDoH3Avg10000},
-    {"latency-doh3-avg1000000", &latencyDoH3Avg1000000},
-    {"uptime", uptimeOfProcess},
-    {"real-memory-usage", getRealMemoryUsage},
-    {"special-memory-usage", getSpecialMemoryUsage},
-    {"udp-in-errors", [](const std::string&) { return udpErrorStats("udp-in-errors"); }},
-    {"udp-noport-errors", [](const std::string&) { return udpErrorStats("udp-noport-errors"); }},
-    {"udp-recvbuf-errors", [](const std::string&) { return udpErrorStats("udp-recvbuf-errors"); }},
-    {"udp-sndbuf-errors", [](const std::string&) { return udpErrorStats("udp-sndbuf-errors"); }},
-    {"udp-in-csum-errors", [](const std::string&) { return udpErrorStats("udp-in-csum-errors"); }},
-    {"udp6-in-errors", [](const std::string&) { return udp6ErrorStats("udp6-in-errors"); }},
-    {"udp6-recvbuf-errors", [](const std::string&) { return udp6ErrorStats("udp6-recvbuf-errors"); }},
-    {"udp6-sndbuf-errors", [](const std::string&) { return udp6ErrorStats("udp6-sndbuf-errors"); }},
-    {"udp6-noport-errors", [](const std::string&) { return udp6ErrorStats("udp6-noport-errors"); }},
-    {"udp6-in-csum-errors", [](const std::string&) { return udp6ErrorStats("udp6-in-csum-errors"); }},
-    {"tcp-listen-overflows", [](const std::string&) { return tcpErrorStats("ListenOverflows"); }},
-    {"noncompliant-queries", &nonCompliantQueries},
-    {"noncompliant-responses", &nonCompliantResponses},
-    {"proxy-protocol-invalid", &proxyProtocolInvalid},
-    {"rdqueries", &rdQueries},
-    {"empty-queries", &emptyQueries},
-    {"cache-hits", &cacheHits},
-    {"cache-misses", &cacheMisses},
-    {"cpu-iowait", getCPUIOWait},
-    {"cpu-steal", getCPUSteal},
-    {"cpu-sys-msec", getCPUTimeSystem},
-    {"cpu-user-msec", getCPUTimeUser},
-    {"fd-usage", getOpenFileDescriptors},
-    {"dyn-blocked", &dynBlocked},
+  entries{std::vector<EntryTriple>{
+    {"responses", "", &responses},
+    {"servfail-responses", "", &servfailResponses},
+    {"queries", "", &queries},
+    {"frontend-nxdomain", "", &frontendNXDomain},
+    {"frontend-servfail", "", &frontendServFail},
+    {"frontend-noerror", "", &frontendNoError},
+    {"acl-drops", "", &aclDrops},
+    {"rule-drop", "", &ruleDrop},
+    {"rule-nxdomain", "", &ruleNXDomain},
+    {"rule-refused", "", &ruleRefused},
+    {"rule-servfail", "", &ruleServFail},
+    {"rule-truncated", "", &ruleTruncated},
+    {"self-answered", "", &selfAnswered},
+    {"downstream-timeouts", "", &downstreamTimeouts},
+    {"downstream-send-errors", "", &downstreamSendErrors},
+    {"trunc-failures", "", &truncFail},
+    {"no-policy", "", &noPolicy},
+    {"latency0-1", "", &latency0_1},
+    {"latency1-10", "", &latency1_10},
+    {"latency10-50", "", &latency10_50},
+    {"latency50-100", "", &latency50_100},
+    {"latency100-1000", "", &latency100_1000},
+    {"latency-slow", "", &latencySlow},
+    {"latency-avg100", "", &latencyAvg100},
+    {"latency-avg1000", "", &latencyAvg1000},
+    {"latency-avg10000", "", &latencyAvg10000},
+    {"latency-avg1000000", "", &latencyAvg1000000},
+    {"latency-tcp-avg100", "", &latencyTCPAvg100},
+    {"latency-tcp-avg1000", "", &latencyTCPAvg1000},
+    {"latency-tcp-avg10000", "", &latencyTCPAvg10000},
+    {"latency-tcp-avg1000000", "", &latencyTCPAvg1000000},
+    {"latency-dot-avg100", "", &latencyDoTAvg100},
+    {"latency-dot-avg1000", "", &latencyDoTAvg1000},
+    {"latency-dot-avg10000", "", &latencyDoTAvg10000},
+    {"latency-dot-avg1000000", "", &latencyDoTAvg1000000},
+    {"latency-doh-avg100", "", &latencyDoHAvg100},
+    {"latency-doh-avg1000", "", &latencyDoHAvg1000},
+    {"latency-doh-avg10000", "", &latencyDoHAvg10000},
+    {"latency-doh-avg1000000", "", &latencyDoHAvg1000000},
+    {"latency-doq-avg100", "", &latencyDoQAvg100},
+    {"latency-doq-avg1000", "", &latencyDoQAvg1000},
+    {"latency-doq-avg10000", "", &latencyDoQAvg10000},
+    {"latency-doq-avg1000000", "", &latencyDoQAvg1000000},
+    {"latency-doh3-avg100", "", &latencyDoH3Avg100},
+    {"latency-doh3-avg1000", "", &latencyDoH3Avg1000},
+    {"latency-doh3-avg10000", "", &latencyDoH3Avg10000},
+    {"latency-doh3-avg1000000", "", &latencyDoH3Avg1000000},
+    {"uptime", "", uptimeOfProcess},
+    {"real-memory-usage", "", getRealMemoryUsage},
+    {"special-memory-usage", "", getSpecialMemoryUsage},
+    {"udp-in-errors", "", [](const std::string&) { return udpErrorStats("udp-in-errors"); }},
+    {"udp-noport-errors", "", [](const std::string&) { return udpErrorStats("udp-noport-errors"); }},
+    {"udp-recvbuf-errors", "", [](const std::string&) { return udpErrorStats("udp-recvbuf-errors"); }},
+    {"udp-sndbuf-errors", "", [](const std::string&) { return udpErrorStats("udp-sndbuf-errors"); }},
+    {"udp-in-csum-errors", "", [](const std::string&) { return udpErrorStats("udp-in-csum-errors"); }},
+    {"udp6-in-errors", "", [](const std::string&) { return udp6ErrorStats("udp6-in-errors"); }},
+    {"udp6-recvbuf-errors", "", [](const std::string&) { return udp6ErrorStats("udp6-recvbuf-errors"); }},
+    {"udp6-sndbuf-errors", "", [](const std::string&) { return udp6ErrorStats("udp6-sndbuf-errors"); }},
+    {"udp6-noport-errors", "", [](const std::string&) { return udp6ErrorStats("udp6-noport-errors"); }},
+    {"udp6-in-csum-errors", "", [](const std::string&) { return udp6ErrorStats("udp6-in-csum-errors"); }},
+    {"tcp-listen-overflows", "", [](const std::string&) { return tcpErrorStats("ListenOverflows"); }},
+    {"noncompliant-queries", "", &nonCompliantQueries},
+    {"noncompliant-responses", "", &nonCompliantResponses},
+    {"proxy-protocol-invalid", "", &proxyProtocolInvalid},
+    {"rdqueries", "", &rdQueries},
+    {"empty-queries", "", &emptyQueries},
+    {"cache-hits", "", &cacheHits},
+    {"cache-misses", "", &cacheMisses},
+    {"cpu-iowait", "", getCPUIOWait},
+    {"cpu-steal", "", getCPUSteal},
+    {"cpu-sys-msec", "", getCPUTimeSystem},
+    {"cpu-user-msec", "", getCPUTimeUser},
+    {"fd-usage", "", getOpenFileDescriptors},
+    {"dyn-blocked", "", &dynBlocked},
 #ifndef DISABLE_DYNBLOCKS
-    {"dyn-block-nmg-size", [](const std::string&) { return dnsdist::DynamicBlocks::getClientAddressDynamicRules().size(); }},
+    {"dyn-block-nmg-size", "", [](const std::string&) { return dnsdist::DynamicBlocks::getClientAddressDynamicRules().size(); }},
 #endif /* DISABLE_DYNBLOCKS */
-    {"security-status", &securityStatus},
-    {"doh-query-pipe-full", &dohQueryPipeFull},
-    {"doh-response-pipe-full", &dohResponsePipeFull},
-    {"doq-response-pipe-full", &doqResponsePipeFull},
-    {"doh3-response-pipe-full", &doh3ResponsePipeFull},
-    {"outgoing-doh-query-pipe-full", &outgoingDoHQueryPipeFull},
-    {"tcp-query-pipe-full", &tcpQueryPipeFull},
-    {"tcp-cross-protocol-query-pipe-full", &tcpCrossProtocolQueryPipeFull},
-    {"tcp-cross-protocol-response-pipe-full", &tcpCrossProtocolResponsePipeFull},
+    {"security-status", "", &securityStatus},
+    {"doh-query-pipe-full", "", &dohQueryPipeFull},
+    {"doh-response-pipe-full", "", &dohResponsePipeFull},
+    {"doq-response-pipe-full", "", &doqResponsePipeFull},
+    {"doh3-response-pipe-full", "", &doh3ResponsePipeFull},
+    {"outgoing-doh-query-pipe-full", "", &outgoingDoHQueryPipeFull},
+    {"tcp-query-pipe-full", "", &tcpQueryPipeFull},
+    {"tcp-cross-protocol-query-pipe-full", "", &tcpCrossProtocolQueryPipeFull},
+    {"tcp-cross-protocol-response-pipe-full", "", &tcpCrossProtocolResponsePipeFull},
     // Latency histogram
-    {"latency-sum", &latencySum},
-    {"latency-count", &latencyCount},
+    {"latency-sum", "", &latencySum},
+    {"latency-count", "", &latencyCount},
   }}
 {
 }
@@ -176,18 +178,16 @@ std::optional<std::string> declareCustomMetric(const std::string& name, const st
   const std::string finalCustomName(customName ? *customName : "");
   if (type == "counter") {
     auto customCounters = s_customCounters.write_lock();
-    auto itp = customCounters->insert({name, MutableCounter()});
+    auto itp = customCounters->emplace(name, std::map<std::string, MutableCounter>());
     if (itp.second) {
-      g_stats.entries.write_lock()->emplace_back(Stats::EntryPair{name, &(*customCounters)[name].d_value});
       dnsdist::prometheus::PrometheusMetricDefinition def{name, type, description, finalCustomName};
       dnsdist::webserver::addMetricDefinition(def);
     }
   }
   else if (type == "gauge") {
     auto customGauges = s_customGauges.write_lock();
-    auto itp = customGauges->insert({name, MutableGauge()});
+    auto itp = customGauges->emplace(name, std::map<std::string, MutableGauge>());
     if (itp.second) {
-      g_stats.entries.write_lock()->emplace_back(Stats::EntryPair{name, &(*customGauges)[name].d_value});
       dnsdist::prometheus::PrometheusMetricDefinition def{name, type, description, finalCustomName};
       dnsdist::webserver::addMetricDefinition(def);
     }
@@ -198,57 +198,108 @@ std::optional<std::string> declareCustomMetric(const std::string& name, const st
   return std::nullopt;
 }
 
-std::variant<uint64_t, Error> incrementCustomCounter(const std::string_view& name, uint64_t step)
+static string prometheusLabelValueEscape(const string& value)
 {
-  auto customCounters = s_customCounters.read_lock();
+  string ret;
+
+  for (char i : value) {
+    if (i == '"' || i == '\\') {
+      ret += '\\';
+      ret += i;
+    }
+    else if (i == '\n') {
+      ret += '\\';
+      ret += 'n';
+    }
+    else
+      ret += i;
+  }
+  return ret;
+}
+
+static std::string generateCombinationOfLabels(const std::unordered_map<std::string, std::string>& labels)
+{
+  return std::accumulate(labels.begin(), labels.end(), std::string(), [](const std::string& acc, const std::pair<std::string, std::string>& l) {
+    return acc + (acc.empty() ? std::string() : ",") + l.first + "=" + "\"" + prometheusLabelValueEscape(l.second) + "\"";
+  });
+}
+
+std::variant<uint64_t, Error> incrementCustomCounter(const std::string_view& name, uint64_t step, const std::unordered_map<std::string, std::string>& labels)
+{
+  auto customCounters = s_customCounters.write_lock();
   auto metric = customCounters->find(name);
   if (metric != customCounters->end()) {
-    metric->second.d_value += step;
-    return metric->second.d_value.load();
+    auto combinationOfLabels = generateCombinationOfLabels(labels);
+    auto metricEntry = metric->second.find(combinationOfLabels);
+    if (metricEntry == metric->second.end()) {
+      metricEntry = metric->second.emplace(combinationOfLabels, MutableCounter()).first;
+      g_stats.entries.write_lock()->emplace_back(Stats::EntryTriple{std::string(name), combinationOfLabels, &metricEntry->second.d_value});
+    }
+    metricEntry->second.d_value += step;
+    return metricEntry->second.d_value.load();
   }
   return std::string("Unable to increment custom metric '") + std::string(name) + "': no such counter";
 }
 
-std::variant<uint64_t, Error> decrementCustomCounter(const std::string_view& name, uint64_t step)
+std::variant<uint64_t, Error> decrementCustomCounter(const std::string_view& name, uint64_t step, const std::unordered_map<std::string, std::string>& labels)
 {
-  auto customCounters = s_customCounters.read_lock();
+  auto customCounters = s_customCounters.write_lock();
   auto metric = customCounters->find(name);
   if (metric != customCounters->end()) {
-    metric->second.d_value -= step;
-    return metric->second.d_value.load();
+    auto combinationOfLabels = generateCombinationOfLabels(labels);
+    auto metricEntry = metric->second.find(combinationOfLabels);
+    if (metricEntry == metric->second.end()) {
+      metricEntry = metric->second.emplace(combinationOfLabels, MutableCounter()).first;
+      g_stats.entries.write_lock()->emplace_back(Stats::EntryTriple{std::string(name), combinationOfLabels, &metricEntry->second.d_value});
+    }
+    metricEntry->second.d_value -= step;
+    return metricEntry->second.d_value.load();
   }
   return std::string("Unable to decrement custom metric '") + std::string(name) + "': no such counter";
 }
 
-std::variant<double, Error> setCustomGauge(const std::string_view& name, const double value)
+std::variant<double, Error> setCustomGauge(const std::string_view& name, const double value, const std::unordered_map<std::string, std::string>& labels)
 {
-  auto customGauges = s_customGauges.read_lock();
+  auto customGauges = s_customGauges.write_lock();
   auto metric = customGauges->find(name);
   if (metric != customGauges->end()) {
-    metric->second.d_value = value;
+    auto combinationOfLabels = generateCombinationOfLabels(labels);
+    auto metricEntry = metric->second.find(combinationOfLabels);
+    if (metricEntry == metric->second.end()) {
+      metricEntry = metric->second.emplace(combinationOfLabels, MutableGauge()).first;
+      g_stats.entries.write_lock()->emplace_back(Stats::EntryTriple{std::string(name), combinationOfLabels, &metricEntry->second.d_value});
+    }
+    metricEntry->second.d_value = value;
     return value;
   }
 
   return std::string("Unable to set metric '") + std::string(name) + "': no such gauge";
 }
 
-std::variant<double, Error> getCustomMetric(const std::string_view& name)
+std::variant<double, Error> getCustomMetric(const std::string_view& name, const std::unordered_map<std::string, std::string>& labels)
 {
   {
     auto customCounters = s_customCounters.read_lock();
     auto counter = customCounters->find(name);
     if (counter != customCounters->end()) {
-      return static_cast<double>(counter->second.d_value.load());
+      auto combinationOfLabels = generateCombinationOfLabels(labels);
+      auto metricEntry = counter->second.find(combinationOfLabels);
+      if (metricEntry != counter->second.end()) {
+        return static_cast<double>(metricEntry->second.d_value.load());
+      }
     }
   }
   {
     auto customGauges = s_customGauges.read_lock();
     auto gauge = customGauges->find(name);
     if (gauge != customGauges->end()) {
-      return gauge->second.d_value.load();
+      auto combinationOfLabels = generateCombinationOfLabels(labels);
+      auto metricEntry = gauge->second.find(combinationOfLabels);
+      if (metricEntry != gauge->second.end()) {
+        return metricEntry->second.d_value.load();
+      }
     }
   }
   return std::string("Unable to get metric '") + std::string(name) + "': no such metric";
 }
-
 }

--- a/pdns/dnsdistdist/dnsdist-metrics.cc
+++ b/pdns/dnsdistdist/dnsdist-metrics.cc
@@ -211,17 +211,18 @@ static string prometheusLabelValueEscape(const string& value)
 {
   string ret;
 
-  for (char i : value) {
-    if (i == '"' || i == '\\') {
+  for (char lblchar : value) {
+    if (lblchar == '"' || lblchar == '\\') {
       ret += '\\';
-      ret += i;
+      ret += lblchar;
     }
-    else if (i == '\n') {
+    else if (lblchar == '\n') {
       ret += '\\';
       ret += 'n';
     }
-    else
-      ret += i;
+    else {
+      ret += lblchar;
+    }
   }
   return ret;
 }
@@ -229,8 +230,8 @@ static string prometheusLabelValueEscape(const string& value)
 static std::string generateCombinationOfLabels(const std::unordered_map<std::string, std::string>& labels)
 {
   auto ordered = std::map(labels.begin(), labels.end());
-  return std::accumulate(ordered.begin(), ordered.end(), std::string(), [](const std::string& acc, const std::pair<std::string, std::string>& l) {
-    return acc + (acc.empty() ? std::string() : ",") + l.first + "=" + "\"" + prometheusLabelValueEscape(l.second) + "\"";
+  return std::accumulate(ordered.begin(), ordered.end(), std::string(), [](const std::string& acc, const std::pair<std::string, std::string>& label) {
+    return acc + (acc.empty() ? std::string() : ",") + label.first + "=" + "\"" + prometheusLabelValueEscape(label.second) + "\"";
   });
 }
 

--- a/pdns/dnsdistdist/dnsdist-metrics.hh
+++ b/pdns/dnsdistdist/dnsdist-metrics.hh
@@ -25,6 +25,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <variant>
 
 #include "lock.hh"
@@ -35,10 +36,10 @@ namespace dnsdist::metrics
 using Error = std::string;
 
 [[nodiscard]] std::optional<Error> declareCustomMetric(const std::string& name, const std::string& type, const std::string& description, std::optional<std::string> customName);
-[[nodiscard]] std::variant<uint64_t, Error> incrementCustomCounter(const std::string_view& name, uint64_t step);
-[[nodiscard]] std::variant<uint64_t, Error> decrementCustomCounter(const std::string_view& name, uint64_t step);
-[[nodiscard]] std::variant<double, Error> setCustomGauge(const std::string_view& name, const double value);
-[[nodiscard]] std::variant<double, Error> getCustomMetric(const std::string_view& name);
+[[nodiscard]] std::variant<uint64_t, Error> incrementCustomCounter(const std::string_view& name, uint64_t step, const std::unordered_map<std::string, std::string>& labels);
+[[nodiscard]] std::variant<uint64_t, Error> decrementCustomCounter(const std::string_view& name, uint64_t step, const std::unordered_map<std::string, std::string>& labels);
+[[nodiscard]] std::variant<double, Error> setCustomGauge(const std::string_view& name, const double value, const std::unordered_map<std::string, std::string>& labels);
+[[nodiscard]] std::variant<double, Error> getCustomMetric(const std::string_view& name, const std::unordered_map<std::string, std::string>& labels);
 
 using pdns::stat_t;
 
@@ -89,13 +90,14 @@ struct Stats
   pdns::stat_double_t latencyDoH3Avg100{0}, latencyDoH3Avg1000{0}, latencyDoH3Avg10000{0}, latencyDoH3Avg1000000{0};
   using statfunction_t = std::function<uint64_t(const std::string&)>;
   using entry_t = std::variant<stat_t*, pdns::stat_double_t*, statfunction_t>;
-  struct EntryPair
+  struct EntryTriple
   {
     std::string d_name;
+    std::string d_labels;
     entry_t d_value;
   };
 
-  SharedLockGuarded<std::vector<EntryPair>> entries;
+  SharedLockGuarded<std::vector<EntryTriple>> entries;
 };
 
 extern struct Stats g_stats;

--- a/pdns/dnsdistdist/dnsdist-metrics.hh
+++ b/pdns/dnsdistdist/dnsdist-metrics.hh
@@ -35,7 +35,7 @@ namespace dnsdist::metrics
 {
 using Error = std::string;
 
-[[nodiscard]] std::optional<Error> declareCustomMetric(const std::string& name, const std::string& type, const std::string& description, std::optional<std::string> customName);
+[[nodiscard]] std::optional<Error> declareCustomMetric(const std::string& name, const std::string& type, const std::string& description, std::optional<std::string> customName, bool withLabels);
 [[nodiscard]] std::variant<uint64_t, Error> incrementCustomCounter(const std::string_view& name, uint64_t step, const std::unordered_map<std::string, std::string>& labels);
 [[nodiscard]] std::variant<uint64_t, Error> decrementCustomCounter(const std::string_view& name, uint64_t step, const std::unordered_map<std::string, std::string>& labels);
 [[nodiscard]] std::variant<double, Error> setCustomGauge(const std::string_view& name, const double value, const std::unordered_map<std::string, std::string>& labels);

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -931,7 +931,7 @@ static void addStatsToJSONObject(Json::object& obj)
     if (entry.d_name == "special-memory-usage") {
       continue; // Too expensive for get-all
     }
-    if (entry.d_labels.empty()) {
+    if (!entry.d_labels.empty()) {
       continue; // Skip labeled metrics to prevent duplicates
     }
     if (const auto& val = std::get_if<pdns::stat_t*>(&entry.d_value)) {

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -931,7 +931,7 @@ static void addStatsToJSONObject(Json::object& obj)
     if (entry.d_name == "special-memory-usage") {
       continue; // Too expensive for get-all
     }
-    if (entry.d_labels != "") {
+    if (entry.d_labels.empty()) {
       continue; // Skip labeled metrics to prevent duplicates
     }
     if (const auto& val = std::get_if<pdns::stat_t*>(&entry.d_value)) {

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -1912,7 +1912,7 @@ void setMaxConcurrentConnections(size_t max)
 void WebserverThread(Socket sock)
 {
   setThreadName("dnsdist/webserv");
-  //coverity[auto_causes_copy]
+  // coverity[auto_causes_copy]
   const auto local = *dnsdist::configuration::getCurrentRuntimeConfiguration().d_webServerAddress;
   infolog("Webserver launched on %s", local.toStringWithPort());
 

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -500,6 +500,10 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
         prometheusMetricName = metricDetails.customName;
       }
 
+      if (!entry.d_labels.empty()) {
+        prometheusMetricName += "{" + entry.d_labels + "}";
+      }
+
       // for these we have the help and types encoded in the sources
       // but we need to be careful about labels in custom metrics
       std::string helpName = prometheusMetricName.substr(0, prometheusMetricName.find('{'));

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -931,6 +931,9 @@ static void addStatsToJSONObject(Json::object& obj)
     if (entry.d_name == "special-memory-usage") {
       continue; // Too expensive for get-all
     }
+    if (entry.d_labels != "") {
+      continue; // Skip labeled metrics to prevent duplicates
+    }
     if (const auto& val = std::get_if<pdns::stat_t*>(&entry.d_value)) {
       obj.emplace(entry.d_name, (double)(*val)->load());
     }

--- a/pdns/dnsdistdist/docs/reference/custommetrics.rst
+++ b/pdns/dnsdistdist/docs/reference/custommetrics.rst
@@ -17,7 +17,7 @@ Then you can update those at runtime using the following functions, depending on
   .. versionchanged:: 1.8.1
     This function can now be used at runtime, instead of only at configuration time.
 
-  .. versionchanged:: ?
+  .. versionchanged:: 2.0.0
     This function now takes options, with ``withLabels`` option added. ``prometheusName`` can now be provided in options.
 
  .. note::
@@ -46,7 +46,7 @@ Then you can update those at runtime using the following functions, depending on
   .. versionchanged:: 1.8.1
     Optional ``step`` parameter added.
 
-  .. versionchanged:: ?
+  .. versionchanged:: 2.0.0
     This function now takes options, with ``labels`` option added. ``step`` can now be provided in options.
 
  .. note::
@@ -72,7 +72,7 @@ Then you can update those at runtime using the following functions, depending on
   .. versionchanged:: 1.8.1
     Optional ``step`` parameter added.
 
-  .. versionchanged:: ?
+  .. versionchanged:: 2.0.0
     This function now takes options, with ``labels`` option added. ``step`` can now be provided in options.
 
  .. note::
@@ -95,7 +95,7 @@ Then you can update those at runtime using the following functions, depending on
 
   .. versionadded:: 1.8.0
 
-  .. versionchanged:: ?
+  .. versionchanged:: 2.0.0
     This function now takes options, with ``labels`` option added.
 
  .. note::
@@ -114,7 +114,7 @@ Then you can update those at runtime using the following functions, depending on
 
   .. versionadded:: 1.8.0
 
-  .. versionchanged:: ?
+  .. versionchanged:: 2.0.0
     This function now takes options, with ``labels`` option added.
 
  .. note::

--- a/pdns/dnsdistdist/docs/reference/custommetrics.rst
+++ b/pdns/dnsdistdist/docs/reference/custommetrics.rst
@@ -10,12 +10,18 @@ Then you can update those at runtime using the following functions, depending on
  * manipulate counters using :func:`incMetric` and  :func:`decMetric`
  * update a gauge using :func:`setMetric`
 
-.. function:: declareMetric(name, type, description [, prometheusName]) -> bool
+.. function:: declareMetric(name, type, description [, prometheusName|options]) -> bool
 
   .. versionadded:: 1.8.0
 
   .. versionchanged:: 1.8.1
     This function can now be used at runtime, instead of only at configuration time.
+
+  .. versionchanged:: ?
+    This function now takes options, with ``withLabels`` option added. ``prometheusName`` can now be provided in options.
+
+ .. note::
+    Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Re-declaring an existing metric with the same name and type will not reset it.
   Re-declaring with the same name but a different type will cause one of them to be masked.
@@ -25,28 +31,52 @@ Then you can update those at runtime using the following functions, depending on
   :param str name: The name of the metric, lowercase alphanumerical characters and dashes (-) only
   :param str type: The desired type in ``gauge`` or ``counter``
   :param str description: The description of the metric
-  :param str prometheusName: The name to use in the prometheus metrics, if supplied. Otherwise the regular name will be used, prefixed with ``dnsdist_`` and ``-`` replaced by ``_``.
+  :param str prometheusName: The name to use in the prometheus metrics, if supplied. Otherwise the regular name will be used, prefixed with ``dnsdist_`` and ``-`` replaced by ``_``
+  :param table options: A table with key: value pairs with metric options.
 
-.. function:: incMetric(name [, step]) -> int
+  Options:
+
+  * ``name``: str - The name to use in the prometheus metrics, if supplied. Otherwise the regular name will be used, prefixed with ``dnsdist_`` and ``-`` replaced by ``_``
+  * ``withLabels=false``: bool - If set to true, labels will be expected when updating this metric and it will not be automatically created without labels. Defaults to ``false``, which automatically creates this metric without labels with default value.
+
+.. function:: incMetric(name [, step|options]) -> int
 
   .. versionadded:: 1.8.0
 
   .. versionchanged:: 1.8.1
     Optional ``step`` parameter added.
+
+  .. versionchanged:: ?
+    This function now takes options, with ``labels`` option added. ``step`` can now be provided in options.
+
+ .. note::
+    Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Increment counter by one (or more, see the ``step`` parameter), will issue an error if the metric is not declared or not a ``counter``.
 
   Returns the new value.
 
   :param str name: The name of the metric
-  :param int step: By how much the counter should be incremented, default to 1.
+  :param int step: By how much the counter should be incremented, default to 1
+  :param table options: A table with key: value pairs with metric options.
 
-.. function:: decMetric(name) -> int
+  Options:
+
+  * ``step``: int - By ow much the counter should be incremented, default to 1
+  * ``labels={}``: table - Set of key: value pairs with labels and their values that should be used to increment the metric. Different combinations of labels have different metric values.
+
+.. function:: decMetric(name [, step|options]) -> int
 
   .. versionadded:: 1.8.0
 
   .. versionchanged:: 1.8.1
     Optional ``step`` parameter added.
+
+  .. versionchanged:: ?
+    This function now takes options, with ``labels`` option added. ``step`` can now be provided in options.
+
+ .. note::
+    Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Decrement counter by one (or more, see the ``step`` parameter), will issue an error if the metric is not declared or not a ``counter``.
 
@@ -54,18 +84,41 @@ Then you can update those at runtime using the following functions, depending on
 
   :param str name: The name of the metric
   :param int step: By how much the counter should be decremented, default to 1.
+  :param table options: A table with key: value pairs with metric options.
 
-.. function:: getMetric(name) -> double
+  Options:
+
+  * ``step``: int - By ow much the counter should be decremented, default to 1
+  * ``labels={}``: table - Set of key: value pairs with labels and their values that should be used to decrement the metric. Different combinations of labels have different metric values.
+
+.. function:: getMetric(name [, options]) -> double
 
   .. versionadded:: 1.8.0
+
+  .. versionchanged:: ?
+    This function now takes options, with ``labels`` option added.
+
+ .. note::
+    Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Get metric value.
 
   :param str name: The name of the metric
+  :param table options: A table with key: value pairs with metric options.
 
-.. function:: setMetric(name, value) -> double
+  Options:
+
+  * ``labels={}``: table - Set of key: value pairs with labels and their values that should be used to read the metric. Different combinations of labels have different metric values.
+
+.. function:: setMetric(name, value [, options]) -> double
 
   .. versionadded:: 1.8.0
+
+  .. versionchanged:: ?
+    This function now takes options, with ``labels`` option added.
+
+ .. note::
+    Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Set the new value, will issue an error if the metric is not declared or not a ``gauge``.
 
@@ -73,3 +126,8 @@ Then you can update those at runtime using the following functions, depending on
 
   :param str name: The name of the metric
   :param double value: The new value
+  :param table options: A table with key: value pairs with metric options.
+
+  Options:
+
+  * ``labels={}``: table - Set of key: value pairs with labels and their values that should be used to set the metric. Different combinations of labels have different metric values.

--- a/pdns/dnsdistdist/docs/reference/custommetrics.rst
+++ b/pdns/dnsdistdist/docs/reference/custommetrics.rst
@@ -62,7 +62,7 @@ Then you can update those at runtime using the following functions, depending on
 
   Options:
 
-  * ``step``: int - By ow much the counter should be incremented, default to 1
+  * ``step``: int - By how much the counter should be incremented, default to 1
   * ``labels={}``: table - Set of key: value pairs with labels and their values that should be used to increment the metric. Different combinations of labels have different metric values.
 
 .. function:: decMetric(name [, step|options]) -> int
@@ -88,7 +88,7 @@ Then you can update those at runtime using the following functions, depending on
 
   Options:
 
-  * ``step``: int - By ow much the counter should be decremented, default to 1
+  * ``step``: int - By how much the counter should be decremented, default to 1
   * ``labels={}``: table - Set of key: value pairs with labels and their values that should be used to decrement the metric. Different combinations of labels have different metric values.
 
 .. function:: getMetric(name [, options]) -> double

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -878,6 +878,10 @@ class TestAPICustomStatistics(APITestsBase):
     declareMetric("my-custom-metric", "counter", "Number of statistics")
     declareMetric("my-other-metric", "counter", "Another number of statistics")
     declareMetric("my-gauge", "gauge", "Current memory usage")
+    declareMetric("my-labeled-gauge", "gauge", "Custom gauge with labels", { withLabels = true })
+    setMetric("my-labeled-gauge", 123, { labels = { foo = "bar" } })
+    declareMetric("my-labeled-counter", "counter", "Custom counter with labels", { withLabels = true })
+    incMetric("my-labeled-counter", { labels = { foo = "bar" } })
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -899,3 +903,8 @@ class TestAPICustomStatistics(APITestsBase):
         for key in expected:
             self.assertIn(key, content)
             self.assertTrue(content[key] >= 0)
+
+        unexpected = ['my-labeled-gauge', 'my-labeled-counter']
+
+        for key in unexpected:
+            self.assertNotIn(key, content)


### PR DESCRIPTION
### Short description

This adds support for prometheus labels on custom metrics. Changes the metrics maps to hold a map of labels to metric values for each metric. Metrics without labels have an empty string label combination value.

Adds an optional options table as the last parameter of `incMetric`, `decMetric`, `setMetric` and `getMetric`, which can be used to set labels by using the `label` key or to set the previously used parameter (either `step` or `value`).

Closes: #13359

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
