### PR TITLE
API: allow fetching disabled RRsets

### DIFF
--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -156,6 +156,7 @@ Methods required for different features
 :Secondary operation: ``getUnfreshSlaveInfos``, ``startTransaction``, ``commitTransaction``, ``abortTransaction``, ``feedRecord``, ``setFresh``
 :DNSSEC operation (live-signing): ``getDomainKeys``, ``getBeforeAndAfterNamesAbsolute``
 :Filling the Zone Cache: ``getAllDomains``
+:HTTP API specific: ``APILookup``
 
 ``initialize``
 ~~~~~~~~~~~~~~
@@ -163,7 +164,7 @@ Methods required for different features
 Called to initialize the backend. This is not called for HTTP connector.
 You should do your initializations here.
 
--  Mandatory: Yes (except HTTP connector)
+-  Mandatory: yes (except HTTP connector)
 -  Parameters: all parameters in connection string
 -  Reply: true on success / false on failure
 
@@ -190,7 +191,7 @@ Response:
 This method is used to do the basic query. You can omit auth, but if you
 are using DNSSEC this can lead into trouble.
 
--  Mandatory: Yes
+-  Mandatory: yes
 -  Parameters: qtype, qname, zone_id
 -  Optional parameters: remote, local, real-remote
 -  Reply: array of ``qtype,qname,content,ttl,domain_id,scopeMask,auth``
@@ -236,6 +237,20 @@ Response:
 
     {"result":[{"qtype":"A", "qname":"www.example.com", "content":"203.0.113.2", "ttl": 60}]}
 
+``APILookup``
+~~~~~~~~~~~~~
+
+This method is similar to :ref:`remote-lookup`, but also returns disabled
+records. It allows for an extra optional parameter, ``include_disabled`` which, 
+if present and set to false, will only return non-disabled records (in which
+case, the behaviour is equivalent to the ``lookup`` method.)
+
+-  Mandatory: no (required if the HTTP API is to be used)
+-  Parameters: qtype, qname, zone_id
+-  Optional parameters: remote, local, real-remote, include_disabled
+-  Reply: array of ``qtype,qname,content,ttl,domain_id,scopeMask,auth,disabled``
+-  Optional values: scopeMask and auth
+
 ``list``
 ~~~~~~~~
 
@@ -243,7 +258,7 @@ Lists all records for the zonename. If you are running DNSSEC, you
 should take care of setting auth to appropriate value, otherwise things
 can go wrong.
 
--  Mandatory: No (Gives AXFR support)
+-  Mandatory: no (gives AXFR support)
 -  Parameters: zonename, domain_id
 -  Optional parameters: domain_id
 -  Reply: array of ``qtype,qname,content,ttl,domain_id,scopeMask,auth``
@@ -385,7 +400,7 @@ one of NSEC3PARAM, PRESIGNED, SOA-EDIT. Can be others, too. You **must**
 always return something, if there are no values, you shall return an empty
 array.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name, kind
 -  Reply: array of strings
 
@@ -429,7 +444,7 @@ Replaces the value(s) on domain name for variable kind to string(s) on
 array value. The old value is discarded. Value can be an empty array,
 which can be interpreted as deletion request.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name, kind, value
 -  Reply: true on success, false on failure
 
@@ -543,7 +558,7 @@ Response:
 
 Adds key into local storage. See :ref:`remote-getdomainkeys` for more information.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name, key=\ ``<flags,active,published,content>``, id
 -  Reply: true for success, false for failure
 
@@ -607,7 +622,7 @@ Response:
 
 Removes key id from domain name.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name, id
 -  Reply: true for success, false for failure
 
@@ -649,7 +664,7 @@ Response:
 
 Activates key id for domain name.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name, id
 -  Reply: true for success, false for failure
 
@@ -691,7 +706,7 @@ Response:
 
 Deactivates key id for domain name.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name, id
 -  Reply: true for success, false for failure
 
@@ -733,7 +748,7 @@ Response:
 
 Publish key id for domain name.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name, id
 -  Reply: true for success, false for failure
 
@@ -776,7 +791,7 @@ Response:
 
 Unpublish key id for domain name.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name, id
 -  Reply: true for success, false for failure
 
