### PR TITLE
Provide record timestamps in the API

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: "0.0.16"
+  version: "0.0.17"
   title: PowerDNS Authoritative HTTP API
   license:
     name: MIT
@@ -1289,6 +1289,9 @@ definitions:
       disabled:
         type: boolean
         description: 'Whether or not this record is disabled. When unset, the record is not disabled'
+      modified_at:
+        type: integer
+        description: 'Timestamp of the last change to the record'
 
   Comment:
     title: Comment

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1751,6 +1751,8 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
  *                 cursor, i.e. same qname but possibly different qtype)
  * d_currentrrsetpos: position in the above when returning its elements one
  *                    by one
+ * d_currentrrsettime: timestamp of d_currentrrset (can't be stored in
+ *                     DNSZoneRecord)
  * d_currentKey: database key at cursor
  * d_currentVal: database contents at cursor
  * d_includedisabled: whether to include disabled records in the results
@@ -1900,6 +1902,7 @@ bool LMDBBackend::get(DNSZoneRecord& zr)
       }
 
       deserializeFromBuffer(d_currentVal.get<string_view>(), d_currentrrset);
+      d_currentrrsettime = LMDBLS::LSgetTimestamp(d_currentVal.getNoStripHeader<string_view>()) / (1000UL * 1000UL * 1000UL);
       d_currentrrsetpos = 0;
     }
     else {
@@ -1963,6 +1966,7 @@ bool LMDBBackend::get(DNSResourceRecord& rr)
   rr.domain_id = zr.domain_id;
   rr.auth = zr.auth;
   rr.disabled = zr.disabled;
+  rr.last_modified = d_currentrrsettime;
 
   return true;
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1902,7 +1902,7 @@ bool LMDBBackend::get(DNSZoneRecord& zr)
       }
 
       deserializeFromBuffer(d_currentVal.get<string_view>(), d_currentrrset);
