### PR TITLE
dnsdist-2.0.x: Backport to 15751 - Error on unsupported backend protocols from YAML

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -448,6 +448,17 @@ static std::shared_ptr<DownstreamState> createBackendFromConfiguration(const dns
   const auto& tlsConf = config.tls;
   auto protocol = boost::to_lower_copy(std::string(config.protocol));
   if (protocol == "dot" || protocol == "doh") {
+#if !defined(HAVE_DNS_OVER_TLS)
+    if (protocol == "dot") {
+      throw std::runtime_error("Backend " + std::string(config.address) + " is configured to use DNS over TLS but DoT support is not available");
+    }
+#endif /* HAVE_DNS_OVER_TLS */
+#if !defined(HAVE_DNS_OVER_HTTPS)
+    if (protocol == "doh") {
+      throw std::runtime_error("Backend " + std::string(config.address) + " is configured to use DNS over HTTPS but DoH support is not available");
+    }
+#endif /* HAVE_DNS_OVER_HTTPS */
+
     backendConfig.d_tlsParams.d_provider = std::string(tlsConf.provider);
     backendConfig.d_tlsParams.d_ciphers = std::string(tlsConf.ciphers);
     backendConfig.d_tlsParams.d_ciphers13 = std::string(tlsConf.ciphers_tls_13);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport 15751 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
