### PR TITLE
dnsdist: protobuf, support packetCacheHit and outgoingQueries fields

### DIFF
--- a/pdns/dnsdistdist/dnsdist-idstate.hh
+++ b/pdns/dnsdistdist/dnsdist-idstate.hh
@@ -177,6 +177,7 @@ struct InternalQueryState
   bool useZeroScope{false};
   bool forwardedOverUDP{false};
   bool selfGenerated{false};
+  bool cacheHit{false};
 };
 
 struct IDState

--- a/pdns/dnsdistdist/dnsdist-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-protobuf.cc
@@ -180,6 +180,9 @@ void DNSDistProtoBufMessage::serialize(std::string& data) const
     msg.setEDNSSubnet(*d_ednsSubnet, 128);
   }
 
+  if (d_dr != nullptr) {
+    msg.setPacketCacheHit(d_dr->ids.cacheHit);
+  }
   msg.startResponse();
   if (d_queryTime) {
     // coverity[store_truncates_time_t]

--- a/pdns/dnsdistdist/dnsdist-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-protobuf.cc
@@ -182,6 +182,7 @@ void DNSDistProtoBufMessage::serialize(std::string& data) const
 
   if (d_dr != nullptr) {
     msg.setPacketCacheHit(d_dr->ids.cacheHit);
+    msg.setOutgoingQueries((d_dr->ids.cacheHit || d_dr->ids.selfGenerated) ? 0 : 1);
   }
   msg.startResponse();
   if (d_queryTime) {

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1338,6 +1338,7 @@ static bool prepareOutgoingResponse([[maybe_unused]] const ClientState& clientSt
   DNSResponse dnsResponse(dnsQuestion.ids, dnsQuestion.getMutableData(), backend);
   dnsResponse.d_incomingTCPState = dnsQuestion.d_incomingTCPState;
   dnsResponse.ids.selfGenerated = true;
+  dnsResponse.ids.cacheHit = cacheHit;
 
   const auto& chains = dnsdist::configuration::getCurrentRuntimeConfiguration().d_ruleChains;
   const auto& cacheHitRespRules = dnsdist::rules::getResponseRuleChain(chains, dnsdist::rules::ResponseRuleChain::CacheHitResponseRules);

--- a/pdns/dnsdistdist/docs/reference/rules-management.rst
+++ b/pdns/dnsdistdist/docs/reference/rules-management.rst
@@ -203,7 +203,7 @@ For Rules related to responses:
   .. versionchanged:: 1.9.0
     Passing a string or list of strings instead of a :class:`DNSRule` is deprecated, use :func:`NetmaskGroupRule` or :func:`QNameSuffixRule` instead
 
-  Add a Rule and Action for responses to the existing rules.
+  Add a Rule and Action for responses to the existing rules. This won't be triggered if the response is due to a cache hit (see :func:`addCacheHitResponseAction`) or is self generated (see :func:`addSelfAnsweredResponseAction`).
   If a string (or list of) is passed as the first parameter instead of a :class:`DNSRule`, it behaves as if the string or list of strings was passed to :func:`NetmaskGroupRule` or :func:`SuffixMatchNodeRule`.
 
   :param DNSrule rule: A :class:`DNSRule`, e.g. an :func:`AllRule`, or a compounded bunch of rules using e.g. :func:`AndRule`. Before 1.9.0 it was also possible to pass a string (or list of strings) but doing so is now deprecated.

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -548,6 +548,65 @@ class TestProtobufExtendedDNSErrorTags(DNSDistProtobufTest):
         self.assertIn(15, msg.meta[0].value.intVal)
         self.assertIn('Blocked by RPZ!', msg.meta[0].value.stringVal)
 
+class TestProtobufCacheHit(DNSDistProtobufTest):
+    _config_params = ['_testServerPort', '_protobufServerPort']
+    _config_template = """
+    newServer{address="127.0.0.1:%s"}
+    rl = newRemoteLogger('127.0.0.1:%d')
+    pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
+    getPool(""):setCache(pc)
+
+    addResponseAction(AllRule(), RemoteLogResponseAction(rl, nil, false, {serverID='dnsdist-server-1'}))
+    addCacheHitResponseAction(AllRule(), RemoteLogResponseAction(rl, nil, false, {serverID='dnsdist-server-1'}))
+    """
+
+    def testProtobufExtendedError(self):
+        """
+        Protobuf: CacheHit field
+        """
+        name = 'cachehit.protobuf.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        # fill the cache
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+
+        if self._protobufQueue.empty():
+            # let the protobuf messages the time to get there
+            time.sleep(1)
+
+        # check the protobuf message corresponding to the UDP response
+        msg = self.getFirstProtobufMessage()
+        self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
+        self.assertTrue(msg.HasField('packetCacheHit'))
+        self.assertFalse(msg.packetCacheHit)
+
+        # now shoud be a cache hit
+        (_, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedResponse)
+        self.assertEqual(response, receivedResponse)
+
+        if self._protobufQueue.empty():
+            # let the protobuf messages the time to get there
+            time.sleep(1)
+
+        # check the protobuf message corresponding to the UDP response
+        msg = self.getFirstProtobufMessage()
+        self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
+        self.assertTrue(msg.HasField('packetCacheHit'))
+        self.assertTrue(msg.packetCacheHit)
+
 class TestProtobufMetaDOH(DNSDistProtobufTest):
 
     _serverKey = 'server.key'

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -591,6 +591,8 @@ class TestProtobufCacheHit(DNSDistProtobufTest):
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
         self.assertTrue(msg.HasField('packetCacheHit'))
         self.assertFalse(msg.packetCacheHit)
+        self.assertTrue(msg.HasField('outgoingQueries'))
+        self.assertEqual(msg.outgoingQueries, 1)
 
         # now shoud be a cache hit
         (_, receivedResponse) = self.sendUDPQuery(query, response)
@@ -606,6 +608,8 @@ class TestProtobufCacheHit(DNSDistProtobufTest):
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
         self.assertTrue(msg.HasField('packetCacheHit'))
         self.assertTrue(msg.packetCacheHit)
+        self.assertTrue(msg.HasField('outgoingQueries'))
+        self.assertEqual(msg.outgoingQueries, 0)
 
 class TestProtobufMetaDOH(DNSDistProtobufTest):
 


### PR DESCRIPTION
### Short description
Properly set `packetCacheHit` and `outgoingQueries` fields in logged protobuf messages. The number of `outgoingQueries` is set to `0` when the answer is either self generated or a cachehit. Otherwise set to `1`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
