### PR TITLE
Add missing #if statements to dnsdist-lua.cc

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -2260,6 +2260,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
       bool ignoreTLSConfigurationErrors = false;
       if (getOptionalValue<bool>(vars, "ignoreTLSConfigurationErrors", ignoreTLSConfigurationErrors) > 0 && ignoreTLSConfigurationErrors) {
+#if defined(HAVE_LIBSSL)
         // we are asked to try to load the certificates so we can return a potential error
         // and properly ignore the frontend before actually launching it
         try {
@@ -2269,6 +2270,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
           errlog("Ignoring DoH frontend: '%s'", e.what());
           return;
         }
+#endif /* HAVE_LIBSSL */
       }
 
       checkAllParametersConsumed("addDOHLocal", vars);
@@ -2357,6 +2359,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
       bool ignoreTLSConfigurationErrors = false;
       if (getOptionalValue<bool>(vars, "ignoreTLSConfigurationErrors", ignoreTLSConfigurationErrors) > 0 && ignoreTLSConfigurationErrors) {
+#if defined(HAVE_LIBSSL)
         // we are asked to try to load the certificates so we can return a potential error
         // and properly ignore the frontend before actually launching it
         try {
@@ -2366,6 +2369,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
           errlog("Ignoring DoH3 frontend: '%s'", e.what());
           return;
         }
+#endif /* HAVE_LIBSSL */
       }
 
       checkAllParametersConsumed("addDOH3Local", vars);
@@ -2433,6 +2437,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
       bool ignoreTLSConfigurationErrors = false;
       if (getOptionalValue<bool>(vars, "ignoreTLSConfigurationErrors", ignoreTLSConfigurationErrors) > 0 && ignoreTLSConfigurationErrors) {
+#if defined(HAVE_LIBSSL)
         // we are asked to try to load the certificates so we can return a potential error
         // and properly ignore the frontend before actually launching it
         try {
@@ -2442,6 +2447,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
           errlog("Ignoring DoQ frontend: '%s'", e.what());
           return;
         }
+#endif /* HAVE_LIBSSL */
       }
 
       checkAllParametersConsumed("addDOQLocal", vars);


### PR DESCRIPTION
This adds some missing #if statements to support building without OpenSSL.

### Short description
When compiling dnsdist 2.0.0 without OpenSSL support it fails in several places.
This patch adds #if defined(HAVE_LIBSSL) where needed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
