### PR TITLE
dnsdist: Fix our `meson` build not reaching a stable state

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/Makefile.am
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/Makefile.am
@@ -17,5 +17,5 @@ rust/src/lib.rs dnsdist-configuration-yaml-items-generated.cc: dnsdist-settings-
 	@if test "$(PYTHON)" = ":"; then echo "Settings definitions have changed, python is needed to regenerate the related settings files but python was not found. Please install python and re-run configure"; exit 1; fi
 	@if ! $(PYTHON) --version | grep -q "Python 3"; then echo $(PYTHON) should be at least version 3. Please install python 3 and re-run configure; exit 1; fi
 	$(MAKE) -C rust clean
-	(cd ${srcdir} && $(PYTHON) dnsdist-settings-generator.py ../ ./ ../)
+	(cd ${srcdir} && $(PYTHON) dnsdist-settings-generator.py ../ ./ ../ ../)
 	$(PYTHON) dnsdist-settings-documentation-generator.py

--- a/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
@@ -46,7 +46,6 @@
 
 import os
 import re
-import shutil
 import sys
 import tempfile
 import yaml
@@ -378,7 +377,7 @@ void convertRuntimeFlatSettingsFromRust(const dnsdist::rust::settings::GlobalCon
 ''')
 
     os.rename(cxx_flat_settings_fp.name, out_file_path + '/dnsdist-configuration-yaml-items-generated.cc')
-    shutil.copy(out_file_path + '/dnsdist-configuration-yaml-items-generated.cc', build_dir_path)
+    os.symlink(os.path.abspath(out_file_path + '/dnsdist-configuration-yaml-items-generated.cc'), build_dir_path + '/dnsdist-configuration-yaml-items-generated.cc')
 
 def generate_actions_config(output, def_dir, response, default_functions):
     suffix = 'ResponseAction' if response else 'Action'

--- a/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
@@ -377,7 +377,8 @@ void convertRuntimeFlatSettingsFromRust(const dnsdist::rust::settings::GlobalCon
 ''')
 
     os.rename(cxx_flat_settings_fp.name, out_file_path + '/dnsdist-configuration-yaml-items-generated.cc')
-    os.symlink(os.path.abspath(out_file_path + '/dnsdist-configuration-yaml-items-generated.cc'), build_dir_path + '/dnsdist-configuration-yaml-items-generated.cc')
+    if out_file_path != build_dir_path:
+        os.symlink(os.path.abspath(out_file_path + '/dnsdist-configuration-yaml-items-generated.cc'), build_dir_path + '/dnsdist-configuration-yaml-items-generated.cc')
 
 def generate_actions_config(output, def_dir, response, default_functions):
     suffix = 'ResponseAction' if response else 'Action'

--- a/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
@@ -2,7 +2,6 @@ sources = files(
   'dnsdist-settings-generator.py',
   '../dnsdist-settings-definitions.yml',
   'dnsdist-configuration-yaml-items-generated-pre-in.cc',
-  'dnsdist-configuration-yaml-items-generated.cc',
   'dnsdist-settings-documentation-generator.py',
   'rust-pre-in.rs',
   'rust-middle-in.rs',
@@ -16,7 +15,7 @@ generated = [
 python = find_program('python3')
 
 rust_lib_sources = custom_target(
-  command: [python, '@INPUT0@', '@SOURCE_ROOT@', '@SOURCE_ROOT@/dnsdist-rust-lib', '@SOURCE_ROOT@'],
+  command: [python, '@INPUT0@', '@SOURCE_ROOT@', '@SOURCE_ROOT@/dnsdist-rust-lib', '@SOURCE_ROOT@', '@BUILD_ROOT@'],
   input: sources,
   output: generated,
 )


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Before this commit calling `meson compile` a second time right after building triggered a re-generation of the `dnsdist-configuration-yaml-items-generated.cc` file because `meson` wants it to be present in the build directory, but we also want to generate it in the source directory so that it can be included in the repository.
The current solution is a bit dirty, but our options are limited because some files are only generated when YAML support is available, because they require Rust, and we need them to be in the dist tarball. Otto suggested that we could generate them only when building the dist tarball, I'll look into it in a bit, but since 2.0.0-alpha2 is on its way I think it makes sense to commit this solution first.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
