### PR TITLE
Boring minor cleanups

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -580,7 +580,7 @@ set, DNSKEY, CDS and CDNSKEY records in the zonefiles are ignored.
 .. _setting-direct-dnskey-signature:
 
 ``direct-dnskey-signature``
------------------
+---------------------------
 
 -  Boolean
 -  Default: no


### PR DESCRIPTION
### Short description
This innocent-looking PR attempts to clean a few minor things:
- address documentation build warnings 
- ~~address code build warnings when building the authoritative server by moving `static` code within the `#ifdef ... #endif` blocks which is its only user.~~ <-- fixed in the meantime by other changes

There is no guarantee you won't fall asleep out of boredom while looking at it.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code (really)
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] warned reviewers about the soporific nature of this PR