### PR TITLE
Check against contentless records in doAdditionalProcessing()

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -536,6 +536,9 @@ void PacketHandler::doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPack
         case QType::SVCB: /* fall-through */
         case QType::HTTPS: {
           auto rrc = getRR<SVCBBaseRecordContent>(rr.dr);
+          if (!rrc) {
+            break;
+          }
           content = rrc->getTarget();
           if (content.isRoot()) {
             content = rr.dr.d_name;
@@ -547,6 +550,9 @@ void PacketHandler::doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPack
         }
         case QType::NAPTR: {
           auto naptrContent = getRR<NAPTRRecordContent>(rr.dr);
+          if (!naptrContent) {
+            break;
+          }
           auto flags = naptrContent->getFlags();
           toLowerInPlace(flags);
           if (flags.find('a') != string::npos) {


### PR DESCRIPTION
### Short description
As noticed by @omoerbeek, the `NAPTR` handling introduced in #15083 is not careful enough and assumes `NAPTR` records are never empty.

This PR adds the missing checks (and to `SVCB` records as well while there)

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
