### PR TITLE
dnsdist: add pooling support for `RemoteLoggerInterface`

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -287,6 +287,7 @@ dnsdist_SOURCES = \
 	proxy-protocol.cc proxy-protocol.hh \
 	qtype.cc qtype.hh \
 	remote_logger.cc remote_logger.hh \
+	remote_logger_pool.cc remote_loggerpool.hh \
 	sholder.hh \
 	snmp-agent.cc snmp-agent.hh \
 	sstuff.hh \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -287,7 +287,7 @@ dnsdist_SOURCES = \
 	proxy-protocol.cc proxy-protocol.hh \
 	qtype.cc qtype.hh \
 	remote_logger.cc remote_logger.hh \
-	remote_logger_pool.cc remote_loggerpool.hh \
+	remote_logger_pool.cc remote_logger_pool.hh \
 	sholder.hh \
 	snmp-agent.cc snmp-agent.hh \
 	sstuff.hh \

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1435,9 +1435,12 @@ std::shared_ptr<DNSActionWrapper> getDnstapLogAction(const DnstapLogActionConfig
   if (!logger && !(dnsdist::configuration::yaml::s_inClientMode || dnsdist::configuration::yaml::s_inConfigCheckMode)) {
     throw std::runtime_error("Unable to find the dnstap logger named '" + std::string(config.logger_name) + "'");
   }
+  boost::optional<dnsdist::actions::DnstapAlterFunction> alterFuncHolder;
   dnsdist::actions::DnstapAlterFunction alterFunc;
-  dnsdist::configuration::yaml::getLuaFunctionFromConfiguration(alterFunc, config.alter_function_name, config.alter_function_code, config.alter_function_file, "dnstap log action");
-  auto action = dnsdist::actions::getDnstapLogAction(std::string(config.identity), std::move(logger), std::move(alterFunc));
+  if (dnsdist::configuration::yaml::getLuaFunctionFromConfiguration(alterFunc, config.alter_function_name, config.alter_function_code, config.alter_function_file, "dnstap log action")) {
+    alterFuncHolder = std::move(alterFunc);
+  }
+  auto action = dnsdist::actions::getDnstapLogAction(std::string(config.identity), std::move(logger), alterFuncHolder ? std::move(*alterFuncHolder) : std::optional<dnsdist::actions::DnstapAlterFunction>());
   return newDNSActionWrapper(std::move(action), config.name);
 #endif
 }
@@ -1451,9 +1454,12 @@ std::shared_ptr<DNSResponseActionWrapper> getDnstapLogResponseAction(const Dnsta
   if (!logger && !(dnsdist::configuration::yaml::s_inClientMode || dnsdist::configuration::yaml::s_inConfigCheckMode)) {
     throw std::runtime_error("Unable to find the dnstap logger named '" + std::string(config.logger_name) + "'");
   }
+  boost::optional<dnsdist::actions::DnstapAlterResponseFunction> alterFuncHolder;
   dnsdist::actions::DnstapAlterResponseFunction alterFunc;
-  dnsdist::configuration::yaml::getLuaFunctionFromConfiguration(alterFunc, config.alter_function_name, config.alter_function_code, config.alter_function_file, "dnstap log response action");
-  auto action = dnsdist::actions::getDnstapLogResponseAction(std::string(config.identity), std::move(logger), std::move(alterFunc));
+  if (dnsdist::configuration::yaml::getLuaFunctionFromConfiguration(alterFunc, config.alter_function_name, config.alter_function_code, config.alter_function_file, "dnstap log response action")) {
+    alterFuncHolder = std::move(alterFunc);
+  }
+  auto action = dnsdist::actions::getDnstapLogResponseAction(std::string(config.identity), std::move(logger), alterFuncHolder ? std::move(*alterFuncHolder) : std::optional<dnsdist::actions::DnstapAlterResponseFunction>());
   return newDNSResponseActionWrapper(std::move(action), config.name);
 #endif
 }

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -63,7 +63,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
 #endif /* HAVE_IPCIPHER */
 
   /* ProtobufMessage */
