### PR TITLE
libssl depends on libcrypto

### DIFF
--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -4,6 +4,7 @@ opt_libssl_dir = get_option('tls-libssl-dir')
 
 if opt_libssl_dir != ''
   dep_libssl = declare_dependency(
+    dependencies: [dep_libcrypto],
     include_directories: [opt_libssl_dir / 'include'],
     link_args: ['-L' + opt_libssl_dir / 'lib', '-lssl'],
   )


### PR DESCRIPTION
Otherwise all kinds of meson setup logic goes wrong, symptom: DoH connection from 127.0.0.1:44825 expected ALPN value 'h2', got ''

Should fix #15708

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
