### PR TITLE
Use meson to generate docs (html + pdf)

### DIFF
--- a/.github/actions/spell-check/excludes.txt
+++ b/.github/actions/spell-check/excludes.txt
@@ -92,6 +92,7 @@ SUMS$
 \.yml$
 \.zip$
 ^codedocs/doxygen\.conf$
+^docs/depfile.py$
 ^docs/http-api/tsigkey\.rst$
 ^docs/lua-records/reference/index\.rst$
 ^modules/remotebackend/example\.rb$

--- a/.github/actions/spell-check/excludes.txt
+++ b/.github/actions/spell-check/excludes.txt
@@ -92,7 +92,7 @@ SUMS$
 \.yml$
 \.zip$
 ^codedocs/doxygen\.conf$
-^docs/depfile.py$
+^docs/depfile\.py$
 ^docs/http-api/tsigkey\.rst$
 ^docs/lua-records/reference/index\.rst$
 ^modules/remotebackend/example\.rb$

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -284,6 +284,7 @@ defpol
 defttl
 Dehaine
 DENIC
+depfile
 descclassname
 descname
 Dessel

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,8 @@
 #
 # import os
 import glob
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import sys
+from pathlib import Path
 import guzzle_sphinx_theme
 import datetime
 
@@ -30,13 +30,15 @@ import datetime
 #
 # needs_sphinx = '1.0'
 
+sys.path.append(str(Path('.').resolve()))
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 #extensions = []
 #extensions = ['redjack.sphinx.lua', 'sphinxcontrib.httpdomain', 'sphinxjsondomain']
 extensions = ['sphinxcontrib.openapi',
-              'sphinxcontrib.fulltoc', 'changelog']
+              'sphinxcontrib.fulltoc', 'changelog', 'depfile']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -237,3 +239,6 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
+
+depfile = 'sphinx.d'
+depfile_stamp = 'sphinx.stamp'

--- a/docs/depfile.py
+++ b/docs/depfile.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+#
+# QEMU depfile generation extension
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This work is licensed under the terms of the GNU GPLv2 or later.
+# See the COPYING file in the top-level directory.
+
+"""depfile is a Sphinx extension that writes a dependency file for
+   an external build system"""
+
+import os
+import sphinx
+import sys
+from pathlib import Path
+
+__version__ = '1.0'
+
+def get_infiles(env):
+    for x in env.found_docs:
+        yield str(env.doc2path(x))
+        yield from ((os.path.join(env.srcdir, dep)
+                    for dep in env.dependencies[x]))
+    for mod in sys.modules.values():
+        if hasattr(mod, '__file__'):
+            if mod.__file__:
+                yield mod.__file__
+    # this is perhaps going to include unused files:
+    for static_path in env.config.html_static_path + env.config.templates_path:
+        for path in Path(static_path).rglob('*'):
+            yield str(path)
+
+    # also include kdoc script
+    #yield str(env.config.kerneldoc_bin[1])
+
+
+def write_depfile(app, exception):
+    if exception:
+        return
+
+    env = app.env
+    if not env.config.depfile:
+        return
+
+    # Using a directory as the output file does not work great because
+    # its timestamp does not necessarily change when the contents change.
+    # So create a timestamp file.
+    if env.config.depfile_stamp:
+        with open(env.config.depfile_stamp, 'w') as f:
+            print('depfile.py: Writing ' + env.config.depfile_stamp)
+
+    with open(env.config.depfile, 'w') as f:
+        print('depfile.py: Writing ' + env.config.depfile)
+        print((env.config.depfile_stamp or app.outdir) + ": \\", file=f)
+        print(*get_infiles(env), file=f)
+        for x in get_infiles(env):
+            print(x + ":", file=f)
+
+def setup(app):
+    app.add_config_value('depfile', None, 'env')
+    app.add_config_value('depfile_stamp', None, 'env')
+    app.connect('build-finished', write_depfile)
+
+    return dict(
+        version = __version__,
+        parallel_read_safe = True,
+        parallel_write_safe = True
+    )

--- a/docs/generate-docs.py
+++ b/docs/generate-docs.py
@@ -40,7 +40,7 @@ def main():
     files = list(itertools.chain.from_iterable(files))
     sphinx_build = venv_directory.joinpath("bin").joinpath("sphinx-build")
 
-    if args.latex_name:
+    if args.pdf_name:
         buildargs = [
             sphinx_build,
             "-M",
@@ -60,8 +60,8 @@ def main():
         buildargs + files, # default is to do all
         check=True
     )
