### PR TITLE
GH Actions - build-and-test-all: use meson builds for regression tests

### DIFF
--- a/.github/actions/spell-check/allow.txt
+++ b/.github/actions/spell-check/allow.txt
@@ -607,6 +607,7 @@ datalen
 datapoints
 datapos
 dataret
+datefudge
 datestr
 datetime
 DBC

--- a/.github/scripts/normalize_paths_in_coverage.py
+++ b/.github/scripts/normalize_paths_in_coverage.py
@@ -8,6 +8,7 @@ if __name__ == '__main__':
     version = sys.argv[2]
     inputFile = sys.argv[3]
     outputFile = sys.argv[4]
+    fromDistDir = sys.argv[5]
     with open(inputFile, mode='r') as inputFilePtr:
         with open(outputFile, mode='w') as outputFilePtr:
             for line in inputFilePtr:
@@ -38,7 +39,7 @@ if __name__ == '__main__':
                     distPath = os.path.join(repositoryRoot, 'pdns', 'dnsdistdist', f'dnsdist-{version}')
                     relativeToDist = os.path.relpath(target, distPath)
                     target = os.path.join('pdns', 'dnsdistdist', relativeToDist)
-                else:
+                elif fromDistDir == '1':
                     print(f'Ignoring {target} that we could not map to a distdir', file=sys.stderr)
                     continue
 

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -112,9 +112,8 @@ jobs:
       - run: ${{ env.INV_CMD }} ci-auth-run-unit-tests ${{ matrix.builder == 'meson' && '--meson' || '' }}
         env:
           PDNS_BUILD_PATH: ../pdns-${{ env.BUILDER_VERSION }}
-      - run: ${{ env.INV_CMD }} generate-coverage-info ./testrunner $GITHUB_WORKSPACE
+      - run: ${{ env.INV_CMD }} generate-coverage-info ./pdns-auth-testrunner $GITHUB_WORKSPACE
         if: ${{ env.COVERAGE == 'yes' && matrix.builder == 'meson' }}
-        working-directory: ./pdns-${{ env.BUILDER_VERSION }}${{ matrix.builder == 'meson' && '' || '/pdns' }}
       - name: Coveralls Parallel auth unit
         if: ${{ env.COVERAGE == 'yes' && matrix.builder == 'meson' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -112,10 +112,10 @@ jobs:
         env:
           PDNS_BUILD_PATH: ../pdns-${{ env.BUILDER_VERSION }}
       - run: ${{ env.INV_CMD }} generate-coverage-info ./testrunner $GITHUB_WORKSPACE
-        if: ${{ env.COVERAGE == 'yes' && matrix.builder != 'meson' }}
-        working-directory: ./pdns-${{ env.BUILDER_VERSION }}/pdns
+        if: ${{ env.COVERAGE == 'yes' && matrix.builder == 'meson' }}
+        working-directory: ./pdns-${{ env.BUILDER_VERSION }}${{ matrix.builder == 'meson' && '' || '/pdns' }}
       - name: Coveralls Parallel auth unit
-        if: ${{ env.COVERAGE == 'yes' && matrix.builder != 'meson' }}
+        if: ${{ env.COVERAGE == 'yes' && matrix.builder == 'meson' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: auth-unit-${{ env.SANITIZERS }}
@@ -201,9 +201,9 @@ jobs:
       - run: ${{ env.INV_CMD }} ci-rec-build ${{ matrix.builder == 'meson' && '--meson' || '' }}
       - run: ${{ env.INV_CMD }} ci-rec-run-unit-tests ${{ matrix.builder == 'meson' && '--meson' || '' }}
       - run: ${{ env.INV_CMD }} generate-coverage-info ./testrunner $GITHUB_WORKSPACE
-        if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder != 'meson' }}
+        if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder == 'meson' }}
       - name: Coveralls Parallel rec unit
