### PR TITLE
dnsdist: Export only FFI symbols, regardless of visibility

### DIFF
--- a/pdns/dnsdistdist/meson/lua/meson.build
+++ b/pdns/dnsdistdist/meson/lua/meson.build
@@ -42,8 +42,8 @@ conf.set('HAVE_LUA', dep_lua.found(), description: 'Lua')
 conf.set('HAVE_LUA_HPP', have_luahpp, description: 'Have <lua.hpp>')
 
 if dep_lua.found() and dep_lua.name() == 'luajit'
- # export all symbols with default visibility, to be able to use the Lua FFI interface
- add_project_link_arguments('-rdynamic', language: ['c', 'cpp'])
+  # export FFI interfaces symbols, to be able to use the Lua FFI interface
+  add_project_link_arguments('-Wl,--export-dynamic-symbol=dnsdist_ffi_*', language: ['c', 'cpp'])
 endif
 
 summary('Lua', dep_lua.found(), bool_yn: true, section: 'Lua')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is a lot better than the existing `rdynamic` option because the symbols of our internal, static Rust library are somehow showing up in the final binary otherwise.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
