### PR TITLE
dnsdist: Ignore `re2`'s broken compilation flags

### DIFF
--- a/pdns/dnsdistdist/meson/re2/meson.build
+++ b/pdns/dnsdistdist/meson/re2/meson.build
@@ -1,5 +1,12 @@
 opt_libre2 = get_option('re2')
 dep_libre2 = dependency('re2', required: opt_libre2)
 
+if dep_libre2.found()
+    # we need to NOT pick the CFLAGS because re2 "helpfully" puts -std=c++11 here
+    dep_libre2 = dep_libre2.partial_dependency(
+        link_args: true
+    )
+endif
+
 conf.set('HAVE_RE2', dep_libre2.found(), description: 're2')
 summary('Re2', dep_libre2.found(), bool_yn: true, section: 're2')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Apparently some version(s) of `re2` pass `-std=c++11` in the result of `pkg-config --cflags`, which helpfully downgrades us from C++17 to C++11. Let's just ignore what it says.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
