### PR TITLE
dnsdist-2.0.x: Backport 15833 - Fix narrowing conversion on 32-bit systems by using uint64_t instead of size_t

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-configuration-items.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-configuration-items.cc
@@ -38,7 +38,7 @@ struct BooleanConfigurationItems
 struct UnsignedIntegerConfigurationItems
 {
   const std::function<void(dnsdist::configuration::RuntimeConfiguration& config, uint64_t value)> mutator;
-  const size_t maximumValue{std::numeric_limits<uint64_t>::max()};
+  const uint64_t maximumValue{std::numeric_limits<uint64_t>::max()};
 };
 
 struct StringConfigurationItems
@@ -53,7 +53,7 @@ struct BooleanImmutableConfigurationItems
 struct UnsignedIntegerImmutableConfigurationItems
 {
   const std::function<void(dnsdist::configuration::ImmutableConfiguration& config, uint64_t value)> mutator;
-  const size_t maximumValue{std::numeric_limits<uint64_t>::max()};
+  const uint64_t maximumValue{std::numeric_limits<uint64_t>::max()};
 };
 
 struct DoubleImmutableConfigurationItems

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -253,7 +253,7 @@ static void parseTLSConfig(TLSConfig& config, const std::string& context, boost:
 
 #endif // defined(HAVE_DNS_OVER_TLS) || defined(HAVE_DNS_OVER_HTTPS)
 
-void checkParameterBound(const std::string& parameter, uint64_t value, size_t max)
+void checkParameterBound(const std::string& parameter, uint64_t value, uint64_t max)
 {
   if (value > max) {
     throw std::runtime_error("The value (" + std::to_string(value) + ") passed to " + parameter + " is too large, the maximum is " + std::to_string(max));

--- a/pdns/dnsdistdist/dnsdist-lua.hh
+++ b/pdns/dnsdistdist/dnsdist-lua.hh
@@ -42,7 +42,7 @@ using luadnsrule_t = boost::variant<string, LuaArray<std::string>, std::shared_p
 std::shared_ptr<DNSRule> makeRule(const luadnsrule_t& var, const std::string& calledFrom);
 
 void parseRuleParams(boost::optional<luaruleparams_t>& params, boost::uuids::uuid& uuid, std::string& name, uint64_t& creationOrder);
-void checkParameterBound(const std::string& parameter, uint64_t value, size_t max = std::numeric_limits<uint16_t>::max());
+void checkParameterBound(const std::string& parameter, uint64_t value, uint64_t max = std::numeric_limits<uint16_t>::max());
 
 void setupLua(LuaContext& luaCtx, bool client, bool configCheck, const std::string& config);
 void setupLuaActions(LuaContext& luaCtx);

--- a/pdns/dnsdistdist/test-dnsdistrules_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrules_cc.cc
@@ -12,7 +12,7 @@
 #include "dnsdist-rules.hh"
 #include "dnsdist-rules-factory.hh"
 
-void checkParameterBound(const std::string& parameter, uint64_t value, size_t max)
+void checkParameterBound(const std::string& parameter, uint64_t value, uint64_t max)
 {
   if (value > max) {
     throw std::runtime_error("The value passed to " + parameter + " is too large, the maximum is " + std::to_string(max));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #15833 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
