### PR TITLE
dnsdist: Deprecate the `options` parameter of `HTTPStatusAction`

### DIFF
--- a/pdns/dnsdistdist/dnsdist-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-actions-definitions.yml
@@ -79,7 +79,7 @@
     - name: "vars"
       type: "ResponseConfig"
       default: true
-      description: "The response options"
+      description: "The response options (deprecated since 2.0.0, do not use)"
 - name: "KeyValueStoreLookup"
   description: "Does a lookup into the key value store using the key returned by ``lookup_key_name``, and storing the result if any into the tag named ``destination_tag``. The store can be a ``CDB`` or a ``LMDB`` database.  The key can be based on the qname, source IP or the value of an existing tag. Subsequent rules are processed after this action. Note that the tag is always created, even if there was no match, but in that case the content is empty"
   skip-cpp: true

--- a/pdns/dnsdistdist/docs/reference/actions.rst
+++ b/pdns/dnsdistdist/docs/reference/actions.rst
@@ -174,12 +174,15 @@ The following actions exist.
   .. versionchanged:: 1.5.0
     Added the optional parameter ``options``.
 
+  .. versionchanged:: 2.0.0
+    The ``options`` parameter is now deprecated.
+
   Return an HTTP response with a status code of ''status''. For HTTP redirects, ''body'' should be the redirect URL.
 
   :param int status: The HTTP status code to return.
   :param string body: The body of the HTTP response, or a URL if the status code is a redirect (3xx).
   :param string contentType: The HTTP Content-Type header to return for a 200 response, ignored otherwise. Default is ''application/dns-message''.
-  :param table options: A table with key: value pairs with options.
+  :param table options: A table with key: value pairs with options. Deprecated since 2.0.0 as it had unexpected side-effects.
 
   Options:
 

--- a/pdns/dnsdistdist/docs/reference/yaml-actions.rst
+++ b/pdns/dnsdistdist/docs/reference/yaml-actions.rst
@@ -117,7 +117,7 @@ Parameters:
 - **status**: Unsigned integer - The HTTP status code to return
 - **body**: String - The body of the HTTP response, or a URL if the status code is a redirect (3xx)
 - **content_type**: String ``("")`` - The HTTP Content-Type header to return for a 200 response, ignored otherwise. Default is ``application/dns-message``
-- **vars**: :ref:`ResponseConfig <yaml-settings-ResponseConfig>` - The response options
+- **vars**: :ref:`ResponseConfig <yaml-settings-ResponseConfig>` - The response options (deprecated since 2.0.0, do not use)
 
 
 .. _yaml-settings-KeyValueStoreLookupAction:

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -15,6 +15,8 @@ XPF support has been removed.
 
 :meth:`Server:setAuto` used to reset the health-check mode to ``active`` even if it had previously been set to ``lazy`` via :meth:`Server:setLazyAuto`. This is no longer the case, and :meth:`Server:setActiveAuto` should be used instead to set the health-check mode to ``Active``.
 
+The ``options`` parameter of :func:`HTTPStatusAction` has been deprecated because it had unexpected side-effects, and should thus no longer be used.
+
 1.8.x to 1.9.0
 --------------
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
As noted in #14791, it is probably not working as expected and there is no practical use for it anyway.
Closes #14791 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

