### PR TITLE
capture std::function by reference

### DIFF
--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -144,7 +144,7 @@ static void bareHandlerWrapper(const WebServer::HandlerFunction& handler, YaHTTP
 
 void WebServer::registerBareHandler(const string& url, const HandlerFunction& handler, const std::string& method)
 {
-  YaHTTP::THandlerFunction f = [=](YaHTTP::Request* req, YaHTTP::Response* resp){return bareHandlerWrapper(handler, req, resp);};
+  auto f = [&](YaHTTP::Request* req, YaHTTP::Response* resp){return bareHandlerWrapper(handler, req, resp);};
   YaHTTP::Router::Map(method, url, std::move(f));
 }
 
@@ -200,7 +200,7 @@ void WebServer::apiWrapper(const WebServer::HandlerFunction& handler, HttpReques
 }
 
 void WebServer::registerApiHandler(const string& url, const HandlerFunction& handler, const std::string& method, bool allowPassword) {
-  auto f = [=](HttpRequest *req, HttpResponse* resp){apiWrapper(handler, req, resp, allowPassword);};
+  auto f = [&](HttpRequest *req, HttpResponse* resp){apiWrapper(handler, req, resp, allowPassword);};
   registerBareHandler(url, f, method);
 }
 
@@ -218,7 +218,7 @@ void WebServer::webWrapper(const WebServer::HandlerFunction& handler, HttpReques
 }
 
 void WebServer::registerWebHandler(const string& url, const HandlerFunction& handler, const std::string& method) {
-  auto f = [=](HttpRequest *req, HttpResponse *resp){webWrapper(handler, req, resp);};
+  auto f = [&](HttpRequest *req, HttpResponse *resp){webWrapper(handler, req, resp);};
   registerBareHandler(url, f, method);
 }
 


### PR DESCRIPTION
clang-tidy is reporting memory leaks.

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
