### PR TITLE
rec and dnsdist: properly set up env vars for rust build

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+export CARGO="${CARGO:-$_defaultCARGO}"
+
 #echo "PWD=$PWD"
 #echo "srcdir=$srcdir"
 #echo "builddir=$builddir"

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
@@ -4,13 +4,14 @@ infile = 'Cargo.toml'
 outfile = 'libdnsdist_rust.a'
 
 env = environment()
-env.append('CARGO', cargo.full_path())
-env.append('SYSCONFDIR', conf.get('SYSCONFDIR'))
-env.append('builddir', '.')
-env.append('generatedheadersdir', meson.current_build_dir() + '/..')
-env.append('srcdir', meson.current_source_dir())
-env.append('RUST_TARGET', '')
-env.append('RUSTC_TARGET_ARCH', '')
+env.set('_defaultCARGO', cargo.full_path())
+env.set('SYSCONFDIR', conf.get('SYSCONFDIR'))
+env.set('builddir', '.')
+env.set('generatedheadersdir', meson.current_build_dir() + '/..')
+env.set('srcdir', meson.current_source_dir())
+# The two calls below set the env var to an empty string if it does not exist already and leave it alone otherwise
+env.append('RUST_TARGET', '', separator: '')
+env.append('RUSTC_TARGET_ARCH', '', separator: '')
 
 lib_dnsdist_rust = custom_target('libdnsdist_rust.a',
   output: [outfile, 'cxx.h'],

--- a/pdns/recursordist/rec-rust-lib/rust/build_recrust
+++ b/pdns/recursordist/rec-rust-lib/rust/build_recrust
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+export CARGO="${CARGO:-$_defaultCARGO}"
+
 #echo "PWD=$PWD"
 #echo "srcdir=$srcdir"
 #echo "builddir=$builddir"

--- a/pdns/recursordist/rec-rust-lib/rust/meson.build
+++ b/pdns/recursordist/rec-rust-lib/rust/meson.build
@@ -6,14 +6,15 @@ outfile = 'librecrust.a'
 
 
 env = environment()
-env.append('CARGO', cargo.full_path())
-env.append('SYSCONFDIR', conf.get('SYSCONFDIR').strip('"'))
-env.append('NODCACHEDIRNOD', conf.get('NODCACHEDIRNOD').strip('"'))
-env.append('NODCACHEDIRUDR', conf.get('NODCACHEDIRUDR').strip('"'))
-env.append('builddir', '.')
-env.append('srcdir', meson.current_source_dir())
-env.append('RUST_TARGET', '')
-env.append('RUSTC_TARGET_ARCH', '')
+env.set('_defaultCARGO', cargo.full_path())
+env.set('SYSCONFDIR', conf.get('SYSCONFDIR').strip('"'))
+env.set('NODCACHEDIRNOD', conf.get('NODCACHEDIRNOD').strip('"'))
+env.set('NODCACHEDIRUDR', conf.get('NODCACHEDIRUDR').strip('"'))
+env.set('builddir', '.')
+env.set('srcdir', meson.current_source_dir())
+# The two calls below set the env var to the empty string if it does not exist already and leave it alone otherwise
+env.append('RUST_TARGET', '', separator: '')
+env.append('RUSTC_TARGET_ARCH', '', separator: '')
 
 lib_recrust = custom_target('librecrust.a',
   output: [outfile, 'cxx.h', 'lib.rs.h', 'misc.rs.h', 'web.rs.h'],


### PR DESCRIPTION
env.append() appends to an existing value

Should fix the error in #15896, but the reported location of cargo still might be wrong. I don't understand that part yet, as find_program() is supposed to check PATH.... unless one of the listed cases in https://mesonbuild.com/Reference-manual_functions.html#find_program finds `cargo`, and then PATH is not consulted?

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
