### PR TITLE
ci: Fix various warnings reported by zizmor

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -74,6 +74,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - name: get timestamp for cache
         id: get-stamp
         run: |
@@ -165,6 +166,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - name: get timestamp for cache
         id: get-stamp
         run: |
@@ -252,6 +254,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - name: get timestamp for cache
         id: get-stamp
         run: |
@@ -358,6 +361,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
@@ -489,6 +493,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
@@ -532,6 +537,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
@@ -581,6 +587,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
@@ -634,6 +641,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
@@ -688,6 +696,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
@@ -733,6 +742,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
@@ -793,6 +803,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
@@ -830,6 +841,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - name: install pip build dependencies
         run: |
           python3 -m venv ${REPO_HOME}/.venv
@@ -869,6 +881,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - name: Get list of jobs in the workflow
         run: "cat .github/workflows/build-and-test-all.yml | jc --yaml | jq -rS '.[].jobs | keys | .[]' | grep -vE 'collect|get-runner-container-image' | tee /tmp/workflow-jobs-list.yml"
       - name: Get list of prerequisite jobs

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -32,6 +32,7 @@ env:
   LLVM_PROFILE_FILE: "/tmp/code-%p.profraw"
   OPTIMIZATIONS: yes
   INV_CMD: ". ${REPO_HOME}/.venv/bin/activate && inv"
+  BRANCH_NAME: ${{ inputs.branch-name || github.ref_name }}
 
 jobs:
   get-runner-container-image:
@@ -41,13 +42,13 @@ jobs:
       id: ${{ steps.get-runner-image.outputs.image-id }}
       tag: ${{ steps.get-runner-image.outputs.tag }}
     env:
-      DEFAULT_RUNNER_DOCKER_IMAGE: base-pdns-ci-image/debian-12-pdns-base
       DEFAULT_IMAGE_TAG: master # update when backporting, e.g. auth-4.9.x
+      DOCKER_IMAGE: ${{ inputs.runner-docker-image-name || 'base-pdns-ci-image/debian-12-pdns-base' }}
     steps:
       - id: get-runner-image
         run: |
-          echo "image-id=ghcr.io/powerdns/${{ inputs.runner-docker-image-name || env.DEFAULT_RUNNER_DOCKER_IMAGE }}" >> "$GITHUB_OUTPUT"
-          echo "tag=${{ env.DEFAULT_IMAGE_TAG }}" >> "$GITHUB_OUTPUT"
+          echo "image-id=ghcr.io/powerdns/$DOCKER_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "tag=$DEFAULT_IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
   build-auth:
     name: build auth (${{ matrix.builder }})
@@ -125,7 +126,7 @@ jobs:
       - run: ${{ env.INV_CMD }} ci-auth-install ${{ matrix.builder == 'meson' && '--meson' || '' }}
       - run: ccache -s
       - if: ${{ matrix.builder != 'meson' }}
-        run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+        run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - if: ${{ matrix.builder != 'meson' }}
         name: Store the binaries
         uses: actions/upload-artifact@v4 # this takes 30 seconds, maybe we want to tar
@@ -188,7 +189,7 @@ jobs:
         working-directory: .
       - run: ${{ env.INV_CMD }} install-rec-build-deps
         working-directory: ./pdns/recursordist/
-      - run: ${{ env.INV_CMD }} ci-install-rust ${{ env.REPO_HOME }}
+      - run: ${{ env.INV_CMD }} ci-install-rust ${REPO_HOME}
         working-directory: ./pdns/recursordist/
       - run: ${{ env.INV_CMD }} ci-autoconf ${{ matrix.builder == 'meson' && '--meson' || '' }}
         working-directory: ./pdns/recursordist/
@@ -210,7 +211,7 @@ jobs:
       - run: ${{ env.INV_CMD }} ci-rec-install ${{ matrix.builder == 'meson' && '--meson' || '' }}
       - run: ccache -s
       - if: ${{ matrix.builder != 'meson' }}
-        run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+        run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - if: ${{ matrix.builder != 'meson' }}
         name: Store the binaries
         uses: actions/upload-artifact@v4 # this takes 30 seconds, maybe we want to tar
@@ -278,9 +279,9 @@ jobs:
         working-directory: .
       - run: ${{ env.INV_CMD }} install-lld-linker-if-needed
         working-directory: ./pdns/dnsdistdist/
-      - run: ${{ env.INV_CMD }} ci-install-rust ${{ env.REPO_HOME }}
+      - run: ${{ env.INV_CMD }} ci-install-rust ${REPO_HOME}
         working-directory: ./pdns/dnsdistdist/
-      - run: ${{ env.INV_CMD }} ci-build-and-install-quiche ${{ env.REPO_HOME }}
+      - run: ${{ env.INV_CMD }} ci-build-and-install-quiche ${REPO_HOME}
         working-directory: ./pdns/dnsdistdist/
       - run: ${{ env.INV_CMD }} ci-autoconf
         if: ${{ matrix.builder == 'autotools' }}
@@ -308,7 +309,7 @@ jobs:
       - run: ${{ env.INV_CMD }} ci-make-install
         if: ${{ matrix.builder == 'autotools' }}
       - run: ccache -s
-      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Store the binaries
         if: ${{ matrix.builder == 'autotools' }}
         uses: actions/upload-artifact@v4 # this takes 30 seconds, maybe we want to tar
@@ -362,7 +363,7 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.branch-name }}
           persist-credentials: false
-      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
@@ -494,7 +495,7 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.branch-name }}
           persist-credentials: false
-      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
@@ -538,7 +539,7 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.branch-name }}
           persist-credentials: false
-      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
@@ -588,7 +589,7 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.branch-name }}
           persist-credentials: false
-      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
@@ -642,7 +643,7 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.branch-name }}
           persist-credentials: false
-      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
@@ -697,7 +698,7 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.branch-name }}
           persist-credentials: false
-      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
@@ -743,7 +744,7 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.branch-name }}
           persist-credentials: false
-      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
@@ -804,7 +805,7 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.branch-name }}
           persist-credentials: false
-      - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - run: echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Fetch the binaries
         uses: actions/download-artifact@v4
         with:
@@ -865,6 +866,8 @@ jobs:
       - test-recursor-ubicloud-bulk
     if: success() || failure()
     runs-on: ubuntu-24.04
+    env:
+      NEEDS: ${{ toJSON(needs) }}
     steps:
       - name: Coveralls Parallel Finished
         if: ${{ env.COVERAGE == 'yes' }}
@@ -875,7 +878,7 @@ jobs:
       - name: Install jq and jc
         run: "sudo apt-get update && sudo apt-get install jq jc"
       - name: Fail job if any of the previous jobs failed
