### PR TITLE
EDNS0 padding support in auth

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -563,6 +563,8 @@ common_sources += files(
   src_dir / 'ednscookies.hh',
   src_dir / 'ednsoptions.cc',
   src_dir / 'ednsoptions.hh',
+  src_dir / 'ednspadding.cc',
+  src_dir / 'ednspadding.hh',
   src_dir / 'ednssubnet.cc',
   src_dir / 'ednssubnet.hh',
   src_dir / 'gss_context.cc',

--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -128,6 +128,7 @@ libtestremotebackend_la_SOURCES = \
 	../../pdns/dnswriter.cc \
 	../../pdns/ednscookies.cc \
 	../../pdns/ednsoptions.cc ../../pdns/ednsoptions.hh \
+	../../pdns/ednspadding.cc ../../pdns/ednspadding.hh \
 	../../pdns/ednssubnet.cc \
 	../../pdns/gss_context.cc ../../pdns/gss_context.hh \
 	../../pdns/iputils.cc \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -236,6 +236,7 @@ pdns_server_SOURCES = \
 	dynmessenger.hh \
 	ednscookies.cc ednscookies.hh \
 	ednsoptions.cc ednsoptions.hh \
+	ednspadding.cc ednspadding.hh \
 	ednssubnet.cc ednssubnet.hh \
 	expected.hh \
 	gettime.cc gettime.hh \
@@ -373,6 +374,7 @@ pdnsutil_SOURCES = \
 	dynlistener.cc \
 	ednscookies.cc ednscookies.hh \
 	ednsoptions.cc ednsoptions.hh \
+	ednspadding.cc ednspadding.hh \
 	ednssubnet.cc \
 	gettime.cc gettime.hh \
 	gss_context.cc gss_context.hh \
@@ -749,6 +751,7 @@ ixfrdist_SOURCES = \
 	ednscookies.cc ednscookies.hh \
 	ednsextendederror.cc ednsextendederror.hh \
 	ednsoptions.cc ednsoptions.hh \
+	ednspadding.cc ednspadding.hh \
 	ednssubnet.cc ednssubnet.hh \
 	gss_context.cc gss_context.hh \
 	iputils.hh iputils.cc \
@@ -1408,6 +1411,7 @@ testrunner_SOURCES = \
 	dnswriter.cc \
 	ednscookies.cc ednscookies.hh \
 	ednsoptions.cc ednsoptions.hh \
+	ednspadding.cc ednspadding.hh \
 	ednssubnet.cc \
 	gettime.cc gettime.hh \
 	gss_context.cc gss_context.hh \

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -365,13 +365,12 @@ void DNSPacket::wrapup(bool throwsOnTruncation)
 
       if (d_ednspadding) {
         size_t remaining = d_tcp ? 65535 : getMaxReplyLen();
-        const size_t blockSize = 468; // RFC8467 4.1
         // Note that optsize already contains the size of the EDNS0 padding
         // option header.
-        size_t modulo = (pw.size() + optsize) % blockSize;
+        size_t modulo = (pw.size() + optsize) % rfc8467::serverPaddingBlockSize;
         size_t padSize = 0;
         if (modulo > 0) {
-          padSize = std::min(blockSize - modulo, remaining);
+          padSize = std::min(rfc8467::serverPaddingBlockSize - modulo, remaining);
         }
         opts.emplace_back(EDNSOptionCode::PADDING, makeEDNSPaddingOptString(padSize));
       }

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -40,6 +40,7 @@
 #include "dnsbackend.hh"
 #include "ednsoptions.hh"
 #include "ednscookies.hh"
+#include "ednspadding.hh"
 #include "pdnsexception.hh"
 #include "dnspacket.hh"
 #include "logger.hh"
@@ -303,6 +304,11 @@ void DNSPacket::wrapup(bool throwsOnTruncation)
     }
   }
 
