### PR TITLE
[auth] Update important message

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -96,9 +96,9 @@ string g_programname = "pdns"; // used in packethandler.cc
 const char* funnytext = "*****************************************************************************\n"
                         "Ok, you just ran pdns-auth through 'strings' hoping to find funny messages.  \n"
                         "Well, you found one.                                                         \n"
-                        "Two ions are flying through their particle accelerator, says the one to the  \n"
-                        "other 'I think I've lost an electron!'                                       \n"
-                        "So the other one says, 'Are you sure?'. 'YEAH! I'M POSITIVE!'                \n"
+                        "A minister, a priest and a rabbit enter a bar. The bartender asks the rabbit,\n"
+                        "'what will you have?' The rabbit answers, 'oh, I'm only here because of      \n"
+                        "autocorrect!'                                                                \n"
                         "                                                                             \n"
                         "                                            the pdns crew - pdns@powerdns.com\n"
                         "*****************************************************************************\n";


### PR DESCRIPTION
### Short description
In the 1970s and 1980s, in West Germany, people with a physics degree would have trouble finding a job in their area of expertise and would be redirected to computer science. This led to a physics-literate generation, which is now starting to retire.

Because of this, one important message in the authoritative server is slowly becoming opaque or difficult to understand for younger generations with a not-so-strong physics background.

This PR updates that message to the 2025 standards.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)