### PR TITLE
[pdnsutil] Suggest increase-serial after create-zone

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -469,6 +469,7 @@ This value is used when a zone is created without providing a SOA record. @ is r
 
 Use this soa-edit value for all zones if no
 :ref:`metadata-soa-edit` metadata value is set.
+This is used by :doc:`pdnsutil increase-serial <manpages/pdnsutil.1>`.
 
 .. _setting-default-soa-edit-signed:
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1588,6 +1588,15 @@ static int createZone(const DNSName &zone, const DNSName& nsname) {
 
   di.backend->commitTransaction();
 
+  // Zone is not secured yet, suggest applying default-soa-edit rule to the
+  // serial number, if applicable.
+  if (sd.serial == 0) {
+    string edit_kind = ::arg()["default-soa-edit"];
+    if (!edit_kind.empty() && !pdns_iequals(edit_kind, "NONE")) {
+      cout << "Consider invoking 'pdnsutil increase-serial " << zone << "'" << endl;
+    }
+  }
+
   return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
### Short description
~~This addresses #8785 by applying the `default-soa-edit` recipe to the freshly created zone serial number, unless `default-soa-content` contains a non-zero serial number.~~

This now only suggests invoking `increase-serial` if relevant.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
