### PR TITLE
EDNSSubnetOpts refactoring

### DIFF
--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -243,8 +243,8 @@ void parseQueryFile(const std::string& queryFile, vector<std::shared_ptr<vector<
 
     if (!subnet.empty() || addECS) {
       EDNSSubnetOpts opt;
-      opt.source = Netmask(subnet.empty() ? "0.0.0.0/32" : subnet);
-      ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+      opt.setSource(Netmask(subnet.empty() ? "0.0.0.0/32" : subnet));
+      ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     }
 
     if (!ednsOptions.empty() || (packetWriter.getHeader()->id % 2) != 0) {

--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -65,8 +65,8 @@ bool DNSDistPacketCache::getClientSubnet(const PacketBuffer& packet, size_t qnam
 
       EDNSSubnetOpts eso;
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-      if (getEDNSSubnetOptsFromString(reinterpret_cast<const char*>(&packet.at(optRDPosition + ecsOptionStartPosition + (EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE))), ecsOptionSize - (EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE), &eso)) {
-        subnet = eso.source;
+      if (EDNSSubnetOpts::getFromString(reinterpret_cast<const char*>(&packet.at(optRDPosition + ecsOptionStartPosition + (EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE))), ecsOptionSize - (EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE), &eso)) {
+        subnet = eso.getSource();
         return true;
       }
     }

--- a/pdns/dnsdistdist/dnsdist-ecs.cc
+++ b/pdns/dnsdistdist/dnsdist-ecs.cc
@@ -436,8 +436,8 @@ void generateECSOption(const ComboAddress& source, string& res, uint16_t ECSPref
 {
   Netmask sourceNetmask(source, ECSPrefixLength);
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = sourceNetmask;
-  string payload = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(sourceNetmask);
+  string payload = ecsOpts.makeOptString();
   generateEDNSOption(EDNSOptionCode::ECS, payload, res);
 }
 

--- a/pdns/dnsdistdist/test-dnsdist_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdist_cc.cc
@@ -478,8 +478,8 @@ BOOST_AUTO_TEST_CASE(replaceECSWithSameSize)
   GenericDNSPacketWriter<PacketBuffer> packetWriter(query, name, QType::A, QClass::IN, 0);
   packetWriter.getHeader()->rd = 1;
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV4);
-  string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOption = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOption);
   packetWriter.addOpt(512, 0, 0, opts);
@@ -518,8 +518,8 @@ BOOST_AUTO_TEST_CASE(replaceECSWithSameSizeAlreadyParsed)
   GenericDNSPacketWriter<PacketBuffer> packetWriter(query, ids.qname, QType::A, QClass::IN, 0);
   packetWriter.getHeader()->rd = 1;
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV4);
-  string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOption = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOption);
   packetWriter.addOpt(512, 0, 0, opts);
@@ -565,8 +565,8 @@ BOOST_AUTO_TEST_CASE(replaceECSWithSmaller)
   GenericDNSPacketWriter<PacketBuffer> packetWriter(query, name, QType::A, QClass::IN, 0);
   packetWriter.getHeader()->rd = 1;
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, 32);
-  string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, 32));
+  string origECSOption = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOption);
   packetWriter.addOpt(512, 0, 0, opts);
@@ -605,8 +605,8 @@ BOOST_AUTO_TEST_CASE(replaceECSWithLarger)
   EDNSSubnetOpts ecsOpts;
   // smaller (less specific so less bits) option
   static_assert(8 < ECSSourcePrefixV4, "The ECS scope should be smaller");
-  ecsOpts.source = Netmask(origRemote, 8);
-  string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, 8));
+  string origECSOption = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOption);
   packetWriter.addOpt(512, 0, 0, opts);
@@ -661,8 +661,8 @@ BOOST_AUTO_TEST_CASE(replaceECSFollowedByTSIG)
   GenericDNSPacketWriter<PacketBuffer> packetWriter(query, name, QType::A, QClass::IN, 0);
   packetWriter.getHeader()->rd = 1;
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, 8);
-  string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, 8));
+  string origECSOption = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOption);
   packetWriter.addOpt(512, 0, 0, opts);
@@ -720,8 +720,8 @@ BOOST_AUTO_TEST_CASE(replaceECSAfterAN)
   packetWriter.startRecord(DNSName("powerdns.com."), QType::A, 0, QClass::IN, DNSResourceRecord::ANSWER, true);
   packetWriter.commit();
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, 8);
-  string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, 8));
+  string origECSOption = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOption);
   packetWriter.addOpt(512, 0, 0, opts);
@@ -778,8 +778,8 @@ BOOST_AUTO_TEST_CASE(replaceECSAfterAuth)
   packetWriter.startRecord(DNSName("powerdns.com."), QType::A, 0, QClass::IN, DNSResourceRecord::AUTHORITY, true);
   packetWriter.commit();
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, 8);
-  string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, 8));
+  string origECSOption = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOption);
   packetWriter.addOpt(512, 0, 0, opts);
@@ -834,8 +834,8 @@ BOOST_AUTO_TEST_CASE(replaceECSBetweenTwoRecords)
   GenericDNSPacketWriter<PacketBuffer> packetWriter(query, name, QType::A, QClass::IN, 0);
   packetWriter.getHeader()->rd = 1;
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, 8);
-  string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, 8));
+  string origECSOption = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOption);
   packetWriter.startRecord(DNSName("additional"), QType::A, 0, QClass::IN, DNSResourceRecord::ADDITIONAL, false);
@@ -1099,8 +1099,8 @@ BOOST_AUTO_TEST_CASE(removeECSWhenOnlyOption)
   packetWriter.commit();
 
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV4);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOptionStr);
   packetWriter.addOpt(512, 0, 0, opts);
@@ -1149,8 +1149,8 @@ BOOST_AUTO_TEST_CASE(removeECSWhenFirstOption)
   packetWriter.commit();
 
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV6);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV6));
+  string origECSOptionStr = ecsOpts.makeOptString();
   EDNSCookiesOpt cookiesOpt("deadbeefdeadbeef");
   string cookiesOptionStr = cookiesOpt.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
@@ -1202,9 +1202,8 @@ BOOST_AUTO_TEST_CASE(removeECSWhenIntermediaryOption)
   packetWriter.commit();
 
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV4);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
-
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
   EDNSCookiesOpt cookiesOpt("deadbeefdeadbeef");
   string cookiesOptionStr1 = cookiesOpt.makeOptString();
   string cookiesOptionStr2 = cookiesOpt.makeOptString();
