### PR TITLE
dnsdist: Don't build with `libedit` if disabled via `meson`

### DIFF
--- a/pdns/dnsdistdist/meson/libedit/meson.build
+++ b/pdns/dnsdistdist/meson/libedit/meson.build
@@ -1,5 +1,5 @@
 opt_libedit = get_option('libedit')
-dep_libedit = dependency('libedit', required: false)
+dep_libedit = dependency('libedit', required: opt_libedit)
 
 if not dep_libedit.found()
   dep_libedit = cxx.find_library('edit', required: opt_libedit)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Based on a patch by Robert Edmonds (thanks!).

Closes #15516 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
