### PR TITLE
dnsdist: add SetEDNSOptionResponseAction

### DIFF
--- a/pdns/dnsdistdist/dnsdist-actions-factory.cc
+++ b/pdns/dnsdistdist/dnsdist-actions-factory.cc
@@ -1032,6 +1032,31 @@ private:
   std::string d_data;
 };
 
+class SetEDNSOptionResponseAction : public DNSResponseAction
+{
+public:
+  // this action does not stop the processing
+  SetEDNSOptionResponseAction(uint16_t code, std::string data) :
+    d_code(code), d_data(std::move(data))
+  {
+  }
+
+  DNSResponseAction::Action operator()(DNSResponse* response, std::string* ruleresult) const override
+  {
+    setEDNSOption(*response, d_code, d_data);
+    return Action::None;
+  }
+
+  [[nodiscard]] std::string toString() const override
+  {
+    return "add EDNS Option to response (code=" + std::to_string(d_code) + ")";
+  }
+
+private:
+  uint16_t d_code;
+  std::string d_data;
+};
+
 class SetNoRecurseAction : public DNSAction
 {
 public:

--- a/pdns/dnsdistdist/dnsdist-actions-factory.cc
+++ b/pdns/dnsdistdist/dnsdist-actions-factory.cc
@@ -1018,7 +1018,7 @@ public:
   DNSAction::Action operator()(DNSQuestion* dnsquestion, std::string* ruleresult) const override
   {
     (void)ruleresult;
-    setEDNSOption(*dnsquestion, d_code, d_data);
+    setEDNSOption(*dnsquestion, d_code, d_data, true);
     return Action::None;
   }
 
@@ -1041,9 +1041,9 @@ public:
   {
   }
 
-  DNSResponseAction::Action operator()(DNSResponse* response, std::string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* response, [[maybe_unused]] std::string* ruleresult) const override
   {
-    setEDNSOption(*response, d_code, d_data);
+    setEDNSOption(*response, d_code, d_data, false);
     return Action::None;
   }
 

--- a/pdns/dnsdistdist/dnsdist-console.cc
+++ b/pdns/dnsdistdist/dnsdist-console.cc
@@ -830,6 +830,7 @@ static const std::vector<dnsdist::console::ConsoleKeyword> s_consoleKeywords{
   {"SetECSPrefixLengthAction", true, "v4, v6", "Set the ECS prefix length. Subsequent rules are processed after this action"},
   {"SetMacAddrAction", true, "option", "Add the source MAC address to the query as EDNS0 option option. This action is currently only supported on Linux. Subsequent rules are processed after this action"},
   {"SetEDNSOptionAction", true, "option, data", "Add arbitrary EDNS option and data to the query. Subsequent rules are processed after this action"},
+  {"SetEDNSOptionResponseAction", true, "option, data", "Add arbitrary EDNS option and data to the response. Subsequent rules are processed after this action"},
   {"SetExtendedDNSErrorAction", true, "infoCode [, extraText]", "Set an Extended DNS Error status that will be added to the response corresponding to the current query. Subsequent rules are processed after this action"},
   {"SetExtendedDNSErrorResponseAction", true, "infoCode [, extraText]", "Set an Extended DNS Error status that will be added to this response. Subsequent rules are processed after this action"},
   {"SetNoRecurseAction", true, "", "strip RD bit from the question, let it go through"},

--- a/pdns/dnsdistdist/dnsdist-ecs.cc
+++ b/pdns/dnsdistdist/dnsdist-ecs.cc
@@ -1163,7 +1163,7 @@ bool getEDNS0Record(const PacketBuffer& packet, EDNS0Record& edns0)
   return true;
 }
 
-bool setEDNSOption(DNSQuestion& dnsQuestion, uint16_t ednsCode, const std::string& ednsData)
+bool setEDNSOption(DNSQuestion& dnsQuestion, uint16_t ednsCode, const std::string& ednsData, bool isQuery)
 {
   std::string optRData;
   generateEDNSOption(ednsCode, ednsData, optRData);
@@ -1183,7 +1183,7 @@ bool setEDNSOption(DNSQuestion& dnsQuestion, uint16_t ednsCode, const std::strin
     }
 
     dnsQuestion.getMutableData() = std::move(newContent);
-    if (!dnsQuestion.ids.ednsAdded && ednsAdded) {
+    if (isQuery && !dnsQuestion.ids.ednsAdded && ednsAdded) {
       dnsQuestion.ids.ednsAdded = true;
     }
 
@@ -1196,8 +1196,11 @@ bool setEDNSOption(DNSQuestion& dnsQuestion, uint16_t ednsCode, const std::strin
       header.arcount = htons(1);
       return true;
     });
-    // make sure that any EDNS sent by the backend is removed before forwarding the response to the client
-    dnsQuestion.ids.ednsAdded = true;
+
+    if (isQuery) {
+      // make sure that any EDNS sent by the backend is removed before forwarding the response to the client
+      dnsQuestion.ids.ednsAdded = true;
+    }
   }
 
   return true;

--- a/pdns/dnsdistdist/dnsdist-ecs.hh
+++ b/pdns/dnsdistdist/dnsdist-ecs.hh
@@ -51,7 +51,7 @@ bool parseEDNSOptions(const DNSQuestion& dnsQuestion);
 bool queryHasEDNS(const DNSQuestion& dnsQuestion);
 bool getEDNS0Record(const PacketBuffer& packet, EDNS0Record& edns0);
 
-bool setEDNSOption(DNSQuestion& dnsQuestion, uint16_t ednsCode, const std::string& data);
+bool setEDNSOption(DNSQuestion& dnsQuestion, uint16_t ednsCode, const std::string& data, bool isQuery = true);
 
 struct InternalQueryState;
 namespace dnsdist

--- a/pdns/dnsdistdist/dnsdist-lua-response-actions-generated.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-response-actions-generated.cc
@@ -14,6 +14,9 @@ luaCtx.writeFunction("LogResponseAction", [](boost::optional<std::string> file_n
 luaCtx.writeFunction("LuaFFIPerThreadResponseAction", [](std::string code) {
   return dnsdist::actions::getLuaFFIPerThreadResponseAction(code);
 });
+luaCtx.writeFunction("SetEDNSOptionResponseAction", [](uint32_t code, std::string data) {
+  return dnsdist::actions::getSetEDNSOptionResponseAction(code, data);
+});
 luaCtx.writeFunction("SetExtendedDNSErrorResponseAction", [](uint16_t info_code, boost::optional<std::string> extra_text) {
   return dnsdist::actions::getSetExtendedDNSErrorResponseAction(info_code, extra_text ? *extra_text : "");
 });

--- a/pdns/dnsdistdist/dnsdist-response-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-response-actions-definitions.yml
@@ -173,7 +173,7 @@ The function will be invoked in a per-thread Lua state, without access to the gl
       default: true
       description: "A list of ``name``=``key`` pairs, for meta-data to be added to Protocol Buffer message"
 - name: "SetEDNSOption"
-  description: "Add arbitrary EDNS option and data to the response. Any existing EDNS content with the same option code will be overwritten. Subsequent rules are processed after this action"
+  description: "Add arbitrary EDNS option and data to the response. Any existing EDNS content with the same option code will be replaced. Subsequent rules are processed after this action"
   parameters:
     - name: "code"
       type: "u32"

--- a/pdns/dnsdistdist/dnsdist-response-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-response-actions-definitions.yml
@@ -172,6 +172,16 @@ The function will be invoked in a per-thread Lua state, without access to the gl
       type: "Vec<ProtoBufMetaConfiguration>"
       default: true
       description: "A list of ``name``=``key`` pairs, for meta-data to be added to Protocol Buffer message"
+- name: "SetEDNSOption"
+  description: "Add arbitrary EDNS option and data to the response. Any existing EDNS content with the same option code will be overwritten. Subsequent rules are processed after this action"
+  skip-rust: true
+  parameters:
+    - name: "code"
+      type: "u32"
+      description: "The EDNS option number"
+    - name: "data"
+      type: "String"
+      description: "The EDNS0 option raw content"
 - name: "SetExtendedDNSError"
   description: "Set an Extended DNS Error status that will be added to the response. Subsequent rules are processed after this action"
   parameters:

--- a/pdns/dnsdistdist/dnsdist-response-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-response-actions-definitions.yml
@@ -174,7 +174,6 @@ The function will be invoked in a per-thread Lua state, without access to the gl
       description: "A list of ``name``=``key`` pairs, for meta-data to be added to Protocol Buffer message"
 - name: "SetEDNSOption"
   description: "Add arbitrary EDNS option and data to the response. Any existing EDNS content with the same option code will be overwritten. Subsequent rules are processed after this action"
-  skip-rust: true
   parameters:
     - name: "code"
       type: "u32"

--- a/pdns/dnsdistdist/dnsdist-response-actions-factory-generated.cc
+++ b/pdns/dnsdistdist/dnsdist-response-actions-factory-generated.cc
@@ -19,6 +19,10 @@ std::shared_ptr<DNSResponseAction> getLuaFFIPerThreadResponseAction(const std::s
 {
   return std::shared_ptr<DNSResponseAction>(new LuaFFIPerThreadResponseAction(code));
 }
+std::shared_ptr<DNSResponseAction> getSetEDNSOptionResponseAction(uint32_t code, const std::string& data)
+{
+  return std::shared_ptr<DNSResponseAction>(new SetEDNSOptionResponseAction(code, data));
+}
 std::shared_ptr<DNSResponseAction> getSetExtendedDNSErrorResponseAction(uint16_t info_code, const std::string& extra_text)
 {
   return std::shared_ptr<DNSResponseAction>(new SetExtendedDNSErrorResponseAction(info_code, extra_text));

--- a/pdns/dnsdistdist/dnsdist-response-actions-factory-generated.hh
+++ b/pdns/dnsdistdist/dnsdist-response-actions-factory-generated.hh
@@ -4,6 +4,7 @@ std::shared_ptr<DNSResponseAction> getDelayResponseAction(uint32_t msec);
 std::shared_ptr<DNSResponseAction> getDropResponseAction();
 std::shared_ptr<DNSResponseAction> getLogResponseAction(const std::string& file_name, bool append, bool buffered, bool verbose_only, bool include_timestamp);
 std::shared_ptr<DNSResponseAction> getLuaFFIPerThreadResponseAction(const std::string& code);
+std::shared_ptr<DNSResponseAction> getSetEDNSOptionResponseAction(uint32_t code, const std::string& data);
 std::shared_ptr<DNSResponseAction> getSetExtendedDNSErrorResponseAction(uint16_t info_code, const std::string& extra_text);
 std::shared_ptr<DNSResponseAction> getSetReducedTTLResponseAction(uint8_t percentage);
 std::shared_ptr<DNSResponseAction> getSetSkipCacheResponseAction();

--- a/pdns/dnsdistdist/dnsdist-rust-bridge-actions-generated.cc
+++ b/pdns/dnsdistdist/dnsdist-rust-bridge-actions-generated.cc
@@ -179,6 +179,11 @@ std::shared_ptr<DNSResponseActionWrapper> getLuaFFIPerThreadResponseAction(const
   auto action = dnsdist::actions::getLuaFFIPerThreadResponseAction(std::string(config.code));
   return newDNSResponseActionWrapper(std::move(action), config.name);
 }
+std::shared_ptr<DNSResponseActionWrapper> getSetEDNSOptionResponseAction(const SetEDNSOptionResponseActionConfiguration& config)
+{
+  auto action = dnsdist::actions::getSetEDNSOptionResponseAction(config.code, std::string(config.data));
+  return newDNSResponseActionWrapper(std::move(action), config.name);
+}
 std::shared_ptr<DNSResponseActionWrapper> getSetExtendedDNSErrorResponseAction(const SetExtendedDNSErrorResponseActionConfiguration& config)
 {
   auto action = dnsdist::actions::getSetExtendedDNSErrorResponseAction(config.info_code, std::string(config.extra_text));

--- a/pdns/dnsdistdist/dnsdist-rust-bridge-actions-generated.hh
+++ b/pdns/dnsdistdist/dnsdist-rust-bridge-actions-generated.hh
@@ -107,6 +107,8 @@ struct LuaFFIPerThreadResponseActionConfiguration;
 std::shared_ptr<DNSResponseActionWrapper> getLuaFFIPerThreadResponseAction(const LuaFFIPerThreadResponseActionConfiguration& config);
 struct RemoteLogResponseActionConfiguration;
 std::shared_ptr<DNSResponseActionWrapper> getRemoteLogResponseAction(const RemoteLogResponseActionConfiguration& config);
+struct SetEDNSOptionResponseActionConfiguration;
+std::shared_ptr<DNSResponseActionWrapper> getSetEDNSOptionResponseAction(const SetEDNSOptionResponseActionConfiguration& config);
 struct SetExtendedDNSErrorResponseActionConfiguration;
 std::shared_ptr<DNSResponseActionWrapper> getSetExtendedDNSErrorResponseAction(const SetExtendedDNSErrorResponseActionConfiguration& config);
 struct SetMaxReturnedTTLResponseActionConfiguration;

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/src/lib.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/src/lib.rs
@@ -649,6 +649,15 @@ mod dnsdistsettings {
 
     #[derive(Deserialize, Serialize, Debug, PartialEq)]
     #[serde(deny_unknown_fields)]
+    struct SetEDNSOptionResponseActionConfiguration {
+        #[serde(default, skip_serializing_if = "crate::is_default")]
+        name: String,
+        code: u32,
+        data: String,
+    }
+
+    #[derive(Deserialize, Serialize, Debug, PartialEq)]
+    #[serde(deny_unknown_fields)]
     struct SetExtendedDNSErrorResponseActionConfiguration {
         #[serde(default, skip_serializing_if = "crate::is_default")]
         name: String,
@@ -2234,6 +2243,7 @@ mod dnsdistsettings {
         fn getLuaFFIResponseAction(config: &LuaFFIResponseActionConfiguration) -> Result<SharedPtr<DNSResponseActionWrapper>>;
         fn getLuaFFIPerThreadResponseAction(config: &LuaFFIPerThreadResponseActionConfiguration) -> Result<SharedPtr<DNSResponseActionWrapper>>;
         fn getRemoteLogResponseAction(config: &RemoteLogResponseActionConfiguration) -> Result<SharedPtr<DNSResponseActionWrapper>>;
+        fn getSetEDNSOptionResponseAction(config: &SetEDNSOptionResponseActionConfiguration) -> Result<SharedPtr<DNSResponseActionWrapper>>;
         fn getSetExtendedDNSErrorResponseAction(config: &SetExtendedDNSErrorResponseActionConfiguration) -> Result<SharedPtr<DNSResponseActionWrapper>>;
         fn getSetMaxReturnedTTLResponseAction(config: &SetMaxReturnedTTLResponseActionConfiguration) -> Result<SharedPtr<DNSResponseActionWrapper>>;
         fn getSetMaxTTLResponseAction(config: &SetMaxTTLResponseActionConfiguration) -> Result<SharedPtr<DNSResponseActionWrapper>>;
@@ -2526,6 +2536,7 @@ enum ResponseAction {
     LuaFFI(dnsdistsettings::LuaFFIResponseActionConfiguration),
     LuaFFIPerThread(dnsdistsettings::LuaFFIPerThreadResponseActionConfiguration),
     RemoteLog(dnsdistsettings::RemoteLogResponseActionConfiguration),
+    SetEDNSOption(dnsdistsettings::SetEDNSOptionResponseActionConfiguration),
     SetExtendedDNSError(dnsdistsettings::SetExtendedDNSErrorResponseActionConfiguration),
     SetMaxReturnedTTL(dnsdistsettings::SetMaxReturnedTTLResponseActionConfiguration),
     SetMaxTTL(dnsdistsettings::SetMaxTTLResponseActionConfiguration),
@@ -4029,6 +4040,11 @@ fn get_one_response_action_from_serde(action: &ResponseAction) -> Result<dnsdist
         ResponseAction::RemoteLog(config) => {
                 return Ok(dnsdistsettings::SharedDNSResponseAction {
                     action: dnsdistsettings::getRemoteLogResponseAction(&config)?,
+                });
+            }
+        ResponseAction::SetEDNSOption(config) => {
+                return Ok(dnsdistsettings::SharedDNSResponseAction {
+                    action: dnsdistsettings::getSetEDNSOptionResponseAction(&config)?,
                 });
             }
         ResponseAction::SetExtendedDNSError(config) => {

--- a/pdns/dnsdistdist/docs/reference/actions.rst
+++ b/pdns/dnsdistdist/docs/reference/actions.rst
@@ -597,7 +597,7 @@ The following actions exist.
 
   .. versionadded:: 1.9.11
 
-  Add arbitrary EDNS option and data to the response. Any existing EDNS content with the same option code will be overwritten.
+  Add arbitrary EDNS option and data to the response. Any existing EDNS content with the same option code will be replaced.
   Subsequent rules are processed after this action.
 
   :param int option: The EDNS option number

--- a/pdns/dnsdistdist/docs/reference/actions.rst
+++ b/pdns/dnsdistdist/docs/reference/actions.rst
@@ -593,6 +593,16 @@ The following actions exist.
   :param int option: The EDNS option number
   :param string data: The EDNS0 option raw content
 
+.. function:: SetEDNSOptionResponseAction(option)
+
+  .. versionadded:: 1.9.11
+
+  Add arbitrary EDNS option and data to the response. Any existing EDNS content with the same option code will be overwritten.
+  Subsequent rules are processed after this action.
+
+  :param int option: The EDNS option number
+  :param string data: The EDNS0 option raw content
+
 .. function:: SetExtendedDNSErrorAction(infoCode [, extraText])
 
   .. versionadded:: 1.9.0

--- a/regression-tests.dnsdist/test_Responses.py
+++ b/regression-tests.dnsdist/test_Responses.py
@@ -605,7 +605,7 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
 
     def testAdvancedSetEDNSOptionResponseOverwrite(self):
         """
-        Responses: Set EDNS Option in response overwrites existing option
+        Responses: Set EDNS Option in response replaces existing option
         """
         name = 'setednsoptionresponse-overwrite.responses.tests.powerdns.com.'
         initialECO = cookiesoption.CookiesOption(b'aaaaaaaa', b'bbbbbbbb')
@@ -619,9 +619,9 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
                                     '127.0.0.1')
         response.answer.append(rrset)
 
-        overWrittenECO = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
+        replacementECO = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
         expectedResponse = dns.message.make_response(query)
-        expectedResponse.use_edns(edns=True, payload=512, options=[overWrittenECO])
+        expectedResponse.use_edns(edns=True, payload=512, options=[replacementECO])
         expectedResponse.answer.append(rrset)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):

--- a/regression-tests.dnsdist/test_Responses.py
+++ b/regression-tests.dnsdist/test_Responses.py
@@ -2,6 +2,7 @@
 from datetime import datetime, timedelta
 import time
 import dns
+import cookiesoption
 from dnsdisttests import DNSDistTest
 
 class TestResponseRuleNXDelayed(DNSDistTest):
@@ -566,3 +567,91 @@ class TestResponseRewriteServFail(DNSDistTest):
             receivedQuery.id = query.id
             self.assertEqual(query, receivedQuery)
             self.assertEqual(response, receivedResponse)
+
+class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
+    _config_template = """
+    addResponseAction(AllRule(), SetEDNSOptionResponseAction(10, "deadbeefdeadc0de"))
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testAdvancedSetEDNSOptionResponse(self):
+        """
+        Responses: Set EDNS Option in response
+        """
+        name = 'setednsoptionresponse.responses.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        eco = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
+        expectedResponse = dns.message.make_response(query, use_edns=True, payload=512, options=[eco])
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.checkResponseEDNS(expectedResponse, receivedResponse)
+
+    def testAdvancedSetEDNSOptionResponseOverwrite(self):
+        """
+        Responses: Set EDNS Option in response overwrites existing option
+        """
+        name = 'setednsoptionresponse-overwrite.responses.tests.powerdns.com.'
+        initialECO = cookiesoption.CookiesOption(b'aaaaaaaa', b'bbbbbbbb')
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query, use_edns=True, payload=512, options=[initialECO])
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        overWrittenECO = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
+        expectedResponse = dns.message.make_response(query, use_edns=True, payload=512, options=[overWrittenECO])
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.checkResponseEDNS(expectedResponse, receivedResponse)
+
+    def testAdvancedSetEDNSOptionResponseWithDOSet(self):
+        """
+        Responses: Set EDNS Option in response (DO bit set)
+        """
+        name = 'setednsoptionresponse-do.responses.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, want_dnssec=True, payload=4096)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        eco = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
+        expectedResponse = dns.message.make_response(query, use_edns=True, payload=4096, options=[eco], want_dnssec=True)
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.checkResponseEDNS(expectedResponse, receivedResponse)

--- a/regression-tests.dnsdist/test_Responses.py
+++ b/regression-tests.dnsdist/test_Responses.py
@@ -579,8 +579,9 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
         Responses: Set EDNS Option in response
         """
         name = 'setednsoptionresponse.responses.tests.powerdns.com.'
-        query = dns.message.make_query(name, 'A', 'IN')
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
         response = dns.message.make_response(query)
+        response.use_edns(edns=True, payload=512)
         rrset = dns.rrset.from_text(name,
                                     3600,
                                     dns.rdataclass.IN,
@@ -589,7 +590,8 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
         response.answer.append(rrset)
 
         eco = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
-        expectedResponse = dns.message.make_response(query, use_edns=True, payload=512, options=[eco])
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.use_edns(edns=True, payload=512, options=[eco])
         expectedResponse.answer.append(rrset)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -599,7 +601,7 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
             self.assertEqual(query, receivedQuery)
-            self.checkResponseEDNS(expectedResponse, receivedResponse)
+            self.checkResponseEDNSWithoutECS(expectedResponse, receivedResponse, 1)
 
     def testAdvancedSetEDNSOptionResponseOverwrite(self):
         """
@@ -607,8 +609,9 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
         """
         name = 'setednsoptionresponse-overwrite.responses.tests.powerdns.com.'
         initialECO = cookiesoption.CookiesOption(b'aaaaaaaa', b'bbbbbbbb')
-        query = dns.message.make_query(name, 'A', 'IN')
-        response = dns.message.make_response(query, use_edns=True, payload=512, options=[initialECO])
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
+        response = dns.message.make_response(query)
+        response.use_edns(edns=True, payload=512, options=[initialECO])
         rrset = dns.rrset.from_text(name,
                                     3600,
                                     dns.rdataclass.IN,
@@ -617,7 +620,8 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
         response.answer.append(rrset)
 
         overWrittenECO = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
-        expectedResponse = dns.message.make_response(query, use_edns=True, payload=512, options=[overWrittenECO])
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.use_edns(edns=True, payload=512, options=[overWrittenECO])
         expectedResponse.answer.append(rrset)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -627,7 +631,7 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
             self.assertEqual(query, receivedQuery)
-            self.checkResponseEDNS(expectedResponse, receivedResponse)
+            self.checkResponseEDNSWithoutECS(expectedResponse, receivedResponse, 1)
 
     def testAdvancedSetEDNSOptionResponseWithDOSet(self):
         """
@@ -636,6 +640,7 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
         name = 'setednsoptionresponse-do.responses.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, want_dnssec=True, payload=4096)
         response = dns.message.make_response(query)
+        response.use_edns(edns=True, payload=1024)
         rrset = dns.rrset.from_text(name,
                                     3600,
                                     dns.rdataclass.IN,
@@ -644,7 +649,8 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
         response.answer.append(rrset)
 
         eco = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
-        expectedResponse = dns.message.make_response(query, use_edns=True, payload=4096, options=[eco], want_dnssec=True)
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.use_edns(edns=True, payload=1024, options=[eco])
         expectedResponse.answer.append(rrset)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -654,4 +660,4 @@ class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
             self.assertEqual(query, receivedQuery)
-            self.checkResponseEDNS(expectedResponse, receivedResponse)
+            self.checkResponseEDNSWithoutECS(expectedResponse, receivedResponse, 1)


### PR DESCRIPTION
### Short description
This Pull Request adds the new SetEDNSOptionResponseAction to dnsdist, allowing arbitrary EDNS options and data to be added to DNS responses. It also includes documentation and a regression test for this new action.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
