### PR TITLE
auth gsqlite3: enable Foreign Key support by default

### DIFF
--- a/builder-support/debian/authoritative/debian-buster/config/gsqlite3.conf
+++ b/builder-support/debian/authoritative/debian-buster/config/gsqlite3.conf
@@ -16,7 +16,7 @@ gsqlite3-dnssec=on
 #################################
 # gsqlite3-pragma-foreign-keys	Enable foreign key constraints
 #
-# gsqlite3-pragma-foreign-keys=no
+# gsqlite3-pragma-foreign-keys=yes
 
 #################################
 # gsqlite3-pragma-journal-mode	SQLite3 journal mode

--- a/docs/backends/generic-sqlite3.rst
+++ b/docs/backends/generic-sqlite3.rst
@@ -94,7 +94,13 @@ Set this to 0 for blazing speed.
 ``gsqlite3-pragma-foreign-keys``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+-  Boolean
+-  Default: yes
+
 Enable foreign key constraints.
+
+.. note::
+  Before version 5.0.0, the default was no.
 
 .. _setting-gsqlite3-dnssec:
 

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -76,7 +76,7 @@ public:
   {
     declare(suffix, "database", "Filename of the SQLite3 database", "powerdns.sqlite");
     declare(suffix, "pragma-synchronous", "Set this to 0 for blazing speed", "");
-    declare(suffix, "pragma-foreign-keys", "Enable foreign key constraints", "no");
+    declare(suffix, "pragma-foreign-keys", "Enable foreign key constraints", "yes");
     declare(suffix, "pragma-journal-mode", "SQLite3 journal mode", "WAL");
 
     declare(suffix, "dnssec", "Enable DNSSEC processing", "no");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Defaulting it to off is surprising, and 5.0.0 is probably a good time to flip the default.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
