### PR TITLE
lmdb NSEC3 record handling hygiene: return of the wrath of the seventh son of the phantom of the beast

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2740,7 +2740,7 @@ bool LMDBBackend::updateDNSSECOrderNameAndAuth(domainid_t domain_id, const DNSNa
   }
 
   bool hasOrderName = !ordername.empty() && isNsec3;
-  bool needNSEC3 = hasOrderName;
+  bool keepNSEC3 = hasOrderName;
 
   do {
     if (compoundOrdername::getQType(key.getNoStripHeader<StringView>()) == QType::NSEC3) {
@@ -2758,8 +2758,8 @@ bool LMDBBackend::updateDNSSECOrderNameAndAuth(domainid_t domain_id, const DNSNa
       // If there is at least one entry for that qname, with a different qtype
       // than the one we are working for, known to be associated to an NSEC3
       // record, then we should NOT delete it.
-      if (!needNSEC3) {
-        needNSEC3 = lrr.hasOrderName && isDifferentQType;
+      if (!keepNSEC3) {
+        keepNSEC3 = lrr.hasOrderName && isDifferentQType;
       }
 
       if (!isDifferentQType && (lrr.hasOrderName != hasOrderName || lrr.auth != auth)) {
@@ -2774,7 +2774,7 @@ bool LMDBBackend::updateDNSSECOrderNameAndAuth(domainid_t domain_id, const DNSNa
     }
   } while (cursor.next(key, val) == 0);
 
-  if (!needNSEC3) {
+  if (!keepNSEC3) {
     // NSEC3 link to be removed: need to remove an existing pair, if any
     deleteNSEC3RecordPair(txn, domain_id, rel);
   }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2752,11 +2752,12 @@ bool LMDBBackend::updateDNSSECOrderNameAndAuth(domainid_t domain_id, const DNSNa
     newRRs.reserve(lrrs.size());
     for (auto& lrr : lrrs) {
       lrr.qtype = compoundOrdername::getQType(key.getNoStripHeader<StringView>());
-      if (!needNSEC3 && qtype != QType::ANY) {
-        needNSEC3 = (lrr.hasOrderName && QType(qtype) != lrr.qtype);
+      bool isDifferentQType = qtype != QType::ANY && QType(qtype) != lrr.qtype;
+      if (!needNSEC3) {
+        needNSEC3 = lrr.hasOrderName && isDifferentQType;
       }
 
-      if ((qtype == QType::ANY || QType(qtype) == lrr.qtype) && (lrr.hasOrderName != hasOrderName || lrr.auth != auth)) {
+      if (!isDifferentQType && (lrr.hasOrderName != hasOrderName || lrr.auth != auth)) {
         lrr.auth = auth;
         lrr.hasOrderName = hasOrderName;
         changed = true;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -264,9 +264,9 @@ public:
   public:
     LMDBResourceRecord() = default;
     LMDBResourceRecord(const DNSResourceRecord& rr) :
-      DNSResourceRecord(rr), ordername(false) {}
+      DNSResourceRecord(rr), hasOrderName(false) {}
 
-    bool ordername{false};
+    bool hasOrderName{false};
   };
 
 private:

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -266,6 +266,8 @@ public:
     LMDBResourceRecord(const DNSResourceRecord& rr) :
       DNSResourceRecord(rr), hasOrderName(false) {}
 
+    // This field is set if the in-base DNSResourceRecord also has an
+    // NSEC3 record chain associated to it.
     bool hasOrderName{false};
   };
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -877,25 +877,25 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
 
     it = rss.find(qname);
     if(it == rss.end() || it->second.update || it->second.auth != auth || it->second.ordername != ordername) {
-      sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, auth, QType::ANY, haveNSEC3);
+      sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, auth, QType::ANY, haveNSEC3 && !narrow);
       ++updates;
     }
 
     if(realrr)
     {
       if (dsnames.count(qname)) {
-        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, true, QType::DS, haveNSEC3);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, true, QType::DS, haveNSEC3 && !narrow);
         ++updates;
       }
       if (!auth || nsset.count(qname)) {
         ordername.clear();
         if(isOptOut && !dsnames.count(qname)){
-          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::NS, haveNSEC3);
+          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::NS, haveNSEC3 && !narrow);
           ++updates;
         }
-        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::A, haveNSEC3);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::A, haveNSEC3 && !narrow);
         ++updates;
-        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::AAAA, haveNSEC3);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::AAAA, haveNSEC3 && !narrow);
         ++updates;
       }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1007,7 +1007,7 @@ static int increaseSerial(const ZoneName& zone, DNSSECKeeper &dsk)
       ordername=DNSName("");
     if(g_verbose)
       cerr<<"'"<<rr.qname<<"' -> '"<< ordername <<"'"<<endl;
