### PR TITLE
More domain ID love

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -889,7 +889,7 @@ void Bind2Backend::doEmptyNonTerminals(std::shared_ptr<recordstorage_t>& records
 
 void Bind2Backend::loadConfig(string* status) // NOLINT(readability-function-cognitive-complexity) 13379 https://github.com/PowerDNS/pdns/issues/13379 Habbie: zone2sql.cc, bindbackend2.cc: reduce complexity
 {
-  static int domain_id = 1;
+  static domainid_t domain_id = 1;
 
   if (!getArg("config").empty()) {
     BindParser BP;

--- a/modules/ldapbackend/native.cc
+++ b/modules/ldapbackend/native.cc
@@ -426,7 +426,7 @@ bool LdapBackend::getDomainInfo(const ZoneName& domain, DomainInfo& info, bool /
     if (result.count("PdnsDomainId") && !result["PdnsDomainId"].empty())
       info.id = static_cast<domainid_t>(std::stoll(result["PdnsDomainId"][0]));
     else
-      info.id = 0;
+      info.id = UnknownDomainID;
 
     info.serial = sd.serial;
     info.zone = domain;

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -256,6 +256,7 @@ public:
 
   void parseDomainInfo(const domaininfo_result_t& row, DomainInfo& di)
   {
+    di.id = UnknownDomainID;
     for (const auto& item : row) {
       if (item.first == "account")
         di.account = boost::get<string>(item.second);
@@ -293,6 +294,7 @@ public:
       if (!getAuth(domain, &sd))
         return false;
 
+      di.id = sd.domain_id;
       di.zone = domain;
       di.backend = this;
       di.serial = sd.serial;

--- a/modules/tinydnsbackend/tinydnsbackend.hh
+++ b/modules/tinydnsbackend/tinydnsbackend.hh
@@ -105,6 +105,7 @@ private:
   uint64_t d_taiepoch;
   QType d_qtype;
   std::unique_ptr<CDB> d_cdbReader;
+  domainid_t d_currentDomain{UnknownDomainID}; // domain id to return with data obtained from d_cdbReader above.
   DNSPacket* d_dnspacket; // used for location and edns-client support.
   bool d_isWildcardQuery; // Indicate if the query received was a wildcard query.
   bool d_isAxfr; // Indicate if we received a list() and not a lookup().


### PR DESCRIPTION
### Short description
This makes sure than, for backends which may not be able to provide a sensical value for the "domain id" field of `DomainInfo`, we use `UnknownDomainID`.

The 2nd commit will also make the TinyDNS backend return the domain id it was initially queried for, in its `DNSResourceRecord` results, for consistency (note that that value may be `UnknownDomainID`).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
