### PR TITLE
Add a quiet option to pdnsutil

### DIFF
--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -19,8 +19,9 @@ Options
 -------
 
 -h, --help              Show summary of options
--v, --verbose           Be more verbose.
---force                 Force an action
+-v, --verbose           Be more verbose
+-f, --force             Force an action
+-q, --quiet             Be quiet
 --config-name <NAME>    Virtual configuration name
 --config-dir <DIR>      Location of pdns.conf. Default is /etc/powerdns.
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -60,8 +60,9 @@ po::variables_map g_vm;
 string g_programname="pdns";
 
 namespace {
-  bool g_verbose;
   bool g_force;
+  bool g_quiet;
+  bool g_verbose;
 }
 
 ArgvMap &arg()
@@ -191,7 +192,7 @@ public:
 
 UtilBackend::~UtilBackend()
 {
-  if (hasCreatedLocalFiles()) {
+  if (!g_quiet && hasCreatedLocalFiles()) {
     cout<<"WARNING: local files have been created as a result of this operation."<<endl
         <<"Be sure to check the files owner, group and permission to make sure that"<<endl
         <<"the authoritative server can correctly use them."<<endl;
@@ -2806,7 +2807,7 @@ static int rectifyAllZones(vector<string>& cmds, [[maybe_unused]] const std::str
 {
   bool quiet = (cmds.size() >= 2 && cmds.at(1) == "quiet");
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!rectifyAllZones(dk, quiet)) {
+  if (!rectifyAllZones(dk, quiet || g_quiet)) {
     return 1;
   }
   return 0;
@@ -4859,7 +4860,8 @@ try
     ("help,h", "produce help message")
     ("version", "show version")
     ("verbose,v", "be verbose")
-    ("force", "force an action")
+    ("force,f", "force an action")
+    ("quiet,q", "be quiet")
     ("config-name", po::value<string>()->default_value(""), "virtual configuration name")
     ("config-dir", po::value<string>()->default_value(SYSCONFDIR), "location of pdns.conf")
     ("no-colors", "do not use colors in output")
@@ -4876,8 +4878,9 @@ try
     cmds = g_vm["commands"].as<vector<string> >();
   }
 
-  g_verbose = g_vm.count("verbose") != 0;
   g_force = g_vm.count("force") != 0;
+  g_quiet = g_vm.count("quiet") != 0;
+  g_verbose = g_vm.count("verbose") != 0;
 
   if (g_vm.count("version") != 0) {
     cout<<"pdnsutil "<<VERSION<<endl;

--- a/regression-tests.nobackend/lmdb-id-generation/command
+++ b/regression-tests.nobackend/lmdb-id-generation/command
@@ -18,8 +18,8 @@ do
   lmdb-random-ids=${random}
 EOF
 
-  $PDNSUTIL --config-dir="${workdir}" --config-name=lmdb create-zone example.com
-  ids=$( for i in a b c ; do $PDNSUTIL --config-dir="${workdir}" --config-name=lmdb add-zone-key example.com ksk ; done | xargs )
+  $PDNSUTIL -q --config-dir="${workdir}" --config-name=lmdb create-zone example.com
+  ids=$( for i in a b c ; do $PDNSUTIL -q --config-dir="${workdir}" --config-name=lmdb add-zone-key example.com ksk ; done | xargs )
   if [ $random = no ]
   then
     if [ "$ids" = "1 2 3" ]

--- a/regression-tests.nobackend/lmdb-id-generation/expected_result
+++ b/regression-tests.nobackend/lmdb-id-generation/expected_result
@@ -1,8 +1,2 @@
-WARNING: local files have been created as a result of this operation.
-Be sure to check the files owner, group and permission to make sure that
-the authoritative server can correctly use them.
 sequential generator generated 1 2 3 correctly
-WARNING: local files have been created as a result of this operation.
-Be sure to check the files owner, group and permission to make sure that
-the authoritative server can correctly use them.
 random generator generated something other than 1 2 3, good


### PR DESCRIPTION
### Short description
Some (well, one) `pdnsutil` commands have a "quiet" option. This adds a global "quiet" option which can be used to reduce the output from `pdnsutil`.

Use this option to silence the "new files may have been created, check permission and ownership" warning added recently, for the sake of some regression tests, where these messages come in the way of getting a clean output.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
