### PR TITLE
dnsdist: Fix package building on arm64 EL-8 

### DIFF
--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -75,9 +75,16 @@ export CXX=clang++
 # build-id SHA1 prevents an issue with the debug symbols ("export: `-Wl,--build-id=sha1': not a valid identifier")
 # and -ldl an issue with the dlsym not being found ("ld.lld: error: undefined symbol: dlsym eferenced by weak.rs:142 (library/std/src/sys/pal/unix/weak.rs:142) [...] in archive ./dnsdist-rust-lib/rust/libdnsdist_rust.a)
 export LDFLAGS="-fuse-ld=lld -Wl,--build-id=sha1 -ldl"
+
 %if 0%{?rhel} < 9
-export CFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -gdwarf-4"
-export CXXFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -gdwarf-4"
+# starting with EL-9 we get these hardening settings for free by just setting the right toolchain (see above)
+%ifarch aarch64
+%define cf_protection %{nil}
+%else
+%define cf_protection -fcf-protection
+%endif
+export CFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection %{cf_protection} -gdwarf-4"
+export CXXFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection %{cf_protection} -gdwarf-4"
 %endif
 
 #export AR=gcc-ar

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -91,6 +91,8 @@ export CXXFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURC
 #export RANLIB=gcc-ranlib
 export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/opt/lib64/pkgconfig
 
+# Note that the RPM meson macro "helpfully" sets
+# --auto-features=enabled so our auto-detection is broken
 %meson \
   --sysconfdir=/etc/dnsdist \
   -Dunit-tests=true \
@@ -113,6 +115,9 @@ export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/opt/lib64/pkgconfig
   -Dre2=enabled \
   -Ddns-over-quic=true \
   -Ddns-over-http3=true \
+%ifarch aarch64
+  -Dxsk=disabled \
+%endif
   -Dyaml=enabled
 %meson_build
 

--- a/pdns/dnsdistdist/meson/xsk/meson.build
+++ b/pdns/dnsdistdist/meson/xsk/meson.build
@@ -1,7 +1,7 @@
 opt_xsk = get_option('xsk')
 if opt_xsk.allowed()
-  dep_libbpf = dependency('libbpf', required: opt_xsk)
-  dep_libxdp = dependency('libxdp', required: opt_xsk)
+  dep_libbpf = dependency('libbpf', required: opt_xsk.enabled())
+  dep_libxdp = dependency('libxdp', required: opt_xsk.enabled())
 
   conf.set('HAVE_BPF', dep_libbpf.found(), description: 'BPF library')
   conf.set('HAVE_XDP', dep_libxdp.found(), description: 'XDP library')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Disable `-fcf-protection` on arm64 EL-8, it's not supported
- Disable `XSK` on EL arm64, it is not supported
- Fix `bpf`/`xdp` detection when `XSK` is set to `auto`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
