### PR TITLE
dnsdist: Support DSCP marking towards downstream server

### DIFF
--- a/.github/actions/spell-check/allow.txt
+++ b/.github/actions/spell-check/allow.txt
@@ -864,6 +864,8 @@ drsoa
 dsa
 DSANSEC
 dsc
+dscp
+DSCP
 dsdelegation
 dsdigestalgorithm
 dses

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -140,6 +140,7 @@ bool DownstreamState::reconnect(bool initialAttempt)
     }
 
     try {
+      setDscp(fd, d_config.remote.sin4.sin_family, d_config.dscp);
       SConnect(fd, d_config.remote);
       if (sockets.size() > 1) {
         (*mplexer.lock())->addReadFD(fd, [](int, boost::any) {});

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -487,6 +487,8 @@ static std::shared_ptr<DownstreamState> createBackendFromConfiguration(const dns
     tlsCtx = getTLSContext(backendConfig.d_tlsParams);
   }
 
+  backendConfig.dscp = config.dscp;
+
   auto downstream = std::make_shared<DownstreamState>(std::move(backendConfig), std::move(tlsCtx), !configCheck);
 
 #if defined(HAVE_XSK)
@@ -506,8 +508,6 @@ static std::shared_ptr<DownstreamState> createBackendFromConfiguration(const dns
   if (autoUpgradeConf.enabled && downstream->getProtocol() != dnsdist::Protocol::DoT && downstream->getProtocol() != dnsdist::Protocol::DoH) {
     dnsdist::ServiceDiscovery::addUpgradeableServer(downstream, autoUpgradeConf.interval, std::string(autoUpgradeConf.pool), autoUpgradeConf.doh_key, autoUpgradeConf.keep);
   }
-
-  backendConfig.dscp = config.dscp;
 
   return downstream;
 }

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -507,6 +507,8 @@ static std::shared_ptr<DownstreamState> createBackendFromConfiguration(const dns
     dnsdist::ServiceDiscovery::addUpgradeableServer(downstream, autoUpgradeConf.interval, std::string(autoUpgradeConf.pool), autoUpgradeConf.doh_key, autoUpgradeConf.keep);
   }
 
+  backendConfig.dscp = config.dscp;
+
   return downstream;
 }
 

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -503,6 +503,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
                          getOptionalValue<bool>(vars, "enableRenegotiation", config.d_tlsParams.d_enableRenegotiation);
                          getOptionalValue<bool>(vars, "ktls", config.d_tlsParams.d_ktls);
                          getOptionalValue<std::string>(vars, "subjectName", config.d_tlsSubjectName);
+                         getOptionalIntegerValue("newServer", vars, "dscp", config.dscp);
 
                          if (vars->count("keyLogFile") > 0) {
 #ifdef HAVE_SSL_CTX_SET_KEYLOG_CALLBACK

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/src/lib.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/src/lib.rs
@@ -1844,6 +1844,8 @@ mod dnsdistsettings {
         cpus: String,
         #[serde(default, skip_serializing_if = "crate::is_default")]
         xsk: String,
+        #[serde(default, skip_serializing_if = "crate::is_default")]
+        dscp: u8,
     }
 
     #[derive(Deserialize, Serialize, Debug, PartialEq)]

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1425,6 +1425,10 @@ backend:
       type: "String"
       default: ""
       description: "The name of an XSK sockets map to attach to this frontend, if any"
+    - name: "dscp"
+      type: "u8"
+      default: 0
+      description: "The DSCP marking value to be applied. Range 0-63. Default is 0 which means no action for DSCP marking."
 
 tuning:
   description: "Tuning settings"

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -81,6 +81,7 @@ bool ConnectionToBackend::reconnect()
          the other end to acknowledge our initial packet before we could
          send the rest. */
       setTCPNoDelay(socket.getHandle());
+      setDscp(socket.getHandle(), d_ds->d_config.remote.sin4.sin_family, d_ds->d_config.dscp);
 
 #ifdef SO_BINDTODEVICE
       if (!d_ds->d_config.sourceItfName.empty()) {

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -592,6 +592,7 @@ struct DownstreamState : public std::enable_shared_from_this<DownstreamState>
     uint8_t maxCheckFailures{1};
     uint8_t minRiseSuccesses{1};
     uint8_t udpTimeout{0};
+    uint8_t dscp{0};
     Availability availability{Availability::Auto};
     bool d_tlsSubjectIsAddr{false};
     bool mustResolve{false};

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -759,6 +759,7 @@ Servers
     ``xskSockets``                            ``array``            "An array of :class:`XskSocket` objects to enable ``XSK`` / ``AF_XDP`` support for this backend. See :doc:`../advanced/xsk` for more information."
     ``MACAddr``                              ``str``               "When the ``xskSocket`` option is set, this parameter can be used to specify the destination MAC address to use to reach the backend. If this options is not specified, dnsdist will try to get it from the IP of the backend by looking into the system's MAC address table, but it will fail if the corresponding MAC address is not present."
     ``keyLogFile``                           ``str``               "Write the TLS keys in the specified file so that an external program can decrypt TLS exchanges, in the format described in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format. Note that this feature requires OpenSSL >= 1.1.1."
+    ``dscp``                                 ``number``            "The DSCP marking value to be applied. Range 0-63. Default is 0 which means no action for DSCP marking."
 
 .. function:: getServer(index) -> Server
 

--- a/pdns/dnsdistdist/docs/reference/yaml-settings.rst
+++ b/pdns/dnsdistdist/docs/reference/yaml-settings.rst
@@ -101,6 +101,7 @@ Generic settings for backends
 - **mac_address**: String ``("")`` - When the ``xsk`` option is set, this parameter can be used to specify the destination MAC address to use to reach the backend. If this options is not specified, dnsdist will try to get it from the IP of the backend by looking into the system's MAC address table, but it will fail if the corresponding MAC address is not present
 - **cpus**: String ``("")`` - Set the CPU affinity for this thread, asking the scheduler to run it on a single CPU id, or a set of CPU ids. This parameter is only available if the OS provides the ``pthread_setaffinity_np()`` function
 - **xsk**: String ``("")`` - The name of an XSK sockets map to attach to this frontend, if any
+- **dscp**: Unsigned integer ``(0)`` - The DSCP marking value to be applied. Range 0-63. Default is 0 which means no action for DSCP marking.
 
 
 .. _yaml-settings-BindConfiguration:

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1082,6 +1082,36 @@ bool setReuseAddr(int sock)
   return true;
 }
 
+void setDscp(int sock, unsigned short family, uint8_t dscp)
+{
+  int val;
+  unsigned int len;
+
+  if (dscp == 0 || dscp > 63) {
+    // No DSCP marking
+    return;
+  }
+
+  if (family == AF_INET) {
+    if (getsockopt(sock, IPPROTO_IP, IP_TOS, &val, &len)<0) {
+      throw std::runtime_error(string("Set DSCP failed: ")+stringerror());
+    }
+    val = (dscp<<2) | (val&0x3);
+    if (setsockopt(sock, IPPROTO_IP, IP_TOS, &val, sizeof(val))<0) {
+      throw std::runtime_error(string("Set DSCP failed: ")+stringerror());
+    }
+  }
+  else if (family == AF_INET6) {
+    if (getsockopt(sock, IPPROTO_IPV6, IPV6_TCLASS, &val, &len)<0) {
+      throw std::runtime_error(string("Set DSCP failed: ")+stringerror());
+    }
+    val = (dscp<<2) | (val&0x3);
+    if (setsockopt(sock, IPPROTO_IPV6, IPV6_TCLASS, &val, sizeof(val))<0) {
+      throw std::runtime_error(string("Set DSCP failed: ")+stringerror());
+    }
+  }
+}
+
 bool isNonBlocking(int sock)
 {
   int flags=fcntl(sock,F_GETFL,0);

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1084,8 +1084,8 @@ bool setReuseAddr(int sock)
 
 void setDscp(int sock, unsigned short family, uint8_t dscp)
 {
-  int val;
-  unsigned int len;
+  int val = 0;
+  unsigned int len = 0;
 
   if (dscp == 0 || dscp > 63) {
     // No DSCP marking

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -593,6 +593,8 @@ bool setSocketTimestamps(int fd);
 //! Sets the socket into blocking mode.
 bool setBlocking( int sock );
 
+void setDscp(int sock, unsigned short family, uint8_t dscp);
+
 //! Sets the socket into non-blocking mode.
 bool setNonBlocking( int sock );
 bool setTCPNoDelay(int sock);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Some users would want to setup DSCP marking for DNS packets according to its network engineering needs. This PR is to provide such a configurable capability.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
