### PR TITLE
dnsdist: don't try creating symlink if it already exists

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
@@ -377,8 +377,9 @@ void convertRuntimeFlatSettingsFromRust(const dnsdist::rust::settings::GlobalCon
 ''')
 
     os.rename(cxx_flat_settings_fp.name, out_file_path + '/dnsdist-configuration-yaml-items-generated.cc')
-    if out_file_path != build_dir_path:
-        os.symlink(os.path.abspath(out_file_path + '/dnsdist-configuration-yaml-items-generated.cc'), build_dir_path + '/dnsdist-configuration-yaml-items-generated.cc')
+    target = build_dir_path + '/dnsdist-configuration-yaml-items-generated.cc'
+    if out_file_path != build_dir_path and not os.path.exists(target):
+        os.symlink(os.path.abspath(out_file_path + '/dnsdist-configuration-yaml-items-generated.cc'), target)
 
 def generate_actions_config(output, def_dir, response, default_functions):
     suffix = 'ResponseAction' if response else 'Action'

--- a/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
@@ -378,7 +378,9 @@ void convertRuntimeFlatSettingsFromRust(const dnsdist::rust::settings::GlobalCon
 
     os.rename(cxx_flat_settings_fp.name, out_file_path + '/dnsdist-configuration-yaml-items-generated.cc')
     target = build_dir_path + '/dnsdist-configuration-yaml-items-generated.cc'
-    if out_file_path != build_dir_path and not os.path.exists(target):
+    if out_file_path != build_dir_path:
+        if os.path.exists(target):
+            os.unlink(target)
         os.symlink(os.path.abspath(out_file_path + '/dnsdist-configuration-yaml-items-generated.cc'), target)
 
 def generate_actions_config(output, def_dir, response, default_functions):

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1551,14 +1551,14 @@ tcp_tuning:
       lua-name: "setMaxTLSNewSessionRatePerClient"
       internal-field-name: "d_maxTLSNewSessionsRatePerClient"
       runtime-configurable: false
-      description: "Set the maximum number of new TLS sessions, without resumption, that a given client (see ``connections_mask_v4``, ``connections_mask_v6`` and ``connection_mask_v4_port`` to see how clients can be aggregated) can open, per second, over the last ``connection_rate_interval`` minutes. Clients exceeding this rate will not be able to open new TCP connections for ``ban_duration_for_exceeding_tcp_tls_rate`` seconds. See also ``max_connection_rate_per_client`` and ```max_tls_resumed_session_rate_per_client`"
+      description: "Set the maximum number of new TLS sessions, without resumption, that a given client (see ``connections_mask_v4``, ``connections_mask_v6`` and ``connection_mask_v4_port`` to see how clients can be aggregated) can open, per second, over the last ``connection_rate_interval`` minutes. Clients exceeding this rate will not be able to open new TCP connections for ``ban_duration_for_exceeding_tcp_tls_rate`` seconds. See also ``max_connection_rate_per_client`` and ``max_tls_resumed_session_rate_per_client``"
     - name: "max_tls_resumed_session_rate_per_client"
       type: "u64"
       default: "0"
       lua-name: "setMaxTLSResumedSessionRatePerClient"
       internal-field-name: "d_maxTLSResumedSessionsRatePerClient"
       runtime-configurable: false
-      description: "Set the maximum number of resumed TLS sessions that a given client (see ``connections_mask_v4``, ``connections_mask_v6`` and ``connection_mask_v4_port`` to see how clients can be aggregated) can open, per second, over the last ``connection_rate_interval`` minutes. Clients exceeding this rate will not be able to open new TCP connections for ``ban_duration_for_exceeding_tcp_tls_rate`` seconds. See also ``max_connection_rate_per_client`` and ```max_tls_new_session_rate_per_client`"
+      description: "Set the maximum number of resumed TLS sessions that a given client (see ``connections_mask_v4``, ``connections_mask_v6`` and ``connection_mask_v4_port`` to see how clients can be aggregated) can open, per second, over the last ``connection_rate_interval`` minutes. Clients exceeding this rate will not be able to open new TCP connections for ``ban_duration_for_exceeding_tcp_tls_rate`` seconds. See also ``max_connection_rate_per_client`` and ``max_tls_new_session_rate_per_client``"
     - name: "max_read_ios_per_query"
       type: "u32"
       default: "50"

--- a/pdns/dnsdistdist/docs/quickstart.rst
+++ b/pdns/dnsdistdist/docs/quickstart.rst
@@ -146,6 +146,7 @@ Adding network ranges to the :term:`ACL` is done with the :func:`setACL` and :fu
 And in ``yaml`` format:
 
 .. code-block:: yaml
+
 acl:
   - "192.0.2.0/28"
   - "2001:db8:1::/56"


### PR DESCRIPTION
I am seeing: ```FileExistsError: [Errno 17] File exists: '/Users/otto/pdns/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-configuration-yaml-items-generated.cc' -> './dnsdist-rust-lib//dnsdist-configuration-yaml-items-generated.cc'```

after a change in `dnsdist-settings-definitions.yml`.

Plus three typos in docs.

I also noticed stable state is not reach until a second run of meson compile after changing `dnsdist-settings-definitions.yml`. Did not investigate that one.

```
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /opt/homebrew/bin/ninja -C /Users/otto/pdns/pdns/dnsdistdist/build -v
ninja: Entering directory `/Users/otto/pdns/pdns/dnsdistdist/build'
[1/8] /bin/sh -c 'test ! -e ../config.h'
[2/8] /opt/homebrew/bin/python3 ../dnsdist-rust-lib/dnsdist-settings-generator.py .. ../dnsdist-rust-lib .. .
[2/8] /opt/homebrew/bin/meson --internal exe --unpickle /Users/otto/pdns/pdns/dnsdistdist/build/meson-private/meson_exe_sh_18b89a33f1ed6d92cd91906e38f1ce83480d5204.dat
   Compiling dnsdist-rust v2.0.0 (/Users/otto/pdns/pdns/dnsdistdist/dnsdist-rust-lib/rust)
    Finished `release` profile [optimized] target(s) in 11.56s
[4/5] c++  -o testrunner testrunner.p/testrunner.cc.o testrunner.p/pollmplexer.cc.o testrunner.p/kqueuemplexer.cc.o testrunner.p/dnsdist-lua-ffi.cc.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-force_load libdnsdist-test.a -rdynamic '-Wno-#warnings' -Wl,-rpath,@loader_path/dnsdist-rust-lib/rust -Wl,-rpath,/opt/homebrew/Cellar/luajit/2.1.1744318430/lib -Wl,-rpath,/opt/homebrew/Cellar/tinycdb/0.81_1/lib -Wl,-rpath,/opt/homebrew/Cellar/fstrm/0.6.1/lib -Wl,-rpath,/opt/homebrew/Cellar/openssl@3/3.5.0/lib -Wl,-rpath,/opt/homebrew/Cellar/gnutls/3.8.9/lib -Wl,-rpath,/opt/homebrew/Cellar/libnghttp2/1.65.0/lib -Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,/opt/homebrew/Cellar/libsodium/1.0.20/lib -Wl,-rpath,/opt/homebrew/opt/lmdb/lib libdnsdist-common.a ext/arc4random/libarc4random.a ext/ipcrypt/libipcrypt.a ext/json11/libjson11.a ext/lmdb-safe/liblmdb-safe.a ext/yahttp/yahttp/libyahttp.a dnsdist-rust-lib/rust/libdnsdist_rust.a /opt/homebrew/Cellar/boost/1.88.0/lib/libboost_unit_test_framework.dylib /opt/homebrew/Cellar/luajit/2.1.1744318430/lib/libluajit-5.1.dylib /opt/homebrew/Cellar/tinycdb/0.81_1/lib/libcdb.dylib /opt/homebrew/Cellar/fstrm/0.6.1/lib/libfstrm.dylib /opt/homebrew/Cellar/openssl@3/3.5.0/lib/libcrypto.dylib /opt/homebrew/Cellar/gnutls/3.8.9/lib/libgnutls.dylib -ledit /opt/homebrew/Cellar/libnghttp2/1.65.0/lib/libnghttp2.dylib /opt/homebrew/lib/libdnsdist-quiche.dylib /opt/homebrew/Cellar/libsodium/1.0.20/lib/libsodium.dylib /opt/homebrew/Cellar/openssl@3/3.5.0/lib/libssl.dylib /opt/homebrew/opt/lmdb/lib/liblmdb.dylib
[5/5] c++  -o dnsdist dnsdist.p/dnsdist.cc.o dnsdist.p/dnstap.cc.o dnsdist.p/fstrm_logger.cc.o dnsdist.p/dnsdist-lua-ffi.cc.o dnsdist.p/dnsdist-lua-inspection-ffi.cc.o dnsdist.p/pollmplexer.cc.o dnsdist.p/kqueuemplexer.cc.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -rdynamic '-Wno-#warnings' -Wl,-rpath,@loader_path/dnsdist-rust-lib/rust -Wl,-rpath,/opt/homebrew/Cellar/luajit/2.1.1744318430/lib -Wl,-rpath,/opt/homebrew/Cellar/tinycdb/0.81_1/lib -Wl,-rpath,/opt/homebrew/Cellar/fstrm/0.6.1/lib -Wl,-rpath,/opt/homebrew/Cellar/openssl@3/3.5.0/lib -Wl,-rpath,/opt/homebrew/Cellar/gnutls/3.8.9/lib -Wl,-rpath,/opt/homebrew/Cellar/libnghttp2/1.65.0/lib -Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,/opt/homebrew/Cellar/libsodium/1.0.20/lib -Wl,-rpath,/opt/homebrew/opt/lmdb/lib libdnsdist-common.a ext/arc4random/libarc4random.a ext/ipcrypt/libipcrypt.a ext/json11/libjson11.a ext/lmdb-safe/liblmdb-safe.a ext/yahttp/yahttp/libyahttp.a dnsdist-rust-lib/rust/libdnsdist_rust.a /opt/homebrew/Cellar/luajit/2.1.1744318430/lib/libluajit-5.1.dylib /opt/homebrew/Cellar/tinycdb/0.81_1/lib/libcdb.dylib /opt/homebrew/Cellar/fstrm/0.6.1/lib/libfstrm.dylib /opt/homebrew/Cellar/openssl@3/3.5.0/lib/libcrypto.dylib /opt/homebrew/Cellar/gnutls/3.8.9/lib/libgnutls.dylib -ledit /opt/homebrew/Cellar/libnghttp2/1.65.0/lib/libnghttp2.dylib /opt/homebrew/lib/libdnsdist-quiche.dylib /opt/homebrew/Cellar/libsodium/1.0.20/lib/libsodium.dylib /opt/homebrew/Cellar/openssl@3/3.5.0/lib/libssl.dylib /opt/homebrew/opt/lmdb/lib/liblmdb.dylib
mbp:dnsdistdist otto$ m -v
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /opt/homebrew/bin/ninja -C /Users/otto/pdns/pdns/dnsdistdist/build -v
ninja: Entering directory `/Users/otto/pdns/pdns/dnsdistdist/build'
[1/6] /bin/sh -c 'test ! -e ../config.h'
[2/6] ccache c++ -Ilibdnsdist-common.a.p -I. -I.. -Iext/arc4random -I../ext/arc4random -Iext/ipcrypt -I../ext/ipcrypt -Iext/json11 -I../ext/json11 -Iext/lmdb-safe -I../ext/lmdb-safe -I../ext/protozero/include -Iext/yahttp -I../ext/yahttp -Idnsdist-rust-lib -I../dnsdist-rust-lib -Idnsdist-rust-lib/rust -I/opt/homebrew/include -I/opt/homebrew/Cellar/tinycdb/0.81_1/include -I/opt/homebrew/Cellar/fstrm/0.6.1/include -I/opt/homebrew/Cellar/openssl@3/3.5.0/include -I/opt/homebrew/Cellar/gnutls/3.8.9/include -I/opt/homebrew/Cellar/nettle/3.10.1/include -I/opt/homebrew/Cellar/libtasn1/4.20.0/include -I/opt/homebrew/Cellar/libidn2/2.3.8/include -I/opt/homebrew/Cellar/p11-kit/0.25.5/include/p11-kit-1 -I/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/editline -I/opt/homebrew/Cellar/libnghttp2/1.65.0/include -I/opt/homebrew/Cellar/libsodium/1.0.20/include -I/opt/homebrew/opt/lmdb/include -I/opt/homebrew/Cellar/luajit/2.1.1744318430/include/luajit-2.1 -fdiagnostics-color=always -D_LIBCPP_ENABLE_ASSERTIONS=1 -Wall -Winvalid-pch -Wextra -std=c++17 -O2 -g -DDNSDIST -DHAVE_CONFIG_H -ferror-limit=0 -Wshadow -Wmissing-declarations -Wredundant-decls -Wno-ignored-attributes -fvisibility=hidden -D__APPLE_USE_RFC_3542 -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE -fstack-protector --param=ssp-buffer-size=4 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -DBOOST_CONTAINER_USE_STD_EXCEPTIONS '-Wno-#warnings' -DBOOST_ALL_NO_LIB -MD -MQ libdnsdist-common.a.p/dnsdist-rust-lib_dnsdist-configuration-yaml-items-generated.cc.o -MF libdnsdist-common.a.p/dnsdist-rust-lib_dnsdist-configuration-yaml-items-generated.cc.o.d -o libdnsdist-common.a.p/dnsdist-rust-lib_dnsdist-configuration-yaml-items-generated.cc.o -c ../dnsdist-rust-lib/dnsdist-configuration-yaml-items-generated.cc
[3/6] ccache c++ -Ilibdnsdist-common.a.p -I. -I.. -Iext/arc4random -I../ext/arc4random -Iext/ipcrypt -I../ext/ipcrypt -Iext/json11 -I../ext/json11 -Iext/lmdb-safe -I../ext/lmdb-safe -I../ext/protozero/include -Iext/yahttp -I../ext/yahttp -Idnsdist-rust-lib -I../dnsdist-rust-lib -Idnsdist-rust-lib/rust -I/opt/homebrew/include -I/opt/homebrew/Cellar/tinycdb/0.81_1/include -I/opt/homebrew/Cellar/fstrm/0.6.1/include -I/opt/homebrew/Cellar/openssl@3/3.5.0/include -I/opt/homebrew/Cellar/gnutls/3.8.9/include -I/opt/homebrew/Cellar/nettle/3.10.1/include -I/opt/homebrew/Cellar/libtasn1/4.20.0/include -I/opt/homebrew/Cellar/libidn2/2.3.8/include -I/opt/homebrew/Cellar/p11-kit/0.25.5/include/p11-kit-1 -I/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/editline -I/opt/homebrew/Cellar/libnghttp2/1.65.0/include -I/opt/homebrew/Cellar/libsodium/1.0.20/include -I/opt/homebrew/opt/lmdb/include -I/opt/homebrew/Cellar/luajit/2.1.1744318430/include/luajit-2.1 -fdiagnostics-color=always -D_LIBCPP_ENABLE_ASSERTIONS=1 -Wall -Winvalid-pch -Wextra -std=c++17 -O2 -g -DDNSDIST -DHAVE_CONFIG_H -ferror-limit=0 -Wshadow -Wmissing-declarations -Wredundant-decls -Wno-ignored-attributes -fvisibility=hidden -D__APPLE_USE_RFC_3542 -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE -fstack-protector --param=ssp-buffer-size=4 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -DBOOST_CONTAINER_USE_STD_EXCEPTIONS '-Wno-#warnings' -DBOOST_ALL_NO_LIB -MD -MQ libdnsdist-common.a.p/dnsdist-configuration-yaml.cc.o -MF libdnsdist-common.a.p/dnsdist-configuration-yaml.cc.o.d -o libdnsdist-common.a.p/dnsdist-configuration-yaml.cc.o -c ../dnsdist-configuration-yaml.cc
[4/6] rm -f libdnsdist-common.a && ar csr libdnsdist-common.a libdnsdist-common.a.p/meson-generated_dnslabeltext.cc.o libdnsdist-common.a.p/bpf-filter.cc.o libdnsdist-common.a.p/capabilities.cc.o libdnsdist-common.a.p/channel.cc.o libdnsdist-common.a.p/coverage.cc.o libdnsdist-common.a.p/credentials.cc.o libdnsdist-common.a.p/dns.cc.o libdnsdist-common.a.p/dnscrypt.cc.o libdnsdist-common.a.p/dnsdist-actions.cc.o libdnsdist-common.a.p/dnsdist-actions-factory.cc.o libdnsdist-common.a.p/dnsdist-async.cc.o libdnsdist-common.a.p/dnsdist-backend.cc.o libdnsdist-common.a.p/dnsdist-cache.cc.o libdnsdist-common.a.p/dnsdist-carbon.cc.o libdnsdist-common.a.p/dnsdist-concurrent-connections.cc.o libdnsdist-common.a.p/dnsdist-configuration.cc.o libdnsdist-common.a.p/dnsdist-configuration-yaml.cc.o libdnsdist-common.a.p/dnsdist-console.cc.o libdnsdist-common.a.p/dnsdist-crypto.cc.o libdnsdist-common.a.p/dnsdist-discovery.cc.o libdnsdist-common.a.p/dnsdist-dnscrypt.cc.o libdnsdist-common.a.p/dnsdist-dnsparser.cc.o libdnsdist-common.a.p/dnsdist-dnsquestion.cc.o libdnsdist-common.a.p/dnsdist-doh-common.cc.o libdnsdist-common.a.p/dnsdist-dynblocks.cc.o libdnsdist-common.a.p/dnsdist-dynbpf.cc.o libdnsdist-common.a.p/dnsdist-ecs.cc.o libdnsdist-common.a.p/dnsdist-edns.cc.o libdnsdist-common.a.p/dnsdist-frontend.cc.o libdnsdist-common.a.p/dnsdist-healthchecks.cc.o libdnsdist-common.a.p/dnsdist-idstate.cc.o libdnsdist-common.a.p/dnsdist-internal-queries.cc.o libdnsdist-common.a.p/dnsdist-kvs.cc.o libdnsdist-common.a.p/dnsdist-lbpolicies.cc.o libdnsdist-common.a.p/dnsdist-lua-actions.cc.o libdnsdist-common.a.p/dnsdist-lua-bindings.cc.o libdnsdist-common.a.p/dnsdist-lua-bindings-dnscrypt.cc.o libdnsdist-common.a.p/dnsdist-lua-bindings-dnsparser.cc.o libdnsdist-common.a.p/dnsdist-lua-bindings-dnsquestion.cc.o libdnsdist-common.a.p/dnsdist-lua-bindings-kvs.cc.o libdnsdist-common.a.p/dnsdist-lua-bindings-network.cc.o libdnsdist-common.a.p/dnsdist-lua-bindings-packetcache.cc.o libdnsdist-common.a.p/dnsdist-lua-bindings-protobuf.cc.o libdnsdist-common.a.p/dnsdist-lua-bindings-rings.cc.o libdnsdist-common.a.p/dnsdist-lua-configuration-items.cc.o libdnsdist-common.a.p/dnsdist-lua.cc.o libdnsdist-common.a.p/dnsdist-lua-hooks.cc.o libdnsdist-common.a.p/dnsdist-lua-inspection.cc.o libdnsdist-common.a.p/dnsdist-lua-network.cc.o libdnsdist-common.a.p/dnsdist-lua-rules.cc.o libdnsdist-common.a.p/dnsdist-lua-vars.cc.o libdnsdist-common.a.p/dnsdist-lua-web.cc.o libdnsdist-common.a.p/dnsdist-mac-address.cc.o libdnsdist-common.a.p/dnsdist-metrics.cc.o libdnsdist-common.a.p/dnsdist-nghttp2.cc.o libdnsdist-common.a.p/dnsdist-nghttp2-in.cc.o libdnsdist-common.a.p/dnsdist-protobuf.cc.o libdnsdist-common.a.p/dnsdist-protocols.cc.o libdnsdist-common.a.p/dnsdist-proxy-protocol.cc.o libdnsdist-common.a.p/dnsdist-query-count.cc.o libdnsdist-common.a.p/dnsdist-random.cc.o libdnsdist-common.a.p/dnsdist-resolver.cc.o libdnsdist-common.a.p/dnsdist-rings.cc.o libdnsdist-common.a.p/dnsdist-rule-chains.cc.o libdnsdist-common.a.p/dnsdist-rules.cc.o libdnsdist-common.a.p/dnsdist-secpoll.cc.o libdnsdist-common.a.p/dnsdist-session-cache.cc.o libdnsdist-common.a.p/dnsdist-self-answers.cc.o libdnsdist-common.a.p/dnsdist-snmp.cc.o libdnsdist-common.a.p/dnsdist-svc.cc.o libdnsdist-common.a.p/dnsdist-systemd.cc.o libdnsdist-common.a.p/dnsdist-tcp.cc.o libdnsdist-common.a.p/dnsdist-tcp-downstream.cc.o libdnsdist-common.a.p/dnsdist-web.cc.o libdnsdist-common.a.p/dnsdist-xsk.cc.o libdnsdist-common.a.p/dnsname.cc.o libdnsdist-common.a.p/dnsparser.cc.o libdnsdist-common.a.p/dnswriter.cc.o libdnsdist-common.a.p/dolog.cc.o libdnsdist-common.a.p/doh3.cc.o libdnsdist-common.a.p/ednscookies.cc.o libdnsdist-common.a.p/ednsextendederror.cc.o libdnsdist-common.a.p/ednsoptions.cc.o libdnsdist-common.a.p/ednssubnet.cc.o libdnsdist-common.a.p/gettime.cc.o libdnsdist-common.a.p/iputils.cc.o libdnsdist-common.a.p/libssl.cc.o libdnsdist-common.a.p/misc.cc.o libdnsdist-common.a.p/protozero.cc.o libdnsdist-common.a.p/proxy-protocol.cc.o libdnsdist-common.a.p/qtype.cc.o libdnsdist-common.a.p/remote_logger.cc.o libdnsdist-common.a.p/remote_logger_pool.cc.o libdnsdist-common.a.p/snmp-agent.cc.o libdnsdist-common.a.p/statnode.cc.o libdnsdist-common.a.p/svc-records.cc.o libdnsdist-common.a.p/tcpiohandler.cc.o libdnsdist-common.a.p/threadname.cc.o libdnsdist-common.a.p/uuid-utils.cc.o libdnsdist-common.a.p/xsk.cc.o libdnsdist-common.a.p/cdb.cc.o libdnsdist-common.a.p/doq.cc.o libdnsdist-common.a.p/ipcipher.cc.o libdnsdist-common.a.p/doq-common.cc.o libdnsdist-common.a.p/dnsdist-rust-lib_dnsdist-configuration-yaml-items-generated.cc.o && ranlib -c libdnsdist-common.a
[5/6] c++  -o testrunner testrunner.p/testrunner.cc.o testrunner.p/pollmplexer.cc.o testrunner.p/kqueuemplexer.cc.o testrunner.p/dnsdist-lua-ffi.cc.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-force_load libdnsdist-test.a -rdynamic '-Wno-#warnings' -Wl,-rpath,@loader_path/dnsdist-rust-lib/rust -Wl,-rpath,/opt/homebrew/Cellar/luajit/2.1.1744318430/lib -Wl,-rpath,/opt/homebrew/Cellar/tinycdb/0.81_1/lib -Wl,-rpath,/opt/homebrew/Cellar/fstrm/0.6.1/lib -Wl,-rpath,/opt/homebrew/Cellar/openssl@3/3.5.0/lib -Wl,-rpath,/opt/homebrew/Cellar/gnutls/3.8.9/lib -Wl,-rpath,/opt/homebrew/Cellar/libnghttp2/1.65.0/lib -Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,/opt/homebrew/Cellar/libsodium/1.0.20/lib -Wl,-rpath,/opt/homebrew/opt/lmdb/lib libdnsdist-common.a ext/arc4random/libarc4random.a ext/ipcrypt/libipcrypt.a ext/json11/libjson11.a ext/lmdb-safe/liblmdb-safe.a ext/yahttp/yahttp/libyahttp.a dnsdist-rust-lib/rust/libdnsdist_rust.a /opt/homebrew/Cellar/boost/1.88.0/lib/libboost_unit_test_framework.dylib /opt/homebrew/Cellar/luajit/2.1.1744318430/lib/libluajit-5.1.dylib /opt/homebrew/Cellar/tinycdb/0.81_1/lib/libcdb.dylib /opt/homebrew/Cellar/fstrm/0.6.1/lib/libfstrm.dylib /opt/homebrew/Cellar/openssl@3/3.5.0/lib/libcrypto.dylib /opt/homebrew/Cellar/gnutls/3.8.9/lib/libgnutls.dylib -ledit /opt/homebrew/Cellar/libnghttp2/1.65.0/lib/libnghttp2.dylib /opt/homebrew/lib/libdnsdist-quiche.dylib /opt/homebrew/Cellar/libsodium/1.0.20/lib/libsodium.dylib /opt/homebrew/Cellar/openssl@3/3.5.0/lib/libssl.dylib /opt/homebrew/opt/lmdb/lib/liblmdb.dylib
[6/6] c++  -o dnsdist dnsdist.p/dnsdist.cc.o dnsdist.p/dnstap.cc.o dnsdist.p/fstrm_logger.cc.o dnsdist.p/dnsdist-lua-ffi.cc.o dnsdist.p/dnsdist-lua-inspection-ffi.cc.o dnsdist.p/pollmplexer.cc.o dnsdist.p/kqueuemplexer.cc.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -rdynamic '-Wno-#warnings' -Wl,-rpath,@loader_path/dnsdist-rust-lib/rust -Wl,-rpath,/opt/homebrew/Cellar/luajit/2.1.1744318430/lib -Wl,-rpath,/opt/homebrew/Cellar/tinycdb/0.81_1/lib -Wl,-rpath,/opt/homebrew/Cellar/fstrm/0.6.1/lib -Wl,-rpath,/opt/homebrew/Cellar/openssl@3/3.5.0/lib -Wl,-rpath,/opt/homebrew/Cellar/gnutls/3.8.9/lib -Wl,-rpath,/opt/homebrew/Cellar/libnghttp2/1.65.0/lib -Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,/opt/homebrew/Cellar/libsodium/1.0.20/lib -Wl,-rpath,/opt/homebrew/opt/lmdb/lib libdnsdist-common.a ext/arc4random/libarc4random.a ext/ipcrypt/libipcrypt.a ext/json11/libjson11.a ext/lmdb-safe/liblmdb-safe.a ext/yahttp/yahttp/libyahttp.a dnsdist-rust-lib/rust/libdnsdist_rust.a /opt/homebrew/Cellar/luajit/2.1.1744318430/lib/libluajit-5.1.dylib /opt/homebrew/Cellar/tinycdb/0.81_1/lib/libcdb.dylib /opt/homebrew/Cellar/fstrm/0.6.1/lib/libfstrm.dylib /opt/homebrew/Cellar/openssl@3/3.5.0/lib/libcrypto.dylib /opt/homebrew/Cellar/gnutls/3.8.9/lib/libgnutls.dylib -ledit /opt/homebrew/Cellar/libnghttp2/1.65.0/lib/libnghttp2.dylib /opt/homebrew/lib/libdnsdist-quiche.dylib /opt/homebrew/Cellar/libsodium/1.0.20/lib/libsodium.dylib /opt/homebrew/Cellar/openssl@3/3.5.0/lib/libssl.dylib /opt/homebrew/opt/lmdb/lib/liblmdb.dylib
mbp:dnsdistdist otto$ m -v
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /opt/homebrew/bin/ninja -C /Users/otto/pdns/pdns/dnsdistdist/build -v
ninja: Entering directory `/Users/otto/pdns/pdns/dnsdistdist/build'
[1/1] /bin/sh -c 'test ! -e ../config.h'
```
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
