### PR TITLE
[tools] fix sdig link

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -579,11 +579,11 @@ sdig_CPPFLAGS += $(LIBSSL_CFLAGS)
 sdig_LDADD += $(LIBSSL_LIBS)
 endif
 
+endif
+
 if LIBSODIUM
 sdig_CPPFLAGS +=$(LIBSODIUM_CFLAGS)
 sdig_LDADD += $(LIBSODIUM_LIBS)
-endif
-
 endif
 
 calidns_SOURCES = \


### PR DESCRIPTION
### Short description
As mentioned in [this comment](https://github.com/PowerDNS/pdns/pull/15140#issuecomment-2653144673), if using autotools, `sdig` will fail to link due to libsodium dependencies.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