@@ -1261,8 +1260,8 @@ BOOST_AUTO_TEST_CASE(removeECSWhenLastOption)
   EDNSCookiesOpt cookiesOpt("deadbeefdeadbeef");
   string cookiesOptionStr = cookiesOpt.makeOptString();
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV4);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::COOKIE, cookiesOptionStr);
   opts.emplace_back(EDNSOptionCode::ECS, origECSOptionStr);
@@ -1308,8 +1307,8 @@ BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenOnlyOption)
   packetWriter.xfr32BitInt(0x01020304);
 
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV4);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, origECSOptionStr);
   packetWriter.addOpt(512, 0, 0, opts);
@@ -1347,8 +1346,8 @@ BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenFirstOption)
   packetWriter.xfr32BitInt(0x01020304);
 
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV4);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
   EDNSCookiesOpt cookiesOpt("deadbeefdeadbeef");
   string cookiesOptionStr = cookiesOpt.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
@@ -1389,8 +1388,8 @@ BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenIntermediaryOption)
   packetWriter.xfr32BitInt(0x01020304);
 
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV4);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
   EDNSCookiesOpt cookiesOpt("deadbeefdeadbeef");
   string cookiesOptionStr1 = cookiesOpt.makeOptString();
   string cookiesOptionStr2 = cookiesOpt.makeOptString();
@@ -1433,8 +1432,8 @@ BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenLastOption)
   packetWriter.xfr32BitInt(0x01020304);
 
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(origRemote, ECSSourcePrefixV4);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
   EDNSCookiesOpt cookiesOpt("deadbeefdeadbeef");
   string cookiesOptionStr = cookiesOpt.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
@@ -1500,8 +1499,8 @@ BOOST_AUTO_TEST_CASE(test_getEDNSZ)
   uint16_t qtype = QType::A;
   uint16_t qclass = QClass::IN;
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(ComboAddress("127.0.0.1"), ECSSourcePrefixV4);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(ComboAddress("127.0.0.1"), ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
   EDNSCookiesOpt cookiesOpt("deadbeefdeadbeef");
   string cookiesOptionStr = cookiesOpt.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
@@ -1730,8 +1729,8 @@ BOOST_AUTO_TEST_CASE(test_addEDNSToQueryTurnedResponse)
   uint16_t zValue = 0;
   uint16_t udpPayloadSize = 0;
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(ComboAddress("127.0.0.1"), ECSSourcePrefixV4);
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(ComboAddress("127.0.0.1"), ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
   EDNSCookiesOpt cookiesOpt("deadbeefdeadbeef");
   string cookiesOptionStr = cookiesOpt.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
@@ -1849,8 +1848,8 @@ BOOST_AUTO_TEST_CASE(test_getEDNSOptionsStart)
   const uint16_t qtype = QType::A;
   const uint16_t qclass = QClass::IN;
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(ComboAddress("127.0.0.1"), ECSSourcePrefixV4);
-  const string ecsOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(ComboAddress("127.0.0.1"), ECSSourcePrefixV4));
+  const string ecsOptionStr = ecsOpts.makeOptString();
   GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::ECS, ecsOptionStr);
   const ComboAddress rem("127.0.0.1");
@@ -1949,8 +1948,8 @@ BOOST_AUTO_TEST_CASE(test_isEDNSOptionInOpt)
   const uint16_t qtype = QType::A;
   const uint16_t qclass = QClass::IN;
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(ComboAddress("127.0.0.1"), ECSSourcePrefixV4);
-  const string ecsOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(Netmask(ComboAddress("127.0.0.1"), ECSSourcePrefixV4));
+  const string ecsOptionStr = ecsOpts.makeOptString();
   const size_t sizeOfECSContent = ecsOptionStr.size();
   const size_t sizeOfECSOption = /* option code */ 2 + /* option length */ 2 + sizeOfECSContent;
   EDNSCookiesOpt cookiesOpt("deadbeefdeadbeef");

--- a/pdns/dnsdistdist/test-dnsdistedns.cc
+++ b/pdns/dnsdistdist/test-dnsdistedns.cc
@@ -135,8 +135,8 @@ BOOST_AUTO_TEST_CASE(getExtendedDNSError)
       .extraText = "Synthesized from aggressive NSEC cache"};
     opts.emplace_back(EDNSOptionCode::EXTENDEDERROR, makeEDNSExtendedErrorOptString(ede));
     EDNSSubnetOpts ecsOpt;
-    ecsOpt.source = Netmask(ComboAddress("192.0.2.1"), 24U);
-    const auto ecsOptStr = makeEDNSSubnetOptsString(ecsOpt);
+    ecsOpt.setSource(Netmask(ComboAddress("192.0.2.1"), 24U));
+    const auto ecsOptStr = ecsOpt.makeOptString();
     opts.emplace_back(EDNSOptionCode::ECS, ecsOptStr);
     pw.addOpt(512, 0, 0, opts);
     pw.commit();
@@ -155,8 +155,8 @@ BOOST_AUTO_TEST_CASE(getExtendedDNSError)
     pw.getHeader()->rd = 1;
     GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
     EDNSSubnetOpts ecsOpt;
