### PR TITLE
Backport 15706 to rec-5.1.x: Prevent a crash in the ZoneToCache unit tests

### DIFF
--- a/pdns/recursordist/test-rec-zonetocache.cc
+++ b/pdns/recursordist/test-rec-zonetocache.cc
@@ -172,6 +172,7 @@ static void zonemdGenericTest(const std::string& lines, pdns::ZoneMD::Config mod
 
 BOOST_AUTO_TEST_CASE(test_zonetocachegeneric)
 {
+  SyncRes::setDomainMap(std::make_shared<SyncRes::domainmap_t>());
   g_log.setLoglevel(Logger::Critical);
   g_log.toConsole(Logger::Critical);
   zonemdGenericTest(genericTest, pdns::ZoneMD::Config::Require, pdns::ZoneMD::Config::Ignore, 4U);


### PR DESCRIPTION
Backport of #15706 

Sadly this missed the rec-5.1.7 tag...