### PR TITLE
dnsdist: Gracefully fall back to older versions of Quiche

### DIFF
--- a/pdns/dnsdistdist/meson/quiche/meson.build
+++ b/pdns/dnsdistdist/meson/quiche/meson.build
@@ -1,18 +1,20 @@
 dep_libquiche = dependency('', required: false)
 opt_libquiche = get_option('quiche')
+opt_quic = get_option('dns-over-quic')
+opt_doh3 = get_option('dns-over-http3')
 
-if (get_option('dns-over-quic') or get_option('dns-over-http3')) and opt_libquiche.allowed()
-  dep_libquiche = dependency('quiche', version: '>= 0.23.0', required: opt_libquiche)
+if (opt_quic or opt_doh3) and opt_libquiche.allowed()
+  dep_libquiche = dependency('quiche', version: '>= 0.23.0', required: false)
   if dep_libquiche.found()
     conf.set('HAVE_QUICHE_H3_EVENT_HEADERS_HAS_MORE_FRAMES', dep_libquiche.found(), description: 'if the Quiche API has quiche_h3_event_headers_has_more_frames instead of quiche_h3_event_headers_has_body')
   else
-    dep_libquiche = dependency('quiche', version: '>= 0.22.0', required: opt_libquiche)
+    dep_libquiche = dependency('quiche', version: '>= 0.22.0', required: false)
   endif
 
   if dep_libquiche.found()
     conf.set('HAVE_QUICHE_STREAM_ERROR_CODES', dep_libquiche.found(), description: 'if the Quiche API includes error code in quiche_conn_stream_recv and quiche_conn_stream_send')
   else
-    dep_libquiche = dependency('quiche', version: '>= 0.15.0', required: opt_libquiche)
+    dep_libquiche = dependency('quiche', version: '>= 0.15.0', required: opt_libquiche or opt_quic or opt_doh3)
   endif
 endif
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Before this commit we only tried older versions of Quiche if the `quiche` feature was not explicitely enabled, and failed otherwise.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
