### PR TITLE
Add record search capability to the LMDB backend

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -11,7 +11,7 @@ LMDB backend
 * DNSSEC: Yes
 * Disabled data: Yes
 * Comments: No
-* Search: No
+* Search: since version 5.0.0
 * Views: Yes
 * API: Read-Write
 * Multiple instances: No

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -11,8 +11,8 @@ upgrade notes if your version is older than 3.4.2.
 4.9.0 to 5.0.0/master
 ---------------------
 
-LMDB backend, views and DNS Update support
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LMDB backend, views
+^^^^^^^^^^^^^^^^^^^
 
 Version 5.0.0-alpha1 ships a new version of the LMDB database schema (called version 6), in support of the new views feature.
 There is no downgrade process.
@@ -25,7 +25,16 @@ While many things have been thoroughly tested, some loose ends likely remain.
 Specifically, catalog zones have not been updated for views support at all.
 Most other things are expected to work; if you find something wrong, please :ref:`let us know <getting-support>`.
 
+LMDB backend, DNS Update support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The LMDB backend also now supports :doc:`DNS Update <dnsupdate>` (RFC2136).
+
+LMDB backend, search support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The record search from the :doc:`HTTP API <http-api/search>` functionality has 
+been implemented in the LMDB backend.
 
 LOC record parsing
 ^^^^^^^^^^^^^^^^^^

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -88,6 +88,7 @@ public:
   bool feedEnts3(domainid_t domain_id, const DNSName& domain, map<DNSName, bool>& nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
   bool replaceRRSet(domainid_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
   bool replaceComments(domainid_t domain_id, const DNSName& qname, const QType& qt, const vector<Comment>& comments) override;
+  bool searchRecords(const string& pattern, size_t maxResults, vector<DNSResourceRecord>& result) override;
 
   void viewList(vector<string>& /* result */) override;
   void viewListZones(const string& /* view */, vector<ZoneName>& /* result */) override;

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -2118,7 +2118,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.assertEqual(serverset['records'], rrset2['records'])
         self.assertEqual(serverset['comments'], rrset['comments'])
 
-    @unittest.skipIf(is_auth_lmdb(), "No search in LMDB")
     def test_search_rr_exact_zone(self):
         name = unique_zone_name()
         self.create_zone(name=name, serial=22, soa_edit_api='')
@@ -2138,7 +2137,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
              u'ttl': 3600, u'type': u'SOA', u'name': name},
         ])
 
-    @unittest.skipIf(is_auth_lmdb(), "No search in LMDB")
     def test_search_rr_exact_zone_filter_type_zone(self):
         name = unique_zone_name()
         data_type = "zone"
@@ -2150,7 +2148,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
             {u'object_type': u'zone', u'name': name, u'zone_id': name},
         ])
 
-    @unittest.skipIf(is_auth_lmdb(), "No search in LMDB")
     def test_search_rr_exact_zone_filter_type_record(self):
         name = unique_zone_name()
         data_type = "record"
@@ -2170,7 +2167,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
              u'ttl': 3600, u'type': u'SOA', u'name': name},
         ])
 
-    @unittest.skipIf(is_auth_lmdb(), "No search in LMDB")
     def test_search_rr_substring(self):
         name = unique_zone_name()
         search = name[5:-5]
@@ -2181,7 +2177,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         # should return zone, SOA, ns1, ns2
         self.assertEqual(len(r.json()), 4)
 
-    @unittest.skipIf(is_auth_lmdb(), "No search in LMDB")
     def test_search_rr_case_insensitive(self):
         name = unique_zone_name()+'testsuffix.'
         self.create_zone(name=name)
@@ -2191,7 +2186,7 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         # should return zone, SOA, ns1, ns2
         self.assertEqual(len(r.json()), 4)
 
-    @unittest.skipIf(is_auth_lmdb(), "No search or comments in LMDB")
+    @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
     def test_search_rr_comment(self):
         name = unique_zone_name()
         rrsets = [{
@@ -2219,7 +2214,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.assertEqual(data[0]['name'], name)
         self.assertEqual(data[0]['content'], rrsets[0]['comments'][0]['content'])
 
-    @unittest.skipIf(is_auth_lmdb(), "No search in LMDB")
     def test_search_after_rectify_with_ent(self):
         name = unique_zone_name()
         search = name.split('.')[0]


### PR DESCRIPTION
### Short description
As proposed in #14079, this adds (quite crudely) search support to the LMDB backend.
Note that only records may be searched, as the LMDB does not currently support comments.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
