### PR TITLE
dnsdist-2.0.x: Backport 15819 - Handle named rcodes in the YAML configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -869,6 +869,7 @@ if get_option('unit-tests')
       src_dir / 'test-credentials_cc.cc',
       src_dir / 'test-digests_hh.cc',
       src_dir / 'test-distributor_hh.cc',
+      src_dir / 'test-dns_cc.cc',
       src_dir / 'test-dns_random_hh.cc',
       src_dir / 'test-dnsname_cc.cc',
       src_dir / 'test-dnsparser_cc.cc',

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1398,6 +1398,7 @@ testrunner_SOURCES = \
 	test-credentials_cc.cc \
 	test-digests_hh.cc \
 	test-distributor_hh.cc \
+	test-dns_cc.cc \
 	test-dns_random_hh.cc \
 	test-dnsname_cc.cc \
 	test-dnsparser_cc.cc \

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -85,6 +85,18 @@ std::string RCode::to_short_s(uint8_t rcode) {
   return rcodes_short_s.at(rcode);
 }
 
+std::optional<uint8_t> RCode::from_short(const std::string_view& rcode_string)
+{
+  uint8_t position = 0;
+  for (const auto& short_rcode : rcodes_short_s) {
+    if (short_rcode == rcode_string) {
+      return position;
+    }
+    ++position;
+  }
+  return std::nullopt;
+}
+
 std::string ERCode::to_s(uint16_t rcode) {
   if (rcode >= RCode::rcodes_s.size()) {
     return std::string("Err#")+std::to_string(rcode);

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -58,7 +58,7 @@ const std::array<std::string, 24> RCode::rcodes_s = {
   "Bad/missing Server Cookie"
 };
 
-static const std::array<std::string, 11> rcodes_short_s =  {
+static const std::array<std::string, 24> rcodes_short_s =  {
   "noerror",
   "formerr",
   "servfail",
@@ -70,6 +70,19 @@ static const std::array<std::string, 11> rcodes_short_s =  {
   "nxrrset",
   "notauth",
   "notzone",
+  "rcode11",
+  "rcode12",
+  "rcode13",
+  "rcode14",
+  "rcode15",
+  "badvers",
+  "badkey",
+  "badtime",
+  "badmode",
+  "badname",
+  "badalg",
+  "badtrunc",
+  "badcookie",
 };
 
 std::string RCode::to_s(uint8_t rcode) {
@@ -80,10 +93,10 @@ std::string RCode::to_s(uint8_t rcode) {
 }
 
 std::string RCode::to_short_s(uint8_t rcode) {
-  if (rcode >= rcodes_short_s.size()) {
-    return "rcode" + std::to_string(rcode);
+  if (rcode > 0xF) {
+    return std::string("ErrOutOfRange");
   }
-  return rcodes_short_s.at(rcode);
+  return ERCode::to_short_s(rcode);
 }
 
 std::optional<uint8_t> RCode::from_short(const std::string_view& rcode_string)
@@ -92,14 +105,34 @@ std::optional<uint8_t> RCode::from_short(const std::string_view& rcode_string)
   if (position == rcodes_short_s.end()) {
     return std::nullopt;
   }
-  return std::distance(rcodes_short_s.begin(), position);
+  auto code = std::distance(rcodes_short_s.begin(), position);
+  if (code > 0xF) {
+    return std::nullopt;
+  }
+  return code;
 }
 
 std::string ERCode::to_s(uint16_t rcode) {
   if (rcode >= RCode::rcodes_s.size()) {
-    return std::string("Err#")+std::to_string(rcode);
+    return std::string("Err#") + std::to_string(rcode);
   }
   return RCode::rcodes_s.at(rcode);
+}
+
+std::string ERCode::to_short_s(uint16_t rcode) {
+  if (rcode >= rcodes_short_s.size()) {
+    return "rcode" + std::to_string(rcode);
+  }
+  return rcodes_short_s.at(rcode);
+}
+
+std::optional<uint16_t> ERCode::from_short(const std::string_view& ercode_string)
+{
+  const auto* position = std::find(rcodes_short_s.begin(), rcodes_short_s.end(), ercode_string);
+  if (position == rcodes_short_s.end()) {
+    return std::nullopt;
+  }
+  return std::distance(rcodes_short_s.begin(), position);
 }
 
 std::string Opcode::to_s(uint8_t opcode) {

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -87,14 +87,11 @@ std::string RCode::to_short_s(uint8_t rcode) {
 
 std::optional<uint8_t> RCode::from_short(const std::string_view& rcode_string)
 {
-  uint8_t position = 0;
-  for (const auto& short_rcode : rcodes_short_s) {
-    if (short_rcode == rcode_string) {
-      return position;
-    }
-    ++position;
+  auto position = std::find(rcodes_short_s.begin(), rcodes_short_s.end(), rcode_string);
+  if (position == rcodes_short_s.end()) {
+    return std::nullopt;
   }
-  return std::nullopt;
+  return std::distance(rcodes_short_s.begin(), position);
 }
 
 std::string ERCode::to_s(uint16_t rcode) {

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -87,14 +87,14 @@ static const std::array<std::string, 24> rcodes_short_s =  {
 
 std::string RCode::to_s(uint8_t rcode) {
   if (rcode > 0xF) {
-    return std::string("ErrOutOfRange");
+    return "ErrOutOfRange";
   }
   return ERCode::to_s(rcode);
 }
 
 std::string RCode::to_short_s(uint8_t rcode) {
   if (rcode > 0xF) {
-    return std::string("ErrOutOfRange");
+    return "ErrOutOfRange";
   }
   return ERCode::to_short_s(rcode);
 }

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -58,7 +58,7 @@ const std::array<std::string, 24> RCode::rcodes_s = {
   "Bad/missing Server Cookie"
 };
 
-static const std::array<std::string, 10> rcodes_short_s =  {
+static const std::array<std::string, 11> rcodes_short_s =  {
   "noerror",
   "formerr",
   "servfail",
@@ -69,6 +69,7 @@ static const std::array<std::string, 10> rcodes_short_s =  {
   "yxrrset",
   "nxrrset",
   "notauth",
+  "notzone",
 };
 
 std::string RCode::to_s(uint8_t rcode) {

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -88,7 +88,7 @@ std::string RCode::to_short_s(uint8_t rcode) {
 
 std::optional<uint8_t> RCode::from_short(const std::string_view& rcode_string)
 {
-  auto position = std::find(rcodes_short_s.begin(), rcodes_short_s.end(), rcode_string);
+  const auto* position = std::find(rcodes_short_s.begin(), rcodes_short_s.end(), rcode_string);
   if (position == rcodes_short_s.end()) {
     return std::nullopt;
   }

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -23,6 +23,8 @@
 #include "qtype.hh"
 #include "dnsname.hh"
 #include <ctime>
+#include <optional>
+#include <string_view>
 #include <sys/types.h>
 
 #undef BADSIG  // signal.h SIG_ERR
@@ -35,6 +37,7 @@ public:
   enum rcodes_ : uint8_t { NoError=0, FormErr=1, ServFail=2, NXDomain=3, NotImp=4, Refused=5, YXDomain=6, YXRRSet=7, NXRRSet=8, NotAuth=9, NotZone=10};
   static std::string to_s(uint8_t rcode);
   static std::string to_short_s(uint8_t rcode);
+  static std::optional<uint8_t> from_short(const std::string_view& rcode_string);
   const static std::array<std::string, 24> rcodes_s;
 };
 

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -46,6 +46,8 @@ class ERCode
 public:
   enum rcodes_ : uint16_t { BADVERS=16, BADSIG=16, BADKEY=17, BADTIME=18, BADMODE=19, BADNAME=20, BADALG=21, BADTRUNC=22, BADCOOKIE=23 };
   static std::string to_s(uint16_t rcode);
+  static std::string to_short_s(uint16_t rcode);
+  static std::optional<uint16_t> from_short(const std::string_view& ercode_string);
 };
 
 class Opcode

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -392,6 +392,7 @@ testrunner_SOURCES = \
 	test-connectionmanagement_hh.cc \
 	test-credentials_cc.cc \
 	test-delaypipe_hh.cc \
+	test-dns_cc.cc \
 	test-dnscrypt_cc.cc \
 	test-dnsdist-connections-cache.cc \
 	test-dnsdist-dnsparser.cc \

--- a/pdns/dnsdistdist/dnsdist-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-actions-definitions.yml
@@ -53,9 +53,6 @@
 - name: "ERCode"
   description: "Reply immediately by turning the query into a response with the specified EDNS extended rcode"
   skip-cpp: true
-  changes:
-    - version: 2.1.0
-      content: "The ``rcode`` parameter used to be an unsigned integer and is now a string"
   parameters:
     - name: "rcode"
       type: "RCode"
@@ -257,9 +254,6 @@ The function will be invoked in a per-thread Lua state, without access to the gl
       description: "Whether subsequent rules should be executed after this one"
 - name: "RCode"
   description: "Reply immediately by turning the query into a response with the specified rcode"
-  changes:
-    - version: 2.1.0
-      content: "The ``rcode`` parameter used to be an unsigned integer and is now a string"
   skip-cpp: true
   parameters:
     - name: "rcode"

--- a/pdns/dnsdistdist/dnsdist-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-actions-definitions.yml
@@ -53,6 +53,9 @@
 - name: "ERCode"
   description: "Reply immediately by turning the query into a response with the specified EDNS extended rcode"
   skip-cpp: true
+  changes:
+    - version: 2.1.0
+      content: "The ``rcode`` parameter used to be an unsigned integer and is now a string"
   parameters:
     - name: "rcode"
       type: "RCode"
@@ -254,6 +257,9 @@ The function will be invoked in a per-thread Lua state, without access to the gl
       description: "Whether subsequent rules should be executed after this one"
 - name: "RCode"
   description: "Reply immediately by turning the query into a response with the specified rcode"
+  changes:
+    - version: 2.1.0
+      content: "The ``rcode`` parameter used to be an unsigned integer and is now a string"
   skip-cpp: true
   parameters:
     - name: "rcode"

--- a/pdns/dnsdistdist/dnsdist-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-actions-definitions.yml
@@ -55,7 +55,8 @@
   skip-cpp: true
   parameters:
     - name: "rcode"
-      type: "u8"
+      type: "RCode"
+      rust-type: "String"
       description: "The RCODE to respond with"
     - name: "vars"
       type: "ResponseConfig"
@@ -256,7 +257,8 @@ The function will be invoked in a per-thread Lua state, without access to the gl
   skip-cpp: true
   parameters:
     - name: "rcode"
-      type: "u8"
+      type: "RCode"
+      rust-type: "String"
       description: "The response code"
     - name: "vars"
       type: "ResponseConfig"

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -132,6 +132,17 @@ static bool getOptionalLuaFunction(T& destination, const ::rust::string& functio
   return true;
 }
 
+static uint8_t strToRCode(const std::string& context, const std::string& parameterName, const ::rust::String& rcode_rust_string)
+{
+  auto rcode_str = std::string(rcode_rust_string);
+  boost::to_lower(rcode_str);
+  auto rcode = RCode::from_short(rcode_str);
+  if (!rcode) {
+    return checkedConversionFromStr<uint8_t>(context, parameterName, rcode_rust_string);
+  }
+  return *rcode;
+}
+
 static std::optional<std::string> loadContentFromConfigurationFile(const std::string& fileName)
 {
   /* no check on the file size, don't do this with just any file! */
@@ -615,7 +626,7 @@ static void loadDynamicBlockConfiguration(const dnsdist::rust::settings::Dynamic
           ruleParams.d_tagSettings->d_name = std::string(rule.tag_name);
           ruleParams.d_tagSettings->d_value = std::string(rule.tag_value);
         }
-        dbrgObj->setRCodeRate(checkedConversionFromStr<int>("dynamic-rules.rules.rcode_rate", "rcode", rule.rcode), std::move(ruleParams));
+        dbrgObj->setRCodeRate(strToRCode("dynamic-rules.rules.rcode_rate", "rcode", rule.rcode), std::move(ruleParams));
       }
       else if (rule.rule_type == "rcode-ratio") {
         DynBlockRulesGroup::DynBlockRatioRule ruleParams(std::string(rule.comment), rule.action_duration, rule.ratio, rule.warning_ratio, rule.seconds, rule.action.empty() ? DNSAction::Action::None : DNSAction::typeFromString(std::string(rule.action)), rule.minimum_number_of_responses);
@@ -624,7 +635,7 @@ static void loadDynamicBlockConfiguration(const dnsdist::rust::settings::Dynamic
           ruleParams.d_tagSettings->d_name = std::string(rule.tag_name);
           ruleParams.d_tagSettings->d_value = std::string(rule.tag_value);
         }
-        dbrgObj->setRCodeRatio(checkedConversionFromStr<int>("dynamic-rules.rules.rcode_ratio", "rcode", rule.rcode), std::move(ruleParams));
+        dbrgObj->setRCodeRatio(strToRCode("dynamic-rules.rules.rcode_ratio", "rcode", rule.rcode), std::move(ruleParams));
       }
       else if (rule.rule_type == "qtype-rate") {
         DynBlockRulesGroup::DynBlockRule ruleParams(std::string(rule.comment), rule.action_duration, rule.rate, rule.warning_rate, rule.seconds, rule.action.empty() ? DNSAction::Action::None : DNSAction::typeFromString(std::string(rule.action)));

--- a/pdns/dnsdistdist/dnsdist-rules-generator.py
+++ b/pdns/dnsdistdist/dnsdist-rules-generator.py
@@ -66,6 +66,8 @@ def type_to_cpp(type_str, lua_interface, inside_container=False):
         if inside_container:
             return 'std::string'
         return 'const std::string&'
+    if type_str == 'RCode':
+        return 'uint8_t'
     return type_str
 
 def get_cpp_object_name(name, is_class=True):

--- a/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
@@ -498,6 +498,8 @@ def get_cpp_parameters(struct_name, parameters, skip_name):
             field = f'convertSVCRecordParameters({field})'
         elif ptype == 'SOAParams':
             field = f'convertSOAParams({field})'
+        elif ptype == 'RCode':
+            field = f'dnsdist::configuration::yaml::strToRCode("{struct_name}", "{name}", {field})'
         output += field
     return output
 

--- a/pdns/dnsdistdist/dnsdist-selectors-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-selectors-definitions.yml
@@ -44,7 +44,8 @@
   description: "Matches queries or responses with the specified rcode. The full 16bit RCode will be matched. If no EDNS OPT RR is present, the upper 12 bits are treated as 0"
   parameters:
     - name: "rcode"
-      type: "u64"
+      type: "RCode"
+      rust-type: "String"
       description: "The full 16bit RCode will be matched. If no EDNS OPT RR is present, the upper 12 bits are treated as 0"
 - name: "HTTPHeader"
   description: "Matches DNS over HTTPS queries with a HTTP header name whose content matches the supplied regular expression. It is necessary to set the ``keepIncomingHeaders`` to :func:`addDOHLocal()` to use this rule"
@@ -340,7 +341,8 @@ Set the ``source`` parameter to ``false`` to match against destination address i
   description: "Matches queries or responses with the specified rcode"
   parameters:
     - name: "rcode"
-      type: "u64"
+      type: "RCode"
+      rust-type: "String"
       description: "The response code, as a numerical value"
 - name: "RD"
   description: "Matches queries with the RD flag set"

--- a/pdns/dnsdistdist/dnsdist-selectors-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-selectors-definitions.yml
@@ -42,6 +42,9 @@
       description: "The EDNS version to match on"
 - name: "ERCode"
   description: "Matches queries or responses with the specified rcode. The full 16bit RCode will be matched. If no EDNS OPT RR is present, the upper 12 bits are treated as 0"
+  changes:
+    - version: 2.1.0
+      content: "The ``rcode`` parameter used to be an unsigned integer and is now a string"
   parameters:
     - name: "rcode"
       type: "RCode"
@@ -339,6 +342,9 @@ Set the ``source`` parameter to ``false`` to match against destination address i
       description: "The qtype, as a numerical value"
 - name: "RCode"
   description: "Matches queries or responses with the specified rcode"
+  changes:
+    - version: 2.1.0
+      content: "The ``rcode`` parameter used to be an unsigned integer and is now a string"
   parameters:
     - name: "rcode"
       type: "RCode"

--- a/pdns/dnsdistdist/dnsdist-selectors-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-selectors-definitions.yml
@@ -42,9 +42,6 @@
       description: "The EDNS version to match on"
 - name: "ERCode"
   description: "Matches queries or responses with the specified rcode. The full 16bit RCode will be matched. If no EDNS OPT RR is present, the upper 12 bits are treated as 0"
-  changes:
-    - version: 2.1.0
-      content: "The ``rcode`` parameter used to be an unsigned integer and is now a string"
   parameters:
     - name: "rcode"
       type: "RCode"
@@ -342,9 +339,6 @@ Set the ``source`` parameter to ``false`` to match against destination address i
       description: "The qtype, as a numerical value"
 - name: "RCode"
   description: "Matches queries or responses with the specified rcode"
-  changes:
-    - version: 2.1.0
-      content: "The ``rcode`` parameter used to be an unsigned integer and is now a string"
   parameters:
     - name: "rcode"
       type: "RCode"

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -578,6 +578,9 @@ dynamic_rules_settings:
 
 dynamic_rule:
   description: "Dynamic rule settings"
+  changes:
+    - version: 2.1.0
+      content: "The ``rcode`` parameter used to be an unsigned integer and is now a string"
   parameters:
     - name: "type"
       rename: "rule_type"

--- a/pdns/dnsdistdist/dnsdist-settings-documentation-generator.py
+++ b/pdns/dnsdistdist/dnsdist-settings-documentation-generator.py
@@ -105,6 +105,20 @@ def process_object(object_name, entries, entry_type, is_setting_struct=False, lu
     output += '-' * len(object_name) + '\n'
     output += '\n'
 
+    if 'version_added' in entries:
+        output += '  .. versionadded:: ' + entries['version_added'] + '\n'
+        output += '\n'
+
+    if 'changes' in entries:
+        for change in entries['changes']:
+            if not 'version' in change or not 'content' in change:
+                continue
+            version = change['version']
+            content = change['content']
+        output += f' .. versionchanged:: {version}\n'
+        output += f'   {content}\n'
+        output += '\n'
+
     if 'description' in entries:
         description = entries['description']
         output += description + '\n'

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -1,11 +1,6 @@
 Upgrade Guide
 =============
 
-2.0.x to 2.1.0
---------------
-
-Since 2.1.0, ``rcode``s in the ``YAML`` configuration can be specified either by their case-insensitive names (e.g. ``refused``), or by their numerical values (e.g. ``"5"``). Unfortunately in some contexts (:func:`RCodeRule`, :func:`ERCodeRule`, :func:`RCodeAction` and :func:`ERCodeAction`) this has the side-effect that a numerical value (``5``) is no longer accepted and has to be converted to a string (``"5"``).
-
 1.9.x to 2.0.0
 --------------
 

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -4,7 +4,7 @@ Upgrade Guide
 2.0.x to 2.1.0
 --------------
 
-Since 2.1.0, ``rcode``s in the ``YAML`` configuration can be specified either by their case-insensitive names (e.g. ``refused``), or by their numerical values (e.g. ``"5"``). Unfortunately in some contexts (:func:`RCodeRule`, :func:`ERCodeRule`, :func:`RCodeAction` and :func:`ERCodeAction`) this has a the side-effect that a numerical value (``5``) is no longer accepted and has to be converted to a string (``"5"``).
+Since 2.1.0, ``rcode``s in the ``YAML`` configuration can be specified either by their case-insensitive names (e.g. ``refused``), or by their numerical values (e.g. ``"5"``). Unfortunately in some contexts (:func:`RCodeRule`, :func:`ERCodeRule`, :func:`RCodeAction` and :func:`ERCodeAction`) this has the side-effect that a numerical value (``5``) is no longer accepted and has to be converted to a string (``"5"``).
 
 1.9.x to 2.0.0
 --------------

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -1,6 +1,11 @@
 Upgrade Guide
 =============
 
+2.0.x to 2.1.0
+--------------
+
+Since 2.1.0, ``rcode``s in the ``YAML`` configuration can be specified either by their case-insensitive names (e.g. ``refused``), or by their numerical values (e.g. ``"5"``). Unfortunately in some contexts (:func:`RCodeRule`, :func:`ERCodeRule`, :func:`RCodeAction` and :func:`ERCodeAction`) this has a the side-effect that a numerical value (``5``) is no longer accepted and has to be converted to a string (``"5"``).
+
 1.9.x to 2.0.0
 --------------
 

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -517,6 +517,7 @@ test_sources += files(
   src_dir / 'test-connectionmanagement_hh.cc',
   src_dir / 'test-credentials_cc.cc',
   src_dir / 'test-delaypipe_hh.cc',
+  src_dir / 'test-dns_cc.cc',
   src_dir / 'test-dnscrypt_cc.cc',
   src_dir / 'test-dnsdistasync.cc',
   src_dir / 'test-dnsdistbackend_cc.cc',

--- a/pdns/dnsdistdist/test-dns_cc.cc
+++ b/pdns/dnsdistdist/test-dns_cc.cc
@@ -1,0 +1,1 @@
+../test-dns_cc.cc

--- a/pdns/test-dns_cc.cc
+++ b/pdns/test-dns_cc.cc
@@ -33,7 +33,8 @@ BOOST_AUTO_TEST_SUITE(test_dnscc)
 
 BOOST_AUTO_TEST_CASE(test_rcode)
 {
-  BOOST_CHECK_EQUAL(RCode::to_s(255), "ErrOutOfRange");
+  BOOST_CHECK_EQUAL(RCode::to_s(16), "ErrOutOfRange");
+  BOOST_CHECK_EQUAL(RCode::to_short_s(16), "ErrOutOfRange");
 
   for (uint8_t idx = 0; idx <= RCode::NotZone; idx++) {
     auto long_s = RCode::to_s(idx);
@@ -45,6 +46,7 @@ BOOST_AUTO_TEST_CASE(test_rcode)
   }
 
   BOOST_CHECK_EQUAL(RCode::to_s(RCode::NotZone + 1), "Err#11");
+  BOOST_CHECK(!RCode::from_short("badcookie"));
 }
 
 BOOST_AUTO_TEST_CASE(test_ercode)
@@ -52,6 +54,10 @@ BOOST_AUTO_TEST_CASE(test_ercode)
   for (uint16_t idx = ERCode::BADVERS; idx <= ERCode::BADCOOKIE; idx++) {
     auto long_s = ERCode::to_s(idx);
     BOOST_CHECK(long_s.size() > 0);
+    auto short_s = ERCode::to_short_s(idx);
+    auto ercode = ERCode::from_short(short_s);
+    BOOST_CHECK(ercode);
+    BOOST_CHECK_EQUAL(*ercode, idx);
   }
 
   BOOST_CHECK_EQUAL(ERCode::to_s(ERCode::BADCOOKIE + 1), "Err#24");

--- a/pdns/test-dns_cc.cc
+++ b/pdns/test-dns_cc.cc
@@ -1,0 +1,80 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include "dns.hh"
+
+BOOST_AUTO_TEST_SUITE(test_dnscc)
+
+BOOST_AUTO_TEST_CASE(test_rcode)
+{
+  BOOST_CHECK_EQUAL(RCode::to_s(255), "ErrOutOfRange");
+
+  for (uint8_t idx = 0; idx <= RCode::NotZone; idx++) {
+    auto long_s = RCode::to_s(idx);
+    BOOST_CHECK(long_s.size() > 0);
+    auto short_s = RCode::to_short_s(idx);
+    auto rcode = RCode::from_short(short_s);
+    BOOST_CHECK(rcode);
+    BOOST_CHECK_EQUAL(*rcode, idx);
+  }
+
+  BOOST_CHECK_EQUAL(RCode::to_s(RCode::NotZone + 1), "Err#11");
+}
+
+BOOST_AUTO_TEST_CASE(test_ercode)
+{
+  for (uint16_t idx = ERCode::BADVERS; idx <= ERCode::BADCOOKIE; idx++) {
+    auto long_s = ERCode::to_s(idx);
+    BOOST_CHECK(long_s.size() > 0);
+  }
+
+  BOOST_CHECK_EQUAL(ERCode::to_s(ERCode::BADCOOKIE + 1), "Err#24");
+}
+
+BOOST_AUTO_TEST_CASE(test_opcode)
+{
+  for (uint8_t idx = Opcode::Query; idx <= Opcode::Update; idx++) {
+    auto long_s = Opcode::to_s(idx);
+    BOOST_CHECK(long_s.size() > 0);
+  }
+
+  BOOST_CHECK_EQUAL(Opcode::to_s(Opcode::Update + 1), std::to_string(Opcode::Update + 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_resource_record_place)
+{
+  for (uint8_t idx = DNSResourceRecord::Place::QUESTION; idx <= DNSResourceRecord::Place::ADDITIONAL; idx++) {
+    auto long_s = DNSResourceRecord::placeString(idx);
+    BOOST_CHECK(long_s.size() > 0);
+  }
+
+  BOOST_CHECK_EQUAL(DNSResourceRecord::placeString(DNSResourceRecord::Place::ADDITIONAL + 1), "?");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -816,7 +816,7 @@ query_rules:
       qname: "refused.doh.tests.powerdns.com."
     action:
       type: "RCode"
-      rcode: 5
+      rcode: "Refused"
   - name: "Spoof"
     selector:
       type: "QName"

--- a/regression-tests.dnsdist/test_DOH3.py
+++ b/regression-tests.dnsdist/test_DOH3.py
@@ -258,7 +258,7 @@ query_rules:
       qname: "refused.doq.tests.powerdns.com."
     action:
       type: "RCode"
-      rcode: 5
+      rcode: "Refused"
   - name: "Spoof"
     selector:
       type: "QName"

--- a/regression-tests.dnsdist/test_DOQ.py
+++ b/regression-tests.dnsdist/test_DOQ.py
@@ -96,7 +96,7 @@ query_rules:
       qname: "refused.doq.tests.powerdns.com."
     action:
       type: "RCode"
-      rcode: 5
+      rcode: "5"
   - name: "Spoof"
     selector:
       type: "QName"

--- a/regression-tests.dnsdist/test_DynBlocksServFail.py
+++ b/regression-tests.dnsdist/test_DynBlocksServFail.py
@@ -134,7 +134,7 @@ dynamic_rules:
         action_duration: %d
         comment: "Exceeded query rate"
         action: "Drop"
-        rcode: "2"
+        rcode: "servfail"
 
 backends:
   - address: "127.0.0.1:%d"

--- a/regression-tests.dnsdist/test_DynBlocksServFail.py
+++ b/regression-tests.dnsdist/test_DynBlocksServFail.py
@@ -112,3 +112,40 @@ class TestDynBlockGroupServFails(DynBlocksTest):
         """
         name = 'servfailrate.group.dynblocks.tests.powerdns.com.'
         self.doTestRCodeRate(name, dns.rcode.SERVFAIL)
+
+class TestDynBlockGroupServFailsYAML(DynBlocksTest):
+
+    _yaml_config_template = """---
+dynamic_rules:
+  - name: "Block client generating too many ServFails"
+    mask_ipv4: 24
+    mask_ipv6: 128
+    exclude_ranges:
+      - "192.0.2.1/32"
+      - "192.0.2.2/32"
+    include_ranges:
+      - "127.0.0.0/24"
+    exclude_domains:
+      - "unused."
+    rules:
+      - type: "rcode-rate"
+        rate: %d
+        seconds: %d
+        action_duration: %d
+        comment: "Exceeded query rate"
+        action: "Drop"
+        rcode: "2"
+
+backends:
+  - address: "127.0.0.1:%d"
+    protocol: Do53
+"""
+    _config_params = []
+    _yaml_config_params = ['_dynBlockQPS', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort']
+
+    def testDynBlocksServFailRate(self):
+        """
+        Dyn Blocks (group / YAML): Server Failure Rate
+        """
+        name = 'servfailrate.group.dynblocks.tests.powerdns.com.'
+        self.doTestRCodeRate(name, dns.rcode.SERVFAIL)

--- a/regression-tests.dnsdist/test_Yaml.py
+++ b/regression-tests.dnsdist/test_Yaml.py
@@ -218,7 +218,7 @@ query_rules:
         - "refused.yaml-lua-mix.test.powerdns.com."
     action:
       type: "RCode"
-      rcode: 5
+      rcode: "Refused"
 
 """
     _dnsDistPort = pickAvailablePort()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #15819 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
