### PR TITLE
[tools] Let pdnsutil always setup a SOA-EDIT-API metadata when creating zones

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -41,6 +41,10 @@ A few changes of behaviour have been implemented in :doc:`pdnsutil <pdnsutil>`.
 * The ``add-record``, ``delete-rrset``, ``edit-zone``, ``increase-serial`` and
   ``replace-rrset`` operations will now refuse to work on secondary zones unless
   the ``--force`` option is passed.
+* When a zone gets created with either ``create-zone``,
+  ``create-secondary-zone`` or ``load-zone`` (if the zone wasn't existing
+  already), a :ref:`metadata-soa-edit-api` metadata with a value of ``DEFAULT``
+  will be added to the zone.
 
 4.8.0 to 4.9.0
 --------------

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1539,6 +1539,21 @@ static int zonemdVerifyFile(const DNSName& zone, const string& fname) {
   return EXIT_FAILURE;
 }
 
+// Wrapper around UeberBackend::createDomain, which will also set up the
+// default metadata, matching the behaviour of the REST API.
+static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const DNSName& zone, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries)
+{
+  backend.createDomain(zone, kind, primaries, "");
+  if (!backend.getDomainInfo(zone, info)) {
+    cerr << "Zone '" << zone << "' was not created!" << endl;
+    return false;
+  }
+  info.backend->startTransaction(zone, static_cast<int>(info.id));
+  info.backend->setDomainMetadataOne(zone, "SOA-EDIT-API", "DEFAULT");
+  info.backend->commitTransaction();
+  return true;
+}
+
 static int loadZone(const DNSName& zone, const string& fname) {
   UtilBackend B; //NOLINT(readability-identifier-length)
   DomainInfo di;
@@ -1553,10 +1568,7 @@ static int loadZone(const DNSName& zone, const string& fname) {
       return EXIT_FAILURE;
     }
     cerr<<"Creating '"<<zone<<"'"<<endl;
-    B.createDomain(zone, DomainInfo::Native, vector<ComboAddress>(), "");
-
-    if(!B.getDomainInfo(zone, di)) {
-      cerr << "Zone '" << zone << "' was not created." << endl;
+    if (!createZoneWithDefaults(B, di, zone, DomainInfo::Native, vector<ComboAddress>())) {
       return EXIT_FAILURE;
     }
   }
@@ -1637,9 +1649,7 @@ static int createZone(const DNSName &zone, const DNSName& nsname) {
   rr.content = makeSOAContent(sd)->getZoneRepresentation(true);
 
   cerr<<"Creating empty zone '"<<zone<<"'"<<endl;
-  B.createDomain(zone, DomainInfo::Native, vector<ComboAddress>(), "");
-  if(!B.getDomainInfo(zone, di)) {
-    cerr << "Zone '" << zone << "' was not created!" << endl;
+  if (!createZoneWithDefaults(B, di, zone, DomainInfo::Native, vector<ComboAddress>())) {
     return EXIT_FAILURE;
   }
 
@@ -3195,8 +3205,7 @@ static int createSecondaryZone(vector<string>& cmds, const std::string_view syno
     primaries.emplace_back(cmds.at(i), 53);
   }
   cerr << "Creating secondary zone '" << zone << "', with primaries '" << comboAddressVecToString(primaries) << "'" << endl;
-  B.createDomain(zone, DomainInfo::Secondary, primaries, "");
-  if(!B.getDomainInfo(zone, di)) {
+  if (!createZoneWithDefaults(B, di, zone, DomainInfo::Secondary, primaries)) {
     cerr << "Zone '" << zone << "' was not created!" << endl;
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
### Short description
This is a fix for #9096. Every time `pdnsutil` will create a zone, it will now put a `SOA-EDIT-API` metadata with a value of `DEFAULT`, to match what creating the zone from the API would have done.

Ok, I lied, not every time. When migrating using `pdnsutil b2b-migrate`, this will not be done, as this operation will copy all the existing metadata from the source (which may, on purpose, not have a `SOA-EDIT-API` metadata).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)