### PR TITLE
delete existing matching zones during (re)import

### DIFF
--- a/docs/manpages/zone2sql.1.rst
+++ b/docs/manpages/zone2sql.1.rst
@@ -58,16 +58,16 @@ OUTPUT Options
 OTHER Options
 -------------
 
+--delete-matching-domains
+    Adds a delete statement to the sql output to allow re-importing zones.
+    Mostly only useful during testing. This should not be used on a live DB
+    as you will override the zone with previous data.
+    You should have the optional foreign key relationship enabled in your 
+    schema if you use this or it will leave created abandoned records
 --filter-duplicate-soa
     If there's more than one SOA record in the zone (possibly because it
     was AXFR'd), ignore it. If this option is not set, all SOA records
     in the zone are emitted.
---delete-matching-domains
-    Adds a delete statement to the sql output to allow re-importing zones.
-    Mostly only useful during testing. This hould not be used on a live DB
-    as you will override the zone with previous data.
-    You should have the optional foreign key relationship enabled in your 
-    schema if you use this or it will leave created abandoned records
 --help
     List all options
 --on-error-resume-next

--- a/docs/manpages/zone2sql.1.rst
+++ b/docs/manpages/zone2sql.1.rst
@@ -60,11 +60,10 @@ OTHER Options
 
 --delete-matching-domains
     Adds a delete statement to the sql output to allow re-importing zones.
-    Mostly only useful during testing. This should not be used on a live DB
-    as you will override the zone with previous data.
+    Mostly only useful during testing.
     Since this will only delete the domain, but not its records, 
     you should have the optional foreign key relationship enabled in your 
-    schema in order not to leave dangling records.
+    schema in order to avoid leaving dangling records.
 --filter-duplicate-soa
     If there's more than one SOA record in the zone (possibly because it
     was AXFR'd), ignore it. If this option is not set, all SOA records

--- a/docs/manpages/zone2sql.1.rst
+++ b/docs/manpages/zone2sql.1.rst
@@ -62,6 +62,10 @@ OTHER Options
     If there's more than one SOA record in the zone (possibly because it
     was AXFR'd), ignore it. If this option is not set, all SOA records
     in the zone are emitted.
+--delete-matching-domains
+    Adds a delete statement to the sql output to allow re-importing zones.
+    Mostly only useful during testing. This hould not be used on a live DB
+    as you will override the zone with previous data.
 --help
     List all options
 --on-error-resume-next

--- a/docs/manpages/zone2sql.1.rst
+++ b/docs/manpages/zone2sql.1.rst
@@ -66,6 +66,8 @@ OTHER Options
     Adds a delete statement to the sql output to allow re-importing zones.
     Mostly only useful during testing. This hould not be used on a live DB
     as you will override the zone with previous data.
+    You should have the optional foreign key relationship enabled in your 
+    schema if you use this or it will leave created abandoned records
 --help
     List all options
 --on-error-resume-next

--- a/docs/manpages/zone2sql.1.rst
+++ b/docs/manpages/zone2sql.1.rst
@@ -62,8 +62,9 @@ OTHER Options
     Adds a delete statement to the sql output to allow re-importing zones.
     Mostly only useful during testing. This should not be used on a live DB
     as you will override the zone with previous data.
-    You should have the optional foreign key relationship enabled in your 
-    schema if you use this or it will leave created abandoned records
+    Since this will only delete the domain, but not its records, 
+    you should have the optional foreign key relationship enabled in your 
+    schema in order not to leave dangling records.
 --filter-duplicate-soa
     If there's more than one SOA record in the zone (possibly because it
     was AXFR'd), ignore it. If this option is not set, all SOA records

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -114,6 +114,9 @@ static void startNewTransaction()
 static void emitDomain(const ZoneName& domain, const vector<ComboAddress>* primaries = nullptr)
 {
   string iDomain = domain.toStringRootDot();
+  if (::arg().mustDo("delete-matching-domains")) {
+    cout << "DELETE FROM domains WHERE name=" << toLower(sqlstr(iDomain)) << ";" << endl;
+  }
   if (!::arg().mustDo("secondary")) {
     cout<<"insert into domains (name,type) values ("<<toLower(sqlstr(iDomain))<<",'NATIVE');"<<endl;
   }
@@ -209,6 +212,7 @@ try
     ::arg().setSwitch("transactions","If target SQL supports it, use transactions")="no";
     ::arg().setSwitch("on-error-resume-next","Continue after errors")="no";
     ::arg().setSwitch("filter-duplicate-soa","Filter second SOA in zone")="yes";
+    ::arg().setSwitch("delete-matching-domains", "Delete existing matching domains before emitting new domain")="no";
     ::arg().set("zone","Zonefile to parse")="";
     ::arg().set("zone-name","Specify an $ORIGIN in case it is not present")="";
     ::arg().set("named-conf","Bind 8/9 named.conf to parse")="";


### PR DESCRIPTION

### Short description
adds functionality to zone2sql import script to have a delete statement. useful for testing / retesting zone imports

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
