### PR TITLE
dnsdist: Python with YAML is no longer optional to build dnsdist

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1205,6 +1205,7 @@ rsasha
 Rueckert
 rulesets
 runtimedir
+rustc
 rustup
 Ruthensteiner
 Rvd

--- a/pdns/dnsdistdist/docs/install.rst
+++ b/pdns/dnsdistdist/docs/install.rst
@@ -62,7 +62,7 @@ dnsdist depends on the following libraries:
 * `re2 <https://github.com/google/re2>`_ (optional)
 * `TinyCDB <https://www.corpit.ru/mjt/tinycdb.html>`_ (optional, CDB support)
 
-Since 2.0.0, the optional ``yaml`` configuration requires a Rust compiler.
+Since 2.0.0, the optional ``yaml`` configuration requires a Rust development environment, including ``rustc`` and ``cargo``.
 
 Should :program:`dnsdist` be run on a system with systemd, it is highly recommended to have
 the systemd header files (``libsystemd-dev`` on Debian and ``systemd-devel`` on CentOS)

--- a/pdns/dnsdistdist/docs/install.rst
+++ b/pdns/dnsdistdist/docs/install.rst
@@ -42,7 +42,7 @@ dnsdist is also available in `FreeBSD ports <http://www.freshports.org/dns/dnsdi
 Installing from Source
 ----------------------
 
-In order to compile dnsdist, a modern compiler with C++ 2017 support and GNU make are required.
+In order to compile dnsdist, a modern compiler with C++ 2017 support, a Python 3 interpreter with the ``YAML`` module, and either GNU make or ``meson`` with ``ninja`` are required.
 dnsdist depends on the following libraries:
 
 * `Boost <http://boost.org/>`_
@@ -62,7 +62,7 @@ dnsdist depends on the following libraries:
 * `re2 <https://github.com/google/re2>`_ (optional)
 * `TinyCDB <https://www.corpit.ru/mjt/tinycdb.html>`_ (optional, CDB support)
 
-Since 2.0.0, the optional ``yaml`` configuration requires a Rust compiler and a Python 3 interpreter.
+Since 2.0.0, the optional ``yaml`` configuration requires a Rust compiler.
 
 Should :program:`dnsdist` be run on a system with systemd, it is highly recommended to have
 the systemd header files (``libsystemd-dev`` on Debian and ``systemd-devel`` on CentOS)

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -5,7 +5,7 @@ Upgrade Guide
 --------------
 
 Since 2.0.0, a Python 3 interpreter with the ``YAML`` module is required to build :program:`dnsdist`.
-:program:`dnsdist` 2.0.0 also supports a new, optional ``yaml`` :doc:`configuration format <reference/yaml-settings>`. To build with this feature enabled, a Rust compiler is needed.
+:program:`dnsdist` 2.0.0 also supports a new, optional ``yaml`` :doc:`configuration format <reference/yaml-settings>`. To build with this feature enabled, a Rust development environment, including ``rustc`` and ``cargo`` is needed.
 
 :func:`showTLSContexts` has been renamed to :func:`showTLSFrontends`.
 :func:`getTLSContext` and the associated :class:`TLSContext` have been removed, please use :func:`getTLSFrontend` and the associated :class:`TLSFrontend` instead.

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -4,7 +4,8 @@ Upgrade Guide
 1.9.x to 2.0.0
 --------------
 
-:program:`dnsdist` supports a new, optional ``yaml`` :doc:`configuration format <reference/yaml-settings>`. To build :program:`dnsdist` with this feature enabled, a Rust compiler and a Python 3 interpreter are needed.
+Since 2.0.0, a Python 3 interpreter with the ``YAML`` module is required to build :program:`dnsdist`.
+:program:`dnsdist` 2.0.0 also supports a new, optional ``yaml`` :doc:`configuration format <reference/yaml-settings>`. To build with this feature enabled, a Rust compiler is needed.
 
 :func:`showTLSContexts` has been renamed to :func:`showTLSFrontends`.
 :func:`getTLSContext` and the associated :class:`TLSContext` have been removed, please use :func:`getTLSFrontend` and the associated :class:`TLSFrontend` instead.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Hopefully fixes https://github.com/PowerDNS/pdns/issues/15710 :)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
