### PR TITLE
rec: Fix stack-use-after-scope reported by ASAN

### DIFF
--- a/pdns/recursordist/mtasker_context.cc
+++ b/pdns/recursordist/mtasker_context.cc
@@ -160,11 +160,11 @@ extern "C"
       *ptr = res.fctx;
     }
 #endif
+    auto start = std::move(*work);
     notifyStackSwitchDone();
     args = nullptr;
 
     try {
-      auto start = std::move(*work);
       start();
     }
     catch (...) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Technically we are indeed using a stack that is no longer the active one, because we just switched to a different context, but since the previous stack still exists that I do not believe it is a real issue. After this commit we access the previous stack before notifying ASAN that the stack switch is finished, so we are still allowed to do that.
Note that clang 19 ASAN is fine with both behaviour, but GCC 14 and 15 ASAN aren't.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
