### PR TITLE
rec: add bigger (and v6 enabled) bulk test on ubicloud

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -659,7 +659,7 @@ jobs:
           fail-on-error: false
 
   test-recursor-ubicloud-bulk:
-    if: ${{ vars.REC_BULKTEST_USE_UBICLOUD == '1' }}
+    if: ${{ vars.REC_BULKTEST_USE_UBICLOUD == '1' || github.repository == 'PowerDNS/pdns' }}
     name: 'test rec ubicloud bulk'
     needs:
       - build-recursor

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -623,6 +623,7 @@ jobs:
         threads: [1, 2, 3, 4, 8]
         mthreads: [2048]
         shards: [1, 2, 1024]
+        IPv6: [0]
     container:
       image: "${{ needs.get-runner-container-image.outputs.id }}:${{ needs.get-runner-container-image.outputs.tag }}"
       env:
@@ -644,7 +645,7 @@ jobs:
           path: /opt/pdns-recursor
       - run: inv install-clang-runtime
       - run: inv install-rec-bulk-deps
-      - run: inv test-bulk-recursor ${{ matrix.threads }} ${{ matrix.mthreads }} ${{ matrix.shards }}
+      - run: inv test-bulk-recursor 100 ${{ matrix.threads }} ${{ matrix.mthreads }} ${{ matrix.shards }} ${{ matrix.IPv6 }}
       - run: inv generate-coverage-info /opt/pdns-recursor/sbin/pdns_recursor $GITHUB_WORKSPACE
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
       - name: Coveralls Parallel recursor bulk
@@ -656,6 +657,50 @@ jobs:
           parallel: true
           allow-empty: true
           fail-on-error: false
+
+  test-recursor-ubicloud-bulk:
+    name: 'test rec ubicloud bulk'
+    needs:
+      - build-recursor
+    runs-on: ubicloud-standard-8-ubuntu-2404
+    strategy:
+      matrix:
+        sanitizers: [ubsan+asan] # TSAN disabled for now
+        threads: [8]
+        mthreads: [2048]
+        shards: [1024]
+        IPv6: [0, 1]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
+          submodules: recursive
+          ref: ${{ inputs.branch-name }}
+      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - name: Fetch the binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: pdns-recursor-full-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          path: /opt/pdns-recursor
+      - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
+      - run: inv install-rec-bulk-ubicloud-deps
+      - run: inv test-bulk-recursor 50000 ${{ matrix.threads }} ${{ matrix.mthreads }} ${{ matrix.shards }} ${{ matrix.IPv6 }}
+        env:
+          UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp'
+          ASAN_OPTIONS: detect_leaks=0
+          TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ github.workspace }}/pdns/recursordist/recursor-tsan.supp"
+      #  Disabled, it gives us: "/bin/bash: line 1: llvm-profdata-13: command not found" due to mismatch between deb and ubuntu versions
+      #- run: inv generate-coverage-info /opt/pdns-recursor/sbin/pdns_recursor $GITHUB_WORKSPACE
+      #  if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
+      #- name: Coveralls Parallel recursor bulk
+      #  if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
+      #  uses: coverallsapp/github-action@v2
+      #  with:
+      #    flag-name: rec-regression-bulk-full-${{ matrix.sanitizers }}
+      #    path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
+      #    parallel: true
+      #    allow-empty: true
+      #    fail-on-error: false
 
   test-dnsdist-regression:
     needs:
@@ -736,6 +781,7 @@ jobs:
       - test-recursor-api
       - test-recursor-regression
       - test-recursor-bulk
+      - test-recursor-ubicloud-bulk
     if: success() || failure()
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -659,6 +659,7 @@ jobs:
           fail-on-error: false
 
   test-recursor-ubicloud-bulk:
+    if: ${{ vars.REC_BULKTEST_USE_UBICLOUD == '1' }}
     name: 'test rec ubicloud bulk'
     needs:
       - build-recursor

--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -17,11 +17,17 @@ shards=$5
 : ${TRACE:="fail"}
 : ${DNSBULKTEST:="../pdns/dnsbulktest"}
 
+echo Current working dir is `pwd`
+
 if [ $IPv6 = 1 ]
 then
-        QLA6=" ::"
+    echo \$ dig -6 @k.root-servers.net . SOA
+    dig -6 @k.root-servers.net . SOA # Do we actually have v6 connectivity?
+    QLA6=" ::"
 else
-        QLA6=""
+    echo \$ dig -4 @k.root-servers.net . SOA
+    dig -4 @k.root-servers.net . SOA # Do we actually have v4 connectivity?
+    QLA6=""
 fi
 
 rm -f recursor.pid pdns_recursor.pid
@@ -42,7 +48,7 @@ fi
 
 # warm up the cache
 echo
-echo === First run with limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
+echo === First run with IPv6=$IPv6 limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
 kill -USR1 $(cat pdns_recursor.pid) || true
 ${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. get-all || true
@@ -51,7 +57,7 @@ sleep 5
 
 # rerun 1 with hot cache
 echo
-echo === Second run with limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
+echo === Second run with IPv6=$IPv6 limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
 kill -USR1 $(cat pdns_recursor.pid) || true
 ${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. get-all || true
@@ -60,7 +66,7 @@ sleep 5
 
 # rerun 2 with hot cache
 echo
-echo === Third run with limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
+echo === Third run with IPv6=$IPv6 limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
 kill -USR1 $(cat pdns_recursor.pid) || true
 ${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. get-all || true
@@ -73,7 +79,7 @@ cat recursor.log
 echo "=== END RECURSOR LOG ==="
 sleep 1
 ${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. ping
-kill $(cat pdns_recursor.pid) 
+kill $(cat pdns_recursor.pid)
 sleep 5
 
 . ./bulktest.results


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

On ubicloud we do not run in a container any more, as it lacks v6 connectivity. We are running a debian executable on ubuntu, this is not causing any real issues (so far) except for some boost dependencies version mismatches. Luckily the boost packages required are available on ubuntu 24.04. 

Current state of affairs:
- We run mini (100 names) tsan and ubsan+asan tests on GH (v4 only)
- We run two medium sized (50k names) ubsan + asan tests on ubicloud (v4 only and v6 enabled)

Big (or medium) tsan tests do not work as they get killed due to excessive memory requirements (many TB virtual plus many GB resident).

Plan is to add a bigger version of the bulk test in daily. That one should use a auto-built recursor package.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
