### PR TITLE
[auth] Backend capabilities

### DIFF
--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -181,6 +181,7 @@ class Bind2Backend : public DNSBackend
 public:
   Bind2Backend(const string& suffix = "", bool loadZones = true);
   ~Bind2Backend() override;
+  unsigned int getCapabilities() override;
   void getUnfreshSecondaryInfos(vector<DomainInfo>* unfreshDomains) override;
   void getUpdatedPrimaries(vector<DomainInfo>& changedDomains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes) override;
   bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial = true) override;
@@ -220,7 +221,6 @@ public:
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
   bool deleteTSIGKey(const DNSName& name) override;
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys) override;
-  bool doesDNSSEC() override;
   // end of DNSSEC
 
   typedef multi_index_container<BB2DomainInfo,

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -38,12 +38,11 @@ void Bind2Backend::setupDNSSEC()
 
 unsigned int Bind2Backend::getCapabilities()
 {
+  unsigned int caps = CAP_LIST;
   if (d_hybrid) {
-    return CAP_DNSSEC | CAP_LIST;
+    caps |= CAP_DNSSEC;
   }
-  else {
-    return CAP_LIST;
-  }
+  return caps;
 }
 
 bool Bind2Backend::getNSEC3PARAM(const DNSName& /* name */, NSEC3PARAMRecordContent* /* ns3p */)
@@ -204,10 +203,11 @@ void Bind2Backend::freeStatements()
 
 unsigned int Bind2Backend::getCapabilities()
 {
+  unsigned int caps = CAP_LIST;
   if (d_dnssecdb || d_hybrid) {
-    return CAP_DNSSEC | CAP_LIST;
+    caps |= CAP_DNSSEC;
   }
-  return CAP_LIST;
+  return caps;
 }
 
 bool Bind2Backend::getNSEC3PARAM(const DNSName& name, NSEC3PARAMRecordContent* ns3p)

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -36,9 +36,14 @@ void Bind2Backend::setupDNSSEC()
   }
 }
 
-bool Bind2Backend::doesDNSSEC()
+unsigned int Bind2Backend::getCapabilities()
 {
-  return d_hybrid;
+  if (d_hybrid) {
+    return CAP_DNSSEC | CAP_LIST;
+  }
+  else {
+    return CAP_LIST;
+  }
 }
 
 bool Bind2Backend::getNSEC3PARAM(const DNSName& /* name */, NSEC3PARAMRecordContent* /* ns3p */)
@@ -197,9 +202,12 @@ void Bind2Backend::freeStatements()
   d_getTSIGKeysQuery_stmt.reset();
 }
 
-bool Bind2Backend::doesDNSSEC()
+unsigned int Bind2Backend::getCapabilities()
 {
-  return d_dnssecdb || d_hybrid;
+  if (d_dnssecdb || d_hybrid) {
+    return CAP_DNSSEC | CAP_LIST;
+  }
+  return CAP_LIST;
 }
 
 bool Bind2Backend::getNSEC3PARAM(const DNSName& name, NSEC3PARAMRecordContent* ns3p)

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -57,12 +57,11 @@ public:
 
   unsigned int getCapabilities() override
   {
+    unsigned int caps = 0;
     if (d_dnssec) {
-      return CAP_DNSSEC;
+      caps |= CAP_DNSSEC;
     }
-    else {
-      return 0;
-    }
+    return caps;
   }
 
   void lookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p = nullptr) override;

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -55,6 +55,16 @@ public:
   GeoIPBackend(const std::string& suffix = "");
   ~GeoIPBackend() override;
 
+  unsigned int getCapabilities() override
+  {
+    if (d_dnssec) {
+      return CAP_DNSSEC;
+    }
+    else {
+      return 0;
+    }
+  }
+
   void lookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p = nullptr) override;
   bool list(const DNSName& /* target */, int /* domain_id */, bool /* include_disabled */ = false) override { return false; } // not supported
   bool get(DNSResourceRecord& r) override;
