### PR TITLE
[auth] Rework PacketHandler::doQuestion()

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1591,20 +1591,22 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
 
   if(d_sd.qname==pkt.qdomain) {
     if(!d_dk.isPresigned(d_sd.qname)) {
-      if(pkt.qtype.getCode() == QType::DNSKEY) {
+      switch (pkt.qtype.getCode()) {
+      case QType::DNSKEY:
         if(addDNSKEY(pkt, state.r)) {
           return true;
         }
-      }
-      else if(pkt.qtype.getCode() == QType::CDNSKEY) {
+        break;
+      case QType::CDNSKEY:
         if(addCDNSKEY(pkt,state.r)) {
           return true;
         }
-      }
-      else if(pkt.qtype.getCode() == QType::CDS) {
+        break;
+      case QType::CDS:
         if(addCDS(pkt,state.r)) {
           return true;
         }
+        break;
       }
     }
     if(pkt.qtype.getCode() == QType::NSEC3PARAM) {

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -113,13 +113,12 @@ private:
     std::unique_ptr<DNSPacket> r{nullptr};
     set<DNSName> authSet;
     DNSName target;
-    int retargetcount{0};
     bool doSigs{false};
     bool noCache{false};
     bool retargeted{false};
   };
   bool opcodeQueryInner(DNSPacket&, queryState&);
-  bool opcodeQueryInner2(DNSPacket&, queryState&);
+  bool opcodeQueryInner2(DNSPacket&, queryState&, bool);
   std::unique_ptr<DNSPacket> opcodeQuery(DNSPacket&, bool);
   std::unique_ptr<DNSPacket> opcodeNotify(DNSPacket&, bool);
   std::unique_ptr<DNSPacket> opcodeUpdate(DNSPacket&, bool);

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -109,6 +109,13 @@ private:
 
   void tkeyHandler(const DNSPacket& p, std::unique_ptr<DNSPacket>& r); //<! process TKEY record, and adds TKEY record to (r)eply, or error code.
 
+  struct queryState {
+    std::unique_ptr<DNSPacket> r{nullptr};
+    set<DNSName> authSet;
+    bool doSigs{false};
+    bool noCache{false};
+  };
+  bool opcodeQueryInner(DNSPacket&, queryState&);
   std::unique_ptr<DNSPacket> opcodeQuery(DNSPacket&, bool);
   std::unique_ptr<DNSPacket> opcodeNotify(DNSPacket&, bool);
   std::unique_ptr<DNSPacket> opcodeUpdate(DNSPacket&, bool);

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -109,6 +109,11 @@ private:
 
   void tkeyHandler(const DNSPacket& p, std::unique_ptr<DNSPacket>& r); //<! process TKEY record, and adds TKEY record to (r)eply, or error code.
 
+  std::unique_ptr<DNSPacket> opcodeQuery(DNSPacket&, bool);
+  std::unique_ptr<DNSPacket> opcodeNotify(DNSPacket&, bool);
+  std::unique_ptr<DNSPacket> opcodeUpdate(DNSPacket&, bool);
+  std::unique_ptr<DNSPacket> opcodeNotImplemented(DNSPacket&, bool);
+
   static AtomicCounter s_count;
   static std::mutex s_rfc2136lock;
   bool d_logDNSDetails;

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -112,10 +112,14 @@ private:
   struct queryState {
     std::unique_ptr<DNSPacket> r{nullptr};
     set<DNSName> authSet;
+    DNSName target;
+    int retargetcount{0};
     bool doSigs{false};
     bool noCache{false};
+    bool retargeted{false};
   };
   bool opcodeQueryInner(DNSPacket&, queryState&);
+  bool opcodeQueryInner2(DNSPacket&, queryState&);
   std::unique_ptr<DNSPacket> opcodeQuery(DNSPacket&, bool);
   std::unique_ptr<DNSPacket> opcodeNotify(DNSPacket&, bool);
   std::unique_ptr<DNSPacket> opcodeUpdate(DNSPacket&, bool);


### PR DESCRIPTION
### Short description
This moderately evil PR reworks the logic within `doQuestion` to get rid of the `goto` statements within this large chunk of code. This is done in reasonably simple steps, and is probably better reviewed on a per-commit basis.

The steps are:
- after the common checks, make each question opcode handled by its own routine (Query/Notify/Update and NotImplemented for all the other opcodes).
- split the Query logic in two parts: an inner part which performs the logic before the `sendit` label, and an outer part which takes over from `sendit` onwards. The return value of the inner part tells the outer part whether the `sendit` logic must be applied (add additional records, etc) or if the response packet should be sent in its current state.
- split the inner part of the Query logic again in two parts: an "even more inner" part which actually handles the query, and the other part handles retargeting. This gets rid of the `retargeted` label.
- then there a few more commits to tie loose edges and make `clang-tidy` happy enough.

There no intended changes in behaviour, and these changes have been made very carefully to not introduce any by accident.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)