### PR TITLE
dnsdist-2.0.x: Backport 15747 - Add a Lua binding to get objects declared in YAML

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1187,12 +1187,11 @@ void addLuaBindingsForYAMLObjects([[maybe_unused]] LuaContext& luaCtx)
 #if defined(HAVE_YAML_CONFIGURATION)
   using ReturnValue = boost::optional<boost::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction>, std::shared_ptr<DNSResponseAction>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<XSKMap>>>;
 
-  luaCtx.writeFunction("getObjectFromYAMLConfiguration", [](const std::string& name) {
-    ReturnValue object{boost::none};
+  luaCtx.writeFunction("getObjectFromYAMLConfiguration", [](const std::string& name) -> ReturnValue {
     auto map = s_registeredTypesMap.lock();
     auto item = map->find(name);
     if (item == map->end()) {
-      return object;
+      return boost::none;
     }
     if (auto* ptr = std::get_if<std::shared_ptr<DNSDistPacketCache>>(&item->second)) {
       return ReturnValue(*ptr);
@@ -1225,7 +1224,7 @@ void addLuaBindingsForYAMLObjects([[maybe_unused]] LuaContext& luaCtx)
       return ReturnValue(*ptr);
     }
 
-    return object;
+    return boost::none;
   });
 #endif /* HAVE_YAML_CONFIGURATION */
 }

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.hh
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.hh
@@ -25,7 +25,10 @@
 
 #include <string>
 
+class LuaContext;
+
 namespace dnsdist::configuration::yaml
 {
 bool loadConfigurationFromFile(const std::string& fileName, bool isClient, bool configCheck);
+void addLuaBindingsForYAMLObjects(LuaContext& luaCtx);
 }

--- a/pdns/dnsdistdist/dnsdist-console-completion.cc
+++ b/pdns/dnsdistdist/dnsdist-console-completion.cc
@@ -115,6 +115,7 @@ static std::vector<dnsdist::console::completion::ConsoleKeyword> s_consoleKeywor
   {"getListOfRangesOfNetworkInterface", true, "itf", "returns the list of network ranges configured on a given network interface, as strings"},
   {"getMACAddress", true, "IP addr", "return the link-level address (MAC) corresponding to the supplied neighbour  IP address, if known by the kernel"},
   {"getMetric", true, "name", "Get the value of a custom metric"},
+  {"getObjectFromYAMLConfiguration", true, "name", "Get an object created in YAML configuration"},
   {"getOutgoingTLSSessionCacheSize", true, "", "returns the number of TLS sessions (for outgoing connections) currently cached"},
   {"getPool", true, "name", "return the pool named `name`, or \"\" for the default pool"},
   {"getPoolServers", true, "pool", "return servers part of this pool"},

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -38,6 +38,7 @@
 #include "dnsdist-carbon.hh"
 #include "dnsdist-concurrent-connections.hh"
 #include "dnsdist-configuration.hh"
+#include "dnsdist-configuration-yaml.hh"
 #include "dnsdist-console.hh"
 #include "dnsdist-console-completion.hh"
 #include "dnsdist-crypto.hh"
@@ -3195,6 +3196,7 @@ void setupLuaBindingsOnly(LuaContext& luaCtx, bool client, bool configCheck)
   setupLuaInspection(luaCtx);
   setupLuaVars(luaCtx);
   setupLuaWeb(luaCtx);
+  dnsdist::configuration::yaml::addLuaBindingsForYAMLObjects(luaCtx);
 
 #ifdef LUAJIT_VERSION
   luaCtx.executeCode(getLuaFFIWrappers());

--- a/pdns/dnsdistdist/dnsdist-settings-documentation-generator.py
+++ b/pdns/dnsdistdist/dnsdist-settings-documentation-generator.py
@@ -142,6 +142,8 @@ If the configuration file passed to :program:`dnsdist` via the ``-C`` command-li
 By default, when a YAML configuration file is used, any Lua configuration file used along the YAML configuration should only contain functions, and ideally even those should be defined either inline in the YAML file or in separate files included from the YAML configuration, for clarity. It is however possible to change this behaviour using the :func:`enableLuaConfiguration` directive to enable Lua configuration directives, but it is strongly advised not to use this directive unless absolutely necessary, and to prefer doing all the configuration in either Lua or YAML but to not mix them.
 Note that Lua directives that can be used at runtime are always available via the :doc:`../guides/console`, regardless of whether they are enabled during configuration.
 
+It is possible to access objects declared in the YAML configuration from the console via :func:`getObjectFromYAMLConfiguration`.
+
 A YAML configuration file contains several sections, that are described below.
 
 '''

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -2264,6 +2264,14 @@ Other functions
 
   :returns: A timespec object, see :ref:`timespec`
 
+.. function:: getObjectFromYAMLConfiguration
+
+  .. versionadded:: 2.0.0
+
+  Return a pointer to an object (:class:`KeyValueStore`, :class:`DNSAction`, class::`DNSRule`, ...) declared in the YAML configuration.
+
+  :param str name: The name assigned to the object in the YAML configuration
+
 .. function:: getResolvers(path)
 
   .. versionadded:: 1.8.0


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #15747 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
