### PR TITLE
dnsdist: Add support for calling Lua methods when exiting

### DIFF
--- a/pdns/dnsdistdist/dnsdist-console.cc
+++ b/pdns/dnsdistdist/dnsdist-console.cc
@@ -498,6 +498,7 @@ static const std::vector<dnsdist::console::ConsoleKeyword> s_consoleKeywords{
   {"addCacheHitResponseAction", true, R"(DNS rule, DNS response action [, {uuid="UUID", name="name"}}])", "add a cache hit response rule"},
   {"addCacheInsertedResponseAction", true, R"(DNS rule, DNS response action [, {uuid="UUID", name="name"}}])", "add a cache inserted response rule"},
   {"addMaintenanceCallback", true, "callback", "register a function to be called as part of the maintenance hook, every second"},
+  {"addExitCallback", true, "callback", "register a function to be called when DNSdist exits"},
   {"addResponseAction", true, R"(DNS rule, DNS response action [, {uuid="UUID", name="name"}}])", "add a response rule"},
   {"addSelfAnsweredResponseAction", true, R"(DNS rule, DNS response action [, {uuid="UUID", name="name"}}])", "add a self-answered response rule"},
   {"addXFRResponseAction", true, R"(DNS rule, DNS response action [, {uuid="UUID", name="name"}}])", "add a XFR response rule"},

--- a/pdns/dnsdistdist/dnsdist-lua-hooks.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-hooks.hh
@@ -29,5 +29,7 @@ namespace dnsdist::lua::hooks
 {
 void runMaintenanceHooks(const LuaContext& context);
 void clearMaintenanceHooks();
+void runExitCallbacks(const LuaContext& context);
+void clearExitCallbacks();
 void setupLuaHooks(LuaContext& luaCtx);
 }

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -911,20 +911,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
+  void doExitNicely(int exitCode = EXIT_SUCCESS);
+
   luaCtx.writeFunction("shutdown", []() {
-#ifdef HAVE_SYSTEMD
-    sd_notify(0, "STOPPING=1");
-#endif /* HAVE_SYSTEMD */
-#if 0
-    // Useful for debugging leaks, but might lead to race under load
-    // since other threads are still running.
-    for (auto& frontend : getDoTFrontends()) {
-      frontend->cleanup();
-    }
-    g_rings.clear();
-#endif /* 0 */
-    pdns::coverage::dumpCoverageData();
-    _exit(0);
+    doExitNicely();
   });
 
   typedef LuaAssociativeTable<boost::variant<bool, std::string>> showserversopts_t;

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -2160,9 +2160,17 @@ These values can be set at configuration time via:
 Other functions
 ---------------
 
+.. function:: addExitCallback(callback)
+
+  .. versionadded:: 2.0.0
+
+  Register a Lua function to be called when :program:`dnsdist` exists.
+
+  :param function callback: The function to be called. It takes no parameter and returns no value.
+
 .. function:: addMaintenanceCallback(callback)
 
-  .. versionadded:: 1.10.0
+  .. versionadded:: 1.9.0
 
   Register a Lua function to be called as part of the ``maintenance`` hook, which is executed roughly every second.
   The function should not block for a long period of time, as it would otherwise delay the execution of the other functions registered for this hook, as well as the execution of the :func:`maintenance` function.

--- a/regression-tests.dnsdist/test_Async.py
+++ b/regression-tests.dnsdist/test_Async.py
@@ -515,6 +515,8 @@ class TestAsyncFFI(DNSDistTest, AsyncTests):
       collectgarbage()
     end
 
+    addExitCallback(atExit)
+
     -- this only matters for tests actually reaching the backend
     addAction('tcp-only.async.tests.powerdns.com', PoolAction('tcp-only', false))
     addAction('cache.async.tests.powerdns.com', PoolAction('cache', false))
@@ -627,6 +629,8 @@ class TestAsyncLua(DNSDistTest, AsyncTests):
       listener = nil
       collectgarbage()
     end
+
+    addExitCallback(atExit)
 
     -- this only matters for tests actually reaching the backend
     addAction('tcp-only.async.tests.powerdns.com', PoolAction('tcp-only', false))


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds support for calling Lua method when exiting, making it possible to clean up Lua objects. It also does a long overdue refactoring of handling termination of the dnsdist process.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
