### PR TITLE
lmdb NSEC3 record handling hygiene bugfix

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2828,11 +2828,6 @@ bool LMDBBackend::updateEmptyNonTerminals(domainid_t domain_id, set<DNSName>& in
       // cout <<" -"<<n<<endl;
       n.makeUsRelative(di.zone);
       txn->txn->del(txn->db->dbi, co(domain_id, n, QType::ENT));
-      // Remove possible orphaned NSEC3 record pair tied to that ENT.
-      auto cursor = txn->txn->getCursor(txn->db->dbi);
-      if (hasOrphanedNSEC3Record(cursor, domain_id, n)) {
-        deleteNSEC3RecordPair(txn, domain_id, n);
-      }
     }
   }
   if (needCommit)

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -342,6 +342,7 @@ private:
   static bool getAfterForwardFromStart(MDBROCursor& cursor, MDBOutVal& key, MDBOutVal& val, domainid_t id, DNSName& after);
   static bool isNSEC3BackRecord(LMDBResourceRecord& lrr, const MDBOutVal& key, const MDBOutVal& val);
   static bool isValidAuthRecord(const MDBOutVal& key, const MDBOutVal& val);
+  static bool hasOrphanedNSEC3Record(MDBRWCursor& cursor, domainid_t domain_id, const DNSName& qname);
   static void deleteNSEC3RecordPair(const std::shared_ptr<RecordsRWTransaction>& txn, domainid_t domain_id, const DNSName& qname);
   void writeNSEC3RecordPair(const std::shared_ptr<RecordsRWTransaction>& txn, domainid_t domain_id, const DNSName& qname, const DNSName& ordername);
 


### PR DESCRIPTION
### Short description
One of the commits in #15767 turned to be too aggressively deleting data when it should not have. This PR reverts the incorrect logic.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] worn a brown paper bag over my head in shame