-  pick luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(std::string)>("setTag", [](DNSDistProtoBufMessage& message, const std::string& strValue) {
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(std::string)>("setTag", [](DNSDistProtoBufMessage& message, const std::string& strValue) {
     message.addTag(strValue);
   });
   luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(LuaArray<std::string>)>("setTagArray", [](DNSDistProtoBufMessage& message, const LuaArray<std::string>& tags) {

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -149,7 +149,9 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
     checkAllParametersConsumed("newFrameStreamUnixLogger", params);
     auto connectionCount = options.find("connectionCount");
     auto count = connectionCount == options.end() ? 1 : connectionCount->second;
-    options.erase(connectionCount);
+    if (connectionCount != options.end()) {
+      options.erase(connectionCount);
+    }
     if (count > 1) {
       std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
       loggers.reserve(count);
@@ -176,7 +178,9 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
     checkAllParametersConsumed("newFrameStreamTcpLogger", params);
     auto connectionCount = options.find("connectionCount");
     auto count = connectionCount == options.end() ? 1 : connectionCount->second;
-    options.erase(connectionCount);
+    if (connectionCount != options.end()) {
+      options.erase(connectionCount);
+    }
     if (count > 1) {
       std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
       loggers.reserve(count);

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -147,7 +147,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
 
       LuaAssociativeTable<unsigned int> options;
       parseFSTRMOptions(params, options);
-      checkAllParametersConsumed("newRemoteLogger", params);
+      checkAllParametersConsumed("newFrameStreamUnixLogger", params);
       auto connectionCount = options.find("connectionCount");
       auto count = connectionCount == options.end() ? 1 : connectionCount->second;
       options.erase(connectionCount);

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -128,6 +128,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
     auto count = connectionCount ? *connectionCount : 1;
     if (count > 1) {
       std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
+      loggers.reserve(count);
       for (uint64_t i = 0; i < count; i++) {
         loggers.push_back(std::make_shared<RemoteLogger>(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client));
       }
@@ -151,6 +152,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
     options.erase(connectionCount);
     if (count > 1) {
       std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
+      loggers.reserve(count);
       for (uint64_t i = 0; i < count; i++) {
         loggers.push_back(std::make_shared<FrameStreamLogger>(AF_UNIX, address, !client, options));
       }
@@ -159,7 +161,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
 
     return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_UNIX, address, !client, options));
 #else
-      throw std::runtime_error("fstrm support is required to build an AF_UNIX FrameStreamLogger");
+    throw std::runtime_error("fstrm support is required to build an AF_UNIX FrameStreamLogger");
 #endif /* HAVE_FSTRM */
   });
 
@@ -177,6 +179,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
     options.erase(connectionCount);
     if (count > 1) {
       std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
+      loggers.reserve(count);
       for (uint64_t i = 0; i < count; i++) {
         loggers.push_back(std::make_shared<FrameStreamLogger>(AF_INET, address, !client, options));
       }
@@ -185,7 +188,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
 
     return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_INET, address, !client, options));
 #else
-      throw std::runtime_error("fstrm with TCP support is required to build an AF_INET FrameStreamLogger");
+    throw std::runtime_error("fstrm with TCP support is required to build an AF_INET FrameStreamLogger");
 #endif /* HAVE_FSTRM */
   });
 

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -39,7 +39,7 @@ static void parseFSTRMOptions(boost::optional<LuaAssociativeTable<unsigned int>>
     return;
   }
 
-  static std::vector<std::string> const potentialOptions = { "bufferHint", "flushTimeout", "inputQueueSize", "outputQueueSize", "queueNotifyThreshold", "reopenInterval", "connectionCount" };
+  static std::vector<std::string> const potentialOptions = {"bufferHint", "flushTimeout", "inputQueueSize", "outputQueueSize", "queueNotifyThreshold", "reopenInterval", "connectionCount"};
 
   for (const auto& potentialOption : potentialOptions) {
     getOptionalValue<unsigned int>(params, potentialOption, options[potentialOption]);
@@ -50,20 +50,20 @@ static void parseFSTRMOptions(boost::optional<LuaAssociativeTable<unsigned int>>
 void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
 {
 #ifdef HAVE_IPCIPHER
-  luaCtx.registerFunction<ComboAddress(ComboAddress::*)(const std::string& key)const>("ipencrypt", [](const ComboAddress& ca, const std::string& key) {
-      return encryptCA(ca, key);
-    });
-  luaCtx.registerFunction<ComboAddress(ComboAddress::*)(const std::string& key)const>("ipdecrypt", [](const ComboAddress& ca, const std::string& key) {
-      return decryptCA(ca, key);
-    });
+  luaCtx.registerFunction<ComboAddress (ComboAddress::*)(const std::string& key) const>("ipencrypt", [](const ComboAddress& ca, const std::string& key) {
+    return encryptCA(ca, key);
+  });
+  luaCtx.registerFunction<ComboAddress (ComboAddress::*)(const std::string& key) const>("ipdecrypt", [](const ComboAddress& ca, const std::string& key) {
+    return decryptCA(ca, key);
+  });
 
   luaCtx.writeFunction("makeIPCipherKey", [](const std::string& password) {
-      return makeIPCipherKey(password);
-    });
+    return makeIPCipherKey(password);
+  });
 #endif /* HAVE_IPCIPHER */
 
   /* ProtobufMessage */
- pick luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(std::string)>("setTag", [](DNSDistProtoBufMessage& message, const std::string& strValue) {
+  pick luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(std::string)>("setTag", [](DNSDistProtoBufMessage& message, const std::string& strValue) {
     message.addTag(strValue);
   });
   luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(LuaArray<std::string>)>("setTagArray", [](DNSDistProtoBufMessage& message, const LuaArray<std::string>& tags) {
@@ -72,132 +72,131 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(boost::optional <time_t> sec, boost::optional <uint32_t> uSec)>("setProtobufResponseType",
-                                        [](DNSDistProtoBufMessage& message, boost::optional <time_t> sec, boost::optional <uint32_t> uSec) {
-      message.setType(pdns::ProtoZero::Message::MessageType::DNSResponseType);
-      message.setQueryTime(sec ? *sec : 0, uSec ? *uSec : 0);
-    });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(boost::optional<time_t> sec, boost::optional<uint32_t> uSec)>("setProtobufResponseType",
+                                                                                                                         [](DNSDistProtoBufMessage& message, boost::optional<time_t> sec, boost::optional<uint32_t> uSec) {
+                                                                                                                           message.setType(pdns::ProtoZero::Message::MessageType::DNSResponseType);
+                                                                                                                           message.setQueryTime(sec ? *sec : 0, uSec ? *uSec : 0);
+                                                                                                                         });
 
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(const std::string& strQueryName, uint16_t uType, uint16_t uClass, uint32_t uTTL, const std::string& strBlob)>("addResponseRR", [](DNSDistProtoBufMessage& message,
-                                                            const std::string& strQueryName, uint16_t uType, uint16_t uClass, uint32_t uTTL, const std::string& strBlob) {
-      message.addRR(DNSName(strQueryName), uType, uClass, uTTL, strBlob);
-    });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(const Netmask&)>("setEDNSSubnet", [](DNSDistProtoBufMessage& message, const Netmask& subnet) { message.setEDNSSubnet(subnet); });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(const DNSName&, uint16_t, uint16_t)>("setQuestion", [](DNSDistProtoBufMessage& message, const DNSName& qname, uint16_t qtype, uint16_t qclass) { message.setQuestion(qname, qtype, qclass); });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(size_t)>("setBytes", [](DNSDistProtoBufMessage& message, size_t bytes) { message.setBytes(bytes); });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(time_t, uint32_t)>("setTime", [](DNSDistProtoBufMessage& message, time_t sec, uint32_t usec) { message.setTime(sec, usec); });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(time_t, uint32_t)>("setQueryTime", [](DNSDistProtoBufMessage& message, time_t sec, uint32_t usec) { message.setQueryTime(sec, usec); });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(uint8_t)>("setResponseCode", [](DNSDistProtoBufMessage& message, uint8_t rcode) { message.setResponseCode(rcode); });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(const std::string& strQueryName, uint16_t uType, uint16_t uClass, uint32_t uTTL, const std::string& strBlob)>("addResponseRR", [](DNSDistProtoBufMessage& message, const std::string& strQueryName, uint16_t uType, uint16_t uClass, uint32_t uTTL, const std::string& strBlob) {
+    message.addRR(DNSName(strQueryName), uType, uClass, uTTL, strBlob);
+  });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(const Netmask&)>("setEDNSSubnet", [](DNSDistProtoBufMessage& message, const Netmask& subnet) { message.setEDNSSubnet(subnet); });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(const DNSName&, uint16_t, uint16_t)>("setQuestion", [](DNSDistProtoBufMessage& message, const DNSName& qname, uint16_t qtype, uint16_t qclass) { message.setQuestion(qname, qtype, qclass); });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(size_t)>("setBytes", [](DNSDistProtoBufMessage& message, size_t bytes) { message.setBytes(bytes); });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(time_t, uint32_t)>("setTime", [](DNSDistProtoBufMessage& message, time_t sec, uint32_t usec) { message.setTime(sec, usec); });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(time_t, uint32_t)>("setQueryTime", [](DNSDistProtoBufMessage& message, time_t sec, uint32_t usec) { message.setQueryTime(sec, usec); });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(uint8_t)>("setResponseCode", [](DNSDistProtoBufMessage& message, uint8_t rcode) { message.setResponseCode(rcode); });
 
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(const ComboAddress&, boost::optional<uint16_t>)>("setRequestor", [](DNSDistProtoBufMessage& message, const ComboAddress& addr, boost::optional<uint16_t> port) {
-      message.setRequestor(addr);
-      if (port) {
-        message.setRequestorPort(*port);
-      }
-    });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(const std::string&, boost::optional<uint16_t>)>("setRequestorFromString", [](DNSDistProtoBufMessage& message, const std::string& str, boost::optional<uint16_t> port) {
-      message.setRequestor(ComboAddress(str));
-      if (port) {
-        message.setRequestorPort(*port);
-      }
-    });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(const ComboAddress&, boost::optional<uint16_t>)>("setResponder", [](DNSDistProtoBufMessage& message, const ComboAddress& addr, boost::optional<uint16_t> port) {
-      message.setResponder(addr);
-      if (port) {
-        message.setResponderPort(*port);
-      }
-    });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(const std::string&, boost::optional<uint16_t>)>("setResponderFromString", [](DNSDistProtoBufMessage& message, const std::string& str, boost::optional<uint16_t> port) {
-      message.setResponder(ComboAddress(str));
-      if (port) {
-        message.setResponderPort(*port);
-      }
-    });
-  luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(const std::string&)>("setServerIdentity", [](DNSDistProtoBufMessage& message, const std::string& str) {
-      message.setServerIdentity(str);
-    });
-
-  luaCtx.registerFunction<void(DnstapMessage::*)(const std::string&)>("setExtra", [](DnstapMessage& message, const std::string& str) {
-      message.setExtra(str);
-    });
-
-  /* RemoteLogger */
-  luaCtx.writeFunction("newRemoteLogger", [client,configCheck](const std::string& remote, boost::optional<uint16_t> timeout, boost::optional<uint64_t> maxQueuedEntries, boost::optional<uint8_t> reconnectWaitTime, boost::optional<uint64_t> connectionCount) {
-      if (client || configCheck) {
-        return std::shared_ptr<RemoteLoggerInterface>(nullptr);
-      }
-      auto count = connectionCount ? *connectionCount : 1;
-      if (count > 1) {
-        std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
-        for (uint64_t i = 0; i < count; i++) {
-          loggers.emplace_back(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client));
-        }
-        return std::shared_ptr<RemoteLoggerInterface>(new RemoteLoggerPool(std::move(loggers)));
-      }
-      else {
-        return std::shared_ptr<RemoteLoggerInterface>(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client));
-      }
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(const ComboAddress&, boost::optional<uint16_t>)>("setRequestor", [](DNSDistProtoBufMessage& message, const ComboAddress& addr, boost::optional<uint16_t> port) {
+    message.setRequestor(addr);
+    if (port) {
+      message.setRequestorPort(*port);
+    }
+  });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(const std::string&, boost::optional<uint16_t>)>("setRequestorFromString", [](DNSDistProtoBufMessage& message, const std::string& str, boost::optional<uint16_t> port) {
+    message.setRequestor(ComboAddress(str));
+    if (port) {
+      message.setRequestorPort(*port);
+    }
+  });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(const ComboAddress&, boost::optional<uint16_t>)>("setResponder", [](DNSDistProtoBufMessage& message, const ComboAddress& addr, boost::optional<uint16_t> port) {
+    message.setResponder(addr);
+    if (port) {
+      message.setResponderPort(*port);
+    }
+  });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(const std::string&, boost::optional<uint16_t>)>("setResponderFromString", [](DNSDistProtoBufMessage& message, const std::string& str, boost::optional<uint16_t> port) {
+    message.setResponder(ComboAddress(str));
+    if (port) {
+      message.setResponderPort(*port);
+    }
+  });
+  luaCtx.registerFunction<void (DNSDistProtoBufMessage::*)(const std::string&)>("setServerIdentity", [](DNSDistProtoBufMessage& message, const std::string& str) {
+    message.setServerIdentity(str);
   });
 
-  luaCtx.writeFunction("newFrameStreamUnixLogger", [client,configCheck]([[maybe_unused]] const std::string& address, [[maybe_unused]] boost::optional<LuaAssociativeTable<unsigned int>> params) {
-#ifdef HAVE_FSTRM
-      if (client || configCheck) {
-        return std::shared_ptr<RemoteLoggerInterface>(nullptr);
-      }
+  luaCtx.registerFunction<void (DnstapMessage::*)(const std::string&)>("setExtra", [](DnstapMessage& message, const std::string& str) {
+    message.setExtra(str);
+  });
 
-      LuaAssociativeTable<unsigned int> options;
-      parseFSTRMOptions(params, options);
-      checkAllParametersConsumed("newFrameStreamUnixLogger", params);
-      auto connectionCount = options.find("connectionCount");
-      auto count = connectionCount == options.end() ? 1 : connectionCount->second;
-      options.erase(connectionCount);
-      if (count > 1) {
-        std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
-        for (uint64_t i = 0; i < count; i++) {
-          loggers.emplace_back(new FrameStreamLogger(AF_UNIX, address, !client, options));
-        }
-        return std::shared_ptr<RemoteLoggerInterface>(new RemoteLoggerPool(std::move(loggers)));
+  /* RemoteLogger */
+  luaCtx.writeFunction("newRemoteLogger", [client, configCheck](const std::string& remote, boost::optional<uint16_t> timeout, boost::optional<uint64_t> maxQueuedEntries, boost::optional<uint8_t> reconnectWaitTime, boost::optional<uint64_t> connectionCount) {
+    if (client || configCheck) {
+      return std::shared_ptr<RemoteLoggerInterface>(nullptr);
+    }
+    auto count = connectionCount ? *connectionCount : 1;
+    if (count > 1) {
+      std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
+      for (uint64_t i = 0; i < count; i++) {
+        loggers.emplace_back(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client));
       }
-      else {
-        return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_UNIX, address, !client, options));
+      return std::shared_ptr<RemoteLoggerInterface>(new RemoteLoggerPool(std::move(loggers)));
+    }
+    else {
+      return std::shared_ptr<RemoteLoggerInterface>(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client));
+    }
+  });
+
+  luaCtx.writeFunction("newFrameStreamUnixLogger", [client, configCheck]([[maybe_unused]] const std::string& address, [[maybe_unused]] boost::optional<LuaAssociativeTable<unsigned int>> params) {
+#ifdef HAVE_FSTRM
+    if (client || configCheck) {
+      return std::shared_ptr<RemoteLoggerInterface>(nullptr);
+    }
+
+    LuaAssociativeTable<unsigned int> options;
+    parseFSTRMOptions(params, options);
+    checkAllParametersConsumed("newFrameStreamUnixLogger", params);
+    auto connectionCount = options.find("connectionCount");
+    auto count = connectionCount == options.end() ? 1 : connectionCount->second;
+    options.erase(connectionCount);
+    if (count > 1) {
+      std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
+      for (uint64_t i = 0; i < count; i++) {
+        loggers.emplace_back(new FrameStreamLogger(AF_UNIX, address, !client, options));
       }
+      return std::shared_ptr<RemoteLoggerInterface>(new RemoteLoggerPool(std::move(loggers)));
+    }
+    else {
+      return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_UNIX, address, !client, options));
+    }
 #else
     throw std::runtime_error("fstrm support is required to build an AF_UNIX FrameStreamLogger");
 #endif /* HAVE_FSTRM */
   });
 
-  luaCtx.writeFunction("newFrameStreamTcpLogger", [client,configCheck]([[maybe_unused]] const std::string& address, [[maybe_unused]] boost::optional<LuaAssociativeTable<unsigned int>> params) {
+  luaCtx.writeFunction("newFrameStreamTcpLogger", [client, configCheck]([[maybe_unused]] const std::string& address, [[maybe_unused]] boost::optional<LuaAssociativeTable<unsigned int>> params) {
 #if defined(HAVE_FSTRM) && defined(HAVE_FSTRM_TCP_WRITER_INIT)
-      if (client || configCheck) {
-        return std::shared_ptr<RemoteLoggerInterface>(nullptr);
-      }
+    if (client || configCheck) {
+      return std::shared_ptr<RemoteLoggerInterface>(nullptr);
+    }
 
-      LuaAssociativeTable<unsigned int> options;
-      parseFSTRMOptions(params, options);
-      checkAllParametersConsumed("newFrameStreamTcpLogger", params);
-      auto connectionCount = options.find("connectionCount");
-      auto count = connectionCount == options.end() ? 1 : connectionCount->second;
-      options.erase(connectionCount);
-      if (count > 1) {
-        std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
-        for (uint64_t i = 0; i < count; i++) {
-          loggers.emplace_back(new FrameStreamLogger(AF_INET, address, !client, options));
-        }
-        return std::shared_ptr<RemoteLoggerInterface>(new RemoteLoggerPool(std::move(loggers)));
+    LuaAssociativeTable<unsigned int> options;
+    parseFSTRMOptions(params, options);
+    checkAllParametersConsumed("newFrameStreamTcpLogger", params);
+    auto connectionCount = options.find("connectionCount");
+    auto count = connectionCount == options.end() ? 1 : connectionCount->second;
+    options.erase(connectionCount);
+    if (count > 1) {
+      std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
+      for (uint64_t i = 0; i < count; i++) {
+        loggers.emplace_back(new FrameStreamLogger(AF_INET, address, !client, options));
       }
-      else {
-        return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_INET, address, !client, options));
-      }
+      return std::shared_ptr<RemoteLoggerInterface>(new RemoteLoggerPool(std::move(loggers)));
+    }
+    else {
+      return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_INET, address, !client, options));
+    }
 #else
-      throw std::runtime_error("fstrm with TCP support is required to build an AF_INET FrameStreamLogger");
+    throw std::runtime_error("fstrm with TCP support is required to build an AF_INET FrameStreamLogger");
 #endif /* HAVE_FSTRM */
-    });
+  });
 
-  luaCtx.registerFunction<std::string(std::shared_ptr<RemoteLoggerInterface>::*)()const>("toString", [](const std::shared_ptr<RemoteLoggerInterface>& logger) {
-      if (logger) {
-        return logger->toString();
-      }
-      return std::string();
+  luaCtx.registerFunction<std::string (std::shared_ptr<RemoteLoggerInterface>::*)() const>("toString", [](const std::shared_ptr<RemoteLoggerInterface>& logger) {
+    if (logger) {
+      return logger->toString();
+    }
+    return std::string();
   });
 }
 #else /* DISABLE_PROTOBUF */

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/src/lib.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/src/lib.rs
@@ -1197,6 +1197,8 @@ mod dnsdistsettings {
         max_queued_entries: u64,
         #[serde(default = "crate::U8::<1>::value", skip_serializing_if = "crate::U8::<1>::is_equal")]
         reconnect_wait_time: u8,
+        #[serde(default = "crate::U64::<1>::value", skip_serializing_if = "crate::U64::<1>::is_equal")]
+        connection_count: u64,
     }
 
     #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -1217,6 +1219,8 @@ mod dnsdistsettings {
         queue_notify_threshold: u64,
         #[serde(default, skip_serializing_if = "crate::is_default")]
         reopen_interval: u64,
+        #[serde(default = "crate::U64::<1>::value", skip_serializing_if = "crate::U64::<1>::is_equal")]
+        connection_count: u64,
     }
 
     #[derive(Deserialize, Serialize, Debug, PartialEq)]

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -208,6 +208,10 @@ protobuf_logger:
       type: "u8"
       default: 1
       description: "Time in seconds between reconnection attempts"
+    - name: "connection_count"
+      type: "u64"
+      default: 1
+      description: "Number of connections to open to the endpoint"
 
 dnstap_logger:
   description: "Endpoint to send queries and/or responses data to, using the dnstap format"
@@ -248,6 +252,10 @@ dnstap_logger:
       type: "u64"
       default: 0
       description: "The number of queue entries to allocate for each output queue. According to the libfstrm library, the minimum is 2, the maximum is system-dependent and based on IOV_MAX, and the default is 64"
+    - name: "connection_count"
+      type: "u64"
+      default: 1
+      description: "Number of connections to open to the endpoint"
 
 proto_buf_meta:
   description: "Meta-data entry to be added to a Protocol Buffer message"

--- a/pdns/dnsdistdist/docs/reference/dnstap.rst
+++ b/pdns/dnsdistdist/docs/reference/dnstap.rst
@@ -13,6 +13,9 @@ To use FrameStream transport, :program:`dnsdist` must have been built with `libf
 
 .. function:: newFrameStreamUnixLogger(path [, options])
 
+  .. versionchanged:: 2.0.0
+    Added ``connectionCount`` option.
+
   .. versionchanged:: 1.5.0
     Added the optional parameter ``options``.
 
@@ -25,7 +28,8 @@ To use FrameStream transport, :program:`dnsdist` must have been built with `libf
   The following options apply to the settings of the `framestream library
   <https://github.com/farsightsec/fstrm>`. Refer to the documentation of that library for the default and
   allowed values for these options, as well as their exact descriptions. For all these options, absence or a
-  zero value has the effect of using the library-provided default value.
+  zero value has the effect of using the library-provided default value. ``connectionCount`` can be used to open
+  multiple connections to the socket, for potential throughput boost.
 
   * ``bufferHint=0``: unsigned
   * ``flushTimeout=0``: unsigned
@@ -33,8 +37,12 @@ To use FrameStream transport, :program:`dnsdist` must have been built with `libf
   * ``outputQueueSize=0``: unsigned
   * ``queueNotifyThreshold=0``: unsigned
   * ``reopenInterval=0``: unsigned
+  * ``connectionCount=1``: unsigned
 
 .. function:: newFrameStreamTcpLogger(address [, options])
+
+  .. versionchanged:: 2.0.0
+    Added ``connectionCount`` option.
 
   .. versionchanged:: 1.5.0
     Added the optional parameter ``options``.
@@ -49,7 +57,8 @@ To use FrameStream transport, :program:`dnsdist` must have been built with `libf
   The following options apply to the settings of the `framestream library
   <https://github.com/farsightsec/fstrm>`. Refer to the documentation of that library for the default and
   allowed values for these options, as well as their exact descriptions. For all these options, absence or a
-  zero value has the effect of using the library-provided default value.
+  zero value has the effect of using the library-provided default value. ``connectionCount`` can be used to open
+  multiple connections to the socket, for potential throughput boost.
 
   * ``bufferHint=0``: unsigned
   * ``flushTimeout=0``: unsigned
@@ -57,6 +66,7 @@ To use FrameStream transport, :program:`dnsdist` must have been built with `libf
   * ``outputQueueSize=0``: unsigned
   * ``queueNotifyThreshold=0``: unsigned
   * ``reopenInterval=0``: unsigned
+  * ``connectionCount=1``: unsigned
 
 .. class:: DnstapMessage
 

--- a/pdns/dnsdistdist/docs/reference/protobuf.rst
+++ b/pdns/dnsdistdist/docs/reference/protobuf.rst
@@ -1,7 +1,10 @@
 Protobuf Logging Reference
 ==========================
 
-.. function:: newRemoteLogger(address [, timeout=2[, maxQueuedEntries=100[, reconnectWaitTime=1]]])
+.. function:: newRemoteLogger(address [, timeout=2[, maxQueuedEntries=100[, reconnectWaitTime=1[, connectionCount=1]]]])
+
+  .. versionchanged:: 2.0.0
+    Added the optional ``connectionCount`` parameter.
 
   Create a Remote Logger object, to use with :func:`RemoteLogAction` and :func:`RemoteLogResponseAction`.
 
@@ -9,6 +12,7 @@ Protobuf Logging Reference
   :param int timeout: TCP connect timeout in seconds
   :param int maxQueuedEntries: Queue this many messages before dropping new ones (e.g. when the remote listener closes the connection)
   :param int reconnectWaitTime: Time in seconds between reconnection attempts
+  :param int connectionCount: Number of connections to open to the socket
 
 .. class:: DNSDistProtoBufMessage
 

--- a/pdns/dnsdistdist/docs/reference/yaml-settings.rst
+++ b/pdns/dnsdistdist/docs/reference/yaml-settings.rst
@@ -204,6 +204,7 @@ Endpoint to send queries and/or responses data to, using the dnstap format
 - **output_queue_size**: Unsigned integer ``(0)`` - The number of queue entries to allocate for each output queue. According to the libfstrm library, the minimum is 2, the maximum is system-dependent and based on ``IOV_MAX``, and the default is 64
 - **queue_notify_threshold**: Unsigned integer ``(0)`` - The number of outstanding queue entries to allow on an input queue before waking the I/O thread. According to the libfstrm library, the minimum is 1 and the default is 32
 - **reopen_interval**: Unsigned integer ``(0)`` - The number of queue entries to allocate for each output queue. According to the libfstrm library, the minimum is 2, the maximum is system-dependent and based on IOV_MAX, and the default is 64
+- **connection_count**: Unsigned integer ``(1)`` - Number of connections to open to the endpoint
 
 
 .. _yaml-settings-DohTuningConfiguration:
@@ -773,6 +774,7 @@ Endpoint to send queries and/or responses data to, using the native PowerDNS for
 - **timeout**: Unsigned integer ``(2)`` - TCP connect timeout in seconds
 - **max_queued_entries**: Unsigned integer ``(100)`` - Queue this many messages before dropping new ones (e.g. when the remote listener closes the connection)
 - **reconnect_wait_time**: Unsigned integer ``(1)`` - Time in seconds between reconnection attempts
+- **connection_count**: Unsigned integer ``(1)`` - Number of connections to open to the endpoint
 
 
 .. _yaml-settings-ProxyProtocolConfiguration:

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -201,6 +201,7 @@ common_sources += files(
   src_dir / 'proxy-protocol.cc',
   src_dir / 'qtype.cc',
   src_dir / 'remote_logger.cc',
+  src_dir / 'remote_logger_pool.cc',
   src_dir / 'snmp-agent.cc',
   src_dir / 'statnode.cc',
   src_dir / 'svc-records.cc',

--- a/pdns/dnsdistdist/remote_logger_pool.cc
+++ b/pdns/dnsdistdist/remote_logger_pool.cc
@@ -1,0 +1,1 @@
+../remote_logger_pool.cc

--- a/pdns/dnsdistdist/remote_logger_pool.hh
+++ b/pdns/dnsdistdist/remote_logger_pool.hh
@@ -1,0 +1,1 @@
+../remote_logger_pool.hh

--- a/pdns/remote_logger_pool.cc
+++ b/pdns/remote_logger_pool.cc
@@ -4,7 +4,6 @@
 #include <sys/un.h>
 
 #include "config.h"
-#include "lock.hh"
 #include "remote_logger_pool.hh"
 
 RemoteLoggerPool::RemoteLoggerPool(std::vector<std::shared_ptr<RemoteLoggerInterface>>&& pool) :
@@ -15,14 +14,7 @@ RemoteLoggerPool::RemoteLoggerPool(std::vector<std::shared_ptr<RemoteLoggerInter
 [[nodiscard]] std::string RemoteLoggerPool::toString()
 {
   auto stats = this->getStats();
-  std::string loggersDesc;
-  for (size_t i = 0; i < this->d_pool.size(); i++) {
-    if (i > 0) {
-      loggersDesc += ", ";
-    }
-    loggersDesc += d_pool[i]->toString();
-  }
-  return "RemoteLoggerPool of " + std::to_string(d_pool.size()) + " loggers (" + std::to_string(stats.d_queued) + " processed, " + std::to_string(stats.d_pipeFull + stats.d_tooLarge + stats.d_otherError) + " dropped)[ " + loggersDesc + "]";
+  return "Pool of " + std::to_string(d_pool.size()) + " loggers (" + std::to_string(stats.d_queued) + " processed, " + std::to_string(stats.d_pipeFull + stats.d_tooLarge + stats.d_otherError) + " dropped)";
 }
 
 RemoteLoggerInterface::Result RemoteLoggerPool::queueData(const std::string& data)

--- a/pdns/remote_logger_pool.cc
+++ b/pdns/remote_logger_pool.cc
@@ -27,11 +27,14 @@ RemoteLoggerPool::RemoteLoggerPool(std::vector<std::shared_ptr<RemoteLoggerInter
 
 RemoteLoggerInterface::Result RemoteLoggerPool::queueData(const std::string& data)
 {
-  auto pool_it = d_pool_it.lock();
-  auto result = (**pool_it)->queueData(data);
-  (*pool_it)++;
-  if (*pool_it == d_pool.end()) {
-    *pool_it = d_pool.begin();
+  std::shared_ptr<RemoteLoggerInterface> logger;
+  {
+    auto pool_it = d_pool_it.lock();
+    logger = **pool_it;
+    (*pool_it)++;
+    if (*pool_it == d_pool.end()) {
+      *pool_it = d_pool.begin();
+    }
   }
-  return result;
+  return logger->queueData(data);
 }

--- a/pdns/remote_logger_pool.cc
+++ b/pdns/remote_logger_pool.cc
@@ -8,7 +8,7 @@
 #include "remote_logger_pool.hh"
 
 RemoteLoggerPool::RemoteLoggerPool(std::vector<std::shared_ptr<RemoteLoggerInterface>>&& pool) :
-  d_pool(std::move(pool)), d_pool_it(d_pool.begin())
+  d_pool(std::move(pool)), d_counter(0)
 {
 }
 
@@ -27,14 +27,6 @@ RemoteLoggerPool::RemoteLoggerPool(std::vector<std::shared_ptr<RemoteLoggerInter
 
 RemoteLoggerInterface::Result RemoteLoggerPool::queueData(const std::string& data)
 {
-  std::shared_ptr<RemoteLoggerInterface> logger;
-  {
-    auto pool_it = d_pool_it.lock();
-    logger = **pool_it;
-    (*pool_it)++;
-    if (*pool_it == d_pool.end()) {
-      *pool_it = d_pool.begin();
-    }
-  }
+  std::shared_ptr<RemoteLoggerInterface> logger = d_pool.at(d_counter++ % d_pool.size());
   return logger->queueData(data);
 }

--- a/pdns/remote_logger_pool.cc
+++ b/pdns/remote_logger_pool.cc
@@ -1,0 +1,37 @@
+#include <memory>
+#include <numeric>
+#include <string>
+#include <unistd.h>
+#include <sys/un.h>
+
+#include "config.h"
+#include "remote_logger_pool.hh"
+
+RemoteLoggerPool::RemoteLoggerPool(std::vector<std::shared_ptr<RemoteLoggerInterface>>&& pool) :
+  d_pool(std::move(pool))
+{
+  d_pool_it = d_pool.begin();
+}
+
+[[nodiscard]] std::string RemoteLoggerPool::toString()
+{
+  auto stats = this->getStats();
+  std::string loggersDesc;
+  for (size_t i = 0; i < this->d_pool.size(); i++) {
+    if (i > 0) {
+      loggersDesc += ", ";
+    }
+    loggersDesc += d_pool[i]->toString();
+  }
+  return "RemoteLoggerPool of " + std::to_string(d_pool.size()) + " loggers (" + std::to_string(stats.d_queued) + " processed, " + std::to_string(stats.d_pipeFull + stats.d_tooLarge + stats.d_otherError) + " dropped)[ " + loggersDesc + "]";
+}
+
+RemoteLoggerInterface::Result RemoteLoggerPool::queueData(const std::string& data)
+{
+  auto result = (*d_pool_it)->queueData(data);
+  d_pool_it++;
+  if (d_pool_it == d_pool.end()) {
+    d_pool_it = d_pool.begin();
+  }
+  return result;
+}

--- a/pdns/remote_logger_pool.hh
+++ b/pdns/remote_logger_pool.hh
@@ -1,0 +1,62 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+#include "config.h"
+#include "remote_logger.hh"
+#include <memory>
+#include <vector>
+
+class RemoteLoggerPool : public RemoteLoggerInterface
+{
+public:
+  RemoteLoggerPool(std::vector<std::shared_ptr<RemoteLoggerInterface>>&& pool);
+  RemoteLoggerPool(const RemoteLoggerPool&) = delete;
+  RemoteLoggerPool(RemoteLoggerPool&&) = delete;
+  RemoteLoggerPool& operator=(const RemoteLoggerPool&) = delete;
+  RemoteLoggerPool& operator=(RemoteLoggerPool&&) = delete;
+  [[nodiscard]] RemoteLoggerInterface::Result queueData(const std::string& data) override;
+
+  [[nodiscard]] std::string address() const override
+  {
+    return "";
+  }
+
+  [[nodiscard]] std::string name() const override
+  {
+    return "";
+  }
+
+  [[nodiscard]] std::string toString() override;
+
+  [[nodiscard]] RemoteLoggerInterface::Stats getStats() override
+  {
+    Stats total_stats;
+    for (auto& logger : d_pool) {
+      total_stats += logger->getStats();
+    }
+    return total_stats;
+  }
+
+private:
+  std::vector<std::shared_ptr<RemoteLoggerInterface>> d_pool;
+  std::vector<std::shared_ptr<RemoteLoggerInterface>>::iterator d_pool_it;
+};

--- a/pdns/remote_logger_pool.hh
+++ b/pdns/remote_logger_pool.hh
@@ -45,7 +45,7 @@ public:
 
   [[nodiscard]] std::string name() const override
   {
-    return "";
+    return "Pool of " + std::to_string(d_pool.size()) + " loggers";
   }
 
   [[nodiscard]] std::string toString() override;

--- a/pdns/remote_logger_pool.hh
+++ b/pdns/remote_logger_pool.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 #include "config.h"
+#include "lock.hh"
 #include "remote_logger.hh"
 #include <memory>
 #include <vector>
@@ -58,5 +59,5 @@ public:
 
 private:
   std::vector<std::shared_ptr<RemoteLoggerInterface>> d_pool;
-  std::vector<std::shared_ptr<RemoteLoggerInterface>>::iterator d_pool_it;
+  LockGuarded<std::vector<std::shared_ptr<RemoteLoggerInterface>>::iterator> d_pool_it;
 };

--- a/pdns/remote_logger_pool.hh
+++ b/pdns/remote_logger_pool.hh
@@ -21,14 +21,16 @@
  */
 #pragma once
 #include "config.h"
-#include "lock.hh"
 #include "remote_logger.hh"
+#include <atomic>
+#include <cstddef>
 #include <memory>
 #include <vector>
 
 class RemoteLoggerPool : public RemoteLoggerInterface
 {
 public:
+  // this expects a non-empty vector
   RemoteLoggerPool(std::vector<std::shared_ptr<RemoteLoggerInterface>>&& pool);
   RemoteLoggerPool(const RemoteLoggerPool&) = delete;
   RemoteLoggerPool(RemoteLoggerPool&&) = delete;
@@ -59,5 +61,5 @@ public:
 
 private:
   std::vector<std::shared_ptr<RemoteLoggerInterface>> d_pool;
-  LockGuarded<std::vector<std::shared_ptr<RemoteLoggerInterface>>::iterator> d_pool_it;
+  std::atomic<size_t> d_counter;
 };

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -467,7 +467,7 @@ class TestDnstapOverFrameStreamTcpLogger(DNSDistTest):
     def startResponders(cls):
         DNSDistTest.startResponders()
 
-        cls._fstrmLoggerListener = threading.Thread(name='FrameStreamUnixListener', target=cls.FrameStreamUnixListener, args=[cls._fstrmLoggerPort])
+        cls._fstrmLoggerListener = threading.Thread(name='FrameStreamTcpListener', target=cls.FrameStreamTcpListener, args=[cls._fstrmLoggerPort])
         cls._fstrmLoggerListener.daemon = True
         cls._fstrmLoggerListener.start()
 

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -529,7 +529,7 @@ class TestDnstapOverRemotePoolTcpLogger(DNSDistTest):
     """
 
     @classmethod
-    def FrameStreamUnixListener(cls, port):
+    def FrameStreamTcpListener(cls, port):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.bind(("127.0.0.1", port))

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -36,7 +36,7 @@ def checkDnstapBase(testinstance, dnstap, protocol, initiator):
     testinstance.assertEqual(socket.inet_ntop(socket.AF_INET, dnstap.message.response_address), initiator)
     testinstance.assertTrue(dnstap.message.HasField('response_port'))
     testinstance.assertEqual(dnstap.message.response_port, testinstance._dnsDistPort)
-  
+
 
 def checkDnstapQuery(testinstance, dnstap, protocol, query, initiator='127.0.0.1'):
     testinstance.assertEqual(dnstap.message.type, dnstap_pb2.Message.CLIENT_QUERY)
@@ -325,7 +325,7 @@ def fstrm_read_and_dispatch_control_frame(conn):
     return cft
 
 
-def fstrm_handle_bidir_connection(conn, on_data):
+def fstrm_handle_bidir_connection(conn, on_data, exit_early=False):
     data = None
     while True:
         data = conn.recv(4)
@@ -344,6 +344,8 @@ def fstrm_handle_bidir_connection(conn, on_data):
                 break
 
             on_data(data)
+            if exit_early:
+                break
 
 
 class TestDnstapOverFrameStreamUnixLogger(DNSDistTest):
@@ -512,3 +514,96 @@ class TestDnstapOverFrameStreamTcpLogger(DNSDistTest):
 
         checkDnstapQuery(self, dnstap, dnstap_pb2.UDP, query)
         checkDnstapNoExtra(self, dnstap)
+
+class TestDnstapOverRemotePoolTcpLogger(DNSDistTest):
+    _fstrmLoggerPort = pickAvailablePort()
+    _fstrmLoggerQueue = Queue()
+    _fstrmLoggerCounter = 0
+    _poolConnectionCount = 5
+    _config_params = ['_testServerPort', '_fstrmLoggerPort', '_poolConnectionCount']
+    _config_template = """
+    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    fslu = newFrameStreamTcpLogger('127.0.0.1:%s', { connectionCount = %s })
+
+    addAction(AllRule(), DnstapLogAction("a.server", fslu))
+    """
+
+    @classmethod
+    def FrameStreamUnixListener(cls, port):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(("127.0.0.1", port))
+        except socket.error as e:
+            print("Error binding in the framestream listener: %s" % str(e))
+            sys.exit(1)
+
+        sock.listen(100)
+
+        def handle_connection(conn):
+            fstrm_handle_bidir_connection(conn, lambda data: \
+                cls._fstrmLoggerQueue.put(data, True, timeout=2.0), exit_early=True)
+            conn.close()
+
+        threads = []
+        while True:
+            (conn, _) = sock.accept()
+            thread = threading.Thread(target=handle_connection, args=[conn])
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+        sock.close()
+
+    @classmethod
+    def startResponders(cls):
+        DNSDistTest.startResponders()
+
+        cls._fstrmLoggerListener = threading.Thread(name='FrameStreamUnixListener', target=cls.FrameStreamUnixListener, args=[cls._fstrmLoggerPort])
+        cls._fstrmLoggerListener.daemon = True
+        cls._fstrmLoggerListener.start()
+
+    def getFirstDnstap(self):
+        data = self._fstrmLoggerQueue.get(True, timeout=2.0)
+        self.assertTrue(data)
+        dnstap = dnstap_pb2.Dnstap()
+        dnstap.ParseFromString(data)
+        return dnstap
+
+    def testDnstapOverFrameStreamTcp(self):
+        """
+        Dnstap: Send query packed in dnstap to a tcp socket fstrmlogger server
+        """
+        for i in range(self._poolConnectionCount):
+            name = 'query.dnstap.tests.powerdns.com.'
+
+            target = 'target.dnstap.tests.powerdns.com.'
+            query = dns.message.make_query(name, 'A', 'IN')
+            response = dns.message.make_response(query)
+
+            rrset = dns.rrset.from_text(name,
+                                        3600,
+                                        dns.rdataclass.IN,
+                                        dns.rdatatype.CNAME,
+                                        target)
+            response.answer.append(rrset)
+
+            rrset = dns.rrset.from_text(target,
+                                        3600,
+                                        dns.rdataclass.IN,
+                                        dns.rdatatype.A,
+                                        '127.0.0.1')
+            response.answer.append(rrset)
+
+            (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
+
+            # check the dnstap message corresponding to the UDP query
+            dnstap = self.getFirstDnstap()
+
+            checkDnstapQuery(self, dnstap, dnstap_pb2.UDP, query)
+            checkDnstapNoExtra(self, dnstap)

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -522,8 +522,8 @@ class TestDnstapOverRemotePoolTcpLogger(DNSDistTest):
     _poolConnectionCount = 5
     _config_params = ['_testServerPort', '_fstrmLoggerPort', '_poolConnectionCount']
     _config_template = """
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
-    fslu = newFrameStreamTcpLogger('127.0.0.1:%s', { connectionCount = %s })
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
+    fslu = newFrameStreamTcpLogger('127.0.0.1:%d', { connectionCount = %d })
 
     addAction(AllRule(), DnstapLogAction("a.server", fslu))
     """

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -447,7 +447,7 @@ class TestDnstapOverFrameStreamTcpLogger(DNSDistTest):
     """
 
     @classmethod
-    def FrameStreamUnixListener(cls, port):
+    def FrameStreamTcpListener(cls, port):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.bind(("127.0.0.1", port))

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -559,7 +559,7 @@ class TestDnstapOverRemotePoolTcpLogger(DNSDistTest):
     def startResponders(cls):
         DNSDistTest.startResponders()
 
-        cls._fstrmLoggerListener = threading.Thread(name='FrameStreamUnixListener', target=cls.FrameStreamUnixListener, args=[cls._fstrmLoggerPort])
+        cls._fstrmLoggerListener = threading.Thread(name='FrameStreamTcpListener', target=cls.FrameStreamTcpListener, args=[cls._fstrmLoggerPort])
         cls._fstrmLoggerListener.daemon = True
         cls._fstrmLoggerListener.start()
 


### PR DESCRIPTION
### Short description
This adds a new kind of `RemoteLoggerInterface`: `RemoteLoggerPool`. It can take multiple other `RemoteLoggerInterface`s and pass data to them in round-robin order by default.

This also adds additional option to `newRemoteLogger`, `newFrameStreamTcpLogger` and `newFrameStreamUnixLogger`: `connectionCount`, which can be used to generate a pool with multiple connections.

Closes: #14861

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
