### PR TITLE
better rm in LMDB #2

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -941,7 +941,7 @@ public:
 #endif
 
 #ifndef DNSDIST
-  void del(int flags=0)
+  void del()
   {
     MDBOutVal key, val;
 
@@ -972,7 +972,7 @@ public:
     }
     else {
       // do a normal delete
-      if (int rc_del = mdb_cursor_del(*this, flags); rc_del != 0) {
+      if (int rc_del = mdb_cursor_del(*this, 0); rc_del != 0) {
         throw std::runtime_error("deleting data: " + std::string(mdb_strerror(rc_del)));
       }
     }

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -822,7 +822,7 @@ public:
         T value;
         deserializeFromBuffer(data.get<std::string>(), value);
         clearIndex(key.get<uint32_t>(), value);
-        cursor.del();
+        cursor.del(key);
       }
     }
 

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -158,10 +158,7 @@ struct LMDBIndexOps
     auto scombined = makeCombinedKey(keyConv(d_parent->getMember(type)), idVal);
     MDBInVal combined(scombined);
 
-    int errCode = txn->del(d_idx, combined);
-    if (errCode != 0) {
-      throw std::runtime_error("Error deleting from index: " + std::string(mdb_strerror(errCode)));
-    }
+    txn->del(d_idx, combined);
   }
 
   void openDB(std::shared_ptr<MDBEnv>& env, string_view str, int flags)

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1120,7 +1120,7 @@ void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, uint16_t qtype,
   if (cursor.prefix(match, key, val) == 0) {
     do {
       if (qtype == QType::ANY || compoundOrdername::getQType(key.getNoStripHeader<StringView>()) == qtype) {
-        cursor.del();
+        cursor.del(key);
       }
     } while (cursor.next(key, val) == 0);
   }
@@ -1318,7 +1318,7 @@ bool LMDBBackend::replaceRRSet(domainid_t domain_id, const DNSName& qname, const
     match = co(domain_id, relative, qt.getCode());
     // There should be at most one exact match here.
     if (cursor.find(match, key, val) == 0) {
-      cursor.del();
+      cursor.del(key);
     }
   }
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -685,8 +685,6 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
 
   string syncMode = toLower(getArg("sync-mode"));
 
-  d_random_ids = mustDo("random-ids");
-
   if (syncMode == "nosync")
     d_asyncFlag = MDB_NOSYNC;
   else if (syncMode == "nometasync")
@@ -704,9 +702,6 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     throw std::runtime_error(std::string("Unable to parse the 'map-size' LMDB value: ") + e.what());
   }
 
-  LMDBLS::s_flag_deleted = mustDo("flag-deleted");
-  d_handle_dups = false;
-
   if (mustDo("lightning-stream")) {
     d_random_ids = true;
     d_handle_dups = true;
@@ -715,6 +710,11 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     if (atoi(getArg("shards").c_str()) != 1) {
       throw std::runtime_error(std::string("running with Lightning Stream support requires shards=1"));
     }
+  }
+  else {
+    d_random_ids = mustDo("random-ids");
+    d_handle_dups = false;
+    LMDBLS::s_flag_deleted = mustDo("flag-deleted");
   }
 
   bool opened = false;


### PR DESCRIPTION
### Short description
The focus of this PR is to simplify the logic of LMDB deletions when running in `flag-deleted` mode. In this mode, deletions are not performed, specific deletion markers are put as the data instead.

Therefore:
- it is not necessary to delete existing data before writing the marker, the marker will replace the existing data (if any) anyway.
- similarly, it is not necessary to check for data existence before writing the marker.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
