### PR TITLE
datefudge: more portable date parsing; py3 fixes

### DIFF
--- a/regression-tests.nobackend/edns1/test-edns.py
+++ b/regression-tests.nobackend/edns1/test-edns.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import socket

--- a/regression-tests.nobackend/negcache-tests-dotted-cname/pipe.py
+++ b/regression-tests.nobackend/negcache-tests-dotted-cname/pipe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/regression-tests.nobackend/soa-edit/command
+++ b/regression-tests.nobackend/soa-edit/command
@@ -31,7 +31,7 @@ rm -f soa-edit/bind-dnssec.db
 $PDNSUTIL --config-dir=soa-edit create-bind-db soa-edit/bind-dnssec.db
 $PDNSUTIL --config-dir soa-edit/ set-meta minimal.com SOA-EDIT INCREMENT-WEEKS
 # Wed Dec 17 23:59:50 2014 UTC
-datefudge "$(date -d@1418860790)" $PDNS --config-dir=soa-edit &
+datefudge "$(LC_ALL=C date -d@1418860790)" $PDNS --config-dir=soa-edit &
 bindwait
 
 $SDIG 127.0.0.1 $port minimal.com SOA | LC_ALL=C sort


### PR DESCRIPTION
### Short description
This makes the datefudge call work on systems with common non-C locales.

After opening this PR, I found two more tests that did not run on my system. The second commit fixes those by explicitly calling `python3`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
