### PR TITLE
rec: fix a race in the RPZ regression test and modify handling of auths

### DIFF
--- a/regression-tests.recursor-dnssec/basicDNSSEC.py
+++ b/regression-tests.recursor-dnssec/basicDNSSEC.py
@@ -5,6 +5,7 @@ import os
 class BasicDNSSEC(RecursorTest):
     __test__ = False
     _config_template = """dnssec=validate"""
+    _auth_zones = RecursorTest._default_auth_zones
 
     @classmethod
     def setUp(cls):

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -409,7 +409,7 @@ PrivateKey: Ep9uo6+wwjb4MaOmqq7LHav2FLrjotVOeZg8JT1Qk04=
     # This dict is keyed with the suffix of the IP address and its value
     # is a list of zones hosted on that IP. Note that delegations should
     # go into the _zones's zonecontent
-    _auth_zones = {
+    _default_auth_zones = {
         '8': {'threads': 1,
               'zones': ['ROOT']},
         '9': {'threads': 1,
@@ -434,6 +434,7 @@ PrivateKey: Ep9uo6+wwjb4MaOmqq7LHav2FLrjotVOeZg8JT1Qk04=
         '18': {'threads': 1,
                'zones': ['example']}
     }
+    _auth_zones = {}
     # Other IPs used:
     #  2: test_Interop.py
     #  3-7: free?

--- a/regression-tests.recursor-dnssec/test_API.py
+++ b/regression-tests.recursor-dnssec/test_API.py
@@ -3,26 +3,7 @@ import requests
 
 from recursortests import RecursorTest
 
-class APIRecursorTest(RecursorTest):
-
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
-
-class APIAllowedRecursorTest(APIRecursorTest):
+class APIAllowedRecursorTest(RecursorTest):
     _confdir = 'APIAllowedRecursor'
     _wsPort = 8042
     _wsTimeout = 2
@@ -47,7 +28,7 @@ api-key=%s
         self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
 
-class APIDeniedRecursorTest(APIRecursorTest):
+class APIDeniedRecursorTest(RecursorTest):
     _confdir = 'APIDeniedRecursor'
     _wsPort = 8042
     _wsTimeout = 2

--- a/regression-tests.recursor-dnssec/test_Additionals.py
+++ b/regression-tests.recursor-dnssec/test_Additionals.py
@@ -4,7 +4,7 @@ from recursortests import RecursorTest
 
 class AdditionalsDefaultTest(RecursorTest):
     _confdir = 'AdditionalsDefault'
-
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """
     dnssec=validate
     disable-packetcache
@@ -42,6 +42,7 @@ class AdditionalsDefaultTest(RecursorTest):
 
 class AdditionalsResolveImmediatelyTest(RecursorTest):
     _confdir = 'AdditionalsResolveImmediately'
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """
     dnssec=validate
     disable-packetcache
@@ -104,6 +105,7 @@ class AdditionalsResolveImmediatelyTest(RecursorTest):
 
 class AdditionalsResolveCacheOnlyTest(RecursorTest):
     _confdir = 'AdditionalsResolveCacheOnly'
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """
     dnssec=validate
     disable-packetcache

--- a/regression-tests.recursor-dnssec/test_AggressiveNSECCache.py
+++ b/regression-tests.recursor-dnssec/test_AggressiveNSECCache.py
@@ -12,7 +12,7 @@ class AggressiveNSECCacheBase(RecursorTest):
     _wsTimeout = 10
     _wsPassword = 'secretpassword'
     _apiKey = 'secretapikey'
-    #_recursorStartupDelay = 4.0
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """
     dnssec=validate
     aggressive-nsec-cache-size=10000

--- a/regression-tests.recursor-dnssec/test_AnyBind.py
+++ b/regression-tests.recursor-dnssec/test_AnyBind.py
@@ -5,6 +5,7 @@ from recursortests import RecursorTest
 
 class AnyBindTest(RecursorTest):
     _confdir = 'AnyBind'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate
     local-address=0.0.0.0

--- a/regression-tests.recursor-dnssec/test_Carbon.py
+++ b/regression-tests.recursor-dnssec/test_Carbon.py
@@ -26,22 +26,6 @@ class CarbonTest(RecursorTest):
     carbon-ourname=%s
     carbon-server=127.0.0.1:%s,127.0.01:%s
     """ % (_carbonNamespace, _carbonInstance, _carbonInterval, _carbonServerName, _carbonServer1Port,  _carbonServer2Port)
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
 
     @classmethod
     def CarbonResponder(cls, port):

--- a/regression-tests.recursor-dnssec/test_Chain.py
+++ b/regression-tests.recursor-dnssec/test_Chain.py
@@ -8,6 +8,7 @@ class ChainTest(RecursorTest):
     """
     These regression tests test the chaining of outgoing requests.
     """
+    _auth_zones = RecursorTest._default_auth_zones
     _chainSize = 200
     _confdir = 'Chain'
     _wsPort = 8042

--- a/regression-tests.recursor-dnssec/test_DNS64.py
+++ b/regression-tests.recursor-dnssec/test_DNS64.py
@@ -6,6 +6,7 @@ from recursortests import RecursorTest
 class DNS64Test(RecursorTest):
 
     _confdir = 'DNS64'
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """
     serve-rfc6303=no
     auth-zones=example.dns64=configs/%s/example.dns64.zone

--- a/regression-tests.recursor-dnssec/test_ECS.py
+++ b/regression-tests.recursor-dnssec/test_ECS.py
@@ -98,24 +98,6 @@ ecs-add-for=0.0.0.0/0
             cls._UDPResponder.daemon = True
             cls._UDPResponder.start()
 
-    @classmethod
-    def setUpClass(cls):
-        cls.setUpSockets()
-
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-        print("Launching tests..")
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
-
 class NoECSTest(ECSTest):
     _confdir = 'NoECS'
 
@@ -554,22 +536,6 @@ dnssec=validate
 
     _roothints = None
 
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
 
     @classmethod
     def generateRecursorConfig(cls, confdir):

--- a/regression-tests.recursor-dnssec/test_EDNSPadding.py
+++ b/regression-tests.recursor-dnssec/test_EDNSPadding.py
@@ -10,28 +10,14 @@ from recursortests import RecursorTest
 class RecursorEDNSPaddingTest(RecursorTest):
 
     _confdir = 'RecursorEDNSPadding'
-
-    @classmethod
-    def setUpClass(cls):
-        cls.setUpSockets()
-
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-        cls.generateAllAuthConfig(confdir)
-
-        # we only need these auths and this cuts the needed time in half
-        if cls._auth_zones:
-            for auth_suffix in ['8', '9', '10']:
-                authconfdir = os.path.join(confdir, 'auth-%s' % auth_suffix)
-                ipaddress = cls._PREFIX + '.' + auth_suffix
-                cls.startAuth(authconfdir, ipaddress)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-        print("Launching tests..")
+    _auth_zones = {
+        '8': {'threads': 1,
+              'zones': ['ROOT']},
+        '9': {'threads': 1,
+              'zones': ['secure.example', 'islandofsecurity.example']},
+        '10': {'threads': 1,
+            'zones': ['example']},
+    }
 
     def checkPadding(self, message, numberOfBytes=None):
         self.assertEqual(message.edns, 0)

--- a/regression-tests.recursor-dnssec/test_Expired.py
+++ b/regression-tests.recursor-dnssec/test_Expired.py
@@ -14,6 +14,7 @@ class ExpiredTest(RecursorTest):
     because they are expired.
     """
     _confdir = 'Expired'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate"""
 
@@ -32,6 +33,7 @@ class ExpiredWithEDETest(RecursorTest):
     because they are expired.
     """
     _confdir = 'ExpiredWithEDE'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """
     dnssec=validate

--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -56,23 +56,6 @@ extended-resolution-errors=yes
     _roothints = None
 
     @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
-
-    @classmethod
     def generateRecursorConfig(cls, confdir):
         rpzFilePath = os.path.join(confdir, 'zone.rpz')
         with open(rpzFilePath, 'w') as rpzZone:
@@ -219,27 +202,6 @@ dnssec=validate
 extended-resolution-errors=no
     """
     _roothints = None
-
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
-
-    @classmethod
-    def generateRecursorConfig(cls, confdir):
-        super(NoExtendedErrorsTest, cls).generateRecursorConfig(confdir)
 
     @pytest.mark.external
     def testNotIncepted(self):

--- a/regression-tests.recursor-dnssec/test_Flags.py
+++ b/regression-tests.recursor-dnssec/test_Flags.py
@@ -7,6 +7,7 @@ from recursortests import RecursorTest
 
 class FlagsTest(RecursorTest):
     _confdir = 'Flags'
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """dnssec=%s"""
     _config_params = ['_dnssec_setting']
     _dnssec_setting = None

--- a/regression-tests.recursor-dnssec/test_Interop.py
+++ b/regression-tests.recursor-dnssec/test_Interop.py
@@ -9,6 +9,7 @@ import threading
 
 class InteropTest(RecursorTest):
     _confdir = 'Interop'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate
 packetcache-ttl=0 # explicitly disable packetcache
@@ -153,6 +154,7 @@ forward-zones+=undelegated.insecure.example=%s.12
 
 class InteropProcessTest(RecursorTest):
     _confdir = 'InteropProcess'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=process
 packetcache-ttl=0 # explicitly disable packetcache

--- a/regression-tests.recursor-dnssec/test_KeepOpenTCP.py
+++ b/regression-tests.recursor-dnssec/test_KeepOpenTCP.py
@@ -7,6 +7,7 @@ from recursortests import RecursorTest
 
 class KeepOpenTCPTest(RecursorTest):
     _confdir = 'KeepOpenTCP'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate
 packetcache-ttl=10

--- a/regression-tests.recursor-dnssec/test_LockedCache.py
+++ b/regression-tests.recursor-dnssec/test_LockedCache.py
@@ -10,6 +10,7 @@ class LockedCacheTest(RecursorTest):
     Test that a locked cached entry is *not* updated by the same additional encountered in a second query
     """
     _confdir = 'LockedCache'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """
     dnssec=validate
@@ -60,6 +61,7 @@ class NotLockedCacheTest(RecursorTest):
     Test that a not locked cached entry *is* updated by the same additional encountered in a second query
     """
     _confdir = 'NotLockedCache'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """
     dnssec=validate

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -116,19 +116,6 @@ class GettagRecursorTest(RecursorTest):
     end
     """
 
-    @classmethod
-    def setUpClass(cls):
-
-        cls.setUpSockets()
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
-
     def testA(self):
         name = 'gettag.lua.'
         expected = [
@@ -353,24 +340,6 @@ quiet=no
             cls._UDPResponder.setDaemon(True)
             cls._UDPResponder.start()
 
-    @classmethod
-    def setUpClass(cls):
-        cls.setUpSockets()
-
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-        print("Launching tests..")
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
-
     def testNoData(self):
         expected = dns.rrset.from_text('nodata.luahooks.example.', 3600, dns.rdataclass.IN, 'AAAA', '2001:DB8::1')
         query = dns.message.make_query('nodata.luahooks.example.', 'AAAA', 'IN')
@@ -459,6 +428,7 @@ class LuaDNS64Test(RecursorTest):
     """Tests the dq.followupAction("getFakeAAAARecords")"""
 
     _confdir = 'LuaDNS64'
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """
     """
     _lua_dns_script_file = """
@@ -752,6 +722,7 @@ class PolicyEventFilterOnFollowUpTest(RecursorTest):
     """
 
     _confdir = 'PolicyEventFilterOnFollowUp'
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """
     """
     _lua_config_file = """
@@ -803,6 +774,7 @@ class PolicyEventFilterOnFollowUpWithNativeDNS64Test(RecursorTest):
     """
 
     _confdir = 'PolicyEventFilterOnFollowUpWithNativeDNS64'
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """
     dns64-prefix=1234::/96
     """
@@ -839,6 +811,7 @@ class LuaPostResolveFFITest(RecursorTest):
     """Tests postresolve_ffi interface"""
 
     _confdir = 'LuaPostResolveFFI'
+    _auth_zones = RecursorTest._default_auth_zones
     _config_template = """
     """
     _lua_dns_script_file = """

--- a/regression-tests.recursor-dnssec/test_NTA.py
+++ b/regression-tests.recursor-dnssec/test_NTA.py
@@ -3,6 +3,7 @@ from recursortests import RecursorTest
 
 class NTATest(RecursorTest):
     _confdir = 'NTA'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate"""
     _lua_config_file = """addNTA("bogus.example")

--- a/regression-tests.recursor-dnssec/test_NamedForward.py
+++ b/regression-tests.recursor-dnssec/test_NamedForward.py
@@ -17,18 +17,6 @@ forward-zones-recurse=.=dns.quad9.net;dns.google;one.one.one.one
 system-resolver-ttl=10
     """
 
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
     def testA(self):
         expected = dns.rrset.from_text('dns.google.', 0, dns.rdataclass.IN, 'A', '8.8.8.8', '8.8.4.4')
         query = dns.message.make_query('dns.google', 'A', want_dnssec=True)

--- a/regression-tests.recursor-dnssec/test_NoDS.py
+++ b/regression-tests.recursor-dnssec/test_NoDS.py
@@ -4,6 +4,7 @@ from recursortests import RecursorTest
 
 class NoDSTest(RecursorTest):
     _confdir = 'NoDS'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate"""
     _lua_config_file = """clearDS(".")"""

--- a/regression-tests.recursor-dnssec/test_NoDSYAML.py
+++ b/regression-tests.recursor-dnssec/test_NoDSYAML.py
@@ -3,6 +3,7 @@ from recursortests import RecursorTest
 
 class NoDSYAMLTest(RecursorTest):
     _confdir = 'NoDSYAML'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """
 dnssec:

--- a/regression-tests.recursor-dnssec/test_OOOTCP.py
+++ b/regression-tests.recursor-dnssec/test_OOOTCP.py
@@ -5,6 +5,7 @@ from recursortests import RecursorTest
 
 class OOOTCPTest(RecursorTest):
     _confdir = 'OOOTCP'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate
 """

--- a/regression-tests.recursor-dnssec/test_Prometheus.py
+++ b/regression-tests.recursor-dnssec/test_Prometheus.py
@@ -6,23 +6,6 @@ import unittest
 from recursortests import RecursorTest
 
 class RecPrometheusTest(RecursorTest):
-
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
  
     def checkPrometheusContentBasic(self, content):
         for line in content.splitlines():

--- a/regression-tests.recursor-dnssec/test_ProxyByTable.py
+++ b/regression-tests.recursor-dnssec/test_ProxyByTable.py
@@ -7,6 +7,7 @@ class ProxyByTableTest(RecursorTest):
     This test makes sure that we correctly use the proxy-mapped address during the ACL check
     """
     _confdir = 'ProxyByTable'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate
     auth-zones=authzone.example=configs/%s/authzone.zone

--- a/regression-tests.recursor-dnssec/test_ProxyProtocol.py
+++ b/regression-tests.recursor-dnssec/test_ProxyProtocol.py
@@ -15,26 +15,7 @@ except NameError:
 from recursortests import RecursorTest
 from proxyprotocol import ProxyProtocol
 
-class ProxyProtocolTest(RecursorTest):
-
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
-
-class ProxyProtocolAllowedTest(ProxyProtocolTest):
+class ProxyProtocolAllowedTest(RecursorTest):
     _confdir = 'ProxyProtocolAllowed'
     _wsPort = 8042
     _wsTimeout = 2
@@ -134,7 +115,7 @@ class ProxyProtocolAllowedTest(ProxyProtocolTest):
       dq:addAnswer(pdns.A, '192.0.2.1', 60)
       return true
     end
-    """ % (ProxyProtocolTest._recursorPort, ProxyProtocolTest._recursorPort)
+    """ % (RecursorTest._recursorPort, RecursorTest._recursorPort)
 
     _config_template = """
     proxy-protocol-from=127.0.0.1
@@ -637,7 +618,7 @@ class ProxyProtocolAllowedFFITest(ProxyProtocolAllowedTest):
     end
     """ % (ProxyProtocolAllowedTest._recursorPort)
 
-class ProxyProtocolNotAllowedTest(ProxyProtocolTest):
+class ProxyProtocolNotAllowedTest(RecursorTest):
     _confdir = 'ProxyProtocolNotAllowed'
     _lua_dns_script_file = """
 
@@ -673,7 +654,7 @@ class ProxyProtocolNotAllowedTest(ProxyProtocolTest):
             res = sender(query, False, '127.0.0.42', '255.255.255.255', 0, 65535, [ [0, b'foo' ], [ 255, b'bar'] ])
             self.assertEqual(res, None)
 
-class ProxyProtocolExceptionTest(ProxyProtocolTest):
+class ProxyProtocolExceptionTest(RecursorTest):
     _confdir = 'ProxyProtocolException'
     _lua_dns_script_file = """
 
@@ -687,7 +668,7 @@ class ProxyProtocolExceptionTest(ProxyProtocolTest):
     proxy-protocol-from=127.0.0.1/32
     proxy-protocol-exceptions=127.0.0.1:%d
     allow-from=127.0.0.0/24, ::1/128
-""" % (ProxyProtocolTest._recursorPort)
+""" % (RecursorTest._recursorPort)
 
     def testNoHeaderProxyProtocol(self):
         qname = 'no-header.proxy-protocol-not-allowed.recursor-tests.powerdns.com.'
@@ -710,7 +691,7 @@ class ProxyProtocolExceptionTest(ProxyProtocolTest):
             res = sender(query, False, '127.0.0.42', '255.255.255.255', 0, 65535, [ [0, b'foo' ], [ 255, b'bar'] ])
             self.assertEqual(res, None)
 
-class ProxyProtocolConfigReloadTest(ProxyProtocolTest):
+class ProxyProtocolConfigReloadTest(RecursorTest):
     _confdir = 'ProxyProtocolConfigReload'
     _lua_dns_script_file = """
 

--- a/regression-tests.recursor-dnssec/test_RDFlag.py
+++ b/regression-tests.recursor-dnssec/test_RDFlag.py
@@ -4,6 +4,7 @@ from recursortests import RecursorTest
 
 class RDNotAllowedTest(RecursorTest):
     _confdir = 'RDNotAllowed'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """
 """
@@ -19,6 +20,7 @@ class RDNotAllowedTest(RecursorTest):
 
 class RDAllowedTest(RecursorTest):
     _confdir = 'RDAllowed'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """
     disable-packetcache=yes

--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -426,13 +426,16 @@ e 3600 IN A 192.0.2.42
         incr = .1
         # There's a file base race here, so do a few attempts
         while attempts < timeout:
-            zone = dns.zone.from_file(file, 'zone.rpz', relativize=False, check_origin=False, allow_include=False)
-            soa = zone['']
-            rdataset = soa.find_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
-            # if the above call did not throw an exception the SOA has the right owner, continue
-            soa = zone.get_soa()
-            if soa.serial == serial and soa.mname == dns.name.from_text('ns.zone.rpz.'):
-                return # we found what we expected
+            try:
+                zone = dns.zone.from_file(file, 'zone.rpz', relativize=False, check_origin=False, allow_include=False)
+                soa = zone['']
+                rdataset = soa.find_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
+                # if the above call did not throw an exception the SOA has the right owner, continue
+                soa = zone.get_soa()
+                if soa.serial == serial and soa.mname == dns.name.from_text('ns.zone.rpz.'):
+                    return # we found what we expected
+            except e as FileNotFoundError:
+                pass
             attempts = attempts + incr
             time.sleep(incr)
         raise AssertionError("Waited %d seconds for the dumpfile to be updated to %d but the serial is still %d" % (timeout, serial, soa.serial))

--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -190,7 +190,7 @@ class RPZServer(object):
 
             for b in lenprefix:
                 conn.send(bytes([b]))
-                time.sleep(0.5)
+                time.sleep(0.1)
 
             conn.send(wire)
             self._currentSerial = serial
@@ -446,6 +446,7 @@ e 3600 IN A 192.0.2.42
         rpzServer.moveToSerial(serial)
 
         attempts = 0
+        incr = .1
         while attempts < timeout:
             currentSerial = rpzServer.getCurrentSerial()
             if currentSerial > serial:
@@ -455,8 +456,8 @@ e 3600 IN A 192.0.2.42
                 self.checkDump(serial)
                 return
 
-            attempts = attempts + 1
-            time.sleep(1)
+            attempts = attempts + incr
+            time.sleep(incr)
 
         raise AssertionError("Waited %d seconds for the serial to be updated to %d but the serial is still %d" % (timeout, serial, currentSerial))
 

--- a/regression-tests.recursor-dnssec/test_RootNXTrust.py
+++ b/regression-tests.recursor-dnssec/test_RootNXTrust.py
@@ -35,6 +35,7 @@ class RootNXTrustRecursorTest(RecursorTest):
 
 class RootNXTrustDisabledTest(RootNXTrustRecursorTest):
     _confdir = 'RootNXTrustDisabled'
+    _auth_zones = RecursorTest._default_auth_zones
     _wsPort = 8042
     _wsTimeout = 2
     _wsPassword = 'secretpassword'
@@ -88,6 +89,7 @@ extended-resolution-errors
 
 class RootNXTrustEnabledTest(RootNXTrustRecursorTest):
     _confdir = 'RootNXTrustEnabled'
+    _auth_zones = RecursorTest._default_auth_zones
     _wsPort = 8042
     _wsTimeout = 2
     _wsPassword = 'secretpassword'

--- a/regression-tests.recursor-dnssec/test_RoutingTag.py
+++ b/regression-tests.recursor-dnssec/test_RoutingTag.py
@@ -87,20 +87,6 @@ ecs-add-for=0.0.0.0/0
             cls._UDPResponder.start()
 
     @classmethod
-    def setUpClass(cls):
-        cls.setUpSockets()
-
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-        print("Launching tests..")
-
-    @classmethod
     def tearDownClass(cls):
         cls.tearDownRecursor()
         os.unlink('tagfile')

--- a/regression-tests.recursor-dnssec/test_ServerNames.py
+++ b/regression-tests.recursor-dnssec/test_ServerNames.py
@@ -8,6 +8,7 @@ class ServerNamesTest(RecursorTest):
     """
 
     _confdir = 'ServerNames'
+    _auth_zones = RecursorTest._default_auth_zones
     _servername = 'awesome-pdns1.example.com'
     _versionbind = 'Awesome!'
     _versionbind_expected = dns.rrset.from_text('version.bind.', 86400, 'CH', 'TXT', _versionbind)

--- a/regression-tests.recursor-dnssec/test_Simple.py
+++ b/regression-tests.recursor-dnssec/test_Simple.py
@@ -4,6 +4,7 @@ from recursortests import RecursorTest
 
 class SimpleTest(RecursorTest):
     _confdir = 'Simple'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate
 auth-zones=authzone.example=configs/%s/authzone.zone""" % _confdir

--- a/regression-tests.recursor-dnssec/test_SimpleDoT.py
+++ b/regression-tests.recursor-dnssec/test_SimpleDoT.py
@@ -18,19 +18,6 @@ devonly-regression-test-mode
 
     _roothints = None
 
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
     @pytest.mark.external
     def testTXT(self):
         expected = dns.rrset.from_text('dot-test-target.powerdns.org.', 0, dns.rdataclass.IN, 'TXT', 'https://github.com/PowerDNS/pdns/pull/12825')

--- a/regression-tests.recursor-dnssec/test_SimpleForwardOverDoT.py
+++ b/regression-tests.recursor-dnssec/test_SimpleForwardOverDoT.py
@@ -16,18 +16,6 @@ forward-zones-recurse=.=1.1.1.1:853;8.8.8.8:853;9.9.9.9:853
 devonly-regression-test-mode
     """
 
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
     @pytest.mark.external
     def testA(self):
         expected = dns.rrset.from_text('dns.google.', 0, dns.rdataclass.IN, 'A', '8.8.8.8', '8.8.4.4')

--- a/regression-tests.recursor-dnssec/test_SimpleTCP.py
+++ b/regression-tests.recursor-dnssec/test_SimpleTCP.py
@@ -4,6 +4,7 @@ from recursortests import RecursorTest
 
 class SimpleTCPTest(RecursorTest):
     _confdir = 'SimpleTCP'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate
 auth-zones=authzone.example=configs/%s/authzone.zone""" % _confdir

--- a/regression-tests.recursor-dnssec/test_SimpleYAML.py
+++ b/regression-tests.recursor-dnssec/test_SimpleYAML.py
@@ -4,6 +4,7 @@ from recursortests import RecursorTest
 
 class SimpleYAMLTest(RecursorTest):
     _confdir = 'SimpleYAML'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """
 recursor:

--- a/regression-tests.recursor-dnssec/test_Sortlist.py
+++ b/regression-tests.recursor-dnssec/test_Sortlist.py
@@ -4,6 +4,7 @@ from recursortests import RecursorTest
 
 class SortlistTest(RecursorTest):
     _confdir = 'Sortlist'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=off"""
     _lua_config_file = """addSortList("0.0.0.0/0", 

--- a/regression-tests.recursor-dnssec/test_TTL.py
+++ b/regression-tests.recursor-dnssec/test_TTL.py
@@ -4,6 +4,7 @@ from recursortests import RecursorTest
 
 class BogusMaxTTLTest(RecursorTest):
     _confdir = 'BogusMaxTTL'
+    _auth_zones = RecursorTest._default_auth_zones
 
     _config_template = """dnssec=validate
 max-cache-bogus-ttl=5"""

--- a/regression-tests.recursor-dnssec/test_TraceFail.py
+++ b/regression-tests.recursor-dnssec/test_TraceFail.py
@@ -12,23 +12,6 @@ trace=fail
 forward-zones-recurse=.=127.0.0.1:9999
 """
 
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
-
     def testA(self):
         query = dns.message.make_query('example', 'A', want_dnssec=False)
         res = self.sendUDPQuery(query)

--- a/regression-tests.recursor-dnssec/test_ZTC.py
+++ b/regression-tests.recursor-dnssec/test_ZTC.py
@@ -6,7 +6,6 @@ import subprocess
 from recursortests import RecursorTest
 
 class ZTCTest(RecursorTest):
-
     _confdir = 'ZTC'
     _config_template = """
 dnssec:
@@ -20,27 +19,14 @@ recordcache:
 """
 
     @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorYamlConfig(confdir, False)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
+    def generateRecursorConfig(cls, confdir):
+        super(ZTCTest, cls).generateRecursorYamlConfig(confdir, False)
 
     def testZTC(self):
         grepCmd = ['grep', 'validationStatus="Secure"', 'configs/' + self._confdir + '/recursor.log']
         ret = b''
-        for i in range(30):
-            time.sleep(1)
+        for i in range(300):
+            time.sleep(0.1)
             try:
                 ret = subprocess.check_output(grepCmd, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as e:

--- a/regression-tests.recursor-dnssec/test_basicNSEC.py
+++ b/regression-tests.recursor-dnssec/test_basicNSEC.py
@@ -4,3 +4,4 @@ import unittest
 class basicNSECTest(BasicDNSSEC):
     __test__ = True
     _confdir = 'basicNSEC'
+    _auth_zones = BasicDNSSEC._auth_zones

--- a/regression-tests.recursor-dnssec/test_basicNSEC3.py
+++ b/regression-tests.recursor-dnssec/test_basicNSEC3.py
@@ -6,6 +6,7 @@ import subprocess
 class basicNSEC3Test(BasicDNSSEC):
     __test__ = True
     _confdir = 'basicNSEC3'
+    _auth_zones = BasicDNSSEC._auth_zones
 
     @classmethod
     def secureZone(cls, confdir, zonename, key=None):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

The general change is to not start auths by default, but have the test class include a statement
```
    _auth_zones = RecursorTest._default_auth_zones
```
 if they need the auths to be started. Saves a minute on the whole regression test in CI, locally even more.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