@@ -819,7 +834,7 @@ Response:
 
 Retrieves the key needed to sign AXFR.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name
 -  Reply: algorithm, content
 
@@ -865,7 +880,7 @@ Everything else will default to something. Default values: serial:0,
 kind:NATIVE, id:-1, notified_serial:-1, last_check:0, masters: [].
 Masters, if present, must be array of strings.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name
 -  Reply: zone
 -  Optional values: serial, kind, id, notified_serial, last_check,
@@ -909,7 +924,7 @@ Response:
 
 Updates last notified serial for the domain id. Any errors are ignored.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: id, serial
 -  Reply: true for success, false for failure
 
@@ -955,7 +970,7 @@ Response:
 
 Determines whether given IP is primary for given domain name.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: name,ip
 -  Reply: true for success, false for failure.
 
@@ -999,7 +1014,7 @@ Creates new domain with given record(s) as primary servers. IP address is
 the address where notify is received from. nsset is array of NS resource
 records.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: ip,domain,nsset,account
 -  Reply: true for success, false for failure. can also return
    account=>name of account< and nameserver.
@@ -1061,7 +1076,7 @@ Alternative response
 Creates new domain. This method is called when NOTIFY is received and
 you are superslaving.
 
- - Mandatory: No
+ - Mandatory: no
  - Parameters: ip, domain
  - Optional parameters: nameserver, account
  - Reply: true for success, false for failure
@@ -1107,7 +1122,7 @@ Response:
 This method replaces a given resource record with new set. The new qtype
 can be different from the old.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: domain_id, qname, qtype, rrset
 -  Reply: true for success, false for failure
 
@@ -1154,7 +1169,7 @@ Response:
 Asks to feed new record into system. If startTransaction was called,
 trxId identifies a transaction. It is not always called by PowerDNS.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: rr, trxid
 -  Reply: true for success, false for failure
 
@@ -1206,7 +1221,7 @@ _sip._upd.example.com, but no _udp.example.com. PowerDNS requires
 that there exists a non-terminal in between, and this instructs you to
 add one. If startTransaction is called, trxid identifies a transaction.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: nonterm, trxid
 -  Reply: true for success, false for failure
 
@@ -1253,7 +1268,7 @@ Response:
 Same as :ref:`remote-feedents`, but provides NSEC3 hashing
 parameters. Note that salt is BYTE value, and can be non-readable text.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: trxid, domain_id, domain, times, salt, narrow, nonterm
 -  Reply: true for success, false for failure
 
@@ -1300,7 +1315,7 @@ Response:
 Starts a new transaction. Transaction ID is chosen for you. Used to
 identify f.ex. AXFR transfer.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: domain_id, domain, trxid
 -  Reply: true for success, false for failure
 
@@ -1347,7 +1362,7 @@ Response:
 Signals successful transfer and asks to commit data into permanent
 storage.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: trxid
 -  Reply: true for success, false for failure
 
@@ -1391,7 +1406,7 @@ Response:
 
 Signals failed transaction, and that you should rollback any changes.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: trxid
 -  Reply: true for success, false for failure
 
@@ -1436,7 +1451,7 @@ Response:
 Asks you to calculate a new serial based on the given data and update
 the serial.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: domain,sd
 -  Reply: true for success, false for failure
 
@@ -1700,7 +1715,7 @@ Response:
 Called when a primary freshness check succeeded. This does not indicate the
 zone was updated on the primary.
 
--  Mandatory: No
+-  Mandatory: no
 -  Parameters: id
 -  Reply: true for success, false for failure
 

--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -196,6 +196,10 @@ paths:
           in: query
           description: Limit output to the RRset of this type. Can only be used together with rrset_name.
           type: string
+        - name: include_disabled
+          in: query
+          description: '“true” (default) or “false”, whether to include disabled RRsets in the response.'
+          type: boolean
       responses:
         '200':
           description: A Zone

--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -94,6 +94,9 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=0 and name=?");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=0 and name=? and domain_id=?");
 
