### PR TITLE
Provide an IP_OFFMASK value for systems lacking it

### DIFF
--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -43,6 +43,12 @@
 #include "dnsrecords.hh"
 #include "statnode.hh"
 
+#if !defined(IP_OFFMASK)
+// Solaris and derivatives do not define IP_OFFMASK in <netinet/ip.h>.
+// We can't even use ~(IP_RF | IP_DF | IP_MF) as it doesn't define IP_RF either.
+#define IP_OFFMASK 0x1fff /* mask for fragmenting bits */
+#endif
+
 namespace po = boost::program_options;
 po::variables_map g_vm;
 


### PR DESCRIPTION
### Short description
Trivial boring one-liner-in-spirit change to fix #8060 for people wanting to run PowerDNS on Solaris or its derivatives.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
