### PR TITLE
dnsdist: Gather Server Name Indication on QUIC (DoQ, DoH3) connections

### DIFF
--- a/pdns/dnsdistdist/doh3.hh
+++ b/pdns/dnsdistdist/doh3.hh
@@ -101,6 +101,7 @@ struct DOH3Unit
   PacketBuffer serverConnID;
   dnsdist::doh3::h3_headers_t headers;
   std::shared_ptr<DownstreamState> downstream{nullptr};
+  std::shared_ptr<const std::string> sni{nullptr};
   std::string d_contentTypeOut;
   DOH3ServerConfig* dsc{nullptr};
   uint64_t streamID{0};

--- a/pdns/dnsdistdist/doq-common.cc
+++ b/pdns/dnsdistdist/doq-common.cc
@@ -325,6 +325,18 @@ bool recvAsync(Socket& socket, PacketBuffer& buffer, ComboAddress& clientAddr, C
   return !buffer.empty();
 }
 
-};
+std::string getSNIFromQuicheConnection(const QuicheConnection& conn)
+{
+#if defined(HAVE_QUICHE_CONN_SERVER_NAME)
+  const uint8_t* sniPtr = nullptr;
+  size_t sniPtrSize = 0;
+  quiche_conn_server_name(conn.get(), &sniPtr, &sniPtrSize);
+  if (sniPtrSize > 0) {
+    return std::string(reinterpret_cast<const char*>(sniPtr), sniPtrSize);
+  }
+#endif /* HAVE_QUICHE_CONN_SERVER_NAME */
+  return {};
+}
+}
 
 #endif

--- a/pdns/dnsdistdist/doq-common.hh
+++ b/pdns/dnsdistdist/doq-common.hh
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 
 #include "config.h"
 
@@ -97,7 +98,7 @@ void handleVersionNegociation(Socket& sock, const PacketBuffer& clientConnID, co
 void flushEgress(Socket& sock, QuicheConnection& conn, const ComboAddress& peer, const ComboAddress& localAddr, PacketBuffer& buffer);
 void configureQuiche(QuicheConfig& config, const QuicheParams& params, bool isHTTP);
 bool recvAsync(Socket& socket, PacketBuffer& buffer, ComboAddress& clientAddr, ComboAddress& localAddr);
-
+std::string getSNIFromQuicheConnection(const QuicheConnection& conn);
 };
 
 #endif

--- a/pdns/dnsdistdist/doq.hh
+++ b/pdns/dnsdistdist/doq.hh
@@ -84,6 +84,7 @@ struct DOQUnit
   PacketBuffer response;
   PacketBuffer serverConnID;
   std::shared_ptr<DownstreamState> downstream{nullptr};
+  std::shared_ptr<const std::string> sni{nullptr};
   DOQServerConfig* dsc{nullptr};
   uint64_t streamID{0};
   size_t proxyProtocolPayloadSize{0};

--- a/pdns/dnsdistdist/m4/pdns_with_quiche.m4
+++ b/pdns/dnsdistdist/m4/pdns_with_quiche.m4
@@ -21,6 +21,16 @@ AC_DEFUN([PDNS_WITH_QUICHE], [
           AC_DEFINE([HAVE_QUICHE], [1], [Define to 1 if you have quiche])
         ], [ : ])
       ])
+      AS_IF([test "x$HAVE_QUICHE" = "x1"], [
+        save_CFLAGS=$CFLAGS
+        save_LIBS=$LIBS
+        CFLAGS="$QUICHE_CFLAGS $CFLAGS"
+        LIBS="$QUICHE_LIBS $LIBS"
+        AC_CHECK_FUNCS([quiche_conn_server_name])
+        CFLAGS=$save_CFLAGS
+        LIBS=$save_LIBS
+
+      ])
     ])
   ])
   AM_CONDITIONAL([HAVE_QUICHE], [test "x$QUICHE_LIBS" != "x"])