-    ecsOpt.source = Netmask(ComboAddress("192.0.2.1"), 24U);
-    const auto ecsOptStr = makeEDNSSubnetOptsString(ecsOpt);
+    ecsOpt.setSource(Netmask(ComboAddress("192.0.2.1"), 24U));
+    const auto ecsOptStr = ecsOpt.makeOptString();
     opts.emplace_back(EDNSOptionCode::ECS, ecsOptStr);
     const EDNSExtendedError ede{
       .infoCode = static_cast<uint16_t>(EDNSExtendedError::code::Synthesized),

--- a/pdns/dnsdistdist/test-dnsdistpacketcache_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistpacketcache_cc.cc
@@ -801,8 +801,8 @@ BOOST_AUTO_TEST_CASE(test_PCCollision)
     pwQ.getHeader()->id = qid;
     GenericDNSPacketWriter<PacketBuffer>::optvect_t ednsOptions;
     EDNSSubnetOpts opt;
-    opt.source = Netmask("10.0.59.220/32");
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    opt.setSource(Netmask("10.0.59.220/32"));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     pwQ.addOpt(512, 0, 0, ednsOptions);
     pwQ.commit();
 
@@ -812,7 +812,7 @@ BOOST_AUTO_TEST_CASE(test_PCCollision)
     bool found = localCache.get(dnsQuestion, 0, &key, subnetOut, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_REQUIRE(subnetOut);
-    BOOST_CHECK_EQUAL(subnetOut->toString(), opt.source.toString());
+    BOOST_CHECK_EQUAL(subnetOut->toString(), opt.getSource().toString());
 
     PacketBuffer response;
     GenericDNSPacketWriter<PacketBuffer> pwR(response, ids.qname, ids.qtype, QClass::IN, 0);
@@ -831,7 +831,7 @@ BOOST_AUTO_TEST_CASE(test_PCCollision)
     found = localCache.get(dnsQuestion, 0, &key, subnetOut, dnssecOK, receivedOverUDP);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_REQUIRE(subnetOut);
-    BOOST_CHECK_EQUAL(subnetOut->toString(), opt.source.toString());
+    BOOST_CHECK_EQUAL(subnetOut->toString(), opt.getSource().toString());
   }
 
   /* now lookup for the same query with a different ECS value,
@@ -843,8 +843,8 @@ BOOST_AUTO_TEST_CASE(test_PCCollision)
     pwQ.getHeader()->id = qid;
     GenericDNSPacketWriter<PacketBuffer>::optvect_t ednsOptions;
     EDNSSubnetOpts opt;
-    opt.source = Netmask("10.0.167.48/32");
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    opt.setSource(Netmask("10.0.167.48/32"));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     pwQ.addOpt(512, 0, 0, ednsOptions);
     pwQ.commit();
 
@@ -855,7 +855,7 @@ BOOST_AUTO_TEST_CASE(test_PCCollision)
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK_EQUAL(secondKey, key);
     BOOST_REQUIRE(subnetOut);
-    BOOST_CHECK_EQUAL(subnetOut->toString(), opt.source.toString());
+    BOOST_CHECK_EQUAL(subnetOut->toString(), opt.getSource().toString());
     BOOST_CHECK_EQUAL(localCache.getLookupCollisions(), 1U);
   }
 

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -325,7 +325,7 @@ void DNSPacket::wrapup(bool throwsOnTruncation)
   {
     // this is an upper bound
     optsize += EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE + 2 + 1 + 1; // code+len+family+src len+scope len
-    optsize += d_eso.source.isIPv4() ? 4 : 16;
+    optsize += d_eso.getSource().isIPv4() ? 4 : 16;
   }
 
   if (d_haveednscookie) {
@@ -371,10 +371,10 @@ void DNSPacket::wrapup(bool throwsOnTruncation)
       if(d_haveednssubnet) {
         EDNSSubnetOpts eso = d_eso;
         // use the scopeMask from the resolver, if it is greater - issue #5469
-        maxScopeMask = max(maxScopeMask, eso.scope.getBits());
-        eso.scope = Netmask(eso.source.getNetwork(), maxScopeMask);
+        maxScopeMask = max(maxScopeMask, eso.getScopePrefixLength());
+        eso.setScopePrefixLength(maxScopeMask);
 
-        string opt = makeEDNSSubnetOptsString(eso);
+        string opt = eso.makeOptString();
         opts.emplace_back(8, opt); // 'EDNS SUBNET'
       }
 
@@ -617,7 +617,7 @@ try
         d_wantsnsid=true;
       }
       else if(s_doEDNSSubnetProcessing && (option.first == EDNSOptionCode::ECS)) { // 'EDNS SUBNET'
-        if(getEDNSSubnetOptsFromString(option.second, &d_eso)) {
+        if (EDNSSubnetOpts::getFromString(option.second, &d_eso)) {
           //cerr<<"Parsed, source: "<<d_eso.source.toString()<<", scope: "<<d_eso.scope.toString()<<", family = "<<d_eso.scope.getNetwork().sin4.sin_family<<endl;
           d_haveednssubnet=true;
         }
@@ -716,13 +716,13 @@ bool DNSPacket::hasValidEDNSCookie() const
 }
 
 void DNSPacket::setRealRemote(const Netmask& netmask) {
-  d_eso.source = netmask;
+  d_eso.setSource(netmask);
   d_haveednssubnet = true;
 }
 
 Netmask DNSPacket::getRealRemote() const
 {
-  return d_haveednssubnet ? d_eso.source : Netmask{getInnerRemote()};
+  return d_haveednssubnet ? d_eso.getSource() : Netmask{getInnerRemote()};
 }
 
 void DNSPacket::setSocket(Utility::sock_t sock)

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -289,7 +289,7 @@ void DNSProxy::mainloop()
         // update the EDNS options with info from the resolver - issue #5469
         // note that this relies on the ECS string encoder to use the source network, and only take the prefix length from scope
         iter->second.complete->d_eso.setScopePrefixLength(packet.d_eso.getScopePrefixLength());
-        DLOG(g_log << "from dnsproxy::mainLoop: updated EDNS options from resolver EDNS source: " << iter->second.complete->d_eso.getSource().toString() << " EDNS scope: " << Netmask(iter->second.complete->d_eso.getSource().getNetwork(), iter->second.complete->d_eso.getScopePrefixLength()).toString() << endl);
+        DLOG(g_log << "from dnsproxy::mainLoop: updated EDNS options from resolver EDNS source: " << iter->second.complete->d_eso.getSource().toString() << " EDNS scope: " << iter->second.complete->d_eso.getScope().toString() << endl);
 
         if (mdp.d_header.rcode == RCode::NoError) {
           for (const auto& answer : mdp.d_answers) {

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -558,14 +558,15 @@ static void addECSOption(char* packet, const size_t packetSize, uint16_t* len, c
   struct dnsheader* dh = (struct dnsheader*) packet;
 
   EDNSSubnetOpts eso;
-  if(stamp < 0)
-    eso.source = Netmask(remote);
+  if(stamp < 0) {
+    eso.setSource(Netmask(remote));
+  }
   else {
     ComboAddress stamped(remote);
     *((char*)&stamped.sin4.sin_addr.s_addr)=stamp;
-    eso.source = Netmask(stamped);
+    eso.setSource(Netmask(stamped));
   }
-  string optRData=makeEDNSSubnetOptsString(eso);
+  string optRData = eso.makeOptString();
   string record;
   generateEDNSOption(EDNSOptionCode::ECS, optRData, record);
   generateOptRR(record, EDNSRR);

--- a/pdns/ednssubnet.hh
+++ b/pdns/ednssubnet.hh
@@ -20,9 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include "namespaces.hh"
+
 #include "iputils.hh"
-#include "dnsname.hh"
 
 struct EDNSSubnetOpts
 {
@@ -30,6 +29,6 @@ struct EDNSSubnetOpts
   Netmask scope;
 };
 
-bool getEDNSSubnetOptsFromString(const string& options, EDNSSubnetOpts* eso);
+bool getEDNSSubnetOptsFromString(const std::string& options, EDNSSubnetOpts* eso);
 bool getEDNSSubnetOptsFromString(const char* options, unsigned int len, EDNSSubnetOpts* eso);
-string makeEDNSSubnetOptsString(const EDNSSubnetOpts& eso);
+std::string makeEDNSSubnetOptsString(const EDNSSubnetOpts& eso);

--- a/pdns/ednssubnet.hh
+++ b/pdns/ednssubnet.hh
@@ -50,6 +50,10 @@ public:
   {
     return scopeBits;
   }
+  [[nodiscard]] Netmask getScope() const
+  {
+    return {source.getNetwork(), scopeBits};
+  }
   [[nodiscard]] std::string makeOptString() const;
   static bool getFromString(const std::string& options, EDNSSubnetOpts* eso);
   static bool getFromString(const char* options, unsigned int len, EDNSSubnetOpts* eso);

--- a/pdns/ednssubnet.hh
+++ b/pdns/ednssubnet.hh
@@ -23,12 +23,38 @@
 
 #include "iputils.hh"
 
-struct EDNSSubnetOpts
+class EDNSSubnetOpts
 {
-  Netmask source;
-  Netmask scope;
-};
+public:
+  void setSource(const Netmask& netmask)
+  {
+    source = netmask;
+  }
+  [[nodiscard]] const Netmask& getSource() const
+  {
+    return source;
+  }
+  [[nodiscard]] uint8_t getFamily() const
+  {
+    return source.getNetwork().sin4.sin_family;
+  }
+  [[nodiscard]] uint8_t getSourcePrefixLength() const
+  {
+    return source.getBits();
+  }
+  void setScopePrefixLength(uint8_t scope)
+  {
+    scopeBits = scope;
+  }
+  [[nodiscard]] uint8_t getScopePrefixLength() const
+  {
+    return scopeBits;
+  }
+  [[nodiscard]] std::string makeOptString() const;
+  static bool getFromString(const std::string& options, EDNSSubnetOpts* eso);
+  static bool getFromString(const char* options, unsigned int len, EDNSSubnetOpts* eso);
 
-bool getEDNSSubnetOptsFromString(const std::string& options, EDNSSubnetOpts* eso);
-bool getEDNSSubnetOptsFromString(const char* options, unsigned int len, EDNSSubnetOpts* eso);
-std::string makeEDNSSubnetOptsString(const EDNSSubnetOpts& eso);
+private:
+  Netmask source;
+  uint8_t scopeBits{};
+};

--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -89,8 +89,8 @@ boost::optional<Netmask> RecursorLua4::DNSQuestion::getEDNSSubnet() const
     for (const auto& option : *ednsOptions) {
       if (option.first == EDNSOptionCode::ECS) {
         EDNSSubnetOpts eso;
-        if (getEDNSSubnetOptsFromString(option.second, &eso)) {
-          return eso.source;
+        if (EDNSSubnetOpts::getFromString(option.second, &eso)) {
+          return eso.getSource();
         }
         break;
       }

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -631,7 +631,7 @@ void protobufLogResponse(const struct dnsheader* header, LocalStateHolder<LuaCon
   pbMessage.setId(header->id);
 
   pbMessage.setTime();
-  pbMessage.setEDNSSubnet(ednssubnet.source, ednssubnet.source.isIPv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
+  pbMessage.setEDNSSubnet(ednssubnet.getSource(), ednssubnet.getSource().isIPv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
   pbMessage.setRequestorId(requestorId);
   pbMessage.setDeviceId(deviceId);
   pbMessage.setDeviceName(deviceName);

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -277,7 +277,7 @@ static void doProtobufLogQuery(bool logQuery, LocalStateHolder<LuaConfigItems>& 
 {
   try {
     if (logQuery && !(luaconfsLocal->protobufExportConfig.taggedOnly && comboWriter->d_policyTags.empty())) {
-      protobufLogQuery(luaconfsLocal, comboWriter->d_uuid, comboWriter->d_source, comboWriter->d_destination, comboWriter->d_mappedSource, comboWriter->d_ednssubnet.source, true, conn->qlen, qname, qtype, qclass, comboWriter->d_policyTags, comboWriter->d_requestorId, comboWriter->d_deviceId, comboWriter->d_deviceName, comboWriter->d_meta, ednsVersion, *dnsheader);
+      protobufLogQuery(luaconfsLocal, comboWriter->d_uuid, comboWriter->d_source, comboWriter->d_destination, comboWriter->d_mappedSource, comboWriter->d_ednssubnet.getSource(), true, conn->qlen, qname, qtype, qclass, comboWriter->d_policyTags, comboWriter->d_requestorId, comboWriter->d_deviceId, comboWriter->d_deviceName, comboWriter->d_meta, ednsVersion, *dnsheader);
     }
   }
   catch (const std::exception& e) {
@@ -329,14 +329,14 @@ static void doProcessTCPQuestion(std::unique_ptr<DNSComboWriter>& comboWriter, s
       if (t_pdl) {
         try {
           if (t_pdl->hasGettagFFIFunc()) {
-            RecursorLua4::FFIParams params(qname, qtype, comboWriter->d_local, comboWriter->d_remote, comboWriter->d_destination, comboWriter->d_source, comboWriter->d_ednssubnet.source, comboWriter->d_data, comboWriter->d_gettagPolicyTags, comboWriter->d_records, ednsOptions, comboWriter->d_proxyProtocolValues, requestorId, deviceId, deviceName, comboWriter->d_routingTag, comboWriter->d_rcode, comboWriter->d_ttlCap, comboWriter->d_variable, true, logQuery, comboWriter->d_logResponse, comboWriter->d_followCNAMERecords, comboWriter->d_extendedErrorCode, comboWriter->d_extendedErrorExtra, comboWriter->d_responsePaddingDisabled, comboWriter->d_meta);
+            RecursorLua4::FFIParams params(qname, qtype, comboWriter->d_local, comboWriter->d_remote, comboWriter->d_destination, comboWriter->d_source, comboWriter->d_ednssubnet.getSource(), comboWriter->d_data, comboWriter->d_gettagPolicyTags, comboWriter->d_records, ednsOptions, comboWriter->d_proxyProtocolValues, requestorId, deviceId, deviceName, comboWriter->d_routingTag, comboWriter->d_rcode, comboWriter->d_ttlCap, comboWriter->d_variable, true, logQuery, comboWriter->d_logResponse, comboWriter->d_followCNAMERecords, comboWriter->d_extendedErrorCode, comboWriter->d_extendedErrorExtra, comboWriter->d_responsePaddingDisabled, comboWriter->d_meta);
             comboWriter->d_eventTrace.add(RecEventTrace::LuaGetTagFFI);
             comboWriter->d_tag = t_pdl->gettag_ffi(params);
             comboWriter->d_eventTrace.add(RecEventTrace::LuaGetTagFFI, comboWriter->d_tag, false);
           }
           else if (t_pdl->hasGettagFunc()) {
             comboWriter->d_eventTrace.add(RecEventTrace::LuaGetTag);
-            comboWriter->d_tag = t_pdl->gettag(comboWriter->d_source, comboWriter->d_ednssubnet.source, comboWriter->d_destination, qname, qtype, &comboWriter->d_gettagPolicyTags, comboWriter->d_data, ednsOptions, true, requestorId, deviceId, deviceName, comboWriter->d_routingTag, comboWriter->d_proxyProtocolValues);
+            comboWriter->d_tag = t_pdl->gettag(comboWriter->d_source, comboWriter->d_ednssubnet.getSource(), comboWriter->d_destination, qname, qtype, &comboWriter->d_gettagPolicyTags, comboWriter->d_data, ednsOptions, true, requestorId, deviceId, deviceName, comboWriter->d_routingTag, comboWriter->d_proxyProtocolValues);
             comboWriter->d_eventTrace.add(RecEventTrace::LuaGetTag, comboWriter->d_tag, false);
           }
           // Copy d_gettagPolicyTags to d_policyTags, so other Lua hooks see them and can add their

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -6114,10 +6114,10 @@ void SyncRes::setQuerySource(const ComboAddress& requestor, const boost::optiona
 {
   d_requestor = requestor;
 
-  if (incomingECS && incomingECS->source.getBits() > 0) {
-    d_cacheRemote = incomingECS->source.getMaskedNetwork();
-    uint8_t bits = std::min(incomingECS->source.getBits(), (incomingECS->source.isIPv4() ? s_ecsipv4limit : s_ecsipv6limit));
-    ComboAddress trunc = incomingECS->source.getNetwork();
+  if (incomingECS && incomingECS->getSourcePrefixLength() > 0) {
+    d_cacheRemote = incomingECS->getSource().getMaskedNetwork();
+    uint8_t bits = std::min(incomingECS->getSourcePrefixLength(), (incomingECS->getSource().isIPv4() ? s_ecsipv4limit : s_ecsipv6limit));
+    ComboAddress trunc = incomingECS->getSource().getNetwork();
     trunc.truncate(bits);
     d_outgoingECSNetwork = boost::optional<Netmask>(Netmask(trunc, bits));
   }
@@ -6130,7 +6130,7 @@ void SyncRes::setQuerySource(const ComboAddress& requestor, const boost::optiona
       trunc.truncate(bits);
       d_outgoingECSNetwork = boost::optional<Netmask>(Netmask(trunc, bits));
     }
-    else if (s_ecsScopeZero.source.getBits() > 0) {
+    else if (s_ecsScopeZero.getSourcePrefixLength() > 0) {
       /* RFC7871 says we MUST NOT send any ECS if the source scope is 0.
          But using an empty ECS in that case would mean inserting
          a non ECS-specific entry into the cache, preventing any further
@@ -6145,8 +6145,8 @@ void SyncRes::setQuerySource(const ComboAddress& requestor, const boost::optiona
          indicator of the applicable scope.  Subsequent Stub Resolver queries
          for /0 can then be answered from this cached response.
       */
-      d_outgoingECSNetwork = boost::optional<Netmask>(s_ecsScopeZero.source.getMaskedNetwork());
-      d_cacheRemote = s_ecsScopeZero.source.getNetwork();
+      d_outgoingECSNetwork = boost::optional<Netmask>(s_ecsScopeZero.getSource().getMaskedNetwork());
+      d_cacheRemote = s_ecsScopeZero.getSource().getNetwork();
     }
     else {
       // ECS disabled because no scope-zero address could be derived.

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -299,7 +299,7 @@ public:
 
   static void setECSScopeZeroAddress(const Netmask& scopeZeroMask)
   {
-    s_ecsScopeZero.source = scopeZeroMask;
+    s_ecsScopeZero.setSource(scopeZeroMask);
   }
 
   static void clearECSStats()

--- a/pdns/recursordist/test-ednsoptions_cc.cc
+++ b/pdns/recursordist/test-ednsoptions_cc.cc
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(test_getEDNSOption)
   BOOST_CHECK_EQUAL(res, 0);
 
   EDNSSubnetOpts eso;
-  BOOST_REQUIRE(EDNSSubnetOpts::getFromString(reinterpret_cast<const char*>(&query.at(pos + 9 + ecsStartPosition + 4)), ecsLen - 4, &eso));
+  BOOST_REQUIRE(EDNSSubnetOpts::getFromString(reinterpret_cast<const char*>(&query.at(pos + 9 + ecsStartPosition + 4)), ecsLen - 4, &eso)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
   BOOST_CHECK(eso.getSource() == ecs);
 }

--- a/pdns/recursordist/test-ednsoptions_cc.cc
+++ b/pdns/recursordist/test-ednsoptions_cc.cc
@@ -28,8 +28,8 @@ static void getRawQueryWithECSAndCookie(const DNSName& name, const Netmask& ecs,
   EDNSCookiesOpt cookiesOpt(clientCookie + serverCookie);
   string cookiesOptionStr = cookiesOpt.makeOptString();
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = ecs;
-  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  ecsOpts.setSource(ecs);
+  string origECSOptionStr = ecsOpts.makeOptString();
   DNSPacketWriter::optvect_t opts;
   opts.emplace_back(EDNSOptionCode::COOKIE, cookiesOptionStr);
   opts.emplace_back(EDNSOptionCode::ECS, origECSOptionStr);
@@ -65,9 +65,9 @@ BOOST_AUTO_TEST_CASE(test_getEDNSOption)
   BOOST_CHECK_EQUAL(res, 0);
 
   EDNSSubnetOpts eso;
-  BOOST_REQUIRE(getEDNSSubnetOptsFromString(reinterpret_cast<const char*>(&query.at(pos + 9 + ecsStartPosition + 4)), ecsLen - 4, &eso));
+  BOOST_REQUIRE(EDNSSubnetOpts::getFromString(reinterpret_cast<const char*>(&query.at(pos + 9 + ecsStartPosition + 4)), ecsLen - 4, &eso));
 
-  BOOST_CHECK(eso.source == ecs);
+  BOOST_CHECK(eso.getSource() == ecs);
 }
 
 BOOST_AUTO_TEST_CASE(test_getEDNSOptions)
@@ -105,8 +105,8 @@ BOOST_AUTO_TEST_CASE(test_getEDNSOptions)
   BOOST_REQUIRE_GT(it->second.values.at(0).size, 0U);
 
   EDNSSubnetOpts eso;
-  BOOST_REQUIRE(getEDNSSubnetOptsFromString(it->second.values.at(0).content, it->second.values.at(0).size, &eso));
-  BOOST_CHECK(eso.source == ecs);
+  BOOST_REQUIRE(EDNSSubnetOpts::getFromString(it->second.values.at(0).content, it->second.values.at(0).size, &eso));
+  BOOST_CHECK(eso.getSource() == ecs);
 
   it = options.find(EDNSOptionCode::COOKIE);
   BOOST_REQUIRE(it != options.end());
@@ -121,9 +121,9 @@ static void checkECSOptionValidity(const std::string& sourceStr, uint8_t sourceM
 {
   ComboAddress source(sourceStr);
   EDNSSubnetOpts ecsOpts;
-  ecsOpts.source = Netmask(source, sourceMask);
+  ecsOpts.setSource(Netmask(source, sourceMask));
 
-  string ecsOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  string ecsOptionStr = ecsOpts.makeOptString();
 
   /* 2 bytes for family, one for source mask and one for scope mask */
   const size_t ecsHeaderSize = 4;
@@ -157,9 +157,9 @@ static void checkECSOptionValidity(const std::string& sourceStr, uint8_t sourceM
   }
 
   EDNSSubnetOpts parsed;
-  BOOST_REQUIRE(getEDNSSubnetOptsFromString(ecsOptionStr, &parsed));
-  BOOST_REQUIRE(parsed.source == Netmask(truncated, sourceMask));
-  BOOST_REQUIRE_EQUAL(ecsOpts.scope.getBits(), parsed.scope.getBits());
+  BOOST_REQUIRE(EDNSSubnetOpts::getFromString(ecsOptionStr, &parsed));
+  BOOST_REQUIRE(parsed.getSource() == Netmask(truncated, sourceMask));
+  BOOST_REQUIRE_EQUAL(ecsOpts.getScopePrefixLength(), parsed.getScopePrefixLength());
 }
 
 BOOST_AUTO_TEST_CASE(test_makeEDNSSubnetOptsString)

--- a/pdns/recursordist/test-syncres_cc1.cc
+++ b/pdns/recursordist/test-syncres_cc1.cc
@@ -1138,7 +1138,7 @@ BOOST_AUTO_TEST_CASE(test_edns_subnet_by_domain)
   SyncRes::addEDNSDomain(target);
 
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("192.0.2.128/32");
+  incomingECS.setSource(Netmask("192.0.2.128/32"));
   sr->setQuerySource(ComboAddress(), boost::optional<const EDNSSubnetOpts&>(incomingECS));
 
   sr->setAsyncCallback([&](const ComboAddress& address, const DNSName& domain, int /* type */, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, boost::optional<Netmask>& srcmask, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
@@ -1198,7 +1198,7 @@ BOOST_AUTO_TEST_CASE(test_edns_subnet_by_addr)
   SyncRes::addEDNSRemoteSubnet("192.0.2.1/32");
 
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("2001:DB8::FF/128");
+  incomingECS.setSource(Netmask("2001:DB8::FF/128"));
   sr->setQuerySource(ComboAddress(), boost::optional<const EDNSSubnetOpts&>(incomingECS));
 
   sr->setAsyncCallback([&](const ComboAddress& address, const DNSName& domain, int /* type */, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, boost::optional<Netmask>& srcmask, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
@@ -1339,7 +1339,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_honor_incoming_mask)
   SyncRes::clearEDNSLocalSubnets();
   SyncRes::addEDNSLocalSubnet("192.0.2.254/32");
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("192.0.0.0/16");
+  incomingECS.setSource(Netmask("192.0.0.0/16"));
   sr->setQuerySource(ComboAddress("192.0.2.127"), boost::optional<const EDNSSubnetOpts&>(incomingECS));
 
   sr->setAsyncCallback([&](const ComboAddress& address, const DNSName& domain, int /* type */, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, boost::optional<Netmask>& srcmask, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
@@ -1384,7 +1384,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_honor_incoming_mask_zero)
   SyncRes::clearEDNSLocalSubnets();
   SyncRes::addEDNSLocalSubnet("192.0.2.254/32");
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("0.0.0.0/0");
+  incomingECS.setSource(Netmask("0.0.0.0/0"));
   sr->setQuerySource(ComboAddress("192.0.2.127"), boost::optional<const EDNSSubnetOpts&>(incomingECS));
 
   sr->setAsyncCallback([&](const ComboAddress& address, const DNSName& domain, int /* type */, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, boost::optional<Netmask>& srcmask, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {

--- a/pdns/recursordist/test-syncres_cc2.cc
+++ b/pdns/recursordist/test-syncres_cc2.cc
@@ -1121,7 +1121,7 @@ BOOST_AUTO_TEST_CASE(test_dont_skip_negcache_for_variable_response)
   SyncRes::addEDNSDomain(DNSName("powerdns.com."));
 
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("192.0.2.128/32");
+  incomingECS.setSource(Netmask("192.0.2.128/32"));
   sr->setQuerySource(ComboAddress(), boost::optional<const EDNSSubnetOpts&>(incomingECS));
 
   sr->setAsyncCallback([&](const ComboAddress& address, const DNSName& domain, int /* type */, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, boost::optional<Netmask>& srcmask, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
@@ -1176,7 +1176,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_limit_allowed)
   SyncRes::addEDNSDomain(DNSName("powerdns.com."));
 
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("192.0.2.128/32");
+  incomingECS.setSource(Netmask("192.0.2.128/32"));
   sr->setQuerySource(ComboAddress(), boost::optional<const EDNSSubnetOpts&>(incomingECS));
   SyncRes::s_ecsipv4cachelimit = 24;
 
@@ -1215,7 +1215,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_limit_no_ttl_limit_allowed)
   SyncRes::addEDNSDomain(DNSName("powerdns.com."));
 
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("192.0.2.128/32");
+  incomingECS.setSource(Netmask("192.0.2.128/32"));
   sr->setQuerySource(ComboAddress(), boost::optional<const EDNSSubnetOpts&>(incomingECS));
   SyncRes::s_ecsipv4cachelimit = 16;
 
@@ -1254,7 +1254,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_ttllimit_allowed)
   SyncRes::addEDNSDomain(DNSName("powerdns.com."));
 
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("192.0.2.128/32");
+  incomingECS.setSource(Netmask("192.0.2.128/32"));
   sr->setQuerySource(ComboAddress(), boost::optional<const EDNSSubnetOpts&>(incomingECS));
   SyncRes::s_ecscachelimitttl = 30;
 
@@ -1293,7 +1293,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_ttllimit_and_scope_allowed)
   SyncRes::addEDNSDomain(DNSName("powerdns.com."));
 
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("192.0.2.128/32");
+  incomingECS.setSource(Netmask("192.0.2.128/32"));
   sr->setQuerySource(ComboAddress(), boost::optional<const EDNSSubnetOpts&>(incomingECS));
   SyncRes::s_ecscachelimitttl = 100;
   SyncRes::s_ecsipv4cachelimit = 24;
@@ -1333,7 +1333,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_ttllimit_notallowed)
   SyncRes::addEDNSDomain(DNSName("powerdns.com."));
 
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("192.0.2.128/32");
+  incomingECS.setSource(Netmask("192.0.2.128/32"));
   sr->setQuerySource(ComboAddress(), boost::optional<const EDNSSubnetOpts&>(incomingECS));
   SyncRes::s_ecscachelimitttl = 100;
   SyncRes::s_ecsipv4cachelimit = 16;
@@ -1667,7 +1667,7 @@ BOOST_AUTO_TEST_CASE(test_cache_min_max_ecs_ttl)
   const ComboAddress ns("192.0.2.1:53");
 
   EDNSSubnetOpts incomingECS;
-  incomingECS.source = Netmask("192.0.2.128/32");
+  incomingECS.setSource(Netmask("192.0.2.128/32"));
   sr->setQuerySource(ComboAddress(), boost::optional<const EDNSSubnetOpts&>(incomingECS));
   SyncRes::addEDNSDomain(target);
 

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -171,7 +171,7 @@ static void printReply(const string& reply, bool showflags, bool hidesoadetails,
         EDNSSubnetOpts reso;
         if (EDNSSubnetOpts::getFromString(iter->second, &reso)) {
           cerr << "EDNS Subnet response: " << reso.getSource().toString()
-               << ", scope: " << Netmask(reso.getSource().getNetwork(), reso.getScopePrefixLength()).toString()
+               << ", scope: " << reso.getScope().toString()
                << ", family = " << std::to_string(reso.getFamily())
                << endl;
         }

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -71,8 +71,8 @@ static void fillPacket(vector<uint8_t>& packet, const string& q, const string& t
     DNSPacketWriter::optvect_t opts;
     if (ednsnm) {
       EDNSSubnetOpts eo;
-      eo.source = *ednsnm;
-      opts.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(eo));
+      eo.setSource(*ednsnm);
+      opts.emplace_back(EDNSOptionCode::ECS, eo.makeOptString());
     }
 
     pw.addOpt(bufsize, 0, dnssec ? EDNSOpts::DNSSECOK : 0, opts);
@@ -169,10 +169,10 @@ static void printReply(const string& reply, bool showflags, bool hidesoadetails,
          iter != edo.d_options.end(); ++iter) {
       if (iter->first == EDNSOptionCode::ECS) { // 'EDNS subnet'
         EDNSSubnetOpts reso;
-        if (getEDNSSubnetOptsFromString(iter->second, &reso)) {
-          cerr << "EDNS Subnet response: " << reso.source.toString()
-               << ", scope: " << reso.scope.toString()
-               << ", family = " << reso.scope.getNetwork().sin4.sin_family
+        if (EDNSSubnetOpts::getFromString(iter->second, &reso)) {
+          cerr << "EDNS Subnet response: " << reso.getSource().toString()
+               << ", scope: " << Netmask(reso.getSource().getNetwork(), reso.getScopePrefixLength()).toString()
+               << ", family = " << std::to_string(reso.getFamily())
                << endl;
         }
       } else if (iter->first == EDNSOptionCode::PADDING) {

--- a/pdns/stubresolver.cc
+++ b/pdns/stubresolver.cc
@@ -131,7 +131,7 @@ int stubDoResolve(const DNSName& qname, uint16_t qtype, vector<DNSZoneRecord>& r
 
   if (d_eso != nullptr) {
     // pass along EDNS subnet from client if given - issue #5469
-    string origECSOptionStr = makeEDNSSubnetOptsString(*d_eso);
+    string origECSOptionStr = d_eso->makeOptString();
     DNSPacketWriter::optvect_t opts;
     opts.emplace_back(EDNSOptionCode::ECS, origECSOptionStr);
     packetWriter.addOpt(512, 0, 0, opts);

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -349,8 +349,8 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
     }
 
     {
-      ecsOpts.source = Netmask(ComboAddress("192.0.2.1"), 32);
-      opts.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(ecsOpts));
+      ecsOpts.setSource(Netmask(ComboAddress("192.0.2.1"), 32));
+      opts.emplace_back(EDNSOptionCode::ECS, ecsOpts.makeOptString());
       DNSPacketWriter pw(pak, DNSName("www.powerdns.com"), QType::A);
       pw.addOpt(512, 0, 0, opts);
       pw.commit();
@@ -361,8 +361,8 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
 
     {
       DNSPacketWriter pw(pak, DNSName("www.powerdns.com"), QType::A);
-      ecsOpts.source = Netmask(ComboAddress("192.0.2.2"), 32);
-      opts.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(ecsOpts));
+      ecsOpts.setSource(Netmask(ComboAddress("192.0.2.2"), 32));
+      opts.emplace_back(EDNSOptionCode::ECS, ecsOpts.makeOptString());
       pw.addOpt(512, 0, 0, opts);
       pw.commit();
       ecs2.parse((char*)&pak[0], pak.size());
@@ -372,8 +372,8 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
 
     {
       DNSPacketWriter pw(pak, DNSName("www.powerdns.com"), QType::A);
-      ecsOpts.source = Netmask(ComboAddress("192.0.2.3"), 16);
-      opts.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(ecsOpts));
+      ecsOpts.setSource(Netmask(ComboAddress("192.0.2.3"), 16));
+      opts.emplace_back(EDNSOptionCode::ECS, ecsOpts.makeOptString());
       pw.addOpt(512, 0, 0, opts);
       pw.commit();
       ecs3.parse((char*)&pak[0], pak.size());

--- a/pdns/test-packetcache_hh.cc
+++ b/pdns/test-packetcache_hh.cc
@@ -56,9 +56,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw1.getHeader()->rd = true;
     pw1.getHeader()->qr = false;
     pw1.getHeader()->id = 0x42;
-    opt.source = Netmask("10.0.59.220/32");
+    opt.setSource(Netmask("10.0.59.220/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     pw1.addOpt(512, 0, 0, ednsOptions);
     pw1.commit();
 
@@ -70,9 +70,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw2.getHeader()->rd = true;
     pw2.getHeader()->qr = false;
     pw2.getHeader()->id = 0x84;
-    opt.source = Netmask("10.0.167.48/32");
+    opt.setSource(Netmask("10.0.167.48/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     pw2.addOpt(512, 0, 0, ednsOptions);
     pw2.commit();
 
@@ -128,9 +128,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw1.getHeader()->rd = true;
     pw1.getHeader()->qr = false;
     pw1.getHeader()->id = 0x42;
-    opt.source = Netmask("10.0.41.6/32");
+    opt.setSource(Netmask("10.0.41.6/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     pw1.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);
     pw1.commit();
 
@@ -142,9 +142,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw2.getHeader()->rd = true;
     pw2.getHeader()->qr = false;
     pw2.getHeader()->id = 0x84;
-    opt.source = Netmask("10.0.119.79/32");
+    opt.setSource(Netmask("10.0.119.79/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     /* no EDNSOpts::DNSSECOK !! */
     pw2.addOpt(512, 0, 0, ednsOptions);
     pw2.commit();
@@ -164,9 +164,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw1.getHeader()->rd = true;
     pw1.getHeader()->qr = false;
     pw1.getHeader()->id = 0x42;
-    opt.source = Netmask("192.0.2.1/32");
+    opt.setSource(Netmask("192.0.2.1/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     EDNSCookiesOpt cookiesOpt(string("deadbeefdeadbeef"));
     ednsOptions.emplace_back(EDNSOptionCode::COOKIE, cookiesOpt.makeOptString());
     pw1.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);
@@ -180,9 +180,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw2.getHeader()->rd = true;
     pw2.getHeader()->qr = false;
     pw2.getHeader()->id = 0x84;
-    opt.source = Netmask("192.0.2.1/32");
+    opt.setSource(Netmask("192.0.2.1/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     cookiesOpt.makeFromString(string("deadbeefbadc0fee"));
     ednsOptions.emplace_back(EDNSOptionCode::COOKIE, cookiesOpt.makeOptString());
     pw2.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);
@@ -315,9 +315,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     pw1.getHeader()->rd = true;
     pw1.getHeader()->qr = false;
     pw1.getHeader()->id = 0x42;
-    opt.source = Netmask("10.0.18.199/32");
+    opt.setSource(Netmask("10.0.18.199/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     pw1.addOpt(512, 0, 0, ednsOptions);
     pw1.commit();
 
@@ -329,9 +329,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     pw2.getHeader()->rd = true;
     pw2.getHeader()->qr = false;
     pw2.getHeader()->id = 0x84;
-    opt.source = Netmask("10.0.131.66/32");
+    opt.setSource(Netmask("10.0.131.66/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     pw2.addOpt(512, 0, 0, ednsOptions);
     pw2.commit();
 
@@ -350,9 +350,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     pw1.getHeader()->rd = true;
     pw1.getHeader()->qr = false;
     pw1.getHeader()->id = 0x42;
-    opt.source = Netmask("192.0.2.1/32");
+    opt.setSource(Netmask("192.0.2.1/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     EDNSCookiesOpt cookiesOpt(string("deadbeefdead\x11\xee\x00\x00").c_str(), 16);
     ednsOptions.emplace_back(EDNSOptionCode::COOKIE, cookiesOpt.makeOptString());
     pw1.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);
@@ -366,9 +366,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     pw2.getHeader()->rd = true;
     pw2.getHeader()->qr = false;
     pw2.getHeader()->id = 0x84;
-    opt.source = Netmask("192.0.2.1/32");
+    opt.setSource(Netmask("192.0.2.1/32"));
     ednsOptions.clear();
-    ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
     cookiesOpt.makeFromString(string("deadbeefdead\x67\x44\x00\x00").c_str(), 16);
     ednsOptions.emplace_back(EDNSOptionCode::COOKIE, cookiesOpt.makeOptString());
     pw2.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes #13704 

Uses beter (rfc7871 derived) names for things and introduced encapsulation to hide the internal representation of `EDNSSubnetOpts`.

Most of this are mechanical changes, the real stuff is in `ednssubnet.??`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
