### PR TITLE
mysql: use MYSQL_TYPE_LONGLONG on 64bit platforms

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -116,7 +116,12 @@ public:
       releaseStatement();
       throw SSqlException("Attempt to bind more parameters than query has: " + d_query);
     }
-    d_req_bind[d_paridx].buffer_type = MYSQL_TYPE_LONG;
+    if constexpr (sizeof(long) == 4) {
+      d_req_bind[d_paridx].buffer_type = MYSQL_TYPE_LONG; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    }
+    else {
+      d_req_bind[d_paridx].buffer_type = MYSQL_TYPE_LONGLONG; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    }
     d_req_bind[d_paridx].buffer = new long[1];
     *((long*)d_req_bind[d_paridx].buffer) = value;
     d_paridx++;
@@ -129,7 +134,12 @@ public:
       releaseStatement();
       throw SSqlException("Attempt to bind more parameters than query has: " + d_query);
     }
-    d_req_bind[d_paridx].buffer_type = MYSQL_TYPE_LONG;
+    if constexpr (sizeof(long) == 4) {
+      d_req_bind[d_paridx].buffer_type = MYSQL_TYPE_LONG; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    }
+    else {
+      d_req_bind[d_paridx].buffer_type = MYSQL_TYPE_LONGLONG; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    }
     d_req_bind[d_paridx].buffer = new unsigned long[1];
     d_req_bind[d_paridx].is_unsigned = 1;
     *((unsigned long*)d_req_bind[d_paridx].buffer) = value;


### PR DESCRIPTION
### Short description
Found on s390x

DB contents:
```

MariaDB [pdns]> select * from records;
+----+-----------+-------------------------+------+----------------------------------------------------------+--------+------+----------+-----------+------+
| id | domain_id | name                    | type | content                                                  | ttl    | prio | disabled | ordername | auth |
+----+-----------+-------------------------+------+----------------------------------------------------------+--------+------+----------+-----------+------+
|  1 |         1 | mysql.example.org       | SOA  | ns1.example.org dns.example.org 1 10800 3600 604800 3600 | 172800 |    0 |        0 | NULL      |    1 |
|  2 |         1 | mysql.example.org       | NS   | ns1.example.org                                          | 172800 |    0 |        0 | NULL      |    1 |
|  3 |         1 | smoke.mysql.example.org | A    | 127.0.0.222                                              | 172800 |    0 |        0 | NULL      |    1 |
+----+-----------+-------------------------+------+----------------------------------------------------------+--------+------+----------+-----------+------+
3 rows in set (0.000 sec)

MariaDB [pdns]> SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR 0) and domain_id=1 order by name, type;
+----------------------------------------------------------+--------+------+------+-----------+----------+-------------------------+------+-----------+
| content                                                  | ttl    | prio | type | domain_id | disabled | name                    | auth | ordername |
+----------------------------------------------------------+--------+------+------+-----------+----------+-------------------------+------+-----------+
| ns1.example.org                                          | 172800 |    0 | NS   |         1 |        0 | mysql.example.org       |    1 | NULL      |
| ns1.example.org dns.example.org 1 10800 3600 604800 3600 | 172800 |    0 | SOA  |         1 |        0 | mysql.example.org       |    1 | NULL      |
| 127.0.0.222                                              | 172800 |    0 | A    |         1 |        0 | smoke.mysql.example.org |    1 | NULL      |
+----------------------------------------------------------+--------+------+------+-----------+----------+-------------------------+------+-----------+
3 rows in set (0.001 sec)
```

