### PR TITLE
[auth] minor web service cleanup

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -963,12 +963,10 @@ static bool isValidMetadataKind(const string& kind, bool readonly)
     "SOA-EDIT-DNSUPDATE",
     "TSIG-ALLOW-AXFR",
     "TSIG-ALLOW-DNSUPDATE",
-    "TSIG-ALLOW-DNSUPDATE",
   };
 
   // the following options do not allow modifications via API
   static vector<string> protectedOptions{
-    "API-RECTIFY",
     "AXFR-MASTER-TSIG",
     "LUA-AXFR-SCRIPT",
     "NSEC3NARROW",

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -943,18 +943,16 @@ static bool isValidMetadataKind(const string& kind, bool readonly)
 {
   static vector<string> builtinOptions{
     "ALLOW-AXFR-FROM",
-    "AXFR-SOURCE",
     "ALLOW-DNSUPDATE-FROM",
-    "TSIG-ALLOW-DNSUPDATE",
-    "FORWARD-DNSUPDATE",
-    "SOA-EDIT-DNSUPDATE",
-    "NOTIFY-DNSUPDATE",
     "ALSO-NOTIFY",
     "AXFR-MASTER-TSIG",
-    "GSS-ALLOW-AXFR-PRINCIPAL",
+    "AXFR-SOURCE",
+    "FORWARD-DNSUPDATE",
     "GSS-ACCEPTOR-PRINCIPAL",
+    "GSS-ALLOW-AXFR-PRINCIPAL",
     "IXFR",
     "LUA-AXFR-SCRIPT",
+    "NOTIFY-DNSUPDATE",
     "NSEC3NARROW",
     "NSEC3PARAM",
     "PRESIGNED",
@@ -962,7 +960,9 @@ static bool isValidMetadataKind(const string& kind, bool readonly)
     "PUBLISH-CDS",
     "SLAVE-RENOTIFY",
     "SOA-EDIT",
+    "SOA-EDIT-DNSUPDATE",
     "TSIG-ALLOW-AXFR",
+    "TSIG-ALLOW-DNSUPDATE",
     "TSIG-ALLOW-DNSUPDATE",
   };
 
@@ -970,10 +970,10 @@ static bool isValidMetadataKind(const string& kind, bool readonly)
   static vector<string> protectedOptions{
     "API-RECTIFY",
     "AXFR-MASTER-TSIG",
+    "LUA-AXFR-SCRIPT",
     "NSEC3NARROW",
     "NSEC3PARAM",
     "PRESIGNED",
-    "LUA-AXFR-SCRIPT",
     "TSIG-ALLOW-AXFR",
   };
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -22,6 +22,7 @@
 #include "dnsbackend.hh"
 #include "webserver.hh"
 #include <array>
+#include <string_view>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -941,59 +942,41 @@ static void updateDomainSettingsFromDocument(UeberBackend& backend, DomainInfo& 
 
 static bool isValidMetadataKind(const string& kind, bool readonly)
 {
-  static vector<string> builtinOptions{
-    "ALLOW-AXFR-FROM",
-    "ALLOW-DNSUPDATE-FROM",
-    "ALSO-NOTIFY",
-    "AXFR-MASTER-TSIG",
-    "AXFR-SOURCE",
-    "FORWARD-DNSUPDATE",
-    "GSS-ACCEPTOR-PRINCIPAL",
-    "GSS-ALLOW-AXFR-PRINCIPAL",
-    "IXFR",
-    "LUA-AXFR-SCRIPT",
-    "NOTIFY-DNSUPDATE",
-    "NSEC3NARROW",
-    "NSEC3PARAM",
-    "PRESIGNED",
-    "PUBLISH-CDNSKEY",
-    "PUBLISH-CDS",
-    "SLAVE-RENOTIFY",
-    "SOA-EDIT",
-    "SOA-EDIT-DNSUPDATE",
-    "TSIG-ALLOW-AXFR",
-    "TSIG-ALLOW-DNSUPDATE",
-  };
-
-  // the following options do not allow modifications via API
-  static vector<string> protectedOptions{
-    "AXFR-MASTER-TSIG",
-    "LUA-AXFR-SCRIPT",
-    "NSEC3NARROW",
-    "NSEC3PARAM",
-    "PRESIGNED",
-    "TSIG-ALLOW-AXFR",
+  const static vector<std::pair<std::string_view, bool /* readonly */>> builtinOptions{
+    {"ALLOW-AXFR-FROM", false},
+    {"ALLOW-DNSUPDATE-FROM", false},
+    {"ALSO-NOTIFY", false},
+    {"AXFR-MASTER-TSIG", true},
+    {"AXFR-SOURCE", false},
+    {"FORWARD-DNSUPDATE", false},
+    {"GSS-ACCEPTOR-PRINCIPAL", false},
+    {"GSS-ALLOW-AXFR-PRINCIPAL", false},
+    {"IXFR", false},
+    {"LUA-AXFR-SCRIPT", true},
+    {"NOTIFY-DNSUPDATE", false},
+    {"NSEC3NARROW", true},
+    {"NSEC3PARAM", true},
+    {"PRESIGNED", true},
+    {"PUBLISH-CDNSKEY", false},
+    {"PUBLISH-CDS", false},
+    {"SLAVE-RENOTIFY", false},
+    {"SOA-EDIT", true},
+    {"SOA-EDIT-DNSUPDATE", false},
+    {"TSIG-ALLOW-AXFR", false},
+    {"TSIG-ALLOW-DNSUPDATE", false},
   };
 
   if (kind.find("X-") == 0) {
     return true;
   }
 
-  bool found = false;
-
-  for (const string& builtinOption : builtinOptions) {
-    if (kind == builtinOption) {
-      for (const string& protectedOption : protectedOptions) {
-        if (!readonly && builtinOption == protectedOption) {
-          return false;
-        }
-      }
-      found = true;
-      break;
+  for (const auto& builtinOption : builtinOptions) {
+    if (kind == builtinOption.first) {
+      return readonly || !builtinOption.second;
     }
   }
 
-  return found;
+  return false;
 }
 
 /* Return OpenAPI document describing the supported API.


### PR DESCRIPTION
### Short description
While looking at another issue, I couldn't help but notice a few minor cracks in the webservice code, with regard to zone metadata queries:
- the `API-RECTIFY` metadata is supposed to be queryable but not changeable, but due to it being missing from the known metadata names, it was not queryable.
- the `SOA-EDIT-API` metadata is supposed to be queryable and not changeable, but was also missing.

This PR updates the list of known metadata names, sorts it, and eventually reworks the data structure used to prevent a double search (once for a known name, once to know its readonly status).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)