### PR TITLE
Backport 15706 to rec 5.2.x: Prevent a crash in the ZoneToCache unit tests

### DIFF
--- a/pdns/recursordist/test-rec-zonetocache.cc
+++ b/pdns/recursordist/test-rec-zonetocache.cc
@@ -172,6 +172,7 @@ static void zonemdGenericTest(const std::string& lines, pdns::ZoneMD::Config mod
 
 BOOST_AUTO_TEST_CASE(test_zonetocachegeneric)
 {
+  SyncRes::setDomainMap(std::make_shared<SyncRes::domainmap_t>());
   g_log.setLoglevel(Logger::Critical);
   g_log.toConsole(Logger::Critical);
   zonemdGenericTest(genericTest, pdns::ZoneMD::Config::Require, pdns::ZoneMD::Config::Ignore, 4U);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
