### PR TITLE
rec: Prevent a crash when exiting nicely

### DIFF
--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -108,7 +108,7 @@ TCPConnection::~TCPConnection()
          g_slogtcpin->error(Logr::Error, e.reason, "Error closing TCPConnection socket", "exception", Logging::Loggable("PDNSException")));
   }
 
-  if (t_tcpClientCounts->count(d_remote) != 0 && (*t_tcpClientCounts)[d_remote]-- == 0) {
+  if (t_tcpClientCounts && t_tcpClientCounts->count(d_remote) != 0 && (*t_tcpClientCounts)[d_remote]-- == 0) {
     t_tcpClientCounts->erase(d_remote);
   }
   --s_currentConnections;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If a TCP connection is alive when we are exiting, we might dereference a `null` pointer when the TCP connection destructor is called after the thread-local `t_tcpClientCounts` object has been destroyed.

Spotted by UBSAN in the regression tests:
```
Mar 20 12:43:46 msg="Received rec_control command via control socket" subsystem="control" level="0" prio="Info" tid="0" ts="1742474626.168" command="quit-nicely"
Mar 20 12:43:46 msg="Exiting on user request" subsystem="runtime" level="0" prio="Notice" tid="0" ts="1742474626.168" nicely="1"
rec-tcp.cc:111:26: runtime error: member call on null pointer of type 'std::map<ComboAddress, unsigned int, ComboAddress::addressOnlyLessThan>'
      #0 0x557fb203936a in TCPConnection::~TCPConnection() /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/rec-tcp.cc:111:26
      #1 0x557fb2062a15 in void std::_Destroy<TCPConnection>(TCPConnection*) /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_construct.h:151:19
      #2 0x557fb2062a15 in void std::allocator_traits<std::allocator<void> >::destroy<TCPConnection>(std::allocator<void>&, TCPConnection*) /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/alloc_traits.h:648:4
      #3 0x557fb2062a15 in std::_Sp_counted_ptr_inplace<TCPConnection, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr_base.h:613:2
      #4 0x557fb13e136d in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr_base.h:346:8
      #5 0x557fb13e1164 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr_base.h:1071:11
      #6 0x557fb2061d92 in std::__shared_ptr<TCPConnection, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr_base.h:1524:31
      #7 0x557fb2061d92 in boost::any::holder<std::shared_ptr<TCPConnection> >::~holder() /usr/include/boost/any.hpp:169:15
      #8 0x557fb2061d92 in boost::any::holder<std::shared_ptr<TCPConnection> >::~holder() /usr/include/boost/any.hpp:169:15
      #9 0x557fb1cf3ddc in boost::any::~any() /usr/include/boost/any.hpp:77:13
      #10 0x557fb1d006e1 in FDMultiplexer::Callback::~Callback() /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/./mplexer.hh:64:10
      #11 0x557fb1d006e1 in void std::__new_allocator<boost::multi_index::detail::hashed_index_node<boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<FDMultiplexer::Callback, std::allocator<FDMultiplexer::Callback> > > > >::destroy<FDMultiplexer::Callback>(FDMultiplexer::Callback*) /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/new_allocator.h:181:10
      #12 0x557fb1d006e1 in void std::allocator_traits<std::allocator<boost::multi_index::detail::hashed_index_node<boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<FDMultiplexer::Callback, std::allocator<FDMultiplexer::Callback> > > > > >::destroy<FDMultiplexer::Callback>(std::allocator<boost::multi_index::detail::hashed_index_node<boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<FDMultiplexer::Callback, std::allocator<FDMultiplexer::Callback> > > > >&, FDMultiplexer::Callback*) /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/alloc_traits.h:535:8
      #13 0x557fb1d006e1 in boost::multi_index::multi_index_container<FDMultiplexer::Callback, boost::multi_index::indexed_by<boost::multi_index::hashed_unique<boost::multi_index::tag<FDMultiplexer::FDBasedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, int, &(FDMultiplexer::Callback::d_fd)>, mpl_::na, mpl_::na>, boost::multi_index::ordered_non_unique<boost::multi_index::tag<FDMultiplexer::TTDOrderedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, timeval, &(FDMultiplexer::Callback::d_ttd)>, FDMultiplexer::ttd_compare>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::allocator<FDMultiplexer::Callback> >::destroy_value(boost::multi_index::detail::hashed_index_node<boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<FDMultiplexer::Callback, std::allocator<FDMultiplexer::Callback> > > >*) /usr/include/boost/multi_index_container.hpp:670:5
      #14 0x557fb1d7555c in boost::multi_index::multi_index_container<FDMultiplexer::Callback, boost::multi_index::indexed_by<boost::multi_index::hashed_unique<boost::multi_index::tag<FDMultiplexer::FDBasedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, int, &(FDMultiplexer::Callback::d_fd)>, mpl_::na, mpl_::na>, boost::multi_index::ordered_non_unique<boost::multi_index::tag<FDMultiplexer::TTDOrderedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, timeval, &(FDMultiplexer::Callback::d_ttd)>, FDMultiplexer::ttd_compare>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::allocator<FDMultiplexer::Callback> >::delete_node_(boost::multi_index::detail::hashed_index_node<boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<FDMultiplexer::Callback, std::allocator<FDMultiplexer::Callback> > > >*) /usr/include/boost/multi_index_container.hpp:939:5
      #15 0x557fb1d7555c in boost::multi_index::detail::index_base<FDMultiplexer::Callback, boost::multi_index::indexed_by<boost::multi_index::hashed_unique<boost::multi_index::tag<FDMultiplexer::FDBasedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, int, &(FDMultiplexer::Callback::d_fd)>, mpl_::na, mpl_::na>, boost::multi_index::ordered_non_unique<boost::multi_index::tag<FDMultiplexer::TTDOrderedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, timeval, &(FDMultiplexer::Callback::d_ttd)>, FDMultiplexer::ttd_compare>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::allocator<FDMultiplexer::Callback> >::final_delete_node_(boost::multi_index::detail::hashed_index_node<boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<FDMultiplexer::Callback, std::allocator<FDMultiplexer::Callback> > > >*) /usr/include/boost/multi_index/detail/index_base.hpp:265:55
      #16 0x557fb1d75498 in boost::multi_index::detail::hashed_index<boost::multi_index::member<FDMultiplexer::Callback, int, &(FDMultiplexer::Callback::d_fd)>, boost::hash<int>, std::equal_to<int>, boost::multi_index::detail::nth_layer<1, FDMultiplexer::Callback, boost::multi_index::indexed_by<boost::multi_index::hashed_unique<boost::multi_index::tag<FDMultiplexer::FDBasedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, int, &(FDMultiplexer::Callback::d_fd)>, mpl_::na, mpl_::na>, boost::multi_index::ordered_non_unique<boost::multi_index::tag<FDMultiplexer::TTDOrderedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, timeval, &(FDMultiplexer::Callback::d_ttd)>, FDMultiplexer::ttd_compare>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::allocator<FDMultiplexer::Callback> >, boost::mpl::v_item<FDMultiplexer::FDBasedTag, boost::mpl::vector0<mpl_::na>, 0>, boost::multi_index::detail::hashed_unique_tag>::delete_all_nodes_(boost::multi_index::detail::hashed_unique_tag) /usr/include/boost/multi_index/hashed_index.hpp:900:13
      #17 0x557fb1d74b9f in boost::multi_index::detail::hashed_index<boost::multi_index::member<FDMultiplexer::Callback, int, &(FDMultiplexer::Callback::d_fd)>, boost::hash<int>, std::equal_to<int>, boost::multi_index::detail::nth_layer<1, FDMultiplexer::Callback, boost::multi_index::indexed_by<boost::multi_index::hashed_unique<boost::multi_index::tag<FDMultiplexer::FDBasedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, int, &(FDMultiplexer::Callback::d_fd)>, mpl_::na, mpl_::na>, boost::multi_index::ordered_non_unique<boost::multi_index::tag<FDMultiplexer::TTDOrderedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, timeval, &(FDMultiplexer::Callback::d_ttd)>, FDMultiplexer::ttd_compare>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::allocator<FDMultiplexer::Callback> >, boost::mpl::v_item<FDMultiplexer::FDBasedTag, boost::mpl::vector0<mpl_::na>, 0>, boost::multi_index::detail::hashed_unique_tag>::delete_all_nodes_() /usr/include/boost/multi_index/hashed_index.hpp:893:5
      #18 0x557fb1d74b9f in boost::multi_index::multi_index_container<FDMultiplexer::Callback, boost::multi_index::indexed_by<boost::multi_index::hashed_unique<boost::multi_index::tag<FDMultiplexer::FDBasedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, int, &(FDMultiplexer::Callback::d_fd)>, mpl_::na, mpl_::na>, boost::multi_index::ordered_non_unique<boost::multi_index::tag<FDMultiplexer::TTDOrderedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, timeval, &(FDMultiplexer::Callback::d_ttd)>, FDMultiplexer::ttd_compare>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::allocator<FDMultiplexer::Callback> >::delete_all_nodes_() /usr/include/boost/multi_index_container.hpp:945:12
      #19 0x557fb1d74b9f in boost::multi_index::multi_index_container<FDMultiplexer::Callback, boost::multi_index::indexed_by<boost::multi_index::hashed_unique<boost::multi_index::tag<FDMultiplexer::FDBasedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, int, &(FDMultiplexer::Callback::d_fd)>, mpl_::na, mpl_::na>, boost::multi_index::ordered_non_unique<boost::multi_index::tag<FDMultiplexer::TTDOrderedTag, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::member<FDMultiplexer::Callback, timeval, &(FDMultiplexer::Callback::d_ttd)>, FDMultiplexer::ttd_compare>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::allocator<FDMultiplexer::Callback> >::~multi_index_container() /usr/include/boost/multi_index_container.hpp:334:5
      #20 0x557fb24b0238 in FDMultiplexer::~FDMultiplexer() /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/./mplexer.hh:73:36
      #21 0x557fb24b0238 in EpollFDMultiplexer::~EpollFDMultiplexer() /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/epollmplexer.cc:45:3
      #22 0x557fb24b02ec in EpollFDMultiplexer::~EpollFDMultiplexer() /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/epollmplexer.cc:41:3
      #23 0x557fb1cf2209 in std::default_delete<FDMultiplexer>::operator()(FDMultiplexer*) const /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:95:2
      #24 0x557fb1cf2209 in std::unique_ptr<FDMultiplexer, std::default_delete<FDMultiplexer> >::~unique_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:396:4
      #25 0x7ff2c02c122e in __call_tls_dtors (/lib/x86_64-linux-gnu/libc.so.6+0x3e22e)
      #26 0x7ff2c030c02f  (/lib/x86_64-linux-gnu/libc.so.6+0x8902f)
      #27 0x7ff2c038baff in clone (/lib/x86_64-linux-gnu/libc.so.6+0x108aff)
  
  SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior rec-tcp.cc:111:26 in 
  ```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
