### PR TITLE
Überbackend (questionable) improvements

### DIFF
--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -375,7 +375,7 @@ bool Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key, int64_t
     ASSERT_ROW_COLUMNS("get-last-inserted-key-id-query", row, 1);
     id = std::stoi(row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
-    return true;
+    return id != 0;
   }
   catch (SSqlException& e) {
     id = -2;

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1030,7 +1030,7 @@ bool GSQLBackend::addDomainKey(const DNSName& name, const KeyData& key, int64_t&
     ASSERT_ROW_COLUMNS("get-last-inserted-key-id-query", row, 1);
     id = std::stoi(row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
-    return true;
+    return id != 0;
   }
   catch (SSqlException &e) {
     id = -2;

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -1132,7 +1132,9 @@ BOOST_AUTO_TEST_CASE(test_multi_backends_metadata) {
       BOOST_CHECK_EQUAL(values.size(), 0U);
       values.clear();
       BOOST_CHECK(ub.getDomainMetadata(DNSName("powerdns.org."), "test-data-b", values));
-      BOOST_CHECK_EQUAL(values.size(), 0U);
+      BOOST_CHECK_EQUAL(values.size(), 2U);
+      BOOST_CHECK_EQUAL(values.at(0), "value1");
+      BOOST_CHECK_EQUAL(values.at(1), "value2");
     }
 
     {

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -161,32 +161,44 @@ bool UeberBackend::addDomainKey(const DNSName& name, const DNSBackend::KeyData& 
 }
 bool UeberBackend::getDomainKeys(const DNSName& name, std::vector<DNSBackend::KeyData>& keys)
 {
+  bool ret = false;
   for (auto& backend : backends) {
     if (backend->getDomainKeys(name, keys)) {
-      return true;
+      ret = true;
+      if (!keys.empty()) {
+        return true;
+      }
     }
   }
-  return false;
+  return ret;
 }
 
 bool UeberBackend::getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string>>& meta)
 {
+  bool ret = false;
   for (auto& backend : backends) {
     if (backend->getAllDomainMetadata(name, meta)) {
-      return true;
+      ret = true;
+      if (!meta.empty()) {
+        return true;
+      }
     }
   }
-  return false;
+  return ret;
 }
 
 bool UeberBackend::getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta)
 {
+  bool ret = false;
   for (auto& backend : backends) {
     if (backend->getDomainMetadata(name, kind, meta)) {
-      return true;
+      ret = true;
+      if (!meta.empty()) {
+        return true;
+      }
     }
   }
-  return false;
+  return ret;
 }
 
 bool UeberBackend::getDomainMetadata(const DNSName& name, const std::string& kind, std::string& meta)
@@ -597,12 +609,16 @@ bool UeberBackend::autoPrimaryRemove(const AutoPrimary& primary)
 
 bool UeberBackend::autoPrimariesList(std::vector<AutoPrimary>& primaries)
 {
+  bool ret = false;
   for (auto& backend : backends) {
     if (backend->autoPrimariesList(primaries)) {
-      return true;
+      ret = true;
+      if (!primaries.empty()) {
+        return true;
+      }
     }
   }
-  return false;
+  return ret;
 }
 
 bool UeberBackend::autoPrimaryBackend(const string& ipAddr, const DNSName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** dnsBackend)

--- a/regression-tests.auth-py/test_GSSTSIG.py
+++ b/regression-tests.auth-py/test_GSSTSIG.py
@@ -34,6 +34,24 @@ dnsupdate-require-tsig=no
                  }
 
     @classmethod
+    def secureZone(cls, confdir, zonename, key=None):
+        # This particular test uses a sqlite-only configuration, unlike
+        # all the other tests in that directory. Because of this, we
+        # need to perform an explicit create-zone, otherwise import-zone-key
+        # would fail.
+        zone = '.' if zonename == 'ROOT' else zonename
+        pdnsutilCmd = [os.environ['PDNSUTIL'],
+                       '--config-dir=%s' % confdir,
+                       'create-zone',
+                       zone]
+        print(' '.join(pdnsutilCmd))
+        try:
+            subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
+        super(GSSTSIGBase, cls).secureZone(confdir, zonename, key)
+
+    @classmethod
     def setUpClass(cls):
         super(GSSTSIGBase, cls).setUpClass()
         os.system("$PDNSUTIL --config-dir=configs/auth delete-zone example.net")


### PR DESCRIPTION
### Short description
This is the result of my investigation of #15045.
A bugfix leads to another and another and eventually things appear to work again.

So, this attempts to fix two issues:
- when an sql insertion fails, not as a severe problem (such as a database connection timeout) but simply because no insertion took place, this should be reported as an error, but was not.
- when querying an Überbackend setup with more than one source, if the query of one source suceeds but returns no results, the remaining sources should be queried as well, so that another source returning success AND results can be preferred.

As a result of these fixes, "sql+bind-with-dnssec-db" setups can now properly make use of the bind dnssec database if the first backend (sql) reports errors (for writes) and no content (for reads) due to the domain being worked on being absent from that database, but present in bind.

However, I'm raising the "I don't know what I am doing" flag, this _might_ break other multiple-backend setups I have not thought of. Reviewers welcome!

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)