### PR TITLE
docs: zone: `modified_at` is a separate property when updating RRSets

### DIFF
--- a/docs/common/api/zone.rst
+++ b/docs/common/api/zone.rst
@@ -10,7 +10,8 @@ RRSet
   :property integer ttl: DNS TTL of the records, in seconds. MUST NOT be included when ``changetype`` is set to "DELETE".
   :property string changetype: MUST be added when updating the RRSet. Must be ``REPLACE`` or ``DELETE``. With ``DELETE``, all existing RRs matching ``name`` and ``type`` will be deleted,  including all comments. With ``REPLACE``: when ``records`` is present, all existing RRs matching ``name`` and ``type`` will be deleted, and then new records given in ``records`` will be created. If no records are left, any existing comments will be deleted as well. When ``comments`` is present, all existing comments for the RRs matching ``name`` and ``type`` will be deleted, and then new comments given in ``comments`` will be created.
   :property [RREntry] records: All records in this RRSet. When updating records, this is the list of new records (replacing the old ones). Must be empty when ``changetype`` is set to ``DELETE``. An empty list results in deletion of all records (and comments).
-  :property [Comment] comments: List of :json:object:`Comment`. Must be empty when ``changetype`` is set to ``DELETE``. An empty list results in deletion of all comments. ``modified_at`` is optional and defaults to the current server time.
+  :property [Comment] comments: List of :json:object:`Comment`. Must be empty when ``changetype`` is set to ``DELETE``. An empty list results in deletion of all comments.
+  :property integer modified_at: optional timestamp, defaults to the current server time.
 
 RREntry
 -------


### PR DESCRIPTION
`modified_at` is a stand alone property, so it warrants its own item in the RRSet object properties.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document