### PR TITLE
rec regr tests: allow to set moduledir using an env var

### DIFF
--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -482,12 +482,12 @@ options {
         };""" % (zone, zonename))
 
     @classmethod
-    def generateAuthConfig(cls, confdir, threads):
+    def generateAuthConfig(cls, confdir, threads, extra=''):
         bind_dnssec_db = os.path.join(confdir, 'bind-dnssec.sqlite3')
 
         with open(os.path.join(confdir, 'pdns.conf'), 'w') as pdnsconf:
             pdnsconf.write("""
-module-dir=../regression-tests/modules
+module-dir={moduledir}
 launch=bind
 daemon=no
 bind-config={confdir}/named.conf
@@ -501,9 +501,12 @@ log-dns-details=yes
 loglevel=9
 enable-lua-records
 dname-processing=yes
-distributor-threads={threads}""".format(confdir=confdir,
-                                        bind_dnssec_db=bind_dnssec_db,
-                                        threads=threads))
+distributor-threads={threads}
+{extra}""".format(moduledir=os.environ['PDNSMODULEDIR'],
+                  confdir=confdir,
+                  bind_dnssec_db=bind_dnssec_db,
+                  threads=threads,
+                  extra=extra))
 
         pdnsutilCmd = [os.environ['PDNSUTIL'],
                        '--config-dir=%s' % confdir,

--- a/regression-tests.recursor-dnssec/runtests
+++ b/regression-tests.recursor-dnssec/runtests
@@ -30,6 +30,8 @@ mkdir -p configs
 
 export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
 export PDNSUTIL=${PDNSUTIL:-${PWD}/../pdns/pdnsutil}
+export PDNSMODULEDIR=${PDNSMODULEDIR:-${PWD}/../regression-tests/modules}
+
 export PDNSRECURSOR=${PDNSRECURSOR:-${PWD}/../pdns/recursordist/pdns_recursor}
 export RECCONTROL=${RECCONTROL:-${PWD}/../pdns/recursordist/rec_control}
 


### PR DESCRIPTION
This makes picking the right modulerdir explicit instead of hard-coded. With meson the location varies, and also I would like to use packaged modules even when I happen to have backend .so's in the default place.

There's also an extra arg  (called extra) needed by the upcoming cookie code.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
