### PR TITLE
rec: create service unit files when building using meson

### DIFF
--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -595,7 +595,7 @@ if dep_systemd.found()
   summary('Service Group', systemd_service_group, section: 'Systemd')
 
   # ProtectSystem=full will disallow write access to /etc and /usr, possibly not being
-  # able to write slaved-zones into sqlite3 or zonefiles.
+  # able to write RPZ dumps or API related files.
   systemd_service_conf.set(
     'ProtectSystem', have_systemd_protect_system ? 'ProtectSystem=full' : '',
   )

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -582,3 +582,99 @@ if python.found()
     ] + man_pages,
   )
 endif
+
+if dep_systemd.found()
+  systemd_service_conf = configuration_data()
+  systemd_service_conf.set('BinDir', get_option('prefix') / get_option('bindir'))
+  systemd_service_conf.set('StaticBinDir', get_option('prefix') / get_option('sbindir'))
+  systemd_service_user = get_option('systemd-service-user')
+  systemd_service_group = get_option('systemd-service-group')
+  systemd_service_conf.set('ServiceUser', systemd_service_user)
+  systemd_service_conf.set('ServiceGroup', systemd_service_group)
+  summary('Service User', systemd_service_user, section: 'Systemd')
+  summary('Service Group', systemd_service_group, section: 'Systemd')
+
+  # ProtectSystem=full will disallow write access to /etc and /usr, possibly not being
+  # able to write slaved-zones into sqlite3 or zonefiles.
+  systemd_service_conf.set(
+    'ProtectSystem', have_systemd_protect_system ? 'ProtectSystem=full' : '',
+  )
+  systemd_service_conf.set(
+    'SystemCallArchitectures',
+    have_systemd_system_call_architectures ? 'SystemCallArchitectures=native' : '',
+  )
+  systemd_system_call_filter = '~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete'
+  systemd_service_conf.set(
+    'SystemCallFilter',
+    have_systemd_system_call_filter ? 'SystemCallFilter=' + systemd_system_call_filter : '',
+  )
+  systemd_service_conf.set(
+    'ProtectProc',
+    have_systemd_protect_proc ? 'ProtectProc=invisible' : '',
+  )
+
+  systemd_features = {
+    'LockPersonality': have_systemd_lock_personality,
+    'PrivateDevices': have_systemd_private_devices,
+    'PrivateTmp': have_systemd_private_tmp,
+    'PrivateUsers': false, # Setting it to true prevents us from opening our sockets.
+    'ProtectClock': have_systemd_protect_clock,
+    'ProtectControlGroups': have_systemd_protect_control_groups,
+    'ProtectHome': have_systemd_protect_home,
+    'ProtectHostname': have_systemd_protect_hostname,
+    'ProtectKernelLogs': have_systemd_protect_kernel_logs,
+    'ProtectKernelModules': have_systemd_protect_kernel_modules,
+    'ProtectKernelTunables': have_systemd_protect_kernel_tunables,
+    'RestrictNamespaces': have_systemd_restrict_namespaces,
+    'RestrictRealtime': have_systemd_restrict_realtime,
+    'RestrictSUIDSGID': have_systemd_restrict_suidsgid,
+    'PrivateIPC': have_systemd_private_ipc,
+    'RemoveIPC': have_systemd_remove_ipc,
+  }
+
+  foreach feature, enable_it: systemd_features
+    systemd_service_conf.set(feature, enable_it ? feature + '=true': '')
+  endforeach
+
+  rec_service_conf = configuration_data()
+  rec_service_conf.merge_from(systemd_service_conf)
+  # Disabled, it breaks LuaJIT.
+  rec_service_conf.set(
+    'MemoryDenyWriteExecute',
+    have_systemd_memory_deny_write_execute ? 'MemoryDenyWriteExecute=false' : '',
+  )
+  rec_service_conf.set(
+    'RestrictAddressFamilies',
+    have_systemd_restrict_address_families ? 'RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6' : '',
+  )
+
+  enable_socket_dir = (not have_systemd_with_runtime_dir_env) and have_systemd_percent_t
+
+  rec_service_conf_general = configuration_data()
+  rec_service_conf_general.merge_from(rec_service_conf)
+  rec_service_conf_general.set('Description', 'PowerDNS Recursor')
+  rec_service_conf_general.set('ConfigName', '')
+  rec_service_conf_general.set('SocketDir', enable_socket_dir ? '--socket-dir=%t/pdns-recursor' : '')
+  rec_service_conf_general.set('SyslogIdentifier', 'pdns-recursor')
+  rec_service_conf_general.set('RuntimeDirectory', 'pdns-recursor')
+
+  configure_file(
+    input: 'pdns-recursor.service.meson.in',
+    output: 'pdns-recursor.service',
+    configuration: rec_service_conf_general,
+  )
+
+  rec_service_conf_instance = configuration_data()
+  rec_service_conf_instance.merge_from(rec_service_conf)
+  rec_service_conf_instance.set('Description', 'PowerDNS Recursor %i')
+  rec_service_conf_instance.set('ConfigName', '--config-name=%i')
+  rec_service_conf_instance.set('SocketDir', enable_socket_dir ? '--socket-dir=%t/pdns-recursor-%i' : '')
+  rec_service_conf_instance.set('SyslogIdentifier', 'pdns-recursor-%i')
+  rec_service_conf_instance.set('RuntimeDirectory', have_systemd_percent_t ? 'pdns-recursor-%i' : 'pdns-recursor')
+
+  configure_file(
+    input: 'pdns-recursor.service.meson.in',
+    output: 'pdns-recursor@.service',
+    configuration: rec_service_conf_instance,
+  )
+endif

