### PR TITLE
rec-5.0.x: Allow build-tags to run on forks

### DIFF
--- a/.github/workflows/build-tags.yml
+++ b/.github/workflows/build-tags.yml
@@ -8,6 +8,11 @@ on:
     - 'dnsdist-*'
     - 'rec-*'
 
+permissions:
+  actions: read
+  id-token: write
+  contents: write
+
 jobs:
   call-build-packages-auth:
     uses: PowerDNS/pdns/.github/workflows/build-packages.yml@master


### PR DESCRIPTION
build-tags uses: PowerDNS/pdns/.github/workflows/build-packages.yml@master As of f107ec62467b8779db9bbdb175721ef232ed52e5, that workflow requires:

    permissions:
      actions: read   # To read the workflow path.
      id-token: write # To sign the provenance.
      contents: write # To be able to upload assets as release artifacts

Per https://docs.github.com/en/actions/using-workflows/reusing-workflows in order for this to work, the calling job (in build-tags) needs to have the maximum required permissions in order for the calling workflow to be run.

(cherry picked from commit 8c4888c19d4997d7e443c6ad4953e716ee5429b0)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
