### PR TITLE
builder: add el-10 target, based on rockylinux:10 for now

### DIFF
--- a/.github/workflows/build-packages-daily-master.yml
+++ b/.github/workflows/build-packages-daily-master.yml
@@ -21,6 +21,7 @@ jobs:
       os: >-
           el-8
           el-9
+          el-10
           debian-bullseye
           debian-bookworm
           debian-trixie
@@ -41,6 +42,7 @@ jobs:
       os: >-
           el-8
           el-9
+          el-10
           debian-bullseye
           debian-bookworm
           debian-trixie
@@ -61,6 +63,7 @@ jobs:
       os: >-
           el-8
           el-9
+          el-10
           debian-bullseye
           debian-bookworm
           debian-trixie

--- a/.github/workflows/build-packages-daily-master.yml
+++ b/.github/workflows/build-packages-daily-master.yml
@@ -1,5 +1,5 @@
 ---
-name: 'daily: build packages for master '
+name: 'daily: build packages for master'
 
 on:
   schedule:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -17,6 +17,7 @@ on:
         default: >-
           el-8
           el-9
+          el-10
           debian-bullseye
           debian-bookworm
           debian-trixie
@@ -102,6 +103,8 @@ jobs:
       pkghashes-el-8-aarch64: ${{ steps.pkghashes.outputs.pkghashes-el-8-aarch64 }}
       pkghashes-el-9-x86_64: ${{ steps.pkghashes.outputs.pkghashes-el-9-x86_64 }}
       pkghashes-el-9-aarch64: ${{ steps.pkghashes.outputs.pkghashes-el-9-aarch64 }}
+      pkghashes-el-10-x86_64: ${{ steps.pkghashes.outputs.pkghashes-el-10-x86_64 }}
+      pkghashes-el-10-aarch64: ${{ steps.pkghashes.outputs.pkghashes-el-10-aarch64 }}
       pkghashes-debian-bullseye-x86_64: ${{ steps.pkghashes.outputs.pkghashes-debian-bullseye-x86_64 }}
       pkghashes-debian-bullseye-aarch64: ${{ steps.pkghashes.outputs.pkghashes-debian-bullseye-aarch64 }}
       pkghashes-debian-bookworm-x86_64: ${{ steps.pkghashes.outputs.pkghashes-debian-bookworm-x86_64 }}

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -175,7 +175,7 @@ jobs:
         env:
           TARGET_ARCH: ${{ steps.getarch.outputs.target-arch }}
         run: |
-          echo "pkghashes-${OS}-${TARGET_ARCH}=$(sha256sum ./packages/*.rpm ./packages/*.deb ./packages/*.json | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "pkghashes-${OS}-${TARGET_ARCH}=$(shopt -s nullglob; sha256sum ./packages/*.rpm ./packages/*.deb ./packages/*.json | base64 -w0)" >> $GITHUB_OUTPUT
       - name: Generate source hash for provenance
         shell: bash
         id: srchashes

--- a/.github/workflows/builder-dispatch.yml
+++ b/.github/workflows/builder-dispatch.yml
@@ -18,6 +18,7 @@ on:
         default: >-
           el-8
           el-9
+          el-10
           debian-bullseye
           debian-bookworm
           debian-trixie

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -35,14 +35,9 @@ jobs:
       matrix:
         product: ['authoritative', 'recursor', 'dnsdist']
         os:
-          - el-8
           - centos-9-stream
           - centos-10-stream
-          - el-10
-          - ubuntu-noble
           - ubuntu-oracular
-          - debian-bookworm
-          - debian-trixie
           - amazon-2023
         runner-os: ${{ fromJson(needs.prepare.outputs.runnerlist )}}
       fail-fast: false

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -38,6 +38,7 @@ jobs:
           - el-8
           - centos-9-stream
           - centos-10-stream
+          - el-10
           - ubuntu-noble
           - ubuntu-oracular
           - debian-bookworm

--- a/BUILDING-PACKAGES.md
+++ b/BUILDING-PACKAGES.md
@@ -83,3 +83,5 @@ pkghashes-debian-bookworm: ${{ steps.pkghashes.outputs.pkghashes-debian-bookworm
 pkghashes-ubuntu-focal: ${{ steps.pkghashes.outputs.pkghashes-ubuntu-focal }}
 pkghashes-ubuntu-jammy: ${{ steps.pkghashes.outputs.pkghashes-ubuntu-jammy }}
 ```
+
+For targets that get release packages, also add them to `.github/workflows/build-packages-daily-master.yml` so that we notice breakage.

--- a/builder-support/dockerfiles/Dockerfile.target.el-10
+++ b/builder-support/dockerfiles/Dockerfile.target.el-10
@@ -1,0 +1,18 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+# This defines the distribution base layer
+# Put only the bare minimum of common commands here, without dev tools
+FROM quay.io/rockylinux/rockylinux:10 as dist-base
+
+ARG BUILDER_CACHE_BUSTER=
+
+RUN touch /var/lib/rpm/* && dnf install -y epel-release && \
+    crb enable
+
+# Do the actual rpm build
+@INCLUDE Dockerfile.rpmbuild
+
+# Do a test install and verify
+# Can be skipped with skippackagetest=1 in the environment
+@EXEC [ "$skippackagetest" = "" ] && include Dockerfile.rpmtest

--- a/builder-support/helpers/install_meson.sh
+++ b/builder-support/helpers/install_meson.sh
@@ -2,6 +2,8 @@
 set -v
 set -e
 
+[ -e /tmp/.pdns_meson_installed ] && exit 0  # we already have meson, let's assume we put it there earlier
+
 readonly MESON_VERSION=$(jq -r .version < meson.json)
 readonly MESON_TARBALL="${MESON_VERSION}.tar.gz"
 readonly MESON_TARBALL_URL="https://github.com/mesonbuild/meson/archive/${MESON_TARBALL}"
@@ -31,3 +33,5 @@ fi
 
 cd ..
 rm -rf "${MESON_TARBALL}" "meson-${MESON_VERSION}"
+
+touch /tmp/.pdns_meson_installed

--- a/builder-support/helpers/install_quiche.sh
+++ b/builder-support/helpers/install_quiche.sh
@@ -2,6 +2,8 @@
 set -v
 set -e
 
+[ -e /tmp/.pdns_quiche_installed ] && exit 0
+
 readonly QUICHE_VERSION=$(jq -r .version < quiche.json)
 readonly QUICHE_TARBALL="${QUICHE_VERSION}.tar.gz"
 readonly QUICHE_TARBALL_URL="https://github.com/cloudflare/quiche/archive/${QUICHE_TARBALL}"
@@ -73,3 +75,5 @@ PC
 
 cd ..
 rm -rf "${QUICHE_TARBALL}" "quiche-${QUICHE_VERSION}"
+
+touch /tmp/.pdns_quiche_installed

--- a/builder-support/helpers/install_rust.sh
+++ b/builder-support/helpers/install_rust.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+[ -e /tmp/.pdns_rust_installed ] && exit 0
+
 ARCH=$(arch)
 
 # Default version
@@ -52,3 +54,5 @@ cd $RUST_VERSION
 
 cd ..
 rm -rf $RUST_VERSION
+
+touch /tmp/.pdns_rust_installed


### PR DESCRIPTION
### Short description
plus fix invoking `build.sh` without `-m`

draft PR until the centos-10-stream merge shows green in daily CI.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
