### PR TITLE
dnsdist: add option to support cache sharing between different payload sizes

### DIFF
--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -459,27 +459,17 @@ uint32_t DNSDistPacketCache::getKey(const DNSName::string_t& qname, size_t qname
     throw std::range_error("Computing packet cache key for an invalid packet size (" + std::to_string(packet.size()) + ")");
   }
 
-  if (d_settings.d_skipHashingAR) {
-    /* skip Additional Resource Records */
-    result = burtle(&packet.at(2), sizeof(dnsheader) - 4, result);
-  }
-  else {
-    result = burtle(&packet.at(2), sizeof(dnsheader) - 2, result);
-  }
+  result = burtle(&packet.at(2), sizeof(dnsheader) - 2, result);
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   result = burtleCI(reinterpret_cast<const unsigned char*>(qname.c_str()), qname.length(), result);
   if (packet.size() < sizeof(dnsheader) + qnameWireLength) {
     throw std::range_error("Computing packet cache key for an invalid packet (" + std::to_string(packet.size()) + " < " + std::to_string(sizeof(dnsheader) + qnameWireLength) + ")");
   }
   if (packet.size() > ((sizeof(dnsheader) + qnameWireLength))) {
-    if (d_settings.d_skipHashingAR) {
-      /* only need to include the 2+2 bytes for qtype and qclass */
-      result = burtle(&packet.at(sizeof(dnsheader) + qnameWireLength), 4, result);
-    }
-    else if (!d_settings.d_optionsToSkip.empty()) {
+    if (!d_settings.d_optionsToSkip.empty()) {
       /* skip EDNS options if any */
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-      result = PacketCache::hashAfterQname(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()), result, sizeof(dnsheader) + qnameWireLength, d_settings.d_optionsToSkip);
+      result = PacketCache::hashAfterQname(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()), result, sizeof(dnsheader) + qnameWireLength, d_settings.d_optionsToSkip, d_settings.d_payloadRanks);
     }
     else {
       result = burtle(&packet.at(sizeof(dnsheader) + qnameWireLength), packet.size() - (sizeof(dnsheader) + qnameWireLength), result);

--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -466,7 +466,7 @@ uint32_t DNSDistPacketCache::getKey(const DNSName::string_t& qname, size_t qname
     throw std::range_error("Computing packet cache key for an invalid packet (" + std::to_string(packet.size()) + " < " + std::to_string(sizeof(dnsheader) + qnameWireLength) + ")");
   }
   if (packet.size() > ((sizeof(dnsheader) + qnameWireLength))) {
-    if (!d_settings.d_optionsToSkip.empty()) {
+    if (!d_settings.d_optionsToSkip.empty() || !d_settings.d_payloadRanks.empty()) {
       /* skip EDNS options if any */
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       result = PacketCache::hashAfterQname(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()), result, sizeof(dnsheader) + qnameWireLength, d_settings.d_optionsToSkip, d_settings.d_payloadRanks);

--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -459,14 +459,24 @@ uint32_t DNSDistPacketCache::getKey(const DNSName::string_t& qname, size_t qname
     throw std::range_error("Computing packet cache key for an invalid packet size (" + std::to_string(packet.size()) + ")");
   }
 
-  result = burtle(&packet.at(2), sizeof(dnsheader) - 2, result);
+  if (d_settings.d_skipHashingAR) {
+    /* skip Additional Resource Records */
+    result = burtle(&packet.at(2), sizeof(dnsheader) - 4, result);
+  }
+  else {
+    result = burtle(&packet.at(2), sizeof(dnsheader) - 2, result);
+  }
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   result = burtleCI(reinterpret_cast<const unsigned char*>(qname.c_str()), qname.length(), result);
   if (packet.size() < sizeof(dnsheader) + qnameWireLength) {
     throw std::range_error("Computing packet cache key for an invalid packet (" + std::to_string(packet.size()) + " < " + std::to_string(sizeof(dnsheader) + qnameWireLength) + ")");
   }
   if (packet.size() > ((sizeof(dnsheader) + qnameWireLength))) {
-    if (!d_settings.d_optionsToSkip.empty()) {
+    if (d_settings.d_skipHashingAR) {
+      /* only need to include the 2+2 bytes for qtype and qclass */
+      result = burtle(&packet.at(sizeof(dnsheader) + qnameWireLength), 4, result);
+    }
+    else if (!d_settings.d_optionsToSkip.empty()) {
       /* skip EDNS options if any */
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       result = PacketCache::hashAfterQname(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()), result, sizeof(dnsheader) + qnameWireLength, d_settings.d_optionsToSkip);

--- a/pdns/dnsdistdist/dnsdist-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-cache.hh
@@ -51,6 +51,7 @@ public:
     bool d_deferrableInsertLock{true};
     bool d_parseECS{false};
     bool d_keepStaleData{false};
+    bool d_skipHashingAR{false};
   };
 
   DNSDistPacketCache(CacheSettings settings);

--- a/pdns/dnsdistdist/dnsdist-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-cache.hh
@@ -38,6 +38,7 @@ public:
   struct CacheSettings
   {
     std::unordered_set<uint16_t> d_optionsToSkip{EDNSOptionCode::COOKIE};
+    std::vector<uint16_t> d_payloadRanks{};
     size_t d_maxEntries{0};
     size_t d_maximumEntrySize{4096};
     uint32_t d_maxTTL{86400};
@@ -51,7 +52,6 @@ public:
     bool d_deferrableInsertLock{true};
     bool d_parseECS{false};
     bool d_keepStaleData{false};
-    bool d_skipHashingAR{false};
   };
 
   DNSDistPacketCache(CacheSettings settings);

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1096,8 +1096,7 @@ bool loadConfigurationFromFile(const std::string& fileName, [[maybe_unused]] boo
       if (cache.maximum_entry_size >= sizeof(dnsheader)) {
         settings.d_maximumEntrySize = cache.maximum_entry_size;
       }
-      for (const auto& rankstr : cache.payload_ranks) {
-        auto rank = pdns::checked_stoi<uint16_t>(std::string(rankstr));
+      for (const auto& rank : cache.payload_ranks) {
         if (rank < 512 || rank > settings.d_maximumEntrySize) {
           continue;
         }

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1095,6 +1095,9 @@ bool loadConfigurationFromFile(const std::string& fileName, [[maybe_unused]] boo
       if (cache.maximum_entry_size >= sizeof(dnsheader)) {
         settings.d_maximumEntrySize = cache.maximum_entry_size;
       }
+      if (!cache.parse_ecs) {
+        settings.d_skipHashingAR = cache.skip_hashing_ar;
+      }
       auto packetCacheObj = std::make_shared<DNSDistPacketCache>(settings);
 
       registerType<DNSDistPacketCache>(packetCacheObj, cache.name);

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -38,6 +38,7 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
       .d_shardCount = 20,
     };
     bool cookieHashing = false;
+    bool skipHashingAR = false;
     LuaArray<uint16_t> skipOptions;
     size_t maximumEntrySize{4096};
 
@@ -54,6 +55,7 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
     getOptionalValue<size_t>(vars, "truncatedTTL", settings.d_truncatedTTL);
     getOptionalValue<bool>(vars, "cookieHashing", cookieHashing);
     getOptionalValue<size_t>(vars, "maximumEntrySize", maximumEntrySize);
+    getOptionalValue<bool>(vars, "skipHashingAR", skipHashingAR);
 
     if (maximumEntrySize >= sizeof(dnsheader)) {
       settings.d_maximumEntrySize = maximumEntrySize;
@@ -80,6 +82,9 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
     if (client) {
       settings.d_maxEntries = 1;
       settings.d_shardCount = 1;
+    }
+    if (!settings.d_parseECS) {
+      settings.d_skipHashingAR = skipHashingAR;
     }
 
     return std::make_shared<DNSDistPacketCache>(settings);

--- a/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
@@ -77,7 +77,9 @@ def is_value_rust_default(rust_type, value):
     if rust_type == 'String':
         return value == ''
     if rust_type == 'Vec<String>':
-        return value == ''
+        return value == '' or value == '[]'
+    if is_vector_of(rust_type):
+        return value == '[]'
     return False
 
 def get_rust_field_name(name):

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1936,6 +1936,10 @@ packet_cache:
       type: "Vec<String>"
       default: ""
       description: "Extra list of EDNS option codes to skip when hashing the packet (if ``cookie_hashing`` above is false, EDNS cookie option number will be added to this list internally)"
+    - name: "skip_hashing_ar"
+      type: "bool"
+      default: "false"
+      description: "If true, the whole Additional Resource Record section (including all EDNS options) will be skipped when hashing the packet. This will allow cache entry sharing between multiple clients who will use different EDNS0 payload size in its request for the same query name/type/class. However, if ``parse_ecs`` abvoe is true, this parameter is ignored since the answer to the same query name/type/class might be different if ECS option is used"
 
 proxy_protocol:
   description: "Proxy Protocol-related settings"

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1937,8 +1937,8 @@ packet_cache:
       default: ""
       description: "Extra list of EDNS option codes to skip when hashing the packet (if ``cookie_hashing`` above is false, EDNS cookie option number will be added to this list internally)"
     - name: "payload_ranks"
-      type: "Vec<String>"
-      default: ""
+      type: "Vec<u16>"
+      default: "[]"
       description: "List of payload size used when hashing the packet. The list will be sorted in ascend order and searched to find a lower bound value for the payload size in the packet. If found then it will be used for packet hashing. Values less than 512 or greater than ``maximum_entry_size`` above will be discarded. This option is to enable cache entry sharing between clients using different payload sizes when needed"
 
 proxy_protocol:

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1939,7 +1939,7 @@ packet_cache:
     - name: "payload_ranks"
       type: "Vec<u16>"
       default: "[]"
-      description: "List of payload size used when hashing the packet. The list will be sorted in ascend order and searched to find a lower bound value for the payload size in the packet. If found then it will be used for packet hashing. Values less than 512 or greater than ``maximum_entry_size`` above will be discarded. This option is to enable cache entry sharing between clients using different payload sizes when needed"
+      description: "List of payload size used when hashing the packet. The list will be sorted in ascending order and searched to find a lower bound value for the payload size in the packet. If found then it will be used for packet hashing. Values less than 512 or greater than ``maximum_entry_size`` above will be discarded. This option is to enable cache entry sharing between clients using different payload sizes when needed"
 
 proxy_protocol:
   description: "Proxy Protocol-related settings"

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1936,10 +1936,10 @@ packet_cache:
       type: "Vec<String>"
       default: ""
       description: "Extra list of EDNS option codes to skip when hashing the packet (if ``cookie_hashing`` above is false, EDNS cookie option number will be added to this list internally)"
-    - name: "skip_hashing_ar"
-      type: "bool"
-      default: "false"
-      description: "If true, the whole Additional Resource Record section (including all EDNS options) will be skipped when hashing the packet. This will allow cache entry sharing between multiple clients who will use different EDNS0 payload size in its request for the same query name/type/class. However, if ``parse_ecs`` abvoe is true, this parameter is ignored since the answer to the same query name/type/class might be different if ECS option is used"
+    - name: "payload_ranks"
+      type: "Vec<String>"
+      default: ""
+      description: "List of payload size used when hashing the packet. The list will be sorted in ascend order and searched to find a lower bound value for the payload size in the packet. If found then it will be used for packet hashing. Values less than 512 or greater than ``maximum_entry_size`` above will be discarded. This option is to enable cache entry sharing between clients using different payload sizes when needed"
 
 proxy_protocol:
   description: "Proxy Protocol-related settings"

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -639,15 +639,7 @@ void handleResponseSent(const DNSName& qname, const QType& qtype, double udiff, 
 
 static void handleResponseTC4UDPClient(uint16_t udpPayloadSize, PacketBuffer& response, DNSResponse& dnsResponse)
 {
-  if (udpPayloadSize == 0) {
-    uint16_t zValue = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    getEDNSUDPPayloadSizeAndZ(reinterpret_cast<const char*>(response.data()), response.size(), &udpPayloadSize, &zValue);
-    if (udpPayloadSize < 512) {
-      udpPayloadSize = 512;
-    }
-  }
-  if (response.size() > udpPayloadSize) {
+  if (udpPayloadSize > 0 && response.size() > udpPayloadSize) {
     vinfolog("Got a response of size %d while the initial UDP payload size was %d, truncating", response.size(), udpPayloadSize);
     truncateTC(dnsResponse.getMutableData(), dnsResponse.getMaximumSize(), dnsResponse.ids.qname.wirelength(), dnsdist::configuration::getCurrentRuntimeConfiguration().d_addEDNSToSelfGeneratedResponses);
     dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsResponse.getMutableData(), [](dnsheader& header) {

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -637,12 +637,18 @@ void handleResponseSent(const DNSName& qname, const QType& qtype, double udiff, 
   doLatencyStats(incomingProtocol, udiff);
 }
 
-static void handleResponseForUDPClient(InternalQueryState& ids, PacketBuffer& response, const std::shared_ptr<DownstreamState>& backend, bool isAsync, bool selfGenerated)
+static void handleResponseTC4UDPClient(uint16_t udpPayloadSize, PacketBuffer& response, DNSResponse& dnsResponse)
 {
-  DNSResponse dnsResponse(ids, response, backend);
-
-  if (ids.udpPayloadSize > 0 && response.size() > ids.udpPayloadSize) {
-    vinfolog("Got a response of size %d while the initial UDP payload size was %d, truncating", response.size(), ids.udpPayloadSize);
+  if (udpPayloadSize == 0) {
+    uint16_t zValue = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    getEDNSUDPPayloadSizeAndZ(reinterpret_cast<const char*>(response.data()), response.size(), &udpPayloadSize, &zValue);
+    if (udpPayloadSize < 512) {
+      udpPayloadSize = 512;
+    }
+  }
+  if (response.size() > udpPayloadSize) {
+    vinfolog("Got a response of size %d while the initial UDP payload size was %d, truncating", response.size(), udpPayloadSize);
     truncateTC(dnsResponse.getMutableData(), dnsResponse.getMaximumSize(), dnsResponse.ids.qname.wirelength(), dnsdist::configuration::getCurrentRuntimeConfiguration().d_addEDNSToSelfGeneratedResponses);
     dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsResponse.getMutableData(), [](dnsheader& header) {
       header.tc = true;
@@ -652,6 +658,13 @@ static void handleResponseForUDPClient(InternalQueryState& ids, PacketBuffer& re
   else if (dnsResponse.getHeader()->tc && dnsdist::configuration::getCurrentRuntimeConfiguration().d_truncateTC) {
     truncateTC(response, dnsResponse.getMaximumSize(), dnsResponse.ids.qname.wirelength(), dnsdist::configuration::getCurrentRuntimeConfiguration().d_addEDNSToSelfGeneratedResponses);
   }
+}
+
+static void handleResponseForUDPClient(InternalQueryState& ids, PacketBuffer& response, const std::shared_ptr<DownstreamState>& backend, bool isAsync, bool selfGenerated)
+{
+  DNSResponse dnsResponse(ids, response, backend);
+
+  handleResponseTC4UDPClient(ids.udpPayloadSize, response, dnsResponse);
 
   /* when the answer is encrypted in place, we need to get a copy
      of the original header before encryption to fill the ring buffer */
@@ -1862,6 +1875,15 @@ static void processUDPQuery(ClientState& clientState, const struct msghdr* msgh,
       dnsQuestion.proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>(std::move(proxyProtocolValues));
     }
 
+    // save UDP payload size from origin query
+    uint16_t udpPayloadSize = 0;
+    uint16_t zValue = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    getEDNSUDPPayloadSizeAndZ(reinterpret_cast<const char*>(query.data()), query.size(), &udpPayloadSize, &zValue);
+    if (udpPayloadSize < 512) {
+      udpPayloadSize = 512;
+    }
+
     std::shared_ptr<DownstreamState> backend{nullptr};
     auto result = processQuery(dnsQuestion, backend);
 
@@ -1882,6 +1904,9 @@ static void processUDPQuery(ClientState& clientState, const struct msghdr* msgh,
       }
 #endif /* defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE) */
 #endif /* DISABLE_RECVMMSG */
+      /* ensure payload size is not exceeded */
+      DNSResponse dnsResponse(ids, query, nullptr);
+      handleResponseTC4UDPClient(udpPayloadSize, query, dnsResponse);
       /* we use dest, always, because we don't want to use the listening address to send a response since it could be 0.0.0.0 */
       sendUDPResponse(clientState.udpFD, query, dnsQuestion.ids.delayMsec, dest, remote);
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1065,7 +1065,7 @@ See :doc:`../guides/cache` for a how to.
   * ``cookieHashing=false``: bool - If true, EDNS Cookie values will be hashed, resulting in separate entries for different cookies in the packet cache. This is required if the backend is sending answers with EDNS Cookies, otherwise a client might receive an answer with the wrong cookie.
   * ``skipOptions={}``: Extra list of EDNS option codes to skip when hashing the packet (if ``cookieHashing`` above is false, EDNS cookie option number will be added to this list internally).
   * ``maximumEntrySize=4096``: int - The maximum size, in bytes, of a DNS packet that can be inserted into the packet cache. Default is 4096 bytes, which was the fixed size before 1.9.0, and is also a hard limit for UDP responses.
-  * ``payloadRanks={}``: List of payload size used when hashing the packet. The list will be sorted in ascend order and searched to find a lower bound value for the payload size in the packet. If found then it will be used for packet hashing. Values less than 512 or greater than ``maximumEntrySize`` above will be discarded. This option is to enable cache entry sharing between clients using different payload sizes when needed.
+  * ``payloadRanks={}``: List of payload size used when hashing the packet. The list will be sorted in ascending order and searched to find a lower bound value for the payload size in the packet. If found then it will be used for packet hashing. Values less than 512 or greater than ``maximumEntrySize`` above will be discarded. This option is to enable cache entry sharing between clients using different payload sizes when needed.
 
 .. class:: PacketCache
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1043,7 +1043,7 @@ See :doc:`../guides/cache` for a how to.
     ``truncatedTTL`` parameter added.
 
   .. versionchanged:: 2.0.0
-    ``skipHashingAR`` parameter added.
+    ``payloadRanks`` parameter added.
 
   Creates a new :class:`PacketCache` with the settings specified.
 
@@ -1065,7 +1065,7 @@ See :doc:`../guides/cache` for a how to.
   * ``cookieHashing=false``: bool - If true, EDNS Cookie values will be hashed, resulting in separate entries for different cookies in the packet cache. This is required if the backend is sending answers with EDNS Cookies, otherwise a client might receive an answer with the wrong cookie.
   * ``skipOptions={}``: Extra list of EDNS option codes to skip when hashing the packet (if ``cookieHashing`` above is false, EDNS cookie option number will be added to this list internally).
   * ``maximumEntrySize=4096``: int - The maximum size, in bytes, of a DNS packet that can be inserted into the packet cache. Default is 4096 bytes, which was the fixed size before 1.9.0, and is also a hard limit for UDP responses.
-  * ``skipHashingAR=false``: bool - If true, the whole Additional Resource Record section (including all EDNS options) will be skipped when hashing the packet. This will allow cache entry sharing between multiple clients who will use different EDNS0 payload size in its request for the same query name/type/class. However, if ``parseECS`` abvoe is true, this parameter is ignored since the answer to the same query name/type/class might be different if ECS option is used.
+  * ``payloadRanks={}``: List of payload size used when hashing the packet. The list will be sorted in ascend order and searched to find a lower bound value for the payload size in the packet. If found then it will be used for packet hashing. Values less than 512 or greater than ``maximumEntrySize`` above will be discarded. This option is to enable cache entry sharing between clients using different payload sizes when needed.
 
 .. class:: PacketCache
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1042,6 +1042,9 @@ See :doc:`../guides/cache` for a how to.
   .. versionchanged:: 2.0.0
     ``truncatedTTL`` parameter added.
 
+  .. versionchanged:: 2.0.0
+    ``skipHashingAR`` parameter added.
+
   Creates a new :class:`PacketCache` with the settings specified.
 
   :param int maxEntries: The maximum number of entries in this cache
@@ -1062,6 +1065,7 @@ See :doc:`../guides/cache` for a how to.
   * ``cookieHashing=false``: bool - If true, EDNS Cookie values will be hashed, resulting in separate entries for different cookies in the packet cache. This is required if the backend is sending answers with EDNS Cookies, otherwise a client might receive an answer with the wrong cookie.
   * ``skipOptions={}``: Extra list of EDNS option codes to skip when hashing the packet (if ``cookieHashing`` above is false, EDNS cookie option number will be added to this list internally).
   * ``maximumEntrySize=4096``: int - The maximum size, in bytes, of a DNS packet that can be inserted into the packet cache. Default is 4096 bytes, which was the fixed size before 1.9.0, and is also a hard limit for UDP responses.
+  * ``skipHashingAR=false``: bool - If true, the whole Additional Resource Record section (including all EDNS options) will be skipped when hashing the packet. This will allow cache entry sharing between multiple clients who will use different EDNS0 payload size in its request for the same query name/type/class. However, if ``parseECS`` abvoe is true, this parameter is ignored since the answer to the same query name/type/class might be different if ECS option is used.
 
 .. class:: PacketCache
 

--- a/pdns/dnsdistdist/docs/reference/yaml-settings.rst
+++ b/pdns/dnsdistdist/docs/reference/yaml-settings.rst
@@ -744,6 +744,7 @@ Packet-cache settings
 - **cookie_hashing**: Boolean ``(false)`` - If true, EDNS Cookie values will be hashed, resulting in separate entries for different cookies in the packet cache. This is required if the backend is sending answers with EDNS Cookies, otherwise a client might receive an answer with the wrong cookie
 - **maximum_entry_size**: Unsigned integer ``(4096)`` - The maximum size, in bytes, of a DNS packet that can be inserted into the packet cache
 - **options_to_skip**: Sequence of String ``("")`` - Extra list of EDNS option codes to skip when hashing the packet (if ``cookie_hashing`` above is false, EDNS cookie option number will be added to this list internally)
+- **payload_ranks**: Sequence of Unsigned integer ``([])`` - List of payload size used when hashing the packet. The list will be sorted in ascend order and searched to find a lower bound value for the payload size in the packet. If found then it will be used for packet hashing. Values less than 512 or greater than ``maximum_entry_size`` above will be discarded. This option is to enable cache entry sharing between clients using different payload sizes when needed
 
 
 .. _yaml-settings-PoolConfiguration:

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -5,8 +5,6 @@ import dns
 import clientsubnetoption
 import cookiesoption
 import requests
-import random
-import string
 from dnsdisttests import DNSDistTest, pickAvailablePort
 
 class TestCaching(DNSDistTest):
@@ -538,7 +536,7 @@ class TestCaching(DNSDistTest):
         """
         numberOfQueries = 10
         name = 'large-answer.cache.tests.powerdns.com.'
-        query = dns.message.make_query(name, 'TXT', 'IN')
+        query = dns.message.make_query(name, 'TXT', 'IN', payload=4096)
         response = dns.message.make_response(query)
         # we prepare a large answer
         content = ""
@@ -547,7 +545,7 @@ class TestCaching(DNSDistTest):
                 content = content + ', '
             content = content + (str(i)*50)
         # pad up to 4096
-        content = content + 'A'*42
+        content = content + 'A'*31
 
         rrset = dns.rrset.from_text(name,
                                     3600,
@@ -3126,7 +3124,7 @@ class TestCacheEmptyTC(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertEqual(receivedResponse, response)
 
-class TestCachingSkipAR(DNSDistTest):
+class TestCachingPayloadRanks(DNSDistTest):
 
     _verboseMode = True
     _testServerPort = pickAvailablePort()
@@ -3138,7 +3136,7 @@ class TestCachingSkipAR(DNSDistTest):
     _config_template = """
     webserver("127.0.0.1:%s")
     setWebserverConfig({apiKey="%s"})
-    pc = newPacketCache(100, {maxTTL=86400, minTTL=1, skipHashingAR=true})
+    pc = newPacketCache(100, {maxTTL=86400, minTTL=1, payloadRanks={768, 512, 4096, 1280, 1024, 2048}})
     getPool(""):setCache(pc)
     newServer{address="127.0.0.1:%d"}
     """
@@ -3157,17 +3155,14 @@ class TestCachingSkipAR(DNSDistTest):
         pool = pools[poolID]
         return int(pool[metricName])
 
-    def testCacheSkipAR(self):
+    def testCachePayloadRanks(self):
         """
-        Cache: Testing ``skipHashingAR`` parameter for caching
+        Cache: Testing ``payloadRanks`` parameter for caching
 
-        dnsdist is configured to cache entries with ``skipHashingAR`` turned on,
-        cache entry will be used even with/without AR section or different payload
-        size is used.
         """
         # testing with and without EDNS0 payload size
         name1 = 'cached.cache.tests.powerdns.com.'
-        query1 = dns.message.make_query(name1, 'AAAA', 'IN')
+        query1 = dns.message.make_query(name1, 'AAAA', 'IN', payload=512)
         query1_1 = dns.message.make_query(name1, 'AAAA', 'IN', payload=600)
         response1 = dns.message.make_response(query1)
         rrset1 = dns.rrset.from_text(name1,
@@ -3192,7 +3187,7 @@ class TestCachingSkipAR(DNSDistTest):
         self.assertEqual(self.getPoolMetric(0, 'cacheHits'), 1)
         self.assertEqual(receivedResponse, response1)
 
-        # query1_1 shall also hit cache even it inlcudes Opt RR for payload size
+        # query1_1 shall also hit cache since 600 round down to 512
         (_, receivedResponse) = self.sendUDPQuery(query1_1, response=None, useQueue=False)
         self.assertTrue(receivedResponse)
         self.assertEqual(self.getPoolMetric(0, 'cacheHits'), 2)
@@ -3201,12 +3196,9 @@ class TestCachingSkipAR(DNSDistTest):
 
         # testing for large sized cache entry
         name2 = 'bigcached.cache.tests.powerdns.com.'
-        cookieBytes = ''.join(random.choices(string.hexdigits, k=8)).lower().encode()
-        myCookie = dns.edns.CookieOption(client=cookieBytes, server=b'')
-        query2 = dns.message.make_query(name2, 'AAAA', 'IN', payload=4096)
-        query2_1 = dns.message.make_query(name2, 'AAAA', 'IN', payload=2000)
-        query2_2 = dns.message.make_query(name2, 'AAAA', 'IN', payload=1500, options=[myCookie])
-        query2_3 = dns.message.make_query(name2, 'AAAA', 'IN', payload=800)
+        query2 = dns.message.make_query(name2, 'AAAA', 'IN', payload=1279)
+        query2_1 = dns.message.make_query(name2, 'AAAA', 'IN', payload=1200)
+        query2_2 = dns.message.make_query(name2, 'AAAA', 'IN', payload=1024)
 
         response2 = dns.message.make_response(query2)
         v6addr_list = []
@@ -3234,23 +3226,16 @@ class TestCachingSkipAR(DNSDistTest):
         self.assertEqual(self.getPoolMetric(0, 'cacheHits'), 3)
         self.assertEqual(receivedResponse, response2)
 
-        # query2_1 shall also hit cache even it has a different payload size
+        # query2_1 shall hit cache
         (_, receivedResponse) = self.sendUDPQuery(query2_1, response=None, useQueue=False)
         self.assertTrue(receivedResponse)
         self.assertEqual(self.getPoolMetric(0, 'cacheHits'), 4)
         self.assertEqual(len(receivedResponse.answer), 1)
         self.assertEqual(receivedResponse.answer[0], rrset2)
 
-        # query2_2 shall also hit cache even it has a different payload size and EDNS COOKIE
+        # query2_2 shall hit cache but truncated since payload size is not enough
         (_, receivedResponse) = self.sendUDPQuery(query2_2, response=None, useQueue=False)
         self.assertTrue(receivedResponse)
         self.assertEqual(self.getPoolMetric(0, 'cacheHits'), 5)
-        self.assertEqual(len(receivedResponse.answer), 1)
-        self.assertEqual(receivedResponse.answer[0], rrset2)
-
-        # query2_3 shall also hit cache but truncated since payload size is not enough
-        (_, receivedResponse) = self.sendUDPQuery(query2_3, response=None, useQueue=False)
-        self.assertTrue(receivedResponse)
-        self.assertEqual(self.getPoolMetric(0, 'cacheHits'), 6)
         self.assertEqual(len(receivedResponse.answer), 0)
         self.assertEqual(receivedResponse.flags & dns.flags.TC, dns.flags.TC)

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -544,7 +544,7 @@ class TestCaching(DNSDistTest):
             if len(content) > 0:
                 content = content + ', '
             content = content + (str(i)*50)
-        # pad up to 4096
+        # pad up to 4096 (less 11 for EDNS)
         content = content + 'A'*31
 
         rrset = dns.rrset.from_text(name,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Use case arise that two clients with different udp payload size, a customized client uses 4096 while glibc resolver uses 1232. User would like to share cache result for the same query name, type and class in this case. The downstream servers does not use ECS and would not return different answers upon other EDNS options so this is to add an option to support such use case.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
