### PR TITLE
Auth webserver Unix socket support

### DIFF
--- a/docs/http-api/index.rst
+++ b/docs/http-api/index.rst
@@ -17,8 +17,8 @@ The following webserver related configuration items are available:
 * :ref:`setting-webserver`: If set to anything but 'no', a webserver is launched.
 * :ref:`setting-webserver-address`: Address to bind the webserver to. Defaults to 127.0.0.1, which implies that only the local computer is able to connect to the nameserver! To allow remote hosts to connect, change to 0.0.0.0 or the physical IP address of your nameserver.
 * :ref:`setting-webserver-password`: If set, viewers will have to enter this password in order to gain access to the statistics, in addition to entering the configured API key on the index page.
-* :ref:`setting-webserver-port`: Port to bind the webserver to.
-* :ref:`setting-webserver-allow-from`: Netmasks that are allowed to connect to the webserver
+* :ref:`setting-webserver-port`: Port to bind the webserver to (not relevant if :ref:`setting-webserver-address` is set to a Unix socket path).
+* :ref:`setting-webserver-allow-from`: Netmasks that are allowed to connect to the webserver (not relevant if :ref:`setting-webserver-address` is set to a Unix socket path).
 * :ref:`setting-webserver-max-bodysize`: Maximum request/response body size in megabytes
 * :ref:`setting-webserver-connection-timeout`: Request/response timeout in seconds
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -2035,7 +2035,7 @@ Start a webserver for monitoring. See :doc:`performance`".
 -  IP Address
 -  Default: 127.0.0.1
 
-IP Address for webserver/API to listen on.
+IP Address or Unix socket path for webserver/API to listen on.
 
 .. _setting-webserver-allow-from:
 
@@ -2046,6 +2046,7 @@ IP Address for webserver/API to listen on.
 -  Default: 127.0.0.1,::1
 
 Webserver/API access is only allowed from these subnets.
+Ignored if ``webserver-address`` is set to a Unix socket path.
 
 .. _setting-webserver-hash-plaintext-credentials:
 
@@ -2141,6 +2142,7 @@ Password required to access the webserver. Since 4.6.0 the password can be hashe
 -  Default: 8081
 
 The port where webserver/API will listen on.
+Ignored if ``webserver-address`` is set to a Unix socket path.
 
 .. _setting-webserver-print-arguments:
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -239,7 +239,7 @@ static void declareArguments()
 
   ::arg().setSwitch("webserver", "Start a webserver for monitoring (api=yes also enables the HTTP listener)") = "no";
   ::arg().setSwitch("webserver-print-arguments", "If the webserver should print arguments") = "no";
-  ::arg().set("webserver-address", "IP Address of webserver/API to listen on") = "127.0.0.1";
+  ::arg().set("webserver-address", "IP Address or Unix socket path for webserver/API to listen on") = "127.0.0.1";
   ::arg().set("webserver-port", "Port of webserver/API to listen on") = "8081";
   ::arg().set("webserver-password", "Password required for accessing the webserver") = "";
   ::arg().set("webserver-allow-from", "Webserver/API access is only allowed from these subnets") = "127.0.0.1,::1";

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -31,6 +31,7 @@
 #include "misc.hh"
 #include <netdb.h>
 #include <sstream>
+#include <sys/un.h>
 
 #include "namespaces.hh"
 
@@ -86,6 +87,7 @@ union ComboAddress
 {
   sockaddr_in sin4{};
   sockaddr_in6 sin6;
+  sockaddr_un sinun;
 
   bool operator==(const ComboAddress& rhs) const
   {
@@ -198,7 +200,10 @@ union ComboAddress
     if (sin4.sin_family == AF_INET) {
       return sizeof(sin4);
     }
-    return sizeof(sin6);
+    if (sin6.sin6_family == AF_INET6) {
+      return sizeof(sin6);
+    }
+    return sizeof(sinun);
   }
 
   ComboAddress()
@@ -227,10 +232,16 @@ union ComboAddress
     setSockaddr(reinterpret_cast<const struct sockaddr*>(socketAddress), sizeof(struct sockaddr_in));
   };
 
+  ComboAddress(const struct sockaddr_un* socketAddress)
+  {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    setSockaddr(reinterpret_cast<const struct sockaddr*>(socketAddress), sizeof(struct sockaddr_un));
+  };
+
   void setSockaddr(const struct sockaddr* socketAddress, socklen_t salen)
   {
     if (salen > sizeof(struct sockaddr_in6)) {
-      throw PDNSException("ComboAddress can't handle other than sockaddr_in or sockaddr_in6");
+      throw PDNSException("ComboAddress can't handle other than sockaddr_in, sockaddr_in6 or sockaddr_un");
     }
     memcpy(this, socketAddress, salen);
   }
