### PR TITLE
Make keyUnconv a bit less inefficient

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1469,10 +1469,11 @@ static DNSName keyUnconv(std::string& instr)
 
   DNSName tmp;
 
-  for (auto const& label : labels) {
-    tmp.appendRawLabel(label);
+  while (!labels.empty()) {
+    tmp.appendRawLabel(labels.back());
+    labels.pop_back();
   }
-  return tmp.labelReverse();
+  return tmp;
 }
 
 static std::string makeBadDataExceptionMessage(const std::string& where, std::exception& exc, MDBOutVal& key, MDBOutVal& val)


### PR DESCRIPTION
### Short description
This routine (only used for to enumerate the contents of a view) chops an lmdb key into a vector of labels, then builds a DNSName with all the labels in reverse order, and reverses it. But we know enough to be able to build it with the labels in right order and save that reverse call... (not sure this is good enough to allow us to get rid of the comment regarding this routine's efficiency, though)

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
