### PR TITLE
GH Actions - build-docker-images.yaml: allow testing image building without credentials

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           platforms: ${{ inputs.platforms }}
       - name: Login to Docker Hub
+        if: ${{ inputs.push }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -94,7 +95,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}
+          images: ${{ secrets.DOCKERHUB_ORGANIZATION_NAME || 'powerdns' }}/${{ inputs.image-name }}
           tags: ${{ inputs.image-tags }}
       - name: Build and load powerdns product images
         id: build-image

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -33,10 +33,10 @@ ADD configure.ac Makefile.am /source/
 COPY builder/helpers/set-configure-ac-version.sh /usr/local/bin
 
 ARG MAKEFLAGS=
-ENV MAKEFLAGS ${MAKEFLAGS:--j2}
+ENV MAKEFLAGS=${MAKEFLAGS:--j2}
 
 ARG DOCKER_FAKE_RELEASE=NO
-ENV DOCKER_FAKE_RELEASE ${DOCKER_FAKE_RELEASE}
+ENV DOCKER_FAKE_RELEASE=${DOCKER_FAKE_RELEASE}
 
 RUN if [ "${DOCKER_FAKE_RELEASE}" = "YES" ]; then \
       BUILDER_VERSION="$(IS_RELEASE=YES BUILDER_MODULES=authoritative ./builder-support/gen-version | sed 's/\([0-9]\+\.[0-9]\+\.[0-9]\+\(\(alpha|beta|rc\)\d\+\)\)?.*/\1/')" set-configure-ac-version.sh;\

--- a/Dockerfile-dnsdist
+++ b/Dockerfile-dnsdist
@@ -28,10 +28,10 @@ COPY .git /source/.git
 WORKDIR /source/pdns/dnsdistdist
 
 ARG MAKEFLAGS=
-ENV MAKEFLAGS ${MAKEFLAGS:--j2}
+ENV MAKEFLAGS=${MAKEFLAGS:--j2}
 
 ARG DOCKER_FAKE_RELEASE=NO
-ENV DOCKER_FAKE_RELEASE ${DOCKER_FAKE_RELEASE}
+ENV DOCKER_FAKE_RELEASE=${DOCKER_FAKE_RELEASE}
 
 RUN touch dnsdist.1 # avoid having to install pandoc and venv
 

--- a/Dockerfile-recursor
+++ b/Dockerfile-recursor
@@ -36,10 +36,10 @@ RUN cd /source/ && ./install_rust.sh
 WORKDIR /source/pdns/recursordist
 
 ARG MAKEFLAGS=
-ENV MAKEFLAGS ${MAKEFLAGS:--j2}
+ENV MAKEFLAGS=${MAKEFLAGS:--j2}
 
 ARG DOCKER_FAKE_RELEASE=NO
-ENV DOCKER_FAKE_RELEASE ${DOCKER_FAKE_RELEASE}
+ENV DOCKER_FAKE_RELEASE=${DOCKER_FAKE_RELEASE}
 
 # Manpage deps
 # RUN apt-get install -y python3-venv && apt-get clean


### PR DESCRIPTION
### Short description
This PR allows not setting credentials when setting `push: false`. Useful for testing images.

Removes warning: `LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 39)`

Test: <https://github.com/romeroalx/pdns/actions/runs/12885369941>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
