### PR TITLE
dnsdist: Fix XSK mode detection when built with `meson`

### DIFF
--- a/pdns/dnsdistdist/meson/xsk/meson.build
+++ b/pdns/dnsdistdist/meson/xsk/meson.build
@@ -3,6 +3,11 @@ if opt_xsk.allowed()
   dep_libbpf = dependency('libbpf', required: opt_xsk.enabled())
   dep_libxdp = dependency('libxdp', required: opt_xsk.enabled())
 
+  if dep_libbpf.found() and dep_libxdp.found()
+    has = cxx.has_function('bpf_xdp_query', dependencies: dep_libbpf)
+    conf.set('HAVE_BPF_XDP_QUERY', has, description: 'Have BPF bpf_xdp_query')
+  endif
+
   conf.set('HAVE_BPF', dep_libbpf.found(), description: 'BPF library')
   conf.set('HAVE_XDP', dep_libxdp.found(), description: 'XDP library')
   conf.set('HAVE_XSK', dep_libbpf.found() and dep_libxdp.found(), description: 'AF_XDP (XSK) support enabled')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The detection of whether `bpf_xdp_query` is available was not done.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
