### PR TITLE
dnsdist: Reduce memory usage with fast-changing dynamic backends

### DIFF
--- a/dockerdata/dnsdist-resolver.lua
+++ b/dockerdata/dnsdist-resolver.lua
@@ -145,6 +145,8 @@ function _M.maintenance()
             end
         end
     end
+    collectgarbage()
+    collectgarbage()
 end
 
 return _M


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The Lua code in `dnsdist-resolver.lua` periodically check whether the IP addresses associated with configured backend names have changed, and if they have it does potentially remove backends whose IP addresses are no longer present, and adds backends for new IP addresses. Each backend configured in DNSdist uses a fair amount of memory because of the states we pre-allocate for UDP queries, and unfortunately it looks like Lua holds to removed backends for quite a while by default, causing the removed backends to actually co-exist in memory with the new ones for a long time, leading to a higher than necessary memory consumption. This is particularly problematic when you realize that the memory allocator usually hold onto memory even when the program releases it. So in environments where IP addresses are updated very often, DNSdist can consume several times the memory it actually needs, which is not nice. This commit forces Lua to do a garbage collection cycle after refreshing servers, thus releasing removed servers much more quickly. This is far from ideal, but I don't have a better idea yet.

Related to https://github.com/PowerDNS/pdns/issues/15446

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
