### PR TITLE
Better behaviour with non-working DNSSEC configurations

### DIFF
--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -249,7 +249,7 @@ public:
 
   virtual bool getBeforeAndAfterNamesAbsolute(uint32_t /* id */, const DNSName& qname, DNSName& /* unhashed */, DNSName& /* before */, DNSName& /* after */)
   {
-    throw PDNSException("DNSSEC operation invoked on non-DNSSEC capable backend, qname: '" + qname.toString() + "'");
+    throw PDNSException("DNSSEC operation invoked on non-DNSSEC capable backend, qname: '" + qname.toLogString() + "'");
   }
 
   virtual bool getBeforeAndAfterNames(uint32_t /* id */, const ZoneName& zonename, const DNSName& qname, DNSName& before, DNSName& after);

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -247,11 +247,9 @@ public:
   virtual bool getTSIGKeys(std::vector<struct TSIGKey>& /* keys */) { return false; }
   virtual bool deleteTSIGKey(const DNSName& /* name */) { return false; }
 
-  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t /* id */, const DNSName& /* qname */, DNSName& /* unhashed */, DNSName& /* before */, DNSName& /* after */)
+  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t /* id */, const DNSName& qname, DNSName& /* unhashed */, DNSName& /* before */, DNSName& /* after */)
   {
-    std::cerr << "Default beforeAndAfterAbsolute called!" << std::endl;
-    abort();
-    return false;
+    throw PDNSException("DNSSEC operation invoked on non-DNSSEC capable backend, qname: '" + qname.toString() + "'");
   }
 
   virtual bool getBeforeAndAfterNames(uint32_t /* id */, const ZoneName& zonename, const DNSName& qname, DNSName& before, DNSName& after);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -885,7 +885,7 @@ void PacketHandler::addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const 
     }
   }
 
-  if (!d_sd.db->doesDNSSEC()) {
+  if (!d_sd.db->doesDNSSEC() && !narrow) {
     // We are in a configuration where the zone is primarily served by a
     // non-DNSSEC-capable backend, but DNSSEC keys have been added to the
     // zone in a second, DNSSEC-capable backend, which caused d_dnssec to

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -986,7 +986,7 @@ void PacketHandler::addNSEC(DNSPacket& /* p */, std::unique_ptr<DNSPacket>& r, c
     // zone in a second, DNSSEC-capable backend, which caused d_dnssec to
     // be set to true. While it would be nice to support such a zone
     // configuration, we don't. Log a warning and skip DNSSEC processing.
-    g_log << Logger::Notice << "Backend for zone '" << d_sd.qname << "' does not support DNSSEC operation, not adding NSEC hashes" << endl;
+    g_log << Logger::Notice << "Backend for zone '" << d_sd.qname << "' does not support DNSSEC operation, not adding NSEC records" << endl;
     return;
   }
 


### PR DESCRIPTION
### Short description
As was reported on the pdns-users lists some time ago, if you set up a multiple backend configuration where your DNS records are served by a non-DNSSEC capable backend and your DNS keys are served by e.g. a database backend, some requests will cause the server to commit suicide with no useful information in the logs.

This PR attemps to improve this situation a bit:
- the first commit replaces the `abort` call by the throwing of an exception, which will cause it to end up in the logs, and a proper ServFail response.
- the second commit attempts to recognize that situation, in which case it will log a low-priority message and keep processing the request - but there won't be any NSEC data in the response.

I am not sure the second commit is worth having - but I also am quite sure that anything is better than a brutal call to `abort`.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)