### PR TITLE
dnsdist: Fix building on EL-8 (we now need Python 3.12 instead of 3.11)

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -1,7 +1,7 @@
 FROM dist-base as package-builder
 RUN if $(grep -q 'release 8' /etc/redhat-release); then \
       yum upgrade -y && \
-      yum install --allowerasing -y rpm-build rpmdevtools python3.11 curl jq "@Development Tools" ninja-build hostname python3.11-pip python3.11-yaml ; \
+      yum install --allowerasing -y rpm-build rpmdevtools python3.12 curl jq "@Development Tools" ninja-build hostname python3.12-pip python3.12-yaml ; \
     else \
       yum upgrade -y && \
       yum install --allowerasing -y rpm-build rpmdevtools python3 curl jq "@Development Tools" ninja-build hostname python3-pip python3-yaml ; \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise `pip` is not found when installing `meson`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
