### PR TITLE
dnsdist: Generate tarballs via `meson dist`

### DIFF
--- a/builder-support/gen-version
+++ b/builder-support/gen-version
@@ -10,7 +10,7 @@ DIRTY=""
 git status | grep -q clean || DIRTY='.dirty'
 
 # Special environment variable to signal that we are building a release, as this
-# has consequenses for the version number.
+# has consequences for the version number.
 if [ "${IS_RELEASE}" = "YES" ]; then
   TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
   if [ -n "${TAG}" ]; then
@@ -53,7 +53,7 @@ if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
     # We used 0.0.XXXXgHASH for master in the previous incarnation of our build pipeline.
     # This now becomes 0.0.XXXX.0.gHASH, as 0.0.0.XXXX.gHASH (which is more correct)
     # would break upgrades for those running master
-    # This _should_ be ok for forever is we stick to X.Y.Z for version numbers
+    # This _should_ be ok for forever if we stick to X.Y.Z for version numbers
     LAST_TAG=0.0
     COMMITS_SINCE_TAG="$(git rev-list --count 12c868770afc20b6cc0da439d881105151d557dd..HEAD 2> /dev/null).0"
     [ "${COMMITS_SINCE_TAG}" = ".0" ] && COMMITS_SINCE_TAG=0.0

--- a/pdns/dnsdistdist/builder-support/gen-version
+++ b/pdns/dnsdistdist/builder-support/gen-version
@@ -10,7 +10,7 @@ DIRTY=""
 git status | grep -q clean || DIRTY='.dirty'
 
 # Special environment variable to signal that we are building a release, as this
-# has consequenses for the version number.
+# has consequences for the version number.
 if [ "${IS_RELEASE}" = "YES" ]; then
   TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
   if [ -n "${TAG}" ]; then
@@ -53,7 +53,7 @@ if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
     # We used 0.0.XXXXgHASH for master in the previous incarnation of our build pipeline.
     # This now becomes 0.0.XXXX.0.gHASH, as 0.0.0.XXXX.gHASH (which is more correct)
     # would break upgrades for those running master
-    # This _should_ be ok for forever is we stick to X.Y.Z for version numbers
+    # This _should_ be ok for forever if we stick to X.Y.Z for version numbers
     LAST_TAG=0.0
     COMMITS_SINCE_TAG="$(git rev-list --count 12c868770afc20b6cc0da439d881105151d557dd..HEAD 2> /dev/null).0"
     [ "${COMMITS_SINCE_TAG}" = ".0" ] && COMMITS_SINCE_TAG=0.0