-    if args.latex_name:
-        os.rename(build_root.joinpath('latex').joinpath(args.latex_name), args.latex_name)
+    if args.pdf_name:
+        os.rename(build_root.joinpath('latex').joinpath(args.pdf_name), args.pdf_name)
 
 def create_argument_parser():
     """Create command-line argument parser."""
@@ -105,10 +105,10 @@ def create_argument_parser():
         help="Target directory for man-pages relative to the build root",
     )
     parser.add_argument(
-        "--latex-name",
+        "--pdf-name",
         type=Path,
         required=False,
-        help="Generate latex instead of html",
+        help="Generate pdf instead of html",
     )
     parser.add_argument(
         "files",

--- a/docs/generate-docs.py
+++ b/docs/generate-docs.py
@@ -41,7 +41,7 @@ def main():
     sphinx_build = venv_directory.joinpath("bin").joinpath("sphinx-build")
 
     if args.pdf_name:
-        buildargs = [
+        build_args = [
             sphinx_build,
             "-M",
             "latexpdf",
@@ -49,7 +49,7 @@ def main():
             '.'
         ]
     else:
-        buildargs = [
+        build_args = [
             sphinx_build,
             "-b",
             "html",
@@ -57,7 +57,7 @@ def main():
             target_directory,
         ]
     subprocess.run(
-        buildargs + files, # default is to do all
+        build_args + files, # if files is empty, it means do all files
         check=True
     )
     if args.pdf_name:

--- a/docs/generate-docs.py
+++ b/docs/generate-docs.py
@@ -1,0 +1,105 @@
+"""Generate docs using sphinx in a venv."""
+
+import argparse
+import glob
+import itertools
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+
+def main():
+    """Start the script."""
+    args = create_argument_parser()
+
+    source_root = args.source_root
+    build_root = args.build_root
+
+    # Create the venv.
+    venv_directory = build_root.joinpath(args.venv_name)
+    venv.create(
+        venv_directory,
+        with_pip=True,
+        clear=True,
+        upgrade_deps=True,
+        prompt=args.venv_name,
+    )
+
+    # Install some stuff into the venv.
+    requirements_file = source_root.joinpath(args.requirements_file)
+    pip = venv_directory.joinpath("bin").joinpath("pip")
+    subprocess.run([pip, "install", "-U", "pip", "setuptools", "wheel"], check=True)
+    subprocess.run([pip, "install", "-r", requirements_file], check=True)
+
+    # Run sphinx to generate the man-pages.
+    source_directory = source_root.joinpath(args.source_directory)
+    target_directory = build_root.joinpath(args.target_directory)
+    files = [glob.glob(str(source_root.joinpath(pat))) for pat in args.files]
+    files = list(itertools.chain.from_iterable(files))
+    sphinx_build = venv_directory.joinpath("bin").joinpath("sphinx-build")
+    subprocess.run(
+        [
+            sphinx_build,
+            "-b",
+            "html",
+            source_directory,
+            target_directory,
+        ]
+        + files, # default is to do all
+        check=True
+    )
+
+
+def create_argument_parser():
+    """Create command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Create a virtualenv from a requirements file"
+    )
+    parser.add_argument(
+        "--build-root",
+        type=Path,
+        required=True,
+        help="Build root",
+    )
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        required=True,
+        help="Source root",
+    )
+    parser.add_argument(
+        "--venv-name",
+        type=str,
+        required=True,
+        help="Name for the virtualenv",
+    )
+    parser.add_argument(
+        "--requirements-file",
+        type=Path,
+        required=True,
+        help="Package requirements file relative to the source root",
+    )
+    parser.add_argument(
+        "--source-directory",
+        type=Path,
+        required=True,
+        help="Docs directory relative to the source root (contains conf.py)",
+    )
+    parser.add_argument(
+        "--target-directory",
+        type=Path,
+        required=True,
+        help="Target directory for man-pages relative to the build root",
+    )
+    parser.add_argument(
+        "files",
+        type=Path,
+        nargs="*",
+        help="Input files relative to the source root",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/generate-docs.py
+++ b/docs/generate-docs.py
@@ -66,7 +66,7 @@ def main():
 def create_argument_parser():
     """Create command-line argument parser."""
     parser = argparse.ArgumentParser(
-        description="Create a virtualenv from a requirements file"
+        description="Build html and pdf docs for PowerDNS open source products"
     )
     parser.add_argument(
         "--build-root",
@@ -102,7 +102,7 @@ def create_argument_parser():
         "--target-directory",
         type=Path,
         required=True,
-        help="Target directory for man-pages relative to the build root",
+        help="Target directory relative to the build root",
     )
     parser.add_argument(
         "--pdf-name",

--- a/docs/generate-man-pages.py
+++ b/docs/generate-man-pages.py
@@ -54,7 +54,7 @@ def main():
 def create_argument_parser():
     """Create command-line argument parser."""
     parser = argparse.ArgumentParser(
-        description="Create a virtualenv from a requirements file"
+        description="Build man pages for PowerDNS open source products"
     )
     parser.add_argument(
         "--build-root",

--- a/meson.build
+++ b/meson.build
@@ -1124,47 +1124,48 @@ if get_option('unit-tests-backends')
   endforeach
 endif
 
-html_docs = custom_target(
-  'html-docs',
-  command: [
-      python,
-      product_source_dir / docs_dir / 'generate-docs.py',
-      '--build-root', '@BUILD_ROOT@',
-      '--source-root', '@SOURCE_ROOT@',
-      '--venv-name', 'venv-docs',
-      '--requirements-file', docs_dir / 'requirements.txt',
-      '--source-directory', docs_dir,
-      '--target-directory', '@BUILD_ROOT@' / 'html-docs',
-  ],
-  output: 'html-docs',
-  console: true,
-)
+if python.found()
+  html_docs = custom_target(
+    'html-docs',
+    command: [
+        python,
+        product_source_dir / docs_dir / 'generate-docs.py',
+        '--build-root', '@BUILD_ROOT@',
+        '--source-root', '@SOURCE_ROOT@',
+        '--venv-name', 'venv-docs',
+        '--requirements-file', docs_dir / 'requirements.txt',
+        '--source-directory', docs_dir,
+        '--target-directory', '@BUILD_ROOT@' / 'html-docs',
+    ],
+    output: 'html-docs',
+    console: true,
+  )
 
-docs_tarball = custom_target(
-  'html-docs.tar.bz2',
-  command: ['tar', 'cjf', 'html-docs.tar.bz2', html_docs],
-  output: 'html-docs.tar.bz2',
-)
+  docs_tarball = custom_target(
+    'html-docs.tar.bz2',
+    command: ['tar', 'cjf', 'html-docs.tar.bz2', html_docs],
+    output: 'html-docs.tar.bz2',
+  )
 
-pdf_docs = custom_target(
-  command: [
-      python,
-      product_source_dir / docs_dir / 'generate-docs.py',
-      '--build-root', '@BUILD_ROOT@',
-      '--source-root', '@SOURCE_ROOT@',
-      '--venv-name', 'venv-docs',
-      '--requirements-file', docs_dir / 'requirements.txt',
-      '--source-directory', docs_dir,
-      '--target-directory', '@BUILD_ROOT@',
-      '--pdf-name', 'PowerDNS-Authoritative.pdf',
-  ],
-  output: 'PowerDNS-Authoritative.pdf',
-  console: true,
-)
+  pdf_docs = custom_target(
+    command: [
+        python,
+        product_source_dir / docs_dir / 'generate-docs.py',
+        '--build-root', '@BUILD_ROOT@',
+        '--source-root', '@SOURCE_ROOT@',
+        '--venv-name', 'venv-docs',
+        '--requirements-file', docs_dir / 'requirements.txt',
+        '--source-directory', docs_dir,
+        '--target-directory', '@BUILD_ROOT@',
+        '--pdf-name', 'PowerDNS-Authoritative.pdf',
+    ],
+    output: 'PowerDNS-Authoritative.pdf',
+    console: true,
+  )
 
-run_target(
-  'all-docs',
-  # args mentioned in command line become auto-dependency
-  command: ['echo', 'Generated', html_docs, docs_tarball, pdf_docs],
-)
-
+  run_target(
+    'all-docs',
+    # args mentioned in command line become auto-dependency
+    command: ['echo', 'Generated', html_docs, docs_tarball, pdf_docs],
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -1123,3 +1123,48 @@ if get_option('unit-tests-backends')
     endif
   endforeach
 endif
+
+html_docs = custom_target(
+  'html-docs',
+  command: [
+      python,
+      product_source_dir / docs_dir / 'generate-docs.py',
+      '--build-root', '@BUILD_ROOT@',
+      '--source-root', '@SOURCE_ROOT@',
+      '--venv-name', 'venv-docs',
+      '--requirements-file', docs_dir / 'requirements.txt',
+      '--source-directory', docs_dir,
+      '--target-directory', '@BUILD_ROOT@' / 'html-docs',
+  ],
+  output: 'html-docs',
+  console: true,
+)
+
+docs_tarball = custom_target(
+  'html-docs.tar.bz2',
+  command: ['tar', 'cjf', 'html-docs.tar.bz2', html_docs],
+  output: 'html-docs.tar.bz2',
+)
+
+pdf_docs = custom_target(
+  command: [
+      python,
+      product_source_dir / docs_dir / 'generate-docs.py',
+      '--build-root', '@BUILD_ROOT@',
+      '--source-root', '@SOURCE_ROOT@',
+      '--venv-name', 'venv-docs',
+      '--requirements-file', docs_dir / 'requirements.txt',
+      '--source-directory', docs_dir,
+      '--target-directory', '@BUILD_ROOT@',
+      '--pdf-name', 'PowerDNS-Authoritative.pdf',
+  ],
+  output: 'PowerDNS-Authoritative.pdf',
+  console: true,
+)
+
+run_target(
+  'all-docs',
+  # args mentioned in command line become auto-dependency
+  command: ['echo', 'Generated', html_docs, docs_tarball, pdf_docs],
+)
+

--- a/meson.build
+++ b/meson.build
@@ -1125,9 +1125,6 @@ if get_option('unit-tests-backends')
 endif
 
 if python.found()
-  find_rst_files = run_command(['find', docs_dir, '-name', '*.rst'])
-  rst_files = find_rst_files.stdout().strip().split('\n')
-
   html_docs = custom_target(
     'html-docs',
     command: [
@@ -1140,9 +1137,9 @@ if python.found()
         '--source-directory', docs_dir,
         '--target-directory', '@BUILD_ROOT@' / 'html-docs',
     ],
-    output: 'html-docs',
+    output: 'sphinx.stamp',
     console: true,
-    depend_files: rst_files,
+    depfile: 'sphinx.d',
   )
 
   docs_tarball = custom_target(
@@ -1165,7 +1162,7 @@ if python.found()
     ],
     output: 'PowerDNS-Authoritative.pdf',
     console: true,
-    depend_files: rst_files,
+    depfile: 'sphinx.d',
   )
 
   run_target(

--- a/meson.build
+++ b/meson.build
@@ -1125,6 +1125,9 @@ if get_option('unit-tests-backends')
 endif
 
 if python.found()
+  find_rst_files = run_command(['find', docs_dir, '-name', '*.rst'])
+  rst_files = find_rst_files.stdout().strip().split('\n')
+
   html_docs = custom_target(
     'html-docs',
     command: [
@@ -1139,6 +1142,7 @@ if python.found()
     ],
     output: 'html-docs',
     console: true,
+    depend_files: rst_files,
   )
 
   docs_tarball = custom_target(
@@ -1161,6 +1165,7 @@ if python.found()
     ],
     output: 'PowerDNS-Authoritative.pdf',
     console: true,
+    depend_files: rst_files,
   )
 
   run_target(

--- a/pdns/dnsdistdist/docs/conf.py
+++ b/pdns/dnsdistdist/docs/conf.py
@@ -20,6 +20,8 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import sys
+from pathlib import Path
 import datetime
 
 # -- General configuration ------------------------------------------------
@@ -28,11 +30,13 @@ import datetime
 #
 # needs_sphinx = '1.0'
 
+sys.path.append(str(Path('.').resolve()))
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['redjack.sphinx.lua', 'sphinxcontrib.httpdomain', 'sphinxjsondomain',
-              'sphinxcontrib.fulltoc', 'changelog']
+              'sphinxcontrib.fulltoc', 'changelog', 'depfile']
 primary_domain = 'lua'
 
 # Add any paths that contain templates here, relative to this directory.
@@ -200,4 +204,5 @@ epub_copyright = copyright
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
 
-
+depfile = 'sphinx.d'
+depfile_stamp = 'sphinx.stamp'

--- a/pdns/dnsdistdist/docs/depfile.py
+++ b/pdns/dnsdistdist/docs/depfile.py
@@ -1,0 +1,1 @@
+../../../docs/depfile.py

--- a/pdns/dnsdistdist/docs/generate-docs.py
+++ b/pdns/dnsdistdist/docs/generate-docs.py
@@ -1,0 +1,1 @@
+../../../docs/generate-docs.py

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -689,3 +689,46 @@ install_data(
   install_dir : get_option('sysconfdir'),
   follow_symlinks: true
 )
+
+html_docs = custom_target(
+  'html-docs',
+  command: [
+      python,
+      product_source_dir / docs_dir / 'generate-docs.py',
+      '--build-root', '@BUILD_ROOT@',
+      '--source-root', '@SOURCE_ROOT@',
+      '--venv-name', 'venv-docs',
+      '--requirements-file', docs_dir / 'requirements.txt',
+      '--source-directory', docs_dir,
+      '--target-directory', '@BUILD_ROOT@' / 'html-docs',
+  ],
+  output: 'html-docs',
+  console: true,
+)
+
+docs_tarball = custom_target(
+  'html-docs.tar.bz2',
+  command: ['tar', 'cjf', 'html-docs.tar.bz2', html_docs],
+  output: 'html-docs.tar.bz2',
+)
+
+latex_docs = custom_target(
+  command: [
+      python,
+      product_source_dir / docs_dir / 'generate-docs.py',
+      '--build-root', '@BUILD_ROOT@',
+      '--source-root', '@SOURCE_ROOT@',
+      '--venv-name', 'venv-docs',
+      '--requirements-file', docs_dir / 'requirements.txt',
+      '--source-directory', docs_dir,
+      '--target-directory', '@BUILD_ROOT@',
+      '--latex-name', 'dnsdist.pdf',
+  ],
+  output: 'dnsdist.pdf',
+  console: true,
+)
+
+run_target(
+  'all-docs',
+  command: ['echo', html_docs, docs_tarball, latex_docs],
+)

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -690,46 +690,48 @@ install_data(
   follow_symlinks: true
 )
 
-html_docs = custom_target(
-  'html-docs',
-  command: [
-      python,
-      product_source_dir / docs_dir / 'generate-docs.py',
-      '--build-root', '@BUILD_ROOT@',
-      '--source-root', '@SOURCE_ROOT@',
-      '--venv-name', 'venv-docs',
-      '--requirements-file', docs_dir / 'requirements.txt',
-      '--source-directory', docs_dir,
-      '--target-directory', '@BUILD_ROOT@' / 'html-docs',
-  ],
-  output: 'html-docs',
-  console: true,
-)
+if python.found()
+  html_docs = custom_target(
+    'html-docs',
+    command: [
+        python,
+        product_source_dir / docs_dir / 'generate-docs.py',
+        '--build-root', '@BUILD_ROOT@',
+        '--source-root', '@SOURCE_ROOT@',
+        '--venv-name', 'venv-docs',
+        '--requirements-file', docs_dir / 'requirements.txt',
+        '--source-directory', docs_dir,
+        '--target-directory', '@BUILD_ROOT@' / 'html-docs',
+    ],
+    output: 'html-docs',
+    console: true,
+  )
 
-docs_tarball = custom_target(
-  'html-docs.tar.bz2',
-  command: ['tar', 'cjf', 'html-docs.tar.bz2', html_docs],
-  output: 'html-docs.tar.bz2',
-)
+  docs_tarball = custom_target(
+    'html-docs.tar.bz2',
+    command: ['tar', 'cjf', 'html-docs.tar.bz2', html_docs],
+    output: 'html-docs.tar.bz2',
+  )
 
-pdf_docs = custom_target(
-  command: [
-      python,
-      product_source_dir / docs_dir / 'generate-docs.py',
-      '--build-root', '@BUILD_ROOT@',
-      '--source-root', '@SOURCE_ROOT@',
-      '--venv-name', 'venv-docs',
-      '--requirements-file', docs_dir / 'requirements.txt',
-      '--source-directory', docs_dir,
-      '--target-directory', '@BUILD_ROOT@',
-      '--pdf-name', 'dnsdist.pdf',
-  ],
-  output: 'dnsdist.pdf',
-  console: true,
-)
+  pdf_docs = custom_target(
+    command: [
+        python,
+        product_source_dir / docs_dir / 'generate-docs.py',
+        '--build-root', '@BUILD_ROOT@',
+        '--source-root', '@SOURCE_ROOT@',
+        '--venv-name', 'venv-docs',
+        '--requirements-file', docs_dir / 'requirements.txt',
+        '--source-directory', docs_dir,
+        '--target-directory', '@BUILD_ROOT@',
+        '--pdf-name', 'dnsdist.pdf',
+    ],
+    output: 'dnsdist.pdf',
+    console: true,
+  )
 
-run_target(
-  'all-docs',
-  # args mentioned in command line become auto-dependency
-  command: ['echo', 'Generated', html_docs, docs_tarball, pdf_docs],
-)
+  run_target(
+    'all-docs',
+    # args mentioned in command line become auto-dependency
+    command: ['echo', 'Generated', html_docs, docs_tarball, pdf_docs],
+  )
+endif

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -691,6 +691,9 @@ install_data(
 )
 
 if python.found()
+  find_rst_files = run_command(['find', docs_dir, '-name', '*.rst'])
+  rst_files = find_rst_files.stdout().strip().split('\n')
+
   html_docs = custom_target(
     'html-docs',
     command: [
@@ -705,6 +708,7 @@ if python.found()
     ],
     output: 'html-docs',
     console: true,
+    depend_files: rst_files,
   )
 
   docs_tarball = custom_target(
@@ -727,6 +731,7 @@ if python.found()
     ],
     output: 'dnsdist.pdf',
     console: true,
+    depend_files: rst_files,
   )
 
   run_target(

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -712,7 +712,7 @@ docs_tarball = custom_target(
   output: 'html-docs.tar.bz2',
 )
 
-latex_docs = custom_target(
+pdf_docs = custom_target(
   command: [
       python,
       product_source_dir / docs_dir / 'generate-docs.py',
@@ -722,7 +722,7 @@ latex_docs = custom_target(
       '--requirements-file', docs_dir / 'requirements.txt',
       '--source-directory', docs_dir,
       '--target-directory', '@BUILD_ROOT@',
-      '--latex-name', 'dnsdist.pdf',
+      '--pdf-name', 'dnsdist.pdf',
   ],
   output: 'dnsdist.pdf',
   console: true,
@@ -730,5 +730,6 @@ latex_docs = custom_target(
 
 run_target(
   'all-docs',
-  command: ['echo', html_docs, docs_tarball, latex_docs],
+  # args mentioned in command line become auto-dependency
+  command: ['echo', 'Generated', html_docs, docs_tarball, pdf_docs],
 )

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -691,8 +691,6 @@ install_data(
 )
 
 if python.found()
-  find_rst_files = run_command(['find', docs_dir, '-name', '*.rst'])
-  rst_files = find_rst_files.stdout().strip().split('\n')
 
   html_docs = custom_target(
     'html-docs',
@@ -706,9 +704,9 @@ if python.found()
         '--source-directory', docs_dir,
         '--target-directory', '@BUILD_ROOT@' / 'html-docs',
     ],
-    output: 'html-docs',
+    output: 'sphinx.stamp',
     console: true,
-    depend_files: rst_files,
+    depfile: 'sphinx.d',
   )
 
   docs_tarball = custom_target(
@@ -731,7 +729,7 @@ if python.found()
     ],
     output: 'dnsdist.pdf',
     console: true,
-    depend_files: rst_files,
+    depfile: 'sphinx.d',
   )
 
   run_target(

--- a/pdns/recursordist/docs/conf.py
+++ b/pdns/recursordist/docs/conf.py
@@ -18,8 +18,8 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 # import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import sys
+from pathlib import Path
 import guzzle_sphinx_theme
 import datetime
 
@@ -29,13 +29,15 @@ import datetime
 #
 # needs_sphinx = '1.0'
 
+sys.path.append(str(Path('.').resolve()))
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 #extensions = []
 #extensions = ['redjack.sphinx.lua', 'sphinxcontrib.httpdomain', 'sphinxjsondomain']
 extensions = ['redjack.sphinx.lua', 'sphinxcontrib.httpdomain', 'sphinxjsondomain',
-              'sphinxcontrib.fulltoc', 'changelog']
+              'sphinxcontrib.fulltoc', 'changelog', 'depfile']
 primary_domain = 'lua'
 
 # Add any paths that contain templates here, relative to this directory.
@@ -208,3 +210,6 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
+
+depfile = 'sphinx.d'
+depfile_stamp = 'sphinx.stamp'

--- a/pdns/recursordist/docs/depfile.py
+++ b/pdns/recursordist/docs/depfile.py
@@ -1,0 +1,1 @@
+../../../docs/depfile.py

--- a/pdns/recursordist/docs/generate-docs.py
+++ b/pdns/recursordist/docs/generate-docs.py
@@ -1,0 +1,1 @@
+../../../docs/generate-docs.py

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -734,47 +734,48 @@ dep_conf_distfile = custom_target(
   install_dir:  get_option('sysconfdir'),
 )
 
-html_docs = custom_target(
-  'html-docs',
-  command: [
-      python,
-      product_source_dir / docs_dir / 'generate-docs.py',
-      '--build-root', '@BUILD_ROOT@',
-      '--source-root', '@SOURCE_ROOT@',
-      '--venv-name', 'venv-docs',
-      '--requirements-file', docs_dir / 'requirements.txt',
-      '--source-directory', docs_dir,
-      '--target-directory', '@BUILD_ROOT@' / 'html-docs',
-  ],
-  output: 'html-docs',
-  console: true,
-)
+if python.found()
+  html_docs = custom_target(
+    'html-docs',
+    command: [
+        python,
+        product_source_dir / docs_dir / 'generate-docs.py',
+        '--build-root', '@BUILD_ROOT@',
+        '--source-root', '@SOURCE_ROOT@',
+        '--venv-name', 'venv-docs',
+        '--requirements-file', docs_dir / 'requirements.txt',
+        '--source-directory', docs_dir,
+        '--target-directory', '@BUILD_ROOT@' / 'html-docs',
+    ],
+    output: 'html-docs',
+    console: true,
+  )
 
-docs_tarball = custom_target(
-  'html-docs.tar.bz2',
-  command: ['tar', 'cjf', 'html-docs.tar.bz2', html_docs],
-  output: 'html-docs.tar.bz2',
-)
+  docs_tarball = custom_target(
+    'html-docs.tar.bz2',
+    command: ['tar', 'cjf', 'html-docs.tar.bz2', html_docs],
+    output: 'html-docs.tar.bz2',
+  )
 
-pdf_docs = custom_target(
-  command: [
-      python,
-      product_source_dir / docs_dir / 'generate-docs.py',
-      '--build-root', '@BUILD_ROOT@',
-      '--source-root', '@SOURCE_ROOT@',
-      '--venv-name', 'venv-docs',
-      '--requirements-file', docs_dir / 'requirements.txt',
-      '--source-directory', docs_dir,
-      '--target-directory', '@BUILD_ROOT@',
-      '--pdf-name', 'PowerDNS-Recursor.pdf',
-  ],
-  output: 'PowerDNS-Recursor.pdf',
-  console: true,
-)
+  pdf_docs = custom_target(
+    command: [
+        python,
+        product_source_dir / docs_dir / 'generate-docs.py',
+        '--build-root', '@BUILD_ROOT@',
+        '--source-root', '@SOURCE_ROOT@',
+        '--venv-name', 'venv-docs',
+        '--requirements-file', docs_dir / 'requirements.txt',
+        '--source-directory', docs_dir,
+        '--target-directory', '@BUILD_ROOT@',
+        '--pdf-name', 'PowerDNS-Recursor.pdf',
+    ],
+    output: 'PowerDNS-Recursor.pdf',
+    console: true,
+  )
 
-run_target(
-  'all-docs',
-  # args mentioned in command line become auto-dependency
-  command: ['echo', 'Generated', html_docs, docs_tarball, pdf_docs],
-)
-
+  run_target(
+    'all-docs',
+    # args mentioned in command line become auto-dependency
+    command: ['echo', 'Generated', html_docs, docs_tarball, pdf_docs],
+  )
+endif

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -735,6 +735,9 @@ dep_conf_distfile = custom_target(
 )
 
 if python.found()
+  find_rst_files = run_command(['find', docs_dir, '-name', '*.rst'])
+  rst_files = find_rst_files.stdout().strip().split('\n')
+
   html_docs = custom_target(
     'html-docs',
     command: [
@@ -749,6 +752,7 @@ if python.found()
     ],
     output: 'html-docs',
     console: true,
+    depend_files: rst_files,
   )
 
   docs_tarball = custom_target(
@@ -771,6 +775,7 @@ if python.found()
     ],
     output: 'PowerDNS-Recursor.pdf',
     console: true,
+    depend_files: rst_files,
   )
 
   run_target(

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -734,3 +734,16 @@ dep_conf_distfile = custom_target(
   install_dir:  get_option('sysconfdir'),
 )
 
+run_target(
+  'html-docs',
+  command: [
+      python,
+      product_source_dir / docs_dir / 'generate-docs.py',
+      '--build-root', '@BUILD_ROOT@',
+      '--source-root', '@SOURCE_ROOT@',
+      '--venv-name', 'venv-docs',
+      '--requirements-file', docs_dir / 'requirements.txt',
+      '--source-directory', docs_dir,
+      '--target-directory', '@BUILD_ROOT@' / 'html-docs',
+  ]
+)

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -735,8 +735,6 @@ dep_conf_distfile = custom_target(
 )
 
 if python.found()
-  find_rst_files = run_command(['find', docs_dir, '-name', '*.rst'])
-  rst_files = find_rst_files.stdout().strip().split('\n')
 
   html_docs = custom_target(
     'html-docs',
@@ -750,9 +748,10 @@ if python.found()
         '--source-directory', docs_dir,
         '--target-directory', '@BUILD_ROOT@' / 'html-docs',
     ],
-    output: 'html-docs',
+    output: 'sphinx.stamp',
     console: true,
-    depend_files: rst_files,
+    depfile: 'sphinx.d',
+    depends: [ metricfiles, recrust ], # for generated .rst files
   )
 
   docs_tarball = custom_target(
@@ -775,7 +774,8 @@ if python.found()
     ],
     output: 'PowerDNS-Recursor.pdf',
     console: true,
-    depend_files: rst_files,
+    depfile: 'sphinx.d',
+    depends: [ metricfiles, recrust ], # for generated .rst files
   )
 
   run_target(

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -756,7 +756,7 @@ docs_tarball = custom_target(
   output: 'html-docs.tar.bz2',
 )
 
-latex_docs = custom_target(
+pdf_docs = custom_target(
   command: [
       python,
       product_source_dir / docs_dir / 'generate-docs.py',
@@ -766,7 +766,7 @@ latex_docs = custom_target(
       '--requirements-file', docs_dir / 'requirements.txt',
       '--source-directory', docs_dir,
       '--target-directory', '@BUILD_ROOT@',
-      '--latex-name', 'PowerDNS-Recursor.pdf',
+      '--pdf-name', 'PowerDNS-Recursor.pdf',
   ],
   output: 'PowerDNS-Recursor.pdf',
   console: true,
@@ -774,6 +774,7 @@ latex_docs = custom_target(
 
 run_target(
   'all-docs',
-  command: ['echo', 'Generated', html_docs, docs_tarball, latex_docs],
+  # args mentioned in command line become auto-dependency
+  command: ['echo', 'Generated', html_docs, docs_tarball, pdf_docs],
 )
 

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -734,7 +734,7 @@ dep_conf_distfile = custom_target(
   install_dir:  get_option('sysconfdir'),
 )
 
-run_target(
+html_docs = custom_target(
   'html-docs',
   command: [
       python,
@@ -745,5 +745,35 @@ run_target(
       '--requirements-file', docs_dir / 'requirements.txt',
       '--source-directory', docs_dir,
       '--target-directory', '@BUILD_ROOT@' / 'html-docs',
-  ]
+  ],
+  output: 'html-docs',
+  console: true,
 )
+
+docs_tarball = custom_target(
+  'html-docs.tar.bz2',
+  command: ['tar', 'cjf', 'html-docs.tar.bz2', html_docs],
+  output: 'html-docs.tar.bz2',
+)
+
+latex_docs = custom_target(
+  command: [
+      python,
+      product_source_dir / docs_dir / 'generate-docs.py',
+      '--build-root', '@BUILD_ROOT@',
+      '--source-root', '@SOURCE_ROOT@',
+      '--venv-name', 'venv-docs',
+      '--requirements-file', docs_dir / 'requirements.txt',
+      '--source-directory', docs_dir,
+      '--target-directory', '@BUILD_ROOT@',
+      '--latex-name', 'PowerDNS-Recursor.pdf',
+  ],
+  output: 'PowerDNS-Recursor.pdf',
+  console: true,
+)
+
+run_target(
+  'all-docs',
+  command: ['echo', 'Generated', html_docs, docs_tarball, latex_docs],
+)
+


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Same script used for rec, auth and dnsdist docs. All meson.build file gain a few new targets: `html_docs`, `html-docs.tar.bz2` and `product-name.pdf` and a do all called `all-docs`.

To test run `meson compile -C builddir *target*`.

Note that generating a pdf needs latex. The meson script does not check for that atm.

TODO:
- [X] <strike>generating doc sources(by `dnsdist-rust-lib/dnsdist-settings-documentation-generator.py`) for dnsdist (see `Makefile.am` in `dnsdist-rust-lib`)</strike> these file are actually in git, so no need to generate them 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
