### PR TITLE
rec meson followup: extend unittest max time once more and add trixie daily builds

### DIFF
--- a/.github/workflows/build-packages-daily-master.yml
+++ b/.github/workflows/build-packages-daily-master.yml
@@ -43,6 +43,7 @@ jobs:
           el-9
           debian-bullseye
           debian-bookworm
+          debian-trixie
           ubuntu-jammy
           ubuntu-noble
     secrets:
@@ -62,6 +63,7 @@ jobs:
           el-9
           debian-bullseye
           debian-bookworm
+          debian-trixie
           ubuntu-jammy
           ubuntu-noble
     secrets:

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -593,7 +593,8 @@ foreach tool, info: tools
 endforeach
 
 if get_option('unit-tests')
-  test('testrunner', testrunner, timeout: 60) # default timeout of 30s is a bit short for some targets
+  # default timeout of 30s is too short for some ubicloud targets. Unknown *why* they are so slow.
+  test('testrunner', testrunner, timeout: 120)
 endif
 
 # Man-pages.


### PR DESCRIPTION
ubicloud is low in some cases

And add trixie to dnsdist and rec daily package build targets

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
