### PR TITLE
rec: start to listen on ::1 by default, but don't consider it an error if that fails

### DIFF
--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -2710,7 +2710,7 @@ unsigned int makeUDPServerSockets(deferredAdd_t& deferredAdds, Logr::log_t log, 
     if (socketFd < 0) {
       throw PDNSException("Making a UDP server socket for resolver: " + stringerror());
     }
-    logVec.emplace_back(address.toStringWithPort());
+
     if (!setSocketTimestamps(socketFd)) {
       SLOG(g_log << Logger::Warning << "Unable to enable timestamp reporting for socket" << endl,
            log->info(Logr::Warning, "Unable to enable timestamp reporting for socket"));
@@ -2776,13 +2776,19 @@ unsigned int makeUDPServerSockets(deferredAdd_t& deferredAdds, Logr::log_t log, 
 
     socklen_t socklen = address.getSocklen();
     if (::bind(socketFd, reinterpret_cast<struct sockaddr*>(&address), socklen) < 0) { // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-      throw PDNSException("Resolver binding to server socket on " + address.toStringWithPort() + ": " + stringerror());
+      int err = errno;
+      if (address != ComboAddress{"::1", defaultLocalPort}) {
+        throw PDNSException("Resolver binding to server socket on " + address.toStringWithPort() + ": " + stringerror(err));
+      }
+      log->info(Logr::Warning, "Cannot listen on this address, skipping", "proto", Logging::Loggable("UDP"), "address", Logging::Loggable(address), "error", Logging::Loggable(stringerror(err)));
+      continue;
     }
 
     setNonBlocking(socketFd);
 
     deferredAdds.emplace_back(socketFd, handleNewUDPQuestion);
     g_listenSocketsAddresses[socketFd] = address; // this is written to only from the startup thread, not from the workers
+    logVec.emplace_back(address.toStringWithPort());
   }
   if (doLog) {
     log->info(Logr::Info, "Listening for queries", "proto", Logging::Loggable("UDP"), "addresses", Logging::IterLoggable(logVec.cbegin(), logVec.cend()), "socketInstances", Logging::Loggable(instances), "reuseport", Logging::Loggable(g_reusePort));

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -1265,8 +1265,9 @@ Indication of how many queries will be averaged to get the average latency repor
         'section' : 'incoming',
         'oldname' : 'local-address',
         'type' : LType.ListSocketAddresses,
-        'default' : '127.0.0.1',
+        'default' : '127.0.0.1, ::1',
         'help' : 'IP addresses to listen on, separated by spaces or commas. Also accepts ports.',
+        'versionchanged': ('5.3.0', '::1 was added to the list'),
         'doc' : '''
 Local IP addresses to which we bind. Each address specified can
 include a port number; if no port is included then the


### PR DESCRIPTION

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

The failure *is* reported if the `incoming.listen` setting is !default.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
