### PR TITLE
Correctly report SQL insertion errors

### DIFF
--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -375,6 +375,10 @@ bool Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key, int64_t
     ASSERT_ROW_COLUMNS("get-last-inserted-key-id-query", row, 1);
     id = std::stoi(row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
+    if (id == 0) {
+      // No insert took place, report as error.
+      id = -1;
+    }
     return true;
   }
   catch (SSqlException& e) {

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1030,6 +1030,10 @@ bool GSQLBackend::addDomainKey(const DNSName& name, const KeyData& key, int64_t&
     ASSERT_ROW_COLUMNS("get-last-inserted-key-id-query", row, 1);
     id = std::stoi(row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
+    if (id == 0) {
+      // No insert took place, report as error.
+      id = -1;
+    }
     return true;
   }
   catch (SSqlException &e) {

--- a/regression-tests.auth-py/test_GSSTSIG.py
+++ b/regression-tests.auth-py/test_GSSTSIG.py
@@ -34,6 +34,24 @@ dnsupdate-require-tsig=no
                  }
 
     @classmethod
+    def secureZone(cls, confdir, zonename, key=None):
+        # This particular test uses a sqlite-only configuration, unlike
+        # all the other tests in that directory. Because of this, we
+        # need to perform an explicit create-zone, otherwise import-zone-key
+        # would fail.
+        zone = '.' if zonename == 'ROOT' else zonename
+        pdnsutilCmd = [os.environ['PDNSUTIL'],
+                       '--config-dir=%s' % confdir,
+                       'create-zone',
+                       zone]
+        print(' '.join(pdnsutilCmd))
+        try:
+            subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
+        super(GSSTSIGBase, cls).secureZone(confdir, zonename, key)
+
+    @classmethod
     def setUpClass(cls):
         super(GSSTSIGBase, cls).setUpClass()
         os.system("$PDNSUTIL --config-dir=configs/auth delete-zone example.net")


### PR DESCRIPTION
### Short description
When an sql insertion fails, not as a severe problem (such as a database connection timeout) but simply because no insertion took place, this should be reported as an error, but was not.

A consequence of this fix is that the `test_GSSTSIG.py` test now fail because `pdnsutil import-key-zone` now reports failure, as the sqlite database is empty at this state in the test run. The second commit addresses this by issueing `pdnsutil create-zone` first. (this operation targets the `example.org` zone which is not used/relevant in this test anyway)

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] added a random checkbox which noone will notice