### PR TITLE
dnsdist: Do not register Xsk sockets on configuration check or client mode

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -486,8 +486,8 @@ static std::shared_ptr<DownstreamState> createBackendFromConfiguration(const dns
     if (!xskMap) {
       throw std::runtime_error("XSK map " + std::string(config.xsk) + " attached to backend " + std::string(config.address) + " not found");
     }
-    downstream->registerXsk(*xskMap);
     if (!configCheck) {
+      downstream->registerXsk(*xskMap);
       infolog("Added downstream server %s via XSK in %s mode", std::string(config.address), xskMap->at(0)->getXDPMode());
     }
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It does not make sense, and in some cases might lead to a crash because the Xsk socket is actually an empty shared pointer in client mode.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
