### PR TITLE
dnsdist: Fix a crash in the TCP concurrent connections map

### DIFF
--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -71,7 +71,7 @@ using map_t = boost::multi_index_container<
     boost::multi_index::ordered_non_unique<boost::multi_index::tag<TimeTag>,
                                            boost::multi_index::member<ClientEntry, time_t, &ClientEntry::d_lastSeen>>>>;
 
-static std::vector<LockGuarded<map_t>> s_tcpClientsConnectionMetrics{10};
+static std::vector<LockGuarded<map_t>> s_tcpClientsConnectionMetrics{NB_SHARDS};
 
 static AddressAndPortRange getRange(const ComboAddress& from)
 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The bug was introduced in 99d1e8f044d43b9a75ffc70fed22ea674a9b7859. Thanks to Robert Edmonds for finding, reporting and proposing a patch fixing the issue!

Fixes https://github.com/PowerDNS/pdns/issues/15552

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

