### PR TITLE
auth: createForward and createForward6 will use the zone_record as base

### DIFF
--- a/pdns/lua-auth4.hh
+++ b/pdns/lua-auth4.hh
@@ -45,5 +45,5 @@ private:
   luacall_axfr_filter_t d_axfr_filter;
   luacall_prequery_t d_prequery;
 };
-std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& qname,
+std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& qname, const DNSRecord& zone_record,
                                                    const DNSName& zone, int zoneid, const DNSPacket& dnsp, uint16_t qtype, unique_ptr<AuthLua4>& LUA);

--- a/pdns/lua-auth4.hh
+++ b/pdns/lua-auth4.hh
@@ -45,5 +45,5 @@ private:
   luacall_axfr_filter_t d_axfr_filter;
   luacall_prequery_t d_prequery;
 };
-std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& query, const DNSRecord& zone_record,
-                                                   const DNSName& zone, int zoneid, const DNSPacket& dnsp, uint16_t qtype, unique_ptr<AuthLua4>& LUA);
+std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& query, const DNSZoneRecord& zone_record,
+                                                   const DNSName& zone, const DNSPacket& dnsp, uint16_t qtype, unique_ptr<AuthLua4>& LUA);

--- a/pdns/lua-auth4.hh
+++ b/pdns/lua-auth4.hh
@@ -45,5 +45,5 @@ private:
   luacall_axfr_filter_t d_axfr_filter;
   luacall_prequery_t d_prequery;
 };
-std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& qname, const DNSRecord& zone_record,
+std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& query, const DNSRecord& zone_record,
                                                    const DNSName& zone, int zoneid, const DNSPacket& dnsp, uint16_t qtype, unique_ptr<AuthLua4>& LUA);

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -654,6 +654,7 @@ typedef struct AuthLuaRecordContext
 {
   ComboAddress          bestwho;
   DNSName               qname;
+  DNSRecord             zone_record;
   DNSName               zone;
   int                   zoneid;
 } lua_record_ctx_t;
@@ -915,8 +916,14 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
       return std::string("error");
     });
   lua.writeFunction("createForward", []() {
-      static string allZerosIP("0.0.0.0");
-      DNSName rel=s_lua_record_ctx->qname.makeRelative(s_lua_record_ctx->zone);
+      static string allZerosIP{"0.0.0.0"};
+      DNSName record_name{s_lua_record_ctx->zone_record.d_name};
+      if (record_name.isWildcard() == false) {
+        return allZerosIP;
+      }
+      record_name.chopOff();
+      DNSName rel{s_lua_record_ctx->qname.makeRelative(record_name)};
+
       // parts is something like ["1", "2", "3", "4", "static"] or
       // ["1", "2", "3", "4"] or ["ip40414243", "ip-addresses", ...]
       auto parts = rel.getRawLabels();
@@ -972,7 +979,14 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
     });
 
   lua.writeFunction("createForward6", []() {
-      DNSName rel=s_lua_record_ctx->qname.makeRelative(s_lua_record_ctx->zone);
+      static string allZerosIP{"::"};
+      DNSName record_name{s_lua_record_ctx->zone_record.d_name};
+      if (record_name.isWildcard() == false) {
+        return allZerosIP;
+      }
+      record_name.chopOff();
+      DNSName rel{s_lua_record_ctx->qname.makeRelative(record_name)};
+
       auto parts = rel.getRawLabels();
       if(parts.size()==8) {
         string tot;
@@ -1008,7 +1022,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
         }
       }
 
-      return std::string("::");
+      return allZerosIP;
     });
   lua.writeFunction("createReverse6", [](string format, boost::optional<std::unordered_map<string,string>> e){
       vector<ComboAddress> candidates;
@@ -1395,7 +1409,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
     });
 }
 
