### PR TITLE
recursor/meson: fix typo in comment

### DIFF
--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -13,7 +13,7 @@ project(
 )
 meson.add_dist_script('meson-dist-script.sh')
 
-# When runniog meson dist, the command below produces multiple lines on stderr:
+# When running meson dist, the command below produces multiple lines on stderr:
 # Unable to evaluate subdir([]) in AstInterpreter --> Skipping
 meson.add_dist_script('version.sh', 'set-dist', meson.project_version())
 


### PR DESCRIPTION
### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