-        if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder != 'meson' }}
+        if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder == 'meson' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: rec-unit-${{ matrix.features }}-${{ matrix.sanitizers }}
@@ -297,9 +297,9 @@ jobs:
       - run: ${{ env.INV_CMD }} ci-dnsdist-make-bear ${{ matrix.builder }}
       - run: ${{ env.INV_CMD }} ci-dnsdist-run-unit-tests ${{ matrix.builder }}
       - run: ${{ env.INV_CMD }} generate-coverage-info ./testrunner $GITHUB_WORKSPACE
-        if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder == 'autotools'}}
+        if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder == 'meson'}}
       - name: Coveralls Parallel dnsdist unit
-        if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder == 'autotools' }}
+        if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder == 'meson' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: dnsdist-unit-${{ matrix.features }}-${{ matrix.sanitizers }}

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -125,13 +125,18 @@ jobs:
           fail-on-error: false
       - run: ${{ env.INV_CMD }} ci-auth-install ${{ matrix.builder == 'meson' && '--meson' || '' }}
       - run: ccache -s
-      - if: ${{ matrix.builder != 'meson' }}
-        run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
-      - if: ${{ matrix.builder != 'meson' }}
+      - name: Prepare binaries folder
+        if: ${{ matrix.builder == 'meson' }}
+        run: |
+          echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
+          mkdir -p /opt/pdns-auth/bin
+          for i in $(find . -maxdepth 1 -type f -executable); do cp ${i} /opt/pdns-auth/bin/; done
+          mkdir -p /opt/pdns-auth/sbin; mv /opt/pdns-auth/bin/pdns-auth /opt/pdns-auth/sbin/
+      - if: ${{ matrix.builder == 'meson' }}
         name: Store the binaries
         uses: actions/upload-artifact@v4 # this takes 30 seconds, maybe we want to tar
         with:
-          name: pdns-auth-${{ env.normalized-branch-name }}
+          name: pdns-auth-${{ matrix.builder}}-${{ env.normalized-branch-name }}
           path: /opt/pdns-auth
           retention-days: 1
 
@@ -142,14 +147,12 @@ jobs:
     needs: get-runner-container-image
     strategy:
       matrix:
+        builder: [autotools, meson]
         sanitizers: [asan+ubsan, tsan]
         features: [least, full]
-        builder: [autotools, meson]
         exclude:
           - sanitizers: tsan
             features: least
-          - builder: meson
-            sanitizers: tsan
       fail-fast: false
     container:
       image: "${{ needs.get-runner-container-image.outputs.id }}:${{ needs.get-runner-container-image.outputs.tag }}"
@@ -210,13 +213,13 @@ jobs:
           fail-on-error: false
       - run: ${{ env.INV_CMD }} ci-rec-install ${{ matrix.builder == 'meson' && '--meson' || '' }}
       - run: ccache -s
-      - if: ${{ matrix.builder != 'meson' }}
+      - if: ${{ matrix.builder == 'meson' }}
         run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
-      - if: ${{ matrix.builder != 'meson' }}
+      - if: ${{ matrix.builder == 'meson' }}
         name: Store the binaries
         uses: actions/upload-artifact@v4 # this takes 30 seconds, maybe we want to tar
         with:
-          name: pdns-recursor-${{ matrix.features }}-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          name: pdns-recursor-${{ matrix.features }}-${{ matrix.sanitizers }}-${{ matrix.builder}}-${{ env.normalized-branch-name }}
           path: /opt/pdns-recursor
           retention-days: 1
 
@@ -233,8 +236,6 @@ jobs:
         exclude:
           - sanitizers: tsan
             features: least
-          - sanitizers: tsan
-            builder: meson
       fail-fast: false
     container:
       image: "${{ needs.get-runner-container-image.outputs.id }}:${{ needs.get-runner-container-image.outputs.tag }}"
@@ -306,12 +307,16 @@ jobs:
           parallel: true
           allow-empty: true
           fail-on-error: false
-      - run: ${{ env.INV_CMD }} ci-make-install
-        if: ${{ matrix.builder == 'autotools' }}
+      - run: ${{ env.INV_CMD }} ci-dnsdist-install ${{ matrix.builder == 'meson' && '--meson' || '' }}
       - run: ccache -s
