### PR TITLE
Stop listing the trusted keys at the end of tests

### DIFF
--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -326,8 +326,6 @@ dotests () {
         ./toxml
         ./totar
 
-        cat ./trustedkeys
-
         if [ -s "./failed_tests" ]
         then
                 for t in `cat failed_tests`


### PR DESCRIPTION
### Short description
In #2979, the complete list of keys was displayed at the end of tests, but this can be considered a leftover debug bit. However it makes the "N out N tests (100%) tests passed" line less visible when running tests. So let's remove it before this change turns 10 and starts throwing teenager tantrums.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
