### PR TITLE
dnsdist: Better handling of out-of-tree builds

### DIFF
--- a/pdns/dnsdistdist/.gitignore
+++ b/pdns/dnsdistdist/.gitignore
@@ -35,6 +35,7 @@
 /testrunner
 /dnsdist
 /fuzz_target_dnsdistcache
+/fuzz_target_xsk
 /*.pb.cc
 /*.pb.h
 /dnsdist.service

--- a/pdns/dnsdistdist/dnsdist-rust-lib/Makefile.am
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/Makefile.am
@@ -17,5 +17,5 @@ rust/src/lib.rs dnsdist-configuration-yaml-items-generated.cc: dnsdist-settings-
 	@if test "$(PYTHON)" = ":"; then echo "Settings definitions have changed, python is needed to regenerate the related settings files but python was not found. Please install python and re-run configure"; exit 1; fi
 	@if ! $(PYTHON) --version | grep -q "Python 3"; then echo $(PYTHON) should be at least version 3. Please install python 3 and re-run configure; exit 1; fi
 	$(MAKE) -C rust clean
-	(cd ${srcdir} && $(PYTHON) dnsdist-settings-generator.py ../dnsdist-settings-definitions.yml ./)
+	(cd ${srcdir} && $(PYTHON) dnsdist-settings-generator.py ../ ./ ../)
 	$(PYTHON) dnsdist-settings-documentation-generator.py

--- a/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
@@ -16,7 +16,7 @@ generated = [
 python = find_program('python3')
 
 rust_lib_sources = custom_target(
-  command: [python, '@INPUT0@', '@INPUT1@', '@SOURCE_ROOT@/dnsdist-rust-lib', '@BUILD_ROOT@/dnsdist-rust-lib'],
+  command: [python, '@INPUT0@', '@SOURCE_ROOT@', '@SOURCE_ROOT@/dnsdist-rust-lib', '@BUILD_ROOT@'],
   input: sources,
   output: generated,
 )

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -552,6 +552,10 @@ foreach tool, info: tools
   endif
 endforeach
 
+if get_option('unit-tests')
+  test('testrunner', testrunner)
+endif
+
 # Man-pages.
 py = import('python')
 python = py.find_installation('python3', modules: 'venv', required: false)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Our Python script to generate actions, selectors and settings from the YAML definitions of these items was making too many assumptions about the current working directory, which is just wrong outside of  the autotools world.
This PR also add our unit tests to `meson test`, and add the XSK fuzzing target to `.gitignore`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
