### PR TITLE
dnsdist: Enable the new YAML configuration in our packages

### DIFF
--- a/builder-support/debian/dnsdist/debian-bookworm/control
+++ b/builder-support/debian/dnsdist/debian-bookworm/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: PowerDNS.COM BV <powerdns.support.sales@powerdns.com>
 Uploaders: PowerDNS.COM BV <powerdns.support.sales@powerdns.com>
 Build-Depends: debhelper (>= 10),
+               clang,
                libboost-all-dev,
                libbpf-dev [linux-any],
                libcap-dev,
@@ -22,6 +23,7 @@ Build-Depends: debhelper (>= 10),
                libsystemd-dev [linux-any],
                libwslay-dev,
                libxdp-dev [linux-any],
+               lld,
                pkg-config,
                python3-yaml,
                ragel,

--- a/builder-support/debian/dnsdist/debian-bookworm/control
+++ b/builder-support/debian/dnsdist/debian-bookworm/control
@@ -23,6 +23,7 @@ Build-Depends: debhelper (>= 10),
                libwslay-dev,
                libxdp-dev [linux-any],
                pkg-config,
+               python3-yaml,
                ragel,
                systemd [linux-any]
 Standards-Version: 4.1.5

--- a/builder-support/debian/dnsdist/debian-bookworm/rules
+++ b/builder-support/debian/dnsdist/debian-bookworm/rules
@@ -10,6 +10,12 @@ include /usr/share/dpkg/default.mk
 
 # for atomic support on powerpc (automatic on mipsel)
 LDFLAGS += -latomic
+# We need clang (LLVM) to link the Rust static library and the C++ code with LTO enabled
+# build-id SHA1 prevents an issue with the debug symbols
+# and the --no-as-needed -ldl an issue with the dlsym not being found
+LDFLAGS += -fuse-ld=lld -Wl,--build-id=sha1 -Wl,--no-as-needed -ldl
+CC=clang
+CXX=clang++
 
 # Only enable systemd integration on Linux operating systems
 ifeq ($(DEB_HOST_ARCH_OS),linux)

--- a/builder-support/debian/dnsdist/debian-bookworm/rules
+++ b/builder-support/debian/dnsdist/debian-bookworm/rules
@@ -59,6 +59,7 @@ override_dh_auto_configure:
 	  --enable-dns-over-tls \
 	  --enable-dnscrypt \
 	  --enable-dnstap \
+	  --enable-yaml \
 	  --with-ebpf \
 	  --with-gnutls \
 	  --with-h2o \

--- a/builder-support/debian/dnsdist/debian-bookworm/rules
+++ b/builder-support/debian/dnsdist/debian-bookworm/rules
@@ -11,8 +11,8 @@ include /usr/share/dpkg/default.mk
 # for atomic support on powerpc (automatic on mipsel)
 LDFLAGS += -latomic
 # We need clang (LLVM) to link the Rust static library and the C++ code with LTO enabled
-# build-id SHA1 prevents an issue with the debug symbols
-# and the --no-as-needed -ldl an issue with the dlsym not being found
+# build-id SHA1 prevents an issue with the debug symbols ("export: `-Wl,--build-id=sha1': not a valid identifier")
+# and the --no-as-needed -ldl an issue with the dlsym not being found ("ld.lld: error: undefined symbol: dlsym eferenced by weak.rs:142 (library/std/src/sys/pal/unix/weak.rs:142) [...] in archive ./dnsdist-rust-lib/rust/libdnsdist_rust.a)
 LDFLAGS += -fuse-ld=lld -Wl,--build-id=sha1 -Wl,--no-as-needed -ldl
 CC=clang
 CXX=clang++

--- a/builder-support/debian/dnsdist/debian-buster/control
+++ b/builder-support/debian/dnsdist/debian-buster/control
@@ -21,6 +21,7 @@ Build-Depends: debhelper (>= 10),
                libsystemd-dev [linux-any],
                libwslay-dev,
                pkg-config,
+               python3-yaml,
                ragel,
                systemd [linux-any]
 Standards-Version: 4.1.5

--- a/builder-support/debian/dnsdist/debian-buster/control
+++ b/builder-support/debian/dnsdist/debian-buster/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: PowerDNS.COM BV <powerdns.support.sales@powerdns.com>
 Uploaders: PowerDNS.COM BV <powerdns.support.sales@powerdns.com>
 Build-Depends: debhelper (>= 10),
+               clang,
                libboost-all-dev,
                libcap-dev,
                libcdb-dev,
@@ -20,6 +21,7 @@ Build-Depends: debhelper (>= 10),
                libssl-dev,
                libsystemd-dev [linux-any],
                libwslay-dev,
+               lld,
                pkg-config,
                python3-yaml,
                ragel,

--- a/builder-support/debian/dnsdist/debian-buster/rules
+++ b/builder-support/debian/dnsdist/debian-buster/rules
@@ -10,6 +10,12 @@ include /usr/share/dpkg/default.mk
 
 # for atomic support on powerpc (automatic on mipsel)
 LDFLAGS += -latomic
