### PR TITLE
End sentences with dots, not commas.

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1147,7 +1147,7 @@ static int listZone(const ZoneName &zone) {
     return EXIT_FAILURE;
   }
   if ((di.backend->getCapabilities() & DNSBackend::CAP_LIST) == 0) {
-    cerr << "Backend for zone '" << zone << "' does not support listing its contents," << endl;
+    cerr << "Backend for zone '" << zone << "' does not support listing its contents." << endl;
     return EXIT_FAILURE;
   }
 
@@ -1318,7 +1318,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col) {
     return EXIT_FAILURE;
   }
   if ((di.backend->getCapabilities() & DNSBackend::CAP_LIST) == 0) {
-    cerr << "Backend for zone '" << zone << "' does not support listing its contents," << endl;
+    cerr << "Backend for zone '" << zone << "' does not support listing its contents." << endl;
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
### Short description
One recurring mistake I do while typing at the keyboard is to hit the "," key instead of the "." key - they are next to each other, after all. With a small enough font size I do not always notice, and it looks like I was not alone, as fellow developers let me merge a PR with commas instead of dots at the end of sentences.
This PR fixes it, and it is probably shorter than this "short" description.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
