### PR TITLE
pdnsutil: smarter SOA handling in zone edit

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1952,6 +1952,7 @@ static bool increaseZoneSerial(DNSSECKeeper& dsk, DomainInfo& info, std::vector<
   return true;
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity): despite moving a lot of it into subroutines, it's still a bit over the threshold as of 20250811
 static int editZone(const ZoneName &zone, const PDNSColors& col)
 {
   UtilBackend B; //NOLINT(readability-identifier-length)

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2102,6 +2102,10 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
           changed[{diff.d_name,diff.d_type}]+=str.str();
         }
       }
+      if (changed.empty()) {
+        cout<<endl<<"No changes to apply."<<endl;
+        return(EXIT_SUCCESS);
+      }
       cout<<"Detected the following changes:"<<endl;
       for(auto& change : changed) {
         cout<<change.second;
@@ -2112,7 +2116,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
       }
       // If the SOA record has not been modified, ask the user if they want to
       // update the serial number.
-      if (!changed.empty() && isSameZoneSerial(soa, info, post)) {
+      if (isSameZoneSerial(soa, info, post)) {
         state = ASKSOA;
       }
       else {
@@ -2151,10 +2155,6 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
       }
       break;
     case ASKAPPLY:
-      if(changed.empty()) {
-        cout<<endl<<"No changes to apply."<<endl;
-        return(EXIT_SUCCESS);
-      }
       cout<<endl<<"(a)pply these changes, (e)dit again, (r)etry with original zone, (q)uit: "<<std::flush;
       resp = ::tolower(read1char());
       if (resp != '\n') {


### PR DESCRIPTION
### Short description
If you `pdnsutil zone edit` your zone but don't change its SOA record, you will be prompted for an automatic serial number increase. But if you edit the SOA and leave the serial number unchanged, you won't get asked anything even though an increase is probably necessary.

This is because the lazy logic only asks whether it should perform an update if the SOA record is not modified.

This PR changes the logic to what mere mortals would expect, i.e. ``always asks to increase the serial number unless the SOA serial number field itself changes''.

There are a bunch of cleanup commits first (getting rid of the `goto`, reducing the scope of some local variables, and throwing a bear carcass to `clang-tidy` to keep it from complaining loudly that this code has been written many years ago). In order to do a serious/thorough review, reviewing on a per-commit basis is advised.

Also, as a bonus, the delta between the last SOA and the proposed SOA with the serial number increase is shown on the terminal for inspection. This used to be the case but although the output was still set up, it was no longer being displayed.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
