### PR TITLE
Consistent spelling of "Lua record" in logs

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -313,13 +313,13 @@ static void declareArguments()
   ::arg().setSwitch("resolve-across-zones", "Resolve CNAME targets and other referrals across local zones") = "yes";
   ::arg().setSwitch("8bit-dns", "Allow 8bit dns queries") = "no";
 #ifdef HAVE_LUA_RECORDS
-  ::arg().setSwitch("enable-lua-records", "Process LUA records for all zones (metadata overrides this)") = "no";
-  ::arg().setSwitch("lua-records-insert-whitespace", "Insert whitespace when combining LUA chunks") = "no";
-  ::arg().set("lua-records-exec-limit", "LUA records scripts execution limit (instructions count). Values <= 0 mean no limit") = "1000";
+  ::arg().setSwitch("enable-lua-records", "Process Lua records for all zones (metadata overrides this)") = "no";
+  ::arg().setSwitch("lua-records-insert-whitespace", "Insert whitespace when combining Lua chunks") = "no";
+  ::arg().set("lua-records-exec-limit", "Lua records scripts execution limit (instructions count). Values <= 0 mean no limit") = "1000";
   ::arg().set("lua-health-checks-expire-delay", "Stops doing health checks after the record hasn't been used for that delay (in seconds)") = "3600";
-  ::arg().set("lua-health-checks-interval", "LUA records health checks monitoring interval in seconds") = "5";
+  ::arg().set("lua-health-checks-interval", "Lua records health checks monitoring interval in seconds") = "5";
   ::arg().set("lua-consistent-hashes-cleanup-interval", "Pre-computed hashes cleanup interval (in seconds)") = "3600";
-  ::arg().set("lua-consistent-hashes-expire-delay", "Cleanup pre-computed hashes that haven't been used for the given delay (in seconds). See pickchashed() LUA function") = "86400";
+  ::arg().set("lua-consistent-hashes-expire-delay", "Cleanup pre-computed hashes that haven't been used for the given delay (in seconds). See pickchashed() Lua function") = "86400";
 #endif
   ::arg().setSwitch("axfr-lower-serial", "Also AXFR a zone from a primary with a lower serial") = "no";
 

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -139,12 +139,12 @@ private:
       try {
         weight = stoi(content);
         if(!status) {
-          g_log<<Logger::Info<<"LUA record monitoring declaring "<<remstring<<" UP for URL "<<cd.url<<"!"<<" with WEIGHT "<<content<<"!"<<endl;
+          g_log<<Logger::Info<<"Lua record monitoring declaring "<<remstring<<" UP for URL "<<cd.url<<"!"<<" with WEIGHT "<<content<<"!"<<endl;
         }
       }
       catch (const std::exception&) {
         if(!status) {
-          g_log<<Logger::Info<<"LUA record monitoring declaring "<<remstring<<" UP for URL "<<cd.url<<"!"<<endl;
+          g_log<<Logger::Info<<"Lua record monitoring declaring "<<remstring<<" UP for URL "<<cd.url<<"!"<<endl;
         }
       }
 
@@ -153,7 +153,7 @@ private:
     }
     catch(std::exception& ne) {
       if(status || first)
-        g_log<<Logger::Info<<"LUA record monitoring declaring "<<remstring<<" DOWN for URL "<<cd.url<<", error: "<<ne.what()<<endl;
+        g_log<<Logger::Info<<"Lua record monitoring declaring "<<remstring<<" DOWN for URL "<<cd.url<<", error: "<<ne.what()<<endl;
       setWeight(cd, 0);
       setDown(cd);
     }
@@ -387,7 +387,7 @@ static std::string getGeo(const std::string& ip, GeoIPInterface::GeoIPQueryAttri
   extern std::function<std::string(const std::string& ip, int)> g_getGeo;
   if(!g_getGeo) {
     if(!initialized) {
-      g_log<<Logger::Error<<"LUA Record attempted to use GeoIPBackend functionality, but backend not launched"<<endl;
+      g_log<<Logger::Error<<"Lua record attempted to use GeoIPBackend functionality, but backend not launched"<<endl;
       initialized=true;
     }
     return "unknown";
@@ -642,7 +642,7 @@ static vector<ComboAddress> useSelector(const std::string &selector, const Combo
   else if(selector=="hashed")
     ret.emplace_back(pickHashed<ComboAddress>(bestwho, candidates));
   else {
-    g_log<<Logger::Warning<<"LUA Record called with unknown selector '"<<selector<<"'"<<endl;
+    g_log<<Logger::Warning<<"Lua record called with unknown selector '"<<selector<<"'"<<endl;
     ret.emplace_back(pickRandom<ComboAddress>(candidates));
   }
 
@@ -1152,10 +1152,10 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
         return fmt.str();
       }
       catch(std::exception& ex) {
-        g_log<<Logger::Error<<"LUA Record exception: "<<ex.what()<<endl;
+        g_log<<Logger::Error<<"Lua record exception: "<<ex.what()<<endl;
       }
       catch(PDNSException& ex) {
-        g_log<<Logger::Error<<"LUA Record exception: "<<ex.reason<<endl;
+        g_log<<Logger::Error<<"Lua record exception: "<<ex.reason<<endl;
       }
       return std::string("unknown");
     });
@@ -1516,7 +1516,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
         }
       }
       catch(std::exception& e) {
-        g_log<<Logger::Error<<"Failed to load include record for LUArecord "<<rec<<": "<<e.what()<<endl;
+        g_log<<Logger::Error<<"Failed to load include record for Lua record "<<rec<<": "<<e.what()<<endl;
       }
     });
 }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -409,7 +409,7 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
 #ifdef HAVE_LUA_RECORDS
       if (rr.dr.d_type == QType::LUA && !d_dk.isPresigned(d_sd.qname)) {
         if(!doLua) {
-          DLOG(g_log<<"Have a wildcard Lua match, but not doing LUA record for this zone"<<endl);
+          DLOG(g_log<<"Have a wildcard Lua match, but not doing Lua record for this zone"<<endl);
           continue;
         }
 

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -409,11 +409,11 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
 #ifdef HAVE_LUA_RECORDS
       if (rr.dr.d_type == QType::LUA && !d_dk.isPresigned(d_sd.qname)) {
         if(!doLua) {
-          DLOG(g_log<<"Have a wildcard LUA match, but not doing LUA record for this zone"<<endl);
+          DLOG(g_log<<"Have a wildcard Lua match, but not doing LUA record for this zone"<<endl);
           continue;
         }
 
-        DLOG(g_log<<"Have a wildcard LUA match"<<endl);
+        DLOG(g_log<<"Have a wildcard Lua match"<<endl);
 
         auto rec=getRR<LUARecordContent>(rr.dr);
         if (!rec) {


### PR DESCRIPTION
### Short description
While trying to help a user trying to make use of Lua records, I couldn't help but notice the related log messages would use different spellings for "Lua".

This PR attempts to homogeneize this, to make searching in the logs easier.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
