### PR TITLE
dnsdist: Bump the required version of `meson` to 1.3

### DIFF
--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -4,7 +4,7 @@ project(
   version: run_command('../../builder-support' / 'gen-version', check: true).stdout().strip(),
   license: 'GPLv2',
   license_files: 'NOTICE',
-  meson_version: '>= 1.2.1',
+  meson_version: '>= 1.3.0',
   default_options: [
     'buildtype=debugoptimized',
     'warning_level=2',          # TODO Move this to 3 to enable -Wpedantic


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since we now use the `follow_symlinks` option of `install_data()`. We could probably make it work with older versions but a quick look at what distributions provide suggests that 1.2.1 or 1.3.0 is practically the same amount of pain.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