+    declare(suffix, "api-id-query", "API basic with ID query", record_query + " (disabled=0 or ?) and type=? and name=? and domain_id=?");
+    declare(suffix, "api-any-id-query", "API any with ID query", record_query + " (disabled=0 or ?) and name=? and domain_id=?");
+
     declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type");
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=0 and (name=? OR name like ?) and domain_id=?");
 

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -75,6 +75,9 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=0 and name=?");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=0 and name=? and domain_id=?");
 
+    declare(suffix, "api-id-query", "API basic with ID query", record_query + " (disabled=0 or disabled=?) and type=? and name=? and domain_id=?");
+    declare(suffix, "api-any-id-query", "API any with ID query", record_query + " (disabled=0 or disabled=?) and name=? and domain_id=?");
+
     declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,CONVERT(varchar(255), ordername, 0) FROM records WHERE (disabled=0 OR disabled=?) and domain_id=? order by name, type");
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=0 and (name=? OR name like ?) and domain_id=?");
 

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -102,6 +102,9 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=false and name=$1");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=false and name=$1 and domain_id=$2");
 
+    declare(suffix, "api-id-query", "API basic with ID query", record_query + " (disabled=false or $1) and type=$2 and name=$3 and domain_id=$4");
+    declare(suffix, "api-any-id-query", "API any with ID query", record_query + " (disabled=false or $1) and name=$2 and domain_id=$3");
+
     declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int,ordername FROM records WHERE (disabled=false OR $1) and domain_id=$2 order by name, type");
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=false and (name=$1 OR name like $2) and domain_id=$3");
 

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -88,6 +88,9 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=0 and name=:qname");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=0 and name=:qname and domain_id=:domain_id");
 
+    declare(suffix, "api-id-query", "API basic with ID query", record_query + " (disabled=0 or :include_disabled) and type=:qtype and name=:qname and domain_id=:domain_id");
+    declare(suffix, "api-any-id-query", "API any with ID query", record_query + " (disabled=0 or :include_disabled) and name=:qname and domain_id=:domain_id");
+
     declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR :include_disabled) and domain_id=:domain_id order by name, type");
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=0 and (name=:zone OR name like :wildzone) and domain_id=:domain_id");
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1481,14 +1481,14 @@ bool LMDBBackend::list(const ZoneName& target, int /* id */, bool include_disabl
   return true;
 }
 
-void LMDBBackend::lookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* /* p */)
+void LMDBBackend::lookupInternal(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* /* p */, bool include_disabled)
 {
   if (d_dolog) {
     g_log << Logger::Warning << "Got lookup for " << qdomain << "|" << type.toString() << " in zone " << zoneId << endl;
     d_dtime.set();
   }
 
-  d_includedisabled = false;
+  d_includedisabled = include_disabled;
 
   DNSName hunt(qdomain);
   DomainInfo di;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -79,7 +79,7 @@ public:
 
   void getAllDomains(vector<DomainInfo>* domains, bool doSerial, bool include_disabled) override;
   void lookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* p = nullptr) override { lookupInternal(type, qdomain, zoneId, p, false); }
-  void APILookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* p = nullptr, bool include_disabled = false) override { lookupInternal(type, qdomain, zoneId, p, include_disabled); }
+  void APILookup(const QType& type, const DNSName& qdomain, int zoneId, bool include_disabled = false) override { lookupInternal(type, qdomain, zoneId, nullptr, include_disabled); }
   bool get(DNSResourceRecord& rr) override;
   bool get(DNSZoneRecord& dzr) override;
 

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -78,7 +78,8 @@ public:
   bool replaceComments(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<Comment>& comments) override;
 
   void getAllDomains(vector<DomainInfo>* domains, bool doSerial, bool include_disabled) override;
-  void lookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* p = nullptr) override;
+  void lookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* p = nullptr) override { lookupInternal(type, qdomain, zoneId, p, false); }
+  void APILookup(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* p = nullptr, bool include_disabled = false) override { lookupInternal(type, qdomain, zoneId, p, include_disabled); }
   bool get(DNSResourceRecord& rr) override;
   bool get(DNSZoneRecord& dzr) override;
 
@@ -311,6 +312,7 @@ private:
 
   void getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow);
 
