### PR TITLE
Damage control in Lua createForward()

### DIFF
--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -1046,6 +1046,8 @@ class TestLuaRecords(BaseLuaTest):
                 "ip40414243": "64.65.66.67",
                 "ipp40414243": "64.65.66.67",
                 "ip4041424": "0.0.0.0",
+                "ip-441424": "0.0.0.0",
+                "ip-5abcdef": "0.0.0.0",
                 "host64-22-33-44": "64.22.33.44",
                 "2.2.2.2": "0.0.0.0"   # filtered
             }),
@@ -1057,7 +1059,8 @@ class TestLuaRecords(BaseLuaTest):
                 "2001--db8" : "2001::db8",
                 "20010002000300040005000600070db8" : "2001:2:3:4:5:6:7:db8",
                 "blabla20010002000300040005000600070db8" : "2001:2:3:4:5:6:7:db8",
-                "4000-db8--1" : "fe80::1"   # filtered, with fallback address override
+                "4000-db8--1" : "fe80::1",   # filtered, with fallback address override
+                "l1.l2.l3.l4.l5.l6.l7.l8" : "fe80::1"
             }),
             ".createreverse6.example.org." : (dns.rdatatype.PTR, {
                 "8.b.d.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.2" : "2001--db8.example.com.",


### PR DESCRIPTION
### Short description
This adds a missing validation step in `createForward`, where a code path would be too confident assuming the data it works on is a valid hex representation of an ipv4 address.

This is a one-liner in spirit, the changes are a bit larger in order to appease `clang-tidy`.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
