### PR TITLE
[geoip] Try and be more helpful in YAML error exceptions

### DIFF
--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -392,12 +392,20 @@ void GeoIPBackend::initialize()
     g_log << Logger::Warning << "No GeoIP database files loaded!" << endl;
   }
 
-  if (!getArg("zones-file").empty()) {
+  std::string zonesFile{getArg("zones-file")};
+  if (!zonesFile.empty()) {
     try {
-      config = YAML::LoadFile(getArg("zones-file"));
+      config = YAML::LoadFile(zonesFile);
     }
     catch (YAML::Exception& ex) {
-      throw PDNSException(string("Cannot read config file ") + ex.msg);
+      std::string description{};
+      if (!ex.mark.is_null()) {
+        description = "Configuration error in " + zonesFile + ", line " + std::to_string(ex.mark.line + 1) + ", column " + std::to_string(ex.mark.column + 1);
+      }
+      else {
+        description = "Cannot read config file " + zonesFile;
+      }
+      throw PDNSException(description + ": " + ex.msg);
     }
   }
 


### PR DESCRIPTION
### Short description
Once upon a time, a PowerDNS user forgot to put a space after a semicolon in a YAML configuration file, and `pdns_server` complained with something as unpleasant as:
```
Caught an exception instantiating a backend (geoip): Cannot read config file illegal map value
```

The changes in this PR try to give a bit more information to help figure out what went wrong:
```
Caught an exception instantiating a backend (geoip): Configuration error in /users/miod/config/geoip/zones.yml, line 5, column 10: illegal map value
```

Note that the error location, in this particular error case, points to the next keyword in the file. But even if it is not 100% accurate, this helps narrowing where the problem must be, which can be helpful for large files.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)