+  void lookupInternal(const QType& type, const DNSName& qdomain, int zoneId, DNSPacket* p, bool include_disabled);
   bool getSerial(DomainInfo& di);
 
   bool upgradeToSchemav3();

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -226,7 +226,7 @@ void RemoteBackend::lookup(const QType& qtype, const DNSName& qdomain, int zoneI
 }
 
 // Similar to lookup above, but passes an extra include_disabled parameter.
-void RemoteBackend::APILookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p, bool include_disabled)
+void RemoteBackend::APILookup(const QType& qtype, const DNSName& qdomain, int zoneId, bool include_disabled)
 {
   if (d_index != -1) {
     throw PDNSException("Attempt to lookup while one running");
@@ -235,12 +235,6 @@ void RemoteBackend::APILookup(const QType& qtype, const DNSName& qdomain, int zo
   string localIP = "0.0.0.0";
   string remoteIP = "0.0.0.0";
   string realRemote = "0.0.0.0/0";
-
-  if (pkt_p != nullptr) {
-    localIP = pkt_p->getLocal().toString();
-    realRemote = pkt_p->getRealRemote().toString();
-    remoteIP = pkt_p->getInnerRemote().toString();
-  }
 
   Json query = Json::object{
     {"method", "APILookup"},

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -225,6 +225,39 @@ void RemoteBackend::lookup(const QType& qtype, const DNSName& qdomain, int zoneI
   d_index = 0;
 }
 
+// Similar to lookup above, but passes an extra include_disabled parameter.
+void RemoteBackend::APILookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p, bool include_disabled)
+{
+  if (d_index != -1) {
+    throw PDNSException("Attempt to lookup while one running");
+  }
+
+  string localIP = "0.0.0.0";
+  string remoteIP = "0.0.0.0";
+  string realRemote = "0.0.0.0/0";
+
+  if (pkt_p != nullptr) {
+    localIP = pkt_p->getLocal().toString();
+    realRemote = pkt_p->getRealRemote().toString();
+    remoteIP = pkt_p->getInnerRemote().toString();
+  }
+
+  Json query = Json::object{
+    {"method", "APILookup"},
+    {"parameters", Json::object{{"qtype", qtype.toString()}, {"qname", qdomain.toString()}, {"remote", remoteIP}, {"local", localIP}, {"real-remote", realRemote}, {"zone-id", zoneId}, {"include-disabled", include_disabled}}}};
+
+  if (!this->send(query) || !this->recv(d_result)) {
+    return;
+  }
+
+  // OK. we have result parameters in result. do not process empty result.
+  if (!d_result["result"].is_array() || d_result["result"].array_items().empty()) {
+    return;
+  }
+
+  d_index = 0;
+}
+
 bool RemoteBackend::list(const ZoneName& target, int domain_id, bool include_disabled)
 {
   if (d_index != -1) {

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -169,6 +169,7 @@ public:
 
   unsigned int getCapabilities() override;
   void lookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr) override;
+  void APILookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr, bool include_disabled = false) override;
   bool get(DNSResourceRecord& rr) override;
   bool list(const ZoneName& target, int domain_id, bool include_disabled = false) override;
 

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -169,7 +169,7 @@ public:
 
   unsigned int getCapabilities() override;
   void lookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr) override;
-  void APILookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr, bool include_disabled = false) override;
+  void APILookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, bool include_disabled = false) override;
   bool get(DNSResourceRecord& rr) override;
   bool list(const ZoneName& target, int domain_id, bool include_disabled = false) override;
 

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1461,7 +1461,7 @@ void GSQLBackend::lookup(const QType& qtype, const DNSName& qname, int domain_id
   d_qname=qname;
 }
 
