### PR TITLE
meson systemd option cleanup

### DIFF
--- a/Dockerfile-dnsdist
+++ b/Dockerfile-dnsdist
@@ -79,7 +79,7 @@ RUN mkdir /build && \
       -Dlibsodium=enabled \
       -Dquiche=enabled \
       -Dre2=enabled \
-      -Dsystemd=disabled \
+      -Dsystemd-service=disabled \
       -Dxsk=enabled && \
     meson compile -C ${BUILDDIR} && \
     meson install -C ${BUILDDIR} --destdir /build && \

--- a/builder-support/debian/dnsdist/debian-bookworm/rules
+++ b/builder-support/debian/dnsdist/debian-bookworm/rules
@@ -10,10 +10,10 @@ include /usr/share/dpkg/default.mk
 
 # Only enable systemd integration on Linux operating systems
 ifeq ($(DEB_HOST_ARCH_OS),linux)
-MESON_ARGS += -Dsystemd=enabled
+MESON_ARGS += -Dsystemd-service=enabled
 DH_ARGS += --with systemd
 else
-MESON_ARGS += -Dsystemd=disabled
+MESON_ARGS += -Dsystemd-service=disabled
 endif
 
 # Only enable BPF/XDP on Linux operating systems

--- a/builder-support/debian/dnsdist/debian-bullseye/rules
+++ b/builder-support/debian/dnsdist/debian-bullseye/rules
@@ -10,10 +10,10 @@ include /usr/share/dpkg/default.mk
 
 # Only enable systemd integration on Linux operating systems
 ifeq ($(DEB_HOST_ARCH_OS),linux)
-MESON_ARGS += -Dsystemd=enabled
+MESON_ARGS += -Dsystemd-service=enabled
 DH_ARGS += --with systemd
 else
-MESON_ARGS += -Dsystemd=disabled
+MESON_ARGS += -Dsystemd-service=disabled
 endif
 
 # Only disable luajit on arm64

