### PR TITLE
Lua for all

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ PTHREAD_SET_NAME
 AC_FUNC_STRERROR_R
 AX_CXX_CXXFS
 
-PDNS_WITH_LUA([mandatory])
+PDNS_WITH_LUA
 PDNS_CHECK_LUA_HPP
 
 AC_MSG_CHECKING([whether we will enable compiler security checks])

--- a/m4/pdns_with_lua.m4
+++ b/m4/pdns_with_lua.m4
@@ -16,7 +16,7 @@ AC_DEFUN([PDNS_WITH_LUA],[
 
   AC_MSG_RESULT([$with_lua])
 
-  AS_IF([test "x$with_lua" = "xno" -a "$1" = "mandatory"], [
+  AS_IF([test "x$with_lua" = "xno"], [
     AC_MSG_ERROR([--without-lua specified, but Lua is not optional])
   ])
 
@@ -24,37 +24,35 @@ AC_DEFUN([PDNS_WITH_LUA],[
   luajit_min_version='2.0.2'
   lua_min_version='5.1'
 
-  AS_IF([test "x$with_lua" != "xno"], [
-    AS_IF([test "x$with_lua" != "xauto"], [
-      with_lua_version=${lua_min_version}
-      AS_IF([echo "x$with_lua" | ${GREP} 'jit' >/dev/null 2>&1], [with_lua_version=${luajit_min_version}])
-      PKG_CHECK_MODULES([LUA], $with_lua >= $with_lua_version, [
-        AC_DEFINE([HAVE_LUA], [1], [Define to 1 if you have Lua])
-        LUAPC=$with_lua
-      ], [
-        AC_MSG_ERROR([Selected Lua ($with_lua) not found])
-      ])
+  AS_IF([test "x$with_lua" != "xauto"], [
+    with_lua_version=${lua_min_version}
+    AS_IF([echo "x$with_lua" | ${GREP} 'jit' >/dev/null 2>&1], [with_lua_version=${luajit_min_version}])
+    PKG_CHECK_MODULES([LUA], $with_lua >= $with_lua_version, [
+      AC_DEFINE([HAVE_LUA], [1], [Define to 1 if you have Lua])
+      LUAPC=$with_lua
     ], [
-      PKG_CHECK_MODULES([LUA], [luajit >= ${luajit_min_version}], [
-        LUAPC=luajit
-        AC_DEFINE([HAVE_LUA], [1], [Define to 1 if you have Lua])
-      ], [ : ])
-      AS_IF([test -z "$LUAPC"], [
-        found_lua=n
-        m4_foreach_w([luapc], [lua5.3 lua-5.3 lua53 lua5.2 lua-5.2 lua52 lua5.1 lua-5.1 lua51 lua], [
-          AS_IF([test "$found_lua" != "y"], [
-            PKG_CHECK_MODULES([LUA], [luapc >= ${lua_min_version}], [
-              AC_DEFINE([HAVE_LUA], [1], [Define to 1 if you have lua])
-              found_lua=y
-              LUAPC=luapc
-            ], [ : ])
-          ])
+      AC_MSG_ERROR([Selected Lua ($with_lua) not found])
+    ])
+  ], [
+    PKG_CHECK_MODULES([LUA], [luajit >= ${luajit_min_version}], [
+      LUAPC=luajit
+      AC_DEFINE([HAVE_LUA], [1], [Define to 1 if you have Lua])
+    ], [ : ])
+    AS_IF([test -z "$LUAPC"], [
+      found_lua=n
+      m4_foreach_w([luapc], [lua5.3 lua-5.3 lua53 lua5.2 lua-5.2 lua52 lua5.1 lua-5.1 lua51 lua], [
+        AS_IF([test "$found_lua" != "y"], [
+          PKG_CHECK_MODULES([LUA], [luapc >= ${lua_min_version}], [
+            AC_DEFINE([HAVE_LUA], [1], [Define to 1 if you have lua])
+            found_lua=y
+            LUAPC=luapc
+          ], [ : ])
         ])
       ])
     ])
   ])
 
-  AS_IF([test -z "$LUAPC" -a "$1" = "mandatory"], [
+  AS_IF([test -z "$LUAPC"], [
     AC_MSG_ERROR([No Lua not found, but is mandatory])
   ])
 

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -68,7 +68,7 @@ AC_SUBST([ARC4RANDOM_LIBS], ['$(top_builddir)/ext/arc4random/libarc4random.la'])
 
 AC_CHECK_HEADERS([sys/random.h])
 
-PDNS_WITH_LUA([mandatory])
+PDNS_WITH_LUA
 AS_IF([test "x$LUAPC" = "xluajit"], [
   # export all symbols with default visibility, to be able to use the Lua FFI interface
   AC_MSG_NOTICE([Adding -rdynamic to export all symbols for the Lua FFI interface])

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -56,7 +56,7 @@ PDNS_ENABLE_UNIT_TESTS
 PDNS_ENABLE_REPRODUCIBLE
 PDNS_ENABLE_COVERAGE
 
-PDNS_WITH_LUA([mandatory])
+PDNS_WITH_LUA
 AS_IF([test "x$LUAPC" = "xluajit"], [
   # export all symbols to be able to use the Lua FFI interface
   AC_MSG_NOTICE([Adding -rdynamic to export all symbols for the Lua FFI interface])


### PR DESCRIPTION
### Short description
Lua is mandatory for all three projects (auth, recursor, dnsdist), so the `autoconf` logic can be simplified a bit.

Better reviewed with whitespace changes ignored due to indent decrease in `pdns_with_lua.m4`.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
