### PR TITLE
pdnsutil: clarify provenance of default TTL

### DIFF
--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -245,7 +245,7 @@ ZONE MANIPULATION COMMANDS
 add-record *ZONE* *NAME* *TYPE* [*TTL*] *CONTENT*
 
     Add one or more records of *NAME* and *TYPE* to *ZONE* with *CONTENT*
-    and optional *TTL*. If *TTL* is not set, default will be used.
+    and optional *TTL*. If *TTL* is not set, the configured *default-ttl* will be used.
 
 add-autoprimary *IP* *NAMESERVER* [*ACCOUNT*]
 


### PR DESCRIPTION
### Short description
Clarify where default TTL on `add-record` comes from

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
