### PR TITLE
LuaWrapper: Add support for `std::optional`

### DIFF
--- a/pdns/test-luawrapper.cc
+++ b/pdns/test-luawrapper.cc
@@ -41,8 +41,8 @@ BOOST_AUTO_TEST_SUITE(test_luawrapper)
 BOOST_AUTO_TEST_CASE(test_boost_optional)
 {
   LuaContext context;
-  context.writeFunction("testOptional", [](boost::optional<int> in) -> boost::optional<int> {
-    return in;
+  context.writeFunction("testOptional", [](boost::optional<int> incoming) -> boost::optional<int> {
+    return incoming;
   });
 
   BOOST_REQUIRE(!context.executeCode<boost::optional<int>>("return testOptional(nil)"));
@@ -57,8 +57,8 @@ BOOST_AUTO_TEST_CASE(test_boost_optional)
 BOOST_AUTO_TEST_CASE(test_std_optional)
 {
   LuaContext context;
-  context.writeFunction("testOptional", [](std::optional<int> in) -> std::optional<int> {
-    return in;
+  context.writeFunction("testOptional", [](std::optional<int> incoming) -> std::optional<int> {
+    return incoming;
   });
 
   BOOST_REQUIRE(!context.executeCode<std::optional<int>>("return testOptional(nil)"));

--- a/pdns/test-luawrapper.cc
+++ b/pdns/test-luawrapper.cc
@@ -35,3 +35,39 @@ BOOST_AUTO_TEST_CASE(test_registerFunction)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(test_luawrapper)
+
+BOOST_AUTO_TEST_CASE(test_boost_optional)
+{
+  LuaContext context;
+  context.writeFunction("testOptional", [](boost::optional<int> in) -> boost::optional<int> {
+    return in;
+  });
+
+  BOOST_REQUIRE(!context.executeCode<boost::optional<int>>("return testOptional(nil)"));
+
+  {
+    auto result = context.executeCode<boost::optional<int>>("return testOptional(1)");
+    BOOST_REQUIRE(result);
+    BOOST_CHECK_EQUAL(*result, 1);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_std_optional)
+{
+  LuaContext context;
+  context.writeFunction("testOptional", [](std::optional<int> in) -> std::optional<int> {
+    return in;
+  });
+
+  BOOST_REQUIRE(!context.executeCode<std::optional<int>>("return testOptional(nil)"));
+
+  {
+    auto result = context.executeCode<std::optional<int>>("return testOptional(1)");
+    BOOST_REQUIRE(result);
+    BOOST_CHECK_EQUAL(*result, 1);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
My motivation is that now that `std::optional` is available I prefer using it instead of `boost::optional`, and it is silly to have to convert between the two around the C++/Lua interface.
Ideally I would not mind removing support for `boost::optional` in LuaWrapper altogether, but this would require a significant amount of work.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
