### PR TITLE
dnsdist: Upgrade clang to 19 in our CI

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -234,7 +234,6 @@ jobs:
     container:
       image: "${{ needs.get-runner-container-image.outputs.id }}:${{ needs.get-runner-container-image.outputs.tag }}"
       env:
-        CLANG_VERSION: '19'
         SANITIZERS: ${{ matrix.sanitizers }}
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
@@ -243,6 +242,8 @@ jobs:
     defaults:
       run:
         working-directory: ./pdns/dnsdistdist/dnsdist-${{ env.BUILDER_VERSION }}
+    env:
+      CLANG_VERSION: ${{ contains(needs.get-runner-container-image.outputs.id, 'debian-11') && '13' || '19' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -768,7 +769,6 @@ jobs:
     container:
       image: "${{ needs.get-runner-container-image.outputs.id }}:${{ needs.get-runner-container-image.outputs.tag }}"
       env:
-        CLANG_VERSION: '19'
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         # Disabling (intercept_send=0) the custom send wrappers for ASAN and TSAN because they cause the tools to report a race that doesn't exist on actual implementations of send(), see https://github.com/google/sanitizers/issues/1498
         ASAN_OPTIONS: intercept_send=0
@@ -779,6 +779,8 @@ jobs:
         SANITIZERS: ${{ matrix.sanitizers }}
         COVERAGE: yes
       options: --sysctl net.ipv6.conf.all.disable_ipv6=0 --privileged
+    env:
+      CLANG_VERSION: ${{ contains(needs.get-runner-container-image.outputs.id, 'debian-11') && '13' || '19' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -234,6 +234,7 @@ jobs:
     container:
       image: "${{ needs.get-runner-container-image.outputs.id }}:${{ needs.get-runner-container-image.outputs.tag }}"
       env:
+        CLANG_VERSION: '19'
         SANITIZERS: ${{ matrix.sanitizers }}
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
@@ -266,6 +267,8 @@ jobs:
         run: |
           python3 -m venv ${REPO_HOME}/.venv
           . ${REPO_HOME}/.venv/bin/activate && pip install -r ${REPO_HOME}/meson/requirements.txt
+        working-directory: .
+      - run: ${{ env.INV_CMD }} install-clang
         working-directory: .
       - run: ${{ env.INV_CMD }} install-lld-linker-if-needed
         working-directory: ./pdns/dnsdistdist/
@@ -765,6 +768,7 @@ jobs:
     container:
       image: "${{ needs.get-runner-container-image.outputs.id }}:${{ needs.get-runner-container-image.outputs.tag }}"
       env:
+        CLANG_VERSION: '19'
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         # Disabling (intercept_send=0) the custom send wrappers for ASAN and TSAN because they cause the tools to report a race that doesn't exist on actual implementations of send(), see https://github.com/google/sanitizers/issues/1498
         ASAN_OPTIONS: intercept_send=0

--- a/tasks.py
+++ b/tasks.py
@@ -178,7 +178,10 @@ def install_clang(c):
     """
     install clang and llvm
     """
-    c.sudo(f'apt-get -y --no-install-recommends install clang-{clang_version} llvm-{clang_version}')
+    if int(clang_version) >= 14:
+        c.sudo(f'apt-get -y --no-install-recommends install clang-{clang_version} llvm-{clang_version} llvm-{clang_version}-dev libclang-rt-{clang_version}-dev')
+    else:
+        c.sudo(f'apt-get -y --no-install-recommends install clang-{clang_version} llvm-{clang_version} llvm-{clang_version}-dev')
 
 @task
 def install_clang_tidy_tools(c):
@@ -187,7 +190,10 @@ def install_clang_tidy_tools(c):
 @task
 def install_clang_runtime(c):
     # this gives us the symbolizer, for symbols in asan/ubsan traces
-    c.sudo(f'apt-get -y --no-install-recommends install clang-{clang_version}')
+    # on Debian we need llvm-symbolizer-XX
+    #c.sudo(f'apt-get -y --no-install-recommends install llvm-symbolizer-{clang_version}')
+    # on Ubuntu we need llvm-XX instead
+    c.sudo(f'apt-get -y --no-install-recommends install llvm-{clang_version}')
 
 @task
 def ci_install_rust(c, repo):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
To get rid of the `WARNING: Symbolizer buffer too small` warning, which is caused by big backtraces, and fixed in clang >= 15 by using a dynamic symbolizer buffer size.
I only upgrade it for dnsdist because of a compatibility issue between `libfaketime` and the ASAN implementation in recent versions of `clang`:

https://github.com/wolfcw/libfaketime/issues/365

It seems to be fixed in the `libfaketime` repository. There has not been any release since the fix, but I guess we could compile from a more recent commit.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
