### PR TITLE
pdnsutil: check for key presence after import

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2899,6 +2899,26 @@ static int unpublishZoneKey(vector<string>& cmds)
   return 0;
 }
 
+static int checkZoneKey(DNSSECKeeper &dsk, DNSName &zone, int64_t keyId)
+{
+  if (keyId == -1) {
+    cerr<<std::to_string(keyId)<<": Key was added, but backend does not support returning of key id"<<endl;
+    return 0;
+  }
+  if (keyId < -1) {
+    cerr<<std::to_string(keyId)<<": Key was added, but there was a failure while returning the key id"<<endl;
+    return 1;
+  }
+  try {
+    dsk.getKeyById(zone, keyId);
+    cout<<std::to_string(keyId)<<endl;
+  } catch (std::exception& exc) {
+    cerr<<std::to_string(keyId)<<": Key was added, but there was a failure while reading it back: " <<exc.what()<<endl;
+    return 1;
+  }
+  return 0;
+}
+
 static int addZoneKey(vector<string>& cmds)
 {
   if(cmds.size() < 3 ) {
@@ -2971,21 +2991,7 @@ static int addZoneKey(vector<string>& cmds)
   if (bits != 0) {
     cerr<<"Requested specific key size of "<<bits<<" bits"<<endl;
   }
-  if (id == -1) {
-    cerr<<std::to_string(id)<<": Key was added, but backend does not support returning of key id"<<endl;
-  } else if (id < -1) {
-    cerr<<std::to_string(id)<<": Key was added, but there was a failure while returning the key id"<<endl;
-    return 1;
-  } else {
-    try {
-      dk.getKeyById(zone, id);
-      cout<<std::to_string(id)<<endl;
-    } catch (std::exception& e) {
-      cerr<<std::to_string(id)<<": Key was added, but there was a failure while reading it back: " <<e.what()<<endl;
-      return 1;
-    }
-  }
-  return 0;
+  return checkZoneKey(dk, zone, id);
 }
 
 static int removeZoneKey(vector<string>& cmds)
@@ -3567,7 +3573,7 @@ static int importZoneKeyPEM(vector<string>& cmds)
     return 1;
   }
 
-  const string zone = cmds.at(1);
+  DNSName zone(cmds.at(1));
   const string filename = cmds.at(2);
   const auto algorithm = pdns::checked_stoi<unsigned int>(cmds.at(3));
 
@@ -3615,21 +3621,11 @@ static int importZoneKeyPEM(vector<string>& cmds)
 
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   int64_t id{-1}; // NOLINT(readability-identifier-length)
-  if (!dk.addKey(DNSName(zone), dpk, id)) {
+  if (!dk.addKey(zone, dpk, id)) {
     cerr << "Adding key failed, perhaps DNSSEC not enabled in configuration?" << endl;
     return 1;
   }
-
-  if (id == -1) {
-    cerr << std::to_string(id) << "Key was added, but backend does not support returning of key id" << endl;
-    }
-  else if (id < -1) {
-    cerr << std::to_string(id) << "Key was added, but there was a failure while returning the key id" << endl;
-  }
-  else {
-    cout << std::to_string(id) << endl;
-  }
-  return 0;
+  return checkZoneKey(dk, zone, id);
 }
 
 static int importZoneKey(vector<string>& cmds)
@@ -3638,7 +3634,7 @@ static int importZoneKey(vector<string>& cmds)
     cerr<<"Syntax: pdnsutil import-zone-key ZONE FILE [ksk|zsk] [active|inactive]"<<endl;
     return 1;
   }
-  string zone = cmds.at(1);
+  DNSName zone(cmds.at(1));
   string fname = cmds.at(2);
   DNSKEYRecordContent drc;
   shared_ptr<DNSCryptoKeyEngine> key(DNSCryptoKeyEngine::makeFromISCFile(drc, fname.c_str()));
@@ -3681,18 +3677,11 @@ static int importZoneKey(vector<string>& cmds)
 
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   int64_t id{-1}; // NOLINT(readability-identifier-length)
-  if (!dk.addKey(DNSName(zone), dpk, id, active, published)) {
+  if (!dk.addKey(zone, dpk, id, active, published)) {
     cerr<<"Adding key failed, perhaps DNSSEC not enabled in configuration?"<<endl;
     return 1;
   }
-  if (id == -1) {
-    cerr<<std::to_string(id)<<"Key was added, but backend does not support returning of key id"<<endl;
-  } else if (id < -1) {
-    cerr<<std::to_string(id)<<"Key was added, but there was a failure while returning the key id"<<endl;
-  } else {
-    cout<<std::to_string(id)<<endl;
-  }
-  return 0;
+  return checkZoneKey(dk, zone, id);
 }
 
 static int expotZoneDNSKey(vector<string>& cmds)


### PR DESCRIPTION
### Short description
This applies the same "fetch key after add" verification logic, added to `pdnsutil` `add-zone-key` command recently, to the `import-zone-key` and `import-zone-key-pem` commands.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document although not recently
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code (somehow)
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
