### PR TITLE
Document mysql foreign keys being incompatible with group replication

### DIFF
--- a/docs/backends/generic-mysql.rst
+++ b/docs/backends/generic-mysql.rst
@@ -48,6 +48,11 @@ domains table. The following SQL does the job:
 .. literalinclude:: ../../modules/gmysqlbackend/enable-foreign-keys.mysql.sql
    :language: SQL
 
+.. warning::
+  Please note, however, that setting up these foreign key constraints prevents
+  the PowerDNS database from being usable with mysql group replication, if you
+  are using multiple servers.
+
 Using MySQL/MariaDB replication
 -------------------------------
 


### PR DESCRIPTION
### Short description
As discussed on pdns-users@ recently, the use of foreign key constraints with the mysql database prevents it from being usable with group replication, and the error messages are not really helpful, so put a warning in the documentation to save our future selves some time.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
