### PR TITLE
[tools] Honour default-ttl in pdnsutil load-zone

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1543,6 +1543,7 @@ static int loadZone(const DNSName& zone, const string& fname) {
   }
   DNSBackend* db = di.backend;
   ZoneParserTNG zpt(fname, zone);
+  zpt.setDefaultTTL(::arg().asNum("default-ttl"));
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
 
   DNSResourceRecord rr;

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -41,7 +41,7 @@ const static string g_INstr("IN");
 ZoneParserTNG::ZoneParserTNG(const string& fname, DNSName  zname, string  reldir, bool upgradeContent):
   d_reldir(std::move(reldir)), d_zonename(std::move(zname)), d_defaultttl(3600),
   d_templatecounter(0), d_templatestop(0), d_templatestep(0),
-  d_havedollarttl(false), d_fromfile(true), d_upgradeContent(upgradeContent)
+  d_havespecificttl(false), d_fromfile(true), d_upgradeContent(upgradeContent)
 {
   stackFile(fname);
 }
@@ -49,7 +49,7 @@ ZoneParserTNG::ZoneParserTNG(const string& fname, DNSName  zname, string  reldir
 ZoneParserTNG::ZoneParserTNG(const vector<string>& zonedata, DNSName  zname, bool upgradeContent):
   d_zonename(std::move(zname)), d_zonedata(zonedata), d_defaultttl(3600),
   d_templatecounter(0), d_templatestop(0), d_templatestep(0),
-  d_havedollarttl(false), d_fromfile(false), d_upgradeContent(upgradeContent)
+  d_havespecificttl(false), d_fromfile(false), d_upgradeContent(upgradeContent)
 {
   d_zonedataline = d_zonedata.begin();
 }
@@ -338,6 +338,7 @@ pair<string,int> ZoneParserTNG::getLineNumAndFile()
     return {d_filestates.top().d_filename, d_filestates.top().d_lineno};
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
 {
  retry:;
@@ -363,7 +364,7 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
     string command=makeString(d_line, d_parts[0]);
     if(pdns_iequals(command,"$TTL") && d_parts.size() > 1) {
       d_defaultttl=makeTTLFromZone(trim_right_copy_if(makeString(d_line, d_parts[1]), boost::is_any_of(";")));
-      d_havedollarttl=true;
+      d_havespecificttl=true;
     }
     else if(pdns_iequals(command,"$INCLUDE") && d_parts.size() > 1 && d_fromfile) {
       string fname=unquotify(makeString(d_line, d_parts[1]));
@@ -515,8 +516,9 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
     }
     if(!haveTTL && !haveQTYPE && isTimeSpec(nextpart)) {
       rr.ttl=makeTTLFromZone(nextpart);
-      if(!d_havedollarttl)
+      if (!d_havespecificttl) {
         d_defaultttl = rr.ttl;
+      }
       haveTTL=true;
       // cout<<"ttl is probably: "<<rr.ttl<<endl;
       continue;

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -53,6 +53,11 @@ public:
   {
     d_maxIncludes = max;
   }
+  void setDefaultTTL(int ttl)
+  {
+    d_defaultttl = ttl;
+    d_havespecificttl = true;
+  }
 private:
   bool getLine();
   bool getTemplateLine();
@@ -81,7 +86,7 @@ private:
   size_t d_maxIncludes{20};
   int d_defaultttl;
   uint32_t d_templatecounter, d_templatestop, d_templatestep;
-  bool d_havedollarttl;
+  bool d_havespecificttl;
   bool d_fromfile;
   bool d_generateEnabled{true};
   bool d_upgradeContent;


### PR DESCRIPTION
### Short description
This trivial mechanical PR lets `pdnsutil load-zone` default to the `default-ttl` setting as the TTL value for entries lacking a TTL, if `$TTL` is not set in the file being loaded.

This addresses #8494.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
