### PR TITLE
SVCB: allow parsing keys in generic format without value

### DIFF
--- a/pdns/test-svc_records_cc.cc
+++ b/pdns/test-svc_records_cc.cc
@@ -53,6 +53,9 @@ BOOST_AUTO_TEST_CASE(test_SvcParam_keyFromString) {
     k = SvcParam::keyFromString("key666");
     BOOST_CHECK(k == 666);
 
+    k = SvcParam::keyFromString("key00666");
+    BOOST_CHECK(k == 666);
+
     BOOST_CHECK_THROW(SvcParam::keyFromString("MANDATORY"), std::invalid_argument);
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
To avoid other issues, increase strictness of value checks for *known* keys, regardless if they are in generic or canonical format.

Also add a test for key00NNN (= leading zeroes).

https://github.com/PowerDNS/pdns/issues/15479

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