--- a/pdns/recursordist/pdns-recursor.service.meson.in
+++ b/pdns/recursordist/pdns-recursor.service.meson.in
@@ -1,0 +1,52 @@
+[Unit]
+Description=@Description@
+Documentation=man:pdns_recursor(1)
+Documentation=man:rec_control(1)
+Documentation=https://doc.powerdns.com
+Wants=network-online.target
+After=network-online.target time-sync.target
+
+[Service]
+ExecStart=@StaticBinDir@/pdns_recursor @ConfigName@ @SocketDir@ --daemon=no --write-pid=no --disable-syslog --log-timestamp=no
+User=@ServiceUser@
+Group=@ServiceGroup@
+Type=notify
+Restart=on-failure
+StartLimitInterval=0
+RuntimeDirectory=@RuntimeDirectory@
+SyslogIdentifier=@SyslogIdentifier@
+
+# Tuning
+LimitNOFILE=16384
+
+# Sandboxing
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_CHOWN
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_CHOWN
+@LockPersonality@
+NoNewPrivileges=true
+@PrivateDevices@
+@PrivateTmp@
+# Setting PrivateUsers=true prevents us from opening our sockets
+@ProtectClock@
+@ProtectControlGroups@
+@ProtectHome@
+@ProtectHostname@
+@ProtectKernelLogs@
+@ProtectKernelModules@
+@ProtectKernelTunables@
+@ProtectSystem@
+@RestrictAddressFamilies@
+@RestrictNamespaces@
+@RestrictRealtime@
+@RestrictSUIDSGID@
+@SystemCallArchitectures@
+@SystemCallFilter@
+@ProtectProc@
+@PrivateIPC@
+@RemoveIPC@
+DevicePolicy=closed
+# Not enabled by default because it does not play well with LuaJIT
+@MemoryDenyWriteExecute@
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Stolen from auth mostly.
Fixes #15116

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master

Diff between autotools and meson:

```
--- pdns-recursor.service	2025-02-04 15:14:44.839361699 +0100
+++ build/pdns-recursor.service	2025-02-04 16:29:17.886166778 +0100
@@ -1,12 +1,13 @@
 [Unit]
 Description=PowerDNS Recursor
-Documentation=man:pdns_recursor(1) man:rec_control(1)
+Documentation=man:pdns_recursor(1)
+Documentation=man:rec_control(1)
 Documentation=https://doc.powerdns.com
 Wants=network-online.target
 After=network-online.target time-sync.target
 
 [Service]
-ExecStart=/usr/local/sbin/pdns_recursor --daemon=no --write-pid=no --disable-syslog --log-timestamp=no
+ExecStart=/usr/local/sbin/pdns_recursor   --daemon=no --write-pid=no --disable-syslog --log-timestamp=no
 User=pdns
 Group=pdns
 Type=notify
@@ -45,7 +46,7 @@
 RemoveIPC=true
 DevicePolicy=closed
 # Not enabled by default because it does not play well with LuaJIT
-# MemoryDenyWriteExecute=true
+MemoryDenyWriteExecute=false
 
 [Install]
 WantedBy=multi-user.target
```
and
```
--- pdns-recursor@.service	2025-02-04 15:15:09.019383814 +0100
+++ build/pdns-recursor@.service	2025-02-04 16:29:17.890166782 +0100
@@ -1,12 +1,13 @@
 [Unit]
 Description=PowerDNS Recursor %i
-Documentation=man:pdns_recursor(1) man:rec_control(1)
+Documentation=man:pdns_recursor(1)
+Documentation=man:rec_control(1)
 Documentation=https://doc.powerdns.com
 Wants=network-online.target
 After=network-online.target time-sync.target
 
 [Service]
-ExecStart=/usr/local/sbin/pdns_recursor --config-name=%i --daemon=no --write-pid=no --disable-syslog --log-timestamp=no
+ExecStart=/usr/local/sbin/pdns_recursor --config-name=%i  --daemon=no --write-pid=no --disable-syslog --log-timestamp=no
 User=pdns
 Group=pdns
 Type=notify
@@ -45,7 +46,7 @@
 RemoveIPC=true
 DevicePolicy=closed
 # Not enabled by default because it does not play well with LuaJIT
-# MemoryDenyWriteExecute=true
+MemoryDenyWriteExecute=false
 
 [Install]
 WantedBy=multi-user.target
```