### PR TITLE
dnsdist: Fix an iterator out-of-bound read when removing a TCP-only server

### DIFF
--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -1078,6 +1078,7 @@ void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
   bool tcpOnly = true;
   for (auto it = newServers->begin(); it != newServers->end();) {
     if (found) {
+      tcpOnly = tcpOnly && it->second->isTCPOnly();
       /* we need to renumber the servers placed
          after the removed one, for Lua (custom policies) */
       it->first = idx++;
@@ -1087,10 +1088,10 @@ void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
       it = newServers->erase(it);
       found = true;
     } else {
+      tcpOnly = tcpOnly && it->second->isTCPOnly();
       idx++;
       it++;
     }
-    tcpOnly = tcpOnly && it->second->isTCPOnly();
   }
   d_tcpOnly = tcpOnly;
   *servers = std::move(newServers);

--- a/regression-tests.dnsdist/test_PoolManagement.py
+++ b/regression-tests.dnsdist/test_PoolManagement.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import dns
+from dnsdisttests import DNSDistTest, pickAvailablePort
+
+class TestPoolManagement(DNSDistTest):
+    _config_template = """
+    local backendPort = %d
+    server1 = newServer{address="127.0.0.1:"..backendPort, tcpOnly=true}
+    server2 = newServer{address="127.0.0.1:"..backendPort, tcpOnly=true}
+    server3 = newServer{address="127.0.0.1:"..backendPort, tcpOnly=true}
+    server1:addPool("new-pool")
+    server2:addPool("new-pool")
+    server3:addPool("new-pool")
+    server1:rmPool("new-pool")
+    server1:addPool("new-pool")
+    rmServer(server1)
+    rmServer(server2)
+    server3:rmPool("new-pool")
+    """
+
+    def testSimpleA(self):
+        """
+        Pool management: A query without EDNS
+        """
+        name = 'pool-mngmt.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=False)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Introduced in https://github.com/PowerDNS/pdns/pull/15418 so we will need to backport this one to 1.9.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
