### PR TITLE
rec: store authority recs and signatures as shared pointers to const data

### DIFF
--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -38,6 +38,7 @@ using namespace ::boost::multi_index;
 #include "stat_t.hh"
 #include "logger.hh"
 #include "validate.hh"
+#include "recursor_cache.hh"
 
 class AggressiveNSECCache
 {
@@ -154,7 +155,7 @@ private:
   std::shared_ptr<LockGuarded<ZoneEntry>> getBestZone(const DNSName& zone);
   bool getNSECBefore(time_t now, std::shared_ptr<LockGuarded<ZoneEntry>>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry);
   bool getNSEC3(time_t now, std::shared_ptr<LockGuarded<ZoneEntry>>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry);
-  bool getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded<ZoneEntry>>& zoneEntry, std::vector<DNSRecord>& soaSet, std::vector<std::shared_ptr<const RRSIGRecordContent>>& soaSignatures, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC, const OptLog&, pdns::validation::ValidationContext& validationContext);
+  bool getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded<ZoneEntry>>& zoneEntry, std::vector<DNSRecord>& soaSet, const MemRecursorCache::SigRecs& soaSignatures, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC, const OptLog&, pdns::validation::ValidationContext& validationContext);
   bool synthesizeFromNSEC3Wildcard(time_t now, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC, ZoneEntry::CacheEntry& nextCloser, const DNSName& wildcardName, const OptLog&);
   bool synthesizeFromNSECWildcard(time_t now, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC, ZoneEntry::CacheEntry& nsec, const DNSName& wildcardName, const OptLog&);
 

--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -420,8 +420,8 @@ void ZoneData::ZoneToCache(const RecZoneToCache::Config& config)
       bool auth = isRRSetAuth(qname, qtype);
       // Same decision as updateCacheFromRecords() (we do not test for NSEC since we skip those completely)
       if (auth || (qtype == QType::NS || qtype == QType::A || qtype == QType::AAAA || qtype == QType::DS)) {
-        g_recCache->replace(d_now, qname, qtype, v, sigsrr,
-                            std::vector<std::shared_ptr<DNSRecord>>(), auth, d_zone);
+        g_recCache->replace(d_now, qname, qtype, v, sigsrr, nullptr,
+                            auth, d_zone);
       }
       break;
     }

--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -420,7 +420,7 @@ void ZoneData::ZoneToCache(const RecZoneToCache::Config& config)
       bool auth = isRRSetAuth(qname, qtype);
       // Same decision as updateCacheFromRecords() (we do not test for NSEC since we skip those completely)
       if (auth || (qtype == QType::NS || qtype == QType::A || qtype == QType::AAAA || qtype == QType::DS)) {
-        g_recCache->replace(d_now, qname, qtype, v, sigsrr, nullptr,
+        g_recCache->replace(d_now, qname, qtype, v, sigsrr, {},
                             auth, d_zone);
       }
       break;

--- a/pdns/recursordist/recursor_cache.hh
+++ b/pdns/recursordist/recursor_cache.hh
@@ -73,9 +73,18 @@ public:
   static constexpr Flags Refresh = 1 << 1;
   static constexpr Flags ServeStale = 1 << 2;
 
-  [[nodiscard]] time_t get(time_t, const DNSName& qname, QType qtype, Flags flags, vector<DNSRecord>* res, const ComboAddress& who, const OptTag& routingTag = boost::none, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures = nullptr, std::shared_ptr<std::vector<DNSRecord>>* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr, ComboAddress* fromAuthIP = nullptr);
+  // The type used to pass auth record data to replace(); If the vector is non-empty, the cache will
+  // store a shared pointer to the copied data. The shared pointer will be returned by get().  There
+  // are optimizations: an empty vector will be stored as a nullptr, but get() will return a pointer
+  // to an already existing empty vector in that case, this is more convenient for the caller, since
+  // it avoid checking for nullptr, just iterate as for the non-empty case.
+  using AuthRecsVec = std::vector<DNSRecord>;
+  using AuthRecs = std::shared_ptr<const AuthRecsVec>; // const to avoid modifying the vector, which would be bad for shared data
+  const static AuthRecs s_emptyAuthRecs;
 
-  void replace(time_t, const DNSName& qname, QType qtype, const vector<DNSRecord>& content, const vector<shared_ptr<const RRSIGRecordContent>>& signatures, const std::shared_ptr<std::vector<DNSRecord>>& authorityRecs, bool auth, const DNSName& authZone, boost::optional<Netmask> ednsmask = boost::none, const OptTag& routingTag = boost::none, vState state = vState::Indeterminate, boost::optional<ComboAddress> from = boost::none, bool refresh = false, time_t ttl_time = time(nullptr));
+  [[nodiscard]] time_t get(time_t, const DNSName& qname, QType qtype, Flags flags, vector<DNSRecord>* res, const ComboAddress& who, const OptTag& routingTag = boost::none, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures = nullptr, AuthRecs* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr, ComboAddress* fromAuthIP = nullptr);
+
+  void replace(time_t, const DNSName& qname, QType qtype, const vector<DNSRecord>& content, const vector<shared_ptr<const RRSIGRecordContent>>& signatures, const AuthRecsVec& authorityRecs, bool auth, const DNSName& authZone, boost::optional<Netmask> ednsmask = boost::none, const OptTag& routingTag = boost::none, vState state = vState::Indeterminate, boost::optional<ComboAddress> from = boost::none, bool refresh = false, time_t ttl_time = time(nullptr));
 
   void doPrune(time_t now, size_t keep);
   uint64_t doDump(int fileDesc, size_t maxCacheEntries);
@@ -135,7 +144,7 @@ private:
 
     records_t d_records;
     std::vector<std::shared_ptr<const RRSIGRecordContent>> d_signatures;
-    std::shared_ptr<std::vector<DNSRecord>> d_authorityRecs;
+    AuthRecs d_authorityRecs;
     DNSName d_qname;
     DNSName d_authZone;
     ComboAddress d_from;
@@ -347,7 +356,7 @@ private:
   static Entries getEntries(MapCombo::LockedContent& map, const DNSName& qname, QType qtype, const OptTag& rtag);
   static cache_t::const_iterator getEntryUsingECSIndex(MapCombo::LockedContent& map, time_t now, const DNSName& qname, QType qtype, bool requireAuth, const ComboAddress& who, bool serveStale);
 
-  static time_t handleHit(time_t now, MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures, std::shared_ptr<std::vector<DNSRecord>>* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone, ComboAddress* fromAuthIP);
+  static time_t handleHit(time_t now, MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures, AuthRecs* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone, ComboAddress* fromAuthIP);
   static void updateStaleEntry(time_t now, OrderedTagIterator_t& entry);
   static void handleServeStaleBookkeeping(time_t, bool, OrderedTagIterator_t&);
 };

