### PR TITLE
dnsdist: Enable the DoQ and DoH3 parts of the SNI tests in our CI

### DIFF
--- a/regression-tests.dnsdist/runtests
+++ b/regression-tests.dnsdist/runtests
@@ -2,6 +2,8 @@
 set -e
 
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+# requires Quiche >= 0.23.2
+export ENABLE_SNI_TESTS_WITH_QUICHE=yes
 
 if [ ! -d .venv ]; then
   python3 -m venv .venv

--- a/regression-tests.dnsdist/test_SNI.py
+++ b/regression-tests.dnsdist/test_SNI.py
@@ -38,7 +38,6 @@ class TestSNI(DNSDistTest):
     """
     _config_params = ['_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohWithNGHTTP2ServerPort', '_serverCert', '_serverKey', '_doqServerPort', '_serverCert', '_serverKey', '_doh3ServerPort', '_serverCert', '_serverKey', '_serverName']
 
-    # enable these once Quiche > 0.22 is available, including https://github.com/cloudflare/quiche/pull/1895
     @unittest.skipUnless('ENABLE_SNI_TESTS_WITH_QUICHE' in os.environ, "SNI tests with Quiche are disabled")
     def testServerNameIndicationWithQuiche(self):
         name = 'simple.sni.tests.powerdns.com.'

--- a/regression-tests.dnsdist/test_SNI.py
+++ b/regression-tests.dnsdist/test_SNI.py
@@ -39,7 +39,7 @@ class TestSNI(DNSDistTest):
     _config_params = ['_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_dohWithNGHTTP2ServerPort', '_serverCert', '_serverKey', '_doqServerPort', '_serverCert', '_serverKey', '_doh3ServerPort', '_serverCert', '_serverKey', '_serverName']
 
     # enable these once Quiche > 0.22 is available, including https://github.com/cloudflare/quiche/pull/1895
-    @unittest.skipUnless('ENABLE_SNI_TESTS_WITH_QUICHE' in os.environ, "SNI tests with Quicheare disabled")
+    @unittest.skipUnless('ENABLE_SNI_TESTS_WITH_QUICHE' in os.environ, "SNI tests with Quiche are disabled")
     def testServerNameIndicationWithQuiche(self):
         name = 'simple.sni.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=False)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We now build with Quiche >= 0.23.2 so we can enable them.

Closes https://github.com/PowerDNS/pdns/issues/15079

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
