### PR TITLE
Remove never used argument

### DIFF
--- a/pdns/dnsdistdist/dnsdist-svc.cc
+++ b/pdns/dnsdistdist/dnsdist-svc.cc
@@ -79,7 +79,7 @@ bool generateSVCPayload(std::vector<uint8_t>& payload, uint16_t priority, const 
   pw.startRecord(g_rootdnsname, QType::A, 60, QClass::IN, DNSResourceRecord::ANSWER, false);
   size_t offset = pw.size();
   pw.xfr16BitInt(priority);
-  pw.xfrName(target, false, true);
+  pw.xfrName(target, false);
   pw.xfrSvcParamKeyVals(params);
   pw.commit();
 

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -136,7 +136,7 @@ public:
     val=get8BitInt();
   }
 
-  void xfrName(DNSName& name, bool /* compress */ = false, bool /* noDot */ = false)
+  void xfrName(DNSName& name, bool /* compress */ = false)
   {
     name = getName();
   }

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -357,7 +357,7 @@ boilerplate_conv(OPENPGPKEY,
 
 boilerplate_conv(SVCB,
                  conv.xfr16BitInt(d_priority);
-                 conv.xfrName(d_target, false, true);
+                 conv.xfrName(d_target, false);
                  if (d_priority != 0) {
                    conv.xfrSvcParamKeyVals(d_params);
                  }
@@ -365,7 +365,7 @@ boilerplate_conv(SVCB,
 
 boilerplate_conv(HTTPS,
                  conv.xfr16BitInt(d_priority);
-                 conv.xfrName(d_target, false, true);
+                 conv.xfrName(d_target, false);
                  if (d_priority != 0) {
                    conv.xfrSvcParamKeyVals(d_params);
                  }

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -316,7 +316,7 @@ template <typename Container> uint16_t GenericDNSPacketWriter<Container>::lookup
   return bestpos;
 }
 // this is the absolute hottest function in the pdns recursor
-template <typename Container> void GenericDNSPacketWriter<Container>::xfrName(const DNSName& name, bool compress, bool)
+template <typename Container> void GenericDNSPacketWriter<Container>::xfrName(const DNSName& name, bool compress)
 {
   if(l_verbose)
     cout<<"Wants to write "<<name<<", compress="<<compress<<", canonic="<<d_canonic<<", LC="<<d_lowerCase<<endl;

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -127,7 +127,7 @@ public:
 
   void xfr8BitInt(uint8_t val);
 
-  void xfrName(const DNSName& label, bool compress=false, bool noDot=false);
+  void xfrName(const DNSName& name, bool compress=false);
   void xfrText(const string& text, bool multi=false, bool lenField=true);
   void xfrUnquotedText(const string& text, bool lenField);
   void xfrBlob(const string& blob, int len=-1);

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -251,7 +251,7 @@ void RecordTextReader::xfr8BitInt(uint8_t &val)
 }
 
 // this code should leave all the escapes around
-void RecordTextReader::xfrName(DNSName& val, bool, bool)
+void RecordTextReader::xfrName(DNSName& val, [[maybe_unused]] bool compress)
 {
   skipSpaces();
   DNSName sval;
@@ -793,7 +793,7 @@ void RecordTextWriter::xfr8BitInt(const uint8_t& val)
 }
 
 // should not mess with the escapes
-void RecordTextWriter::xfrName(const DNSName& val, bool /* unused */, bool /* noDot */)
+void RecordTextWriter::xfrName(const DNSName& val, bool /* unused */)
 {
   if(!d_string.empty())
     d_string.append(1,' ');

--- a/pdns/rcpgenerator.hh
+++ b/pdns/rcpgenerator.hh
@@ -55,7 +55,7 @@ public:
   void xfrCAPort(ComboAddress &val);
   void xfrTime(uint32_t& val);
 
-  void xfrName(DNSName& val, bool compress=false, bool noDot=false);
+  void xfrName(DNSName& val, bool compress=false);
   void xfrText(string& val, bool multi=false, bool lenField=true);
   void xfrUnquotedText(string& val, bool lenField=true);
   void xfrHexBlob(string& val, bool keepReading=false);
@@ -99,7 +99,7 @@ public:
   void xfrBase32HexBlob(const string& val);
 
   void xfrType(const uint16_t& val);
-  void xfrName(const DNSName& val, bool compress=false, bool noDot=false);
+  void xfrName(const DNSName& val, bool compress=false);
   void xfrText(const string& val, bool multi=false, bool lenField=true);
   void xfrUnquotedText(const string& val, bool lenField=true);
   void xfrBlobNoSpaces(const string& val, int len=-1);


### PR DESCRIPTION
### Short description
While looking at other things, I couldn't help but notice that the last argument of the `xfrName` (de)serialization functions is never used in the current state of the code.

This simple PR removes it and should not cause any difference in behaviour.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
