### PR TITLE
Make the record representation of ALIAS match CNAME

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -36,7 +36,10 @@ void DNSResourceRecord::setContent(const string &cont) {
     case QType::MX:
       if (content.size() >= 2 && *(content.rbegin()+1) == ' ')
         return;
-      /* Falls through. */
+      [[fallthrough]];
+#if !defined(RECURSOR)
+    case QType::ALIAS:
+#endif
     case QType::CNAME:
     case QType::DNAME:
     case QType::NS:
@@ -64,6 +67,9 @@ string DNSResourceRecord::getZoneRepresentation(bool noDot) const {
       if (*(last.rbegin()) != '.' && !noDot)
         ret << ".";
       break;
+#if !defined(RECURSOR)
+    case QType::ALIAS:
+#endif
     case QType::CNAME:
     case QType::DNAME:
     case QType::NS:

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1113,8 +1113,17 @@ static int listZone(const DNSName &zone) {
 
   while(di.backend->get(rr)) {
     if(rr.qtype.getCode() != 0) {
-      if ( (rr.qtype.getCode() == QType::NS || rr.qtype.getCode() == QType::SRV || rr.qtype.getCode() == QType::MX || rr.qtype.getCode() == QType::CNAME) && !rr.content.empty() && rr.content[rr.content.size()-1] != '.')
-	rr.content.append(1, '.');
+      switch (rr.qtype.getCode()) {
+      case QType::ALIAS:
+      case QType::CNAME:
+      case QType::MX:
+      case QType::NS:
+      case QType::SRV:
+        if (!rr.content.empty() && rr.content[rr.content.size()-1] != '.') {
+          rr.content.append(1, '.');
+        }
+        break;
+      }
 
       cout<<rr.qname<<"\t"<<rr.ttl<<"\tIN\t"<<rr.qtype.toString()<<"\t"<<rr.content<<"\n";
     }

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -607,7 +607,9 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
     }
     break;
 
-
+#if !defined(RECURSOR)
+  case QType::ALIAS:
+#endif
   case QType::NS:
   case QType::CNAME:
   case QType::DNAME:

--- a/regression-tests.nobackend/lmdb-schema-upgrade/expected_result
+++ b/regression-tests.nobackend/lmdb-schema-upgrade/expected_result
@@ -14,7 +14,7 @@ external.example.com	120	IN	CNAME	somewhere.else.net.
 external-mail.example.com	120	IN	MX	25 server1.test.com.
 france.example.com	120	IN	NS	ns1.otherprovider.net.
 france.example.com	120	IN	NS	ns2.otherprovider.net.
-google-alias.example.com	120	IN	ALIAS	google-public-dns-a.google.com
+google-alias.example.com	120	IN	ALIAS	google-public-dns-a.google.com.
 hightype.example.com	120	IN	A	192.168.1.5
 hightype.example.com	120	IN	TYPE65534	\# 5 07ed260001
 host-0.example.com	120	IN	A	192.168.1.0
@@ -20338,7 +20338,7 @@ external.example.com	120	IN	CNAME	somewhere.else.net.
 external-mail.example.com	120	IN	MX	25 server1.test.com.
 france.example.com	120	IN	NS	ns1.otherprovider.net.
 france.example.com	120	IN	NS	ns2.otherprovider.net.
-google-alias.example.com	120	IN	ALIAS	google-public-dns-a.google.com
+google-alias.example.com	120	IN	ALIAS	google-public-dns-a.google.com.
 hightype.example.com	120	IN	A	192.168.1.5
 hightype.example.com	120	IN	TYPE65534	\# 5 07ed260001
 host-0.example.com	120	IN	A	192.168.1.0


### PR DESCRIPTION
### Short description
There are a couples of issues where people have noticed odd behaviour with ALIAS records. My understanding of them is that they should be represented similarly to CNAME records, except for name compression.

This PR implements this and makes sure that they are stored with a non-root trailing dot[1], and said dot is removed for display and when serving the record contents.

[1] Except on LMDB, which always stores records without non-root trailing dots; I suppose this is intentional in order to save space in the database.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] no idea what I am doing