@@ -239,12 +250,16 @@ union ComboAddress
   explicit ComboAddress(const string& str, uint16_t port = 0)
   {
     memset(&sin6, 0, sizeof(sin6));
+    memset(&sinun, 0, sizeof(sinun));
     sin4.sin_family = AF_INET;
     sin4.sin_port = 0;
     if (makeIPv4sockaddr(str, &sin4) != 0) {
       sin6.sin6_family = AF_INET6;
       if (makeIPv6sockaddr(str, &sin6) < 0) {
-        throw PDNSException("Unable to convert presentation address '" + str + "'");
+        sinun.sun_family = AF_UNIX;
+        if (makeUNsockaddr(str, &sinun) < 0) {
+          throw PDNSException("Unable to convert presentation address '" + str + "'");
+        }
       }
     }
     if (sin4.sin_port == 0) { // 'str' overrides port!
@@ -259,6 +274,10 @@ union ComboAddress
   [[nodiscard]] bool isIPv4() const
   {
     return sin4.sin_family == AF_INET;
+  }
+  [[nodiscard]] bool isUnixSocket() const
+  {
+    return sin4.sin_family == AF_UNIX;
   }
 
   [[nodiscard]] bool isMappedIPv4() const
@@ -358,6 +377,9 @@ union ComboAddress
 
   [[nodiscard]] string toStringWithPort() const
   {
+    if (sinun.sun_family == AF_UNIX) {
+      return toString();
+    }
     if (sin4.sin_family == AF_INET) {
       return toString() + ":" + std::to_string(ntohs(sin4.sin_port));
     }
@@ -504,7 +526,10 @@ inline ComboAddress makeComboAddress(const string& str)
   if (inet_pton(AF_INET, str.c_str(), &address.sin4.sin_addr) <= 0) {
     address.sin4.sin_family = AF_INET6;
     if (makeIPv6sockaddr(str, &address.sin6) < 0) {
-      throw NetmaskException("Unable to convert '" + str + "' to a netmask");
+      address.sin4.sin_family = AF_UNIX;
+      if (makeUNsockaddr(str, &address.sinun) < 0) {
+        throw NetmaskException("Unable to convert '" + str + "' to a netmask");
+      }
     }
   }
   return address;
@@ -702,6 +727,11 @@ public:
   [[nodiscard]] bool isIPv4() const
   {
     return d_network.sin4.sin_family == AF_INET;
+  }
+
+  [[nodiscard]] bool isUnixSocket() const
+  {
+    return d_network.sinun.sun_family == AF_UNIX;
   }
 
   bool operator<(const Netmask& rhs) const
@@ -1467,6 +1497,9 @@ private:
     else if (value.isIPv6()) {
       node = d_root->right.get();
     }
+    else if (value.isUnixSocket()) {
+      node = d_root->left.get();
+    }
     else {
       throw NetmaskException("invalid address family");
     }
@@ -1766,6 +1799,11 @@ public:
   [[nodiscard]] bool isIPv6() const
   {
     return d_addr.isIPv6();
+  }
+
+  [[nodiscard]] bool isUnixSocket() const
+  {
+    return d_addr.isUnixSocket();
   }
 
   [[nodiscard]] AddressAndPortRange getNormalized() const

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -38,6 +38,10 @@
 #include <yahttp/router.hpp>
 #include <algorithm>
 #include <bitset>
+#include <unistd.h>
+#include <filesystem>
+
+namespace filesystem = std::filesystem;
 
 json11::Json HttpRequest::json()
 {
@@ -626,16 +630,30 @@ WebServer::WebServer(string listenaddress, int port) :
 
 void WebServer::bind()
 {
+  if (filesystem::is_socket(d_listenaddress.c_str())) {
+    int err=unlink(d_listenaddress.c_str());
+    if(err < 0 && errno!=ENOENT) {
+      g_log<<Logger::Critical<<"Unable to remove existing socket at '"<<d_listenaddress.c_str()<<"': "<<stringerror()<<endl;
+      exit(1);
+    }
+  }
+
   try {
     d_server = createServer();
-    SLOG(g_log<<Logger::Warning<<d_logprefix<<"Listening for HTTP requests on "<<d_server->d_local.toStringWithPort()<<endl,
-         d_slog->info(Logr::Info, "Listening for HTTP requests", "address", Logging::Loggable(d_server->d_local)));
+    if (d_server->d_local.isUnixSocket()) {
+      SLOG(g_log<<Logger::Warning<<d_logprefix<<"Listening for HTTP requests on "<<d_listenaddress<<endl,
+           d_slog->info(Logr::Info, "Listening for HTTP requests", "path", Logging::Loggable(d_listenaddress)));
+    } else {
+        SLOG(g_log<<Logger::Warning<<d_logprefix<<"Listening for HTTP requests on "<<d_server->d_local.toStringWithPort()<<endl,
+             d_slog->info(Logr::Info, "Listening for HTTP requests", "address", Logging::Loggable(d_server->d_local)));
+    }
   }
   catch(NetworkError &e) {
     SLOG(g_log<<Logger::Error<<d_logprefix<<"Listening on HTTP socket failed: "<<e.what()<<endl,
          d_slog->error(Logr::Error, e.what(), "Listening on HTTP socket failed", "exception", Logging::Loggable("NetworkError")));
     d_server = nullptr;
   }
+
 }
 
 void WebServer::go()
@@ -651,7 +669,7 @@ void WebServer::go()
         if (!client) {
           continue;
         }
-        if (client->acl(d_acl)) {
+        if (client->acl(d_acl) || d_server->d_local.isUnixSocket()) {
           std::thread webHandler(WebServerConnectionThreadStart, this, client);
           webHandler.detach();
         } else {


### PR DESCRIPTION
### Short description

This introduces support for binding to a Unix instead of a TCP/IP socket, which is useful in applications where binding to a TCP/IP socket is not desired due to security and/or performance considerations or constraints of the surrounding system.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)