### PR TITLE
dnsdist: add a count to track the number of query restarts

### DIFF
--- a/pdns/dnsdistdist/dnsdist-idstate.hh
+++ b/pdns/dnsdistdist/dnsdist-idstate.hh
@@ -168,6 +168,7 @@ struct InternalQueryState
   uint16_t cacheFlags{0}; // DNS flags as sent to the backend // 2
   uint16_t udpPayloadSize{0}; // Max UDP payload size from the query // 2
   dnsdist::Protocol protocol; // 1
+  uint8_t restartCount{0}; // 1
   bool ednsAdded{false};
   bool ecsAdded{false};
   bool skipCache{false};

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
@@ -656,6 +656,7 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
     dnsResponse.asynchronous = true;
     dnsResponse.getMutableData() = *dnsResponse.ids.d_packet;
     dnsResponse.ids.d_proxyProtocolPayloadSize = 0;
+    dnsResponse.ids.restartCount++;
     auto query = dnsdist::getInternalQueryFromDQ(dnsResponse, false);
     return dnsdist::queueQueryResumptionEvent(std::move(query));
   });
@@ -666,6 +667,10 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
 
   luaCtx.registerFunction<bool (DNSResponse::*)()>("getStaleCacheHit", [](DNSResponse& dnsResponse) {
     return dnsResponse.ids.staleCacheHit;
+  });
+
+  luaCtx.registerFunction<uint8_t (DNSResponse::*)()>("getRestartCount", [](DNSResponse& dnsResponse) {
+    return dnsResponse.ids.restartCount;
   });
 #endif /* DISABLE_NON_FFI_DQ_BINDINGS */
 }

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -163,6 +163,7 @@ void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dr,
 void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dr, uint16_t qtype) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dr, const char* initialName, size_t initialNameSize) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsresponse_get_stale_cache_hit(const dnsdist_ffi_dnsresponse_t* dnsResponse) __attribute__ ((visibility ("default")));
+uint8_t dnsdist_ffi_dnsresponse_get_restart_count(const dnsdist_ffi_dnsresponse_t* dnsResponse) __attribute__ ((visibility ("default")));
 
 bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsresponse_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -845,6 +845,11 @@ bool dnsdist_ffi_dnsresponse_get_stale_cache_hit(const dnsdist_ffi_dnsresponse_t
   return dnsResponse->dr->ids.staleCacheHit;
 }
 
