### PR TITLE
dnsdist: Fix several unused parameter warnings without DoH support

### DIFF
--- a/pdns/dnsdistdist/dnsdist-actions-factory.cc
+++ b/pdns/dnsdistdist/dnsdist-actions-factory.cc
@@ -2417,7 +2417,7 @@ std::shared_ptr<DNSAction> getKeyValueStoreRangeLookupAction(std::shared_ptr<Key
 }
 #endif /* defined(HAVE_LMDB) || defined(HAVE_CDB) */
 
-std::shared_ptr<DNSAction> getHTTPStatusAction(uint16_t status, PacketBuffer&& body, const std::string& contentType, const dnsdist::ResponseConfig& responseConfig)
+std::shared_ptr<DNSAction> getHTTPStatusAction([[maybe_unused]] uint16_t status, [[maybe_unused]] PacketBuffer&& body, [[maybe_unused]] const std::string& contentType, [[maybe_unused]] const dnsdist::ResponseConfig& responseConfig)
 {
 #if defined(HAVE_DNS_OVER_HTTPS)
   return std::shared_ptr<DNSAction>(new HTTPStatusAction(status, std::move(body), contentType, responseConfig));

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -883,7 +883,7 @@ static void handleLoggingConfiguration(const dnsdist::rust::settings::LoggingCon
 
 #endif /* defined(HAVE_YAML_CONFIGURATION) */
 
-bool loadConfigurationFromFile(const std::string& fileName, bool isClient, bool configCheck)
+bool loadConfigurationFromFile(const std::string& fileName, [[maybe_unused]] bool isClient, [[maybe_unused]] bool configCheck)
 {
 #if defined(HAVE_YAML_CONFIGURATION)
   // this is not very elegant but passing a context to the functions called by the

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -419,7 +419,7 @@ size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dq, c
   return totalCount;
 }
 
-size_t dnsdist_ffi_dnsquestion_get_http_headers(dnsdist_ffi_dnsquestion_t* ref, [[maybe_unused]] const dnsdist_ffi_http_header_t** out)
+size_t dnsdist_ffi_dnsquestion_get_http_headers([[maybe_unused]] dnsdist_ffi_dnsquestion_t* ref, [[maybe_unused]] const dnsdist_ffi_http_header_t** out)
 {
 #if defined(HAVE_DNS_OVER_HTTPS) || defined(HAVE_DNS_OVER_HTTP3)
   const auto processHeaders = [&ref](const std::unordered_map<std::string, std::string>& headers) {
@@ -498,7 +498,7 @@ void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dq, const cha
   dq->result = std::string(str, strSize);
 }
 
-void dnsdist_ffi_dnsquestion_set_http_response(dnsdist_ffi_dnsquestion_t* ref, [[maybe_unused]] uint16_t statusCode, [[maybe_unused]] const char* body, [[maybe_unused]] size_t bodyLen, [[maybe_unused]] const char* contentType)
+void dnsdist_ffi_dnsquestion_set_http_response([[maybe_unused]] dnsdist_ffi_dnsquestion_t* ref, [[maybe_unused]] uint16_t statusCode, [[maybe_unused]] const char* body, [[maybe_unused]] size_t bodyLen, [[maybe_unused]] const char* contentType)
 {
 #if defined(HAVE_DNS_OVER_HTTPS)
   if (ref->dq->ids.du) {

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -2697,7 +2697,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       frontend->loadTicketsKey(key);
     }
   });
-  luaCtx.writeFunction("loadTicketsKey", [](const std::string& key) {
+  luaCtx.writeFunction("loadTicketsKey", []([[maybe_unused]] const std::string& key) {
     for (const auto& frontend : dnsdist::getFrontends()) {
       if (!frontend) {
         continue;

--- a/pdns/dnsdistdist/dnsdist-rules.cc
+++ b/pdns/dnsdistdist/dnsdist-rules.cc
@@ -32,7 +32,7 @@ HTTPHeaderRule::HTTPHeaderRule(const std::string& header, const std::string& reg
 #endif /* HAVE_DNS_OVER_HTTPS || HAVE_DNS_OVER_HTTP3 */
 }
 
-bool HTTPHeaderRule::matches(const DNSQuestion* dnsQuestion) const
+bool HTTPHeaderRule::matches([[maybe_unused]] const DNSQuestion* dnsQuestion) const
 {
 #if defined(HAVE_DNS_OVER_HTTPS)
   if (dnsQuestion->ids.du) {
@@ -72,7 +72,7 @@ HTTPPathRule::HTTPPathRule(std::string path) :
 #endif /* HAVE_DNS_OVER_HTTPS || HAVE_DNS_OVER_HTTP3 */
 }
 
-bool HTTPPathRule::matches(const DNSQuestion* dnsQuestion) const
+bool HTTPPathRule::matches([[maybe_unused]] const DNSQuestion* dnsQuestion) const
 {
 #if defined(HAVE_DNS_OVER_HTTPS)
   if (dnsQuestion->ids.du) {
@@ -101,7 +101,7 @@ HTTPPathRegexRule::HTTPPathRegexRule(const std::string& regex) :
 #endif /* HAVE_DNS_OVER_HTTPS || HAVE_DNS_OVER_HTTP3 */
 }
 
-bool HTTPPathRegexRule::matches(const DNSQuestion* dnsQuestion) const
+bool HTTPPathRegexRule::matches([[maybe_unused]] const DNSQuestion* dnsQuestion) const
 {
 #if defined(HAVE_DNS_OVER_HTTPS)
   if (dnsQuestion->ids.du) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This time I'm using `[[maybe_unused]]` because the parameters will be used in some configurations. So ``[[maybe_unused]]`` is not actually useless!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