--- a/pdns/dnsdistdist/builder-support/gen-version
+++ b/pdns/dnsdistdist/builder-support/gen-version
@@ -1,1 +1,77 @@
-../../../builder-support/gen-version
+#!/bin/sh
+if [ ! -z "${BUILDER_VERSION}" ]; then
+  printf ${BUILDER_VERSION}
+  exit 0
+fi
+
+VERSION="unknown"
+
+DIRTY=""
+git status | grep -q clean || DIRTY='.dirty'
+
+# Special environment variable to signal that we are building a release, as this
+# has consequenses for the version number.
+if [ "${IS_RELEASE}" = "YES" ]; then
+  TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
+  if [ -n "${TAG}" ]; then
+    # We're on a tag
+    echo "${TAG}${DIRTY}" > .version
+    printf "${TAG}${DIRTY}"
+    exit 0
+  fi
+  echo 'This is not a tag, either tag this commit or do not set $IS_RELEASE' >&2
+  exit 1
+fi
+
+#
+# Generate the version number based on the branch
+#
+if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
+  if [ -n "${BUILDER_MODULES}" ]; then
+    match=${BUILDER_MODULES}
+    [ $match = "authoritative" ] && match='auth'
+    [ $match = "recursor" ] && match='rec'
+    GIT_VERSION="$(git describe --match=${match}-* --tags | cut -d- -f2-)"
+    if [ $(echo ${GIT_VERSION} | awk -F"-" '{print NF-1}') = '3' ]; then
+      # A prerelease happened before
+      LAST_TAG="$(echo ${GIT_VERSION} | cut -d- -f1-2)"
+      COMMITS_SINCE_TAG="$(echo ${GIT_VERSION} | cut -d- -f3)"
+      GIT_HASH="$(echo ${GIT_VERSION} | cut -d- -f4)"
+    elif [ $(echo ${GIT_VERSION} | awk -F"-" '{print NF-1}') = '1' ]; then
+      # Exactly on a pre-release
+      LAST_TAG="$(echo ${GIT_VERSION} | cut -d- -f1-2)"
+    else
+      LAST_TAG="$(echo ${GIT_VERSION} | cut -d- -f1)"
+      COMMITS_SINCE_TAG="$(echo ${GIT_VERSION} | cut -d- -f2)"
+      GIT_HASH="$(echo ${GIT_VERSION} | cut -d- -f3)"
+    fi
+  fi
+
+  if [ -z "${GIT_VERSION}" ]; then
+    # BUILDER_SUPPORT has more than one product listed, fall back to the 0.0.0 logic
+
+    # We used 0.0.XXXXgHASH for master in the previous incarnation of our build pipeline.
+    # This now becomes 0.0.XXXX.0.gHASH, as 0.0.0.XXXX.gHASH (which is more correct)
+    # would break upgrades for those running master
+    # This _should_ be ok for forever is we stick to X.Y.Z for version numbers
+    LAST_TAG=0.0
+    COMMITS_SINCE_TAG="$(git rev-list --count 12c868770afc20b6cc0da439d881105151d557dd..HEAD 2> /dev/null).0"
+    [ "${COMMITS_SINCE_TAG}" = ".0" ] && COMMITS_SINCE_TAG=0.0
+    GIT_HASH="g$(git rev-parse HEAD | cut -c1-10 2> /dev/null)"
+  fi
+
+  BRANCH=".$(git rev-parse --abbrev-ref HEAD | perl -p -e 's/[^[:alnum:]]//g;')"
+
+  TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
+  if [ -n "${TAG}" ]; then # We're exactly on a tag
+    COMMITS_SINCE_TAG="0"
+    GIT_HASH="g$(git show --no-patch --format=format:%h HEAD 2>/dev/null)"
+    if [ -z "$GIT_HASH" ]; then
+      GIT_HASH="g$(git show --format=format:%h HEAD | head -n1)"
+    fi
+  fi
+
+  VERSION="${LAST_TAG}.${COMMITS_SINCE_TAG}${BRANCH}.${GIT_HASH}${DIRTY}"
+fi
+
+printf $VERSION

--- a/pdns/dnsdistdist/meson-dist-script.sh
+++ b/pdns/dnsdistdist/meson-dist-script.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -e
+
+echo Running meson-dist-script
+echo PWD=$(pwd)
+echo MESON_SOURCE_ROOT=$MESON_SOURCE_ROOT
+echo MESON_PROJECT_DIST_ROOT=$MESON_PROJECT_DIST_ROOT
+
+cd "$MESON_PROJECT_DIST_ROOT"
+
+# Get all symlinks
+symlinks=$(find . -type l)
+
+# If these two get out-of-sync, fix it! It used to be a symlink but that can no longer be as we are
+# working with a partial checkout in the dist root dir.
+cmp "$MESON_SOURCE_ROOT"/../../builder-support/gen-version "$MESON_PROJECT_DIST_ROOT"/builder-support/gen-version
+
+# Get the dereffed symbolic links (the actual files being pointed to) from the source dir
+# Extract them over the existing symbolic links
+tar -C "$MESON_SOURCE_ROOT" -hcf - $symlinks | tar -xf - -C "$MESON_PROJECT_DIST_ROOT"
+
+# Run autoconf for people using autotools to build, this creates a configure script with VERSION set
+echo Running autoreconf -vi so distfile is still usable for autotools building
+# Run autoconf for people using autotools to build, this creates a configure sc
+autoreconf -vi
+
+# Generate man pages
+cd "$MESON_PROJECT_BUILD_ROOT"
+meson compile man-pages
+cp -vp *.1 "$MESON_PROJECT_DIST_ROOT"
+
+rm -rf "$MESON_PROJECT_DIST_ROOT"/autom4te.cache
+
+# Generate a few files to reduce build dependencies
+echo 'If the below command generates an error, remove dnslabeltext.cc from source dir (remains of an autotools build?) and start again with a clean meson setup'
+ninja libdnsdist-dnslabeltext.a.p/dnslabeltext.cc
+cp -vp libdnsdist-dnslabeltext.a.p/dnslabeltext.cc "$MESON_PROJECT_DIST_ROOT"

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -1,7 +1,7 @@
 project(
   'dnsdist',
   ['c', 'cpp'],
-  version: run_command('../../builder-support' / 'gen-version', check: true).stdout().strip(),
+  version: run_command('version.sh', 'get-vcs', check: true).stdout().strip(),
   license: 'GPLv2',
   license_files: 'NOTICE',
   meson_version: '>= 1.3.0',
@@ -12,6 +12,12 @@ project(
     'b_pie=true',
   ],
 )