--- a/pdns/recursordist/recursor_cache.hh
+++ b/pdns/recursordist/recursor_cache.hh
@@ -73,9 +73,9 @@ public:
   static constexpr Flags Refresh = 1 << 1;
   static constexpr Flags ServeStale = 1 << 2;
 
-  [[nodiscard]] time_t get(time_t, const DNSName& qname, QType qtype, Flags flags, vector<DNSRecord>* res, const ComboAddress& who, const OptTag& routingTag = boost::none, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures = nullptr, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr, ComboAddress* fromAuthIP = nullptr);
+  [[nodiscard]] time_t get(time_t, const DNSName& qname, QType qtype, Flags flags, vector<DNSRecord>* res, const ComboAddress& who, const OptTag& routingTag = boost::none, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures = nullptr, std::shared_ptr<std::vector<DNSRecord>>* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr, ComboAddress* fromAuthIP = nullptr);
 
-  void replace(time_t, const DNSName& qname, QType qtype, const vector<DNSRecord>& content, const vector<shared_ptr<const RRSIGRecordContent>>& signatures, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs, bool auth, const DNSName& authZone, boost::optional<Netmask> ednsmask = boost::none, const OptTag& routingTag = boost::none, vState state = vState::Indeterminate, boost::optional<ComboAddress> from = boost::none, bool refresh = false, time_t ttl_time = time(nullptr));
+  void replace(time_t, const DNSName& qname, QType qtype, const vector<DNSRecord>& content, const vector<shared_ptr<const RRSIGRecordContent>>& signatures, const std::shared_ptr<std::vector<DNSRecord>>& authorityRecs, bool auth, const DNSName& authZone, boost::optional<Netmask> ednsmask = boost::none, const OptTag& routingTag = boost::none, vState state = vState::Indeterminate, boost::optional<ComboAddress> from = boost::none, bool refresh = false, time_t ttl_time = time(nullptr));
 
   void doPrune(time_t now, size_t keep);
   uint64_t doDump(int fileDesc, size_t maxCacheEntries);
@@ -135,7 +135,7 @@ private:
 
     records_t d_records;
     std::vector<std::shared_ptr<const RRSIGRecordContent>> d_signatures;
-    std::vector<std::shared_ptr<DNSRecord>> d_authorityRecs;
+    std::shared_ptr<std::vector<DNSRecord>> d_authorityRecs;
     DNSName d_qname;
     DNSName d_authZone;
     ComboAddress d_from;
@@ -347,7 +347,7 @@ private:
   static Entries getEntries(MapCombo::LockedContent& map, const DNSName& qname, QType qtype, const OptTag& rtag);
   static cache_t::const_iterator getEntryUsingECSIndex(MapCombo::LockedContent& map, time_t now, const DNSName& qname, QType qtype, bool requireAuth, const ComboAddress& who, bool serveStale);
 
-  static time_t handleHit(time_t now, MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone, ComboAddress* fromAuthIP);
+  static time_t handleHit(time_t now, MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures, std::shared_ptr<std::vector<DNSRecord>>* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone, ComboAddress* fromAuthIP);
   static void updateStaleEntry(time_t now, OrderedTagIterator_t& entry);
   static void handleServeStaleBookkeeping(time_t, bool, OrderedTagIterator_t&);
 };

--- a/pdns/recursordist/recursor_cache.hh
+++ b/pdns/recursordist/recursor_cache.hh
@@ -83,8 +83,8 @@ public:
   // pointer gets copied, while earlier code would copy all shared pointer in the vector.
   //
   // In the current SyncRes code, AuthRecs never get appended to a non-empty vector while SigRecs do
-  // get appended in some cases; the handleHit() code will take measures. In the futrue we might
-  // want a more specialized datastructure than a vector, it would require another level of
+  // get appended in some cases; the handleHit() code will take measures. In the future we might
+  // want a more specialized data structure than a vector, it would require another level of
   // indirection though, so for now we construct a new shared vector if appending is needed. See
   // handleHit() for details.
   using AuthRecsVec = std::vector<DNSRecord>;

