### PR TITLE
rec: allow negation in outgoing.edns_subnet_allow_list

### DIFF
--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -6206,7 +6206,7 @@ void SyncRes::parseEDNSSubnetAllowlist(const std::string& alist)
   stringtok(parts, alist, ",; ");
   for (const auto& allow : parts) {
     try {
-      s_ednsremotesubnets.addMask(Netmask(allow));
+      s_ednsremotesubnets.addMask(allow);
     }
     catch (...) {
       s_ednsdomains.add(DNSName(allow));


### PR DESCRIPTION
Casting input part to Netmask does not allow to insert negation in s_ednsremotesubnets list as ComboAddress would not allow, however if we directly use addMask from NetmaskGroup negation are handled properly. In case the input is not a valid netmask, catch() will still add the string as a domain.

Note that this does not allow names to be negated.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
