### PR TITLE
rec: avoid curl during build if unnecessary

### DIFF
--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -354,12 +354,14 @@ librec_signers_openssl = declare_dependency(
 pubsuffix_dl_source =  'effective_tld_names.dat'
 pubsuffix_cc = src_dir / 'pubsuffix.cc'
 if not fs.is_file(pubsuffix_cc)
-  curl_command = find_program('curl', required: true)
-  pubsuffix_dl_source = custom_target(
-    'pubsuffix-dl',
-    command: [curl_command, '-s', '-S', '-o', '@OUTPUT@', 'https://publicsuffix.org/list/public_suffix_list.dat'],
-    output: pubsuffix_dl_source
-  )
+  if not fs.is_file(pubsuffix_dl_source)
+    curl_command = find_program('curl', required: true)
+    pubsuffix_dl_source = custom_target(
+      'pubsuffix-dl',
+      command: [curl_command, '-s', '-S', '-o', '@OUTPUT@', 'https://publicsuffix.org/list/public_suffix_list.dat'],
+      output: pubsuffix_dl_source
+    )
+  endif
 
   mkpubsuffix_command = find_program('mkpubsuffixcc', required: true)
   pubsuffix_cc = custom_target(


### PR DESCRIPTION
### Short description
As mentioned on irc, when `pubsuffix.cc` does not exist, it needs to be built from `effective_tld_names.dat`, which must be downloaded if it does not exist either.

When building with autoconf, these two steps are well-split. But when building with meson, the absence of the first file causes the complete "download, then generate" action, even if the file to download is already there.

This PR ought to fix this.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
