### PR TITLE
Disable check-spelling sarif for PowerDNS/pdns

### DIFF
--- a/.github/workflows/spelling3.yml
+++ b/.github/workflows/spelling3.yml
@@ -48,7 +48,7 @@ jobs:
           post_comment: 0
           use_magic_file: 1
           warnings: bad-regex,binary-file,deprecated-feature,ignored-expect-variant,large-file,limited-references,no-newline-at-eof,noisy-file,non-alpha-in-dictionary,token-is-substring,unexpected-line-ending,whitespace-in-dictionary,minified-file,unsupported-configuration,no-files-to-check,unclosed-block-ignore-begin,unclosed-block-ignore-end
-          use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && !env.DO_NOT_USE_SARIF_REPORTING && 1 }}
+          use_sarif: ${{ (!github.event.pull_request || (github.repository_owner != 'PowerDNS' && github.event.pull_request.head.repo.full_name == github.repository)) && !vars.DO_NOT_USE_SARIF_REPORTING && 1 }}
           dictionary_source_prefixes: >
             {
             "cspell": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20241114/dictionaries/"


### PR DESCRIPTION
### Short description
- #15577 tried to enable sarif reporting, and it sort of does, some of the time: https://github.com/PowerDNS/pdns/actions/runs/16053668287, but it doesn't work properly for repositories that use `pull_request`.
  I need to go back to the drawing board on this. I don't think it's possible to use v0.0.25 w/ `pull_request` + sarif in repositories that rely on pull requests from forks.

Worse, afaict, there's no documentation on how to actually use sarif reporting for forks -- I'll be filing a ticket against [github docs](http://github.com/github/docs/issues/) about this, but doing so requires trying to find some repositories with samples of how to trigger a sarif report so I can show that this is mostly fundamentally broken, so it's going to take a bit (I do hope to get it done by next week and I have started playing with it, but not with much success).

Note: If there was a ruleset created for check-spelling, it'll need to be disabled. I don't think it was created as I don't think it'd have worked and we talked about how to use it which is what led me to this investigation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
