### PR TITLE
pdnsutil: report corrupted records

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -261,10 +261,12 @@ public:
   string directBackendCmd(const string &query) override;
   bool searchRecords(const string &pattern, size_t maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, size_t maxResults, vector<Comment>& result) override;
+  bool get_unsafe(DNSResourceRecord& rec, std::vector<std::pair<std::string, std::string>>& invalid) override;
 
 protected:
   string pattern2SQLPattern(const string& pattern);
   void extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& rr);
+  void extractRecord_unsafe(SSqlStatement::row_t& row, DNSResourceRecord& rec, std::vector<std::pair<std::string, std::string>>& invalid);
   void extractComment(SSqlStatement::row_t& row, Comment& c);
   void setLastCheck(domainid_t domain_id, time_t lastcheck);
   bool isConnectionUsable() {

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -517,6 +517,18 @@ public:
 
   const string& getPrefix() { return d_prefix; };
 
+  // The following routine allows callers to retrieve invalid records from
+  // the backend, which would not be returned by get(). This is used by
+  // pdnsutil for diagnostic purposes.
+  // The default implementation simply wraps get() and pretends there are
+  // no invalid or corrupted records in the backend storage.
+
+  virtual bool get_unsafe(DNSResourceRecord& rec, std::vector<std::pair<std::string, std::string>>& invalid)
+  {
+    invalid.clear();
+    return get(rec);
+  }
+
 protected:
   bool mustDo(const string& key);
   const string& getArg(const string& key);

--- a/regression-tests.nobackend/gsqlite3-corrupted-record/command
+++ b/regression-tests.nobackend/gsqlite3-corrupted-record/command
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+## source ../regression-tests/common
+
+rm -f pdns-gsqlite3.conf pdns.sqlite3
+
+cat > pdns-gsqlite3.conf << __EOF__
+launch=gsqlite3
+gsqlite3-database=pdns.sqlite3
+module-dir=../regression-tests/modules
+__EOF__
+
+ARGS="--config-dir=. --config-name=gsqlite3"
+
+sqlite3 pdns.sqlite3 < ../modules/gsqlite3backend/schema.sqlite3.sql
+tosql gsqlite | sqlite3 pdns.sqlite3
+echo ANALYZE\; | sqlite3 pdns.sqlite3
+
+# Create zone
+$PDNSUTIL $ARGS zone create bug.less
+
+# Add some valid records
+$PDNSUTIL $ARGS rrset add bug.less bug.less NS no.bug.less
+$PDNSUTIL $ARGS rrset add bug.less no.bug.less A 1.2.3.4
+$PDNSUTIL $ARGS rrset add bug.less never.bug.less A 1.2.3.4
+
+# Alter some records to make their contents invalid
+echo "UPDATE records SET name='this-name-turns-out-to-be-an-invalid-dns-name-because-it-is-way-larger-than-sixty-three-characters-and-this-is-not-allowed-for-labels.bug.less' WHERE name='no.bug.less';" | sqlite3 pdns.sqlite3 2>&1
+echo "UPDATE records SET ordername='..' WHERE name='never.bug.less';" | sqlite3 pdns.sqlite3 2>&1
+
+# Check that pdnsutil zone list doesn't show the invalid records
+$PDNSUTIL $ARGS zone list bug.less
+
+# Check that pdnsutil zone check reports the invalid records
+$PDNSUTIL $ARGS zone check bug.less
+
+exit 0

--- a/regression-tests.nobackend/gsqlite3-corrupted-record/description
+++ b/regression-tests.nobackend/gsqlite3-corrupted-record/description
@@ -1,0 +1,2 @@
+This test checks that an intentionally crafted incorrect record gets ignored
+during regular lookups and reported as incorrect by pdnsutil zone check.

--- a/regression-tests.nobackend/gsqlite3-corrupted-record/expected_result
+++ b/regression-tests.nobackend/gsqlite3-corrupted-record/expected_result
@@ -1,0 +1,12 @@
+New rrset:
+bug.less. 3600 IN NS no.bug.less
+New rrset:
+no.bug.less. 3600 IN A 1.2.3.4
+New rrset:
+never.bug.less. 3600 IN A 1.2.3.4
+$ORIGIN .
+bug.less	3600	IN	NS	no.bug.less.
+bug.less	3600	IN	SOA	a.misconfigured.dns.server.invalid hostmaster.bug.less 0 10800 3600 604800 3600
+[Warning] Ill-formed 'never.bug.less' record in backend storage: field ordername has invalid content '..'
+[Warning] Ill-formed record in backend storage: field qname has invalid content 'this-name-turns-out-to-be-an-invalid-dns-name-because-it-is-way-larger-than-sixty-three-characters-and-this-is-not-allowed-for-labels.bug.less'
+Checked 2 records of 'bug.less', 0 errors, 2 warnings.


### PR DESCRIPTION
### Short description
The SQL-based backends silently ignore ill-formed records found in the database. This PR adds plumbing to let `pdnsutil` get these records, so that `pdnsutil zone check` may report them. Fixing the record contents, however, is out of `pdnsutil`'s capacity.

Addresses #4941 

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
