### PR TITLE
docs: clarify geoip service health checks uses lua records

### DIFF
--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -23,9 +23,9 @@ This backend (which is a.k.a. the YAML backend) allows visitors to be sent to a 
 no appreciable delay, as would otherwise be incurred with a protocol
 level redirect. Additionally, the GeoIP backend can be used to provide
 service over several clusters, any of which can be taken out of use
-easily, for example for maintenance purposes. This backend can utilize
-EDNS Client Subnet extension for decision making, if provided in query
-and you have turned on
+easily, for example for maintenance purposes, by using :doc:`Lua records <../lua-records>`.
+This backend can utilize EDNS Client Subnet extension for decision
+making, if provided in a query and you have turned on
 :ref:`setting-edns-subnet-processing`.
 
 Prerequisites


### PR DESCRIPTION
### Short description

The geoip backend documentation mentions:

> Additionally, the GeoIP backend can be used to provide service over
> several clusters, any of which can be taken out of use easily, for
> example for maintenance purposes.

But no details on how that is achieved. Without knowing Lua records exist, it's hard to find how to do it.

Add a reference to the Lua records documentation to make it easier to see the connection.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
