### PR TITLE
[auth] Use a unique type for domain ids (to bind them all, etc)

### DIFF
--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -187,19 +187,19 @@ public:
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool getSerial = true) override;
   time_t getCtime(const string& fname);
   // DNSSEC
-  bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
-  void lookup(const QType&, const DNSName& qdomain, int zoneId, DNSPacket* p = nullptr) override;
-  bool list(const ZoneName& target, int domainId, bool include_disabled = false) override;
+  bool getBeforeAndAfterNamesAbsolute(domainid_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
+  void lookup(const QType& qtype, const DNSName& qname, domainid_t zoneId, DNSPacket* p = nullptr) override;
+  bool list(const ZoneName& target, domainid_t domainId, bool include_disabled = false) override;
   bool get(DNSResourceRecord&) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled = false) override;
 
   static DNSBackend* maker();
   static std::mutex s_startup_lock;
 
-  void setStale(uint32_t domain_id) override;
-  void setFresh(uint32_t domain_id) override;
-  void setNotified(uint32_t id, uint32_t serial) override;
-  bool startTransaction(const ZoneName& qname, int domainId) override;
+  void setStale(domainid_t domain_id) override;
+  void setFresh(domainid_t domain_id) override;
+  void setNotified(domainid_t id, uint32_t serial) override;
+  bool startTransaction(const ZoneName& qname, domainid_t domainId) override;
   bool feedRecord(const DNSResourceRecord& rr, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
   bool commitTransaction() override;
   bool abortTransaction() override;
@@ -242,13 +242,13 @@ private:
   void setupDNSSEC();
   void setupStatements();
   void freeStatements();
-  static bool safeGetBBDomainInfo(int id, BB2DomainInfo* bbd);
+  static bool safeGetBBDomainInfo(domainid_t id, BB2DomainInfo* bbd);
   static void safePutBBDomainInfo(const BB2DomainInfo& bbd);
   static bool safeGetBBDomainInfo(const ZoneName& name, BB2DomainInfo* bbd);
   static bool safeRemoveBBDomainInfo(const ZoneName& name);
   shared_ptr<SSQLite3> d_dnssecdb;
   bool getNSEC3PARAM(const ZoneName& name, NSEC3PARAMRecordContent* ns3p);
-  void setLastCheck(uint32_t domain_id, time_t lastcheck);
+  static void setLastCheck(domainid_t domain_id, time_t lastcheck);
   bool getNSEC3PARAMuncached(const ZoneName& name, NSEC3PARAMRecordContent* ns3p);
   class handle
   {
@@ -269,7 +269,7 @@ private:
     DNSName qname;
     ZoneName domain;
 
-    int id{-1};
+    domainid_t id{UnknownDomainID};
     QType qtype;
     bool d_list{false};
     bool mustlog{false};
@@ -304,14 +304,14 @@ private:
   handle d_handle;
   static string s_binddirectory; //!< this is used to store the 'directory' setting of the bind configuration
   static int s_first; //!< this is raised on construction to prevent multiple instances of us being generated
-  int d_transaction_id;
+  domainid_t d_transaction_id;
   static bool s_ignore_broken_records;
   bool d_hybrid;
   bool d_upgradeContent;
 
   BB2DomainInfo createDomainEntry(const ZoneName& domain, const string& filename); //!< does not insert in s_state
 
-  void queueReloadAndStore(unsigned int id);
+  void queueReloadAndStore(domainid_t id);
   static bool findBeforeAndAfterUnhashed(std::shared_ptr<const recordstorage_t>& records, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after);
   static void insertRecord(std::shared_ptr<recordstorage_t>& records, const ZoneName& zoneName, const DNSName& qname, const QType& qtype, const string& content, int ttl, const std::string& hashed = string(), const bool* auth = nullptr);
   void reload() override;

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -64,8 +64,8 @@ public:
     return caps;
   }
 
-  void lookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p = nullptr) override;
-  bool list(const ZoneName& /* target */, int /* domain_id */, bool /* include_disabled */ = false) override { return false; } // not supported
+  void lookup(const QType& qtype, const DNSName& qdomain, domainid_t zoneId, DNSPacket* pkt_p = nullptr) override;
+  bool list(const ZoneName& /* target */, domainid_t /* domain_id */, bool /* include_disabled */ = false) override { return false; } // not supported
   bool get(DNSResourceRecord& r) override;
   void reload() override;
   void rediscover(string* status = nullptr) override;
@@ -92,7 +92,7 @@ private:
   bool hasDNSSECkey(const ZoneName& name);
   bool lookup_static(const GeoIPDomain& dom, const DNSName& search, const QType& qtype, const DNSName& qdomain, const Netmask& addr, GeoIPNetmask& gl);
   void setupNetmasks(const YAML::Node& domain, GeoIPDomain& dom);
-  bool loadDomain(const YAML::Node& domain, std::uint32_t domainID, GeoIPDomain& dom);
+  bool loadDomain(const YAML::Node& domain, domainid_t domainID, GeoIPDomain& dom);
   void loadDomainsFromDirectory(const std::string& dir, vector<GeoIPDomain>& domains);
   vector<DNSResourceRecord> d_result;
   vector<GeoIPInterface> d_files;

