### PR TITLE
lua comboaddress: raw docs, cleanups, dnsdist add getRaw

### DIFF
--- a/docs/lua-records/reference/comboaddress.rst
+++ b/docs/lua-records/reference/comboaddress.rst
@@ -60,7 +60,7 @@ Functions and methods of a ``ComboAddress``
 
   .. method:: ComboAddress:getRaw() -> string
 
-    Returns in raw bytes format format
+    Returns in raw bytes format
 
   .. method:: ComboAddress:toStringWithPort() -> string
 

--- a/pdns/dnsdistdist/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings.cc
@@ -249,6 +249,7 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.registerFunction<string (ComboAddress::*)() const>("__tostring", [](const ComboAddress& addr) { return addr.toString(); });
   luaCtx.registerFunction<string (ComboAddress::*)() const>("toString", [](const ComboAddress& addr) { return addr.toString(); });
   luaCtx.registerFunction<string (ComboAddress::*)() const>("toStringWithPort", [](const ComboAddress& addr) { return addr.toStringWithPort(); });
+  luaCtx.registerFunction<string (ComboAddress::*)() const>("getRaw", [](const ComboAddress& addr) { return addr.toByteString(); });
   luaCtx.registerFunction<uint16_t (ComboAddress::*)() const>("getPort", [](const ComboAddress& addr) { return ntohs(addr.sin4.sin_port); });
   luaCtx.registerFunction<void (ComboAddress::*)(unsigned int)>("truncate", [](ComboAddress& addr, unsigned int bits) { addr.truncate(bits); });
   luaCtx.registerFunction<bool (ComboAddress::*)() const>("isIPv4", [](const ComboAddress& addr) { return addr.sin4.sin_family == AF_INET; });

--- a/pdns/dnsdistdist/docs/reference/comboaddress.rst
+++ b/pdns/dnsdistdist/docs/reference/comboaddress.rst
@@ -64,6 +64,10 @@ ComboAddresses can be IPv4 or IPv6, and unless you want to know, you don't need 
 
     Returns in human-friendly format
 
+  .. method:: ComboAddress:getRaw() -> string
+
+    Returns in raw bytes format format
+
   .. method:: ComboAddress:tostringWithPort() -> string
                    ComboAddress:toStringWithPort() -> string
 

--- a/pdns/dnsdistdist/docs/reference/comboaddress.rst
+++ b/pdns/dnsdistdist/docs/reference/comboaddress.rst
@@ -66,7 +66,7 @@ ComboAddresses can be IPv4 or IPv6, and unless you want to know, you don't need 
 
   .. method:: ComboAddress:getRaw() -> string
 
-    Returns in raw bytes format format
+    Returns in raw bytes format
 
   .. method:: ComboAddress:tostringWithPort() -> string
                    ComboAddress:toStringWithPort() -> string

--- a/pdns/dnsdistdist/docs/reference/comboaddress.rst
+++ b/pdns/dnsdistdist/docs/reference/comboaddress.rst
@@ -12,6 +12,14 @@ ComboAddresses can be IPv4 or IPv6, and unless you want to know, you don't need 
 
   :param string address: The IP address, with optional port, to represent.
 