+meson.add_dist_script('meson-dist-script.sh')
+
+# When running meson dist, the command below produces multiple lines on stderr:
+# Unable to evaluate subdir([]) in AstInterpreter --> Skipping
+meson.add_dist_script('version.sh', 'set-dist', meson.project_version())
+
 add_project_arguments('-DDNSDIST', language: 'cpp')
 
 

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -574,27 +574,34 @@ if get_option('man-pages') and python.found()
   foreach tool, info: tools
     if 'manpages' in info
       foreach man_page: info['manpages']
-        generated_man_pages += man_page
+        if not fs.is_file(man_page)
+          generated_man_pages += man_page
+        endif
       endforeach
     endif
   endforeach
-  custom_target(
-     'man-pages',
-     input: man_pages,
-     output: generated_man_pages,
-     install: true,
-     install_dir: join_paths(get_option('mandir'), 'man1'),
-     command: [
-       python,
-       product_source_dir / docs_dir / 'generate-man-pages.py',
-       '--build-root', '@BUILD_ROOT@',
-       '--source-root', '@SOURCE_ROOT@',
-       '--venv-name', 'venv-dnsdist-man-pages',
-       '--requirements-file', docs_dir / 'requirements.txt',
-       '--source-directory', docs_dir,
-       '--target-directory', '@BUILD_ROOT@',
-     ] + man_pages,
-  )
+  if generated_man_pages.length() != 0
+    summary('Generating man pages', true, section: 'Manual Pages')
+    custom_target(
+       'man-pages',
+       input: man_pages,
+       output: generated_man_pages,
+       install: true,
+       install_dir: join_paths(get_option('mandir'), 'man1'),
+       command: [
+         python,
+         product_source_dir / docs_dir / 'generate-man-pages.py',
+         '--build-root', '@BUILD_ROOT@',
+         '--source-root', '@SOURCE_ROOT@',
+         '--venv-name', 'venv-dnsdist-man-pages',
+         '--requirements-file', docs_dir / 'requirements.txt',
+         '--source-directory', docs_dir,
+         '--target-directory', '@BUILD_ROOT@',
+       ] + man_pages,
+    )
+  else
+    summary('Generating man pages', false, section: 'Manual Pages')
+  endif
 endif
 
 if dep_systemd_prog.found()

--- a/pdns/dnsdistdist/version.sh
+++ b/pdns/dnsdistdist/version.sh
@@ -1,0 +1,1 @@
+../recursordist/version.sh

--- a/pdns/recursordist/builder-support/gen-version
+++ b/pdns/recursordist/builder-support/gen-version
@@ -10,7 +10,7 @@ DIRTY=""
 git status | grep -q clean || DIRTY='.dirty'
 
 # Special environment variable to signal that we are building a release, as this
-# has consequenses for the version number.
+# has consequences for the version number.
 if [ "${IS_RELEASE}" = "YES" ]; then
   TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
   if [ -n "${TAG}" ]; then
@@ -53,7 +53,7 @@ if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
     # We used 0.0.XXXXgHASH for master in the previous incarnation of our build pipeline.
     # This now becomes 0.0.XXXX.0.gHASH, as 0.0.0.XXXX.gHASH (which is more correct)
     # would break upgrades for those running master
-    # This _should_ be ok for forever is we stick to X.Y.Z for version numbers
+    # This _should_ be ok for forever if we stick to X.Y.Z for version numbers
     LAST_TAG=0.0
     COMMITS_SINCE_TAG="$(git rev-list --count 12c868770afc20b6cc0da439d881105151d557dd..HEAD 2> /dev/null).0"
     [ "${COMMITS_SINCE_TAG}" = ".0" ] && COMMITS_SINCE_TAG=0.0


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR mimics what was done for the recursor, allowing DNSdist tarballs to be generated via `meson`. The resulting tarball builds fine, and looking at the differences with the same tarball generated via `autotools` did not show any issue (there are some differences, mostly generated files that are present in the `meson`-generated tarball and not in the `autotools` one. If anything this is a missing optimization in the `autotools` version). `htmlfiles.h` is included in the `autotools` version and not in the `meson` one, but that does not seem to be an issue.
It also includes the `man-pages` optimization added to the recursor in https://github.com/PowerDNS/pdns/pull/15161.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

