### PR TITLE
bye bye strcasestr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,7 +148,7 @@ PDNS_FROM_GIT
 dnl Checks for library functions.
 dnl the *_r functions are in posix so we can use them unconditionally, but the ext/yahttp code is
 dnl using the defines.
-AC_CHECK_FUNCS_ONCE([strcasestr localtime_r gmtime_r recvmmsg sched_setscheduler])
+AC_CHECK_FUNCS_ONCE([localtime_r gmtime_r recvmmsg sched_setscheduler])
 AC_CHECK_FUNCS_ONCE([getrandom getentropy arc4random arc4random_uniform arc4random_buf])
 PDNS_CHECK_SECURE_MEMSET
 

--- a/meson/various-functions/meson.build
+++ b/meson/various-functions/meson.build
@@ -1,5 +1,4 @@
 funcs = [
-  'strcasestr',
   'localtime_r',
   'gmtime_r',
   'recvmmsg',

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -105,7 +105,7 @@ PDNS_CHECK_CURL
 
 dnl the *_r functions are in posix so we can use them unconditionally, but the ext/yahttp code is
 dnl using the defines.
-AC_CHECK_FUNCS_ONCE([localtime_r gmtime_r strcasestr])
+AC_CHECK_FUNCS_ONCE([localtime_r gmtime_r])
 AC_CHECK_FUNCS_ONCE([getrandom getentropy arc4random arc4random_uniform arc4random_buf])
 PDNS_CHECK_SECURE_MEMSET
 

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -50,47 +50,6 @@ using json11::Json;
 extern StatBag S;
 #endif
 
-#ifndef HAVE_STRCASESTR
-
-/*
- * strcasestr() locates the first occurrence in the string s1 of the
- * sequence of characters (excluding the terminating null character)
- * in the string s2, ignoring case.  strcasestr() returns a pointer
- * to the located string, or a null pointer if the string is not found.
- * If s2 is empty, the function returns s1.
- */
-
-static char*
-strcasestr(const char* s1, const char* s2)
-{
-  int* cm = __trans_lower;
-  const uchar_t* us1 = (const uchar_t*)s1;
-  const uchar_t* us2 = (const uchar_t*)s2;
-  const uchar_t* tptr;
-  int c;
-
-  if (us2 == NULL || *us2 == '\0')
-    return ((char*)us1);
-
-  c = cm[*us2];
-  while (*us1 != '\0') {
-    if (c == cm[*us1++]) {
-      tptr = us1;
-      while (cm[c = *++us2] == cm[*us1++] && c != '\0')
-        continue;
-      if (c == '\0')
-        return ((char*)tptr - 1);
-      us1 = tptr;
-      us2 = (const uchar_t*)s2;
-      c = cm[*us2];
-    }
-  }
-
-  return (NULL);
-}
-
-#endif // HAVE_STRCASESTR
-
 static Json getServerDetail()
 {
   return Json::object{


### PR DESCRIPTION
### Short description
There is a `strcasestr` implementation in case the function is not provided by libc, which was apparently needed by json-related code and added to run on older Solaris versions, in the auth 3.x days.

However, years later, nothing in the current code uses this function anymore, so there is no need to 1) check for its availability and 2) provide an implementation if it is missing.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
