### PR TITLE
auth lua records: new option to set the http status code to match in ifurlup function

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -573,6 +573,7 @@ htbp
 htmlescape
 htmlhelp
 httpapi
+httpcode
 httpdomain
 hubert
 iana

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -149,6 +149,7 @@ Record creation functions
   - ``stringmatch``: check ``url`` for this string, only declare 'up' if found
   - ``useragent``: Set the HTTP "User-Agent" header in the requests. By default it is set to "PowerDNS Authoritative Server"
   - ``byteslimit``: Limit the maximum download size to ``byteslimit`` bytes (default 0 meaning no limit).
+  - ``httpcode``: Set the HTTP status code to match in response. (default is 200)
 
   An example of a list of address sets:
 

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -113,7 +113,12 @@ private:
       if (cd.opts.count("byteslimit")) {
         byteslimit = static_cast<size_t>(std::atoi(cd.opts.at("byteslimit").c_str()));
       }
-      MiniCurl mc(useragent);
+      int http_code = 200;
+      if (cd.opts.count("httpcode") != 0) {
+        http_code = pdns::checked_stoi<int>(cd.opts.at("httpcode"));
+      }
+
+      MiniCurl minicurl(useragent, false);
 
       string content;
       const ComboAddress* rem = nullptr;
@@ -126,10 +131,10 @@ private:
 
       if (cd.opts.count("source")) {
         ComboAddress src(cd.opts.at("source"));
-        content=mc.getURL(cd.url, rem, &src, timeout, false, false, byteslimit);
+        content=minicurl.getURL(cd.url, rem, &src, timeout, false, false, byteslimit, http_code);
       }
       else {
-        content=mc.getURL(cd.url, rem, nullptr, timeout, false, false, byteslimit);
+        content=minicurl.getURL(cd.url, rem, nullptr, timeout, false, false, byteslimit, http_code);
       }
       if (cd.opts.count("stringmatch") && content.find(cd.opts.at("stringmatch")) == string::npos) {
         throw std::runtime_error(boost::str(boost::format("unable to match content with `%s`") % cd.opts.at("stringmatch")));

--- a/pdns/minicurl.hh
+++ b/pdns/minicurl.hh
@@ -43,11 +43,11 @@ public:
 
   static void init();
 
-  MiniCurl(const string& useragent="MiniCurl/0.0");
+  MiniCurl(const string& useragent="MiniCurl/0.0", bool failonerror=true);
   ~MiniCurl();
   MiniCurl& operator=(const MiniCurl&) = delete;
 
-  std::string getURL(const std::string& str, const ComboAddress* rem=nullptr, const ComboAddress* src=nullptr, int timeout = 2, bool fastopen = false, bool verify = false, size_t byteslimit = 0);
+  std::string getURL(const std::string& str, const ComboAddress* rem=nullptr, const ComboAddress* src=nullptr, int timeout = 2, bool fastopen = false, bool verify = false, size_t byteslimit = 0, int http_status = 200);
   std::string postURL(const std::string& str, const std::string& postdata, MiniCurlHeaders& headers, int timeout = 2, bool fastopen = false, bool verify = false);
 
 private:
@@ -70,6 +70,7 @@ private:
   std::string d_data;
   size_t d_byteslimit{};
   bool d_fresh{true};
+  bool d_failonerror;
 
   void setupURL(const std::string& str, const ComboAddress* rem, const ComboAddress* src, int timeout, size_t byteslimit, bool fastopen, bool verify);
   void setHeaders(const MiniCurlHeaders& headers);


### PR DESCRIPTION
### Short description
This supersedes #10431. Sorry for the mess.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
