### PR TITLE
typo in pdns_server manpage

### DIFF
--- a/docs/manpages/pdns_server.1.rst
+++ b/docs/manpages/pdns_server.1.rst
@@ -27,7 +27,7 @@ See the online documentation for all options. The most important ones are:
 --control-console       Run the server in a special monitor mode. This enables detailed
                         logging and exposes the raw control socket.
 --loglevel=<LEVEL>      Set the logging level.
---config                Show the currently configuration. There are three optional values:
+--config                Show the current configuration. There are three optional values:
 
                         --config=default       show the default configuration.
                         --config=diff          show modified options in the current configuration.


### PR DESCRIPTION
### Short description
fix small typo in manpage

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
