### PR TITLE
dnsdist-1.9.x: backport 15610 - add SetEDNSOptionResponseAction

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -797,6 +797,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "SetECSPrefixLengthAction", true, "v4, v6", "Set the ECS prefix length. Subsequent rules are processed after this action" },
   { "SetMacAddrAction", true, "option", "Add the source MAC address to the query as EDNS0 option option. This action is currently only supported on Linux. Subsequent rules are processed after this action" },
   { "SetEDNSOptionAction", true, "option, data", "Add arbitrary EDNS option and data to the query. Subsequent rules are processed after this action" },
+  { "SetEDNSOptionResponseAction", true, "option, data", "Add arbitrary EDNS option and data to the response. Subsequent rules are processed after this action"},
   { "SetExtendedDNSErrorAction", true, "infoCode [, extraText]", "Set an Extended DNS Error status that will be added to the response corresponding to the current query. Subsequent rules are processed after this action" },
   { "SetExtendedDNSErrorResponseAction", true, "infoCode [, extraText]", "Set an Extended DNS Error status that will be added to this response. Subsequent rules are processed after this action" },
   { "SetNoRecurseAction", true, "", "strip RD bit from the question, let it go through" },

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -1101,6 +1101,31 @@ private:
   std::string d_data;
 };
 
+class SetEDNSOptionResponseAction : public DNSResponseAction
+{
+public:
+  // this action does not stop the processing
+  SetEDNSOptionResponseAction(uint16_t code, std::string data) :
+    d_code(code), d_data(std::move(data))
+  {
+  }
+
+  DNSResponseAction::Action operator()(DNSResponse* response, std::string* ruleresult) const override
+  {
+    setEDNSOption(*response, d_code, d_data);
+    return Action::None;
+  }
+
+  [[nodiscard]] std::string toString() const override
+  {
+    return "add EDNS Option (code=" + std::to_string(d_code) + ")";
+  }
+
+private:
+  uint16_t d_code;
+  std::string d_data;
+};
+
 class SetNoRecurseAction : public DNSAction
 {
 public:
@@ -1856,7 +1881,6 @@ private:
   std::optional<std::string> d_exportExtendedErrorsToMeta{std::nullopt};
   bool d_includeCNAME;
 };
-
 #endif /* DISABLE_PROTOBUF */
 
 class DropResponseAction : public DNSResponseAction
@@ -2508,6 +2532,10 @@ void setupLuaActions(LuaContext& luaCtx)
 
   luaCtx.writeFunction("SetEDNSOptionAction", [](int code, const std::string& data) {
     return std::shared_ptr<DNSAction>(new SetEDNSOptionAction(code, data));
+  });
+
+  luaCtx.writeFunction("SetEDNSOptionResponseAction", [](int code, const std::string& data) {
+    return std::shared_ptr<DNSResponseAction>(new SetEDNSOptionResponseAction(code, data));
   });
 
   luaCtx.writeFunction("PoolAction", [](const std::string& poolname, boost::optional<bool> stopProcessing) {

--- a/pdns/dnsdistdist/docs/reference/actions.rst
+++ b/pdns/dnsdistdist/docs/reference/actions.rst
@@ -586,6 +586,16 @@ The following actions exist.
   :param int option: The EDNS option number
   :param string data: The EDNS0 option raw content
 
+.. function:: SetEDNSOptionResponseAction(option)
+
+  .. versionadded:: 1.9.11
+
+  Add arbitrary EDNS option and data to the response. Any existing EDNS content with the same option code will be replaced.
+  Subsequent rules are processed after this action.
+
+  :param int option: The EDNS option number
+  :param string data: The EDNS0 option raw content
+
 .. function:: SetExtendedDNSErrorAction(infoCode [, extraText])
 
   .. versionadded:: 1.9.0

--- a/regression-tests.dnsdist/test_Responses.py
+++ b/regression-tests.dnsdist/test_Responses.py
@@ -2,6 +2,7 @@
 from datetime import datetime, timedelta
 import time
 import dns
+import cookiesoption
 from dnsdisttests import DNSDistTest
 
 class TestResponseRuleNXDelayed(DNSDistTest):
@@ -505,3 +506,97 @@ class TestResponseClearRecordsType(DNSDistTest):
             receivedQuery.id = query.id
             self.assertEqual(query, receivedQuery)
             self.assertEqual(expectedResponse, receivedResponse)
+
+class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
+    _config_template = """
+    addResponseAction(AllRule(), SetEDNSOptionResponseAction(10, "deadbeefdeadc0de"))
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testAdvancedSetEDNSOptionResponse(self):
+        """
+        Responses: Set EDNS Option in response
+        """
+        name = 'setednsoptionresponse.responses.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
+        response = dns.message.make_response(query)
+        response.use_edns(edns=True, payload=512)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        eco = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.use_edns(edns=True, payload=512, options=[eco])
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.checkResponseEDNSWithoutECS(expectedResponse, receivedResponse, 1)
+
+    def testAdvancedSetEDNSOptionResponseOverwrite(self):
+        """
+        Responses: Set EDNS Option in response replaces existing option
+        """
+        name = 'setednsoptionresponse-overwrite.responses.tests.powerdns.com.'
+        initialECO = cookiesoption.CookiesOption(b'aaaaaaaa', b'bbbbbbbb')
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
+        response = dns.message.make_response(query)
+        response.use_edns(edns=True, payload=512, options=[initialECO])
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        replacementECO = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.use_edns(edns=True, payload=512, options=[replacementECO])
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.checkResponseEDNSWithoutECS(expectedResponse, receivedResponse, 1)
+
+    def testAdvancedSetEDNSOptionResponseWithDOSet(self):
+        """
+        Responses: Set EDNS Option in response (DO bit set)
+        """
+        name = 'setednsoptionresponse-do.responses.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, want_dnssec=True, payload=4096)
+        response = dns.message.make_response(query)
+        response.use_edns(edns=True, payload=1024)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        eco = cookiesoption.CookiesOption(b'deadbeef', b'deadc0de')
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.use_edns(edns=True, payload=1024, options=[eco])
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEqual(query, receivedQuery)
+            self.checkResponseEDNSWithoutECS(expectedResponse, receivedResponse, 1)


### PR DESCRIPTION
### Short description
This Pull Request adds the new SetEDNSOptionResponseAction to dnsdist, allowing arbitrary EDNS options and data to be added to DNS responses. It also includes documentation and a regression test for this new action.

It is a back port of #15610 for 1.9.x

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] checked that this code was merged to master
