### PR TITLE
docs: clarify secondary behaviour when xfr-cycle-interval elapses

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -2189,8 +2189,9 @@ If enabled, only a single RR will be put into each AXFR chunk, making some zones
 
 On a primary, this is the amount of seconds between the primary checking
 the SOA serials in its database to determine to send out NOTIFYs to the
-secondaries. On secondaries, this is the number of seconds between the secondary
-checking for updates to zones.
+secondaries. On secondaries, this is the number of seconds between the
+check for zones where the REFRESH period has expired. For zones where
+that is the case, secondaries will request updates from the primary.
 
 .. _setting-xfr-max-received-mbytes:
 


### PR DESCRIPTION
### Short description

Clarify documentation according to what @Habbie believes to be true.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [N/A] compiled this code
- [N/A] tested this code
- [x] included documentation (including possible behaviour changes)
- [N/A] documented the code
- [N/A] added or modified regression test(s)
- [N/A] added or modified unit test(s)
