### PR TITLE
build-and-test-all: Build DNSdist on Ubicloud runners when needed

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -220,7 +220,7 @@ jobs:
   build-dnsdist:
     name: build dnsdist
     if: ${{ !github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ ( vars.REPOSITORY_USE_UBICLOUD == '1' ) && 'ubicloud-standard-4-ubuntu-2404' || 'ubuntu-24.04' }}
     needs: get-runner-container-image
     strategy:
       matrix:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
GH actions provides us with a 16 GB runner on public repositories, but only 7 GB on private ones. Unfortunately our current workflow assumes that we can get away with 4 concurrent jobs when building DNSdist, which is true when we have 16 GB available but not with 7 GB.
So this commit switches to Ubicloud runners (standard 4, 4 vCPU, 16 GB) for repositories defining the `REPOSITORY_USE_UBICLOUD` variable to 1. These runners are also significantly faster than the GH actions ones.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
