### PR TITLE
Set setuptools==77.0.3 to avoid error "invalid dash-separated key"

### DIFF
--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -85,7 +85,7 @@ jobs:
 
   list-pip-requirement-files:
     if: ${{ vars.SCHEDULED_MISC_DAILIES }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       req-files: ${{ steps.get-list-requirements.outputs.files }}
     steps:
@@ -98,7 +98,7 @@ jobs:
   validate-pip-hashes:
     if: ${{ vars.SCHEDULED_MISC_DAILIES }}
     name: ${{ matrix.requirements-file }} - Validate list of packages and hashes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: list-pip-requirement-files
     env:
       SERVICE_IP_ADDR: 127.0.0.1
@@ -120,12 +120,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      # Configure pip index-url set to proxpi
-      - run: pip config set global.index-url http://${{ env.SERVICE_IP_ADDR }}:5000/index/
-      - run: pip config set global.trusted-host ${{ env.SERVICE_IP_ADDR }}
+      - name: setup pip and test install the packages
+        run: |
+          python3 -m venv ${GITHUB_WORKSPACE}/.venv
+          . ${GITHUB_WORKSPACE}/.venv/bin/activate
+          pip config set global.index-url http://${{ env.SERVICE_IP_ADDR }}:5000/index/
+          pip config set global.trusted-host ${{ env.SERVICE_IP_ADDR }}
+          pip install -U pip setuptools==77.0.3 setuptools-git wheel
+          pip install -r ${{ matrix.requirements-file }}
       - id: proxpi-docker
         run: echo "id=$(docker ps | grep "epicwink/proxpi" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-      - run: pip install -r ${{ matrix.requirements-file }}
       - name: Get the list of packages requested to the pip proxy
         run: |
           docker logs ${{ steps.proxpi-docker.outputs.id }} 2>&1 | grep whl | awk '{print $8}' | cut -d "/" -f 4 | awk -F'-' '{print $1"=="$2}' | sort -u --ignore-case | sed 's/_/-/' | egrep -v "pip==|setuptools==|wheel==|setuptools-git==" > /tmp/proxpi.log

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -66,7 +66,7 @@ mans/.complete: .venv
 
 .venv: requirements.txt
 	$(PYTHON) -m venv .venv
-	.venv/bin/pip install -U pip setuptools setuptools-git wheel
+	.venv/bin/pip install -U pip setuptools==77.0.3 setuptools-git wheel
 	.venv/bin/pip install -r ${srcdir}/requirements.txt
 
 .NOTPARALLEL: \

--- a/docs/Makefile.sphinx
+++ b/docs/Makefile.sphinx
@@ -21,5 +21,5 @@ help: .venv
 
 .venv:
 	python3 -m venv .venv
-	.venv/bin/pip install -U pip setuptools setuptools-git wheel
+	.venv/bin/pip install -U pip setuptools==77.0.3 setuptools-git wheel
 	.venv/bin/pip install -r requirements.txt

--- a/docs/generate-docs.py
+++ b/docs/generate-docs.py
@@ -30,7 +30,7 @@ def main():
     # Install some stuff into the venv.
     requirements_file = source_root.joinpath(args.requirements_file)
     pip = venv_directory.joinpath("bin").joinpath("pip")
-    subprocess.run([pip, "install", "-U", "pip", "setuptools", "wheel"], check=True)
+    subprocess.run([pip, "install", "-U", "pip", "setuptools==77.0.3", "wheel"], check=True)
     subprocess.run([pip, "install", "-r", requirements_file], check=True)
 
     # Run sphinx to generate the docs

--- a/docs/generate-man-pages.py
+++ b/docs/generate-man-pages.py
@@ -29,7 +29,7 @@ def main():
     # Install some stuff into the venv.
     requirements_file = source_root.joinpath(args.requirements_file)
     pip = venv_directory.joinpath("bin").joinpath("pip")
-    subprocess.run([pip, "install", "-U", "pip", "setuptools", "wheel"], check=True)
+    subprocess.run([pip, "install", "-U", "pip", "setuptools==77.0.3", "wheel"], check=True)
     subprocess.run([pip, "install", "-r", requirements_file], check=True)
 
     # Run sphinx to generate the man-pages.

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -97,7 +97,7 @@ api-swagger.yaml: $(wildcard ${srcdir}/../docs/http-api/swagger/authoritative-ap
 if HAVE_VENV
 api-swagger.json: api-swagger.yaml requirements.txt
 	$(PYTHON) -m venv .venv
-	.venv/bin/pip install -U pip setuptools setuptools-git wheel
+	.venv/bin/pip install -U pip setuptools==77.0.3 setuptools-git wheel
 	.venv/bin/pip install -r ${srcdir}/requirements.txt
 	.venv/bin/python ${srcdir}/convert-yaml-to-json.py $< $@
 else # if HAVE_VENV

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -656,7 +656,7 @@ endif # if !HAVE_MANPAGES
 
 .venv: docs/requirements.txt
 	$(PYTHON) -m venv .venv
-	.venv/bin/pip install -U pip setuptools setuptools-git wheel
+	.venv/bin/pip install -U pip setuptools==77.0.3 setuptools-git wheel
 	.venv/bin/pip install -r $<
 
 latex/dnsdist.pdf: docs/** .venv

--- a/pdns/dnsdistdist/docs/Makefile.sphinx
+++ b/pdns/dnsdistdist/docs/Makefile.sphinx
@@ -21,7 +21,7 @@ help: .venv
 
 .venv:
 	python3 -m venv .venv
-	.venv/bin/pip install -U pip setuptools setuptools-git wheel
+	.venv/bin/pip install -U pip setuptools==77.0.3 setuptools-git wheel
 	.venv/bin/pip install -r requirements.txt
 
 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -588,7 +588,7 @@ endif # if !HAVE_MANPAGES
 
 .venv: docs/requirements.txt
 	$(PYTHON) -m venv .venv
-	.venv/bin/pip install -U pip setuptools setuptools-git wheel
+	.venv/bin/pip install -U pip setuptools==77.0.3 setuptools-git wheel
 	.venv/bin/pip install -r ${top_srcdir}/docs/requirements.txt
 
 html-docs: docs/** .venv

--- a/pdns/recursordist/docs/Makefile.sphinx
+++ b/pdns/recursordist/docs/Makefile.sphinx
@@ -21,7 +21,7 @@ help: .venv
 
 .venv:
 	python3 -m venv .venv
-	.venv/bin/pip install -U pip setuptools setuptools-git wheel
+	.venv/bin/pip install -U pip setuptools==77.0.3 setuptools-git wheel
 	.venv/bin/pip install -r requirements.txt
 
 


### PR DESCRIPTION
### Short description

This PR pins the version of `setuptools` directly as part of a `pip install` command instead of a requirement file. It is not recommended to include `setuptools` in a `requirement.txt` that has hashes for the packages as it is considered "unsafe".

For the chosen version of `setuptools==77.0.3`, keys that include a dash in `setup.cfg` will only print a warning but still install the package.

Test `docs`: <https://github.com/romeroalx/pdns/actions/runs/14044687240>

Test `misc-dailies`:  <https://github.com/romeroalx/pdns/actions/runs/14044687271>


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
