### PR TITLE
rec: check bounds of rcode stats counter index (safe right now)

### DIFF
--- a/pdns/recursordist/lwres.hh
+++ b/pdns/recursordist/lwres.hh
@@ -79,10 +79,10 @@ public:
   }
 
   vector<DNSRecord> d_records;
+  uint32_t d_usec{0};
   int d_rcode{0};
   bool d_validpacket{false};
   bool d_aabit{false}, d_tcbit{false};
-  uint32_t d_usec{0};
   bool d_haveEDNS{false};
 };
 

--- a/pdns/recursordist/rec-tcounters.hh
+++ b/pdns/recursordist/rec-tcounters.hh
@@ -195,8 +195,8 @@ struct Counters
       }
       return *this;
     }
-    static const size_t numberoOfRCodes = 16;
-    std::array<uint64_t, numberoOfRCodes> rcodeCounters;
+    static const size_t numberOfRCodes = 16;
+    std::array<uint64_t, numberOfRCodes> rcodeCounters;
   };
   // An RCodes histogram
   RCodeCounters auth{};

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -5552,7 +5552,9 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
   }
 
   accountAuthLatency(lwr.d_usec, remoteIP.sin4.sin_family);
-  ++t_Counters.at(rec::RCode::auth).rcodeCounters.at(static_cast<uint8_t>(lwr.d_rcode));
+  if (lwr.d_rcode >= 0 && lwr.d_rcode < static_cast<decltype(lwr.d_rcode)>(rec::Counters::RCodeCounters::numberOfRCodes)) {
+    ++t_Counters.at(rec::RCode::auth).rcodeCounters.at(static_cast<uint8_t>(lwr.d_rcode));
+  }
 
   if (!dontThrottle) {
     dontThrottle = shouldNotThrottle(&nsName, &remoteIP);

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -5552,7 +5552,7 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
   }
 
   accountAuthLatency(lwr.d_usec, remoteIP.sin4.sin_family);
-  if (lwr.d_rcode >= 0 && lwr.d_rcode < static_cast<decltype(lwr.d_rcode)>(rec::Counters::RCodeCounters::numberOfRCodes)) {
+  if (lwr.d_rcode >= 0 && lwr.d_rcode < static_cast<decltype(lwr.d_rcode)>(t_Counters.at(rec::RCode::auth).rcodeCounters.size())) {
     ++t_Counters.at(rec::RCode::auth).rcodeCounters.at(static_cast<uint8_t>(lwr.d_rcode));
   }
 


### PR DESCRIPTION
Safe right now as `LWResult::d_rcode` gets assigned from the 4 bit `rcode` in the header.  But that might change one day. I'd rather make `LWResult::d_rcode` an `uint8_t`, but that causes a conflict with the OOB resolving code that does not make a difference between `res` and `d_rcode`.

Also fix a typo in a constant name and reorder fields in `LWResult` largest to smallest.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
