### PR TITLE
dnsdist: Return `nil` for non-existing Lua objects

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
@@ -62,12 +62,12 @@ void setupLuaBindingsDNSCrypt([[maybe_unused]] LuaContext& luaCtx, [[maybe_unuse
     return result;
   });
 
-  luaCtx.registerFunction<std::shared_ptr<DNSCryptCertificatePair> (std::shared_ptr<DNSCryptContext>::*)(size_t idx)>("getCertificatePair", [](std::shared_ptr<DNSCryptContext>& ctx, size_t idx) {
+  luaCtx.registerFunction<boost::optional<std::shared_ptr<DNSCryptCertificatePair>> (std::shared_ptr<DNSCryptContext>::*)(size_t idx)>("getCertificatePair", [](std::shared_ptr<DNSCryptContext>& ctx, size_t idx) -> boost::optional<std::shared_ptr<DNSCryptCertificatePair>> {
     if (ctx == nullptr) {
       throw std::runtime_error("DNSCryptContext::getCertificatePair() called on a nil value");
     }
 
-    std::shared_ptr<DNSCryptCertificatePair> result = nullptr;
+    boost::optional<std::shared_ptr<DNSCryptCertificatePair>> result{boost::none};
     auto pairs = ctx->getCertificates();
     if (idx < pairs.size()) {
       result = pairs.at(idx);

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
@@ -62,7 +62,7 @@ void setupLuaBindingsDNSCrypt([[maybe_unused]] LuaContext& luaCtx, [[maybe_unuse
     return result;
   });
 
-  luaCtx.registerFunction<boost::optional<std::shared_ptr<DNSCryptCertificatePair>> (std::shared_ptr<DNSCryptContext>::*)(size_t idx)>("getCertificatePair", [](std::shared_ptr<DNSCryptContext>& ctx, size_t idx) -> boost::optional<std::shared_ptr<DNSCryptCertificatePair>> {
+  luaCtx.registerFunction<boost::optional<std::shared_ptr<DNSCryptCertificatePair>> (std::shared_ptr<DNSCryptContext>::*)(size_t idx)>("getCertificatePair", [](std::shared_ptr<DNSCryptContext>& ctx, size_t idx) {
     if (ctx == nullptr) {
       throw std::runtime_error("DNSCryptContext::getCertificatePair() called on a nil value");
     }

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
@@ -687,7 +687,7 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
     return dnsdist::queueQueryResumptionEvent(std::move(query));
   });
 
-  luaCtx.registerFunction<boost::optional<std::shared_ptr<DownstreamState>> (DNSResponse::*)(void) const>("getSelectedBackend", [](const DNSResponse& dnsResponse) -> boost::optional<std::shared_ptr<DownstreamState>> {
+  luaCtx.registerFunction<boost::optional<std::shared_ptr<DownstreamState>> (DNSResponse::*)(void) const>("getSelectedBackend", [](const DNSResponse& dnsResponse) {
     return dnsResponse.d_downstream ? dnsResponse.d_downstream : boost::optional<std::shared_ptr<DownstreamState>>();
   });
 

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
@@ -687,8 +687,8 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
     return dnsdist::queueQueryResumptionEvent(std::move(query));
   });
 
-  luaCtx.registerFunction<std::shared_ptr<DownstreamState> (DNSResponse::*)(void) const>("getSelectedBackend", [](const DNSResponse& dnsResponse) {
-    return dnsResponse.d_downstream;
+  luaCtx.registerFunction<boost::optional<std::shared_ptr<DownstreamState>> (DNSResponse::*)(void) const>("getSelectedBackend", [](const DNSResponse& dnsResponse) -> boost::optional<std::shared_ptr<DownstreamState>> {
+    return dnsResponse.d_downstream ? dnsResponse.d_downstream : boost::optional<std::shared_ptr<DownstreamState>>();
   });
 
   luaCtx.registerFunction<bool (DNSResponse::*)()>("getStaleCacheHit", [](DNSResponse& dnsResponse) {

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -1592,7 +1592,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     g_outputBuffer = ret.str();
   });
 
-  luaCtx.writeFunction("getDNSCryptBind", [](uint64_t idx) -> boost::optional<std::shared_ptr<DNSCryptContext>> {
+  luaCtx.writeFunction("getDNSCryptBind", [](uint64_t idx) {
     setLuaNoSideEffect();
     boost::optional<std::shared_ptr<DNSCryptContext>> ret{boost::none};
     /* we are only interested in distinct DNSCrypt binds,
@@ -1735,7 +1735,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
-  luaCtx.writeFunction("getBind", [](uint64_t num) -> boost::optional<ClientState*> {
+  luaCtx.writeFunction("getBind", [](uint64_t num) {
     setLuaNoSideEffect();
     boost::optional<ClientState*> ret{boost::none};
     auto frontends = dnsdist::getFrontends();
@@ -2478,7 +2478,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
 #ifdef HAVE_DNS_OVER_QUIC
-  luaCtx.writeFunction("getDOQFrontend", [client](uint64_t index) -> boost::optional<std::shared_ptr<DOQFrontend>> {
+  luaCtx.writeFunction("getDOQFrontend", [client](uint64_t index) {
     boost::optional<std::shared_ptr<DOQFrontend>> result{boost::none};
     if (client) {
       return result;
@@ -2560,7 +2560,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
 #ifdef HAVE_DNS_OVER_HTTP3
-  luaCtx.writeFunction("getDOH3Frontend", [client](uint64_t index) -> boost::optional<std::shared_ptr<DOH3Frontend>> {
+  luaCtx.writeFunction("getDOH3Frontend", [client](uint64_t index) {
     boost::optional<std::shared_ptr<DOH3Frontend>> result{boost::none};
     if (client) {
       return result;
@@ -2629,7 +2629,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #endif
   });
 
-  luaCtx.writeFunction("getDOHFrontend", [client]([[maybe_unused]] uint64_t index) -> boost::optional<std::shared_ptr<DOHFrontend>> {
+  luaCtx.writeFunction("getDOHFrontend", [client]([[maybe_unused]] uint64_t index) {
     boost::optional<std::shared_ptr<DOHFrontend>> result{boost::none};
     if (client) {
       return result;
@@ -2859,7 +2859,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #endif
   });
 
-  luaCtx.writeFunction("getTLSFrontend", []([[maybe_unused]] uint64_t index) -> boost::optional<std::shared_ptr<TLSFrontend>> {
+  luaCtx.writeFunction("getTLSFrontend", []([[maybe_unused]] uint64_t index) {
     boost::optional<std::shared_ptr<TLSFrontend>> result{boost::none};
 #ifdef HAVE_DNS_OVER_TLS
     setLuaNoSideEffect();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Until now we were returning an empty shared pointer, but unfortunately LuaWrapper is currently not smart enough to turn that into a `nil` value.

This is a better fix than https://github.com/PowerDNS/pdns/pull/15707 for https://github.com/PowerDNS/pdns/issues/15699 although I would still like https://github.com/PowerDNS/pdns/pull/15707 to get merged for defense in depth.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
