### PR TITLE
dnsdist: Refactor server pools and load-balancing policies

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -244,6 +244,7 @@ dnsdist_SOURCES = \
 	dnsdist-rules.cc dnsdist-rules.hh \
 	dnsdist-secpoll.cc dnsdist-secpoll.hh \
 	dnsdist-self-answers.cc dnsdist-self-answers.hh \
+	dnsdist-server-pool.hh \
 	dnsdist-session-cache.cc dnsdist-session-cache.hh \
 	dnsdist-snmp.cc dnsdist-snmp.hh \
 	dnsdist-svc.cc dnsdist-svc.hh \

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -1010,16 +1010,10 @@ bool DownstreamState::parseAvailabilityConfigFromStr(DownstreamState::Config& co
   return false;
 }
 
-size_t ServerPool::countServers(bool upOnly)
+size_t ServerPool::countServers(bool upOnly) const
 {
-  std::shared_ptr<const ServerPolicy::NumberedServerVector> servers = nullptr;
-  {
-    auto lock = d_servers.read_lock();
-    servers = *lock;
-  }
-
   size_t count = 0;
-  for (const auto& server : *servers) {
+  for (const auto& server : d_servers) {
     if (!upOnly || std::get<1>(server)->isUp() ) {
       count++;
     }
@@ -1028,51 +1022,36 @@ size_t ServerPool::countServers(bool upOnly)
   return count;
 }
 
-size_t ServerPool::poolLoad()
+size_t ServerPool::poolLoad() const
 {
-  std::shared_ptr<const ServerPolicy::NumberedServerVector> servers = nullptr;
-  {
-    auto lock = d_servers.read_lock();
-    servers = *lock;
-  }
-
   size_t load = 0;
-  for (const auto& server : *servers) {
+  for (const auto& server : d_servers) {
     size_t serverOutstanding = std::get<1>(server)->outstanding.load();
     load += serverOutstanding;
   }
   return load;
 }
 
-const std::shared_ptr<const ServerPolicy::NumberedServerVector> ServerPool::getServers()
+const ServerPolicy::NumberedServerVector& ServerPool::getServers() const
 {
-  std::shared_ptr<const ServerPolicy::NumberedServerVector> result;
-  {
-    result = *(d_servers.read_lock());
-  }
-  return result;
+  return d_servers;
 }
 
-void ServerPool::addServer(shared_ptr<DownstreamState>& server)
+void ServerPool::addServer(std::shared_ptr<DownstreamState>& server)
 {
-  auto servers = d_servers.write_lock();
-  /* we can't update the content of the shared pointer directly even when holding the lock,
-     as other threads might hold a copy. We can however update the pointer as long as we hold the lock. */
-  unsigned int count = static_cast<unsigned int>((*servers)->size());
-  auto newServers = ServerPolicy::NumberedServerVector(*(*servers));
-  newServers.emplace_back(++count, server);
+  unsigned int count = static_cast<unsigned int>(d_servers.size());
+  d_servers.emplace_back(++count, server);
   /* we need to reorder based on the server 'order' */
-  std::stable_sort(newServers.begin(), newServers.end(), [](const std::pair<unsigned int,std::shared_ptr<DownstreamState> >& a, const std::pair<unsigned int,std::shared_ptr<DownstreamState> >& b) {
+  std::stable_sort(d_servers.begin(), d_servers.end(), [](const std::pair<unsigned int,std::shared_ptr<DownstreamState> >& a, const std::pair<unsigned int,std::shared_ptr<DownstreamState> >& b) {
       return a.second->d_config.order < b.second->d_config.order;
     });
   /* and now we need to renumber for Lua (custom policies) */
   size_t idx = 1;
-  for (auto& serv : newServers) {
+  for (auto& serv : d_servers) {
     serv.first = idx++;
   }
-  *servers = std::make_shared<const ServerPolicy::NumberedServerVector>(std::move(newServers));
 
-  if ((*servers)->size() == 1) {
+  if (d_servers.size() == 1) {
     d_tcpOnly = server->isTCPOnly();
   }
   else if (!server->isTCPOnly()) {
@@ -1082,14 +1061,10 @@ void ServerPool::addServer(shared_ptr<DownstreamState>& server)
 
 void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
 {
-  auto servers = d_servers.write_lock();
-  /* we can't update the content of the shared pointer directly even when holding the lock,
-     as other threads might hold a copy. We can however update the pointer as long as we hold the lock. */
-  auto newServers = std::make_shared<ServerPolicy::NumberedServerVector>(*(*servers));
   size_t idx = 1;
   bool found = false;
   bool tcpOnly = true;
-  for (auto it = newServers->begin(); it != newServers->end();) {
+  for (auto it = d_servers.begin(); it != d_servers.end();) {
     if (found) {
       tcpOnly = tcpOnly && it->second->isTCPOnly();
       /* we need to renumber the servers placed
@@ -1098,7 +1073,7 @@ void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
       it++;
     }
     else if (it->second == server) {
-      it = newServers->erase(it);
+      it = d_servers.erase(it);
       found = true;
     } else {
       tcpOnly = tcpOnly && it->second->isTCPOnly();
@@ -1107,7 +1082,6 @@ void ServerPool::removeServer(shared_ptr<DownstreamState>& server)
     }
   }
   d_tcpOnly = tcpOnly;
-  *servers = std::move(newServers);
 }
 
 namespace dnsdist::backend

--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -193,13 +193,13 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint)
       base += ".pools.";
       base += poolName;
       base += ".";
-      const std::shared_ptr<ServerPool> pool = entry.second;
+      const ServerPool& pool = entry.second;
       str << base << "servers"
-          << " " << pool->countServers(false) << " " << now << "\r\n";
+          << " " << pool.countServers(false) << " " << now << "\r\n";
       str << base << "servers-up"
-          << " " << pool->countServers(true) << " " << now << "\r\n";
-      if (pool->packetCache != nullptr) {
-        const auto& cache = pool->packetCache;
+          << " " << pool.countServers(true) << " " << now << "\r\n";
+      if (pool.packetCache != nullptr) {
+        const auto& cache = pool.packetCache;
         str << base << "cache-size"
             << " " << cache->getMaxEntries() << " " << now << "\r\n";
         str << base << "cache-entries"

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1181,13 +1181,19 @@ bool loadConfigurationFromFile(const std::string& fileName, [[maybe_unused]] boo
     }
 
     for (const auto& pool : globalConfig.pools) {
-      std::shared_ptr<ServerPool> poolObj = createPoolIfNotExists(std::string(pool.name));
-      if (!pool.packet_cache.empty()) {
-        poolObj->packetCache = getRegisteredTypeByName<DNSDistPacketCache>(pool.packet_cache);
-      }
-      if (!pool.policy.empty()) {
-        poolObj->policy = getRegisteredTypeByName<ServerPolicy>(pool.policy);
-      }
+      dnsdist::configuration::updateRuntimeConfiguration([&pool](dnsdist::configuration::RuntimeConfiguration& config) {
+        auto [poolIt, inserted] = config.d_pools.emplace(std::string(pool.name), ServerPool());
+        if (inserted) {
+          vinfolog("Creating pool %s", pool.name);
+        }
+
+        if (!pool.packet_cache.empty()) {
+          poolIt->second.packetCache = getRegisteredTypeByName<DNSDistPacketCache>(pool.packet_cache);
+        }
+        if (!pool.policy.empty()) {
+          poolIt->second.policy = getRegisteredTypeByName<ServerPolicy>(pool.policy);
+        }
+      });
     }
 
     loadRulesConfiguration(globalConfig);

--- a/pdns/dnsdistdist/dnsdist-configuration.hh
+++ b/pdns/dnsdistdist/dnsdist-configuration.hh
@@ -33,6 +33,7 @@
 #include "dnsdist-carbon.hh"
 #include "dnsdist-query-count.hh"
 #include "dnsdist-rule-chains.hh"
+#include "dnsdist-server-pool.hh"
 #include "iputils.hh"
 
 class ServerPolicy;
@@ -118,7 +119,7 @@ struct RuntimeConfiguration
 #ifndef DISABLE_CARBON
   std::vector<dnsdist::Carbon::Endpoint> d_carbonEndpoints;
 #endif /* DISABLE_CARBON */
-  std::unordered_map<std::string, std::shared_ptr<ServerPool>> d_pools;
+  std::unordered_map<std::string, ServerPool> d_pools;
   std::shared_ptr<const CredentialsHolder> d_webPassword;
   std::shared_ptr<const CredentialsHolder> d_webAPIKey;
   std::optional<std::unordered_map<std::string, std::string>> d_webCustomHeaders;

--- a/pdns/dnsdistdist/dnsdist-lbpolicies.cc
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.cc
@@ -31,7 +31,7 @@ static constexpr size_t s_staticArrayCutOff = 16;
 template <typename T> using DynamicIndexArray = std::vector<std::pair<T, size_t>>;
 template <typename T> using StaticIndexArray = std::array<std::pair<T, size_t>, s_staticArrayCutOff>;
 
-template <class T> static std::shared_ptr<DownstreamState> getLeastOutstanding(const ServerPolicy::NumberedServerVector& servers, T& poss)
+template <class T> static std::optional<ServerPolicy::SelectedServerPosition> getLeastOutstanding(const ServerPolicy::NumberedServerVector& servers, T& poss)
 {
   /* so you might wonder, why do we go through this trouble? The data on which we sort could change during the sort,
      which would suck royally and could even lead to crashes. So first we snapshot on what we sort, and then we sort */
@@ -44,22 +44,21 @@ template <class T> static std::shared_ptr<DownstreamState> getLeastOutstanding(c
   }
 
   if (usableServers == 0) {
-    return shared_ptr<DownstreamState>();
+    return std::nullopt;
   }
 
   std::nth_element(poss.begin(), poss.begin(), poss.begin() + usableServers, [](const typename T::value_type& a, const typename T::value_type& b) { return a.first < b.first; });
-  // minus 1 because the NumberedServerVector starts at 1 for Lua
-  return servers.at(poss.begin()->second - 1).second;
+  return poss.begin()->second;
 }
 
 // get server with least outstanding queries, and within those, with the lowest order, and within those: the fastest
-shared_ptr<DownstreamState> leastOutstanding(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
+std::optional<ServerPolicy::SelectedServerPosition> leastOutstanding(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
 {
   (void)dq;
   using LeastOutstandingType = std::tuple<int,int,double>;
 
   if (servers.size() == 1 && servers[0].second->isUp()) {
-    return servers[0].second;
+    return 1;
   }
 
   if (servers.size() <= s_staticArrayCutOff) {
@@ -72,17 +71,17 @@ shared_ptr<DownstreamState> leastOutstanding(const ServerPolicy::NumberedServerV
   return getLeastOutstanding(servers, poss);
 }
 
-shared_ptr<DownstreamState> firstAvailable(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
+std::optional<ServerPolicy::SelectedServerPosition> firstAvailable(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
 {
   for (auto& d : servers) {
     if (d.second->isUp() && d.second->qps.checkOnly()) {
-      return d.second;
+      return d.first;
     }
   }
   return leastOutstanding(servers, dq);
 }
 
-template <class T> static std::shared_ptr<DownstreamState> getValRandom(const ServerPolicy::NumberedServerVector& servers, T& poss, const unsigned int val, const double targetLoad)
+template <class T> static std::optional<ServerPolicy::SelectedServerPosition> getValRandom(const ServerPolicy::NumberedServerVector& servers, T& poss, const unsigned int val, const double targetLoad)
 {
   constexpr int max = std::numeric_limits<int>::max();
   int sum = 0;
@@ -105,20 +104,19 @@ template <class T> static std::shared_ptr<DownstreamState> getValRandom(const Se
 
   // Catch the case where usableServers or sum are equal to 0 to avoid a SIGFPE
   if (usableServers == 0 || sum == 0) {
-    return shared_ptr<DownstreamState>();
+    return std::nullopt;
   }
 
   int r = val % sum;
   auto p = std::upper_bound(poss.begin(), poss.begin() + usableServers, r, [](int r_, const typename T::value_type& a) { return  r_ < a.first;});
   if (p == poss.begin() + usableServers) {
-    return shared_ptr<DownstreamState>();
+    return std::nullopt;
   }
 
-  // minus 1 because the NumberedServerVector starts at 1 for Lua
-  return servers.at(p->second - 1).second;
+  return p->second;
 }
 
-static shared_ptr<DownstreamState> valrandom(const unsigned int val, const ServerPolicy::NumberedServerVector& servers)
+static std::optional<ServerPolicy::SelectedServerPosition> valrandom(const unsigned int val, const ServerPolicy::NumberedServerVector& servers)
 {
   using ValRandomType = int;
   double targetLoad = std::numeric_limits<double>::max();
@@ -149,28 +147,28 @@ static shared_ptr<DownstreamState> valrandom(const unsigned int val, const Serve
   return getValRandom(servers, poss, val, targetLoad);
 }
 
-shared_ptr<DownstreamState> wrandom(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
+std::optional<ServerPolicy::SelectedServerPosition> wrandom(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
 {
   (void)dq;
   return valrandom(dns_random_uint32(), servers);
 }
 
-shared_ptr<DownstreamState> whashedFromHash(const ServerPolicy::NumberedServerVector& servers, size_t hash)
+std::optional<ServerPolicy::SelectedServerPosition> whashedFromHash(const ServerPolicy::NumberedServerVector& servers, size_t hash)
 {
   return valrandom(hash, servers);
 }
 
-shared_ptr<DownstreamState> whashed(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
+std::optional<ServerPolicy::SelectedServerPosition> whashed(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
 {
   const auto hashPerturbation = dnsdist::configuration::getImmutableConfiguration().d_hashPerturbation;
   return whashedFromHash(servers, dq->ids.qname.hash(hashPerturbation));
 }
 
-shared_ptr<DownstreamState> chashedFromHash(const ServerPolicy::NumberedServerVector& servers, size_t qhash)
+std::optional<ServerPolicy::SelectedServerPosition> chashedFromHash(const ServerPolicy::NumberedServerVector& servers, size_t qhash)
 {
   unsigned int sel = std::numeric_limits<unsigned int>::max();
   unsigned int min = std::numeric_limits<unsigned int>::max();
-  shared_ptr<DownstreamState> ret = nullptr, first = nullptr;
+  std::optional<ServerPolicy::SelectedServerPosition> ret, first;
 
   double targetLoad = std::numeric_limits<double>::max();
   const auto consistentHashBalancingFactor = dnsdist::configuration::getImmutableConfiguration().d_consistentHashBalancingFactor;
@@ -197,44 +195,45 @@ shared_ptr<DownstreamState> chashedFromHash(const ServerPolicy::NumberedServerVe
         d.second->hash();
       }
       {
+        const auto position = d.first;
         const auto& server = d.second;
         auto hashes = server->hashes.read_lock();
         // we want to keep track of the last hash
         if (min > *(hashes->begin())) {
           min = *(hashes->begin());
-          first = server;
+          first = position;
         }
 
         auto hash_it = std::lower_bound(hashes->begin(), hashes->end(), qhash);
         if (hash_it != hashes->end()) {
           if (*hash_it < sel) {
             sel = *hash_it;
-            ret = server;
+            ret = position;
           }
         }
       }
     }
   }
-  if (ret != nullptr) {
+  if (ret) {
     return ret;
   }
-  if (first != nullptr) {
+  if (first) {
     return first;
   }
-  return shared_ptr<DownstreamState>();
+  return std::nullopt;
 }
 
-shared_ptr<DownstreamState> chashed(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
+std::optional<ServerPolicy::SelectedServerPosition> chashed(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
 {
   const auto hashPerturbation = dnsdist::configuration::getImmutableConfiguration().d_hashPerturbation;
   return chashedFromHash(servers, dq->ids.qname.hash(hashPerturbation));
 }
 
-shared_ptr<DownstreamState> roundrobin(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
+std::optional<ServerPolicy::SelectedServerPosition> roundrobin(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq)
 {
   (void)dq;
   if (servers.empty()) {
-    return shared_ptr<DownstreamState>();
+    return std::nullopt;
   }
 
   vector<size_t> candidates;
@@ -248,7 +247,7 @@ shared_ptr<DownstreamState> roundrobin(const ServerPolicy::NumberedServerVector&
 
   if (candidates.empty()) {
     if (dnsdist::configuration::getCurrentRuntimeConfiguration().d_roundrobinFailOnNoServer) {
-      return shared_ptr<DownstreamState>();
+      return std::nullopt;
     }
     for (auto& d : servers) {
       candidates.push_back(d.first);
@@ -256,17 +255,19 @@ shared_ptr<DownstreamState> roundrobin(const ServerPolicy::NumberedServerVector&
   }
 
   static unsigned int counter;
-  return servers.at(candidates.at((counter++) % candidates.size()) - 1).second;
+  return candidates.at((counter++) % candidates.size());
 }
 
-shared_ptr<DownstreamState> orderedWrandUntag(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dnsq)
+std::optional<ServerPolicy::SelectedServerPosition> orderedWrandUntag(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dnsq)
 {
   if (servers.empty()) {
-    return {};
+    return std::nullopt;
   }
 
   ServerPolicy::NumberedServerVector candidates;
   candidates.reserve(servers.size());
+  std::vector<ServerPolicy::SelectedServerPosition> positionsMap;
+  positionsMap.reserve(servers.size());
 
   int curOrder = std::numeric_limits<int>::max();
   unsigned int curNumber = 1;
@@ -279,14 +280,19 @@ shared_ptr<DownstreamState> orderedWrandUntag(const ServerPolicy::NumberedServer
       }
       curOrder = svr.second->d_config.order;
       candidates.push_back(ServerPolicy::NumberedServer(curNumber++, svr.second));
+      positionsMap.push_back(svr.first);
     }
   }
 
   if (candidates.empty()) {
-    return {};
+    return std::nullopt;
   }
 
-  return wrandom(candidates, dnsq);
+  auto selected = wrandom(candidates, dnsq);
+  if (selected) {
+    return positionsMap.at(*selected - 1);
+  }
+  return selected;
 }
 
 const ServerPolicy::NumberedServerVector& getDownstreamCandidates(const std::string& poolName)
@@ -406,42 +412,51 @@ const ServerPolicy::ffipolicyfunc_t& ServerPolicy::getPerThreadPolicy() const
   return state->d_policies.at(d_name);
 }
 
-std::shared_ptr<DownstreamState> ServerPolicy::getSelectedBackend(const ServerPolicy::NumberedServerVector& servers, DNSQuestion& dq) const
+ServerPolicy::SelectedBackend ServerPolicy::getSelectedBackend(const ServerPolicy::NumberedServerVector& servers, DNSQuestion& dq) const
 {
-  std::shared_ptr<DownstreamState> selectedBackend{nullptr};
+  ServerPolicy::SelectedBackend result{servers};
 
   if (d_isLua) {
     if (!d_isFFI) {
+      std::optional<SelectedServerPosition> position;
+      {
+        auto lock = g_lua.lock();
+        position = d_policy(servers, &dq);
+      }
+      if (position && *position > 0 && *position <= servers.size()) {
+        result.setSelected(*position - 1);
+      }
+      return result;
+    }
+
+    dnsdist_ffi_dnsquestion_t dnsq(&dq);
+    dnsdist_ffi_servers_list_t serversList(servers);
+    ServerPolicy::SelectedServerPosition selected = 0;
+
+    if (!d_isPerThread) {
       auto lock = g_lua.lock();
-      selectedBackend = d_policy(servers, &dq);
+      selected = d_ffipolicy(&serversList, &dnsq);
     }
     else {
-      dnsdist_ffi_dnsquestion_t dnsq(&dq);
-      dnsdist_ffi_servers_list_t serversList(servers);
-      unsigned int selected = 0;
-
-      if (!d_isPerThread) {
-        auto lock = g_lua.lock();
-        selected = d_ffipolicy(&serversList, &dnsq);
-      }
-      else {
-        const auto& policy = getPerThreadPolicy();
-        selected = policy(&serversList, &dnsq);
-      }
-
-      if (selected >= servers.size()) {
-        /* invalid offset, meaning that there is no server available */
-        return {};
-      }
-
-      selectedBackend = servers.at(selected).second;
+      const auto& policy = getPerThreadPolicy();
+      selected = policy(&serversList, &dnsq);
     }
-  }
-  else {
-    selectedBackend = d_policy(servers, &dq);
+
+    if (selected >= servers.size()) {
+      /* invalid offset, meaning that there is no server available */
+      return result;
+    }
+
+    result.setSelected(selected);
+    return result;
   }
 
-  return selectedBackend;
+  auto position = d_policy(servers, &dq);
+  if (position && *position > 0 && *position <= servers.size()) {
+    result.setSelected(*position - 1);
+  }
+
+  return result;
 }
 
 namespace dnsdist::lbpolicies

--- a/pdns/dnsdistdist/dnsdist-lbpolicies.hh
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.hh
@@ -92,13 +92,13 @@ public:
 struct ServerPool;
 
 using pools_t = std::map<std::string, std::shared_ptr<ServerPool>>;
-std::shared_ptr<ServerPool> getPool(const std::string& poolName);
-std::shared_ptr<ServerPool> createPoolIfNotExists(const string& poolName);
+const ServerPool& getPool(const std::string& poolName);
+const ServerPool& createPoolIfNotExists(const string& poolName);
 void setPoolPolicy(const string& poolName, std::shared_ptr<ServerPolicy> policy);
 void addServerToPool(const string& poolName, std::shared_ptr<DownstreamState> server);
 void removeServerFromPool(const string& poolName, std::shared_ptr<DownstreamState> server);
 
-std::shared_ptr<const ServerPolicy::NumberedServerVector> getDownstreamCandidates(const std::string& poolName);
+const ServerPolicy::NumberedServerVector& getDownstreamCandidates(const std::string& poolName);
 
 std::shared_ptr<DownstreamState> firstAvailable(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
 

--- a/pdns/dnsdistdist/dnsdist-lbpolicies.hh
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.hh
@@ -21,6 +21,9 @@
  */
 #pragma once
 
+#include <memory>
+#include <optional>
+
 struct dnsdist_ffi_servers_list_t;
 struct dnsdist_ffi_server_t;
 struct dnsdist_ffi_dnsquestion_t;
@@ -33,14 +36,15 @@ struct PerThreadPoliciesState;
 class ServerPolicy
 {
 public:
+  using SelectedServerPosition = unsigned int;
   template <class T>
   using Numbered = std::pair<unsigned int, T>;
-  using NumberedServer = Numbered<shared_ptr<DownstreamState>>;
+  using NumberedServer = Numbered<std::shared_ptr<DownstreamState>>;
   template <class T>
   using NumberedVector = std::vector<std::pair<unsigned int, T>>;
-  using NumberedServerVector = NumberedVector<shared_ptr<DownstreamState>>;
-  using policyfunc_t = std::function<std::shared_ptr<DownstreamState>(const NumberedServerVector& servers, const DNSQuestion*)>;
-  using ffipolicyfunc_t = std::function<unsigned int(dnsdist_ffi_servers_list_t* servers, dnsdist_ffi_dnsquestion_t* dq)>;
+  using NumberedServerVector = NumberedVector<std::shared_ptr<DownstreamState>>;
+  using policyfunc_t = std::function<std::optional<SelectedServerPosition>(const NumberedServerVector& servers, const DNSQuestion*)>;
+  using ffipolicyfunc_t = std::function<SelectedServerPosition(dnsdist_ffi_servers_list_t* servers, dnsdist_ffi_dnsquestion_t* dq)>;
 
   ServerPolicy(const std::string& name_, policyfunc_t policy_, bool isLua_) :
     d_name(name_), d_policy(std::move(policy_)), d_isLua(isLua_)
@@ -59,7 +63,43 @@ public:
   {
   }
 
-  std::shared_ptr<DownstreamState> getSelectedBackend(const ServerPolicy::NumberedServerVector& servers, DNSQuestion& dq) const;
+  class SelectedBackend
+  {
+  public:
+    SelectedBackend(const NumberedServerVector& backends) :
+      d_backends(&backends)
+    {
+    }
+
+    void setSelected(SelectedServerPosition selected)
+    {
+      if (selected >= d_backends->size()) {
+        throw std::runtime_error("Setting an invalid backend position (" + std::to_string(selected) + " out of " + std::to_string(d_backends->size()) + ") from the server policy");
+      }
+      d_selected = selected;
+    }
+
+    operator bool() const noexcept
+    {
+      return d_selected.has_value();
+    }
+
+    DownstreamState* operator->() const noexcept
+    {
+      return (*d_backends)[*d_selected].second.get();
+    }
+
+    const std::shared_ptr<DownstreamState>& get() const noexcept
+    {
+      return (*d_backends)[*d_selected].second;
+    }
+
+  private:
+    const NumberedServerVector* d_backends{nullptr};
+    std::optional<SelectedServerPosition> d_selected;
+  };
+
+  SelectedBackend getSelectedBackend(const ServerPolicy::NumberedServerVector& servers, DNSQuestion& dq) const;
 
   const std::string& getName() const
   {
@@ -68,7 +108,7 @@ public:
 
   std::string toString() const
   {
-    return string("ServerPolicy") + (d_isLua ? " (Lua)" : "") + " \"" + d_name + "\"";
+    return std::string("ServerPolicy") + (d_isLua ? " (Lua)" : "") + " \"" + d_name + "\"";
   }
 
 private:
@@ -93,23 +133,22 @@ struct ServerPool;
 
 using pools_t = std::map<std::string, std::shared_ptr<ServerPool>>;
 const ServerPool& getPool(const std::string& poolName);
-const ServerPool& createPoolIfNotExists(const string& poolName);
-void setPoolPolicy(const string& poolName, std::shared_ptr<ServerPolicy> policy);
-void addServerToPool(const string& poolName, std::shared_ptr<DownstreamState> server);
-void removeServerFromPool(const string& poolName, std::shared_ptr<DownstreamState> server);
+const ServerPool& createPoolIfNotExists(const std::string& poolName);
+void setPoolPolicy(const std::string& poolName, std::shared_ptr<ServerPolicy> policy);
+void addServerToPool(const std::string& poolName, std::shared_ptr<DownstreamState> server);
+void removeServerFromPool(const std::string& poolName, std::shared_ptr<DownstreamState> server);
 
 const ServerPolicy::NumberedServerVector& getDownstreamCandidates(const std::string& poolName);
 
-std::shared_ptr<DownstreamState> firstAvailable(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
-
-std::shared_ptr<DownstreamState> leastOutstanding(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
-std::shared_ptr<DownstreamState> wrandom(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
-std::shared_ptr<DownstreamState> whashed(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
-std::shared_ptr<DownstreamState> whashedFromHash(const ServerPolicy::NumberedServerVector& servers, size_t hash);
-std::shared_ptr<DownstreamState> chashed(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
-std::shared_ptr<DownstreamState> chashedFromHash(const ServerPolicy::NumberedServerVector& servers, size_t hash);
-std::shared_ptr<DownstreamState> roundrobin(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
-std::shared_ptr<DownstreamState> orderedWrandUntag(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dnsq);
+std::optional<ServerPolicy::SelectedServerPosition> firstAvailable(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
+std::optional<ServerPolicy::SelectedServerPosition> leastOutstanding(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
+std::optional<ServerPolicy::SelectedServerPosition> wrandom(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
+std::optional<ServerPolicy::SelectedServerPosition> whashed(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
+std::optional<ServerPolicy::SelectedServerPosition> whashedFromHash(const ServerPolicy::NumberedServerVector& servers, size_t hash);
+std::optional<ServerPolicy::SelectedServerPosition> chashed(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
+std::optional<ServerPolicy::SelectedServerPosition> chashedFromHash(const ServerPolicy::NumberedServerVector& servers, size_t hash);
+std::optional<ServerPolicy::SelectedServerPosition> roundrobin(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dq);
+std::optional<ServerPolicy::SelectedServerPosition> orderedWrandUntag(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dnsq);
 
 #include <unordered_map>
 

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -725,28 +725,24 @@ void dnsdist_ffi_servers_list_get_server(const dnsdist_ffi_servers_list_t* list,
   *out = &list->ffiServers.at(idx);
 }
 
-static size_t dnsdist_ffi_servers_get_index_from_server(const ServerPolicy::NumberedServerVector& servers, const std::shared_ptr<DownstreamState>& server)
-{
-  for (const auto& pair : servers) {
-    if (pair.second == server) {
-      return pair.first - 1;
-    }
-  }
-  throw std::runtime_error("Unable to find servers in server list");
-}
-
 size_t dnsdist_ffi_servers_list_chashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dq, size_t hash)
 {
   (void)dq;
-  auto server = chashedFromHash(list->servers, hash);
-  return dnsdist_ffi_servers_get_index_from_server(list->servers, server);
+  auto serverPosition = chashedFromHash(list->servers, hash);
+  if (!serverPosition) {
+    throw std::runtime_error("Unable to find servers in server list");
+  }
+  return *serverPosition;
 }
 
 size_t dnsdist_ffi_servers_list_whashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dq, size_t hash)
 {
   (void)dq;
-  auto server = whashedFromHash(list->servers, hash);
-  return dnsdist_ffi_servers_get_index_from_server(list->servers, server);
+  auto serverPosition = whashedFromHash(list->servers, hash);
+  if (!serverPosition) {
+    throw std::runtime_error("Unable to find servers in server list");
+  }
+  return *serverPosition;
 }
 
 uint64_t dnsdist_ffi_server_get_outstanding(const dnsdist_ffi_server_t* server)

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1260,12 +1260,12 @@ size_t dnsdist_ffi_packetcache_get_domain_list_by_addr(const char* poolName, con
     return 0;
   }
 
-  auto pool = poolIt->second;
-  if (!pool->packetCache) {
+  const auto& pool = poolIt->second;
+  if (!pool.packetCache) {
     return 0;
   }
 
-  auto domains = pool->packetCache->getDomainsContainingRecords(ca);
+  auto domains = pool.packetCache->getDomainsContainingRecords(ca);
   if (domains.size() == 0) {
     return 0;
   }
@@ -1309,12 +1309,12 @@ size_t dnsdist_ffi_packetcache_get_address_list_by_domain(const char* poolName, 
     return 0;
   }
 
-  auto pool = poolIt->second;
-  if (!pool->packetCache) {
+  const auto& pool = poolIt->second;
+  if (!pool.packetCache) {
     return 0;
   }
 
-  auto addresses = pool->packetCache->getRecordsForDomain(name);
+  auto addresses = pool.packetCache->getRecordsForDomain(name);
   if (addresses.size() == 0) {
     return 0;
   }

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -1007,9 +1007,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
   luaCtx.writeFunction("getPoolServers", [](const string& pool) {
-    // coverity[auto_causes_copy]
-    const auto poolServers = getDownstreamCandidates(pool);
-    return *poolServers;
+    return getDownstreamCandidates(pool);
   });
 
   luaCtx.writeFunction("getServer", [client](boost::variant<unsigned int, std::string> identifier) -> boost::optional<std::shared_ptr<DownstreamState>> {
@@ -1635,16 +1633,16 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       const auto pools = dnsdist::configuration::getCurrentRuntimeConfiguration().d_pools;
       for (const auto& entry : pools) {
         const string& name = entry.first;
-        const std::shared_ptr<ServerPool> pool = entry.second;
-        string cache = pool->packetCache != nullptr ? pool->packetCache->toString() : "";
+        const auto& pool = entry.second;
+        string cache = pool.packetCache != nullptr ? pool.packetCache->toString() : "";
         string policy = defaultPolicyName;
-        if (pool->policy != nullptr) {
-          policy = pool->policy->getName();
+        if (pool.policy != nullptr) {
+          policy = pool.policy->getName();
         }
         string servers;
 
-        const auto poolServers = pool->getServers();
-        for (const auto& server : *poolServers) {
+        const auto& poolServers = pool.getServers();
+        for (const auto& server : poolServers) {
           if (!servers.empty()) {
             servers += ", ";
           }
@@ -1679,10 +1677,19 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
   luaCtx.writeFunction("getPool", [client](const string& poolName) {
     if (client) {
-      return std::make_shared<ServerPool>();
+      return std::make_shared<dnsdist::lua::LuaServerPoolObject>(poolName);
     }
-    std::shared_ptr<ServerPool> pool = createPoolIfNotExists(poolName);
-    return pool;
+    bool created = false;
+    dnsdist::configuration::updateRuntimeConfiguration([&poolName, &created](dnsdist::configuration::RuntimeConfiguration& config) {
+      auto [poolIt, inserted] = config.d_pools.emplace(poolName, ServerPool());
+      created = inserted;
+    });
+
+    if (created) {
+      vinfolog("Creating pool %s", poolName);
+    }
+
+    return std::make_shared<dnsdist::lua::LuaServerPoolObject>(poolName);
   });
 
   luaCtx.writeFunction("setVerboseLogDestination", [](const std::string& dest) {
@@ -2068,11 +2075,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.writeFunction("showPoolServerPolicy", [](const std::string& pool) {
     setLuaSideEffect();
     auto poolObj = getPool(pool);
-    if (poolObj->policy == nullptr) {
+    if (poolObj.policy == nullptr) {
       g_outputBuffer = dnsdist::configuration::getCurrentRuntimeConfiguration().d_lbPolicy->getName() + "\n";
     }
     else {
-      g_outputBuffer = poolObj->policy->getName() + "\n";
+      g_outputBuffer = poolObj.policy->getName() + "\n";
     }
   });
 #endif /* DISABLE_POLICIES_BINDINGS */

--- a/pdns/dnsdistdist/dnsdist-lua.hh
+++ b/pdns/dnsdistdist/dnsdist-lua.hh
@@ -85,6 +85,16 @@ std::optional<FunctionType> getFunctionFromLuaCode(const std::string& code, cons
 
   return std::nullopt;
 }
+
+struct LuaServerPoolObject
+{
+  LuaServerPoolObject(std::string name) :
+    poolName(std::move(name))
+  {
+  }
+
+  std::string poolName;
+};
 }
 
 namespace dnsdist::configuration::lua

--- a/pdns/dnsdistdist/dnsdist-rules-factory.hh
+++ b/pdns/dnsdistdist/dnsdist-rules-factory.hh
@@ -1178,7 +1178,7 @@ public:
   bool matches(const DNSQuestion* dnsQuestion) const override
   {
     (void)dnsQuestion;
-    return (getPool(d_poolname)->countServers(true) > 0);
+    return (getPool(d_poolname).countServers(true) > 0);
   }
 
   string toString() const override
@@ -1201,7 +1201,7 @@ public:
   bool matches(const DNSQuestion* dnsQuestion) const override
   {
     (void)dnsQuestion;
-    return (getPool(d_poolname)->poolLoad()) > d_limit;
+    return (getPool(d_poolname).poolLoad()) > d_limit;
   }
 
   string toString() const override

--- a/pdns/dnsdistdist/dnsdist-server-pool.hh
+++ b/pdns/dnsdistdist/dnsdist-server-pool.hh
@@ -1,0 +1,63 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+#include <memory>
+
+#include "dnsdist-lbpolicies.hh"
+
+class DNSDistPacketCache;
+
+struct ServerPool
+{
+  const std::shared_ptr<DNSDistPacketCache> getCache() const
+  {
+    return packetCache;
+  }
+
+  bool getECS() const
+  {
+    return d_useECS;
+  }
+
+  void setECS(bool useECS)
+  {
+    d_useECS = useECS;
+  }
+
+  size_t poolLoad() const;
+  size_t countServers(bool upOnly) const;
+  const ServerPolicy::NumberedServerVector& getServers() const;
+  void addServer(std::shared_ptr<DownstreamState>& server);
+  void removeServer(std::shared_ptr<DownstreamState>& server);
+  bool isTCPOnly() const
+  {
+    return d_tcpOnly;
+  }
+
+  std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
+  std::shared_ptr<ServerPolicy> policy{nullptr};
+
+private:
+  ServerPolicy::NumberedServerVector d_servers;
+  bool d_useECS{false};
+  bool d_tcpOnly{false};
+};

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -864,12 +864,12 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
       poolName = "_default_";
     }
     const string label = "{pool=\"" + poolName + "\"}";
-    const std::shared_ptr<ServerPool> pool = entry.second;
-    output << "dnsdist_pool_servers" << label << " " << pool->countServers(false) << "\n";
-    output << "dnsdist_pool_active_servers" << label << " " << pool->countServers(true) << "\n";
+    const auto& pool = entry.second;
+    output << "dnsdist_pool_servers" << label << " " << pool.countServers(false) << "\n";
+    output << "dnsdist_pool_active_servers" << label << " " << pool.countServers(true) << "\n";
 
-    if (pool->packetCache != nullptr) {
-      const auto& cache = pool->packetCache;
+    if (pool.packetCache != nullptr) {
+      const auto& cache = pool.packetCache;
 
       output << cachebase << "cache_size"              <<label << " " << cache->getMaxEntries()       << "\n";
       output << cachebase << "cache_entries"           <<label << " " << cache->getEntriesCount()     << "\n";
@@ -1247,11 +1247,11 @@ static void handleStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
     const auto& localPools = dnsdist::configuration::getCurrentRuntimeConfiguration().d_pools;
     pools.reserve(localPools.size());
     for (const auto& pool : localPools) {
-      const auto& cache = pool.second->packetCache;
+      const auto& cache = pool.second.packetCache;
       Json::object entry{
         {"id", num++},
         {"name", pool.first},
-        {"serversCount", (double)pool.second->countServers(false)},
+        {"serversCount", (double)pool.second.countServers(false)},
         {"cacheSize", (double)(cache ? cache->getMaxEntries() : 0)},
         {"cacheEntries", (double)(cache ? cache->getEntriesCount() : 0)},
         {"cacheHits", (double)(cache ? cache->getHits() : 0)},
@@ -1358,10 +1358,10 @@ static void handlePoolStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
   }
 
   const auto& pool = poolIt->second;
-  const auto& cache = pool->packetCache;
+  const auto& cache = pool.packetCache;
   Json::object entry{
     {"name", poolName->second},
-    {"serversCount", (double)pool->countServers(false)},
+    {"serversCount", (double)pool.countServers(false)},
     {"cacheSize", (double)(cache ? cache->getMaxEntries() : 0)},
     {"cacheEntries", (double)(cache ? cache->getEntriesCount() : 0)},
     {"cacheHits", (double)(cache ? cache->getHits() : 0)},
@@ -1375,7 +1375,7 @@ static void handlePoolStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
 
   Json::array servers;
   int num = 0;
-  for (const auto& server : *pool->getServers()) {
+  for (const auto& server : pool.getServers()) {
     addServerToJSON(servers, num, server.second);
     num++;
   }
@@ -1581,7 +1581,7 @@ static void handleCacheManagement(const YaHTTP::Request& req, YaHTTP::Response& 
     type = QType::chartocode(expungeType->second.c_str());
   }
 
-  std::shared_ptr<ServerPool> pool;
+  std::optional<ServerPool> pool;
   try {
     pool = getPool(poolName->second);
   }

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1415,12 +1415,11 @@ static ProcessQueryResult handleQueryTurnedIntoSelfAnsweredResponse(DNSQuestion&
   return ProcessQueryResult::SendAnswer;
 }
 
-static void selectBackendForOutgoingQuery(DNSQuestion& dnsQuestion, const std::shared_ptr<ServerPool>& serverPool, std::shared_ptr<DownstreamState>& selectedBackend)
+static void selectBackendForOutgoingQuery(DNSQuestion& dnsQuestion, const ServerPool& serverPool, std::shared_ptr<DownstreamState>& selectedBackend)
 {
-  std::shared_ptr<ServerPolicy> poolPolicy = serverPool->policy;
-  const auto& policy = poolPolicy != nullptr ? *poolPolicy : *dnsdist::configuration::getCurrentRuntimeConfiguration().d_lbPolicy;
-  const auto servers = serverPool->getServers();
-  selectedBackend = policy.getSelectedBackend(*servers, dnsQuestion);
+  const auto& policy = serverPool.policy != nullptr ? *serverPool.policy : *dnsdist::configuration::getCurrentRuntimeConfiguration().d_lbPolicy;
+  const auto& servers = serverPool.getServers();
+  selectedBackend = policy.getSelectedBackend(servers, dnsQuestion);
 }
 
 ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_ptr<DownstreamState>& selectedBackend)
@@ -1431,15 +1430,15 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
     if (dnsQuestion.getHeader()->qr) { // something turned it into a response
       return handleQueryTurnedIntoSelfAnsweredResponse(dnsQuestion);
     }
-    std::shared_ptr<ServerPool> serverPool = getPool(dnsQuestion.ids.poolName);
-    dnsQuestion.ids.packetCache = serverPool->packetCache;
+    const auto& serverPool = getPool(dnsQuestion.ids.poolName);
+    dnsQuestion.ids.packetCache = serverPool.packetCache;
     selectBackendForOutgoingQuery(dnsQuestion, serverPool, selectedBackend);
     bool willBeForwardedOverUDP = !dnsQuestion.overTCP() || dnsQuestion.ids.protocol == dnsdist::Protocol::DoH;
     if (selectedBackend && selectedBackend->isTCPOnly()) {
       willBeForwardedOverUDP = false;
     }
     else if (!selectedBackend) {
-      willBeForwardedOverUDP = !serverPool->isTCPOnly();
+      willBeForwardedOverUDP = !serverPool.isTCPOnly();
     }
 
     uint32_t allowExpired = selectedBackend ? 0 : dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL;
@@ -1448,7 +1447,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       dnsQuestion.ids.dnssecOK = (dnsdist::getEDNSZ(dnsQuestion) & EDNS_HEADER_FLAG_DO) != 0;
     }
 
-    if (dnsQuestion.useECS && ((selectedBackend && selectedBackend->d_config.useECS) || (!selectedBackend && serverPool->getECS()))) {
+    if (dnsQuestion.useECS && ((selectedBackend && selectedBackend->d_config.useECS) || (!selectedBackend && serverPool.getECS()))) {
       // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
       // we need ECS parsing (parseECS) to be true so we can be sure that the initial incoming query did not have an existing
       // ECS option, which would make it unsuitable for the zero-scope feature.
@@ -1532,9 +1531,9 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       /* let's be nice and allow the selection of a different pool,
          but no second cache-lookup for you */
       if (dnsQuestion.ids.poolName != existingPool) {
-        serverPool = getPool(dnsQuestion.ids.poolName);
-        dnsQuestion.ids.packetCache = serverPool->packetCache;
-        selectBackendForOutgoingQuery(dnsQuestion, serverPool, selectedBackend);
+        const auto& newServerPool = getPool(dnsQuestion.ids.poolName);
+        dnsQuestion.ids.packetCache = newServerPool.packetCache;
+        selectBackendForOutgoingQuery(dnsQuestion, newServerPool, selectedBackend);
       }
     }
 
@@ -2329,7 +2328,7 @@ static void maintThread()
       for (const auto& entry : pools) {
         const auto& pool = entry.second;
 
-        auto packetCache = pool->packetCache;
+        const auto& packetCache = pool.packetCache;
         if (!packetCache) {
           continue;
         }
@@ -2341,7 +2340,7 @@ static void maintThread()
            has all its backends down) */
         if (packetCache->keepStaleData() && !iter->second) {
           /* so far all pools had at least one backend up */
-          if (pool->countServers(true) == 0) {
+          if (pool.countServers(true) == 0) {
             iter->second = true;
           }
         }
@@ -3128,7 +3127,7 @@ static void setupPools()
   }
   else {
     for (const auto& entry : dnsdist::configuration::getCurrentRuntimeConfiguration().d_pools) {
-      if (entry.second->policy != nullptr && entry.second->policy->getName() == "chashed") {
+      if (entry.second.policy != nullptr && entry.second.policy->getName() == "chashed") {
         precompute = true;
         break;
       }

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1431,7 +1431,6 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       return handleQueryTurnedIntoSelfAnsweredResponse(dnsQuestion);
     }
     const auto& serverPool = getPool(dnsQuestion.ids.poolName);
-    dnsQuestion.ids.packetCache = serverPool.packetCache;
     selectBackendForOutgoingQuery(dnsQuestion, serverPool, selectedBackend);
     bool willBeForwardedOverUDP = !dnsQuestion.overTCP() || dnsQuestion.ids.protocol == dnsdist::Protocol::DoH;
     if (selectedBackend && selectedBackend->isTCPOnly()) {
@@ -1443,7 +1442,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
 
     uint32_t allowExpired = selectedBackend ? 0 : dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL;
 
-    if (dnsQuestion.ids.packetCache && !dnsQuestion.ids.skipCache && !dnsQuestion.ids.dnssecOK) {
+    if (serverPool.packetCache && !dnsQuestion.ids.skipCache && !dnsQuestion.ids.dnssecOK) {
       dnsQuestion.ids.dnssecOK = (dnsdist::getEDNSZ(dnsQuestion) & EDNS_HEADER_FLAG_DO) != 0;
     }
 
@@ -1451,8 +1450,8 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
       // we need ECS parsing (parseECS) to be true so we can be sure that the initial incoming query did not have an existing
       // ECS option, which would make it unsuitable for the zero-scope feature.
-      if (dnsQuestion.ids.packetCache && !dnsQuestion.ids.skipCache && (!selectedBackend || !selectedBackend->d_config.disableZeroScope) && dnsQuestion.ids.packetCache->isECSParsingEnabled()) {
-        if (dnsQuestion.ids.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, &dnsQuestion.ids.cacheKeyNoECS, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, willBeForwardedOverUDP, allowExpired, false, true, false)) {
+      if (serverPool.packetCache && !dnsQuestion.ids.skipCache && (!selectedBackend || !selectedBackend->d_config.disableZeroScope) && serverPool.packetCache->isECSParsingEnabled()) {
+        if (serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, &dnsQuestion.ids.cacheKeyNoECS, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, willBeForwardedOverUDP, allowExpired, false, true, false)) {
 
           vinfolog("Packet cache hit for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size());
 
@@ -1477,12 +1476,12 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       }
     }
 
-    if (dnsQuestion.ids.packetCache && !dnsQuestion.ids.skipCache) {
+    if (serverPool.packetCache && !dnsQuestion.ids.skipCache) {
       /* First lookup, which takes into account how the protocol over which the query will be forwarded.
          For DoH, this lookup is done with the protocol set to TCP but we will retry over UDP below,
          therefore we do not record a miss for queries received over DoH and forwarded over TCP
          yet, as we will do a second-lookup */
-      if (dnsQuestion.ids.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, dnsQuestion.ids.protocol == dnsdist::Protocol::DoH ? &dnsQuestion.ids.cacheKeyTCP : &dnsQuestion.ids.cacheKey, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH && willBeForwardedOverUDP, allowExpired, false, true, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH || !willBeForwardedOverUDP)) {
+      if (serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, dnsQuestion.ids.protocol == dnsdist::Protocol::DoH ? &dnsQuestion.ids.cacheKeyTCP : &dnsQuestion.ids.cacheKey, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH && willBeForwardedOverUDP, allowExpired, false, true, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH || !willBeForwardedOverUDP)) {
 
         dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion.getMutableData(), [flags = dnsQuestion.ids.origFlags](dnsheader& header) {
           restoreFlags(&header, flags);
@@ -1502,7 +1501,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       if (dnsQuestion.ids.protocol == dnsdist::Protocol::DoH && willBeForwardedOverUDP) {
         /* do a second-lookup for responses received over UDP, but we do not want TC=1 answers */
         /* we need to be careful to keep the existing cache-key (TCP) */
-        if (dnsQuestion.ids.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, &dnsQuestion.ids.cacheKey, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, true, allowExpired, false, false, true)) {
+        if (serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, &dnsQuestion.ids.cacheKey, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, true, allowExpired, false, false, true)) {
           if (!prepareOutgoingResponse(*dnsQuestion.ids.cs, dnsQuestion, true)) {
             return ProcessQueryResult::Drop;
           }
@@ -1534,6 +1533,9 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
         const auto& newServerPool = getPool(dnsQuestion.ids.poolName);
         dnsQuestion.ids.packetCache = newServerPool.packetCache;
         selectBackendForOutgoingQuery(dnsQuestion, newServerPool, selectedBackend);
+      }
+      else {
+        dnsQuestion.ids.packetCache = serverPool.packetCache;
       }
     }
 

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1415,14 +1415,14 @@ static ProcessQueryResult handleQueryTurnedIntoSelfAnsweredResponse(DNSQuestion&
   return ProcessQueryResult::SendAnswer;
 }
 
-static void selectBackendForOutgoingQuery(DNSQuestion& dnsQuestion, const ServerPool& serverPool, std::shared_ptr<DownstreamState>& selectedBackend)
+static ServerPolicy::SelectedBackend selectBackendForOutgoingQuery(DNSQuestion& dnsQuestion, const ServerPool& serverPool)
 {
   const auto& policy = serverPool.policy != nullptr ? *serverPool.policy : *dnsdist::configuration::getCurrentRuntimeConfiguration().d_lbPolicy;
   const auto& servers = serverPool.getServers();
-  selectedBackend = policy.getSelectedBackend(servers, dnsQuestion);
+  return policy.getSelectedBackend(servers, dnsQuestion);
 }
 
-ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_ptr<DownstreamState>& selectedBackend)
+ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_ptr<DownstreamState>& outgoingBackend)
 {
   const uint16_t queryId = ntohs(dnsQuestion.getHeader()->id);
 
@@ -1431,7 +1431,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       return handleQueryTurnedIntoSelfAnsweredResponse(dnsQuestion);
     }
     const auto& serverPool = getPool(dnsQuestion.ids.poolName);
-    selectBackendForOutgoingQuery(dnsQuestion, serverPool, selectedBackend);
+    auto selectedBackend = selectBackendForOutgoingQuery(dnsQuestion, serverPool);
     bool willBeForwardedOverUDP = !dnsQuestion.overTCP() || dnsQuestion.ids.protocol == dnsdist::Protocol::DoH;
     if (selectedBackend && selectedBackend->isTCPOnly()) {
       willBeForwardedOverUDP = false;
@@ -1532,7 +1532,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       if (dnsQuestion.ids.poolName != existingPool) {
         const auto& newServerPool = getPool(dnsQuestion.ids.poolName);
         dnsQuestion.ids.packetCache = newServerPool.packetCache;
-        selectBackendForOutgoingQuery(dnsQuestion, newServerPool, selectedBackend);
+        selectedBackend = selectBackendForOutgoingQuery(dnsQuestion, newServerPool);
       }
       else {
         dnsQuestion.ids.packetCache = serverPool.packetCache;
@@ -1572,6 +1572,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
     }
 
     selectedBackend->incQueriesCount();
+    outgoingBackend = selectedBackend.get();
     return ProcessQueryResult::PassToBackend;
   }
   catch (const std::exception& e) {

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -936,51 +936,6 @@ public:
 
 void responderThread(std::shared_ptr<DownstreamState> dss);
 
-class DNSDistPacketCache;
-
-struct ServerPool
-{
-  ServerPool() :
-    d_servers(std::make_shared<const ServerPolicy::NumberedServerVector>())
-  {
-  }
-
-  ~ServerPool()
-  {
-  }
-
-  const std::shared_ptr<DNSDistPacketCache> getCache() const { return packetCache; };
-
-  bool getECS() const
-  {
-    return d_useECS;
-  }
-
-  void setECS(bool useECS)
-  {
-    d_useECS = useECS;
-  }
-
-  std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
-  std::shared_ptr<ServerPolicy> policy{nullptr};
-
-  size_t poolLoad();
-  size_t countServers(bool upOnly);
-  const std::shared_ptr<const ServerPolicy::NumberedServerVector> getServers();
-  void addServer(shared_ptr<DownstreamState>& server);
-  void removeServer(shared_ptr<DownstreamState>& server);
-  bool isTCPOnly() const
-  {
-    // coverity[missing_lock]
-    return d_tcpOnly;
-  }
-
-private:
-  SharedLockGuarded<std::shared_ptr<const ServerPolicy::NumberedServerVector>> d_servers;
-  bool d_useECS{false};
-  bool d_tcpOnly{false};
-};
-
 enum ednsHeaderFlags
 {
   EDNS_HEADER_FLAG_NONE = 0,

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -505,10 +505,10 @@ BOOST_AUTO_TEST_CASE(test_PacketCache)
   packetCache->insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, boost::none);
 
   std::string poolName("test-pool");
-  auto testPool = std::make_shared<ServerPool>();
-  testPool->packetCache = packetCache;
+  auto testPool = ServerPool();
+  testPool.packetCache = packetCache;
   std::string poolWithNoCacheName("test-pool-without-cache");
-  auto testPoolWithNoCache = std::make_shared<ServerPool>();
+  auto testPoolWithNoCache = ServerPool();
   dnsdist::configuration::updateRuntimeConfiguration([&poolName, &testPool, &poolWithNoCacheName, &testPoolWithNoCache](dnsdist::configuration::RuntimeConfiguration& config) {
     config.d_pools.emplace(poolName, testPool);
     config.d_pools.emplace(poolWithNoCacheName, testPoolWithNoCache);

--- a/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
@@ -553,7 +553,7 @@ BOOST_AUTO_TEST_CASE(test_lua)
     local counter = 0
     function luaroundrobin(servers, dq)
       counter = counter + 1
-      return servers[1 + (counter % #servers)]
+      return 1 + (counter % #servers)
     end
 
     setServerPolicyLua("luaroundrobin", luaroundrobin)
@@ -582,7 +582,9 @@ BOOST_AUTO_TEST_CASE(test_lua)
 
     for (const auto& name : names) {
       auto dnsQuestion = getDQ(&name);
-      auto server = pol->getSelectedBackend(servers, dnsQuestion);
+      auto selectedServer = pol->getSelectedBackend(servers, dnsQuestion);
+      BOOST_REQUIRE(selectedServer);
+      const auto& server = selectedServer.get();
       BOOST_REQUIRE(serversMap.count(server) == 1);
       ++serversMap[server];
     }

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -395,7 +395,7 @@ class TestRoutingCustomLuaRoundRobinLB(RoundRobinTest, DNSDistTest):
     local counter = 0
     function luaroundrobin(servers_list, dq)
       counter = counter + 1
-      return servers_list[(counter %% #servers_list)+1]
+      return (counter %% #servers_list)+1
     end
     setServerPolicy(newServerPolicy("custom lua round robin policy", luaroundrobin))
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since the refactoring of the runtime configuration, the content of a Server Pool is now in effect immutable (we have to create a new copy and update it), so we no longer have to lock and reference count Server Pools and their content. This means we can save the cost of updating the reference counters of shared pointers in several places, yielding a nice performance improvement (~7% in my tests, but more tests are needed).

This is a breaking change for custom load-balancing policies written in Lua: they now need to return the index in the servers array of the backend they want to select, instead of returning a reference to the backend.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

