### PR TITLE
TSIG metadata tweaks

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -4687,13 +4687,16 @@ static int activateTSIGKey(vector<string>& cmds, const std::string_view synopsis
   }
   if (!found) {
     meta.push_back(name);
-  }
-  if (B.setDomainMetadata(zname, metaKey, meta)) {
-    cout << "Enabled TSIG key " << name << " for " << zname << endl;
+    if (B.setDomainMetadata(zname, metaKey, meta)) {
+      cout << "Enabled TSIG key " << name << " for " << zname << endl;
+    }
+    else {
+      cerr << "Failure enabling TSIG key " << name << " for " << zname << endl;
+      return 1;
+    }
   }
   else {
-    cerr << "Failure enabling TSIG key " << name << " for " << zname << endl;
-    return 1;
+    cout << "TSIG key " << name << " is already enabled in zone " << zname << endl;
   }
   return 0;
 }
@@ -4735,13 +4738,16 @@ static int deactivateTSIGKey(vector<string>& cmds, const std::string_view synops
   }
   if (iter != meta.end()) {
     meta.erase(iter);
-  }
-  if (B.setDomainMetadata(zname, metaKey, meta)) {
-    cout << "Disabled TSIG key " << name << " for " << zname << endl;
+    if (B.setDomainMetadata(zname, metaKey, meta)) {
+      cout << "Disabled TSIG key " << name << " for " << zname << endl;
+    }
+    else {
+      cerr << "Failure disabling TSIG key " << name << " for " << zname << endl;
+      return 1;
+    }
   }
   else {
-    cerr << "Failure disabling TSIG key " << name << " for " << zname << endl;
-    return 1;
+    cout << "TSIG key " << name << " is not currently enabled in zone " << zname << endl;
   }
   return 0;
 }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2853,7 +2853,10 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
 
     meta.clear();
     if (B.getDomainMetadata(zone, "AXFR-MASTER-TSIG", meta) && !meta.empty()) {
-      cout << "Zone uses following TSIG key(s): " << boost::join(meta, ",") << endl;
+      // Although AXFR-MASTER-TSIG may contain a list of keys, the current
+      // state of DNSSECKeeper::getTSIGForAccess() causes only the first one
+      // to be ever used, so only list the first item here.
+      cout << "Zone uses following TSIG key: " << meta.front() << endl;
     }
 
     std::map<std::string, std::vector<std::string> > metamap;


### PR DESCRIPTION
### Short description
This is prompted by #9015.

Of the two metadata containing TSIG key names:
- `TSIG-ALLOW-AXFR` may contain multiple keys, although only the first one will be used to send signed notifications (and this particular behaviour is documented).
- `AXFR-MASTER-TSIG` may contain multiple keys, but only the first one will ever be used/considered in the current state of the code, and the documentation says it's a single key name

This PR prevents setting more than one key in `AXFR-MASTER-TSIG` from the API. The behaviour of `pdnsutil` to also prevent this was already implemented in commit 2a7cebaddbd89a534539fd733f73bdb89d248e7d.

As a bonus, `pdnsutil` will now skip performing `setDomainMetadata` calls if the metadata contents do not change.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
