### PR TITLE
dnsdist-1.9.x: Backport of #14967 -  Fix ECS zero-scope with incoming DoH queries

### DIFF
--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -155,8 +155,8 @@ struct InternalQueryState
   int32_t d_streamID{-1}; // 4
   uint32_t cacheKey{0}; // 4
   uint32_t cacheKeyNoECS{0}; // 4
-  // DoH-only */
-  uint32_t cacheKeyUDP{0}; // 4
+  // DoH-only: if we received a TC=1 answer, we had to retry over TCP and thus we need the TCP cache key */
+  uint32_t cacheKeyTCP{0}; // 4
   uint32_t ttlCap{0}; // cap the TTL _after_ inserting into the packet cache // 4
   int backendFD{-1}; // 4
   int delayMsec{0};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14967 to rel/dnsdist-1.9.x

The zero-scope feature involves a first cache lookup before the ECS information has been added to the query, then on a miss a second, regular lookup is done. When we get a response from the backend that contains an ECS scope set to 0, we can insert it into the cache in a way that allows using it for all clients, but we must be careful to use the key that was computed during the first lookup, and not the second one.
Incoming DoH queries make that even more interesting because while they are received over TCP, they are initially forwarded to the backend over UDP but can be retried over TCP if a TC=1 answer is received. In that case we must be very careful not to insert the answer into the cache using the wrong protocol, as we don't want to serve a TC=1 answer to a client contacting us over TCP, for example. The computation of the cache key and protocol was unfortunately broken for the incoming query received over DoH, forwarded over UDP and response has a zero scope case. This commit fixes it.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