-    sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, rr.qname, ordername, true, QType::ANY, haveNSEC3);
+    sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, rr.qname, ordername, true, QType::ANY, haveNSEC3 && !narrow);
   }
 
   sd.db->commitTransaction();

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -234,15 +234,15 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
             ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, rr->d_name)));
 
           if (*narrow) {
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), auth, QType::ANY, true);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), auth, QType::ANY, false);
 	  }
           else {
             di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, ordername, auth, QType::ANY, true);
 	  }
           if(!auth || rrType == QType::DS) {
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::NS, true);
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::A, true);
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::AAAA, true);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::NS, !*narrow);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::A, !*narrow);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::AAAA, !*narrow);
           }
 
         } else { // NSEC
@@ -305,22 +305,22 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
           ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, rr->d_name)));
 
         if (*narrow) {
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), auth, QType::ANY, true);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), auth, QType::ANY, false);
 	}
         else {
           di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, ordername, auth, QType::ANY, true);
 	}
 
         if (fixDS) {
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, ordername, true, QType::DS, true);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, ordername, true, QType::DS, !*narrow);
 	}
 
         if(!auth) {
           if (ns3pr->d_flags != 0) {
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::NS, true);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::NS, !*narrow);
 	  }
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::A, true);
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::AAAA, true);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::A, !*narrow);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::AAAA, !*narrow);
         }
       }
       else { // NSEC
@@ -354,14 +354,14 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
               ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, qname)));
 
             if (*narrow) {
-              di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), auth, QType::ANY, true);
+              di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), auth, QType::ANY, false);
 	    }
             else {
               di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, ordername, auth, QType::ANY, true);
 	    }
 
             if (ns3pr->d_flags != 0) {
-              di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::NS, true);
+              di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::NS, !*narrow);
 	    }
           }
           else { // NSEC
@@ -369,8 +369,8 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
             di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, ordername, false, QType::NS, false);
           }
 
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::A, *haveNSEC3);
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::AAAA, *haveNSEC3);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::A, *haveNSEC3 && !*narrow);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::AAAA, *haveNSEC3 && !*narrow);
         }
       }
     }
@@ -479,7 +479,7 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
           else { // NSEC
             ordername=changeRec.makeRelative(di->zone);
           }
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, changeRec, ordername, true, QType::ANY, *haveNSEC3);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, changeRec, ordername, true, QType::ANY, *haveNSEC3 && !*narrow);
         }
       }
 
@@ -547,7 +547,7 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
         if(! *narrow) {
           ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, i)));
 	}
-        di->backend->updateDNSSECOrderNameAndAuth(di->id, i, ordername, true, QType::ANY, true);
+        di->backend->updateDNSSECOrderNameAndAuth(di->id, i, ordername, true, QType::ANY, !*narrow);
       }
     }
   }
@@ -1091,6 +1091,6 @@ void PacketHandler::increaseSerial(const string &msgPrefix, const DomainInfo *di
     } else { // NSEC
       ordername = rr.qname.makeRelative(di->zone);
     }
-    di->backend->updateDNSSECOrderNameAndAuth(di->id, rr.qname, ordername, true, QType::ANY, haveNSEC3);
+    di->backend->updateDNSSECOrderNameAndAuth(di->id, rr.qname, ordername, true, QType::ANY, haveNSEC3 && !narrow);
   }
 }


### PR DESCRIPTION
### Short description
I am still digging into that LMDB+NSEC3 rabbit hole. Every DNS Resource Record serialized in the database has a flag supposed to tell us whether there are NSEC3 records for it. Except the value of the flag were not always correct.

This PR makes sure that this flag is set when such records exist or are about to be added. And cleared when they are removed but that particular record is not deleted afterwards. This also makes sure that NSEC3 in narrow mode will create spurious NSEC3 records.

Probably better reviewed on a commit-by-commit basis. The 3rd one ~will amaze you~ is a bit tricky, but correct (write down a truth table of the `if()` condition and body, for the two `qtype == ANY` and `qtype != ANY` conditions, and you'll see the new version yields the same results as before).

I guess this should also be mentioned as contributing to fix #11612.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] scratched my head multiple times trying to understand the whole ensechilada