### PR TITLE
Specify the list of target-os for the daily build of packages

### DIFF
--- a/.github/workflows/build-packages-daily-master.yml
+++ b/.github/workflows/build-packages-daily-master.yml
@@ -18,6 +18,13 @@ jobs:
       is_release: 'NO'
       product: 'authoritative'
       ref: master
+      os: >-
+          el-8
+          el-9
+          debian-bullseye
+          debian-bookworm
+          ubuntu-jammy
+          ubuntu-noble
     secrets:
       DOWNLOADS_AUTOBUILT_SECRET: ${{ secrets.DOWNLOADS_AUTOBUILT_SECRET }}
       DOWNLOADS_AUTOBUILT_RSYNCTARGET: ${{ secrets.DOWNLOADS_AUTOBUILT_RSYNCTARGET }}
@@ -30,6 +37,13 @@ jobs:
       is_release: 'NO'
       product: 'dnsdist'
       ref: master
+      os: >-
+          el-8
+          el-9
+          debian-bullseye
+          debian-bookworm
+          ubuntu-jammy
+          ubuntu-noble
     secrets:
       DOWNLOADS_AUTOBUILT_SECRET: ${{ secrets.DOWNLOADS_AUTOBUILT_SECRET }}
       DOWNLOADS_AUTOBUILT_RSYNCTARGET: ${{ secrets.DOWNLOADS_AUTOBUILT_RSYNCTARGET }}
@@ -42,6 +56,13 @@ jobs:
       is_release: 'NO'
       product: 'recursor'
       ref: master
+      os: >-
+          el-8
+          el-9
+          debian-bullseye
+          debian-bookworm
+          ubuntu-jammy
+          ubuntu-noble
     secrets:
       DOWNLOADS_AUTOBUILT_SECRET: ${{ secrets.DOWNLOADS_AUTOBUILT_SECRET }}
       DOWNLOADS_AUTOBUILT_RSYNCTARGET: ${{ secrets.DOWNLOADS_AUTOBUILT_RSYNCTARGET }}

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -56,8 +56,26 @@ jobs:
       # but, as this whole workflow needs at least 30 minutes to run, I prefer spending a few seconds here
       # so that the command remains readable, because jo is simpler to use.
       - run: sudo apt-get update && sudo apt-get -y install jo
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: recursive
+          ref: ${{ inputs.ref }}
       - id: get-oslist
-        run: echo "oslist=$(jo -a ${{ inputs.os }})" >> "$GITHUB_OUTPUT"
+        run: |
+          available_targets=$(ls builder-support/dockerfiles/Dockerfile.target.* )
+          for i in $(echo "${{ inputs.os }}"); do
+            if echo $available_targets | grep -qq $i; then
+              targets+=($i)
+            else
+              if [[ "${{ inputs.ref }}" == "master" ]]; then
+                echo "::error title=Dockerfile not found for ${i}::OS ${i} not available as target in ${{ inputs.ref }}" && exit 1
+              else
+                echo "::warning title=Packages will not be generated for ${i}::OS ${i} not available as target in ${{ inputs.ref }}"
+              fi
+            fi
+          done
+          echo "oslist=$(jo -a ${targets[*]})" >> "$GITHUB_OUTPUT"
       - id: get-runnerlist
         run: echo "runnerlist=$(jo -a ubuntu-24.04 ${{ vars.ARM64_USE_UBICLOUD == '1' && 'ubicloud-standard-2-arm' || '' }})" >> "$GITHUB_OUTPUT"
       - id: get-archlist
@@ -155,7 +173,7 @@ jobs:
           rsync -4rlptD built_pkgs/* "$RSYNCTARGET"
 
   check-hashes:
-    needs: build
+    needs: [prepare, build]
     name: Check if hashes were created for all requested targets
     runs-on: ubuntu-24.04
     steps:
@@ -163,7 +181,7 @@ jobs:
         run: echo '${{ toJSON(needs.build.outputs) }}' | jq 'keys[]' | grep -vE 'version|product-name' | tee /tmp/build-outputs.txt
       - name: Get list of OS inputs
         run: |
-          for os in ${{ inputs.os }}; do
+          for os in $(echo '${{ needs.prepare.outputs.oslist }}' | jq -r '.[]'); do
             for architecture in x86_64 ${{ vars.ARM64_USE_UBICLOUD == '1' && 'aarch64' || '' }}; do
               echo "\"pkghashes-$os-$architecture\"" | tee -a /tmp/os-inputs.txt
             done

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -157,7 +157,7 @@ jobs:
         shell: bash
         id: srchashes
         run: |
-          echo "srchashes=$(sha256sum ./built_pkgs/*/*/${{ steps.normalize-name.outputs.normalized-package-name }}-${{ steps.getversion.outputs.version }}.tar.bz2 | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "srchashes=$(sha256sum ./built_pkgs/*/*/${{ steps.normalize-name.outputs.normalized-package-name }}-${{ steps.getversion.outputs.version }}.tar.* | base64 -w0)" >> $GITHUB_OUTPUT
       - name: Upload packages to downloads.powerdns.com
         env:
           SSHKEY: ${{ secrets.DOWNLOADS_AUTOBUILT_SECRET }}


### PR DESCRIPTION
~The dockerfile for building `ubuntu-focal` is still needed. The target is still used by `build-packages.yml`. It was removed in #15277~

Specify the list of target os for the building daily packages for master. 

Skip with a [warning](https://github.com/romeroalx/pdns/actions/runs/13837226839/job/38715241163#step:4:7) the OS for which there is no target dockerfile

Error: <https://github.com/PowerDNS/pdns/actions/runs/13827425631>

Test: <https://github.com/romeroalx/pdns/actions/runs/13837226839>
 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
