### PR TITLE
dnsdist: Clean up incoming TCP connections counters once per minute

### DIFF
--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -96,7 +96,7 @@ static bool checkTCPConnectionsRate(const boost::circular_buffer<ClientActivity>
   uint64_t connectionsSeen = 0;
   uint64_t tlsNewSeen = 0;
   uint64_t tlsResumedSeen = 0;
-  time_t cutOff = now - (interval * 60); // interval is in seconds
+  const auto cutOff = static_cast<time_t>(now - (interval * 60)); // interval is in seconds
   for (const auto& entry : activity) {
     if (entry.bucketEndTime < cutOff) {
       continue;
@@ -139,7 +139,7 @@ void IncomingConcurrentTCPConnectionsManager::cleanup(time_t now)
 
   const auto& immutable = dnsdist::configuration::getImmutableConfiguration();
   const auto interval = immutable.d_tcpConnectionsRatePerClientInterval;
-  time_t cutOff = now - (interval * 60); // interval in minutes
+  const auto cutOff = static_cast<time_t>(now - (interval * 60)); // interval in minutes
   for (auto& shard : s_tcpClientsConnectionMetrics) {
     auto db = shard.lock();
     auto& index = db->get<TimeTag>();

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -96,7 +96,7 @@ static bool checkTCPConnectionsRate(const boost::circular_buffer<ClientActivity>
   uint64_t connectionsSeen = 0;
   uint64_t tlsNewSeen = 0;
   uint64_t tlsResumedSeen = 0;
-  const auto cutOff = static_cast<time_t>(now - (interval * 60)); // interval is in seconds
+  const auto cutOff = static_cast<time_t>(now - (interval * 60)); // interval is in minutes
   for (const auto& entry : activity) {
     if (entry.bucketEndTime < cutOff) {
       continue;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In some setups the cleaning was too aggressive, wasting CPU cycles.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