--- a/pdns/recursordist/recursor_cache.hh
+++ b/pdns/recursordist/recursor_cache.hh
@@ -82,9 +82,13 @@ public:
   using AuthRecs = std::shared_ptr<const AuthRecsVec>; // const to avoid modifying the vector, which would be bad for shared data
   const static AuthRecs s_emptyAuthRecs;
 
-  [[nodiscard]] time_t get(time_t, const DNSName& qname, QType qtype, Flags flags, vector<DNSRecord>* res, const ComboAddress& who, const OptTag& routingTag = boost::none, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures = nullptr, AuthRecs* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr, ComboAddress* fromAuthIP = nullptr);
+  using SigRecsVec = std::vector<std::shared_ptr<const RRSIGRecordContent>>;
+  using SigRecs = std::shared_ptr<const SigRecsVec>;
+  const static SigRecs s_emptySigRecs;
 
-  void replace(time_t, const DNSName& qname, QType qtype, const vector<DNSRecord>& content, const vector<shared_ptr<const RRSIGRecordContent>>& signatures, const AuthRecsVec& authorityRecs, bool auth, const DNSName& authZone, boost::optional<Netmask> ednsmask = boost::none, const OptTag& routingTag = boost::none, vState state = vState::Indeterminate, boost::optional<ComboAddress> from = boost::none, bool refresh = false, time_t ttl_time = time(nullptr));
+  [[nodiscard]] time_t get(time_t, const DNSName& qname, QType qtype, Flags flags, vector<DNSRecord>* res, const ComboAddress& who, const OptTag& routingTag = boost::none, SigRecs* signatures = nullptr, AuthRecs* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr, ComboAddress* fromAuthIP = nullptr);
+
+  void replace(time_t, const DNSName& qname, QType qtype, const vector<DNSRecord>& content, const SigRecsVec& signatures, const AuthRecsVec& authorityRecs, bool auth, const DNSName& authZone, boost::optional<Netmask> ednsmask = boost::none, const OptTag& routingTag = boost::none, vState state = vState::Indeterminate, boost::optional<ComboAddress> from = boost::none, bool refresh = false, time_t ttl_time = time(nullptr));
 
   void doPrune(time_t now, size_t keep);
   uint64_t doDump(int fileDesc, size_t maxCacheEntries);
@@ -143,7 +147,7 @@ private:
     bool shouldReplace(time_t now, bool auth, vState state, bool refresh);
 
     records_t d_records;
-    std::vector<std::shared_ptr<const RRSIGRecordContent>> d_signatures;
+    SigRecs d_signatures;
     AuthRecs d_authorityRecs;
     DNSName d_qname;
     DNSName d_authZone;
@@ -356,7 +360,7 @@ private:
   static Entries getEntries(MapCombo::LockedContent& map, const DNSName& qname, QType qtype, const OptTag& rtag);
   static cache_t::const_iterator getEntryUsingECSIndex(MapCombo::LockedContent& map, time_t now, const DNSName& qname, QType qtype, bool requireAuth, const ComboAddress& who, bool serveStale);
 
-  static time_t handleHit(time_t now, MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, vector<std::shared_ptr<const RRSIGRecordContent>>* signatures, AuthRecs* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone, ComboAddress* fromAuthIP);
+  static time_t handleHit(time_t now, MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, SigRecs* signatures, AuthRecs* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone, ComboAddress* fromAuthIP);
   static void updateStaleEntry(time_t now, OrderedTagIterator_t& entry);
   static void handleServeStaleBookkeeping(time_t, bool, OrderedTagIterator_t&);
 };

--- a/pdns/recursordist/reczones-helpers.cc
+++ b/pdns/recursordist/reczones-helpers.cc
@@ -41,7 +41,7 @@ static void putIntoCache(time_t now, QType qtype, vState state, const ComboAddre
     // Put non-default root hints into cache as authoritative.  As argued below in
     // putDefaultHintsIntoCache, this is actually wrong, but people might depend on it by having
     // root-hints that refer to servers that aren't actually capable or willing to serve root data.
-    g_recCache->replace(now, name, qtype, aset, {}, nullptr, true, g_rootdnsname, boost::none, boost::none, state, from);
+    g_recCache->replace(now, name, qtype, aset, {}, {}, true, g_rootdnsname, boost::none, boost::none, state, from);
   }
 }
 

--- a/pdns/recursordist/reczones-helpers.cc
+++ b/pdns/recursordist/reczones-helpers.cc
@@ -41,7 +41,7 @@ static void putIntoCache(time_t now, QType qtype, vState state, const ComboAddre
     // Put non-default root hints into cache as authoritative.  As argued below in
     // putDefaultHintsIntoCache, this is actually wrong, but people might depend on it by having
     // root-hints that refer to servers that aren't actually capable or willing to serve root data.
-    g_recCache->replace(now, name, qtype, aset, {}, {}, true, g_rootdnsname, boost::none, boost::none, state, from);
+    g_recCache->replace(now, name, qtype, aset, {}, nullptr, true, g_rootdnsname, boost::none, boost::none, state, from);
   }
 }
 

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -678,10 +678,10 @@ private:
   boost::optional<Netmask> getEDNSSubnetMask(const DNSName& name, const ComboAddress& rem);
 
   static bool validationEnabled();
