### PR TITLE
minor tsan fixes

### DIFF
--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -148,7 +148,7 @@ private:
   uint64_t d_maxEntries{0};
   size_t d_mapscount;
   time_t d_lastclean; // doesn't need to be atomic
-  unsigned long d_nextclean{4096};
+  AtomicCounter  d_nextclean{4096};
   unsigned int d_cleaninterval{4096};
   uint32_t d_ttl{0};
   bool d_cleanskipped{false};

--- a/pdns/auth-querycache.hh
+++ b/pdns/auth-querycache.hh
@@ -118,7 +118,7 @@ private:
 
   uint64_t d_maxEntries{0};
   time_t d_lastclean; // doesn't need to be atomic
-  unsigned long d_nextclean{4096};
+  AtomicCounter d_nextclean{4096};
   unsigned int d_cleaninterval{4096};
   bool d_cleanskipped{false};
 


### PR DESCRIPTION
### Short description
Make a few more variables atomic, to prevent data races between threads when they are being updated and appease TSan.
Fixes: #11816 

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] checked for commas-vs-dot typos in my changes