### PR TITLE
dnsdist: Better handling of the `dlsym` missing symbol in our Rust lib

### DIFF
--- a/builder-support/debian/dnsdist/debian-bookworm/rules
+++ b/builder-support/debian/dnsdist/debian-bookworm/rules
@@ -42,10 +42,9 @@ override_dh_auto_clean:
 #LDFLAGS += -latomic
 # We need clang (LLVM) to link the Rust static library and the C++ code with LTO enabled
 # build-id SHA1 prevents an issue with the debug symbols ("export: `-Wl,--build-id=sha1': not a valid identifier")
-# and the -ldl an issue with the dlsym not being found ("ld.lld: error: undefined symbol: dlsym eferenced by weak.rs:142 (library/std/src/sys/pal/unix/weak.rs:142) [...] in archive ./dnsdist-rust-lib/rust/libdnsdist_rust.a)
 
 override_dh_auto_configure:
-	LDFLAGS="-latomic -fuse-ld=lld -Wl,--build-id=sha1 -ldl" \
+	LDFLAGS="-latomic -fuse-ld=lld -Wl,--build-id=sha1" \
 	CC=clang \
 	CXX=clang++ \
 	PKG_CONFIG_PATH=/opt/lib/pkgconfig dh_auto_configure -- \

--- a/builder-support/debian/dnsdist/debian-bullseye/rules
+++ b/builder-support/debian/dnsdist/debian-bullseye/rules
@@ -35,10 +35,9 @@ override_dh_auto_clean:
 #LDFLAGS += -latomic
 # We need clang (LLVM) to link the Rust static library and the C++ code with LTO enabled
 # build-id SHA1 prevents an issue with the debug symbols ("export: `-Wl,--build-id=sha1': not a valid identifier")
-# and the -ldl an issue with the dlsym not being found ("ld.lld: error: undefined symbol: dlsym eferenced by weak.rs:142 (library/std/src/sys/pal/unix/weak.rs:142) [...] in archive ./dnsdist-rust-lib/rust/libdnsdist_rust.a)
 
 override_dh_auto_configure:
-	LDFLAGS="-latomic -fuse-ld=lld -Wl,--build-id=sha1 -ldl" \
+	LDFLAGS="-latomic -fuse-ld=lld -Wl,--build-id=sha1" \
 	CC=clang \
 	CXX=clang++ \
 	PKG_CONFIG_PATH=/opt/lib/pkgconfig dh_auto_configure -- \

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -73,8 +73,7 @@ dnsdist is a high-performance DNS loadbalancer that is scriptable in Lua.
 export CC=clang
 export CXX=clang++
 # build-id SHA1 prevents an issue with the debug symbols ("export: `-Wl,--build-id=sha1': not a valid identifier")
-# and -ldl an issue with the dlsym not being found ("ld.lld: error: undefined symbol: dlsym eferenced by weak.rs:142 (library/std/src/sys/pal/unix/weak.rs:142) [...] in archive ./dnsdist-rust-lib/rust/libdnsdist_rust.a)
-export LDFLAGS="-fuse-ld=lld -Wl,--build-id=sha1 -ldl"
+export LDFLAGS="-fuse-ld=lld -Wl,--build-id=sha1"
 
 %if 0%{?rhel} < 9
 # starting with EL-9 we get these hardening settings for free by just setting the right toolchain (see above)

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -108,8 +108,10 @@ endif
 
 if get_option('yaml').allowed()
   subdir('dnsdist-rust-lib')
+  subdir('meson' / 'dlopen') # our Rust static library needs dlopen
 else
   dep_dnsdist_rust_lib = declare_dependency()
+  dep_dlopen = declare_dependency()
 endif
 
 common_sources += files(
@@ -335,6 +337,7 @@ deps = [
   dep_arc4random,
   dep_boost,
   dep_cdb,
+  dep_dlopen,
   dep_dnstap,
   dep_htmlfiles,
   dep_ipcrypt,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Successful package build run at: https://github.com/rgacogne/pdns/actions/runs/13988473202
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