Debug log without the fix:
```
Mar 21 07:37:26 gmysql Connection successful. Connected to database 'pdns' on '127.0.0.1'.
Mar 21 07:37:26 Query 2930121542320: binding domain str mysql.example.org
Mar 21 07:37:26 Query 2930121542320: select id,name,master,last_check,notified_serial,type,options,catalog,account from domains where name=?
Mar 21 07:37:26 Query 2930121542320: returned 1 rows
Mar 21 07:37:26 Query 2930121542320: 466 us to execute
Mar 21 07:37:26 Query 2930121542320: 478 us total to last row
Mar 21 07:37:26 Query 2930121540608: binding qtype str SOA
Mar 21 07:37:26 Query 2930121540608: binding qname str mysql.example.org
Mar 21 07:37:26 Query 2930121540608: SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and type=? and name=?
Mar 21 07:37:26 Query 2930121540608: returned 1 rows
Mar 21 07:37:26 Query 2930121540608: 39 us to execute
Mar 21 07:37:26 GSQLBackend get() was called for record: basic-query
Mar 21 07:37:26 GSQLBackend get() found a new row
Mar 21 07:37:26 GSQLBackend get() was called for record: basic-query
Mar 21 07:37:26 Query 2930121540608: 66 us total to last row
Mar 21 07:37:26 GSQLBackend constructing handle for list of domain id '1'
Mar 21 07:37:26 Query 2930121541632: binding include_disabled long 0
Mar 21 07:37:26 Query 2930121541632: binding domain_id long 1
Mar 21 07:37:26 Query 2930121541632: SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type
Mar 21 07:37:26 Query 2930121541632: returned 0 rows
Mar 21 07:37:26 Query 2930121541632: 6113 us to execute
$ORIGIN .
Mar 21 07:37:26 GSQLBackend get() was called for record: list-query
Mar 21 07:37:26 Query 2930121541632: 6161 us total to last row
```

MariaDB log:
```
37 Reset stmt	
37 Prepare	SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type
37 Execute	SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR 0) and domain_id=0 order by name, type
```

Fixed debug log:
```
Mar 21 07:52:22 gmysql Connection successful. Connected to database 'pdns' on '127.0.0.1'.
Mar 21 07:52:22 Query 2929797733040: binding domain str mysql.example.org
Mar 21 07:52:22 Query 2929797733040: select id,name,master,last_check,notified_serial,type,options,catalog,account from domains where name=?
Mar 21 07:52:22 Query 2929797733040: returned 1 rows
Mar 21 07:52:22 Query 2929797733040: 56 us to execute
Mar 21 07:52:22 Query 2929797733040: 69 us total to last row
Mar 21 07:52:22 Query 2929797731328: binding qtype str SOA
Mar 21 07:52:22 Query 2929797731328: binding qname str mysql.example.org
Mar 21 07:52:22 Query 2929797731328: SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and type=? and name=?
Mar 21 07:52:22 Query 2929797731328: returned 1 rows
Mar 21 07:52:22 Query 2929797731328: 29 us to execute
Mar 21 07:52:22 GSQLBackend get() was called for record: basic-query
Mar 21 07:52:22 GSQLBackend get() found a new row
Mar 21 07:52:22 GSQLBackend get() was called for record: basic-query
Mar 21 07:52:22 Query 2929797731328: 60 us total to last row
Mar 21 07:52:22 GSQLBackend constructing handle for list of domain id '1'
Mar 21 07:52:22 Query 2929797732352: binding include_disabled long 0 sizeof 8
Mar 21 07:52:22 Query 2929797732352: binding domain_id long 1 sizeof 8
Mar 21 07:52:22 Query 2929797732352: SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type
Mar 21 07:52:22 Query 2929797732352: returned 3 rows
Mar 21 07:52:22 Query 2929797732352: 381 us to execute
$ORIGIN .
Mar 21 07:52:22 GSQLBackend get() was called for record: list-query
Mar 21 07:52:22 GSQLBackend get() found a new row
Mar 21 07:52:22 GSQLBackend get() was called for record: list-query
Mar 21 07:52:22 GSQLBackend get() found a new row
Mar 21 07:52:22 GSQLBackend get() was called for record: list-query
Mar 21 07:52:22 GSQLBackend get() found a new row
Mar 21 07:52:22 GSQLBackend get() was called for record: list-query
Mar 21 07:52:22 Query 2929797732352: 450 us total to last row
mysql.example.org	172800	IN	NS	ns1.example.org.
mysql.example.org	172800	IN	SOA	ns1.example.org dns.example.org 1 10800 3600 604800 3600
smoke.mysql.example.org	172800	IN	A	127.0.0.222
```

Fixed MariaDB log:
```
42 Reset stmt	
42 Prepare	SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type
42 Execute	SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR 0) and domain_id=1 order by name, type

```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
