### PR TITLE
Rewrite pdnsutil in klingon

### DIFF
--- a/docs/appendices/backend-writers-guide.rst
+++ b/docs/appendices/backend-writers-guide.rst
@@ -166,7 +166,7 @@ furthermore, only about its A record:
 
       bool list(const string &target, domainid_t id)
       {
-        return false; // we don't support pdnsutil list-zone or AXFR
+        return false; // we don't support pdnsutil zone list or AXFR
       }
 
       void lookup(const QType &type, const string &qdomain, domainid_t zoneId, DNSPacket *p)
@@ -353,7 +353,7 @@ Methods
   the backend. The currently used capabilities are:
 
 * `CAP_DNSSEC`     Backend implements :ref:`backend-dnssec`.
-* `CAP_LIST`       Backend implements `list`, for AXFR or `pdnsutil list-zone`
+* `CAP_LIST`       Backend implements `list`, for AXFR or `pdnsutil zone list`
 
 .. cpp:function:: void DNSBackend::lookup(const QType &qtype, const string &qdomain, domainid_t zoneId, DNSPacket *pkt=nullptr)
 
@@ -928,7 +928,7 @@ contain `CAP_DNSSEC` if that backend supports DNSSEC.
 
 .. cpp:function:: virtual bool feedEnts(domainid_t domain_id, map<DNSName,bool> &nonterm)
 
-  This method is used by ``pdnsutil rectify-zone`` to populate missing non-terminals. This is used when you have, say, record like _sip._upd.example.com, but no _udp.example.com. PowerDNS requires that there exists a non-terminal in between, and this instructs you to add one.
+  This method is used by ``pdnsutil zone rectify`` to populate missing non-terminals. This is used when you have, say, record like _sip._upd.example.com, but no _udp.example.com. PowerDNS requires that there exists a non-terminal in between, and this instructs you to add one.
 
 .. cpp:function:: virtual bool feedEnts3(domainid_t domain_id, const DNSName &domain, map<DNSName,bool> &nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow)
 

--- a/docs/appendices/types.rst
+++ b/docs/appendices/types.rst
@@ -9,7 +9,8 @@ grouped.
   Host names and the MNAME of a SOA records are NEVER
   terminated with a '.' in PowerDNS storage! If a trailing '.' is present
   it will inevitably cause problems, problems that may be hard to debug.
-  Use ``pdnsutil zone check`` to validate your zone data.
+  Use ``pdnsutil zone check`` (or ``pdnsutil check-zone`` prior to version
+  5.0) to validate your zone data.
 
 .. note::
   Whenever the storage format is mentioned, this relates only to the way

--- a/docs/appendices/types.rst
+++ b/docs/appendices/types.rst
@@ -9,7 +9,7 @@ grouped.
   Host names and the MNAME of a SOA records are NEVER
   terminated with a '.' in PowerDNS storage! If a trailing '.' is present
   it will inevitably cause problems, problems that may be hard to debug.
-  Use ``pdnsutil check-zone`` to validate your zone data.
+  Use ``pdnsutil zone check`` to validate your zone data.
 
 .. note::
   Whenever the storage format is mentioned, this relates only to the way

--- a/docs/backends/generic-sql.rst
+++ b/docs/backends/generic-sql.rst
@@ -25,9 +25,9 @@ Native operation
 
 To add a domain, issue the following::
 
-    pdnsutil create-zone example.com
+    pdnsutil zone create example.com
 
-Records can now be added using ``pdnsutil add-record`` or ``pdnsutil edit-zone``.
+Records can now be added using ``pdnsutil rrset add`` or ``pdnsutil zone edit``.
 
 Secondary operation
 ^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ Secondary operation
 These backends are fully secondary capable. To become a secondary of the
 'example.com' domain, using 198.51.100.6 as the primary execute this::
 
