### PR TITLE
[evil] ZoneName, step 2

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -286,7 +286,7 @@ bool Bind2Backend::feedRecord(const DNSResourceRecord& rr, const DNSName& /* ord
     qname = rr.qname.toString();
   }
   else if (rr.qname.isPartOf(d_transaction_qname)) {
-    if (rr.qname == d_transaction_qname) {
+    if (rr.qname == d_transaction_qname.operator const DNSName&()) {
       qname = "@";
     }
     else {
@@ -823,7 +823,7 @@ void Bind2Backend::fixupOrderAndAuth(std::shared_ptr<recordstorage_t>& records, 
 
     if (!skip && nsec3zone && iter->qtype != QType::RRSIG && (iter->auth || (iter->qtype == QType::NS && (ns3pr.d_flags == 0u)) || (dssets.count(iter->qname) != 0u))) {
       Bind2DNSRecord bdr = *iter;
-      bdr.nsec3hash = toBase32Hex(hashQNameWithSalt(ns3pr, bdr.qname + zoneName));
+      bdr.nsec3hash = toBase32Hex(hashQNameWithSalt(ns3pr, bdr.qname + zoneName.operator const DNSName&()));
       records->replace(iter, bdr);
     }
 
@@ -874,7 +874,7 @@ void Bind2Backend::doEmptyNonTerminals(std::shared_ptr<recordstorage_t>& records
   rr.ttl = 0;
   for (auto& nt : nonterm) {
     string hashed;
-    rr.qname = nt.first + zoneName;
+    rr.qname = nt.first + zoneName.operator const DNSName&();
     if (nsec3zone && nt.second)
       hashed = toBase32Hex(hashQNameWithSalt(ns3pr, rr.qname));
     insertRecord(records, zoneName, rr.qname, rr.qtype, rr.content, rr.ttl, hashed, &nt.second);
@@ -1143,7 +1143,7 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qn
         iter = --hashindex.end();
       before = DNSName(iter->nsec3hash);
     }
-    unhashed = iter->qname + bbd.d_name;
+    unhashed = iter->qname + bbd.d_name.operator const DNSName&();
 
     return true;
   }
@@ -1168,7 +1168,7 @@ void Bind2Backend::lookup(const QType& qtype, const DNSName& qname, int zoneId, 
     }
   }
   else {
-    domain = qname;
+    domain = ZoneName(qname);
     do {
       found = safeGetBBDomainInfo(domain, &bbd);
     } while (!found && qtype != QType::SOA && domain.chopOff());
@@ -1275,7 +1275,8 @@ bool Bind2Backend::handle::get_normal(DNSResourceRecord& r)
   }
   DLOG(g_log << "Bind2Backend get() returning a rr with a " << QType(d_iter->qtype).getCode() << endl);
 
-  r.qname = qname.empty() ? domain : (qname + domain);
+  const DNSName& domainName(domain);
+  r.qname = qname.empty() ? domainName : (qname + domainName);
   r.domain_id = id;
   r.content = (d_iter)->content;
   //  r.domain_id=(d_iter)->domain_id;
@@ -1319,7 +1320,8 @@ bool Bind2Backend::list(const ZoneName& /* target */, int domainId, bool /* incl
 bool Bind2Backend::handle::get_list(DNSResourceRecord& r)
 {
   if (d_qname_iter != d_qname_end) {
-    r.qname = d_qname_iter->qname.empty() ? domain : (d_qname_iter->qname + domain);
+    const DNSName& domainName(domain);
+    r.qname = d_qname_iter->qname.empty() ? domainName : (d_qname_iter->qname + domainName);
     r.domain_id = id;
     r.content = (d_qname_iter)->content;
     r.qtype = (d_qname_iter)->qtype;
@@ -1475,7 +1477,8 @@ bool Bind2Backend::searchRecords(const string& pattern, size_t maxResults, vecto
       shared_ptr<const recordstorage_t> rhandle = h.d_records.get();
 
       for (recordstorage_t::const_iterator ri = rhandle->begin(); result.size() < maxResults && ri != rhandle->end(); ri++) {
-        DNSName name = ri->qname.empty() ? i.d_name : (ri->qname + i.d_name);
+        const DNSName& domainName(i.d_name);
+        DNSName name = ri->qname.empty() ? domainName : (ri->qname + domainName);
         if (sm.match(name) || sm.match(ri->content)) {
           DNSResourceRecord r;
           r.qname = std::move(name);

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -219,11 +219,11 @@ bool GeoIPBackend::loadDomain(const YAML::Node& domain, std::uint32_t domainID, 
 {
   try {
     dom.id = domainID;
-    dom.domain = DNSName(domain["domain"].as<string>());
+    dom.domain = ZoneName(domain["domain"].as<string>());
     dom.ttl = domain["ttl"].as<int>();
 
     for (auto recs = domain["records"].begin(); recs != domain["records"].end(); recs++) {
-      DNSName qname = DNSName(recs->first.as<string>());
+      ZoneName qname = ZoneName(recs->first.as<string>());
       vector<GeoIPDNSResourceRecord> rrs;
 
       for (auto item = recs->second.begin(); item != recs->second.end(); item++) {
@@ -231,7 +231,7 @@ bool GeoIPBackend::loadDomain(const YAML::Node& domain, std::uint32_t domainID, 
         GeoIPDNSResourceRecord rr;
         rr.domain_id = static_cast<int>(dom.id);
         rr.ttl = dom.ttl;
-        rr.qname = qname;
+        rr.qname = qname.operator const DNSName&();
         if (rec->first.IsNull()) {
           rr.qtype = QType(0);
         }
@@ -276,7 +276,7 @@ bool GeoIPBackend::loadDomain(const YAML::Node& domain, std::uint32_t domainID, 
         rr.auth = true;
         rrs.push_back(rr);
       }
-      std::swap(dom.records[qname], rrs);
+      std::swap(dom.records[qname.operator const DNSName&()], rrs);
     }
 
     setupNetmasks(domain, dom);

--- a/modules/ldapbackend/native.cc
+++ b/modules/ldapbackend/native.cc
@@ -28,7 +28,7 @@ bool LdapBackend::list(const ZoneName& target, int domain_id, bool /* include_di
 {
   try {
     d_in_list = true;
-    d_qname = target;
+    d_qname = target.operator const DNSName&();
     d_qtype = QType::ANY;
     d_results_cache.clear();
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -856,6 +856,44 @@ namespace serialization
   }
 
   template <class Archive>
+  void save(Archive& arc, const ZoneName& zone, const unsigned int /* version */)
+  {
+    // Because ZoneName is an object containing a single DNSName field,
+    // we can't naively write
+    //   arc & zone.operator const DNSName&();
+    // because the serialization actually writes the class version number in
+    // front of our provided serialization, thus causing it to be larger than
+    // the DNSName serialization. In order to remain interoperable with
+    // existing serializations, we skip the DNSName's own version number and
+    // directly serialize its contents.
+    const DNSName& name = zone.operator const DNSName&();
+    if (name.empty()) {
+      arc& std::string(); // it's arc.operator& but clang-format is confused here
+    }
+    else {
+      arc & name.toDNSStringLC();
+    }
+  }
+
+  template <class Archive>
+  void load(Archive& arc, ZoneName& zone, const unsigned int /* version */)
+  {
+    // Similarly to save() above, we can't write
+    //   DNSName tmp;
+    //   arc & tmp;
+    //   zone = ZoneName(tmp);
+    // but have to reconstruct a DNSName from a string.
+    string tmp;
+    arc & tmp;
+    if (tmp.empty()) {
+      zone = ZoneName();
+    }
+    else {
+      zone = ZoneName(DNSName(tmp.c_str(), tmp.size(), 0, false));
+    }
+  }
+
+  template <class Archive>
   void save(Archive& ar, const QType& g, const unsigned int /* version */)
   {
     ar & g.getCode();
@@ -939,6 +977,7 @@ namespace serialization
 } // namespace boost
 
 BOOST_SERIALIZATION_SPLIT_FREE(DNSName);
+BOOST_SERIALIZATION_SPLIT_FREE(ZoneName);
 BOOST_SERIALIZATION_SPLIT_FREE(QType);
 BOOST_SERIALIZATION_SPLIT_FREE(LMDBBackend::KeyDataDB);
 BOOST_SERIALIZATION_SPLIT_FREE(DomainInfo);
@@ -1490,7 +1529,7 @@ void LMDBBackend::lookupInternal(const QType& type, const DNSName& qdomain, int 
 
   d_includedisabled = include_disabled;
 
-  DNSName hunt(qdomain);
+  ZoneName hunt(qdomain);
   DomainInfo di;
   if (zoneId < 0) {
     auto rotxn = d_tdomains->getROTransaction();
@@ -1587,7 +1626,7 @@ bool LMDBBackend::get(DNSZoneRecord& zr)
 
       zr.disabled = lrr.disabled;
       if (!zr.disabled || d_includedisabled) {
-        zr.dr.d_name = compoundOrdername::getQName(key) + d_lookupdomain;
+        zr.dr.d_name = compoundOrdername::getQName(key) + d_lookupdomain.operator const DNSName&();
         zr.domain_id = compoundOrdername::getDomainID(key);
         zr.dr.d_type = compoundOrdername::getQType(key).getCode();
         zr.dr.d_ttl = lrr.ttl;
@@ -1877,7 +1916,7 @@ void LMDBBackend::getUpdatedPrimaries(vector<DomainInfo>& updatedDomains, std::u
     }
 
     if (di.kind == DomainInfo::Producer) {
-      catalogs.insert(di.zone);
+      catalogs.insert(di.zone.operator const DNSName&());
       catalogHashes[di.zone].process("\0");
       return false; // Producer fresness check is performed elsewhere
     }
@@ -2155,7 +2194,7 @@ bool LMDBBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qna
       }
     }
     before = co.getQName(key.getNoStripHeader<StringView>());
-    unhashed = DNSName(lrr.content.c_str(), lrr.content.size(), 0, false) + di.zone;
+    unhashed = DNSName(lrr.content.c_str(), lrr.content.size(), 0, false) + di.zone.operator const DNSName&();
 
     // now to find after .. at the beginning of the zone
     if (cursor.lower_bound(co(id), key, val)) {
@@ -2253,7 +2292,7 @@ bool LMDBBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qna
           }
         }
         before = co.getQName(key.getNoStripHeader<StringView>());
-        unhashed = DNSName(lrr.content.c_str(), lrr.content.size(), 0, false) + di.zone;
+        unhashed = DNSName(lrr.content.c_str(), lrr.content.size(), 0, false) + di.zone.operator const DNSName&();
         // cout <<"Should still find 'after'!"<<endl;
         // for 'after', we need to find the first hash of this zone
 
@@ -2283,7 +2322,7 @@ bool LMDBBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qna
       ++count;
     }
     before = co.getQName(key.getNoStripHeader<StringView>());
-    unhashed = DNSName(lrr.content.c_str(), lrr.content.size(), 0, false) + di.zone;
+    unhashed = DNSName(lrr.content.c_str(), lrr.content.size(), 0, false) + di.zone.operator const DNSName&();
     // cout<<"Went backwards, found "<<before<<endl;
     // return us to starting point
     while (count--)
@@ -2347,8 +2386,8 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
     // cout << "Hit end of database, bummer"<<endl;
     cursor.last(key, val);
     if (compoundOrdername::getDomainID(key.getNoStripHeader<string_view>()) == domainId) {
-      before = co.getQName(key.getNoStripHeader<string_view>()) + zonename;
-      after = zonename;
+      before = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
+      after = zonename.operator const DNSName&();
     }
     // else
     // cout << "We were at end of database, but this zone is not there?!"<<endl;
@@ -2358,7 +2397,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
 
   if (compoundOrdername::getQType(key.getNoStripHeader<string_view>()).getCode() != 0 && compoundOrdername::getDomainID(key.getNoStripHeader<string_view>()) == domainId && compoundOrdername::getQName(key.getNoStripHeader<string_view>()) == qname2) { // don't match ENTs
     // cout << "Had an exact match!"<<endl;
-    before = qname2 + zonename;
+    before = qname2 + zonename.operator const DNSName&();
     int rc;
     for (;;) {
       rc = cursor.next(key, val);
@@ -2375,16 +2414,16 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
     }
     if (rc != 0 || compoundOrdername::getDomainID(key.getNoStripHeader<string_view>()) != domainId) {
       // cout << "We hit the end of the zone or database. 'after' is apex" << endl;
-      after = zonename;
+      after = zonename.operator const DNSName&();
       return false;
     }
-    after = co.getQName(key.getNoStripHeader<string_view>()) + zonename;
+    after = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
     return true;
   }
 
   if (compoundOrdername::getDomainID(key.getNoStripHeader<string_view>()) != domainId) {
     // cout << "Ended up in next zone, 'after' is zonename" <<endl;
-    after = zonename;
+    after = zonename.operator const DNSName&();
     // cout << "Now hunting for previous" << endl;
     int rc;
     for (;;) {
@@ -2405,7 +2444,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
         break;
     }
 
-    before = co.getQName(key.getNoStripHeader<string_view>()) + zonename;
+    before = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
     // cout<<"Found: "<< before<<endl;
     return true;
   }
@@ -2417,7 +2456,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
     LMDBResourceRecord lrr;
     deserializeFromBuffer(val.get<StringView>(), lrr);
     if (co.getQType(key.getNoStripHeader<string_view>()).getCode() && (lrr.auth || co.getQType(key.getNoStripHeader<string_view>()).getCode() == QType::NS)) {
-      after = co.getQName(key.getNoStripHeader<string_view>()) + zonename;
+      after = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
       // cout <<"Found auth ("<<lrr.auth<<") or an NS record "<<after<<", type: "<<co.getQType(key.getNoStripHeader<string_view>()).toString()<<", ttl = "<<lrr.ttl<<endl;
       // cout << makeHexDump(val.get<string>()) << endl;
       break;
@@ -2428,7 +2467,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
       ++skips;
     if (rc != 0 || compoundOrdername::getDomainID(key.getNoStripHeader<string_view>()) != domainId) {
       // cout << "  oops, hit end of database or zone. This means after is apex" <<endl;
-      after = zonename;
+      after = zonename.operator const DNSName&();
       break;
     }
   }
@@ -2443,7 +2482,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
       // cout << "We hit the beginning of the zone or database.. now what" << endl;
       return false;
     }
-    before = co.getQName(key.getNoStripHeader<string_view>()) + zonename;
+    before = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
     LMDBResourceRecord lrr;
     deserializeFromBuffer(val.get<string_view>(), lrr);
     // cout<<"And before to "<<before<<", auth = "<<rr.auth<<endl;

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2386,7 +2386,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
     // cout << "Hit end of database, bummer"<<endl;
     cursor.last(key, val);
     if (compoundOrdername::getDomainID(key.getNoStripHeader<string_view>()) == domainId) {
-      before = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
+      before = compoundOrdername::getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
       after = zonename.operator const DNSName&();
     }
     // else
@@ -2417,7 +2417,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
       after = zonename.operator const DNSName&();
       return false;
     }
-    after = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
+    after = compoundOrdername::getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
     return true;
   }
 
@@ -2444,7 +2444,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
         break;
     }
 
-    before = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
+    before = compoundOrdername::getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
     // cout<<"Found: "<< before<<endl;
     return true;
   }
@@ -2456,7 +2456,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
     LMDBResourceRecord lrr;
     deserializeFromBuffer(val.get<StringView>(), lrr);
     if (co.getQType(key.getNoStripHeader<string_view>()).getCode() && (lrr.auth || co.getQType(key.getNoStripHeader<string_view>()).getCode() == QType::NS)) {
-      after = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
+      after = compoundOrdername::getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
       // cout <<"Found auth ("<<lrr.auth<<") or an NS record "<<after<<", type: "<<co.getQType(key.getNoStripHeader<string_view>()).toString()<<", ttl = "<<lrr.ttl<<endl;
       // cout << makeHexDump(val.get<string>()) << endl;
       break;
@@ -2482,7 +2482,7 @@ bool LMDBBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zone
       // cout << "We hit the beginning of the zone or database.. now what" << endl;
       return false;
     }
