### PR TITLE
rec: Fix a typo in the FWCatz regression tests

### DIFF
--- a/regression-tests.recursor-dnssec/test_FWCatz.py
+++ b/regression-tests.recursor-dnssec/test_FWCatz.py
@@ -299,7 +299,7 @@ recursor:
             except Exception as e:
                 ex = e
             attempts = attempts + 1
-            sleep(0.1)
+            time.sleep(0.1)
         if ex is not None:
             raise ex
         raise AssertionError('expected content not found')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Observed on GH actions:
```
  test_FWCatz.py:353:
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

  self = <test_FWCatz.FWCatzXFRRecursorTest testMethod=testFWCatz>
  expected = {'forward_zones': [{'forwarders': ['1.2.3.4'], 'zone': 'c.'}]}

      def checkForwards(self, expected):
          attempts = 0
          tries = 10
          ex = None
          while attempts < tries:
              try:
                  with open('configs/' + self._confdir + '/catzone.forward.catz.') as file:
                      reality = yaml.safe_load(file);
                      if expected == reality:
                          return
              except Exception as e:
                  ex = e
              attempts = attempts + 1
  >           sleep(0.1)
  E           NameError: name 'sleep' is not defined
```


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
