### PR TITLE
Backport 15938 to rec-5.3.x: put lib.rs into tarball

### DIFF
--- a/pdns/recursordist/meson-dist-script.sh
+++ b/pdns/recursordist/meson-dist-script.sh
@@ -22,14 +22,9 @@ tar -C "$MESON_SOURCE_ROOT" -hcf - $symlinks | tar -xf - -C "$MESON_PROJECT_DIST
 echo Running autoreconf -vi so distfile is still usable for autotools building
 # Run autoconf for people using autotools to build, this creates a configure sc
 autoreconf -vi
-
-# Generate man pages
-cd "$MESON_PROJECT_BUILD_ROOT"
-ninja pdns_recursor.1
-cp -vp *.1 "$MESON_PROJECT_DIST_ROOT"
-
 rm -rf "$MESON_PROJECT_DIST_ROOT"/autom4te.cache
 
+cd "$MESON_PROJECT_BUILD_ROOT"
 
 # Generate  a few files to reduce build dependencies
 echo 'If the below command generates an error, remove dnslabeltext.cc from source dir (remains of an autotools build?) and start again with a clean meson setup'
@@ -39,3 +34,10 @@ echo 'If the below command generates an error, remove effective_tld_names.dat an
 ninja pubsuffix.cc
 cp -vp pubsuffix.cc "$MESON_PROJECT_DIST_ROOT"
 
+# Generate the sources for our Rust-based library, lib.rs is needed by a pre-configure step on some build systems
+meson compile rec-rust-sources
+cp -vp "$MESON_SOURCE_ROOT"/rec-rust-lib/rust/src/lib.rs "$MESON_PROJECT_DIST_ROOT"/rec-rust-lib/rust/src/
+
+# Generate man pages
+meson compile man-pages
+cp -vp *.1 "$MESON_PROJECT_DIST_ROOT"

--- a/pdns/recursordist/rec-rust-lib/meson.build
+++ b/pdns/recursordist/rec-rust-lib/meson.build
@@ -14,6 +14,7 @@ generated = [
 python = find_program('python3')
 
 recrust = custom_target(
+  'rec-rust-sources',
   command: [python, '@INPUT0@', '@SOURCE_ROOT@/rec-rust-lib', '@BUILD_ROOT@/rec-rust-lib'],
   input: sources,
   output: generated,


### PR DESCRIPTION
Plus some rearrangement is more like the dnsdist one

(cherry picked from commit d7ee4a5f4661c073b1e474bfc67a39faa0297e35)

Backport of #15938 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
