### PR TITLE
lmdb-safe: Fix a small race in `getMDBEnv`

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -183,18 +183,18 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64
   struct stat statbuf{};
   if (stat(fname, &statbuf) != 0) {
     if (errno != ENOENT) {
-      throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
+      throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
     }
     std::lock_guard<std::mutex> lock(mut);
     /* we need to check again _after_ taking the lock, otherwise a different thread might have created
        it in the meantime */
     if (stat(fname, &statbuf) != 0) {
       if (errno != ENOENT) {
-        throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
+        throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
       }
       auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
       if (stat(fname, &statbuf) != 0) {
-        throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
+        throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
       }
       auto key = std::tie(statbuf.st_dev, statbuf.st_ino);
       s_envs.emplace(key, Value{fresh, flags});


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
I believe there is a small race in the `getMDBEnv`: if the database file does not exist when we first try to get the file metadata, we acquire the lock then create a new `MDBEnv` and store it in the map. But what happens if a different thread created the database between our first check and the call to `MDBEnv`? I believe we would create a new environment and override the existing entry in the map, bypassing the check.
This commit introduces a second check right after acquiring the lock to prevent that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
