### PR TITLE
dnsdist: Limit the number of concurrent build jobs to 4 on CI

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -869,7 +869,7 @@ def ci_dnsdist_make(c):
     c.run(f'make -j{get_build_concurrency(4)} -k V=1')
 
 def ci_dnsdist_run_ninja(c):
-    c.run(f'. {repo_home}/.venv/bin/activate && ninja -j{get_build_concurrency()} --verbose')
+    c.run(f'. {repo_home}/.venv/bin/activate && ninja -j{get_build_concurrency(4)} --verbose')
 
 @task
 def ci_dnsdist_make_bear(c, builder):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We are experiencing a lot of build failures on GH actions when building with `meson` and `ASAN+UBSAN`, likely running out of memory. We could try to be smarter and only reduce the concurrency when building with `ASAN+UBSAN`, but for now let's see if it makes the failures go away.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
