### PR TITLE
dnsdist: Share tickets key between identical frontends created via YAML

### DIFF
--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -164,7 +164,7 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint)
         errorCounters = &front->tlsFrontend->d_tlsCounters;
       }
       else if (front->dohFrontend != nullptr) {
-        errorCounters = &front->dohFrontend->d_tlsContext.d_tlsCounters;
+        errorCounters = &front->dohFrontend->d_tlsContext->d_tlsCounters;
       }
       if (errorCounters != nullptr) {
         str << base << "tlsdhkeytoosmall" << ' ' << errorCounters->d_dhKeyTooSmall << " " << now << "\r\n";
@@ -227,7 +227,7 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint)
       std::map<std::string, uint64_t> dohFrontendDuplicates;
       const string base = "dnsdist." + hostname + ".main.doh.";
       for (const auto& doh : dnsdist::getDoHFrontends()) {
-        string name = doh->d_tlsContext.d_addr.toStringWithPort();
+        string name = doh->d_tlsContext->d_addr.toStringWithPort();
         std::replace(name.begin(), name.end(), '.', '_');
         std::replace(name.begin(), name.end(), ':', '_');
         std::replace(name.begin(), name.end(), '[', '_');

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -239,7 +239,7 @@ static bool validateTLSConfiguration(const dnsdist::rust::settings::BindConfigur
   return true;
 }
 
-static bool handleTLSConfiguration(const dnsdist::rust::settings::BindConfiguration& bind, ClientState& state, std::shared_ptr<const TLSFrontend> parent)
+static bool handleTLSConfiguration(const dnsdist::rust::settings::BindConfiguration& bind, ClientState& state, const std::shared_ptr<const TLSFrontend>& parent)
 {
   auto tlsConfig = getTLSConfigFromRustIncomingTLS(bind.tls);
   if (!validateTLSConfiguration(bind, tlsConfig)) {
@@ -717,7 +717,7 @@ static void loadBinds(const ::rust::Vec<dnsdist::rust::settings::BindConfigurati
           if (!handleTLSConfiguration(bind, *state, tlsFrontendParent)) {
             continue;
           }
-          if (tlsFrontendParent == nullptr) {
+          if (tlsFrontendParent == nullptr && (protocol == "dot" || protocol == "doh")) {
             tlsFrontendParent = state->getTLSFrontend();
           }
         }

--- a/pdns/dnsdistdist/dnsdist-doh-common.cc
+++ b/pdns/dnsdistdist/dnsdist-doh-common.cc
@@ -26,17 +26,17 @@
 #ifdef HAVE_DNS_OVER_HTTPS
 void DOHFrontend::rotateTicketsKey(time_t now)
 {
-  return d_tlsContext.rotateTicketsKey(now);
+  return d_tlsContext->rotateTicketsKey(now);
 }
 
 void DOHFrontend::loadTicketsKeys(const std::string& keyFile)
 {
-  return d_tlsContext.loadTicketsKeys(keyFile);
+  return d_tlsContext->loadTicketsKeys(keyFile);
 }
 
 void DOHFrontend::loadTicketsKey(const std::string& key)
 {
-  return d_tlsContext.loadTicketsKey(key);
+  return d_tlsContext->loadTicketsKey(key);
 }
 
 void DOHFrontend::handleTicketsKeyRotation()
@@ -45,26 +45,26 @@ void DOHFrontend::handleTicketsKeyRotation()
 
 std::string DOHFrontend::getNextTicketsKeyRotation() const
 {
-  return d_tlsContext.getNextTicketsKeyRotation();
+  return d_tlsContext->getNextTicketsKeyRotation();
 }
 
 size_t DOHFrontend::getTicketsKeysCount()
 {
-  return d_tlsContext.getTicketsKeysCount();
+  return d_tlsContext->getTicketsKeysCount();
 }
 
 void DOHFrontend::reloadCertificates()
 {
   if (isHTTPS()) {
-    d_tlsContext.setupTLS();
+    d_tlsContext->setupTLS();
   }
 }
 
 void DOHFrontend::setup()
 {
   if (isHTTPS()) {
-    if (!d_tlsContext.setupTLS()) {
-      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + d_tlsContext.d_addr.toStringWithPort());
+    if (!d_tlsContext->setupTLS()) {
+      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + d_tlsContext->d_addr.toStringWithPort());
     }
   }
 }

--- a/pdns/dnsdistdist/dnsdist-doh-common.hh
+++ b/pdns/dnsdistdist/dnsdist-doh-common.hh
@@ -81,11 +81,12 @@ private:
 
 struct DOHFrontend
 {
-  DOHFrontend()
+  DOHFrontend() :
+    d_tlsContext(std::make_shared<TLSFrontend>(TLSFrontend::ALPN::DoH))
   {
   }
   DOHFrontend(std::shared_ptr<TLSCtx> tlsCtx) :
-    d_tlsContext(std::move(tlsCtx))
+    d_tlsContext(std::make_shared<TLSFrontend>(std::move(tlsCtx)))
   {
   }
 
@@ -95,7 +96,7 @@ struct DOHFrontend
 
   std::shared_ptr<DOHServerConfig> d_dsc{nullptr};
   std::shared_ptr<std::vector<std::shared_ptr<DOHResponseMapEntry>>> d_responsesMap;
-  TLSFrontend d_tlsContext{TLSFrontend::ALPN::DoH};
+  std::shared_ptr<TLSFrontend> d_tlsContext;
   std::string d_serverTokens{"h2o/dnsdist"};
   std::unordered_map<std::string, std::string> d_customResponseHeaders;
   std::string d_library;
@@ -141,12 +142,12 @@ struct DOHFrontend
 
   time_t getTicketsKeyRotationDelay() const
   {
-    return d_tlsContext.d_tlsConfig.d_ticketsKeyRotationDelay;
+    return d_tlsContext->d_tlsConfig.d_ticketsKeyRotationDelay;
   }
 
   bool isHTTPS() const
   {
-    return !d_tlsContext.d_tlsConfig.d_certKeyPairs.empty();
+    return !d_tlsContext->d_tlsConfig.d_certKeyPairs.empty();
   }
 
 #ifndef HAVE_DNS_OVER_HTTPS

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -778,7 +778,7 @@ void setupLuaInspection(LuaContext& luaCtx)
         errorCounters = &frontend->tlsFrontend->d_tlsCounters;
       }
       else if (frontend->dohFrontend != nullptr) {
-        errorCounters = &frontend->dohFrontend->d_tlsContext.d_tlsCounters;
+        errorCounters = &frontend->dohFrontend->d_tlsContext->d_tlsCounters;
       }
       if (errorCounters == nullptr) {
         continue;

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1084,7 +1084,7 @@ bind:
     - name: "threads"
       type: "u32"
       default: "1"
-      description: "Number of listening threads to create for this frontend"
+      description: "Number of listening threads to create for this frontend. Note that each listening thread will have its own metrics, but identical DoT and DoH threads will share the same TLS Session Ticket Encryption Keys to improve session resumption rates. One side-effect is that rotating / altering the STEKs on all threads in a frontend group except the first one will be ignored, to prevent unwanted actions by existing code. :func:`reloadAllCertificates` properly handles frontend groups."
     - name: "interface"
       type: "String"
       default: ""

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -27,7 +27,7 @@ public:
   enum class QueryProcessingResult : uint8_t { Forwarded, TooSmall, InvalidHeaders, Dropped, SelfAnswered, NoBackend, Asynchronous };
   enum class ProxyProtocolResult : uint8_t { Reading, Done, Error };
 
-  IncomingTCPConnectionState(ConnectionInfo&& ci, TCPClientThreadData& threadData, const struct timeval& now): d_buffer(sizeof(uint16_t)), d_ci(std::move(ci)), d_handler(d_ci.fd, timeval{dnsdist::configuration::getCurrentRuntimeConfiguration().d_tcpRecvTimeout,0}, d_ci.cs->tlsFrontend ? d_ci.cs->tlsFrontend->getContext() : (d_ci.cs->dohFrontend ? d_ci.cs->dohFrontend->d_tlsContext.getContext() : nullptr), now.tv_sec), d_connectionStartTime(now), d_ioState(make_unique<IOStateHandler>(*threadData.mplexer, d_ci.fd)), d_threadData(threadData), d_creatorThreadID(std::this_thread::get_id())
+  IncomingTCPConnectionState(ConnectionInfo&& ci, TCPClientThreadData& threadData, const struct timeval& now): d_buffer(sizeof(uint16_t)), d_ci(std::move(ci)), d_handler(d_ci.fd, timeval{dnsdist::configuration::getCurrentRuntimeConfiguration().d_tcpRecvTimeout,0}, d_ci.cs->tlsFrontend ? d_ci.cs->tlsFrontend->getContext() : (d_ci.cs->dohFrontend ? d_ci.cs->dohFrontend->d_tlsContext->getContext() : nullptr), now.tv_sec), d_connectionStartTime(now), d_ioState(make_unique<IOStateHandler>(*threadData.mplexer, d_ci.fd)), d_threadData(threadData), d_creatorThreadID(std::this_thread::get_id())
   {
     d_origDest.reset();
     d_origDest.sin4.sin_family = d_ci.remote.sin4.sin_family;
@@ -156,7 +156,7 @@ public:
     if (!d_ci.cs->hasTLS()) {
       return false;
     }
-    return d_ci.cs->getTLSFrontend().d_proxyProtocolOutsideTLS;
+    return d_ci.cs->getTLSFrontend()->d_proxyProtocolOutsideTLS;
   }
 
   virtual bool forwardViaUDPFirst() const

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -751,7 +751,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
           errorCounters = &front->tlsFrontend->d_tlsCounters;
         }
         else if (front->dohFrontend != nullptr) {
-          errorCounters = &front->dohFrontend->d_tlsContext.d_tlsCounters;
+          errorCounters = &front->dohFrontend->d_tlsContext->d_tlsCounters;
         }
 
         if (errorCounters != nullptr) {
@@ -789,7 +789,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
 #ifdef HAVE_DNS_OVER_HTTPS
   std::map<std::string,uint64_t> dohFrontendDuplicates;
   for(const auto& doh : dnsdist::getDoHFrontends()) {
-    const string frontName = doh->d_tlsContext.d_addr.toStringWithPort();
+    const string frontName = doh->d_tlsContext->d_addr.toStringWithPort();
     uint64_t threadNumber = 0;
     auto dupPair = frontendDuplicates.emplace(frontName, 1);
     if (!dupPair.second) {
@@ -1188,7 +1188,7 @@ static void handleStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
       errorCounters = &front->tlsFrontend->d_tlsCounters;
     }
     else if (front->dohFrontend != nullptr) {
-      errorCounters = &front->dohFrontend->d_tlsContext.d_tlsCounters;
+      errorCounters = &front->dohFrontend->d_tlsContext->d_tlsCounters;
     }
     if (errorCounters != nullptr) {
       frontend["tlsHandshakeFailuresDHKeyTooSmall"] = (double)errorCounters->d_dhKeyTooSmall;
@@ -1212,7 +1212,7 @@ static void handleStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
     for (const auto& doh : dohFrontends) {
       dohs.emplace_back(Json::object{
         {"id", num++},
-        {"address", doh->d_tlsContext.d_addr.toStringWithPort()},
+        {"address", doh->d_tlsContext->d_addr.toStringWithPort()},
         {"http-connects", (double)doh->d_httpconnects},
         {"http1-queries", (double)doh->d_http1Stats.d_nbQueries},
         {"http2-queries", (double)doh->d_http2Stats.d_nbQueries},

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -396,10 +396,10 @@ struct ClientState
     return tlsFrontend != nullptr || (dohFrontend != nullptr && dohFrontend->isHTTPS());
   }
 
-  const TLSFrontend& getTLSFrontend() const
+  const std::shared_ptr<const TLSFrontend> getTLSFrontend() const
   {
     if (tlsFrontend != nullptr) {
-      return *tlsFrontend;
+      return tlsFrontend;
     }
     if (dohFrontend) {
       return dohFrontend->d_tlsContext;

--- a/pdns/dnsdistdist/docs/advanced/tls-sessions-management.rst
+++ b/pdns/dnsdistdist/docs/advanced/tls-sessions-management.rst
@@ -28,13 +28,15 @@ Keys management for incoming connections in dnsdist
 
 dnsdist supports both server's side (sessions) and client's side (tickets) resumption for incoming connections (client to dnsdist).
 
-Since server-side sessions cannot be shared between several instances, and pretty much all clients support tickets anyway, we do recommend disabling the sessions by passing ``numberOfStoredSessions=0`` to the :func:`addDOHLocal` (for DNS over HTTPS) and :func:`addTLSLocal` (for DNS over TLS) functions.
+Since server-side sessions cannot be shared between several instances, and pretty much all clients support tickets anyway, we do recommend disabling the sessions by passing ``numberOfStoredSessions=0`` to the :func:`addDOHLocal` (for DNS over HTTPS) and :func:`addTLSLocal` (for DNS over TLS) functions, or setting ``tls.number_of_stored_sessions=0`` on a :ref:`frontend configuration <yaml-settings-BindConfiguration>` when using YAML.
 
-By default, dnsdist will generate a new, random STEK at startup for each :func:`addTLSLocal` and :func:`addDOHLocal` directive, and rotate these STEKs every 12 hours. For each frontend it will keep 5 keys in memory, with only the last one marked as active and used to encrypt new tickets while the remaining ones can still be used to decrypt existing tickets after a rotation. The rotation time and the number of keys to keep in memory can be configured via the ``numberOfTicketsKeys`` and ``ticketsKeysRotationDelay`` parameters of the :func:`addDOHLocal` (for DNS over HTTPS) and :func:`addTLSLocal` (for DNS over TLS) functions.
+By default, dnsdist will generate a new, random STEK at startup for each frontend created via :func:`addTLSLocal` and :func:`addDOHLocal` directive, and rotate these STEKs every 12 hours. For each frontend it will keep 5 keys in memory, with only the last one marked as active and used to encrypt new tickets while the remaining ones can still be used to decrypt existing tickets after a rotation. The rotation time and the number of keys to keep in memory can be configured via the ``numberOfTicketsKeys`` and ``ticketsKeysRotationDelay`` parameters of the :func:`addDOHLocal` (for DNS over HTTPS) and :func:`addTLSLocal` (for DNS over TLS) functions.
 When the automatic rotation mechanism kicks in a new, random key will be added to the list of keys. With the OpenSSL provider, the new key becomes active, so new tickets will be encrypted with this key, and the existing keys become passive and only be used to decrypt existing tickets. With the GnuTLS provider only one key is currently supported so the existing keys are immediately discarded.
 This automatic rotation can be disabled by setting ``ticketsKeysRotationDelay`` to 0.
 
 It is also possible to manually request a STEK rotation using the :func:`getDOHFrontend` (DoH) and :func:`getTLSFrontend` (DoT) functions to retrieve the bind object, and calling its ``rotateTicketsKey`` method (:meth:`DOHFrontend:rotateTicketsKey`, :meth:`TLSFrontend:rotateTicketsKey`).
+
+There is an important difference when the YAML configuration is used: groups of identical frontends can be created via the ``threads`` parameter of a :ref:`frontend configuration <yaml-settings-BindConfiguration>`. Identical frontends then share the same STEKs, even after an automatic or manual rotation. In addition to that, any operation on the STEKs should be done on the first frontend of the group, as attempting to alter the STEKs of the other frontends in a group will be ignored to avoid unwanted side-effects.
 
 The default settings should be fine for most deployments, but generating a random key for every dnsdist instance will not allow resuming the session from a different instance in a cluster. It is also not very useful to have a different key for every :func:`addTLSLocal` and :func:`addDOHLocal` directive if you are using the same certificate and key, and it would be much better to use the same STEK to improve the session resumption ratio.
 
@@ -48,7 +50,7 @@ For the GnuTLS provider (DoT), the operation is the same but requires only 64 cr
 
   dd if=/dev/urandom of=/secure-tmp-fs/tickets.key bs=64 count=1
 
-The file can then be loaded at startup by using the ``ticketKeyFile`` parameter of the :func:`addDOHLocal` (for DNS over HTTPS) and :func:`addTLSLocal` (for DNS over TLS) functions.
+The file can then be loaded at startup by using the ``ticketKeyFile`` parameter of the :func:`addDOHLocal` (for DNS over HTTPS) and :func:`addTLSLocal` (for DNS over TLS) functions, or the ``tls.ticket_key_file`` of a :ref:`frontend configuration <yaml-settings-BindConfiguration>` when using YAML.
 
 If the file contains several keys, so for example 240 random bytes, dnsdist will load several STEKs, using the last one for encrypting new tickets and all of them to decrypt existing tickets.
 

--- a/pdns/dnsdistdist/docs/reference/yaml-settings.rst
+++ b/pdns/dnsdistdist/docs/reference/yaml-settings.rst
@@ -112,7 +112,7 @@ General settings for frontends
 - **listen_address**: String - Address and port to listen to
 - **reuseport**: Boolean ``(false)`` - Set the ``SO_REUSEPORT`` socket option, allowing several sockets to be listening on this address and port
 - **protocol**: String ``(Do53)`` - The DNS protocol for this frontend. Supported values are: Do53, DoT, DoH, DoQ, DoH3, DNSCrypt
-- **threads**: Unsigned integer ``(1)`` - Number of listening threads to create for this frontend
+- **threads**: Unsigned integer ``(1)`` - Number of listening threads to create for this frontend. Note that each listening thread will have its own metrics, but identical DoT and DoH threads will share the same TLS Session Ticket Encryption Keys to improve session resumption rates. One side-effect is that rotating / altering the STEKs on all threads in a frontend group except the first one will be ignored, to prevent unwanted actions by existing code. :func:`reloadAllCertificates` properly handles frontend groups.
 - **interface**: String ``("")`` - Set the network interface to use
 - **cpus**: String ``("")`` - Set the CPU affinity for this listener thread, asking the scheduler to run it on a single CPU id, or a set of CPU ids. This parameter is only available if the OS provides the ``pthread_setaffinity_np()`` function
 - **enable_proxy_protocol**: Boolean ``(false)`` - Whether to expect a proxy protocol v2 header in front of incoming queries coming from an address allowed by the ACL in :ref:`yaml-settings-ProxyProtocolConfiguration`. Default is ``true``, meaning that queries are expected to have a proxy protocol payload if they come from an address present in the proxy protocol ACL

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1530,16 +1530,16 @@ static void setupAcceptContext(DOHAcceptContext& ctx, DOHServerConfig& dsc, bool
   nativeCtx->ctx = &dsc.h2o_ctx;
   nativeCtx->hosts = dsc.h2o_config.hosts;
   auto dohFrontend = std::atomic_load_explicit(&dsc.dohFrontend, std::memory_order_acquire);
-  ctx.d_ticketsKeyRotationDelay = dohFrontend->d_tlsContext.d_tlsConfig.d_ticketsKeyRotationDelay;
+  ctx.d_ticketsKeyRotationDelay = dohFrontend->d_tlsContext->d_tlsConfig.d_ticketsKeyRotationDelay;
 
   if (setupTLS && dohFrontend->isHTTPS()) {
     try {
       setupTLSContext(ctx,
-                      dohFrontend->d_tlsContext.d_tlsConfig,
-                      dohFrontend->d_tlsContext.d_tlsCounters);
+                      dohFrontend->d_tlsContext->d_tlsConfig,
+                      dohFrontend->d_tlsContext->d_tlsCounters);
     }
     catch (const std::runtime_error& e) {
-      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + dohFrontend->d_tlsContext.d_addr.toStringWithPort() + "': " + e.what());
+      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + dohFrontend->d_tlsContext->d_addr.toStringWithPort() + "': " + e.what());
     }
   }
   ctx.d_cs = dsc.clientState;
@@ -1582,7 +1582,7 @@ void dohThread(ClientState* clientState)
     setThreadName("dnsdist/doh");
     // I wonder if this registers an IP address.. I think it does
     // this may mean we need to actually register a site "name" here and not the IP address
-    h2o_hostconf_t *hostconf = h2o_config_register_host(&dsc->h2o_config, h2o_iovec_init(dohFrontend->d_tlsContext.d_addr.toString().c_str(), dohFrontend->d_tlsContext.d_addr.toString().size()), 65535);
+    h2o_hostconf_t *hostconf = h2o_config_register_host(&dsc->h2o_config, h2o_iovec_init(dohFrontend->d_tlsContext->d_addr.toString().c_str(), dohFrontend->d_tlsContext->d_addr.toString().size()), 65535);
 
     dsc->paths = dohFrontend->d_urls;
     for (const auto& url : dsc->paths) {
@@ -1606,11 +1606,11 @@ void dohThread(ClientState* clientState)
     setupAcceptContext(*dsc->accept_ctx, *dsc, false);
 
     if (create_listener(dsc, clientState->tcpFD) != 0) {
-      throw std::runtime_error("DOH server failed to listen on " + dohFrontend->d_tlsContext.d_addr.toStringWithPort() + ": " + stringerror(errno));
+      throw std::runtime_error("DOH server failed to listen on " + dohFrontend->d_tlsContext->d_addr.toStringWithPort() + ": " + stringerror(errno));
     }
     for (const auto& [addr, descriptor] : clientState->d_additionalAddresses) {
       if (create_listener(dsc, descriptor) != 0) {
-        throw std::runtime_error("DOH server failed to listen on additional address " + addr.toStringWithPort() + " for DOH local" + dohFrontend->d_tlsContext.d_addr.toStringWithPort() + ": " + stringerror(errno));
+        throw std::runtime_error("DOH server failed to listen on additional address " + addr.toStringWithPort() + " for DOH local" + dohFrontend->d_tlsContext->d_addr.toStringWithPort() + ": " + stringerror(errno));
       }
     }
 
@@ -1736,11 +1736,11 @@ void H2ODOHFrontend::setup()
   if  (isHTTPS()) {
     try {
       setupTLSContext(*d_dsc->accept_ctx,
-                      d_tlsContext.d_tlsConfig,
-                      d_tlsContext.d_tlsCounters);
+                      d_tlsContext->d_tlsConfig,
+                      d_tlsContext->d_tlsCounters);
     }
     catch (const std::runtime_error& e) {
-      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + d_tlsContext.d_addr.toStringWithPort() + "': " + e.what());
+      throw std::runtime_error("Error setting up TLS context for DoH listener on '" + d_tlsContext->d_addr.toStringWithPort() + "': " + e.what());
     }
   }
 }

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -1883,6 +1883,14 @@ bool TLSFrontend::setupTLS()
 {
 #if defined(HAVE_DNS_OVER_TLS) || defined(HAVE_DNS_OVER_HTTPS)
   std::shared_ptr<TLSCtx> newCtx{nullptr};
+  if (d_parentFrontend) {
+    newCtx = d_parentFrontend->getContext();
+    if (newCtx) {
+      std::atomic_store_explicit(&d_ctx, std::move(newCtx), std::memory_order_release);
+      return true;
+    }
+  }
+
   /* get the "best" available provider */
 #if defined(HAVE_GNUTLS)
   if (d_provider == "gnutls") {

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -155,28 +155,33 @@ public:
 
   void rotateTicketsKey(time_t now)
   {
-    if (d_ctx != nullptr) {
+    if (d_ctx != nullptr && d_parentFrontend == nullptr) {
       d_ctx->rotateTicketsKey(now);
     }
   }
 
   void loadTicketsKeys(const std::string& file)
   {
-    if (d_ctx != nullptr) {
+    if (d_ctx != nullptr && d_parentFrontend == nullptr) {
       d_ctx->loadTicketsKeys(file);
     }
   }
 
   void loadTicketsKey(const std::string& key)
   {
-    if (d_ctx != nullptr) {
+    if (d_ctx != nullptr && d_parentFrontend == nullptr) {
       d_ctx->loadTicketsKey(key);
     }
   }
 
-  std::shared_ptr<TLSCtx> getContext()
+  std::shared_ptr<TLSCtx> getContext() const
   {
     return std::atomic_load_explicit(&d_ctx, std::memory_order_acquire);
+  }
+
+  void setParent(std::shared_ptr<const TLSFrontend> parent)
+  {
+    std::atomic_store_explicit(&d_parentFrontend, std::move(parent), std::memory_order_release);
   }
 
   void cleanup()
@@ -242,6 +247,7 @@ public:
   bool d_proxyProtocolOutsideTLS{false};
 protected:
   std::shared_ptr<TLSCtx> d_ctx{nullptr};
+  std::shared_ptr<const TLSFrontend> d_parentFrontend{nullptr};
 };
 
 class TCPIOHandler

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -663,7 +663,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         return sock
 
     @classmethod
-    def openTLSConnection(cls, port, serverName, caCert=None, timeout=2.0, alpn=[]):
+    def openTLSConnection(cls, port, serverName, caCert=None, timeout=2.0, alpn=[], sslctx=None, session=None):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         if timeout:
@@ -671,10 +671,11 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
         # 2.7.9+
         if hasattr(ssl, 'create_default_context'):
-            sslctx = ssl.create_default_context(cafile=caCert)
-            if len(alpn)> 0 and hasattr(sslctx, 'set_alpn_protocols'):
-              sslctx.set_alpn_protocols(alpn)
-            sslsock = sslctx.wrap_socket(sock, server_hostname=serverName)
+            if not sslctx:
+                sslctx = ssl.create_default_context(cafile=caCert)
+                if len(alpn)> 0 and hasattr(sslctx, 'set_alpn_protocols'):
+                    sslctx.set_alpn_protocols(alpn)
+            sslsock = sslctx.wrap_socket(sock, server_hostname=serverName, session=session)
         else:
             sslsock = ssl.wrap_socket(sock, ca_certs=caCert, cert_reqs=ssl.CERT_REQUIRED)
 

--- a/regression-tests.dnsdist/test_TLSSessionResumption.py
+++ b/regression-tests.dnsdist/test_TLSSessionResumption.py
@@ -2,7 +2,9 @@
 import base64
 import dns
 import os
+import requests
 import shutil
+import ssl
 import subprocess
 import tempfile
 import time
@@ -297,3 +299,92 @@ class TestTLSSessionResumptionDOT(DNSDistTLSSessionResumptionTest):
         # reload from file 2, the latest session should resume
         self.sendConsoleCommand("getTLSFrontend(0):loadTicketsKeys('/tmp/ticketKeys.2')")
         self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot.2', '/tmp/session.dot.2', allowNoTicket=True))
+
+class TestTLSSessionResumptionDOTIdenticalFrontends(DNSDistTest):
+    """
+    Check that identical frontends share the same TLS session ticket encryption key
+    """
+    _webTimeout = 2.0
+    _webServerPort = pickAvailablePort()
+    _webServerBasicAuthPassword = 'secret'
+    _webServerAPIKey = 'apisecret'
+    _webServerBasicAuthPasswordHashed = '$scrypt$ln=10,p=1,r=8$6DKLnvUYEeXWh3JNOd3iwg==$kSrhdHaRbZ7R74q3lGBqO1xetgxRxhmWzYJ2Qvfm7JM='
+    _webServerAPIKeyHashed = '$scrypt$ln=10,p=1,r=8$9v8JxDfzQVyTpBkTbkUqYg==$bDQzAOHeK1G9UvTPypNhrX48w974ZXbFPtRKS34+aso='
+    _serverKey = 'server.key'
+    _serverCert = 'server.chain'
+    _serverName = 'tls.tests.dnsdist.org'
+    _caCert = 'ca.pem'
+    _tlsServerPort = pickAvailablePort()
+    _numberOfIdenticalFrontends = 10
+    _config_template = ""
+    _config_params = []
+    _yaml_config_template = """---
+webserver:
+  listen_address: "127.0.0.1:%d"
+  password: "%s"
+  api_key: "%s"
+  acl:
+    - 127.0.0.0/8
+backends:
+  - address: "127.0.0.1:%d"
+    protocol: "Do53"
+binds:
+  - listen_address: "127.0.0.1:%d"
+    reuseport: true
+    protocol: "DoT"
+    threads: %d
+    tls:
+      certificates:
+        - certificate: "%s"
+          key: "%s"
+      provider: "openssl"
+    """
+    _yaml_config_params = ['_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed', '_testServerPort', '_tlsServerPort', '_numberOfIdenticalFrontends', '_serverCert', '_serverKey']
+
+    def testTLSSessionResumptionAcrossIdenticalFrontends(self):
+        """
+        TCP Session Resumption: Check that identical frontends share the same STEK
+        """
+        name = 'identical-frontends.tls-session-resumption.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+
+        session = None
+        sslctx = ssl.create_default_context(cafile=self._caCert)
+        nb_connections = self._numberOfIdenticalFrontends * 20
+        for idx in range(nb_connections):
+            conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert, timeout=1, sslctx=sslctx, session=session)
+            self.sendTCPQueryOverConnection(conn, query, response=response, timeout=1)
+            (receivedQuery, receivedResponse) = self.recvTCPResponseOverConnection(conn, useQueue=True, timeout=1)
+            receivedQuery.id = query.id
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
+            if idx == 0:
+                self.assertFalse(conn.session_reused)
+                session = conn.session
+            else:
+                self.assertTrue(conn.session_reused)
+
+        headers = {'x-api-key': self._webServerAPIKey}
+        url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost'
+        r = requests.get(url, headers=headers, timeout=self._webTimeout)
+        self.assertTrue(r)
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json())
+        content = r.json()
+        self.assertTrue(len(content['frontends']), self._numberOfIdenticalFrontends + 2)
+
+        new_sessions = 0
+        resumed_sessions = 0
+        tls_frontends_seen = {}
+        for frontend in content['frontends']:
+            if frontend['type'] != 'TCP (DNS over TLS)':
+                continue
+            new_sessions = new_sessions + int(frontend['tlsNewSessions'])
+            resumed_sessions = resumed_sessions + int(frontend['tlsResumptions'])
+            if int(frontend['tlsNewSessions']) > 0 or int(frontend['tlsResumptions']) > 0:
+                tls_frontends_seen[frontend['id']] = True
+
+        self.assertEqual(new_sessions, 1)
+        self.assertEqual(resumed_sessions, nb_connections - new_sessions)
+        self.assertGreater(len(tls_frontends_seen), 1)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Using the same Session Ticket Encryption Key on identical frontends allow TLS sessions to be resumed in a much more efficient way, reducing the latency and CPU usage. While it was already possible to do so by manually managing the STEK, the default behaviour was to create and use a different STEK for each frontend, because our Lua configuration makes it almost impossible to ensure that two frontends are identical.
This is not an issue with the new YAML configuration format, so let's share the STEK automatically in this case.

Closes https://github.com/PowerDNS/pdns/issues/13336
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
