### PR TITLE
dnsdist-2.0.x: Backport 15739 - lmdb-safe: Fix a small race in `getMDBEnv`

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -188,18 +188,18 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64
   struct stat statbuf{};
   if (stat(fname, &statbuf) != 0) {
     if (errno != ENOENT) {
-      throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
+      throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
     }
     std::lock_guard<std::mutex> lock(mut);
     /* we need to check again _after_ taking the lock, otherwise a different thread might have created
        it in the meantime */
     if (stat(fname, &statbuf) != 0) {
       if (errno != ENOENT) {
-        throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
+        throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
       }
       auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
       if (stat(fname, &statbuf) != 0) {
-        throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
+        throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
       }
       auto key = std::tie(statbuf.st_dev, statbuf.st_ino);
       s_envs.emplace(key, Value{fresh, flags});

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -185,39 +185,45 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64
   static std::map<tuple<dev_t, ino_t>, Value> s_envs;
   static std::mutex mut;
 
-  struct stat statbuf;
-  if(stat(fname, &statbuf)) {
-    if(errno != ENOENT)
+  struct stat statbuf{};
+  if (stat(fname, &statbuf) != 0) {
+    if (errno != ENOENT) {
       throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
-    else {
-      std::lock_guard<std::mutex> l(mut);
-      auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
-      if(stat(fname, &statbuf))
+    }
+    std::lock_guard<std::mutex> lock(mut);
+    /* we need to check again _after_ taking the lock, otherwise a different thread might have created
+       it in the meantime */
+    if (stat(fname, &statbuf) != 0) {
+      if (errno != ENOENT) {
         throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
+      }
+      auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
+      if (stat(fname, &statbuf) != 0) {
+        throw std::runtime_error("Unable to stat prospective mdb database: "+string(strerror(errno)));
+      }
       auto key = std::tie(statbuf.st_dev, statbuf.st_ino);
-      s_envs[key] = {fresh, flags};
+      s_envs.emplace(key, Value{fresh, flags});
       return fresh;
     }
   }
 
-  std::lock_guard<std::mutex> l(mut);
+  std::lock_guard<std::mutex> lock(mut);
   auto key = std::tie(statbuf.st_dev, statbuf.st_ino);
   auto iter = s_envs.find(key);
-  if(iter != s_envs.end()) {
+  if (iter != s_envs.end()) {
     auto sp = iter->second.wp.lock();
-    if(sp) {
-      if(iter->second.flags != flags)
+    if (sp) {
+      if (iter->second.flags != flags) {
         throw std::runtime_error("Can't open mdb with differing flags");
+      }
 
       return sp;
     }
-    else {
-      s_envs.erase(iter); // useful if make_shared fails
-    }
+    s_envs.erase(iter); // useful if make_shared fails
   }
 
   auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
-  s_envs[key] = {fresh, flags};
+  s_envs.emplace(key, Value{fresh, flags});
 
   return fresh;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #15739 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