@@ -64,7 +74,6 @@ public:
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
 
   // dnssec support
-  bool doesDNSSEC() override { return d_dnssec; };
   bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string>>& meta) override;
   bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta) override;
   bool getDomainKeys(const DNSName& name, std::vector<DNSBackend::KeyData>& keys) override;

--- a/modules/ldapbackend/ldapbackend.hh
+++ b/modules/ldapbackend/ldapbackend.hh
@@ -170,6 +170,7 @@ public:
   ~LdapBackend() override;
 
   // Native backend
+  unsigned int getCapabilities() override { return CAP_LIST; }
   bool list(const DNSName& target, int domain_id, bool include_disabled = false) override;
   void lookup(const QType& qtype, const DNSName& qdomain, int zoneid, DNSPacket* p = nullptr) override;
   bool get(DNSResourceRecord& rr) override;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -62,6 +62,7 @@ public:
   explicit LMDBBackend(const string& suffix = "");
   ~LMDBBackend();
 
+  unsigned int getCapabilities() override { return CAP_DNSSEC | CAP_DIRECT | CAP_LIST; }
   bool list(const DNSName& target, int id, bool include_disabled) override;
 
   bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool getserial = true) override;
@@ -142,11 +143,6 @@ public:
   bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype = QType::ANY) override;
 
   bool updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& insert, set<DNSName>& erase, bool remove) override;
-
-  bool doesDNSSEC() override
-  {
-    return true;
-  }
 
   // other
   string directBackendCmd(const string& query) override;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -62,7 +62,7 @@ public:
   explicit LMDBBackend(const string& suffix = "");
   ~LMDBBackend();
 
-  unsigned int getCapabilities() override { return CAP_DNSSEC | CAP_DIRECT | CAP_LIST; }
+  unsigned int getCapabilities() override { return CAP_DNSSEC | CAP_DIRECT | CAP_LIST | CAP_CREATE; }
   bool list(const DNSName& target, int id, bool include_disabled) override;
 
   bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool getserial = true) override;

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -131,12 +131,11 @@ public:
 
   unsigned int getCapabilities() override
   {
+    unsigned int caps = CAP_DIRECT | CAP_LIST;
     if (d_dnssec) {
-      return CAP_DNSSEC | CAP_DIRECT | CAP_LIST;
+      caps |= CAP_DNSSEC;
     }
-    else {
-      return CAP_DIRECT | CAP_LIST;
-    }
+    return caps;
   }
 
   void parseLookup(const lookup_result_t& result)

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -129,9 +129,14 @@ public:
     }
   }
 
-  bool doesDNSSEC() override
+  unsigned int getCapabilities() override
   {
-    return d_dnssec;
+    if (d_dnssec) {
+      return CAP_DNSSEC | CAP_DIRECT | CAP_LIST;
+    }
+    else {
+      return CAP_DIRECT | CAP_LIST;
+    }
   }
 
   void parseLookup(const lookup_result_t& result)

--- a/modules/pipebackend/pipebackend.hh
+++ b/modules/pipebackend/pipebackend.hh
@@ -50,6 +50,8 @@ class PipeBackend : public DNSBackend
 public:
   PipeBackend(const string& suffix = "");
   ~PipeBackend() override;
+
+  unsigned int getCapabilities() override { return CAP_DIRECT | CAP_LIST; }
   void lookup(const QType&, const DNSName& qdomain, int zoneId, DNSPacket* p = nullptr) override;
   bool list(const DNSName& target, int domain_id, bool include_disabled = false) override;
   bool get(DNSResourceRecord& r) override;

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -508,10 +508,11 @@ bool RemoteBackend::unpublishDomainKey(const DNSName& name, unsigned int id)
 
 unsigned int RemoteBackend::getCapabilities()
 {
+  unsigned int caps = CAP_DIRECT | CAP_LIST;
   if (d_dnssec) {
-    return CAP_DNSSEC | CAP_DIRECT | CAP_LIST;
+    caps |= CAP_DNSSEC;
   }
-  return CAP_DIRECT | CAP_LIST;
+  return caps;
 }
 
 bool RemoteBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, std::string& content)

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -506,9 +506,12 @@ bool RemoteBackend::unpublishDomainKey(const DNSName& name, unsigned int id)
   return this->send(query) && this->recv(answer);
 }
 
