### PR TITLE
rec: Prevent a crash in the ZoneToCache unit tests

### DIFF
--- a/pdns/recursordist/test-rec-zonetocache.cc
+++ b/pdns/recursordist/test-rec-zonetocache.cc
@@ -172,6 +172,7 @@ static void zonemdGenericTest(const std::string& lines, pdns::ZoneMD::Config mod
 
 BOOST_AUTO_TEST_CASE(test_zonetocachegeneric)
 {
+  SyncRes::setDomainMap(std::make_shared<SyncRes::domainmap_t>());
   g_log.setLoglevel(Logger::Critical);
   g_log.toConsole(Logger::Critical);
   zonemdGenericTest(genericTest, pdns::ZoneMD::Config::Require, pdns::ZoneMD::Config::Ignore, 4U);


### PR DESCRIPTION
### Short description
 
Since 753ad2390bfbc90f6bc1b68f980ef4bcdc2cfddc ZoneToCache checks whether a given zone has a recursive forward rule, so we need the Domain map to be properly initialized in all tests, as they can be executed in random order.

Fixes:
```
ThreadSanitizer:DEADLYSIGNAL
==35969==ERROR: ThreadSanitizer: SEGV on unknown address 0x000000000018 (pc 0x5568e9f8bb04 bp 0x4c00000000000 sp 0x7ffcc13b77f0 T35969)
==35969==The signal is caused by a READ memory access.
==35969==Hint: address points to the zero page.
    #0 std::_Hashtable<DNSName, std::pair<DNSName const, SyncRes::AuthDomain>, std::allocator<std::pair<DNSName const, SyncRes::AuthDomain> >, std::__detail::_Select1st, std::equal_to<DNSName>, std::hash<DNSName>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::empty() const /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/hashtable.h:653:23 (testrunner+0x47fb04)
    #1 std::unordered_map<DNSName, SyncRes::AuthDomain, std::hash<DNSName>, std::equal_to<DNSName>, std::allocator<std::pair<DNSName const, SyncRes::AuthDomain> > >::empty() const /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unordered_map.h:306:21 (testrunner+0x47fb04)
    #2 SyncRes::getBestAuthZone(DNSName*) /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/syncres.cc:2464:29 (testrunner+0x47fb04)
    #3 SyncRes::isRecursiveForward(DNSName const&) /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/syncres.cc:1098:21 (testrunner+0x47fb04)
    #4 ZoneData::ZoneToCache(RecZoneToCache::Config const&) /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/rec-zonetocache.cc:423:28 (testrunner+0x404931)
    #5 RecZoneToCache::ZoneToCache(RecZoneToCache::Config const&, RecZoneToCache::State&) /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/rec-zonetocache.cc:473:10 (testrunner+0x4059fd)
    #6 rec_zonetocache::zonemdGenericTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, pdns::ZoneMD::Config, pdns::ZoneMD::Config, unsigned long) /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/test-rec-zonetocache.cc:157:3 (testrunner+0x7a7113)
    #7 rec_zonetocache::test_zonetocachegeneric::test_method() /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/test-rec-zonetocache.cc:177:3 (testrunner+0x7a60a5)
    #8 rec_zonetocache::test_zonetocachegeneric_invoker() /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/test-rec-zonetocache.cc:173:1 (testrunner+0x7a60a5)
    #9 boost::detail::function::void_function_invoker0<void (*)(), void>::invoke(boost::detail::function::function_buffer&) /usr/include/boost/function/function_template.hpp:117:11 (testrunner+0x57dfab)
    #10 <null> <null> (libboost_unit_test_framework.so.1.74.0+0x323fd)
    #11 boost::execution_monitor::catch_signals(boost::function<int ()> const&) <null> (libboost_unit_test_framework.so.1.74.0+0x30b0c)
    #12 boost::execution_monitor::execute(boost::function<int ()> const&) <null> (libboost_unit_test_framework.so.1.74.0+0x30b90)
    #13 boost::execution_monitor::vexecute(boost::function<void ()> const&) <null> (libboost_unit_test_framework.so.1.74.0+0x30c60)
    #14 boost::unit_test::unit_test_monitor_t::execute_and_translate(boost::function<void ()> const&, unsigned long) <null> (libboost_unit_test_framework.so.1.74.0+0x5f1a0)
    #15 <null> <null> (libboost_unit_test_framework.so.1.74.0+0x37cdf)
    #16 <null> <null> (libboost_unit_test_framework.so.1.74.0+0x381d0)
    #17 <null> <null> (libboost_unit_test_framework.so.1.74.0+0x381d0)
    #18 boost::unit_test::framework::run(unsigned long, bool) <null> (libboost_unit_test_framework.so.1.74.0+0x3bf36)
    #19 boost::unit_test::unit_test_main(bool (*)(), int, char**) <null> (libboost_unit_test_framework.so.1.74.0+0x5e10d)
    #20 main /__w/pdns/pdns/pdns/recursordist/pdns-recursor-0.0.0-git1/testrunner.cc:84:10 (testrunner+0xc85591)
    #21 <null> <null> (libc.so.6+0x27249)
    #22 __libc_start_main <null> (libc.so.6+0x27304)
    #23 _start <null> (testrunner+0x1b79e0)
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
