### PR TITLE
dnsdist-2.0.x: Backport 15918 - Update a cache's atomic counter without holding the lock

### DIFF
--- a/pdns/dnsdistdist/dnsdist-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-cache.hh
@@ -133,7 +133,7 @@ private:
 
   bool cachedValueMatches(const CacheValue& cachedValue, uint16_t queryFlags, const DNSName& qname, uint16_t qtype, uint16_t qclass, bool receivedOverUDP, bool dnssecOK, const boost::optional<Netmask>& subnet) const;
   uint32_t getShardIndex(uint32_t key) const;
-  void insertLocked(CacheShard& shard, std::unordered_map<uint32_t, CacheValue>& map, uint32_t key, CacheValue& newValue);
+  bool insertLocked(std::unordered_map<uint32_t, CacheValue>& map, uint32_t key, CacheValue& newValue);
 
   std::vector<CacheShard> d_shards;
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #15918 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