-      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
+      - name: Prepare binaries folder
+        if: ${{ matrix.builder == 'meson' }}
+        run: |
+          echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
+          mkdir -p /opt/dnsdist/bin
+          for i in $(find . -maxdepth 1 -type f -executable); do cp ${i} /opt/dnsdist/bin/; done
       - name: Store the binaries
-        if: ${{ matrix.builder == 'autotools' }}
+        if: ${{ matrix.builder == 'meson' }}
         uses: actions/upload-artifact@v4 # this takes 30 seconds, maybe we want to tar
         with:
           name: dnsdist-${{ matrix.features }}-${{ matrix.sanitizers }}-${{ matrix.builder}}-${{ env.normalized-branch-name }}
@@ -367,7 +372,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-auth-${{ env.normalized-branch-name }}
+          name: pdns-auth-meson-${{ env.normalized-branch-name }}
           path: /opt/pdns-auth
       - name: install pip build dependencies
         run: |
@@ -377,7 +382,7 @@ jobs:
       - run: ${{ env.INV_CMD }} install-clang-runtime
       - run: ${{ env.INV_CMD }} install-auth-test-deps -b ${{ matrix.backend }}
       - run: ${{ env.INV_CMD }} test-api auth -b ${{ matrix.backend }}
-      - run: ${{ env.INV_CMD }} generate-coverage-info /opt/pdns-auth/sbin/pdns_server $GITHUB_WORKSPACE
+      - run: ${{ env.INV_CMD }} generate-coverage-info /opt/pdns-auth/sbin/pdns-auth $GITHUB_WORKSPACE
         if: ${{ env.COVERAGE == 'yes' }}
       - name: Coveralls Parallel auth API ${{ matrix.backend }}
         if: ${{ env.COVERAGE == 'yes' }}
@@ -499,7 +504,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-auth-${{ env.normalized-branch-name }}
+          name: pdns-auth-meson-${{ env.normalized-branch-name }}
           path: /opt/pdns-auth
       # FIXME: install recursor for backends that have ALIAS
       - name: install pip build dependencies
@@ -509,7 +514,7 @@ jobs:
       - run: ${{ env.INV_CMD }} install-clang-runtime
       - run: ${{ env.INV_CMD }} install-auth-test-deps -b ${{ matrix.backend }}
       - run: ${{ env.INV_CMD }} test-auth-backend -b ${{ matrix.backend }}
-      - run: ${{ env.INV_CMD }} generate-coverage-info /opt/pdns-auth/sbin/pdns_server $GITHUB_WORKSPACE
+      - run: ${{ env.INV_CMD }} generate-coverage-info /opt/pdns-auth/sbin/pdns-auth $GITHUB_WORKSPACE
         if: ${{ env.COVERAGE == 'yes' }}
       - name: Coveralls Parallel auth backend ${{ matrix.backend }}
         if: ${{ env.COVERAGE == 'yes' }}
@@ -543,7 +548,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-auth-${{ env.normalized-branch-name }}
+          name: pdns-auth-meson-${{ env.normalized-branch-name }}
           path: /opt/pdns-auth
       - name: install pip build dependencies
         run: |
@@ -593,7 +598,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-recursor-full-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          name: pdns-recursor-full-${{ matrix.sanitizers }}-meson-${{ env.normalized-branch-name }}
           path: /opt/pdns-recursor
       - name: install pip build dependencies
         run: |
@@ -647,7 +652,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-recursor-full-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          name: pdns-recursor-full-${{ matrix.sanitizers }}-meson-${{ env.normalized-branch-name }}
           path: /opt/pdns-recursor
       - name: install pip build dependencies
         run: |
@@ -702,7 +707,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-recursor-full-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          name: pdns-recursor-full-${{ matrix.sanitizers }}-meson-${{ env.normalized-branch-name }}
           path: /opt/pdns-recursor
       - name: install pip build dependencies
         run: |
