### PR TITLE
Fix syntax of commented out dynblockrules

### DIFF
--- a/pdns/dnsdistdist/dnsdistconf.lua
+++ b/pdns/dnsdistdist/dnsdistconf.lua
@@ -80,9 +80,9 @@
 
 -- local dbr = dynBlockRulesGroup()
 -- dbr:setQueryRate(30, 10, "Exceeded query rate", 60)
--- dbr:setRCodeRate(dnsdist.NXDOMAIN, 20, 10, "Exceeded NXD rate", 60)
--- dbr:setRCodeRate(dnsdist.SERVFAIL, 20, 10, "Exceeded ServFail rate", 60)
--- dbr:setQTypeRate(dnsdist.ANY, 5, 10, "Exceeded ANY rate", 60)
+-- dbr:setRCodeRate(DNSRCode.NXDOMAIN, 20, 10, "Exceeded NXD rate", 60)
+-- dbr:setRCodeRate(DNSRCode.SERVFAIL, 20, 10, "Exceeded ServFail rate", 60)
+-- dbr:setQTypeRate(DNSQType.ANY, 5, 10, "Exceeded ANY rate", 60)
 -- dbr:setResponseByteRate(10000, 10, "Exceeded resp BW rate", 60)
 -- function maintenance()
 --  dbr:apply()


### PR DESCRIPTION
### Short description
As found the hard way in #15224, fix the commented out example so that it can be used out of the box.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)