-  uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures, uint32_t signaturesTTL, const MemRecursorCache::AuthRecsVec& authorityRecs) const;
+  uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const MemRecursorCache::SigRecsVec& signatures, uint32_t signaturesTTL, const MemRecursorCache::AuthRecsVec& authorityRecs) const;
   void updateValidationState(const DNSName& qname, vState& state, vState stateUpdate, const string& prefix);
-  vState validateRecordsWithSigs(unsigned int depth, const string& prefix, const DNSName& qname, QType qtype, const DNSName& name, QType type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures);
-  vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures, unsigned int depth, const string& prefix);
+  vState validateRecordsWithSigs(unsigned int depth, const string& prefix, const DNSName& qname, QType qtype, const DNSName& name, QType type, const std::vector<DNSRecord>& records, const MemRecursorCache::SigRecsVec& signatures);
+  vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const MemRecursorCache::SigRecsVec& signatures, unsigned int depth, const string& prefix);
   vState getDNSKeys(const DNSName& signer, skeyset_t& keys, bool& servFailOccurred, unsigned int depth, const string& prefix);
   dState getDenialValidationState(const NegCache::NegCacheEntry& negEntry, dState expectedState, bool referralToUnsigned, const string& prefix);
   void updateDenialValidationState(const DNSName& qname, vState& neValidationState, const DNSName& neName, vState& state, dState denialState, dState expectedState, bool isDS, unsigned int depth, const string& prefix);

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -678,7 +678,7 @@ private:
   boost::optional<Netmask> getEDNSSubnetMask(const DNSName& name, const ComboAddress& rem);
 
   static bool validationEnabled();
-  uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures, uint32_t signaturesTTL, const std::shared_ptr<std::vector<DNSRecord>>& authorityRecs) const;
+  uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures, uint32_t signaturesTTL, const MemRecursorCache::AuthRecsVec& authorityRecs) const;
   void updateValidationState(const DNSName& qname, vState& state, vState stateUpdate, const string& prefix);
   vState validateRecordsWithSigs(unsigned int depth, const string& prefix, const DNSName& qname, QType qtype, const DNSName& name, QType type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures);
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures, unsigned int depth, const string& prefix);

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -678,7 +678,7 @@ private:
   boost::optional<Netmask> getEDNSSubnetMask(const DNSName& name, const ComboAddress& rem);
 
   static bool validationEnabled();
-  uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures, uint32_t signaturesTTL, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs) const;
+  uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures, uint32_t signaturesTTL, const std::shared_ptr<std::vector<DNSRecord>>& authorityRecs) const;
   void updateValidationState(const DNSName& qname, vState& state, vState stateUpdate, const string& prefix);
   vState validateRecordsWithSigs(unsigned int depth, const string& prefix, const DNSName& qname, QType qtype, const DNSName& name, QType type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures);
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures, unsigned int depth, const string& prefix);

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -21,7 +21,7 @@ static void simple(time_t now)
   MemRecursorCache MRC;
 
   std::vector<DNSRecord> records;
-  std::shared_ptr<std::vector<DNSRecord>> authRecords;
+  MemRecursorCache::AuthRecsVec authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   const DNSName authZone(".");
 
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheGhost)
   MemRecursorCache MRC;
 
   std::vector<DNSRecord> records;
-  std::shared_ptr<std::vector<DNSRecord>> authRecords;
+  MemRecursorCache::AuthRecsVec authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
 
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheReplaceAuthByNonAuthMargin)
   MemRecursorCache MRC;
 
   std::vector<DNSRecord> records;
-  std::shared_ptr<std::vector<DNSRecord>> authRecords;
+  MemRecursorCache::AuthRecsVec authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
 
@@ -535,7 +535,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCache_ExpungingExpiredEntries)
 
   std::vector<DNSRecord> records;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
-  std::shared_ptr<std::vector<DNSRecord>> authRecs;
+  MemRecursorCache::AuthRecsVec authRecs;
   const DNSName authZone(".");
   BOOST_CHECK_EQUAL(MRC.size(), 0U);
   time_t now = time(nullptr);
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCache_ExpungingValidEntries)
 
   std::vector<DNSRecord> records;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
-  std::shared_ptr<std::vector<DNSRecord>> authRecs;
+  MemRecursorCache::AuthRecsVec authRecs;
   const DNSName authZone(".");
   BOOST_CHECK_EQUAL(MRC.size(), 0U);
   time_t now = time(nullptr);
@@ -810,7 +810,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheECSIndex)
   const DNSName power("powerdns.com.");
   const DNSName authZone(".");
   std::vector<DNSRecord> records;
-  std::shared_ptr<std::vector<DNSRecord>> authRecords;
+  MemRecursorCache::AuthRecsVec authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
   std::vector<DNSRecord> retrieved;
@@ -970,7 +970,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCache_Wipe)
   const DNSName power("powerdns.com.");
   const DNSName authZone(".");
   std::vector<DNSRecord> records;
-  std::shared_ptr<std::vector<DNSRecord>> authRecords;
+  MemRecursorCache::AuthRecsVec authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
   std::vector<DNSRecord> retrieved;
@@ -1059,7 +1059,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheTagged)
   MemRecursorCache MRC;
 
   const DNSName authZone(".");
-  std::shared_ptr<std::vector<DNSRecord>> authRecords;
+  MemRecursorCache::AuthRecsVec authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
   time_t ttd = now + 30;
@@ -1293,14 +1293,14 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
   MemRecursorCache MRC;
 
   const DNSName authZone(".");
