### PR TITLE
dnsdist: Enforce that additional addresses are DoT/DoH only

### DIFF
--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1129,7 +1129,7 @@ bind:
     - name: "additional_addresses"
       type: "Vec<String>"
       default: ""
-      description: "List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses"
+      description: "List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses. This is only supported for DoT and DoH frontends, and therefore passing a non-empty list for other protocols will trigger an error"
     - name: "xsk"
       type: "String"
       default: ""


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
I want to support additional addresses on frontends for all protocols, but the amount of code to change is too important for the 2.0 branch. So for now, let's document and enforce the current limitation to prevent surprises.

See https://github.com/PowerDNS/pdns/issues/15517
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
