### PR TITLE
Replace dnsutils with bind9-dnsutils

### DIFF
--- a/build-scripts/docker/repo-test/templates/Dockerfile-debian.jinja2
+++ b/build-scripts/docker/repo-test/templates/Dockerfile-debian.jinja2
@@ -1,6 +1,6 @@
 FROM {{ os_image }}:{{ os_version }}
 
-RUN apt-get update && apt-get install -y curl gnupg dnsutils apt-transport-https
+RUN apt-get update && apt-get install -y curl gnupg bind9-dnsutils apt-transport-https
 
 {% if release.startswith('dnsdist-') %}
 COPY pkg-pin /etc/apt/preferences.d/dnsdist

--- a/builder-support/debian/authoritative/debian-buster/control
+++ b/builder-support/debian/authoritative/debian-buster/control
@@ -3,11 +3,11 @@ Section: net
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Priority: optional
 Standards-Version: 4.5.1
-Build-Depends: bison,
+Build-Depends: bind9-dnsutils | dnsutils,
+               bison,
                curl,
                debhelper-compat (= 10),
                default-libmysqlclient-dev,
-               dnsutils,
                flex,
                libboost-all-dev,
                libcdb-dev,

--- a/builder-support/debian/recursor/debian-buster/tests/control
+++ b/builder-support/debian/recursor/debian-buster/tests/control
@@ -1,4 +1,4 @@
 Tests: smoke
-Depends: dnsutils,
+Depends: bind9-dnsutils,
          @
 Restrictions: needs-root

--- a/tasks.py
+++ b/tasks.py
@@ -60,7 +60,7 @@ rec_build_deps = [
 ]
 rec_bulk_deps = [
     'curl',
-    'dnsutils',
+    'bind9-dnsutils',
     'libboost-all-dev',
     'libcap2',
     'libfstrm0',
@@ -74,7 +74,7 @@ rec_bulk_deps = [
 ]
 rec_bulk_ubicloud_deps = [
     'curl',
-    'dnsutils',
+    'bind9-dnsutils',
     'libboost-context1.74.0',
     'libboost-system1.74.0',
     'libboost-filesystem1.74.0',
@@ -110,7 +110,7 @@ auth_test_deps = [   # FIXME: we should be generating some of these from shlibde
     'bind9utils',
     'curl',
     'default-jre-headless',
-    'dnsutils',
+    'bind9-dnsutils',
     'faketime',
     'gawk',
     'krb5-user',


### PR DESCRIPTION
### Short description
bind9-dnsutils exists starting in Debian bullseye, and dnsutils stopped existing in trixie.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
