### PR TITLE
dnsdist: Better handling of non-existent Lua function name in YAML

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -144,7 +144,11 @@ template <class FuncType>
 static bool getLuaFunctionFromConfiguration(FuncType& destination, const ::rust::string& functionName, const ::rust::string& functionCode, const ::rust::string& functionFile, const std::string& context)
 {
   if (!functionName.empty()) {
-    return getOptionalLuaFunction<FuncType>(destination, functionName);
+    auto found = getOptionalLuaFunction<FuncType>(destination, functionName);
+    if (found) {
+      return true;
+    }
+    throw std::runtime_error("Unable to locate the Lua function named '" + std::string(functionName) + "', referenced by a lua directive in " + context + " context");
   }
   if (!functionCode.empty()) {
     auto function = dnsdist::lua::getFunctionFromLuaCode<FuncType>(std::string(functionCode), context);

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -148,7 +148,7 @@ static bool getLuaFunctionFromConfiguration(FuncType& destination, const ::rust:
     if (found) {
       return true;
     }
-    throw std::runtime_error("Unable to locate the Lua function named '" + std::string(functionName) + "', referenced by a lua directive in " + context + " context");
+    throw std::runtime_error("Unable to locate the Lua function named '" + std::string(functionName) + "', referenced by a Lua directive in " + context + " context");
   }
   if (!functionCode.empty()) {
     auto function = dnsdist::lua::getFunctionFromLuaCode<FuncType>(std::string(functionCode), context);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This commit changes the way DNSdist handles a non-existent Lua function name being referenced from the YAML configuration: instead of silently ignoring the problem, it loudly complains before exiting.

See https://github.com/PowerDNS/pdns/discussions/15350
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
