### PR TITLE
dnsdist: Switch `eBPF` support to `auto` when building with `meson`

### DIFF
--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -122,6 +122,7 @@ export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/opt/lib64/pkgconfig
 %if "%{_arch}" == "aarch64" || 0%{?amzn2023}
   -Dxsk=disabled \
 %endif
+  -Debpf=enabled \
   -Dyaml=enabled
 %meson_build
 

--- a/pdns/dnsdistdist/meson_options.txt
+++ b/pdns/dnsdistdist/meson_options.txt
@@ -35,7 +35,7 @@ option('quiche', type: 'feature', value: 'auto', description: 'Enable Quiche lib
 option('re2', type: 'feature', value: 'auto', description: 'Enable re2 for regular expressions')
 option('xsk', type: 'feature', value: 'auto', description: 'Enable AF_XDP / XSK')
 option('fuzz-targets', type: 'boolean', value: false, description: 'Enable fuzzing targets')
-option('ebpf', type: 'feature', value: 'disabled', description: 'Enable eBPF support')
+option('ebpf', type: 'feature', value: 'auto', description: 'Enable eBPF support')
 option('fuzzer_ldflags', type: 'string', value: '', description: 'Linker flags used for the fuzzing targets (a path to the libFuzzer static library, for example)')
 option('yaml', type: 'feature', value: 'disabled', description: 'Enable YAML configuration')
 option('man-pages', type: 'boolean', value: true, description: 'Generate man pages')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It used to be that way with `autotools` and I don't see any good reason to disable it by default.
Also explicitly enable eBPF support in our EL-based packages.

Successful packages test run: https://github.com/rgacogne/pdns/actions/runs/15040674021

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