--- a/regression-tests.dnsdist/doh3client.py
+++ b/regression-tests.dnsdist/doh3client.py
@@ -228,7 +228,7 @@ async def async_h3_query(
 
 
 def doh3_query(query, baseurl, timeout=2, port=853, verify=None, server_hostname=None, post=False, additional_headers=None, raw_response=False):
-    configuration = QuicConfiguration(alpn_protocols=H3_ALPN, is_client=True)
+    configuration = QuicConfiguration(alpn_protocols=H3_ALPN, is_client=True, server_name=server_hostname)
     if verify:
         configuration.load_verify_locations(verify)
 

--- a/regression-tests.dnsdist/doqclient.py
+++ b/regression-tests.dnsdist/doqclient.py
@@ -88,7 +88,7 @@ class StreamResetError(Exception):
         super().__init__(message)
 
 def quic_query(query, host='127.0.0.1', timeout=2, port=853, verify=None, server_hostname=None):
-    configuration = QuicConfiguration(alpn_protocols=["doq"], is_client=True)
+    configuration = QuicConfiguration(alpn_protocols=["doq"], is_client=True, server_name=server_hostname)
     if verify:
         configuration.load_verify_locations(verify)
     (result, serial) = asyncio.run(
@@ -108,7 +108,7 @@ def quic_query(query, host='127.0.0.1', timeout=2, port=853, verify=None, server
     return (result, serial)
 
 def quic_bogus_query(query, host='127.0.0.1', timeout=2, port=853, verify=None, server_hostname=None):
-    configuration = QuicConfiguration(alpn_protocols=["doq"], is_client=True)
+    configuration = QuicConfiguration(alpn_protocols=["doq"], is_client=True, server_name=server_hostname)
     if verify:
         configuration.load_verify_locations(verify)
     (result, _) = asyncio.run(

--- a/regression-tests.dnsdist/test_SNI.py
+++ b/regression-tests.dnsdist/test_SNI.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+import base64
+import dns
+import os
+import unittest
+import pycurl
+
+from dnsdisttests import DNSDistTest, pickAvailablePort
+
+class TestSNI(DNSDistTest):
+    _serverKey = 'server.key'
+    _serverCert = 'server.chain'
+    _serverName = 'tls.tests.dnsdist.org'
+    _caCert = 'ca.pem'
+    _tlsServerPort = pickAvailablePort()
+    _dohWithNGHTTP2ServerPort = pickAvailablePort()
+    _doqServerPort = pickAvailablePort()
+    _doh3ServerPort = pickAvailablePort()
+    _dohWithNGHTTP2BaseURL = ("https://%s:%d/" % (_serverName, _dohWithNGHTTP2ServerPort))
+    _dohBaseURL = ("https://%s:%d/" % (_serverName, _doh3ServerPort))
+
+    _config_template = """
+    newServer{address="127.0.0.1:%d"}
+
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl" })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", {"/"}, {library="nghttp2"})
+    addDOQLocal("127.0.0.1:%d", "%s", "%s")
+    addDOH3Local("127.0.0.1:%d", "%s", "%s")
+
+    function displaySNI(dq)
+      local sni = dq:getServerNameIndication()
+      if sni ~= '%s' then
+        return DNSAction.Spoof, '1.2.3.4'
+      end
+      return DNSAction.Allow
+    end
+    addAction(AllRule(), LuaAction(displaySNI))
+    """
+    _config_params = ['_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohWithNGHTTP2ServerPort', '_serverCert', '_serverKey', '_doqServerPort', '_serverCert', '_serverKey', '_doh3ServerPort', '_serverCert', '_serverKey', '_serverName']
+
+    # enable these once Quiche > 0.22 is available, including https://github.com/cloudflare/quiche/pull/1895
+    @unittest.skipUnless('ENABLE_SNI_TESTS_WITH_QUICHE' in os.environ, "SNI tests with Quicheare disabled")
+    def testServerNameIndicationWithQuiche(self):
+        name = 'simple.sni.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=False)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+        for method in ["sendDOQQueryWrapper", "sendDOH3QueryWrapper"]:
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response, timeout=1)
+            self.assertTrue(receivedQuery)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertTrue(receivedResponse)
+            if method == 'sendDOQQueryWrapper':
+                # dnspython sets the ID to 0
+                receivedResponse.id = response.id
+            self.assertEqual(response, receivedResponse)
+
+    def testServerNameIndication(self):
+        name = 'simple.sni.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=False)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+        for method in ["sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper"]:
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response, timeout=1)
+            self.assertTrue(receivedQuery)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(response, receivedResponse)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds Server Name Indication support for incoming QUIC (DoQ, DoH3) connections. It requires an accessor in the Quiche library that has not been merged yet, see https://github.com/cloudflare/quiche/pull/1895

Closes #14048.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

