### PR TITLE
rec: fix negativetrustanchor.server CH TXT query processing (disabled by default)

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -470,6 +470,7 @@ DNSName PacketReader::getName()
   throw PDNSException("PacketReader::getName(): name is empty");
 }
 
+// FIXME see #6010 and #3503 if you want a proper solution
 string txtEscape(const string &name)
 {
   string ret;

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -470,22 +470,24 @@ DNSName PacketReader::getName()
   throw PDNSException("PacketReader::getName(): name is empty");
 }
 
-static string txtEscape(const string &name)
+string txtEscape(const string &name)
 {
   string ret;
-  char ebuf[5];
+  std::array<char, 5> ebuf{};
 
-  for(char i : name) {
-    if((unsigned char) i >= 127 || (unsigned char) i < 32) {
-      snprintf(ebuf, sizeof(ebuf), "\\%03u", (unsigned char)i);
-      ret += ebuf;
+  for (char letter : name) {
+    const unsigned uch = static_cast<unsigned char>(letter);
+    if (uch >= 127 || uch < 32) {
+      snprintf(ebuf.data(), ebuf.size(), "\\%03u", uch);
+      ret += ebuf.data();
     }
-    else if(i=='"' || i=='\\'){
+    else if (letter == '"' || letter == '\\'){
       ret += '\\';
-      ret += i;
+      ret += letter;
     }
-    else
-      ret += i;
+    else {
+      ret += letter;
+    }
   }
   return ret;
 }

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -670,3 +670,5 @@ private:
   uint32_t d_notyouroffset;  // only 'moveOffset' can touch this
   const uint32_t&  d_offset; // look.. but don't touch
 };
+
+string txtEscape(const string &name);

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -838,27 +838,6 @@ void RecordTextWriter::xfrHexBlob(const string& val, bool)
   }
 }
 
-// FIXME copied from dnsparser.cc, see #6010 and #3503 if you want a proper solution
-static string txtEscape(const string &name)
-{
-  string ret;
-  char ebuf[5];
-
-  for(char i : name) {
-    if((unsigned char) i >= 127 || (unsigned char) i < 32) {
-      snprintf(ebuf, sizeof(ebuf), "\\%03u", (unsigned char)i);
-      ret += ebuf;
-    }
-    else if(i=='"' || i=='\\'){
-      ret += '\\';
-      ret += i;
-    }
-    else
-      ret += i;
-  }
-  return ret;
-}
-
 void RecordTextWriter::xfrSVCBValueList(const vector<string> &val) {
   bool shouldQuote{false};
   vector<string> escaped;

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -896,6 +896,7 @@ bool SyncRes::doSpecialNamesResolve(const DNSName& qname, const QType qtype, con
         ans << "\"";
         answers.emplace_back(QType::TXT, ans.str());
       }
+      d_wasVariable = true;
     }
   }
 
@@ -908,11 +909,12 @@ bool SyncRes::doSpecialNamesResolve(const DNSName& qname, const QType qtype, con
         ans << "\"";
         ans << negAnchor.first.toString(); // Explicit toString to have a trailing dot
         if (negAnchor.second.length() != 0) {
-          ans << " " << negAnchor.second;
+          ans << " " << txtEscape(negAnchor.second);
         }
         ans << "\"";
         answers.emplace_back(QType::TXT, ans.str());
       }
+      d_wasVariable = true;
     }
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Should fix both issues reported in #15660

I chose to get rid of the extra copy of txtEscape and expose it. Better have one version than two, even if it might be broken?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
