### PR TITLE
rec: make sure t_tcpClientCounts is always initialized

### DIFF
--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2872,7 +2872,6 @@ static void recursorThread()
       t_proxyProtocolACL = g_initialProxyProtocolACL;
       t_proxyProtocolExceptions = g_initialProxyProtocolExceptions;
       t_udpclientsocks = std::make_unique<UDPClientSocks>();
-      t_tcpClientCounts = std::make_unique<tcpClientCounts_t>();
       if (g_proxyMapping) {
         t_proxyMapping = make_unique<ProxyMapping>(*g_proxyMapping);
       }

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -288,9 +288,6 @@ extern boost::container::flat_set<uint16_t> g_avoidUdpSourcePorts;
 /* without reuseport, all listeners share the same sockets */
 typedef vector<pair<int, std::function<void(int, boost::any&)>>> deferredAdd_t;
 
-typedef map<ComboAddress, uint32_t, ComboAddress::addressOnlyLessThan> tcpClientCounts_t;
-extern thread_local std::unique_ptr<tcpClientCounts_t> t_tcpClientCounts;
-
 inline MT_t* getMT()
 {
   return g_multiTasker ? g_multiTasker.get() : nullptr;

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -68,7 +68,8 @@ bool g_anyToTcp;
 
 uint16_t TCPConnection::s_maxInFlight;
 
-thread_local std::unique_ptr<tcpClientCounts_t> t_tcpClientCounts;
+using tcpClientCounts_t = map<ComboAddress, uint32_t, ComboAddress::addressOnlyLessThan>;
+static thread_local std::unique_ptr<tcpClientCounts_t> t_tcpClientCounts = std::make_unique<tcpClientCounts_t>();
 
 static void handleRunningTCPQuestion(int fileDesc, FDMultiplexer::funcparam_t& var);
 


### PR DESCRIPTION
And while there make it file-local.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This is an attempt to fix the ASAN crash in https://github.com/PowerDNS/pdns/pull/15257#issuecomment-2706009670
but I'm not sure how this scenario (`t_tcpClientCounts` not-initialized or a `nullptr`) can happen, as RecursorThreads are only cleanup up after they have been fully initialized and the multiplexer (the relevant parent in the dt cal stack) is only created for RecursorThreads after `t_tcpClientCounts` is inited.

But as this method of letting the runtime do the init is much cleaner, I decided to create the PR anyway. 

I did not succeed in reproducing the ASAN issue locally.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
