### PR TITLE
lmdb-safe: Remove the read-only transactions counter

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -110,14 +110,10 @@ public:
   int getRWTX();
   void incRWTX();
   void decRWTX();
-  int getROTX();
-  void incROTX();
-  void decROTX();
 private:
   std::mutex d_openmut;
   std::shared_mutex d_countmutex;
   std::unordered_map<std::thread::id, std::atomic<int>> d_RWtransactionsOut;
-  std::unordered_map<std::thread::id, std::atomic<int>> d_ROtransactionsOut;
 };
 
 std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

LMDB requires:
- a transaction and its cursors must only be used by a single thread
- a thread may only have a single transaction at a time
- but, if `MDB_NOTLS` is in use, this does not apply to read-only transactions.

The first and second points are the reasons why we are keeping track of transactions, but because of the third point we cannot be strict with regard to read-only transactions, unless we keep track of whether the `MDB_NOTLS` flag is in use.

I recently noticed that I made a mistake in c340aa91bf37d8105d2b2390eecbadfca88c1d27, and `MDBEnv::getROTX()` now returns the number of read-write transactions instead of the number of read-only transactions. I also noticed that `MDBEnv::getROTX()` is not actually used, and we only enforce that a thread that already has a read-write transaction cannot open another transaction.
Since `MDBEnv::getROTX()` is not used, it makes not much sense to bear the cost of tracking read-only transactions so this commit removes the read-only transactions counter.

Another option would be to make lmdb-safe stricter: if we kept track of whether the `MDB_NOTLS` flag is in use, we could enforce:
- only one transaction when `MDB_NOTLS` is NOT in use. We then need to check both counters when opening a new transaction.
- only one read-write transaction but several read-only transaction allowed when `MDB_NOTLS` is in use.

@Habbie @miodvallat Any thoughts on which option makes more sense?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