-  std::shared_ptr<std::vector<DNSRecord>> authRecords = std::make_shared<std::vector<DNSRecord>>();
+  MemRecursorCache::AuthRecsVec authRecords;
   DNSRecord dr;
   dr.d_place = DNSResourceRecord::ANSWER;
   dr.d_name = DNSName("hi");
   dr.d_type = QType::AAAA;
   dr.d_ttl = 3600;
   dr.setContent(std::make_shared<ARecordContent>(ComboAddress("1::2:3:4")));
-  authRecords->emplace_back(dr);
+  authRecords.emplace_back(dr);
 
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   signatures.emplace_back(std::dynamic_pointer_cast<RRSIGRecordContent>(RRSIGRecordContent::make("DNSKEY 8 0 172800 20241111000000 20241021000000 20326 . alCFgDZS+0l5zcpQ/7R+5OFeCrk9KGkNP2F9ynXIXG6QigPj/9qjm0xx ItRJUUim+SrJywAmLKe+48oTUeSRyDKVVg3LGDekLKcIVz0EBqTL2y44 usDlUlxqx5O0LQVHy4h/hm9+dCXFiSBWoV0LcAplV9OYWhxi+CxmxZU5 8vK6eVAde8E2JHdeDuy23WF5lxYEg1q7ehEt5EdRvZ7hZzfawEFR3Qv3 WMootO2eBAAneIe94daJP/i1iwQJ4p+bGVCZ4sJk+Pk9J7lwEQq6Ghkd SpLsRxArUhvoVgtnh0LkAV7TsajYk8K2JRt7wHNDbBV6+Vdq2bh7ZPGv LiGkIQ==")));
@@ -1340,7 +1340,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
 
     for (size_t counter = 0; counter < expected + 10; counter++) {
       std::vector<DNSRecord> retrieved;
-      std::shared_ptr<std::vector<DNSRecord>> authRecs;
+      MemRecursorCache::AuthRecs authRecs;
       std::vector<std::shared_ptr<const RRSIGRecordContent>> sigs;
       bool variable = false;
       vState state = vState::Indeterminate;
@@ -1355,7 +1355,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
         BOOST_CHECK_EQUAL(sigs.at(0)->getZoneRepresentation(), signatures.at(0)->getZoneRepresentation());
         BOOST_CHECK_EQUAL(authRecs->size(), 1U);
 
-        BOOST_CHECK_EQUAL(authRecs->at(0).toString(), authRecords->at(0).toString());
+        BOOST_CHECK_EQUAL(authRecs->at(0).toString(), authRecords.at(0).toString());
         BOOST_CHECK_EQUAL(state, vState::Insecure);
         BOOST_CHECK_EQUAL(wasAuth, true);
         BOOST_CHECK_EQUAL(fromZone, authZone);

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -21,7 +21,7 @@ static void simple(time_t now)
   MemRecursorCache MRC;
 
   std::vector<DNSRecord> records;
-  std::vector<std::shared_ptr<DNSRecord>> authRecords;
+  std::shared_ptr<std::vector<DNSRecord>> authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   const DNSName authZone(".");
 
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheGhost)
   MemRecursorCache MRC;
 
   std::vector<DNSRecord> records;
-  std::vector<std::shared_ptr<DNSRecord>> authRecords;
+  std::shared_ptr<std::vector<DNSRecord>> authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
 
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheReplaceAuthByNonAuthMargin)
   MemRecursorCache MRC;
 
   std::vector<DNSRecord> records;
-  std::vector<std::shared_ptr<DNSRecord>> authRecords;
+  std::shared_ptr<std::vector<DNSRecord>> authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
 
@@ -535,7 +535,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCache_ExpungingExpiredEntries)
 
   std::vector<DNSRecord> records;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
-  std::vector<std::shared_ptr<DNSRecord>> authRecs;
+  std::shared_ptr<std::vector<DNSRecord>> authRecs;
   const DNSName authZone(".");
   BOOST_CHECK_EQUAL(MRC.size(), 0U);
   time_t now = time(nullptr);
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCache_ExpungingValidEntries)
 
   std::vector<DNSRecord> records;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
-  std::vector<std::shared_ptr<DNSRecord>> authRecs;
+  std::shared_ptr<std::vector<DNSRecord>> authRecs;
   const DNSName authZone(".");
   BOOST_CHECK_EQUAL(MRC.size(), 0U);
   time_t now = time(nullptr);
@@ -810,7 +810,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheECSIndex)
   const DNSName power("powerdns.com.");
   const DNSName authZone(".");
   std::vector<DNSRecord> records;
-  std::vector<std::shared_ptr<DNSRecord>> authRecords;
+  std::shared_ptr<std::vector<DNSRecord>> authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
   std::vector<DNSRecord> retrieved;
@@ -970,7 +970,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCache_Wipe)
   const DNSName power("powerdns.com.");
   const DNSName authZone(".");
   std::vector<DNSRecord> records;
-  std::vector<std::shared_ptr<DNSRecord>> authRecords;
+  std::shared_ptr<std::vector<DNSRecord>> authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
   std::vector<DNSRecord> retrieved;
@@ -1059,7 +1059,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheTagged)
   MemRecursorCache MRC;
 
   const DNSName authZone(".");
-  std::vector<std::shared_ptr<DNSRecord>> authRecords;
+  std::shared_ptr<std::vector<DNSRecord>> authRecords;
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   time_t now = time(nullptr);
   time_t ttd = now + 30;
