### PR TITLE
Backport 15867 to auth 4.9.x

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -1110,6 +1110,9 @@ definitions:
       disabled:
         type: boolean
         description: 'Whether or not this record is disabled. When unset, the record is not disabled'
+      modified_at:
+        type: integer
+        description: 'Timestamp of the last change to the record'
 
   Comment:
     title: Comment

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1513,6 +1513,7 @@ bool LMDBBackend::get(DNSZoneRecord& zr)
       }
 
       serFromString(d_currentVal.get<string_view>(), d_currentrrset);
+      d_currentrrsettime = LMDBLS::LSgetTimestamp(d_currentVal.getNoStripHeader<string_view>()) / (1000UL * 1000UL * 1000UL);
       d_currentrrsetpos = 0;
     }
     else {
@@ -1567,6 +1568,7 @@ bool LMDBBackend::get(DNSResourceRecord& rr)
   rr.domain_id = zr.domain_id;
   rr.auth = zr.auth;
   rr.disabled = zr.disabled;
+  rr.last_modified = d_currentrrsettime;
 
   return true;
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1513,7 +1513,7 @@ bool LMDBBackend::get(DNSZoneRecord& zr)
       }
 
       serFromString(d_currentVal.get<string_view>(), d_currentrrset);
-      d_currentrrsettime = LMDBLS::LSgetTimestamp(d_currentVal.getNoStripHeader<string_view>()) / (1000UL * 1000UL * 1000UL);
+      d_currentrrsettime = static_cast<time_t>(LMDBLS::LSgetTimestamp(d_currentVal.getNoStripHeader<string_view>()) / (1000UL * 1000UL * 1000UL));
       d_currentrrsetpos = 0;
     }
     else {

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -323,6 +323,7 @@ private:
 
   vector<LMDBResourceRecord> d_currentrrset;
   size_t d_currentrrsetpos;
+  time_t d_currentrrsettime;
   MDBOutVal d_currentKey;
   MDBOutVal d_currentVal;
   bool d_includedisabled;

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -77,7 +77,7 @@ public:
 
   // Aligned on 8-byte boundaries on systems where time_t is 8 bytes and int
   // is 4 bytes, aka modern linux on x86_64
-  time_t last_modified{}; //!< For autocalculating SOA serial numbers - the backend needs to fill this in
+  time_t last_modified{}; //!< Timestamp of last update, if known by the backend
 
   uint32_t ttl{}; //!< Time To Live of this record
   uint32_t signttl{}; //!< If non-zero, use this TTL as original TTL in the RRSIG

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -523,9 +523,13 @@ static void fillZone(UeberBackend& backend, const DNSName& zonename, HttpRespons
 
       while (rit != records.end() && rit->qname == current_qname && rit->qtype == current_qtype) {
         ttl = min(ttl, rit->ttl);
-        rrset_records.push_back(Json::object{
+        auto object = Json::object{
           {"disabled", rit->disabled},
-          {"content", makeApiRecordContent(rit->qtype, rit->content)}});
+          {"content", makeApiRecordContent(rit->qtype, rit->content)}};
+        if (rit->last_modified != 0) {
+          object["modified_at"] = (double)rit->last_modified;
+        }
+        rrset_records.push_back(object);
         rit++;
       }
       while (cit != comments.end() && cit->qname == current_qname && cit->qtype == current_qtype) {
@@ -2578,6 +2582,9 @@ static void apiServerSearchData(HttpRequest* req, HttpResponse* resp)
         {"ttl", (double)resourceRecord.ttl},
         {"disabled", resourceRecord.disabled},
         {"content", makeApiRecordContent(resourceRecord.qtype, resourceRecord.content)}};
+      if (resourceRecord.last_modified != 0) {
+        object["modified_at"] = (double)resourceRecord.last_modified;
+      }
 
       val = zoneIdZone.find(resourceRecord.domain_id);
       if (val != zoneIdZone.end()) {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -10,9 +10,15 @@ from pprint import pprint
 from test_helper import ApiTestCase, unique_zone_name, is_auth, is_auth_lmdb, is_recursor, get_db_records, pdnsutil_rectify, sdig
 
 
+def remove_timestamp(json):
+    for item in json:
+        if 'modified_at' in item:
+            del item['modified_at']
+
 def get_rrset(data, qname, qtype):
     for rrset in data['rrsets']:
         if rrset['name'] == qname and rrset['type'] == qtype:
+            remove_timestamp(rrset['records'])
             return rrset
     return None
 
@@ -884,7 +890,10 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         data = self.get_zone(example_com['id'], rrset_name="host-18000.example.com.")
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'rrsets'):
             self.assertIn(k, data)
-        self.assertEqual(data['rrsets'],
+        received_rrsets = data['rrsets']
+        for rrset in received_rrsets:
+            remove_timestamp(rrset['records'])
+        self.assertEqual(received_rrsets,
             [
                 {
                     'comments': [],
@@ -907,7 +916,10 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         data = self.get_zone(powerdnssec_org['id'], rrset_name="localhost.powerdnssec.org.")
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'rrsets'):
             self.assertIn(k, data)
-        self.assertEqual(sorted(data['rrsets'], key=operator.itemgetter('type')),
+        received_rrsets = data['rrsets']
+        for rrset in received_rrsets:
+            remove_timestamp(rrset['records'])
+        self.assertEqual(sorted(received_rrsets, key=operator.itemgetter('type')),
             [
                 {
                     'comments': [],
@@ -942,7 +954,10 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         data = self.get_zone(powerdnssec_org['id'], rrset_name="localhost.powerdnssec.org.", rrset_type="AAAA")
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'rrsets'):
             self.assertIn(k, data)
-        self.assertEqual(data['rrsets'],
+        received_rrsets = data['rrsets']
+        for rrset in received_rrsets:
+            remove_timestamp(rrset['records'])
+        self.assertEqual(received_rrsets,
             [
                 {
                     'comments': [],
@@ -2088,8 +2103,10 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.create_zone(name=name, serial=22, soa_edit_api='')
         r = self.session.get(self.url("/api/v1/servers/localhost/search-data?q=" + name.rstrip('.')))
         self.assert_success_json(r)
-        print(r.json())
-        self.assertCountEqual(r.json(), [
+        json = r.json()
+        print(json)
+        remove_timestamp(json)
+        self.assertCountEqual(json, [
             {u'object_type': u'zone', u'name': name, u'zone_id': name},
             {u'content': u'ns1.example.com.',
              u'zone_id': name, u'zone': name, u'object_type': u'record', u'disabled': False,
@@ -2121,8 +2138,10 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.create_zone(name=name, serial=22, soa_edit_api='')
         r = self.session.get(self.url("/api/v1/servers/localhost/search-data?q=" + name.rstrip('.') + "&object_type=" + data_type))
         self.assert_success_json(r)
-        print(r.json())
-        self.assertCountEqual(r.json(), [
+        json = r.json()
+        print(json)
+        remove_timestamp(json)
+        self.assertCountEqual(json, [
             {u'content': u'ns1.example.com.',
              u'zone_id': name, u'zone': name, u'object_type': u'record', u'disabled': False,
              u'ttl': 3600, u'type': u'NS', u'name': name},
@@ -2413,7 +2432,10 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
             rrset.setdefault('comments', [])
             for record in rrset['records']:
                 record.setdefault('disabled', False)
-        assert_eq_rrsets(data['rrsets'], rrsets)
+        received_rrsets = data['rrsets']
+        for rrset in received_rrsets:
+            remove_timestamp(rrset['records'])
+        assert_eq_rrsets(received_rrsets, rrsets)
 
     def test_zone_replace_rrsets_dnssec(self):
         """With dnssec: check automatic rectify is done"""

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -2524,6 +2524,41 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         rrsets = base_rrsets + templated_rrsets(invalid_rrsets, name)
         self.put_zone(name, {'rrsets': rrsets}, expect_error=expected_error)
 
+    @unittest.skipIf(not is_auth_lmdb(), "No rrset timestamps except with LMDB")
+    def test_check_rrset_modified_at(self):
+        name = 'host-18000.example.com.'
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones"))
+        domains = r.json()
+        example_com = [domain for domain in domains if domain['name'] == u'example.com.'][0]
+
+        # verify single record from name that has a single record
+        data = self.get_zone(example_com['id'], rrset_name="host-18000.example.com.")
+        modified_at = data['rrsets'][0]['records'][0]['modified_at']
+
+        # write back the same data anyway, to get a new timestamp
+        rrset = {
+            'changetype': 'replace',
+            'name': name,
+            'type': 'A',
+            'ttl': 120,
+            'records':
+            [
+                {
+                    'content': '192.168.1.80',
+                }
+            ]
+        }
+        payload = {'rrsets': [rrset]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/example.com"),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assert_success(r)
+
+        # get the changed record.
+        data = self.get_zone(example_com['id'], rrset_name="host-18000.example.com.")
+        modified_at_new = data['rrsets'][0]['records'][0]['modified_at']
+        self.assertGreater(modified_at_new, modified_at)
 
 @unittest.skipIf(not is_auth(), "Not applicable")
 class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):


### PR DESCRIPTION
### Short description
This is backport of the "records timestamps in the API" PR. The only change compared to what is is master is that I did not change the API swagger version in this PR.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] checked that this code was merged to master