--- a/modules/ldapbackend/ldapbackend.hh
+++ b/modules/ldapbackend/ldapbackend.hh
@@ -82,15 +82,15 @@ class LdapBackend : public DNSBackend
   PowerLDAP* d_pldap;
   LdapAuthenticator* d_authenticator;
 
-  bool (LdapBackend::*d_list_fcnt)(const ZoneName&, int);
-  void (LdapBackend::*d_lookup_fcnt)(const QType&, const DNSName&, DNSPacket*, int);
+  bool (LdapBackend::*d_list_fcnt)(const ZoneName&, domainid_t);
+  void (LdapBackend::*d_lookup_fcnt)(const QType&, const DNSName&, DNSPacket*, domainid_t);
 
-  bool list_simple(const ZoneName& target, int domain_id);
-  bool list_strict(const ZoneName& target, int domain_id);
+  bool list_simple(const ZoneName& target, domainid_t domain_id);
+  bool list_strict(const ZoneName& target, domainid_t domain_id);
 
-  void lookup_simple(const QType& qtype, const DNSName& qdomain, DNSPacket* p, int zoneid);
-  void lookup_strict(const QType& qtype, const DNSName& qdomain, DNSPacket* p, int zoneid);
-  void lookup_tree(const QType& qtype, const DNSName& qdomain, DNSPacket* p, int zoneid);
+  void lookup_simple(const QType& qtype, const DNSName& qname, DNSPacket* p, domainid_t zoneid);
+  void lookup_strict(const QType& qtype, const DNSName& qname, DNSPacket* p, domainid_t zoneid);
+  void lookup_tree(const QType& qtype, const DNSName& qname, DNSPacket* p, domainid_t zoneid);
 
   bool reconnect();
 
@@ -111,13 +111,13 @@ public:
 
   // Native backend
   unsigned int getCapabilities() override { return CAP_LIST; }
-  bool list(const ZoneName& target, int domain_id, bool include_disabled = false) override;
-  void lookup(const QType& qtype, const DNSName& qdomain, int zoneid, DNSPacket* p = nullptr) override;
+  bool list(const ZoneName& target, domainid_t domain_id, bool include_disabled = false) override;
+  void lookup(const QType& qtype, const DNSName& qname, domainid_t zoneid, DNSPacket* dnspkt = nullptr) override;
   bool get(DNSResourceRecord& rr) override;
 
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool getSerial = true) override;
 
   // Primary backend
   void getUpdatedPrimaries(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes) override;
-  void setNotified(uint32_t id, uint32_t serial) override;
+  void setNotified(domainid_t id, uint32_t serial) override;
 };

--- a/modules/ldapbackend/native.cc
+++ b/modules/ldapbackend/native.cc
@@ -84,7 +84,7 @@ static const char* ldap_attrany[] = { // NOLINT(cppcoreguidelines-avoid-c-arrays
   "PdnsRecordOrdername",
   nullptr};
 
