### PR TITLE
dnsdist: Generate files when building the release tarball

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
@@ -18,6 +18,7 @@ generated = [
 python = find_program('python3')
 
 rust_lib_sources = custom_target(
+  'rust-lib-sources',
   command: [python, '@INPUT0@', '@SOURCE_ROOT@', '@SOURCE_ROOT@/dnsdist-rust-lib', '@OUTDIR@'],
   input: sources,
   output: generated,

--- a/pdns/dnsdistdist/meson-dist-script.sh
+++ b/pdns/dnsdistdist/meson-dist-script.sh
@@ -24,15 +24,28 @@ tar -C "$MESON_SOURCE_ROOT" -hcf - $symlinks | tar -xf - -C "$MESON_PROJECT_DIST
 echo Running autoreconf -vi so distfile is still usable for autotools building
 # Run autoconf for people using autotools to build, this creates a configure sc
 autoreconf -vi
-
-# Generate man pages
-cd "$MESON_PROJECT_BUILD_ROOT"
-meson compile man-pages
-cp -vp *.1 "$MESON_PROJECT_DIST_ROOT"
-
 rm -rf "$MESON_PROJECT_DIST_ROOT"/autom4te.cache
+
+cd "$MESON_PROJECT_BUILD_ROOT"
+
+# Generate YAML documentation
+meson compile yaml-settings-docs
+cp -vp "$MESON_SOURCE_ROOT"/docs/reference/yaml-*.rst "$MESON_PROJECT_DIST_ROOT"/docs/reference/
 
 # Generate a few files to reduce build dependencies
 echo 'If the below command generates an error, remove dnslabeltext.cc from source dir (remains of an autotools build?) and start again with a clean meson setup'
 ninja libdnsdist-common.a.p/dnslabeltext.cc
 cp -vp libdnsdist-common.a.p/dnslabeltext.cc "$MESON_PROJECT_DIST_ROOT"
+
+# Generate rules (selectors, actions)
+meson compile rules
+cp -vp dnsdist-*generated.hh dnsdist-*generated-body.hh "$MESON_PROJECT_DIST_ROOT"
+
+# Generate the sources for our Rust-based library
+meson compile rust-lib-sources
+cp -vp dnsdist-rust-lib/*.cc *.hh "$MESON_PROJECT_DIST_ROOT"/dnsdist-rust-lib/
+cp -vp "$MESON_SOURCE_ROOT"/dnsdist-rust-lib/rust/src/lib.rs "$MESON_PROJECT_DIST_ROOT"/dnsdist-rust-lib/rust/src/
+
+# Generate man pages
+meson compile man-pages
+cp -vp *.1 "$MESON_PROJECT_DIST_ROOT"

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -327,6 +327,7 @@ py = import('python')
 python = py.find_installation('python3', required: true)
 
 selectors_actions_sources = custom_target(
+  'rules',
   command: [
     python,
     '@INPUT0@',


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Some build systems are very unhappy with `dnsdist-rust-lib/rust/src/lib.rs` not existing before actually starting the build process (mostly because of `cargo-vendor`), so let's make their life easier. We might even save a few CPU cycles as a nice side-effect :smile: 

This should solve the issue reported by HellSpawn on IRC and Winfried in https://github.com/PowerDNS/pdns/discussions/15702#discussioncomment-13547972

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
