### PR TITLE
auth: restore correct logging level for startup version message

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -1527,7 +1527,7 @@ int main(int argc, char** argv)
   DLOG(g_log << Logger::Warning << "Verbose logging in effect" << endl);
 
   for (const string& line : getProductVersionLines()) {
-    g_log << Logger::Info << line << endl;
+    g_log << Logger::Warning << line << endl;
   }
 
   try {


### PR DESCRIPTION
### Short description
The loglevel was accidentally bumped to Info in an earlier PR (but after 4.9)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