@@ -1293,14 +1293,14 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
   MemRecursorCache MRC;
 
   const DNSName authZone(".");
-  std::vector<std::shared_ptr<DNSRecord>> authRecords;
+  std::shared_ptr<std::vector<DNSRecord>> authRecords = std::make_shared<std::vector<DNSRecord>>();
   DNSRecord dr;
   dr.d_place = DNSResourceRecord::ANSWER;
   dr.d_name = DNSName("hi");
   dr.d_type = QType::AAAA;
   dr.d_ttl = 3600;
   dr.setContent(std::make_shared<ARecordContent>(ComboAddress("1::2:3:4")));
-  authRecords.emplace_back(std::make_shared<DNSRecord>(dr));
+  authRecords->emplace_back(dr);
 
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
   signatures.emplace_back(std::dynamic_pointer_cast<RRSIGRecordContent>(RRSIGRecordContent::make("DNSKEY 8 0 172800 20241111000000 20241021000000 20326 . alCFgDZS+0l5zcpQ/7R+5OFeCrk9KGkNP2F9ynXIXG6QigPj/9qjm0xx ItRJUUim+SrJywAmLKe+48oTUeSRyDKVVg3LGDekLKcIVz0EBqTL2y44 usDlUlxqx5O0LQVHy4h/hm9+dCXFiSBWoV0LcAplV9OYWhxi+CxmxZU5 8vK6eVAde8E2JHdeDuy23WF5lxYEg1q7ehEt5EdRvZ7hZzfawEFR3Qv3 WMootO2eBAAneIe94daJP/i1iwQJ4p+bGVCZ4sJk+Pk9J7lwEQq6Ghkd SpLsRxArUhvoVgtnh0LkAV7TsajYk8K2JRt7wHNDbBV6+Vdq2bh7ZPGv LiGkIQ==")));
@@ -1340,7 +1340,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
 
     for (size_t counter = 0; counter < expected + 10; counter++) {
       std::vector<DNSRecord> retrieved;
-      std::vector<std::shared_ptr<DNSRecord>> authRecs;
+      std::shared_ptr<std::vector<DNSRecord>> authRecs;
       std::vector<std::shared_ptr<const RRSIGRecordContent>> sigs;
       bool variable = false;
       vState state = vState::Indeterminate;
@@ -1353,9 +1353,9 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
         BOOST_CHECK_EQUAL(getRR<ARecordContent>(retrieved.at(0))->getCA().toString(), dr0Content.toString());
         BOOST_CHECK_EQUAL(sigs.size(), 1U);
         BOOST_CHECK_EQUAL(sigs.at(0)->getZoneRepresentation(), signatures.at(0)->getZoneRepresentation());
-        BOOST_CHECK_EQUAL(authRecs.size(), 1U);
+        BOOST_CHECK_EQUAL(authRecs->size(), 1U);
 
-        BOOST_CHECK_EQUAL(authRecs.at(0)->toString(), authRecords.at(0)->toString());
+        BOOST_CHECK_EQUAL(authRecs->at(0).toString(), authRecords->at(0).toString());
         BOOST_CHECK_EQUAL(state, vState::Insecure);
         BOOST_CHECK_EQUAL(wasAuth, true);
         BOOST_CHECK_EQUAL(fromZone, authZone);

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -1342,7 +1342,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
     for (size_t counter = 0; counter < expected + 10; counter++) {
       std::vector<DNSRecord> retrieved;
       MemRecursorCache::AuthRecs authRecs;
-      std::vector<std::shared_ptr<const RRSIGRecordContent>> sigs;
+      MemRecursorCache::SigRecs sigs;
       bool variable = false;
       vState state = vState::Indeterminate;
       bool wasAuth = false;
@@ -1352,8 +1352,8 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
         matches++;
         BOOST_CHECK_EQUAL(retrieved.size(), rset0.size());
         BOOST_CHECK_EQUAL(getRR<ARecordContent>(retrieved.at(0))->getCA().toString(), dr0Content.toString());
-        BOOST_CHECK_EQUAL(sigs.size(), 1U);
-        BOOST_CHECK_EQUAL(sigs.at(0)->getZoneRepresentation(), signatures.at(0)->getZoneRepresentation());
+        BOOST_CHECK_EQUAL(sigs->size(), 1U);
+        BOOST_CHECK_EQUAL(sigs->at(0)->getZoneRepresentation(), signatures.at(0)->getZoneRepresentation());
         BOOST_CHECK_EQUAL(authRecs->size(), 1U);
 
         BOOST_CHECK_EQUAL(authRecs->at(0).toString(), authRecords.at(0).toString());

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -1432,11 +1432,11 @@ struct NOPTest
   }
 };
 
