### PR TITLE
dnsdist: Fix missing LLD dependency in the Coverity workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -70,6 +70,7 @@ jobs:
           python-version: '3.11'
       - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
       - run: inv install-clang
+      - run: inv install-lld-linker-if-needed
       - run: inv install-dnsdist-build-deps --skipXDP
       - run: inv install-coverity-tools dnsdist
       - run: inv coverity-clang-configure


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since https://github.com/PowerDNS/pdns/pull/14969 we need LLD to be able to link against the DNSdist static Rust library and LTO enabled, as oldish linkers choke on that. This PR makes sure LLD is installed in the Coverity workflow.
I have tested that this PR properly installs LLD in the environment, I can't test the whole workflow because it requires secrets that are only available on the main PowerDNS repository.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
