### PR TITLE
[auth] lmdb: be more robust against marked-as-deleted items

### DIFF
--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -275,15 +275,19 @@ public:
     // }
 
     //! Get item with id, from main table directly
-    bool get(uint32_t itemId, T& value)
+    int get2(uint32_t itemId, T& value)
     {
       MDBOutVal data{};
-      if((*d_parent.d_txn)->get(d_parent.d_parent->d_main, itemId, data)) {
-        return false;
+      int rc;
+      rc = (*d_parent.d_txn)->get(d_parent.d_parent->d_main, itemId, data);
+      if (rc == 0) {
+        deserializeFromBuffer(data.get<std::string>(), value);
       }
-
-      deserializeFromBuffer(data.get<std::string>(), value);
-      return true;
+      return rc;
+    }
+    bool get(uint32_t itemId, T& value)
+    {
+      return get2(itemId, value) == 0;
     }
 
     //! Get item through index N, then via the main database
@@ -301,17 +305,24 @@ public:
       // because we know we only want one item, pass onlyOldest=true to consistently get the same one out of a set of duplicates
       get_multi<N>(key, ids, true);
 
-      if (ids.size() == 0) {
+      switch (ids.size()) {
+      case 0:
         return 0;
-      }
-
-      if (ids.size() == 1) {
-        if (get(ids[0], out)) {
+      case 1: {
+        auto rc = get2(ids[0], out);
+        if (rc == 0) {
           return ids[0];
         }
+        if (rc == MDB_NOTFOUND) {
+          /* element not present, or has been marked deleted */
+          return 0;
+        }
+        throw std::runtime_error("in index get, failed (" + std::to_string(rc) + ")");
+        break;
       }
-
-      throw std::runtime_error("in index get, found more than one item");
+      default:
+        throw std::runtime_error("in index get, found more than one item");
+      }
     }
 
     // //! Cardinality of index N


### PR DESCRIPTION
### Short description
We (@Habbie and I) have been puzzled by seeing `in index get, found more than one item` exceptions thrown by the LMDB backend. The message was misleading - what happened was that there was exactly one item, but it was marked as deleted, so retrieving it correctly failed, and this possible outcome was not guarded against.

This PR attempts to provide more accurate exception messages, and to correctly handle this situation by returning no result (absence of data).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code (but not much)
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
