### PR TITLE
doc(dnsdist): remove superfluous code block in YAML config

### DIFF
--- a/pdns/dnsdistdist/dnsdist-settings-documentation-generator.py
+++ b/pdns/dnsdistdist/dnsdist-settings-documentation-generator.py
@@ -144,7 +144,6 @@ Note that Lua directives that can be used at runtime are always available via th
 
 A YAML configuration file contains several sections, that are described below.
 
-.. code-block:: yaml\n
 '''
 
     objects = get_objects(def_file)

--- a/pdns/dnsdistdist/docs/reference/yaml-settings.rst
+++ b/pdns/dnsdistdist/docs/reference/yaml-settings.rst
@@ -16,8 +16,6 @@ Note that Lua directives that can be used at runtime are always available via th
 
 A YAML configuration file contains several sections, that are described below.
 
-.. code-block:: yaml
-
 .. _yaml-settings-GlobalConfiguration:
 
 GlobalConfiguration


### PR DESCRIPTION
### Short description

Browsing through the dnsdist docs, I noticed that there an empty code block in the new YAML config page for dnsdist.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
