### PR TITLE
sdig: implement cookie support

### DIFF
--- a/docs/manpages/sdig.1.rst
+++ b/docs/manpages/sdig.1.rst
@@ -58,7 +58,7 @@ tlsProvider *name*
 opcode *OPNUM*
     Use opcode *OPNUM* instead of 0 (Query). For example, ``sdig 192.0.2.1 53 example.com SOA opcode 4`` sends a ``NOTIFY``.
 cookie *COOKIE*
-    if *COOKIE* is -d send a random client cookie. Otherwise send the given cookie, which should be a hex string received from a server earlier.
+    if *COOKIE* is - send a random client cookie. Otherwise send the given cookie, which should be a hex string received from a server earlier.
 
 Examples
 --------

--- a/docs/manpages/sdig.1.rst
+++ b/docs/manpages/sdig.1.rst
@@ -57,6 +57,8 @@ tlsProvider *name*
     when using DoT, use TLS provider *name*. Currently supported (if compiled in): `openssl` and `gnutls`. Default is `openssl` if available.
 opcode *OPNUM*
     Use opcode *OPNUM* instead of 0 (Query). For example, ``sdig 192.0.2.1 53 example.com SOA opcode 4`` sends a ``NOTIFY``.
+cookie *COOKIE*
+    if *COOKIE* is -d send a random client cookie. Otherwise send the given cookie, which should be a hex string received from a server earlier.
 
 Examples
 --------

--- a/docs/manpages/sdig.1.rst
+++ b/docs/manpages/sdig.1.rst
@@ -58,7 +58,7 @@ tlsProvider *name*
 opcode *OPNUM*
     Use opcode *OPNUM* instead of 0 (Query). For example, ``sdig 192.0.2.1 53 example.com SOA opcode 4`` sends a ``NOTIFY``.
 cookie *COOKIE*
-    if *COOKIE* is - send a random client cookie. Otherwise send the given cookie, which should be a hex string received from a server earlier.
+    if *COOKIE* is ``-`` send a random client cookie. Otherwise send the given cookie, which should be a hex string received from a server earlier.
 
 Examples
 --------

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -540,6 +540,7 @@ sdig_SOURCES = \
 	dnsrecords.cc \
 	dnswriter.cc dnswriter.hh \
 	dolog.hh \
+	ednscookies.cc ednscookies.hh \
 	ednsextendederror.cc ednsextendederror.hh \
 	ednssubnet.cc iputils.cc \
 	libssl.cc libssl.hh \

--- a/pdns/ednscookies.cc
+++ b/pdns/ednscookies.cc
@@ -19,11 +19,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#ifdef HAVE_CONFIG_H
+
 #include "config.h"
-#endif
+
 #include "ednscookies.hh"
-#include "misc.hh"
+#include "iputils.hh"
 
 #ifdef HAVE_CRYPTO_SHORTHASH
 #include <sodium.h>
@@ -54,11 +54,13 @@ bool EDNSCookiesOpt::makeFromString(const char* option, unsigned int len)
 string EDNSCookiesOpt::makeOptString() const
 {
   string ret;
-  if (!isWellFormed())
+  if (!isWellFormed()) {
     return ret;
+  }
   ret.assign(client);
-  if (server.length() != 0)
+  if (server.length() != 0) {
     ret.append(server);
+  }
   return ret;
 }
 
