### PR TITLE
dnsdist: Allow registering NMG objects from YAML

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1785,9 +1785,8 @@ void registerKVSObjects([[maybe_unused]] const KeyValueStoresConfiguration& conf
 void registerNMGObjects(const ::rust::Vec<NetmaskGroupConfiguration>& nmgs)
 {
   for (const auto& netmaskGroup : nmgs) {
-    std::shared_ptr<NetmaskGroup> nmg;
     bool registered = true;
-    nmg = dnsdist::configuration::yaml::getRegisteredTypeByName<NetmaskGroup>(std::string(netmaskGroup.name));
+    auto nmg = dnsdist::configuration::yaml::getRegisteredTypeByName<NetmaskGroup>(std::string(netmaskGroup.name));
     if (!nmg) {
       nmg = std::make_shared<NetmaskGroup>();
       registered = false;

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1782,6 +1782,26 @@ void registerKVSObjects([[maybe_unused]] const KeyValueStoresConfiguration& conf
 #endif /* defined(HAVE_LMDB) || defined(HAVE_CDB) */
 }
 
+void registerNMGObjects(const ::rust::Vec<NetmaskGroupConfiguration>& nmgs)
+{
+  for (const auto& netmaskGroup : nmgs) {
+    std::shared_ptr<NetmaskGroup> nmg;
+    bool registered = true;
+    nmg = dnsdist::configuration::yaml::getRegisteredTypeByName<NetmaskGroup>(std::string(netmaskGroup.name));
+    if (!nmg) {
+      nmg = std::make_shared<NetmaskGroup>();
+      registered = false;
+    }
+
+    for (const auto& netmask : netmaskGroup.netmasks) {
+      nmg->addMask(std::string(netmask));
+    }
+    if (!registered) {
+      dnsdist::configuration::yaml::registerType<NetmaskGroup>(nmg, netmaskGroup.name);
+    }
+  }
+}
+
 std::shared_ptr<DNSSelector> getLuaSelector(const LuaSelectorConfiguration& config)
 {
   dnsdist::selectors::LuaSelectorFunction function;

--- a/pdns/dnsdistdist/dnsdist-rust-bridge.hh
+++ b/pdns/dnsdistdist/dnsdist-rust-bridge.hh
@@ -33,10 +33,12 @@ struct DNSResponseActionWrapper
 struct ProtobufLoggerConfiguration;
 struct DnstapLoggerConfiguration;
 struct KeyValueStoresConfiguration;
+struct NetmaskGroupConfiguration;
 
 void registerProtobufLogger(const ProtobufLoggerConfiguration& config);
 void registerDnstapLogger(const DnstapLoggerConfiguration& config);
 void registerKVSObjects(const KeyValueStoresConfiguration& config);
+void registerNMGObjects(const ::rust::Vec<NetmaskGroupConfiguration>& nmgs);
 
 #include "dnsdist-rust-bridge-actions-generated.hh"
 #include "dnsdist-rust-bridge-selectors-generated.hh"

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
@@ -15,6 +15,7 @@
         fn registerProtobufLogger(config: &ProtobufLoggerConfiguration);
         fn registerDnstapLogger(config: &DnstapLoggerConfiguration);
         fn registerKVSObjects(config: &KeyValueStoresConfiguration);
+        fn registerNMGObjects(nmgs: &Vec<NetmaskGroupConfiguration>);
     }
 }
 

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-post-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-post-in.rs
@@ -74,6 +74,7 @@ fn get_global_configuration_from_serde(
     config.load_balancing_policies = serde.load_balancing_policies;
     config.logging = serde.logging;
     config.metrics = serde.metrics;
+    config.netmask_groups = serde.netmask_groups;
     config.packet_caches = serde.packet_caches;
     config.pools = serde.pools;
     config.proxy_protocol = serde.proxy_protocol;
@@ -89,6 +90,8 @@ fn get_global_configuration_from_serde(
     register_remote_loggers(&config.remote_logging);
     // this needs to be done before the rules so that they can refer to the KVS objects
     dnsdistsettings::registerKVSObjects(&config.key_value_stores);
+    // this needs to be done before the rules so that they can refer to the NMG objects
+    dnsdistsettings::registerNMGObjects(&config.netmask_groups);
     // this needs to be done BEFORE the rules so that they can refer to the selectors
     // by name
     config.selectors = get_selectors_from_serde(&serde.selectors)?;

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -73,6 +73,10 @@ global:
       type: "MetricsConfiguration"
       default: true
       description: "Metrics-related settings"
+    - name: "netmask_groups"
+      type: "Vec<NetmaskGroupConfiguration>"
+      default: true
+      description: "Netmask groups definitions"
     - name: "packet_caches"
       type: "Vec<PacketCacheConfiguration>"
       default: true
@@ -1873,6 +1877,17 @@ general:
                      Keeping ``CAP_SYS_ADMIN`` on kernel 5.8+ for example allows loading eBPF programs and altering eBPF maps at runtime even if the ``kernel.unprivileged_bpf_disabled`` sysctl is set.
                      Note that this does not grant the capabilities to the process, doing so might be done by running it as root which we don't advise, or by adding capabilities via the systemd unit file, for example.
                      Please also be aware that switching to a different user via ``--uid`` will still drop all capabilities."
+
+netmask_group:
+  description: "Group of netmasks"
+  parameters:
+    - name: "name"
+      type: "String"
+      description: "The name of this netmask group"
+    - name: "netmasks"
+      type: "Vec<String>"
+      default: ""
+      description: "List of netmasks"
 
 packet_cache:
   description: "Packet-cache settings"

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1887,7 +1887,7 @@ netmask_group:
     - name: "netmasks"
       type: "Vec<String>"
       default: ""
-      description: "List of netmasks"
+      description: "List of netmasks. A subnet that is not followed by ``/`` will be interpreted as a ``/32`` or ``/128`` subnet (a single address), depending on address family. It is possible to exclude ranges by prefixing an item with the negation character ``!``"
 
 packet_cache:
   description: "Packet-cache settings"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Until now it was possible to reference NMG objects in the YAML configuration but not to create one, which is a bit silly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
