### PR TITLE
.gitignore glitch

### DIFF
--- a/pdns/.gitignore
+++ b/pdns/.gitignore
@@ -36,7 +36,7 @@
 /nproxy
 /speedtest
 /tcpbench
-/tsig-tests
+/tsig_tests
 version_generated.h
 /zone2ldap
 /zone2sql


### PR DESCRIPTION
### Short description
When I made sure `tsig-tests` were built when using autoconf, I had to change the dash to an underscore due to ~autoconf being a major pain in the you-know-what~ technical reasons, but forgot to update the `.gitignore` file accordingly.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
