### PR TITLE
dnsdist: Explicitly use the versions present in `Cargo.lock` when building

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/Makefile.am
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/Makefile.am
@@ -10,7 +10,7 @@ if HAVE_YAML_CONFIGURATION
 all install: libdnsdist_rust.a
 
 libdnsdist_rust.a: src/lib.rs src/helpers.rs Cargo.toml Cargo.lock
-	SYSCONFDIR=$(sysconfdir) $(CARGO) build --release $(RUST_TARGET) --target-dir=$(builddir)/target --manifest-path ${srcdir}/Cargo.toml
+	SYSCONFDIR=$(sysconfdir) $(CARGO) build --release $(RUST_TARGET) --target-dir=$(builddir)/target --manifest-path ${srcdir}/Cargo.toml --locked
 	cp target/release/libdnsdist_rust.a libdnsdist_rust.a
 	cp target/cxxbridge/dnsdist-rust/src/lib.rs.h lib.rs.h
 	cp target/cxxbridge/rust/cxx.h cxx.h

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
@@ -9,7 +9,7 @@
 mytarget=${CARGO_TARGET_DIR-target}
 #echo "mytarget=${mytarget}"
 
-$CARGO build --release $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml
+$CARGO build --release $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml --locked
 
 cp -p target/$RUSTC_TARGET_ARCH/release/libdnsdist_rust.a $builddir/dnsdist-rust-lib/rust/libdnsdist_rust.a
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The documentation states that only `cargo update` and `cargo install` should update the dependencies present in the `Cargo.lock` file, but it still seems safer to explictly ask `cargo build` to not update them.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