+  if (d_ednspadding) {
+    // actual padding length not included yet
+    optsize += EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE;
+  }
+
   if (d_trc.d_algoName.hasLabels()) {
     // TSIG is not OPT, but we count it in optsize anyway
     optsize += d_trc.d_algoName.wirelength() + 3 + 1 + 2; // algo + time + fudge + maclen
@@ -355,6 +361,19 @@ void DNSPacket::wrapup(bool throwsOnTruncation)
       if (d_haveednscookie && d_eco.isWellFormed()) {
         d_eco.makeServerCookie(s_EDNSCookieKey, getInnerRemote());
         opts.emplace_back(EDNSOptionCode::COOKIE, d_eco.makeOptString());
+      }
+
+      if (d_ednspadding) {
+        size_t remaining = d_tcp ? 65535 : getMaxReplyLen();
+        const size_t blockSize = 468; // RFC8467 4.1
+        // Note that optsize already contains the size of the EDNS0 padding
+        // option header.
+        size_t modulo = (pw.size() + optsize) % blockSize;
+        size_t padSize = 0;
+        if (modulo > 0) {
+          padSize = std::min(blockSize - modulo, remaining);
+        }
+        opts.emplace_back(EDNSOptionCode::PADDING, makeEDNSPaddingOptString(padSize));
       }
 
       if(!opts.empty() || d_haveednssection || d_dnssecOk)
@@ -425,6 +444,7 @@ std::unique_ptr<DNSPacket> DNSPacket::replyPacket() const
   r->d_haveednssubnet = d_haveednssubnet;
   r->d_haveednssection = d_haveednssection;
   r->d_haveednscookie = d_haveednscookie;
+  r->d_ednspadding = d_ednspadding;
   r->d_ednsversion = 0;
   r->d_ednsrcode = 0;
   r->d_xfr = d_xfr;
@@ -606,6 +626,7 @@ try
   d_haveednssection = false;
   d_haveednscookie = false;
   d_ednscookievalid = false;
+  d_ednspadding = false;
 
   if(getEDNSOpts(mdp, &edo)) {
     d_haveednssection=true;
@@ -632,6 +653,9 @@ try
         d_haveednscookie = true;
         d_eco.makeFromString(option.second);
         d_ednscookievalid = d_eco.isValid(s_EDNSCookieKey, getInnerRemote());
+      }
+      else if (option.first == EDNSOptionCode::PADDING) {
+        d_ednspadding = true;
       }
       else {
         // cerr<<"Have an option #"<<iter->first<<": "<<makeHexDump(iter->second)<<endl;

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -207,6 +207,7 @@ private:
   bool d_haveednscookie{false};
   bool d_ednscookievalid{false};
   bool d_haveednssection{false};
+  bool d_ednspadding{false};
   bool d_isQuery;
 
   Logr::log_t d_slog;

--- a/pdns/ednspadding.hh
+++ b/pdns/ednspadding.hh
@@ -24,3 +24,10 @@
 #include <string>
 
 std::string makeEDNSPaddingOptString(size_t bytes);
+
+namespace rfc8467
+{
+// Constants from RFC8467 4.1 "Recommended Strategy: Block-Length Padding"
+constexpr size_t clientPaddingBlockSize = 128;
+constexpr size_t serverPaddingBlockSize = 468;
+}

--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -506,7 +506,7 @@ static void addPadding(const DNSPacketWriter& pw, size_t bufsize, DNSPacketWrite
   const size_t currentSize = pw.getSizeWithOpts(opts);
   if (currentSize < (bufsize - 4)) {
     const size_t remaining = bufsize - (currentSize + 4);
-    /* from rfc8647, "4.1.  Recommended Strategy: Block-Length Padding":
+    /* from rfc8467, "4.1.  Recommended Strategy: Block-Length Padding":
        Clients SHOULD pad queries to the closest multiple of 128 octets.
        Note we are in the client role here.
     */

--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -506,15 +506,11 @@ static void addPadding(const DNSPacketWriter& pw, size_t bufsize, DNSPacketWrite
   const size_t currentSize = pw.getSizeWithOpts(opts);
   if (currentSize < (bufsize - 4)) {
     const size_t remaining = bufsize - (currentSize + 4);
-    /* from rfc8467, "4.1.  Recommended Strategy: Block-Length Padding":
-       Clients SHOULD pad queries to the closest multiple of 128 octets.
-       Note we are in the client role here.
-    */
-    const size_t blockSize = 128;
-    const size_t modulo = (currentSize + 4) % blockSize;
+    // Note we are in the client role here.
+    const size_t modulo = (currentSize + 4) % rfc8467::clientPaddingBlockSize;
     size_t padSize = 0;
     if (modulo > 0) {
-      padSize = std::min(blockSize - modulo, remaining);
+      padSize = std::min(rfc8467::clientPaddingBlockSize - modulo, remaining);
     }
     opts.emplace_back(EDNSOptionCode::PADDING, makeEDNSPaddingOptString(padSize));
   }

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -1667,7 +1667,7 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
 
       if (currentSize < (maxSize - 4)) {
         size_t remaining = maxSize - (currentSize + 4);
-        /* from rfc8647, "4.1.  Recommended Strategy: Block-Length Padding":
+        /* from rfc8467, "4.1.  Recommended Strategy: Block-Length Padding":
            If a server receives a query that includes the EDNS(0) "Padding"
            option, it MUST pad the corresponding response (see Section 4 of
            RFC 7830) and SHOULD pad the corresponding response to a

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -1667,17 +1667,10 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
 
       if (currentSize < (maxSize - 4)) {
         size_t remaining = maxSize - (currentSize + 4);
-        /* from rfc8467, "4.1.  Recommended Strategy: Block-Length Padding":
-           If a server receives a query that includes the EDNS(0) "Padding"
-           option, it MUST pad the corresponding response (see Section 4 of
-           RFC 7830) and SHOULD pad the corresponding response to a
-           multiple of 468 octets (see below).
-        */
-        const size_t blockSize = 468;
-        size_t modulo = (currentSize + 4) % blockSize;
+        size_t modulo = (currentSize + 4) % rfc8467::serverPaddingBlockSize;
         size_t padSize = 0;
         if (modulo > 0) {
-          padSize = std::min(blockSize - modulo, remaining);
+          padSize = std::min(rfc8467::serverPaddingBlockSize - modulo, remaining);
         }
         returnedEdnsOptions.emplace_back(EDNSOptionCode::PADDING, makeEDNSPaddingOptString(padSize));
       }

--- a/regression-tests.auth-py/paddingoption.py
+++ b/regression-tests.auth-py/paddingoption.py
@@ -1,0 +1,1 @@
+../regression-tests.common/paddingoption.py

--- a/regression-tests.auth-py/test_EDNSPadding.py
+++ b/regression-tests.auth-py/test_EDNSPadding.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import dns
+import os
+import socket
+
+import paddingoption
+
+from authtests import AuthTest
+
+
+class AuthEDNSPaddingTest(AuthTest):
+    _config_template = """
+launch={backend}
+"""
+
+    _zones = {
+        "example.org": """
+example.org.                 3600 IN SOA  {soa}
+example.org.                 3600 IN NS   ns1.example.org.
+example.org.                 3600 IN NS   ns2.example.org.
+ns1.example.org.             3600 IN A    192.0.2.10
+ns2.example.org.             3600 IN A    192.0.2.11
+
+www.example.org.             3600 IN A    192.0.2.5
+        """,
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setUpSockets()
+
+        cls.startResponders()
+
+        confdir = os.path.join("configs", cls._confdir)
+        cls.createConfigDir(confdir)
+
+        cls.generateAllAuthConfig(confdir)
+        cls.startAuth(confdir, "0.0.0.0")
+
+        print("Launching tests..")
+
+    @classmethod
+    def setUpSockets(cls):
+        print("Setting up UDP socket..")
+        cls._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        cls._sock.settimeout(2.0)
+        cls._sock.connect((cls._PREFIX + ".2", cls._authPort))
+
+    def checkPadding(self, message):
+        self.assertEqual(message.edns, 0)
+        self.assertEqual(len(message.options), 1)
+        for option in message.options:
+            self.assertEqual(option.otype, 12)
+
+    def checkNoEDNS(self, message):
+        self.assertEqual(message.edns, -1)
+
+
+class TestEDNSPadding(AuthEDNSPaddingTest):
+    def testQueryWithPadding(self):
+        name = "www.example.org."
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, "A", "192.0.2.5")
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, "A", options=[po])
+        res = self.sendUDPQuery(query)
+        self.checkPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+    def testQueryWithoutPadding(self):
+        name = "www.example.org."
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, "A", "192.0.2.5")
+        query = dns.message.make_query(name, "A")
+        res = self.sendUDPQuery(query)
+        self.checkNoEDNS(res)
+        self.assertRRsetInAnswer(res, expected)


### PR DESCRIPTION
### Short description
Even though the auth<->recursor communication can probably be considered trustworthy, the auth server should nevertheless respond to queries containing the EDNS0 padding option with a similarly padded response. This PR achieves this.

~~(still marked as draft as I need to work on tests - I only checked the output of simple `dig` queries with and without `+padding=128`)~~

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)