### PR TITLE
dnsdist-2.0.x: Backport 15729 - Enforce that additional addresses are DoT/DoH only

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -681,7 +681,6 @@ static void handleAdditionalAddressesForFrontend(const std::shared_ptr<ClientSta
   }
 }
 
-
 static void loadBinds(const ::rust::Vec<dnsdist::rust::settings::BindConfiguration>& binds)
 {
   for (const auto& bind : binds) {

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -663,6 +663,25 @@ static void loadDynamicBlockConfiguration(const dnsdist::rust::settings::Dynamic
   }
 }
 
+static void handleAdditionalAddressesForFrontend(const std::shared_ptr<ClientState>& state, const std::string& protocol, const ::rust::Vec<::rust::String>& additionalAddresses)
+{
+  if (protocol == "dot" || protocol == "doh") {
+    for (const auto& addr : additionalAddresses) {
+      try {
+        ComboAddress address{std::string(addr)};
+        state->d_additionalAddresses.emplace_back(address, -1);
+      }
+      catch (const PDNSException& e) {
+        errlog("Unable to parse additional address %s for %s bind: %s", std::string(addr), protocol, e.reason);
+      }
+    }
+  }
+  else if (!additionalAddresses.empty()) {
+    throw std::runtime_error("Passing a non-empty additional_addresses value to a " + protocol + " frontend is not supported");
+  }
+}
+
+
 static void loadBinds(const ::rust::Vec<dnsdist::rust::settings::BindConfiguration>& binds)
 {
   for (const auto& bind : binds) {
@@ -706,20 +725,7 @@ static void loadBinds(const ::rust::Vec<dnsdist::rust::settings::BindConfigurati
           state->d_tcpConcurrentConnectionsLimit = bind.tcp.max_concurrent_connections;
         }
 
-        if (protocol == "dot" || protocol == "doh") {
-          for (const auto& addr : bind.additional_addresses) {
-            try {
-              ComboAddress address{std::string(addr)};
-              state->d_additionalAddresses.emplace_back(address, -1);
-            }
-            catch (const PDNSException& e) {
-              errlog("Unable to parse additional address %s for %s bind: %s", std::string(addr), protocol, e.reason);
-            }
-          }
-        }
-        else if (!bind.additional_addresses.empty()) {
-          throw std::runtime_error("Passing a non-empty additional_addresses value to a " + protocol + " frontend is not supported");
-        }
+        handleAdditionalAddressesForFrontend(state, protocol, bind.additional_addresses);
 
         if (protocol == "dnscrypt") {
 #if defined(HAVE_DNSCRYPT)

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1129,7 +1129,7 @@ bind:
     - name: "additional_addresses"
       type: "Vec<String>"
       default: ""
-      description: "List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses"
+      description: "List of additional addresses (with port) to listen on. Using this option instead of creating a new frontend for each address avoids the creation of new thread and Frontend objects, reducing the memory usage. The drawback is that there will be a single set of metrics for all addresses. This is only supported for DoT and DoH frontends, and therefore passing a non-empty list for other protocols will trigger an error"
     - name: "xsk"
       type: "String"
       default: ""


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #15729 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
