### PR TITLE
Lua GeoIPQueryAttribute documentation update

### DIFF
--- a/docs/appendices/backend-writers-guide.rst
+++ b/docs/appendices/backend-writers-guide.rst
@@ -575,7 +575,7 @@ The following excerpt from the DNSBackend shows the relevant functions:
 
 The mentioned DomainInfo struct looks like this:
 
-.. cpp:struct:: DomainInfo
+.. cpp:class:: DomainInfo
 
 .. cpp:member:: domainid_t DomainInfo::id
 

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -501,7 +501,8 @@ Helper functions
   :param string address: The IP address to lookup.
   :param int attr: The attribute identifier for the lookup.
 
-  You can use the following constants as the attribute:
+  From version 5.0.0 onwards, instead of the numerical value of the attribute
+  identifier, you can use the following constants as the attribute:
 
   - `GeoIPQueryAttribute.ASn`
   - `GeoIPQueryAttribute.City`


### PR DESCRIPTION
### Short description
This documents that symbolic constants for GeoIPQueryAttribute are not available to Lua records in versions predating 5.0.0.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