+.. function:: newCAFromRaw(rawaddress[, port]) -> ComboAddress
+
+  Returns a new :class:`ComboAddress` object based on the 4- or 16-octet string.
+  For example, ``newCAFromRaw('ABCD')`` makes a ``ComboAddress`` object holding the IP ``65.66.67.68``, because those are the ASCII values for those four letters.
+
+  :param string rawaddress: The IPv4 of IPv6 address as a 4/16 octet string
+  :param int port: The optional port number
+
 .. class:: ComboAddress
 
   A ``ComboAddress`` represents an IP address with possibly a port number.

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -147,22 +147,16 @@ void BaseLua4::prepareContext() {
   d_lw->registerFunction<bool(DNSResourceRecord::*)()>("disabled", [](DNSResourceRecord& rec) { return rec.disabled; });
 
   // ComboAddress
-  d_lw->registerFunction<bool(ComboAddress::*)()>("isIPv4", [](const ComboAddress& ca) { return ca.sin4.sin_family == AF_INET; });
-  d_lw->registerFunction<bool(ComboAddress::*)()>("isIPv6", [](const ComboAddress& ca) { return ca.sin4.sin_family == AF_INET6; });
-  d_lw->registerFunction<uint16_t(ComboAddress::*)()>("getPort", [](const ComboAddress& ca) { return ntohs(ca.sin4.sin_port); } );
-  d_lw->registerFunction<bool(ComboAddress::*)()>("isMappedIPv4", [](const ComboAddress& ca) { return ca.isMappedIPv4(); });
-  d_lw->registerFunction<ComboAddress(ComboAddress::*)()>("mapToIPv4", [](const ComboAddress& ca) { return ca.mapToIPv4(); });
-  d_lw->registerFunction<void(ComboAddress::*)(unsigned int)>("truncate", [](ComboAddress& ca, unsigned int bits) { ca.truncate(bits); });
-  d_lw->registerFunction<string(ComboAddress::*)()>("toString", [](const ComboAddress& ca) { return ca.toString(); });
-  d_lw->registerToStringFunction<string(ComboAddress::*)()>([](const ComboAddress& ca) { return ca.toString(); });
-  d_lw->registerFunction<string(ComboAddress::*)()>("toStringWithPort", [](const ComboAddress& ca) { return ca.toStringWithPort(); });
-  d_lw->registerFunction<string(ComboAddress::*)()>("getRaw", [](const ComboAddress& ca) {
-      if(ca.sin4.sin_family == AF_INET) {
-        auto t=ca.sin4.sin_addr.s_addr; return string((const char*)&t, 4);
-      }
-      else
-        return string((const char*)&ca.sin6.sin6_addr.s6_addr, 16);
-    } );
+  d_lw->registerFunction<bool(ComboAddress::*)()>("isIPv4", [](const ComboAddress& addr) { return addr.sin4.sin_family == AF_INET; });
+  d_lw->registerFunction<bool(ComboAddress::*)()>("isIPv6", [](const ComboAddress& addr) { return addr.sin4.sin_family == AF_INET6; });
+  d_lw->registerFunction<uint16_t(ComboAddress::*)()>("getPort", [](const ComboAddress& addr) { return ntohs(addr.sin4.sin_port); } );
+  d_lw->registerFunction<bool(ComboAddress::*)()>("isMappedIPv4", [](const ComboAddress& addr) { return addr.isMappedIPv4(); });
+  d_lw->registerFunction<ComboAddress(ComboAddress::*)()>("mapToIPv4", [](const ComboAddress& addr) { return addr.mapToIPv4(); });
+  d_lw->registerFunction<void(ComboAddress::*)(unsigned int)>("truncate", [](ComboAddress& addr, unsigned int bits) { addr.truncate(bits); });
+  d_lw->registerFunction<string(ComboAddress::*)()>("toString", [](const ComboAddress& addr) { return addr.toString(); });
+  d_lw->registerToStringFunction<string(ComboAddress::*)()>([](const ComboAddress& addr) { return addr.toString(); });
+  d_lw->registerFunction<string(ComboAddress::*)()>("toStringWithPort", [](const ComboAddress& addr) { return addr.toStringWithPort(); });
+  d_lw->registerFunction<string(ComboAddress::*)()>("getRaw", [](const ComboAddress& addr) { return addr.toByteString(); });
 
   d_lw->writeFunction("newCA", [](const std::string& a) { return ComboAddress(a); });
   d_lw->writeFunction("newCAFromRaw", [](const std::string& raw, boost::optional<uint16_t> port) {


### PR DESCRIPTION
### Short description
Add newCAFromRaw docs, getRaw func+doc

It's mostly dumb copy-paste

Fixes #15246

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
   - I don't see any existing dnsdist regression/unit tests using these functions and I think adding them is beyond the scope
- [ ] added or modified unit test(s)