-    before = co.getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
+    before = compoundOrdername::getQName(key.getNoStripHeader<string_view>()) + zonename.operator const DNSName&();
     LMDBResourceRecord lrr;
     deserializeFromBuffer(val.get<string_view>(), lrr);
     // cout<<"And before to "<<before<<", auth = "<<rr.auth<<endl;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -56,6 +56,12 @@ std::string keyConv(const T& t)
   return ret;
 }
 
+template <class T, typename std::enable_if<std::is_same<T, ZoneName>::value, T>::type* = nullptr>
+std::string keyConv(const T& t)
+{
+  return keyConv(t.operator const DNSName&());
+}
+
 class LMDBBackend : public DNSBackend
 {
 public:

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -194,7 +194,7 @@ public:
       throw PDNSException("list attempted while another was running");
 
     logCall("list", "target=" << target << ",domain_id=" << domain_id);
-    list_result_t result = f_list(target, domain_id);
+    list_result_t result = f_list(target.operator const DNSName&(), domain_id);
 
     if (result.which() == 0)
       return false;
@@ -294,7 +294,7 @@ public:
     }
 
     logCall("get_domaininfo", "domain=" << domain);
-    get_domaininfo_result_t result = f_get_domaininfo(domain);
+    get_domaininfo_result_t result = f_get_domaininfo(domain.operator const DNSName&());
 
     if (result.which() == 0)
       return false;
