### PR TITLE
rec: Disable fortify on package builds, it is supplied db package build infra

### DIFF
--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -37,7 +37,7 @@ override_dh_auto_clean:
 
 # We need clang (LLVM) to link the Rust static library and the C++ code with LTO enabled
 # build-id SHA1 prevents an issue with the debug symbols ("export: `-Wl,--build-id=sha1': not a valid identifier")
-
+# disably fortify as it is handled by package build infra
 override_dh_auto_configure:
 	LDFLAGS="-latomic -fuse-ld=lld -Wl,--build-id=sha1" \
 	CC=clang \
@@ -47,6 +47,7 @@ override_dh_auto_configure:
 	-Db_lto=true \
 	-Db_lto_mode=thin \
 	-Db_pie=true \
+	-Dhardening-fortify-source=disabled \
 	-Dunit-tests=true \
 	-Ddns-over-tls=enabled \
 	-Ddnstap=enabled \

--- a/builder-support/debian/recursor/debian-trixie/rules
+++ b/builder-support/debian/recursor/debian-trixie/rules
@@ -37,7 +37,7 @@ override_dh_auto_clean:
 
 # We need clang (LLVM) to link the Rust static library and the C++ code with LTO enabled
 # build-id SHA1 prevents an issue with the debug symbols ("export: `-Wl,--build-id=sha1': not a valid identifier")
-
+# disably fortify as it is handled by package build infra
 override_dh_auto_configure:
 	LDFLAGS="-latomic -fuse-ld=lld -Wl,--build-id=sha1" \
 	CC=clang \
@@ -47,6 +47,7 @@ override_dh_auto_configure:
 	-Db_lto=true \
 	-Db_lto_mode=thin \
 	-Db_pie=true \
+	-Dhardening-fortify-source=disabled \
 	-Dunit-tests=true \
 	-Ddns-over-tls=enabled \
 	-Ddnstap=enabled \

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -93,12 +93,14 @@ export CXXFLAGS="-O2 -g -pipe -Wall -Wno-deprecated-declarations -Wno-deprecated
 
 # Note that the RPM meson macro "helpfully" sets
 # --auto-features=enabled so our auto-detection is broken
+# disably fortify as it is handled by package build infra
 %meson \
     --sysconfdir=%{_sysconfdir}/%{name} \
     -Dunit-tests=true \
     -Db_lto=true \
     -Db_lto_mode=thin \
     -Db_pie=true \
+    -Dhardening-fortify-source=disabled \
     -Ddns-over-tls=enabled \
     -Ddnstap=enabled \
     -Dlibcap=enabled \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

So dev builds use auto, and package builds use the infra supplied flag. This should avoid the redefinition warning in all cases.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
