### PR TITLE
recursor udp-source-port-avoid default setting add 4791 port

### DIFF
--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -3002,7 +3002,8 @@ A sequence of UDP port numbers to avoid when binding. For example:
 
 See :ref:`setting-udp-source-port-min`.
  ''',
-    'versionadded': '4.2.0'
+        'versionadded': '4.2.0',
+        'versionchanged': ('5.2.0', 'port 4791 was added in the default list'),
     },
     {
         'name' : 'udp_truncation_threshold',

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -2981,11 +2981,11 @@ See :ref:`setting-udp-source-port-min`.
         'name' : 'udp_source_port_avoid',
         'section' : 'outgoing',
         'type' : LType.ListStrings,
-        'default' : '11211,4791',
-        'help' : 'List of comma separated UDP port number to avoid',
+        'default' : '4791,11211',
+        'help' : 'List of comma separated UDP port numbers to avoid',
         'doc' : '''
 A list of comma-separated UDP port numbers to avoid when binding.
-Ex: `5300,11211,4791`
+Ex: `4791,5300,11211`
 
 See :ref:`setting-udp-source-port-min`.
  ''',
@@ -2996,9 +2996,9 @@ A sequence of UDP port numbers to avoid when binding. For example:
 
  outgoing:
    udp_source_port_avoid:
+   - 4791
    - 5300
    - 11211
-   - 4791
 
 See :ref:`setting-udp-source-port-min`.
  ''',

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -2981,11 +2981,11 @@ See :ref:`setting-udp-source-port-min`.
         'name' : 'udp_source_port_avoid',
         'section' : 'outgoing',
         'type' : LType.ListStrings,
-        'default' : '11211',
+        'default' : '11211,4791',
         'help' : 'List of comma separated UDP port number to avoid',
         'doc' : '''
 A list of comma-separated UDP port numbers to avoid when binding.
-Ex: `5300,11211`
+Ex: `5300,11211,4791`
 
 See :ref:`setting-udp-source-port-min`.
  ''',
@@ -2998,6 +2998,7 @@ A sequence of UDP port numbers to avoid when binding. For example:
    udp_source_port_avoid:
    - 5300
    - 11211
+   - 4791
 
 See :ref:`setting-udp-source-port-min`.
  ''',

--- a/pdns/recursordist/settings/table.py
+++ b/pdns/recursordist/settings/table.py
@@ -3003,7 +3003,7 @@ A sequence of UDP port numbers to avoid when binding. For example:
 See :ref:`setting-udp-source-port-min`.
  ''',
         'versionadded': '4.2.0',
-        'versionchanged': ('5.2.0', 'port 4791 was added in the default list'),
+        'versionchanged': ('5.2.0', 'port 4791 was added to the default list'),
     },
     {
         'name' : 'udp_truncation_threshold',


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The local UDP port of the recursor needs to avoid port **4791** of the **RDMA network card Roce v2 protocol** to prevent random access to this port, causing read timeouts

When the recursor sends a DNS request and the local port is specified as 4791, if there is RDMA hardware on the machine, when the response with dst as port 4791 reaches the network card driver, it will be directly processed by the hardware as Roce v2 protocol, and the recursor will not get a response to this request.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