-std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& query, const DNSName& zone, int zoneid, const DNSPacket& dnsp, uint16_t qtype, unique_ptr<AuthLua4>& LUA)
+std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& query, const DNSRecord& zone_record, const DNSName& zone, int zoneid, const DNSPacket& dnsp, uint16_t qtype, unique_ptr<AuthLua4>& LUA)
 {
   if(!LUA ||                  // we don't have a Lua state yet
      !g_LuaRecordSharedState) { // or we want a new one even if we had one
@@ -1409,6 +1423,7 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
 
   s_lua_record_ctx = std::make_unique<lua_record_ctx_t>();
   s_lua_record_ctx->qname = query;
+  s_lua_record_ctx->zone_record = zone_record;
   s_lua_record_ctx->zone = zone;
   s_lua_record_ctx->zoneid = zoneid;
 

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -654,9 +654,8 @@ typedef struct AuthLuaRecordContext
 {
   ComboAddress          bestwho;
   DNSName               qname;
-  DNSRecord             zone_record;
+  DNSZoneRecord         zone_record;
   DNSName               zone;
-  int                   zoneid;
 } lua_record_ctx_t;
 
 static thread_local unique_ptr<lua_record_ctx_t> s_lua_record_ctx;
@@ -766,7 +765,7 @@ static std::vector<std::shared_ptr<EntryHashesHolder>> getCHashedEntries(const i
 
 static std::string pickConsistentWeightedHashed(const ComboAddress& bestwho, const std::vector<std::pair<int, std::string>>& items)
 {
-  const auto& zoneId = s_lua_record_ctx->zoneid;
+  const auto& zoneId = s_lua_record_ctx->zone_record.domain_id;
   const auto queryName = s_lua_record_ctx->qname.toString();
   unsigned int sel = std::numeric_limits<unsigned int>::max();
   unsigned int min = std::numeric_limits<unsigned int>::max();
@@ -917,7 +916,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
     });
   lua.writeFunction("createForward", []() {
       static string allZerosIP{"0.0.0.0"};
-      DNSName record_name{s_lua_record_ctx->zone_record.d_name};
+      DNSName record_name{s_lua_record_ctx->zone_record.dr.d_name};
       if (!record_name.isWildcard()) {
         return allZerosIP;
       }
@@ -980,7 +979,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
 
   lua.writeFunction("createForward6", []() {
       static string allZerosIP{"::"};
-      DNSName record_name{s_lua_record_ctx->zone_record.d_name};
+      DNSName record_name{s_lua_record_ctx->zone_record.dr.d_name};
       if (!record_name.isWildcard()) {
         return allZerosIP;
       }
@@ -1397,7 +1396,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
         return;
       }
       try {
-        vector<DNSZoneRecord> drs = lookup(rec, QType::LUA, s_lua_record_ctx->zoneid);
+        vector<DNSZoneRecord> drs = lookup(rec, QType::LUA, s_lua_record_ctx->zone_record.domain_id);
         for(const auto& dr : drs) {
           auto lr = getRR<LUARecordContent>(dr.dr);
           lua.executeCode(lr->getCode());
@@ -1409,7 +1408,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
     });
 }
 
-std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& query, const DNSRecord& zone_record, const DNSName& zone, int zoneid, const DNSPacket& dnsp, uint16_t qtype, unique_ptr<AuthLua4>& LUA)
+std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& query, const DNSZoneRecord& zone_record, const DNSName& zone, const DNSPacket& dnsp, uint16_t qtype, unique_ptr<AuthLua4>& LUA)
 {
   if(!LUA ||                  // we don't have a Lua state yet
      !g_LuaRecordSharedState) { // or we want a new one even if we had one
@@ -1425,11 +1424,10 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
   s_lua_record_ctx->qname = query;
   s_lua_record_ctx->zone_record = zone_record;
   s_lua_record_ctx->zone = zone;
-  s_lua_record_ctx->zoneid = zoneid;
 
   lua.writeVariable("qname", query);
   lua.writeVariable("zone", zone);
-  lua.writeVariable("zoneid", zoneid);
+  lua.writeVariable("zoneid", zone_record.domain_id);
   lua.writeVariable("who", dnsp.getInnerRemote());
   lua.writeVariable("localwho", dnsp.getLocal());
   lua.writeVariable("dh", (dnsheader*)&dnsp.d);

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -918,7 +918,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
   lua.writeFunction("createForward", []() {
       static string allZerosIP{"0.0.0.0"};
       DNSName record_name{s_lua_record_ctx->zone_record.d_name};
-      if (record_name.isWildcard() == false) {
+      if (!record_name.isWildcard()) {
         return allZerosIP;
       }
       record_name.chopOff();
@@ -981,7 +981,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
   lua.writeFunction("createForward6", []() {
       static string allZerosIP{"::"};
       DNSName record_name{s_lua_record_ctx->zone_record.d_name};
-      if (record_name.isWildcard() == false) {
+      if (!record_name.isWildcard()) {
         return allZerosIP;
       }
       record_name.chopOff();

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -427,7 +427,7 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
           //    noCache=true;
           DLOG(g_log<<"Executing Lua: '"<<rec->getCode()<<"'"<<endl);
           try {
-            auto recvec=luaSynth(rec->getCode(), target, d_sd.qname, d_sd.domain_id, p, rec->d_type, s_LUA);
+            auto recvec=luaSynth(rec->getCode(), target, rr.dr, d_sd.qname, d_sd.domain_id, p, rec->d_type, s_LUA);
             for (const auto& r : recvec) {
               rr.dr.d_type = rec->d_type; // might be CNAME
               rr.dr.setContent(r);
@@ -1622,7 +1622,7 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
         if(rec->d_type == QType::CNAME || rec->d_type == p.qtype.getCode() || (p.qtype.getCode() == QType::ANY && rec->d_type != QType::RRSIG)) {
           noCache=true;
           try {
-            auto recvec=luaSynth(rec->getCode(), target, d_sd.qname, d_sd.domain_id, p, rec->d_type, s_LUA);
+            auto recvec=luaSynth(rec->getCode(), target, rr.dr, d_sd.qname, d_sd.domain_id, p, rec->d_type, s_LUA);
             if(!recvec.empty()) {
               for (const auto& r_it : recvec) {
                 rr.dr.d_type = rec->d_type; // might be CNAME

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -427,7 +427,7 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
           //    noCache=true;
           DLOG(g_log<<"Executing Lua: '"<<rec->getCode()<<"'"<<endl);
           try {
-            auto recvec=luaSynth(rec->getCode(), target, rr.dr, d_sd.qname, d_sd.domain_id, p, rec->d_type, s_LUA);
+            auto recvec=luaSynth(rec->getCode(), target, rr, d_sd.qname, p, rec->d_type, s_LUA);
             for (const auto& r : recvec) {
               rr.dr.d_type = rec->d_type; // might be CNAME
               rr.dr.setContent(r);
@@ -1622,7 +1622,7 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
         if(rec->d_type == QType::CNAME || rec->d_type == p.qtype.getCode() || (p.qtype.getCode() == QType::ANY && rec->d_type != QType::RRSIG)) {
           noCache=true;
           try {
-            auto recvec=luaSynth(rec->getCode(), target, rr.dr, d_sd.qname, d_sd.domain_id, p, rec->d_type, s_LUA);
+            auto recvec=luaSynth(rec->getCode(), target, rr, d_sd.qname, p, rec->d_type, s_LUA);
             if(!recvec.empty()) {
               for (const auto& r_it : recvec) {
                 rr.dr.d_type = rec->d_type; // might be CNAME

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -148,6 +148,7 @@ resolve          IN    LUA    A   ";local r=resolve('localhost', 1) local t={{}}
 filterforwardempty IN LUA A "filterForward('192.0.2.1', newNMG{{'192.1.2.0/24'}}, '')"
 
 *.createforward  IN    LUA    A     "filterForward(createForward(), newNMG{{'1.0.0.0/8', '64.0.0.0/8'}})"
+*.createforward6 IN    LUA    AAAA  "filterForward(createForward6(), newNMG{{'2000::/3'}}, 'fe80::1')"
 *.createreverse  IN    LUA    PTR   "createReverse('%5%.example.com', {{['10.10.10.10'] = 'quad10.example.com.'}})"
 *.createreverse6 IN    LUA    PTR   "createReverse6('%33%.example.com', {{['2001:db8::1'] = 'example.example.com.'}})"
 
@@ -160,14 +161,7 @@ lookmeup         IN           A  192.0.2.5
 dblookup         IN    LUA    A  "dblookup('lookmeup.example.org', pdns.A)[1]"
 
 whitespace       IN    LUA    TXT "'foo" "bar'"
-        """,
-        'createforward6.example.org': """
-createforward6.example.org.                 3600 IN SOA  {soa}
-createforward6.example.org.                 3600 IN NS   ns1.example.org.
-createforward6.example.org.                 3600 IN NS   ns2.example.org.
-*                                                IN    LUA    AAAA  "filterForward(createForward6(), newNMG{{'2000::/3'}}, 'fe80::1')"
         """
-# the separate createforward6 zone is because some of the code in lua-record.cc insists on working relatively to the zone apex
     }
     _web_rrsets = []
 
@@ -1004,7 +998,7 @@ createforward6.example.org.                 3600 IN NS   ns2.example.org.
                 "invalid": "0.0.0.0",
                 "1-2-3-4": "1.2.3.4",
                 "1-2-3-4.foo": "1.2.3.4",
-                "1-2-3-4.foo.bar": "0.0.0.0",
+                "1-2-3-4.foo.bar": "1.2.3.4",
                 "1-2-3-4.foo.bar.baz": "0.0.0.0",
                 "1-2-3-4.foo.bar.baz.quux": "0.0.0.0",
                 "ip-1-2-3-4": "1.2.3.4",


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`createForward` and `createForward6` will use the `zone_record` as base. Closes #7522
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
