### PR TITLE
scrub harder in zone rectify

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1107,7 +1107,7 @@ static std::shared_ptr<DNSRecordContent> deserializeContentZR(uint16_t qtype, co
 #define StringView string
 #endif
 
-void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match)
+void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match, QType qtype)
 {
   auto cursor = txn.txn->getCursor(txn.db->dbi);
   MDBOutVal key{};
@@ -1115,7 +1115,9 @@ void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, const std::stri
 
   if (cursor.prefix(match, key, val) == 0) {
     do {
-      cursor.del(key);
+      if (qtype == QType::ANY || compoundOrdername::getQType(key.getNoStripHeader<StringView>()) == qtype) {
+        cursor.del(key);
+      }
     } while (cursor.next(key, val) == 0);
   }
 }
@@ -3172,6 +3174,25 @@ bool LMDBBackend::hasCreatedLocalFiles() const
   // But since this information is for the sake of pdnsutil, this is not
   // really a problem.
   return MDBDbi::d_creationCount != 0;
+}
+
+// Hook for rectifyZone operation.
+// Before the operation starts, we forcibly remove all NSEC3 records from the
+// domain, since logic flaws in older versions may have left us with dangling
+// records. The appropriate records will be regenerated with
+// updateDNSSECOrderNameAndAuth() calls anyway.
+void LMDBBackend::rectifyZoneHook(domainid_t domain_id, bool before) const
+{
+  if (!before) {
+    return;
+  }
+
+  if (!d_rwtxn) {
+    throw DBException("rectifyZoneHook invoked outside of a transaction");
+  }
+
+  compoundOrdername order;
+  LMDBBackend::deleteDomainRecords(*d_rwtxn, order(domain_id), QType::NSEC3);
 }
 
 class LMDBFactory : public BackendFactory

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -171,6 +171,8 @@ public:
 
   bool hasCreatedLocalFiles() const override;
 
+  void rectifyZoneHook(domainid_t domain_id, bool before) const override;
+
   // functions to use without constructing a backend object
   static std::pair<uint32_t, uint32_t> getSchemaVersionAndShards(std::string& filename);
   static bool upgradeToSchemav5(std::string& filename);
@@ -335,7 +337,7 @@ private:
   std::shared_ptr<RecordsROTransaction> getRecordsROTransaction(domainid_t id, const std::shared_ptr<LMDBBackend::RecordsRWTransaction>& rwtxn = nullptr);
   int genChangeDomain(const ZoneName& domain, const std::function<void(DomainInfo&)>& func);
   int genChangeDomain(domainid_t id, const std::function<void(DomainInfo&)>& func);
-  static void deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match);
+  static void deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match, QType qtype = QType::ANY);
 
   void getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow);
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -855,6 +855,8 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
   if (doTransaction)
     sd.db->startTransaction(zone, UnknownDomainID);
 
+  sd.db->rectifyZoneHook(sd.domain_id, true);
+
   bool realrr=true;
   bool doent=true;
   int updates=0;
@@ -966,6 +968,8 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
       goto dononterm;
     }
   }
+
+  sd.db->rectifyZoneHook(sd.domain_id, false);
 
   if (doTransaction)
     sd.db->commitTransaction();

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -513,6 +513,10 @@ public:
     return false;
   }
 
+  virtual void rectifyZoneHook(domainid_t /*domain_id*/, bool /*before*/) const
+  {
+  }
+
   const string& getPrefix() { return d_prefix; };
 
 protected:


### PR DESCRIPTION
### Short description
This adds plumbing to the backend so that they can perform specific actions at the beginning, and at the end, of a zone rectification.

Make use of this in LMDB to destroy all NSEC3 records before rectification, as these records will be recomputed. This allows us to get rid of possibly dangling records left by older versions of the LMDB backend (where here older means "before the NSEC3 logic fixes of this month", i.e. before 20250711).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
