### PR TITLE
dnsdist: Fix a few warnings from Coverity

### DIFF
--- a/pdns/dnsdistdist/bpf-filter.cc
+++ b/pdns/dnsdistdist/bpf-filter.cc
@@ -974,9 +974,10 @@ bool BPFFilter::supportsMatchAction(MatchAction action) const
     return true;
   }
   return d_mapFormat == BPFFilter::MapFormat::WithActions;
-#endif /* HAVE_EBPF */
+#else
   (void)action;
   return false;
+#endif /* HAVE_EBPF */
 }
 
 bool BPFFilter::isExternal() const

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
@@ -207,6 +207,7 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
       return empty;
     }
 
+    // coverity[auto_causes_copy]
     return *dnsQuestion.ids.qTag;
   });
 
@@ -552,9 +553,11 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
 
   luaCtx.registerFunction<LuaAssociativeTable<std::string> (DNSQuestion::*)(void) const>("getHTTPHeaders", [](const DNSQuestion& dnsQuestion) {
     if (dnsQuestion.ids.du) {
+      // coverity[auto_causes_copy]
       return dnsQuestion.ids.du->getHTTPHeaders();
     }
     if (dnsQuestion.ids.doh3u) {
+      // coverity[auto_causes_copy]
       return dnsQuestion.ids.doh3u->getHTTPHeaders();
     }
     return LuaAssociativeTable<std::string>();

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -715,7 +715,7 @@ void setupLuaInspection(LuaContext& luaCtx)
     for (const auto& entry : histo) {
       int stars = static_cast<int>(70.0 * entry.second / highest);
       char value = '*';
-      if (stars == 0 && entry.second != 0) {
+      if (stars == 0 && entry.second != 0 && highest != 0.0) {
         stars = 1; // you get 1 . to show something is there..
         if (70.0 * entry.second / highest > 0.5) {
           value = ':';

--- a/pdns/dnsdistdist/dnsdist-lua-rules.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-rules.cc
@@ -233,7 +233,7 @@ static void mvRule(IdentifierTypeT chainIdentifier, unsigned int from, unsigned 
     auto subject = rules[from];
     rules.erase(rules.begin() + from);
     if (destination > rules.size()) {
-      rules.push_back(subject);
+      rules.push_back(std::move(subject));
     }
     else {
       if (from < destination) {

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -2226,7 +2226,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       if (getOptionalValue<decltype(customResponseHeaders)>(vars, "customResponseHeaders", customResponseHeaders) > 0) {
         for (auto const& headerMap : customResponseHeaders) {
           auto headerResponse = std::pair(boost::to_lower_copy(headerMap.first), headerMap.second);
-          frontend->d_customResponseHeaders.insert(headerResponse);
+          frontend->d_customResponseHeaders.insert(std::move(headerResponse));
         }
       }
 
@@ -3082,7 +3082,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         checkAllParametersConsumed("declareMetric", vars);
       }
     }
-    auto result = dnsdist::metrics::declareCustomMetric(name, type, description, customName, withLabels);
+    auto result = dnsdist::metrics::declareCustomMetric(name, type, description, std::move(customName), withLabels);
     if (result) {
       g_outputBuffer += *result + "\n";
       errlog("Error in declareMetric: %s", *result);

--- a/pdns/dnsdistdist/dnsdist-metrics.cc
+++ b/pdns/dnsdistdist/dnsdist-metrics.cc
@@ -242,7 +242,7 @@ static T& initializeOrGetMetric(const std::string_view& name, std::map<std::stri
   auto metricEntry = metricEntries.find(combinationOfLabels);
   if (metricEntry == metricEntries.end()) {
     metricEntry = metricEntries.emplace(std::piecewise_construct, std::forward_as_tuple(combinationOfLabels), std::forward_as_tuple()).first;
-    g_stats.entries.write_lock()->emplace_back(Stats::EntryTriple{std::string(name), combinationOfLabels, &metricEntry->second.d_value});
+    g_stats.entries.write_lock()->emplace_back(Stats::EntryTriple{std::string(name), std::move(combinationOfLabels), &metricEntry->second.d_value});
   }
   return metricEntry->second;
 }

--- a/pdns/dnsdistdist/dnsdist-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-protobuf.cc
@@ -260,7 +260,7 @@ ProtoBufMetaKey::ProtoBufMetaKey(const std::string& key)
           if (!typeIt->d_caseSensitive) {
             boost::algorithm::to_lower(variable);
           }
-          d_subKey = variable;
+          d_subKey = std::move(variable);
         }
         return;
       }
@@ -383,7 +383,7 @@ const ProtoBufMetaKey::TypeContainer ProtoBufMetaKey::s_types = {
                                             auto tag = key;
                                             tag.append(":");
                                             tag.append(value);
-                                            result.push_back(tag);
+                                            result.push_back(std::move(tag));
                                           }
                                         }
                                         return result;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Nothing exciting: mostly missed optimizations in places where the performance does not matter much (configuration parsing) and a few false positives (places where a copy is actually what we want, and Coverity is not smart enough to understand it).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
