### PR TITLE
Force various files to be skipped when generating git archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
 # https://github.com/github/linguist/blob/master/docs/overrides.md
 */zones/* linguist-language=DNS-Zone
+
+# not needed in `git archive` tarballs, only in raw git clones
+.gitattributes export-ignore
+.gitmodules export-ignore
+.gitignore export-ignore
+
+.github export-ignore
+.circleci export-ignore


### PR DESCRIPTION
Meson utilizes `git archive` as the first step in producing a release tarball. Certain files don't need to be distributed in release tarballs at all -- namely, files used by git itself, or by github when processing a git repository for e.g. CI purposes. They have no use case outside of a git repo -- not even as documentation.

Exclude these files from the tarball. This affects both `meson dist` and the github autogenerated tarballs on the Tags page. More work is needed to have `meson dist` reach parity with automake's `make distcheck`, but this is a start.