### PR TITLE
build-docker-images: workaround for building arm64 images

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -81,6 +81,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: linux/arm64/v8
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx for multi-platform builds
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
Since one of the recent versions of the Github Ubuntu 22 and 2 Runners, cross-compiling arm64 image builds fails. This issue is being tracked here: <https://github.com/actions/runner-images/issues/11471>

As mentioned in the same issue, a workaround is to use an older version of the image used by the action `setup-qemu-action`. 

Instead of using the default version (`latest`), this PR changes it to an older one (`qemu-v7.0.0-28`).

Test: <https://github.com/romeroalx/pdns/actions/runs/13538882430>




### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
