### PR TITLE
dnsdist-1.9.x: Backport 15520 - Fix building with GCC 15.1: missing `cstdint` include

### DIFF
--- a/pdns/noinitvector.hh
+++ b/pdns/noinitvector.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <new>
 #include <utility>


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #15520 to dnsdist-1.9.x:

GCC 15.1 complains about a missing `cstdint` include when building `DNSdist`:
```
In file included from ../doh3.hh:29,
                 from ../doh3.cc:23:
../noinitvector.hh:67:35: error: ‘uint8_t’ was not declared in this scope
   67 | using PacketBuffer = NoInitVector<uint8_t>;
      |                                   ^~~~~~~
../noinitvector.hh:7:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    6 | #include <vector>
  +++ |+#include <cstdint>
    7 |
../noinitvector.hh:67:42: error: template argument 1 is invalid
   67 | using PacketBuffer = NoInitVector<uint8_t>;
      |                                          ^
In file included from ../dnsdist-idstate.hh:27,
                 from ../doh3.hh:48:
../dnscrypt.hh:247:20: error: ‘PacketBuffer’ has not been declared
  247 |   void parsePacket(PacketBuffer& packet, bool tcp, time_t now);
      |                    ^~~~~~~~~~~~
../dnscrypt.hh:248:31: error: ‘PacketBuffer’ has not been declared
  248 |   void getDecrypted(bool tcp, PacketBuffer& packet);
      |                               ^~~~~~~~~~~~
../dnscrypt.hh:249:43: error: ‘PacketBuffer’ has not been declared
  249 |   void getCertificateResponse(time_t now, PacketBuffer& response) const;
      |                                           ^~~~~~~~~~~~
../dnscrypt.hh:250:23: err
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
