### PR TITLE
lmdb: be more careful when looking into the domains table

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1687,8 +1687,8 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
     auto txn = d_tdomains->getROTransaction();
 
     DomainInfo di;
-    if (auto id = txn.get<0>(domain, di); id != 0) {
-      idvec.push_back(id);
+    if (auto domain_id = txn.get<0>(domain, di); domain_id != 0) {
+      idvec.push_back(domain_id);
     }
   }
   else {
@@ -2031,7 +2031,7 @@ bool LMDBBackend::getDomainInfo(const ZoneName& domain, DomainInfo& info, bool g
   return true;
 }
 
-int LMDBBackend::genChangeDomain(const ZoneName& domain, const std::function<void(DomainInfo&)>& func)
+bool LMDBBackend::genChangeDomain(const ZoneName& domain, const std::function<void(DomainInfo&)>& func)
 {
   auto txn = d_tdomains->getRWTransaction();
 
@@ -2049,7 +2049,7 @@ int LMDBBackend::genChangeDomain(const ZoneName& domain, const std::function<voi
 }
 
 // NOLINTNEXTLINE(readability-identifier-length)
-int LMDBBackend::genChangeDomain(domainid_t id, const std::function<void(DomainInfo&)>& func)
+bool LMDBBackend::genChangeDomain(domainid_t id, const std::function<void(DomainInfo&)>& func)
 {
   DomainInfo di;
 

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -333,8 +333,8 @@ private:
   void openAllTheDatabases();
   std::shared_ptr<RecordsRWTransaction> getRecordsRWTransaction(domainid_t id);
   std::shared_ptr<RecordsROTransaction> getRecordsROTransaction(domainid_t id, const std::shared_ptr<LMDBBackend::RecordsRWTransaction>& rwtxn = nullptr);
-  int genChangeDomain(const ZoneName& domain, const std::function<void(DomainInfo&)>& func);
-  int genChangeDomain(domainid_t id, const std::function<void(DomainInfo&)>& func);
+  bool genChangeDomain(const ZoneName& domain, const std::function<void(DomainInfo&)>& func);
+  bool genChangeDomain(domainid_t id, const std::function<void(DomainInfo&)>& func);
   static void deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match);
 
   void getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow);


### PR DESCRIPTION
### Short description
There are a couple of places where searches for a given domain in the domains table does not check for a possible "domain not found" error condition and attempts to proceed anyway. Better not do that.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
