### PR TITLE
Boring coverity-induced changes

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1173,7 +1173,7 @@ static string lua_createReverse6(const string &format, boost::optional<opts_t> e
         lquad.append(1, labels[31 - chunk * 4 - quartet][0]);
         together += labels[31 - chunk * 4 - quartet][0];
       }
-      quads.push_back(lquad);
+      quads.push_back(std::move(lquad));
     }
     ComboAddress ip6(together,0);
 

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1770,7 +1770,7 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
   /* Add in SOA if required */
   if(state.target==d_sd.qname()) {
       zrr=makeEditedDNSZRFromSOAData(d_dk, d_sd);
-      rrset.push_back(zrr);
+      rrset.push_back(std::move(zrr));
   }
 
   DLOG(g_log<<"After first ANY query for '"<<state.target<<"', id="<<d_sd.domain_id<<": weDone="<<weDone<<", weHaveUnauth="<<weHaveUnauth<<", weRedirected="<<weRedirected<<", haveAlias='"<<haveAlias<<"'"<<endl);
@@ -1828,7 +1828,7 @@ bool PacketHandler::opcodeQueryInner2(DNSPacket& pkt, queryState &state, bool re
     if(tryWildcard(pkt, state.r, state.target, wildcard, wereRetargeted, nodata)) {
       if(wereRetargeted) {
         if (!retargeted) {
-          state.r->qdomainwild=wildcard;
+          state.r->qdomainwild=std::move(wildcard);
         }
         state.retargeted = true;
         return true;

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -350,7 +350,7 @@ void UeberBackend::updateZoneCache()
       nettree.insert_or_assign(net, tag);
     }
   }
-  g_zoneCache.replace(nettree); // FIXME: this needs some smart pending stuff too
+  g_zoneCache.replace(std::move(nettree)); // FIXME: this needs some smart pending stuff too
 
   AuthZoneCache::ViewsMap viewsmap;
   for (auto& backend : backends) {
@@ -360,13 +360,13 @@ void UeberBackend::updateZoneCache()
       vector<ZoneName> zones;
       backend->viewListZones(view, zones);
       for (ZoneName& zone : zones) {
-        auto zonename = DNSName(zone);
+        const auto& zonename = zone.operator const DNSName&();
         auto variant = zone.getVariant();
-        viewsmap[view][zonename] = variant;
+        viewsmap[view][zonename] = std::move(variant);
       }
     }
   }
-  g_zoneCache.replace(viewsmap);
+  g_zoneCache.replace(std::move(viewsmap));
 }
 
 void UeberBackend::rediscover(string* status)

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2045,7 +2045,7 @@ static void apiServerZonesGET(HttpRequest* req, HttpResponse* resp)
     zonename.makeUsLowerCase();
     DomainInfo domainInfo;
     if (backend.getDomainInfo(zonename, domainInfo)) {
-      domains.push_back(domainInfo);
+      domains.push_back(std::move(domainInfo));
     }
   }
   else {


### PR DESCRIPTION
### Short description
This adds a few uses of `std::move` and a few `auto` type changes to eliminate object copies, as advised by Coverity.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] verified gcc 15 does not emit new warnings after these changes