### PR TITLE
If SONAME is present in the generated quiche lib set it to the correct value

### DIFF
--- a/builder-support/helpers/install_quiche.sh
+++ b/builder-support/helpers/install_quiche.sh
@@ -46,7 +46,7 @@ RUST_BACKTRACE=1 cargo build --release --no-default-features --features ffi,bori
 # packaged rustc puts it in anyway.
 # See (https://sources.debian.org/patches/rustc/1.85.0%2Bdfsg2-3/behaviour/d-rustc-add-soname.patch/).
 # So if it is present, patch it to the correct name.
-if objdump -p target/release/libquiche.${SOEXT} | fgrep -q SONAME
+if objdump -p target/release/libquiche.${SOEXT} | grep -F -q SONAME
 then
   patchelf --set-soname libdnsdist-quiche.so target/release/libquiche.${SOEXT}
 fi

--- a/builder-support/helpers/install_quiche.sh
+++ b/builder-support/helpers/install_quiche.sh
@@ -42,6 +42,15 @@ sed -i 's/ffi = \["dep:cdylib-link-lines"\]/ffi = \[\]/' quiche/Cargo.toml
 sed -i 's,cdylib_link_lines::metabuild();,//cdylib_link_lines::metabuild();,' quiche/src/build.rs
 RUST_BACKTRACE=1 cargo build --release --no-default-features --features ffi,boringssl-boring-crate --package quiche
 
+# While we tried to get rid of the SONAME in libquiche.so, on debian trixie's
+# packaged rustc puts it in anyway.
+# See (https://sources.debian.org/patches/rustc/1.85.0%2Bdfsg2-3/behaviour/d-rustc-add-soname.patch/).
+# So if it is present, patch it to the correct name.
+if objdump -p target/release/libquiche.${SOEXT} | fgrep -q SONAME
+then
+  patchelf --set-soname libdnsdist-quiche.so target/release/libquiche.${SOEXT}
+fi
+
 install -m644 quiche/include/quiche.h "${INSTALL_PREFIX}"/include
 install -m644 target/release/libquiche.${SOEXT} "${LIBDIR}"/libdnsdist-quiche.${SOEXT}
 


### PR DESCRIPTION
This is needed as we rename the file. We try to not include the SONAME, but some systems include it anyway.

Fixes #15427

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
