### PR TITLE
Fixes the documentation workflows upload

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,7 @@
 # - PUBLISH_DOCS_TO_AWS: Set to 'true' to enable publishing to AWS
 # - PUBLISH_DOCS_TO_NETLIFY: Set to 'true' to enable publishing to Netlify
 # - PUBLISH_DOCS_TO_WEB1: Set to 'true' to enable publishing to Web1
+# - DOCS_WORKFLOW_BRANCH_OVERRIDE: Set to 'true' to allow publishing from non-master branches (for testing)
 
 # - AWS_REGION: AWS region for S3 and CloudFront
 # - AWS_S3_BUCKET_DOCS: S3 bucket name for documentation
@@ -140,7 +141,7 @@ jobs:
   publish-to-netlify:
     name: Publish to Netlify
     needs: build-docs
-    if: ${{ vars.PUBLISH_DOCS_TO_NETLIFY == 'true' && github.ref_name == 'master' }}
+    if: ${{ (github.ref_name == 'master' || vars.DOCS_WORKFLOW_BRANCH_OVERRIDE == 'true') && vars.PUBLISH_DOCS_TO_NETLIFY == 'true' }}
     runs-on: ubuntu-22.04
     env:
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_API_TOKEN }}
@@ -194,7 +195,7 @@ jobs:
   publish-to-web1:
     name: Publish to Web1
     needs: build-docs
-    if: ${{ github.ref_name == 'master' && vars.PUBLISH_DOCS_TO_WEB1 == 'true' }}
+    if: ${{ (github.ref_name == 'master' || vars.DOCS_WORKFLOW_BRANCH_OVERRIDE == 'true') && vars.PUBLISH_DOCS_TO_WEB1 == 'true' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Check required secrets
@@ -250,7 +251,7 @@ jobs:
   publish-to-aws:
     name: Publish to AWS
     needs: build-docs
-    if: ${{ github.ref_name == 'master' && vars.PUBLISH_DOCS_TO_AWS == 'true' }}
+    if: ${{ (github.ref_name == 'master' || vars.DOCS_WORKFLOW_BRANCH_OVERRIDE == 'true') && vars.PUBLISH_DOCS_TO_AWS == 'true' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Check required secrets
@@ -274,14 +275,15 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - name: Install and configure rclone
         run: |
-          apt-get update
-          apt-get install -y rclone
+          sudo apt-get update
+          sudo apt-get install -y rclone
           mkdir -p ~/.config/rclone/
           cat > ~/.config/rclone/rclone.conf << EOF
           [docs-s3]
           type = s3
           provider = AWS
           env_auth = true
+          region = ${{ vars.AWS_REGION }}
           EOF
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -299,29 +301,41 @@ jobs:
           if [ -n "$AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST" ]; then
             tar -xf artifacts/dnsdist-html-docs-${{needs.build-docs.outputs.pdns_version}}/dnsdist-html-docs.tar
             cp artifacts/dnsdist-${{needs.build-docs.outputs.pdns_version}}.pdf/dnsdist.pdf dnsdist-html-docs/
-            rclone copy dnsdist-html-docs/ docs-s3:$AWS_S3_BUCKET_DOCS/dnsdist.org/
-            # Invalidate CloudFront cache for DNSdist
+            
+            # Copy files to S3
+            echo "Copying DNSdist docs to S3..."
+            rclone copy --checksum dnsdist-html-docs/ docs-s3:$AWS_S3_BUCKET_DOCS/dnsdist.org/
+            
+            # Always run invalidation
+            echo "Running CloudFront invalidation for DNSdist..."
             aws cloudfront create-invalidation \
               --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST \
-              --paths "/*" \
-              --no-wait
+              --paths "/*"
+            echo "Invalidation completed."
           fi
+          
           if [ -n "$AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS" ]; then
             tar -xf artifacts/recursor-html-docs-${{needs.build-docs.outputs.pdns_version}}/rec-html-docs.tar
             cp artifacts/PowerDNS-Recursor-${{needs.build-docs.outputs.pdns_version}}.pdf/PowerDNS-Recursor.pdf rec-html-docs/
-            rclone copy rec-html-docs/ docs-s3:$AWS_S3_BUCKET_DOCS/docs.powerdns.com/recursor/
+            
+            # Copy all PowerDNS docs to S3
+            echo "Copying Recursor docs to S3..."
+            rclone copy --checksum rec-html-docs/ docs-s3:$AWS_S3_BUCKET_DOCS/docs.powerdns.com/recursor/
 
             tar -xf artifacts/authoritative-html-docs-${{needs.build-docs.outputs.pdns_version}}/auth-html-docs.tar
             cp artifacts/PowerDNS-Authoritative-${{needs.build-docs.outputs.pdns_version}}.pdf/PowerDNS-Authoritative.pdf auth-html-docs/
-            rclone copy auth-html-docs/ docs-s3:$AWS_S3_BUCKET_DOCS/docs.powerdns.com/authoritative/
+            echo "Copying Authoritative docs to S3..."
+            rclone copy --checksum auth-html-docs/ docs-s3:$AWS_S3_BUCKET_DOCS/docs.powerdns.com/authoritative/
 
             tar -xf artifacts/website-${{needs.build-docs.outputs.pdns_version}}/website.tar
-            rclone copy website/docs.powerdns.com/ docs-s3:$AWS_S3_BUCKET_DOCS/docs.powerdns.com/
+            echo "Copying website files to S3..."
+            rclone copy --checksum website/docs.powerdns.com/ docs-s3:$AWS_S3_BUCKET_DOCS/docs.powerdns.com/
 
-            # Invalidate CloudFront cache for docs.powerdns.com
+            # Always run invalidation
+            echo "Running CloudFront invalidation for PowerDNS docs..."
             aws cloudfront create-invalidation \
               --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS \
-              --paths "/*" \
-              --no-wait
+              --paths "/*"
+            echo "Invalidation completed."
           fi
 


### PR DESCRIPTION
Fixes the documentation workflows upload. Uses sudo to install rclone, omits the --no-wait flag on the invalidations, since that doesn't exist (...). Lastly, adds the possibility to set DOCS_WORKFLOW_BRANCH_OVERRIDE in which case the workflow doesn't check for the branch it's running on, so it can be tested on other branches. Useful in forks.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
