### PR TITLE
auth backend transaction fixes in error cases

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -820,6 +820,7 @@ int PacketHandler::processUpdate(DNSPacket& packet) { // NOLINT(readability-func
     if (dnsRecord->d_place == DNSResourceRecord::ANSWER) {
       // Last line of 3.2.3
       if (dnsRecord->d_class != QClass::IN && dnsRecord->d_class != QClass::NONE && dnsRecord->d_class != QClass::ANY) {
+        di.backend->abortTransaction();
         return RCode::FormErr;
       }
 


### PR DESCRIPTION
### Short description
While investigating something, I couldn't help but notice that there were a few code paths where a `startTransaction` call was not matched by either a `commitTransaction` or an `abortTransaction` call - in other words, there were `abortTransaction` calls missing in some failure path.

This almost trivial PR addresses this. Probably easier to review with whitespace changes hidden due to indent changes.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
