### PR TITLE
Better LMDB error information

### DIFF
--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -698,7 +698,7 @@ public:
       }
 
       if (rc != 0 && rc != MDB_NOTFOUND) {
-        throw std::runtime_error("error during get_multi");
+        throw std::runtime_error("error during get_multi" + MDBError(rc));
       }
     };
 

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -453,7 +453,7 @@ public:
           d_end = true;
         }
         else if(rc != 0) {
-          throw std::runtime_error("in genoperator, " + std::string(mdb_strerror(rc)));
+          throw std::runtime_error("in genoperator, " + MDBError(rc));
         }
         else if(!d_prefix.empty() &&
           // d_key.getNoStripHeader<std::string>().rfind(d_prefix, 0)!=0 &&


### PR DESCRIPTION
### Short description
This PR makes sure that exceptions raised because of LMDB errors carry the LMDB error information, rather than have us use our crystal balls to figure out that.

The support contract prices for crystal balls are becoming closer and closer to unaffordable nowadays, so we have to take action to reduce the wear on ours.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
