### PR TITLE
rec: New Coverity Variable copied when it could be moved cases

### DIFF
--- a/pdns/arguments.cc
+++ b/pdns/arguments.cc
@@ -433,7 +433,7 @@ void ArgvMap::parseOne(const string& arg, const string& parseOnly, bool lax)
       }
       else {
         d_params[var] = val;
-        d_cleared.insert(var);
+        d_cleared.insert(std::move(var));
       }
     }
     else {

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -631,7 +631,7 @@ void PacketReader::xfrSvcParamKeyVals(set<SvcParam> &kvs) {
           throw std::out_of_range("alpn length of 0");
         }
         xfrBlob(alpn, alpnLen);
-        alpns.push_back(alpn);
+        alpns.push_back(std::move(alpn));
       }
       kvs.insert(SvcParam(key, std::move(alpns)));
       break;
@@ -672,7 +672,7 @@ void PacketReader::xfrSvcParamKeyVals(set<SvcParam> &kvs) {
       bool doAuto{d_internal && len == 0};
       auto param = SvcParam(key, std::move(addresses));
       param.setAutoHint(doAuto);
-      kvs.insert(param);
+      kvs.insert(std::move(param));
       break;
     }
     case SvcParam::ech: {

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -780,7 +780,7 @@ void SVCBBaseRecordContent::setHints(const SvcParam::SvcParamKey &key, const std
   try {
     auto newParam = SvcParam(key, std::move(h));
     d_params.erase(p);
-    d_params.insert(newParam);
+    d_params.insert(std::move(newParam));
   } catch (...) {
     // XXX maybe we should SERVFAIL instead?
     return;

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -408,7 +408,7 @@ void RecordTextReader::xfrSvcParamKeyVals(set<SvcParam>& val) // NOLINT(readabil
       try {
         auto p = SvcParam(key, std::move(hints));
         p.setAutoHint(doAuto);
-        val.insert(p);
+        val.insert(std::move(p));
       }
       catch (const std::invalid_argument& e) {
         throw RecordTextException(e.what());
@@ -880,7 +880,7 @@ void RecordTextWriter::xfrSVCBValueList(const vector<string> &val) {
       }
       unescaped += ch;
     }
-    escaped.push_back(unescaped);
+    escaped.push_back(std::move(unescaped));
   }
   if (shouldQuote) {
     d_string.append(1, '"');

--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -139,7 +139,7 @@ void RecursorLua4::DNSQuestion::addRecord(uint16_t type, const std::string& cont
   dnsRecord.d_type = type;
   dnsRecord.d_place = place;
   dnsRecord.setContent(DNSRecordContent::make(type, QClass::IN, content));
-  records.push_back(dnsRecord);
+  records.push_back(std::move(dnsRecord));
 }
 
 void RecursorLua4::DNSQuestion::addAnswer(uint16_t type, const std::string& content, boost::optional<int> ttl, boost::optional<string> name)

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -814,7 +814,7 @@ int getFakePTRRecords(const DNSName& qname, vector<DNSRecord>& ret)
   record.setContent(std::make_shared<CNAMERecordContent>(newquery));
   // Copy the TTL of the synthesized CNAME from the actual answer
   record.d_ttl = (rcode == RCode::NoError && !answers.empty()) ? answers.at(0).d_ttl : SyncRes::s_minimumTTL;
-  ret.push_back(record);
+  ret.push_back(std::move(record));
 
   ret.insert(ret.end(), answers.begin(), answers.end());
 

--- a/pdns/recursordist/pubsuffixloader.cc
+++ b/pdns/recursordist/pubsuffixloader.cc
@@ -86,7 +86,7 @@ void initPublicSuffixList(const std::string& file)
       vector<string> parts;
       stringtok(parts, low, ".");
       reverse(parts.begin(), parts.end());
-      pbList.push_back(parts);
+      pbList.push_back(std::move(parts));
     }
   }
 

--- a/pdns/recursordist/rec-lua-conf.cc
+++ b/pdns/recursordist/rec-lua-conf.cc
@@ -809,7 +809,7 @@ void loadRecursorLuaConfig(const std::string& fname, ProxyMapping& proxyMapping,
 
   try {
     Lua->executeCode(ifs);
-    newLuaConfig = lci;
+    newLuaConfig = std::move(lci);
   }
   catch (const LuaContext::ExecutionErrorException& e) {
     SLOG(g_log << Logger::Error << "Unable to load Lua script from '" + fname + "': ",

--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -99,7 +99,7 @@ void ZoneData::parseDRForCache(DNSRecord& dnsRecord)
   case QType::NSEC3:
     break;
   case QType::RRSIG: {
-    const auto rrsig = getRR<RRSIGRecordContent>(dnsRecord);
+    auto rrsig = getRR<RRSIGRecordContent>(dnsRecord);
     if (rrsig == nullptr) {
       break;
     }
@@ -110,7 +110,7 @@ void ZoneData::parseDRForCache(DNSRecord& dnsRecord)
     }
     else {
       vector<shared_ptr<const RRSIGRecordContent>> sigsrr;
-      sigsrr.push_back(rrsig);
+      sigsrr.push_back(std::move(rrsig));
       d_sigs.insert({sigkey, sigsrr});
     }
     break;

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -1561,7 +1561,7 @@ DNSName getRegisteredName(const DNSName& dom)
   while (!parts.empty()) {
     if (parts.size() == 1 || binary_search(g_pubs.begin(), g_pubs.end(), parts)) {
 
-      string ret = last;
+      string ret = std::move(last);
       if (!ret.empty())
         ret += ".";
 
@@ -1643,7 +1643,7 @@ static string addDontThrottleNames(T begin, T end)
   while (begin != end) {
     try {
       auto d = DNSName(*begin);
-      toAdd.push_back(d);
+      toAdd.push_back(std::move(d));
     }
     catch (const std::exception& e) {
       return "Problem parsing '" + *begin + "': " + e.what() + ", nothing added\n";
@@ -1936,7 +1936,7 @@ RecursorControlChannel::Answer luaconfig(bool broadcast)
       lci = g_luaconfs.getCopy();
       if (broadcast) {
         startLuaConfigDelayedThreads(lci, lci.generation);
-        broadcastFunction([=] { return pleaseSupplantProxyMapping(proxyMapping); });
+        broadcastFunction([pmap = std::move(proxyMapping)] { return pleaseSupplantProxyMapping(pmap); });
       }
       else {
         // Initial proxy mapping

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -208,8 +208,8 @@ string reloadZoneConfiguration(bool yaml)
     // these explicitly-named captures should not be necessary, as lambda
     // capture of tuple-like structured bindings is permitted, but some
     // compilers still don't allow it
-    broadcastFunction([dmap = newDomainMap] { return pleaseUseNewSDomainsMap(dmap); });
-    broadcastFunction([nsset = newNotifySet] { return pleaseSupplantAllowNotifyFor(nsset); });
+    broadcastFunction([dmap = std::move(newDomainMap)] { return pleaseUseNewSDomainsMap(dmap); });
+    broadcastFunction([nsset = std::move(newNotifySet)] { return pleaseSupplantAllowNotifyFor(nsset); });
 
     // Wipe the caches *after* the new auth domain info has been set
     // up, as a query during setting up might fill the caches

--- a/pdns/recursordist/settings/generate.py
+++ b/pdns/recursordist/settings/generate.py
@@ -316,7 +316,7 @@ def gen_cxx_oldkvtobridgestruct(file, entries):
     file.write('const std::string& value, ::rust::String& section, ::rust::String& fieldname, ')
     file.write('::rust::String& type_name, pdns::rust::settings::rec::Value& rustvalue)')
     file.write('{ // NOLINT(readability-function-cognitive-complexity)\n')
-    file.write('  if (const auto newname = arg().isDeprecated(key); !newname.empty()) {\n')
+    file.write('  if (const auto& newname = arg().isDeprecated(key); !newname.empty()) {\n')
     file.write('    key = newname;\n')
     file.write('  }\n')
     for entry in entries:

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -942,7 +942,7 @@ void SyncRes::AuthDomain::addSOA(std::vector<DNSRecord>& records) const
   if (ziter != d_records.end()) {
     DNSRecord dnsRecord = *ziter;
     dnsRecord.d_place = DNSResourceRecord::AUTHORITY;
-    records.push_back(dnsRecord);
+    records.push_back(std::move(dnsRecord));
   }
 }
 
@@ -1028,7 +1028,7 @@ int SyncRes::AuthDomain::getRecords(const DNSName& qname, const QType qtype, std
       if (dnsRecord.d_type == qtype || qtype == QType::ANY || dnsRecord.d_type == QType::CNAME) {
         dnsRecord.d_name = qname;
         dnsRecord.d_place = DNSResourceRecord::ANSWER;
-        records.push_back(dnsRecord);
+        records.push_back(std::move(dnsRecord));
       }
     }
 
@@ -2592,7 +2592,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName& qname, const QType qtype, vector<
         break;
       }
       if (g_recCache->get(d_now.tv_sec, dnameName, QType::DNAME, flags, &cset, d_cacheRemote, d_routingTag, d_doDNSSEC ? &signatures : nullptr, d_doDNSSEC ? &authorityRecs : nullptr, &d_wasVariable, &context.state, &wasAuth, &authZone, &d_fromAuthIP) > 0) {
-        foundName = dnameName;
+        foundName = std::move(dnameName);
         foundQT = QType::DNAME;
         break;
       }
@@ -2664,13 +2664,13 @@ bool SyncRes::doCNAMECacheCheck(const DNSName& qname, const QType qtype, vector<
           sigdr.setContent(signature);
           sigdr.d_place = DNSResourceRecord::ANSWER;
           sigdr.d_class = QClass::IN;
-          ret.push_back(sigdr);
+          ret.push_back(std::move(sigdr));
         }
 
         for (const auto& rec : *authorityRecs) {
           DNSRecord authDR(rec);
           authDR.d_ttl = ttl;
-          ret.push_back(authDR);
+          ret.push_back(std::move(authDR));
         }
       }
 
@@ -3099,7 +3099,7 @@ bool SyncRes::doCacheCheck(const DNSName& qname, const DNSName& authname, bool w
       dnsRecord.setContent(signature);
       dnsRecord.d_place = DNSResourceRecord::ANSWER;
       dnsRecord.d_class = QClass::IN;
-      ret.push_back(dnsRecord);
+      ret.push_back(std::move(dnsRecord));
     }
 
     for (const auto& rec : *authorityRecs) {
@@ -4025,7 +4025,7 @@ vState SyncRes::getDNSKeys(const DNSName& signer, skeyset_t& keys, bool& servFai
         if (key.d_type == QType::DNSKEY) {
           auto content = getRR<DNSKEYRecordContent>(key);
           if (content) {
-            keys.insert(content);
+            keys.insert(std::move(content));
           }
         }
       }
@@ -4246,7 +4246,7 @@ static void allowAdditionalEntry(std::unordered_set<DNSName>& allowedAdditionals
         if (target.isRoot()) {
           target = rec.d_name;
         }
-        allowedAdditionals.insert(target);
+        allowedAdditionals.insert(std::move(target));
       }
       else {
         // FIXME: Alias mode not implemented yet
@@ -4710,7 +4710,7 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, const string&
         tcache[{rec.d_name, rec.d_type, rec.d_place}].d_ttl_time = d_now.tv_sec;
         dnsRecord.d_ttl += d_now.tv_sec;
         dnsRecord.d_place = DNSResourceRecord::ANSWER;
-        tcache[{rec.d_name, rec.d_type, rec.d_place}].records.push_back(dnsRecord);
+        tcache[{rec.d_name, rec.d_type, rec.d_place}].records.push_back(std::move(dnsRecord));
       }
     }
     else

--- a/pdns/recursordist/validate-recursor.cc
+++ b/pdns/recursordist/validate-recursor.cc
@@ -65,7 +65,7 @@ bool updateTrustAnchorsFromFile(const std::string& fname, map<DNSName, dsset_t>&
           throw PDNSException("Unable to parse DNSKEY record '" + resourceRecord.qname.toString() + " " + resourceRecord.getZoneRepresentation() + "'");
         }
         auto dsr = makeDSFromDNSKey(resourceRecord.qname, *dnskeyr, DNSSECKeeper::DIGEST_SHA256);
-        newDSAnchors[resourceRecord.qname].insert(dsr);
+        newDSAnchors[resourceRecord.qname].insert(std::move(dsr));
       }
     }
     if (dsAnchors == newDSAnchors) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Couple of cases where a variable can be moved, spotted by the new version of Coverity. All Severity "Low". You'd expect a compiler to move an object in a few cases without help, but lets follow Coverity.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
