### PR TITLE
[autocconf] [auth] Build tsig-tests if --enable-tools

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -180,7 +180,7 @@ EXTRA_PROGRAMS = \
 	sdig \
 	speedtest \
 	testrunner \
-	tsig-tests \
+	tsig_tests \
 	zone2ldap
 
 pdns_server_SOURCES = \
@@ -931,6 +931,10 @@ tsig_tests_SOURCES += pkcs11signers.cc pkcs11signers.hh
 tsig_tests_LDADD += $(P11KIT1_LIBS)
 endif
 
+if GSS_TSIG
+tsig_tests_LDADD += $(GSS_LIBS)
+endif
+
 speedtest_SOURCES = \
 	arguments.cc arguments.hh \
 	base32.cc \
@@ -1510,7 +1514,7 @@ pdns_control_LDFLAGS = \
        $(AM_LDFLAGS) \
        $(LIBCRYPTO_LDFLAGS)
 
-noinst_PROGRAMS = speedtest
+noinst_PROGRAMS = speedtest tsig_tests
 
 if UNIT_TESTS
 noinst_PROGRAMS += testrunner


### PR DESCRIPTION
### Short description
I found the hard way that changes I was brewing would build with autoconf but not with meson, because autoconf no longer cause `tsig-tests` to be built, which made me miss changes required in `tsig-tests.cc`.

This PR causes this test program to be built again if `--enable-tools` is used (similarly to `speedtest`).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] asked for permission to submit PRs before 8am