--- a/meson.build
+++ b/meson.build
@@ -135,7 +135,7 @@ deps = [
   dep_dlopen,
   dep_pkcs11,
   dep_gss_tsig,
-  dep_systemd,
+  dep_libsystemd,
   dep_arc4random,
   dep_ipcrypt,
   dep_json11,
@@ -157,7 +157,7 @@ deps = [
   dep_boost_test,
 ]
 
-if dep_systemd.found()
+if dep_libsystemd.found()
   systemd_service_conf = configuration_data()
   systemd_service_conf.set('BinDir', get_option('prefix') / get_option('bindir'))
   systemd_service_conf.set('StaticBinDir', get_option('prefix') / get_option('sbindir'))

--- a/meson/libsystemd/meson.build
+++ b/meson/libsystemd/meson.build
@@ -1,9 +1,9 @@
-opt_systemd = get_option('systemd')
+opt_systemd = get_option('systemd-service')
 
-dep_systemd = dependency('libsystemd', required: opt_systemd)
-conf.set('HAVE_SYSTEMD', dep_systemd.found(), description: 'libsystemd')
-summary('libsystemd', dep_systemd.found(), bool_yn: true, section: 'Configuration')
+dep_libsystemd = dependency('libsystemd', required: opt_systemd)
+conf.set('HAVE_SYSTEMD', dep_libsystemd.found(), description: 'libsystemd')
+summary('libsystemd', dep_libsystemd.found(), bool_yn: true, section: 'Configuration')
 
-if dep_systemd.found()
-  summary('Lib Version', dep_systemd.version(), section: 'Systemd')
+if dep_libsystemd.found()
+  summary('Lib Version', dep_libsystemd.version(), section: 'Systemd')
 endif

--- a/meson/systemd/meson.build
+++ b/meson/systemd/meson.build
@@ -1,4 +1,6 @@
-dep_systemd_prog = dependency('systemd', required: false)
+opt_systemd = get_option('systemd-service')
+
+dep_systemd_prog = dependency('systemd', required: opt_systemd)
 summary('Systemd', dep_systemd_prog.found(), bool_yn: true, section: 'Configuration')
 
 # Map systemd features to systemd/systemctl version.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -36,7 +36,7 @@ option('module-lua2', type: 'combo', choices: ['disabled', 'static', 'dynamic'],
 option('tools', type: 'boolean', value: false, description: 'Build extra tools')
 option('tools-ixfrdist', type: 'boolean', value: false, description: 'Build ixfrdist')
 option('lua-records', type: 'boolean', value: true, description: 'Support Lua records')
-option('systemd', type: 'feature', value: 'auto', description: 'Systemd notification (requires libsystemd)')
+option('systemd-service', type: 'feature', value: 'auto', description: 'Systemd integration (requires libsystemd)')
 option('systemd-service-user', type: 'string', value: 'pdns', description: 'Systemd service user (setuid and unit file; user is not created)')
 option('systemd-service-group', type: 'string', value: 'pdns', description: 'Systemd service group (setgid and unit file; group is not created)')
 option('auto-var-init', type: 'combo', value: 'disabled', choices: ['zero', 'pattern', 'disabled'], description: 'Enable initialization of automatic variables')

--- a/modules/lmdbbackend/meson.build
+++ b/modules/lmdbbackend/meson.build
@@ -6,4 +6,4 @@ module_extras = files(
   'lmdbbackend.hh',
 )
 
-module_deps = [deps, dep_lmdb_safe, dep_lmdb, dep_boost_serialization, dep_systemd]
+module_deps = [deps, dep_lmdb_safe, dep_lmdb, dep_boost_serialization, dep_libsystemd]

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -411,7 +411,7 @@ tools = {
       dep_lua,
       dep_protozero,
       dep_json11,
-      dep_systemd,
+      dep_libsystemd,
       dep_yahttp,
     ],
     'install': true,
@@ -607,7 +607,7 @@ if get_option('man-pages') and python.found()
   endif
 endif
 
-if dep_systemd_prog.found()
+if dep_libsystemd.found()
 
   systemd_system_unit_dir = dep_systemd_prog.get_variable(
     'systemdsystemunitdir',

--- a/pdns/dnsdistdist/meson_options.txt
+++ b/pdns/dnsdistdist/meson_options.txt
@@ -20,7 +20,7 @@ option('dns-over-http3', type: 'boolean', value: false, description: 'Enable DNS
 option('dns-over-quic', type: 'boolean', value: false, description: 'Enable DNS over QUIC')
 option('unit-tests', type: 'boolean', value: false, description: 'Build and run unit tests')
 option('reproducible', type: 'boolean', value: false, description: 'Reproducible builds (for distro maintainers, makes debugging difficult)')
-option('systemd', type: 'feature', value: 'auto', description: 'Systemd notification (requires libsystemd)')
+option('systemd-service', type: 'feature', value: 'auto', description: 'Systemd integration (requires libsystemd)')
 option('systemd-service-user', type: 'string', value: 'dnsdist', description: 'Systemd service user (setuid and unit file; user is not created)')
 option('systemd-service-group', type: 'string', value: 'dnsdist', description: 'Systemd service group (setgid and unit file; group is not created)')
 option('auto-var-init', type: 'combo', value: 'disabled', choices: ['zero', 'pattern', 'disabled'], description: 'Enable initialization of automatic variables')

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -440,7 +440,7 @@ tools = {
       dep_json11,
       dep_recrust,
       dep_rust_recrust,
-      dep_systemd,
+      dep_libsystemd,
       librec_signers_openssl,
       librec_signers_sodium,
       dep_pubsuffix,
@@ -633,7 +633,7 @@ if python.found()
   endif
 endif
 
-if dep_systemd.found()
+if dep_libsystemd.found()
   systemd_system_unit_dir = dep_systemd_prog.get_variable(
     'systemdsystemunitdir',
   )

--- a/pdns/recursordist/meson_options.txt
+++ b/pdns/recursordist/meson_options.txt
@@ -13,7 +13,7 @@ option('unit-tests', type: 'boolean', value: false, description: 'Build and run 
 # not relevant for rec, but accessed by boost meson.build
 option('unit-tests-backends', type: 'boolean', value: false, description: 'Build and run backend unit tests')
 option('reproducible', type: 'boolean', value: false, description: 'Reproducible builds (for distro maintainers, makes debugging difficult)')
-option('systemd', type: 'feature', value: 'auto', description: 'Systemd notification (requires libsystemd)')
+option('systemd-service', type: 'feature', value: 'auto', description: 'Systemd integration (requires libsystemd)')
 option('systemd-service-user', type: 'string', value: 'pdns', description: 'Systemd service user (setuid and unit file; user is not created)')
 option('systemd-service-group', type: 'string', value: 'pdns', description: 'Systemd service group (setgid and unit file; group is not created)')
 option('auto-var-init', type: 'combo', value: 'disabled', choices: ['zero', 'pattern', 'disabled'], description: 'Enable initialization of automatic variables')

--- a/tasks.py
+++ b/tasks.py
@@ -602,7 +602,7 @@ def ci_rec_configure_meson(c, features, build_dir):
             "-D dns-over-tls=false",
             "-D dnstap=disabled",
             "-D nod=false",
-            "-D systemd=disabled",
+            "-D system-service=disabled",
             "-D lua=luajit",
             "-D libcap=disabled",
             "-D libcurl=disabled",
@@ -775,7 +775,7 @@ def ci_dnsdist_configure_meson(features, additional_flags, additional_ld_flags, 
                       -D lmdb=enabled \
                       -D nghttp2=enabled \
                       -D re2=enabled \
-                      -D systemd=enabled \
+                      -D systemd-service=enabled \
                       -D tls-gnutls=enabled \
                       -D dns-over-https=true \
                       -D dns-over-http3=true \
@@ -795,7 +795,7 @@ def ci_dnsdist_configure_meson(features, additional_flags, additional_ld_flags, 
                       -D lmdb=disabled \
                       -D nghttp2=disabled \
                       -D re2=disabled \
-                      -D systemd=disabled \
+                      -D systemd-service=disabled \
                       -D tls-gnutls=disabled \
                       -D dns-over-https=false \
                       -D dns-over-http3=false \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

For meson there are two parts of systemd support: runtime support (`libsystemd`) and the unit files (`systemd`). Make them both recognize the new `systemd-service` meson option.  Originally, only one of them did: `libsystemd` honoroured the `systemd` option, while `systemd` itself did not.

Hope I did not overlook the places where the option is used.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