-   pdnsutil create-secondary-zone example.com 198.51.100.6
+   pdnsutil zone create-secondary example.com 198.51.100.6
 
 And wait a while for PowerDNS to pick up the addition - which happens
 within one minute (this is determined by the
@@ -64,8 +64,8 @@ seconds by default.
 
 PowerDNS has support for multiple primaries per zone, and also port numbers for these primaries::
 
-   pdnsutil create-secondary-zone example.com 198.51.100.6 2001:0DB8:15:4AF::4
-   pdnsutil create-secondary-zone example.net 198.51.100.20:5301 '[2001:0DB8:11:6E::4]:54'
+   pdnsutil zone create secondary example.com 198.51.100.6 2001:0DB8:15:4AF::4
+   pdnsutil zone create secondary example.net 198.51.100.20:5301 '[2001:0DB8:11:6E::4]:54'
 
 Autoprimary operation
 ^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ Autoprimary operation
 To configure a :ref:`autoprimary <autoprimary-operation>` with IP address 203.0.113.53 which lists this
 installation as 'autosecondary.example.com', issue the following::
 
-    pdnsutil add-autoprimary 203.0.113.53 autosecondary.example.com internal
+    pdnsutil autoprimary add 203.0.113.53 autosecondary.example.com internal
 
 From now on, valid notifies from 203.0.113.53 for which the zone lists an NS record
 containing 'autosecondary.example.com' will lead to the provisioning of a
@@ -88,8 +88,8 @@ of serial changes. Raising the serial number of a domain suffices to
 trigger PowerDNS to send out notifications. To configure a domain for
 primary operation instead of the default native replication, issue::
 
-    pdnsutil create-zone example.com
-    pdnsutil set-kind example.com MASTER
+    pdnsutil zone create example.com
+    pdnsutil zone set-kind example.com MASTER
 
 .. _generic-sql-disabled-data:
 
@@ -127,7 +127,7 @@ Rules for filling out DNSSEC fields
 
 Two additional fields in the 'records' table are important: 'auth' and
 'ordername'. These fields are set correctly on an incoming zone
-transfer, and also by running ``pdnsutil rectify-zone``.
+transfer, and also by running ``pdnsutil zone rectify``.
 
 The 'auth' field should be set to '1' for data for which the zone itself
 is authoritative, which includes the SOA record and its own NS records.
@@ -152,7 +152,7 @@ www' as its ordername.
 
 In 'NSEC3' non-narrow mode, the ordername should contain a lowercase
 base32hex encoded representation of the salted & iterated hash of the
-full record name. ``pdnsutil hash-zone-record zone record`` can be used
+full record name. ``pdnsutil rrset hash zone record`` can be used
 to calculate this hash.
 
 In addition, PowerDNS fully supports empty non-terminals. If you have a
@@ -227,7 +227,7 @@ is!
 DNSSEC queries
 ^^^^^^^^^^^^^^
 
-These queries are used by e.g. ``pdnsutil rectify-zone``. Make sure to
+These queries are used by e.g. ``pdnsutil zone rectify``. Make sure to
 read :ref:`rules-for-filling-out-dnssec-fields`
 if you wish to calculate ordername and auth without using pdns-rectify.
 

--- a/docs/backends/generic-sql.rst
+++ b/docs/backends/generic-sql.rst
@@ -27,7 +27,13 @@ To add a domain, issue the following::
 
     pdnsutil zone create example.com
 
-Records can now be added using ``pdnsutil rrset add`` or ``pdnsutil zone edit``.
+or, prior to version 5.0::
+
+    pdnsutil create-zone example.com
+
+Records can now be added using ``pdnsutil rrset add`` or ``pdnsutil zone edit``
+(respectively ``pdnsutil add-record`` and ``pdnsutil edit-zone`` prior to
+version 5.0).
 
 Secondary operation
 ^^^^^^^^^^^^^^^^^^^
@@ -36,6 +42,10 @@ These backends are fully secondary capable. To become a secondary of the
 'example.com' domain, using 198.51.100.6 as the primary execute this::
 
    pdnsutil zone create-secondary example.com 198.51.100.6
+
+or, prior to version 5.0::
+
+   pdnsutil create-secondary-zone example.com 198.51.100.6
 
 And wait a while for PowerDNS to pick up the addition - which happens
 within one minute (this is determined by the
@@ -67,6 +77,11 @@ PowerDNS has support for multiple primaries per zone, and also port numbers for 
    pdnsutil zone create secondary example.com 198.51.100.6 2001:0DB8:15:4AF::4
    pdnsutil zone create secondary example.net 198.51.100.20:5301 '[2001:0DB8:11:6E::4]:54'
 
+or, prior to version 5.0::
+
+   pdnsutil create-secondary-zone example.com 198.51.100.6 2001:0DB8:15:4AF::4
+   pdnsutil create-secondary-zone example.net 198.51.100.20:5301 '[2001:0DB8:11:6E::4]:54'
+
 Autoprimary operation
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -74,6 +89,10 @@ To configure a :ref:`autoprimary <autoprimary-operation>` with IP address 203.0.
 installation as 'autosecondary.example.com', issue the following::
 
     pdnsutil autoprimary add 203.0.113.53 autosecondary.example.com internal
+
+or, prior to version 5.0::
+
+    pdnsutil add-autoprimary 203.0.113.53 autosecondary.example.com internal
 
 From now on, valid notifies from 203.0.113.53 for which the zone lists an NS record
 containing 'autosecondary.example.com' will lead to the provisioning of a
@@ -90,6 +109,11 @@ primary operation instead of the default native replication, issue::
 
     pdnsutil zone create example.com
     pdnsutil zone set-kind example.com MASTER
+
+or, prior to version 5.0::
+
+    pdnsutil create-zone example.com
+    pdnsutil set-kind example.com MASTER
 
 .. _generic-sql-disabled-data:
 
@@ -127,7 +151,8 @@ Rules for filling out DNSSEC fields
 
 Two additional fields in the 'records' table are important: 'auth' and
 'ordername'. These fields are set correctly on an incoming zone
-transfer, and also by running ``pdnsutil zone rectify``.
+transfer, and also by running ``pdnsutil zone rectify`` (``pdnsutil
+rectify-zone`` prior to version 5.0).
 
 The 'auth' field should be set to '1' for data for which the zone itself
 is authoritative, which includes the SOA record and its own NS records.
@@ -152,8 +177,9 @@ www' as its ordername.
 
 In 'NSEC3' non-narrow mode, the ordername should contain a lowercase
 base32hex encoded representation of the salted & iterated hash of the
-full record name. ``pdnsutil rrset hash zone record`` can be used
-to calculate this hash.
+full record name. ``pdnsutil rrset hash zone record`` (``pdnsutil
+hash-zone-record zone record`` prior to version 5.0) can be used to calculate
+this hash.
 
 In addition, PowerDNS fully supports empty non-terminals. If you have a
 zone example.com, and a host a.b.c.example.com in it, rectify-zone (and
@@ -227,7 +253,8 @@ is!
 DNSSEC queries
 ^^^^^^^^^^^^^^
 
-These queries are used by e.g. ``pdnsutil zone rectify``. Make sure to
+These queries are used by e.g. ``pdnsutil zone rectify`` (``pdnsutil
+rectify-zone`` prior to version 5.0). Make sure to
 read :ref:`rules-for-filling-out-dnssec-fields`
 if you wish to calculate ordername and auth without using pdns-rectify.
 

--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -152,4 +152,4 @@ LMDB Structure
 --------------
 
 PowerDNS will create the database structure, no need to manually create the database schema.
-Also, it is not possible to directly query the LMDB DB, so recommendation is to use either the API, or pdnsutil.
+Also, it is not possible to directly query the LMDB DB, so recommendation is to use either the API, or :doc:`pdnsutil <../manpages/pdnsutil.1>`.

--- a/docs/backends/pipe.rst
+++ b/docs/backends/pipe.rst
@@ -291,7 +291,7 @@ values. The default value for scopebits is 0. The default for auth is 1
 Direct backend commands
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-With abi-version 5 you can use :doc:`backend-cmd <../dnssec/pdnsutil>` for
+With abi-version 5 you can use :doc:`backend-cmd <../manpages/pdnsutil.1>` for
 executing commands on your backend. PowerDNS will use the following
 query/answer format:
 

--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -243,7 +243,7 @@ Response:
 ~~~~~~~~~~~~~
 
 This method is similar to :ref:`remote-lookup`, but also returns disabled
-records. It allows for an extra optional parameter, ``include_disabled`` which, 
+records. It allows for an extra optional parameter, ``include_disabled`` which,
 if present and set to false, will only return non-disabled records (in which
 case, the behaviour is equivalent to the ``lookup`` method.)
 
@@ -285,7 +285,7 @@ Response (split into lines for ease of reading)
       {"qtype":"MX", "qname":"example.com", "content":"10 mx1.example.com.", "ttl": 60},
       {"qtype":"A", "qname":"www.example.com", "content":"203.0.113.2", "ttl": 60},
       {"qtype":"A", "qname":"ns1.example.com", "content":"192.0.2.2", "ttl": 60},
-      {"qtype":"A", "qname":"mx1.example.com", "content":"192.0.2.3", "ttl": 60} 
+      {"qtype":"A", "qname":"mx1.example.com", "content":"192.0.2.3", "ttl": 60}
     ]}
 
 Example HTTP/RPC
@@ -473,7 +473,7 @@ Query:
 .. code-block:: http
 
     PATCH /dnsapi/setdomainmetadata/example.com/PRESIGNED HTTP/1.1
-    Content-Type: application/x-www-form-urlencoded 
+    Content-Type: application/x-www-form-urlencoded
     Content-Length: 12
 
     value[]=YES&
@@ -1217,7 +1217,8 @@ Response:
 ``feedEnts``
 ~~~~~~~~~~~~
 
-This method is used by ``pdnsutil zone rectify`` to populate missing
+This method is used by ``pdnsutil zone rectify`` (``pdnsutil rectify-zone``
+prior to version 5.0) to populate missing
 non-terminals. This is used when you have, say, record like
 _sip._upd.example.com, but no _udp.example.com. PowerDNS requires
 that there exists a non-terminal in between, and this instructs you to
@@ -1498,7 +1499,7 @@ Response:
 ~~~~~~~~~~~~~~~~~~~~
 
 Can be used to send arbitrary commands to your backend using
-:doc:`../dnssec/pdnsutil`.
+:doc:`../manpages/pdnsutil.1`.
 
 -  Mandatory: no
 -  Parameters: query
@@ -1767,10 +1768,10 @@ Query:
 
 .. code-block:: json
 
-    { 
+    {
       "method": "lookup",
       "parameters": {
-         "qname": "example.com", 
+         "qname": "example.com",
          "qtype": "SOA",
          "zone_id": "-1"
       }
@@ -1781,10 +1782,10 @@ Reply:
 .. code-block:: json
 
     {
-      "result": 
-       [ 
+      "result":
+       [
          { "qtype": "SOA",
-           "qname": "example.com", 
+           "qname": "example.com",
            "content": "dns1.icann.org. hostmaster.icann.org. 2012080849 7200 3600 1209600 3600",
            "ttl": 3600,
            "domain_id": -1

--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -1217,7 +1217,7 @@ Response:
 ``feedEnts``
 ~~~~~~~~~~~~
 
-This method is used by pdnsutil rectify-zone to populate missing
+This method is used by ``pdnsutil zone rectify`` to populate missing
 non-terminals. This is used when you have, say, record like
 _sip._upd.example.com, but no _udp.example.com. PowerDNS requires
 that there exists a non-terminal in between, and this instructs you to

--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -89,8 +89,8 @@ Create a producer zone:
 
 .. code-block:: shell
 
-  pdnsutil load-zone catalog.example ZONEFILE
-  pdnsutil set-kind catalog.example producer
+  pdnsutil zone load catalog.example ZONEFILE
+  pdnsutil zone set-kind catalog.example producer
 
 Creating producer zones is supported in the :doc:`API <http-api/zone>`, using type ``PRODUCER``.
 
@@ -102,8 +102,8 @@ In the example below ``example.com`` is the member and ``catalog.example`` is th
 
 .. code-block:: shell
 
-  pdnsutil set-catalog example.com catalog.example
-  pdnsutil set-kind example.com primary
+  pdnsutil catalog set example.com catalog.example
+  pdnsutil zone set-kind example.com primary
 
 Setting catalog values is supported in the :doc:`API <http-api/zone>`, by setting the ``catalog`` property in the zone properties.
 Setting the catalog to an empty ``""`` removes the member zone from the catalog it is in.
@@ -116,8 +116,8 @@ PowerDNS currently supports the following properties:
 
 .. code-block:: shell
 
-  pdnsutil set-option example.com producer coo other-catalog.example
-  pdnsutil set-option example.com producer group pdns-group-x pdns-group-y
+  pdnsutil zone set-option example.com producer coo other-catalog.example
+  pdnsutil zone set-option example.com producer group pdns-group-x pdns-group-y
 
 There is also an option to set a specific <unique-N> value for a zone. This is done by setting a the ``unique`` value.
 This is used to signal a state reset to the consumer.
@@ -125,7 +125,7 @@ The value for ``unique`` is a single DNS label.
 
 .. code-block:: shell
 
-  pdnsutil --config-dir=. --config-name=gmysql set-option test.com producer unique 123
+  pdnsutil --config-dir=. --config-name=gmysql zone set-option test.com producer unique 123
 
 Setting options is not yet supported in the API.
 
@@ -137,8 +137,8 @@ The only difference is the type, which is now set to CONSUMER.
 
 .. code-block:: shell
 
-  pdnsutil create-secondary-zone catalog.example 192.0.2.42
-  pdnsutil set-kind catalog.example consumer
+  pdnsutil zone create-secondary catalog.example 192.0.2.42
+  pdnsutil zone set-kind catalog.example consumer
 
 Creating consumer zones is supported in the :doc:`API <http-api/zone>`, using type ``CONSUMER``.
 
@@ -154,7 +154,7 @@ server in order to fully apply the changes.
 
 .. code-block:: shell
 
-  pdnsutil change-secondary-zone-primary catalog.example 192.0.2.45
+  pdnsutil zone change-primary catalog.example 192.0.2.45
   pdns_control retrieve catalog.example
 
 This will update the primary server contact details in each zone

--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -92,6 +92,13 @@ Create a producer zone:
   pdnsutil zone load catalog.example ZONEFILE
   pdnsutil zone set-kind catalog.example producer
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+  pdnsutil load-zone catalog.example ZONEFILE
+  pdnsutil set-kind catalog.example producer
+
 Creating producer zones is supported in the :doc:`API <http-api/zone>`, using type ``PRODUCER``.
 
 Assigning members to a producer zone
@@ -104,6 +111,13 @@ In the example below ``example.com`` is the member and ``catalog.example`` is th
 
   pdnsutil catalog set example.com catalog.example
   pdnsutil zone set-kind example.com primary
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+  pdnsutil set-catalog example.com catalog.example
+  pdnsutil set-kind example.com primary
 
 Setting catalog values is supported in the :doc:`API <http-api/zone>`, by setting the ``catalog`` property in the zone properties.
 Setting the catalog to an empty ``""`` removes the member zone from the catalog it is in.
@@ -119,6 +133,13 @@ PowerDNS currently supports the following properties:
   pdnsutil zone set-option example.com producer coo other-catalog.example
   pdnsutil zone set-option example.com producer group pdns-group-x pdns-group-y
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+  pdnsutil set-option example.com producer coo other-catalog.example
+  pdnsutil set-option example.com producer group pdns-group-x pdns-group-y
+
 There is also an option to set a specific <unique-N> value for a zone. This is done by setting a the ``unique`` value.
 This is used to signal a state reset to the consumer.
 The value for ``unique`` is a single DNS label.
@@ -126,6 +147,12 @@ The value for ``unique`` is a single DNS label.
 .. code-block:: shell
 
   pdnsutil --config-dir=. --config-name=gmysql zone set-option test.com producer unique 123
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+  pdnsutil --config-dir=. --config-name=gmysql set-option test.com producer unique 123
 
 Setting options is not yet supported in the API.
 
@@ -139,6 +166,13 @@ The only difference is the type, which is now set to CONSUMER.
 
   pdnsutil zone create-secondary catalog.example 192.0.2.42
   pdnsutil zone set-kind catalog.example consumer
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+  pdnsutil create-secondary-zone catalog.example 192.0.2.42
+  pdnsutil set-kind catalog.example consumer
 
 Creating consumer zones is supported in the :doc:`API <http-api/zone>`, using type ``CONSUMER``.
 
@@ -155,6 +189,13 @@ server in order to fully apply the changes.
 .. code-block:: shell
 
   pdnsutil zone change-primary catalog.example 192.0.2.45
+  pdns_control retrieve catalog.example
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+  pdnsutil change-secondary-zone-primary catalog.example 192.0.2.45
   pdns_control retrieve catalog.example
 
 This will update the primary server contact details in each zone

--- a/docs/dnssec/advice.rst
+++ b/docs/dnssec/advice.rst
@@ -6,7 +6,7 @@ bewildering array of settings that can be configured.
 
 It is easy to (mis)configure DNSSEC in such a way that your domain
 will not operate reliably, or even, at all. We advise operators to stick
-to the keying defaults of ``pdnsutil secure-zone``.
+to the keying defaults of ``pdnsutil zone secure``.
 
 .. note::
   GOST may be more widely available in Russia, because it might

--- a/docs/dnssec/advice.rst
+++ b/docs/dnssec/advice.rst
@@ -6,7 +6,8 @@ bewildering array of settings that can be configured.
 
 It is easy to (mis)configure DNSSEC in such a way that your domain
 will not operate reliably, or even, at all. We advise operators to stick
-to the keying defaults of ``pdnsutil zone secure``.
+to the keying defaults of ``pdnsutil zone secure`` (``pdnsutil secure-zone``
+prior to version 5.0).
 
 .. note::
   GOST may be more widely available in Russia, because it might

--- a/docs/dnssec/index.rst
+++ b/docs/dnssec/index.rst
@@ -23,6 +23,12 @@ As an example, securing an existing zone can be as simple as:
 
     $ pdnsutil zone secure powerdnssec.org
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    $ pdnsutil secure-zone powerdnssec.org
+
 Alternatively, PowerDNS can serve pre-signed zones, without knowledge of
 private keys.
 

--- a/docs/dnssec/index.rst
+++ b/docs/dnssec/index.rst
@@ -21,7 +21,7 @@ As an example, securing an existing zone can be as simple as:
 
 .. code-block:: shell
 
-    $ pdnsutil secure-zone powerdnssec.org
+    $ pdnsutil zone secure powerdnssec.org
 
 Alternatively, PowerDNS can serve pre-signed zones, without knowledge of
 private keys.

--- a/docs/dnssec/migration.rst
+++ b/docs/dnssec/migration.rst
@@ -19,7 +19,8 @@ all the changes in database schemas as shown in the :doc:`upgrade documentation 
 .. warning::
   Once the relevant ``backend-dnssec`` switch has been set,
   stricter rules apply for filling out the database! The short version is:
-  run ``pdnsutil zone rectify-all``, even those not secured with DNSSEC!
+  run ``pdnsutil zone rectify-all`` (``pdnsutil rectify-all-zones`` prior to
+  version 5.0), even those not secured with DNSSEC!
   For more information, see the :ref:`generic-sql-handling-dnssec-signed-zones`.
 
 To deliver a correctly signed zone with the :ref:`dnssec-pdnsutil-dnssec-defaults`, invoke:
@@ -28,12 +29,24 @@ To deliver a correctly signed zone with the :ref:`dnssec-pdnsutil-dnssec-default
 
     pdnsutil zone secure ZONE
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil secure-zone ZONE
+
 To view the DS records for this zone (to transfer to the parent zone),
 run:
 
 .. code-block:: shell
 
     pdnsutil zone show ZONE
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil show-zone ZONE
 
 For a more traditional setup with a KSK and a ZSK, use the following
 sequence of commands:
@@ -43,6 +56,14 @@ sequence of commands:
     pdnsutil zone add-key ZONE ksk 2048 active rsasha256
     pdnsutil zone add-key ZONE zsk 1024 active rsasha256
     pdnsutil zone add-key ZONE zsk 1024 inactive rsasha256
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil add-zone-key ZONE ksk 2048 active rsasha256
+    pdnsutil add-zone-key ZONE zsk 1024 active rsasha256
+    pdnsutil add-zone-key ZONE zsk 1024 inactive rsasha256
 
 This will add a 2048-bit RSA Key Signing Key and two 1024-bit RSA Zone
 Signing Keys. One of the ZSKs is inactive and can be rolled to if
@@ -65,7 +86,8 @@ without changes. In such cases, signing happens externally to PowerDNS,
 possibly via OpenDNSSEC, ldns-sign or dnssec-sign.
 
 PowerDNS needs to know if a zone should receive DNSSEC processing. To
-configure, run ``pdnsutil zone set-presigned ZONE``.
+configure, run ``pdnsutil zone set-presigned ZONE`` (``pdnsutil set-presigned
+ZONE`` prior to version 5.0).
 
 If you import presigned zones into your database, please do not import
 the NSEC or NSEC3 records. PowerDNS will synthesize these itself.
@@ -75,7 +97,8 @@ automatically.
 
 .. warning::
   Right now, you will also need to configure NSEC/NSEC3 settings
-  for pre-signed zones using ``pdnsutil zone set-nsec3``. Default is NSEC, in
+  for pre-signed zones using ``pdnsutil zone set-nsec3`` (``pdnsutil set-nsec3``
+  prior to version 5.0). Default is NSEC, in
   which case no further configuration is necessary.
 
 From existing DNSSEC non-PowerDNS setups, live signing
@@ -88,6 +111,12 @@ KSK, use
 .. code-block:: shell
 
     pdnsutil zone import-key ZONE FILENAME ksk
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil import-zone-key ZONE FILENAME ksk
 
 replace ``ksk`` with ``zsk`` for a Zone Signing Key.
 

--- a/docs/dnssec/migration.rst
+++ b/docs/dnssec/migration.rst
@@ -19,30 +19,30 @@ all the changes in database schemas as shown in the :doc:`upgrade documentation 
 .. warning::
   Once the relevant ``backend-dnssec`` switch has been set,
   stricter rules apply for filling out the database! The short version is:
-  run ``pdnsutil rectify-all-zones``, even those not secured with DNSSEC!
+  run ``pdnsutil zone rectify-all``, even those not secured with DNSSEC!
   For more information, see the :ref:`generic-sql-handling-dnssec-signed-zones`.
 
 To deliver a correctly signed zone with the :ref:`dnssec-pdnsutil-dnssec-defaults`, invoke:
 
 .. code-block:: shell
 
-    pdnsutil secure-zone ZONE
+    pdnsutil zone secure ZONE
 
 To view the DS records for this zone (to transfer to the parent zone),
 run:
 
 .. code-block:: shell
 
-    pdnsutil show-zone ZONE
+    pdnsutil zone show ZONE
 
 For a more traditional setup with a KSK and a ZSK, use the following
 sequence of commands:
 
 .. code-block:: shell
 
-    pdnsutil add-zone-key ZONE ksk 2048 active rsasha256
-    pdnsutil add-zone-key ZONE zsk 1024 active rsasha256
-    pdnsutil add-zone-key ZONE zsk 1024 inactive rsasha256
+    pdnsutil zone add-key ZONE ksk 2048 active rsasha256
+    pdnsutil zone add-key ZONE zsk 1024 active rsasha256
+    pdnsutil zone add-key ZONE zsk 1024 inactive rsasha256
 
 This will add a 2048-bit RSA Key Signing Key and two 1024-bit RSA Zone
 Signing Keys. One of the ZSKs is inactive and can be rolled to if
@@ -65,7 +65,7 @@ without changes. In such cases, signing happens externally to PowerDNS,
 possibly via OpenDNSSEC, ldns-sign or dnssec-sign.
 
 PowerDNS needs to know if a zone should receive DNSSEC processing. To
-configure, run ``pdnsutil set-presigned ZONE``.
+configure, run ``pdnsutil zone set-presigned ZONE``.
 
 If you import presigned zones into your database, please do not import
 the NSEC or NSEC3 records. PowerDNS will synthesize these itself.
@@ -75,7 +75,7 @@ automatically.
 
 .. warning::
   Right now, you will also need to configure NSEC/NSEC3 settings
-  for pre-signed zones using ``pdnsutil set-nsec3``. Default is NSEC, in
+  for pre-signed zones using ``pdnsutil zone set-nsec3``. Default is NSEC, in
   which case no further configuration is necessary.
 
 From existing DNSSEC non-PowerDNS setups, live signing
@@ -87,7 +87,7 @@ KSK, use
 
 .. code-block:: shell
 
-    pdnsutil import-zone-key ZONE FILENAME ksk
+    pdnsutil zone import-key ZONE FILENAME ksk
 
 replace ``ksk`` with ``zsk`` for a Zone Signing Key.
 

--- a/docs/dnssec/modes-of-operation.rst
+++ b/docs/dnssec/modes-of-operation.rst
@@ -157,7 +157,7 @@ is retrieved from a primary server, this keying material will be used
 when serving data from this zone.
 
 As part of the zone retrieval, the equivalent of
-``pdnsutil rectify-zone`` is run to make sure that all DNSSEC-related
+``pdnsutil zone rectify`` is run to make sure that all DNSSEC-related
 fields are set correctly in the backend.
 
 Signed AXFR
@@ -187,7 +187,7 @@ database. Then, restart PowerDNS.
 .. note::
   This SQLite database is different from the database used for the regular :doc:`SQLite 3 backend <../backends/generic-sqlite3>`.
 
-After this, you can use ``pdnsutil secure-zone`` and all other pdnsutil
+After this, you can use ``pdnsutil zone secure`` and all other pdnsutil
 commands on your BIND zones without trouble.
 
 .. _dnssec-modes-hybrid-bind:

--- a/docs/dnssec/modes-of-operation.rst
+++ b/docs/dnssec/modes-of-operation.rst
@@ -157,8 +157,9 @@ is retrieved from a primary server, this keying material will be used
 when serving data from this zone.
 
 As part of the zone retrieval, the equivalent of
-``pdnsutil zone rectify`` is run to make sure that all DNSSEC-related
-fields are set correctly in the backend.
+``pdnsutil zone rectify`` (``pdnsutil rectify-zone`` prior to version 5.0) is
+run to make sure that all DNSSEC-related fields are set correctly in the
+backend.
 
 Signed AXFR
 -----------
@@ -187,8 +188,9 @@ database. Then, restart PowerDNS.
 .. note::
   This SQLite database is different from the database used for the regular :doc:`SQLite 3 backend <../backends/generic-sqlite3>`.
 
-After this, you can use ``pdnsutil zone secure`` and all other pdnsutil
-commands on your BIND zones without trouble.
+After this, you can use ``pdnsutil zone secure`` (``pdnsutil secure-zone`` prior
+to version 5.0) and all other :doc:`pdnsutil <../manpages/pdnsutil.1>` commands on
+your BIND zones without trouble.
 
 .. _dnssec-modes-hybrid-bind:
 

--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -18,7 +18,8 @@ Manual
 As automation is not very widespread, DS publication often needs to occur
 manually as follows:
 
-1. utilize ``pdnsutil zone show`` to display DS and DNSKEY parameters,
+1. utilize ``pdnsutil zone show`` (``pdnsutil show-zone`` prior to version 5.0)
+   to display DS and DNSKEY parameters,
 2. transfer these parameters securely to your parent.
 
 Some parents accept DS format, while some accept DNSKEY (and use it to derive
@@ -92,6 +93,12 @@ Going insecure
 
     pdnsutil zone dnssec-disable ZONE
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil disable-dnssec ZONE
+
 .. warning::
   Going insecure with a zone that has a DS record in the
   parent zone will make the zone BOGUS. Make sure the parent zone removes
@@ -115,6 +122,12 @@ e.g.
 
     pdnsutil zone set-nsec3 example.net '1 0 0 -'
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil set-nsec3 example.net '1 0 0 -'
+
 The quoted part is the content of the NSEC3PARAM records, as defined in
 :rfc:`RFC 5155 <5155#section-4>`, in order:
 
@@ -134,6 +147,12 @@ To convert a zone from NSEC3 to NSEC operations, run:
 .. code-block:: shell
 
     pdnsutil zone unset-nsec3 ZONE
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil unset-nsec3 ZONE
 
 .. warning::
   Don't change from NSEC to NSEC3 (or the other way around)

--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -18,7 +18,7 @@ Manual
 As automation is not very widespread, DS publication often needs to occur
 manually as follows:
 
-1. utilize ``pdnsutil show-zone`` to display DS and DNSKEY parameters,
+1. utilize ``pdnsutil zone show`` to display DS and DNSKEY parameters,
 2. transfer these parameters securely to your parent.
 
 Some parents accept DS format, while some accept DNSKEY (and use it to derive
@@ -34,7 +34,7 @@ DS records from them. This works for both DS initialization (bootstrapping)
 and DS updates (rollovers).
 
 CDS/CDNSKEY record publication can be enabled using
-``pdnsutil set-publish-cds`` / ``pdnsutil set-publish-cdnskey``.
+``pdnsutil zone set-publish-cds`` or ``pdnsutil zone set-publish-cdnskey``.
 
 For bootstrapping, this method lacks authentication (there is no preexisting
 chain of trust). Some registries work around this by observing CDS/CDNSKEY
@@ -64,8 +64,8 @@ enable authenticated bootstrapping as follows:
    .. code-block:: shell
 
       nshost=ns1.example.net
-      pdnsutil create-zone _signal.$nshost $nshost  # create NS record too
-      pdnsutil set-signaling-zone _signal.$nshost
+      pdnsutil zone create _signal.$nshost $nshost  # create NS record too
+      pdnsutil zone set-signaling _signal.$nshost
 
    You can do this on ``ns1.example.net`` directly, or on another instance
    serving the same zones. This is useful when not all instances are
@@ -81,7 +81,7 @@ Note: A nameserver can't bootstrap its own parent. (The above example
 won't work to bootstrap ``example.net``; see step 1.) If no other zones
 are served under that hostname, you can skip creating its signaling zone.
 
-``pdnsutil set-signaling-zone _signal.$nshost`` is equivalent to securing
+``pdnsutil zone set-signaling _signal.$nshost`` is equivalent to securing
 the zone, enabling NSEC3 narrow mode, and setting the ``SIGNALING-ZONE``
 metadata, which will make the zone behave as an :rfc:`9615` signaling zone.
 
@@ -90,7 +90,7 @@ Going insecure
 
 .. code-block:: shell
 
-    pdnsutil disable-dnssec ZONE
+    pdnsutil zone dnssec-disable ZONE
 
 .. warning::
   Going insecure with a zone that has a DS record in the
@@ -107,13 +107,13 @@ NSEC3 instead, issue:
 
 .. code-block:: shell
 
-    pdnsutil set-nsec3 ZONE [PARAMETERS] ['narrow']
+    pdnsutil zone set-nsec3 ZONE [PARAMETERS] ['narrow']
 
 e.g.
 
 .. code-block:: shell
 
-    pdnsutil set-nsec3 example.net '1 0 0 -'
+    pdnsutil zone set-nsec3 example.net '1 0 0 -'
 
 The quoted part is the content of the NSEC3PARAM records, as defined in
 :rfc:`RFC 5155 <5155#section-4>`, in order:
@@ -133,7 +133,7 @@ To convert a zone from NSEC3 to NSEC operations, run:
 
 .. code-block:: shell
 
-    pdnsutil unset-nsec3 ZONE
+    pdnsutil zone unset-nsec3 ZONE
 
 .. warning::
   Don't change from NSEC to NSEC3 (or the other way around)

--- a/docs/dnssec/pdnsutil.rst
+++ b/docs/dnssec/pdnsutil.rst
@@ -14,7 +14,8 @@ For a list of available commands, see the :doc:`manpage <../manpages/pdnsutil.1>
 DNSSEC Defaults
 ---------------
 
-Since version 4.0, when securing a zone using ``pdnsutil zone secure``,
+Since version 4.0, when securing a zone using ``pdnsutil zone secure``
+(``pdnsutil secure-zone`` prior to version 5.0),
 a single ECDSA (algorithm 13, ECDSAP256SHA256) key is generated that is
 used as CSK. Before 4.0, 3 RSA (algorithm 8) keys were generated, one as
 the KSK and two ZSKs. As all keys are online in the database, it made no

--- a/docs/dnssec/pdnsutil.rst
+++ b/docs/dnssec/pdnsutil.rst
@@ -14,7 +14,7 @@ For a list of available commands, see the :doc:`manpage <../manpages/pdnsutil.1>
 DNSSEC Defaults
 ---------------
 
-Since version 4.0, when securing a zone using ``pdnsutil secure-zone``,
+Since version 4.0, when securing a zone using ``pdnsutil zone secure``,
 a single ECDSA (algorithm 13, ECDSAP256SHA256) key is generated that is
 used as CSK. Before 4.0, 3 RSA (algorithm 8) keys were generated, one as
 the KSK and two ZSKs. As all keys are online in the database, it made no

--- a/docs/dnssec/pkcs11.rst
+++ b/docs/dnssec/pkcs11.rst
@@ -40,6 +40,10 @@ These instructions have been tested on Debian 10 (Buster).
 
     pdnsutil zone show example.com
 
+  or, prior to version 5.0::
+
+    pdnsutil show-zone example.com
+
 SoftHSM2 with forwarding
 ------------------------
 
@@ -172,6 +176,10 @@ Smart Card token on Ubuntu 14.04.
 - Verify that everything worked, you should see valid data there. ::
 
     pdnsutil zone show zone
+
+  or, prior to version 5.0::
+
+    pdnsutil show-zone zone
 
 - Note that the physical token is pretty slow, so you have to use it as
   hidden primary. It has been observed to produce about 1.5 signatures/second.

--- a/docs/dnssec/pkcs11.rst
+++ b/docs/dnssec/pkcs11.rst
@@ -38,7 +38,7 @@ These instructions have been tested on Debian 10 (Buster).
 
 -  Verify that everything worked, you should see valid data there::
 
-    pdnsutil show-zone example.com
+    pdnsutil zone show example.com
 
 SoftHSM2 with forwarding
 ------------------------
@@ -92,7 +92,7 @@ Then assign the HSM token to your zone with::
 
   pdnsutil hsm assign example.com ecdsa256 ksk p11-kit-client 'ecdsa#1' 1234 'my key'
 
-And then verify with ``show-zone`` that the zone now has a valid key.
+And then verify with ``zone show`` that the zone now has a valid key.
 
 You can do this over SSH as well (note that the example connects from token server to DNS server)::
 
@@ -171,7 +171,7 @@ Smart Card token on Ubuntu 14.04.
 
 - Verify that everything worked, you should see valid data there. ::
 
-    pdnsutil show-zone zone
+    pdnsutil zone show zone
 
 - Note that the physical token is pretty slow, so you have to use it as
   hidden primary. It has been observed to produce about 1.5 signatures/second.

--- a/docs/dnsupdate.rst
+++ b/docs/dnsupdate.rst
@@ -111,7 +111,7 @@ options (See :ref:`above <dnsupdate-configuration-options>`).
 This will allow 198.51.100.0/8 and 203.0.113.2/32 to send DNS update
 messages for the example.org domain::
 
-    pdnsutil set-meta example.org ALLOW-DNSUPDATE-FROM 198.51.100.0/8 203.0.113.2/32
+    pdnsutil metadata set example.org ALLOW-DNSUPDATE-FROM 198.51.100.0/8 203.0.113.2/32
 
 .. _metadata-tsig-allow-dnsupdate:
 
@@ -123,20 +123,20 @@ update. If you have GSS-TSIG enabled, you can use Kerberos principals
 here. Here is an example using :program:`pdnsutil` to create a key named
 `test`::
 
-    $ pdnsutil generate-tsig-key test hmac-sha512
+    $ pdnsutil tsigkey generate test hmac-sha512
     Create new TSIG key test hmac-sha512 [base64-encoded key]
 
-    $ pdnsutil list-tsig-keys | grep test
+    $ pdnsutil tsigkey list | grep test
     test. hmac-sha512. [base64-encoded key]
 
 This adds the key with the name `test` to the zone's metadata. Note, the
-keys need to be added separately with `add-meta`, not as a comma or
+keys need to be added separately with `metadata add`, not as a comma or
 space-separated list::
 
-    $ pdnsutil add-meta example.org TSIG-ALLOW-DNSUPDATE test
+    $ pdnsutil metadata add example.org TSIG-ALLOW-DNSUPDATE test
     Set 'example.org' meta TSIG-ALLOW-DNSUPDATE = test
 
-    $ pdnsutil get-meta example.org TSIG-ALLOW-DNSUPDATE
+    $ pdnsutil metadata get example.org TSIG-ALLOW-DNSUPDATE
     TSIG-ALLOW-DNSUPDATE = test
 
 This is an example of using the new `test` TSIG key with the :program:`nsupdate`
@@ -172,7 +172,7 @@ FORWARD-DNSUPDATE
 See :ref:`Configuration options <dnsupdate-configuration-options>` for what it does,
 but per domain::
 
-    pdnsutil set-meta example.org FORWARD-DNSUPDATE 'yes'
+    pdnsutil metadata set example.org FORWARD-DNSUPDATE 'yes'
 
 The existence of the entry (even with an empty value) enables the forwarding.
 This domain-specific setting is only useful when the configuration
@@ -189,7 +189,7 @@ Send a notification to all secondary servers after every update. This will
 speed up the propagation of changes and is very useful for acme
 verification::
 
-    pdnsutil set-meta example.org NOTIFY-DNSUPDATE 1
+    pdnsutil metadata set example.org NOTIFY-DNSUPDATE 1
 
 .. _metadata-soa-edit-dnsupdate:
 
@@ -220,7 +220,7 @@ logic to change the SOA is not executed.
 
 An example::
 
-    pdnsutil set-meta example.org SOA-EDIT-DNSUPDATE INCREASE
+    pdnsutil metadata set example.org SOA-EDIT-DNSUPDATE INCREASE
 
 This will make the SOA Serial increase by one, for every successful
 update.
@@ -363,8 +363,8 @@ domainmetadata table.
 
 ::
 
-    pdnsutil set-meta example.org ALLOW-DNSUPDATE-FROM 127.0.0.1
-    pdnsutil set-meta 1.168.192.in-addr.arpa ALLOW-DNSUPDATE-FROM 127.0.0.1
+    pdnsutil metadata set example.org ALLOW-DNSUPDATE-FROM 127.0.0.1
+    pdnsutil metadata set 1.168.192.in-addr.arpa ALLOW-DNSUPDATE-FROM 127.0.0.1
 
 This gives the ip '127.0.0.1' access to send update messages. Make sure
 you use the ip address of the machine that runs **dhcpd**.
@@ -374,9 +374,9 @@ via the domainmetadata table:
 
 ::
 
-    pdnsutil import-tsig-key dhcpdupdate hmac-md5 FYhvwsW1ZtFZqWzsMpqhbg==
-    pdnsutil set-meta example.org TSIG-ALLOW-DNSUPDATE dhcpdupdate
-    pdnsutil set-meta 1.168.192.in-addr.arpa TSIG-ALLOW-DNSUPDATE dhcpdupdate
+    pdnsutil tsigkey import dhcpdupdate hmac-md5 FYhvwsW1ZtFZqWzsMpqhbg==
+    pdnsutil metadata set example.org TSIG-ALLOW-DNSUPDATE dhcpdupdate
+    pdnsutil metadata set 1.168.192.in-addr.arpa TSIG-ALLOW-DNSUPDATE dhcpdupdate
 
 This will:
 

--- a/docs/dnsupdate.rst
+++ b/docs/dnsupdate.rst
@@ -113,6 +113,10 @@ messages for the example.org domain::
 
     pdnsutil metadata set example.org ALLOW-DNSUPDATE-FROM 198.51.100.0/8 203.0.113.2/32
 
+or, prior to version 5.0::
+
+    pdnsutil set-meta example.org ALLOW-DNSUPDATE-FROM 198.51.100.0/8 203.0.113.2/32
+
 .. _metadata-tsig-allow-dnsupdate:
 
 TSIG-ALLOW-DNSUPDATE
@@ -129,14 +133,29 @@ here. Here is an example using :program:`pdnsutil` to create a key named
     $ pdnsutil tsigkey list | grep test
     test. hmac-sha512. [base64-encoded key]
 
+or, prior to version 5.0::
+
+    $ pdnsutil generate-tsig-key test hmac-sha512
+    Create new TSIG key test hmac-sha512 [base64-encoded key]
+
+    $ pdnsutil list-tsig-keys | grep test
+    test. hmac-sha512. [base64-encoded key]
+
 This adds the key with the name `test` to the zone's metadata. Note, the
-keys need to be added separately with `metadata add`, not as a comma or
-space-separated list::
+keys need to be added separately, not as a comma or space-separated list::
 
     $ pdnsutil metadata add example.org TSIG-ALLOW-DNSUPDATE test
     Set 'example.org' meta TSIG-ALLOW-DNSUPDATE = test
 
     $ pdnsutil metadata get example.org TSIG-ALLOW-DNSUPDATE
+    TSIG-ALLOW-DNSUPDATE = test
+
+or, prior to version 5.0::
+
+    $ pdnsutil add-meta example.org TSIG-ALLOW-DNSUPDATE test
+    Set 'example.org' meta TSIG-ALLOW-DNSUPDATE = test
+
+    $ pdnsutil get-meta example.org TSIG-ALLOW-DNSUPDATE
     TSIG-ALLOW-DNSUPDATE = test
 
 This is an example of using the new `test` TSIG key with the :program:`nsupdate`
@@ -174,6 +193,10 @@ but per domain::
 
     pdnsutil metadata set example.org FORWARD-DNSUPDATE 'yes'
 
+or, prior to version 5.0::
+
+    pdnsutil set-meta example.org FORWARD-DNSUPDATE 'yes'
+
 The existence of the entry (even with an empty value) enables the forwarding.
 This domain-specific setting is only useful when the configuration
 option :ref:`setting-forward-dnsupdate` is set to 'no', as that will disable it
@@ -190,6 +213,10 @@ speed up the propagation of changes and is very useful for acme
 verification::
 
     pdnsutil metadata set example.org NOTIFY-DNSUPDATE 1
+
+or, prior to version 5.0::
+
+    pdnsutil set-meta example.org NOTIFY-DNSUPDATE 1
 
 .. _metadata-soa-edit-dnsupdate:
 
@@ -221,6 +248,10 @@ logic to change the SOA is not executed.
 An example::
 
     pdnsutil metadata set example.org SOA-EDIT-DNSUPDATE INCREASE
+
+or, prior to version 5.0::
+
+    pdnsutil set-meta example.org SOA-EDIT-DNSUPDATE INCREASE
 
 This will make the SOA Serial increase by one, for every successful
 update.
@@ -361,10 +392,17 @@ parameter. That's not very useful, so we're going to give permissions
 per zone (including the appropriate reverse zone), via the
 domainmetadata table.
 
-::
+.. code-block:: shell
 
     pdnsutil metadata set example.org ALLOW-DNSUPDATE-FROM 127.0.0.1
     pdnsutil metadata set 1.168.192.in-addr.arpa ALLOW-DNSUPDATE-FROM 127.0.0.1
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil set-meta example.org ALLOW-DNSUPDATE-FROM 127.0.0.1
+    pdnsutil set-meta 1.168.192.in-addr.arpa ALLOW-DNSUPDATE-FROM 127.0.0.1
 
 This gives the ip '127.0.0.1' access to send update messages. Make sure
 you use the ip address of the machine that runs **dhcpd**.
@@ -372,11 +410,19 @@ you use the ip address of the machine that runs **dhcpd**.
 Another thing we want to do, is add TSIG security. This can only be done
 via the domainmetadata table:
 
-::
+.. code-block:: shell
 
     pdnsutil tsigkey import dhcpdupdate hmac-md5 FYhvwsW1ZtFZqWzsMpqhbg==
     pdnsutil metadata set example.org TSIG-ALLOW-DNSUPDATE dhcpdupdate
     pdnsutil metadata set 1.168.192.in-addr.arpa TSIG-ALLOW-DNSUPDATE dhcpdupdate
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil import-tsig-key dhcpdupdate hmac-md5 FYhvwsW1ZtFZqWzsMpqhbg==
+    pdnsutil set-meta example.org TSIG-ALLOW-DNSUPDATE dhcpdupdate
+    pdnsutil set-meta 1.168.192.in-addr.arpa TSIG-ALLOW-DNSUPDATE dhcpdupdate
 
 This will:
 

--- a/docs/domainmetadata.rst
+++ b/docs/domainmetadata.rst
@@ -15,7 +15,7 @@ For the implementation in non-sql backends, please review your backend's
 documentation.
 
 Apart from raw SQL statements, setting domain metadata can be done with
-``pdnsutil set-meta`` and retrieving metadata is done with ``pdnsutil get-meta``.
+``pdnsutil metadata set`` and retrieving metadata is done with ``pdnsutil metadata get``.
 
 The following options can only be read (not written to) via the HTTP API metadata endpoint.
 
@@ -46,7 +46,7 @@ Example:
 
 .. code-block:: shell
 
-    pdnsutil set-meta powerdns.org ALLOW-AXFR-FROM AUTO-NS 2001:db8::/48
+    pdnsutil metadata set powerdns.org ALLOW-AXFR-FROM AUTO-NS 2001:db8::/48
 
 Each ACL has its own row in the database:
 
@@ -78,8 +78,8 @@ number. e.g.:
 
 .. code-block:: shell
 
-    pdnsutil set-meta powerdns.org ALSO-NOTIFY 192.0.2.1:5300
-    pdnsutil set-meta powerdns.org ALLOW-AXFR-FROM 2001:db8:53::1
+    pdnsutil metadata set powerdns.org ALSO-NOTIFY 192.0.2.1:5300
+    pdnsutil metadata set powerdns.org ALLOW-AXFR-FROM 2001:db8:53::1
 
 
 API-RECTIFY
@@ -150,14 +150,14 @@ NSEC3NARROW
 -----------
 
 Set to "1" to tell PowerDNS this zone operates in NSEC3 'narrow' mode.
-See ``set-nsec3`` for :doc:`pdnsutil <dnssec/pdnsutil>`.
+See ``zone set-nsec3`` for :doc:`pdnsutil <dnssec/pdnsutil>`.
 
 NSEC3PARAM
 ----------
 
 NSEC3 parameters of a DNSSEC zone. Will be used to synthesize the
 NSEC3PARAM record. If present, NSEC3 is used, if not present, zones
-default to NSEC. See ``set-nsec3`` in :doc:`pdnsutil <dnssec/pdnsutil>`.
+default to NSEC. See ``zone set-nsec3`` in :doc:`pdnsutil <dnssec/pdnsutil>`.
 Example content: "1 0 0 -".
 
 .. _metadata-presigned:
@@ -168,10 +168,10 @@ PRESIGNED
 This zone carries DNSSEC RRSIGs (signatures), and is presigned. PowerDNS
 sets this flag automatically upon incoming zone transfers (AXFR) if it
 detects DNSSEC records in the zone. However, if you import a presigned
-zone using ``zone2sql`` or ``pdnsutil load-zone`` you must explicitly
+zone using ``zone2sql`` or ``pdnsutil zone load`` you must explicitly
 set the zone to be ``PRESIGNED``. Note that PowerDNS will not be able to
 correctly serve the zone if the imported data is bogus or incomplete.
-Also see ``set-presigned`` in :doc:`pdnsutil <dnssec/pdnsutil>`.
+Also see ``zone set-presigned`` in :doc:`pdnsutil <dnssec/pdnsutil>`.
 
 If a zone is presigned, the content of the metadata must be "1" (without
 the quotes). Any other value will not signal presignedness.
@@ -191,8 +191,8 @@ a comma- separated list of `signature algorithm
 numbers <https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml#ds-rr-types-1>`__.
 
 This metadata can also be set using the
-:doc:`pdnsutil <dnssec/pdnsutil>` commands ``set-publish-cdnskey``
-and ``set-publish-cds``. For an example for an :rfc:`7344` key rollover,
+:doc:`pdnsutil <dnssec/pdnsutil>` commands ``zone set-publish-cdnskey``
+and ``zone set-publish-cds``. For an example for an :rfc:`7344` key rollover,
 see the :doc:`guides/kskrollcdnskey`.
 
 Global defaults for these values can be set via :ref:`setting-default-publish-cdnskey` and :ref:`setting-default-publish-cds`.
@@ -260,7 +260,7 @@ If :ref:`GSS-TSIG <tsig-gss-tsig>` is enabled, you can put Kerberos principals h
 Extra metadata
 --------------
 
-Through the API and on the ``pdnsutil set-meta`` commandline, metadata
+Through the API and on the ``pdnsutil metadata set`` commandline, metadata
 unused by PowerDNS can be added. It is mandatory to prefix this extra
 metadata with "X-" and the name of the external application; the API
 will only allow this metadata if it starts with "X-".

--- a/docs/domainmetadata.rst
+++ b/docs/domainmetadata.rst
@@ -15,7 +15,9 @@ For the implementation in non-sql backends, please review your backend's
 documentation.
 
 Apart from raw SQL statements, setting domain metadata can be done with
-``pdnsutil metadata set`` and retrieving metadata is done with ``pdnsutil metadata get``.
+``pdnsutil metadata set`` and retrieving metadata with ``pdnsutil metadata get``
+(respectively ``pdnsutil set-meta`` and ``pdnsutil get-meta`` prior to version
+5.0).
 
 The following options can only be read (not written to) via the HTTP API metadata endpoint.
 
@@ -47,6 +49,13 @@ Example:
 .. code-block:: shell
 
     pdnsutil metadata set powerdns.org ALLOW-AXFR-FROM AUTO-NS 2001:db8::/48
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil set-meta powerdns.org ALLOW-AXFR-FROM AUTO-NS 2001:db8::/48
+
 
 Each ACL has its own row in the database:
 
@@ -81,6 +90,12 @@ number. e.g.:
     pdnsutil metadata set powerdns.org ALSO-NOTIFY 192.0.2.1:5300
     pdnsutil metadata set powerdns.org ALLOW-AXFR-FROM 2001:db8:53::1
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil set-meta powerdns.org ALSO-NOTIFY 192.0.2.1:5300
+    pdnsutil set-meta powerdns.org ALLOW-AXFR-FROM 2001:db8:53::1
 
 API-RECTIFY
 -----------
@@ -150,14 +165,14 @@ NSEC3NARROW
 -----------
 
 Set to "1" to tell PowerDNS this zone operates in NSEC3 'narrow' mode.
-See ``zone set-nsec3`` for :doc:`pdnsutil <dnssec/pdnsutil>`.
+See ``zone set-nsec3`` in :doc:`pdnsutil <manpages/pdnsutil.1>`.
 
 NSEC3PARAM
 ----------
 
 NSEC3 parameters of a DNSSEC zone. Will be used to synthesize the
 NSEC3PARAM record. If present, NSEC3 is used, if not present, zones
-default to NSEC. See ``zone set-nsec3`` in :doc:`pdnsutil <dnssec/pdnsutil>`.
+default to NSEC. See ``zone set-nsec3`` in :doc:`pdnsutil <manpages/pdnsutil.1>`.
 Example content: "1 0 0 -".
 
 .. _metadata-presigned:
@@ -171,7 +186,7 @@ detects DNSSEC records in the zone. However, if you import a presigned
 zone using ``zone2sql`` or ``pdnsutil zone load`` you must explicitly
 set the zone to be ``PRESIGNED``. Note that PowerDNS will not be able to
 correctly serve the zone if the imported data is bogus or incomplete.
-Also see ``zone set-presigned`` in :doc:`pdnsutil <dnssec/pdnsutil>`.
+Also see ``zone set-presigned`` in :doc:`pdnsutil <manpages/pdnsutil.1>`.
 
 If a zone is presigned, the content of the metadata must be "1" (without
 the quotes). Any other value will not signal presignedness.
@@ -191,7 +206,7 @@ a comma- separated list of `signature algorithm
 numbers <https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml#ds-rr-types-1>`__.
 
 This metadata can also be set using the
-:doc:`pdnsutil <dnssec/pdnsutil>` commands ``zone set-publish-cdnskey``
+:doc:`pdnsutil <manpages/pdnsutil.1>` commands ``zone set-publish-cdnskey``
 and ``zone set-publish-cds``. For an example for an :rfc:`7344` key rollover,
 see the :doc:`guides/kskrollcdnskey`.
 

--- a/docs/guides/algoroll.rst
+++ b/docs/guides/algoroll.rst
@@ -16,7 +16,9 @@ Please check that these bigger packets can make it out of your network without t
 .. warning::
 
     For every mutation to your zone (so, every step except updating DS in the parent), make sure that your serial is bumped, so your secondaries pick up the changes too.
-    If you are using AXFR replication, this usually is as simple as ``pdnsutil zone increase-serial example.com``
+    If you are using AXFR replication, this usually is as simple as ``pdnsutil
+    zone increase-serial example.com`` (``pdnsutil increase-serial example.com``
+    prior to version 5.0)
 
 Phase: initial
 --------------
@@ -34,8 +36,16 @@ To create signatures with the new algorithm, without publishing keys, run someth
     pdnsutil zone add-key example.com KSK active unpublished ecdsa384
     pdnsutil zone add-key example.com ZSK active unpublished ecdsa384
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil add-zone-key example.com KSK active unpublished ecdsa384
+    pdnsutil add-zone-key example.com ZSK active unpublished ecdsa384
+
 Note the key IDs that ``zone add-key`` reports.
-You can also retrieve these later with ``pdnsutil zone show example.com``.
+You can also retrieve these later with ``pdnsutil zone show example.com``
+(``pdnsutil show-zone example.com`` prior to version 5.0).
 
 After this, PowerDNS will sign all records in the zone with both the old and new ZSKs, and the DNSKEY set will be signed by both KSKs.
 
@@ -64,7 +74,16 @@ After waiting for all records in our zone to expire from caches, we can publish 
     pdnsutil zone publish-key example.com 3
     pdnsutil zone publish-key example.com 4
 
-Replace ``3`` and ``4`` with the key IDs gathered in the previous step, or find them in ``pdnsutil zone show example.com``.
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil publish-zone-key example.com 3
+    pdnsutil publish-zone-key example.com 4
+
+Replace ``3`` and ``4`` with the key IDs gathered in the previous step, or find
+them in the ``pdnsutil zone show`` output (``pdnsutil show-zone`` prior to
+version 5.0).
 PowerDNS will now publish the new DNSKEYs that have already been used for signing for a while.
 The old DNSKEYs remain published, and active for signing, for now.
 
@@ -81,7 +100,10 @@ Our zone is currently fully signed with two algorithms, and keys for both algori
 This means that a DS for either the old or new algorithm is sufficient for validation.
 We can now switch the DS - there is no need to have DSes for both algorithms in the parent zone.
 
-Using ``pdnsutil zone show example.com`` or ``pdnsutil zone export-ds example.com``, extract the new DNSKEYs or new DSes, depending on what the parent zone operator takes as input.
+Using ``pdnsutil zone show example.com`` or ``pdnsutil zone export-ds
+example.com`` (``pdnsutil show-zone example.com`` or ``pdnsutil export-zone-ds
+example.com`` prior to version 5.0), extract the new DNSKEYs or new DSes,
+depending on what the parent zone operator takes as input.
 Note that these commands print DNSKEYs and/or DSes for both the old and the new algorithm.
 
 Check the DS TTL at the parent, for example: ``dig DS example.com @c.gtld-servers.net`` for a delegation from ``.com``.
@@ -105,6 +127,13 @@ It is time to remove the old DNSKEYs, while keeping their signature:
     pdnsutil zone unpublish-key example.com 1
     pdnsutil zone unpublish-key example.com 2
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil unpublish-zone-key example.com 1
+    pdnsutil unpublish-zone-key example.com 2
+
 Replace ``1`` and ``2`` with the IDs of the old keys.
 
 Please check that your secondaries now only show the new set of keys when queried with ``dig DNSKEY example.com @...``.
@@ -122,6 +151,13 @@ This means we can now safely stop signing with the old keys:
 
     pdnsutil zone deactivate-key example.com 1
     pdnsutil zone deactivate-key example.com 2
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil deactivate-zone-key example.com 1
+    pdnsutil deactivate-zone-key example.com 2
 
 Alternatively, you can use ``zone remove-key`` to remove all traces of the old keys.
 

--- a/docs/guides/algoroll.rst
+++ b/docs/guides/algoroll.rst
@@ -16,7 +16,7 @@ Please check that these bigger packets can make it out of your network without t
 .. warning::
 
     For every mutation to your zone (so, every step except updating DS in the parent), make sure that your serial is bumped, so your secondaries pick up the changes too.
-    If you are using AXFR replication, this usually is as simple as ``pdnsutil increase-serial example.com``
+    If you are using AXFR replication, this usually is as simple as ``pdnsutil zone increase-serial example.com``
 
 Phase: initial
 --------------
@@ -31,11 +31,11 @@ To create signatures with the new algorithm, without publishing keys, run someth
 
 .. code-block:: shell
 
-    pdnsutil add-zone-key example.com KSK active unpublished ecdsa384
-    pdnsutil add-zone-key example.com ZSK active unpublished ecdsa384
+    pdnsutil zone add-key example.com KSK active unpublished ecdsa384
+    pdnsutil zone add-key example.com ZSK active unpublished ecdsa384
 
-Note the key IDs that add-zone-key reports.
-You can also retrieve these later with ``pdnsutil show-zone example.com``.
+Note the key IDs that ``zone add-key`` reports.
+You can also retrieve these later with ``pdnsutil zone show example.com``.
 
 After this, PowerDNS will sign all records in the zone with both the old and new ZSKs, and the DNSKEY set will be signed by both KSKs.
 
@@ -61,10 +61,10 @@ After waiting for all records in our zone to expire from caches, we can publish 
 
 .. code-block:: shell
 
-    pdnsutil publish-zone-key example.com 3
-    pdnsutil publish-zone-key example.com 4
+    pdnsutil zone publish-key example.com 3
+    pdnsutil zone publish-key example.com 4
 
-Replace ``3`` and ``4`` with the key IDs gathered in the previous step, or find them in ``pdnsutil show-zone example.com``.
+Replace ``3`` and ``4`` with the key IDs gathered in the previous step, or find them in ``pdnsutil zone show example.com``.
 PowerDNS will now publish the new DNSKEYs that have already been used for signing for a while.
 The old DNSKEYs remain published, and active for signing, for now.
 
@@ -81,7 +81,7 @@ Our zone is currently fully signed with two algorithms, and keys for both algori
 This means that a DS for either the old or new algorithm is sufficient for validation.
 We can now switch the DS - there is no need to have DSes for both algorithms in the parent zone.
 
-Using ``pdnsutil show-zone example.com`` or ``pdnsutil export-zone-ds example.com``, extract the new DNSKEYs or new DSes, depending on what the parent zone operator takes as input.
+Using ``pdnsutil zone show example.com`` or ``pdnsutil zone export-ds example.com``, extract the new DNSKEYs or new DSes, depending on what the parent zone operator takes as input.
 Note that these commands print DNSKEYs and/or DSes for both the old and the new algorithm.
 
 Check the DS TTL at the parent, for example: ``dig DS example.com @c.gtld-servers.net`` for a delegation from ``.com``.
@@ -102,8 +102,8 @@ It is time to remove the old DNSKEYs, while keeping their signature:
 
 .. code-block:: shell
 
-    pdnsutil unpublish-zone-key example.com 1
-    pdnsutil unpublish-zone-key example.com 2
+    pdnsutil zone unpublish-key example.com 1
+    pdnsutil zone unpublish-key example.com 2
 
 Replace ``1`` and ``2`` with the IDs of the old keys.
 
@@ -120,10 +120,10 @@ This means we can now safely stop signing with the old keys:
 
 .. code-block:: shell
 
-    pdnsutil deactivate-zone-key example.com 1
-    pdnsutil deactivate-zone-key example.com 2
+    pdnsutil zone deactivate-key example.com 1
+    pdnsutil zone deactivate-key example.com 2
 
-Alternatively, you can use ``remove-zone-key`` to remove all traces of the old keys.
+Alternatively, you can use ``zone remove-key`` to remove all traces of the old keys.
 
 Conclusion
 ----------

--- a/docs/guides/basic-database.rst
+++ b/docs/guides/basic-database.rst
@@ -64,13 +64,13 @@ Note the ``REFUSED`` status - this is the code most name servers use to indicate
 
 Now, let's add a zone and some records::
 
-    $ sudo -u pdns pdnsutil create-zone example.com ns1.example.com
+    $ sudo -u pdns pdnsutil zone create example.com ns1.example.com
     Creating empty zone 'example.com'
     Also adding one NS record
-    $ sudo -u pdns pdnsutil add-record example.com example.com MX '25 mail.example.com'
+    $ sudo -u pdns pdnsutil rrset add example.com example.com MX '25 mail.example.com'
     New rrset:
     example.com. 3005 IN MX 25 mail.example.com
-    $ sudo -u pdns pdnsutil add-record example.com www.example.com A 192.0.2.1
+    $ sudo -u pdns pdnsutil rrset add example.com www.example.com A 192.0.2.1
     New rrset:
     www.example.com. 3005 IN A 192.0.2.1
 
@@ -95,7 +95,7 @@ If you see old, or no, data right after changing records, wait for :ref:`setting
 :ref:`setting-negquery-cache-ttl`, :ref:`setting-query-cache-ttl`, or :ref:`setting-zone-cache-refresh-interval`
 to expire before testing.
 
-Now, run ``pdnsutil edit-zone example.com`` and try to add a few more records, and query them with dig to make sure they work.
+Now, run ``pdnsutil zone edit example.com`` and try to add a few more records, and query them with dig to make sure they work.
 
 You now have a working database driven nameserver!
 

--- a/docs/guides/basic-database.rst
+++ b/docs/guides/basic-database.rst
@@ -74,6 +74,18 @@ Now, let's add a zone and some records::
     New rrset:
     www.example.com. 3005 IN A 192.0.2.1
 
+or, prior to version 5.0::
+
+    $ sudo -u pdns pdnsutil create-zone example.com ns1.example.com
+    Creating empty zone 'example.com'
+    Also adding one NS record
+    $ sudo -u pdns pdnsutil add-record example.com example.com MX '25 mail.example.com'
+    New rrset:
+    example.com. 3005 IN MX 25 mail.example.com
+    $ sudo -u pdns pdnsutil add-record example.com www.example.com A 192.0.2.1
+    New rrset:
+    www.example.com. 3005 IN A 192.0.2.1
+
 This should be done as the ``pdns`` user (or root), as sqlite3 requires write access to the directory of the database file.
 
 .. note::
@@ -91,11 +103,13 @@ If we now requery our database, ``www.example.com`` should be present::
 
 If this is not the output you get, remove ``+short`` to see the full output so you can find out what went wrong.
 The first problem could be that PowerDNS has a :ref:`packet-cache` and a :ref:`query-cache` for performance reasons.
-If you see old, or no, data right after changing records, wait for :ref:`setting-cache-ttl`, 
+If you see old, or no, data right after changing records, wait for :ref:`setting-cache-ttl`,
 :ref:`setting-negquery-cache-ttl`, :ref:`setting-query-cache-ttl`, or :ref:`setting-zone-cache-refresh-interval`
 to expire before testing.
 
-Now, run ``pdnsutil zone edit example.com`` and try to add a few more records, and query them with dig to make sure they work.
+Now, run ``pdnsutil zone edit example.com`` (or ``pdnsutil edit-zone
+example.com`` prior to version 5.0) and try to add a few more records, and query
+them with dig to make sure they work.
 
 You now have a working database driven nameserver!
 

--- a/docs/guides/kskroll.rst
+++ b/docs/guides/kskroll.rst
@@ -11,7 +11,9 @@ After every change, use your favourite DNSSEC checker (`DNSViz <https://dnsviz.n
 .. warning::
 
     For every mutation to your zone make sure that your serial is bumped, so your secondaries pick up the changes too.
-    If you are using AXFR replication, this usually is as simple as ``pdnsutil zone increase-serial example.com``
+    If you are using AXFR replication, this usually is as simple as ``pdnsutil
+    zone increase-serial example.com`` (``pdnsutil increase-serial example.com``
+    prior to version 5.0)
 
 Phase: Initial
 --------------
@@ -28,13 +30,27 @@ At first note down algorithm of currently used KSK, because new KSK shall use th
 
     pdnsutil zone show example.com
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil show-zone example.com
+
 To create a new **active** and **published** KSK with the same algorithm for the zone, run something like:
 
 .. code-block:: shell
 
     pdnsutil zone add-key example.com ksk active published ALGORITHM
 
-Please note down the key ID that ``zone add-key`` reports. You can also retrieve it later with ``pdnsutil zone show example.com``.
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil add-zone-key example.com ksk active published ALGORITHM
+
+Please note down the key ID that ``zone add-key`` reports. You can also retrieve
+it later with ``pdnsutil zone show example.com`` (``pdnsutil show-zone
+example.com`` prior to version 5.0).
 
 After this the DNSKEY set will be signed by both KSKs.
 
@@ -49,7 +65,10 @@ The DNSKEY set is currently signed with both KSKs and keys of both are published
 This means that a DS for either old or new KSK is sufficient for validation.
 We can now switch the DS record in the parent zone - there is no need to have DSes for both KSKs in the parent zone.
 
-Using ``pdnsutil zone show example.com`` or ``pdnsutil zone export-ds example.com``, extract the DNSKEY or DS for new KSK, depending on what the parent zone operator takes as input.
+Using ``pdnsutil zone show example.com`` or ``pdnsutil zone export-ds
+example.com`` (respectively ``pdnsutil show-zone example.com`` and ``pdnsutil
+export-zone-ds example.com`` prior to version 5.0), extract the DNSKEY or DS for
+new KSK, depending on what the parent zone operator takes as input.
 Note that these commands print DNSKEYs and/or DSes for both the old and the new KSK.
 
 Check the DS TTL at the parent, for example: ``dig DS example.com @c.gtld-servers.net`` for a delegation from ``.com``.
@@ -70,7 +89,13 @@ It is time to remove the old DNSKEY:
 .. code-block:: shell
 
     pdnsutil zone remove-key example.com OLD_KSK_ID
-    
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil remove-zone-key example.com OLD_KSK_ID
+
 Please check that your secondaries now only show the new set of keys when queried with ``dig DNSKEY example.com @...``.
 
 Conclusion

--- a/docs/guides/kskroll.rst
+++ b/docs/guides/kskroll.rst
@@ -11,7 +11,7 @@ After every change, use your favourite DNSSEC checker (`DNSViz <https://dnsviz.n
 .. warning::
 
     For every mutation to your zone make sure that your serial is bumped, so your secondaries pick up the changes too.
-    If you are using AXFR replication, this usually is as simple as ``pdnsutil increase-serial example.com``
+    If you are using AXFR replication, this usually is as simple as ``pdnsutil zone increase-serial example.com``
 
 Phase: Initial
 --------------
@@ -26,15 +26,15 @@ At first note down algorithm of currently used KSK, because new KSK shall use th
 
 .. code-block:: shell
 
-    pdnsutil show-zone example.com
+    pdnsutil zone show example.com
 
 To create a new **active** and **published** KSK with the same algorithm for the zone, run something like:
 
 .. code-block:: shell
 
-    pdnsutil add-zone-key example.com ksk active published ALGORITHM
+    pdnsutil zone add-key example.com ksk active published ALGORITHM
 
-Please note down the key ID that ``add-zone-key`` reports. You can also retrieve it later with ``pdnsutil show-zone example.com``.
+Please note down the key ID that ``zone add-key`` reports. You can also retrieve it later with ``pdnsutil zone show example.com``.
 
 After this the DNSKEY set will be signed by both KSKs.
 
@@ -49,7 +49,7 @@ The DNSKEY set is currently signed with both KSKs and keys of both are published
 This means that a DS for either old or new KSK is sufficient for validation.
 We can now switch the DS record in the parent zone - there is no need to have DSes for both KSKs in the parent zone.
 
-Using ``pdnsutil show-zone example.com`` or ``pdnsutil export-zone-ds example.com``, extract the DNSKEY or DS for new KSK, depending on what the parent zone operator takes as input.
+Using ``pdnsutil zone show example.com`` or ``pdnsutil zone export-ds example.com``, extract the DNSKEY or DS for new KSK, depending on what the parent zone operator takes as input.
 Note that these commands print DNSKEYs and/or DSes for both the old and the new KSK.
 
 Check the DS TTL at the parent, for example: ``dig DS example.com @c.gtld-servers.net`` for a delegation from ``.com``.
@@ -69,7 +69,7 @@ It is time to remove the old DNSKEY:
 
 .. code-block:: shell
 
-    pdnsutil remove-zone-key example.com OLD_KSK_ID
+    pdnsutil zone remove-key example.com OLD_KSK_ID
     
 Please check that your secondaries now only show the new set of keys when queried with ``dig DNSKEY example.com @...``.
 

--- a/docs/guides/kskrollcdnskey.rst
+++ b/docs/guides/kskrollcdnskey.rst
@@ -9,29 +9,29 @@ rollover. This HowTo follows the rollover example from the RFCs
 We assume the zone name is example.com and is already DNSSEC signed.
 
 Start by adding a new KSK to the zone:
-``pdnsutil add-zone-key example.com ksk 2048 inactive``. The "inactive"
+``pdnsutil zone add-key example.com ksk 2048 inactive``. The "inactive"
 means that the key is not used to sign any ZSK records. This limits the
 size of ``ANY`` and DNSKEY responses.
 
-Publish the CDS records: ``pdnsutil set-publish-cds example.com``, these
+Publish the CDS records: ``pdnsutil zone set-publish-cds example.com``, these
 records will tell the parent zone to update its DS records. Now wait for
 the DS records to be updated in the parent zone.
 
 Once the DS records are updated, do the actual key-rollover:
-``pdnsutil activate-zone-key example.com new-key-id`` and
-``pdnsutil deactivate-zone-key example.com old-key-id``. You can get the
+``pdnsutil zone activate-key example.com new-key-id`` and
+``pdnsutil zone deactivate-key example.com old-key-id``. You can get the
 ``new-key-id`` and ``old-key-id`` by listing them through
-``pdnsutil show-zone example.com``.
+``pdnsutil zone show example.com``.
 
 After the rollover, wait *at least* until the TTL on the DNSKEY records
 have expired so validating resolvers won't mark the zone as BOGUS. When
 the wait is over, delete the old key from the zone:
-``pdnsutil remove-zone-key example.com old-key-id``. This updates the
+``pdnsutil zone remove-key example.com old-key-id``. This updates the
 CDS records to reflect only the new key.
 
 Wait for the parent to pick up on the CDS change. Once the upstream DS
 records show only the DS records for the new KSK, you may disable
 sending out the CDS responses:
-``pdnsutil unset-publish-cds example.com``.
+``pdnsutil zone unset-publish-cds example.com``.
 
 Done!

--- a/docs/guides/kskrollcdnskey.rst
+++ b/docs/guides/kskrollcdnskey.rst
@@ -2,36 +2,72 @@ KSK Rollover using CDS & CDNSKEY Key Rollover
 =============================================
 
 If the upstream registry supports :rfc:`7344` key rollovers you can use
-several :doc:`pdnsutil <../dnssec/pdnsutil>` commands to do this
+several :doc:`pdnsutil <../manpages/pdnsutil.1>` commands to do this
 rollover. This HowTo follows the rollover example from the RFCs
 :rfc:`Appendix B <7344#appendix-B>`.
 
 We assume the zone name is example.com and is already DNSSEC signed.
 
-Start by adding a new KSK to the zone:
-``pdnsutil zone add-key example.com ksk 2048 inactive``. The "inactive"
+Start by adding a new KSK to the zone::
+
+  pdnsutil zone add-key example.com ksk 2048 inactive
+
+or, prior to version 5.0::
+
+  pdnsutil add-zone-key example.com ksk 2048 inactive
+
+The "inactive"
 means that the key is not used to sign any ZSK records. This limits the
 size of ``ANY`` and DNSKEY responses.
 
-Publish the CDS records: ``pdnsutil zone set-publish-cds example.com``, these
-records will tell the parent zone to update its DS records. Now wait for
+Publish the CDS records::
+
+  pdnsutil zone set-publish-cds example.com
+
+or, prior to version 5.0::
+
+  pdnsutil set-publish-cds example.com
+
+These records will tell the parent zone to update its DS records. Now wait for
 the DS records to be updated in the parent zone.
 
 Once the DS records are updated, do the actual key-rollover:
-``pdnsutil zone activate-key example.com new-key-id`` and
-``pdnsutil zone deactivate-key example.com old-key-id``. You can get the
+
+.. code-block:: shell
+
+  pdnsutil zone activate-key example.com new-key-id
+  pdnsutil zone deactivate-key example.com old-key-id
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+  pdnsutil activate-zone-key example.com new-key-id
+  pdnsutil deactivate-zone-key example.com old-key-id
+
+You can get the
 ``new-key-id`` and ``old-key-id`` by listing them through
-``pdnsutil zone show example.com``.
+``pdnsutil zone show example.com`` (``pdnsutil show-zone example.com`` prior to
+version 5.0).
 
 After the rollover, wait *at least* until the TTL on the DNSKEY records
 have expired so validating resolvers won't mark the zone as BOGUS. When
-the wait is over, delete the old key from the zone:
-``pdnsutil zone remove-key example.com old-key-id``. This updates the
-CDS records to reflect only the new key.
+the wait is over, delete the old key from the zone::
+
+  pdnsutil zone remove-key example.com old-key-id
+
+or, prior to version 5.0::
+
+  pdnsutil remove-zone-key example.com old-key-id
+
+This updates the CDS records to reflect only the new key.
 
 Wait for the parent to pick up on the CDS change. Once the upstream DS
 records show only the DS records for the new KSK, you may disable
-sending out the CDS responses:
-``pdnsutil zone unset-publish-cds example.com``.
+sending out the CDS responses::
 
-Done!
+  pdnsutil zone unset-publish-cds example.com
+
+or, prior to version 5.0::
+
+  pdnsutil unset-publish-cds example.com

--- a/docs/guides/svcb.rst
+++ b/docs/guides/svcb.rst
@@ -78,7 +78,7 @@ In this case, the ipv6hint parameter is dropped when answering the query (and on
   ;; ADDITIONAL SECTION:
   no-ipv6.example.org.	3600	IN	A	192.0.2.2
 
-:doc:`pdnsutil <../manpages/pdnsutil.1>` checks if the autohints in SVCB and derived records can be found in the zone when using ``pdnsutil check-zone``.
+:doc:`pdnsutil <../manpages/pdnsutil.1>` checks if the autohints in SVCB and derived records can be found in the zone when using ``pdnsutil zone check``.
 It will emit a warning when there are no hints to be found::
 
   [warning] HTTPS record for no-ipv6.example.org has automatic IPv6 hints, but no AAAA-record for the target at no-ipv6.example.org exists.

--- a/docs/guides/svcb.rst
+++ b/docs/guides/svcb.rst
@@ -78,7 +78,8 @@ In this case, the ipv6hint parameter is dropped when answering the query (and on
   ;; ADDITIONAL SECTION:
   no-ipv6.example.org.	3600	IN	A	192.0.2.2
 
-:doc:`pdnsutil <../manpages/pdnsutil.1>` checks if the autohints in SVCB and derived records can be found in the zone when using ``pdnsutil zone check``.
+:doc:`pdnsutil <../manpages/pdnsutil.1>` checks if the autohints in SVCB and derived records can be found in the zone when using ``pdnsutil zone check``
+(``pdnsutil check-zone`` prior to version 5.0).
 It will emit a warning when there are no hints to be found::
 
   [warning] HTTPS record for no-ipv6.example.org has automatic IPv6 hints, but no AAAA-record for the target at no-ipv6.example.org exists.

--- a/docs/guides/zskroll.rst
+++ b/docs/guides/zskroll.rst
@@ -15,7 +15,7 @@ After every change, use your favourite DNSSEC checker (`DNSViz <https://dnsviz.n
 .. warning::
 
     For every mutation to your zone make sure that your serial is bumped, so your secondaries pick up the changes too.
-    If you are using AXFR replication, this usually is as simple as ``pdnsutil increase-serial example.com``
+    If you are using AXFR replication, this usually is as simple as ``pdnsutil zone increase-serial example.com``
 
 Phase: Initial
 --------------
@@ -30,15 +30,15 @@ At first note down algorithm of currently used ZSK, because new ZSK shall use th
 
 .. code-block:: shell
 
-    pdnsutil show-zone example.com
+    pdnsutil zone show example.com
 
 To create a new **inactive** but **published** ZSK with the same algorithm, run something like:
 
 .. code-block:: shell
 
-    pdnsutil add-zone-key example.com zsk inactive published ALGORITHM
+    pdnsutil zone add-key example.com zsk inactive published ALGORITHM
 
-Please note down the key ID that ``add-zone-key`` reports. You can also retrieve it later with ``pdnsutil show-zone example.com``.
+Please note down the key ID that ``zone add-key`` reports. You can also retrieve it later with ``pdnsutil zone show example.com``.
 
 PowerDNS will now publish the new DNSKEY while the old DNSKEY remains published and active for signing.
 
@@ -53,8 +53,8 @@ To change the RRSIGs on records in the zone, the new DNSKEY must be made active 
 
 .. code-block:: shell
 
-    pdnsutil activate-zone-key example.com NEW-ZSK-ID
-    pdnsutil deactivate-zone-key example.com OLD-ZSK-ID
+    pdnsutil zone activate-key example.com NEW-ZSK-ID
+    pdnsutil zone deactivate-key example.com OLD-ZSK-ID
 
 After this, PowerDNS will sign all records in the zone with the new ZSK and remove all signatures made with the old ZSK.
 
@@ -74,7 +74,7 @@ The last step is to remove the old DNSKEY from the zone:
 
 .. code-block:: shell
 
-    pdnsutil remove-zone-key example.com OLD-ZSK-ID
+    pdnsutil zone remove-key example.com OLD-ZSK-ID
 
 Please check that your secondaries now show only the new DNSKEY when queried with ``dig DNSKEY example.com @...``.
 

--- a/docs/guides/zskroll.rst
+++ b/docs/guides/zskroll.rst
@@ -7,7 +7,7 @@ This How To describes the "Pre-Publish" approach from the above mentioned RFC, a
 Phases are named after the steps in the diagram in that section.
 
 .. warning::
-    
+
     The following instructions assume rollover of a key which is NOT a Secure Entry Point (SEP), please confirm this fact before proceeding any further.
 
 After every change, use your favourite DNSSEC checker (`DNSViz <https://dnsviz.net/>`__, `VeriSign DNSSEC Analyzer <https://dnssec-debugger.verisignlabs.com/>`__, a validating resolver) to make sure no mistakes have crept in.
@@ -15,7 +15,9 @@ After every change, use your favourite DNSSEC checker (`DNSViz <https://dnsviz.n
 .. warning::
 
     For every mutation to your zone make sure that your serial is bumped, so your secondaries pick up the changes too.
-    If you are using AXFR replication, this usually is as simple as ``pdnsutil zone increase-serial example.com``
+    If you are using AXFR replication, this usually is as simple as ``pdnsutil
+    zone increase-serial example.com`` (``pdnsutil increase-serial example.com``
+    prior to version 5.0)
 
 Phase: Initial
 --------------
@@ -32,13 +34,27 @@ At first note down algorithm of currently used ZSK, because new ZSK shall use th
 
     pdnsutil zone show example.com
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil show-zone example.com
+
 To create a new **inactive** but **published** ZSK with the same algorithm, run something like:
 
 .. code-block:: shell
 
     pdnsutil zone add-key example.com zsk inactive published ALGORITHM
 
-Please note down the key ID that ``zone add-key`` reports. You can also retrieve it later with ``pdnsutil zone show example.com``.
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil add-zone-key example.com zsk inactive published ALGORITHM
+
+Please note down the key ID that ``zone add-key`` reports. You can also retrieve
+it later with ``pdnsutil zone show example.com`` (``pdnsutil show-zone
+example.com`` prior to version 5.0).
 
 PowerDNS will now publish the new DNSKEY while the old DNSKEY remains published and active for signing.
 
@@ -56,13 +72,20 @@ To change the RRSIGs on records in the zone, the new DNSKEY must be made active 
     pdnsutil zone activate-key example.com NEW-ZSK-ID
     pdnsutil zone deactivate-key example.com OLD-ZSK-ID
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil activate-zone-key example.com NEW-ZSK-ID
+    pdnsutil deactivate-zone-key example.com OLD-ZSK-ID
+
 After this, PowerDNS will sign all records in the zone with the new ZSK and remove all signatures made with the old ZSK.
 
 Please check that your secondaries now show only the new signatures.
 
 In your zone, check for the highest TTL you can find.
 This includes the SOA TTL and the SOA MINIMUM, which affect negative caching, including NSEC/NSEC3 records.
-:ref:`The DNSKEY TTL is also taken from the SOA MINIMUM.<dnssec-ttl-notes>` 
+:ref:`The DNSKEY TTL is also taken from the SOA MINIMUM.<dnssec-ttl-notes>`
 
 Now wait for at least that long.
 Depending on your setup, this will usually be between a few hours and a few days.
@@ -75,6 +98,12 @@ The last step is to remove the old DNSKEY from the zone:
 .. code-block:: shell
 
     pdnsutil zone remove-key example.com OLD-ZSK-ID
+
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil remove-zone-key example.com OLD-ZSK-ID
 
 Please check that your secondaries now show only the new DNSKEY when queried with ``dig DNSKEY example.com @...``.
 

--- a/docs/http-api/zone.rst
+++ b/docs/http-api/zone.rst
@@ -25,7 +25,8 @@ Comments are per-RRset.
 
   Switching ``dnssec`` to ``true`` (from ``false``) sets up DNSSEC signing
   based on the other flags, this includes running the equivalent of
-  ``secure-zone`` and ``rectify-zone`` (if ``api_rectify`` is set to ``true``).
+  ``pdnsutil zone secure`` and ``pdnsutil zone rectify`` (if ``api_rectify``
+  is set to ``true``).
   This also applies to newly created zones. If ``presigned`` is ``true``,
   no DNSSEC changes will be made to the zone or cryptokeys.
 

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -376,7 +376,8 @@ zone set-publish-cds *ZONE* [*DIGESTALGOS*]
 
 zone show *ZONE*
 
-    Shows all DNSSEC related settings of a zone called *ZONE*.
+    Shows various details of the zone called *ZONE*, including its
+    DNSSEC related settings.
 
 zone unset-nsec3 *ZONE*
 

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -341,16 +341,16 @@ zone set-nsec3 *ZONE* ['*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*'] [**narrow
     resolvers and that a limit can be set with ``max-nsec3-iterations``
     in ``pdns.conf``. The *SALT* is a hexadecimal string encoding the bits
     for the salt, or - to use no salt.
-    
+
     Setting **narrow** will make PowerDNS send out "white lies" (:rfc:`7129`)
     about the next secure record to prevent zone enumeration. Instead of
     looking it up in the database, it will send out the hash + 1 as the next
     secure record. Narrow mode requires online signing capabilities by the
     nameserver and therefore zone transfers are denied.
-    
+
     If only the zone is provided as argument, the 4-parameter quoted string
     defaults to ``'1 0 0 -'``, as recommended by :rfc:`9276`.
-    
+
     A sample commandline would be:
 
     ``pdnsutil zone set-nsec3 powerdnssec.org '1 1 1 ab' narrow``
@@ -410,12 +410,12 @@ zone add-key *ZONE* [**KSK**,\ **ZSK**] [**active**,\ **inactive**] [**published
     the specified *ALGORITHM* and *KEYBITS*. If *KEYBITS* is omitted, the value
     of :ref:`setting-default-ksk-size` or :ref:`setting-default-zsk-size` are
     used.
-    
+
     The key is inactive by default, set it to **active** to immediately use it
     to sign *ZONE*. The key is published in the zone by default, set it to
     **unpublished** to keep it from being returned in a DNSKEY query, which is
     useful for algorithm rollovers.
-    
+
     Prints the id of the added key.
 
 zone deactivate-key *ZONE* *KEY_ID*

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -4,12 +4,12 @@ pdnsutil
 Synopsis
 --------
 
-pdnsutil [OPTION]... *COMMAND*
+:program:`pdnsutil` [OPTION]... *COMMAND*
 
 Description
 -----------
 
-:program:`pdnsutil` (formerly pdnssec) is a powerful command that is the
+:program:`pdnsutil` (formerly ``pdnssec``) is a powerful command that is the
 operator-friendly gateway into DNSSEC and zone management for PowerDNS.
 Behind the scenes, :program:`pdnsutil` manipulates a PowerDNS backend database,
 which also means that for many databases, :program:`pdnsutil` can be run
@@ -28,8 +28,237 @@ Options
 Commands
 --------
 
-There are many available commands, this section splits them up into
-their respective uses.
+There are many available commands. Most commands follow the pattern
+``pdnsutil <object> <action> [arguments...]``, where ``<object>`` is a noun and ``<action>`` is a verb; a few commands which do not apply to any particular object
+kind use only the verb.
+
+AUTOPRIMARY COMMANDS
+--------------------
+
+autoprimary add *IP* *NAMESERVER* [*ACCOUNT*]
+
+    Add a autoprimary entry into the backend. This enables receiving zone
+    updates from other servers.
+
+autoprimary list
+
+    List all autoprimaries.
+
+autoprimary remove *IP* *NAMESERVER*
+
+    Remove an autoprimary from backend. Not supported by BIND backend.
+
+CATALOG ZONE COMMANDS
+---------------------
+
+catalog list-members *CATALOG*
+
+    List all members of catalog zone *CATALOG*"
+
+catalog set *ZONE* [*CATALOG*]
+
+    Change the catalog of *ZONE* to *CATALOG*. If *CATALOG* is omitted,
+    removes *ZONE* from the catalog it is in.
+
+ZONE METADATA COMMANDS
+----------------------
+
+metadata add *ZONE* *KIND* *VALUE* [*VALUE*]...
+
+    Append *VALUE* to the existing *KIND* metadata for *ZONE*.
+    Will return an error if *KIND* does not support multiple values, use
+    ``metadata set`` for these values.
+
+metadata get *ZONE* [*KIND*]...
+
+    Get zone metadata. If no *KIND* given, lists all known.
+
+metadata set *ZONE* *KIND* [*VALUE*]...
+
+    Set zone metadata *KIND* for *ZONE* to *VALUE*, replacing all existing
+    values of *KIND*. An omitted value clears it.
+
+NETWORK COMMANDS
+----------------
+
+network list
+
+    List all defined networks with their chosen views.
+
+network set *NET* [*VIEW*]
+
+    Set the *VIEW* for a the *NET* network, or delete if no *VIEW* argument.
+
+ZONE RECORD COMMANDS
+--------------------
+
+In these commands, the ``rrset`` object name may also be written as ``record``.
+
+rrset add *ZONE* *NAME* *TYPE* [*TTL*] *CONTENT*
+
+    Add one or more records of *NAME* and *TYPE* to *ZONE* with *CONTENT*
+    and optional *TTL*. If *TTL* is not set, the configured *default-ttl* will be used.
+    *NAME* must be absolute.
+
+rrset delete *ZONE* *NAME* *TYPE*
+
+    Delete named RRSET from zone.
+    *NAME* must be absolute.
+
+rrset hash *ZONE* *RNAME*
+
+    This convenience command hashes the name *RNAME* according to the
+    NSEC3 settings of *ZONE*. Refuses to hash for zones with no NSEC3
+    settings.
+
+rrset replace *ZONE* *NAME* *TYPE* [*TTL*] *CONTENT* [*CONTENT*...]
+
+    Replace existing *NAME* in zone *ZONE* with a new set.
+
+TSIG RELATED COMMANDS
+---------------------
+
+These commands manipulate TSIG key information in the database. Some
+commands require an *ALGORITHM*, which can be any of the following:
+
+-  hmac-md5
+-  hmac-sha1
+-  hmac-sha224
+-  hmac-sha256
+-  hmac-sha384
+-  hmac-sha512
+
+tsigkey activate *ZONE* *NAME* {**primary**,\ **secondary**,\ **producer**,\ **consumer**}
+
+    Enable TSIG authenticated AXFR using the key *NAME* for zone *ZONE*.
+    This sets the ``TSIG-ALLOW-AXFR`` (primary/producer) or ``AXFR-MASTER-TSIG``
+    (secondary/consumer) zone metadata.
+
+tsigkey deactivate *ZONE* *NAME* {**primary**,\ **secondary**,\ **producer**,\ **consumer**}
+
+    Disable TSIG authenticated AXFR using the key *NAME* for zone
+    *ZONE*.
+
+tsigkey delete *NAME*
+
+    Delete the TSIG key *NAME*. Warning: this does not deactivate said key.
+
+tsigkey generate *NAME* *ALGORITHM*
+
+    Generate new TSIG key with name *NAME* and the specified algorithm.
+
+tsigkey import *NAME* *ALGORITHM* *KEY*
+
+    Import *KEY* of the specified algorithm as *NAME*.
+
+tsigkey list
+
+    Show a list of all configured TSIG keys.
+
+VIEWS COMMANDS
+--------------
+
+views add-zone *VIEW* *ZONE..VARIANT*
+
+    Add the given *ZONE* *VARIANT* to a *VIEW*.
+
+views del-zone *VIEW* *ZONE..VARIANT*
+
+    Remove a *ZONE* *VARIANT* from a *VIEW*.
+
+views list *VIEW*
+
+    List all zones within *VIEW*.
+
+views list-all
+
+    List all view names.
+
+ZONE MANIPULATION COMMANDS
+--------------------------
+
+zone check *ZONE*
+
+    Check zone *ZONE* for correctness.
+
+zone check-all [exit-on-error]
+
+    Check all zones for correctness, aborting upon finding the first error
+    in any zone if "exit-on-error" is specified.
+
+zone clear *ZONE*
+
+    Clear the records in zone *ZONE*, but leave actual zone and
+    settings unchanged
+
+zone create *ZONE*
+
+    Create an empty zone named *ZONE*.
+
+zone delete *ZONE*
+
+    Delete the zone named *ZONE*.
+
+zone edit *ZONE*
+
+    Opens *ZONE* in zonefile format (regardless of backend it was loaded
+    from) in the editor set in the environment variable **EDITOR**. if
+    **EDITOR** is empty, *pdnsutil* falls back to using *editor*.
+
+zone increase-serial *ZONE*
+
+    Increases the SOA-serial by 1. Uses SOA-EDIT.
+
+zone list *ZONE*
+
+    Show all records for *ZONE*.
+
+zone list-all *KIND*
+
+    List all active zone names of the given *KIND* (primary, secondary,
+    native, producer, consumer), or all if none given. Passing --verbose or
+    -v will also include disabled or empty zones.
+
+zone load *ZONE* *FILE*
+
+    Load records for *ZONE* from *FILE*. If *ZONE* already exists, all
+    records are overwritten, this operation is atomic. If *ZONE* doesn't
+    exist, it is created.
+
+zone set-account *ZONE* *ACCOUNT*
+
+    Change the account (owner) of *ZONE* to *ACCOUNT*.
+
+zone set-kind *ZONE* *KIND*
+
+    Change the kind of *ZONE* to *KIND* (primary, secondary, native, producer,
+    consumer).
+
+zone set-option *ZONE* [*producer* | *consumer*] [*coo* | *unique* | *group*] *VALUE* [*VALUE* ...]
+
+    Set or remove an option for *ZONE*. Providing an empty value removes
+    an option.
+
+zone set-options-json *ZONE* *JSONFILE*
+
+    Change the options of *ZONE* to the contents of *JSONFILE*.
+
+zone zonemd-verify-file *ZONE* *FILE*
+
+    Validate ZONEMD for *ZONE* read from *FILE*.
+
+SECONDARY ZONE COMMANDS
+-----------------------
+
+zone change-primary *ZONE* *PRIMARY* [*PRIMARY*]...
+
+    Change the primaries for secondary zone *ZONE* to new primaries *PRIMARY*. All
+    *PRIMARY*\ s need to to be space-separated IP addresses with an optional port.
+
+zone create-secondary *ZONE* *PRIMARY* [*PRIMARY*]...
+
+    Create a new secondary zone *ZONE* with primaries *PRIMARY*. All *PRIMARY*\ s
+    need to to be space-separated IP addresses with an optional port.
 
 DNSSEC-RELATED COMMANDS
 -----------------------
@@ -57,88 +286,48 @@ bits. The key size may be omitted for the ECC algorithms, which support only
 one valid size per algorithm; for ECDSA256 and ED25519, it is 256;
 for ECDSA384, it is 384; and for ED448, it is... 456.
 
-activate-zone-key *ZONE* *KEY_ID*
-
-    Activate a key with id *KEY_ID* within a zone called *ZONE*.
-
-add-zone-key *ZONE* [**KSK**,\ **ZSK**] [**active**,\ **inactive**] [**published**,\ **unpublished**] *ALGORITHM* [*KEYBITS*]
-
-    Create a new key for zone *ZONE*, and make it a KSK (default) or a ZSK, with
-    the specified *ALGORITHM* and *KEYBITS*. If *KEYBITS* is omitted, the value
-    of :ref:`setting-default-ksk-size` or :ref:`setting-default-zsk-size` are
-    used.
-    
-    The key is inactive by default, set it to **active** to immediately use it
-    to sign *ZONE*. The key is published in the zone by default, set it to
-    **unpublished** to keep it from being returned in a DNSKEY query, which is
-    useful for algorithm rollovers.
-    
-    Prints the id of the added key.
-
-create-bind-db *FILENAME*
-
-    Create DNSSEC database (sqlite3) at *FILENAME* for the BIND backend.
-    Remember to set ``bind-dnssec-db=*FILE*`` in your ``pdns.conf``.
-
-deactivate-zone-key *ZONE* *KEY_ID*
-
-    Deactivate a key with id KEY_ID within a zone called *ZONE*.
-
-disable-dnssec *ZONE*
+zone dnssec-disable *ZONE*
 
     Deactivate all keys and unset PRESIGNED in *ZONE*.
 
-export-zone-dnskey *ZONE* *KEY_ID*
+zone export-dnskey *ZONE* *KEY_ID*
 
     Export DNSKEY and DS of key with key id *KEY_ID* within zone *ZONE* to
     standard output.
 
-export-zone-ds *ZONE*
+zone export-ds *ZONE*
 
     Export all KSK DS records for *ZONE* to standard output.
 
-export-zone-key *ZONE* *KEY_ID*
+zone list-keys [*ZONE*]
 
-    Export full (private) key with key id *KEY_ID* within zone *ZONE* to
-    standard output. The format used is compatible with BIND and NSD/LDNS.
+    List DNSSEC information for all keys or for *ZONE* only. Passing
+    --verbose or -v will also include the keys for disabled or empty zones.
 
-export-zone-key-pem *ZONE* *KEY_ID*
+zone rectify *ZONE*
 
-    Export full (private) key with key id *KEY_ID* within zone *ZONE* to
-    standard output in the PEM file format. The format is compatible with
-    many non-DNS software products.
+    Calculates the 'ordername' and 'auth' fields for a zone called
+    *ZONE* so they comply with DNSSEC settings. Can be used to fix up
+    migrated data.
 
-generate-zone-key {**KSK**,\ **ZSK**} [*ALGORITHM*] [*KEYBITS*]
+zone rectify-all
 
-    Generate a ZSK or KSK with specified algorithm and bits and print it
-    on standard output. If *ALGORITHM* is not set, ECDSA256 is used.
-    If *KEYBITS* is not set, an appropriate keysize is selected
-    for *ALGORITHM*: for RSA keys, 2048 bits for KSK and 1024 bits for ZSK;
-    for ECC keys, the algorithm-required size as mentioned above.
+    Calculates the 'ordername' and 'auth' fields for all zones so they
+    comply with DNSSEC settings. Can be used to fix up migrated data.
 
-import-zone-key *ZONE* *FILE* [**KSK**,\ **ZSK**] [**active**,\ **inactive**] [**published**,\ **unpublished**]
+zone secure *ZONE*
 
-    Import from *FILE* a full (private) key for the zone *ZONE*. The
-    format used is compatible with BIND and NSD/LDNS. **KSK** or **ZSK**
-    specifies the flags this key should have on import. Defaults to KSK,
-    active and published. Prints the id of the added key.
+    Configures a zone called *ZONE* with reasonable DNSSEC settings. You
+    should manually run 'pdnsutil zone rectify' afterwards.
 
-import-zone-key-pem *ZONE* *FILE* *ALGORITHM* {**KSK**,\ **ZSK**}
+zone secure-all [**increase-serial**]
 
-    Import from PEM *FILE* a full (private) key for the zone *ZONE* with a
-    specified *ALGORITHM*. The format used is compatible with many non-DNS
-    software products. **KSK** or **ZSK** specifies the flags this key should
-    have on import. Prints the id of the added key.
+    Configures all zones that are not currently signed with reasonable
+    DNSSEC settings. Setting **increase-serial** will increase the
+    serial of those zones too. You should manually run 'pdnsutil
+    zone rectify-all' afterwards.
 
-publish-zone-key *ZONE* *KEY_ID*
-
-    Publish the key with id *KEY_ID* within zone *ZONE*.
-
-remove-zone-key *ZONE* *KEY_ID*
-
-    Remove a key with id *KEY_ID* from zone *ZONE*.
-
-set-nsec3 *ZONE* ['*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*'] [**narrow**]
+zone set-nsec3 *ZONE* ['*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*'] [**narrow**]
 
     Sets NSEC3 parameters for this zone. The quoted parameters are 4
     values that are used for the NSEC3PARAM record and decide how
@@ -164,306 +353,126 @@ set-nsec3 *ZONE* ['*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*'] [**narrow**]
     
     A sample commandline would be:
 
-    ``pdnsutil set-nsec3 powerdnssec.org '1 1 1 ab' narrow``
+    ``pdnsutil zone set-nsec3 powerdnssec.org '1 1 1 ab' narrow``
 
     **WARNING**: If running in RSASHA1 mode (algorithm 5 or 7), switching
     from NSEC to NSEC3 will require a DS update in the parent zone.
 
-unpublish-zone-key *ZONE* *KEY_ID*
+zone set-presigned *ZONE*
 
-    Unpublish the key with id *KEY_ID* within zone *ZONE*.
+    Switches *ZONE* to presigned operation, utilizing in-zone RRSIGs.
 
-unset-nsec3 *ZONE*
+zone set-publish-cdnskey *ZONE* [**delete**]
 
-    Converts *ZONE* to NSEC operations. **WARNING**: If running in
-    RSASHA1 mode (algorithm 5 or 7), switching from NSEC to NSEC3 will
-    require a DS update at the parent zone!
+    Set *ZONE* to publish CDNSKEY records. Add 'delete' to publish a CDNSKEY
+    with a DNSSEC delete algorithm.
 
-set-publish-cds *ZONE* [*DIGESTALGOS*]
+zone set-publish-cds *ZONE* [*DIGESTALGOS*]
 
     Set *ZONE* to respond to queries for its CDS records. the optional
     argument *DIGESTALGOS* should be a comma-separated list of DS
     algorithms to use. By default, this is 2 (SHA-256). 0 will publish a
     CDS with a DNSSEC delete algorithm.
 
-set-publish-cdnskey *ZONE* [**delete**]
-
-    Set *ZONE* to publish CDNSKEY records. Add 'delete' to publish a CDNSKEY
-    with a DNSSEC delete algorithm.
-
-unset-publish-cds *ZONE*
-
-    Set *ZONE* to stop responding to queries for its CDS records.
-
-unset-publish-cdnskey *ZONE*
-
-    Set *ZONE* to stop publishing CDNSKEY records.
-
-TSIG RELATED COMMANDS
----------------------
-
-These commands manipulate TSIG key information in the database. Some
-commands require an *ALGORITHM*, the following are available:
-
--  hmac-md5
--  hmac-sha1
--  hmac-sha224
--  hmac-sha256
--  hmac-sha384
--  hmac-sha512
-
-activate-tsig-key *ZONE* *NAME* {**primary**,\ **secondary**,\ **producer**,\ **consumer**}
-
-    Enable TSIG authenticated AXFR using the key *NAME* for zone *ZONE*.
-    This sets the ``TSIG-ALLOW-AXFR`` (primary/producer) or ``AXFR-MASTER-TSIG``
-    (secondary/consumer) zone metadata.
-
-deactivate-tsig-key *ZONE* *NAME* {**primary**,\ **secondary**,\ **producer**,\ **consumer**}
-
-    Disable TSIG authenticated AXFR using the key *NAME* for zone
-    *ZONE*.
-
-delete-tsig-key *NAME*
-
-    Delete the TSIG key *NAME*. Warning: this does not deactivate said key.
-
-generate-tsig-key *NAME* *ALGORITHM*
-
-    Generate new TSIG key with name *NAME* and the specified algorithm.
-
-import-tsig-key *NAME* *ALGORITHM* *KEY*
-
-    Import *KEY* of the specified algorithm as *NAME*.
-
-list-tsig-keys
-
-    Show a list of all configured TSIG keys.
-
-ZONE MANIPULATION COMMANDS
---------------------------
-
-add-record *ZONE* *NAME* *TYPE* [*TTL*] *CONTENT*
-
-    Add one or more records of *NAME* and *TYPE* to *ZONE* with *CONTENT*
-    and optional *TTL*. If *TTL* is not set, the configured *default-ttl* will be used.
-    *NAME* must be absolute.
-
-add-autoprimary *IP* *NAMESERVER* [*ACCOUNT*]
-
-    Add a autoprimary entry into the backend. This enables receiving zone
-    updates from other servers.
-
-remove-autoprimary *IP* *NAMESERVER*
-
-    Remove an autoprimary from backend. Not supported by BIND backend.
-
-list-autoprimaries
-
-    List all autoprimaries.
-
-create-zone *ZONE*
-
-    Create an empty zone named *ZONE*.
-
-create-secondary-zone *ZONE* *PRIMARY* [*PRIMARY*]...
-
-    Create a new secondary zone *ZONE* with primaries *PRIMARY*. All *PRIMARY*\ s
-    need to to be space-separated IP addresses with an optional port.
-
-change-secondary-zone-primary *ZONE* *PRIMARY* [*PRIMARY*]...
-
-    Change the primaries for secondary zone *ZONE* to new primaries *PRIMARY*. All
-    *PRIMARY*\ s need to to be space-separated IP addresses with an optional port.
-
-check-all-zones
-
-    Check all zones for correctness.
-
-check-zone *ZONE*
-
-    Check zone *ZONE* for correctness.
-
-clear-zone *ZONE*
-
-    Clear the records in zone *ZONE*, but leave actual zone and
-    settings unchanged
-
-delete-rrset *ZONE* *NAME* *TYPE*
-
-    Delete named RRSET from zone.
-    *NAME* must be absolute.
-
-delete-zone *ZONE*
-
-    Delete the zone named *ZONE*.
-
-edit-zone *ZONE*
-
-    Opens *ZONE* in zonefile format (regardless of backend it was loaded
-    from) in the editor set in the environment variable **EDITOR**. if
-    **EDITOR** is empty, *pdnsutil* falls back to using *editor*.
-
-hash-password [*WORK_FACTOR*]
-
-    This convenience command reads a password (not echoed) from standard
-    input and returns a hashed and salted version, for use as a webserver
-    password or api key.
-    An optional scrypt work factor can be specified, in powers of two,
-    otherwise it defaults to 1024.
-
-hash-zone-record *ZONE* *RNAME*
-
-    This convenience command hashes the name *RNAME* according to the
-    NSEC3 settings of *ZONE*. Refuses to hash for zones with no NSEC3
-    settings.
-
-increase-serial *ZONE*
-
-    Increases the SOA-serial by 1. Uses SOA-EDIT.
-
-list-keys [*ZONE*]
-
-    List DNSSEC information for all keys or for *ZONE* only. Passing
-    --verbose or -v will also include the keys for disabled or empty zones.
-
-list-all-zones *KIND*
-
-    List all active zone names of the given *KIND* (primary, secondary,
-    native, producer, consumer), or all if none given. Passing --verbose or
-    -v will also include disabled or empty zones.
-
-list-member-zones *CATALOG*
-
-    List all members of catalog zone *CATALOG*"
-
-list-zone *ZONE*
-
-    Show all records for *ZONE*.
-
-load-zone *ZONE* *FILE*
-
-    Load records for *ZONE* from *FILE*. If *ZONE* already exists, all
-    records are overwritten, this operation is atomic. If *ZONE* doesn't
-    exist, it is created.
-
-rectify-zone *ZONE*
-
-    Calculates the 'ordername' and 'auth' fields for a zone called
-    *ZONE* so they comply with DNSSEC settings. Can be used to fix up
-    migrated data.
-
-rectify-all-zones
-
-    Calculates the 'ordername' and 'auth' fields for all zones so they
-    comply with DNSSEC settings. Can be used to fix up migrated data.
-
-replace-rrset *ZONE* *NAME* *TYPE* [*TTL*] *CONTENT* [*CONTENT*...]
-
-    Replace existing *NAME* in zone *ZONE* with a new set.
-
-secure-zone *ZONE*
-
-    Configures a zone called *ZONE* with reasonable DNSSEC settings. You
-    should manually run 'pdnsutil rectify-zone' afterwards.
-
-secure-all-zones [**increase-serial**]
-
-    Configures all zones that are not currently signed with reasonable
-    DNSSEC settings. Setting **increase-serial** will increase the
-    serial of those zones too. You should manually run 'pdnsutil
-    rectify-all-zones' afterwards.
-
-set-kind *ZONE* *KIND*
-
-    Change the kind of *ZONE* to *KIND* (primary, secondary, native, producer,
-    consumer).
-
-set-options-json *ZONE* *JSONFILE*
-
-    Change the options of *ZONE* to the contents of *JSONFILE*.
-
-set-option *ZONE* [*producer* | *consumer*] [*coo* | *unique* | *group*] *VALUE* [*VALUE* ...]
-
-    Set or remove an option for *ZONE*. Providing an empty value removes
-    an option.
-
-set-catalog *ZONE* [*CATALOG*]
-
-    Change the catalog of *ZONE* to *CATALOG*. If *CATALOG* is omitted,
-    removes *ZONE* from the catalog it is in.
-
-set-account *ZONE* *ACCOUNT*
-
-    Change the account (owner) of *ZONE* to *ACCOUNT*.
-
-add-meta *ZONE* *KIND* *VALUE* [*VALUE*]...
-
-    Append *VALUE* to the existing *KIND* metadata for *ZONE*.
-    Will return an error if *KIND* does not support multiple values, use
-    **set-meta** for these values.
-
-get-meta *ZONE* [*KIND*]...
-
-    Get zone metadata. If no *KIND* given, lists all known.
-
-set-meta *ZONE* *KIND* [*VALUE*]...
-
-    Set zone metadata *KIND* for *ZONE* to *VALUE*, replacing all existing
-    values of *KIND*. An omitted value clears it.
-
-set-presigned *ZONE*
-
-    Switches *ZONE* to presigned operation, utilizing in-zone RRSIGs.
-
-show-zone *ZONE*
+zone show *ZONE*
 
     Shows all DNSSEC related settings of a zone called *ZONE*.
 
-test-schema *ZONE*
+zone unset-nsec3 *ZONE*
 
-    Test database schema, this creates the zone *ZONE*
+    Converts *ZONE* to NSEC operations. **WARNING**: If running in
+    RSASHA1 mode (algorithm 5 or 7), switching from NSEC to NSEC3 will
+    require a DS update at the parent zone!
 
-unset-presigned *ZONE*
+zone unset-presigned *ZONE*
 
     Disables presigned operation for *ZONE*.
 
-raw-lua-from-content *TYPE* *CONTENT*
+zone unset-publish-cdnskey *ZONE*
 
-    Display record contents in a form suitable for dnsdist's `SpoofRawAction`.
+    Set *ZONE* to stop publishing CDNSKEY records.
 
-zonemd-verify-file *ZONE* *FILE*
+zone unset-publish-cds *ZONE*
 
-    Validate ZONEMD for *ZONE* read from *FILE*.
+    Set *ZONE* to stop responding to queries for its CDS records.
 
-VIEWS COMMANDS
---------------
+ZONE KEY COMMANDS
+-----------------
 
-list-networks
+zone activate-key *ZONE* *KEY_ID*
 
-    List all defined networks with their chosen views.
+    Activate a key with id *KEY_ID* within a zone called *ZONE*.
 
-set-network *NET* [*VIEW*]
+zone add-key *ZONE* [**KSK**,\ **ZSK**] [**active**,\ **inactive**] [**published**,\ **unpublished**] *ALGORITHM* [*KEYBITS*]
 
-    Set the *VIEW* for a the *NET* network, or delete if no *VIEW* argument.
+    Create a new key for zone *ZONE*, and make it a KSK (default) or a ZSK, with
+    the specified *ALGORITHM* and *KEYBITS*. If *KEYBITS* is omitted, the value
+    of :ref:`setting-default-ksk-size` or :ref:`setting-default-zsk-size` are
+    used.
+    
+    The key is inactive by default, set it to **active** to immediately use it
+    to sign *ZONE*. The key is published in the zone by default, set it to
+    **unpublished** to keep it from being returned in a DNSKEY query, which is
+    useful for algorithm rollovers.
+    
+    Prints the id of the added key.
 
-view-add-zone *VIEW* *ZONE..VARIANT*
+zone deactivate-key *ZONE* *KEY_ID*
 
-    Add the given *ZONE* *VARIANT* to a *VIEW*.
+    Deactivate a key with id KEY_ID within a zone called *ZONE*.
 
-view-del-zone *VIEW* *ZONE..VARIANT*
+zone export-key *ZONE* *KEY_ID*
 
-    Remove a *ZONE* *VARIANT* from a *VIEW*.
+    Export full (private) key with key id *KEY_ID* within zone *ZONE* to
+    standard output. The format used is compatible with BIND and NSD/LDNS.
 
-list-view *VIEW*
+zone export-key-pem *ZONE* *KEY_ID*
 
-    List all within *VIEW*.
+    Export full (private) key with key id *KEY_ID* within zone *ZONE* to
+    standard output in the PEM file format. The format is compatible with
+    many non-DNS software products.
 
-list-views
+zone generate-key {**KSK**,\ **ZSK**} [*ALGORITHM*] [*KEYBITS*]
 
-    List all view names.
+    Generate a ZSK or KSK with specified algorithm and bits and print it
+    on standard output. If *ALGORITHM* is not set, ECDSA256 is used.
+    If *KEYBITS* is not set, an appropriate keysize is selected
+    for *ALGORITHM*: for RSA keys, 2048 bits for KSK and 1024 bits for ZSK;
+    for ECC keys, the algorithm-required size as mentioned above.
 
-DEBUGGING TOOLS
----------------
+zone import-key *ZONE* *FILE* [**KSK**,\ **ZSK**] [**active**,\ **inactive**] [**published**,\ **unpublished**]
+
+    Import from *FILE* a full (private) key for the zone *ZONE*. The
+    format used is compatible with BIND and NSD/LDNS. **KSK** or **ZSK**
+    specifies the flags this key should have on import. Defaults to KSK,
+    active and published. Prints the id of the added key.
+
+zone import-key-pem *ZONE* *FILE* *ALGORITHM* {**KSK**,\ **ZSK**}
+
+    Import from PEM *FILE* a full (private) key for the zone *ZONE* with a
+    specified *ALGORITHM*. The format used is compatible with many non-DNS
+    software products. **KSK** or **ZSK** specifies the flags this key should
+    have on import. Prints the id of the added key.
+
+zone publish-key *ZONE* *KEY_ID*
+
+    Publish the key with id *KEY_ID* within zone *ZONE*.
+
+zone remove-key *ZONE* *KEY_ID*
+
+    Remove a key with id *KEY_ID* from zone *ZONE*.
+
+zone unpublish-key *ZONE* *KEY_ID*
+
+    Unpublish the key with id *KEY_ID* within zone *ZONE*.
+
+OTHER/MISCELLANEOUS COMMANDS
+----------------------------
+
+b2b-migrate *OLD* *NEW*
+
+    Migrate data from one backend to another.
+    Needs ``launch=OLD,NEW`` in the configuration.
 
 backend-cmd *BACKEND* *CMD* [*CMD...*]
 
@@ -481,23 +490,41 @@ bench-db [*FILE*]
     *FILE* can be a file with a list, one per line, of zone names to use for this.
     If *FILE* is not specified, powerdns.com is used.
 
-OTHER TOOLS
------------
+create-bind-db *FILENAME*
 
-b2b-migrate *OLD* *NEW*
+    Create DNSSEC database (sqlite3) at *FILENAME* for the BIND backend.
+    Remember to set ``bind-dnssec-db=*FILE*`` in your ``pdns.conf``.
 
-    Migrate data from one backend to another.
-    Needs ``launch=OLD,NEW`` in the configuration.
+hash-password [*WORK_FACTOR*]
+
+    This convenience command reads a password (not echoed) from standard
+    input and returns a hashed and salted version, for use as a webserver
+    password or api key.
+    An optional scrypt work factor can be specified, in powers of two,
+    otherwise it defaults to 1024.
+
+ipdecrypt *IP_ADDRESS* PASSPHRASE_OR_KEY [**key**]
+
+    Decrypt an IP address according to the 'ipcipher' standard. If the
+    passphrase is a base64 key, add the word "key" after it.
 
 ipencrypt *IP_ADDRESS* PASSPHRASE_OR_KEY [**key**]
 
     Encrypt an IP address according to the 'ipcipher' standard. If the
     passphrase is a base64 key, add the word "key" after it.
 
-ipdecrypt *IP_ADDRESS* PASSPHRASE_OR_KEY [**key**]
+list-algorithms [with-backend]
 
-    Decrypt an IP address according to the 'ipcipher' standard. If the
-    passphrase is a base64 key, add the word "key" after it.
+    List all DNSSEC algorithms supported, optionally also listing the
+    cryptographic library used if "with-backend" is specified.
+
+test-schema *ZONE*
+
+    Test database schema, this creates the zone *ZONE*
+
+raw-lua-from-content *TYPE* *CONTENT*
+
+    Display record contents in a form suitable for dnsdist's `SpoofRawAction`.
 
 See also
 --------

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -123,15 +123,15 @@ An example call to ``zone2sql`` could be:
 This will generate the SQL statements for the :doc:`Generic MySQL <backends/generic-mysql>` and pipe them into the pdns-db
 database in MySQL.
 
-Using ``pdnsutil load-zone``
+Using ``pdnsutil zone load``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :doc:`pdnsutil <manpages/pdnsutil.1>` tool has a
-``load-zone`` command that ingests a zone file and imports it into the
+``zone load`` command that ingests a zone file and imports it into the
 first backend that is capable of hosting it.
 
 To import, configure the backend and run
-``pdnsutil load-zone example.com /tmp/example.com.zone`` to import
+``pdnsutil zone load example.com /tmp/example.com.zone`` to import
 the ``example.com`` domain from the ``/tmp/example.com.zone`` file. The
 zone is imported atomically (i.e. it is fully imported, or not) and any
 existing records for that zone are overwritten. This include the SOA record too.
@@ -175,7 +175,7 @@ Moving from source to target
    sure you properly clear **ALL** data from target backend before
    retrying.
 -  Remove (or comment out) old backend from pdns.conf, and run
-   ``pdnsutil rectify-all-zones`` and ``pdnsutil check-all-zones`` to
+   ``pdnsutil zone rectify-all`` and ``pdnsutil zone check-all`` to
    make sure everything is OK.
 -  If everything is OK, then go ahead to restart your PowerDNS service.
    Check logs to make sure everything went ok.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -131,7 +131,8 @@ The :doc:`pdnsutil <manpages/pdnsutil.1>` tool has a
 first backend that is capable of hosting it.
 
 To import, configure the backend and run
-``pdnsutil zone load example.com /tmp/example.com.zone`` to import
+``pdnsutil zone load example.com /tmp/example.com.zone`` (``pdnsutil load-zone
+example.com /tmp/example.com.zone`` prior to version 5.0) to import
 the ``example.com`` domain from the ``/tmp/example.com.zone`` file. The
 zone is imported atomically (i.e. it is fully imported, or not) and any
 existing records for that zone are overwritten. This include the SOA record too.
@@ -175,7 +176,8 @@ Moving from source to target
    sure you properly clear **ALL** data from target backend before
    retrying.
 -  Remove (or comment out) old backend from pdns.conf, and run
-   ``pdnsutil zone rectify-all`` and ``pdnsutil zone check-all`` to
-   make sure everything is OK.
+   ``pdnsutil zone rectify-all`` and ``pdnsutil zone check-all`` (respectively
+   ``pdnsutil rectify-all-zones`` and ``pdnsutil check-all-zones`` prior to
+   version 5.0) to make sure everything is OK.
 -  If everything is OK, then go ahead to restart your PowerDNS service.
    Check logs to make sure everything went ok.

--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -215,7 +215,8 @@ In such cases, make sure to delete the zone contents to force a fresh
 retrieval.
 
 Finally, IXFR updates that "plug" Empty Non-Terminals do not yet remove
-ENT records. A 'pdnsutil zone rectify' may be required.
+ENT records. A ``pdnsutil zone rectify`` (``pdnsutil rectify-zone`` prior to
+version 5.0) may be required.
 
 PowerDNS itself is currently only able to retrieve updates via IXFR. It
 cannot serve IXFR updates.
@@ -263,7 +264,8 @@ There is no need to fill the account name out but it does help keep
 track of where a domain comes from.
 Additionally, if a secondary selects multiple autoprimaries for a zone based on the name of the primary, it also checks that the ``account`` field is the same for all.
 Adding a autoprimary can be done either directly in the database,
-or by using the 'pdnsutil autoprimary add' command.
+or by using the ``pdnsutil autoprimary add`` command (``pdnsutil
+add-autoprimary`` prior to version 5.0).
 
 .. warning::
   When a secondary receives notification while bootstrapping a new domain using autosecondary feature, it will send
@@ -288,7 +290,7 @@ the outcome of the function defines what PowerDNS does with the records.
 
 What you can accomplish using a Lua script:
 
-- Ensure consistent values on SOA 
+- Ensure consistent values on SOA
 - Change incoming SOA serial number to a YYYYMMDDnn format
 - Ensure consistent NS RRset
 - Timestamp the zone transfer with a TXT record
@@ -296,6 +298,10 @@ What you can accomplish using a Lua script:
 This script can be enabled like this::
 
     pdnsutil metadata set example.com LUA-AXFR-SCRIPT /path/to/lua/script.lua
+
+or, prior to version 5.0::
+
+    pdnsutil set-meta example.com LUA-AXFR-SCRIPT /path/to/lua/script.lua
 
 .. warning::
   The Lua script must both exist and be syntactically

--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -215,7 +215,7 @@ In such cases, make sure to delete the zone contents to force a fresh
 retrieval.
 
 Finally, IXFR updates that "plug" Empty Non-Terminals do not yet remove
-ENT records. A 'pdnsutil rectify-zone' may be required.
+ENT records. A 'pdnsutil zone rectify' may be required.
 
 PowerDNS itself is currently only able to retrieve updates via IXFR. It
 cannot serve IXFR updates.
@@ -263,7 +263,7 @@ There is no need to fill the account name out but it does help keep
 track of where a domain comes from.
 Additionally, if a secondary selects multiple autoprimaries for a zone based on the name of the primary, it also checks that the ``account`` field is the same for all.
 Adding a autoprimary can be done either directly in the database,
-or by using the 'pdnsutil add-autoprimary' command.
+or by using the 'pdnsutil autoprimary add' command.
 
 .. warning::
   When a secondary receives notification while bootstrapping a new domain using autosecondary feature, it will send
@@ -295,7 +295,7 @@ What you can accomplish using a Lua script:
 
 This script can be enabled like this::
 
-    pdnsutil set-meta example.com LUA-AXFR-SCRIPT /path/to/lua/script.lua
+    pdnsutil metadata set example.com LUA-AXFR-SCRIPT /path/to/lua/script.lua
 
 .. warning::
   The Lua script must both exist and be syntactically

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -111,7 +111,7 @@ Backend manipulation
 ``pdnsutil``
 ~~~~~~~~~~~~
 
-To perform zone and record changes using inbuilt tools, the ``pdnsutil`` command can be used. All available options are described in the online :doc:`manual page <manpages/pdnsutil.1>` as well as in ``man pdnsutil``.
+To perform zone and record changes using inbuilt tools, the :doc:`pdnsutil <../manpages/pdnsutil.1>` command can be used. All available options are described in the online :doc:`manual page <../manpages/pdnsutil.1>` as well as in ``man pdnsutil``.
 
 Running in the foreground
 -------------------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -393,9 +393,9 @@ When a primary zone is created via the API, and the request does not specify a c
 -  Default: ecdsa256
 
 The default algorithm for creating zone keys when running
-:doc:`pdnsutil add-zone-key <manpages/pdnsutil.1>` if no algorithm is specified,
+:doc:`pdnsutil zone add-key <manpages/pdnsutil.1>` if no algorithm is specified,
 and also the algorithm that should be used for the KSK when running
-:doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
+:doc:`pdnsutil zone secure <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
 to enable DNSSEC. Must be one of:
 
 * rsasha1
@@ -419,7 +419,7 @@ to enable DNSSEC. Must be one of:
 -  Integer
 -  Default: whichever is default for `default-ksk-algorithm`_
 
-The default keysize for the KSK generated with :doc:`pdnsutil secure-zone <dnssec/pdnsutil>`.
+The default keysize for the KSK generated with :doc:`pdnsutil zone secure <dnssec/pdnsutil>`.
 Only relevant for algorithms with non-fixed keysizes (like RSA).
 
 .. _setting-default-publish-cdnskey:
@@ -469,7 +469,7 @@ This value is used when a zone is created without providing a SOA record. @ is r
 
 Use this soa-edit value for all zones if no
 :ref:`metadata-soa-edit` metadata value is set.
-This is used by :doc:`pdnsutil increase-serial <manpages/pdnsutil.1>`.
+This is used by :doc:`pdnsutil zone increase-serial <manpages/pdnsutil.1>`.
 
 .. _setting-default-soa-edit-signed:
 
@@ -528,9 +528,9 @@ TTL to use when none is provided.
 -  Default: (empty)
 
 The default algorithm for creating zone keys when running
-:doc:`pdnsutil add-zone-key <manpages/pdnsutil.1>` if no algorithm is specified,
+:doc:`pdnsutil zone add-key <manpages/pdnsutil.1>` if no algorithm is specified,
 and also the algorithm that should be used for the ZSK when running
-:doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
+:doc:`pdnsutil zone secure <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
 to enable DNSSEC. Must be one of:
 
 * rsasha1
@@ -554,7 +554,7 @@ to enable DNSSEC. Must be one of:
 -  Integer
 -  Default: 0 (automatic default for `default-zsk-algorithm`_)
 
-The default keysize for the ZSK generated with :doc:`pdnsutil secure-zone <dnssec/pdnsutil>`.
+The default keysize for the ZSK generated with :doc:`pdnsutil zone secure <dnssec/pdnsutil>`.
 Only relevant for algorithms with non-fixed keysizes (like RSA).
 
 .. _setting-delay-notifications:

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -592,7 +592,7 @@ when automatic publication is turned off.
 
 .. versionadded:: 5.0.0
 
-Read signatures of DNSKEY records directly from the backend. 
+Read signatures of DNSKEY records directly from the backend.
 If not set and the record is not presigned, DNSKEY records will be signed directly by PDNS Authoritative.
 Please only use this if you are sure that you need it.
 

--- a/docs/tsig.rst
+++ b/docs/tsig.rst
@@ -45,6 +45,13 @@ Another way of importing and activating TSIG keys into the database is using
     pdnsutil tsigkey import test hmac-md5 'kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys='
     pdnsutil tsigkey activate powerdnssec.org test primary
 
+or, prior to version 5.0:
+
+.. code-block:: shell
+
+    pdnsutil import-tsig-key test hmac-md5 'kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys='
+    pdnsutil activate-tsig-key powerdnssec.org test primary
+
 To ease interoperability, the equivalent configuration above in BIND
 would look like this::
 

--- a/docs/tsig.rst
+++ b/docs/tsig.rst
@@ -42,8 +42,8 @@ Another way of importing and activating TSIG keys into the database is using
 
 .. code-block:: shell
 
-    pdnsutil import-tsig-key test hmac-md5 'kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys='
-    pdnsutil activate-tsig-key powerdnssec.org test master
+    pdnsutil tsigkey import test hmac-md5 'kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys='
+    pdnsutil tsigkey activate powerdnssec.org test primary
 
 To ease interoperability, the equivalent configuration above in BIND
 would look like this::
@@ -54,7 +54,7 @@ would look like this::
     };
 
     zone "powerdnssec.org" {
-        type master;
+        type primary;
         file "powerdnssec.org";
         allow-transfer {  key test.; };
     };
@@ -88,8 +88,8 @@ This can also be done using
 
 .. code-block:: shell
 
-    pdnsutil import-tsig-key test hmac-md5 'kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys='
-    pdnsutil activate-tsig-key powerdnssec.org test slave
+    pdnsutil tsigkey import test hmac-md5 'kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys='
+    pdnsutil tsigkey activate powerdnssec.org test secondary
 
 This setup corresponds to the ``TSIG-ALLOW-AXFR`` access rule defined in
 the previous section.
@@ -107,7 +107,7 @@ quite) similar to the following BIND statements::
     };
 
     zone "powerdnssec.org" {
-     type slave;
+     type secondary;
      masters { 127.0.0.1; };
      file "powerdnssec.org";
     };

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -75,135 +75,137 @@ The old syntax is still recognized, so that existing scripts and finger memory
 will keep working. However, you are advised to switch to the new command syntax,
 using this conversion table:
 
-+-----------------------------------+--------------------------------+
-| Old syntax                        | New syntax                     |
-+===================================+================================+
-| ``activate-tsig-key``             | ``tsigkey activate``           |
-+-----------------------------------+--------------------------------+
-| ``activate-zone-key``             | ``zone activate-key``          |
-+-----------------------------------+--------------------------------+
-| ``add-autoprimary``               | ``autoprimary add``            |
-+-----------------------------------+--------------------------------+
-| ``add-meta``                      | ``metadata add``               |
-+-----------------------------------+--------------------------------+
-| ``add-record``                    | ``rrset add``                  |
-+-----------------------------------+--------------------------------+
-| ``add-zone-key``                  | ``zone add-key``               |
-+-----------------------------------+--------------------------------+
-| ``change-secondary-zone-primary`` | ``zone change-primary``        |
-+-----------------------------------+--------------------------------+
-| ``check-all-zones``               | ``zone check-all``             |
-+-----------------------------------+--------------------------------+
-| ``check-zone``                    | ``zone check``                 |
-+-----------------------------------+--------------------------------+
-| ``clear-zone``                    | ``zone clear``                 |
-+-----------------------------------+--------------------------------+
-| ``create-secondary-zone``         | ``zone create-secondary``      |
-+-----------------------------------+--------------------------------+
-| ``create-zone``                   | ``zone create``                |
-+-----------------------------------+--------------------------------+
-| ``deactivate-tsig-key``           | ``tsigkey deactivate``         |
-+-----------------------------------+--------------------------------+
-| ``deactivate-zone-key``           | ``zone deactivate-key``        |
-+-----------------------------------+--------------------------------+
-| ``delete-rrset``                  | ``rrset delete``               |
-+-----------------------------------+--------------------------------+
-| ``delete-tsig-key``               | ``tsigkey delete``             |
-+-----------------------------------+--------------------------------+
-| ``delete-zone``                   | ``zone delete``                |
-+-----------------------------------+--------------------------------+
-| ``disable-dnssec``                | ``zone dnssec-disable``        |
-+-----------------------------------+--------------------------------+
-| ``edit-zone``                     | ``zone edit``                  |
-+-----------------------------------+--------------------------------+
-| ``export-zone-dnskey``            | ``zone export-dnskey``         |
-+-----------------------------------+--------------------------------+
-| ``export-zone-ds``                | ``zone export-ds``             |
-+-----------------------------------+--------------------------------+
-| ``export-zone-key``               | ``zone export-key``            |
-+-----------------------------------+--------------------------------+
-| ``export-zone-key-pem``           | ``zone export-key-pem``        |
-+-----------------------------------+--------------------------------+
-| ``generate-tsig-key``             | ``tsigkey generate``           |
-+-----------------------------------+--------------------------------+
-| ``generate-zone-key``             | ``zone generate-key``          |
-+-----------------------------------+--------------------------------+
-| ``get-meta``                      | ``metadata get``               |
-+-----------------------------------+--------------------------------+
-| ``hash-zone-record``              | ``rrset hash``                 |
-+-----------------------------------+--------------------------------+
-| ``import-tsig-key``               | ``tsigkey import``             |
-+-----------------------------------+--------------------------------+
-| ``import-zone-key``               | ``zone import-key``            |
-+-----------------------------------+--------------------------------+
-| ``import-zone-key-pem``           | ``zone import-key-pem``        |
-+-----------------------------------+--------------------------------+
-| ``increase-serial``               | ``zone increase-serial``       |
-+-----------------------------------+--------------------------------+
-| ``list-all-zones``                | ``zone list-all``              |
-+-----------------------------------+--------------------------------+
-| ``list-autoprimaries``            | ``autoprimary list``           |
-+-----------------------------------+--------------------------------+
-| ``list-keys``                     | ``zone list-keys``             |
-+-----------------------------------+--------------------------------+
-| ``list-member-zones``             | ``catalog list-members``       |
-+-----------------------------------+--------------------------------+
-| ``list-tsig-keys``                | ``tsigkey list``               |
-+-----------------------------------+--------------------------------+
-| ``list-zone``                     | ``zone list``                  |
-+-----------------------------------+--------------------------------+
-| ``load-zone``                     | ``zone load``                  |
-+-----------------------------------+--------------------------------+
-| ``publish-zone-key``              | ``zone publish-key``           |
-+-----------------------------------+--------------------------------+
-| ``rectify-all-zones``             | ``zone rectify-all``           |
-+-----------------------------------+--------------------------------+
-| ``rectify-zone``                  | ``zone rectify``               |
-+-----------------------------------+--------------------------------+
-| ``remove-autoprimary``            | ``autoprimary remove``         |
-+-----------------------------------+--------------------------------+
-| ``remove-zone-key``               | ``zone remove-key``            |
-+-----------------------------------+--------------------------------+
-| ``replace-rrset``                 | ``rrset replace``              |
-+-----------------------------------+--------------------------------+
-| ``secure-all-zones``              | ``zone secure-all``            |
-+-----------------------------------+--------------------------------+
-| ``secure-zone``                   | ``zone secure``                |
-+-----------------------------------+--------------------------------+
-| ``set-account``                   | ``zone set-account``           |
-+-----------------------------------+--------------------------------+
-| ``set-catalog``                   | ``catalog set``                |
-+-----------------------------------+--------------------------------+
-| ``set-kind``                      | ``zone set-kind``              |
-+-----------------------------------+--------------------------------+
-| ``set-meta``                      | ``metadata set``               |
-+-----------------------------------+--------------------------------+
-| ``set-nsec3``                     | ``zone set-nsec3``             |
-+-----------------------------------+--------------------------------+
-| ``set-option``                    | ``zone set-option``            |
-+-----------------------------------+--------------------------------+
-| ``set-options-json``              | ``zone set-options-json``      |
-+-----------------------------------+--------------------------------+
-| ``set-presigned``                 | ``zone set-presigned``         |
-+-----------------------------------+--------------------------------+
-| ``set-publish-cdnskey``           | ``zone set-publish-cdnskey``   |
-+-----------------------------------+--------------------------------+
-| ``set-publish-cds``               | ``zone set-publish-cds``       |
-+-----------------------------------+--------------------------------+
-| ``show-zone``                     | ``zone show``                  |
-+-----------------------------------+--------------------------------+
-| ``unpublish-zone-key``            | ``zone unpublish-key``         |
-+-----------------------------------+--------------------------------+
-| ``unset-nsec3``                   | ``zone unset-nsec3``           |
-+-----------------------------------+--------------------------------+
-| ``unset-presigned``               | ``zone unset-presigned``       |
-+-----------------------------------+--------------------------------+
-| ``unset-publish-cdnskey``         | ``zone unset-publish-cdnskey`` |
-+-----------------------------------+--------------------------------+
-| ``unset-publish-cds``             | ``zone unset-publish-cds``     |
-+-----------------------------------+--------------------------------+
-| ``zonemd-verify-file``            | ``zone zonemd-verify-file``    |
-+-----------------------------------+--------------------------------+
+.. list-table:: pdnsutil syntax conversion table
+   :header-rows: 1
+
+   * - Old syntax
+     - New syntax
+   * - ``activate-tsig-key``
+     - ``tsigkey activate``
+   * - ``activate-zone-key``
+     - ``zone activate-key``
+   * - ``add-autoprimary``
+     - ``autoprimary add``
+   * - ``add-meta``
+     - ``metadata add``
+   * - ``add-record``
+     - ``rrset add``
+   * - ``add-zone-key``
+     - ``zone add-key``
+   * - ``change-secondary-zone-primary``
+     - ``zone change-primary``
+   * - ``check-all-zones``
+     - ``zone check-all``
+   * - ``check-zone``
+     - ``zone check``
+   * - ``clear-zone``
+     - ``zone clear``
+   * - ``create-secondary-zone``
+     - ``zone create-secondary``
+   * - ``create-zone``
+     - ``zone create``
+   * - ``deactivate-tsig-key``
+     - ``tsigkey deactivate``
+   * - ``deactivate-zone-key``
+     - ``zone deactivate-key``
+   * - ``delete-rrset``
+     - ``rrset delete``
+   * - ``delete-tsig-key``
+     - ``tsigkey delete``
+   * - ``delete-zone``
+     - ``zone delete``
+   * - ``disable-dnssec``
+     - ``zone dnssec-disable``
+   * - ``edit-zone``
+     - ``zone edit``
+   * - ``export-zone-dnskey``
+     - ``zone export-dnskey``
+   * - ``export-zone-ds``
+     - ``zone export-ds``
+   * - ``export-zone-key``
+     - ``zone export-key``
+   * - ``export-zone-key-pem``
+     - ``zone export-key-pem``
+   * - ``generate-tsig-key``
+     - ``tsigkey generate``
+   * - ``generate-zone-key``
+     - ``zone generate-key``
+   * - ``get-meta``
+     - ``metadata get``
+   * - ``hash-zone-record``
+     - ``rrset hash``
+   * - ``import-tsig-key``
+     - ``tsigkey import``
+   * - ``import-zone-key``
+     - ``zone import-key``
+   * - ``import-zone-key-pem``
+     - ``zone import-key-pem``
+   * - ``increase-serial``
+     - ``zone increase-serial``
+   * - ``list-all-zones``
+     - ``zone list-all``
+   * - ``list-autoprimaries``
+     - ``autoprimary list``
+   * - ``list-keys``
+     - ``zone list-keys``
+   * - ``list-member-zones``
+     - ``catalog list-members``
+   * - ``list-tsig-keys``
+     - ``tsigkey list``
+   * - ``list-zone``
+     - ``zone list``
+   * - ``load-zone``
+     - ``zone load``
+   * - ``publish-zone-key``
+     - ``zone publish-key``
+   * - ``rectify-all-zones``
+     - ``zone rectify-all``
+   * - ``rectify-zone``
+     - ``zone rectify``
+   * - ``remove-autoprimary``
+     - ``autoprimary remove``
+   * - ``remove-zone-key``
+     - ``zone remove-key``
+   * - ``replace-rrset``
+     - ``rrset replace``
+   * - ``secure-all-zones``
+     - ``zone secure-all``
+   * - ``secure-zone``
+     - ``zone secure``
+   * - ``set-account``
+     - ``zone set-account``
+   * - ``set-catalog``
+     - ``catalog set``
+   * - ``set-kind``
+     - ``zone set-kind``
+   * - ``set-meta``
+     - ``metadata set``
+   * - ``set-nsec3``
+     - ``zone set-nsec3``
+   * - ``set-option``
+     - ``zone set-option``
+   * - ``set-options-json``
+     - ``zone set-options-json``
+   * - ``set-presigned``
+     - ``zone set-presigned``
+   * - ``set-publish-cdnskey``
+     - ``zone set-publish-cdnskey``
+   * - ``set-publish-cds``
+     - ``zone set-publish-cds``
+   * - ``show-zone``
+     - ``zone show``
+   * - ``unpublish-zone-key``
+     - ``zone unpublish-key``
+   * - ``unset-nsec3``
+     - ``zone unset-nsec3``
+   * - ``unset-presigned``
+     - ``zone unset-presigned``
+   * - ``unset-publish-cdnskey``
+     - ``zone unset-publish-cdnskey``
+   * - ``unset-publish-cds``
+     - ``zone unset-publish-cds``
+   * - ``zonemd-verify-file``
+     - ``zone zonemd-verify-file``
 
 Commands not listed above have not changed syntax.
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -39,7 +39,7 @@ been implemented in the LMDB backend.
 LOC record parsing
 ^^^^^^^^^^^^^^^^^^
 
-The parsing and validation of LOC records is modified to be conforming to the `rfc:1876`.
+The parsing and validation of LOC records is modified to be conforming to the :rfc:`1876`.
 This may cause records previously rejected to be accepted and vice versa.
 
 LUA records whitespace insertion
@@ -62,18 +62,160 @@ ixfrdist IPv6 support
 ``ixfrdist`` now binds listening sockets with `IPV6_V6ONLY set`, which means that ``[::]`` no longer accepts IPv4 connections.
 If you want to listen on both IPv4 and IPv6, you need to add a line with ``0.0.0.0`` to the ``listen`` section of your ixfrdist configuration.
 
-pdnsutil behaviour changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+pdnsutil syntax and behaviour changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A few changes of behaviour have been implemented in :doc:`pdnsutil <manpages/pdnsutil.1>`.
+The :doc:`pdnsutil <manpages/pdnsutil.1>` syntax has been overhauled in order to be more
+orthogonal and consistent. Most commands will now take the form
+``pdnsutil <object> <action> [arguments...]``, where ``<object>`` is a noun and
+``<action>`` is a verb; a few commands which do not apply to any particular
+object kind use only the verb.
 
-* The ``add-zone-key`` command used to default to creating a ZSK,
+The old syntax is still recognized, so that existing scripts and finger memory
+will keep working. However, you are advised to switch to the new command syntax,
+using this conversion table:
+
++-----------------------------------+--------------------------------+
+| Old syntax                        | New syntax                     |
++===================================+================================+
+| ``activate-tsig-key``             | ``tsigkey activate``           |
++-----------------------------------+--------------------------------+
+| ``activate-zone-key``             | ``zone activate-key``          |
++-----------------------------------+--------------------------------+
+| ``add-autoprimary``               | ``autoprimary add``            |
++-----------------------------------+--------------------------------+
+| ``add-meta``                      | ``metadata add``               |
++-----------------------------------+--------------------------------+
+| ``add-record``                    | ``rrset add``                  |
++-----------------------------------+--------------------------------+
+| ``add-zone-key``                  | ``zone add-key``               |
++-----------------------------------+--------------------------------+
+| ``change-secondary-zone-primary`` | ``zone change-primary``        |
++-----------------------------------+--------------------------------+
+| ``check-all-zones``               | ``zone check-all``             |
++-----------------------------------+--------------------------------+
+| ``check-zone``                    | ``zone check``                 |
++-----------------------------------+--------------------------------+
+| ``clear-zone``                    | ``zone clear``                 |
++-----------------------------------+--------------------------------+
+| ``create-secondary-zone``         | ``zone create-secondary``      |
++-----------------------------------+--------------------------------+
+| ``create-zone``                   | ``zone create``                |
++-----------------------------------+--------------------------------+
+| ``deactivate-tsig-key``           | ``tsigkey deactivate``         |
++-----------------------------------+--------------------------------+
+| ``deactivate-zone-key``           | ``zone deactivate-key``        |
++-----------------------------------+--------------------------------+
+| ``delete-rrset``                  | ``rrset delete``               |
++-----------------------------------+--------------------------------+
+| ``delete-tsig-key``               | ``tsigkey delete``             |
++-----------------------------------+--------------------------------+
+| ``delete-zone``                   | ``zone delete``                |
++-----------------------------------+--------------------------------+
+| ``disable-dnssec``                | ``zone dnssec-disable``        |
++-----------------------------------+--------------------------------+
+| ``edit-zone``                     | ``zone edit``                  |
++-----------------------------------+--------------------------------+
+| ``export-zone-dnskey``            | ``zone export-dnskey``         |
++-----------------------------------+--------------------------------+
+| ``export-zone-ds``                | ``zone export-ds``             |
++-----------------------------------+--------------------------------+
+| ``export-zone-key``               | ``zone export-key``            |
++-----------------------------------+--------------------------------+
+| ``export-zone-key-pem``           | ``zone export-key-pem``        |
++-----------------------------------+--------------------------------+
+| ``generate-tsig-key``             | ``tsigkey generate``           |
++-----------------------------------+--------------------------------+
+| ``generate-zone-key``             | ``zone generate-key``          |
++-----------------------------------+--------------------------------+
+| ``get-meta``                      | ``metadata get``               |
++-----------------------------------+--------------------------------+
+| ``hash-zone-record``              | ``rrset hash``                 |
++-----------------------------------+--------------------------------+
+| ``import-tsig-key``               | ``tsigkey import``             |
++-----------------------------------+--------------------------------+
+| ``import-zone-key``               | ``zone import-key``            |
++-----------------------------------+--------------------------------+
+| ``import-zone-key-pem``           | ``zone import-key-pem``        |
++-----------------------------------+--------------------------------+
+| ``increase-serial``               | ``zone increase-serial``       |
++-----------------------------------+--------------------------------+
+| ``list-all-zones``                | ``zone list-all``              |
++-----------------------------------+--------------------------------+
+| ``list-autoprimaries``            | ``autoprimary list``           |
++-----------------------------------+--------------------------------+
+| ``list-keys``                     | ``zone list-keys``             |
++-----------------------------------+--------------------------------+
+| ``list-member-zones``             | ``catalog list-members``       |
++-----------------------------------+--------------------------------+
+| ``list-tsig-keys``                | ``tsigkey list``               |
++-----------------------------------+--------------------------------+
+| ``list-zone``                     | ``zone list``                  |
++-----------------------------------+--------------------------------+
+| ``load-zone``                     | ``zone load``                  |
++-----------------------------------+--------------------------------+
+| ``publish-zone-key``              | ``zone publish-key``           |
++-----------------------------------+--------------------------------+
+| ``rectify-all-zones``             | ``zone rectify-all``           |
++-----------------------------------+--------------------------------+
+| ``rectify-zone``                  | ``zone rectify``               |
++-----------------------------------+--------------------------------+
+| ``remove-autoprimary``            | ``autoprimary remove``         |
++-----------------------------------+--------------------------------+
+| ``remove-zone-key``               | ``zone remove-key``            |
++-----------------------------------+--------------------------------+
+| ``replace-rrset``                 | ``rrset replace``              |
++-----------------------------------+--------------------------------+
+| ``secure-all-zones``              | ``zone secure-all``            |
++-----------------------------------+--------------------------------+
+| ``secure-zone``                   | ``zone secure``                |
++-----------------------------------+--------------------------------+
+| ``set-account``                   | ``zone set-account``           |
++-----------------------------------+--------------------------------+
+| ``set-catalog``                   | ``catalog set``                |
++-----------------------------------+--------------------------------+
+| ``set-kind``                      | ``zone set-kind``              |
++-----------------------------------+--------------------------------+
+| ``set-meta``                      | ``metadata set``               |
++-----------------------------------+--------------------------------+
+| ``set-nsec3``                     | ``zone set-nsec3``             |
++-----------------------------------+--------------------------------+
+| ``set-option``                    | ``zone set-option``            |
++-----------------------------------+--------------------------------+
+| ``set-options-json``              | ``zone set-options-json``      |
++-----------------------------------+--------------------------------+
+| ``set-presigned``                 | ``zone set-presigned``         |
++-----------------------------------+--------------------------------+
+| ``set-publish-cdnskey``           | ``zone set-publish-cdnskey``   |
++-----------------------------------+--------------------------------+
+| ``set-publish-cds``               | ``zone set-publish-cds``       |
++-----------------------------------+--------------------------------+
+| ``show-zone``                     | ``zone show``                  |
++-----------------------------------+--------------------------------+
+| ``unpublish-zone-key``            | ``zone unpublish-key``         |
++-----------------------------------+--------------------------------+
+| ``unset-nsec3``                   | ``zone unset-nsec3``           |
++-----------------------------------+--------------------------------+
+| ``unset-presigned``               | ``zone unset-presigned``       |
++-----------------------------------+--------------------------------+
+| ``unset-publish-cdnskey``         | ``zone unset-publish-cdnskey`` |
++-----------------------------------+--------------------------------+
+| ``unset-publish-cds``             | ``zone unset-publish-cds``     |
++-----------------------------------+--------------------------------+
+| ``zonemd-verify-file``            | ``zone zonemd-verify-file``    |
++-----------------------------------+--------------------------------+
+
+Commands not listed above have not changed syntax.
+
+A few changes of behaviour have been implemented as well:
+
+* The ``zone add-key`` command used to default to creating a ZSK,
   if no key type was given. This default has changed to KSK.
-* The ``add-record``, ``delete-rrset``, ``edit-zone``, ``increase-serial`` and
-  ``replace-rrset`` operations will now refuse to work on secondary zones unless
-  the ``--force`` option is passed.
-* When a zone gets created with either ``create-zone``,
-  ``create-secondary-zone`` or ``load-zone`` (if the zone wasn't existing
+* The ``rrset add``, ``rrset delete``, ``rrset replace``, ``zone edit``
+  and ``zone increase-serial`` operations will now refuse to work on secondary
+  zones unless the ``--force`` option is passed.
+* When a zone gets created with either ``zone create``,
+  ``zone create-secondary`` or ``zone load`` (if the zone wasn't existing
   already), a :ref:`metadata-soa-edit-api` metadata with a value of ``DEFAULT``
   will be added to the zone.
 * ``add-record`` and ``delete-rrset`` now treat all names as absolute.
@@ -173,7 +315,7 @@ However, this feature interacts badly with handling of presigned zones.
 In version 4.5.0, this feature was accidentally broken in the implementation of the zone cache.
 In 4.6.0, this automatic conversion is fully removed.
 If you still have ``@`` signs in any SOA RNAMEs, 4.6.0 will serve those out literally.
-You can find any stray ``@`` signs by running ``pdnsutil check-all-zones``.
+You can find any stray ``@`` signs by running ``pdnsutil zone check-all``.
 
 New default NSEC3 parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +325,7 @@ Following `draft-ietf-dnsop-nsec3-guidance (Guidance for NSEC3 parameter setting
 SHA1 DSes
 ^^^^^^^^^
 
-``pdnsutil show-zone`` and ``pdnsutil export-zone-ds`` no longer emit SHA1 DS records, unless ``--verbose`` is in use.
+``pdnsutil zone show`` and ``pdnsutil zone export-ds`` no longer emit SHA1 DS records, unless ``--verbose`` is in use.
 
 Privileged port binding in Docker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -324,7 +466,7 @@ SOA autofilling (i.e. allowing incomplete SOAs in the database) and the API ``se
 * :ref:`setting-soa-retry-default`
 
 Replace them with :ref:`setting-default-soa-content`, but be aware that this will only be used at zone creation time.
-Please run ``pdnsutil check-all-zones`` to check for incomplete SOAs.
+Please run ``pdnsutil zone check-all`` to check for incomplete SOAs.
 
 The :ref:`setting-do-ipv6-additional-processing` setting was removed. IPv6 additional processing now always happens when IPv4 additional processing happens.
 
@@ -349,7 +491,7 @@ On RHEL/CentOS 8, the gmysql backend now uses ``mariadb-connector-c`` instead of
 This change was made because the default MySQL implementation for RHEL8 is MariaDB, and MariaDB and MySQL cannot be installed in parallel due to conflicting RPM packages.
 The mariadb client lib will connect to your existing MySQL servers without trouble.
 
-Unknown record encoding (`RFC 3597 <https://tools.ietf.org/html/rfc3597>`__) has become more strict as a result of the fixes for :doc:`PowerDNS Security Advisory 2020-05 <../security-advisories/powerdns-advisory-2020-05>`. Please use ``pdnsutil check-all-zones`` to review your zone contents.
+Unknown record encoding (`RFC 3597 <https://tools.ietf.org/html/rfc3597>`__) has become more strict as a result of the fixes for :doc:`PowerDNS Security Advisory 2020-05 <../security-advisories/powerdns-advisory-2020-05>`. Please use ``pdnsutil zone check-all`` to review your zone contents.
 
 The previous set of indexes for the gsqlite3 backend was found to be poor.
 4.3.1 ships a new schema, and a migration:
@@ -424,7 +566,7 @@ Schema changes
 Implicit 5->7 algorithm upgrades
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Since version 3.0 (the first version of the PowerDNS Authoritative Server that supported DNSSEC signing), we have automatically, silently, upgraded algorithm 5 (RSASHA1) keys to algorithm 7 (RSASHA1-NSEC3-SHA1) when the user enabled NSEC3. This has been a source of confusion, and because of that, we introduced warnings for users of this feature in 4.0 and 4.1. To see if you are affected, run ``pdnsutil check-all-zones`` from version 4.0 or up. In this release, the automatic upgrade is gone, and affected zones will break if no action is taken.
+Since version 3.0 (the first version of the PowerDNS Authoritative Server that supported DNSSEC signing), we have automatically, silently, upgraded algorithm 5 (RSASHA1) keys to algorithm 7 (RSASHA1-NSEC3-SHA1) when the user enabled NSEC3. This has been a source of confusion, and because of that, we introduced warnings for users of this feature in 4.0 and 4.1. To see if you are affected, run ``pdnsutil zone check-all`` from version 4.0 or up. In this release, the automatic upgrade is gone, and affected zones will break if no action is taken.
 
 .. _ixfr-in-corruption-4.3.0:
 
@@ -438,7 +580,7 @@ You could accomplish that by deleting all records in the zone with an SQL query 
 4.2.X to 4.2.3
 --------------
 
-Unknown record encoding (`RFC 3597 <https://tools.ietf.org/html/rfc3597>`__) has become more strict as a result of the fixes for :doc:`PowerDNS Security Advisory 2020-05 <../security-advisories/powerdns-advisory-2020-05>`. Please use ``pdnsutil check-all-zones`` to review your zone contents.
+Unknown record encoding (`RFC 3597 <https://tools.ietf.org/html/rfc3597>`__) has become more strict as a result of the fixes for :doc:`PowerDNS Security Advisory 2020-05 <../security-advisories/powerdns-advisory-2020-05>`. Please use ``pdnsutil zone check-all`` to review your zone contents.
 
 4.X.X to 4.2.2
 --------------
@@ -465,7 +607,7 @@ You could accomplish that by deleting all records in the zone with an SQL query 
 4.1.X to 4.1.14
 ---------------
 
-Unknown record encoding (`RFC 3597 <https://tools.ietf.org/html/rfc3597>`__) has become more strict as a result of the fixes for :doc:`PowerDNS Security Advisory 2020-05 <../security-advisories/powerdns-advisory-2020-05>`. Please use ``pdnsutil check-all-zones`` to review your zone contents.
+Unknown record encoding (`RFC 3597 <https://tools.ietf.org/html/rfc3597>`__) has become more strict as a result of the fixes for :doc:`PowerDNS Security Advisory 2020-05 <../security-advisories/powerdns-advisory-2020-05>`. Please use ``pdnsutil zone check-all`` to review your zone contents.
 
 4.1.0 to 4.1.1
 --------------
@@ -625,4 +767,4 @@ MBOXFW records. Thus, make sure to clean up the records in the DB.
 
 In version 3.X, the PowerDNS Authoritative Server silently ignored records that
 have a 'priority' field (like MX or SRV), but where one was not in the database.
-In 4.X, :doc:`pdnsutil check-zone <manpages/pdnsutil.1>` will complain about this.
+In 4.X, :doc:`pdnsutil zone check <manpages/pdnsutil.1>` will complain about this.

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -119,14 +119,14 @@ the rest of the Internet.
 
 Let's start by defining the specific networks::
 
-  pdnsutil set-network 10.0.0.0/8 internal
-  pdnsutil set-network 172.16.0.0/12 internal
-  pdnsutil set-network 192.168.0.0/16 internal
-  pdnsutil set-network fc00::/7 internal
+  pdnsutil network set 10.0.0.0/8 internal
+  pdnsutil network set 172.16.0.0/12 internal
+  pdnsutil network set 192.168.0.0/16 internal
+  pdnsutil network set fc00::/7 internal
 
-  pdnsutil set-network 198.51.100.0/24 trusted
-  pdnsutil set-network 203.0.113.0/24 trusted
-  pdnsutil set-network 2001:db8::/32 trusted
+  pdnsutil network set 198.51.100.0/24 trusted
+  pdnsutil network set 203.0.113.0/24 trusted
+  pdnsutil network set 2001:db8::/32 trusted
 
 Once these commands have been run, queries originating from these particular
 networks will select either the "internal" or "trusted" view, while queries
@@ -135,7 +135,7 @@ may consider an always-existing default (nameless) view.
 
 You can check the result of these commands with::
 
-  $ pdnsutil list-networks
+  $ pdnsutil network list
   10.0.0.0/8      internal
   172.16.0.0/12   internal
   192.168.0.0/16  internal
@@ -149,19 +149,19 @@ outcome when resolving domain queries.
 
 Let's differentiate these views now::
 
-  pdnsutil view-add-zone internal example.com..internal
-  pdnsutil view-add-zone internal example2.com..secret
+  pdnsutil views add-zone internal example.com..internal
+  pdnsutil views add-zone internal example2.com..secret
 
-  pdnsutil view-add-zone trusted example.com..trusted
+  pdnsutil views add-zone trusted example.com..trusted
 
-Note that the `view-add-zone` command does not create any zone! You will need
+Note that the `views add-zone` command does not create any zone! You will need
 to create these zones, like you would do for any other "regular" zone::
 
-  pdnsutil create-zone example.com..internal
-  pdnsutil create-zone example2.com..secret
-  pdnsutil create-zone example.com..trusted
+  pdnsutil zone create example.com..internal
+  pdnsutil zone create example2.com..secret
+  pdnsutil zone create example.com..trusted
 
-and then use `load-zone`, `edit-zone`, or `add-record` to add contents to these
+and then use `zone load`, `zone edit`, or `rrset add` to add contents to these
 zones.
 
 With these settings in place, queries for the `example.com.` zone will be
@@ -179,13 +179,13 @@ As seen in this example, a given view may cause multiple zones to be resolved
 differently. At any time, you can check which views are setup, and the details
 of a given view::
 
-  $ pdnsutil list-views
+  $ pdnsutil views list-all
   internal
   trusted
-  $ pdnsutil list-view internal
+  $ pdnsutil views list internal
   example.com..internal
   example2.com..secret
-  $ pdnsutil list-view trusted
+  $ pdnsutil views list trusted
   example.com..trusted
 
 Bind configuration adaptation
@@ -215,14 +215,14 @@ https://www.zytrax.com/books/dns/ch7/view.html::
 
 The equivalent PowerDNS setup would be::
 
-  pdnsutil set-network 192.168.23.0/24 trusted
-  pdnsutil set-network 0.0.0.0/0 badguys
+  pdnsutil network set 192.168.23.0/24 trusted
+  pdnsutil network set 0.0.0.0/0 badguys
 
-  pdnsutil view-add-zone trusted primary.example.com..internal
-  pdnsutil view-add-zone badguys primary.example.com..external
+  pdnsutil views add-zone trusted primary.example.com..internal
+  pdnsutil views add-zone badguys primary.example.com..external
 
-  pdnsutil load-zone example.com..internal internal/primary.example.com
-  pdnsutil load-zone example.com..external external/primary.example.com
+  pdnsutil zone load example.com..internal internal/primary.example.com
+  pdnsutil zone load example.com..external external/primary.example.com
 
 .. _views-catalog-zones:
 

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -149,12 +149,12 @@ outcome when resolving domain queries.
 
 Let's differentiate these views now::
 
-  pdnsutil views add-zone internal example.com..internal
-  pdnsutil views add-zone internal example2.com..secret
+  pdnsutil view add-zone internal example.com..internal
+  pdnsutil view add-zone internal example2.com..secret
 
-  pdnsutil views add-zone trusted example.com..trusted
+  pdnsutil view add-zone trusted example.com..trusted
 
-Note that the `views add-zone` command does not create any zone! You will need
+Note that the `view add-zone` command does not create any zone! You will need
 to create these zones, like you would do for any other "regular" zone::
 
   pdnsutil zone create example.com..internal
@@ -179,13 +179,13 @@ As seen in this example, a given view may cause multiple zones to be resolved
 differently. At any time, you can check which views are setup, and the details
 of a given view::
 
-  $ pdnsutil views list-all
+  $ pdnsutil view list-all
   internal
   trusted
-  $ pdnsutil views list internal
+  $ pdnsutil view list internal
   example.com..internal
   example2.com..secret
-  $ pdnsutil views list trusted
+  $ pdnsutil view list trusted
   example.com..trusted
 
 Bind configuration adaptation
@@ -218,8 +218,8 @@ The equivalent PowerDNS setup would be::
   pdnsutil network set 192.168.23.0/24 trusted
   pdnsutil network set 0.0.0.0/0 badguys
 
-  pdnsutil views add-zone trusted primary.example.com..internal
-  pdnsutil views add-zone badguys primary.example.com..external
+  pdnsutil view add-zone trusted primary.example.com..internal
+  pdnsutil view add-zone badguys primary.example.com..external
 
   pdnsutil zone load example.com..internal internal/primary.example.com
   pdnsutil zone load example.com..external external/primary.example.com

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -580,6 +580,7 @@ static const commandDispatcher topLevelDispatcher{
   {"network", {true, {networkCommands}}},
   {"record", {false, {rrsetCommands}}}, // sugar
   {"rrset", {true, {rrsetCommands}}},
+  {"tsig", {false, {TSIGKEYCommands}}}, // sugar
   {"tsig-key", {false, {TSIGKEYCommands}}}, // sugar
   {"tsigkey", {true, {TSIGKEYCommands}}},
   {"view", {true, {viewsCommands}}},

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -582,7 +582,7 @@ static const commandDispatcher topLevelDispatcher{
   {"rrset", {true, {rrsetCommands}}},
   {"tsig-key", {false, {TSIGKEYCommands}}}, // sugar
   {"tsigkey", {true, {TSIGKEYCommands}}},
-  {"views", {true, {viewsCommands}}},
+  {"view", {true, {viewsCommands}}},
   {"zone", {true, {zoneMainCommands, zoneSecondaryCommands, zoneDNSSECCommands, zoneKeyCommands}}}
 };
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -377,6 +377,9 @@ static const groupCommandDispatcher zoneMainCommands{
    {"set-options-json", {true, setOptionsJson,
     "ZONE JSONFILE",
     "\tChange the options of ZONE to JSONFILE"}},
+   {"show", {true, showZone,
+    "ZONE",
+    "\tShow various details about a zone, including DNSSEC keys"}},
    {"zonemd-verify-file", {true, zonemdVerifyFile,
     "ZONE FILENAME",
     "\tValidate ZONEMD for ZONE"}}}
@@ -438,9 +441,6 @@ static const groupCommandDispatcher zoneDNSSECCommands{
     "ZONE",
     "\tConfigure zone for RFC 9615 DNSSEC bootstrapping\n"
     "\t(zone name must begin with _signal.)"}},
-   {"show", {true, showZone,
-    "ZONE",
-    "\tShow DNSSEC (public) key details about a zone"}},
    {"unset-nsec3", {true, unsetNSec3,
     "ZONE",
     "\tSwitch ZONE back to NSEC"}},
@@ -5476,7 +5476,7 @@ static bool parseCommand(std::vector<std::string>& cmds, std::string& writtencom
     {"set-presigned", {"set-presigned", zoneDNSSECCommands}},
     {"set-publish-cdnskey", {"set-publish-cdnskey", zoneDNSSECCommands}},
     {"set-publish-cds", {"set-publish-cds", zoneDNSSECCommands}},
-    {"show-zone", {"show", zoneDNSSECCommands}},
+    {"show-zone", {"show", zoneMainCommands}},
     {"unpublish-zone-key", {"unpublish-key", zoneKeyCommands}},
     {"unset-nsec3", {"unset-nsec3", zoneDNSSECCommands}},
     {"unset-presigned", {"unset-presigned", zoneDNSSECCommands}},

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -68,6 +68,524 @@ namespace {
   bool g_verbose;
 }
 
+// Forward declarations of command handlers
+
+static int B2BMigrate(vector<string>& cmds, std::string_view synopsis);
+#ifdef HAVE_P11KIT1 // [
+static int HSMAssign(vector<string>& cmds, std::string_view synopsis);
+static int HSMCreateKey(vector<string>& cmds, std::string_view synopsis);
+#else // ] [
+static int HSM(vector<string>& cmds, std::string_view synopsis);
+#endif // ]
+static int activateTSIGKey(vector<string>& cmds, std::string_view synopsis);
+static int activateZoneKey(vector<string>& cmds, std::string_view synopsis);
+static int addAutoprimary(vector<string>& cmds, std::string_view synopsis);
+static int addMeta(vector<string>& cmds, std::string_view synopsis);
+static int addRecord(vector<string>& cmds, std::string_view synopsis);
+static int addZoneKey(vector<string>& cmds, std::string_view synopsis);
+static int backendCmd(vector<string>& cmds, std::string_view synopsis);
+static int backendLookup(vector<string>& cmds, std::string_view synopsis);
+static int benchDb(vector<string>& cmds, std::string_view synopsis);
+static int changeSecondaryZonePrimary(vector<string>& cmds, std::string_view synopsis);
+static int checkAllZones(vector<string>& cmds, std::string_view synopsis);
+static int checkZone(vector<string>& cmds, std::string_view synopsis);
+static int clearZone(vector<string>& cmds, std::string_view synopsis);
+static int createBindDb(vector<string>& cmds, std::string_view synopsis);
+static int createSecondaryZone(vector<string>& cmds, std::string_view synopsis);
+static int createZone(vector<string>& cmds, std::string_view synopsis);
+static int deactivateTSIGKey(vector<string>& cmds, std::string_view synopsis);
+static int deactivateZoneKey(vector<string>& cmds, std::string_view synopsis);
+static int deleteRRSet(vector<string>& cmds, std::string_view synopsis);
+static int deleteTSIGKey(vector<string>& cmds, std::string_view synopsis);
+static int deleteZone(vector<string>& cmds, std::string_view synopsis);
+static int disableDNSSEC(vector<string>& cmds, std::string_view synopsis);
+static int editZone(vector<string>& cmds, std::string_view synopsis);
+static int exportZoneDNSKey(vector<string>& cmds, std::string_view synopsis);
+static int exportZoneDS(vector<string>& cmds, std::string_view synopsis);
+static int exportZoneKey(vector<string>& cmds, std::string_view synopsis);
+static int exportZoneKeyPEM(vector<string>& cmds, std::string_view synopsis);
+static int generateTSIGKey(vector<string>& cmds, std::string_view synopsis);
+static int generateZoneKey(vector<string>& cmds, std::string_view synopsis);
+static int getMeta(vector<string>& cmds, std::string_view synopsis);
+static int hashPassword(vector<string>& cmds, std::string_view synopsis);
+static int hashZoneRecord(vector<string>& cmds, std::string_view synopsis);
+static int importTSIGKey(vector<string>& cmds, std::string_view synopsis);
+static int importZoneKey(vector<string>& cmds, std::string_view synopsis);
+static int importZoneKeyPEM(vector<string>& cmds, std::string_view synopsis);
+static int increaseSerial(vector<string>& cmds, std::string_view synopsis);
+static int ipDecrypt(vector<string>& cmds, std::string_view synopsis);
+static int ipEncrypt(vector<string>& cmds, std::string_view synopsis);
+static int listAlgorithms(vector<string>& cmds, std::string_view synopsis);
+static int listAllZones(vector<string>& cmds, std::string_view synopsis);
+static int listAutoprimaries(vector<string>& cmds, std::string_view synopsis);
+static int listKeys(vector<string>& cmds, std::string_view synopsis);
+static int listMemberZones(vector<string>& cmds, std::string_view synopsis);
+static int listNetwork(vector<string>& cmds, std::string_view synopsis);
+static int listTSIGKeys(vector<string>& cmds, std::string_view synopsis);
+static int listView(vector<string>& cmds, std::string_view synopsis);
+static int listViews(vector<string>& cmds, std::string_view synopsis);
+static int listZone(vector<string>& cmds, std::string_view synopsis);
+static int lmdbGetBackendVersion(vector<string>& cmds, std::string_view synopsis);
+static int loadZone(vector<string>& cmds, std::string_view synopsis);
+static int publishZoneKey(vector<string>& cmds, std::string_view synopsis);
+static int rawLuaFromContent(vector<string>& cmds, std::string_view synopsis);
+static int rectifyAllZones(vector<string>& cmds, std::string_view synopsis);
+static int rectifyZone(vector<string>& cmds, std::string_view synopsis);
+static int removeAutoprimary(vector<string>& cmds, std::string_view synopsis);
+static int removeZoneKey(vector<string>& cmds, std::string_view synopsis);
+static int replaceRRSet(vector<string>& cmds, std::string_view synopsis);
+static int secureAllZones(vector<string>& cmds, std::string_view synopsis);
+static int secureZone(vector<string>& cmds, std::string_view synopsis);
+static int setAccount(vector<string>& cmds, std::string_view synopsis);
+static int setCatalog(vector<string>& cmds, std::string_view synopsis);
+static int setKind(vector<string>& cmds, std::string_view synopsis);
+static int setMeta(vector<string>& cmds, std::string_view synopsis);
+static int setNetwork(vector<string>& cmds, std::string_view synopsis);
+static int setNsec3(vector<string>& cmds, std::string_view synopsis);
+static int setOption(vector<string>& cmds, std::string_view synopsis);
+static int setOptionsJson(vector<string>& cmds, std::string_view synopsis);
+static int setPresigned(vector<string>& cmds, std::string_view synopsis);
+static int setPublishCDNSKey(vector<string>& cmds, std::string_view synopsis);
+static int setPublishCDs(vector<string>& cmds, std::string_view synopsis);
+static int setSignalingZone(vector<string>& cmds, std::string_view synopsis);
+static int showZone(vector<string>& cmds, std::string_view synopsis);
+static int testAlgorithm(vector<string>& cmds, std::string_view synopsis);
+static int testAlgorithms(vector<string>& cmds, std::string_view synopsis);
+static int testSchema(vector<string>& cmds, std::string_view synopsis);
+static int testSpeed(vector<string>& cmds, std::string_view synopsis);
+static int unpublishZoneKey(vector<string>& cmds, std::string_view synopsis);
+static int unsetNSec3(vector<string>& cmds, std::string_view synopsis);
+static int unsetPresigned(vector<string>& cmds, std::string_view synopsis);
+static int unsetPublishCDNSKey(vector<string>& cmds, std::string_view synopsis);
+static int unsetPublishCDs(vector<string>& cmds, std::string_view synopsis);
+static int verifyCrypto(vector<string>& cmds, std::string_view synopsis);
+static int viewAddZone(vector<string>& cmds, std::string_view synopsis);
+static int viewDelZone(vector<string>& cmds, std::string_view synopsis);
+static int zonemdVerifyFile(vector<string>& cmds, std::string_view synopsis);
+
+// Command dispatchers
+
+// Command handlers are invoked with the non-processed command arguments vector,
+// not containing the command name (as multiple command syntaxes may lead to
+// the same handler); therefore their arguments start at position zero in
+// the vector.
+using commandHandler = int (*)(std::vector<std::string>&, const std::string_view);
+
+struct commandEntry {
+  // set if need to invoke reportAllTypes() before invoking handler
+  bool requiresInitialization{false};
+  commandHandler handler{nullptr};
+  // one-line command synopsis, without command name
+  std::string_view synopsis;
+  // short description, may span multiple lines, every line starts with a tab
+  // for indent
+  std::string_view help;
+};
+
+// The commands entries are in a std::map, rather than std::unordered_map, in
+// order to be able to output them in sorted order, when listing the commands
+// in help displays.
+// The first element of the pair describes the group category.
+using groupCommandDispatcher = std::pair<std::string_view, std::map<std::string_view, commandEntry>>;
+
+// clang-format off [
+
+// AUTOPRIMARY
+
+static const groupCommandDispatcher autoprimaryCommands{
+  "Autoprimary",
+  {{"add", {true, addAutoprimary,
+    "IP NAMESERVER [ACCOUNT]",
+    "\tAdd a new autoprimary "}},
+   {"list", {true, listAutoprimaries,
+    "",
+    "\tList all autoprimaries"}},
+   {"remove", {true, removeAutoprimary,
+    "IP NAMESERVER",
+    "\tRemove an autoprimary"}}}
+};
+
+// CATALOG
+
+static const groupCommandDispatcher catalogCommands{
+  "Catalog Zone",
+  {{"list-members", {true, listMemberZones,
+    "CATALOG",
+    "\tList all members of catalog zone CATALOG"}},
+   {"set", {true, setCatalog,
+    "ZONE [CATALOG]",
+    "\tChange the catalog of ZONE to CATALOG, or removes ZONE from its current\n"
+    "\tcatalog if no catalog provided"}}}
+};
+
+// HSM
+
+#ifdef HAVE_P11KIT1 // [
+static const groupCommandDispatcher HSMCommands{
+  "HSM",
+  {{"assign", {true, HSMAssign,
+     "ZONE ALGORITHM {ksk|zsk} MODULE SLOT PIN LABEL [PUBLABEL]",
+     "\tAssign a Hardware Signing Module to a ZONE"}},
+   {"create-key", {true, HSMCreateKey,
+     "ZONE KEY_ID [BITS]",
+     "\tcreate a key using Hardware Signing Module for ZONE (use assign first);\n"
+     "\tBITS defaults to 2048"}}}
+};
+#endif // ]
+
+// META/МETADATA
+
+static const groupCommandDispatcher metadataCommands{
+  "Zone Metadata",
+  {{"add", {true, addMeta,
+    "ZONE KIND VALUE [VALUE...]",
+    "\tAdd zone metadata, this adds to the existing KIND"}},
+   {"get", {true, getMeta,
+    "ZONE [KIND...]",
+    "\tGet zone metadata. If no KIND is given, lists all known"}},
+   {"set", {true, setMeta,
+    "ZONE KIND [VALUE...]",
+    "\tSet zone metadata, replacing all existing records of KIND, optionally\n"
+    "\tproviding a value. An omitted value clears the metadata"}}}
+};
+
+// NETWORKS (VIEWS CONTEXT)
+
+static const groupCommandDispatcher networkCommands{
+  "Networks",
+  {{"list", {true, listNetwork,
+    "",
+    "\tList all defined networks with their chosen views"}},
+   {"set", {true, setNetwork,
+    "NET [VIEW]",
+    "\tSet the view for a network, or delete if no view argument."}}}
+};
+
+// RECORD/RRSET
+
+static const groupCommandDispatcher rrsetCommands{
+  "Zone Record",
+  {{"add", {true, addRecord,
+    R"(ZONE NAME TYPE [TTL] "CONTENT" ["CONTENT"...])",
+    "\tAdd one or more records to the given rrset in ZONE"}},
+   {"delete", {true, deleteRRSet,
+    "ZONE NAME TYPE",
+    "\tDelete named rrset from ZONE"}},
+   {"hash", {true, hashZoneRecord,
+    "ZONE NAME",
+    "\tCalculate the NSEC3 hash for NAME in ZONE"}},
+   {"replace", {true, replaceRRSet,
+    R"(ZONE NAME TYPE [TTL] "CONTENT" ["CONTENT"...])",
+    "\tReplace named rrset from ZONE"}}}
+};
+
+// TSIG-KEY / TSIGKEY
+
+static const groupCommandDispatcher TSIGKEYCommands{
+  "TSIG Key",
+  {{"activate", {true, activateTSIGKey,
+    "ZONE NAME {primary|secondary|producer|consumer}",
+    "\tEnable TSIG authenticated AXFR using the key NAME for ZONE"}},
+   {"deactivate", {true, deactivateTSIGKey,
+    "ZONE NAME {primary|secondary|producer|consumer}",
+    "\tDisable TSIG authenticated AXFR using the key NAME for ZONE"}},
+   {"delete", {true, deleteTSIGKey,
+    "NAME",
+    "\tDelete TSIG key (warning: will not unmap key!)"}},
+   {"generate", {true, generateTSIGKey,
+    "NAME ALGORITHM",
+    "\tGenerate new TSIG key.\n"
+    "\tALGORITHM is one of hmac-{md5,sha1,sha224,sha256,sha384,sha512}"}},
+   {"import", {true, importTSIGKey,
+    "NAME ALGORITHM KEY",
+    "\tImport TSIG key"}},
+   {"list", {true, listTSIGKeys,
+    "",
+    "\tList all TSIG keys"}}}
+};
+
+// VIEWS
+
+static const groupCommandDispatcher viewsCommands{
+  "Views",
+  {{"list", {true, listView,
+    "",
+    "\tList all zones within VIEW"}},
+   {"list-all", {true, listViews,
+    "",
+    "\tList all view names"}},
+   {"add-zone", {true, viewAddZone,
+    "VIEW ZONE..VARIANT",
+    "\tAdd a zone variant to a view"}},
+   {"del-zone", {true, viewDelZone,
+    "VIEW ZONE..VARIANT",
+    "\tRemove a zone variant from a view"}}}
+};
+
+// ZONE
+
+// Zone commands are split into four groups, for the sake of
+// ``pdnsutil zone help'' output.
+
+static const groupCommandDispatcher zoneMainCommands{
+  "Zone",
+  {{"check", {true, checkZone,
+    "ZONE",
+    "\tCheck a zone for correctness"}},
+   {"check-all", {true, checkAllZones,
+    "[exit-on-error]",
+    "\tCheck all zones for correctness. Use exit-on-error to exit immediately\n"
+    "\tupon finding the first error in any zone"}},
+   {"clear", {true, clearZone,
+    "ZONE",
+    "\tClear all records of a zone, but keep everything else"}},
+   {"create", {true, createZone,
+    "ZONE [NSNAME]",
+    "\tCreate empty zone ZONE"}},
+   {"delete", {true, deleteZone,
+    "ZONE",
+    "\tDelete zone ZONE"}},
+   {"edit", {true, editZone,
+    "ZONE",
+    "\tEdit zone contents using $EDITOR"}},
+   {"increase-serial", {true, increaseSerial,
+    "ZONE",
+    "\tIncreases the SOA-serial by 1. Uses SOA-EDIT"}},
+   {"list-all", {true, listAllZones,
+    "[primary|secondary|native|producer|consumer]",
+    "\tList all active zone names.\n"
+    "\tUse --verbose (-v) to include disabled or empty zones"}},
+   {"list", {true, listZone,
+    "ZONE",
+    "\tList zone contents"}},
+   {"load", {true, loadZone,
+    "ZONE FILENAME [ZONE FILENAME]...",
+    "\tLoad ZONE from FILENAME, possibly creating zone or atomically replacing\n"
+    "\tcontents; --verbose or -v will also include the keys for disabled or\n"
+    "\tempty zones"}},
+   {"set-account", {true, setAccount,
+    "ZONE ACCOUNT",
+    "\tChange the account (owner) of ZONE to ACCOUNT"}},
+   {"set-kind", {true, setKind,
+    "ZONE KIND",
+    "\tChange the kind of ZONE to KIND (primary, secondary, native, producer,\n"
+    "\tor consumer)"}},
+   {"set-option", {true, setOption,
+    "ZONE [producer|consumer] [coo|unique|group] VALUE [VALUE...]",
+    "\tSet or remove an option for ZONE. Providing an empty value removes the\n"
+    "\toption"}},
+   {"set-options-json", {true, setOptionsJson,
+    "ZONE JSONFILE",
+    "\tChange the options of ZONE to JSONFILE"}},
+   {"zonemd-verify-file", {true, zonemdVerifyFile,
+    "ZONE FILENAME",
+    "\tValidate ZONEMD for ZONE"}}}
+};
+
+static const groupCommandDispatcher zoneSecondaryCommands{
+  "Secondary Zone",
+  {{"change-primary", {true, changeSecondaryZonePrimary,
+    "ZONE PRIMARY_IP [PRIMARY_IP...]",
+    "\tChange secondary zone ZONE primary IP address(es) to PRIMARY_IP"}},
+   {"create-secondary", {true, createSecondaryZone,
+    "ZONE PRIMARY_IP [PRIMARY_IP...]",
+    "\tCreate secondary zone ZONE with primary IP address(es) PRIMARY_IP"}}}
+};
+
+static const groupCommandDispatcher zoneDNSSECCommands{
+  "DNSSEC",
+  {{"dnssec-disable", {true, disableDNSSEC,
+    "ZONE",
+    "\tDeactivate all keys and unset PRESIGNED in ZONE"}},
+   {"export-dnskey", {true, exportZoneDNSKey,
+    "ZONE KEY_ID",
+    "\tExport the public DNSKEY with the given ID to stdout"}},
+   {"export-ds", {true, exportZoneDS,
+    "ZONE",
+    "\tExport all KSK DS records for ZONE to stdout"}},
+   {"list-keys", {true, listKeys,
+    "[ZONE]",
+    "\tList DNSSEC keys for ZONE.\n"
+    "\tWhen ZONE is unset, display keys for all active zones"}},
+   {"rectify", {true, rectifyZone,
+    "ZONE [ZONE...]",
+    "\tFix up DNSSEC fields (order, auth)"}},
+   {"rectify-all", {true, rectifyAllZones,
+    "[quiet]",
+    "\tRectify all zones. Optionally quiet output with errors only"}},
+   {"secure", {true, secureZone,
+    "ZONE [ZONE...]",
+    "\tAdd DNSSEC to zone ZONE"}},
+   {"secure-all", {true, secureAllZones,
+    "[increase-serial]",
+    "\tSecure all zones without keys"}},
+   {"set-nsec3", {true, setNsec3,
+    "ZONE ['PARAMS' [narrow]]",
+    "\tEnable NSEC3 with PARAMS (default: '1 0 0 -'). Optionally narrow"}},
+   {"set-presigned", {true, setPresigned,
+    "ZONE",
+    "\tUse presigned RRSIGs from storage"}},
+   {"set-publish-cdnskey", {true, setPublishCDNSKey,
+    "ZONE [delete]",
+    "\tEnable sending CDNSKEY responses for ZONE. Add 'delete' to publish\n"
+    "\ta CDNSKEY with a DNSSEC delete algorithm"}},
+   {"set-publish-cds", {true, setPublishCDs,
+    "ZONE [DIGESTALGOS]",
+    "\tEnable sending CDS responses for ZONE, using DIGESTALGOS as signature\n"
+    "\talgorithms; DIGESTALGOS should be a comma-separated list of numbers,\n"
+    "\t(default: '2')"}},
+  { "set-signaling", {true, setSignalingZone,
+    "ZONE",
+    "\tConfigure zone for RFC 9615 DNSSEC bootstrapping\n"
+    "\t(zone name must begin with _signal.)"}},
+   {"show", {true, showZone,
+    "ZONE",
+    "\tShow DNSSEC (public) key details about a zone"}},
+   {"unset-nsec3", {true, unsetNSec3,
+    "ZONE",
+    "\tSwitch ZONE back to NSEC"}},
+   {"unset-presigned", {true, unsetPresigned,
+    "ZONE",
+    "\tStop using presigned RRSIGs on ZONE"}},
+   {"unset-publish-cdnskey", {true, unsetPublishCDNSKey,
+    "ZONE",
+    "\tDisable sending CDNSKEY responses for ZONE"}},
+   {"unset-publish-cds", {true, unsetPublishCDs,
+    "ZONE",
+    "\tDisable sending CDS responses for ZONE"}}}
+};
+
+static const groupCommandDispatcher zoneKeyCommands{
+  "Zone Key",
+  {{"activate-key", {true, activateZoneKey,
+    "ZONE KEY_ID",
+    "\tActivate the key with key id KEY_ID in ZONE"}},
+   {"add-key", {true, addZoneKey,
+    "ZONE [zsk|ksk] [BITS] [active|inactive] [published|unpublished]\n"
+    "    [rsasha1|rsasha1-nsec3-sha1|rsasha256|rsasha512|ecdsa256|ecdsa384"
+#if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBCRYPTO_ED25519)
+         "|ed25519"
+#endif
+#if defined(HAVE_LIBCRYPTO_ED448)
+         "|ed448"
+#endif
+         "]",
+    "\tAdd a ZSK or KSK to zone with specific algorithm and size in bits.\n"
+    "\tIf zsk or ksk is omitted, defaults to zsk"}},
+   {"deactivate-key", {true, deactivateZoneKey,
+    "ZONE KEY_ID",
+    "\tDeactivate the key with key id KEY_ID in ZONE"}},
+   {"export-key", {true, exportZoneKey,
+    "ZONE KEY_ID",
+    "\tExport the private key with the given ID to stdout"}},
+   {"export-key-pem", {true, exportZoneKeyPEM,
+    "ZONE KEY_ID",
+    "\tExport the private key with the given ID to stdout in PEM format"}},
+   {"generate-key", {true, generateZoneKey,
+    "{zsk|ksk} [ALGORITHM] [BITS]",
+    "\tGenerate a ZSK or KSK to stdout with specified ALGORITHM and BITS"}},
+   {"import-key", {true, importZoneKey,
+    "ZONE FILE [active|inactive] [ksk|zsk] [published|unpublished]",
+    "\tImport from a file a private key, ZSK or KSK; defaults to KSK, active\n"
+    "\tand published"}},
+   {"import-key-pem", {true, importZoneKeyPEM,
+    "ZONE FILE ALGORITHM [ksk|zsk]}",
+    "\tImport a private key from a PEM file"}},
+   {"publish-key", {true, publishZoneKey,
+    "ZONE KEY_ID",
+    "\tPublish the zone key with key id KEY_ID in ZONE"}},
+   {"remove-key", {true, removeZoneKey,
+    "ZONE KEY_ID",
+    "\tRemove key with KEY_ID from ZONE"}},
+   {"unpublish-key", {true, unpublishZoneKey,
+    "ZONE KEY_ID",
+    "\tUnpublish the zone key with key id KEY_ID in ZONE"}}}
+};
+
+// OTHER (NO OBJECT NAME PREFIX)
+
+static const groupCommandDispatcher otherCommands{
+  "Other/Miscellaneous",
+  {{"b2b-migrate", {true, B2BMigrate,
+    "OLD NEW",
+    "\tMove all data from one backend to another"}},
+   {"backend-cmd", {true, backendCmd,
+    "BACKEND CMD [CMD...]",
+    "\tPerform one or more backend commands"}},
+   {"backend-lookup", {true, backendLookup,
+    "BACKEND NAME [[TYPE] CLIENT_IP_SUBNET]",
+    "\tPerform a backend lookup of NAME, TYPE (defaulting to ANY) and\n"
+    "\tCLIENT_IP_SUBNET"}},
+   {"bench-db", {true, benchDb,
+    "[FILENAME]",
+    "\tBenchmark database backend with queries, one zone per line"}},
+   {"create-bind-db", {true, createBindDb,
+    "FILENAME",
+    "\tCreate DNSSEC db for BIND backend (bind-dnssec-db)"}},
+   {"hash-password", {true, hashPassword,
+    "[WORK FACTOR]",
+    "\tAsk for a plaintext password or API key and output a salted and hashed\n"
+    "\tversion"}},
+#ifndef HAVE_P11KIT1 // [
+   {"hsm", {false, HSM,
+    "", ""}}, // not functional so hide it
+#endif // ]
+   {"ipdecrypt", {false, ipDecrypt,
+    "IP_ADDRESS PASSPHRASE_OR_KEY [key]",
+    "\tDecrypt IP address using passphrase or base64 key"}},
+   {"ipencrypt", {false, ipEncrypt,
+    "IP_ADDRESS PASSPHRASE_OR_KEY [key]",
+    "\tEncrypt IP address using passphrase or base64 key"}},
+   {"list-algorithms", {false, listAlgorithms,
+    "[with-backend]",
+    "\tList all DNSSEC algorithms supported, optionally also listing the\n"
+    "\tcryptographic library used"}},
+   {"lmdb-get-backend-version", {false, lmdbGetBackendVersion,
+    "",
+    "\tGet schema version supported by backend"}},
+   {"raw-lua-from-content", {true, rawLuaFromContent,
+    "TYPE CONTENT",
+    "\tDisplay record contents in a form suitable for dnsdist's\n"
+    "\t`SpoofRawAction`"}},
+   {"test-algorithm", {false, testAlgorithm,
+    "ALGONUM",
+    ""}}, // TODO: short help line
+   {"test-algorithms", {false, testAlgorithms,
+    "",
+    ""}}, // TODO: short help line
+   {"test-schema", {true, testSchema,
+    "ZONE",
+    "\tTest DB schema - will create ZONE"}},
+   {"test-speed", {true, testSpeed,
+    "ZONE NUM_CORES",
+    ""}}, // TODO: short help line
+   {"verify-crypto", {true, verifyCrypto,
+    "FILENAME",
+    ""}}} // TODO: short help line
+};
+
+// clang-format on ]
+
+using commandDispatcher = std::map<std::string_view, std::pair<bool, std::vector<groupCommandDispatcher>>>;
+
+static const commandDispatcher topLevelDispatcher{
+  {"autoprimary", {true, {autoprimaryCommands}}},
+  {"catalog", {true, {catalogCommands}}},
+#ifdef HAVE_P11KIT1 // [
+  {"hsm", {true, {HSMCommands}}},
+#endif // ]
+  {"meta", {false, {metadataCommands}}}, // sugar
+  {"meta-data", {false, {metadataCommands}}}, // sugar
+  {"metadata", {true, {metadataCommands}}},
+  {"network", {true, {networkCommands}}},
+  {"record", {false, {rrsetCommands}}}, // sugar
+  {"rrset", {true, {rrsetCommands}}},
+  {"tsig-key", {false, {TSIGKEYCommands}}}, // sugar
+  {"tsigkey", {true, {TSIGKEYCommands}}},
+  {"views", {true, {viewsCommands}}},
+  {"zone", {true, {zoneMainCommands, zoneSecondaryCommands, zoneDNSSECCommands, zoneKeyCommands}}}
+};
+
 ArgvMap &arg()
 {
   static ArgvMap arg;
@@ -1556,15 +2074,17 @@ static int editZone(const ZoneName &zone, const PDNSColors& col) {
 }
 
 #ifdef HAVE_IPCIPHER
-static int xcryptIP(const std::string& cmd, const std::string& ip, const std::string& rkey)
+// NOLINTNEXTLINE(readability-identifier-length)
+static int xcryptIP(bool encrypt, const std::string& ip, const std::string& rkey)
 {
-
   ComboAddress ca(ip), ret;
 
-  if(cmd=="ipencrypt")
+  if (encrypt) {
     ret = encryptCA(ca, rkey);
-  else
+  }
+  else {
     ret = decryptCA(ca, rkey);
+  }
 
   cout<<ret.toString()<<endl;
   return EXIT_SUCCESS;
@@ -1757,8 +2277,8 @@ static int createZone(const ZoneName &zone, const DNSName& nsname) {
 static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds) {
   DNSResourceRecord rr;
   vector<DNSResourceRecord> newrrs;
-  ZoneName zone(cmds.at(1));
-  DNSName name = DNSName(cmds.at(2));
+  ZoneName zone(cmds.at(0));
+  DNSName name(cmds.at(1));
   if (!name.isPartOf(zone)) {
     throw PDNSException("Name \"" + name.toString() + "\" to add is not part of zone \"" + zone.toString() + "\".");
   }
@@ -1773,17 +2293,17 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds) {
     throw PDNSException("Operation on a secondary zone is not allowed unless --force");
   }
 
-  rr.qtype = DNSRecordContent::TypeToNumber(cmds.at(3));
+  rr.qtype = DNSRecordContent::TypeToNumber(cmds.at(2));
   rr.ttl = ::arg().asNum("default-ttl");
   rr.auth = true;
   rr.domain_id = di.id;
   rr.qname = name;
   DNSResourceRecord oldrr;
 
-  unsigned int contentStart = 4;
-  if(cmds.size() > 5) {
-    uint32_t ttl = atoi(cmds.at(4).c_str());
-    if (std::to_string(ttl) == cmds.at(4)) {
+  unsigned int contentStart = 3;
+  if(cmds.size() > 4) {
+    uint32_t ttl = atoi(cmds.at(3).c_str());
+    if (std::to_string(ttl) == cmds.at(3)) {
       rr.ttl = ttl;
       contentStart++;
     }
@@ -2734,37 +3254,55 @@ static int lmdbGetBackendVersion([[maybe_unused]] vector<string>& cmds, [[maybe_
 
 static int testAlgorithm(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
-  if (testAlgorithm(pdns::checked_stoi<int>(cmds.at(1)))) {
+  if (testAlgorithm(pdns::checked_stoi<int>(cmds.at(0)))) {
     return 0;
   }
   return 1;
 }
 
-static int ipEncrypt(vector<string>& cmds, const std::string_view synopsis)
+#ifdef HAVE_IPCIPHER // [
+static int ipDecryptOrEncrypt(vector<string>& cmds, const std::string_view synopsis, bool encrypt)
 {
-  if (cmds.size() < 3 || (cmds.size() == 4 && cmds.at(3) != "key")) {
+  if (cmds.size() < 2 || (cmds.size() == 3 && cmds.at(2) != "key")) {
     return usage(synopsis);
   }
-#ifdef HAVE_IPCIPHER
   string key;
-  if(cmds.size()==4) {
-    if (B64Decode(cmds.at(2), key) < 0) {
-      cerr << "Could not parse '" << cmds.at(3) << "' as base64" << endl;
+  if(cmds.size()==3) {
+    if (B64Decode(cmds.at(1), key) < 0) {
+      cerr << "Could not parse '" << cmds.at(1) << "' as base64" << endl;
       return 0;
     }
   }
   else {
-    key = makeIPCipherKey(cmds.at(2));
+    key = makeIPCipherKey(cmds.at(1));
   }
-  return xcryptIP(cmds.at(0), cmds.at(1), key);
+  return xcryptIP(encrypt, cmds.at(0), key);
+}
+#endif // HAVE_IPCIPHER ]
+
+static int ipDecrypt(vector<string>& cmds, const std::string_view synopsis)
+{
+#ifdef HAVE_IPCIPHER
+  return ipDecryptOrEncrypt(cmds, synopsis, false);
 #else
-  cerr<<cmds.at(0)<<" requires ipcipher support which is not available"<<endl;
+  cerr<<"ipdecrypt requires ipcipher support which is not available"<<endl;
   return 0;
 #endif /* HAVE_IPCIPHER */
 }
+
+static int ipEncrypt(vector<string>& cmds, const std::string_view synopsis)
+{
+#ifdef HAVE_IPCIPHER
+  return ipDecryptOrEncrypt(cmds, synopsis, true);
+#else
+  cerr<<"ipencrypt requires ipcipher support which is not available"<<endl;
+  return 0;
+#endif /* HAVE_IPCIPHER */
+}
+
 
 static int testAlgorithms([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
 {
@@ -2776,7 +3314,8 @@ static int testAlgorithms([[maybe_unused]] vector<string>& cmds, [[maybe_unused]
 
 static int listAlgorithms(vector<string>& cmds, const std::string_view synopsis)
 {
-  if ((cmds.size() == 2 && cmds.at(1) != "with-backend") || cmds.size() > 2) {
+  bool withBackend = cmds.size() == 1 && cmds.at(0) == "with-backend";
+  if (cmds.size() > 1 || (cmds.size() == 1 && !withBackend)) {
     return usage(synopsis);
   }
 
@@ -2786,7 +3325,7 @@ static int listAlgorithms(vector<string>& cmds, const std::string_view synopsis)
   for (const auto& algoWithBackend : algosWithBackend){
     string algoName = DNSSECKeeper::algorithm2name(algoWithBackend.first);
     cout<<std::to_string(algoWithBackend.first)<<" - "<<algoName;
-    if (cmds.size() == 2 && cmds.at(1) == "with-backend") {
+    if (withBackend) {
       cout<<" using "<<algoWithBackend.second;
     }
     cout<<endl;
@@ -2799,11 +3338,11 @@ static int listAlgorithms(vector<string>& cmds, const std::string_view synopsis)
 static int createBindDb([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
 {
 #ifdef HAVE_SQLITE3
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
   try {
-    SSQLite3 db(cmds.at(1), "", true); // create=ok //NOLINT(readability-identifier-length)
+    SSQLite3 db(cmds.at(0), "", true); // create=ok //NOLINT(readability-identifier-length)
     vector<string> statements;
     stringtok(statements, static_cast<char *>(sqlCreate), ";");
     for(const string& statement :  statements) {
@@ -2822,14 +3361,14 @@ static int createBindDb([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] 
 
 static int rawLuaFromContent(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
 
   // DNSResourceRecord rr;
-  // rr.qtype = DNSRecordContent::TypeToNumber(cmds.at(1));
-  // rr.content = cmds.at(2);
-  auto drc = DNSRecordContent::make(DNSRecordContent::TypeToNumber(cmds.at(1)), QClass::IN, cmds.at(2));
+  // rr.qtype = DNSRecordContent::TypeToNumber(cmds.at(0));
+  // rr.content = cmds.at(1);
+  auto drc = DNSRecordContent::make(DNSRecordContent::TypeToNumber(cmds.at(0)), QClass::IN, cmds.at(1));
   cout<<makeLuaString(drc->serialize(DNSName(), true))<<endl;
 
   return 0;
@@ -2838,9 +3377,9 @@ static int rawLuaFromContent(vector<string>& cmds, const std::string_view synops
 static int hashPassword(vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
 {
   uint64_t workFactor = CredentialsHolder::s_defaultWorkFactor;
-  if (cmds.size() > 1) {
+  if (!cmds.empty()) {
     try {
-      pdns::checked_stoi_into(workFactor, cmds.at(1));
+      pdns::checked_stoi_into(workFactor, cmds.at(0));
     }
     catch (const std::exception& e) {
       cerr<<"Unable to parse the supplied work factor: "<<e.what()<<endl;
@@ -2862,36 +3401,36 @@ static int hashPassword(vector<string>& cmds, [[maybe_unused]] const std::string
 
 static int zonemdVerifyFile(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3) {
+  if(cmds.size() < 2) {
     return usage(synopsis);
   }
-  if(cmds[1]==".") {
-    cmds[1].clear();
+  if(cmds[0]==".") {
+    cmds[0].clear();
   }
 
-  return zonemdVerifyFile(ZoneName(cmds[1]), cmds[2]);
+  return zonemdVerifyFile(ZoneName(cmds[0]), cmds[1]);
 }
 
 
 // these need DNSSECKeeper
 static int testSchema(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  return testSchema(dk, ZoneName(cmds.at(1)));
+  return testSchema(dk, ZoneName(cmds.at(0)));
 }
 
 static int rectifyZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   int exitCode = 0;
-  for(unsigned int n = 1; n < cmds.size(); ++n) { // NOLINT(readability-identifier-length)
-    if (!rectifyZone(dk, ZoneName(cmds.at(n)))) {
+  for (const auto& name: cmds) {
+    if (!rectifyZone(dk, ZoneName(name))) {
       exitCode = 1;
     }
   }
@@ -2900,7 +3439,7 @@ static int rectifyZone(vector<string>& cmds, const std::string_view synopsis)
 
 static int rectifyAllZones(vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
 {
-  bool quiet = (cmds.size() >= 2 && cmds.at(1) == "quiet");
+  bool quiet = !cmds.empty() && cmds.at(0) == "quiet";
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   if (!rectifyAllZones(dk, quiet || g_quiet)) {
     return 1;
@@ -2910,71 +3449,71 @@ static int rectifyAllZones(vector<string>& cmds, [[maybe_unused]] const std::str
 
 static int checkZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
-  return checkZone(dk, B, ZoneName(cmds.at(1)));
+  return checkZone(dk, B, ZoneName(cmds.at(0)));
 }
 
 static int benchDb(vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
 {
-  dbBench(cmds.size() > 1 ? cmds.at(1) : "");
+  dbBench(cmds.empty() ? "" : cmds.at(0));
   return 0;
 }
 
 static int checkAllZones(vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
 {
-  bool exitOnError = ((cmds.size() >= 2 ? cmds.at(1) : "") == "exit-on-error");
+  bool exitOnError = !cmds.empty() && cmds.at(0) == "exit-on-error";
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   return checkAllZones(dk, exitOnError);
 }
 
 static int listAllZones(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() > 2) {
+  if (cmds.size() > 1) {
     return usage(synopsis);
   }
-  if (cmds.size() == 2) {
-    return listAllZones(synopsis, cmds.at(1));
+  if (cmds.size() == 1) {
+    return listAllZones(synopsis, cmds.at(0));
   }
   return listAllZones(synopsis);
 }
 
 static int listMemberZones(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() != 2) {
+  if (cmds.size() != 1) {
     return usage(synopsis);
   }
-  return listMemberZones(cmds.at(1));
+  return listMemberZones(cmds.at(0));
 }
 
 static int testSpeed(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3) {
+  if(cmds.size() < 2) {
     return usage(synopsis);
   }
-  testSpeed(ZoneName(cmds.at(1)), pdns::checked_stoi<int>(cmds.at(2)));
+  testSpeed(ZoneName(cmds.at(0)), pdns::checked_stoi<int>(cmds.at(1)));
   return 0;
 }
 
 static int verifyCrypto(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
-  verifyCrypto(cmds.at(1));
+  verifyCrypto(cmds.at(0));
   return 0;
 }
 
 static int showZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!showZone(dk, ZoneName(cmds.at(1)))) {
+  if (!showZone(dk, ZoneName(cmds.at(0)))) {
     return 1;
   }
   return 0;
@@ -2982,11 +3521,11 @@ static int showZone(vector<string>& cmds, const std::string_view synopsis)
 
 static int exportZoneDS(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!showZone(dk, ZoneName(cmds.at(1)), true)) {
+  if (!showZone(dk, ZoneName(cmds.at(0)), true)) {
     return 1;
   }
   return 0;
@@ -2994,11 +3533,11 @@ static int exportZoneDS(vector<string>& cmds, const std::string_view synopsis)
 
 static int disableDNSSEC(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   if(!disableDNSSECOnZone(dk, zone)) {
     cerr << "Cannot disable DNSSEC on " << zone << endl;
     return 1;
@@ -3008,15 +3547,15 @@ static int disableDNSSEC(vector<string>& cmds, const std::string_view synopsis)
 
 static int activateZoneKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 3) {
+  if(cmds.size() != 2) {
     return usage(synopsis);
   }
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   // NOLINTNEXTLINE(readability-identifier-length)
-  unsigned int id = atoi(cmds.at(2).c_str()); // if you make this pdns::checked_stoi, the error gets worse
+  unsigned int id = atoi(cmds.at(1).c_str()); // if you make this pdns::checked_stoi, the error gets worse
   if(id == 0)
   {
-    cerr << "Invalid KEY-ID '" << cmds.at(2) << "'" << endl;
+    cerr << "Invalid KEY-ID '" << cmds.at(1) << "'" << endl;
     return 1;
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
@@ -3035,11 +3574,11 @@ static int activateZoneKey(vector<string>& cmds, const std::string_view synopsis
 
 static int deactivateZoneKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 3) {
+  if(cmds.size() != 2) {
     return usage(synopsis);
   }
-  ZoneName zone(cmds.at(1));
-  auto id = pdns::checked_stoi<unsigned int>(cmds.at(2)); // NOLINT(readability-identifier-length)
+  ZoneName zone(cmds.at(0));
+  auto id = pdns::checked_stoi<unsigned int>(cmds.at(1)); // NOLINT(readability-identifier-length)
   if(id == 0)
   {
     cerr<<"Invalid KEY-ID"<<endl;
@@ -3061,15 +3600,15 @@ static int deactivateZoneKey(vector<string>& cmds, const std::string_view synops
 
 static int publishZoneKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 3) {
+  if(cmds.size() != 2) {
     return usage(synopsis);
   }
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   // NOLINTNEXTLINE(readability-identifier-length)
-  unsigned int id = atoi(cmds.at(2).c_str()); // if you make this pdns::checked_stoi, the error gets worse
+  unsigned int id = atoi(cmds.at(1).c_str()); // if you make this pdns::checked_stoi, the error gets worse
   if(id == 0)
   {
-    cerr << "Invalid KEY-ID '" << cmds.at(2) << "'" << endl;
+    cerr << "Invalid KEY-ID '" << cmds.at(1) << "'" << endl;
     return 1;
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
@@ -3088,15 +3627,15 @@ static int publishZoneKey(vector<string>& cmds, const std::string_view synopsis)
 
 static int unpublishZoneKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 3) {
+  if(cmds.size() != 2) {
     return usage(synopsis);
   }
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   // NOLINTNEXTLINE(readability-identifier-length)
-  unsigned int id = atoi(cmds.at(2).c_str()); // if you make this pdns::checked_stoi, the error gets worse
+  unsigned int id = atoi(cmds.at(1).c_str()); // if you make this pdns::checked_stoi, the error gets worse
   if(id == 0)
   {
-    cerr << "Invalid KEY-ID '" << cmds.at(2) << "'" << endl;
+    cerr << "Invalid KEY-ID '" << cmds.at(1) << "'" << endl;
     return 1;
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
@@ -3135,11 +3674,11 @@ static int checkZoneKey(DNSSECKeeper &dsk, ZoneName &zone, int64_t keyId)
 
 static int addZoneKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3 ) {
+  if(cmds.size() < 2 ) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
   DomainInfo di; //NOLINT(readability-identifier-length)
@@ -3156,7 +3695,7 @@ static int addZoneKey(vector<string>& cmds, const std::string_view synopsis)
   int algorithm=-1;
   bool active=false;
   bool published=true;
-  for(unsigned int n=2; n < cmds.size(); ++n) { //NOLINT(readability-identifier-length)
+  for(unsigned int n=1; n < cmds.size(); ++n) { //NOLINT(readability-identifier-length)
     if (pdns_iequals(cmds.at(n), "zsk")) {
       keyOrZone = false;
     }
@@ -3240,12 +3779,12 @@ static int addZoneKey(vector<string>& cmds, const std::string_view synopsis)
 
 static int removeZoneKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3) {
+  if(cmds.size() < 2) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(1));
-  auto id = pdns::checked_stoi<unsigned int>(cmds.at(2)); // NOLINT(readability-identifier-length)
+  ZoneName zone(cmds.at(0));
+  auto id = pdns::checked_stoi<unsigned int>(cmds.at(1)); // NOLINT(readability-identifier-length)
   if (!dk.removeKey(zone, id)) {
      cerr<<"Cannot remove key " << id << " from " << zone <<endl;
     return 1;
@@ -3255,28 +3794,28 @@ static int removeZoneKey(vector<string>& cmds, const std::string_view synopsis)
 
 static int deleteZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
-  return deleteZone(ZoneName(cmds.at(1)));
+  return deleteZone(ZoneName(cmds.at(0)));
 }
 
 static int createZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2 && cmds.size()!=3 ) {
+  if(cmds.size() != 1 && cmds.size()!=2 ) {
     return usage(synopsis);
   }
-  return createZone(ZoneName(cmds.at(1)), cmds.size() > 2 ? DNSName(cmds.at(2)) : DNSName());
+  return createZone(ZoneName(cmds.at(0)), cmds.size() > 1 ? DNSName(cmds.at(1)) : DNSName());
 }
 
 static int createSecondaryZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3 ) {
+  if(cmds.size() < 2 ) {
     return usage(synopsis);
   }
   UtilBackend B; // NOLINT(readability-identifier-length)
   DomainInfo di; // NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   if (B.getDomainInfo(zone, di)) {
     cerr << "Zone '" << zone << "' exists already" << endl;
     return EXIT_FAILURE;
@@ -3292,7 +3831,7 @@ static int createSecondaryZone(vector<string>& cmds, const std::string_view syno
     return EXIT_FAILURE;
   }
   vector<ComboAddress> primaries;
-  for (unsigned i=2; i < cmds.size(); i++) {
+  for (unsigned i=1; i < cmds.size(); i++) {
     primaries.emplace_back(cmds.at(i), 53);
   }
   cerr << "Creating secondary zone '" << zone << "', with primaries '" << comboAddressVecToString(primaries) << "'" << endl;
@@ -3305,18 +3844,18 @@ static int createSecondaryZone(vector<string>& cmds, const std::string_view syno
 
 static int changeSecondaryZonePrimary(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3 ) {
+  if(cmds.size() < 2 ) {
     return usage(synopsis);
   }
   UtilBackend B; // NOLINT(readability-identifier-length)
   DomainInfo di; // NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   if (!B.getDomainInfo(zone, di)) {
     cerr << "Zone '" << zone << "' doesn't exist" << endl;
     return EXIT_FAILURE;
   }
   vector<ComboAddress> primaries;
-  for (unsigned i=2; i < cmds.size(); i++) {
+  for (unsigned i=1; i < cmds.size(); i++) {
     primaries.emplace_back(cmds.at(i), 53);
   }
   cerr << "Updating secondary zone '" << zone << "', primaries to '" << comboAddressVecToString(primaries) << "'" << endl;
@@ -3332,7 +3871,7 @@ static int changeSecondaryZonePrimary(vector<string>& cmds, const std::string_vi
 
 static int addRecord(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 5) {
+  if(cmds.size() < 4) {
     return usage(synopsis);
   }
   return addOrReplaceRecord(true, cmds);
@@ -3340,18 +3879,18 @@ static int addRecord(vector<string>& cmds, const std::string_view synopsis)
 
 static int addAutoprimary(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3) {
+  if(cmds.size() < 2) {
     return usage(synopsis);
   }
-  return addAutoPrimary(cmds.at(1), cmds.at(2), cmds.size() > 3 ? cmds.at(3) : "");
+  return addAutoPrimary(cmds.at(0), cmds.at(1), cmds.size() > 2 ? cmds.at(2) : "");
 }
 
 static int removeAutoprimary(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3) {
+  if(cmds.size() < 2) {
     return usage(synopsis);
   }
-  return removeAutoPrimary(cmds.at(1), cmds.at(2));
+  return removeAutoPrimary(cmds.at(0), cmds.at(1));
 }
 
 static int listAutoprimaries([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
@@ -3361,7 +3900,7 @@ static int listAutoprimaries([[maybe_unused]] vector<string>& cmds, [[maybe_unus
 
 static int replaceRRSet(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 5) {
+  if(cmds.size() < 4) {
     return usage(synopsis);
   }
   return addOrReplaceRecord(false , cmds);
@@ -3369,72 +3908,72 @@ static int replaceRRSet(vector<string>& cmds, const std::string_view synopsis)
 
 static int deleteRRSet(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 4) {
+  if(cmds.size() != 3) {
     return usage(synopsis);
   }
-  return deleteRRSet(cmds.at(1), cmds.at(2), cmds.at(3));
+  return deleteRRSet(cmds.at(0), cmds.at(1), cmds.at(2));
 }
 
 static int listZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
-  if (cmds.at(1) == ".") {
-    cmds.at(1).clear();
+  if (cmds.at(0) == ".") {
+    cmds.at(0).clear();
   }
 
-  return listZone(ZoneName(cmds.at(1)));
+  return listZone(ZoneName(cmds.at(0)));
 }
 
 static int editZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
-  if (cmds.at(1) == ".") {
-    cmds.at(1).clear();
+  if (cmds.at(0) == ".") {
+    cmds.at(0).clear();
   }
 
   PDNSColors col(g_vm.count("no-colors") != 0);
-  return editZone(ZoneName(cmds.at(1)), col);
+  return editZone(ZoneName(cmds.at(0)), col);
 }
 
 static int clearZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 2) {
+  if(cmds.size() != 1) {
     return usage(synopsis);
   }
-  if (cmds.at(1) == ".") {
-    cmds.at(1).clear();
+  if (cmds.at(0) == ".") {
+    cmds.at(0).clear();
   }
 
-  return clearZone(ZoneName(cmds.at(1)));
+  return clearZone(ZoneName(cmds.at(0)));
 }
 
 static int listKeys(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() > 2) {
+  if(cmds.size() > 1) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   string zname;
-  if (cmds.size() == 2) {
-    zname = cmds.at(1);
+  if (cmds.size() == 1) {
+    zname = cmds.at(0);
   }
   return listKeys(zname, dk);
 }
 
 static int loadZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3) {
+  if(cmds.size() < 2) {
     return usage(synopsis);
   }
-  if (cmds.at(1) == ".") {
-    cmds.at(1).clear();
+  if (cmds.at(0) == ".") {
+    cmds.at(0).clear();
   }
 
-  for(size_t n=1; n + 2 <= cmds.size(); n+=2) { // NOLINT(readability-identifier-length)
+  for(size_t n=0; n + 2 <= cmds.size(); n+=2) { // NOLINT(readability-identifier-length)
     int ret = loadZone(ZoneName(cmds.at(n)), cmds.at(n + 1));
     if (ret != 0) {
       return ret;
@@ -3445,14 +3984,14 @@ static int loadZone(vector<string>& cmds, const std::string_view synopsis)
 
 static int secureZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
   vector<ZoneName> mustRectify;
   unsigned int zoneErrors=0;
-  for(unsigned int n = 1; n < cmds.size(); ++n) { // NOLINT(readability-identifier-length)
-    ZoneName zone(cmds.at(n));
+  for (const auto& name : cmds) {
+    ZoneName zone(name);
     dk.startTransaction(zone);
     if(secureZone(dk, zone)) {
       mustRectify.push_back(std::move(zone));
@@ -3474,7 +4013,7 @@ static int secureZone(vector<string>& cmds, const std::string_view synopsis)
 
 static int secureAllZones(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() >= 2 && !pdns_iequals(cmds.at(1), "increase-serial")) {
+  if (!cmds.empty() && !pdns_iequals(cmds.at(0), "increase-serial")) {
     return usage(synopsis);
   }
 
@@ -3491,7 +4030,7 @@ static int secureAllZones(vector<string>& cmds, const std::string_view synopsis)
       cout<<"Securing "<<di.zone<<": ";
       if (secureZone(dk, di.zone)) {
         zonesSecured++;
-        if (cmds.size() == 2) {
+        if (cmds.size() == 1) {
           if (increaseSerial(di.zone, dk) == 0) {
             continue;
           }
@@ -3513,88 +4052,88 @@ static int secureAllZones(vector<string>& cmds, const std::string_view synopsis)
 
 static int setKind(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 3) {
+  if(cmds.size() != 2) {
     return usage(synopsis);
   }
-  ZoneName zone(cmds.at(1));
-  auto kind = DomainInfo::stringToKind(cmds.at(2));
+  ZoneName zone(cmds.at(0));
+  auto kind = DomainInfo::stringToKind(cmds.at(1));
   return setZoneKind(zone, kind);
 }
 
 static int setOptionsJson(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() != 3) {
+  if (cmds.size() != 2) {
     return usage(synopsis);
   }
 
   // Verify json
-  if (!cmds.at(2).empty()) {
+  if (!cmds.at(1).empty()) {
     std::string err;
-    json11::Json doc = json11::Json::parse(cmds.at(2), err);
+    json11::Json doc = json11::Json::parse(cmds.at(1), err);
     if (doc.is_null()) {
       cerr << "Parsing of JSON document failed:" << err << endl;
       return EXIT_FAILURE;
     }
   }
 
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
 
-  return setZoneOptionsJson(zone, cmds.at(2));
+  return setZoneOptionsJson(zone, cmds.at(1));
 }
 
 static int setOption(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 5 || (cmds.size() > 5 && (cmds.at(3) != "group"))) {
+  if (cmds.size() < 4 || (cmds.size() > 4 && (cmds.at(2) != "group"))) {
     return usage(synopsis);
   }
-  if ((cmds.at(2) != "producer" && cmds.at(2) != "consumer") || (cmds.at(3) != "coo" && cmds.at(3) != "unique" && cmds.at(3) != "group")) {
+  if ((cmds.at(1) != "producer" && cmds.at(1) != "consumer") || (cmds.at(2) != "coo" && cmds.at(2) != "unique" && cmds.at(2) != "group")) {
     return usage(synopsis);
   }
 
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   set<string> values;
-  for (unsigned int n = 4; n < cmds.size(); ++n) { // NOLINT(readability-identifier-length)
+  for (unsigned int n = 3; n < cmds.size(); ++n) { // NOLINT(readability-identifier-length)
     if (!cmds.at(n).empty()) {
       values.insert(cmds.at(n));
     }
   }
 
-  return setZoneOption(zone, cmds.at(2), cmds.at(3), values);
+  return setZoneOption(zone, cmds.at(1), cmds.at(2), values);
 }
 
 static int setCatalog(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 2) {
+  if (cmds.empty()) {
     return usage(synopsis);
   }
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   ZoneName catalog; // Create an empty ZoneName()
-  if (cmds.size() > 2 && !cmds.at(2).empty()) {
-    catalog = ZoneName(cmds.at(2));
+  if (cmds.size() > 1 && !cmds.at(1).empty()) {
+    catalog = ZoneName(cmds.at(1));
   }
   return setZoneCatalog(zone, catalog);
 }
 
 static int setAccount(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() != 3) {
+  if(cmds.size() != 2) {
     return usage(synopsis);
   }
-  ZoneName zone(cmds.at(1));
-  return setZoneAccount(zone, cmds.at(2));
+  ZoneName zone(cmds.at(0));
+  return setZoneAccount(zone, cmds.at(1));
 }
 
 static int setNsec3(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
-  string nsec3params = cmds.size() > 2 ? cmds.at(2) : "1 0 0 -";
-  bool narrow = cmds.size() > 3 && cmds.at(3) == "narrow";
+  string nsec3params = cmds.size() > 1 ? cmds.at(1) : "1 0 0 -";
+  bool narrow = cmds.size() > 2 && cmds.at(2) == "narrow";
   NSEC3PARAMRecordContent ns3pr(nsec3params);
 
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   try {
     if (! dk.setNSEC3PARAM(zone, ns3pr, narrow)) {
       cerr<<"Cannot set NSEC3 param for " << zone << endl;
@@ -3625,12 +4164,12 @@ static int setNsec3(vector<string>& cmds, const std::string_view synopsis)
 
 static int setPresigned(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!dk.setPresigned(ZoneName(cmds.at(1)))) {
-    cerr << "Could not set presigned for " << cmds.at(1) << " (is DNSSEC enabled in your backend?)" << endl;
+  if (!dk.setPresigned(ZoneName(cmds.at(0)))) {
+    cerr << "Could not set presigned for " << cmds.at(0) << " (is DNSSEC enabled in your backend?)" << endl;
     return 1;
   }
   return 0;
@@ -3638,12 +4177,12 @@ static int setPresigned(vector<string>& cmds, const std::string_view synopsis)
 
 static int setPublishCDNSKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 2 || (cmds.size() == 3 && cmds.at(2) != "delete")) {
+  if (cmds.empty() || (cmds.size() == 2 && cmds.at(1) != "delete")) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!dk.setPublishCDNSKEY(ZoneName(cmds.at(1)), (cmds.size() == 3 && cmds.at(2) == "delete"))) {
-    cerr << "Could not set publishing for CDNSKEY records for " << cmds.at(1) << endl;
+  if (!dk.setPublishCDNSKEY(ZoneName(cmds.at(0)), (cmds.size() == 2 && cmds.at(1) == "delete"))) {
+    cerr << "Could not set publishing for CDNSKEY records for " << cmds.at(0) << endl;
     return 1;
   }
   return 0;
@@ -3651,18 +4190,18 @@ static int setPublishCDNSKey(vector<string>& cmds, const std::string_view synops
 
 static int setPublishCDs(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
 
   // If DIGESTALGOS is unset
-  if(cmds.size() == 2) {
+  if(cmds.size() == 1) {
     cmds.emplace_back("2");
   }
 
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!dk.setPublishCDS(ZoneName(cmds.at(1)), cmds.at(2))) {
-    cerr << "Could not set publishing for CDS records for " << cmds.at(1) << endl;
+  if (!dk.setPublishCDS(ZoneName(cmds.at(0)), cmds.at(1))) {
+    cerr << "Could not set publishing for CDS records for " << cmds.at(0) << endl;
     return 1;
   }
   return 0;
@@ -3670,16 +4209,16 @@ static int setPublishCDs(vector<string>& cmds, const std::string_view synopsis)
 
 static int setSignalingZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
 
-  if(cmds.size() > 2) {
+  if(cmds.size() > 1) {
     cerr << "Too many arguments" << endl;
     return 1;
   }
 
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
 
   if(zone.operator const DNSName&().countLabels() == 0 || zone.operator const DNSName&().getRawLabel(0) != "_signal") {
     cerr << "Signaling zone's first label must be '_signal': " << zone << endl;
@@ -3728,12 +4267,12 @@ static int setSignalingZone(vector<string>& cmds, const std::string_view synopsi
 
 static int unsetPresigned(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!dk.unsetPresigned(ZoneName(cmds.at(1)))) {
-    cerr << "Could not unset presigned on for " << cmds.at(1) << endl;
+  if (!dk.unsetPresigned(ZoneName(cmds.at(0)))) {
+    cerr << "Could not unset presigned on for " << cmds.at(0) << endl;
     return 1;
   }
   return 0;
@@ -3741,12 +4280,12 @@ static int unsetPresigned(vector<string>& cmds, const std::string_view synopsis)
 
 static int unsetPublishCDNSKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!dk.unsetPublishCDNSKEY(ZoneName(cmds.at(1)))) {
-    cerr << "Could not unset publishing for CDNSKEY records for " << cmds.at(1) << endl;
+  if (!dk.unsetPublishCDNSKEY(ZoneName(cmds.at(0)))) {
+    cerr << "Could not unset publishing for CDNSKEY records for " << cmds.at(0) << endl;
     return 1;
   }
   return 0;
@@ -3754,12 +4293,12 @@ static int unsetPublishCDNSKey(vector<string>& cmds, const std::string_view syno
 
 static int unsetPublishCDs(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!dk.unsetPublishCDS(ZoneName(cmds.at(1)))) {
-    cerr << "Could not unset publishing for CDS records for " << cmds.at(1) << endl;
+  if (!dk.unsetPublishCDS(ZoneName(cmds.at(0)))) {
+    cerr << "Could not unset publishing for CDS records for " << cmds.at(0) << endl;
     return 1;
   }
   return 0;
@@ -3767,12 +4306,12 @@ static int unsetPublishCDs(vector<string>& cmds, const std::string_view synopsis
 
 static int hashZoneRecord(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3) {
+  if(cmds.size() < 2) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(1));
-  DNSName record(cmds.at(2));
+  ZoneName zone(cmds.at(0));
+  DNSName record(cmds.at(1));
   NSEC3PARAMRecordContent ns3pr;
   bool narrow = false;
   if(!dk.getNSEC3PARAM(zone, &ns3pr, &narrow)) {
@@ -3789,12 +4328,12 @@ static int hashZoneRecord(vector<string>& cmds, const std::string_view synopsis)
 
 static int unsetNSec3(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  if (!dk.unsetNSEC3PARAM(ZoneName(cmds.at(1)))) {
-    cerr << "Cannot unset NSEC3 param for " << cmds.at(1) << endl;
+  if (!dk.unsetNSEC3PARAM(ZoneName(cmds.at(0)))) {
+    cerr << "Cannot unset NSEC3 param for " << cmds.at(0) << endl;
     return 1;
   }
   cerr<<"Done, please rectify your zone if your backend needs it (or reload it if you are using the bindbackend)"<<endl;
@@ -3804,13 +4343,13 @@ static int unsetNSec3(vector<string>& cmds, const std::string_view synopsis)
 
 static int exportZoneKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
 
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  string zone = cmds.at(1);
-  auto id = pdns::checked_stoi<unsigned int>(cmds.at(2)); // NOLINT(readability-identifier-length)
+  string zone = cmds.at(0);
+  auto id = pdns::checked_stoi<unsigned int>(cmds.at(1)); // NOLINT(readability-identifier-length)
   DNSSECPrivateKey dpk = dk.getKeyById(ZoneName(zone), id);
   cout << dpk.getKey()->convertToISC() << endl;
   return 0;
@@ -3818,13 +4357,13 @@ static int exportZoneKey(vector<string>& cmds, const std::string_view synopsis)
 
 static int exportZoneKeyPEM(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
 
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  string zone = cmds.at(1);
-  auto id = pdns::checked_stoi<unsigned int>(cmds.at(2)); // NOLINT(readability-identifier-length)
+  string zone = cmds.at(0);
+  auto id = pdns::checked_stoi<unsigned int>(cmds.at(1)); // NOLINT(readability-identifier-length)
   DNSSECPrivateKey dpk = dk.getKeyById(ZoneName(zone), id);
   dpk.getKey()->convertToPEMFile(*stdout);
   return 0;
@@ -3832,22 +4371,22 @@ static int exportZoneKeyPEM(vector<string>& cmds, const std::string_view synopsi
 
 static int increaseSerial(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 2) {
+  if (cmds.empty()) {
     return usage(synopsis);
   }
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  return increaseSerial(ZoneName(cmds.at(1)), dk);
+  return increaseSerial(ZoneName(cmds.at(0)), dk);
 }
 
 static int importZoneKeyPEM(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 4) {
+  if (cmds.size() < 3) {
     return usage(synopsis);
   }
 
-  ZoneName zone(cmds.at(1));
-  const string filename = cmds.at(2);
-  const auto algorithm = pdns::checked_stoi<unsigned int>(cmds.at(3));
+  ZoneName zone(cmds.at(0));
+  const string filename = cmds.at(1);
+  const auto algorithm = pdns::checked_stoi<unsigned int>(cmds.at(2));
 
   errno = 0;
   pdns::UniqueFilePtr filePtr{std::fopen(filename.c_str(), "r")};
@@ -3866,7 +4405,7 @@ static int importZoneKeyPEM(vector<string>& cmds, const std::string_view synopsi
   DNSSECPrivateKey dpk;
 
   uint8_t algo = 0;
-  pdns::checked_stoi_into(algo, cmds.at(3));
+  pdns::checked_stoi_into(algo, cmds.at(2));
   if (algo == DNSSECKeeper::RSASHA1NSEC3SHA1) {
     algo = DNSSECKeeper::RSASHA1;
   }
@@ -3874,15 +4413,15 @@ static int importZoneKeyPEM(vector<string>& cmds, const std::string_view synopsi
   cerr << std::to_string(algo) << endl;
 
   uint16_t flags = 0;
-  if (cmds.size() > 4) {
-    if (pdns_iequals(cmds.at(4), "ZSK")) {
+  if (cmds.size() > 3) {
+    if (pdns_iequals(cmds.at(3), "ZSK")) {
       flags = 256;
     }
-    else if (pdns_iequals(cmds.at(4), "KSK")) {
+    else if (pdns_iequals(cmds.at(3), "KSK")) {
       flags = 257;
     }
     else {
-      cerr << "Unknown key flag '" << cmds.at(4) << "'" << endl;
+      cerr << "Unknown key flag '" << cmds.at(3) << "'" << endl;
       return 1;
     }
   }
@@ -3902,11 +4441,11 @@ static int importZoneKeyPEM(vector<string>& cmds, const std::string_view synopsi
 
 static int importZoneKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3) {
+  if(cmds.size() < 2) {
     return usage(synopsis);
   }
-  ZoneName zone(cmds.at(1));
-  string fname = cmds.at(2);
+  ZoneName zone(cmds.at(0));
+  string fname = cmds.at(1);
   DNSKEYRecordContent drc;
   shared_ptr<DNSCryptoKeyEngine> key(DNSCryptoKeyEngine::makeFromISCFile(drc, fname.c_str()));
 
@@ -3914,7 +4453,7 @@ static int importZoneKey(vector<string>& cmds, const std::string_view synopsis)
   bool active=true;
   bool published=true;
 
-  for(unsigned int n = 3; n < cmds.size(); ++n) { // NOLINT(readability-identifier-length)
+  for(unsigned int n = 2; n < cmds.size(); ++n) { // NOLINT(readability-identifier-length)
     if (pdns_iequals(cmds.at(n), "ZSK")) {
       flags = 256;
     }
@@ -3957,13 +4496,13 @@ static int importZoneKey(vector<string>& cmds, const std::string_view synopsis)
 
 static int exportZoneDNSKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 3) {
+  if(cmds.size() < 2) {
     return usage(synopsis);
   }
 
   DNSSECKeeper dk; //NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(1));
-  auto id = pdns::checked_stoi<unsigned int>(cmds.at(2)); // NOLINT(readability-identifier-length)
+  ZoneName zone(cmds.at(0));
+  auto id = pdns::checked_stoi<unsigned int>(cmds.at(1)); // NOLINT(readability-identifier-length)
   DNSSECPrivateKey dpk=dk.getKeyById(zone, id);
   cout << zone<<" IN DNSKEY "<<dpk.getDNSKEY().getZoneRepresentation() <<endl;
   return 0;
@@ -3971,7 +4510,7 @@ static int exportZoneDNSKey(vector<string>& cmds, const std::string_view synopsi
 
 static int generateZoneKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if(cmds.size() < 2 ) {
+  if(cmds.empty()) {
     return usage(synopsis);
   }
   // need to get algorithm, bits & ksk or zsk from commandline
@@ -3979,21 +4518,21 @@ static int generateZoneKey(vector<string>& cmds, const std::string_view synopsis
   int tmp_algo=0;
   int bits=0;
   int algorithm=DNSSECKeeper::ECDSA256;
-  for(unsigned int n=1; n < cmds.size(); ++n) { // NOLINT(readability-identifier-length)
-    if (pdns_iequals(cmds.at(n), "zsk")) {
+  for (const auto& arg : cmds) {
+    if (pdns_iequals(arg, "zsk")) {
       keyOrZone = false;
     }
-    else if (pdns_iequals(cmds.at(n), "ksk")) {
+    else if (pdns_iequals(arg, "ksk")) {
       keyOrZone = true;
     }
-    else if ((tmp_algo = DNSSECKeeper::shorthand2algorithm(cmds.at(n))) > 0) {
+    else if ((tmp_algo = DNSSECKeeper::shorthand2algorithm(arg)) > 0) {
       algorithm = tmp_algo;
     }
-    else if (pdns::checked_stoi<int>(cmds.at(n)) != 0) {
-      pdns::checked_stoi_into(bits, cmds.at(n));
+    else if (pdns::checked_stoi<int>(arg) != 0) {
+      pdns::checked_stoi_into(bits, arg);
     }
     else {
-      cerr << "Unknown algorithm, key flag or size '" << cmds.at(n) << "'" << endl;
+      cerr << "Unknown algorithm, key flag or size '" << arg << "'" << endl;
       return 0;
     }
   }
@@ -4034,11 +4573,11 @@ static int generateZoneKey(vector<string>& cmds, const std::string_view synopsis
 
 static int generateTSIGKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
-  DNSName name(cmds.at(1));
-  DNSName algo(cmds.at(2));
+  DNSName name(cmds.at(0));
+  DNSName algo(cmds.at(1));
   string key;
   try {
     key = makeTSIGKey(algo);
@@ -4059,12 +4598,12 @@ static int generateTSIGKey(vector<string>& cmds, const std::string_view synopsis
 
 static int importTSIGKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 4) {
+  if (cmds.size() < 3) {
     return usage(synopsis);
   }
-  DNSName name(cmds.at(1));
-  string algo = cmds.at(2);
-  string key = cmds.at(3);
+  DNSName name(cmds.at(0));
+  string algo = cmds.at(1);
+  string key = cmds.at(2);
 
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
   if (B.setTSIGKey(name, DNSName(algo), key)) {
@@ -4079,10 +4618,10 @@ static int importTSIGKey(vector<string>& cmds, const std::string_view synopsis)
 
 static int deleteTSIGKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 2) {
+  if (cmds.empty()) {
     return usage(synopsis);
   }
-  DNSName name(cmds.at(1));
+  DNSName name(cmds.at(0));
 
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
   if (B.deleteTSIGKey(name)) {
@@ -4110,15 +4649,15 @@ static int listTSIGKeys([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] 
 static int activateTSIGKey(vector<string>& cmds, const std::string_view synopsis)
 {
   string metaKey;
-  if (cmds.size() < 4) {
+  if (cmds.size() < 3) {
     return usage(synopsis);
   }
-  ZoneName zname(cmds.at(1));
-  string name = cmds.at(2);
-  if (cmds.at(3) == "primary" || cmds.at(3) == "producer") {
+  ZoneName zname(cmds.at(0));
+  string name = cmds.at(1);
+  if (cmds.at(2) == "primary" || cmds.at(2) == "producer") {
     metaKey = "TSIG-ALLOW-AXFR";
   }
-  else if (cmds.at(3) == "secondary" || cmds.at(3) == "consumer") {
+  else if (cmds.at(2) == "secondary" || cmds.at(2) == "consumer") {
     metaKey = "AXFR-MASTER-TSIG";
   }
   else {
@@ -4158,15 +4697,15 @@ static int activateTSIGKey(vector<string>& cmds, const std::string_view synopsis
 static int deactivateTSIGKey(vector<string>& cmds, const std::string_view synopsis)
 {
   string metaKey;
-  if (cmds.size() < 4) {
+  if (cmds.size() < 3) {
     return usage(synopsis);
   }
-  ZoneName zname(cmds.at(1));
-  string name = cmds.at(2);
-  if (cmds.at(3) == "primary" || cmds.at(3) == "producer") {
+  ZoneName zname(cmds.at(0));
+  string name = cmds.at(1);
+  if (cmds.at(2) == "primary" || cmds.at(2) == "producer") {
     metaKey = "TSIG-ALLOW-AXFR";
   }
-  else if (cmds.at(3) == "secondary" || cmds.at(3) == "consumer") {
+  else if (cmds.at(2) == "secondary" || cmds.at(2) == "consumer") {
     metaKey = "AXFR-MASTER-TSIG";
   }
   else {
@@ -4205,11 +4744,11 @@ static int deactivateTSIGKey(vector<string>& cmds, const std::string_view synops
 
 static int getMeta(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 2) {
+  if (cmds.empty()) {
     return usage(synopsis);
   }
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(1));
+  ZoneName zone(cmds.at(0));
   vector<string> keys;
 
   DomainInfo di; // NOLINT(readability-identifier-length)
@@ -4218,8 +4757,8 @@ static int getMeta(vector<string>& cmds, const std::string_view synopsis)
      return 1;
   }
 
-  if (cmds.size() > 2) {
-    keys.assign(cmds.begin() + 2, cmds.end());
+  if (cmds.size() > 1) {
+    keys.assign(cmds.begin() + 1, cmds.end());
     std::cout << "Metadata for '" << zone << "'" << endl;
     for(const auto& kind :  keys) {
       vector<string> meta;
@@ -4239,32 +4778,41 @@ static int getMeta(vector<string>& cmds, const std::string_view synopsis)
   return 0;
 }
 
-static int setMeta(vector<string>& cmds, const std::string_view synopsis)
+static int setMetaInternal(vector<string>& cmds, const std::string_view synopsis, bool clobber)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
-  ZoneName zone(cmds.at(1));
-  string kind = cmds.at(2);
+  ZoneName zone(cmds.at(0));
+  string kind = cmds.at(1);
   const static std::array<string, 7> multiMetaWhitelist = {"ALLOW-AXFR-FROM", "ALLOW-DNSUPDATE-FROM",
     "ALSO-NOTIFY", "TSIG-ALLOW-AXFR", "TSIG-ALLOW-DNSUPDATE", "GSS-ALLOW-AXFR-PRINCIPAL",
     "PUBLISH-CDS"};
-  bool clobber = (cmds.at(0) != "add-meta");
   if (find(multiMetaWhitelist.begin(), multiMetaWhitelist.end(), kind) == multiMetaWhitelist.end() && kind.find("X-") != 0) {
     if(!clobber) {
+      // This is add-meta
       cerr<<"Refusing to add metadata to single-value metadata "<<kind<<endl;
       return 1;
     }
-    if(cmds.size() > 4) {
+    if(cmds.size() > 3) {
       cerr<<"Refusing to set several metadata to single-value metadata "<<kind<<endl;
       return 1;
     }
   }
-  vector<string> meta(cmds.begin() + 3, cmds.end());
+  vector<string> meta(cmds.begin() + 2, cmds.end());
   return addOrSetMeta(zone, kind, meta, clobber);
 }
 
-#ifdef HAVE_P11KIT1 // {
+static int addMeta(vector<string>& cmds, const std::string_view synopsis)
+{
+  return setMetaInternal(cmds, synopsis, false);
+}
+static int setMeta(vector<string>& cmds, const std::string_view synopsis)
+{
+  return setMetaInternal(cmds, synopsis, true);
+}
+
+#ifdef HAVE_P11KIT1 // [
 
 static int HSMAssign(vector<string>& cmds, const std::string_view synopsis)
 {
@@ -4272,12 +4820,12 @@ static int HSMAssign(vector<string>& cmds, const std::string_view synopsis)
   DomainInfo di; // NOLINT(readability-identifier-length)
   std::vector<DNSBackend::KeyData> keys;
 
-  if (cmds.size() < 9) {
+  if (cmds.size() < 7) {
     return usage(synopsis);
   }
 
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(2));
+  ZoneName zone(cmds.at(0));
 
   // verify zone
   if (!B.getDomainInfo(zone, di)) {
@@ -4285,20 +4833,20 @@ static int HSMAssign(vector<string>& cmds, const std::string_view synopsis)
     return 1;
   }
 
-  int algorithm = DNSSECKeeper::shorthand2algorithm(cmds.at(3));
+  int algorithm = DNSSECKeeper::shorthand2algorithm(cmds.at(1));
   if (algorithm<0) {
-    cerr << "Unable to use unknown algorithm '" << cmds.at(3) << "'" << std::endl;
+    cerr << "Unable to use unknown algorithm '" << cmds.at(1) << "'" << std::endl;
     return 1;
   }
 
-  bool keyOrZone = cmds.at(4) == "ksk";
-  string module = cmds.at(5);
-  string slot = cmds.at(6);
-  string pin = cmds.at(7);
-  string label = cmds.at(8);
+  bool keyOrZone = cmds.at(2) == "ksk";
+  string module = cmds.at(3);
+  string slot = cmds.at(4);
+  string pin = cmds.at(5);
+  string label = cmds.at(6);
   string pub_label;
-  if (cmds.size() > 9) {
-    pub_label = cmds.at(9);
+  if (cmds.size() > 7) {
+    pub_label = cmds.at(7);
   }
   else {
      pub_label = label;
@@ -4353,12 +4901,12 @@ static int HSMAssign(vector<string>& cmds, const std::string_view synopsis)
 
 static int HSMCreateKey(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 4) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
   DomainInfo di; // NOLINT(readability-identifier-length)
-  ZoneName zone(cmds.at(2));
+  ZoneName zone(cmds.at(0));
   unsigned int id{0}; // NOLINT(readability-identifier-length)
   int bits = 2048;
   // verify zone
@@ -4367,7 +4915,7 @@ static int HSMCreateKey(vector<string>& cmds, const std::string_view synopsis)
     return 1;
   }
 
-  pdns::checked_stoi_into(id, cmds.at(3));
+  pdns::checked_stoi_into(id, cmds.at(1));
   std::vector<DNSBackend::KeyData> keys;
   if (!B.getDomainKeys(zone, keys)) {
     cerr << "No keys found for zone " << zone << std::endl;
@@ -4388,8 +4936,8 @@ static int HSMCreateKey(vector<string>& cmds, const std::string_view synopsis)
     cerr << "Could not find key with ID " << id << endl;
     return 1;
   }
-  if (cmds.size() > 4) {
-    pdns::checked_stoi_into(bits, cmds.at(4));
+  if (cmds.size() > 2) {
+    pdns::checked_stoi_into(bits, cmds.at(2));
   }
   if (bits < 1) {
     cerr << "Invalid bit size " << bits << "given, must be positive integer";
@@ -4406,62 +4954,23 @@ static int HSMCreateKey(vector<string>& cmds, const std::string_view synopsis)
   return 0;
 }
 
-struct HSMcommandDispatcher {
-  int (*handler)(std::vector<std::string>&, const std::string_view);
-  const std::string_view synopsis; // one-line command synopsis
-  const std::string_view help; // short description, may span multiple lines,
-                               // every line starts with a tab for indent
-};
-
-// We use std::map instead of std::unordered_map here in order to be able
-// to display a sorted list of commands (the main command set does not
-// need this because the help display groups them in a temporary map).
-// clang-format off
-static const std::map<std::string, HSMcommandDispatcher> HSMcommands{
-  {"assign", {HSMAssign,
-    "hsm assign ZONE ALGORITHM {ksk|zsk} MODULE SLOT PIN LABEL [PUBLABEL]",
-    "\tAssign a Hardware Signing Module to a ZONE"}},
-  {"create-key", {HSMCreateKey,
-    "hsm create-key ZONE KEY_ID [BITS]",
-    "\tcreate a key using Hardware Signing Module for ZONE (use assign first);\n"
-    "\tBITS defaults to 2048"}}
-};
-// clang-format on
-
-#endif // }
+#else // ][
 
 static int HSM([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
 {
-#ifdef HAVE_P11KIT1
-  if (cmds.size() < 2 || cmds.at(1) == "help") {
-    for (const auto& iter : HSMcommands) {
-      cout << iter.second.synopsis << endl;
-      cout << iter.second.help << endl;
-    }
-    return 0;
-  }
-
-  const auto iter = HSMcommands.find(cmds.at(1));
-  if (iter != HSMcommands.end()) {
-    const auto dispatcher = iter->second;
-    return dispatcher.handler(cmds, dispatcher.synopsis);
-  }
-
-  cerr<<"Unknown hsm sub-command '"<<cmds.at(1)<<"'"<<endl;
-  return 1;
-#else
   cerr<<"PKCS#11 support not enabled"<<endl;
   return 1;
-#endif
 }
+
+#endif // ]
 
 static int B2BMigrate(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
 
-  if (cmds.at(1) == cmds.at(2)) {
+  if (cmds.at(0) == cmds.at(1)) {
     cerr << "Error: b2b-migrate OLD NEW: OLD cannot be the same as NEW" << endl;
     return 1;
   }
@@ -4470,20 +4979,20 @@ static int B2BMigrate(vector<string>& cmds, const std::string_view synopsis)
   unique_ptr<DNSBackend> tgt{nullptr};
 
   for (auto& backend : BackendMakers().all()) {
-    if (backend->getPrefix() == cmds.at(1)) {
+    if (backend->getPrefix() == cmds.at(0)) {
        src = std::move(backend);
     }
-    else if (backend->getPrefix() == cmds.at(2)) {
+    else if (backend->getPrefix() == cmds.at(1)) {
        tgt = std::move(backend);
     }
   }
 
   if (src == nullptr) {
-    cerr << "Unknown source backend '" << cmds.at(1) << "'" << endl;
+    cerr << "Unknown source backend '" << cmds.at(0) << "'" << endl;
     return 1;
   }
   if (tgt == nullptr) {
-    cerr << "Unknown target backend '" << cmds.at(2) << "'" << endl;
+    cerr << "Unknown target backend '" << cmds.at(1) << "'" << endl;
     return 1;
   }
 
@@ -4603,29 +5112,29 @@ static int B2BMigrate(vector<string>& cmds, const std::string_view synopsis)
 
 static int backendCmd(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
 
   std::unique_ptr<DNSBackend> matchingBackend{nullptr};
 
   for (auto& backend : BackendMakers().all()) {
-    if (backend->getPrefix() == cmds.at(1)) {
+    if (backend->getPrefix() == cmds.at(0)) {
       matchingBackend = std::move(backend);
     }
   }
 
   if (matchingBackend == nullptr) {
-    cerr << "Unknown backend '" << cmds.at(1) << "'" << endl;
+    cerr << "Unknown backend '" << cmds.at(0) << "'" << endl;
     return 1;
   }
 
   if ((matchingBackend->getCapabilities() & DNSBackend::CAP_DIRECT) == 0) {
-    cerr << "Backend '" << cmds.at(1) << "' does not support direct commands" << endl;
+    cerr << "Backend '" << cmds.at(0) << "' does not support direct commands" << endl;
     return 1;
   }
 
-  for (auto i = next(begin(cmds), 2); i != end(cmds); ++i) {
+  for (auto i = next(begin(cmds), 1); i != end(cmds); ++i) {
     cerr << "== " << *i << endl;
     cout << matchingBackend->directBackendCmd(*i);
   }
@@ -4635,29 +5144,29 @@ static int backendCmd(vector<string>& cmds, const std::string_view synopsis)
 
 static int backendLookup(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
 
   std::unique_ptr<DNSBackend> matchingBackend{nullptr};
 
   for (auto& backend : BackendMakers().all()) {
-    if (backend->getPrefix() == cmds.at(1)) {
+    if (backend->getPrefix() == cmds.at(0)) {
       matchingBackend = std::move(backend);
     }
   }
 
   if (matchingBackend == nullptr) {
-    cerr << "Unknown backend '" << cmds.at(1) << "'" << endl;
+    cerr << "Unknown backend '" << cmds.at(0) << "'" << endl;
     return 1;
   }
 
   QType type = QType::ANY;
-  if (cmds.size() > 3) {
-    type = DNSRecordContent::TypeToNumber(cmds.at(3));
+  if (cmds.size() > 2) {
+    type = DNSRecordContent::TypeToNumber(cmds.at(2));
   }
 
-  ZoneName name{cmds.at(2)};
+  ZoneName name{cmds.at(1)};
   domainid_t domain_id{UnknownDomainID};
 
   if (name.hasVariant()) {
@@ -4677,8 +5186,8 @@ static int backendLookup(vector<string>& cmds, const std::string_view synopsis)
 
   DNSPacket queryPacket(true);
   Netmask clientNetmask;
-  if (cmds.size() > 4) {
-    clientNetmask = cmds.at(4);
+  if (cmds.size() > 3) {
+    clientNetmask = cmds.at(3);
     queryPacket.setRealRemote(clientNetmask);
   }
 
@@ -4709,14 +5218,14 @@ static int backendLookup(vector<string>& cmds, const std::string_view synopsis)
 
 static int listView(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() != 2) {
+  if (cmds.size() != 1) {
     return usage(synopsis);
   }
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
 
   vector<ZoneName> ret;
-  B.viewListZones(cmds.at(1), ret);
+  B.viewListZones(cmds.at(0), ret);
 
   for (const auto& zone : ret) {
     cout << zone << endl;
@@ -4726,7 +5235,7 @@ static int listView(vector<string>& cmds, const std::string_view synopsis)
 
 static int listViews(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() != 1) {
+  if (!cmds.empty()) {
     return usage(synopsis);
   }
 
@@ -4743,14 +5252,14 @@ static int listViews(vector<string>& cmds, const std::string_view synopsis)
 
 static int viewAddZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
 
-  string view{cmds.at(1)};
-  ZoneName zone{cmds.at(2)};
+  string view{cmds.at(0)};
+  ZoneName zone{cmds.at(1)};
   if (!B.viewAddZone(view, zone)) {
     cerr<<"Operation failed."<<endl;
     return 1;
@@ -4767,14 +5276,14 @@ static int viewAddZone(vector<string>& cmds, const std::string_view synopsis)
 
 static int viewDelZone(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 3) {
+  if (cmds.size() < 2) {
     return usage(synopsis);
   }
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
 
-  string view{cmds.at(1)};
-  ZoneName zone{cmds.at(2)};
+  string view{cmds.at(0)};
+  ZoneName zone{cmds.at(1)};
   if (!B.viewDelZone(view, zone)) {
     cerr<<"Operation failed."<<endl;
     return 1;
@@ -4784,7 +5293,7 @@ static int viewDelZone(vector<string>& cmds, const std::string_view synopsis)
 
 static int listNetwork(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.empty()) {
+  if (!cmds.empty()) {
     return usage(synopsis);
   }
 
@@ -4802,16 +5311,16 @@ static int listNetwork(vector<string>& cmds, const std::string_view synopsis)
 
 static int setNetwork(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 2) {
+  if (cmds.empty()) {
     return usage(synopsis);
   }
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
 
-  Netmask net{cmds.at(1)};
+  Netmask net{cmds.at(0)};
   string view{};
-  if (cmds.size() > 2) {
-    view = cmds.at(2);
+  if (cmds.size() > 1) {
+    view = cmds.at(1);
   }
   if (!B.networkSet(net, view)) {
     cerr<<"Operation failed."<<endl;
@@ -4820,348 +5329,287 @@ static int setNetwork(vector<string>& cmds, const std::string_view synopsis)
   return 0;
 }
 
-enum commandGroup {
-  GROUP_AUTOPRIMARY,
-  GROUP_CATALOG,
-  GROUP_META,
-  GROUP_ZONE,
-  GROUP_RRSET,
-  GROUP_DNSSEC,
-  GROUP_CDNSKEY,
-  GROUP_NSEC3,
-  GROUP_TSIGKEY,
-  GROUP_ZONEKEY,
-  GROUP_VIEWS,
-  GROUP_OTHER,
-  GROUP_LAST,
-  GROUP_FIRST = GROUP_AUTOPRIMARY,
-};
+// Display a group of command synopsises
+static void displayCommandGroup(const groupCommandDispatcher& dispatcher, std::string_view prefix)
+{
+  cout << dispatcher.first << " Commands:" << endl
+       << endl;
+  for (const auto& command : dispatcher.second) {
+    // Skip "HSM" command if support not compiled in, and
+    // undocumented commands
+    if (command.second.help.empty()) {
+      continue;
+    }
+    if (!prefix.empty()) {
+      cout << prefix << " ";
+    }
+    cout << command.first;
+    if (!command.second.synopsis.empty()) {
+      cout << " " << command.second.synopsis;
+    }
+    cout << endl;
+    cout << command.second.help << endl;
+  }
+  cout << endl;
+}
 
-static const std::array<std::string_view, GROUP_LAST> groupNames{
-  "Autoprimary",
-  "Catalog",
-  "Metadata",
-  "Zone",
-  "RRSet",
-  "DNSSEC",
-  "CDS/CDNSKEY",
-  "NSEC3",
-  "TSIG key",
-  "Zone key",
-  "Views",
-  "Other"
-};
+// Lowercase a string
+static std::string lowercase(const std::string& input)
+{
+  std::string result(input);
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char chr){ return std::tolower(chr); });
+  return result;
+}
 
-struct commandDispatcher {
-  bool requiresInitialization; // need to invoke reportAllTypes() before handler
-  int (*handler)(std::vector<std::string>&, const std::string_view);
-  commandGroup group;
-  const std::string_view synopsis; // one-line command synopsis
-  const std::string_view help; // short description, may span multiple lines,
-                               // every line starts with a tab for indent
-};
+// Try and recognize a command to invoke from the first few arguments.
+// Updates the passed command-line arguments vector by removing as many
+// entries as necessary, returns the concatenated words in `writtencommand'
+static bool parseCommandExact(std::vector<std::string>& cmds, std::string& writtencommand, commandEntry& command)
+{
+  // Try to recognize the first argument as an object name, to use as a key
+  // to search into the dispatcher.
+  writtencommand = cmds.at(0);
+  unsigned int consumedWords{1};
+  std::string key = lowercase(cmds.at(0));
 
-// clang-format off
-static const std::unordered_map<std::string, commandDispatcher> commands{
-  {"activate-tsig-key", {true, activateTSIGKey, GROUP_TSIGKEY,
-   "activate-tsig-key ZONE NAME {primary|secondary|producer|consumer}",
-   "\tEnable TSIG authenticated AXFR using the key NAME for ZONE"}},
-  {"activate-zone-key", {true, activateZoneKey, GROUP_ZONEKEY,
-   "activate-zone-key ZONE KEY_ID",
-   "\tActivate the key with key id KEY_ID in ZONE"}},
-  {"add-autoprimary", {true, addAutoprimary, GROUP_AUTOPRIMARY,
-   "add-autoprimary IP NAMESERVER [ACCOUNT]",
-   "\tAdd a new autoprimary "}},
-  {"add-meta", {true, setMeta, GROUP_META,
-   "add-meta ZONE KIND VALUE [VALUE...]",
-   "\tAdd zone metadata, this adds to the existing KIND"}},
-  {"add-record", {true, addRecord, GROUP_ZONE,
-   R"(add-record ZONE NAME TYPE [TTL] "CONTENT" ["CONTENT"...])",
-   "\tAdd one or more records to ZONE"}},
-  {"add-zone-key", {true, addZoneKey, GROUP_ZONEKEY,
-   "add-zone-key ZONE [zsk|ksk] [BITS] [active|inactive] [published|unpublished]\n"
-   "    [rsasha1|rsasha1-nsec3-sha1|rsasha256|rsasha512|ecdsa256|ecdsa384"
-#if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBCRYPTO_ED25519)
-        "|ed25519"
+  std::vector<groupCommandDispatcher> dispatchers{};
+  if (const auto& match = topLevelDispatcher.find(key); match != topLevelDispatcher.end()) {
+    if (cmds.size() < 2 || lowercase(cmds.at(1)) == "help") {
+      // ``help'' or no command name follows, display help.
+      cout << match->first << ": missing command name!" << endl
+           << endl;
+      for (const auto& dispatcher : match->second.second) {
+        displayCommandGroup(dispatcher, match->first);
+      }
+      writtencommand.clear(); // to have caller not print "Unknown command"
+      return false;
+    }
+    // Now try the next argument as the real command name, to look for into the
+    // dispatchers list.
+    writtencommand.append(" ");
+    writtencommand.append(cmds.at(1));
+    ++consumedWords;
+    key = lowercase(cmds.at(1));
+    dispatchers.insert(dispatchers.begin(), match->second.second.begin(), match->second.second.end());
+  }
+  else {
+    // This is probably a standalone command without an object prefix.
+    dispatchers.emplace_back(otherCommands);
+  }
+  // Query the sub-dispatchers in sequence
+  for (const auto& dispatcher : dispatchers) {
+    if (const auto& match = dispatcher.second.find(key); match != dispatcher.second.end()) {
+      cmds.erase(cmds.begin(), cmds.begin() + consumedWords);
+      command = match->second;
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool parseCommand(std::vector<std::string>& cmds, std::string& writtencommand, commandEntry& command)
+{
+  // Aim for an exact command match first.
+  if (parseCommandExact(cmds, writtencommand, command)) {
+    return true;
+  }
+  // Now try for the old syntax
+  static const std::unordered_map<std::string_view, std::pair<std::string_view, groupCommandDispatcher>> translations{
+    {"activate-tsig-key", {"activate", TSIGKEYCommands}},
+    {"activate-zone-key", {"activate-key", zoneKeyCommands}},
+    {"add-autoprimary", {"add", autoprimaryCommands}},
+    {"add-meta", {"add", metadataCommands}},
+    {"add-record", {"add", rrsetCommands}},
+    {"add-zone-key", {"add-key", zoneKeyCommands}},
+    {"change-secondary-zone-primary", {"change-primary", zoneSecondaryCommands}},
+    {"check-all-zones", {"check-all", zoneMainCommands}},
+    {"check-zone", {"check", zoneMainCommands}},
+    {"clear-zone", {"clear", zoneMainCommands}},
+    {"create-secondary-zone", {"create-secondary", zoneSecondaryCommands}},
+    {"create-zone", {"create", zoneMainCommands}},
+    {"deactivate-tsig-key", {"deactivate", TSIGKEYCommands}},
+    {"deactivate-zone-key", {"deactivate-key", zoneKeyCommands}},
+    {"delete-rrset", {"delete", rrsetCommands}},
+    {"delete-tsig-key", {"delete", TSIGKEYCommands}},
+    {"delete-zone", {"delete", zoneMainCommands}},
+    {"disable-dnssec", {"dnssec-disable", zoneDNSSECCommands}},
+    {"edit-zone", {"edit", zoneMainCommands}},
+    {"export-zone-dnskey", {"export-dnskey", zoneDNSSECCommands}},
+    {"export-zone-ds", {"export-ds", zoneDNSSECCommands}},
+    {"export-zone-key", {"export-key", zoneKeyCommands}},
+    {"export-zone-key-pem", {"export-key-pem", zoneKeyCommands}},
+    {"generate-tsig-key", {"generate", TSIGKEYCommands}},
+    {"generate-zone-key", {"generate-key", zoneKeyCommands}},
+    {"get-meta", {"get", metadataCommands}},
+    {"hash-zone-record", {"hash", rrsetCommands}},
+    {"import-tsig-key", {"import", TSIGKEYCommands}},
+    {"import-zone-key", {"import-key", zoneKeyCommands}},
+    {"import-zone-key-pem", {"import-key-pem", zoneKeyCommands}},
+    {"increase-serial", {"increase-serial", zoneMainCommands}},
+    {"list-all-zones", {"list-all", zoneMainCommands}},
+    {"list-autoprimaries", {"list", autoprimaryCommands}},
+    {"list-keys", {"list-keys", zoneDNSSECCommands}},
+    {"list-member-zones", {"list-members", catalogCommands}},
+    {"list-networks", {"list", networkCommands}},
+    {"list-tsig-keys", {"list", TSIGKEYCommands}},
+    {"list-view", {"list", viewsCommands}},
+    {"list-views", {"list-all", viewsCommands}},
+    {"list-zone", {"list", zoneMainCommands}},
+    {"load-zone", {"load", zoneMainCommands}},
+    {"publish-zone-key", {"publish-key", zoneKeyCommands}},
+    {"rectify-all-zones", {"rectify-all", zoneDNSSECCommands}},
+    {"rectify-zone", {"rectify", zoneDNSSECCommands}},
+    {"remove-autoprimary", {"remove", autoprimaryCommands}},
+    {"remove-zone-key", {"remove-key", zoneKeyCommands}},
+    {"replace-rrset", {"replace", rrsetCommands}},
+    {"secure-all-zones", {"secure-all", zoneDNSSECCommands}},
+    {"secure-zone", {"secure", zoneDNSSECCommands}},
+    {"set-account", {"set-account", zoneMainCommands}},
+    {"set-catalog", {"set", catalogCommands}},
+    {"set-kind", {"set-kind", zoneMainCommands}},
+    {"set-meta", {"set", metadataCommands}},
+    {"set-network", {"set", networkCommands}},
+    {"set-nsec3", {"set-nsec3", zoneDNSSECCommands}},
+    {"set-option", {"set-option", zoneMainCommands}},
+    {"set-options-json", {"set-options-json", zoneMainCommands}},
+    {"set-presigned", {"set-presigned", zoneDNSSECCommands}},
+    {"set-publish-cdnskey", {"set-publish-cdnskey", zoneDNSSECCommands}},
+    {"set-publish-cds", {"set-publish-cds", zoneDNSSECCommands}},
+    {"show-zone", {"show", zoneDNSSECCommands}},
+    {"unpublish-zone-key", {"unpublish-key", zoneKeyCommands}},
+    {"unset-nsec3", {"unset-nsec3", zoneDNSSECCommands}},
+    {"unset-presigned", {"unset-presigned", zoneDNSSECCommands}},
+    {"unset-publish-cdnskey", {"unset-publish-cdnskey", zoneDNSSECCommands}},
+    {"unset-publish-cds", {"unset-publish-cds", zoneDNSSECCommands}},
+    {"view-add-zone", {"add-zone", viewsCommands}},
+    {"view-del-zone", {"del-zone", viewsCommands}},
+    {"zonemd-verify-file", {"zonemd-verify-file", zoneMainCommands}},
+    // old aliases
+    {"test-zone", {"check", zoneMainCommands}},
+    {"test-all-zones", {"check-all", zoneMainCommands}}
+  };
+  if (const auto& replacement = translations.find(cmds.at(0)); replacement != translations.end()) {
+    const auto& [key, dispatcher] = replacement->second;
+    if (const auto& match = dispatcher.second.find(key); match != dispatcher.second.end()) {
+      writtencommand = cmds.at(0);
+      cmds.erase(cmds.begin());
+      command = match->second;
+      return true;
+    }
+  }
+  return false;
+}
+
+#ifdef UNIT_TEST
+// This test checks that all old-syntax commands are correctly resolving to
+// the right command handler. This only needs to be enabled and tested
+// when the command line parsing logic changes.
+static void checkCommandSyntax()
+{
+  static const std::array tests{
+    std::make_pair("activate-tsig-key", activateTSIGKey),
+    std::make_pair("activate-zone-key", activateZoneKey),
+    std::make_pair("add-autoprimary", addAutoprimary),
+    std::make_pair("add-meta", addMeta),
+    std::make_pair("add-record", addRecord),
+    std::make_pair("add-zone-key", addZoneKey),
+    std::make_pair("b2b-migrate", B2BMigrate),
+    std::make_pair("backend-cmd", backendCmd),
+    std::make_pair("backend-lookup", backendLookup),
+    std::make_pair("bench-db", benchDb),
+    std::make_pair("change-secondary-zone-primary", changeSecondaryZonePrimary),
+    std::make_pair("check-all-zones", (commandHandler)checkAllZones),
+    std::make_pair("check-zone", (commandHandler)checkZone),
+    std::make_pair("clear-zone", (commandHandler)clearZone),
+    std::make_pair("create-bind-db", createBindDb),
+    std::make_pair("create-secondary-zone", createSecondaryZone),
+    std::make_pair("create-zone", (commandHandler)createZone),
+    std::make_pair("deactivate-tsig-key", deactivateTSIGKey),
+    std::make_pair("deactivate-zone-key", deactivateZoneKey),
+    std::make_pair("delete-rrset", (commandHandler)deleteRRSet),
+    std::make_pair("delete-tsig-key", deleteTSIGKey),
+    std::make_pair("delete-zone", (commandHandler)deleteZone),
+    std::make_pair("disable-dnssec", disableDNSSEC),
+    std::make_pair("edit-zone", (commandHandler)editZone),
+    std::make_pair("export-zone-dnskey", exportZoneDNSKey),
+    std::make_pair("export-zone-ds", exportZoneDS),
+    std::make_pair("export-zone-key", exportZoneKey),
+    std::make_pair("export-zone-key-pem", exportZoneKeyPEM),
+    std::make_pair("generate-tsig-key", generateTSIGKey),
+    std::make_pair("generate-zone-key", generateZoneKey),
+    std::make_pair("get-meta", getMeta),
+    std::make_pair("hash-password", (commandHandler)hashPassword),
+    std::make_pair("hash-zone-record", hashZoneRecord),
+#ifndef HAVE_P11KIT1 // [
+    std::make_pair("hsm", HSM),
 #endif
-#if defined(HAVE_LIBCRYPTO_ED448)
-        "|ed448"
+    std::make_pair("import-tsig-key", importTSIGKey),
+    std::make_pair("import-zone-key", importZoneKey),
+    std::make_pair("import-zone-key-pem", importZoneKeyPEM),
+    std::make_pair("increase-serial", (commandHandler)increaseSerial),
+    std::make_pair("ipdecrypt", ipDecrypt),
+    std::make_pair("ipencrypt", ipEncrypt),
+    std::make_pair("list-algorithms", listAlgorithms),
+    std::make_pair("list-all-zones", (commandHandler)listAllZones),
+    std::make_pair("list-autoprimaries", listAutoprimaries),
+    std::make_pair("list-keys", (commandHandler)listKeys),
+    std::make_pair("list-member-zones", (commandHandler)listMemberZones),
+    std::make_pair("list-networks", listNetwork),
+    std::make_pair("list-tsig-keys", listTSIGKeys),
+    std::make_pair("list-view", listView),
+    std::make_pair("list-views", listViews),
+    std::make_pair("list-zone", (commandHandler)listZone),
+    std::make_pair("lmdb-get-backend-version", lmdbGetBackendVersion),
+    std::make_pair("load-zone", (commandHandler)loadZone),
+    std::make_pair("publish-zone-key", publishZoneKey),
+    std::make_pair("raw-lua-from-content", rawLuaFromContent),
+    std::make_pair("rectify-all-zones", (commandHandler)rectifyAllZones),
+    std::make_pair("rectify-zone", (commandHandler)rectifyZone),
+    std::make_pair("remove-autoprimary", removeAutoprimary),
+    std::make_pair("remove-zone-key", removeZoneKey),
+    std::make_pair("replace-rrset", replaceRRSet),
+    std::make_pair("secure-all-zones", secureAllZones),
+    std::make_pair("secure-zone", (commandHandler)secureZone),
+    std::make_pair("set-account", setAccount),
+    std::make_pair("set-catalog", setCatalog),
+    std::make_pair("set-kind", setKind),
+    std::make_pair("set-meta", setMeta),
+    std::make_pair("set-network", setNetwork),
+    std::make_pair("set-nsec3", setNsec3),
+    std::make_pair("set-option", setOption),
+    std::make_pair("set-options-json", setOptionsJson),
+    std::make_pair("set-presigned", setPresigned),
+    std::make_pair("set-publish-cdnskey", setPublishCDNSKey),
+    std::make_pair("set-publish-cds", setPublishCDs),
+    std::make_pair("show-zone", (commandHandler)showZone),
+    std::make_pair("test-algorithm", (commandHandler)testAlgorithm),
+    std::make_pair("test-algorithms", (commandHandler)testAlgorithms),
+    std::make_pair("test-schema", (commandHandler)testSchema),
+    std::make_pair("test-speed", (commandHandler)testSpeed),
+    std::make_pair("unpublish-zone-key", unpublishZoneKey),
+    std::make_pair("unset-nsec3", unsetNSec3),
+    std::make_pair("unset-presigned", unsetPresigned),
+    std::make_pair("unset-publish-cdnskey", unsetPublishCDNSKey),
+    std::make_pair("unset-publish-cds", unsetPublishCDs),
+    std::make_pair("verify-crypto", (commandHandler)verifyCrypto),
+    std::make_pair("view-add-zone", viewAddZone),
+    std::make_pair("view-del-zone", viewDelZone),
+    std::make_pair("zonemd-verify-file", (commandHandler)zonemdVerifyFile),
+    // aliases
+    std::make_pair("test-all-zones", (commandHandler)checkAllZones),
+    std::make_pair("test-zone", (commandHandler)checkZone)
+  };
+  for (const auto& pair : tests) {
+    std::vector<std::string> cmds{pair.first};
+    std::string unused;
+    commandEntry command;
+    if (!parseCommand(cmds, unused, command) || command.handler != pair.second) {
+      cerr << "RECOGNITION OF " << pair.first << " FAILED!" << endl;
+    }
+  }
+}
 #endif
-        "]",
-   "\tAdd a ZSK or KSK to zone with specific algorithm and size in bits.\n"
-   "\tIf zsk or ksk is omitted, defaults to zsk"}},
-  {"b2b-migrate", {true, B2BMigrate, GROUP_OTHER,
-   "b2b-migrate OLD NEW",
-   "\tMove all data from one backend to another"}},
-  {"backend-cmd", {true, backendCmd, GROUP_OTHER,
-   "backend-cmd BACKEND CMD [CMD...]",
-   "\tPerform one or more backend commands"}},
-  {"backend-lookup", {true, backendLookup, GROUP_OTHER,
-   "backend-lookup BACKEND NAME [[TYPE] CLIENT_IP_SUBNET]",
-   "\tPerform a backend lookup of NAME, TYPE (defaulting to ANY) and\n"
-   "\tCLIENT_IP_SUBNET"}},
-  {"bench-db", {true, benchDb, GROUP_OTHER,
-   "bench-db [FILENAME]",
-   "\tBenchmark database backend with queries, one zone per line"}},
-  {"change-secondary-zone-primary", {true, changeSecondaryZonePrimary, GROUP_ZONE,
-   "change-secondary-zone-primary ZONE PRIMARY_IP [PRIMARY_IP...]",
-   "\tChange secondary zone ZONE primary IP address(es) to PRIMARY_IP"}},
-  {"check-all-zones", {true, checkAllZones, GROUP_ZONE,
-   "check-all-zones [exit-on-error]",
-   "\tCheck all zones for correctness. Use exit-on-error to exit immediately\n"
-   "\tupon finding the first error in any zone"}},
-  {"check-zone", {true, checkZone, GROUP_ZONE,
-   "check-zone ZONE",
-   "\tCheck a zone for correctness"}},
-  {"clear-zone", {true, clearZone, GROUP_ZONE,
-   "clear-zone ZONE",
-   "\tClear all records of a zone, but keep everything else"}},
-  {"create-bind-db", {true, createBindDb, GROUP_DNSSEC,
-   "create-bind-db FILENAME",
-   "\tCreate DNSSEC db for BIND backend (bind-dnssec-db)"}},
-  {"create-secondary-zone", {true, createSecondaryZone, GROUP_ZONE,
-   "create-secondary-zone ZONE PRIMARY_IP [PRIMARY_IP...]",
-   "\tCreate secondary zone ZONE with primary IP address(es) PRIMARY_IP"}},
-  {"create-zone", {true, createZone, GROUP_ZONE,
-   "create-zone ZONE [NSNAME]",
-   "\tCreate empty zone ZONE"}},
-  {"deactivate-tsig-key", {true, deactivateTSIGKey, GROUP_TSIGKEY,
-   "deactivate-tsig-key ZONE NAME {primary|secondary|producer|consumer}",
-   "\tDisable TSIG authenticated AXFR using the key NAME for ZONE"}},
-  {"deactivate-zone-key", {true, deactivateZoneKey, GROUP_ZONEKEY,
-   "deactivate-zone-key ZONE KEY_ID",
-   "\tDeactivate the key with key id KEY_ID in ZONE"}},
-  {"delete-rrset", {true, deleteRRSet, GROUP_RRSET,
-   "delete-rrset ZONE NAME TYPE",
-   "\tDelete named RRSET from ZONE"}},
-  {"delete-tsig-key", {true, deleteTSIGKey, GROUP_TSIGKEY,
-   "delete-tsig-key NAME",
-   "\tDelete TSIG key (warning: will not unmap key!)"}},
-  {"delete-zone", {true, deleteZone, GROUP_ZONE,
-   "delete-zone ZONE",
-   "\tDelete zone ZONE"}},
-  {"disable-dnssec", {true, disableDNSSEC, GROUP_DNSSEC,
-   "disable-dnssec ZONE",
-   "\tDeactivate all keys and unset PRESIGNED in ZONE"}},
-  {"edit-zone", {true, editZone, GROUP_ZONE,
-   "edit-zone ZONE",
-   "\tEdit zone contents using $EDITOR"}},
-  {"export-zone-dnskey", {true, exportZoneDNSKey, GROUP_CDNSKEY,
-   "export-zone-dnskey ZONE KEY_ID",
-   "\tExport the public DNSKEY with the given ID to stdout"}},
-  {"export-zone-ds", {true, exportZoneDS, GROUP_CDNSKEY,
-   "export-zone-ds ZONE",
-   "\tExport all KSK DS records for ZONE to stdout"}},
-  {"export-zone-key", {true, exportZoneKey, GROUP_ZONEKEY,
-   "export-zone-key ZONE KEY_ID",
-   "\tExport the private key with the given ID to stdout"}},
-  {"export-zone-key-pem", {true, exportZoneKeyPEM, GROUP_ZONEKEY,
-   "export-zone-key-pem ZONE KEY_ID",
-   "\tExport the private key with the given ID to stdout in PEM format"}},
-  {"generate-tsig-key", {true, generateTSIGKey, GROUP_TSIGKEY,
-   "generate-tsig-key NAME ALGORITHM",
-   "\tGenerate new TSIG key.\n"
-   "\tALGORITHM is one of hmac-{md5,sha1,sha224,sha256,sha384,sha512}"}},
-  {"generate-zone-key", {true, generateZoneKey, GROUP_ZONEKEY,
-   "generate-zone-key {zsk|ksk} [ALGORITHM] [BITS]",
-   "\tGenerate a ZSK or KSK to stdout with specified ALGORITHM and BITS"}},
-  {"get-meta", {true, getMeta, GROUP_META,
-   "get-meta ZONE [KIND...]",
-   "\tGet zone metadata. If no KIND is given, lists all known"}},
-  {"hash-password", {true, hashPassword, GROUP_OTHER,
-   "hash-password [WORK FACTOR]",
-   "\tAsk for a plaintext password or API key and output a salted and hashed\n"
-   "\tversion"}},
-  {"hash-zone-record", {true, hashZoneRecord, GROUP_NSEC3,
-   "hash-zone-record ZONE RNAME",
-   "\tCalculate the NSEC3 hash for RNAME in ZONE"}},
-  {"hsm", {true, HSM, GROUP_OTHER,
-#ifdef HAVE_P11KIT1
-   "hsm SUB_COMMAND [ARGUMENTS...]",
-   "\tHardware Signing Module-related commands.\n"
-   "\tUse \"hsm help\" to get more information"
-#else
-   "", "" // not functional so hide it
-#endif
-   }},
-  {"import-tsig-key", {true, importTSIGKey, GROUP_TSIGKEY,
-   "import-tsig-key NAME ALGORITHM KEY",
-   "\tImport TSIG key"}},
-  {"import-zone-key", {true, importZoneKey, GROUP_ZONEKEY,
-   "import-zone-key ZONE FILE [active|inactive] [ksk|zsk] [published|unpublished]",
-   "\tImport from a file a private key, ZSK or KSK; defaults to KSK, active\n"
-   "\tand published"}},
-  {"import-zone-key-pem", {true, importZoneKeyPEM, GROUP_ZONEKEY,
-   "import-zone-key-pem ZONE FILE ALGORITHM [ksk|zsk]}",
-   "\tImport a private key from a PEM file"}},
-  {"increase-serial", {true, increaseSerial, GROUP_ZONE,
-   "increase-serial ZONE",
-   "\tIncreases the SOA-serial by 1. Uses SOA-EDIT"}},
-  {"ipdecrypt", {false, ipEncrypt, GROUP_OTHER,
-   "ipdecrypt IP_ADDRESS PASSPHRASE_OR_KEY [key]",
-   "\tDecrypt IP address using passphrase or base64 key"}},
-  {"ipencrypt", {false, ipEncrypt, GROUP_OTHER,
-   "ipencrypt IP_ADDRESS PASSPHRASE_OR_KEY [key]",
-   "\tEncrypt IP address using passphrase or base64 key"}},
-  {"list-algorithms", {false, listAlgorithms, GROUP_DNSSEC,
-   "list-algorithms [with-backend]",
-   "\tList all DNSSEC algorithms supported, optionally also listing the\n"
-   "\tcryptographic library used"}},
-  {"list-all-zones", {true, listAllZones, GROUP_ZONE,
-   "list-all-zones [primary|secondary|native|producer|consumer]",
-   "\tList all active zone names.\n"
-   "\tUse --verbose (-v) to include disabled or empty zones"}},
-  {"list-autoprimaries", {true, listAutoprimaries, GROUP_AUTOPRIMARY,
-   "list-autoprimaries",
-   "\tList all autoprimaries"}},
-  {"list-keys", {true, listKeys, GROUP_DNSSEC,
-   "list-keys [ZONE]",
-   "\tList DNSSEC keys for ZONE.\n"
-   "\tWhen ZONE is unset, display keys for all active zones"}},
-  {"list-member-zones", {true, listMemberZones, GROUP_ZONE,
-   "list-member-zones CATALOG",
-   "\tList all members of catalog zone CATALOG"}},
-  {"list-networks", {true, listNetwork, GROUP_VIEWS,
-   "list-networks",
-   "\tList all defined networks with their chosen views"}},
-  {"list-tsig-keys", {true, listTSIGKeys, GROUP_TSIGKEY,
-   "list-tsig-keys",
-   "\tList all TSIG keys"}},
-  {"list-view", {true, listView, GROUP_VIEWS,
-   "list-view VIEW",
-   "\tList all zones within VIEW"}},
-  {"list-views", {true, listViews, GROUP_VIEWS,
-   "list-views",
-   "\tList all view names"}},
-  {"list-zone", {true, listZone, GROUP_ZONE,
-   "list-zone ZONE",
-   "\tList zone contents"}},
-  {"lmdb-get-backend-version", {false, lmdbGetBackendVersion, GROUP_OTHER,
-   "lmdb-get-backend-version",
-   "\tGet schema version supported by backend"}},
-  {"load-zone", {true, loadZone, GROUP_ZONE,
-   "load-zone ZONE FILENAME [ZONE FILENAME]...",
-   "\tLoad ZONE from FILENAME, possibly creating zone or atomically replacing\n"
-   "\tcontents; --verbose or -v will also include the keys for disabled or\n"
-   "\tempty zones"}},
-  {"publish-zone-key", {true, publishZoneKey, GROUP_ZONEKEY,
-   "publish-zone-key ZONE KEY_ID",
-   "\tPublish the zone key with key id KEY_ID in ZONE"}},
-  {"raw-lua-from-content", {true, rawLuaFromContent, GROUP_OTHER,
-   "raw-lua-from-content TYPE CONTENT",
-   "\tDisplay record contents in a form suitable for dnsdist's\n"
-   "\t`SpoofRawAction`"}},
-  {"rectify-all-zones", {true, rectifyAllZones, GROUP_DNSSEC,
-   "rectify-all-zones [quiet]",
-   "\tRectify all zones. Optionally quiet output with errors only"}},
-  {"rectify-zone", {true, rectifyZone, GROUP_DNSSEC,
-   "rectify-zone ZONE [ZONE...]",
-   "\tFix up DNSSEC fields (order, auth)"}},
-  {"remove-autoprimary", {true, removeAutoprimary, GROUP_AUTOPRIMARY,
-   "remove-autoprimary IP NAMESERVER",
-   "\tRemove an autoprimary"}},
-  {"remove-zone-key", {true, removeZoneKey, GROUP_ZONEKEY,
-   "remove-zone-key ZONE KEY_ID",
-   "\tRemove key with KEY_ID from ZONE"}},
-  {"replace-rrset", {true, replaceRRSet, GROUP_RRSET,
-   R"(replace-rrset ZONE NAME TYPE [TTL] "CONTENT" ["CONTENT"...])",
-   "\tReplace named RRSET from ZONE"}},
-  {"secure-all-zones", {true, secureAllZones, GROUP_DNSSEC,
-   "secure-all-zones [increase-serial]",
-   "\tSecure all zones without keys"}},
-  {"secure-zone", {true, secureZone, GROUP_DNSSEC,
-   "secure-zone ZONE [ZONE...]",
-   "\tAdd DNSSEC to zone ZONE"}},
-  {"set-account", {true, setAccount, GROUP_ZONE,
-   "set-account ZONE ACCOUNT",
-   "\tChange the account (owner) of ZONE to ACCOUNT"}},
-  {"set-catalog", {true, setCatalog, GROUP_CATALOG,
-   "set-catalog ZONE [CATALOG]",
-   "\tChange the catalog of ZONE to CATALOG, or removes ZONE from its current\n"
-   "\tcatalog if no catalog provided"}},
-  {"set-kind", {true, setKind, GROUP_ZONE,
-   "set-kind ZONE KIND",
-   "\tChange the kind of ZONE to KIND (primary, secondary, native, producer,\n"
-   "\tor consumer)"}},
-  {"set-meta", {true, setMeta, GROUP_META,
-   "set-meta ZONE KIND [VALUE...]",
-   "\tSet zone metadata, replacing all existing records of KIND, optionally\n"
-   "\tproviding a value. An omitted value clears the metadata"}},
-  {"set-network", {true, setNetwork, GROUP_VIEWS,
-   "set-network NET [VIEW]",
-   "\tSet the view for a network, or delete if no view argument."}},
-  {"set-nsec3", {true, setNsec3, GROUP_NSEC3,
-   "set-nsec3 ZONE ['PARAMS' [narrow]]",
-   "\tEnable NSEC3 with PARAMS (default: '1 0 0 -'). Optionally narrow"}},
-  {"set-option", {true, setOption, GROUP_ZONE,
-   "set-option ZONE [producer|consumer] [coo|unique|group] VALUE [VALUE...]",
-   "\tSet or remove an option for ZONE. Providing an empty value removes the\n"
-   "\toption"}},
-  {"set-options-json", {true, setOptionsJson, GROUP_ZONE,
-   "set-options-json ZONE JSONFILE",
-   "\tChange the options of ZONE to JSONFILE"}},
-  {"set-presigned", {true, setPresigned, GROUP_DNSSEC,
-   "set-presigned ZONE",
-   "\tUse presigned RRSIGs from storage"}},
-  {"set-publish-cdnskey", {true, setPublishCDNSKey, GROUP_CDNSKEY,
-   "set-publish-cdnskey ZONE [delete]",
-   "\tEnable sending CDNSKEY responses for ZONE. Add 'delete' to publish\n"
-   "\ta CDNSKEY with a DNSSEC delete algorithm"}},
-  {"set-publish-cds", {true, setPublishCDs, GROUP_CDNSKEY,
-   "set-publish-cds ZONE [DIGESTALGOS]",
-   "\tEnable sending CDS responses for ZONE, using DIGESTALGOS as signature\n"
-   "\talgorithms; DIGESTALGOS should be a comma-separated list of numbers,\n"
-   "\t(default: '2')"}},
-  {"set-signaling-zone", {true, setSignalingZone, GROUP_CDNSKEY,
-   "set-signaling-zone ZONE",
-   "\tConfigure zone for RFC 9615 DNSSEC bootstrapping\n"
-   "\t(zone name must begin with _signal.)"}},
-  {"show-zone", {true, showZone, GROUP_DNSSEC,
-   "show-zone ZONE",
-   "\tShow DNSSEC (public) key details about a zone"}},
-  {"test-algorithm", {false, testAlgorithm, GROUP_OTHER,
-   "test-algorithm ALGONUM",
-   ""}}, // TODO: short help line
-  {"test-algorithms", {false, testAlgorithms, GROUP_OTHER,
-   "", ""}}, // TODO: synopsis and short help line
-  {"test-schema", {true, testSchema, GROUP_OTHER,
-   "test-schema ZONE",
-   "\tTest DB schema - will create ZONE"}},
-  {"test-speed", {true, testSpeed, GROUP_OTHER,
-   "test-speed ZONE NUM_CORES", ""}}, // TODO: short help line
-  {"unpublish-zone-key", {true, unpublishZoneKey, GROUP_ZONEKEY,
-   "unpublish-zone-key ZONE KEY_ID",
-   "\tUnpublish the zone key with key id KEY_ID in ZONE"}},
-  {"unset-nsec3", {true, unsetNSec3, GROUP_NSEC3,
-   "unset-nsec3 ZONE",
-   "\tSwitch ZONE back to NSEC"}},
-  {"unset-presigned", {true, unsetPresigned, GROUP_DNSSEC,
-   "unset-presigned ZONE",
-   "\tStop using presigned RRSIGs on ZONE"}},
-  {"unset-publish-cdnskey", {true, unsetPublishCDNSKey, GROUP_CDNSKEY,
-   "unset-publish-cdnskey ZONE",
-   "\tDisable sending CDNSKEY responses for ZONE"}},
-  {"unset-publish-cds", {true, unsetPublishCDs, GROUP_CDNSKEY,
-   "unset-publish-cds ZONE",
-   "\tDisable sending CDS responses for ZONE"}},
-  {"verify-crypto", {true, verifyCrypto, GROUP_OTHER,
-   "verify-crypto FILENAME", ""}}, // TODO: short help line
-  {"view-add-zone", {true, viewAddZone, GROUP_VIEWS,
-   "view-add-zone VIEW ZONE..VARIANT",
-   "\tAdd a zone variant to a view"}},
-  {"view-del-zone", {true, viewDelZone, GROUP_VIEWS,
-   "view-del-zone VIEW ZONE..VARIANT",
-   "\tRemove a zone variant from a view"}},
-  {"zonemd-verify-file", {true, zonemdVerifyFile, GROUP_ZONE,
-   "zonemd-verify-file ZONE FILENAME",
-   "\tValidate ZONEMD for ZONE"}}
-};
-// clang-format on
-
-static const std::unordered_map<std::string, std::string> aliases{
-  {"test-zone", "check-zone"},
-  {"test-all-zones", "check-all-zones"}
-};
 
 int main(int argc, char** argv)
 try
@@ -5183,6 +5631,10 @@ try
   po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), g_vm);
   po::notify(g_vm);
 
+#ifdef UNIT_TEST
+  checkCommandSyntax();
+#endif
+
   vector<string> cmds;
 
   if(g_vm.count("commands") != 0) {
@@ -5198,30 +5650,19 @@ try
     return 0;
   }
 
-  if (cmds.empty() || g_vm.count("help") != 0 || cmds.at(0) == "help") {
-    cout << "Usage:\npdnsutil [options] <command> [params...]\n"
+  if (cmds.empty() || g_vm.count("help") != 0 || lowercase(cmds.at(0)) == "help") {
+    cout << "Usage:\npdnsutil [options] <command> [params...]" << endl
          << endl;
-
-    for (unsigned int group = GROUP_FIRST; group < GROUP_LAST; ++group) {
-      cout << groupNames.at(group) << " commands:" << endl << endl;
-      std::map<std::string, commandDispatcher> groupCommands;
-      for (const auto& iter : commands) {
-        if (iter.second.group == group) {
-          groupCommands.insert(iter);
-        }
+    for (const auto& group : topLevelDispatcher) {
+      if (!group.second.first) { // toplevel synonyms (sugar), don't list
+	continue;
       }
-      for (const auto& iter : groupCommands) {
-        auto synopsis = iter.second.synopsis;
-        auto help = iter.second.help;
-        if (synopsis.empty() || help.empty()) { // Don't mention "HSM" command if support not compiled in
-          continue;
-        }
-        cout << synopsis << endl;
-        cout << help << endl;
+      for (const auto& dispatcher : group.second.second) {
+        displayCommandGroup(dispatcher, group.first);
       }
-      cout << endl;
     }
-
+    // Follow with the "objectless" commands.
+    displayCommandGroup(otherCommands, "");
     cout << desc << endl;
 
     return 0;
@@ -5229,57 +5670,17 @@ try
 
   loadMainConfig(g_vm["config-dir"].as<string>());
 
-  const std::string writtencommand = cmds.at(0);
-  const commandDispatcher* dispatcher{nullptr};
-  bool exchanged{false};
-  while (true) {
-    // Search for an exact command name.
-    if (const auto iter = commands.find(cmds.at(0)); iter != commands.end()) {
-      dispatcher = &iter->second;
-      break;
-    }
-    // Search for an alias
-    if (const auto alias = aliases.find(cmds.at(0)); alias != aliases.end()) {
-      if (const auto iter = commands.find(alias->second); iter != commands.end()) {
-        dispatcher = &iter->second;
-        break;
-      }
-    }
-    std::string cmd = cmds.at(0);
-    auto dash = cmd.find('-');
-    // If the command name contains no dash, coalesce with the next argument
-    // and try again.
-    if (dash == std::string::npos && cmds.size() > 1) {
-      cmd.append(1, '-');
-      cmd += cmds.at(1);
-      cmds.erase(cmds.begin());
-      cmds.at(0) = std::move(cmd);
-      continue;
-    }
-    // If the command name contains exactly one dash, exchange both sides
-    // and try again, but only once.
-    if (exchanged) {
-      break;
-    }
-    if (dash != std::string::npos && cmd.find('-', dash + 1) == std::string::npos) {
-      std::string left = cmd.substr(0, dash);
-      std::string right = cmd.substr(dash + 1);
-      right.append(1, '-');
-      right += left;
-      cmds.at(0) = std::move(right);
-      exchanged = true;
-      continue;
-    }
-    break;
-  }
-  if (dispatcher != nullptr) {
-    if (dispatcher->requiresInitialization) {
+  std::string writtencommand;
+  if (commandEntry command; parseCommand(cmds, writtencommand, command)) {
+    if (command.requiresInitialization) {
       reportAllTypes();
     }
-    return dispatcher->handler(cmds, dispatcher->synopsis);
+    return command.handler(cmds, writtencommand.append(" ").append(command.synopsis));
   }
 
-  cerr << "Unknown command '" << writtencommand << "'" << endl;
+  if (!writtencommand.empty()) { // otherwise, parseCommand() has output a diagnostic already
+    cerr << "Unknown command '" << writtencommand << "'" << endl;
+  }
   return 1;
 }
 catch (PDNSException& ae) {

--- a/regression-tests.auth-py/test_AuthSignal.py
+++ b/regression-tests.auth-py/test_AuthSignal.py
@@ -34,16 +34,16 @@ gsqlite3-dnssec=yes
         cls.signaling_prefix = dns.name.from_text('_dsboot.cds-cdnskey.test').relativize(dns.name.root)
         cls.signaling_qname = cls.signaling_prefix.concatenate(cls.signaling_domain)
 
-        os.system("$PDNSUTIL --config-dir=configs/auth create-zone _signal.ns1.example.net")
-        os.system("$PDNSUTIL --config-dir=configs/auth set-signaling-zone _signal.ns1.example.net")
+        os.system("$PDNSUTIL --config-dir=configs/auth zone create _signal.ns1.example.net")
+        os.system("$PDNSUTIL --config-dir=configs/auth zone set-signaling _signal.ns1.example.net")
         query = dns.message.make_query('_signal.ns1.example.net', 'DNSKEY')
         res = cls.sendUDPQuery(query)
         cls.signaling_keytag = dns.dnssec.key_id(res.answer[0][0])
 
-        os.system("$PDNSUTIL --config-dir=configs/auth create-zone cds-cdnskey.test")
-        os.system("$PDNSUTIL --config-dir=configs/auth secure-zone cds-cdnskey.test")
-        os.system("$PDNSUTIL --config-dir=configs/auth set-publish-cds cds-cdnskey.test 2 4")
-        os.system("$PDNSUTIL --config-dir=configs/auth set-publish-cdnskey cds-cdnskey.test")
+        os.system("$PDNSUTIL --config-dir=configs/auth zone create cds-cdnskey.test")
+        os.system("$PDNSUTIL --config-dir=configs/auth zone secure cds-cdnskey.test")
+        os.system("$PDNSUTIL --config-dir=configs/auth zone set-publish-cds cds-cdnskey.test 2 4")
+        os.system("$PDNSUTIL --config-dir=configs/auth zone set-publish-cdnskey cds-cdnskey.test")
 
     def _signalingQuery(self, rdtype):
         query = dns.message.make_query('cds-cdnskey.test', rdtype)
@@ -77,8 +77,8 @@ gsqlite3-dnssec=yes
         self._testSignalingRRset(dns.rdatatype.CDNSKEY)
 
     def testSignalingQueryNoSignal(self):
-        os.system("$PDNSUTIL --config-dir=configs/auth create-zone no-signaling.test")
-        os.system("$PDNSUTIL --config-dir=configs/auth secure-zone no-signaling.test")
+        os.system("$PDNSUTIL --config-dir=configs/auth zone create no-signaling.test")
+        os.system("$PDNSUTIL --config-dir=configs/auth zone secure no-signaling.test")
 
         signaling_prefix = dns.name.from_text('_dsboot.no-signaling.test').relativize(dns.name.root)
         qname = signaling_prefix.concatenate(self.signaling_domain)


### PR DESCRIPTION
### Short description
Ok, the title is a lie.

This PR continues the work towards having more consistency in `pdnsutil` command names. In these changes, commands are now of the form `pdnsutil object-type command arguments...`, where `object-type` is a noun (e.g. "zone", "record", "tsigkey"...) and `command` is a verb (e.g. "create", "list"...).

A conversion logic has been added to let the existing command names run unchanged. Which means that there is sometimes more than one way to invoke a given command.

This shuffles the main command groups a bit, a few commands change groups (`add-zone-record` is now `rrset add` and `hash-zone-record` is now `rrset hash`).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
