### PR TITLE
dnsdist-rust-lib: honor RUSTC_TARGET_ARCH

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/Makefile.am
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/Makefile.am
@@ -11,9 +11,9 @@ all install: libdnsdist_rust.a
 
 libdnsdist_rust.a: src/lib.rs src/helpers.rs Cargo.toml Cargo.lock
 	SYSCONFDIR=$(sysconfdir) $(CARGO) build --release $(RUST_TARGET) --target-dir=$(builddir)/target --manifest-path ${srcdir}/Cargo.toml --locked
-	cp target/release/libdnsdist_rust.a libdnsdist_rust.a
-	cp target/cxxbridge/dnsdist-rust/src/lib.rs.h lib.rs.h
-	cp target/cxxbridge/rust/cxx.h cxx.h
+	cp target/$(RUSTC_TARGET_ARCH)/release/libdnsdist_rust.a libdnsdist_rust.a
+	cp target/$(RUSTC_TARGET_ARCH)/cxxbridge/dnsdist-rust/src/lib.rs.h lib.rs.h
+	cp target/$(RUSTC_TARGET_ARCH)/cxxbridge/rust/cxx.h cxx.h
 
 clean-local:
 	rm -rf libdnsdist_rust.a lib.rs.h cxx.h target


### PR DESCRIPTION
### Short description

Like for pdns-recursor and also like in the meson build.

Necessary as Debian's cargo always puts the output files into `target/<arch>/...`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
