### PR TITLE
auth: prevent createReverse6 from generating illegal IDN record 

### DIFF
--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -415,6 +415,7 @@ Reverse DNS functions
       - ``%3%`` = 0
       - ``%4%`` = 1
   - ``%33%`` converts the compressed address format into a dashed format, e.g. ``2001:a::1`` to ``2001-a--1``
+      This format may add '0' to the result, preventing it from being identified as an illegal IDN by ``dig``.
   - ``%34%`` to ``%41%`` represent the 8 uncompressed 2-byte chunks
       - **Example:** PTR query for ``2001:a:b::123``
       - ``%34%`` - returns ``2001`` (chunk 1)

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1132,6 +1132,16 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
         string dashed=ip6.toString();
         boost::replace_all(dashed, ":", "-");
 
+        // https://github.com/PowerDNS/pdns/issues/7524
+        if (boost::ends_with(dashed, "-")) {
+          // "a--a-" -> "a--a-0"
+          dashed.push_back('0');
+        }
+        if (boost::starts_with(dashed, "-") || dashed.compare(2, 2, "--") == 0) {
+          // "-a--a" -> "0-a--a"               "aa--a" -> "0aa--a"
+          dashed.insert(0, "0");
+        }
+
         for(int i=31; i>=0; --i)
           fmt % labels[i];
         fmt % dashed;

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -162,6 +162,7 @@ filterforwardempty IN LUA A "filterForward('192.0.2.1', newNMG{{'192.1.2.0/24'}}
 
 *.createforward  IN    LUA    A     "filterForward(createForward(), newNMG{{'1.0.0.0/8', '64.0.0.0/8'}})"
 *.createforward6 IN    LUA    AAAA  "filterForward(createForward6(), newNMG{{'2000::/3'}}, 'fe80::1')"
+*.no-filter.createforward6    IN    LUA    AAAA  "createForward6()"
 *.createreverse  IN    LUA    PTR   "createReverse('%5%.example.com', {{['10.10.10.10'] = 'quad10.example.com.'}})"
 *.createreverse6 IN    LUA    PTR   "createReverse6('%33%.example.com', {{['2001:db8::1'] = 'example.example.com.'}})"
 
@@ -1057,6 +1058,46 @@ class TestLuaRecords(BaseLuaTest):
             ".createreverse6.example.org." : (dns.rdatatype.PTR, {
                 "8.b.d.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.2" : "2001--db8.example.com.",
                 "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2" : "example.example.com."   # exception
+            })
+        }
+
+        for suffix, v in expected.items():
+            qtype, pairs = v
+            for prefix, target in pairs.items():
+                name = prefix + suffix
+
+                query = dns.message.make_query(name, qtype)
+                response = dns.message.make_response(query)
+                response.answer.append(dns.rrset.from_text(
+                    name, 0, dns.rdataclass.IN, qtype, target))
+
+                res = self.sendUDPQuery(query)
+                print(res)
+                self.assertRcodeEqual(res, dns.rcode.NOERROR)
+                self.assertEqual(res.answer, response.answer)
+
+    def testCreateForwardAndReverseWithZero(self):
+        """
+        Fix #7524
+        """
+        expected = {
+            ".no-filter.createforward6.example.org." : (dns.rdatatype.AAAA, {
+                "0--0" : "::",
+                "0--1" : "::1",
+                "0aa--0" : "aa::",
+                "0aa--1" : "aa::1",
+                "2001--0" : "2001::",
+                "a-b--c" : "a:b::c",
+                "a--b-c" : "a::b:c"
+            }),
+            ".createreverse6.example.org." : (dns.rdatatype.PTR, {
+                "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0" : "0--0.example.com.",
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0" : "0--1.example.com.",
+                "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.a.0.0" : "0aa--0.example.com.",
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.a.0.0" : "0aa--1.example.com.",
+                "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.2" : "2001--0.example.com.",
+                "c.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.0.0.0.a.0.0.0" : "a-b--c.example.com.",
+                "c.0.0.0.b.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.0.0.0" : "a--b-c.example.com."
             })
         }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`createReverse6` will insert or push '0' to the converted address, so that `dig` will not treated it as an illegal IDN.
Closes #7524
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