@@ -748,7 +753,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: pdns-recursor-full-${{ matrix.sanitizers }}-${{ env.normalized-branch-name }}
+          name: pdns-recursor-full-${{ matrix.sanitizers }}-meson-${{ env.normalized-branch-name }}
           path: /opt/pdns-recursor
       - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
       - name: install pip build dependencies
@@ -809,7 +814,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
-          name: dnsdist-full-${{ matrix.sanitizers }}-autotools-${{ env.normalized-branch-name }}
+          name: dnsdist-full-${{ matrix.sanitizers }}-meson-${{ env.normalized-branch-name }}
           path: /opt/dnsdist
       - name: install pip build dependencies
         run: |

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -28,8 +28,7 @@ env:
   # github.workspace variable points to the Runner home folder. Container home folder defined below.
   REPO_HOME: '/__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}'
   BUILDER_VERSION: '0.0.0-git1'
-  # COVERAGE: ${{ github.repository == 'PowerDNS/pdns' && 'yes' || 'no' }}
-  COVERAGE: no
+  COVERAGE: ${{ github.repository == 'PowerDNS/pdns' && 'yes' || 'no' }}
   LLVM_PROFILE_FILE: "/tmp/code-%p.profraw"
   OPTIMIZATIONS: yes
   INV_CMD: ". ${REPO_HOME}/.venv/bin/activate && inv"

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -28,7 +28,8 @@ env:
   # github.workspace variable points to the Runner home folder. Container home folder defined below.
   REPO_HOME: '/__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}'
   BUILDER_VERSION: '0.0.0-git1'
-  COVERAGE: ${{ github.repository == 'PowerDNS/pdns' && 'yes' || 'no' }}
+  # COVERAGE: ${{ github.repository == 'PowerDNS/pdns' && 'yes' || 'no' }}
+  COVERAGE: no
   LLVM_PROFILE_FILE: "/tmp/code-%p.profraw"
   OPTIMIZATIONS: yes
   INV_CMD: ". ${REPO_HOME}/.venv/bin/activate && inv"
@@ -799,7 +800,7 @@ jobs:
         # IncludeDir tests are disabled because of a weird interaction between TSAN and these tests which ever only happens on GH actions
         SKIP_INCLUDEDIR_TESTS: yes
         SANITIZERS: ${{ matrix.sanitizers }}
-        COVERAGE: yes
+        COVERAGE: no
       options: --sysctl net.ipv6.conf.all.disable_ipv6=0 --privileged
     env:
       CLANG_VERSION: ${{ contains(needs.get-runner-container-image.outputs.id, 'debian-11') && '13' || '19' }}

--- a/meson/code-coverage/meson.build
+++ b/meson/code-coverage/meson.build
@@ -1,6 +1,7 @@
 coverage = get_option('b_coverage')
+clang_coverage = get_option('clang-coverage-format')
 
-if coverage
+if coverage or clang_coverage
   add_project_arguments('-DCOVERAGE', language: ['c', 'cpp'])
 
   if get_option('buildtype') != 'debug'
@@ -10,6 +11,21 @@ if coverage
   if cxx.has_argument('-U_FORTIFY_SOURCE')
     add_project_arguments('-U_FORTIFY_SOURCE', language: ['c', 'cpp'])
   endif
+
 endif
 
