### PR TITLE
Boring trivial dead code removal

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -673,15 +673,10 @@ void DNSPacket::setMaxReplyLen(int bytes)
 }
 
 //! Use this to set where this packet was received from or should be sent to
-void DNSPacket::setRemote(const ComboAddress *outer, std::optional<ComboAddress> inner)
+void DNSPacket::setRemote(const ComboAddress *outer)
 {
   d_remote=*outer;
-  if (inner) {
-    d_inner_remote=*inner;
-  }
-  else {
-    d_inner_remote.reset();
-  }
+  d_inner_remote.reset();
 }
 
 bool DNSPacket::hasEDNSSubnet() const

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -58,7 +58,7 @@ public:
   const string& getString(bool throwsOnTruncation=false); //!< for serialization - just passes the whole packet. If throwsOnTruncation is set, an exception will be raised if the records are too large to fit inside a single DNS payload, instead of setting the TC bit
 
   // address & socket manipulation
-  void setRemote(const ComboAddress*, std::optional<ComboAddress> = std::nullopt);
+  void setRemote(const ComboAddress*);
   ComboAddress getRemote() const;
   ComboAddress getInnerRemote() const; // for proxy protocol
   Netmask getRealRemote() const;


### PR DESCRIPTION
### Short description
While working on other things I couldn't help but notice `DNSPacket::setRemote` is never invoked with two arguments, so there is no need to keep it and its default value. The few pieces of code which care about setting that `d_inner_remote` field do it directly.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] checked an even number of boxes