+uint8_t dnsdist_ffi_dnsresponse_get_restart_count(const dnsdist_ffi_dnsresponse_t* dnsResponse)
+{
+  return dnsResponse->dr->ids.restartCount;
+}
+
 bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs)
 {
   try {

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -450,6 +450,12 @@ DNSResponse object
 
     Get the indicator of whether the cache lookup hit a stale entry.
 
+  .. method:: DNSResponse:getRestartCount() -> uint8_t
+
+    .. versionadded:: 2.0.0
+
+    Get the current restart count, useful when the number of restart attempts is to be checked.
+
   .. method:: DNSResponse:editTTLs(func)
 
     The function ``func`` is invoked for every entry in the answer, authority and additional section.

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -450,7 +450,7 @@ DNSResponse object
 
     Get the indicator of whether the cache lookup hit a stale entry.
 
-  .. method:: DNSResponse:getRestartCount() -> uint8_t
+  .. method:: DNSResponse:getRestartCount() -> int
 
     .. versionadded:: 2.0.0
 

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -449,6 +449,10 @@ BOOST_AUTO_TEST_CASE(test_Response)
   {
     BOOST_CHECK_EQUAL(dnsdist_ffi_dnsresponse_get_stale_cache_hit(&lightDR), false);
   }
+
+  {
+    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsresponse_get_restart_count(&lightDR), 0);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_Server)

--- a/regression-tests.dnsdist/test_RestartQuery.py
+++ b/regression-tests.dnsdist/test_RestartQuery.py
@@ -153,3 +153,89 @@ class TestRestartProxyProtocolThenNot(DNSDistTest):
             (receivedProxyPayload, receivedDNSData) = fromProxyQueue.get(True, 2.0)
             self.assertTrue(receivedProxyPayload)
             self.assertTrue(receivedDNSData)
+
+class QueryCounter:
+
+    def __init__(self, name):
+        self.name = name
+        self.qcnt = 0
+
+    def __call__(self):
+        return self.qcnt
+
+    def create_cb(self):
+        def callback(request):
+            self.qcnt += 1
+            response = dns.message.make_response(request)
+            response.set_rcode(dns.rcode.REFUSED)
+            return response.to_wire()
+        return callback
+
+class TestRestartCount(DNSDistTest):
+
+    _queryCounts = {}
+
+    _testServer1Port = pickAvailablePort()
+    _testServer2Port = pickAvailablePort()
+    _testServer3Port = pickAvailablePort()
+    _testServer4Port = pickAvailablePort()
+    _serverPorts = [_testServer1Port, _testServer2Port, _testServer3Port, _testServer4Port]
+    _config_params = ['_testServer1Port', '_testServer2Port', '_testServer3Port', '_testServer4Port']
+    _config_template = """
+    MaxRestart = 2
+    s0 = newServer{name="s0", address="127.0.0.1:%s"}
+    s0:setUp()
+    s0:addPool("pool0")
+    s1 = newServer{name="s1", address="127.0.0.1:%s"}
+    s1:setUp()
+    s1:addPool("pool1")
+    s2 = newServer{name="s2", address="127.0.0.1:%s"}
+    s2:setUp()
+    s2:addPool("pool2")
+    s3 = newServer{name="s3", address="127.0.0.1:%s"}
+    s3:setUp()
+    s3:addPool("pool3")
+    function makeQueryRestartable(dq) dq:setRestartable() return DNSAction.None end
+    addAction(AllRule(), LuaAction(makeQueryRestartable))
+    function restartQuery(dr)
+        if dr:getRestartCount() < MaxRestart then
+            dr.pool = "pool"..tostring(dr:getRestartCount() + 1)
+            dr:restart()
+        else
+            return DNSResponseAction.ServFail
+        end
+        return DNSResponseAction.None
+    end
+    addResponseAction(RCodeRule(DNSRCode.REFUSED), LuaResponseAction(restartQuery))
+    addAction(AllRule(), PoolAction("pool0"))
+    """
+    @classmethod
+    def startResponders(cls):
+        print("Launching responders..")
+
+        for i, name in enumerate(['s0', 's1', 's2', 's3']):
+            cls._queryCounts[name] = QueryCounter(name)
+            cb = cls._queryCounts[name].create_cb()
+            responder = threading.Thread(name=name, target=cls.UDPResponder, args=[cls._serverPorts[i], cls._toResponderQueue, cls._fromResponderQueue, False, cb])
+            responder.daemon = True
+            responder.start()
+
+    def testDefault(self):
+
+        numberOfQueries = 100
+        name = 'restart.count.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.SERVFAIL)
+
+        # send 100 queries
+        for _ in range(numberOfQueries):
+            (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+        # if restart count is correct, s0/s1/s2 would get all the queies while s3 would get none
+        self.assertEqual(self._queryCounts['s0'](), numberOfQueries)
+        self.assertEqual(self._queryCounts['s1'](), numberOfQueries)
+        self.assertEqual(self._queryCounts['s2'](), numberOfQueries)
+        self.assertEqual(self._queryCounts['s3'](),  0)

--- a/regression-tests.dnsdist/test_RestartQuery.py
+++ b/regression-tests.dnsdist/test_RestartQuery.py
@@ -238,4 +238,4 @@ class TestRestartCount(DNSDistTest):
         self.assertEqual(self._queryCounts['s0'](), numberOfQueries)
         self.assertEqual(self._queryCounts['s1'](), numberOfQueries)
         self.assertEqual(self._queryCounts['s2'](), numberOfQueries)
-        self.assertEqual(self._queryCounts['s3'](),  0)
+        self.assertEqual(self._queryCounts['s3'](), 0)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Sometimes it is useful to keep tracking the total number of query restarts. This is to add a restartCount field to the query which gets incremented everytime it is restarted. The enhancement also provides an interface for lua action to retrieve this count for any further needed checks.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
