### PR TITLE
[auth] [janitor] Mop up some Lua records code

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1590,13 +1590,13 @@ static std::unordered_map<std::string, int> lua_variables{
 
 static void setupLuaRecords(LuaContext& lua)
 {
-  if (g_luaRecordExecLimit > 0) {
-    lua.executeCode(boost::str(boost::format("debug.sethook(report, '', %d)") % g_luaRecordExecLimit));
-  }
-
   lua.writeFunction("report", [](const string& event, const boost::optional<string>& line) -> void {
       lua_report(event, line);
     });
+
+  if (g_luaRecordExecLimit > 0) {
+    lua.executeCode(boost::str(boost::format("debug.sethook(report, '', %d)") % g_luaRecordExecLimit));
+  }
 
   lua.writeFunction("latlon", []() -> string {
       return lua_latlon();

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -619,7 +619,7 @@ static bool getAuth(const DNSName& name, uint16_t qtype, SOAData* soaData)
   }
 }
 
-static std::string getOptionValue(const boost::optional<std::unordered_map<string, string>>& options, const std::string &name, const std::string &defaultValue)
+static std::string getOptionValue(const boost::optional<opts_t>& options, const std::string &name, const std::string &defaultValue)
 {
   string selector=defaultValue;
   if(options) {
@@ -956,7 +956,7 @@ static string lua_latlonMagic()
    return std::to_string(lat)+" "+std::to_string(lon);
 }
 
-static string lua_createReverse(string format, boost::optional<std::unordered_map<string,string>> e)
+static string lua_createReverse(string format, boost::optional<opts_t> e)
 {
   try {
     auto labels = s_lua_record_ctx->qname.getRawLabels();
@@ -1110,7 +1110,7 @@ static string lua_createForward6()
   }
 }
 
-static string lua_createReverse6(const string &format, boost::optional<std::unordered_map<string,string>> excp)
+static string lua_createReverse6(const string &format, boost::optional<opts_t> excp)
 {
   vector<ComboAddress> candidates;
 
@@ -1212,7 +1212,7 @@ static vector<string> lua_filterForward(const string& address, NetmaskGroup& nmg
  *
  * @example ifportup(443, { '1.2.3.4', '5.4.3.2' })"
  */
-static vector<string> lua_ifportup(int port, const boost::variant<iplist_t, ipunitlist_t>& ips, const boost::optional<std::unordered_map<string,string>> options)
+static vector<string> lua_ifportup(int port, const boost::variant<iplist_t, ipunitlist_t>& ips, const boost::optional<opts_t> options)
 {
   port = std::max(port, 0);
   port = std::min(port, static_cast<int>(std::numeric_limits<uint16_t>::max()));
@@ -1611,10 +1611,10 @@ static void setupLuaRecords(LuaContext& lua)
       return lua_createForward6();
     });
 
-  lua.writeFunction("createReverse", [](string format, boost::optional<std::unordered_map<string,string>> e) -> string {
+  lua.writeFunction("createReverse", [](string format, boost::optional<opts_t> e) -> string {
       return lua_createReverse(format, e);
     });
-  lua.writeFunction("createReverse6", [](const string &format, boost::optional<std::unordered_map<string,string>> excp) -> string {
+  lua.writeFunction("createReverse6", [](const string &format, boost::optional<opts_t> excp) -> string {
       return lua_createReverse6(format, excp);
     });
 
@@ -1622,7 +1622,7 @@ static void setupLuaRecords(LuaContext& lua)
       return lua_filterForward(address, nmg, fallback);
     });
 
-  lua.writeFunction("ifportup", [](int port, const boost::variant<iplist_t, ipunitlist_t>& ips, const boost::optional<std::unordered_map<string,string>> options) -> vector<string> {
+  lua.writeFunction("ifportup", [](int port, const boost::variant<iplist_t, ipunitlist_t>& ips, const boost::optional<opts_t> options) -> vector<string> {
       return lua_ifportup(port, ips, options);
     });
 

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -1345,6 +1345,30 @@ lua-health-checks-interval=5
         self.assertAnyRRsetInAnswer(res, reachable_rrs)
         self.assertNoneRRsetInAnswer(res, unreachable_rrs)
 
+class TestLuaRecordsExecLimit(BaseLuaTest):
+     # This configuration is similar to BaseLuaTest, but the exec limit is
+     # set to a very low value.
+    _config_template = """
+geoip-database-files=../modules/geoipbackend/regression-tests/GeoLiteCity.mmdb
+edns-subnet-processing=yes
+launch=bind geoip
+any-to-tcp=no
+enable-lua-records
+lua-records-insert-whitespace=yes
+lua-records-exec-limit=1
+"""
+
+    def testA(self):
+        """
+        Test A query against `any`, failing due to exec-limit
+        """
+        name = 'any.example.org.'
+
+        query = dns.message.make_query(name, 'A')
+
+        res = self.sendUDPQuery(query)
+        self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
+
 if __name__ == '__main__':
     unittest.main()
     exit(0)

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -1202,6 +1202,9 @@ class TestLuaRecords(BaseLuaTest):
 
 
 class TestLuaRecordsShared(TestLuaRecords):
+    # The lua-records-exec-limit parameter needs to be increased from the
+    # default value of 1000, for the testGeoIPQueryAttribute test would hit
+    # the limit.
     _config_template = """
 geoip-database-files=../modules/geoipbackend/regression-tests/GeoLiteCity.mmdb
 edns-subnet-processing=yes
@@ -1210,6 +1213,7 @@ any-to-tcp=no
 enable-lua-records=shared
 lua-records-insert-whitespace=yes
 lua-health-checks-interval=1
+lua-records-exec-limit=1500
 """
 
     def testCounter(self):


### PR DESCRIPTION
### Short description
Today is a new moon, so it's perfect time to work on Lua support in PowerDNS.

This purely janitorial PR splits the monster function `setupLuaRecords` into pieces, so that every single Lua helper function (such as `createReverse`, `ifurlup`...) can be found in its own function.

This will help working in this area in the future.

Probably better reviewed in a per-commit basis, with whitespace changes ignored in the first commit.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)