+# We need clang (LLVM) to link the Rust static library and the C++ code with LTO enabled
+# build-id SHA1 prevents an issue with the debug symbols
+# and the --no-as-needed -ldl an issue with the dlsym not being found
+LDFLAGS += -fuse-ld=lld -Wl,--build-id=sha1 -Wl,--no-as-needed -ldl
+CC=clang
+CXX=clang++
 
 # Only enable systemd integration on Linux operating systems
 ifeq ($(DEB_HOST_ARCH_OS),linux)

--- a/builder-support/debian/dnsdist/debian-buster/rules
+++ b/builder-support/debian/dnsdist/debian-buster/rules
@@ -52,6 +52,7 @@ override_dh_auto_configure:
 	  --enable-dns-over-tls \
 	  --enable-dnscrypt \
 	  --enable-dnstap \
+	  --enable-yaml \
 	  --with-ebpf \
 	  --with-gnutls \
 	  --with-h2o \

--- a/builder-support/debian/dnsdist/debian-buster/rules
+++ b/builder-support/debian/dnsdist/debian-buster/rules
@@ -11,8 +11,8 @@ include /usr/share/dpkg/default.mk
 # for atomic support on powerpc (automatic on mipsel)
 LDFLAGS += -latomic
 # We need clang (LLVM) to link the Rust static library and the C++ code with LTO enabled
-# build-id SHA1 prevents an issue with the debug symbols
-# and the --no-as-needed -ldl an issue with the dlsym not being found
+# build-id SHA1 prevents an issue with the debug symbols ("export: `-Wl,--build-id=sha1': not a valid identifier")
+# and the --no-as-needed -ldl an issue with the dlsym not being found ("ld.lld: error: undefined symbol: dlsym eferenced by weak.rs:142 (library/std/src/sys/pal/unix/weak.rs:142) [...] in archive ./dnsdist-rust-lib/rust/libdnsdist_rust.a)
 LDFLAGS += -fuse-ld=lld -Wl,--build-id=sha1 -Wl,--no-as-needed -ldl
 CC=clang
 CXX=clang++

--- a/builder-support/dockerfiles/Dockerfile.dnsdist
+++ b/builder-support/dockerfiles/Dockerfile.dnsdist
@@ -19,4 +19,3 @@ RUN /dnsdist/builder/helpers/set-configure-ac-version.sh && \
     ./configure --disable-dependency-tracking && \
     make dist
 RUN cp dnsdist-${BUILDER_VERSION}.tar.bz2 /sdist/
-

--- a/builder-support/dockerfiles/Dockerfile.dnsdist
+++ b/builder-support/dockerfiles/Dockerfile.dnsdist
@@ -2,7 +2,7 @@ FROM alpine:3.18 as dnsdist
 ARG BUILDER_CACHE_BUSTER=
 
 RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \
-                       libtool file boost-dev ragel python3 git libedit-dev bash
+                       libtool file boost-dev ragel python3 py3-yaml git libedit-dev bash
 
 ADD builder/helpers/set-configure-ac-version.sh /dnsdist/builder/helpers/
 ADD COPYING /dnsdist/

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -9,6 +9,7 @@ Source: %{name}-%{getenv:BUILDER_VERSION}.tar.bz2
 BuildRequires: readline-devel
 BuildRequires: libedit-devel
 BuildRequires: openssl-devel
+BuildRequires: python3-pyyaml
 
 %if 0%{?suse_version}
 BuildRequires: lua-devel
@@ -109,6 +110,7 @@ export RANLIB=gcc-ranlib
   --enable-dns-over-quic \
   --enable-dns-over-http3 \
   --with-quiche \
+  --enable-yaml \
 %endif
   PKG_CONFIG_PATH=/usr/lib/pkgconfig:/opt/lib64/pkgconfig
 %endif

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -81,8 +81,8 @@ export LDFLAGS=-L/usr/lib64/boost169
 # We need to build with LLVM/clang to be able to use LTO, since we are linking against a static Rust library built with LLVM
 export CC=clang
 export CXX=clang++
-# build-id SHA1 prevents an issue with the debug symbols
-# and the --no-as-needed -ldl an issue with the dlsym not being found
+# build-id SHA1 prevents an issue with the debug symbols ("export: `-Wl,--build-id=sha1': not a valid identifier")
+# and the --no-as-needed -ldl an issue with the dlsym not being found ("ld.lld: error: undefined symbol: dlsym eferenced by weak.rs:142 (library/std/src/sys/pal/unix/weak.rs:142) [...] in archive ./dnsdist-rust-lib/rust/libdnsdist_rust.a)
 export LDFLAGS="-fuse-ld=lld -Wl,--build-id=sha1 -Wl,--no-as-needed -ldl"
 %endif
 

--- a/pdns/dnsdistdist/test-dnsdistrules_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrules_cc.cc
@@ -6,6 +6,7 @@
 #define BOOST_TEST_NO_MAIN
 
 #include <thread>
+#include <variant>
 #include <boost/test/unit_test.hpp>
 
 #include "dnsdist-rules.hh"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR switches the compiler from G++ to clang++ to keep building with LTO, which is not possible with g++ now that we link against a Rust-based static library built with LLVM.

Note that it breaks on EL-7 (no python yaml package) and Debian Buster (linking issue related to std::filesystem I haven't investigated yet). We might get away with not supporting DNSdist 2.0+ on these.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

