### PR TITLE
Backport 15652 to rec-5.1.x: when using ZTC, do not store non-auth data if the name is subject to recursive forwarding

### DIFF
--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -418,10 +418,12 @@ void ZoneData::ZoneToCache(const RecZoneToCache::Config& config)
         sigsrr = iter->second;
       }
       bool auth = isRRSetAuth(qname, qtype);
-      // Same decision as updateCacheFromRecords() (we do not test for NSEC since we skip those completely)
-      if (auth || (qtype == QType::NS || qtype == QType::A || qtype == QType::AAAA || qtype == QType::DS)) {
-        g_recCache->replace(d_now, qname, qtype, v, sigsrr,
-                            std::vector<std::shared_ptr<DNSRecord>>(), auth, d_zone);
+      // Same list as updateCacheFromRecords() (we do not test for NSEC since we skip those completely)
+      // Issue #15651
+      bool storeNonAuth = !SyncRes::isRecursiveForward(qname);
+      if (auth || (storeNonAuth && (qtype == QType::NS || qtype == QType::A || qtype == QType::AAAA || qtype == QType::DS))) {
+        g_recCache->replace(d_now, qname, qtype, v, sigsrr, {},
+                            auth, d_zone);
       }
       break;
     }

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -1057,6 +1057,13 @@ bool SyncRes::isRecursiveForwardOrAuth(const DNSName& qname)
   return iter != t_sstorage.domainmap->end() && (iter->second.isAuth() || iter->second.shouldRecurse());
 }
 
+bool SyncRes::isRecursiveForward(const DNSName& qname)
+{
+  DNSName authname(qname);
+  const auto iter = getBestAuthZone(&authname);
+  return iter != t_sstorage.domainmap->end() && iter->second.shouldRecurse();
+}
+
 bool SyncRes::isForwardOrAuth(const DNSName& qname)
 {
   DNSName authname(qname);

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -282,6 +282,7 @@ public:
   {
     return t_sstorage.domainmap;
   }
+  static bool isRecursiveForward(const DNSName& qname);
 
   static void setECSScopeZeroAddress(const Netmask& scopeZeroMask)
   {


### PR DESCRIPTION
Fixes #15651

(cherry picked from commit 753ad2390bfbc90f6bc1b68f980ef4bcdc2cfddc)

Backport of #15652 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
