### PR TITLE
meson: Pick -lcrypto up from the spot defined by dep_libcrypto

### DIFF
--- a/meson/libcrypto/meson.build
+++ b/meson/libcrypto/meson.build
@@ -44,8 +44,7 @@ if not dep_libcrypto.found()
     have = cxx.has_header(dir / 'include/openssl/crypto.h')
     if have
       dep_libcrypto = declare_dependency(
-        compile_args: ['-L' + dir / 'lib'],
-        link_args: ['-lcrypto'],
+        link_args: ['-L' + dir / 'lib', '-lcrypto'],
         include_directories: include_directories(dir / 'include', is_system: false),
       )
       break

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -5,7 +5,7 @@ opt_libssl_dir = get_option('tls-libssl-dir')
 if opt_libssl_dir != ''
   dep_libssl = declare_dependency(
     include_directories: [opt_libssl_dir / 'include'],
-    link_args: ['-L' + opt_libssl_dir / 'lib', '-lssl', '-lcrypto'],
+    link_args: ['-L' + opt_libssl_dir / 'lib', '-lssl'],
   )
 else
   dep_libssl = dependency('libssl', required: opt_libssl)


### PR DESCRIPTION
This fixes a case where we also had double -lcrypto on the command line: one from dep_libssl, and one from dep_libcrypto.

Also avoid a bunch of warning: as compile commands don't take -L:
c++: warning: argument unused during compilation: '-L/usr/local/eboringssl/lib' [-Wunused-command-line -argument]

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
