### PR TITLE
dnsdist: Fix meson build failure when DoH3 support is disabled

### DIFF
--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -188,6 +188,7 @@ common_sources += files(
   src_dir / 'dnsparser.cc',
   src_dir / 'dnswriter.cc',
   src_dir / 'dolog.cc',
+  src_dir / 'doh3.cc',
   src_dir / 'ednscookies.cc',
   src_dir / 'ednsextendederror.cc',
   src_dir / 'ednsoptions.cc',
@@ -222,12 +223,6 @@ conditional_sources = {
       src_dir / 'doh.cc',
     ],
     'condition': dep_libh2o_evloop.found(),
-   },
-  'doh3': {
-    'sources': [
-      src_dir / 'doh3.cc',
-    ],
-    'condition': get_option('dns-over-http3'),
    },
   'doq': {
     'sources': [


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
