### PR TITLE
dnsdist: Fix spurious failure of the TCP limits regression tests

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -1212,7 +1212,7 @@ void IncomingTCPConnectionState::handleIO()
     }
 
     const auto& immutable = dnsdist::configuration::getImmutableConfiguration();
-    if (d_readIOsCurrentQuery >= immutable.d_maxTCPReadIOsPerQuery) {
+    if (immutable.d_maxTCPReadIOsPerQuery > 0 && d_readIOsCurrentQuery >= immutable.d_maxTCPReadIOsPerQuery) {
       vinfolog("Terminating TCP connection from %s for reaching the maximum number of read IO events per query (%d)", d_ci.remote.toStringWithPort(), immutable.d_maxTCPReadIOsPerQuery);
       dnsdist::IncomingConcurrentTCPConnectionsManager::banClientFor(d_ci.remote, time(nullptr), immutable.d_tcpBanDurationForExceedingMaxReadIOsPerQuery);
       return;

--- a/regression-tests.dnsdist/test_TCPLimits.py
+++ b/regression-tests.dnsdist/test_TCPLimits.py
@@ -29,6 +29,9 @@ class TestTCPLimits(DNSDistTest):
     setMaxTCPConnectionDuration(%d)
     -- disable "near limits" otherwise our tests are broken because connections are forcibly closed
     setTCPConnectionsOverloadThreshold(0)
+    -- disable the maximum number of read IOs per query, otherwise the maximum duration (testTCPDuration)
+    -- test gets us banned very quickly
+    setMaxTCPReadIOsPerQuery(0)
     """
     _config_params = ['_testServerPort', '_tcpIdleTimeout', '_maxTCPQueriesPerConn', '_maxTCPConnsPerClient', '_maxTCPConnDuration']
 
@@ -161,6 +164,7 @@ class TestTCPLimitsReadIO(DNSDistTest):
         self.assertGreater(len(payload), self._maxTCPReadIOsPerQuery)
 
         conn = self.openTCPConnection()
+        conn.send(struct.pack("!H", len(payload)))
 
         count = 0
         failed = False


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The "maximum duration" test used to trigger the maximum number of TCP read IOs, preventing the next test from being run. This PR first makes it possible to define an "unlimited" value for the maximum number of TCP read IOs then use it for this test.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
