### PR TITLE
rec: document file extension of zone forward file and do not accept empty list of forwards

### DIFF
--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -1140,6 +1140,7 @@ The DNSSEC notes from :ref:`setting-forward-zones` apply here as well.
  ''',
     'doc-new' : '''
         Same as :ref:`setting-forward-zones`, parsed from a file as a sequence of `Forward Zone`_.
+        The filename MUST end in ``.yml`` for the content to be parsed as YAML.
 
 .. code-block:: yaml
 

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -65,6 +65,9 @@ static void convertServersForAD(const std::string& zone, const std::string& inpu
 {
   vector<string> servers;
   stringtok(servers, input, sepa);
+  if (servers.empty()) {
+    throw PDNSException("empty list of forwarders for domain '" + zone + '"');
+  }
   authDomain.d_servers.clear();
 
   vector<string> addresses;
@@ -412,6 +415,9 @@ static void processForwardZonesFile(shared_ptr<SyncRes::domainmap_t>& newMap, sh
 
       try {
         convertServersForAD(domain, instructions, authDomain, ",; ", log, false);
+      }
+      catch (const PDNSException& e) {
+        throw PDNSException(e.reason + "on line " + std::to_string(linenum) + " of " + filename);
       }
       catch (...) {
         throw PDNSException("Conversion error parsing line " + std::to_string(linenum) + " of " + filename);


### PR DESCRIPTION

The YAML code already disallows an empty forwarders list. The added case mainly covers the case when an old-style forward file is parsed as if it's YAML. This now generated an error:

Feb 21 09:57:39 msg="Fatal error" error="empty list of forwarders for domain '- zone: example.com\"on line 1 of tmp/f.conf" subsystem="config" level="0" prio="Critical" tid="0" ts="1740128259.137" exception="PDNSException"

This hopefully makes admins realize rec is trying to parse YAML content, but is expecting old-style as the file does not end in in .yml.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