-summary('Code Coverage', coverage, bool_yn: true, section: 'Configuration')
+if coverage
+  if get_option('clang-coverage-format')
+    error('b_coverage and clang-coverage-format cannot be enabled at the same time')
+  endif
+  summary('Code Coverage', coverage, bool_yn: true, section: 'Configuration')
+else
+  if get_option('clang-coverage-format')
+    # let's see if the clang++ specific format is supported,
+    # as it has a much lower overhead and is more accurate,
+    # see https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
+    add_project_arguments('-DCLANG_COVERAGE', '-fprofile-instr-generate', '-fcoverage-mapping', language: ['c', 'cpp'])
+    add_project_link_arguments('-fprofile-instr-generate', '-fcoverage-mapping', language: ['c', 'cpp'])
+    summary('Code Coverage (clang format)', true, bool_yn: true, section: 'Configuration')
+  endif
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -42,3 +42,4 @@ option('systemd-service-user', type: 'string', value: 'pdns', description: 'Syst
 option('systemd-service-group', type: 'string', value: 'pdns', description: 'Systemd service group (setgid and unit file; group is not created)')
 option('auto-var-init', type: 'combo', value: 'disabled', choices: ['zero', 'pattern', 'disabled'], description: 'Enable initialization of automatic variables')
 option('malloc-trace', type: 'boolean', value: false, description: 'Enable malloc-trace')
+option('clang-coverage-format', type: 'boolean', value: false, description: 'Whether to generate coverage data in clang format')

--- a/pdns/dnsdistdist/meson_options.txt
+++ b/pdns/dnsdistdist/meson_options.txt
@@ -39,3 +39,4 @@ option('ebpf', type: 'feature', value: 'auto', description: 'Enable eBPF support
 option('fuzzer_ldflags', type: 'string', value: '', description: 'Linker flags used for the fuzzing targets (a path to the libFuzzer static library, for example)')
 option('yaml', type: 'feature', value: 'disabled', description: 'Enable YAML configuration')
 option('man-pages', type: 'boolean', value: true, description: 'Generate man pages')
+option('clang-coverage-format', type: 'boolean', value: false, description: 'Whether to generate coverage data in clang format')

--- a/pdns/recursordist/meson_options.txt
+++ b/pdns/recursordist/meson_options.txt
@@ -23,3 +23,4 @@ option('dnstap', type: 'feature', value: 'auto', description: 'Enable DNSTAP sup
 option('libcurl', type: 'feature', value: 'auto', description: 'Enable Curl support')
 option('nod', type: 'feature', value: 'enabled', description: 'Enable Newly Observed Domains')
 option('libcap', type: 'feature', value: 'auto', description: 'Enable libcap for capabilities handling')
+option('clang-coverage-format', type: 'boolean', value: false, description: 'Whether to generate coverage data in clang format')

--- a/regression-tests.nobackend/README
+++ b/regression-tests.nobackend/README
@@ -1,4 +1,4 @@
 To run these tests, you need a PowerDNS Authoritative Server with bind,
 gsqlite3, lmdb and random backends.
 
-You also will need to have 'faketime' installed.
+You also will need to have 'datefudge' installed.

--- a/regression-tests.nobackend/soa-edit/command
+++ b/regression-tests.nobackend/soa-edit/command
@@ -28,12 +28,10 @@ rm -f pdns*.pid
 
 rm -f soa-edit/bind-dnssec.db
 
-now=$(date +%s)
-delta=$((now-1418860790)) # Wed Dec 17 23:59:50 2014 UTC
- 
 $PDNSUTIL --config-dir=soa-edit create-bind-db soa-edit/bind-dnssec.db
 $PDNSUTIL --config-dir soa-edit/ set-meta minimal.com SOA-EDIT INCREMENT-WEEKS
-faketime -m -f -$delta $PDNS --config-dir=soa-edit &
+# Wed Dec 17 23:59:50 2014 UTC
+datefudge "$(date -d@1418860790)" $PDNS --config-dir=soa-edit &
 bindwait
 
 $SDIG 127.0.0.1 $port minimal.com SOA | LC_ALL=C sort

--- a/tasks.py
+++ b/tasks.py
@@ -108,7 +108,7 @@ auth_test_deps = [   # FIXME: we should be generating some of these from shlibde
     'curl',
     'default-jre-headless',
     'bind9-dnsutils',
-    'faketime',
+    'datefudge',
     'gawk',
     'krb5-user',
     'ldnsutils',

--- a/tasks.py
+++ b/tasks.py
@@ -937,14 +937,14 @@ def ci_auth_install(c, meson=False):
 @task
 def ci_rec_install(c, meson=False):
     if meson:
-        c.run('meson install')
+        c.sudo(f"bash -c 'source {repo_home}/.venv/bin/activate && meson install'")
     else:
         c.run('make install')
 
 @task
 def ci_dnsdist_install(c, meson=False):
     if meson:
-        c.run('meson install')
+        c.sudo(f"bash -c 'source {repo_home}/.venv/bin/activate && meson install'")
     else:
         c.run('make install')
 

--- a/tasks.py
+++ b/tasks.py
@@ -222,7 +222,7 @@ def is_coverage_enabled():
 
 def get_coverage(meson=False):
     if meson:
-        return '-D b_coverage=true' if os.getenv('COVERAGE') == 'yes' else ''
+        return '-D b_coverage=true' if is_coverage_enabled() else ''
     return '--enable-coverage=clang' if is_coverage_enabled() else ''
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -789,7 +789,8 @@ def ci_dnsdist_configure_meson(features, additional_flags, additional_ld_flags, 
                       -D dns-over-quic=enabled \
                       -D dns-over-tls=enabled \
                       -D reproducible=true \
-                      -D snmp=enabled'
+                      -D snmp=enabled \
+                      -D yaml=enabled'
     else:
       features_set = '-D cdb=disabled \
                       -D dnscrypt=disabled \
@@ -809,7 +810,8 @@ def ci_dnsdist_configure_meson(features, additional_flags, additional_ld_flags, 
                       -D dns-over-quic=disabled \
                       -D dns-over-tls=disabled \
                       -D reproducible=false \
-                      -D snmp=disabled'
+                      -D snmp=disabled \
+                      -D yaml=disabled'
     unittests = get_unit_tests(meson=True)
     fuzztargets = get_fuzzing_targets(meson=True)
     tools = f'''AR=llvm-ar-{clang_version} RANLIB=llvm-ranlib-{clang_version}''' if is_compiler_clang() else ''

--- a/tasks.py
+++ b/tasks.py
@@ -236,7 +236,7 @@ def generate_coverage_info(c, binary, outputDir):
         version = os.getenv('BUILDER_VERSION')
         c.run(f'llvm-profdata-{clang_version} merge -sparse -o {outputDir}/temp.profdata /tmp/code-*.profraw')
         c.run(f'llvm-cov-{clang_version} export --format=lcov --ignore-filename-regex=\'^/usr/\' -instr-profile={outputDir}/temp.profdata -object {binary} > {outputDir}/coverage.lcov')
-        c.run(f'{outputDir}/.github/scripts/normalize_paths_in_coverage.py {outputDir} {version} {outputDir}/coverage.lcov {outputDir}/normalized_coverage.lcov')
+        c.run(f'{outputDir}/.github/scripts/normalize_paths_in_coverage.py {outputDir} {version} {outputDir}/coverage.lcov {outputDir}/normalized_coverage.lcov 0')
         c.run(f'mv {outputDir}/normalized_coverage.lcov {outputDir}/coverage.lcov')
 
 def setup_authbind(c):

--- a/tasks.py
+++ b/tasks.py
@@ -222,7 +222,7 @@ def is_coverage_enabled():
 
 def get_coverage(meson=False):
     if meson:
-        return '-D b_coverage=true' if is_coverage_enabled() else ''
+        return '-Dclang-coverage-format=true' if is_coverage_enabled() else ''
     return '--enable-coverage=clang' if is_coverage_enabled() else ''
 
 @task


### PR DESCRIPTION
### Short description
Use meson builds for regression tests.

It is important to note that instead of installing a product, the output binaries are used in later stages for running the tests. Also, the binaries for auth have different names: i.e. `pdns-auth` instead of `pdns_server` or `pdns-auth-util` instead of `pdnsutil`.

This PR also:
- Enables the `yaml` build option for dnsdist full.

- Uses `datefudge` instead of `faketime`. The original returned the following error:  `libfaketime: Unexpected recursive calls to clock_gettime() without proper initialization. Trying alternative.` which makes the test to hang. There is a known bug for the library related to statically linked programs (see [bugs](https://manpages.ubuntu.com/manpages/trusty/man1/faketime.1.html)) although the reason could be a different one

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