-        run: "for i in `echo '${{ toJSON(needs) }}' | jq -r '.[].result'`; do if [[ $i == 'failure' ]]; then echo '${{ toJSON(needs) }}'; exit 1; fi; done;"
+        run: "for i in `echo ${NEEDS} | jq -r '.[].result'`; do if [[ $i == 'failure' ]]; then echo ${NEEDS}; exit 1; fi; done;"
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
@@ -885,7 +888,7 @@ jobs:
       - name: Get list of jobs in the workflow
         run: "cat .github/workflows/build-and-test-all.yml | jc --yaml | jq -rS '.[].jobs | keys | .[]' | grep -vE 'collect|get-runner-container-image' | tee /tmp/workflow-jobs-list.yml"
       - name: Get list of prerequisite jobs
-        run: "echo '${{ toJSON(needs) }}' | jq -rS 'keys | .[]' | tee /tmp/workflow-needs-list.yml"
+        run: "echo ${NEEDS} | jq -rS 'keys | .[]' | tee /tmp/workflow-needs-list.yml"
       - name: Fail if there is a job missing on the needs list
         run: "if ! diff -q /tmp/workflow-jobs-list.yml /tmp/workflow-needs-list.yml; then exit 1; fi"
 

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -115,7 +115,7 @@ jobs:
         working-directory: ./pdns-${{ env.BUILDER_VERSION }}/pdns
       - name: Coveralls Parallel auth unit
         if: ${{ env.COVERAGE == 'yes' && matrix.builder != 'meson' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: auth-unit-${{ env.SANITIZERS }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -200,7 +200,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder != 'meson' }}
       - name: Coveralls Parallel rec unit
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder != 'meson' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: rec-unit-${{ matrix.features }}-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -298,7 +298,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder == 'autotools'}}
       - name: Coveralls Parallel dnsdist unit
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' && matrix.builder == 'autotools' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: dnsdist-unit-${{ matrix.features }}-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -380,7 +380,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' }}
       - name: Coveralls Parallel auth API ${{ matrix.backend }}
         if: ${{ env.COVERAGE == 'yes' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: auth-api-${{ matrix.backend }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -512,7 +512,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' }}
       - name: Coveralls Parallel auth backend ${{ matrix.backend }}
         if: ${{ env.COVERAGE == 'yes' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: auth-backend-${{ matrix.backend }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -555,7 +555,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' }}
       - name: Coveralls Parallel ixfrdist
         if: ${{ env.COVERAGE == 'yes' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: ixfrdist
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -607,7 +607,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
       - name: Coveralls Parallel recursor API
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: rec-api-full-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -661,7 +661,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
       - name: Coveralls Parallel recursor regression
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: rec-regression-full-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -714,7 +714,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
       - name: Coveralls Parallel recursor bulk
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: rec-regression-bulk-full-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -765,7 +765,7 @@ jobs:
       #  if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
       #- name: Coveralls Parallel recursor bulk
       #  if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
-      #  uses: coverallsapp/github-action@v2
+      #  uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
       #  with:
       #    flag-name: rec-regression-bulk-full-${{ matrix.sanitizers }}
       #    path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -821,7 +821,7 @@ jobs:
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
       - name: Coveralls Parallel dnsdist regression
         if: ${{ env.COVERAGE == 'yes' && matrix.sanitizers != 'tsan' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           flag-name: dnsdist-regression-full-${{ matrix.sanitizers }}
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
@@ -868,7 +868,7 @@ jobs:
     steps:
       - name: Coveralls Parallel Finished
         if: ${{ env.COVERAGE == 'yes' }}
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         with:
           parallel-finished: true
           fail-on-error: false

--- a/.github/workflows/build-docker-images-dispatch.yml
+++ b/.github/workflows/build-docker-images-dispatch.yml
@@ -43,28 +43,31 @@ jobs:
       image-tag: ${{ steps.get-image-tag.outputs.tag }}
       image-name: ${{ steps.get-image-metadata.outputs.name }}
       image-description: ${{ steps.get-image-metadata.outputs.description }}
+    env:
+      INPUT_REF: ${{ inputs.ref }}
+      PRODUCT: ${{ inputs.product }}
     steps:
       - run: |
-          echo '${{ inputs.ref }}' | egrep -qq '^auth-.*|^rec-.*|^dnsdist-.*' && tag=$(echo '${{ inputs.ref }}' | cut -d '-' -f 2-)
+          echo "${INPUT_REF}" | egrep -qq '^auth-.*|^rec-.*|^dnsdist-.*' && tag=$(echo "${INPUT_REF}" | cut -d '-' -f 2-)
           echo "tag=$tag" >> $GITHUB_OUTPUT
         id: get-image-tag
       - run: |
-          if $(echo '${{ inputs.ref }}' | egrep -qq '^auth-.*|^rec-.*|^dnsdist-.*'); then
-            echo "version=$(echo '${{ inputs.ref }}' | cut -d '-' -f 2 | awk -F'.' '{print $1$2}')" >> $GITHUB_ENV
-            echo "branch=$(echo '${{ inputs.ref }}' | cut -d '-' -f 2- | awk -F'.' '{print "v"$1"."$2".x"}')" >> $GITHUB_ENV
+          if $(echo "${INPUT_REF}" | egrep -qq '^auth-.*|^rec-.*|^dnsdist-.*'); then
+            echo "version=$(echo "${INPUT_REF}" | cut -d '-' -f 2 | awk -F'.' '{print $1$2}')" >> $GITHUB_ENV
+            echo "branch=$(echo "${INPUT_REF}" | cut -d '-' -f 2- | awk -F'.' '{print "v"$1"."$2".x"}')" >> $GITHUB_ENV
           else
-            echo "version=$(echo '${{ inputs.ref }}' | tr '/' '-')" >> $GITHUB_ENV
-            echo "branch=${{ inputs.ref }}" >> $GITHUB_ENV
+            echo "version=$(echo "${INPUT_REF}" | tr '/' '-')" >> $GITHUB_ENV
+            echo "branch=${INPUT_REF}" >> $GITHUB_ENV
           fi
       - run: |
-          if $(echo '${{ inputs.product }}'| grep -qq auth); then
-            echo '${{ inputs.ref }}' | egrep -qq '^auth-.*' && description='PowerDNS Authoritative Server '$branch || description='EXPERIMENTAL pdns auth image'
+          if $(echo "$PRODUCT"| grep -qq auth); then
+            echo "${INPUT_REF}" | egrep -qq '^auth-.*' && description='PowerDNS Authoritative Server '$branch || description='EXPERIMENTAL pdns auth image'
             echo "name=pdns-auth-$version" >> $GITHUB_OUTPUT
-          elif (echo '${{ inputs.product }}'| grep -qq recursor); then
-            echo '${{ inputs.ref }}' | egrep -qq '^rec-.*' && description='PowerDNS Recursor '$branch || description='EXPERIMENTAL pdns recursor image'
+          elif (echo "$PRODUCT"| grep -qq recursor); then
+            echo "${INPUT_REF}" | egrep -qq '^rec-.*' && description='PowerDNS Recursor '$branch || description='EXPERIMENTAL pdns recursor image'
             echo "name=pdns-recursor-$version" >> $GITHUB_OUTPUT
           else
-            echo '${{ inputs.ref }}' | egrep -qq '^dnsdist-.*' && description='PowerDNS DNSDist '$branch || description='EXPERIMENTAL dnsdist image'
+            echo "${INPUT_REF}" | egrep -qq '^dnsdist-.*' && description='PowerDNS DNSDist '$branch || description='EXPERIMENTAL dnsdist image'
             echo "name=dnsdist-$version" >> $GITHUB_OUTPUT
           fi
           echo "description=$description" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-docker-images-tags.yml
+++ b/.github/workflows/build-docker-images-tags.yml
@@ -14,17 +14,19 @@ permissions:
 
 jobs:
   prepare:
+    env:
+      REF_NAME: ${{ github.ref_name }}
     runs-on: ubuntu-24.04
     outputs:
       image-name-suffix: ${{ steps.get-image-version.outputs.version }}
       image-tag: ${{ steps.get-image-tag.outputs.tag }}
       image-description-suffix: ${{ steps.get-image-description.outputs.description }}
     steps:
-      - run: echo "version=$(echo '${{ github.ref_name }}' | cut -d '-' -f 2 | awk -F'.' '{print $1$2}')" >> $GITHUB_OUTPUT
+      - run: echo "version=$(echo "${REF_NAME}" | cut -d '-' -f 2 | awk -F'.' '{print $1$2}')" >> $GITHUB_OUTPUT
         id: get-image-version
-      - run: echo "tag=$(echo '${{ github.ref_name }}' | cut -d '-' -f 2-)" >> $GITHUB_OUTPUT
+      - run: echo "tag=$(echo "${REF_NAME}" | cut -d '-' -f 2-)" >> $GITHUB_OUTPUT
         id: get-image-tag
-      - run: echo "description=$(echo '${{ github.ref_name }}' | cut -d '-' -f 2- | awk -F'.' '{print "v"$1"."$2".x"}')" >> $GITHUB_OUTPUT
+      - run: echo "description=$(echo "${REF_NAME}" | cut -d '-' -f 2- | awk -F'.' '{print "v"$1"."$2".x"}')" >> $GITHUB_OUTPUT
         id: get-image-description
 
   call-build-image-auth:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -60,6 +60,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: validate reference only if image will be pushed
         if: ${{ inputs.push }}
         run: |
@@ -77,6 +78,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -63,8 +63,10 @@ jobs:
           persist-credentials: false
       - name: validate reference only if image will be pushed
         if: ${{ inputs.push }}
+        env:
+          REF: ${{ inputs.ref }}
         run: |
-          [[ "${{ inputs.ref }}" == "master" ]] || git describe --tags --exact-match
+          [[ "${REF}" == "master" ]] || git describe --tags --exact-match
 
   build:
     name: build docker image for a product
@@ -150,29 +152,34 @@ jobs:
       matrix:
         runner-os: ${{ fromJson(needs.prepare-test-runner-os-list.outputs.runnerlist )}}
       fail-fast: false
+    env:
+      INPUT_IMAGE_NAME: ${{ inputs.image-name }}
+      INPUT_IMAGE_TAGS: ${{ inputs.image-tags }}
+      INPUT_PLATFORMS: ${{ inputs.platforms }}
     steps:
       - name: Check running image
         run: |
-          image_name='${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}'
-          for tag in `echo '${{ inputs.image-tags }}' | tr '\n' ' '`; do
+          image_name="${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${INPUT_IMAGE_NAME}"
+          for tag in `echo "${INPUT_IMAGE_TAGS}" | tr '\n' ' '`; do
             echo 'Testing: '${image_name}':'${tag};
             # pdns-auth image returns a 134 exit code
             docker run ${image_name}:${tag} --version || [ "$?" == "134" ]
           done
       - name: Check image digest matches
+        env:
+          EXPECTED_DIGEST: ${{ needs.build.outputs.image-digest }}
         run: |
-          output_digest='${{ needs.build.outputs.image-digest }}'
-          image_name='${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}'
-          for tag in `echo '${{ inputs.image-tags }}' | tr '\n' ' '`; do
+          image_name="${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${INPUT_IMAGE_NAME}"
+          for tag in `echo "${INPUT_IMAGE_TAGS}" | tr '\n' ' '`; do
             image_digest=$(docker inspect --format='{{index .RepoDigests 0}}' ${image_name}:${tag} | cut -d '@' -f 2)
-            [[ "${output_digest}" == "${image_digest}" ]] || \
-              ( echo "Image digest does not match => output_digest: "${output_digest}" - image_digest: "${image_digest} && exit 1 )
+            [[ "${EXPECTED_DIGEST}" == "${image_digest}" ]] || \
+              ( echo "Image digest does not match => output_digest: "${EXPECTED_DIGEST}" - image_digest: "${image_digest} && exit 1 )
           done
       - name: Check SBOM and Provenance
         run: |
-          image_name='${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${{ inputs.image-name }}'
-          for tag in `echo '${{ inputs.image-tags }}' | tr '\n' ' '`; do
-            if $(echo '${{ inputs.platforms }}' | grep -qq ','); then
+          image_name="${{ secrets.DOCKERHUB_ORGANIZATION_NAME }}/${INPUT_IMAGE_NAME}"
+          for tag in `echo "${INPUT_IMAGE_TAGS}" | tr '\n' ' '`; do
+            if $(echo "${INPUT_PLATFORMS}" | grep -qq ','); then
               docker buildx imagetools inspect ${image_name}:${tag} --format "{{json .Provenance}}" | jq -e '."linux/'$(dpkg --print-architecture)'" | has("SLSA")'
               docker buildx imagetools inspect ${image_name}:${tag} --format "{{json .SBOM}}" | jq -e '."linux/'$(dpkg --print-architecture)'" | has("SPDX")'
             else

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -61,6 +61,7 @@ jobs:
           fetch-depth: 1
           submodules: recursive
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - id: get-oslist
         run: |
           available_targets=$(ls builder-support/dockerfiles/Dockerfile.target.* )
@@ -114,6 +115,7 @@ jobs:
           fetch-depth: 0 # for correct version numbers
           submodules: recursive
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       # this builds packages and runs our unit tests (make check)
       - run: IS_RELEASE=${{ inputs.is_release}} builder/build.sh -v -m ${{ inputs.product }} ${{ matrix.os }}
       - name: Get version number

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -63,16 +63,19 @@ jobs:
           ref: ${{ inputs.ref }}
           persist-credentials: false
       - id: get-oslist
+        env:
+          OS: ${{ inputs.os }}
+          REF: ${{ inputs.ref }}
         run: |
           available_targets=$(ls builder-support/dockerfiles/Dockerfile.target.* )
-          for i in $(echo "${{ inputs.os }}"); do
+          for i in $(echo "${OS}"); do
             if echo $available_targets | grep -qq $i; then
               targets+=($i)
             else
-              if [[ "${{ inputs.ref }}" == "master" ]]; then
-                echo "::error title=Dockerfile not found for ${i}::OS ${i} not available as target in ${{ inputs.ref }}" && exit 1
+              if [[ "${REF}" == "master" ]]; then
+                echo "::error title=Dockerfile not found for ${i}::OS ${i} not available as target in ${REF}" && exit 1
               else
-                echo "::warning title=Packages will not be generated for ${i}::OS ${i} not available as target in ${{ inputs.ref }}"
+                echo "::warning title=Packages will not be generated for ${i}::OS ${i} not available as target in ${REF}"
               fi
             fi
           done
@@ -109,6 +112,10 @@ jobs:
       pkghashes-ubuntu-noble-x86_64: ${{ steps.pkghashes.outputs.pkghashes-ubuntu-noble-x86_64 }}
       pkghashes-ubuntu-noble-aarch64: ${{ steps.pkghashes.outputs.pkghashes-ubuntu-noble-aarch64 }}
       srchashes: ${{ steps.srchashes.outputs.srchashes }}
+    env:
+      IS_RELEASE: ${{ inputs.is_release}}
+      PRODUCT: ${{ inputs.product }}
+      OS: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,7 +124,7 @@ jobs:
           ref: ${{ inputs.ref }}
           persist-credentials: false
       # this builds packages and runs our unit tests (make check)
-      - run: IS_RELEASE=${{ inputs.is_release}} builder/build.sh -v -m ${{ inputs.product }} ${{ matrix.os }}
+      - run: IS_RELEASE=${IS_RELEASE} builder/build.sh -v -m ${PRODUCT} ${OS}
       - name: Get version number
         run: |
           echo "version=$(readlink builder/tmp/latest)" >> $GITHUB_OUTPUT
@@ -129,15 +136,17 @@ jobs:
       - name: Normalize package name
         id: normalize-name
         run: |
-          if [ "x${{ inputs.product }}" = "xauthoritative" ]; then
+          if [ "x${PRODUCT}" = "xauthoritative" ]; then
             echo "normalized-package-name=pdns" >> $GITHUB_OUTPUT
-          elif [ "x${{ inputs.product }}" = "xrecursor" ]; then
+          elif [ "x${PRODUCT}" = "xrecursor" ]; then
             echo "normalized-package-name=pdns-recursor" >> $GITHUB_OUTPUT
           else
-            echo "normalized-package-name=${{ inputs.product }}" >> $GITHUB_OUTPUT
+            echo "normalized-package-name=${PRODUCT}" >> $GITHUB_OUTPUT
           fi
       - name: Include architecture in the packages compressed file name
-        run: for f in $(ls ./built_pkgs/*/*/*-${{ matrix.os }}.tar.bz2 | sed 's/\.tar.bz2$//'); do mv $f.tar.bz2 $f-${{ steps.getarch.outputs.target-arch }}.tar.bz2; done
+        env:
+          TARGET_ARCH: ${{ steps.getarch.outputs.target-arch }}
+        run: for f in $(ls ./built_pkgs/*/*/*-${OS}.tar.bz2 | sed 's/\.tar.bz2$//'); do mv $f.tar.bz2 $f-${TARGET_ARCH}.tar.bz2; done
       - name: Upload packages as GH artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -147,19 +156,28 @@ jobs:
       - name: Extract packages from the tarball
         # so we get provenance for individual packages (and the JSON package manifests from the builder)
         id: extract
+        env:
+          TARGET_ARCH: ${{ steps.getarch.outputs.target-arch }}
+          PACKAGE_NAME: ${{ steps.normalize-name.outputs.normalized-package-name }}
+          VERSION: ${{ steps.getversion.outputs.version }}
         run: |
           mkdir -m 700 -p ./packages/
-          tar xvf ./built_pkgs/*/*/${{ steps.normalize-name.outputs.normalized-package-name }}-${{ steps.getversion.outputs.version }}-${{ matrix.os }}-${{ steps.getarch.outputs.target-arch }}.tar.bz2 -C ./packages/ --transform='s/.*\///'
+          tar xvf ./built_pkgs/*/*/${PACKAGE_NAME}-${VERSION}-${OS}-${TARGET_ARCH}.tar.bz2 -C ./packages/ --transform='s/.*\///'
       - name: Generate package hashes for provenance
         shell: bash
         id: pkghashes
+        env:
+          TARGET_ARCH: ${{ steps.getarch.outputs.target-arch }}
         run: |
-          echo "pkghashes-${{ matrix.os }}-${{ steps.getarch.outputs.target-arch }}=$(sha256sum ./packages/*.rpm ./packages/*.deb ./packages/*.json | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "pkghashes-${OS}-${TARGET_ARCH}=$(sha256sum ./packages/*.rpm ./packages/*.deb ./packages/*.json | base64 -w0)" >> $GITHUB_OUTPUT
       - name: Generate source hash for provenance
         shell: bash
         id: srchashes
+        env:
+          PACKAGE_NAME: ${{ steps.normalize-name.outputs.normalized-package-name }}
+          VERSION: ${{ steps.getversion.outputs.version }}
         run: |
-          echo "srchashes=$(sha256sum ./built_pkgs/*/*/${{ steps.normalize-name.outputs.normalized-package-name }}-${{ steps.getversion.outputs.version }}.tar.* | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "srchashes=$(sha256sum ./built_pkgs/*/*/${PACKAGE_NAME}-${VERSION}.tar.* | base64 -w0)" >> $GITHUB_OUTPUT
       - name: Upload packages to downloads.powerdns.com
         env:
           SSHKEY: ${{ secrets.DOWNLOADS_AUTOBUILT_SECRET }}
@@ -178,12 +196,15 @@ jobs:
     needs: [prepare, build]
     name: Check if hashes were created for all requested targets
     runs-on: ubuntu-24.04
+    env:
+      OUTPUTS: ${{ toJSON(needs.build.outputs) }}
+      OSLIST: ${{ needs.prepare.outputs.oslist }}
     steps:
       - name: Get list of outputs from build jobs
-        run: echo '${{ toJSON(needs.build.outputs) }}' | jq 'keys[]' | grep -vE 'version|product-name' | tee /tmp/build-outputs.txt
+        run: echo "${OUTPUTS}" | jq 'keys[]' | grep -vE 'version|product-name' | tee /tmp/build-outputs.txt
       - name: Get list of OS inputs
         run: |
-          for os in $(echo '${{ needs.prepare.outputs.oslist }}' | jq -r '.[]'); do
+          for os in $(echo "${OSLIST}" | jq -r '.[]'); do
             for architecture in x86_64 ${{ vars.ARM64_USE_UBICLOUD == '1' && 'aarch64' || '' }}; do
               echo "\"pkghashes-$os-$architecture\"" | tee -a /tmp/os-inputs.txt
             done
@@ -252,6 +273,7 @@ jobs:
           HOSTKEY: ${{ secrets.DOWNLOADS_AUTOBUILT_HOSTKEY }}
           PRODUCT: ${{ needs.build.outputs.product-name }}
           VERSION: ${{ needs.build.outputs.version }}
+          DOWNLOAD_PATH: ${{ steps.download-provenance.outputs.download-path }}
         if:
           "${{ env.SSHKEY != '' }}"
         shell: bash
@@ -261,5 +283,5 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           echo "$HOSTKEY" > ~/.ssh/known_hosts
           mkdir -m 755 -p "slsa/${PRODUCT}/${VERSION}/"
-          mv ${{steps.download-provenance.outputs.download-path}}/*.jsonl "slsa/${PRODUCT}/${VERSION}"
+          mv "${DOWNLOAD_PATH}"/*.jsonl "slsa/${PRODUCT}/${VERSION}"
           rsync -4rlptD slsa/* "$RSYNCTARGET"

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -50,6 +50,7 @@ jobs:
           fetch-depth: 0  # for correct version numbers
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       # this builds packages and runs our unit test (make check)
       - run: builder/build.sh -v -m ${{ matrix.product }} ${{ matrix.os }}
       - name: Get version number

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,6 +66,7 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
+        persist-credentials: false
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
@@ -282,4 +283,5 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 2
+        persist-credentials: false
     - run: if [[ "$(file -i --dereference $(git diff --name-only HEAD^..HEAD -- . :^fuzzing/corpus) | grep binary | grep -v 'image/' | grep -v 'inode/x-empty' | grep -v 'inode/directory' | grep -v '^modules/lmdbbackend/test-assets/' | grep -v '^website/docs.powerdns.com/website/fonts/' | grep -v '^website/docs.powerdns.com/website/img/' | grep -v '^modules/tinydnsbackend/data.cdb' | tee /dev/stderr)" != "" ]]; then exit 1; fi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -160,10 +160,10 @@ jobs:
       working-directory: ./pdns/dnsdistdist/
       run: |
         inv ci-autoconf
-    - run: inv ci-install-rust ${{ env.REPO_HOME }}
+    - run: inv ci-install-rust $REPO_HOME
       if: matrix.product == 'dnsdist'
       working-directory: ./pdns/dnsdistdist/
-    - run: inv ci-build-and-install-quiche ${{ env.REPO_HOME }}
+    - run: inv ci-build-and-install-quiche $REPO_HOME
       if: matrix.product == 'dnsdist'
       working-directory: ./pdns/dnsdistdist/
     - name: Configure dnsdist
@@ -207,7 +207,7 @@ jobs:
       if: matrix.product == 'rec'
       run: |
         inv install-rec-build-deps
-    - run: inv ci-install-rust ${{ env.REPO_HOME }}
+    - run: inv ci-install-rust $REPO_HOME
       if: matrix.product == 'rec'
       working-directory: ./pdns/recursordist/
     - name: Autoreconf rec
@@ -259,17 +259,21 @@ jobs:
     needs: analyze
     runs-on: ubuntu-22.04
     name: Check whether clang-tidy succeeded
+    env:
+      ANNOTATIONS_AUTH: ${{ needs.analyze.outputs.clang-tidy-annotations-auth }}
+      ANNOTATIONS_DIST: ${{ needs.analyze.outputs.clang-tidy-annotations-dnsdist }}
+      ANNOTATIONS_REC: ${{ needs.analyze.outputs.clang-tidy-annotations-rec }}
     steps:
       - run: |
-          if [ "x${{ needs.analyze.outputs.clang-tidy-annotations-auth }}" != "x" -a "${{ needs.analyze.outputs.clang-tidy-annotations-auth }}" != "0" ]; then
+          if [ "x${ANNOTATIONS_AUTH}" != "x" -a "${ANNOTATIONS_AUTH}" != "0" ]; then
             echo "::error::Auth clang-tidy failed"
             exit 1
           fi
-          if [ "x${{ needs.analyze.outputs.clang-tidy-annotations-dnsdist }}" != "x" -a "${{ needs.analyze.outputs.clang-tidy-annotations-dnsdist }}" != "0" ]; then
+          if [ "x${ANNOTATIONS_DIST}" != "x" -a "${ANNOTATIONS_DIST}" != "0" ]; then
             echo "::error::DNSdist clang-tidy failed"
             exit 1
           fi
-          if [ "x${{needs.analyze.outputs.clang-tidy-annotations-rec }}" != "x" -a "${{needs.analyze.outputs.clang-tidy-annotations-rec }}" != "0" ]; then
+          if [ "x${ANNOTATIONS_REC}" != "x" -a "${ANNOTATIONS_REC}" != "0" ]; then
             echo "::error::Rec clang-tidy failed"
             exit 1
           fi

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -65,6 +66,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -107,6 +109,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -82,9 +82,9 @@ jobs:
       - run: inv coverity-clang-configure
       - run: inv ci-autoconf
         working-directory: ./pdns/dnsdistdist/
-      - run: inv ci-install-rust ${{ env.REPO_HOME }}
+      - run: inv ci-install-rust $REPO_HOME
         working-directory: ./pdns/dnsdistdist/
-      - run: inv ci-build-and-install-quiche ${{ env.REPO_HOME }}
+      - run: inv ci-build-and-install-quiche $REPO_HOME
         working-directory: ./pdns/dnsdistdist/
       - run: inv ci-dnsdist-configure full autotools build-dir
         working-directory: ./pdns/dnsdistdist/

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -149,6 +149,7 @@ jobs:
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_API_TOKEN }}
       NETLIFY_SITE_ID_DOCS: ${{ vars.NETLIFY_SITE_ID_DOCS }}
       NETLIFY_SITE_ID_DNSDIST: ${{ vars.NETLIFY_SITE_ID_DNSDIST }}
+      PDNS_VERSION: ${{needs.build-docs.outputs.pdns_version}}
     steps:
       - name: Check required secrets
         run: |
@@ -169,15 +170,15 @@ jobs:
       - name: Deploy docs to Netlify
         run: |
           mkdir -p docs_site/temp
-          tar -xf artifacts/website-${{needs.build-docs.outputs.pdns_version}}/website.tar -C docs_site/temp
+          tar -xf artifacts/website-$PDNS_VERSION/website.tar -C docs_site/temp
           mv docs_site/temp/website/docs.powerdns.com/* docs_site/
           rm -rf docs_site/temp
-          tar -xf artifacts/authoritative-html-docs-${{needs.build-docs.outputs.pdns_version}}/auth-html-docs.tar -C docs_site
-          tar -xf artifacts/recursor-html-docs-${{needs.build-docs.outputs.pdns_version}}/rec-html-docs.tar -C docs_site
+          tar -xf artifacts/authoritative-html-docs-$PDNS_VERSION/auth-html-docs.tar -C docs_site
+          tar -xf artifacts/recursor-html-docs-$PDNS_VERSION/rec-html-docs.tar -C docs_site
           mv docs_site/auth-html-docs docs_site/authoritative
           mv docs_site/rec-html-docs docs_site/recursor
-          cp artifacts/PowerDNS-Authoritative-${{needs.build-docs.outputs.pdns_version}}.pdf/PowerDNS-Authoritative.pdf docs_site/authoritative/
-          cp artifacts/PowerDNS-Recursor-${{needs.build-docs.outputs.pdns_version}}.pdf/PowerDNS-Recursor.pdf docs_site/recursor/
+          cp artifacts/PowerDNS-Authoritative-$PDNS_VERSION.pdf/PowerDNS-Authoritative.pdf docs_site/authoritative/
+          cp artifacts/PowerDNS-Recursor-$PDNS_VERSION.pdf/PowerDNS-Recursor.pdf docs_site/recursor/
           netlify deploy \
             --dir ./docs_site \
             --site $NETLIFY_SITE_ID_DOCS \
@@ -186,8 +187,8 @@ jobs:
 
       - name: Deploy DNSdist docs to Netlify
         run: |
-          tar -xf artifacts/dnsdist-html-docs-${{needs.build-docs.outputs.pdns_version}}/dnsdist-html-docs.tar
-          cp artifacts/dnsdist-${{needs.build-docs.outputs.pdns_version}}.pdf/dnsdist.pdf dnsdist-html-docs/
+          tar -xf artifacts/dnsdist-html-docs-$PDNS_VERSION/dnsdist-html-docs.tar
+          cp artifacts/dnsdist-$PDNS_VERSION.pdf/dnsdist.pdf dnsdist-html-docs/
           netlify deploy \
             --dir ./dnsdist-html-docs \
             --site $NETLIFY_SITE_ID_DNSDIST \
@@ -199,15 +200,22 @@ jobs:
     needs: build-docs
     if: ${{ (github.ref_name == 'master' || vars.DOCS_WORKFLOW_BRANCH_OVERRIDE == 'true') && vars.PUBLISH_DOCS_TO_WEB1 == 'true' }}
     runs-on: ubuntu-22.04
+    env:
+      PDNS_VERSION: ${{needs.build-docs.outputs.pdns_version}}
+      DOCS_HOST: ${{vars.DOCS_HOST}}
+      REC_DOCS_DIR: ${{vars.REC_DOCS_DIR}}
+      AUTH_DOCS_DIR: ${{vars.AUTH_DOCS_DIR}}
+      SSH_KEY: ${{secrets.WEB1_DOCS_SECRET}}
+      HOST_KEY: ${{vars.WEB1_HOSTKEY}}
     steps:
       - name: Check required secrets
         run: |
           missing_secrets=()
-          [ -z "${{ secrets.WEB1_DOCS_SECRET }}" ] && missing_secrets+=("WEB1_DOCS_SECRET")
-          [ -z "${{ vars.WEB1_HOSTKEY }}" ] && missing_secrets+=("WEB1_HOSTKEY")
-          [ -z "${{ vars.DOCS_HOST }}" ] && missing_secrets+=("DOCS_HOST")
-          [ -z "${{ vars.AUTH_DOCS_DIR }}" ] && missing_secrets+=("AUTH_DOCS_DIR")
-          [ -z "${{ vars.REC_DOCS_DIR }}" ] && missing_secrets+=("REC_DOCS_DIR")
+          [ -z "$SSH_KEY" ] && missing_secrets+=("WEB1_DOCS_SECRET")
+          [ -z "$HOSTKEY" ] && missing_secrets+=("WEB1_HOSTKEY")
+          [ -z "$DOCS_HOST" ] && missing_secrets+=("DOCS_HOST")
+          [ -z "AUTH_DOCS_DIR" ] && missing_secrets+=("AUTH_DOCS_DIR")
+          [ -z "REC_DOCS_DIR" ] && missing_secrets+=("REC_DOCS_DIR")
           if [ ${#missing_secrets[@]} -ne 0 ]; then
             echo "Error: The following secrets/variables are missing: ${missing_secrets[*]}"
             exit 1
@@ -223,33 +231,22 @@ jobs:
       - id: setup-ssh
         run: |-
           inv ci-docs-add-ssh --ssh-key="$SSH_KEY" --host-key="$HOST_KEY"
-        env:
-          SSH_KEY: ${{secrets.WEB1_DOCS_SECRET}}
-          HOST_KEY: ${{vars.WEB1_HOSTKEY}}
       - name: Publish Auth docs
         run: |
           mkdir -p ./docs/_build
-          tar -xf artifacts/authoritative-html-docs-${{needs.build-docs.outputs.pdns_version}}/auth-html-docs.tar -C ./docs/_build/
-          cp artifacts/PowerDNS-Authoritative-${{needs.build-docs.outputs.pdns_version}}.pdf/PowerDNS-Authoritative.pdf ./docs/_build/auth-html-docs/
+          tar -xf artifacts/authoritative-html-docs-$PDNS_VERSION/auth-html-docs.tar -C ./docs/_build/
+          cp artifacts/PowerDNS-Authoritative-$PDNS_VERSION.pdf/PowerDNS-Authoritative.pdf ./docs/_build/auth-html-docs/
           inv ci-docs-upload-master --docs-host="${DOCS_HOST}" --pdf="PowerDNS-Authoritative.pdf" --username="docs_powerdns_com" --product="auth" --directory="/${AUTH_DOCS_DIR}/"
-        env:
-          DOCS_HOST: ${{vars.DOCS_HOST}}
-          AUTH_DOCS_DIR: ${{vars.AUTH_DOCS_DIR}}
       - name: Publish Recursor docs
         run: |
-          tar -xf artifacts/recursor-html-docs-${{needs.build-docs.outputs.pdns_version}}/rec-html-docs.tar -C ./docs/_build/
-          cp artifacts/PowerDNS-Recursor-${{needs.build-docs.outputs.pdns_version}}.pdf/PowerDNS-Recursor.pdf ./docs/_build/rec-html-docs/
+          tar -xf artifacts/recursor-html-docs-$PDNS_VERSION/rec-html-docs.tar -C ./docs/_build/
+          cp artifacts/PowerDNS-Recursor-$PDNS_VERSION.pdf/PowerDNS-Recursor.pdf ./docs/_build/rec-html-docs/
           inv ci-docs-upload-master --docs-host="${DOCS_HOST}" --pdf="PowerDNS-Recursor.pdf" --username="docs_powerdns_com" --product="rec" --directory="/${REC_DOCS_DIR}/"
-        env:
-          DOCS_HOST: ${{vars.DOCS_HOST}}
-          REC_DOCS_DIR: ${{vars.REC_DOCS_DIR}}
       - name: Publish DNSdist docs
         run: |
-          tar -xf artifacts/dnsdist-html-docs-${{needs.build-docs.outputs.pdns_version}}/dnsdist-html-docs.tar -C ./docs/_build/
-          cp artifacts/dnsdist-${{needs.build-docs.outputs.pdns_version}}.pdf/dnsdist.pdf ./docs/_build/dnsdist-html-docs/
+          tar -xf artifacts/dnsdist-html-docs-$PDNS_VERSION/dnsdist-html-docs.tar -C ./docs/_build/
+          cp artifacts/dnsdist-$PDNS_VERSION.pdf/dnsdist.pdf ./docs/_build/dnsdist-html-docs/
           inv ci-docs-upload-master --docs-host="${DOCS_HOST}" --pdf="dnsdist.pdf" --username="dnsdist_org" --product="dnsdist" --directory="/${DNSDIST_DOCS_DIR}/"
-        env:
-          DOCS_HOST: ${{vars.DOCS_HOST}}
 
 
   publish-to-aws:
@@ -257,16 +254,24 @@ jobs:
     needs: build-docs
     if: ${{ (github.ref_name == 'master' || vars.DOCS_WORKFLOW_BRANCH_OVERRIDE == 'true') && vars.PUBLISH_DOCS_TO_AWS == 'true' }}
     runs-on: ubuntu-22.04
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_S3_BUCKET_DOCS: ${{ vars.AWS_S3_BUCKET_DOCS }}
+      AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST: ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST }}
+      AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS: ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS }}
+      PDNS_VERSION: ${{needs.build-docs.outputs.pdns_version}}
     steps:
       - name: Check required secrets
         run: |
           missing_secrets=()
-          [ -z "${{ secrets.AWS_ACCESS_KEY_ID }}" ] && missing_secrets+=("AWS_ACCESS_KEY_ID")
-          [ -z "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ] && missing_secrets+=("AWS_SECRET_ACCESS_KEY")
-          [ -z "${{ vars.AWS_REGION }}" ] && missing_secrets+=("AWS_REGION")
-          [ -z "${{ vars.AWS_S3_BUCKET_DOCS }}" ] && missing_secrets+=("AWS_S3_BUCKET_DOCS")
-          [ -z "${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST }}" ] && missing_secrets+=("AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST")
-          [ -z "${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS }}" ] && missing_secrets+=("AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS")
+          [ -z "$AWS_ACCESS_KEY_ID" ] && missing_secrets+=("AWS_ACCESS_KEY_ID")
+          [ -z "$AWS_SECRET_ACCESS_KEY" ] && missing_secrets+=("AWS_SECRET_ACCESS_KEY")
+          [ -z "$AWS_REGION" ] && missing_secrets+=("AWS_REGION")
+          [ -z "$AWS_S3_BUCKET_DOCS" ] && missing_secrets+=("AWS_S3_BUCKET_DOCS")
+          [ -z "$AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST" ] && missing_secrets+=("AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST")
+          [ -z "$AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS" ] && missing_secrets+=("AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS")
           if [ ${#missing_secrets[@]} -ne 0 ]; then
             echo "Error: The following secrets/variables are missing: ${missing_secrets[*]}"
             exit 1
@@ -289,25 +294,18 @@ jobs:
           type = s3
           provider = AWS
           env_auth = true
-          region = ${{ vars.AWS_REGION }}
+          region = $AWS_REGION
           EOF
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Publish to AWS
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          AWS_S3_BUCKET_DOCS: ${{ vars.AWS_S3_BUCKET_DOCS }}
-          AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST: ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST }}
-          AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS: ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS }}
         run: |
           if [ -n "$AWS_CLOUDFRONT_DISTRIBUTION_ID_DNSDIST" ]; then
-            tar -xf artifacts/dnsdist-html-docs-${{needs.build-docs.outputs.pdns_version}}/dnsdist-html-docs.tar
-            cp artifacts/dnsdist-${{needs.build-docs.outputs.pdns_version}}.pdf/dnsdist.pdf dnsdist-html-docs/
-            
+            tar -xf artifacts/dnsdist-html-docs-$PDNS_VERSION/dnsdist-html-docs.tar
+            cp artifacts/dnsdist-$PDNS_VERSION.pdf/dnsdist.pdf dnsdist-html-docs/
+
             # Copy files to S3
             echo "Copying DNSdist docs to S3..."
             rclone copy --checksum dnsdist-html-docs/ docs-s3:$AWS_S3_BUCKET_DOCS/dnsdist.org/
@@ -319,21 +317,21 @@ jobs:
               --paths "/*"
             echo "Invalidation completed."
           fi
-          
+
           if [ -n "$AWS_CLOUDFRONT_DISTRIBUTION_ID_DOCS" ]; then
-            tar -xf artifacts/recursor-html-docs-${{needs.build-docs.outputs.pdns_version}}/rec-html-docs.tar
-            cp artifacts/PowerDNS-Recursor-${{needs.build-docs.outputs.pdns_version}}.pdf/PowerDNS-Recursor.pdf rec-html-docs/
-            
+            tar -xf artifacts/recursor-html-docs-$PDNS_VERSION/rec-html-docs.tar
+            cp artifacts/PowerDNS-Recursor-$PDNS_VERSION.pdf/PowerDNS-Recursor.pdf rec-html-docs/
+
             # Copy all PowerDNS docs to S3
             echo "Copying Recursor docs to S3..."
             rclone copy --checksum rec-html-docs/ docs-s3:$AWS_S3_BUCKET_DOCS/docs.powerdns.com/recursor/
 
-            tar -xf artifacts/authoritative-html-docs-${{needs.build-docs.outputs.pdns_version}}/auth-html-docs.tar
-            cp artifacts/PowerDNS-Authoritative-${{needs.build-docs.outputs.pdns_version}}.pdf/PowerDNS-Authoritative.pdf auth-html-docs/
+            tar -xf artifacts/authoritative-html-docs-$PDNS_VERSION/auth-html-docs.tar
+            cp artifacts/PowerDNS-Authoritative-$PDNS_VERSION.pdf/PowerDNS-Authoritative.pdf auth-html-docs/
             echo "Copying Authoritative docs to S3..."
             rclone copy --checksum auth-html-docs/ docs-s3:$AWS_S3_BUCKET_DOCS/docs.powerdns.com/authoritative/
 
-            tar -xf artifacts/website-${{needs.build-docs.outputs.pdns_version}}/website.tar
+            tar -xf artifacts/website-$PDNS_VERSION/website.tar
             echo "Copying website files to S3..."
             rclone copy --checksum website/docs.powerdns.com/ docs-s3:$AWS_S3_BUCKET_DOCS/docs.powerdns.com/
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -212,6 +214,8 @@ jobs:
           fi
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - run: build-scripts/gh-actions-setup-inv-no-dist-upgrade
       - uses: actions/download-artifact@v4
         with:
@@ -268,6 +272,8 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+          persist-credentials: false
       - name: Update dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -12,6 +12,7 @@ jobs:
       with:
         fetch-depth: 5
         submodules: recursive
+        persist-credentials: false
     - run: docker build -t gcr.io/oss-fuzz-base/base-builder:latest -f Dockerfile-cifuzz .
     - name: Build Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master

--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         fetch-depth: 5
         submodules: recursive
+        persist-credentials: false
 
     - name: Check if Debian is about to toss us off a balcony
       run: ./build-scripts/check-debian-autoremovals.py
@@ -90,6 +91,8 @@ jobs:
       req-files: ${{ steps.get-list-requirements.outputs.files }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Get all requirements.txt files and export them as outputs
       id: get-list-requirements
       run: |
@@ -117,6 +120,8 @@ jobs:
       - run: echo "${{ matrix.requirements-file }}"
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -148,6 +153,7 @@ jobs:
           fetch-depth: 5
           submodules: recursive
           ref: ${{ inputs.branch-name }}
+          persist-credentials: false
       - name: Add PowerDNS Repo
         run: echo 'deb [signed-by=/etc/apt/keyrings/rec-master-pub.asc] http://repo.powerdns.com/ubuntu noble-rec-master main' | sudo tee /etc/apt/sources.list.d/pdns.list
       - name: Add key

--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -103,8 +103,6 @@ jobs:
     name: ${{ matrix.requirements-file }} - Validate list of packages and hashes
     runs-on: ubuntu-22.04
     needs: list-pip-requirement-files
-    env:
-      SERVICE_IP_ADDR: 127.0.0.1
     services:
       database:
         image: epicwink/proxpi
@@ -116,8 +114,11 @@ jobs:
       fail-fast: false
       matrix:
         requirements-file: ${{ fromJson(needs.list-pip-requirement-files.outputs.req-files) }}
+    env:
+      SERVICE_IP_ADDR: 127.0.0.1
+      REQUIREMENTS_FILE: ${{ matrix.requirements-file }}
     steps:
-      - run: echo "${{ matrix.requirements-file }}"
+      - run: echo "${REQUIREMENTS_FILE}"
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v4
         with:
@@ -130,13 +131,15 @@ jobs:
       - run: pip config set global.trusted-host ${{ env.SERVICE_IP_ADDR }}
       - id: proxpi-docker
         run: echo "id=$(docker ps | grep "epicwink/proxpi" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-      - run: pip install -r ${{ matrix.requirements-file }}
+      - run: pip install -r ${REQUIREMENTS_FILE}
       - name: Get the list of packages requested to the pip proxy
+        env:
+          ID: ${{ steps.proxpi-docker.outputs.id }}
         run: |
-          docker logs ${{ steps.proxpi-docker.outputs.id }} 2>&1 | grep whl | awk '{print $8}' | cut -d "/" -f 4 | awk -F'-' '{print $1"=="$2}' | sort -u --ignore-case | sed 's/_/-/' | egrep -v "pip==|setuptools==" > /tmp/proxpi.log
+          docker logs "${ID}" 2>&1 | grep whl | awk '{print $8}' | cut -d "/" -f 4 | awk -F'-' '{print $1"=="$2}' | sort -u --ignore-case | sed 's/_/-/' | egrep -v "pip==|setuptools==" > /tmp/proxpi.log
           cat /tmp/proxpi.log
       - name: check only listed packages were installed
-        run: for i in `cat /tmp/proxpi.log`; do grep -qq -i $i ${{ matrix.requirements-file }} || ( echo "$i not found" && exit 1 ); done
+        run: for i in `cat /tmp/proxpi.log`; do grep -qq -i $i ${REQUIREMENTS_FILE} || ( echo "$i not found" && exit 1 ); done
 
   run-rec-bulk-test-on-ubicloud:
     if: ${{ vars.UBICLOUD_DAILY_REC_BULKTEST == '1' }}

--- a/.github/workflows/secpoll.yml
+++ b/.github/workflows/secpoll.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: recursive
+          persist-credentials: false
       - run: sh docs/secpoll-check.sh docs/secpoll.zone
       - run: echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu noble-auth-master main' | sudo tee /etc/apt/sources.list.d/pdns.list
       - run: "echo -ne 'Package: pdns-*\nPin: origin repo.powerdns.com\nPin-Priority: 600\n' | sudo tee /etc/apt/preferences.d/pdns"

--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   placeholder:
+    permissions:
     name: Should be disabled
     runs-on: ubuntu-latest
     if: false


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Zizmor[1] reports a few warnings when looking at our workflows:
- the credentials are still available in the environment after calling `checkout`, which is not nice. see https://github.com/actions/checkout/issues/485
- we use several external actions without pinning to an exact version. I fixed this for `coveralls`, but not for the remaining ones because it's not clear to me how to pin the exact version of a container image, for example
- very often we pass the result of a template expansion to a shell command, which in theory might be vulnerable to script injection attacks if the input is untrusted. I did not find any untrusted input (except the branch name, in some workflows, but GH has some limitations on the values you can use there) but to prevent any issue in the future I tried to get rid of this pattern as suggested by GH

This PR needs a very thorough review before being merged, as the changes to several workflows have not been tested!

[1]: https://docs.zizmor.sh/
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
