### PR TITLE
dnsdist: Clarify different webserver auths

### DIFF
--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -51,6 +51,45 @@ For example, to remove the X-Frame-Options header and add a X-Custom one:
 
 Credentials can be changed at run time using the :func:`setWebserverConfig` function.
 
+Credentials
+-----------
+
+The webserver uses two kind of authorization: one is HTTP basic auth, with name and
+password; username doesn't matter, only password is checked. Second kind of authorization is
+with an API key, which must be in ``X-API-Key`` request header. Those keys can be different,
+and are two different options to :func:`setWebserverConfig`.
+
+There are also three different options for :func:`setWebserverConfig`, which can disable
+the auth for the calls altogether by setting them to false; they are true by default.
+
+.. list-table::
+   :header-rows: 1
+
+   * - endpoint
+     - option to disable auth
+     - basic auth
+     - API header auth
+   * - main dashboard
+     - ``dashboardRequiresAuthentication``
+     - allowed
+     - not allowed
+   * - ``/jsonstat``
+     - ``statsRequireAuthentication``
+     - allowed
+     - allowed
+   * - ``/metrics``
+     - ``statsRequireAuthentication``
+     - allowed
+     - allowed
+   * - ``/api/v1/servers/localhost``
+     - ``dashboardRequiresAuthentication``
+     - allowed
+     - allowed
+   * - other ``/api/`` endpoints
+     - ``apiRequiresAuthentication``
+     - not allowed
+     - allowed
+
 dnsdist API
 -----------
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -467,7 +467,7 @@ Webserver configuration
   .. versionchanged:: 1.8.0
     ``apiRequiresAuthentication``, ``dashboardRequiresAuthentication`` optional parameters added.
 
-  Setup webserver configuration. See :func:`webserver`.
+  Setup webserver configuration. See :func:`webserver` and :doc:`../guides/webserver`.
 
   :param table options: A table with key: value pairs with webserver options.
 


### PR DESCRIPTION
### Short description

This MR tries to clarify different auths in the built-in webserver in the docs.

I have no idea how do the auth interfere with custom endpoints made in dnsdist config with `registerWebHandler` :( I don't currently use it anywhere.

Fixes #15769

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
