### PR TITLE
Packet Cache fixes for views

### DIFF
--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -43,16 +43,17 @@ AuthPacketCache::AuthPacketCache(size_t mapsCount): d_mapscount(mapsCount), d_la
   d_statnumentries=S.getPointer("packetcache-size");
 
   // Create the MapCombo for the default view
+  auto cache = d_cache.write_lock();
   std::string defaultview{};
-  createViewMap(defaultview);
+  createViewMap(*cache, defaultview);
 }
 
 // Create the vector<MapCombo> for the given view.
 // Assumes there is no existing data for the view. Callers are expected to
 // know what they are doing.
-std::unordered_map<std::string, std::unique_ptr<vector<AuthPacketCache::MapCombo>>>::iterator AuthPacketCache::createViewMap(const std::string& view)
+std::unordered_map<std::string, std::unique_ptr<vector<AuthPacketCache::MapCombo>>>::iterator AuthPacketCache::createViewMap(cache_t& cache, const std::string& view)
 {
-  auto iter = d_cache.emplace(view, std::make_unique<vector<MapCombo>>(d_mapscount));
+  auto iter = cache.emplace(view, std::make_unique<vector<MapCombo>>(d_mapscount));
   auto retval = iter.first;
   auto* map = retval->second.get();
   // Note that this reserves more than intended, especially if multiple views
@@ -85,21 +86,24 @@ bool AuthPacketCache::get(DNSPacket& pkt, DNSPacket& cached, const std::string& 
   string value;
   bool haveSomething;
   time_t now = time(nullptr);
-  auto iter = d_cache.find(view);
-  if (iter == d_cache.end()) {
-    // No data for this view yet.
-    (*d_statnummiss)++;
-    return false;
-  }
-  auto& mapcombo = getMap(iter->second, pkt.qdomain);
   {
-    auto map = mapcombo.d_map.try_read_lock();
-    if (!map.owns_lock()) {
-      S.inc("deferred-packetcache-lookup");
+    auto cache = d_cache.read_lock();
+    auto iter = cache->find(view);
+    if (iter == cache->end()) {
+      // No data for this view yet.
+      (*d_statnummiss)++;
       return false;
     }
+    auto& mapcombo = getMap(iter->second, pkt.qdomain);
+    {
+      auto map = mapcombo.d_map.try_read_lock();
+      if (!map.owns_lock()) {
+        S.inc("deferred-packetcache-lookup");
+        return false;
+      }
 
-    haveSomething = AuthPacketCache::getEntryLocked(*map, pkt.getString(), hash, pkt.qdomain, pkt.qtype.getCode(), pkt.d_tcp, now, value);
+      haveSomething = AuthPacketCache::getEntryLocked(*map, pkt.getString(), hash, pkt.qdomain, pkt.qtype.getCode(), pkt.d_tcp, now, value);
+    }
   }
 
   if (!haveSomething) {
@@ -158,45 +162,48 @@ void AuthPacketCache::insert(DNSPacket& query, DNSPacket& response, unsigned int
   entry.tcp = response.d_tcp;
   entry.query = query.getString();
 
-  auto iter = d_cache.find(view);
-  if (iter == d_cache.end()) {
-    // No data for this view yet, create it.
-    iter = createViewMap(view);
-  }
-  auto& mc = getMap(iter->second, entry.qname); // NOLINT(readability-identifier-length)
   {
-    auto map = mc.d_map.try_write_lock();
-    if (!map.owns_lock()) {
-      S.inc("deferred-packetcache-inserts");
-      return;
+    auto cache = d_cache.write_lock();
+    auto iter = cache->find(view);
+    if (iter == cache->end()) {
+      // No data for this view yet, create it.
+      iter = createViewMap(*cache, view);
     }
-
-    auto& idx = map->get<HashTag>();
-    auto range = idx.equal_range(hash);
-    auto iter2 = range.first;
-
-    for( ; iter2 != range.second ; ++iter2)  {
-      if (!entryMatches(iter2, entry.query, entry.qname, entry.qtype, entry.tcp)) {
-        continue;
+    auto& mc = getMap(iter->second, entry.qname); // NOLINT(readability-identifier-length)
+    {
+      auto map = mc.d_map.try_write_lock();
+      if (!map.owns_lock()) {
+        S.inc("deferred-packetcache-inserts");
+        return;
       }
 
-      moveCacheItemToBack<SequencedTag>(*map, iter2);
-      iter2->value = entry.value;
-      iter2->ttd = now + ourttl;
-      iter2->created = now;
-      return;
-    }
+      auto& idx = map->get<HashTag>();
+      auto range = idx.equal_range(hash);
+      auto iter2 = range.first;
 
-    /* no existing entry found to refresh */
-    map->insert(std::move(entry));
+      for( ; iter2 != range.second ; ++iter2)  {
+        if (!entryMatches(iter2, entry.query, entry.qname, entry.qtype, entry.tcp)) {
+          continue;
+        }
 
-    if (*d_statnumentries >= d_maxEntries) {
-      /* remove the least recently inserted or replaced entry */
-      auto& sidx = map->get<SequencedTag>();
-      sidx.pop_front();
-    }
-    else {
-      ++(*d_statnumentries);
+        moveCacheItemToBack<SequencedTag>(*map, iter2);
+        iter2->value = entry.value;
+        iter2->ttd = now + ourttl;
+        iter2->created = now;
+        return;
+      }
+
+      /* no existing entry found to refresh */
+      map->insert(std::move(entry));
+
+      if (*d_statnumentries >= d_maxEntries) {
+        /* remove the least recently inserted or replaced entry */
+        auto& sidx = map->get<SequencedTag>();
+        sidx.pop_front();
+      }
+      else {
+        ++(*d_statnumentries);
+      }
     }
   }
 }
@@ -231,9 +238,12 @@ uint64_t AuthPacketCache::purge()
   d_statnumentries->store(0);
 
   uint64_t delcount = 0;
-  for (auto& iter : d_cache) {
-    auto* map = iter.second.get();
-    delcount += purgeLockedCollectionsVector(*map);
+  {
+    auto cache = d_cache.write_lock();
+    for (auto& iter : *cache) {
+      auto* map = iter.second.get();
+      delcount += purgeLockedCollectionsVector(*map);
+    }
   }
   return delcount;
 }
@@ -242,9 +252,12 @@ uint64_t AuthPacketCache::purgeExact(const DNSName& qname)
 {
   uint64_t delcount = 0;
 
-  for (auto& iter : d_cache) {
-    auto& mc = getMap(iter.second, qname); // NOLINT(readability-identifier-length)
-    delcount += purgeExactLockedCollection<NameTag>(mc, qname);
+  {
+    auto cache = d_cache.write_lock();
+    for (auto& iter : *cache) {
+      auto& mc = getMap(iter.second, qname); // NOLINT(readability-identifier-length)
+      delcount += purgeExactLockedCollection<NameTag>(mc, qname);
+    }
   }
 
   *d_statnumentries -= delcount;
@@ -256,9 +269,12 @@ uint64_t AuthPacketCache::purgeExact(const std::string& view, const DNSName& qna
 {
   uint64_t delcount = 0;
 
-  if (auto iter = d_cache.find(view); iter != d_cache.end()) {
-    auto& mc = getMap(iter->second, qname); // NOLINT(readability-identifier-length)
-    delcount += purgeExactLockedCollection<NameTag>(mc, qname);
+  {
+    auto cache = d_cache.write_lock();
+    if (auto iter = cache->find(view); iter != cache->end()) {
+      auto& mc = getMap(iter->second, qname); // NOLINT(readability-identifier-length)
+      delcount += purgeExactLockedCollection<NameTag>(mc, qname);
+    }
   }
 
   *d_statnumentries -= delcount;
@@ -276,9 +292,12 @@ uint64_t AuthPacketCache::purge(const string &match)
   uint64_t delcount = 0;
 
   if(boost::ends_with(match, "$")) {
-    for (auto& iter : d_cache) {
-      auto* map = iter.second.get();
-      delcount += purgeLockedCollectionsVector<NameTag>(*map, match);
+    {
+      auto cache = d_cache.write_lock();
+      for (auto& iter : *cache) {
+        auto* map = iter.second.get();
+        delcount += purgeLockedCollectionsVector<NameTag>(*map, match);
+      }
     }
     *d_statnumentries -= delcount;
   }
@@ -292,9 +311,12 @@ uint64_t AuthPacketCache::purge(const string &match)
 void AuthPacketCache::cleanup()
 {
   uint64_t totErased = 0;
-  for (auto& iter : d_cache) {
-    auto* map = iter.second.get();
-    totErased += pruneLockedCollectionsVector<SequencedTag>(*map);
+  {
+    auto cache = d_cache.write_lock();
+    for (auto& iter : *cache) {
+      auto* map = iter.second.get();
+      totErased += pruneLockedCollectionsVector<SequencedTag>(*map);
+    }
   }
   *d_statnumentries -= totErased;
 

--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -282,6 +282,24 @@ uint64_t AuthPacketCache::purgeExact(const std::string& view, const DNSName& qna
   return delcount;
 }
 
+uint64_t AuthPacketCache::purgeView(const std::string& view)
+{
+  uint64_t delcount = 0;
+
+  {
+    auto cache = d_cache.write_lock();
+    if (auto iter = cache->find(view); iter != cache->end()) {
+      auto* map = iter->second.get();
+      delcount += purgeLockedCollectionsVector(*map);
+      cache->erase(iter);
+    }
+  }
+
+  *d_statnumentries -= delcount;
+
+  return delcount;
+}
+
 /* purges entries from the packetcache. If match ends on a $, it is treated as a suffix */
 uint64_t AuthPacketCache::purge(const string &match)
 {

--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -66,6 +66,7 @@ public:
   uint64_t purge(const std::string& match); // could be $ terminated. Is not a dnsname!
   uint64_t purgeExact(const DNSName& qname); // no wildcard matching here
   uint64_t purgeExact(const std::string& view, const DNSName& qname); // same as above, but in the given view
+  uint64_t purgeView(const std::string& view);
 
   uint64_t size() const { return *d_statnumentries; };
 

--- a/pdns/auth-zonecache.cc
+++ b/pdns/auth-zonecache.cc
@@ -277,19 +277,20 @@ void AuthZoneCache::addToView(const std::string& view, const ZoneName& zone)
   map[view][strictZone] = zone.getVariant();
 }
 
-void AuthZoneCache::removeFromView(const std::string& view, const ZoneName& zone)
+bool AuthZoneCache::removeFromView(const std::string& view, const ZoneName& zone)
 {
   const DNSName& strictZone = zone.operator const DNSName&();
   auto views = d_views.write_lock();
   AuthZoneCache::ViewsMap& map = *views;
   if (map.count(view) == 0) {
-    return; // Nothing to do, we did not know about that view
+    return true; // Nothing to do, we did not know about that view
   }
   auto& innerMap = map.at(view);
   if (auto iter = innerMap.find(strictZone); iter != innerMap.end()) {
     innerMap.erase(iter);
   }
   // else nothing to do, we did not know about that zone in that view
+  return innerMap.empty();
 }
 
 void AuthZoneCache::updateNetwork(const Netmask& network, const std::string& view)

--- a/pdns/auth-zonecache.hh
+++ b/pdns/auth-zonecache.hh
@@ -46,7 +46,7 @@ public:
 
   // Views maintainance
   void addToView(const std::string& view, const ZoneName& zone);
-  void removeFromView(const std::string& view, const ZoneName& zone);
+  bool removeFromView(const std::string& view, const ZoneName& zone);
 
   // Network maintainance
   void updateNetwork(const Netmask& network, const std::string& view);

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -708,6 +708,19 @@ BOOST_AUTO_TEST_CASE(test_AuthViews)
 
   // Check that requesting from view2 causes a cache miss
   BOOST_CHECK_EQUAL(queryPacketCache2(PC, ZC, ComboAddress("192.0.2.1"), qname, innerMask, view2, "2.2.2.2"), false);
+
+  // Cache answers for view1 and view2 again
+  feedPacketCache2(PC, view1, 0x01010101, qname);
+  feedPacketCache2(PC, view2, 0x02020202, qname);
+  BOOST_CHECK_EQUAL(PC.size(), 2);
+
+  // Purge view1
+  BOOST_CHECK_EQUAL(PC.purgeView(view1), 1);
+  BOOST_CHECK_EQUAL(PC.size(), 1);
+
+  // Purge view2
+  BOOST_CHECK_EQUAL(PC.purgeView(view2), 1);
+  BOOST_CHECK_EQUAL(PC.size(), 0);
 }
 #endif // ] PDNS_AUTH
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2738,12 +2738,18 @@ static void apiServerViewsDELETE(HttpRequest* req, HttpResponse* resp)
     throw ApiException("Failed to remove " + zoneData.zoneName.toStringFull() + " from view " + view);
   }
   // Notify zone cache of the removed association
+  bool emptyView{false};
   if (g_zoneCache.isEnabled()) {
-    g_zoneCache.removeFromView(view, zoneData.zoneName);
+    emptyView = g_zoneCache.removeFromView(view, zoneData.zoneName);
   }
   // Purge packet cache for that zone
   if (PC.enabled()) {
-    (void)PC.purgeExact(view, zoneData.zoneName.operator const DNSName&());
+    if (emptyView) {
+      (void)PC.purgeView(view);
+    }
+    else {
+      (void)PC.purgeExact(view, zoneData.zoneName.operator const DNSName&());
+    }
   }
 
   resp->body = "";


### PR DESCRIPTION
### Short description
When extending the packet cache to become a set of per-view caches, I neglected to perform proper locking of the topmost data structure. There is thus a possibility of multiple receiver threads attempting to create cache data for a newly-found view, and ~hilarity~ memory corruption occurs.

This PR attempts to fix this, and also adds the ability to remove data for a complete view from the packet cache; this is used by the API when it notices that a view no longer contains any zones (which is what I was intending to do before realizing the locking problem).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
