### PR TITLE
auth-4.7, check return value of getCatalogMembers()

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -789,7 +789,12 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
     zrrs.emplace_back(CatalogInfo::getCatalogVersionRecord(target));
 
     vector<CatalogInfo> members;
-    sd.db->getCatalogMembers(target, members, CatalogInfo::CatalogType::Producer);
+    if (!sd.db->getCatalogMembers(target, members, CatalogInfo::CatalogType::Producer)) {
+      g_log << Logger::Error << logPrefix << "getting catalog members failed, aborting AXFR" << endl;
+      outpacket->setRcode(RCode::ServFail);
+      sendPacket(outpacket, outsock);
+      return 0;
+    }
     for (const auto& ci : members) {
       ci.toDNSZoneRecords(target, zrrs);
     }


### PR DESCRIPTION
### Short description

backport of #15093 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] checked that this code was merged to master
