### PR TITLE
dnsdist: Enable XSK in our Noble and Oracular Ubuntu packages

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-noble
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-noble
@@ -20,7 +20,7 @@ ADD builder-support/debian/recursor/debian-buster/ pdns-recursor-${BUILDER_VERSI
 @ENDIF
 
 @IF [ -n "$M_dnsdist$M_all" ]
-ADD builder-support/debian/dnsdist/debian-buster/ dnsdist-${BUILDER_VERSION}/debian/
+ADD builder-support/debian/dnsdist/debian-bookworm/ dnsdist-${BUILDER_VERSION}/debian/
 @ENDIF
 
 @INCLUDE Dockerfile.debbuild

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-oracular
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-oracular
@@ -20,7 +20,7 @@ ADD builder-support/debian/recursor/debian-buster/ pdns-recursor-${BUILDER_VERSI
 @ENDIF
 
 @IF [ -n "$M_dnsdist$M_all" ]
-ADD builder-support/debian/dnsdist/debian-buster/ dnsdist-${BUILDER_VERSION}/debian/
+ADD builder-support/debian/dnsdist/debian-bookworm/ dnsdist-${BUILDER_VERSION}/debian/
 @ENDIF
 
 @INCLUDE Dockerfile.debbuild


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It turns out that `libbpf-dev` and `libxdp-dev` are there in the end. Note that you need https://github.com/PowerDNS/pdns/pull/15065 to test this PR correctly, otherwise it breaks.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
