### PR TITLE
Let pdnsutil warn when creating local files

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <vector>
 #include <algorithm>
+#include <atomic>
 #include <arpa/inet.h>
 
 #ifndef DNSDIST
@@ -56,6 +57,9 @@ public:
   }
 
   MDB_dbi d_dbi;
+
+  static int mdb_dbi_open(MDB_txn *, const char *, unsigned int, MDB_dbi *);
+  static std::atomic<unsigned int> d_creationCount;
 };
 
 class MDBRWTransactionImpl;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -150,6 +150,8 @@ public:
   // other
   string directBackendCmd(const string& query) override;
 
+  bool hasCreatedLocalFiles() const override;
+
   // functions to use without constructing a backend object
   static std::pair<uint32_t, uint32_t> getSchemaVersionAndShards(std::string& filename);
   static bool upgradeToSchemav5(std::string& filename);

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -465,6 +465,12 @@ public:
     return false;
   }
 
+  //! Returns whether backend operations have caused files to be created.
+  virtual bool hasCreatedLocalFiles() const
+  {
+    return false;
+  }
+
   const string& getPrefix() { return d_prefix; };
 
 protected:

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -886,6 +886,11 @@ bool UeberBackend::searchComments(const string& pattern, size_t maxResults, vect
   return ret;
 }
 
+bool UeberBackend::hasCreatedLocalFiles()
+{
+  return std::any_of(backends.begin(), backends.end(), [](std::unique_ptr<DNSBackend>& backend) { return backend->hasCreatedLocalFiles(); });
+}
+
 AtomicCounter UeberBackend::handle::instances(0);
 
 UeberBackend::handle::handle()

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -141,6 +141,8 @@ public:
 
   bool inTransaction();
 
+  bool hasCreatedLocalFiles();
+
 private:
   handle d_handle;
   vector<DNSZoneRecord> d_answers;

--- a/regression-tests.nobackend/lmdb-id-generation/expected_result
+++ b/regression-tests.nobackend/lmdb-id-generation/expected_result
@@ -1,2 +1,8 @@
+WARNING: local files have been created as a result of this operation.
+Be sure to check the files owner, group and permission to make sure that
+the authoritative server can correctly use them.
 sequential generator generated 1 2 3 correctly
+WARNING: local files have been created as a result of this operation.
+Be sure to check the files owner, group and permission to make sure that
+the authoritative server can correctly use them.
 random generator generated something other than 1 2 3, good

--- a/regression-tests.nobackend/lmdb-metadata-leak/expected_result
+++ b/regression-tests.nobackend/lmdb-metadata-leak/expected_result
@@ -1,5 +1,8 @@
 === random=no
 == creating zone
+WARNING: local files have been created as a result of this operation.
+Be sure to check the files owner, group and permission to make sure that
+the authoritative server can correctly use them.
 Set 'example.com' meta FOO = BAR
 	FOO	BAR
 FOO
@@ -16,6 +19,9 @@ FOO2
 == deleting zone
 === random=yes
 == creating zone
+WARNING: local files have been created as a result of this operation.
+Be sure to check the files owner, group and permission to make sure that
+the authoritative server can correctly use them.
 Set 'example.com' meta FOO = BAR
 	FOO	BAR
 FOO

--- a/regression-tests.nobackend/lmdb-schema-upgrade/expected_result
+++ b/regression-tests.nobackend/lmdb-schema-upgrade/expected_result
@@ -20152,6 +20152,9 @@ usa-ns2.usa.example.com	120	IN	A	192.168.4.2
 *.w4.example.com	120	IN	CNAME	x.y.z.w5.example.com.
 *.w5.example.com	120	IN	A	1.2.3.5
 www.example.com	120	IN	CNAME	outpost.example.com.
+WARNING: local files have been created as a result of this operation.
+Be sure to check the files owner, group and permission to make sure that
+the authoritative server can correctly use them.
 $ORIGIN .
 test.com	3600	IN	NS	ns1.test.com.
 test.com	3600	IN	NS	ns2.test.com.
@@ -40473,6 +40476,9 @@ usa-ns2.usa.example.com	120	IN	A	192.168.4.2
 *.w4.example.com	120	IN	CNAME	x.y.z.w5.example.com.
 *.w5.example.com	120	IN	A	1.2.3.5
 www.example.com	120	IN	CNAME	outpost.example.com.
+WARNING: local files have been created as a result of this operation.
+Be sure to check the files owner, group and permission to make sure that
+the authoritative server can correctly use them.
 $ORIGIN .
 test.com	3600	IN	NS	ns1.test.com.
 test.com	3600	IN	NS	ns2.test.com.


### PR DESCRIPTION
### Short description
As mentioned in issue #11060, if the use of `pdnsutil` causes local files to be created, one must be aware of this in order to make sure that the `pdns_server` process, which is likely to run with different credentials, can make use of these files.

A first version of this work would only display the message if `pdns.conf` contained `setuid` or `setgid` settings, but since not all setups use this (depending on the init system or other shenanigans), it is probably better to always warn.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
