### PR TITLE
Low-hanging signature cache hanging fruit

### DIFF
--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -37,7 +37,7 @@ extern StatBag S;
 
 using signaturecache_t = map<pair<string, string>, string>;
 static SharedLockGuarded<signaturecache_t> g_signatures;
-static int g_cacheweekno;
+static time_t g_cacheweekno;
 
 const static std::set<uint16_t> g_KSKSignedQTypes {QType::DNSKEY, QType::CDS, QType::CDNSKEY};
 AtomicCounter* g_signatureCount;
@@ -65,11 +65,12 @@ static std::string getLookupKeyFromPublicKey(const std::string& pubKey)
 
 static void fillOutRRSIG(DNSSECPrivateKey& dpk, const DNSName& signQName, RRSIGRecordContent& rrc, const sortedRecords_t& toSign)
 {
-  if(!g_signatureCount)
+  if (g_signatureCount == nullptr) {
     g_signatureCount = S.getPointer("signatures");
+  }
 
   DNSKEYRecordContent drc = dpk.getDNSKEY();
-  const std::shared_ptr<DNSCryptoKeyEngine>& rc = dpk.getKey();
+  const std::shared_ptr<DNSCryptoKeyEngine>& engine = dpk.getKey();
   rrc.d_tag = drc.getTag();
   rrc.d_algorithm = drc.d_algorithm;
 
@@ -79,19 +80,18 @@ static void fillOutRRSIG(DNSSECPrivateKey& dpk, const DNSName& signQName, RRSIGR
   bool doCache = true;
   if (doCache) {
     auto signatures = g_signatures.read_lock();
-    signaturecache_t::const_iterator iter = signatures->find(lookup);
-    if (iter != signatures->end()) {
+    if (const auto iter = signatures->find(lookup); iter != signatures->end()) {
       rrc.d_signature=iter->second;
       return;
     }
     // else cerr<<"Miss!"<<endl;
   }
 
-  rrc.d_signature = rc->sign(msg);
+  rrc.d_signature = engine->sign(msg);
   (*g_signatureCount)++;
   if(doCache) {
     /* we add some jitter here so not all your secondaries start pruning their caches at the very same millisecond */
-    int weekno = (time(nullptr) - dns_random(3600)) / (86400*7);  // we just spent milliseconds doing a signature, microsecond more won't kill us
+    time_t weekno = (time(nullptr) - dns_random(3600)) / static_cast<time_t>(86400*7);  // we just spent milliseconds doing a signature, microsecond more won't kill us
     const static int maxcachesize=::arg().asNum("max-signature-cache-entries", INT_MAX);
 
     signaturecache_t oldsigs;


### PR DESCRIPTION
### Short description
As observed in #12899, using a large DNSSEC signature cache has the drawback of cache maintainance being sometimes costly, since it is performed while holding an exclusive lock on the cache.

While a proper fix to that issue is to improve the maintainance logic, a cheap fruit consists of performing the actual entries cleanup (which will invoke a lot of destructors and memory management functions) outside of the lock, after exchanging the cache contents with shiny new empty contents.

(Also I do not dare removing the "blunt but effective" comment yet)

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code (admittedly not much, forcing several small cache sizes for tests)
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
