### PR TITLE
When CARGO_TARGET_DIR is set the generated C++ files end up in a different location

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
@@ -3,11 +3,17 @@
 #echo "PWD=$PWD"
 #echo "srcdir=$srcdir"
 #echo "builddir=$builddir"
+# cxx/cxxbridge generate the files lib.rs.h and cxx.h inside $CARGO_TARGET_DIR if it is set
+# otherwise it uses target
+#echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
+mytarget=${CARGO_TARGET_DIR-target}
+#echo "mytarget=${mytarget}"
 
 $CARGO build --release $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml
 
 cp -p target/$RUSTC_TARGET_ARCH/release/libdnsdist_rust.a $builddir/dnsdist-rust-lib/rust/libdnsdist_rust.a
-cp -p target/$RUSTC_TARGET_ARCH/cxxbridge/dnsdist-rust/src/lib.rs.h $srcdir/lib.rs.h
-cp -p target/$RUSTC_TARGET_ARCH/cxxbridge/dnsdist-rust/src/lib.rs.h $builddir/dnsdist-rust-lib/rust/lib.rs.h
-cp -p target/$RUSTC_TARGET_ARCH/cxxbridge/rust/cxx.h $srcdir/cxx.h
-cp -p target/$RUSTC_TARGET_ARCH/cxxbridge/rust/cxx.h $builddir/dnsdist-rust-lib/rust/cxx.h
+
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/dnsdist-rust/src/lib.rs.h $srcdir/lib.rs.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/dnsdist-rust/src/lib.rs.h $builddir/dnsdist-rust-lib/rust/lib.rs.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/rust/cxx.h $srcdir/cxx.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/rust/cxx.h $builddir/dnsdist-rust-lib/rust/cxx.h

--- a/pdns/recursordist/rec-rust-lib/rust/build_recrust
+++ b/pdns/recursordist/rec-rust-lib/rust/build_recrust
@@ -3,15 +3,21 @@
 #echo "PWD=$PWD"
 #echo "srcdir=$srcdir"
 #echo "builddir=$builddir"
+# cxx/cxxbridge generate the files lib.rs.h and cxx.h inside $CARGO_TARGET_DIR if it is set
+# otherwise it uses target
+#echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
+mytarget=${CARGO_TARGET_DIR-target}
+#echo "mytarget=${mytarget}"
 
 $CARGO build --release $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml
 
-cp -vp target/$RUSTC_TARGET_ARCH/release/librecrust.a $builddir/rec-rust-lib/rust/librecrust.a
-cp -vp target/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/lib.rs.h $srcdir/lib.rs.h
-cp -vp target/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/lib.rs.h $builddir/rec-rust-lib/rust/lib.rs.h
-cp -vp target/$RUSTC_TARGET_ARCH/cxxbridge/rust/cxx.h $srcdir/cxx.h
-cp -vp target/$RUSTC_TARGET_ARCH/cxxbridge/rust/cxx.h $builddir/rec-rust-lib/rust/cxx.h
-cp -vp target/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/web.rs.h $srcdir/web.rs.h
-cp -vp target/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/web.rs.h $builddir/rec-rust-lib/rust/web.rs.h
-cp -vp target/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/misc.rs.h $srcdir/misc.rs.h
-cp -vp target/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/misc.rs.h $builddir/rec-rust-lib/rust/misc.rs.h
+cp -p target/$RUSTC_TARGET_ARCH/release/librecrust.a $builddir/rec-rust-lib/rust/librecrust.a
+
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/lib.rs.h $srcdir/lib.rs.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/lib.rs.h $builddir/rec-rust-lib/rust/lib.rs.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/rust/cxx.h $srcdir/cxx.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/rust/cxx.h $builddir/rec-rust-lib/rust/cxx.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/web.rs.h $srcdir/web.rs.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/web.rs.h $builddir/rec-rust-lib/rust/web.rs.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/misc.rs.h $srcdir/misc.rs.h
+cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/recrust/src/misc.rs.h $builddir/rec-rust-lib/rust/misc.rs.h


### PR DESCRIPTION
This happens in OpenBSD package build. Please test in your build environment. Here al went fine with different in-tree and out-of-tree build dirs.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
