### PR TITLE
Increase zone serial number after zone key operations

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1338,7 +1338,9 @@ static void apiZoneCryptokeysPostProcessing(ZoneData& zoneData)
 
       zoneData.domainInfo.backend->getDomainMetadataOne(zoneData.zoneName, "SOA-EDIT-API", soa_edit_api_kind);
       zoneData.domainInfo.backend->getDomainMetadataOne(zoneData.zoneName, "SOA-EDIT", soa_edit_kind);
+      zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, UnknownDomainID);
       updateZoneSerial(zoneData.domainInfo, soaData, soa_edit_api_kind, soa_edit_kind);
+      zoneData.domainInfo.backend->commitTransaction();
     }
   }
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2441,6 +2441,9 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
 
     // edit SOA (if needed)
     if (!zone_disabled && !soa_edit_api_kind.empty() && !soa_edit_done) {
+      // return old serial in headers, before changing it
+      resp->headers["X-PDNS-Old-Serial"] = std::to_string(soaData.serial);
+
       DNSResourceRecord resourceRecord;
       if (makeIncreasedSOARecord(soaData, soa_edit_api_kind, soa_edit_kind, resourceRecord)) {
         if (!domainInfo.backend->replaceRRSet(domainInfo.id, resourceRecord.qname, resourceRecord.qtype, vector<DNSResourceRecord>(1, resourceRecord))) {
@@ -2448,9 +2451,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
         }
       }
 
-      // return old and new serials in headers
-      resp->headers["X-PDNS-Old-Serial"] = std::to_string(soaData.serial);
-      fillSOAData(resourceRecord.content, soaData);
+      // return new serial in headers
       resp->headers["X-PDNS-New-Serial"] = std::to_string(soaData.serial);
     }
   }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -298,13 +298,15 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             ]
         }
         payload = {'rrsets': [rrset]}
-        self.session.patch(
+        r = self.session.patch(
             self.url("/api/v1/servers/localhost/zones/" + data['id']),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
         data = self.get_zone(data['id'])
         soa_serial = get_first_rec(data, name, 'SOA')['content'].split(' ')[2]
         self.assertEqual(soa_serial[-2:], '02')
+        self.assertEqual(r.headers['X-PDNS-Old-Serial'][-2:], '01')
+        self.assertEqual(r.headers['X-PDNS-New-Serial'][-2:], '02')
 
     def test_create_zone_with_records(self):
         name = unique_zone_name()


### PR DESCRIPTION
### Short description
As mentioned in #11733, operations on zone keys on primary zone should cause a zone serial number increase if the zone has been configured to do so (`SOA-EDIT-API` metadata).

While working on this, I noticed that the feature adding the previous and new serial numbers in HTTP response headers had been broken, and was returning the new value in both headers, because the "old" header was set up from an already updated value. Oops. (I have added a test for this)

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] acknowledged that making a single PR to address two different issues makes me a bad person