### PR TITLE
Optimize reload-zones logic to reduce thread scheduling times

### DIFF
--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -209,8 +209,10 @@ string reloadZoneConfiguration(bool yaml)
     // these explicitly-named captures should not be necessary, as lambda
     // capture of tuple-like structured bindings is permitted, but some
     // compilers still don't allow it
-    broadcastFunction([dmap = newDomainMap] { return pleaseUseNewSDomainsMap(dmap); });
-    broadcastFunction([nsset = newNotifySet] { return pleaseSupplantAllowNotifyFor(nsset); });
+    broadcastFunction([dmap = newDomainMap, nsset = newNotifySet] { 
+        pleaseUseNewSDomainsMap(dmap);
+        return pleaseSupplantAllowNotifyFor(nsset);
+    });
 
     // Wipe the caches *after* the new auth domain info has been set
     // up, as a query during setting up might fill the caches


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When **reload-zones** sets thread local variables, it aggregates two operations into one thread scheduling, and completes the setting of two variables in one function. Because both functions return nullptr, no memory leak occurs.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
