### PR TITLE
dnsdist-1.9.x: Handle Quiche >= 0.23.0 since the API changed

### DIFF
--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -751,7 +751,11 @@ static void processH3HeaderEvent(ClientState& clientState, DOH3Frontend& fronten
   }
 
   if (headers.at(":method") == "POST") {
+#if defined(HAVE_QUICHE_H3_EVENT_HEADERS_HAS_MORE_FRAMES)
+    if (!quiche_h3_event_headers_has_more_frames(event)) {
+#else
     if (!quiche_h3_event_headers_has_body(event)) {
+#endif
       handleImmediateError("Empty POST query");
     }
     return;

--- a/pdns/dnsdistdist/m4/pdns_with_quiche.m4
+++ b/pdns/dnsdistdist/m4/pdns_with_quiche.m4
@@ -10,16 +10,23 @@ AC_DEFUN([PDNS_WITH_QUICHE], [
 
   AS_IF([test "x$with_quiche" != "xno"], [
     AS_IF([test "x$with_quiche" = "xyes" -o "x$with_quiche" = "xauto"], [
-      PKG_CHECK_MODULES([QUICHE], [quiche >= 0.22.0], [
+      PKG_CHECK_MODULES([QUICHE], [quiche >= 0.23.0], [
         [HAVE_QUICHE=1]
         AC_DEFINE([HAVE_QUICHE], [1], [Define to 1 if you have quiche])
+        AC_DEFINE([HAVE_QUICHE_H3_EVENT_HEADERS_HAS_MORE_FRAMES], [1], [Define to 1 if the Quiche API has quiche_h3_event_headers_has_more_frames instead of quiche_h3_event_headers_has_body])
         AC_DEFINE([HAVE_QUICHE_STREAM_ERROR_CODES], [1], [Define to 1 if the Quiche API includes error code in quiche_conn_stream_recv and quiche_conn_stream_send])
       ], [
-        # Quiche is older than 0.22.0, or no Quiche at all
-        PKG_CHECK_MODULES([QUICHE], [quiche >= 0.15.0], [
+        PKG_CHECK_MODULES([QUICHE], [quiche >= 0.22.0], [
           [HAVE_QUICHE=1]
           AC_DEFINE([HAVE_QUICHE], [1], [Define to 1 if you have quiche])
-        ], [ : ])
+          AC_DEFINE([HAVE_QUICHE_STREAM_ERROR_CODES], [1], [Define to 1 if the Quiche API includes error code in quiche_conn_stream_recv and quiche_conn_stream_send])
+        ], [
+          # Quiche is older than 0.22.0, or no Quiche at all
+          PKG_CHECK_MODULES([QUICHE], [quiche >= 0.15.0], [
+            [HAVE_QUICHE=1]
+            AC_DEFINE([HAVE_QUICHE], [1], [Define to 1 if you have quiche])
+          ], [ : ])
+        ])
       ])
     ])
   ])


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #15118 to dnsdist-1.9.x: Quiche 0.23.0 has renamed `quiche_h3_event_headers_has_body` to `quiche_h3_event_headers_has_more_frames`, so we need to handle that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