@@ -66,11 +68,13 @@ void EDNSCookiesOpt::getEDNSCookiesOptFromString(const char* option, unsigned in
 {
   client.clear();
   server.clear();
-  if (len < 8)
+  if (len < 8) {
     return;
-  client = string(option, 8);
+  }
+  const std::string tmp(option, len);
+  client = tmp.substr(0, 8);
   if (len > 8) {
-    server = string(option + 8, len - 8);
+    server = tmp.substr(8);
   }
 }
 
@@ -84,16 +88,16 @@ bool EDNSCookiesOpt::isValid([[maybe_unused]] const string& secret, [[maybe_unus
     // Version is not 1, can't verify
     return false;
   }
-  uint32_t ts;
-  memcpy(&ts, &server[4], sizeof(ts));
-  ts = ntohl(ts);
+  uint32_t timestamp{};
+  memcpy(&timestamp, &server[4], sizeof(timestamp));
+  timestamp = ntohl(timestamp);
   // coverity[store_truncates_time_t]
-  uint32_t now = static_cast<uint32_t>(time(nullptr));
+  auto now = static_cast<uint32_t>(time(nullptr));
   // RFC 9018 section 4.3:
   //    The DNS server
   //    SHOULD allow cookies within a 1-hour period in the past and a
   //    5-minute period into the future
-  if (rfc1982LessThan(now + 300, ts) && rfc1982LessThan(ts + 3600, now)) {
+  if (rfc1982LessThan(now + 300, timestamp) && rfc1982LessThan(timestamp + 3600, now)) {
     return false;
   }
   if (secret.length() != crypto_shorthash_KEYBYTES) {
@@ -103,11 +107,13 @@ bool EDNSCookiesOpt::isValid([[maybe_unused]] const string& secret, [[maybe_unus
   string toHash = client + server.substr(0, 8) + source.toByteString();
   string hashResult;
   hashResult.resize(8);
-  crypto_shorthash(
-    reinterpret_cast<unsigned char*>(&hashResult[0]),
-    reinterpret_cast<const unsigned char*>(&toHash[0]),
-    toHash.length(),
-    reinterpret_cast<const unsigned char*>(&secret[0]));
+
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  crypto_shorthash(reinterpret_cast<unsigned char*>(hashResult.data()),
+                   reinterpret_cast<const unsigned char*>(toHash.data()),
+                   toHash.length(),
+                   reinterpret_cast<const unsigned char*>(secret.data()));
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
   return constantTimeStringEquals(server.substr(8), hashResult);
 #else
   return false;
@@ -119,30 +125,30 @@ bool EDNSCookiesOpt::shouldRefresh() const
   if (server.size() < 16) {
     return true;
   }
-  uint32_t ts;
-  memcpy(&ts, &server[4], sizeof(ts));
-  ts = ntohl(ts);
+  uint32_t timestamp{};
+  memcpy(&timestamp, &server.at(4), sizeof(timestamp));
+  timestamp = ntohl(timestamp);
   // coverity[store_truncates_time_t]
-  uint32_t now = static_cast<uint32_t>(time(nullptr));
+  auto now = static_cast<uint32_t>(time(nullptr));
   // RFC 9018 section 4.3:
   //    The DNS server
   //    SHOULD allow cookies within a 1-hour period in the past and a
   //    5-minute period into the future
   // If this is not the case, we need to refresh
-  if (rfc1982LessThan(now + 300, ts) && rfc1982LessThan(ts + 3600, now)) {
+  if (rfc1982LessThan(now + 300, timestamp) && rfc1982LessThan(timestamp + 3600, now)) {
     return true;
   }
 
   // RFC 9018 section 4.3:
   //    The DNS server SHOULD generate a new Server Cookie at least if the
   //     received Server Cookie from the client is more than half an hour old
-  return rfc1982LessThan(ts + 1800, now);
+  return rfc1982LessThan(timestamp + 1800, now);
 }
 
 bool EDNSCookiesOpt::makeServerCookie([[maybe_unused]] const string& secret, [[maybe_unused]] const ComboAddress& source)
 {
 #ifdef HAVE_CRYPTO_SHORTHASH
-  static_assert(EDNSCookieSecretSize == crypto_shorthash_KEYBYTES * 2, "The EDNSCookieSecretSize is not twice crypto_shorthash_KEYBYTES");
+  static_assert(EDNSCookieSecretSize == crypto_shorthash_KEYBYTES * static_cast<size_t>(2), "The EDNSCookieSecretSize is not twice crypto_shorthash_KEYBYTES");
 
   if (isValid(secret, source) && !shouldRefresh()) {
     return true;
@@ -158,6 +164,7 @@ bool EDNSCookiesOpt::makeServerCookie([[maybe_unused]] const string& secret, [[m
   server.resize(4, '\0'); // 3 reserved bytes
   // coverity[store_truncates_time_t]
   uint32_t now = htonl(static_cast<uint32_t>(time(nullptr)));
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
   server += string(reinterpret_cast<const char*>(&now), sizeof(now));
   server.resize(8);
 
@@ -165,11 +172,11 @@ bool EDNSCookiesOpt::makeServerCookie([[maybe_unused]] const string& secret, [[m
   toHash += server;
   toHash += source.toByteString();
   server.resize(16);
-  crypto_shorthash(
-    reinterpret_cast<unsigned char*>(&server[8]),
-    reinterpret_cast<const unsigned char*>(&toHash[0]),
-    toHash.length(),
-    reinterpret_cast<const unsigned char*>(&secret[0]));
+  crypto_shorthash(reinterpret_cast<unsigned char*>(&server.at(8)),
+                   reinterpret_cast<const unsigned char*>(toHash.data()),
+                   toHash.length(),
+                   reinterpret_cast<const unsigned char*>(secret.data()));
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
   return true;
 #else
   return false;

--- a/pdns/ednscookies.cc
+++ b/pdns/ednscookies.cc
@@ -151,9 +151,9 @@ void EDNSCookiesOpt::makeClientCookie()
   uint32_t lower = dns_random_uint32();
   uint32_t upper = dns_random_uint32();
   client = string();
-  client.resize(8);
+  client.resize(sizeof(lower) + sizeof(upper));
   memcpy(client.data(), &lower, sizeof(lower));
-  memcpy(&client.at(4), &upper, sizeof(upper));
+  memcpy(&client.at(sizeof(lower)), &upper, sizeof(upper));
 }
 
 bool EDNSCookiesOpt::makeServerCookie([[maybe_unused]] const string& secret, [[maybe_unused]] const ComboAddress& source)

--- a/pdns/ednscookies.cc
+++ b/pdns/ednscookies.cc
@@ -23,6 +23,7 @@
 #include "config.h"
 
 #include "ednscookies.hh"
+#include "dns_random.hh"
 #include "iputils.hh"
 
 #ifdef HAVE_CRYPTO_SHORTHASH
@@ -143,6 +144,16 @@ bool EDNSCookiesOpt::shouldRefresh() const
   //    The DNS server SHOULD generate a new Server Cookie at least if the
   //     received Server Cookie from the client is more than half an hour old
   return rfc1982LessThan(timestamp + 1800, now);
+}
+
+void EDNSCookiesOpt::makeClientCookie()
+{
+  uint32_t lower = dns_random_uint32();
+  uint32_t upper = dns_random_uint32();
+  client = string();
+  client.resize(8);
+  memcpy(client.data(), &lower, sizeof(lower));
+  memcpy(&client.at(4), &upper, sizeof(upper));
 }
 
 bool EDNSCookiesOpt::makeServerCookie([[maybe_unused]] const string& secret, [[maybe_unused]] const ComboAddress& source)

--- a/pdns/ednscookies.hh
+++ b/pdns/ednscookies.hh
@@ -52,6 +52,7 @@ struct EDNSCookiesOpt
   }
 
   [[nodiscard]] bool isValid(const std::string& secret, const ComboAddress& source) const;
+  void makeClientCookie();
   bool makeServerCookie(const std::string& secret, const ComboAddress& source);
   [[nodiscard]] std::string makeOptString() const;
   [[nodiscard]] std::string getServer() const

--- a/pdns/ednscookies.hh
+++ b/pdns/ednscookies.hh
@@ -20,8 +20,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include "namespaces.hh"
-#include "iputils.hh"
+
+#include <string>
+
+union ComboAddress;
 
 struct EDNSCookiesOpt
 {
@@ -35,38 +37,39 @@ struct EDNSCookiesOpt
   bool makeFromString(const std::string& option);
   bool makeFromString(const char* option, unsigned int len);
 
-  size_t size() const
+  [[nodiscard]] size_t size() const
   {
     return server.size() + client.size();
   }
 
-  bool isWellFormed() const
+  [[nodiscard]] bool isWellFormed() const
   {
     // RFC7873 section 5.2.2
     //    In summary, valid cookie lengths are 8 and 16 to 40 inclusive.
+    // That's the total size. We account for client and server size seperately
     return (
-      client.size() == 8 && (server.size() == 0 || (server.size() >= 8 && server.size() <= 32)));
+      client.size() == 8 && (server.empty() || (server.size() >= 8 && server.size() <= 32)));
   }
 
-  bool isValid(const string& secret, const ComboAddress& source) const;
-  bool makeServerCookie(const string& secret, const ComboAddress& source);
-  string makeOptString() const;
-  string getServer() const
+  [[nodiscard]] bool isValid(const std::string& secret, const ComboAddress& source) const;
+  bool makeServerCookie(const std::string& secret, const ComboAddress& source);
+  [[nodiscard]] std::string makeOptString() const;
+  [[nodiscard]] std::string getServer() const
   {
     return server;
   }
-  string getClient() const
+  [[nodiscard]] std::string getClient() const
   {
     return client;
   }
 
 private:
-  bool shouldRefresh() const;
+  [[nodiscard]] bool shouldRefresh() const;
 
   // the client cookie
-  string client;
+  std::string client;
   // the server cookie
-  string server;
+  std::string server;
 
   void getEDNSCookiesOptFromString(const char* option, unsigned int len);
 };

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -630,15 +630,16 @@ string U32ToIP(uint32_t val)
 }
 
 
-string makeHexDump(const string& str)
+string makeHexDump(const string& str, const string& sep)
 {
   std::array<char, 5> tmp;
   string ret;
-  ret.reserve(static_cast<size_t>(str.size()*2.2));
+  ret.reserve(static_cast<size_t>(str.size() * (2 + sep.size())));
 
   for (char n : str) {
-    snprintf(tmp.data(), tmp.size(), "%02x ", static_cast<unsigned char>(n));
+    snprintf(tmp.data(), tmp.size(), "%02x", static_cast<unsigned char>(n));
     ret += tmp.data();
+    ret += sep;
   }
   return ret;
 }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -336,7 +336,7 @@ inline double getTime()
   throw runtime_error(why + ": " + stringerror(errno));
 }
 
-string makeHexDump(const string& str);
+string makeHexDump(const string& str, const string& sep = " ");
 //! Convert the hexstring in to a byte string
 string makeBytesFromHex(const string &in);
 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -140,8 +140,8 @@ pdns_recursor_SOURCES = \
 	dnsseckeeper.hh \
 	dnswriter.cc dnswriter.hh \
 	dolog.hh \
-	ednsextendederror.cc ednsextendederror.hh \
 	ednscookies.cc ednscookies.hh \
+	ednsextendederror.cc ednsextendederror.hh \
 	ednsoptions.cc ednsoptions.hh \
 	ednspadding.cc ednspadding.hh \
 	ednssubnet.cc ednssubnet.hh \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -141,6 +141,7 @@ pdns_recursor_SOURCES = \
 	dnswriter.cc dnswriter.hh \
 	dolog.hh \
 	ednsextendederror.cc ednsextendederror.hh \
+	ednscookies.cc ednscookies.hh \
 	ednsoptions.cc ednsoptions.hh \
 	ednspadding.cc ednspadding.hh \
 	ednssubnet.cc ednssubnet.hh \
@@ -358,6 +359,7 @@ testrunner_SOURCES = \
 	test-dnsparser_hh.cc \
 	test-dnsrecordcontent.cc \
 	test-dnsrecords_cc.cc \
+	test-ednscookie_cc.cc \
 	test-ednsoptions_cc.cc \
 	test-filterpo_cc.cc \
 	test-histogram_hh.cc \

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -107,6 +107,7 @@ common_sources += files(
   src_dir / 'dnsrecords.cc',
   src_dir / 'dnssecinfra.cc',
   src_dir / 'dnswriter.cc',
+  src_dir / 'ednscookies.cc',
   src_dir / 'ednsextendederror.cc',
   src_dir / 'ednsoptions.cc',
   src_dir / 'ednspadding.cc',
@@ -445,7 +446,6 @@ tools = {
 
 test_sources = []
 test_sources += files(
-      src_dir / 'ednscookies.cc',
       src_dir / 'test-aggressive_nsec_cc.cc',
       src_dir / 'test-arguments_cc.cc',
       src_dir / 'test-base32_cc.cc',
@@ -457,6 +457,7 @@ test_sources += files(
       src_dir / 'test-dnsparser_hh.cc',
       src_dir / 'test-dnsrecordcontent.cc',
       src_dir / 'test-dnsrecords_cc.cc',
+      src_dir / 'test-ednscookie_cc.cc',
       src_dir / 'test-ednsoptions_cc.cc',
       src_dir / 'test-filterpo_cc.cc',
       src_dir / 'test-histogram_hh.cc',

--- a/pdns/recursordist/test-ednscookie_cc.cc
+++ b/pdns/recursordist/test-ednscookie_cc.cc
@@ -1,0 +1,1 @@
+../test-ednscookie_cc.cc

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -63,8 +63,8 @@ static void fillPacket(vector<uint8_t>& packet, const string& q, const string& t
 {
   DNSPacketWriter pw(packet, DNSName(q), DNSRecordContent::TypeToNumber(t), qclass, opcode);
 
-  if (dnssec || ednsnm || getenv("SDIGBUFSIZE") || cookie) {
-    char* sbuf = getenv("SDIGBUFSIZE");
+  if (dnssec || ednsnm || getenv("SDIGBUFSIZE") != nullptr || cookie) { // NOLINT(concurrency-mt-unsafe) we'resingle threaded
+    char* sbuf = getenv("SDIGBUFSIZE"); // NOLINT(concurrency-mt-unsafe) we'resingle threaded
     int bufsize;
     if (sbuf)
       bufsize = atoi(sbuf);
@@ -222,7 +222,7 @@ static void printReply(const string& reply, bool showflags, bool hidesoadetails,
   }
 }
 
-int main(int argc, char** argv)
+int main(int argc, char** argv) // NOLINT(readability-function-cognitive-complexity) XXX FIXME
 try {
   /* default timeout of 10s */
   struct timeval timeout{10,0};
@@ -246,6 +246,7 @@ try {
   bool dumpluaraw = false;
   std::optional<string> cookie;
 
+  // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, concurrency-mt-unsafe) it's the argv API and w're single-threaded
   for (int i = 1; i < argc; i++) {
     if ((string)argv[i] == "--help") {
       usage();
@@ -353,6 +354,7 @@ try {
       }
     }
   }
+  // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic, concurrency-mt-unsafe)
 
   if (dot) {
     tcp = true;

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -6,6 +6,7 @@
 #include "dnswriter.hh"
 #include "ednsoptions.hh"
 #include "ednssubnet.hh"
+#include "ednscookies.hh"
 #include "ednsextendederror.hh"
 #include "misc.hh"
 #include "proxy-protocol.hh"
@@ -41,6 +42,7 @@ static void usage()
           "[dnssec] [ednssubnet SUBNET/MASK] [hidesoadetails] [hidettl] [recurse] [showflags] "
           "[tcp] [dot] [insecure] [fastOpen] [subjectName name] [caStore file] [tlsProvider openssl|gnutls] "
           "[proxy UDP(0)/TCP(1) SOURCE-IP-ADDRESS-AND-PORT DESTINATION-IP-ADDRESS-AND-PORT] "
+          "[cookie -/HEX] "
           "[dumpluaraw] [opcode OPNUM]"
        << endl;
 }
@@ -57,11 +59,11 @@ static std::unordered_set<uint16_t> s_expectedIDs;
 
 static void fillPacket(vector<uint8_t>& packet, const string& q, const string& t,
                        bool dnssec, const std::optional<Netmask>& ednsnm,
-                       bool recurse, QClass qclass, uint8_t opcode, uint16_t qid)
+                       bool recurse, QClass qclass, uint8_t opcode, uint16_t qid, const std::optional<string>& cookie)
 {
   DNSPacketWriter pw(packet, DNSName(q), DNSRecordContent::TypeToNumber(t), qclass, opcode);
 
-  if (dnssec || ednsnm || getenv("SDIGBUFSIZE")) {
+  if (dnssec || ednsnm || getenv("SDIGBUFSIZE") || cookie) {
     char* sbuf = getenv("SDIGBUFSIZE");
     int bufsize;
     if (sbuf)
@@ -74,7 +76,19 @@ static void fillPacket(vector<uint8_t>& packet, const string& q, const string& t
       eo.setSource(*ednsnm);
       opts.emplace_back(EDNSOptionCode::ECS, eo.makeOptString());
     }
-
+    if (cookie) {
+      EDNSCookiesOpt cookieOpt;
+      if (*cookie == "-") {
+        cookieOpt.makeClientCookie();
+      }
+      else {
+        string unhex = makeBytesFromHex(*cookie);
+        if (!cookieOpt.makeFromString(unhex)) {
+          cerr << "Malformed cookie in argument list, adding anyway" << endl;
+        }
+      }
+      opts.emplace_back(EDNSOptionCode::COOKIE, cookieOpt.makeOptString());
+    }
     pw.addOpt(bufsize, 0, dnssec ? EDNSOpts::DNSSECOK : 0, opts);
     pw.commit();
   }
@@ -104,8 +118,18 @@ static void printReply(const string& reply, bool showflags, bool hidesoadetails,
   }
 
   cout << endl;
-  cout << "Rcode: " << mdp.d_header.rcode << " ("
-       << RCode::to_s(mdp.d_header.rcode) << "), RD: " << mdp.d_header.rd
+  EDNSOpts edo{};
+  bool hasEDNS = getEDNSOpts(mdp, &edo);
+
+  if (hasEDNS) {
+    uint16_t ercode = edo.d_extRCode << 4 | mdp.d_header.rcode;
+    cout << "Rcode: " << ercode << " (" << ERCode::to_s(ercode);
+  }
+  else {
+    cout << "Rcode: " << mdp.d_header.rcode << " (" << RCode::to_s(mdp.d_header.rcode);
+  }
+
+  cout << "), RD: " << mdp.d_header.rd
        << ", QR: " << mdp.d_header.qr;
   cout << ", TC: " << mdp.d_header.tc << ", AA: " << mdp.d_header.aa
        << ", opcode: " << mdp.d_header.opcode << endl;
@@ -162,28 +186,37 @@ static void printReply(const string& reply, bool showflags, bool hidesoadetails,
     cout << "\t" << i->getContent()->getZoneRepresentation() << "\n";
   }
 
-  EDNSOpts edo;
-  if (getEDNSOpts(mdp, &edo)) {
-    //    cerr<<"Have "<<edo.d_options.size()<<" options!"<<endl;
-    for (vector<pair<uint16_t, string>>::const_iterator iter = edo.d_options.begin();
-         iter != edo.d_options.end(); ++iter) {
-      if (iter->first == EDNSOptionCode::ECS) { // 'EDNS subnet'
+  if (hasEDNS) {
+    for (const auto& iter : edo.d_options) {
+      if (iter.first == EDNSOptionCode::ECS) { // 'EDNS subnet'
         EDNSSubnetOpts reso;
-        if (EDNSSubnetOpts::getFromString(iter->second, &reso)) {
+        if (EDNSSubnetOpts::getFromString(iter.second, &reso)) {
           cerr << "EDNS Subnet response: " << reso.getSource().toString()
                << ", scope: " << reso.getScope().toString()
                << ", family = " << std::to_string(reso.getFamily())
                << endl;
         }
-      } else if (iter->first == EDNSOptionCode::PADDING) {
-        cerr << "EDNS Padding size: " << (iter->second.size()) << endl;
-      } else if (iter->first == EDNSOptionCode::EXTENDEDERROR) {
+      }
+      else if (iter.first == EDNSOptionCode::COOKIE) {
+        EDNSCookiesOpt cookie(iter.second);
+        auto client = cookie.getClient();
+        auto server = cookie.getServer();
+        auto dump = makeHexDump(client, "") + makeHexDump(server, "");
+        if (cookie.isWellFormed()) {
+          cerr << "EDNS Cookie response: " << dump << endl;
+        }
+        else {
+          cerr << "EDNS Cookie response malformed: " << dump << endl;
+        }
+      } else if (iter.first == EDNSOptionCode::PADDING) {
+        cerr << "EDNS Padding size: " << iter.second.size() << endl;
+      } else if (iter.first == EDNSOptionCode::EXTENDEDERROR) {
         EDNSExtendedError eee;
-        if (getEDNSExtendedErrorOptFromString(iter->second, eee)) {
+        if (getEDNSExtendedErrorOptFromString(iter.second, eee)) {
           cerr << "EDNS Extended Error response: " << eee.infoCode << "/" << eee.extraText << endl;
         }
       } else {
-        cerr << "Have unknown option " << (int)iter->first << endl;
+        cerr << "Have unknown option " << (int)iter.first << endl;
       }
     }
   }
@@ -211,6 +244,7 @@ try {
   string caStore;
   string tlsProvider = "openssl";
   bool dumpluaraw = false;
+  std::optional<string> cookie;
 
   for (int i = 1; i < argc; i++) {
     if ((string)argv[i] == "--help") {
@@ -303,6 +337,13 @@ try {
         ComboAddress dest(argv[++i]);
         proxyheader = makeProxyHeader(ptcp, src, dest, {});
       }
+      else if (strcmp(argv[i], "cookie") == 0) {
+        if (argc < i + 2) {
+          cerr << "cookie needs an argument"<<endl;
+          exit(EXIT_FAILURE);
+        }
+        cookie = argv[++i];
+      }
       else if (strcmp(argv[i], "dumpluaraw") == 0) {
         dumpluaraw = true;
       }
@@ -356,7 +397,7 @@ try {
 #ifdef HAVE_LIBCURL
     vector<uint8_t> packet;
     s_expectedIDs.insert(0);
-    fillPacket(packet, name, type, dnssec, ednsnm, recurse, qclass, opcode, 0);
+    fillPacket(packet, name, type, dnssec, ednsnm, recurse, qclass, opcode, 0, cookie);
     MiniCurl mc;
     MiniCurl::MiniCurlHeaders mch;
     mch.emplace("Content-Type", "application/dns-message");
@@ -410,7 +451,7 @@ try {
     for (const auto& it : questions) {
       vector<uint8_t> packet;
       s_expectedIDs.insert(counter);
-      fillPacket(packet, it.first, it.second, dnssec, ednsnm, recurse, qclass, opcode, counter);
+      fillPacket(packet, it.first, it.second, dnssec, ednsnm, recurse, qclass, opcode, counter, cookie);
       counter++;
 
       // Prefer to do a single write, so that fastopen can send all the data on SYN
@@ -440,7 +481,7 @@ try {
   {
     vector<uint8_t> packet;
     s_expectedIDs.insert(0);
-    fillPacket(packet, name, type, dnssec, ednsnm, recurse, qclass, opcode, 0);
+    fillPacket(packet, name, type, dnssec, ednsnm, recurse, qclass, opcode, 0, cookie);
     string question(packet.begin(), packet.end());
     Socket sock(dest.sin4.sin_family, SOCK_DGRAM);
     question = proxyheader + question;

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -63,8 +63,8 @@ static void fillPacket(vector<uint8_t>& packet, const string& q, const string& t
 {
   DNSPacketWriter pw(packet, DNSName(q), DNSRecordContent::TypeToNumber(t), qclass, opcode);
 
-  if (dnssec || ednsnm || getenv("SDIGBUFSIZE") != nullptr || cookie) { // NOLINT(concurrency-mt-unsafe) we'resingle threaded
-    char* sbuf = getenv("SDIGBUFSIZE"); // NOLINT(concurrency-mt-unsafe) we'resingle threaded
+  if (dnssec || ednsnm || getenv("SDIGBUFSIZE") != nullptr || cookie) { // NOLINT(concurrency-mt-unsafe) we're single threaded
+    char* sbuf = getenv("SDIGBUFSIZE"); // NOLINT(concurrency-mt-unsafe) we're single threaded
     int bufsize;
     if (sbuf)
       bufsize = atoi(sbuf);
@@ -246,7 +246,7 @@ try {
   bool dumpluaraw = false;
   std::optional<string> cookie;
 
-  // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, concurrency-mt-unsafe) it's the argv API and w're single-threaded
+  // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, concurrency-mt-unsafe) it's the argv API and we're single-threaded
   for (int i = 1; i < argc; i++) {
     if ((string)argv[i] == "--help") {
       usage();

--- a/pdns/test-ednscookie_cc.cc
+++ b/pdns/test-ednscookie_cc.cc
@@ -25,17 +25,18 @@
 
 #define BOOST_TEST_NO_MAIN
 
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-#include "ednscookies.hh"
 
+#include <string>
 #include <boost/test/unit_test.hpp>
+
+#include "ednscookies.hh"
+#include "iputils.hh"
 
 BOOST_AUTO_TEST_SUITE(test_ednscookie)
 BOOST_AUTO_TEST_CASE(test_getEDNSCookiesOptFromString)
 {
-  string cookie("");
+  std::string cookie;
   EDNSCookiesOpt eco(cookie);
   // Length 0
   BOOST_CHECK(!eco.isWellFormed());
@@ -73,7 +74,7 @@ BOOST_AUTO_TEST_CASE(test_getEDNSCookiesOptFromString)
 
 BOOST_AUTO_TEST_CASE(test_ctor)
 {
-  string cookie("");
+  std::string cookie;
   auto eco = EDNSCookiesOpt(cookie);
   BOOST_CHECK(!eco.isWellFormed());
 
@@ -91,7 +92,7 @@ BOOST_AUTO_TEST_CASE(test_createEDNSServerCookie)
   BOOST_CHECK(eco.isWellFormed());
 
   // wrong keysize (not 128 bits)
-  string secret = "blablablabla";
+  std::string secret = "blablablabla";
   BOOST_CHECK(!eco.makeServerCookie(secret, remote));
   BOOST_CHECK(eco.isWellFormed());
   BOOST_CHECK(!eco.isValid(secret, remote));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Pretty basic, user is required to set the correct cookie on a BADCOOKIE answer, which is shown in the first request/reply below. The second request/reply shows what happens if you set a correct cookie.
```
$ ./sdig 192.168.178.3 53 sub.sub.example.com a cookie -
Reply to question for qname='sub.sub.example.com.', qtype=A
Rcode: 23 (Bad/missing Server Cookie), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
2	.	16777216	IN	OPT	AAoAGGrZ7yCJECiwAQAAAGerQcoDWpPycNQHaQ==
EDNS Cookie response: 6ad9ef20891028b00100000067ab41ca035a93f270d40769

$ ./sdig 192.168.178.3 53 sub.sub.example.com a cookie 6ad9ef20891028b00100000067ab41ca035a93f270d40769
Reply to question for qname='sub.sub.example.com.', qtype=A
Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
0	sub.sub.example.com.	60	IN	A	1.2.3.4
2	.	0	IN	OPT	AAoAGGrZ7yCJECiwAQAAAGerQcoDWpPycNQHaQ==
EDNS Cookie response: 6ad9ef20891028b00100000067ab41ca035a93f270d40769
```
Includes tidy of `ednscookie.??` and some prep work to be able to use cookies in rec. Latter is not strictly needed now, but it will be soon so I left that in.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
