### PR TITLE
dnsdist: Fix invalid "qps" in Quickstart Guide

### DIFF
--- a/pdns/dnsdistdist/docs/quickstart.rst
+++ b/pdns/dnsdistdist/docs/quickstart.rst
@@ -35,17 +35,17 @@ The ``yaml`` equivalent, from 2.0+ onwards, would be:
   backends:
     - address: "2001:db8::1"
       protocol: Do53
-      qps: 1
+      queries_per_second: 1
     - address: "2001:db8::2"
       protocol: Do53
-      qps: 1
+      queries_per_second: 1
     - address: "[2001:db8::3]:5300"
       protocol: Do53
-      qps: 10
+      queries_per_second: 10
     - address: "[2001:db8::4]"
       name: "dns1"
       protocol: Do53
-      qps: 10
+      queries_per_second: 10
     - address: "192.0.2.1"
       protocol: Do53
   load_balancing_policies:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
As noted by Holger Hoffstätte, the quickstart guide has an outdated YAML configuration sample which is no longer valid. `qps` has been renamed to `queries_per_second` well before the release candidates.

Fixes https://github.com/PowerDNS/pdns/issues/15912

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