@@ -313,7 +313,7 @@ public:
     logCall("get_all_domains", "");
     for (const auto& row : f_get_all_domains()) {
       DomainInfo di;
-      di.zone = row.first;
+      di.zone = ZoneName(row.first);
       logResult(di.zone);
       parseDomainInfo(row.second, di);
       domains->push_back(di);
@@ -326,7 +326,7 @@ public:
       return false;
 
     logCall("get_all_domain_metadata", "name=" << name);
-    get_all_domain_metadata_result_t result = f_get_all_domain_metadata(name);
+    get_all_domain_metadata_result_t result = f_get_all_domain_metadata(name.operator const DNSName&());
     if (result.which() == 0)
       return false;
 
@@ -346,7 +346,7 @@ public:
       return false;
 
     logCall("get_domain_metadata", "name=" << name << ",kind=" << kind);
-    get_domain_metadata_result_t result = f_get_domain_metadata(name, kind);
+    get_domain_metadata_result_t result = f_get_domain_metadata(name.operator const DNSName&(), kind);
     if (result.which() == 0)
       return false;
 
@@ -364,7 +364,7 @@ public:
       return false;
 
     logCall("get_domain_keys", "name=" << name);
-    get_domain_keys_result_t result = f_get_domain_keys(name);
+    get_domain_keys_result_t result = f_get_domain_keys(name.operator const DNSName&());
 
     if (result.which() == 0)
       return false;

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -178,7 +178,7 @@ public:
   bool getDomainKeys(const ZoneName& name, std::vector<DNSBackend::KeyData>& keys) override;
   bool getTSIGKey(const DNSName& name, DNSName& algorithm, std::string& content) override;
   bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
-  bool setDomainMetadata(const DNSName& name, const string& kind, const std::vector<std::basic_string<char>>& meta) override;
+  bool setDomainMetadata(const ZoneName& name, const string& kind, const std::vector<std::basic_string<char>>& meta) override;
   bool removeDomainKey(const ZoneName& name, unsigned int keyId) override;
   bool addDomainKey(const ZoneName& name, const KeyData& key, int64_t& keyId) override;
   bool activateDomainKey(const ZoneName& name, unsigned int keyId) override;

--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -244,7 +244,7 @@ bool TinyDNSBackend::list(const ZoneName& target, int /* domain_id */, bool /* i
 {
   d_isAxfr = true;
   d_isGetDomains = false;
-  string key = target.toDNSStringLC();
+  string key = target.operator const DNSName&().toDNSStringLC();
   try {
     d_cdbReader = std::make_unique<CDB>(getArg("dbfile"));
   }

--- a/pdns/auth-catalogzone.cc
+++ b/pdns/auth-catalogzone.cc
@@ -116,7 +116,7 @@ void CatalogInfo::updateHash(CatalogHashMap& hashes, const DomainInfo& di) const
 DNSZoneRecord CatalogInfo::getCatalogVersionRecord(const ZoneName& zone)
 {
   DNSZoneRecord dzr;
-  dzr.dr.d_name = DNSName("version") + zone;
+  dzr.dr.d_name = DNSName("version") + zone.operator const DNSName&();
   dzr.dr.d_ttl = 0;
   dzr.dr.d_type = QType::TXT;
   dzr.dr.setContent(std::make_shared<TXTRecordContent>("2"));
@@ -132,7 +132,7 @@ void CatalogInfo::toDNSZoneRecords(const ZoneName& zone, vector<DNSZoneRecord>& 
   else {
     prefix = d_unique;
   }
-  prefix += DNSName("zones") + zone;
+  prefix += DNSName("zones") + zone.operator const DNSName&();
 
   DNSZoneRecord dzr;
   dzr.dr.d_name = prefix;

--- a/pdns/auth-catalogzone.hh
+++ b/pdns/auth-catalogzone.hh
@@ -60,7 +60,7 @@ public:
   void setType(CatalogType type) { d_type = type; }
 
   void updateHash(CatalogHashMap& hashes, const DomainInfo& di) const;
-  DNSName getUnique() const { return DNSName(toBase32Hex(hashQNameWithSalt(std::to_string(d_id), 0, d_zone))); } // salt with domain id to detect recreated zones
+  DNSName getUnique() const { return DNSName(toBase32Hex(hashQNameWithSalt(std::to_string(d_id), 0, DNSName(d_zone)))); } // salt with domain id to detect recreated zones
   static DNSZoneRecord getCatalogVersionRecord(const ZoneName& zone);
   void toDNSZoneRecords(const ZoneName& zone, vector<DNSZoneRecord>& dzrs) const;
 

--- a/pdns/auth-primarycommunicator.cc
+++ b/pdns/auth-primarycommunicator.cc
@@ -53,7 +53,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
 
   try {
     if (d_onlyNotify.size()) {
-      B->lookup(QType(QType::NS), di.zone, di.id);
+      B->lookup(QType(QType::NS), di.zone.operator const DNSName&(), di.id);
       while (B->get(rr))
         nsset.insert(getRR<NSRecordContent>(rr.dr)->getNS());
 
@@ -139,7 +139,7 @@ void CommunicatorClass::getUpdatedProducers(UeberBackend* B, vector<DomainInfo>&
   std::string metaHash;
   std::string mapHash;
   for (auto& ch : catalogHashes) {
-    if (!catalogs.count(ch.first)) {
+    if (!catalogs.count(ch.first.operator const DNSName&())) {
       g_log << Logger::Warning << "orphaned member zones found with catalog '" << ch.first << "'" << endl;
       continue;
     }
@@ -169,7 +169,7 @@ void CommunicatorClass::getUpdatedProducers(UeberBackend* B, vector<DomainInfo>&
 
         DNSResourceRecord rr;
         makeIncreasedSOARecord(sd, "EPOCH", "", rr);
-        di.backend->startTransaction(sd.qname, -1);
+        di.backend->startTransaction(ZoneName(sd.qname), -1);
         if (!di.backend->replaceRRSet(di.id, rr.qname, rr.qtype, vector<DNSResourceRecord>(1, rr))) {
           di.backend->abortTransaction();
           throw PDNSException("backend hosting producer zone '" + sd.qname.toLogString() + "' does not support editing records");
@@ -202,7 +202,7 @@ void CommunicatorClass::primaryUpdateCheck(PacketHandler* P)
   }
 
   for (auto& di : cmdomains) {
-    purgeAuthCachesExact(di.zone);
+    purgeAuthCachesExact(di.zone.operator const DNSName&());
     g_zoneCache.add(di.zone, di.id);
     queueNotifyDomain(di, B);
     di.backend->setNotified(di.id, di.serial);
@@ -237,7 +237,7 @@ time_t CommunicatorClass::doNotifications(PacketHandler* P)
       g_log << Logger::Warning << "Received unsuccessful notification report for '" << p.qdomain << "' from " << from.toStringWithPort() << ", error: " << RCode::to_s(p.d.rcode) << endl;
     }
 
-    if (d_nq.removeIf(from, p.d.id, p.qdomain)) {
+    if (d_nq.removeIf(from, p.d.id, ZoneName(p.qdomain))) {
       g_log << Logger::Notice << "Removed from notification list: '" << p.qdomain << "' to " << from.toStringWithPort() << " " << (p.d.rcode ? RCode::to_s(p.d.rcode) : "(was acknowledged)") << endl;
     }
     else {
@@ -293,7 +293,7 @@ void CommunicatorClass::sendNotification(int sock, const ZoneName& domain, const
   }
 
   vector<uint8_t> packet;
-  DNSPacketWriter pw(packet, domain, QType::SOA, 1, Opcode::Notify);
+  DNSPacketWriter pw(packet, domain.operator const DNSName&(), QType::SOA, 1, Opcode::Notify);
   pw.getHeader()->id = notificationId;
   pw.getHeader()->aa = true;
 

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -87,6 +87,7 @@ struct ZoneStatus
   size_t numDeltas{0};
 };
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static bool catalogDiff(const DomainInfo& di, vector<CatalogInfo>& fromXFR, vector<CatalogInfo>& fromDB, const string& logPrefix)
 {
   extern CommunicatorClass Communicator;
@@ -483,6 +484,7 @@ void CommunicatorClass::ixfrSuck(const ZoneName& domain, const TSIGTriplet& tsig
         vector<DNSRecord> rrset;
         {
           DNSZoneRecord zrr;
+          // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
           di.backend->lookup(QType(g.first.second), g.first.first.operator const DNSName&() + domain.operator const DNSName&(), di.id);
           while (di.backend->get(zrr)) {
             zrr.dr.d_name.makeUsRelative(domain);
@@ -763,8 +765,9 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
             rr.qname += domain.operator const DNSName&();
             rr.qname.makeUsLowerCase();
             rr.domain_id = zs.domain_id;
-            if (!processRecordForZS(domain.operator const DNSName&(), firstNSEC3, rr, zs))
+            if (!processRecordForZS(domain.operator const DNSName&(), firstNSEC3, rr, zs)) {
               continue;
+            }
             if (dr.d_type == QType::SOA) {
               auto sd = getRR<SOARecordContent>(dr);
               zs.soa_serial = sd->d_st.serial;
@@ -881,8 +884,9 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
         if (zs.nsset.count(shorter) && rr.qtype.getCode() != QType::DS)
           rr.auth = false;
 
-        if (shorter == domain.operator const DNSName&()) // stop at apex
+        if (shorter == domain.operator const DNSName&()) { // stop at apex
           break;
+        }
       } while (shorter.chopOff());
 
       // Insert ents
@@ -942,6 +946,7 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
     // Insert empty non-terminals
     if (doent && !nonterm.empty()) {
       if (zs.isNSEC3) {
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
         di.backend->feedEnts3(zs.domain_id, domain.operator const DNSName&(), nonterm, zs.ns3pr, zs.isNarrow);
       }
       else
@@ -1311,6 +1316,7 @@ void CommunicatorClass::secondaryRefresh(PacketHandler* P)
     SOAData sd;
     try {
       // Use UeberBackend cache for SOA. Cache gets cleared after AXFR/IXFR.
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
       B->lookup(QType(QType::SOA), di.zone.operator const DNSName&(), di.id, nullptr);
       DNSZoneRecord zr;
       hasSOA = B->get(zr);
@@ -1334,6 +1340,7 @@ void CommunicatorClass::secondaryRefresh(PacketHandler* P)
     else if (hasSOA && theirserial == ourserial) {
       uint32_t maxExpire = 0, maxInception = 0;
       if (checkSignatures && dk.isPresigned(di.zone)) {
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
         B->lookup(QType(QType::RRSIG), di.zone.operator const DNSName&(), di.id); // can't use DK before we are done with this lookup!
         DNSZoneRecord zr;
         while (B->get(zr)) {

--- a/pdns/axfr-retriever.cc
+++ b/pdns/axfr-retriever.cc
@@ -57,7 +57,7 @@ AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
     d_soacount = 0;
   
     vector<uint8_t> packet;
-    DNSPacketWriter pw(packet, domain, QType::AXFR);
+    DNSPacketWriter pw(packet, DNSName(domain), QType::AXFR);
     pw.getHeader()->id = dns_random_uint16();
 
     if (!tsigConf.name.empty()) {

--- a/pdns/axfr-retriever.cc
+++ b/pdns/axfr-retriever.cc
@@ -57,8 +57,8 @@ AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
     d_soacount = 0;
   
     vector<uint8_t> packet;
-    DNSPacketWriter pw(packet, DNSName(domain), QType::AXFR);
-    pw.getHeader()->id = dns_random_uint16();
+    DNSPacketWriter pwriter(packet, DNSName(domain), QType::AXFR);
+    pwriter.getHeader()->id = dns_random_uint16();
 
     if (!tsigConf.name.empty()) {
       if (tsigConf.algo == DNSName("hmac-md5")) {
@@ -69,9 +69,9 @@ AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
       }
       d_trc.d_time = time(nullptr);
       d_trc.d_fudge = 300;
-      d_trc.d_origID=ntohs(pw.getHeader()->id);
+      d_trc.d_origID=ntohs(pwriter.getHeader()->id);
       d_trc.d_eRcode=0;
-      addTSIG(pw, d_trc, tsigConf.name, tsigConf.secret, "", false);
+      addTSIG(pwriter, d_trc, tsigConf.name, tsigConf.secret, "", false);
     }
   
     uint16_t replen=htons(packet.size());

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -588,7 +588,7 @@ void GSQLBackend::getUpdatedPrimaries(vector<DomainInfo>& updatedDomains, std::u
     }
 
     if (pdns_iequals(row[2], "PRODUCER")) {
-      catalogs.insert(di.zone);
+      catalogs.insert(di.zone.operator const DNSName&());
       catalogHashes[di.zone].process("\0");
       continue; // Producer fresness check is performed elsewhere
     }

--- a/pdns/backends/gsql/ssql.hh
+++ b/pdns/backends/gsql/ssql.hh
@@ -67,6 +67,10 @@ public:
     }
     return bind(name, string(""));
   }
+  SSqlStatement* bind(const string& name, const ZoneName& value)
+  {
+    return bind(name, value.operator const DNSName&());
+  }
   virtual SSqlStatement* bindNull(const string& name) = 0;
   virtual SSqlStatement* execute() = 0;
   ;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -772,14 +772,14 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
     if (!res.second && !res.first->second.update) {
       res.first->second.update = res.first->second.auth != rr.auth || res.first->second.ordername != rr.ordername;
     }
-    else if ((!securedZone || narrow) && rr.qname == zone) {
+    else if ((!securedZone || narrow) && rr.qname == zone.operator const DNSName&()) {
       res.first->second.update = true;
     }
 
     if (rr.qtype.getCode())
     {
       qnames.insert(rr.qname);
-      if(rr.qtype.getCode() == QType::NS && rr.qname != zone)
+      if(rr.qtype.getCode() == QType::NS && rr.qname != zone.operator const DNSName&())
         nsset.insert(rr.qname);
       if(rr.qtype.getCode() == QType::DS)
         dsnames.insert(rr.qname);
@@ -813,13 +813,13 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
     for (auto &loopRR: rrs) {
       bool skip=false;
       DNSName shorter = loopRR.qname;
-      if (shorter != zone && shorter.chopOff() && shorter != zone) {
+      if (shorter != zone.operator const DNSName&() && shorter.chopOff() && shorter != zone.operator const DNSName&()) {
         do {
           if(nsset.count(shorter)) {
             skip=true;
             break;
           }
-        } while(shorter.chopOff() && shorter != zone);
+        } while(shorter.chopOff() && shorter != zone.operator const DNSName&());
       }
       shorter = loopRR.qname;
       if(!skip && (loopRR.qtype.getCode() != QType::NS || !isOptOut)) {
@@ -828,7 +828,7 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
           if(!nsec3set.count(shorter)) {
             nsec3set.insert(shorter);
           }
-        } while(shorter != zone && shorter.chopOff());
+        } while(shorter != zone.operator const DNSName&() && shorter.chopOff());
       }
     }
   }
@@ -901,7 +901,7 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
       if(doent)
       {
         shorter=qname;
-        while(shorter!=zone && shorter.chopOff())
+        while(shorter!=zone.operator const DNSName&() && shorter.chopOff())
         {
           if(!qnames.count(shorter))
           {

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -779,8 +779,9 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
     if (rr.qtype.getCode())
     {
       qnames.insert(rr.qname);
-      if(rr.qtype.getCode() == QType::NS && rr.qname != zone.operator const DNSName&())
+      if(rr.qtype.getCode() == QType::NS && rr.qname != zone.operator const DNSName&()) {
         nsset.insert(rr.qname);
+      }
       if(rr.qtype.getCode() == QType::DS)
         dsnames.insert(rr.qname);
       rrs.emplace_back(rr);

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -250,7 +250,7 @@ vector<std::unique_ptr<DNSBackend>> BackendMakerClass::all(bool metadataOnly)
 */
 bool DNSBackend::getSOA(const ZoneName& domain, SOAData& soaData)
 {
-  this->lookup(QType(QType::SOA), domain, -1);
+  this->lookup(QType(QType::SOA), domain.operator const DNSName&(), -1);
   S.inc("backend-queries");
 
   DNSResourceRecord resourceRecord;
@@ -264,7 +264,7 @@ bool DNSBackend::getSOA(const ZoneName& domain, SOAData& soaData)
         throw PDNSException("Got non-SOA record when asking for SOA, zone: '" + domain.toLogString() + "'");
       }
       hits++;
-      soaData.qname = domain;
+      soaData.qname = domain.operator const DNSName&();
       soaData.ttl = resourceRecord.ttl;
       soaData.db = this;
       soaData.domain_id = resourceRecord.domain_id;
@@ -310,7 +310,7 @@ bool DNSBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zonen
 {
   DNSName unhashed;
   bool ret = this->getBeforeAndAfterNamesAbsolute(domainId, qname.makeRelative(zonename).makeLowerCase(), unhashed, before, after);
-  DNSName lczonename = zonename.makeLowerCase();
+  DNSName lczonename = zonename.makeLowerCase().operator const DNSName&();
   before += lczonename;
   after += lczonename;
   return ret;

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -730,3 +730,31 @@ bool DNSName::RawLabelsVisitor::empty() const
 {
   return d_position == 0;
 }
+
+#if defined(PDNS_AUTH) // [
+std::ostream & operator<<(std::ostream &os, const ZoneName& d)
+{
+  return os <<d.toLogString();
+}
+
+size_t hash_value(ZoneName const& d)
+{
+  return d.hash();
+}
+
+// Sugar while ZoneName::operator DNSName are made explicit. These can't be
+// made inline in class DNSName due to chicken-and-egg declaration order
+// between DNSName and ZoneName.
+bool DNSName::isPartOf(const ZoneName& rhs) const
+{
+  return isPartOf(rhs.operator const DNSName&());
+}
+DNSName DNSName::makeRelative(const ZoneName& zone) const
+{
+  return makeRelative(zone.operator const DNSName&());
+}
+void DNSName::makeUsRelative(const ZoneName& zone)
+{
+  makeUsRelative(zone.operator const DNSName&());
+}
+#endif // ]

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -732,14 +732,14 @@ bool DNSName::RawLabelsVisitor::empty() const
 }
 
 #if defined(PDNS_AUTH) // [
-std::ostream & operator<<(std::ostream &os, const ZoneName& d)
+std::ostream & operator<<(std::ostream &ostr, const ZoneName& zone)
 {
-  return os <<d.toLogString();
+  return ostr << zone.toLogString();
 }
 
-size_t hash_value(ZoneName const& d)
+size_t hash_value(ZoneName const& zone)
 {
-  return d.hash();
+  return zone.hash();
 }
 
 // Sugar while ZoneName::operator DNSName are made explicit. These can't be

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -77,6 +77,9 @@ inline unsigned char dns_tolower(unsigned char c)
 // - EqualityComparable
 // - LessThanComparable
 // - Hash
+#if defined(PDNS_AUTH)
+class ZoneName;
+#endif
 class DNSName
 {
 public:
@@ -219,6 +222,13 @@ public:
   };
   RawLabelsVisitor getRawLabelsVisitor() const;
 
+#if defined(PDNS_AUTH) // [
+  // Sugar while ZoneName::operator DNSName are made explicit
+  bool isPartOf(const ZoneName& rhs) const;
+  DNSName makeRelative(const ZoneName& zone) const;
+  void makeUsRelative(const ZoneName& zone);
+#endif // ]
+
 private:
   string_t d_storage;
 
@@ -308,9 +318,111 @@ inline DNSName operator+(const DNSName& lhs, const DNSName& rhs)
 extern const DNSName g_rootdnsname, g_wildcarddnsname;
 
 // ZoneName: this is equivalent to DNSName, but intended to only store zone
-// names. For the time being, they are strictly identical.
+// names.
+#if defined(PDNS_AUTH) // [
+// Conversions between DNSName and ZoneName are allowed, but must be explicit.
+class ZoneName
+{
+public:
+  ZoneName() = default; //!< Constructs an *empty* ZoneName, NOT the root!
+  // Work around assertion in some boost versions that do not like self-assignment of boost::container::string
+  ZoneName& operator=(const ZoneName& rhs)
+  {
+    if (this != &rhs) {
+      d_name = rhs.d_name;
+    }
+    return *this;
+  }
+  ZoneName& operator=(ZoneName&& rhs) noexcept
+  {
+    if (this != &rhs) {
+      d_name = std::move(rhs.d_name);
+    }
+    return *this;
+  }
+  ZoneName(const ZoneName& a) = default;
+  ZoneName(ZoneName&& a) = default;
+
+  explicit ZoneName(std::string_view name) : d_name(name) {}
+  explicit ZoneName(const DNSName& name) : d_name(name) {}
+
+  bool isPartOf(const ZoneName& rhs) const { return d_name.isPartOf(rhs.d_name); }
+  bool isPartOf(const DNSName& rhs) const { return d_name.isPartOf(rhs); }
+  bool operator==(const ZoneName& rhs) const { return d_name == rhs.d_name; }
+  bool operator!=(const ZoneName& rhs) const { return d_name != rhs.d_name; }
+
+  std::string toString(const std::string& separator=".", const bool trailing=true) const { return d_name.toString(separator, trailing); }
+  void toString(std::string& output, const std::string& separator=".", const bool trailing=true) const { d_name.toString(output, separator, trailing); }
+  std::string toLogString() const { return d_name.toLogString(); }
+  std::string toStringNoDot() const { return d_name.toStringNoDot(); }
+  std::string toStringRootDot() const { return d_name.toStringRootDot(); }
+  std::string toDNSString() const { return d_name.toDNSString(); }
+  std::string toDNSStringLC() const { return d_name.toDNSStringLC(); }
+
+  bool chopOff() { return d_name.chopOff(); }
+  ZoneName makeRelative(const ZoneName& zone) const
+  {
+    ZoneName ret(*this);
+    ret.d_name.makeUsRelative(zone.d_name);
+    return ret;
+  }
+  ZoneName makeLowerCase() const
+  {
+    ZoneName ret(*this);
+    ret.d_name.makeUsLowerCase();
+    return ret;
+  }
+  void makeUsLowerCase() { d_name.makeUsLowerCase(); }
+  void makeUsRelative(const ZoneName& zone) { d_name.makeUsRelative(zone.d_name); }
+  bool isWildcard() const { return d_name.isWildcard(); }
+  bool isHostname() const { return d_name.isHostname(); }
+  size_t wirelength() const { return d_name.wirelength(); }
+  bool empty() const { return d_name.empty(); }
+  bool isRoot() const { return d_name.isRoot(); }
+  void clear() { d_name.clear(); }
+  void trimToLabels(unsigned int trim) { d_name.trimToLabels(trim); }
+  size_t hash(size_t init=0) const { return d_name.hash(init); }
+
+  bool operator<(const ZoneName& rhs) const { return d_name.operator<(rhs.d_name); }
+
+  bool canonCompare(const ZoneName& rhs) const { return d_name.canonCompare(rhs.d_name); }
+
+  typedef boost::container::string string_t;
+
+  const string_t& getStorage() const { return d_name.getStorage(); }
+
+  [[nodiscard]] size_t sizeEstimate() const { return d_name.sizeEstimate(); }
+
+  bool has8bitBytes() const { return d_name.has8bitBytes(); }
+
+  // Conversion from ZoneName to DNSName
+  explicit operator const DNSName&() const { return d_name; }
+  explicit operator DNSName&() { return d_name; }
+private:
+  DNSName d_name;
+};
+
+size_t hash_value(ZoneName const& d);
+
+std::ostream & operator<<(std::ostream &os, const ZoneName& d);
+namespace std {
+    template <>
+    struct hash<ZoneName> {
+        size_t operator () (const ZoneName& dn) const { return dn.hash(0); }
+    };
+}
+
+struct CanonZoneNameCompare
+{
+  bool operator()(const ZoneName& a, const ZoneName& b) const
+  {
+    return a.canonCompare(b);
+  }
+};
+#else // ] [
 using ZoneName = DNSName;
 using CanonZoneNameCompare = CanonDNSNameCompare;
+#endif // ]
 
 template<typename T>
 struct SuffixMatchTree

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -356,16 +356,8 @@ public:
   std::string toLogString() const { return d_name.toLogString(); }
   std::string toStringNoDot() const { return d_name.toStringNoDot(); }
   std::string toStringRootDot() const { return d_name.toStringRootDot(); }
-  std::string toDNSString() const { return d_name.toDNSString(); }
-  std::string toDNSStringLC() const { return d_name.toDNSStringLC(); }
 
   bool chopOff() { return d_name.chopOff(); }
-  ZoneName makeRelative(const ZoneName& zone) const
-  {
-    ZoneName ret(*this);
-    ret.d_name.makeUsRelative(zone.d_name);
-    return ret;
-  }
   ZoneName makeLowerCase() const
   {
     ZoneName ret(*this);
@@ -373,12 +365,7 @@ public:
     return ret;
   }
   void makeUsLowerCase() { d_name.makeUsLowerCase(); }
-  void makeUsRelative(const ZoneName& zone) { d_name.makeUsRelative(zone.d_name); }
-  bool isWildcard() const { return d_name.isWildcard(); }
-  bool isHostname() const { return d_name.isHostname(); }
-  size_t wirelength() const { return d_name.wirelength(); }
   bool empty() const { return d_name.empty(); }
-  bool isRoot() const { return d_name.isRoot(); }
   void clear() { d_name.clear(); }
   void trimToLabels(unsigned int trim) { d_name.trimToLabels(trim); }
   size_t hash(size_t init=0) const { return d_name.hash(init); }
@@ -386,14 +373,6 @@ public:
   bool operator<(const ZoneName& rhs) const { return d_name.operator<(rhs.d_name); }
 
   bool canonCompare(const ZoneName& rhs) const { return d_name.canonCompare(rhs.d_name); }
-
-  typedef boost::container::string string_t;
-
-  const string_t& getStorage() const { return d_name.getStorage(); }
-
-  [[nodiscard]] size_t sizeEstimate() const { return d_name.sizeEstimate(); }
-
-  bool has8bitBytes() const { return d_name.has8bitBytes(); }
 
   // Conversion from ZoneName to DNSName
   explicit operator const DNSName&() const { return d_name; }

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -381,9 +381,9 @@ private:
   DNSName d_name;
 };
 
-size_t hash_value(ZoneName const& d);
+size_t hash_value(ZoneName const& zone);
 
-std::ostream & operator<<(std::ostream &os, const ZoneName& d);
+std::ostream & operator<<(std::ostream &ostr, const ZoneName& zone);
 namespace std {
     template <>
     struct hash<ZoneName> {

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -119,7 +119,7 @@ static int getRRSIGsForRRSET(DNSSECKeeper& dsk, const ZoneName& signer, const DN
   rrc.d_originalttl=signTTL;
   rrc.d_siginception=startOfWeek - 7*86400; // XXX should come from zone metadata
   rrc.d_sigexpire=startOfWeek + 14*86400;
-  rrc.d_signer = signer;
+  rrc.d_signer = signer.operator const DNSName&();
   rrc.d_tag = 0;
 
   DNSSECKeeper::keyset_t keys = dsk.getKeys(signer);

--- a/pdns/fuzz_zoneparsertng.cc
+++ b/pdns/fuzz_zoneparsertng.cc
@@ -49,7 +49,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     std::string tmp(reinterpret_cast<const char*>(data), size);
     boost::split(lines, tmp, boost::is_any_of("\n"));
 
-    ZoneParserTNG zpt(lines, g_rootdnsname);
+    ZoneParserTNG zpt(lines, ZoneName(g_rootdnsname));
     /* limit the number of steps for '$GENERATE' entries */
     zpt.setMaxGenerateSteps(10000);
     zpt.setMaxIncludes(20);

--- a/pdns/ixfrdist-stats.hh
+++ b/pdns/ixfrdist-stats.hh
@@ -102,7 +102,7 @@ class ixfrdistStats {
     std::array<std::atomic<uint64_t>, 16> notimpStats{};
     programStats progStats;
 
-    std::map<ZoneName, perDomainStat>::iterator getRegisteredDomain(const DNSName& d) {
+    std::map<ZoneName, perDomainStat>::iterator getRegisteredDomain(const ZoneName& d) {
       auto ret = domainStats.find(d);
       if (ret == domainStats.end()) {
         throw PDNSException("Domain '" + d.toLogString() + "' not defined in the statistics map");

--- a/pdns/ixfrutils.cc
+++ b/pdns/ixfrutils.cc
@@ -34,15 +34,15 @@
 uint32_t getSerialFromPrimary(const ComboAddress& primary, const ZoneName& zone, shared_ptr<const SOARecordContent>& soarecord, const TSIGTriplet& tsig, const uint16_t timeout)
 {
   vector<uint8_t> packet;
-  DNSPacketWriter pw(packet, zone.operator const DNSName&(), QType::SOA);
+  DNSPacketWriter pwriter(packet, zone.operator const DNSName&(), QType::SOA);
   if(!tsig.algo.empty()) {
     TSIGRecordContent trc;
     trc.d_algoName = tsig.algo;
     trc.d_time = time(nullptr);
     trc.d_fudge = 300;
-    trc.d_origID=ntohs(pw.getHeader()->id);
+    trc.d_origID=ntohs(pwriter.getHeader()->id);
     trc.d_eRcode=0;
-    addTSIG(pw, trc, tsig.name, tsig.secret, "", false);
+    addTSIG(pwriter, trc, tsig.name, tsig.secret, "", false);
   }
 
   Socket s(primary.sin4.sin_family, SOCK_DGRAM);

--- a/pdns/ixfrutils.cc
+++ b/pdns/ixfrutils.cc
@@ -34,7 +34,7 @@
 uint32_t getSerialFromPrimary(const ComboAddress& primary, const ZoneName& zone, shared_ptr<const SOARecordContent>& soarecord, const TSIGTriplet& tsig, const uint16_t timeout)
 {
   vector<uint8_t> packet;
-  DNSPacketWriter pw(packet, zone, QType::SOA);
+  DNSPacketWriter pw(packet, zone.operator const DNSName&(), QType::SOA);
   if(!tsig.algo.empty()) {
     TSIGRecordContent trc;
     trc.d_algoName = tsig.algo;

--- a/pdns/ixplore.cc
+++ b/pdns/ixplore.cc
@@ -88,12 +88,12 @@ int main(int argc, char** argv) {
 
       set_difference(before.cbegin(), before.cend(), after.cbegin(), after.cend(), back_inserter(diff), before.value_comp());
       for(const auto& d : diff) {
-        cout<<'-'<< (d.d_name+zone) <<" IN "<<DNSRecordContent::NumberToType(d.d_type)<<" "<<d.getContent()->getZoneRepresentation()<<endl;
+        cout<<'-'<< (d.d_name+zone.operator const DNSName&()) <<" IN "<<DNSRecordContent::NumberToType(d.d_type)<<" "<<d.getContent()->getZoneRepresentation()<<endl;
       }
       diff.clear();
       set_difference(after.cbegin(), after.cend(), before.cbegin(), before.cend(), back_inserter(diff), before.value_comp());
       for(const auto& d : diff) {
-        cout<<'+'<< (d.d_name+zone) <<" IN "<<DNSRecordContent::NumberToType(d.d_type)<<" "<<d.getContent()->getZoneRepresentation()<<endl;
+        cout<<'+'<< (d.d_name+zone.operator const DNSName&()) <<" IN "<<DNSRecordContent::NumberToType(d.d_type)<<" "<<d.getContent()->getZoneRepresentation()<<endl;
       }
       exit(1);
     }
@@ -189,7 +189,7 @@ int main(int argc, char** argv) {
       }
 
       cout<<"got new serial: "<<serial<<", initiating IXFR!"<<endl;
-      auto deltas = getIXFRDeltas(primary, zone, ourSoa, 20, false, tt);
+      auto deltas = getIXFRDeltas(primary, zone.operator const DNSName&(), ourSoa, 20, false, tt);
       cout<<"Got "<<deltas.size()<<" deltas, applying.."<<endl;
 
       for(const auto& delta : deltas) {
@@ -216,7 +216,7 @@ int main(int argc, char** argv) {
         bool stop=false;
 
         for(const auto& rr : remove) {
-          report<<'-'<< (rr.d_name+zone) <<" IN "<<DNSRecordContent::NumberToType(rr.d_type)<<" "<<rr.getContent()->getZoneRepresentation()<<endl;
+          report<<'-'<< (rr.d_name+zone.operator const DNSName&()) <<" IN "<<DNSRecordContent::NumberToType(rr.d_type)<<" "<<rr.getContent()->getZoneRepresentation()<<endl;
           auto range = records.equal_range(std::tie(rr.d_name, rr.d_type, rr.d_class, rr.getContent()));
           if(range.first == range.second) {
             cout<<endl<<" !! Could not find record "<<rr.d_name<<" to remove!!"<<endl;
@@ -227,7 +227,7 @@ int main(int argc, char** argv) {
         }
 
         for(const auto& rr : add) {
-          report<<'+'<< (rr.d_name+zone) <<" IN "<<DNSRecordContent::NumberToType(rr.d_type)<<" "<<rr.getContent()->getZoneRepresentation()<<endl;
+          report<<'+'<< (rr.d_name+zone.operator const DNSName&()) <<" IN "<<DNSRecordContent::NumberToType(rr.d_type)<<" "<<rr.getContent()->getZoneRepresentation()<<endl;
           records.insert(rr);
         }
         if(stop) {

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -212,9 +212,9 @@ Logger& Logger::operator<<(const DNSName& d)
 }
 
 #if defined(PDNS_AUTH)
-Logger& Logger::operator<<(const ZoneName& d)
+Logger& Logger::operator<<(const ZoneName& zone)
 {
-  *this << d.toLogString();
+  *this << zone.toLogString();
 
   return *this;
 }

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -211,6 +211,15 @@ Logger& Logger::operator<<(const DNSName& d)
   return *this;
 }
 
+#if defined(PDNS_AUTH)
+Logger& Logger::operator<<(const ZoneName& d)
+{
+  *this << d.toLogString();
+
+  return *this;
+}
+#endif
+
 Logger& Logger::operator<<(const ComboAddress& ca)
 {
   *this << ca.toLogString();

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -108,6 +108,9 @@ public:
   Logger& operator<<(const char* s);
   Logger& operator<<(const string& s); //!< log a string
   Logger& operator<<(const DNSName&);
+#if defined(PDNS_AUTH)
+  Logger& operator<<(const ZoneName&);
+#endif
   Logger& operator<<(const ComboAddress&); //!< log an address
   Logger& operator<<(const SockaddrWrapper&); //!< log an address
   Logger& operator<<(Urgency); //!< set the urgency, << style

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -65,7 +65,7 @@ void AuthLua4::postPrepareContext() {
   d_lw->registerFunction<DNSPacket, std::unordered_map<unsigned int, DNSRecord>()>("getRRS", [](DNSPacket &p){ std::unordered_map<unsigned int, DNSRecord> ret; unsigned int i = 0; for(const auto &rec: p.getRRS()) { ret.insert({i++, rec.dr}); } return ret;});
   d_lw->registerMember<DNSPacket, DNSName>("qdomain", [](const DNSPacket &p) -> DNSName { return p.qdomain; }, [](DNSPacket &p, const DNSName& name) { p.qdomain = name; });
   d_lw->registerMember<DNSPacket, DNSName>("qdomainwild", [](const DNSPacket &p) -> DNSName { return p.qdomainwild; }, [](DNSPacket &p, const DNSName& name) { p.qdomainwild = name; });
-  d_lw->registerMember<DNSPacket, DNSName>("qdomainzone", [](const DNSPacket &p) -> DNSName { return p.qdomainzone; }, [](DNSPacket &p, const DNSName& name) { p.qdomainzone = name; });
+  d_lw->registerMember<DNSPacket, DNSName>("qdomainzone", [](const DNSPacket &p) -> DNSName { return p.qdomainzone.operator const DNSName&(); }, [](DNSPacket &p, const DNSName& name) { p.qdomainzone = ZoneName(name); });
 
   d_lw->registerMember<DNSPacket, std::string>("d_peer_principal", [](const DNSPacket &p) -> std::string { return p.d_peer_principal; }, [](DNSPacket &p, const std::string &princ) { p.d_peer_principal = princ; });
   d_lw->registerMember<DNSPacket, const std::string>("qtype", [](const DNSPacket &p) ->  const std::string { return p.qtype.toString(); }, [](DNSPacket &p, const std::string &type) { p.qtype = type; });

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -65,7 +65,7 @@ void AuthLua4::postPrepareContext() {
   d_lw->registerFunction<DNSPacket, std::unordered_map<unsigned int, DNSRecord>()>("getRRS", [](DNSPacket &p){ std::unordered_map<unsigned int, DNSRecord> ret; unsigned int i = 0; for(const auto &rec: p.getRRS()) { ret.insert({i++, rec.dr}); } return ret;});
   d_lw->registerMember<DNSPacket, DNSName>("qdomain", [](const DNSPacket &p) -> DNSName { return p.qdomain; }, [](DNSPacket &p, const DNSName& name) { p.qdomain = name; });
   d_lw->registerMember<DNSPacket, DNSName>("qdomainwild", [](const DNSPacket &p) -> DNSName { return p.qdomainwild; }, [](DNSPacket &p, const DNSName& name) { p.qdomainwild = name; });
-  d_lw->registerMember<DNSPacket, DNSName>("qdomainzone", [](const DNSPacket &p) -> DNSName { return p.qdomainzone.operator const DNSName&(); }, [](DNSPacket &p, const DNSName& name) { p.qdomainzone = ZoneName(name); });
+  d_lw->registerMember<DNSPacket, DNSName>("qdomainzone", [](const DNSPacket &pkt) -> DNSName { return pkt.qdomainzone.operator const DNSName&(); }, [](DNSPacket &pkt, const DNSName& name) { pkt.qdomainzone = ZoneName(name); });
 
   d_lw->registerMember<DNSPacket, std::string>("d_peer_principal", [](const DNSPacket &p) -> std::string { return p.d_peer_principal; }, [](DNSPacket &p, const std::string &princ) { p.d_peer_principal = princ; });
   d_lw->registerMember<DNSPacket, const std::string>("qtype", [](const DNSPacket &p) ->  const std::string { return p.qtype.toString(); }, [](DNSPacket &p, const std::string &type) { p.qtype = type; });

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -103,8 +103,8 @@ void BaseLua4::prepareContext() {
   d_lw->writeFunction("newDN", [](const std::string& dom){ return DNSName(dom); });
   d_lw->registerFunction("__lt", &DNSName::operator<);
   d_lw->registerFunction("canonCompare", &DNSName::canonCompare);
-  d_lw->registerFunction("makeRelative", &DNSName::makeRelative);
-  d_lw->registerFunction("isPartOf", &DNSName::isPartOf);
+  d_lw->registerFunction<DNSName(DNSName::*)(const DNSName&)>("makeRelative", [](const DNSName& name, const DNSName& zone) { return name.makeRelative(zone); });
+  d_lw->registerFunction<bool(DNSName::*)(const DNSName&)>("isPartOf", [](const DNSName& name, const DNSName& rhs) { return name.isPartOf(rhs); });
   d_lw->registerFunction("getRawLabels", &DNSName::getRawLabels);
   d_lw->registerFunction<unsigned int(DNSName::*)()>("countLabels", [](const DNSName& name) { return name.countLabels(); });
   d_lw->registerFunction<size_t(DNSName::*)()>("wireLength", [](const DNSName& name) { return name.wirelength(); });

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1583,7 +1583,7 @@ static vector<string> lua_dblookup(const string& record, uint16_t qtype)
       return ret;
     }
 
-    vector<DNSZoneRecord> drs = lookup(rec, qtype, soaData.domain_id);
+    vector<DNSZoneRecord> drs = lookup(rec.operator const DNSName&(), qtype, soaData.domain_id);
     for (const auto& drec : drs) {
       ret.push_back(drec.dr.getContent()->getZoneRepresentation());
     }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -45,7 +45,11 @@
 #include "namespaces.hh"
 
 class DNSName;
+#if defined(PDNS_AUTH)
+class ZoneName;
+#else
 using ZoneName = DNSName;
+#endif
 
 // Do not change to "using TSIGHashEnum ..." until you know CodeQL does not choke on it
 typedef enum
@@ -480,10 +484,10 @@ inline bool isCanonical(const string& qname)
 inline DNSName toCanonic(const ZoneName& zone, const string& qname)
 {
   if(qname.size()==1 && qname[0]=='@')
-    return zone;
+    return DNSName(zone);
   if(isCanonical(qname))
     return DNSName(qname);
-  return DNSName(qname) += zone;
+  return DNSName(qname) += DNSName(zone);
 }
 
 string stripDot(const string& dom);
@@ -571,6 +575,12 @@ public:
   bool match(const DNSName& name) const {
     return match(name.toStringNoDot());
   }
+
+#if defined(PDNS_AUTH) // [
+  bool match(const ZoneName& name) const {
+    return match(name.toStringNoDot());
+  }
+#endif // ]
 
 private:
   const string d_mask;

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -455,6 +455,7 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
         ret->push_back(rr);
       }
 
+      // NOLINTNEXTLINE(readability-misleading-indentation): go home, clang-tidy, you're drunk
       wildcard=g_wildcarddnsname+subdomain;
       haveSomething=true;
     }
@@ -711,7 +712,7 @@ void PacketHandler::emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name,
     }
     else
 #endif
-      if (d_doExpandALIAS && rr.dr.d_type == QType::ALIAS) {
+    if (d_doExpandALIAS && rr.dr.d_type == QType::ALIAS) {
       // Set the A and AAAA in the NSEC bitmap so aggressive NSEC
       // does not falsely deny the type for this name.
       // This does NOT add the ALIAS to the bitmap, as that record cannot
@@ -797,7 +798,7 @@ void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRec
       }
       else
 #endif
-        if (d_doExpandALIAS && rr.dr.d_type == QType::ALIAS) {
+      if (d_doExpandALIAS && rr.dr.d_type == QType::ALIAS) {
         // Set the A and AAAA in the NSEC3 bitmap so aggressive NSEC
         // does not falsely deny the type for this name.
         // This does NOT add the ALIAS to the bitmap, as that record cannot
@@ -1114,6 +1115,7 @@ int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& 
       g_log << Logger::Error << "Failed to create " << zonename << " for potential autoprimary " << remote << endl;
       return RCode::ServFail;
     }
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     g_zoneCache.add(zonename, di.id);
     if (tsigkeyname.empty() == false) {
       vector<string> meta;
@@ -1164,7 +1166,7 @@ int PacketHandler::processNotify(const DNSPacket& p)
       return RCode::Refused;
     }
     vector<string> meta;
-    if (B.getDomainMetadata(zonename,"AXFR-MASTER-TSIG",meta) && meta.size() > 0) {
+    if (B.getDomainMetadata(zonename,"AXFR-MASTER-TSIG",meta) && !meta.empty()) {
       DNSName expected{meta[0]};
       if (p.getTSIGKeyname() != expected) {
         g_log<<Logger::Warning<<"Received secure NOTIFY for "<<zonename<<" from "<<p.getRemoteString()<<": expected TSIG key '"<<expected<<"', got '"<<p.getTSIGKeyname()<<"' (Refused)"<<endl;
@@ -1176,7 +1178,7 @@ int PacketHandler::processNotify(const DNSPacket& p)
   // Domain verification
   //
   DomainInfo di;
-  if(!B.getDomainInfo(zonename, di, false) || !di.backend) {
+  if(!B.getDomainInfo(zonename, di, false) || di.backend == nullptr) {
     if(::arg().mustDo("autosecondary")) {
       g_log << Logger::Warning << "Received NOTIFY for " << zonename << " from " << p.getRemoteString() << " for which we are not authoritative, trying autoprimary" << endl;
       return tryAutoPrimary(p, p.getTSIGKeyname());

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -121,8 +121,9 @@ PacketHandler::~PacketHandler()
 **/
 bool PacketHandler::addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r)
 {
+  ZoneName zonename(p.qdomain);
   string publishCDNSKEY;
-  d_dk.getPublishCDNSKEY(p.qdomain,publishCDNSKEY);
+  d_dk.getPublishCDNSKEY(zonename,publishCDNSKEY);
   if (publishCDNSKEY.empty())
     return false;
 
@@ -139,7 +140,7 @@ bool PacketHandler::addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r)
   }
 
   bool haveOne=false;
-  for (const auto& value : d_dk.getEntryPoints(p.qdomain)) {
+  for (const auto& value : d_dk.getEntryPoints(zonename)) {
     if (!value.second.published) {
       continue;
     }
@@ -172,7 +173,7 @@ bool PacketHandler::addDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r)
   DNSZoneRecord rr;
   bool haveOne=false;
 
-  for (const auto& value : d_dk.getKeys(p.qdomain)) {
+  for (const auto& value : d_dk.getKeys(ZoneName(p.qdomain))) {
     if (!value.second.published) {
       continue;
     }
@@ -209,7 +210,7 @@ bool PacketHandler::addDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r)
 bool PacketHandler::addCDS(DNSPacket& p, std::unique_ptr<DNSPacket>& r)
 {
   string publishCDS;
-  d_dk.getPublishCDS(p.qdomain, publishCDS);
+  d_dk.getPublishCDS(ZoneName(p.qdomain), publishCDS);
   if (publishCDS.empty())
     return false;
 
@@ -230,7 +231,7 @@ bool PacketHandler::addCDS(DNSPacket& p, std::unique_ptr<DNSPacket>& r)
 
   bool haveOne=false;
 
-  for (const auto& value : d_dk.getEntryPoints(p.qdomain)) {
+  for (const auto& value : d_dk.getEntryPoints(ZoneName(p.qdomain))) {
     if (!value.second.published) {
       continue;
     }
@@ -260,7 +261,7 @@ bool PacketHandler::addNSEC3PARAM(const DNSPacket& p, std::unique_ptr<DNSPacket>
   DNSZoneRecord rr;
 
   NSEC3PARAMRecordContent ns3prc;
-  if(d_dk.getNSEC3PARAM(p.qdomain, &ns3prc)) {
+  if(d_dk.getNSEC3PARAM(ZoneName(p.qdomain), &ns3prc)) {
     rr.dr.d_type=QType::NSEC3PARAM;
     rr.dr.d_ttl=d_sd.minimum;
     rr.dr.d_name=p.qdomain;
@@ -388,9 +389,10 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
 
 #ifdef HAVE_LUA_RECORDS
   bool doLua=g_doLuaRecord;
+  ZoneName zonename(d_sd.qname);
   if(!doLua) {
     string val;
-    d_dk.getFromMeta(d_sd.qname, "ENABLE-LUA-RECORDS", val);
+    d_dk.getFromMeta(zonename, "ENABLE-LUA-RECORDS", val);
     doLua = (val=="1");
   }
 #endif
@@ -407,7 +409,7 @@ bool PacketHandler::getBestWildcard(DNSPacket& p, const DNSName &target, DNSName
         continue;
       }
 #ifdef HAVE_LUA_RECORDS
-      if (rr.dr.d_type == QType::LUA && !d_dk.isPresigned(d_sd.qname)) {
+      if (rr.dr.d_type == QType::LUA && !d_dk.isPresigned(zonename)) {
         if(!doLua) {
           DLOG(g_log<<"Have a wildcard Lua match, but not doing Lua record for this zone"<<endl);
           continue;
@@ -658,6 +660,7 @@ vector<ComboAddress> PacketHandler::getIPAddressFor(const DNSName &target, const
 
 void PacketHandler::emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name, const DNSName& next, int mode)
 {
+  ZoneName zonename(d_sd.qname);
   NSECRecordContent nrc;
   nrc.d_next = next;
 
@@ -665,17 +668,17 @@ void PacketHandler::emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name,
   nrc.set(QType::RRSIG);
   if(d_sd.qname == name) {
     nrc.set(QType::SOA); // 1dfd8ad SOA can live outside the records table
-    if(!d_dk.isPresigned(d_sd.qname)) {
-      auto keyset = d_dk.getKeys(name);
+    if(!d_dk.isPresigned(zonename)) {
+      auto keyset = d_dk.getKeys(zonename);
       for(const auto& value: keyset) {
         if (value.second.published) {
           nrc.set(QType::DNSKEY);
           string publishCDNSKEY;
-          d_dk.getPublishCDNSKEY(name, publishCDNSKEY);
+          d_dk.getPublishCDNSKEY(zonename, publishCDNSKEY);
           if (! publishCDNSKEY.empty())
             nrc.set(QType::CDNSKEY);
           string publishCDS;
-          d_dk.getPublishCDS(name, publishCDS);
+          d_dk.getPublishCDS(zonename, publishCDS);
           if (! publishCDS.empty())
             nrc.set(QType::CDS);
           break;
@@ -693,12 +696,12 @@ void PacketHandler::emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name,
   B.lookup(QType(QType::ANY), name, d_sd.domain_id);
   while(B.get(rr)) {
 #ifdef HAVE_LUA_RECORDS
-    if (rr.dr.d_type == QType::LUA && first && !d_dk.isPresigned(d_sd.qname)) {
+    if (rr.dr.d_type == QType::LUA && first && !d_dk.isPresigned(zonename)) {
       first = false;
       doLua = g_doLuaRecord;
       if (!doLua) {
         string val;
-        d_dk.getFromMeta(d_sd.qname, "ENABLE-LUA-RECORDS", val);
+        d_dk.getFromMeta(zonename, "ENABLE-LUA-RECORDS", val);
         doLua = (val == "1");
       }
     }
@@ -713,12 +716,12 @@ void PacketHandler::emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name,
       // does not falsely deny the type for this name.
       // This does NOT add the ALIAS to the bitmap, as that record cannot
       // be requested.
-      if (!d_dk.isPresigned(d_sd.qname)) {
+      if (!d_dk.isPresigned(zonename)) {
         nrc.set(QType::A);
         nrc.set(QType::AAAA);
       }
     }
-    else if((rr.dr.d_type == QType::DNSKEY || rr.dr.d_type == QType::CDS || rr.dr.d_type == QType::CDNSKEY) && !d_dk.isPresigned(d_sd.qname) && !::arg().mustDo("direct-dnskey")) {
+    else if((rr.dr.d_type == QType::DNSKEY || rr.dr.d_type == QType::CDS || rr.dr.d_type == QType::CDNSKEY) && !d_dk.isPresigned(zonename) && !::arg().mustDo("direct-dnskey")) {
       continue;
     }
     else if(rr.dr.d_type == QType::NS || rr.auth) {
@@ -738,6 +741,7 @@ void PacketHandler::emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name,
 
 void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRecordContent& ns3prc, const DNSName& name, const string& namehash, const string& nexthash, int mode)
 {
+  ZoneName zonename(d_sd.qname);
   NSEC3RecordContent n3rc;
   n3rc.d_algorithm = ns3prc.d_algorithm;
   n3rc.d_flags = ns3prc.d_flags;
@@ -751,17 +755,17 @@ void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRec
     if (d_sd.qname == name) {
       n3rc.set(QType::SOA); // 1dfd8ad SOA can live outside the records table
       n3rc.set(QType::NSEC3PARAM);
-      if(!d_dk.isPresigned(d_sd.qname)) {
-        auto keyset = d_dk.getKeys(name);
+      if(!d_dk.isPresigned(zonename)) {
+        auto keyset = d_dk.getKeys(zonename);
         for(const auto& value: keyset) {
           if (value.second.published) {
             n3rc.set(QType::DNSKEY);
             string publishCDNSKEY;
-            d_dk.getPublishCDNSKEY(name, publishCDNSKEY);
+            d_dk.getPublishCDNSKEY(zonename, publishCDNSKEY);
             if (! publishCDNSKEY.empty())
               n3rc.set(QType::CDNSKEY);
             string publishCDS;
-            d_dk.getPublishCDS(name, publishCDS);
+            d_dk.getPublishCDS(zonename, publishCDS);
             if (! publishCDS.empty())
               n3rc.set(QType::CDS);
             break;
@@ -778,12 +782,12 @@ void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRec
     B.lookup(QType(QType::ANY), name, d_sd.domain_id);
     while(B.get(rr)) {
 #ifdef HAVE_LUA_RECORDS
-      if (rr.dr.d_type == QType::LUA && first && !d_dk.isPresigned(d_sd.qname)) {
+      if (rr.dr.d_type == QType::LUA && first && !d_dk.isPresigned(zonename)) {
         first = false;
         doLua = g_doLuaRecord;
         if (!doLua) {
           string val;
-          d_dk.getFromMeta(d_sd.qname, "ENABLE-LUA-RECORDS", val);
+          d_dk.getFromMeta(zonename, "ENABLE-LUA-RECORDS", val);
           doLua = (val == "1");
         }
       }
@@ -798,12 +802,12 @@ void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRec
         // does not falsely deny the type for this name.
         // This does NOT add the ALIAS to the bitmap, as that record cannot
         // be requested.
-        if (!d_dk.isPresigned(d_sd.qname)) {
+        if (!d_dk.isPresigned(zonename)) {
           n3rc.set(QType::A);
           n3rc.set(QType::AAAA);
         }
       }
-      else if((rr.dr.d_type == QType::DNSKEY || rr.dr.d_type == QType::CDS || rr.dr.d_type == QType::CDNSKEY) && !d_dk.isPresigned(d_sd.qname) && !::arg().mustDo("direct-dnskey")) {
+      else if((rr.dr.d_type == QType::DNSKEY || rr.dr.d_type == QType::CDS || rr.dr.d_type == QType::CDNSKEY) && !d_dk.isPresigned(zonename) && !::arg().mustDo("direct-dnskey")) {
         continue;
       }
       else if(rr.dr.d_type && (rr.dr.d_type == QType::NS || rr.auth)) {
@@ -840,7 +844,7 @@ void PacketHandler::addNSECX(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const 
 {
   NSEC3PARAMRecordContent ns3rc;
   bool narrow = false;
-  if(d_dk.getNSEC3PARAM(d_sd.qname, &ns3rc, &narrow))  {
+  if(d_dk.getNSEC3PARAM(ZoneName(d_sd.qname), &ns3rc, &narrow))  {
     if (mode != 5) // no direct NSEC3 queries, rfc5155 7.2.8
       addNSEC3(p, r, target, wildcard, ns3rc, narrow, mode);
   }
@@ -879,7 +883,7 @@ void PacketHandler::addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const 
   DLOG(g_log<<"addNSEC3() mode="<<mode<<" auth="<<d_sd.qname<<" target="<<target<<" wildcard="<<wildcard<<endl);
 
   if (d_sd.db == nullptr) {
-    if(!B.getSOAUncached(d_sd.qname, d_sd)) {
+    if(!B.getSOAUncached(ZoneName(d_sd.qname), d_sd)) {
       DLOG(g_log<<"Could not get SOA for domain"<<endl);
       return;
     }
@@ -973,8 +977,9 @@ void PacketHandler::addNSEC(DNSPacket& /* p */, std::unique_ptr<DNSPacket>& r, c
 {
   DLOG(g_log<<"addNSEC() mode="<<mode<<" auth="<<d_sd.qname<<" target="<<target<<" wildcard="<<wildcard<<endl);
 
+  ZoneName zonename(d_sd.qname);
   if (d_sd.db == nullptr) {
-    if(!B.getSOAUncached(d_sd.qname, d_sd)) {
+    if(!B.getSOAUncached(zonename, d_sd)) {
       DLOG(g_log<<"Could not get SOA for domain"<<endl);
       return;
     }
@@ -991,7 +996,7 @@ void PacketHandler::addNSEC(DNSPacket& /* p */, std::unique_ptr<DNSPacket>& r, c
   }
 
   DNSName before,after;
-  d_sd.db->getBeforeAndAfterNames(d_sd.domain_id, d_sd.qname, target, before, after);
+  d_sd.db->getBeforeAndAfterNames(d_sd.domain_id, zonename, target, before, after);
   if (mode != 5 || before == target)
     emitNSEC(r, before, after, mode);
 
@@ -1003,7 +1008,7 @@ void PacketHandler::addNSEC(DNSPacket& /* p */, std::unique_ptr<DNSPacket>& r, c
       closest.chopOff();
       closest.prependRawLabel("*");
     }
-    d_sd.db->getBeforeAndAfterNames(d_sd.domain_id, d_sd.qname, closest, before, after);
+    d_sd.db->getBeforeAndAfterNames(d_sd.domain_id, zonename, closest, before, after);
     emitNSEC(r, before, after, mode);
   }
   return;
@@ -1093,7 +1098,8 @@ int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& 
     return RCode::Refused;
   }
 
-  if (!B.autoPrimaryBackend(remote.toString(), p.qdomain, nsset, &nameserver, &account, &db)) {
+  ZoneName zonename(p.qdomain);
+  if (!B.autoPrimaryBackend(remote.toString(), zonename, nsset, &nameserver, &account, &db)) {
     g_log << Logger::Error << "Unable to find backend willing to host " << p.qdomain << " for potential autoprimary " << remote << ". Remote nameservers: " << endl;
     for(const auto& rr: nsset) {
       if(rr.qtype==QType::NS)
@@ -1102,29 +1108,30 @@ int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& 
     return RCode::Refused;
   }
   try {
-    db->createSecondaryDomain(remote.toString(), p.qdomain, nameserver, account);
+    db->createSecondaryDomain(remote.toString(), zonename, nameserver, account);
     DomainInfo di;
-    if (!db->getDomainInfo(p.qdomain, di, false)) {
-      g_log << Logger::Error << "Failed to create " << p.qdomain << " for potential autoprimary " << remote << endl;
+    if (!db->getDomainInfo(zonename, di, false)) {
+      g_log << Logger::Error << "Failed to create " << zonename << " for potential autoprimary " << remote << endl;
       return RCode::ServFail;
     }
-    g_zoneCache.add(p.qdomain, di.id);
+    g_zoneCache.add(zonename, di.id);
     if (tsigkeyname.empty() == false) {
       vector<string> meta;
       meta.push_back(tsigkeyname.toStringNoDot());
-      db->setDomainMetadata(p.qdomain, "AXFR-MASTER-TSIG", meta);
+      db->setDomainMetadata(zonename, "AXFR-MASTER-TSIG", meta);
     }
   }
   catch(PDNSException& ae) {
-    g_log << Logger::Error << "Database error trying to create " << p.qdomain << " for potential autoprimary " << remote << ": " << ae.reason << endl;
+    g_log << Logger::Error << "Database error trying to create " << zonename << " for potential autoprimary " << remote << ": " << ae.reason << endl;
     return RCode::ServFail;
   }
-  g_log << Logger::Warning << "Created new secondary zone '" << p.qdomain << "' from autoprimary " << remote << endl;
+  g_log << Logger::Warning << "Created new secondary zone '" << zonename << "' from autoprimary " << remote << endl;
   return RCode::NoError;
 }
 
 int PacketHandler::processNotify(const DNSPacket& p)
 {
+  ZoneName zonename(p.qdomain);
   /* now what?
      was this notification from an approved address?
      was this notification approved by TSIG?
@@ -1133,10 +1140,10 @@ int PacketHandler::processNotify(const DNSPacket& p)
      if primary is higher -> do stuff
   */
 
-  g_log<<Logger::Debug<<"Received NOTIFY for "<<p.qdomain<<" from "<<p.getRemoteString()<<endl;
+  g_log<<Logger::Debug<<"Received NOTIFY for "<<zonename<<" from "<<p.getRemoteString()<<endl;
 
   if(!::arg().mustDo("secondary") && s_forwardNotify.empty()) {
-    g_log << Logger::Warning << "Received NOTIFY for " << p.qdomain << " from " << p.getRemoteString() << " but secondary support is disabled in the configuration" << endl;
+    g_log << Logger::Warning << "Received NOTIFY for " << zonename << " from " << p.getRemoteString() << " but secondary support is disabled in the configuration" << endl;
     return RCode::Refused;
   }
 
@@ -1144,23 +1151,23 @@ int PacketHandler::processNotify(const DNSPacket& p)
   //
   if(!s_allowNotifyFrom.match(p.getInnerRemote()) || p.d_havetsig) {
     if (p.d_havetsig && p.getTSIGKeyname().empty() == false) {
-        g_log<<Logger::Notice<<"Received secure NOTIFY for "<<p.qdomain<<" from "<<p.getRemoteString()<<", with TSIG key '"<<p.getTSIGKeyname()<<"'"<<endl;
+        g_log<<Logger::Notice<<"Received secure NOTIFY for "<<zonename<<" from "<<p.getRemoteString()<<", with TSIG key '"<<p.getTSIGKeyname()<<"'"<<endl;
     } else {
-      g_log<<Logger::Warning<<"Received NOTIFY for "<<p.qdomain<<" from "<<p.getRemoteString()<<" but the remote is not providing a TSIG key or in allow-notify-from (Refused)"<<endl;
+      g_log<<Logger::Warning<<"Received NOTIFY for "<<zonename<<" from "<<p.getRemoteString()<<" but the remote is not providing a TSIG key or in allow-notify-from (Refused)"<<endl;
       return RCode::Refused;
     }
   }
 
   if ((!::arg().mustDo("allow-unsigned-notify") && !p.d_havetsig) || p.d_havetsig) {
     if (!p.d_havetsig) {
-      g_log<<Logger::Warning<<"Received unsigned NOTIFY for "<<p.qdomain<<" from "<<p.getRemoteString()<<" while a TSIG key was required (Refused)"<<endl;
+      g_log<<Logger::Warning<<"Received unsigned NOTIFY for "<<zonename<<" from "<<p.getRemoteString()<<" while a TSIG key was required (Refused)"<<endl;
       return RCode::Refused;
     }
     vector<string> meta;
-    if (B.getDomainMetadata(p.qdomain,"AXFR-MASTER-TSIG",meta) && meta.size() > 0) {
+    if (B.getDomainMetadata(zonename,"AXFR-MASTER-TSIG",meta) && meta.size() > 0) {
       DNSName expected{meta[0]};
       if (p.getTSIGKeyname() != expected) {
-        g_log<<Logger::Warning<<"Received secure NOTIFY for "<<p.qdomain<<" from "<<p.getRemoteString()<<": expected TSIG key '"<<expected<<"', got '"<<p.getTSIGKeyname()<<"' (Refused)"<<endl;
+        g_log<<Logger::Warning<<"Received secure NOTIFY for "<<zonename<<" from "<<p.getRemoteString()<<": expected TSIG key '"<<expected<<"', got '"<<p.getTSIGKeyname()<<"' (Refused)"<<endl;
         return RCode::Refused;
       }
     }
@@ -1169,41 +1176,41 @@ int PacketHandler::processNotify(const DNSPacket& p)
   // Domain verification
   //
   DomainInfo di;
-  if(!B.getDomainInfo(p.qdomain, di, false) || !di.backend) {
+  if(!B.getDomainInfo(zonename, di, false) || !di.backend) {
     if(::arg().mustDo("autosecondary")) {
-      g_log << Logger::Warning << "Received NOTIFY for " << p.qdomain << " from " << p.getRemoteString() << " for which we are not authoritative, trying autoprimary" << endl;
+      g_log << Logger::Warning << "Received NOTIFY for " << zonename << " from " << p.getRemoteString() << " for which we are not authoritative, trying autoprimary" << endl;
       return tryAutoPrimary(p, p.getTSIGKeyname());
     }
-    g_log<<Logger::Notice<<"Received NOTIFY for "<<p.qdomain<<" from "<<p.getRemoteString()<<" for which we are not authoritative (Refused)"<<endl;
+    g_log<<Logger::Notice<<"Received NOTIFY for "<<zonename<<" from "<<p.getRemoteString()<<" for which we are not authoritative (Refused)"<<endl;
     return RCode::Refused;
   }
 
   if(pdns::isAddressTrustedNotificationProxy(p.getInnerRemote())) {
     if (di.primaries.empty()) {
-      g_log << Logger::Warning << "Received NOTIFY for " << p.qdomain << " from trusted-notification-proxy " << p.getRemoteString() << ", zone does not have any primaries defined (Refused)" << endl;
+      g_log << Logger::Warning << "Received NOTIFY for " << zonename << " from trusted-notification-proxy " << p.getRemoteString() << ", zone does not have any primaries defined (Refused)" << endl;
       return RCode::Refused;
     }
-    g_log<<Logger::Notice<<"Received NOTIFY for "<<p.qdomain<<" from trusted-notification-proxy "<<p.getRemoteString()<<endl;
+    g_log<<Logger::Notice<<"Received NOTIFY for "<<zonename<<" from trusted-notification-proxy "<<p.getRemoteString()<<endl;
   }
   else if (::arg().mustDo("primary") && di.isPrimaryType()) {
-    g_log << Logger::Warning << "Received NOTIFY for " << p.qdomain << " from " << p.getRemoteString() << " but we are primary (Refused)" << endl;
+    g_log << Logger::Warning << "Received NOTIFY for " << zonename << " from " << p.getRemoteString() << " but we are primary (Refused)" << endl;
     return RCode::Refused;
   }
   else if (!di.isPrimary(p.getInnerRemote())) {
-    g_log << Logger::Warning << "Received NOTIFY for " << p.qdomain << " from " << p.getRemoteString() << " which is not a primary (Refused)" << endl;
+    g_log << Logger::Warning << "Received NOTIFY for " << zonename << " from " << p.getRemoteString() << " which is not a primary (Refused)" << endl;
     return RCode::Refused;
   }
 
   if(!s_forwardNotify.empty()) {
     set<string> forwardNotify(s_forwardNotify);
     for(const auto & j : forwardNotify) {
-      g_log<<Logger::Notice<<"Relaying notification of domain "<<p.qdomain<<" from "<<p.getRemoteString()<<" to "<<j<<endl;
-      Communicator.notify(p.qdomain,j);
+      g_log<<Logger::Notice<<"Relaying notification of domain "<<zonename<<" from "<<p.getRemoteString()<<" to "<<j<<endl;
+      Communicator.notify(zonename,j);
     }
   }
 
   if(::arg().mustDo("secondary")) {
-    g_log<<Logger::Notice<<"Received NOTIFY for "<<p.qdomain<<" from "<<p.getRemoteString()<<" - queueing check"<<endl;
+    g_log<<Logger::Notice<<"Received NOTIFY for "<<zonename<<" from "<<p.getRemoteString()<<" - queueing check"<<endl;
     di.receivedNotify = true;
     Communicator.addSecondaryCheckRequest(di, p.getInnerRemote());
   }
@@ -1296,7 +1303,7 @@ bool PacketHandler::tryReferral(DNSPacket& p, std::unique_ptr<DNSPacket>& r, con
   if(!retargeted)
     r->setA(false);
 
-  if(d_dk.isSecuredZone(d_sd.qname) && !addDSforNS(p, r, name) && d_dnssec) {
+  if(d_dk.isSecuredZone(ZoneName(d_sd.qname)) && !addDSforNS(p, r, name) && d_dnssec) {
     addNSECX(p, r, name, DNSName(), 1);
   }
 
@@ -1307,7 +1314,7 @@ void PacketHandler::completeANYRecords(DNSPacket& p, std::unique_ptr<DNSPacket>&
 {
   addNSECX(p, r, target, DNSName(), 5);
   if(d_sd.qname == p.qdomain) {
-    if(!d_dk.isPresigned(d_sd.qname)) {
+    if(!d_dk.isPresigned(ZoneName(d_sd.qname))) {
       addDNSKEY(p, r);
       addCDNSKEY(p, r);
       addCDS(p, r);
@@ -1588,7 +1595,7 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
     return true;
   }
 
-  if(!B.getAuth(state.target, pkt.qtype, &d_sd)) {
+  if(!B.getAuth(ZoneName(state.target), pkt.qtype, &d_sd)) {
     DLOG(g_log<<Logger::Error<<"We have no authority over zone '"<<state.target<<"'"<<endl);
     if (!retargeted) {
       state.r->setA(false); // drop AA if we never had a SOA in the first place
@@ -1598,19 +1605,20 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
   }
   DLOG(g_log<<Logger::Error<<"We have authority, zone='"<<d_sd.qname<<"', id="<<d_sd.domain_id<<endl);
 
+  ZoneName zonename(d_sd.qname);
   if (!retargeted) {
-    state.r->qdomainzone = d_sd.qname;
-  } else if (!d_doResolveAcrossZones && state.r->qdomainzone != d_sd.qname) {
+    state.r->qdomainzone = zonename;
+  } else if (!d_doResolveAcrossZones && state.r->qdomainzone.operator const DNSName&() != d_sd.qname) {
     // We are following a retarget outside the initial zone. Config asked us not to do that.
     return true;
   }
 
-  state.authSet.insert(d_sd.qname);
-  d_dnssec=(pkt.d_dnssecOk && d_dk.isSecuredZone(d_sd.qname));
+  state.authSet.insert(zonename);
+  d_dnssec=(pkt.d_dnssecOk && d_dk.isSecuredZone(zonename));
   state.doSigs |= d_dnssec;
 
   if(d_sd.qname==pkt.qdomain) {
-    if(!d_dk.isPresigned(d_sd.qname)) {
+    if(!d_dk.isPresigned(zonename)) {
       switch (pkt.qtype.getCode()) {
       case QType::DNSKEY:
         if(addDNSKEY(pkt, state.r)) {
@@ -1643,7 +1651,7 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
   }
 
   // this TRUMPS a cname!
-  if(d_dnssec && pkt.qtype.getCode() == QType::NSEC && !d_dk.getNSEC3PARAM(d_sd.qname, nullptr)) {
+  if(d_dnssec && pkt.qtype.getCode() == QType::NSEC && !d_dk.getNSEC3PARAM(zonename, nullptr)) {
     addNSEC(pkt, state.r, state.target, DNSName(), 5);
     if (!state.r->isEmpty()) {
       return true;
@@ -1667,7 +1675,7 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
 #ifdef HAVE_LUA_RECORDS
   if(!doLua) {
     string val;
-    d_dk.getFromMeta(d_sd.qname, "ENABLE-LUA-RECORDS", val);
+    d_dk.getFromMeta(zonename, "ENABLE-LUA-RECORDS", val);
     doLua = (val=="1");
   }
 #endif
@@ -1683,7 +1691,7 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
 
   while(B.get(zrr)) {
 #ifdef HAVE_LUA_RECORDS
-    if (zrr.dr.d_type == QType::LUA && !d_dk.isPresigned(d_sd.qname)) {
+    if (zrr.dr.d_type == QType::LUA && !d_dk.isPresigned(zonename)) {
       if(!doLua) {
         continue;
       }
@@ -1741,7 +1749,7 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
       weRedirected=true;
     }
 
-    if (DP && zrr.dr.d_type == QType::ALIAS && (pkt.qtype.getCode() == QType::A || pkt.qtype.getCode() == QType::AAAA || pkt.qtype.getCode() == QType::ANY) && !d_dk.isPresigned(d_sd.qname)) {
+    if (DP && zrr.dr.d_type == QType::ALIAS && (pkt.qtype.getCode() == QType::A || pkt.qtype.getCode() == QType::AAAA || pkt.qtype.getCode() == QType::ANY) && !d_dk.isPresigned(zonename)) {
       if (!d_doExpandALIAS) {
         g_log<<Logger::Info<<"ALIAS record found for "<<state.target<<", but ALIAS expansion is disabled."<<endl;
         continue;
@@ -1860,7 +1868,7 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
   }
   else if(weDone) {
     bool haveRecords = false;
-    bool presigned = d_dk.isPresigned(d_sd.qname);
+    bool presigned = d_dk.isPresigned(zonename);
     for(const auto& loopRR: rrset) {
       if (loopRR.dr.d_type == QType::ENT) {
         continue;

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -111,7 +111,7 @@ private:
 
   struct queryState {
     std::unique_ptr<DNSPacket> r{nullptr};
-    set<DNSName> authSet;
+    set<ZoneName> authSet;
     DNSName target;
     bool doSigs{false};
     bool noCache{false};

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -345,9 +345,10 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
   bool validKeys=dk.checkKeys(zone, checkKeyErrors);
 
   if (haveNSEC3) {
-    if(isSecure && zone.wirelength() > 222) {
+    auto wirelength = zone.operator const DNSName&().wirelength();
+    if(isSecure && wirelength > 222) {
       numerrors++;
-      cout<<"[Error] zone '" << zone << "' has NSEC3 semantics but is too long to have the hash prepended. Zone name is " << zone.wirelength() << " bytes long, whereas the maximum is 222 bytes." << endl;
+      cout<<"[Error] zone '" << zone << "' has NSEC3 semantics but is too long to have the hash prepended. Zone name is " << wirelength << " bytes long, whereas the maximum is 222 bytes." << endl;
     }
 
     vector<DNSBackend::KeyData> dbkeyset;
@@ -3496,8 +3497,8 @@ static int setNsec3(vector<string>& cmds, const std::string_view synopsis)
 
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   ZoneName zone(cmds.at(1));
-  if (zone.wirelength() > 222) {
-    cerr<<"Cannot enable NSEC3 for " << zone << " as it is too long (" << zone.wirelength() << " bytes, maximum is 222 bytes)"<<endl;
+  if (auto wirelength = zone.operator const DNSName&().wirelength(); wirelength > 222) {
+    cerr<<"Cannot enable NSEC3 for " << zone << " as it is too long (" << wirelength << " bytes, maximum is 222 bytes)"<<endl;
     return 1;
   }
   if(ns3pr.d_algorithm != 1) {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1343,7 +1343,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col) {
     unixDie("Editing file with: '"+cmdline+"', perhaps set EDITOR variable");
   }
   cmdline.clear();
-  ZoneParserTNG zpt(tmpnam, ZoneName(g_rootdnsname));
+  ZoneParserTNG zpt(static_cast<const char *>(tmpnam), ZoneName(g_rootdnsname));
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
   zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
   DNSResourceRecord zrr;
@@ -1986,7 +1986,7 @@ static void testSpeed(const ZoneName& zone, int cores)
     rr.content=tmp;
 
     snprintf(tmp, sizeof(tmp), "r-%u", rnd);
-    rr.qname=DNSName(tmp)+zone.operator const DNSName&();
+    rr.qname=DNSName(static_cast<const char *>(tmp))+zone.operator const DNSName&();
     DNSZoneRecord dzr;
     dzr.dr=DNSRecord(rr);
     if(csp.submit(dzr))
@@ -2265,6 +2265,7 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
     vector<DNSKEYRecordContent> keys;
     DNSZoneRecord zr;
 
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     di.backend->lookup(QType(QType::DNSKEY), zone.operator const DNSName&(), di.id );
     while(di.backend->get(zr)) {
       keys.push_back(*getRR<DNSKEYRecordContent>(zr.dr));
@@ -2519,6 +2520,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   cout<<"Committing"<<endl;
   db->commitTransaction();
   cout<<"Querying TXT"<<endl;
+  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   db->lookup(QType(QType::TXT), zone.operator const DNSName&(), di.id);
   if(db->get(rrget))
   {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1574,7 +1574,7 @@ static int loadZone(const ZoneName& zone, const string& fname) {
   rr.domain_id=di.id;
   bool haveSOA = false;
   while(zpt.get(rr)) {
-    if(!rr.qname.isPartOf(zone) && rr.qname!=zone.operator const DNSName&()) {
+    if(!rr.qname.isPartOf(zone)) {
       cerr<<"File contains record named '"<<rr.qname<<"' which is not part of zone '"<<zone<<"'"<<endl;
       return EXIT_FAILURE;
     }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -379,7 +379,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
     if(B.getSOAUncached(parent, sd_p)) {
       bool ns=false;
       DNSZoneRecord zr;
-      B.lookup(QType(QType::ANY), zone, sd_p.domain_id);
+      B.lookup(QType(QType::ANY), zone.operator const DNSName&(), sd_p.domain_id);
       while(B.get(zr))
         ns |= (zr.dr.d_type == QType::NS);
       if (!ns) {
@@ -587,7 +587,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       numwarnings++;
     }
 
-    if(rr.qname==zone) {
+    if(rr.qname==zone.operator const DNSName&()) {
       // apex checks
       if (rr.qtype.getCode() == QType::NS) {
         hasNsAtApex=true;
@@ -866,7 +866,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
         }
       }
     }
-    if( ! ds_ns && rr.qtype.getCode() == QType::DS && rr.qname != zone ) {
+    if( ! ds_ns && rr.qtype.getCode() == QType::DS && rr.qname != zone.operator const DNSName&() ) {
       cout << "[Warning] DS record without a delegation '" << rr.qname<<"'." << endl;
       numwarnings++;
     }
@@ -981,7 +981,7 @@ static int increaseSerial(const ZoneName& zone, DNSSECKeeper &dsk)
   sd.db->startTransaction(zone, -1);
 
   auto rrs = vector<DNSResourceRecord>{rr};
-  if (!sd.db->replaceRRSet(sd.domain_id, zone, rr.qtype, rrs)) {
+  if (!sd.db->replaceRRSet(sd.domain_id, zone.operator const DNSName&(), rr.qtype, rrs)) {
     cerr << "Backend did not replace SOA record. Backend might not support this operation." << endl;
     sd.db->abortTransaction();
     return -1;
@@ -995,7 +995,7 @@ static int increaseSerial(const ZoneName& zone, DNSSECKeeper &dsk)
     DNSName ordername;
     if(haveNSEC3) {
       if(!narrow)
-        ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, zone)));
+        ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, zone.operator const DNSName&())));
     } else
       ordername=DNSName("");
     if(g_verbose)
@@ -1342,7 +1342,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col) {
     unixDie("Editing file with: '"+cmdline+"', perhaps set EDITOR variable");
   }
   cmdline.clear();
-  ZoneParserTNG zpt(tmpnam, g_rootdnsname);
+  ZoneParserTNG zpt(tmpnam, ZoneName(g_rootdnsname));
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
   zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
   DNSResourceRecord zrr;
@@ -1417,7 +1417,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col) {
     cout<<c.second;
   }
   if (!changed.empty()) {
-    if (changed.find({zone, QType::SOA}) == changed.end()) {
+    if (changed.find({zone.operator const DNSName&(), QType::SOA}) == changed.end()) {
      reAsk3:;
       cout<<endl<<"You have not updated the SOA record! Would you like to increase-serial?"<<endl;
       cout<<"(y)es - increase serial, (n)o - leave SOA record as is, (e)dit your changes, (q)uit: "<<std::flush;
@@ -1425,7 +1425,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col) {
       switch(c) {
         case 'y':
           {
-            DNSRecord oldSoaDR = grouped[{zone, QType::SOA}].at(0); // there should be only one SOA record, so we can use .at(0);
+            DNSRecord oldSoaDR = grouped[{zone.operator const DNSName&(), QType::SOA}].at(0); // there should be only one SOA record, so we can use .at(0);
             ostringstream str;
             str<< col.red() << "-" << oldSoaDR.d_name << " " << oldSoaDR.d_ttl << " IN " << DNSRecordContent::NumberToType(oldSoaDR.d_type) << " " <<oldSoaDR.getContent()->getZoneRepresentation(true) << col.rst() <<endl;
 
@@ -1573,7 +1573,7 @@ static int loadZone(const ZoneName& zone, const string& fname) {
   rr.domain_id=di.id;
   bool haveSOA = false;
   while(zpt.get(rr)) {
-    if(!rr.qname.isPartOf(zone) && rr.qname!=zone) {
+    if(!rr.qname.isPartOf(zone) && rr.qname!=zone.operator const DNSName&()) {
       cerr<<"File contains record named '"<<rr.qname<<"' which is not part of zone '"<<zone<<"'"<<endl;
       return EXIT_FAILURE;
     }
@@ -1613,7 +1613,7 @@ static int createZone(const ZoneName &zone, const DNSName& nsname) {
   }
 
   DNSResourceRecord rr;
-  rr.qname = zone;
+  rr.qname = zone.operator const DNSName&();
   rr.auth = true;
   rr.ttl = ::arg().asNum("default-ttl");
   rr.qtype = "SOA";
@@ -1675,9 +1675,9 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds) {
   ZoneName zone(cmds.at(1));
   DNSName name;
   if (cmds.at(2) == "@")
-    name=zone;
+    name=zone.operator const DNSName&();
   else
-    name = DNSName(cmds.at(2)) + zone;
+    name = DNSName(cmds.at(2)) + zone.operator const DNSName&();
 
   UtilBackend B; //NOLINT(readability-identifier-length)
   DomainInfo di;
@@ -1850,9 +1850,9 @@ static int deleteRRSet(const std::string& zone_, const std::string& name_, const
 
   DNSName name;
   if(name_=="@")
-    name=zone;
+    name=zone.operator const DNSName&();
   else
-    name=DNSName(name_)+zone;
+    name=DNSName(name_)+zone.operator const DNSName&();
 
   QType qt(QType::chartocode(type_.c_str()));
   di.backend->startTransaction(zone, -1);
@@ -1957,7 +1957,7 @@ static bool testAlgorithms()
 static void testSpeed(const ZoneName& zone, int cores)
 {
   DNSResourceRecord rr;
-  rr.qname=DNSName("blah")+zone;
+  rr.qname=DNSName("blah")+zone.operator const DNSName&();
   rr.qtype=QType::A;
   rr.ttl=3600;
   rr.auth=true;
@@ -1985,7 +1985,7 @@ static void testSpeed(const ZoneName& zone, int cores)
     rr.content=tmp;
 
     snprintf(tmp, sizeof(tmp), "r-%u", rnd);
-    rr.qname=DNSName(tmp)+zone;
+    rr.qname=DNSName(tmp)+zone.operator const DNSName&();
     DNSZoneRecord dzr;
     dzr.dr=DNSRecord(rr);
     if(csp.submit(dzr))
@@ -2264,7 +2264,7 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
     vector<DNSKEYRecordContent> keys;
     DNSZoneRecord zr;
 
-    di.backend->lookup(QType(QType::DNSKEY), zone, di.id );
+    di.backend->lookup(QType(QType::DNSKEY), zone.operator const DNSName&(), di.id );
     while(di.backend->get(zr)) {
       keys.push_back(*getRR<DNSKEYRecordContent>(zr.dr));
     }
@@ -2302,19 +2302,19 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
 
       const std::string prefix(exportDS ? "" : "DS = ");
       if (g_verbose) {
-        cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;
+        cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;
       }
-      cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA256).getZoneRepresentation() << " ; ( SHA256 digest )" << endl;
+      cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA256).getZoneRepresentation() << " ; ( SHA256 digest )" << endl;
       if (g_verbose) {
         try {
-          string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
+          string output=makeDSFromDNSKey(zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
           cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( GOST R 34.11-94 digest )" << endl;
         }
         catch(...)
         {}
       }
       try {
-        string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA384).getZoneRepresentation();
+        string output=makeDSFromDNSKey(zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA384).getZoneRepresentation();
         cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( SHA-384 digest )" << endl;
       }
       catch(...)
@@ -2357,19 +2357,19 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
         const auto &key = value.first.getDNSKEY();
         const std::string prefix(exportDS ? "" : "DS = ");
         if (g_verbose) {
-          cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;
+          cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;
         }
-        cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA256).getZoneRepresentation() << " ; ( SHA256 digest )" << endl;
+        cout<<prefix<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA256).getZoneRepresentation() << " ; ( SHA256 digest )" << endl;
         if (g_verbose) {
           try {
-            string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
+            string output=makeDSFromDNSKey(zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
             cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( GOST R 34.11-94 digest )" << endl;
           }
           catch(...)
           {}
         }
         try {
-          string output=makeDSFromDNSKey(zone, key, DNSSECKeeper::DIGEST_SHA384).getZoneRepresentation();
+          string output=makeDSFromDNSKey(zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA384).getZoneRepresentation();
           cout<<prefix<<zone.toString()<<" IN DS "<<output<< " ; ( SHA-384 digest )" << endl;
         }
         catch(...)
@@ -2503,7 +2503,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   db->startTransaction(zone, di.id);
 
   rr.qtype=QType::SOA;
-  rr.qname=zone;
+  rr.qname=zone.operator const DNSName&();
   rr.ttl=86400;
   rr.domain_id=di.id;
   rr.auth=true;
@@ -2518,7 +2518,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   cout<<"Committing"<<endl;
   db->commitTransaction();
   cout<<"Querying TXT"<<endl;
-  db->lookup(QType(QType::TXT), zone, di.id);
+  db->lookup(QType(QType::TXT), zone.operator const DNSName&(), di.id);
   if(db->get(rrget))
   {
     DNSResourceRecord rrthrowaway;
@@ -2540,7 +2540,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   db->startTransaction(zone, di.id);
 
   rr.qtype=QType::SOA;
-  rr.qname=zone;
+  rr.qname=zone.operator const DNSName&();
   rr.ttl=86400;
   rr.domain_id=di.id;
   rr.auth=true;
@@ -2549,11 +2549,11 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   db->feedRecord(rr, DNSName());
 
   rr.qtype=QType::A;
-  rr.qname=DNSName("_underscore")+zone;
+  rr.qname=DNSName("_underscore")+zone.operator const DNSName&();
   rr.content="127.0.0.1";
   db->feedRecord(rr, DNSName());
 
-  rr.qname=DNSName("bla")+zone;
+  rr.qname=DNSName("bla")+zone.operator const DNSName&();
   cout<<"Committing"<<endl;
   db->commitTransaction();
 
@@ -2563,14 +2563,14 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   rectifyZone(dsk, zone);
   cout<<"Checking underscore ordering"<<endl;
   DNSName before, after;
-  db->getBeforeAndAfterNames(di.id, zone, DNSName("z")+zone, before, after);
+  db->getBeforeAndAfterNames(di.id, zone, DNSName("z")+zone.operator const DNSName&(), before, after);
   cout<<"got '"<<before.toString()<<"' < 'z."<<zone.toString()<<"' < '"<<after.toString()<<"'"<<endl;
-  if(before != DNSName("_underscore")+zone)
+  if(before != DNSName("_underscore")+zone.operator const DNSName&())
   {
     cout<<"before is wrong, got '"<<before.toString()<<"', expected '_underscore."<<zone.toString()<<"', aborting"<<endl;
     return EXIT_FAILURE;
   }
-  if(after != zone)
+  if(after != zone.operator const DNSName&())
   {
     cout<<"after is wrong, got '"<<after.toString()<<"', expected '"<<zone.toString()<<"', aborting"<<endl;
     return EXIT_FAILURE;

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -271,10 +271,10 @@ void RecordTextReader::xfrName(DNSName& val, bool, bool)
   }
 
   if (sval.empty()) {
-    sval = d_zone;
+    sval = DNSName(d_zone);
   }
   else if (!d_zone.empty()) {
-    sval += d_zone;
+    sval += DNSName(d_zone);
   }
   val = std::move(sval);
 }

--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -137,7 +137,7 @@ bool increaseSOARecord(DNSResourceRecord& rr, const string& increaseKind, const 
   SOAData sd;
   fillSOAData(rr.content, sd);
 
-  sd.serial = calculateIncreaseSOA(sd.serial, increaseKind, editKind, rr.qname);
+  sd.serial = calculateIncreaseSOA(sd.serial, increaseKind, editKind, ZoneName(rr.qname));
   rr.content = makeSOAContent(sd)->getZoneRepresentation(true);
   return true;
 }
@@ -152,7 +152,7 @@ bool makeIncreasedSOARecord(SOAData& sd, const string& increaseKind, const strin
   if (increaseKind.empty())
     return false;
 
-  sd.serial = calculateIncreaseSOA(sd.serial, increaseKind, editKind, sd.qname);
+  sd.serial = calculateIncreaseSOA(sd.serial, increaseKind, editKind, ZoneName(sd.qname));
   rrout.qname = sd.qname;
   rrout.content = makeSOAContent(sd)->getZoneRepresentation(true);
   rrout.qtype = QType::SOA;
@@ -165,7 +165,7 @@ bool makeIncreasedSOARecord(SOAData& sd, const string& increaseKind, const strin
 
 DNSZoneRecord makeEditedDNSZRFromSOAData(DNSSECKeeper& dk, const SOAData& sd, DNSResourceRecord::Place place) {
   SOAData edited = sd;
-  edited.serial = calculateEditSOA(sd.serial, dk, sd.qname);
+  edited.serial = calculateEditSOA(sd.serial, dk, ZoneName(sd.qname));
 
   DNSRecord soa;
   soa.d_name = sd.qname;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1265,7 +1265,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock)
   }
 
   if (serialPermitsIXFR) {
-    ZoneName target = zonename;
+    const ZoneName& target = zonename;
     TSIGRecordContent trc;
     DNSName tsigkeyname;
     string tsigsecret;

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -139,7 +139,7 @@ public:
   void lookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket *pkt_p = nullptr) override
   {
     d_currentScopeMask = 0;
-    findZone(qdomain, zoneId, d_records, d_currentZone);
+    findZone(ZoneName(qdomain), zoneId, d_records, d_currentZone);
 
     if (d_records) {
       if (qdomain == DNSName("geo.powerdns.com.") && pkt_p != nullptr) {
@@ -263,14 +263,14 @@ public:
       }
 
       auto& idx = records->get<OrderedNameTypeTag>();
-      auto range = idx.equal_range(std::tuple(best, QType::SOA));
+      auto range = idx.equal_range(std::tuple(best.operator const DNSName&(), QType::SOA));
       if (range.first == range.second) {
         return false;
       }
 
       fillSOAData(range.first->d_content, *soadata);
       soadata->ttl = range.first->d_ttl;
-      soadata->qname = best;
+      soadata->qname = best.operator const DNSName&();
       soadata->domain_id = static_cast<int>(zoneId);
       return true;
     }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -434,7 +434,7 @@ static std::vector<std::unique_ptr<DNSBackend>>::iterator findBestMatchingBacken
   return backend;
 }
 
-static bool foundTarget(const DNSName& target, const DNSName& shorter, const QType& qtype, [[maybe_unused]] SOAData* soaData, const bool found)
+static bool foundTarget(const ZoneName& target, const ZoneName& shorter, const QType& qtype, [[maybe_unused]] SOAData* soaData, const bool found)
 {
   if (found == (qtype == QType::DS) || target != shorter) {
     DLOG(g_log << Logger::Error << "found: " << soaData->qname << endl);
@@ -467,7 +467,7 @@ bool UeberBackend::getAuth(const ZoneName& target, const QType& qtype, SOAData* 
     if (cachedOk && g_zoneCache.isEnabled()) {
       if (g_zoneCache.getEntry(shorter, zoneId)) {
         if (fillSOAFromZoneRecord(shorter, zoneId, soaData)) {
-          if (foundTarget(target.operator const DNSName&(), shorter.operator const DNSName&(), qtype, soaData, found)) {
+          if (foundTarget(target, shorter, qtype, soaData, found)) {
             return true;
           }
 
@@ -489,7 +489,7 @@ bool UeberBackend::getAuth(const ZoneName& target, const QType& qtype, SOAData* 
     if (cachedOk && (d_cache_ttl != 0 || d_negcache_ttl != 0)) {
       auto cacheResult = fillSOAFromCache(soaData, shorter);
       if (cacheResult == CacheResult::Hit) {
-        if (foundTarget(target.operator const DNSName&(), shorter.operator const DNSName&(), qtype, soaData, found)) {
+        if (foundTarget(target, shorter, qtype, soaData, found)) {
           return true;
         }
 
@@ -535,7 +535,7 @@ bool UeberBackend::getAuth(const ZoneName& target, const QType& qtype, SOAData* 
       }
     }
 
-    if (foundTarget(target.operator const DNSName&(), shorter.operator const DNSName&(), qtype, soaData, found)) {
+    if (foundTarget(target, shorter, qtype, soaData, found)) {
       return true;
     }
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -398,12 +398,13 @@ static std::vector<std::unique_ptr<DNSBackend>>::iterator findBestMatchingBacken
 
     DLOG(g_log << Logger::Error << "backend: " << backend - backends.begin() << ", qname: " << shorter << endl);
 
-    if (bestMatch->first < shorter.wirelength()) {
+    auto wirelength = shorter.operator const DNSName&().wirelength();
+    if (bestMatch->first < wirelength) {
       DLOG(g_log << Logger::Error << "skipped, we already found a shorter best match in this backend: " << bestMatch->second.qname << endl);
       continue;
     }
 
-    if (bestMatch->first == shorter.wirelength()) {
+    if (bestMatch->first == wirelength) {
       DLOG(g_log << Logger::Error << "use shorter best match: " << bestMatch->second.qname << endl);
       *soaData = bestMatch->second;
       break;
@@ -455,7 +456,7 @@ bool UeberBackend::getAuth(const ZoneName& target, const QType& qtype, SOAData* 
 
   bool found = false;
   ZoneName shorter(target);
-  vector<pair<size_t, SOAData>> bestMatches(backends.size(), pair(target.wirelength() + 1, SOAData()));
+  vector<pair<size_t, SOAData>> bestMatches(backends.size(), pair(target.operator const DNSName&().wirelength() + 1, SOAData()));
 
   bool first = true;
   while (first || shorter.chopOff()) {

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -266,6 +266,13 @@ DNSName apiNameToDNSName(const string& name)
   }
 }
 
+#if defined(PDNS_AUTH)
+ZoneName apiNameToZoneName(const string& name)
+{
+  return ZoneName(apiNameToDNSName(name));
+}
+#endif
+
 ZoneName apiZoneIdToName(const string& identifier)
 {
   string zonename;

--- a/pdns/ws-api.hh
+++ b/pdns/ws-api.hh
@@ -37,6 +37,9 @@ string apiZoneNameToId(const ZoneName& name);
 void apiCheckNameAllowedCharacters(const string& name);
 void apiCheckQNameAllowedCharacters(const string& name);
 DNSName apiNameToDNSName(const string& name);
+#if defined(PDNS_AUTH)
+ZoneName apiNameToZoneName(const string& name);
+#endif
 
 // To be provided by product code.
 void productServerStatisticsFetch(std::map<string, string>& out);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -430,13 +430,13 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
 
   Json::array tsig_primary_keys;
   for (const auto& keyname : tsig_primary) {
-    tsig_primary_keys.emplace_back(apiZoneNameToId(DNSName(keyname)));
+    tsig_primary_keys.emplace_back(apiZoneNameToId(ZoneName(keyname)));
   }
   doc["master_tsig_key_ids"] = tsig_primary_keys;
 
   Json::array tsig_secondary_keys;
   for (const auto& keyname : tsig_secondary) {
-    tsig_secondary_keys.emplace_back(apiZoneNameToId(DNSName(keyname)));
+    tsig_secondary_keys.emplace_back(apiZoneNameToId(ZoneName(keyname)));
   }
   doc["slave_tsig_key_ids"] = tsig_secondary_keys;
 
@@ -763,7 +763,7 @@ static void extractDomainInfoFromDocument(const Json& document, std::optional<Do
 static void extractJsonTSIGKeyIds(UeberBackend& backend, const Json& jsonArray, vector<string>& metadata)
 {
   for (const auto& value : jsonArray.array_items()) {
-    auto keyname(apiZoneIdToName(value.string_value()));
+    DNSName keyname(apiZoneIdToName(value.string_value()));
     DNSName keyAlgo;
     string keyContent;
     if (!backend.getTSIGKey(keyname, keyAlgo, keyContent)) {
@@ -1270,7 +1270,7 @@ static void apiZoneCryptokeysExport(const ZoneName& zonename, int64_t inquireKey
       Json::array dses;
       for (const uint8_t keyid : {DNSSECKeeper::DIGEST_SHA256, DNSSECKeeper::DIGEST_SHA384}) {
         try {
-          string dsRecordContent = makeDSFromDNSKey(zonename, value.first.getDNSKEY(), keyid).getZoneRepresentation();
+          string dsRecordContent = makeDSFromDNSKey(zonename.operator const DNSName&(), value.first.getDNSKEY(), keyid).getZoneRepresentation();
 
           dses.emplace_back(dsRecordContent);
 
@@ -1603,7 +1603,7 @@ static void checkNewRecords(vector<DNSResourceRecord>& records, const ZoneName& 
       }
     }
 
-    if (rec.qname == zone) {
+    if (rec.qname == zone.operator const DNSName&()) {
       if (nonApexTypes.count(rec.qtype.getCode()) != 0) {
         throw ApiException("Record " + rec.qname.toString() + " IN " + rec.qtype.toString() + " is not allowed at apex");
       }
@@ -1647,7 +1647,7 @@ static Json::object makeJSONTSIGKey(const DNSName& keyname, const DNSName& algo,
 {
   Json::object tsigkey = {
     {"name", keyname.toStringNoDot()},
-    {"id", apiZoneNameToId(keyname)},
+    {"id", apiZoneNameToId(ZoneName(keyname))},
     {"algorithm", algo.toStringNoDot()},
     {"key", content},
     {"type", "TSIGKey"}};
@@ -1708,7 +1708,7 @@ class TSIGKeyData
 {
 public:
   TSIGKeyData(HttpRequest* req) :
-    keyName(apiZoneIdToName(req->parameters["id"]))
+    keyName(apiZoneIdToName(req->parameters["id"]).operator const DNSName&())
   {
     try {
       if (!backend.getTSIGKey(keyName, algo, content)) {
@@ -1844,7 +1844,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   DNSSECKeeper dnssecKeeper(&backend);
   DomainInfo domainInfo;
   const auto& document = req->json();
-  ZoneName zonename = apiNameToDNSName(stringFromJson(document, "name"));
+  ZoneName zonename = apiNameToZoneName(stringFromJson(document, "name"));
   apiCheckNameAllowedCharacters(zonename.toString());
   zonename.makeUsLowerCase();
 
@@ -1915,23 +1915,23 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
 
   for (auto& resourceRecord : new_records) {
     resourceRecord.qname.makeUsLowerCase();
-    if (!resourceRecord.qname.isPartOf(zonename) && resourceRecord.qname != zonename) {
+    if (!resourceRecord.qname.isPartOf(zonename) && resourceRecord.qname != zonename.operator const DNSName&()) {
       throw ApiException("RRset " + resourceRecord.qname.toString() + " IN " + resourceRecord.qtype.toString() + ": Name is out of zone");
     }
 
     apiCheckQNameAllowedCharacters(resourceRecord.qname.toString());
 
-    if (resourceRecord.qtype.getCode() == QType::SOA && resourceRecord.qname == zonename) {
+    if (resourceRecord.qtype.getCode() == QType::SOA && resourceRecord.qname == zonename.operator const DNSName&()) {
       have_soa = true;
     }
-    if (resourceRecord.qtype.getCode() == QType::NS && resourceRecord.qname == zonename) {
+    if (resourceRecord.qtype.getCode() == QType::NS && resourceRecord.qname == zonename.operator const DNSName&()) {
       have_zone_ns = true;
     }
   }
 
   // synthesize RRs as needed
   DNSResourceRecord autorr;
-  autorr.qname = zonename;
+  autorr.qname = zonename.operator const DNSName&();
   autorr.auth = true;
   autorr.ttl = ::arg().asNum("default-ttl");
 
@@ -2018,7 +2018,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   if (!catalog && kind == DomainInfo::Primary) {
     const auto& defaultCatalog = ::arg()["default-catalog-zone"];
     if (!defaultCatalog.empty()) {
-      domainInfo.backend->setCatalog(zonename, DNSName(defaultCatalog));
+      domainInfo.backend->setCatalog(zonename, ZoneName(defaultCatalog));
     }
   }
 
@@ -2040,7 +2040,7 @@ static void apiServerZonesGET(HttpRequest* req, HttpResponse* resp)
   if (req->getvars.count("zone") != 0) {
     string zone = req->getvars["zone"];
     apiCheckNameAllowedCharacters(zone);
-    ZoneName zonename = apiNameToDNSName(zone);
+    ZoneName zonename = apiNameToZoneName(zone);
     zonename.makeUsLowerCase();
     DomainInfo domainInfo;
     if (backend.getDomainInfo(zonename, domainInfo)) {
@@ -2123,12 +2123,12 @@ static void apiServerZoneDetailPUT(HttpRequest* req, HttpResponse* resp)
 
     for (auto& resourceRecord : new_records) {
       resourceRecord.qname.makeUsLowerCase();
-      if (!resourceRecord.qname.isPartOf(zoneData.zoneName) && resourceRecord.qname != zoneData.zoneName) {
+      if (!resourceRecord.qname.isPartOf(zoneData.zoneName) && resourceRecord.qname != zoneData.zoneName.operator const DNSName&()) {
         throw ApiException("RRset " + resourceRecord.qname.toString() + " IN " + resourceRecord.qtype.toString() + ": Name is out of zone");
       }
       apiCheckQNameAllowedCharacters(resourceRecord.qname.toString());
 
-      if (resourceRecord.qtype.getCode() == QType::SOA && resourceRecord.qname == zoneData.zoneName) {
+      if (resourceRecord.qtype.getCode() == QType::SOA && resourceRecord.qname == zoneData.zoneName.operator const DNSName&()) {
         haveSoa = true;
       }
     }
@@ -2314,7 +2314,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
 
     for (const auto& rrset : rrsets.array_items()) {
       string changetype = toUpper(stringFromJson(rrset, "changetype"));
-      ZoneName qname = apiNameToDNSName(stringFromJson(rrset, "name"));
+      ZoneName qname = apiNameToZoneName(stringFromJson(rrset, "name"));
       apiCheckQNameAllowedCharacters(qname.toString());
       QType qtype;
       qtype = stringFromJson(rrset, "type");
@@ -2329,7 +2329,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
 
       if (changetype == "DELETE") {
         // delete all matching qname/qtype RRs (and, implicitly comments).
-        if (!domainInfo.backend->replaceRRSet(domainInfo.id, qname, qtype, vector<DNSResourceRecord>())) {
+        if (!domainInfo.backend->replaceRRSet(domainInfo.id, qname.operator const DNSName&(), qtype, vector<DNSResourceRecord>())) {
           throw ApiException("Hosting backend does not support editing records.");
         }
       }
@@ -2353,11 +2353,11 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
           if (replace_records) {
             // ttl shouldn't be part of DELETE, and it shouldn't be required if we don't get new records.
             uint32_t ttl = uintFromJson(rrset, "ttl");
-            gatherRecords(rrset, qname, qtype, ttl, new_records);
+            gatherRecords(rrset, qname.operator const DNSName&(), qtype, ttl, new_records);
 
             for (DNSResourceRecord& resourceRecord : new_records) {
               resourceRecord.domain_id = static_cast<int>(domainInfo.id);
-              if (resourceRecord.qtype.getCode() == QType::SOA && resourceRecord.qname == zonename) {
+              if (resourceRecord.qtype.getCode() == QType::SOA && resourceRecord.qname == zonename.operator const DNSName&()) {
                 soa_edit_done = increaseSOARecord(resourceRecord, soa_edit_api_kind, soa_edit_kind);
               }
             }
@@ -2365,7 +2365,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
           }
 
           if (replace_comments) {
-            gatherComments(rrset, qname, qtype, new_comments);
+            gatherComments(rrset, qname.operator const DNSName&(), qtype, new_comments);
 
             for (Comment& comment : new_comments) {
               comment.domain_id = static_cast<int>(domainInfo.id);
@@ -2381,7 +2381,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
           bool dname_seen = false;
           bool ns_seen = false;
 
-          domainInfo.backend->APILookup(QType(QType::ANY), qname, static_cast<int>(domainInfo.id), false);
+          domainInfo.backend->APILookup(QType(QType::ANY), qname.operator const DNSName&(), static_cast<int>(domainInfo.id), false);
           DNSResourceRecord resourceRecord;
           while (domainInfo.backend->get(resourceRecord)) {
             if (resourceRecord.qtype.getCode() == QType::ENT) {
@@ -2417,16 +2417,16 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
           }
           if (!new_records.empty() && ent_present) {
             QType qt_ent{0};
-            if (!domainInfo.backend->replaceRRSet(domainInfo.id, qname, qt_ent, new_records)) {
+            if (!domainInfo.backend->replaceRRSet(domainInfo.id, qname.operator const DNSName&(), qt_ent, new_records)) {
               throw ApiException("Hosting backend does not support editing records.");
             }
           }
-          if (!domainInfo.backend->replaceRRSet(domainInfo.id, qname, qtype, new_records)) {
+          if (!domainInfo.backend->replaceRRSet(domainInfo.id, qname.operator const DNSName&(), qtype, new_records)) {
             throw ApiException("Hosting backend does not support editing records.");
           }
         }
         if (replace_comments) {
-          if (!domainInfo.backend->replaceComments(domainInfo.id, qname, qtype, new_comments)) {
+          if (!domainInfo.backend->replaceComments(domainInfo.id, qname.operator const DNSName&(), qtype, new_comments)) {
             throw ApiException("Hosting backend does not support editing comments.");
           }
         }
@@ -2588,7 +2588,7 @@ static void apiServerSearchData(HttpRequest* req, HttpResponse* resp)
 
 static void apiServerCacheFlush(HttpRequest* req, HttpResponse* resp)
 {
-  ZoneName canon = apiNameToDNSName(req->getvars["domain"]);
+  ZoneName canon = apiNameToZoneName(req->getvars["domain"]);
 
   if (g_zoneCache.isEnabled()) {
     DomainInfo domainInfo;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1915,7 +1915,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
 
   for (auto& resourceRecord : new_records) {
     resourceRecord.qname.makeUsLowerCase();
-    if (!resourceRecord.qname.isPartOf(zonename) && resourceRecord.qname != zonename.operator const DNSName&()) {
+    if (!resourceRecord.qname.isPartOf(zonename)) {
       throw ApiException("RRset " + resourceRecord.qname.toString() + " IN " + resourceRecord.qtype.toString() + ": Name is out of zone");
     }
 
@@ -2123,7 +2123,7 @@ static void apiServerZoneDetailPUT(HttpRequest* req, HttpResponse* resp)
 
     for (auto& resourceRecord : new_records) {
       resourceRecord.qname.makeUsLowerCase();
-      if (!resourceRecord.qname.isPartOf(zoneData.zoneName) && resourceRecord.qname != zoneData.zoneName.operator const DNSName&()) {
+      if (!resourceRecord.qname.isPartOf(zoneData.zoneName)) {
         throw ApiException("RRset " + resourceRecord.qname.toString() + " IN " + resourceRecord.qtype.toString() + ": Name is out of zone");
       }
       apiCheckQNameAllowedCharacters(resourceRecord.qname.toString());
@@ -2335,7 +2335,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
       }
       else if (changetype == "REPLACE") {
         // we only validate for REPLACE, as DELETE can be used to "fix" out of zone records.
-        if (!qname.isPartOf(zonename) && qname != zonename.operator const DNSName&()) {
+        if (!qname.isPartOf(zonename)) {
           throw ApiException("RRset " + qname.toString() + " IN " + qtype.toString() + ": Name is out of zone");
         }
 

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -95,7 +95,7 @@ static void callback_simple( unsigned int domain_id, const DNSName &domain, cons
         dn += g_zonename.toStringNoDot() + "," + g_basedn;
         cout << "dn: " << dn << endl;
 
-        if( host.countLabels() == 0 ) { host = g_zonename; }
+        if( host.countLabels() == 0 ) { host = g_zonename.operator const DNSName&(); }
 
         if( !g_entries[dn] )
         {
@@ -312,7 +312,7 @@ int main( int argc, char* argv[] )
                                 }
                                 try
                                 {
-                                  if( i.name != g_rootdnsname && i.name != DNSName("localhost") && i.name != DNSName("0.0.127.in-addr.arpa") )
+                                  if( i.name != ZoneName(g_rootdnsname) && i.name != ZoneName("localhost") && i.name != ZoneName("0.0.127.in-addr.arpa") )
                                         {
                                                 cerr << "Parsing file: " << i.filename << ", domain: " << i.name << endl;
                                                 g_zonename = i.name;

--- a/pdns/zonemd.cc
+++ b/pdns/zonemd.cc
@@ -123,7 +123,7 @@ void pdns::ZoneMD::processRecord(const DNSRecord& record)
 
 void pdns::ZoneMD::readRecord(const DNSRecord& record)
 {
-  if (!record.d_name.isPartOf(d_zone) && record.d_name != DNSName(d_zone)) {
+  if (!record.d_name.isPartOf(d_zone)) {
     return;
   }
   if (record.d_class == QClass::IN && record.d_type == QType::SOA && d_soaRecordContent) {

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -481,9 +481,9 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
       goto retry;
   }
   if(qname=="@")
-    rr.qname=d_zonename;
+    rr.qname=DNSName(d_zonename);
   else if(!prevqname && !isCanonical(qname))
-    rr.qname += d_zonename;
+    rr.qname += DNSName(d_zonename);
   d_prevqname=rr.qname;
 
   if(d_parts.empty())

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -31,7 +31,7 @@
 class ZoneParserTNG
 {
 public:
-  ZoneParserTNG(const string& fname, ZoneName zname=g_rootdnsname, string reldir="", bool upgradeContent=false);
+  ZoneParserTNG(const string& fname, ZoneName zname=ZoneName(g_rootdnsname), string reldir="", bool upgradeContent=false);
   ZoneParserTNG(const vector<string>& zonedata, ZoneName zname, bool upgradeContent=false);
 
   ~ZoneParserTNG();


### PR DESCRIPTION
### Short description
tl;dr: no functional changes, now with 50% more uglyness! ~Please upvote and subscribe to my gitube channel!~

### Long description
Now that people have failed to object to the introduction of `ZoneName` as a special case of `DNSName`, it is time to start making it a truly different type.

This PR replaces `ZoneName`, which was an alias for `DNSName`, into a different type, which is currently something wrapping a `DNSName` object and keeping a similar interface.

For the time being, we want to prevent behind-our-backs conversions between `ZoneName` and `DNSName`, so that we are forced to see all the cases where conversion is needed, which will in turn help us rethink interfaces a bit (i.e. which routines should really take `ZoneName` as input, and which should stick to `DNSName`).

Most of the added explicit conversions are `ZoneName` being converted to `DNSName`. This conversion is costless if using `operator const DNSName&()`, which is what the code attempts to do, except for code common to the Authoritative server and the other projects, where `ZoneName` is kept as an alias for `DNSName` and thus this conversion operator is not available.

~There are some unfortunate extra `DNSName` to `ZoneName` conversions in `packethandler.cc`, which can't be eliminated due to local variable scope issues. These scope issues will disappear once #15393 gets reviewed and approved, so this should only be temporary.~

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code (more than once)
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
