### PR TITLE
auth: Fix `ignoring attributes on template argument` warning in the GeoIP backend

### DIFF
--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -89,7 +89,8 @@ struct DirPtrDeleter
      - we avoid the annoying "ignoring attributes on template argument ‘int (*)(DIR*)’"
        warning from the compiler, which is there because closedir is tagged as __nonnull((1))
   */
-  void operator()(DIR* dirPtr) const noexcept {
+  void operator()(DIR* dirPtr) const noexcept
+  {
     closedir(dirPtr);
   }
 };

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -80,12 +80,28 @@ const static std::array<string, 12> GeoIP_MONTHS = {"jan", "feb", "mar", "apr", 
    If the reference is external, we spoof up a CNAME, and good luck with that
 */
 
+struct DirPtrDeleter
+{
+  /* using a deleter instead of decltype(&closedir) has two big advantages:
+     - the deleter is included in the type and does not have to be passed
+       when creating a new object (easier to use, less memory usage, in theory
+       better inlining)
+     - we avoid the annoying "ignoring attributes on template argument ‘int (*)(DIR*)’"
+       warning from the compiler, which is there because closedir is tagged as __nonnull((1))
+  */
+  void operator()(DIR* dirPtr) const noexcept {
+    closedir(dirPtr);
+  }
+};
+
+using UniqueDirPtr = std::unique_ptr<DIR, DirPtrDeleter>;
+
 GeoIPBackend::GeoIPBackend(const string& suffix)
 {
   WriteLock writeLock(&s_state_lock);
   setArgPrefix("geoip" + suffix);
   if (!getArg("dnssec-keydir").empty()) {
-    auto dirHandle = std::unique_ptr<DIR, decltype(&closedir)>(opendir(getArg("dnssec-keydir").c_str()), closedir);
+    auto dirHandle = UniqueDirPtr(opendir(getArg("dnssec-keydir").c_str()));
     if (!dirHandle) {
       throw PDNSException("dnssec-keydir " + getArg("dnssec-keydir") + " does not exist");
     }


### PR DESCRIPTION
g++ 15.1.1 reports:
```
geoipbackend.cc: In constructor 'GeoIPBackend::GeoIPBackend(const std::string&)':
geoipbackend.cc:88:62: warning: ignoring attributes on template argument 'int (*)(DIR*)' [-Wignored-attributes]
   88 |     auto dirHandle = std::unique_ptr<DIR, decltype(&closedir)>(opendir(getArg("dnssec-keydir").c_str()), closedir);
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
