### PR TITLE
rec: add a Lua function to get the config dir and name

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/functions.rst
+++ b/pdns/recursordist/docs/lua-scripting/functions.rst
@@ -65,3 +65,9 @@ These are some functions that don't really have a place in one of the other cate
    Note that setting both limits to zero can produce very large strings. It is wise to set at least one of the limits.
    Additionally, setting ``maxSize`` to zero can lead to less efficient memory management while producing the dump.
 
+.. function:: getConfigDirAndName() -> str, str
+
+   .. versionadded:: 5.2.3
+
+   Get the configuration directory and the instance name.
+   These two values correspond to the :ref:`setting-yaml-recursor.config_dir` and :ref:`setting-yaml-recursor.config_name` settings.

--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -33,6 +33,7 @@
 #include "filterpo.hh"
 #include "rec-snmp.hh"
 #include "rec-main.hh"
+#include "arguments.hh"
 
 boost::optional<dnsheader> RecursorLua4::DNSQuestion::getDH() const
 {
@@ -513,6 +514,13 @@ void RecursorLua4::postPrepareContext() // NOLINT(readability-function-cognitive
       log->info(Logr::Notice, "Lua thread exiting");
     });
     thread.detach();
+  });
+
+  d_lw->writeFunction("getConfigDirAndName", []() -> std::tuple<std::string, std::string> {
+      std::string dir = ::arg()["config-dir"];
+      cleanSlashes(dir);
+      std::string name = ::arg()["config-name"];
+      return {dir, name};
   });
 
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Add a Lua function to get the config directory and config name.

Handy for defining a more complex Lua configuration.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
