### PR TITLE
dnsdist-1.9.x: Backport 15072 - Adjust Content-Type header for Prometheus endpoint to include version

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -913,7 +913,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
   output << "dnsdist_info{version=\"" << VERSION << "\"} " << "1" << "\n";
 
   resp.body = output.str();
-  resp.headers["Content-Type"] = "text/plain";
+  resp.headers["Content-Type"] = "text/plain; version=0.0.4";
 }
 #endif /* DISABLE_PROMETHEUS */
 

--- a/pdns/recursordist/docs/http-api/prometheus.rst
+++ b/pdns/recursordist/docs/http-api/prometheus.rst
@@ -18,7 +18,7 @@ Prometheus Data Endpoint
     HTTP/1.1 200 OK
     Connection: close
     Content-Length: 19203
-    Content-Type: text/plain
+    Content-Type: text/plain; version=0.0.4
     Server: PowerDNS/0.0.16480.0.g876dd46192
 
     # HELP pdns_recursor_all_outqueries Number of outgoing UDP queries since starting

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -562,7 +562,7 @@ static void prometheusMetrics(HttpRequest* /* req */, HttpResponse* resp)
          << "\n";
 
   resp->body = output.str();
-  resp->headers["Content-Type"] = "text/plain";
+  resp->headers["Content-Type"] = "text/plain; version=0.0.4";
   resp->status = 200;
 }
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2664,7 +2664,7 @@ static void prometheusMetrics(HttpRequest* /* req */, HttpResponse* resp)
          << "\n";
 
   resp->body = output.str();
-  resp->headers["Content-Type"] = "text/plain";
+  resp->headers["Content-Type"] = "text/plain; version=0.0.4";
   resp->status = 200;
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #15072 to dnsdist-1.9.x

Prometheus v3 will, by default, be more strict about the content-types returned from scrape endpoints. With the current value (just `text/plain`), it would fail to scrape.

In this commit the value is changed from `text/plain` to `text/plain; version=0.0.4`.

See also [1] and [2]
[1] https://prometheus.io/docs/instrumenting/exposition_formats/ [2] https://prometheus.io/docs/prometheus/3.0/migration/

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
