### PR TITLE
[auth] Log DNS packet parse errors

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -658,6 +658,7 @@ try
   return 0;
 }
 catch(std::exception& e) {
+  g_log << Logger::Debug << "Parse error in packet from " << getRemoteString() << ": " << e.what() << endl;
   return -1;
 }
 


### PR DESCRIPTION
### Short description
As found the hard way in #14513, incoming DNS packets which fail to parse correctly are silently ignored (regardless of the transport protocol being used).

This PR will log these errors at the `Debug` level, similarly to the other "ill-formed packet" errors (e.g. packet too short to be a DNS query).
 
### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)