### PR TITLE
dnsdist: Gracefully handle missing v6 in backend discovery test

### DIFF
--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -439,13 +439,19 @@ class TestBackendDiscoveryByHostname(DNSDistTest):
             self.assertTrue(len(tokens) == 13 or len(tokens) == 14)
             backends[tokens[1]] = tokens[2]
 
-        if len(backends) != 4:
+        if len(backends) == 4:
+            for expected in ['9.9.9.9:53', '149.112.112.112:53', '[2620:fe::9]:53', '[2620:fe::fe]:53']:
+                self.assertIn(expected, backends)
+        elif len(backends) == 2:
+            # looks like we are not getting the IPv6 addresses, thanks GitHub!
+            for expected in ['9.9.9.9:53', '149.112.112.112:53']:
+                self.assertIn(expected, backends)
+        else:
             return False
 
-        for expected in ['9.9.9.9:53', '149.112.112.112:53', '[2620:fe::9]:53', '[2620:fe::fe]:53']:
-            self.assertIn(expected, backends)
         for backend in backends:
-            self.assertTrue(backends[backend])
+            self.assertEqual(backends[backend], 'up')
+
         return True
 
     def testBackendFromHostname(self):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This test has been randomly failing on GH actions lately, and it looks like it is because we sometimes do not get the IPv6 addresses when resolving `dns.quad9.net` via the system resolver.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