-      d_currentrrsettime = LMDBLS::LSgetTimestamp(d_currentVal.getNoStripHeader<string_view>()) / (1000UL * 1000UL * 1000UL);
+      d_currentrrsettime = static_cast<time_t>(LMDBLS::LSgetTimestamp(d_currentVal.getNoStripHeader<string_view>()) / (1000UL * 1000UL * 1000UL));
       d_currentrrsetpos = 0;
     }
     else {

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -355,6 +355,7 @@ private:
   DNSName d_lookupsubmatch;
   vector<LMDBResourceRecord> d_currentrrset;
   size_t d_currentrrsetpos;
+  time_t d_currentrrsettime;
   MDBOutVal d_currentKey;
   MDBOutVal d_currentVal;
   bool d_includedisabled;

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -90,7 +90,7 @@ public:
 
   // Aligned on 8-byte boundaries on systems where time_t is 8 bytes and int
   // is 4 bytes, aka modern linux on x86_64
-  time_t last_modified{}; //!< For autocalculating SOA serial numbers - the backend needs to fill this in
+  time_t last_modified{}; //!< Timestamp of last update, if known by the backend
 
   uint32_t ttl{}; //!< Time To Live of this record
   uint32_t signttl{}; //!< If non-zero, use this TTL as original TTL in the RRSIG

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -525,9 +525,13 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
 
       while (rit != records.end() && rit->qname == current_qname && rit->qtype == current_qtype) {
         ttl = min(ttl, rit->ttl);
-        rrset_records.push_back(Json::object{
+        auto object = Json::object{
           {"disabled", rit->disabled},
-          {"content", makeApiRecordContent(rit->qtype, rit->content)}});
+          {"content", makeApiRecordContent(rit->qtype, rit->content)}};
+        if (rit->last_modified != 0) {
+          object["modified_at"] = (double)rit->last_modified;
+        }
+        rrset_records.push_back(object);
         rit++;
       }
       while (cit != comments.end() && cit->qname == current_qname && cit->qtype == current_qtype) {
@@ -2596,6 +2600,9 @@ static void apiServerSearchData(HttpRequest* req, HttpResponse* resp)
         {"ttl", (double)resourceRecord.ttl},
         {"disabled", resourceRecord.disabled},
         {"content", makeApiRecordContent(resourceRecord.qtype, resourceRecord.content)}};
+      if (resourceRecord.last_modified != 0) {
+        object["modified_at"] = (double)resourceRecord.last_modified;
+      }
 
       val = zoneIdZone.find(resourceRecord.domain_id);
       if (val != zoneIdZone.end()) {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -10,9 +10,15 @@ from pprint import pprint
 from test_helper import ApiTestCase, unique_zone_name, is_auth, is_auth_lmdb, is_recursor, get_db_records, pdnsutil_rectify, sdig
 
 
+def remove_timestamp(json):
+    for item in json:
+        if 'modified_at' in item:
+            del item['modified_at']
+
 def get_rrset(data, qname, qtype):
     for rrset in data['rrsets']:
         if rrset['name'] == qname and rrset['type'] == qtype:
+            remove_timestamp(rrset['records'])
             return rrset
     return None
 
@@ -887,7 +893,10 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         data = self.get_zone(example_com['id'], rrset_name="host-18000.example.com.")
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'rrsets'):
             self.assertIn(k, data)
-        self.assertEqual(data['rrsets'],
+        received_rrsets = data['rrsets']
+        for rrset in received_rrsets:
+            remove_timestamp(rrset['records'])
+        self.assertEqual(received_rrsets,
             [
                 {
                     'comments': [],
@@ -943,7 +952,10 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         data = self.get_zone(powerdnssec_org['id'], rrset_name="localhost.powerdnssec.org.")
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'rrsets'):
             self.assertIn(k, data)
-        self.assertEqual(sorted(data['rrsets'], key=operator.itemgetter('type')),
+        received_rrsets = data['rrsets']
+        for rrset in received_rrsets:
+            remove_timestamp(rrset['records'])
+        self.assertEqual(sorted(received_rrsets, key=operator.itemgetter('type')),
             [
                 {
                     'comments': [],
@@ -978,7 +990,10 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         data = self.get_zone(powerdnssec_org['id'], rrset_name="localhost.powerdnssec.org.", rrset_type="AAAA")
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'rrsets'):
             self.assertIn(k, data)
-        self.assertEqual(data['rrsets'],
+        received_rrsets = data['rrsets']
+        for rrset in received_rrsets:
+            remove_timestamp(rrset['records'])
+        self.assertEqual(received_rrsets,
             [
                 {
                     'comments': [],
@@ -2123,8 +2138,10 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.create_zone(name=name, serial=22, soa_edit_api='')
         r = self.session.get(self.url("/api/v1/servers/localhost/search-data?q=" + name.rstrip('.')))
         self.assert_success_json(r)
-        print(r.json())
-        self.assertCountEqual(r.json(), [
+        json = r.json()
+        print(json)
+        remove_timestamp(json)
+        self.assertCountEqual(json, [
             {u'object_type': u'zone', u'name': name, u'zone_id': name},
             {u'content': u'ns1.example.com.',
              u'zone_id': name, u'zone': name, u'object_type': u'record', u'disabled': False,
@@ -2154,8 +2171,10 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.create_zone(name=name, serial=22, soa_edit_api='')
         r = self.session.get(self.url("/api/v1/servers/localhost/search-data?q=" + name.rstrip('.') + "&object_type=" + data_type))
         self.assert_success_json(r)
-        print(r.json())
-        self.assertCountEqual(r.json(), [
+        json = r.json()
+        print(json)
+        remove_timestamp(json)
+        self.assertCountEqual(json, [
             {u'content': u'ns1.example.com.',
              u'zone_id': name, u'zone': name, u'object_type': u'record', u'disabled': False,
              u'ttl': 3600, u'type': u'NS', u'name': name},
@@ -2443,7 +2462,10 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
             rrset.setdefault('comments', [])
             for record in rrset['records']:
                 record.setdefault('disabled', False)
-        assert_eq_rrsets(data['rrsets'], rrsets)
+        received_rrsets = data['rrsets']
+        for rrset in received_rrsets:
+            remove_timestamp(rrset['records'])
+        assert_eq_rrsets(received_rrsets, rrsets)
 
     def test_zone_replace_rrsets_dnssec(self):
         """With dnssec: check automatic rectify is done"""


### PR DESCRIPTION
### Short description
This adds, similarly to comments, a "last modified" timestamp to the rrsets returned by the HTTP API, when this information is known. Currently only implemented in LMDB. I've been told some people have an interest in this.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
