### PR TITLE
rec: introduce aliases for camelCase field names

### DIFF
--- a/pdns/recursordist/rec-rust-lib/docs-new-preamble-in.rst
+++ b/pdns/recursordist/rec-rust-lib/docs-new-preamble-in.rst
@@ -529,7 +529,7 @@ As of version 5.2.0, a forwarding catalog zone entry is defined as:
        recurse: bool, default false
        notify_allowed: bool, default false
 
-.. versionchanged:: 5.3.0 The aliases ``max_received_bytes``, ``local_address``, ``axfr_timeout`` have been introduced.
+.. versionchanged:: 5.3.0 The aliases ``zone_size_hint``, ``max_received_bytes``, ``local_address``, ``axfr_timeout`` have been introduced.
 
 While this setting has no equivalent old-style Lua configuration, it cannot appear together with :ref:`setting-lua-config-file` being set.
 If you want to use catalog zones to define forwards, you need to convert existing Lua configuration to YAML format.

--- a/pdns/recursordist/rec-rust-lib/rust-bridge-in.rs
+++ b/pdns/recursordist/rec-rust-lib/rust-bridge-in.rs
@@ -263,7 +263,7 @@ pub struct ApiZones {
 pub struct XFR {
     #[serde(default, skip_serializing_if = "crate::is_default")]
     addresses: Vec<String>,
-    #[serde(default, skip_serializing_if = "crate::is_default")]
+    #[serde(default, skip_serializing_if = "crate::is_default", alias = "zone_size_hint")]
     zoneSizeHint: u32,
     #[serde(default, skip_serializing_if = "crate::is_default")]
     tsig: TSIGTriplet,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

These fields originate from the Lua config file and were introduced in the YAML code using the exact camelCase name. As the rest of the fields names use snake_case, introduce aliases for the camelCase fields.

Fixes #15059 (manually, as the fields affected are manually defined as well).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
