### PR TITLE
Fix lmdb-nsec3-optout-variant tests

### DIFF
--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -290,7 +290,13 @@ fi
 optout=0
 pkcs11=0
 
-if [ "${context: -13}" = "-nsec3-optout" ]
+if [ "${context: -8}" = "-variant" ]
+then
+	subcontext=${context%-variant}
+else
+	subcontext=${context}
+fi
+if [ "${subcontext: -13}" = "-nsec3-optout" ]
 then
         optout=1
 fi

--- a/regression-tests/tests/1dyndns-update-nsec3params-with-others/expected_result.lmdb-nsec3-optout-variant
+++ b/regression-tests/tests/1dyndns-update-nsec3params-with-others/expected_result.lmdb-nsec3-optout-variant
@@ -1,1 +1,0 @@
-expected_result.nsec3


### PR DESCRIPTION
### Short description
Fix the logic responsible for deciding whether we run in optout mode in `regression-tests`.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
