### PR TITLE
dnsdist: Fix backend discovery regression test on GH action (again)

### DIFF
--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -453,6 +453,10 @@ class TestBackendDiscoveryByHostname(DNSDistTest):
             return False
 
         for backend in backends:
+            if str(backend) in ['2620:fe::9]:53', '[2620:fe::fe]:53']:
+                # IPv6 is very flaky on GH actions these days,
+                # let's not require these to be up
+                continue
             if backends[backend] != 'up':
                 return False
 

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -454,7 +454,7 @@ class TestBackendDiscoveryByHostname(DNSDistTest):
 
         for backend in backends:
             if str(backend) in ['2620:fe::9]:53', '[2620:fe::fe]:53']:
-                # IPv6 is very flaky on GH actions these days,
+                # IPv6 is very flaky on GH actions these days (202505),
                 # let's not require these to be up
                 continue
             if backends[backend] != 'up':


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Apparently IPv6 is very flaky on GH actions these days, and I see this test failing again and again because DNSdist cannot reliably reach the servers over IPv6. IPv4 is fine from GH actions, v4 and v6 are fine locally, so let's not fail in that case.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
