### PR TITLE
dnsdist: Do not replace EDNS in answers self-generated from a packet

### DIFF
--- a/pdns/dnsdistdist/dnsdist-self-answers.cc
+++ b/pdns/dnsdistdist/dnsdist-self-answers.cc
@@ -233,6 +233,7 @@ bool generateAnswerFromRawPacket(DNSQuestion& dnsQuestion, const PacketBuffer& p
 {
   auto questionId = dnsQuestion.getHeader()->id;
   dnsQuestion.getMutableData() = packet;
+  dnsQuestion.d_selfGeneratedFromPacket = true;
   dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion.getMutableData(), [questionId](dnsheader& header) {
     header.id = questionId;
     return true;

--- a/pdns/dnsdistdist/dnsdist-self-answers.cc
+++ b/pdns/dnsdistdist/dnsdist-self-answers.cc
@@ -94,6 +94,7 @@ bool generateAnswerFromCNAME(DNSQuestion& dnsQuestion, const DNSName& cname, con
     addEDNS(dnsQuestion.getMutableData(), dnsQuestion.getMaximumSize(), dnssecOK, dnsdist::configuration::getCurrentRuntimeConfiguration().d_payloadSizeSelfGenAnswers, 0);
   }
 
+  dnsQuestion.d_selfGeneratedHandledEDNS = true;
   return true;
 }
 
@@ -164,6 +165,7 @@ bool generateAnswerFromIPAddresses(DNSQuestion& dnsQuestion, const std::vector<C
     addEDNS(dnsQuestion.getMutableData(), dnsQuestion.getMaximumSize(), dnssecOK, dnsdist::configuration::getCurrentRuntimeConfiguration().d_payloadSizeSelfGenAnswers, 0);
   }
 
+  dnsQuestion.d_selfGeneratedHandledEDNS = true;
   return true;
 }
 
@@ -226,6 +228,7 @@ bool generateAnswerFromRDataEntries(DNSQuestion& dnsQuestion, const std::vector<
     addEDNS(dnsQuestion.getMutableData(), dnsQuestion.getMaximumSize(), dnssecOK, dnsdist::configuration::getCurrentRuntimeConfiguration().d_payloadSizeSelfGenAnswers, 0);
   }
 
+  dnsQuestion.d_selfGeneratedHandledEDNS = true;
   return true;
 }
 
@@ -233,7 +236,7 @@ bool generateAnswerFromRawPacket(DNSQuestion& dnsQuestion, const PacketBuffer& p
 {
   auto questionId = dnsQuestion.getHeader()->id;
   dnsQuestion.getMutableData() = packet;
-  dnsQuestion.d_selfGeneratedFromPacket = true;
+  dnsQuestion.d_selfGeneratedHandledEDNS = true;
   dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion.getMutableData(), [questionId](dnsheader& header) {
     header.id = questionId;
     return true;

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -326,7 +326,7 @@ static bool fixUpQueryTurnedResponse(DNSQuestion& dnsQuestion, const uint16_t or
     return true;
   });
 
-  if (dnsQuestion.d_selfGeneratedFromPacket) {
+  if (dnsQuestion.d_selfGeneratedHandledEDNS) {
     return true;
   }
   return addEDNSToQueryTurnedResponse(dnsQuestion);

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -326,6 +326,9 @@ static bool fixUpQueryTurnedResponse(DNSQuestion& dnsQuestion, const uint16_t or
     return true;
   });
 
+  if (dnsQuestion.d_selfGeneratedFromPacket) {
+    return true;
+  }
   return addEDNSToQueryTurnedResponse(dnsQuestion);
 }
 

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -184,6 +184,7 @@ public:
   bool ecsOverride;
   bool useECS{true};
   bool asynchronous{false};
+  bool d_selfGeneratedFromPacket{false};
 };
 
 struct DownstreamState;

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -184,7 +184,7 @@ public:
   bool ecsOverride;
   bool useECS{true};
   bool asynchronous{false};
-  bool d_selfGeneratedFromPacket{false};
+  bool d_selfGeneratedHandledEDNS{false};
 };
 
 struct DownstreamState;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
While it makes sense to add/remove EDNS when the answer was generated from the query itself, we should not be doing that when it has been generated from a whole DNS packet, as it probably contains exactly what the user intended it to.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