-struct AuthRecordsTest
+struct RecordsSpeedTest
 {
   [[nodiscard]] static string getName()
   {
-    return "AuthRecordsTest";
+    return "RecordsSpeedTest";
   }
 
   void operator()() const
@@ -1455,6 +1455,9 @@ struct AuthRecordsTest
     authRecords.emplace_back(dr);
     time_t now = time(nullptr);
     time_t ttd = now + 30;
+
+    MemRecursorCache::SigRecsVec signatures;
+    signatures.emplace_back(std::dynamic_pointer_cast<RRSIGRecordContent>(RRSIGRecordContent::make("DNSKEY 8 0 172800 20241111000000 20241021000000 20326 . alCFgDZS+0l5zcpQ/7R+5OFeCrk9KGkNP2F9ynXIXG6QigPj/9qjm0xx ItRJUUim+SrJywAmLKe+48oTUeSRyDKVVg3LGDekLKcIVz0EBqTL2y44 usDlUlxqx5O0LQVHy4h/hm9+dCXFiSBWoV0LcAplV9OYWhxi+CxmxZU5 8vK6eVAde8E2JHdeDuy23WF5lxYEg1q7ehEt5EdRvZ7hZzfawEFR3Qv3 WMootO2eBAAneIe94daJP/i1iwQJ4p+bGVCZ4sJk+Pk9J7lwEQq6Ghkd SpLsRxArUhvoVgtnh0LkAV7TsajYk8K2JRt7wHNDbBV6+Vdq2bh7ZPGv LiGkIQ==")));
 
     DNSName power("powerdns.com.");
     DNSRecord dr0;
@@ -1477,7 +1480,7 @@ struct AuthRecordsTest
       DNSName a = DNSName("hello ") + DNSName(std::to_string(counter));
       BOOST_CHECK_EQUAL(DNSName(a.toString()), a);
 
-      MRC.replace(now, a, QType(QType::A), rset0, {}, authRecords, true, authZone, boost::none, boost::none, vState::Insecure, somebody, false, ttl_time);
+      MRC.replace(now, a, QType(QType::A), rset0, signatures, authRecords, true, authZone, boost::none, boost::none, vState::Insecure, somebody, false, ttl_time);
     }
 
     BOOST_CHECK_EQUAL(MRC.size(), expected);
@@ -1489,7 +1492,7 @@ struct AuthRecordsTest
       for (size_t counter = 0; counter < expected; ++counter) {
         std::vector<DNSRecord> retrieved;
         MemRecursorCache::AuthRecs authRecs;
-        std::vector<std::shared_ptr<const RRSIGRecordContent>> sigs;
+        MemRecursorCache::SigRecs sigs;
         bool variable = false;
         vState state = vState::Indeterminate;
         bool wasAuth = false;
@@ -1507,7 +1510,7 @@ struct AuthRecordsTest
 BOOST_AUTO_TEST_CASE(test_speed)
 {
   doRun(NOPTest());
-  doRun(AuthRecordsTest());
+  doRun(RecordsSpeedTest());
 }
 #endif
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -102,18 +102,18 @@ bool primeHints(time_t now)
     arr.setContent(std::make_shared<ARecordContent>(ComboAddress(rootIps4[c - 'a'])));
     vector<DNSRecord> aset;
     aset.push_back(arr);
-    g_recCache->replace(now, DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<const RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname);
+    g_recCache->replace(now, DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<const RRSIGRecordContent>>(), nullptr, false, g_rootdnsname);
     if (!rootIps6[c - 'a'].empty()) {
       aaaarr.setContent(std::make_shared<AAAARecordContent>(ComboAddress(rootIps6[c - 'a'])));
 
       vector<DNSRecord> aaaaset;
       aaaaset.push_back(aaaarr);
-      g_recCache->replace(now, DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<const RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname);
+      g_recCache->replace(now, DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<const RRSIGRecordContent>>(), nullptr, false, g_rootdnsname);
     }
 
     nsset.push_back(nsrr);
   }
-  g_recCache->replace(now, g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<const RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname); // and stuff in the cache
+  g_recCache->replace(now, g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<const RRSIGRecordContent>>(), nullptr, false, g_rootdnsname); // and stuff in the cache
   return true;
 }
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -102,18 +102,18 @@ bool primeHints(time_t now)
     arr.setContent(std::make_shared<ARecordContent>(ComboAddress(rootIps4[c - 'a'])));
     vector<DNSRecord> aset;
     aset.push_back(arr);
-    g_recCache->replace(now, DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<const RRSIGRecordContent>>(), nullptr, false, g_rootdnsname);
+    g_recCache->replace(now, DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<const RRSIGRecordContent>>(), {}, false, g_rootdnsname);
     if (!rootIps6[c - 'a'].empty()) {
       aaaarr.setContent(std::make_shared<AAAARecordContent>(ComboAddress(rootIps6[c - 'a'])));
 
       vector<DNSRecord> aaaaset;
       aaaaset.push_back(aaaarr);
-      g_recCache->replace(now, DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<const RRSIGRecordContent>>(), nullptr, false, g_rootdnsname);
+      g_recCache->replace(now, DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<const RRSIGRecordContent>>(), {}, false, g_rootdnsname);
     }
 
     nsset.push_back(nsrr);
   }
-  g_recCache->replace(now, g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<const RRSIGRecordContent>>(), nullptr, false, g_rootdnsname); // and stuff in the cache
+  g_recCache->replace(now, g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<const RRSIGRecordContent>>(), {}, false, g_rootdnsname); // and stuff in the cache
   return true;
 }
 

