### PR TITLE
dnsdist-1.9.x: Backport 15418 and 15471: Fix cache lookup for unavailable TCP-only backends

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1447,6 +1447,9 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dq, LocalHolders& holders
     if (selectedBackend && selectedBackend->isTCPOnly()) {
       willBeForwardedOverUDP = false;
     }
+    else if (!selectedBackend) {
+      willBeForwardedOverUDP = !serverPool->isTCPOnly();
+    }
 
     uint32_t allowExpired = selectedBackend ? 0 : g_staleCacheEntriesTTL;
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -971,7 +971,7 @@ public:
     return d_config.d_tcpOnly || d_config.d_tcpCheck || d_tlsCtx != nullptr;
   }
 
-  bool isTCPOnly() const
+  [[nodiscard]] bool isTCPOnly() const
   {
     return d_config.d_tcpOnly || d_tlsCtx != nullptr;
   }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1071,10 +1071,15 @@ struct ServerPool
   const std::shared_ptr<const ServerPolicy::NumberedServerVector> getServers();
   void addServer(shared_ptr<DownstreamState>& server);
   void removeServer(shared_ptr<DownstreamState>& server);
+   bool isTCPOnly() const
+  {
+    return d_tcpOnly;
+  }
 
 private:
   SharedLockGuarded<std::shared_ptr<const ServerPolicy::NumberedServerVector>> d_servers;
   bool d_useECS{false};
+  bool d_tcpOnly{false};
 };
 
 enum ednsHeaderFlags {

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -974,6 +974,13 @@ void ServerPool::addServer(shared_ptr<DownstreamState>& server)
     serv.first = idx++;
   }
   *servers = std::make_shared<const ServerPolicy::NumberedServerVector>(std::move(newServers));
+
+  if ((*servers)->size() == 1) {
+    d_tcpOnly = server->isTCPOnly();
+  }
+  else if (d_tcpOnly && !server->isTCPOnly()) {
+    d_tcpOnly = false;
+  }
 }
 
 void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
@@ -984,6 +991,7 @@ void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
   auto newServers = std::make_shared<ServerPolicy::NumberedServerVector>(*(*servers));
   size_t idx = 1;
   bool found = false;
+  bool tcpOnly = true;
   for (auto it = newServers->begin(); it != newServers->end();) {
     if (found) {
       /* we need to renumber the servers placed
@@ -998,6 +1006,8 @@ void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
       idx++;
       it++;
     }
+    tcpOnly = tcpOnly && it->second->isTCPOnly();
   }
+  d_tcpOnly = tcpOnly;
   *servers = std::move(newServers);
 }

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -978,7 +978,7 @@ void ServerPool::addServer(shared_ptr<DownstreamState>& server)
   if ((*servers)->size() == 1) {
     d_tcpOnly = server->isTCPOnly();
   }
-  else if (d_tcpOnly && !server->isTCPOnly()) {
+  else if (!server->isTCPOnly()) {
     d_tcpOnly = false;
   }
 }

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -994,6 +994,7 @@ void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
   bool tcpOnly = true;
   for (auto it = newServers->begin(); it != newServers->end();) {
     if (found) {
+      tcpOnly = tcpOnly && it->second->isTCPOnly();
       /* we need to renumber the servers placed
          after the removed one, for Lua (custom policies) */
       it->first = idx++;
@@ -1003,10 +1004,10 @@ void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
       it = newServers->erase(it);
       found = true;
     } else {
+      tcpOnly = tcpOnly && it->second->isTCPOnly();
       idx++;
       it++;
     }
-    tcpOnly = tcpOnly && it->second->isTCPOnly();
   }
   d_tcpOnly = tcpOnly;
   *servers = std::move(newServers);

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -1151,15 +1151,19 @@ class TestCachingStale(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
     _staleCacheTTL = 60
-    _config_params = ['_staleCacheTTL', '_consoleKeyB64', '_consolePort', '_testServerPort']
+    _config_params = ['_staleCacheTTL', '_consoleKeyB64', '_consolePort', '_testServerPort', '_testServerPort']
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1, temporaryFailureTTL=0, staleTTL=%d})
     getPool(""):setCache(pc)
+    getPool("tcp-only"):setCache(pc)
     setStaleCacheEntriesTTL(600)
     setKey("%s")
     controlSocket("127.0.0.1:%d")
     newServer{address="127.0.0.1:%d"}
+    newServer{address="127.0.0.1:%d", tcpOnly=true, pool='tcp-only'}
+    addAction(QNameRule('stale-tcp-only.cache.tests.powerdns.com.'), PoolAction('tcp-only'))
     """
+
     def testCacheStale(self):
         """
         Cache: Cache entry, set backend down, get stale entry
@@ -1192,6 +1196,53 @@ class TestCachingStale(DNSDistTest):
 
         # ok, we mark the backend as down
         self.sendConsoleCommand("getServer(0):setDown()")
+        # and we wait for the entry to expire
+        time.sleep(ttl + 1)
+
+        # we should get a cached, stale, entry
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+        for an in receivedResponse.answer:
+            self.assertEqual(an.ttl, self._staleCacheTTL)
+
+        total = 0
+        for key in self._responsesCounter:
+            total += self._responsesCounter[key]
+
+        self.assertEqual(total, misses)
+
+    def testCacheStaleTCPOnly(self):
+        """
+        Cache: Cache entry from TCP-only backend, set backend down, get stale entry
+
+        """
+        misses = 0
+        ttl = 2
+        name = 'stale-tcp-only.cache.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    ttl,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        # Miss
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+        misses += 1
+
+        # next queries should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        # ok, we mark the backend as down
+        self.sendConsoleCommand("getServer(1):setDown()")
         # and we wait for the entry to expire
         time.sleep(ttl + 1)
 

--- a/regression-tests.dnsdist/test_PoolManagement.py
+++ b/regression-tests.dnsdist/test_PoolManagement.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import dns
+from dnsdisttests import DNSDistTest, pickAvailablePort
+
+class TestPoolManagement(DNSDistTest):
+    _config_template = """
+    local backendPort = %d
+    server1 = newServer{address="127.0.0.1:"..backendPort, tcpOnly=true}
+    server2 = newServer{address="127.0.0.1:"..backendPort, tcpOnly=true}
+    server3 = newServer{address="127.0.0.1:"..backendPort, tcpOnly=true}
+    server1:addPool("new-pool")
+    server2:addPool("new-pool")
+    server3:addPool("new-pool")
+    server1:rmPool("new-pool")
+    server1:addPool("new-pool")
+    rmServer(server1)
+    rmServer(server2)
+    server3:rmPool("new-pool")
+    """
+
+    def testSimpleA(self):
+        """
+        Pool management: A query without EDNS
+        """
+        name = 'pool-mngmt.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=False)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #15418 and #15471 (fixing an issue introduced by 15418) to dnsdist-1.9.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
