### PR TITLE
dnsdist-2.0.x: Backport 15738 - Prevent users from opening the same LMDB twice

### DIFF
--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -85,7 +85,7 @@ std::vector<std::string> KeyValueLookupKeySuffix::getKeys(const DNSName& qname)
 bool LMDBKVStore::getValue(const std::string& key, std::string& value)
 {
   try {
-    auto transaction = d_env.getROTransaction();
+    auto transaction = d_env->getROTransaction();
     MDBOutVal result;
     int rc = transaction->get(d_dbi, MDBInVal(key), result);
     if (rc == 0) {
@@ -105,7 +105,7 @@ bool LMDBKVStore::getValue(const std::string& key, std::string& value)
 bool LMDBKVStore::keyExists(const std::string& key)
 {
   try {
-    auto transaction = d_env.getROTransaction();
+    auto transaction = d_env->getROTransaction();
     MDBOutVal result;
     int rc = transaction->get(d_dbi, MDBInVal(key), result);
     if (rc == 0) {
@@ -124,7 +124,7 @@ bool LMDBKVStore::keyExists(const std::string& key)
 bool LMDBKVStore::getRangeValue(const std::string& key, std::string& value)
 {
   try {
-    auto transaction = d_env.getROTransaction();
+    auto transaction = d_env->getROTransaction();
     auto cursor = transaction->getROCursor(d_dbi);
     MDBOutVal actualKey;
     MDBOutVal result;

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -177,7 +177,7 @@ public:
 class LMDBKVStore: public KeyValueStore
 {
 public:
-  LMDBKVStore(const std::string& fname, const std::string& dbName, bool noLock=false): d_env(fname.c_str(), noLock ? MDB_NOSUBDIR|MDB_RDONLY|MDB_NOLOCK : MDB_NOSUBDIR|MDB_RDONLY, 0600, 0), d_dbi(d_env.openDB(dbName, 0)), d_fname(fname), d_dbName(dbName)
+  LMDBKVStore(const std::string& fname, const std::string& dbName, bool noLock=false): d_env(getMDBEnv(fname.c_str(), noLock ? MDB_NOSUBDIR|MDB_RDONLY|MDB_NOLOCK : MDB_NOSUBDIR|MDB_RDONLY, 0600, 0)), d_dbi(d_env->openDB(dbName, 0)), d_fname(fname), d_dbName(dbName)
   {
   }
 
@@ -186,7 +186,7 @@ public:
   bool getRangeValue(const std::string& key, std::string& value) override;
 
 private:
-  MDBEnv d_env;
+  std::shared_ptr<MDBEnv> d_env;
   MDBDbi d_dbi;
   std::string d_fname;
   std::string d_dbName;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of 15738 to rel/dnsdist-2.0.x

As noted by Peter: "LMBD requires that database is opened exactly once per process. Opening multiple times breaks file locks silently, which leads to corrupting the database."

While I don't expect users to actually do that, we already have a nice helper function to prevent this mistake in the lmdb-safe code base, so let's use it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
