### PR TITLE
dnsdist: Increase the time granted for the "timeout then restart" test

### DIFF
--- a/regression-tests.dnsdist/test_TimeoutResponse.py
+++ b/regression-tests.dnsdist/test_TimeoutResponse.py
@@ -102,7 +102,7 @@ class TestTimeoutBackendUdpTcp(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery", "sendDOQQueryWrapper", "sendDOH3QueryWrapper", "sendDOTQueryWrapper", "sendDOHWithNGHTTP2QueryWrapper"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(query, response=None, useQueue=False, timeout=3)
+            (_, receivedResponse) = sender(query, response=None, useQueue=False, timeout=4)
             self.assertTrue(receivedResponse)
             self.assertEqual(receivedResponse, expectedResponse)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This test fails from time to time in our CI. After investigation, it turns out that sometimes the response comes just a few milliseconds after the 3 seconds timeout has expired:

```
Got answer from 127.0.0.1:14191, relayed to 127.0.0.1:36139 (UDP), took 3.00105e+06 us
```

So let's use a slightly larger timeout of 4 seconds. It will not add any delay if the response is received faster than that and will hopefully reduce the number of spurious failures.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
