### PR TITLE
rec: avoid implicit truncating cast of inception skew

### DIFF
--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1712,11 +1712,13 @@ static int initDNSSEC(Logr::log_t log)
     return 1;
   }
 
-  g_signatureInceptionSkew = ::arg().asNum("signature-inception-skew");
-  if (g_signatureInceptionSkew < 0) {
-    SLOG(g_log << Logger::Error << "A negative value for 'signature-inception-skew' is not allowed" << endl,
-         log->info(Logr::Error, "A negative value for 'signature-inception-skew' is not allowed"));
-    return 1;
+  {
+    auto value = ::arg().asNum("signature-inception-skew");
+    if (value < 0) {
+      log->info(Logr::Error, "A negative value for 'signature-inception-skew' is not allowed");
+      return 1;
+    }
+    g_signatureInceptionSkew = value;
   }
 
   g_dnssecLogBogus = ::arg().mustDo("dnssec-log-bogus");

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -28,7 +28,7 @@
 #include "base32.hh"
 #include "logger.hh"
 
-time_t g_signatureInceptionSkew{0};
+uint32_t g_signatureInceptionSkew{0};
 uint16_t g_maxNSEC3Iterations{0};
 uint16_t g_maxRRSIGsPerRecordToConsider{0};
 uint16_t g_maxNSEC3sPerRecordToConsider{0};

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -29,7 +29,7 @@
 #include "dnssecinfra.hh"
 #include "logger.hh"
 
-extern time_t g_signatureInceptionSkew;
+extern uint32_t g_signatureInceptionSkew;
 extern uint16_t g_maxNSEC3Iterations;
 extern uint16_t g_maxRRSIGsPerRecordToConsider;
 extern uint16_t g_maxNSEC3sPerRecordToConsider;


### PR DESCRIPTION
Avoid coverity complaint:
store_truncates_time_t: A time_t value is stored in an integer with too few bits to accommodate it. The expression sig.d_siginception - g_signatureInceptionSkew is cast to unsigned int.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
