### PR TITLE
build-packages: Request more permissions at the reusable workflow level

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -41,13 +41,17 @@ on:
       DOWNLOADS_AUTOBUILT_HOSTKEY:
         required: true
 
-permissions: # least privileges, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
-  contents: read
+permissions:
+  actions: read
+  id-token: write
+  contents: write
 
 jobs:
   prepare:
     name: generate OS runner and arch list
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       oslist: ${{ steps.get-oslist.outputs.oslist }}
       runnerlist: ${{ steps.get-runnerlist.outputs.runnerlist }}
@@ -90,6 +94,8 @@ jobs:
     needs: prepare
     name: for ${{ matrix.os }} ${{ inputs.product }} (${{ inputs.ref }}) on ${{ matrix.runner-os }}
     runs-on: ${{ matrix.runner-os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: ${{fromJson(needs.prepare.outputs.oslist)}}
@@ -199,6 +205,8 @@ jobs:
     needs: [prepare, build]
     name: Check if hashes were created for all requested targets
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     env:
       OUTPUTS: ${{ toJSON(needs.build.outputs) }}
       OSLIST: ${{ needs.prepare.outputs.oslist }}
@@ -253,6 +261,8 @@ jobs:
     needs: [prepare, build, provenance-src, provenance-pkgs]
     name: Upload the provenance artifacts to downloads.powerdns.com
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: ${{fromJson(needs.prepare.outputs.oslist)}}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
To hopefully fix an issue when the workflow is called from `build-tags`:
```
Invalid workflow file: .github/workflows/build-tags.yml#L12
The workflow is not valid. .github/workflows/build-tags.yml (Line: 12, Col: 3): Error calling workflow 'PowerDNS/pdns/.github/workflows/build-packages.yml@master'. The nested job 'provenance-pkgs' is requesting 'actions: read, contents: write, id-token: write', but is only allowed 'actions: none, contents: read, id-token: none'. .github/workflows/build-tags.yml (Line: 12, Col: 3): Error calling workflow 'PowerDNS/pdns/.github/workflows/build-packages.yml@master'. The nested job 'provenance-src' is requesting 'actions: read, contents: write, id-token: write', but is only allowed 'actions: none, contents: read, id-token: none'.
```
And restrict permissions on a per-job basis.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