-void GSQLBackend::APILookup(const QType& qtype, const DNSName& qname, int domain_id, DNSPacket* /* pkt_p */, bool include_disabled)
+void GSQLBackend::APILookup(const QType& qtype, const DNSName& qname, int domain_id, bool include_disabled)
 {
   try {
     reconnectIfNeeded();

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -200,7 +200,7 @@ protected:
 public:
   unsigned int getCapabilities() override;
   void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *p=nullptr) override;
-  void APILookup(const QType &qtype, const DNSName &qname, int domain_id, DNSPacket *p=nullptr, bool include_disabled = false) override;
+  void APILookup(const QType &qtype, const DNSName &qname, int domain_id, bool include_disabled = false) override;
   bool list(const ZoneName &target, int domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -59,6 +59,8 @@ protected:
       d_IdQuery_stmt = d_db->prepare(d_IdQuery, 3);
       d_ANYNoIdQuery_stmt = d_db->prepare(d_ANYNoIdQuery, 1);
       d_ANYIdQuery_stmt = d_db->prepare(d_ANYIdQuery, 2);
+      d_APIIdQuery_stmt = d_db->prepare(d_APIIdQuery, 4);
+      d_APIANYIdQuery_stmt = d_db->prepare(d_APIANYIdQuery, 3);
       d_listQuery_stmt = d_db->prepare(d_listQuery, 2);
       d_listSubZoneQuery_stmt = d_db->prepare(d_listSubZoneQuery, 3);
       d_PrimaryOfDomainsZoneQuery_stmt = d_db->prepare(d_PrimaryOfDomainsZoneQuery, 1);
@@ -129,6 +131,8 @@ protected:
     d_IdQuery_stmt.reset();
     d_ANYNoIdQuery_stmt.reset();
     d_ANYIdQuery_stmt.reset();
+    d_APIIdQuery_stmt.reset();
+    d_APIANYIdQuery_stmt.reset();
     d_listQuery_stmt.reset();
     d_listSubZoneQuery_stmt.reset();
     d_PrimaryOfDomainsZoneQuery_stmt.reset();
@@ -196,6 +200,7 @@ protected:
 public:
   unsigned int getCapabilities() override;
   void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *p=nullptr) override;
+  void APILookup(const QType &qtype, const DNSName &qname, int domain_id, DNSPacket *p=nullptr, bool include_disabled = false) override;
   bool list(const ZoneName &target, int domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
@@ -294,6 +299,9 @@ private:
   string d_ANYNoIdQuery;
   string d_ANYIdQuery;
 
+  string d_APIIdQuery;
+  string d_APIANYIdQuery;
+
   string d_listQuery;
   string d_listSubZoneQuery;
   string d_logprefix;
@@ -375,6 +383,8 @@ private:
   unique_ptr<SSqlStatement> d_IdQuery_stmt;
   unique_ptr<SSqlStatement> d_ANYNoIdQuery_stmt;
   unique_ptr<SSqlStatement> d_ANYIdQuery_stmt;
+  unique_ptr<SSqlStatement> d_APIIdQuery_stmt;
+  unique_ptr<SSqlStatement> d_APIANYIdQuery_stmt;
   unique_ptr<SSqlStatement> d_listQuery_stmt;
   unique_ptr<SSqlStatement> d_listSubZoneQuery_stmt;
   unique_ptr<SSqlStatement> d_PrimaryOfDomainsZoneQuery_stmt;

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -68,9 +68,9 @@ int DNSBackend::getArgAsNum(const string& key)
 }
 
 // Default API lookup has no support for disabled records and simply wraps lookup()
-void DNSBackend::APILookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p, bool /* include_disabled */)
+void DNSBackend::APILookup(const QType& qtype, const DNSName& qdomain, int zoneId, bool /* include_disabled */)
 {
-  lookup(qtype, qdomain, zoneId, pkt_p);
+  lookup(qtype, qdomain, zoneId, nullptr);
 }
 
 void BackendFactory::declare(const string& suffix, const string& param, const string& explanation, const string& value)

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -67,6 +67,12 @@ int DNSBackend::getArgAsNum(const string& key)
   return arg().asNum(d_prefix + "-" + key);
 }
 
+// Default API lookup has no support for disabled records and simply wraps lookup()
+void DNSBackend::APILookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p, bool /* include_disabled */)
+{
+  lookup(qtype, qdomain, zoneId, pkt_p);
+}
+
 void BackendFactory::declare(const string& suffix, const string& param, const string& explanation, const string& value)
 {
   string fullname = d_name + suffix + "-" + param;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -169,6 +169,7 @@ public:
 
   //! lookup() initiates a lookup. A lookup without results should not throw!
   virtual void lookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr) = 0;
