### PR TITLE
dnsdist-2.0.x: Backport 15917 - Return early when a rule chain is empty

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -443,6 +443,10 @@ static bool encryptResponse(PacketBuffer& response, size_t maximumSize, bool tcp
 
 bool applyRulesToResponse(const std::vector<dnsdist::rules::ResponseRuleAction>& respRuleActions, DNSResponse& dnsResponse)
 {
+  if (respRuleActions.empty()) {
+    return true;
+  }
+
   DNSResponseAction::Action action = DNSResponseAction::Action::None;
   std::string ruleresult;
   for (const auto& rrule : respRuleActions) {
@@ -983,6 +987,10 @@ bool processRulesResult(const DNSAction::Action& action, DNSQuestion& dnsQuestio
 
 static bool applyRulesChainToQuery(const std::vector<dnsdist::rules::RuleAction>& rules, DNSQuestion& dnsQuestion)
 {
+  if (rules.empty()) {
+    return true;
+  }
+
   DNSAction::Action action = DNSAction::Action::None;
   string ruleresult;
   bool drop = false;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #15917 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