-bool RemoteBackend::doesDNSSEC()
+unsigned int RemoteBackend::getCapabilities()
 {
-  return d_dnssec;
+  if (d_dnssec) {
+    return CAP_DNSSEC | CAP_DIRECT | CAP_LIST;
+  }
+  return CAP_DIRECT | CAP_LIST;
 }
 
 bool RemoteBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, std::string& content)

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -167,6 +167,7 @@ public:
   RemoteBackend(const std::string& suffix = "");
   ~RemoteBackend() override;
 
+  unsigned int getCapabilities() override;
   void lookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr) override;
   bool get(DNSResourceRecord& rr) override;
   bool list(const DNSName& target, int domain_id, bool include_disabled = false) override;
@@ -185,7 +186,6 @@ public:
   bool unpublishDomainKey(const DNSName& name, unsigned int id) override;
   bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial = true) override;
   void setNotified(uint32_t id, uint32_t serial) override;
-  bool doesDNSSEC() override;
   bool autoPrimaryBackend(const string& ip, const DNSName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** ddb) override;
   bool createSecondaryDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account) override;
   bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;

--- a/modules/tinydnsbackend/tinydnsbackend.hh
+++ b/modules/tinydnsbackend/tinydnsbackend.hh
@@ -67,6 +67,8 @@ class TinyDNSBackend : public DNSBackend
 public:
   // Methods for simple operation
   TinyDNSBackend(const string& suffix);
+
+  unsigned int getCapabilities() override { return CAP_LIST; }
   void lookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p = nullptr) override;
   bool list(const DNSName& target, int domain_id, bool include_disabled = false) override;
   bool get(DNSResourceRecord& rr) override;

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -868,10 +868,11 @@ bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& inse
 
 unsigned int GSQLBackend::getCapabilities()
 {
+  unsigned int caps = CAP_COMMENTS | CAP_DIRECT | CAP_LIST | CAP_CREATE;
   if (d_dnssecQueries) {
-    return CAP_DNSSEC | CAP_COMMENTS | CAP_DIRECT | CAP_LIST | CAP_CREATE;
+    caps |= CAP_DNSSEC;
   }
-  return CAP_COMMENTS | CAP_DIRECT | CAP_LIST | CAP_CREATE;
+  return caps;
 }
 
 bool GSQLBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after)

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -869,9 +869,9 @@ bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& inse
 unsigned int GSQLBackend::getCapabilities()
 {
   if (d_dnssecQueries) {
-    return CAP_DNSSEC | CAP_COMMENTS | CAP_DIRECT | CAP_LIST;
+    return CAP_DNSSEC | CAP_COMMENTS | CAP_DIRECT | CAP_LIST | CAP_CREATE;
   }
-  return CAP_COMMENTS | CAP_DIRECT | CAP_LIST;
+  return CAP_COMMENTS | CAP_DIRECT | CAP_LIST | CAP_CREATE;
 }
 
 bool GSQLBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after)

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -866,9 +866,12 @@ bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& inse
   return true;
 }
 
-bool GSQLBackend::doesDNSSEC()
+unsigned int GSQLBackend::getCapabilities()
 {
-    return d_dnssecQueries;
+  if (d_dnssecQueries) {
+    return CAP_DNSSEC | CAP_COMMENTS | CAP_DIRECT | CAP_LIST;
+  }
+  return CAP_COMMENTS | CAP_DIRECT | CAP_LIST;
 }
 
 bool GSQLBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after)

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -194,6 +194,7 @@ protected:
   }
 
 public:
+  unsigned int getCapabilities() override;
   void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *p=nullptr) override;
   bool list(const DNSName &target, int domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
@@ -228,7 +229,6 @@ public:
   bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t=QType::ANY) override;
 
   bool updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& insert ,set<DNSName>& erase, bool remove) override;
-  bool doesDNSSEC() override;
 
   bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
   bool listSubZone(const DNSName &zone, int domain_id) override;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -162,6 +162,7 @@ public:
     CAP_COMMENTS = 1 << 1, // Backend supports comments
     CAP_DIRECT = 1 << 2, // Backend supports direct commands
     CAP_LIST = 1 << 3, // Backend supports record enumeration
+    CAP_CREATE = 1 << 4, // Backend supports domain creation
   };
 
   virtual unsigned int getCapabilities() = 0;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -156,6 +156,16 @@ class DNSPacket;
 class DNSBackend
 {
 public:
+  enum Capabilities : unsigned int
+  {
+    CAP_DNSSEC = 1 << 0, // Backend supports DNSSEC
+    CAP_COMMENTS = 1 << 1, // Backend supports comments
+    CAP_DIRECT = 1 << 2, // Backend supports direct commands
+    CAP_LIST = 1 << 3, // Backend supports record enumeration
+  };
+
+  virtual unsigned int getCapabilities() = 0;
+
   //! lookup() initiates a lookup. A lookup without results should not throw!
   virtual void lookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr) = 0;
   virtual bool get(DNSResourceRecord&) = 0; //!< retrieves one DNSResource record, returns false if no more were available
@@ -255,9 +265,9 @@ public:
     return false;
   }
 
-  virtual bool doesDNSSEC()
+  bool doesDNSSEC()
   {
-    return false;
+    return (getCapabilities() & CAP_DNSSEC) != 0;
   }
 
   // end DNSSEC

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -107,6 +107,8 @@ public:
   {
   }
 
+  unsigned int getCapabilities() override { return CAP_LIST; }
+
   bool findZone(const DNSName& qdomain, int zoneId, std::shared_ptr<RecordStorage>& records, uint64_t& currentZoneId) const
   {
     currentZoneId = -1;

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -891,6 +891,15 @@ bool UeberBackend::hasCreatedLocalFiles()
   return std::any_of(backends.begin(), backends.end(), [](std::unique_ptr<DNSBackend>& backend) { return backend->hasCreatedLocalFiles(); });
 }
 
+unsigned int UeberBackend::getCapabilities()
+{
+  unsigned int capabilities{0};
+  for (auto& backend : backends) {
+    capabilities |= backend->getCapabilities();
+  }
+  return capabilities;
+}
+
 AtomicCounter UeberBackend::handle::instances(0);
 
 UeberBackend::handle::handle()

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -143,6 +143,8 @@ public:
 
   bool hasCreatedLocalFiles();
 
+  unsigned int getCapabilities();
+
 private:
   handle d_handle;
   vector<DNSZoneRecord> d_answers;


### PR DESCRIPTION
### Short description
This PR allows backends to report whether they support various capabilities - in spirit, this extends the `doesDNSSEC()` method.

This is then used in `pdnsutil` to avoid attempting to perform operations which will fail due to lack of support in the backend, and allows it to provide less cryptic error messages.

Addresses #15006.

The update to the backend's writer's guide is intentionally incomplete, as the omitted two capabilities do not have their relevant backend bits documented yet (it's on a todolist somewhere).

Edit: added another capability and let ÜberBackend report the aggregated capabilities of all configured backends, in order to be able to provide a better error message when a zone creation operation fails because none of the configured backend supports that operation; this addresses #5783 and #6954 with the same ~~stone~~ commit.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] made sure to submit this PR early enough for it not to be mistaken for an april fool's