### PR TITLE
rec: meson build: export ffi symbols so they become available to Lua

### DIFF
--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -18,7 +18,14 @@ meson.add_dist_script('meson-dist-script.sh')
 meson.add_dist_script('version.sh', 'set-dist', meson.project_version())
 
 add_project_arguments('-DRECURSOR', language: 'cpp')
-
+add_project_arguments(
+  '-Wshadow',
+  '-Wmissing-declarations',
+  '-Wredundant-decls',
+  '-Wno-ignored-attributes',
+  '-fvisibility=hidden',
+  language: ['c', 'cpp'],
+)
 
 product_source_dir = meson.current_source_dir()
 product_build_dir = meson.current_build_dir()
@@ -407,6 +414,10 @@ librec_common = declare_dependency(
 tools = {
   'pdns_recursor': {
     'main': src_dir / 'rec-main.cc',
+    'link-args': [
+	'-Wl,--export-dynamic-symbol=pdns_ffi_*',
+	'-Wl,--export-dynamic-symbol=pdns_postresolve_ffi_*',
+    ],
     'files-extra': [
       src_dir / 'capabilities.cc',
       src_dir / 'channel.cc',
@@ -542,6 +553,7 @@ foreach tool, info: tools
   main = files(info['main'])
 
   export_dynamic = 'export-dynamic' in info ? info['export-dynamic'] : false
+  link_args = 'link-args' in info ? info['link-args'] : []
   files_extra = 'files-extra' in info ? info['files-extra'] : []
   deps_extra = 'deps-extra' in info ? info['deps-extra'] : []
   install = 'install' in info ? info['install'] : false
@@ -555,6 +567,7 @@ foreach tool, info: tools
       config_h,
       files_extra,
       export_dynamic: export_dynamic,
+      link_args: link_args,
       dependencies: [
         librec_common,
         deps_extra,


### PR DESCRIPTION
Do that specifically (and unconditionally) for the ffi functions only, we do not need to export everything like the autotools do with `-rdynamic`.

Also add a few useful build options, taken from dnsdist.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
