### PR TITLE
[pdnsutil] Let add-zone-key use defaults from pdns.conf

### DIFF
--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -48,7 +48,7 @@ algorithms are supported:
 
 activate-zone-key *ZONE* *KEY-ID*
     Activate a key with id *KEY-ID* within a zone called *ZONE*.
-add-zone-key *ZONE* [**KSK**,\ **ZSK**] [**active**,\ **inactive**] [**published**,\ **unpublished**] *KEYBITS* *ALGORITHM*
+add-zone-key *ZONE* [**KSK**,\ **ZSK**] [**active**,\ **inactive**] [**published**,\ **unpublished**] [*KEYBITS*] [*ALGORITHM*]
     Create a new key for zone *ZONE*, and make it a KSK or a ZSK (default), with
     the specified algorithm. The key is inactive by default, set it to
     **active** to immediately use it to sign *ZONE*. The key is published

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -49,7 +49,7 @@ algorithms are supported:
 activate-zone-key *ZONE* *KEY-ID*
     Activate a key with id *KEY-ID* within a zone called *ZONE*.
 add-zone-key *ZONE* [**KSK**,\ **ZSK**] [**active**,\ **inactive**] [**published**,\ **unpublished**] [*KEYBITS*] [*ALGORITHM*]
-    Create a new key for zone *ZONE*, and make it a KSK or a ZSK (default), with
+    Create a new key for zone *ZONE*, and make it a KSK (default) or a ZSK, with
     the specified algorithm. The key is inactive by default, set it to
     **active** to immediately use it to sign *ZONE*. The key is published
     in the zone by default, set it to **unpublished** to keep it from

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -392,7 +392,9 @@ When a primary zone is created via the API, and the request does not specify a c
 -  String
 -  Default: ecdsa256
 
-The algorithm that should be used for the KSK when running
+The default algorithm for creating zone keys when running
+:doc:`pdnsutil add-zone-key <manpages/pdnsutil.1>` if no algorithm is specified,
+and also the algorithm that should be used for the KSK when running
 :doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
 to enable DNSSEC. Must be one of:
 
@@ -524,7 +526,9 @@ TTL to use when none is provided.
 -  String
 -  Default: (empty)
 
-The algorithm that should be used for the ZSK when running
+The default algorithm for creating zone keys when running
+:doc:`pdnsutil add-zone-key <manpages/pdnsutil.1>` if no algorithm is specified,
+and also the algorithm that should be used for the ZSK when running
 :doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
 to enable DNSSEC. Must be one of:
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -22,6 +22,14 @@ ixfrdist IPv6 support
 ``ixfrdist`` now binds listening sockets with `IPV6_V6ONLY set`, which means that ``[::]`` no longer accepts IPv4 connections.
 If you want to listen on both IPv4 and IPv6, you need to add a line with ``0.0.0.0`` to the ``listen`` section of your ixfrdist configuration.
 
+pdnsutil behaviour changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A few changes of behaviour have been implemented in ``pdnsutil``.
+
+* The ``add-zone-key`` command used to default to creating a ZSK,
+  if no key type was given. This default has changed to KSK.
+
 4.8.0 to 4.9.0
 --------------
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2948,11 +2948,11 @@ static int addZoneKey(vector<string>& cmds)
     return 0;
   }
 
-  // need to get algorithm, bits & ksk or zsk from commandline
+  // Try to get algorithm, bits & ksk or zsk from commandline
   bool keyOrZone=false;
   int tmp_algo=0;
   int bits=0;
-  int algorithm=DNSSECKeeper::ECDSA256;
+  int algorithm=-1;
   bool active=false;
   bool published=true;
   for(unsigned int n=2; n < cmds.size(); ++n) { //NOLINT(readability-identifier-length)
@@ -2983,6 +2983,46 @@ static int addZoneKey(vector<string>& cmds)
     else {
       cerr << "Unknown algorithm, key flag or size '" << cmds.at(n) << "'" << endl;
       return EXIT_FAILURE;
+    }
+  }
+  // Use configuration defaults for missing values
+  if (bits == 0) {
+    if (keyOrZone) {
+      bits = ::arg().asNum("default-ksk-size");
+      if (bits < 0) {
+         throw runtime_error("Default KSK key size must be equal to or greater than 0");
+      }
+    }
+    else {
+      bits = ::arg().asNum("default-zsk-size");
+      if (bits < 0) {
+         throw runtime_error("Default ZSK key size must be equal to or greater than 0");
+      }
+    }
+  }
+  if (algorithm == -1) {
+    algorithm=DNSSECKeeper::ECDSA256; // default if no override in conf
+    if (keyOrZone) {
+      string k_algo = ::arg()["default-ksk-algorithm"];
+      if (!k_algo.empty()) {
+        if ((tmp_algo = DNSSECKeeper::shorthand2algorithm(k_algo)) > 0) {
+          algorithm = tmp_algo;
+        }
+        else {
+          cout<<"[Warning] Default KSK algorithm is invalid, using ECDSA256"<<endl;
+        }
+      }
+    }
+    else {
+      string z_algo = ::arg()["default-zsk-algorithm"];
+      if (!z_algo.empty()) {
+        if ((tmp_algo = DNSSECKeeper::shorthand2algorithm(z_algo)) > 0) {
+          algorithm = tmp_algo;
+        }
+        else {
+          cout<<"[Warning] Default ZSK algorithm is invalid, using ECDSA256"<<endl;
+        }
+      }
     }
   }
   int64_t id{-1}; //NOLINT(readability-identifier-length)

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2924,7 +2924,7 @@ static int unpublishZoneKey(vector<string>& cmds)
 
 static int addZoneKey(vector<string>& cmds)
 {
-  if(cmds.size() < 3 ) {
+  if(cmds.size() < 2 ) {
     cerr << "Syntax: pdnsutil add-zone-key ZONE [zsk|ksk] [BITS] [active|inactive] [rsasha1|rsasha1-nsec3-sha1|rsasha256|rsasha512|ecdsa256|ecdsa384";
 #if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBCRYPTO_ED25519)
     cerr << "|ed25519";
@@ -2934,7 +2934,7 @@ static int addZoneKey(vector<string>& cmds)
 #endif
     cerr << "]"<<endl;
     cerr << endl;
-    cerr << "If zsk|ksk is omitted, add-zone-key makes a key with flags 256 (a 'ZSK')."<<endl;
+    cerr << "If zsk|ksk is omitted, add-zone-key makes a key with flags 257 (a 'KSK')."<<endl;
     return 0;
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
@@ -2949,7 +2949,7 @@ static int addZoneKey(vector<string>& cmds)
   }
 
   // Try to get algorithm, bits & ksk or zsk from commandline
-  bool keyOrZone=false;
+  bool keyOrZone=true; // default to KSK
   int tmp_algo=0;
   int bits=0;
   int algorithm=-1;


### PR DESCRIPTION
### Short description
As suggested in #3878, in the absence of algorithm names and key sizes on the commandline, `pdnsutil add-zone-key` could make use of the defaults in `pdns.conf`, is any, rather than hardwired values.

This trivial PR implements this and updates the documentation accordingly.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)