### PR TITLE
dnsdist: Fix two issues when building with `meson`

### DIFF
--- a/pdns/dnsdistdist/meson/libssl-providers/meson.build
+++ b/pdns/dnsdistdist/meson/libssl-providers/meson.build
@@ -5,7 +5,7 @@ if opt_libssl_providers
   if not opt_libssl.allowed()
     error('OpenSSL TLS providers requested but libssl is not enabled')
   endif
-  dep_libssl_3_later = dependency('libssl >= 3.0', required: false)
+  dep_libssl_3_later = dependency('libssl', version: '>= 3.0', required: false)
 
   if not dep_libssl_3_later.found()
     error('OpenSSL TLS providers requested but libssl is not >= 3.0')

--- a/pdns/dnsdistdist/meson/quiche/meson.build
+++ b/pdns/dnsdistdist/meson/quiche/meson.build
@@ -15,6 +15,18 @@ if (opt_quic.allowed() or opt_doh3.allowed()) and opt_libquiche.allowed()
   else
     dep_libquiche = dependency('quiche', version: '>= 0.15.0', required: opt_libquiche.enabled() or opt_quic.enabled() or opt_doh3.enabled())
   endif
+
+  if dep_libquiche.found()
+    funcs = [
+      'quiche_conn_server_name',
+    ]
+
+    foreach func: funcs
+      has = cxx.has_function(func, dependencies: dep_libquiche)
+      conf.set('HAVE_' + func.to_upper(), has, description: 'Have Quiche ' + func)
+    endforeach
+  endif
+
 else
   dep_libquiche = dependency('', required: false)
 endif

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -203,7 +203,7 @@ std::pair<bool, std::string> libssl_load_provider(const std::string& providerNam
 }
 #endif /* HAVE_LIBSSL && OPENSSL_VERSION_MAJOR >= 3 && HAVE_TLS_PROVIDERS */
 
-#if defined(HAVE_LIBSSL) && !HAVE_TLS_PROVIDERS
+#if defined(HAVE_LIBSSL) && !defined(HAVE_TLS_PROVIDERS)
 std::pair<bool, std::string> libssl_load_engine([[maybe_unused]] const std::string& engineName, [[maybe_unused]] const std::optional<std::string>& defaultString)
 {
 #if defined(OPENSSL_NO_ENGINE)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
@romeroalx spotted two issues when trying to run our regression tests with meson:
- we forgot to check for the availability of `quiche_conn_server_name` when we migrated from `autotools` to `meson`
- the OpenSSL version check done when providers are enabled did not use the correct syntax

Many thanks!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