+  virtual void APILookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr, bool include_disabled = false);
   virtual bool get(DNSResourceRecord&) = 0; //!< retrieves one DNSResource record, returns false if no more were available
   virtual bool get(DNSZoneRecord& zoneRecord);
 

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -169,7 +169,7 @@ public:
 
   //! lookup() initiates a lookup. A lookup without results should not throw!
   virtual void lookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr) = 0;
-  virtual void APILookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr, bool include_disabled = false);
+  virtual void APILookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, bool include_disabled = false);
   virtual bool get(DNSResourceRecord&) = 0; //!< retrieves one DNSResource record, returns false if no more were available
   virtual bool get(DNSZoneRecord& zoneRecord);
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -373,16 +373,16 @@ static Json::object getZoneInfo(const DomainInfo& domainInfo, DNSSECKeeper* dnss
   return obj;
 }
 
-static bool shouldDoRRSets(HttpRequest* req)
+static bool boolFromHttpRequest(HttpRequest* req, const std::string& var)
 {
-  if (req->getvars.count("rrsets") == 0 || req->getvars["rrsets"] == "true") {
+  if (req->getvars.count(var) == 0 || req->getvars[var] == "true") {
     return true;
   }
-  if (req->getvars["rrsets"] == "false") {
+  if (req->getvars[var] == "false") {
     return false;
   }
 
-  throw ApiException("'rrsets' request parameter value '" + req->getvars["rrsets"] + "' is not supported");
+  throw ApiException("'" + var + "' request parameter value '" + req->getvars[var] + "' is not supported");
 }
 
 static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpResponse* resp, HttpRequest* req)
@@ -440,7 +440,7 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
   }
   doc["slave_tsig_key_ids"] = tsig_secondary_keys;
 
-  if (shouldDoRRSets(req)) {
+  if (boolFromHttpRequest(req, "rrsets")) {
     vector<DNSResourceRecord> records;
     vector<Comment> comments;
 
@@ -458,7 +458,8 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
         if (req->getvars.count("rrset_type") != 0) {
           qType = req->getvars["rrset_type"];
         }
-        domainInfo.backend->lookup(qType, qName, static_cast<int>(domainInfo.id));
+        bool include_disabled = boolFromHttpRequest(req, "include_disabled");
+        domainInfo.backend->APILookup(qType, qName, static_cast<int>(domainInfo.id), nullptr, include_disabled);
       }
       while (domainInfo.backend->get(resourceRecord)) {
         if (resourceRecord.qtype.getCode() == 0) {
@@ -2380,7 +2381,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
           bool dname_seen = false;
           bool ns_seen = false;
 
-          domainInfo.backend->lookup(QType(QType::ANY), qname, static_cast<int>(domainInfo.id));
+          domainInfo.backend->APILookup(QType(QType::ANY), qname, static_cast<int>(domainInfo.id), nullptr, false);
           DNSResourceRecord resourceRecord;
           while (domainInfo.backend->get(resourceRecord)) {
             if (resourceRecord.qtype.getCode() == QType::ENT) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -459,7 +459,7 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
           qType = req->getvars["rrset_type"];
         }
         bool include_disabled = boolFromHttpRequest(req, "include_disabled");
-        domainInfo.backend->APILookup(qType, qName, static_cast<int>(domainInfo.id), nullptr, include_disabled);
+        domainInfo.backend->APILookup(qType, qName, static_cast<int>(domainInfo.id), include_disabled);
       }
       while (domainInfo.backend->get(resourceRecord)) {
         if (resourceRecord.qtype.getCode() == 0) {
@@ -2381,7 +2381,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
           bool dname_seen = false;
           bool ns_seen = false;
 
-          domainInfo.backend->APILookup(QType(QType::ANY), qname, static_cast<int>(domainInfo.id), nullptr, false);
+          domainInfo.backend->APILookup(QType(QType::ANY), qname, static_cast<int>(domainInfo.id), false);
           DNSResourceRecord resourceRecord;
           while (domainInfo.backend->get(resourceRecord)) {
             if (resourceRecord.qtype.getCode() == QType::ENT) {


### PR DESCRIPTION
### Short description
This is an attempt at fixing #11473. The first commit adds the necessary plumbing to be able to gather disabled records. The second commit allows the API to use this feature. 

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
