### PR TITLE
dnsdist: Fix a confusion about contexts/frontends in `getDNSCryptBind`

### DIFF
--- a/pdns/dnsdistdist/dnsdist-frontend.cc
+++ b/pdns/dnsdistdist/dnsdist-frontend.cc
@@ -32,11 +32,11 @@ const std::vector<std::shared_ptr<ClientState>>& getFrontends()
   return dnsdist::configuration::getImmutableConfiguration().d_frontends;
 }
 
-std::vector<std::shared_ptr<DNSCryptContext>> getDNSCryptFrontends()
+std::vector<std::shared_ptr<DNSCryptContext>> getDNSCryptFrontends(bool udpOnly)
 {
   std::vector<std::shared_ptr<DNSCryptContext>> results;
   for (const auto& frontend : getFrontends()) {
-    if (frontend->getProtocol() == dnsdist::Protocol::DNSCryptUDP || frontend->getProtocol() == dnsdist::Protocol::DNSCryptTCP) {
+    if (frontend->getProtocol() == dnsdist::Protocol::DNSCryptUDP || (!udpOnly && frontend->getProtocol() == dnsdist::Protocol::DNSCryptTCP)) {
       results.push_back(frontend->dnscryptCtx);
     }
   }

--- a/pdns/dnsdistdist/dnsdist-frontend.hh
+++ b/pdns/dnsdistdist/dnsdist-frontend.hh
@@ -34,7 +34,7 @@ struct DOH3Frontend;
 namespace dnsdist
 {
 const std::vector<std::shared_ptr<ClientState>>& getFrontends();
-std::vector<std::shared_ptr<DNSCryptContext>> getDNSCryptFrontends();
+std::vector<std::shared_ptr<DNSCryptContext>> getDNSCryptFrontends(bool udpOnly);
 std::vector<std::shared_ptr<TLSFrontend>> getDoTFrontends();
 std::vector<std::shared_ptr<DOHFrontend>> getDoHFrontends();
 std::vector<std::shared_ptr<DOQFrontend>> getDoQFrontends();

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
@@ -108,7 +108,7 @@ void setupLuaBindingsDNSCrypt([[maybe_unused]] LuaContext& luaCtx, [[maybe_unuse
     return ret.str();
   });
 
-  luaCtx.registerFunction<void (DNSCryptContext::*)(const std::string& providerPrivateKeyFile, uint32_t serial, time_t begin, time_t end, boost::optional<DNSCryptExchangeVersion> version)>("generateAndLoadInMemoryCertificate", [](DNSCryptContext& ctx, const std::string& providerPrivateKeyFile, uint32_t serial, time_t begin, time_t end, boost::optional<DNSCryptExchangeVersion> version) {
+  luaCtx.registerFunction<bool (DNSCryptContext::*)(const std::string& providerPrivateKeyFile, uint32_t serial, time_t begin, time_t end, boost::optional<DNSCryptExchangeVersion> version)>("generateAndLoadInMemoryCertificate", [](DNSCryptContext& ctx, const std::string& providerPrivateKeyFile, uint32_t serial, time_t begin, time_t end, boost::optional<DNSCryptExchangeVersion> version) -> bool {
     DNSCryptPrivateKey privateKey;
     DNSCryptCert cert;
 
@@ -120,7 +120,9 @@ void setupLuaBindingsDNSCrypt([[maybe_unused]] LuaContext& luaCtx, [[maybe_unuse
     catch (const std::exception& e) {
       errlog("Error generating a DNSCrypt certificate: %s", e.what());
       g_outputBuffer = "Error generating a DNSCrypt certificate: " + string(e.what()) + "\n";
+      return false;
     }
+    return true;
   });
 
   /* DNSCryptCertificatePair */

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -1594,7 +1594,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.writeFunction("getDNSCryptBind", [](uint64_t idx) {
     setLuaNoSideEffect();
     std::shared_ptr<DNSCryptContext> ret = nullptr;
-    auto frontends = dnsdist::getDNSCryptFrontends();
+    /* we are only interested in distinct DNSCrypt binds,
+       and we have two frontends (UDP and TCP) per bind
+       sharing the same context so we need to retrieve
+       the UDP ones only . */
+    auto frontends = dnsdist::getDNSCryptFrontends(true);
     if (idx < frontends.size()) {
       ret = frontends.at(idx);
     }
@@ -1603,7 +1607,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
   luaCtx.writeFunction("getDNSCryptBindCount", []() {
     setLuaNoSideEffect();
-    return dnsdist::getDNSCryptFrontends().size();
+    /* we are only interested in distinct DNSCrypt binds,
+       and we have two frontends (UDP and TCP) per bind
+       sharing the same context so we need to retrieve
+       the UDP ones only . */
+    return dnsdist::getDNSCryptFrontends(true).size();
   });
 #endif /* HAVE_DNSCRYPT */
 

--- a/pdns/dnsdistdist/docs/reference/dnscrypt.rst
+++ b/pdns/dnsdistdist/docs/reference/dnscrypt.rst
@@ -146,9 +146,12 @@ Context
     :param DNSCryptPrivateKey key: The private key corresponding to the certificate
     :param bool active: Whether the certificate should be advertised to clients. Default is true
 
-  .. method:: DNSCryptContext:generateAndLoadInMemoryCertificate(keyfile, serial, begin, end [, version])
+  .. method:: DNSCryptContext:generateAndLoadInMemoryCertificate(keyfile, serial, begin, end [, version]) -> bool
 
-    Generate a new resolver key and the associated certificate in-memory, sign it with the provided provider key, and add it to the context
+  .. versionchanged:: 2.0.0
+    A return value indicating whether the certificate was correctly loaded has been added. Before 2.0.0 the method did not return any value.
+
+    Generate a new resolver key and the associated certificate in-memory, sign it with the provided provider key, and add it to the context. Returns true if the certificate was correctly loaded, false otherwise.
 
     :param string keyfile: Path to the provider key file to use
     :param int serial: The serial number of the certificate


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We internally keep two different frontends (UDP and TCP) for DNSCrypt configuration binds, but the frontends should not be exposed to the user.
`getDNSCryptBind` should return distinct DNSCrypt contexts, one per DNSCrypt configuration bind. This was broken between 1.9.x and 2.0 during the refactoring of how frontends are internally kept.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
