### PR TITLE
dnsdist: Fix compatibility with `boost::lockfree` >= 1.87.0

### DIFF
--- a/pdns/dnsdistdist/dnsdist-xsk.cc
+++ b/pdns/dnsdistdist/dnsdist-xsk.cc
@@ -46,7 +46,7 @@ void XskResponderThread(std::shared_ptr<DownstreamState> dss, std::shared_ptr<Xs
       if ((pollfds[0].revents & POLLIN) != 0) {
         needNotify = true;
         xskInfo->cleanSocketNotification();
-        xskInfo->processIncomingFrames([&](XskPacket& packet) {
+        xskInfo->processIncomingFrames([&](XskPacket packet) {
           if (packet.getDataLen() < sizeof(dnsheader)) {
             xskInfo->markAsFree(packet);
             return;
@@ -165,7 +165,7 @@ void XskRouter(std::shared_ptr<XskSocket> xsk)
         if ((fds.at(fdIndex).revents & POLLIN) != 0) {
           ready--;
           const auto& info = xsk->getWorkerByDescriptor(fds.at(fdIndex).fd);
-          info->processOutgoingFrames([&](XskPacket& packet) {
+          info->processOutgoingFrames([&](XskPacket packet) {
             if ((packet.getFlags() & XskPacket::UPDATE) == 0) {
               xsk->markAsFree(packet);
               return;
@@ -199,7 +199,7 @@ void XskClientThread(ClientState* clientState)
     while (!xskInfo->hasIncomingFrames()) {
       xskInfo->waitForXskSocket();
     }
-    xskInfo->processIncomingFrames([&](XskPacket& packet) {
+    xskInfo->processIncomingFrames([&](XskPacket packet) {
       if (XskProcessQuery(*clientState, packet)) {
         packet.updatePacket();
         xskInfo->pushToSendQueue(packet);

--- a/pdns/dnsdistdist/xsk.cc
+++ b/pdns/dnsdistdist/xsk.cc
@@ -1185,7 +1185,7 @@ bool XskWorker::hasIncomingFrames()
   return d_incomingPacketsQueue.read_available() != 0U;
 }
 
-void XskWorker::processIncomingFrames(const std::function<void(XskPacket& packet)>& callback)
+void XskWorker::processIncomingFrames(const std::function<void(XskPacket packet)>& callback)
 {
   if (d_type == Type::OutgoingOnly) {
     throw std::runtime_error("Looking for incoming packets in an outgoing-only XSK Worker");
@@ -1194,7 +1194,7 @@ void XskWorker::processIncomingFrames(const std::function<void(XskPacket& packet
   d_incomingPacketsQueue.consume_all(callback);
 }
 
-void XskWorker::processOutgoingFrames(const std::function<void(XskPacket& packet)>& callback)
+void XskWorker::processOutgoingFrames(const std::function<void(XskPacket packet)>& callback)
 {
   d_outgoingPacketsQueue.consume_all(callback);
 }

--- a/pdns/dnsdistdist/xsk.hh
+++ b/pdns/dnsdistdist/xsk.hh
@@ -312,8 +312,8 @@ public:
   void pushToProcessingQueue(XskPacket& packet);
   void pushToSendQueue(XskPacket& packet);
   bool hasIncomingFrames();
-  void processIncomingFrames(const std::function<void(XskPacket& packet)>& callback);
-  void processOutgoingFrames(const std::function<void(XskPacket& packet)>& callback);
+  void processIncomingFrames(const std::function<void(XskPacket packet)>& callback);
+  void processOutgoingFrames(const std::function<void(XskPacket packet)>& callback);
   void markAsFree(const XskPacket& packet);
   // notify worker that at least one packet is available for processing
   void notifyWorker() const;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In https://github.com/boostorg/lockfree/pull/90 `boost::lockfree::spsc_queue` introduced moved semantics, which is great, but added restrictions to the callback functor that did not exist before, breaking the API. This PR fixes that by updating our callbacks to expect an object instead of a reference.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
