### PR TITLE
dnsdist: Document `dnsdist_ffi_stat_node_get_children_*` return children+node stats

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.h
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.h
@@ -34,6 +34,10 @@ void dnsdist_ffi_stat_node_get_full_name_raw(const dnsdist_ffi_stat_node_t* node
 
 unsigned int dnsdist_ffi_stat_node_get_children_count(const dnsdist_ffi_stat_node_t* node) __attribute__((visibility("default")));
 
+/* Note that dnsdist_ffi_stat_node_get_children_* methods return the sum of
+   the queries or responses received for the children of a node AND the node
+   itself. It's quite unexpected but breaking the existing behaviour now would be painful.
+*/
 uint64_t dnsdist_ffi_stat_node_get_children_queries_count(const dnsdist_ffi_stat_node_t* node) __attribute__((visibility("default")));
 uint64_t dnsdist_ffi_stat_node_get_children_noerrors_count(const dnsdist_ffi_stat_node_t* node) __attribute__((visibility("default")));
 uint64_t dnsdist_ffi_stat_node_get_children_nxdomains_count(const dnsdist_ffi_stat_node_t* node) __attribute__((visibility("default")));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The `dnsdist_ffi_stat_node_get_children_*` methods return the sum of the queries or responses received for the children of a node AND the node itself. It's quite unexpected but breaking the existing behaviour now would be painful.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
