### PR TITLE
dnsdist: two fixes to enable building on OpenBSD with quic enabled

### DIFF
--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -5,7 +5,7 @@ opt_libssl_dir = get_option('tls-libssl-dir')
 if opt_libssl_dir != ''
   dep_libssl = declare_dependency(
     include_directories: [opt_libssl_dir / 'include'],
-    link_args: ['-L' + opt_libssl_dir / 'lib', '-lssl'],
+    link_args: ['-L' + opt_libssl_dir / 'lib', '-lssl', '-lcrypto'],
   )
 else
   dep_libssl = dependency('libssl', required: opt_libssl)

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -547,7 +547,7 @@ struct StackOfNamesDeleter
 
 #if defined(OPENSSL_IS_BORINGSSL)
 /* return type of OpenSSL's sk_XXX_num() */
-using SSLStackIndex size_t;
+using SSLStackIndex = size_t;
 #else
 using SSLStackIndex = int;
 #endif


### PR DESCRIPTION
Meson setup used:
```
meson setup build \
        -Dlibedit=auto \
        -Dcdb=auto \
        -Dcpp_args=-DDISABLE_OCSP_STAPLING \
        -Ddns-over-http3=enabled \
        -Ddns-over-https=enabled \
        -Ddns-over-quic=enabled \
        -Ddns-over-tls=enabled \
        -Dlmdb=enabled \
        -Dsnmp=disabled \
        -Dtls-gnutls=disabled \
        -Dtls-libssl-dir=/usr/local/eboringssl \
        -Dunit-tests=true \
        -Dyaml=enabled \
        -Ddnstap=enabled \
```
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
