### PR TITLE
dnsdist: Properly link with `libdl` when building with `autotools`

### DIFF
--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -15,7 +15,9 @@ CPPFLAGS="-DDNSDIST $CPPFLAGS"
 m4_pattern_forbid([^_?PKG_[A-Z_]+$], [*** pkg.m4 missing, please install pkg-config])
 
 LT_PREREQ([2.2.2])
-LT_INIT([disable-static])
+# Rust runtime uses dlopen from its static lib
+LT_INIT([disable-static dlopen])
+AC_SUBST([LIBDL], [$lt_cv_dlopen_libs])
 
 CFLAGS="-g -O3 -Wall -Wextra -Wshadow -fvisibility=hidden $CFLAGS"
 CXXFLAGS="-g -O3 -Wall -Wextra -Wshadow -Wmissing-declarations -Wredundant-decls -fvisibility=hidden $CXXFLAGS"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Depending on the system we might actually need to link with `libdl` when our Rust library is used, and the mechanism to do that was not properly set up when building with `autotools` (we were adding `LIBDL` to the the libraries we need but the variable was not properly filled). Unfortunately the systems we are exercising in our CI do not need to explicitly link with `libdl` so we did not notice.

Reported by @paddg in https://github.com/PowerDNS/pdns/discussions/15804#discussioncomment-13707873

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