--- a/pdns/recursordist/test-syncres_cc2.cc
+++ b/pdns/recursordist/test-syncres_cc2.cc
@@ -1465,7 +1465,7 @@ BOOST_AUTO_TEST_CASE(test_flawed_nsset)
   std::vector<shared_ptr<const RRSIGRecordContent>> sigs;
   addRecordToList(records, target, QType::NS, "pdns-public-ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, now + 3600);
 
-  g_recCache->replace(now, target, QType(QType::NS), records, sigs, nullptr, true, g_rootdnsname, boost::optional<Netmask>());
+  g_recCache->replace(now, target, QType(QType::NS), records, sigs, {}, true, g_rootdnsname, boost::optional<Netmask>());
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
@@ -1571,7 +1571,7 @@ BOOST_AUTO_TEST_CASE(test_cache_hit)
   std::vector<shared_ptr<const RRSIGRecordContent>> sigs;
 
   addRecordToList(records, target, QType::A, "192.0.2.1", DNSResourceRecord::ANSWER, now + 3600);
-  g_recCache->replace(now, target, QType(QType::A), records, sigs, nullptr, true, g_rootdnsname, boost::optional<Netmask>());
+  g_recCache->replace(now, target, QType(QType::A), records, sigs, {}, true, g_rootdnsname, boost::optional<Netmask>());
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
@@ -1760,7 +1760,7 @@ BOOST_AUTO_TEST_CASE(test_cache_expired_ttl)
   std::vector<shared_ptr<const RRSIGRecordContent>> sigs;
   addRecordToList(records, target, QType::A, "192.0.2.42", DNSResourceRecord::ANSWER, now - 60);
 
-  g_recCache->replace(now - 3600, target, QType(QType::A), records, sigs, nullptr, true, g_rootdnsname, boost::optional<Netmask>());
+  g_recCache->replace(now - 3600, target, QType(QType::A), records, sigs, {}, true, g_rootdnsname, boost::optional<Netmask>());
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);

--- a/pdns/recursordist/test-syncres_cc2.cc
+++ b/pdns/recursordist/test-syncres_cc2.cc
@@ -1465,7 +1465,7 @@ BOOST_AUTO_TEST_CASE(test_flawed_nsset)
   std::vector<shared_ptr<const RRSIGRecordContent>> sigs;
   addRecordToList(records, target, QType::NS, "pdns-public-ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, now + 3600);
 
-  g_recCache->replace(now, target, QType(QType::NS), records, sigs, vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname, boost::optional<Netmask>());
+  g_recCache->replace(now, target, QType(QType::NS), records, sigs, nullptr, true, g_rootdnsname, boost::optional<Netmask>());
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
@@ -1571,7 +1571,7 @@ BOOST_AUTO_TEST_CASE(test_cache_hit)
   std::vector<shared_ptr<const RRSIGRecordContent>> sigs;
 
   addRecordToList(records, target, QType::A, "192.0.2.1", DNSResourceRecord::ANSWER, now + 3600);
-  g_recCache->replace(now, target, QType(QType::A), records, sigs, vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname, boost::optional<Netmask>());
+  g_recCache->replace(now, target, QType(QType::A), records, sigs, nullptr, true, g_rootdnsname, boost::optional<Netmask>());
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
@@ -1760,7 +1760,7 @@ BOOST_AUTO_TEST_CASE(test_cache_expired_ttl)
   std::vector<shared_ptr<const RRSIGRecordContent>> sigs;
   addRecordToList(records, target, QType::A, "192.0.2.42", DNSResourceRecord::ANSWER, now - 60);
 
-  g_recCache->replace(now - 3600, target, QType(QType::A), records, sigs, vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname, boost::optional<Netmask>());
+  g_recCache->replace(now - 3600, target, QType(QType::A), records, sigs, nullptr, true, g_rootdnsname, boost::optional<Netmask>());
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);

--- a/pdns/recursordist/test-syncres_cc3.cc
+++ b/pdns/recursordist/test-syncres_cc3.cc
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(test_answer_no_aa)
   /* check that the record in the answer section has not been cached */
   const ComboAddress who;
   vector<DNSRecord> cached;
-  vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
+  MemRecursorCache::SigRecs signatures;
   BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::A), MemRecursorCache::None, &cached, who, boost::none, &signatures), 0);
 }
 

--- a/pdns/recursordist/test-syncres_cc3.cc
+++ b/pdns/recursordist/test-syncres_cc3.cc
@@ -1342,6 +1342,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_cname_wildcard_expanded
   res = testSR->beginResolve(target, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(testSR->getValidationState(), vState::Insecure);
+  BOOST_CHECK(MemRecursorCache::s_emptyAuthRecs->empty());
   BOOST_REQUIRE_EQUAL(ret.size(), 5U);
   BOOST_CHECK_EQUAL(queriesCount, 5U);
 }

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -1367,10 +1367,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_cache_validity)
   /* check that the entry has not been cached for longer than the RRSIG validity */
   const ComboAddress who;
   vector<DNSRecord> cached;
-  vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
+  MemRecursorCache::SigRecs signatures;
   BOOST_REQUIRE_EQUAL(g_recCache->get(tnow, target, QType(QType::A), MemRecursorCache::RequireAuth, &cached, who, boost::none, &signatures), 1);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
-  BOOST_REQUIRE_EQUAL(signatures.size(), 1U);
+  BOOST_REQUIRE_EQUAL(signatures->size(), 1U);
   BOOST_CHECK_EQUAL((cached[0].d_ttl - tnow), 1);
 
   /* again, to test the cache */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Currently, we stored and return vectors, change this to store and return a shared pointer to const vectors. This allows us to return a single shared pointer on get(), avoiding to copy all vector elements. 

This approach does not work for the answer records, as modified (e.g. TTL) `DNSRecord`s are returned.

Speedup of get() of about 10% in a totally artificial test case of a single insert and many gets(). Should also save a bit on memory. We store `nullptr` for empty vectors and make sure `get()` rerurns a ready-made empty vector in that case.

This not only needs review on the detail level, but also on the general approach!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
