### PR TITLE
dnsdist: Properly handle buffering in the "max read IOs" test

### DIFF
--- a/regression-tests.dnsdist/test_TCPLimits.py
+++ b/regression-tests.dnsdist/test_TCPLimits.py
@@ -168,13 +168,16 @@ class TestTCPLimitsReadIO(DNSDistTest):
             try:
                 conn.send(payload[count].to_bytes())
                 count = count + 1
-            except Exception as e:
+                time.sleep(0.001)
+            except:
                 failed = True
                 break
 
         if not failed:
             try:
                 response = self.recvTCPResponseOverConnection(conn)
+                if not response:
+                  failed = True
             except:
                 failed = True
 
@@ -188,7 +191,7 @@ class TestTCPLimitsReadIO(DNSDistTest):
             response = self.recvTCPResponseOverConnection(conn)
             if response is None:
               failed = True
-        except Exception as e:
+        except:
             failed = True
         finally:
             conn.close()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It is completely possible that the entire query will be sent before the dnsdist process notices that the number of IOs is larger than the limit, closes the connection, and the test process is notified of the socket being closed (for example because of buffering). So we need to detect that the connection is closed during our attempt to read the response, rather than while we are sending the query. This commit does that, and also introduces a slight delay after sending each byte of the query, increasing the likelihood of the dnsdist process actually reading bytes one by one.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
