### PR TITLE
dnsdist: Fix regression tests with Python 3.13

### DIFF
--- a/regression-tests.dnsdist/configCA.conf
+++ b/regression-tests.dnsdist/configCA.conf
@@ -1,7 +1,6 @@
 [req]
 default_bits = 2048
 encrypt_key = no
-x509_extensions = custom_extensions
 prompt = no
 distinguished_name = distinguished_name
 
@@ -9,15 +8,12 @@ distinguished_name = distinguished_name
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer:always
 basicConstraints = critical, CA:true
+keyUsage = critical, cRLSign, keyCertSign
 
 [distinguished_name]
 CN = DNSDist TLS regression tests CA
 OU = PowerDNS.com BV
 countryName = NL
-
-[custom_extensions]
-basicConstraints = CA:true
-keyUsage = cRLSign, keyCertSign
 
 [CA_default]
 copy_extensions = copy


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The CA certificates that we are generating as par of our regression tests were lacking the X.509 `Key Usage` extension, causing TLS validation with Python 3.13 to fail with:

> certificate verify failed: CA cert does not include key usage extension

It appears that Python 3.13 enables `VERIFY_X509_STRICT` by default, which makes OpenSSL stricter, and thus it chokes on our invalid CA.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
