### PR TITLE
Add :getQueries() method to Server class

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings.cc
@@ -121,6 +121,7 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
   });
   luaCtx.registerFunction<uint64_t (DownstreamState::*)() const>("getOutstanding", [](const DownstreamState& state) { return state.outstanding.load(); });
   luaCtx.registerFunction<uint64_t (DownstreamState::*)() const>("getDrops", [](const DownstreamState& state) { return state.reuseds.load(); });
+  luaCtx.registerFunction<uint64_t (DownstreamState::*)() const>("getQueries", [](const DownstreamState& state) { return state.queries.load(); });
   luaCtx.registerFunction<double (DownstreamState::*)() const>("getLatency", [](const DownstreamState& state) { return state.getRelevantLatencyUsec(); });
   luaCtx.registerFunction("isUp", &DownstreamState::isUp);
   luaCtx.registerFunction("setDown", &DownstreamState::setDown);

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -835,7 +835,7 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
     Get the number of total queries for this server.
 
-    :returns: The number of dropped queries
+    :returns: The number of total queries
 
   .. method:: Server:getHealthCheckMode() -> str
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -831,7 +831,7 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
   .. method:: Server:getQueries() -> int
 
-    .. versionadded:: 2.0.x
+    .. versionadded:: 2.0.0
 
     Get the number of total queries for this server.
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -829,6 +829,14 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
     :returns: The number of dropped queries
 
+  .. method:: Server:getQueries() -> int
+
+    .. versionadded:: 2.0.x
+
+    Get the number of total queries for this server.
+
+    :returns: The number of dropped queries
+
   .. method:: Server:getHealthCheckMode() -> str
 
     .. versionadded:: 2.0.0


### PR DESCRIPTION
### Short description
This exposes the total number of queries a downstream server has handled similarly to how the :getDrops() method are available within Lua

When doing custom logic within Lua it's sometimes useful to be able to know how many queries a given server has handled, so this simply exposes that metric within the Server class directly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
