### PR TITLE
rec-5.0.x: backport 14565 - gh actions - coveralls: avoid CI failure by setting fail-on-error: false

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -88,6 +88,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
       - run: inv ci-make-install
       - run: ccache -s
       - run: echo "normalized-branch-name=${{ inputs.branch-name || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
@@ -141,6 +142,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   test-recursor-regression:
     needs: build-recursor
@@ -186,6 +188,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   test-recursor-bulk:
     name: 'test rec *mini* bulk'
@@ -229,6 +232,7 @@ jobs:
           path-to-lcov: $GITHUB_WORKSPACE/coverage.lcov
           parallel: true
           allow-empty: true
+          fail-on-error: false
 
   collect:
     needs:
@@ -244,6 +248,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
+          fail-on-error: false
       - name: Install jq and jc
         run: "sudo apt-get update && sudo apt-get install jq jc"
       - name: Fail job if any of the previous jobs failed


### PR DESCRIPTION
### Short description
Backport of #14565 to `rec-5.0.x`.

Avoid CI failures related to Coveralls when upload fails due to any errors.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