-bool LdapBackend::list(const ZoneName& target, int domain_id, bool /* include_disabled */)
+bool LdapBackend::list(const ZoneName& target, domainid_t domain_id, bool /* include_disabled */)
 {
   try {
     d_in_list = true;
@@ -117,7 +117,7 @@ bool LdapBackend::list(const ZoneName& target, int domain_id, bool /* include_di
   return false;
 }
 
-bool LdapBackend::list_simple(const ZoneName& target, int /* domain_id */)
+bool LdapBackend::list_simple(const ZoneName& target, domainid_t /* domain_id */)
 {
   string dn;
   string filter;
@@ -152,7 +152,7 @@ bool LdapBackend::list_simple(const ZoneName& target, int /* domain_id */)
   return true;
 }
 
-bool LdapBackend::list_strict(const ZoneName& target, int domain_id)
+bool LdapBackend::list_strict(const ZoneName& target, domainid_t domain_id)
 {
   if (target.isPartOf(DNSName("in-addr.arpa")) || target.isPartOf(DNSName("ip6.arpa"))) {
     g_log << Logger::Warning << d_myname << " Request for reverse zone AXFR, but this is not supported in strict mode" << endl;
@@ -162,7 +162,7 @@ bool LdapBackend::list_strict(const ZoneName& target, int domain_id)
   return list_simple(target, domain_id);
 }
 
-void LdapBackend::lookup(const QType& qtype, const DNSName& qname, int zoneid, DNSPacket* dnspkt)
+void LdapBackend::lookup(const QType& qtype, const DNSName& qname, domainid_t zoneid, DNSPacket* dnspkt)
 {
   try {
     d_in_list = false;
@@ -196,7 +196,7 @@ void LdapBackend::lookup(const QType& qtype, const DNSName& qname, int zoneid, D
   }
 }
 
-void LdapBackend::lookup_simple(const QType& qtype, const DNSName& qname, DNSPacket* /* dnspkt */, int /* zoneid */)
+void LdapBackend::lookup_simple(const QType& qtype, const DNSName& qname, DNSPacket* /* dnspkt */, domainid_t /* zoneid */)
 {
   string filter, attr, qesc;
   const char** attributes = ldap_attrany + 1; // skip associatedDomain
@@ -218,7 +218,7 @@ void LdapBackend::lookup_simple(const QType& qtype, const DNSName& qname, DNSPac
   d_search = d_pldap->search(getArg("basedn"), LDAP_SCOPE_SUBTREE, filter, attributes);
 }
 
-void LdapBackend::lookup_strict(const QType& qtype, const DNSName& qname, DNSPacket* /* dnspkt */, int /* zoneid */)
+void LdapBackend::lookup_strict(const QType& qtype, const DNSName& qname, DNSPacket* /* dnspkt */, domainid_t /* zoneid */)
 {
   int len;
   vector<string> parts;
@@ -260,7 +260,7 @@ void LdapBackend::lookup_strict(const QType& qtype, const DNSName& qname, DNSPac
   d_search = d_pldap->search(getArg("basedn"), LDAP_SCOPE_SUBTREE, filter, attributes);
 }
 
-void LdapBackend::lookup_tree(const QType& qtype, const DNSName& qname, DNSPacket* /* dnspkt */, int /* zoneid */)
+void LdapBackend::lookup_tree(const QType& qtype, const DNSName& qname, DNSPacket* /* dnspkt */, domainid_t /* zoneid */)
 {
   string filter, attr, qesc, dn;
   const char** attributes = ldap_attrany + 1; // skip associatedDomain
@@ -424,7 +424,7 @@ bool LdapBackend::getDomainInfo(const ZoneName& domain, DomainInfo& info, bool /
     fillSOAData(result["sOARecord"][0], sd);
 
     if (result.count("PdnsDomainId") && !result["PdnsDomainId"].empty())
-      info.id = std::stoi(result["PdnsDomainId"][0]);
+      info.id = static_cast<domainid_t>(std::stoll(result["PdnsDomainId"][0]));
     else
       info.id = 0;
 

--- a/modules/ldapbackend/primary.cc
+++ b/modules/ldapbackend/primary.cc
@@ -71,7 +71,8 @@ void LdapBackend::getUpdatedPrimaries(vector<DomainInfo>& domains, std::unordere
   }
 }
 
-void LdapBackend::setNotified(uint32_t id, uint32_t serial)
+// NOLINTNEXTLINE(readability-identifier-length)
+void LdapBackend::setNotified(domainid_t id, uint32_t serial)
 {
   string filter;
   PowerLDAP::SearchResult::Ptr search;

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -42,6 +42,10 @@
 #include <arpa/inet.h>
 #include "pipebackend.hh"
 
+// The following requirement guarantees UnknownDomainID will get output as "-1"
+// for compatibility.
+static_assert(std::is_signed<domainid_t>::value);
+
 static const char* kBackendId = "[PIPEBackend]";
 
 CoWrapper::CoWrapper(const string& command, int timeout, int abiVersion)
@@ -152,7 +156,7 @@ void PipeBackend::cleanup()
   d_abiVersion = 0;
 }
 
-void PipeBackend::lookup(const QType& qtype, const DNSName& qname, int zoneId, DNSPacket* pkt_p)
+void PipeBackend::lookup(const QType& qtype, const DNSName& qname, domainid_t zoneId, DNSPacket* pkt_p)
 {
   try {
     launch();
@@ -195,7 +199,7 @@ void PipeBackend::lookup(const QType& qtype, const DNSName& qname, int zoneId, D
   d_qname = qname;
 }
 
-bool PipeBackend::list(const ZoneName& target, int domain_id, bool /* include_disabled */)
+bool PipeBackend::list(const ZoneName& target, domainid_t domain_id, bool /* include_disabled */)
 {
   try {
     launch();

--- a/modules/pipebackend/pipebackend.hh
+++ b/modules/pipebackend/pipebackend.hh
@@ -52,8 +52,8 @@ public:
   ~PipeBackend() override;
 
   unsigned int getCapabilities() override { return CAP_DIRECT | CAP_LIST; }
-  void lookup(const QType&, const DNSName& qdomain, int zoneId, DNSPacket* p = nullptr) override;
-  bool list(const ZoneName& target, int domain_id, bool include_disabled = false) override;
+  void lookup(const QType& qtype, const DNSName& qname, domainid_t zoneId, DNSPacket* pkt_p = nullptr) override;
+  bool list(const ZoneName& target, domainid_t domain_id, bool include_disabled = false) override;
   bool get(DNSResourceRecord& r) override;
   string directBackendCmd(const string& query) override;
   static DNSBackend* maker();

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -168,16 +168,16 @@ public:
   ~RemoteBackend() override;
 
   unsigned int getCapabilities() override;
-  void lookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, DNSPacket* pkt_p = nullptr) override;
-  void APILookup(const QType& qtype, const DNSName& qdomain, int zoneId = -1, bool include_disabled = false) override;
+  void lookup(const QType& qtype, const DNSName& qdomain, domainid_t zoneId = UnknownDomainID, DNSPacket* pkt_p = nullptr) override;
+  void APILookup(const QType& qtype, const DNSName& qdomain, domainid_t zoneId = UnknownDomainID, bool include_disabled = false) override;
   bool get(DNSResourceRecord& rr) override;
-  bool list(const ZoneName& target, int domain_id, bool include_disabled = false) override;
+  bool list(const ZoneName& target, domainid_t domain_id, bool include_disabled = false) override;
 
   bool getAllDomainMetadata(const ZoneName& name, std::map<std::string, std::vector<std::string>>& meta) override;
   bool getDomainMetadata(const ZoneName& name, const std::string& kind, std::vector<std::string>& meta) override;
   bool getDomainKeys(const ZoneName& name, std::vector<DNSBackend::KeyData>& keys) override;
   bool getTSIGKey(const DNSName& name, DNSName& algorithm, std::string& content) override;
-  bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
+  bool getBeforeAndAfterNamesAbsolute(domainid_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
   bool setDomainMetadata(const ZoneName& name, const string& kind, const std::vector<std::basic_string<char>>& meta) override;
   bool removeDomainKey(const ZoneName& name, unsigned int keyId) override;
   bool addDomainKey(const ZoneName& name, const KeyData& key, int64_t& keyId) override;
@@ -186,14 +186,14 @@ public:
   bool publishDomainKey(const ZoneName& name, unsigned int keyId) override;
   bool unpublishDomainKey(const ZoneName& name, unsigned int keyId) override;
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool getSerial = true) override;
-  void setNotified(uint32_t id, uint32_t serial) override;
+  void setNotified(domainid_t id, uint32_t serial) override;
   bool autoPrimaryBackend(const string& ipAddress, const ZoneName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** ddb) override;
   bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account) override;
-  bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
+  bool replaceRRSet(domainid_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
   bool feedRecord(const DNSResourceRecord& r, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
-  bool feedEnts(int domain_id, map<DNSName, bool>& nonterm) override;
-  bool feedEnts3(int domain_id, const DNSName& domain, map<DNSName, bool>& nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
-  bool startTransaction(const ZoneName& domain, int domain_id) override;
+  bool feedEnts(domainid_t domain_id, map<DNSName, bool>& nonterm) override;
+  bool feedEnts3(domainid_t domain_id, const DNSName& domain, map<DNSName, bool>& nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
+  bool startTransaction(const ZoneName& domain, domainid_t domain_id) override;
   bool commitTransaction() override;
   bool abortTransaction() override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
@@ -205,8 +205,8 @@ public:
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
   void getUpdatedPrimaries(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes) override;
   void getUnfreshSecondaryInfos(vector<DomainInfo>* domains) override;
-  void setStale(uint32_t domain_id) override;
-  void setFresh(uint32_t domain_id) override;
+  void setStale(domainid_t domain_id) override;
+  void setFresh(domainid_t domain_id) override;
 
   static DNSBackend* maker();
 

--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -28,7 +28,7 @@
 #include <utility>
 
 static string backendname = "[TinyDNSBackend] ";
-uint32_t TinyDNSBackend::s_lastId;
+domainid_t TinyDNSBackend::s_lastId;
 LockGuarded<TinyDNSBackend::TDI_suffix_t> TinyDNSBackend::s_domainInfo;
 
 vector<string> TinyDNSBackend::getLocations()
@@ -131,7 +131,8 @@ void TinyDNSBackend::getUpdatedPrimaries(vector<DomainInfo>& retDomains, std::un
   }
 }
 
-void TinyDNSBackend::setNotified(uint32_t id, uint32_t serial)
+// NOLINTNEXTLINE(readability-identifier-length)
+void TinyDNSBackend::setNotified(domainid_t id, uint32_t serial)
 {
   auto domainInfo = s_domainInfo.lock();
   if (!domainInfo->count(d_suffix)) {
@@ -171,7 +172,7 @@ void TinyDNSBackend::getAllDomains_locked(vector<DomainInfo>* domains, bool getS
   while (get(rr)) {
     if (rr.qtype.getCode() == QType::SOA && dupcheck.insert(rr.qname).second) {
       DomainInfo di;
-      di.id = -1; // Will be overridden by caller
+      di.id = UnknownDomainID; // Will be overridden by caller
       di.backend = this;
       di.zone = ZoneName(rr.qname);
       di.kind = DomainInfo::Primary;
@@ -240,7 +241,7 @@ bool TinyDNSBackend::getDomainInfo(const ZoneName& domain, DomainInfo& di, bool 
   return found;
 }
 
-bool TinyDNSBackend::list(const ZoneName& target, int /* domain_id */, bool /* include_disabled */)
+bool TinyDNSBackend::list(const ZoneName& target, domainid_t /* domain_id */, bool /* include_disabled */)
 {
   d_isAxfr = true;
   d_isGetDomains = false;
@@ -256,7 +257,7 @@ bool TinyDNSBackend::list(const ZoneName& target, int /* domain_id */, bool /* i
   return d_cdbReader->searchSuffix(key);
 }
 
-void TinyDNSBackend::lookup(const QType& qtype, const DNSName& qdomain, int /* zoneId */, DNSPacket* pkt_p)
+void TinyDNSBackend::lookup(const QType& qtype, const DNSName& qdomain, domainid_t /* zoneId */, DNSPacket* pkt_p)
 {
   d_isAxfr = false;
   d_isGetDomains = false;

--- a/modules/tinydnsbackend/tinydnsbackend.hh
+++ b/modules/tinydnsbackend/tinydnsbackend.hh
@@ -38,7 +38,7 @@ using namespace ::boost::multi_index;
 
 struct TinyDomainInfo
 {
-  uint32_t id;
+  domainid_t id;
   uint32_t notified_serial;
   ZoneName zone;
 
@@ -69,15 +69,15 @@ public:
   TinyDNSBackend(const string& suffix);
 
   unsigned int getCapabilities() override { return CAP_LIST; }
-  void lookup(const QType& qtype, const DNSName& qdomain, int zoneId, DNSPacket* pkt_p = nullptr) override;
-  bool list(const ZoneName& target, int domain_id, bool include_disabled = false) override;
+  void lookup(const QType& qtype, const DNSName& qdomain, domainid_t zoneId, DNSPacket* pkt_p = nullptr) override;
+  bool list(const ZoneName& target, domainid_t domain_id, bool include_disabled = false) override;
   bool get(DNSResourceRecord& rr) override;
   bool getDomainInfo(const ZoneName& domain, DomainInfo& di, bool getSerial = true) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
 
   // Primary mode operation
   void getUpdatedPrimaries(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes) override;
-  void setNotified(uint32_t id, uint32_t serial) override;
+  void setNotified(domainid_t id, uint32_t serial) override;
 
 private:
   //TypeDefs
@@ -91,7 +91,7 @@ private:
     TinyDomainInfo,
     indexed_by<
       hashed_unique<tag<tag_zone>, member<TinyDomainInfo, ZoneName, &TinyDomainInfo::zone>>,
-      hashed_unique<tag<tag_domainid>, member<TinyDomainInfo, uint32_t, &TinyDomainInfo::id>>>>
+      hashed_unique<tag<tag_domainid>, member<TinyDomainInfo, domainid_t, &TinyDomainInfo::id>>>>
     TDI_t;
   typedef map<string, TDI_t> TDI_suffix_t;
   typedef TDI_t::index<tag_zone>::type TDIByZone_t;
@@ -115,5 +115,5 @@ private:
 
   // Statics
   static LockGuarded<TDI_suffix_t> s_domainInfo;
-  static uint32_t s_lastId; // used to give a domain an id.
+  static domainid_t s_lastId; // used to give a domain an id.
 };

--- a/pdns/auth-primarycommunicator.cc
+++ b/pdns/auth-primarycommunicator.cc
@@ -53,7 +53,6 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
 
   try {
     if (d_onlyNotify.size()) {
-      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
       B->lookup(QType(QType::NS), di.zone.operator const DNSName&(), di.id);
       while (B->get(rr))
         nsset.insert(getRR<NSRecordContent>(rr.dr)->getNS());
@@ -170,7 +169,7 @@ void CommunicatorClass::getUpdatedProducers(UeberBackend* B, vector<DomainInfo>&
 
         DNSResourceRecord rr;
         makeIncreasedSOARecord(sd, "EPOCH", "", rr);
-        di.backend->startTransaction(ZoneName(sd.qname), -1);
+        di.backend->startTransaction(ZoneName(sd.qname), UnknownDomainID);
         if (!di.backend->replaceRRSet(di.id, rr.qname, rr.qtype, vector<DNSResourceRecord>(1, rr))) {
           di.backend->abortTransaction();
           throw PDNSException("backend hosting producer zone '" + sd.qname.toLogString() + "' does not support editing records");

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -479,12 +479,11 @@ void CommunicatorClass::ixfrSuck(const ZoneName& domain, const TSIGTriplet& tsig
       for (const auto& x : add)
         grouped[{ZoneName(x.d_name), x.d_type}].second.push_back(x);
 
-      di.backend->startTransaction(domain, -1);
+      di.backend->startTransaction(domain, UnknownDomainID);
       for (const auto& g : grouped) {
         vector<DNSRecord> rrset;
         {
           DNSZoneRecord zrr;
-          // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
           di.backend->lookup(QType(g.first.second), g.first.first.operator const DNSName&() + domain.operator const DNSName&(), di.id);
           while (di.backend->get(zrr)) {
             zrr.dr.d_name.makeUsRelative(domain);
@@ -946,7 +945,6 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
     // Insert empty non-terminals
     if (doent && !nonterm.empty()) {
       if (zs.isNSEC3) {
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
         di.backend->feedEnts3(zs.domain_id, domain.operator const DNSName&(), nonterm, zs.ns3pr, zs.isNarrow);
       }
       else
@@ -1316,7 +1314,6 @@ void CommunicatorClass::secondaryRefresh(PacketHandler* P)
     SOAData sd;
     try {
       // Use UeberBackend cache for SOA. Cache gets cleared after AXFR/IXFR.
-      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
       B->lookup(QType(QType::SOA), di.zone.operator const DNSName&(), di.id, nullptr);
       DNSZoneRecord zr;
       hasSOA = B->get(zr);
@@ -1340,7 +1337,6 @@ void CommunicatorClass::secondaryRefresh(PacketHandler* P)
     else if (hasSOA && theirserial == ourserial) {
       uint32_t maxExpire = 0, maxInception = 0;
       if (checkSignatures && dk.isPresigned(di.zone)) {
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
         B->lookup(QType(QType::RRSIG), di.zone.operator const DNSName&(), di.id); // can't use DK before we are done with this lookup!
         DNSZoneRecord zr;
         while (B->get(zr)) {

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -199,17 +199,17 @@ protected:
 
 public:
   unsigned int getCapabilities() override;
-  void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *p=nullptr) override;
-  void APILookup(const QType &qtype, const DNSName &qname, int domain_id, bool include_disabled = false) override;
-  bool list(const ZoneName &target, int domain_id, bool include_disabled=false) override;
+  void lookup(const QType& qtype, const DNSName& qname, domainid_t domain_id, DNSPacket *p=nullptr) override;
+  void APILookup(const QType &qtype, const DNSName &qname, domainid_t domain_id, bool include_disabled = false) override;
+  bool list(const ZoneName &target, domainid_t domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
-  bool startTransaction(const ZoneName &domain, int domain_id=-1) override;
+  bool startTransaction(const ZoneName &domain, domainid_t domain_id=UnknownDomainID) override;
   bool commitTransaction() override;
   bool abortTransaction() override;
   bool feedRecord(const DNSResourceRecord &r, const DNSName &ordername, bool ordernameIsNSEC3=false) override;
-  bool feedEnts(int domain_id, map<DNSName,bool>& nonterm) override;
-  bool feedEnts3(int domain_id, const DNSName &domain, map<DNSName,bool> &nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
+  bool feedEnts(domainid_t domain_id, map<DNSName,bool>& nonterm) override;
+  bool feedEnts3(domainid_t domain_id, const DNSName &domain, map<DNSName,bool> &nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
   bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account) override;
   bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account) override;
   bool deleteDomain(const ZoneName &domain) override;
@@ -217,26 +217,26 @@ public:
   bool autoPrimaryRemove(const AutoPrimary& primary) override;
   bool autoPrimariesList(std::vector<AutoPrimary>& primaries) override;
   bool autoPrimaryBackend(const string& ipAddress, const ZoneName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** db) override;
-  void setStale(uint32_t domain_id) override;
-  void setFresh(uint32_t domain_id) override;
+  void setStale(domainid_t domain_id) override;
+  void setFresh(domainid_t domain_id) override;
   void getUnfreshSecondaryInfos(vector<DomainInfo>* domains) override;
   void getUpdatedPrimaries(vector<DomainInfo>& updatedDomains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes) override;
   bool getCatalogMembers(const ZoneName& catalog, vector<CatalogInfo>& members, CatalogInfo::CatalogType type) override;
   bool getDomainInfo(const ZoneName &domain, DomainInfo &info, bool getSerial=true) override;
-  void setNotified(uint32_t domain_id, uint32_t serial) override;
+  void setNotified(domainid_t domain_id, uint32_t serial) override;
   bool setPrimaries(const ZoneName& domain, const vector<ComboAddress>& primaries) override;
   bool setKind(const ZoneName &domain, const DomainInfo::DomainKind kind) override;
   bool setOptions(const ZoneName& domain, const string& options) override;
   bool setCatalog(const ZoneName& domain, const ZoneName& catalog) override;
   bool setAccount(const ZoneName &domain, const string &account) override;
 
-  bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
-  bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t=QType::ANY) override;
+  bool getBeforeAndAfterNamesAbsolute(domainid_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
+  bool updateDNSSECOrderNameAndAuth(domainid_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t=QType::ANY) override;
 
-  bool updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& insert ,set<DNSName>& erase, bool remove) override;
+  bool updateEmptyNonTerminals(domainid_t domain_id, set<DNSName>& insert ,set<DNSName>& erase, bool remove) override;
 
-  bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
-  bool listSubZone(const ZoneName &zone, int domain_id) override;
+  bool replaceRRSet(domainid_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
+  bool listSubZone(const ZoneName &zone, domainid_t domain_id) override;
   bool addDomainKey(const ZoneName& name, const KeyData& key, int64_t& id) override;
   bool getDomainKeys(const ZoneName& name, std::vector<KeyData>& keys) override;
   bool getAllDomainMetadata(const ZoneName& name, std::map<std::string, std::vector<std::string> >& meta) override;
@@ -254,10 +254,10 @@ public:
   bool deleteTSIGKey(const DNSName& name) override;
   bool getTSIGKeys(std::vector< struct TSIGKey > &keys) override;
 
-  bool listComments(const uint32_t domain_id) override;
+  bool listComments(const domainid_t domain_id) override;
   bool getComment(Comment& comment) override;
   bool feedComment(const Comment& comment) override;
-  bool replaceComments(const uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<Comment>& comments) override;
+  bool replaceComments(const domainid_t domain_id, const DNSName& qname, const QType& qt, const vector<Comment>& comments) override;
   string directBackendCmd(const string &query) override;
   bool searchRecords(const string &pattern, size_t maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, size_t maxResults, vector<Comment>& result) override;
@@ -266,7 +266,7 @@ protected:
   string pattern2SQLPattern(const string& pattern);
   void extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& rr);
   void extractComment(SSqlStatement::row_t& row, Comment& c);
-  void setLastCheck(uint32_t domain_id, time_t lastcheck);
+  void setLastCheck(domainid_t domain_id, time_t lastcheck);
   bool isConnectionUsable() {
     if (d_db) {
       return d_db->isConnectionUsable();

--- a/pdns/comment.hh
+++ b/pdns/comment.hh
@@ -33,6 +33,6 @@ public:
   string account; //!< account last updating this comment
   string content; //!< The actual comment. Example: blah blah
 
-  int domain_id{0};
+  domainid_t domain_id{0};
   QType qtype; //!< qtype of the associated RRset, ie A, CNAME, MX etc
 };

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -835,7 +835,7 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
   }
 
   if (doTransaction)
-    sd.db->startTransaction(zone, -1);
+    sd.db->startTransaction(zone, UnknownDomainID);
 
   bool realrr=true;
   bool doent=true;

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -52,6 +52,13 @@ public:
   static std::string to_s(uint8_t opcode);
 };
 
+// This needs to be a signed type, so that serialization of UnknownDomainID
+// as text is "-1", for compatibility with the remote and pipe backends.
+// See static_assert there for details.
+using domainid_t = int32_t;
+
+constexpr domainid_t UnknownDomainID{-1};
+
 //! This class represents a resource record
 class DNSResourceRecord
 {
@@ -83,7 +90,7 @@ public:
   uint32_t ttl{}; //!< Time To Live of this record
   uint32_t signttl{}; //!< If non-zero, use this TTL as original TTL in the RRSIG
 
-  int domain_id{-1}; //!< If a backend implements this, the domain_id of the zone this record is in
+  domainid_t domain_id{UnknownDomainID}; //!< If a backend implements this, the domain_id of the zone this record is in
   QType qtype; //!< qtype of this record, ie A, CNAME, MX etc
   uint16_t qclass{1}; //!< class of this record
 

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -68,7 +68,7 @@ int DNSBackend::getArgAsNum(const string& key)
 }
 
 // Default API lookup has no support for disabled records and simply wraps lookup()
-void DNSBackend::APILookup(const QType& qtype, const DNSName& qdomain, int zoneId, bool /* include_disabled */)
+void DNSBackend::APILookup(const QType& qtype, const DNSName& qdomain, domainid_t zoneId, bool /* include_disabled */)
 {
   lookup(qtype, qdomain, zoneId, nullptr);
 }
@@ -306,7 +306,7 @@ bool DNSBackend::get(DNSZoneRecord& zoneRecord)
   return true;
 }
 
-bool DNSBackend::getBeforeAndAfterNames(uint32_t domainId, const ZoneName& zonename, const DNSName& qname, DNSName& before, DNSName& after)
+bool DNSBackend::getBeforeAndAfterNames(domainid_t domainId, const ZoneName& zonename, const DNSName& qname, DNSName& before, DNSName& after)
 {
   DNSName unhashed;
   bool ret = this->getBeforeAndAfterNamesAbsolute(domainId, qname.makeRelative(zonename).makeLowerCase(), unhashed, before, after);

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -444,7 +444,7 @@ public:
 
 struct DNSZoneRecord
 {
-  int domain_id{-1};
+  domainid_t domain_id{UnknownDomainID};
   uint8_t scopeMask{0};
   int signttl{0};
   DNSName wildcardname;

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -223,7 +223,7 @@ public:
   bool TSIGGrantsAccess(const ZoneName& zone, const DNSName& keyname);
   bool getTSIGForAccess(const ZoneName& zone, const ComboAddress& primary, DNSName* keyname);
 
-  void startTransaction(const ZoneName& zone, int zone_id)
+  void startTransaction(const ZoneName& zone, domainid_t zone_id)
   {
     (*d_keymetadb->backends.begin())->startTransaction(zone, zone_id);
   }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1115,7 +1115,6 @@ int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& 
       g_log << Logger::Error << "Failed to create " << zonename << " for potential autoprimary " << remote << endl;
       return RCode::ServFail;
     }
-    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     g_zoneCache.add(zonename, di.id);
     if (tsigkeyname.empty() == false) {
       vector<string> meta;

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -277,7 +277,6 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
             break;
 
           bool foundShorter = false;
-          // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
           di->backend->lookup(QType(QType::ANY), shorter.operator const DNSName&(), di->id);
           while (di->backend->get(rec)) {
             if (rec.qname == rr->d_name && rec.qtype == QType::DS)
@@ -339,7 +338,6 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
         DLOG(g_log<<msgPrefix<<"Going to fix auth flags below "<<rr->d_name<<endl);
         insnonterm.clear(); // No ENT's are needed below delegates (auth=0)
         vector<DNSName> qnames;
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
         di->backend->listSubZone(ZoneName(rr->d_name), di->id);
         while(di->backend->get(rec)) {
           if (rec.qtype.getCode() && rec.qtype.getCode() != QType::DS && rr->d_name != rec.qname) // Skip ENT, DS and our already corrected record.
@@ -439,7 +437,6 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
       // If we've removed a delegate, we need to reset ordername/auth for some records.
       if (rrType == QType::NS && rr->d_name != di->zone.operator const DNSName&()) { 
         vector<DNSName> belowOldDelegate, nsRecs, updateAuthFlag;
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
         di->backend->listSubZone(ZoneName(rr->d_name), di->id);
         while (di->backend->get(rec)) {
           if (rec.qtype.getCode()) // skip ENT records, they are always auth=false
@@ -481,7 +478,6 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
       // on that level. If so, we must insert an ENT record.
       // We take extra care here to not 'include' the record that we just deleted. Some backends will still return it as they only reload on a commit.
       bool foundDeeper = false, foundOtherWithSameName = false;
-      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
       di->backend->listSubZone(ZoneName(rr->d_name), di->id);
       while (di->backend->get(rec)) {
         if (rec.qname == rr->d_name && !count(recordsToDelete.begin(), recordsToDelete.end(), rec))
@@ -793,7 +789,7 @@ int PacketHandler::processUpdate(DNSPacket& packet) { // NOLINT(readability-func
 
   std::lock_guard<std::mutex> l(s_rfc2136lock); //TODO: i think this lock can be per zone, not for everything
   g_log<<Logger::Info<<msgPrefix<<"starting transaction."<<endl;
-  if (!di.backend->startTransaction(zonename, -1)) { // Not giving the domain_id means that we do not delete the existing records.
+  if (!di.backend->startTransaction(zonename, UnknownDomainID)) { // Not giving the domain_id means that we do not delete the existing records.
     g_log<<Logger::Error<<msgPrefix<<"Backend for domain "<<zonename<<" does not support transaction. Can't do Update packet."<<endl;
     return RCode::NotImp;
   }
@@ -971,7 +967,6 @@ int PacketHandler::processUpdate(DNSPacket& packet) { // NOLINT(readability-func
     if (nsRRtoDelete.size()) {
       vector<DNSResourceRecord> nsRRInZone;
       DNSResourceRecord rec;
-      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
       di.backend->lookup(QType(QType::NS), di.zone.operator const DNSName&(), di.id);
       while (di.backend->get(rec)) {
         nsRRInZone.push_back(rec);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1997,7 +1997,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
     throw ApiException("Creating domain '" + zonename.toString() + "' failed: lookup of domain ID failed");
   }
 
-  domainInfo.backend->startTransaction(zonename, static_cast<int>(domainInfo.id));
+  domainInfo.backend->startTransaction(zonename, domainInfo.id);
 
   // will be overridden by updateDomainSettingsFromDocument, if given in document.
   domainInfo.backend->setDomainMetadataOne(zonename, "SOA-EDIT-API", "DEFAULT");
@@ -2144,7 +2144,7 @@ static void apiServerZoneDetailPUT(HttpRequest* req, HttpResponse* resp)
 
     checkNewRecords(new_records, zoneData.zoneName);
 
-    zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, static_cast<int>(zoneData.domainInfo.id));
+    zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, zoneData.domainInfo.id);
     for (auto& resourceRecord : new_records) {
       resourceRecord.domain_id = static_cast<int>(zoneData.domainInfo.id);
       zoneData.domainInfo.backend->feedRecord(resourceRecord, DNSName());
@@ -2160,7 +2160,7 @@ static void apiServerZoneDetailPUT(HttpRequest* req, HttpResponse* resp)
   }
   else {
     // avoid deleting current zone contents
-    zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, -1);
+    zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, UnknownDomainID);
   }
 
   // updateDomainSettingsFromDocument will rectify the zone and update SOA serial.
@@ -2179,7 +2179,7 @@ static void apiServerZoneDetailDELETE(HttpRequest* req, HttpResponse* resp)
 
   // delete domain
 
-  zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, -1);
+  zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, UnknownDomainID);
   try {
     if (!zoneData.domainInfo.backend->deleteDomain(zoneData.zoneName)) {
       throw ApiException("Deleting domain '" + zoneData.zoneName.toString() + "' failed: backend delete failed/unsupported");


### PR DESCRIPTION
### Short description
The Authoritative server uses numerical domain ids all over the place to uniquely identify a given domain within a backend.

There are pieces of code which use an `int`, because we use `-1` as a special "i don't know the id yet" value. Others use `uint32_t`. Others use `uint64_t`.

And because of all these mixed types, there are a bunch of "please shut up, `clang-tidy`" annotations because converting between e.g. `int` and `uint32_t` may truncate in one direction, or the other, depending on which environment you run on.

Cleaning this mess was overdue.

This PR:
- introduces a new `domainid_t` type for, well, domain ids.
- introduces a symbolic `UnknownDomainID` value to use instead of `-1`.
- adapts all users accordingly.
- documents, as `static_assert`, unwritten requirements of the `domainid_t` values in some plugins.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] checked an even number of boxes