### PR TITLE
Backport 15981 to rec-5.3.x: add back parent span attributes, they were lost in #15756 

### DIFF
--- a/pdns/recursordist/rec-eventtrace.cc
+++ b/pdns/recursordist/rec-eventtrace.cc
@@ -79,7 +79,14 @@ std::vector<pdns::trace::Span> RecEventTrace::convertToOT(const InitialSpanInfo&
   ret.reserve((d_events.size() / 2) + 1);
 
   // The parent of all Spans
-  ret.emplace_back(Span{.trace_id = span.trace_id, .span_id = span.span_id, .parent_span_id = span.parent_span_id, .end_time_unix_nano = timestamp()});
+  ret.emplace_back(Span{
+    .trace_id = span.trace_id,
+    .span_id = span.span_id,
+    .parent_span_id = span.parent_span_id,
+    .name = "RecRequest",
+    .start_time_unix_nano = span.start_time_unix_nano,
+    .end_time_unix_nano = timestamp(),
+  });
 
   std::vector<SpanID> spanIDs; // mapping of span index in ret vector to SpanID
   std::map<size_t, size_t> ids; // mapping from event record index to index in ret vector (Spans)


### PR DESCRIPTION
Fixes #15974


(cherry picked from commit f9d864dcbdf5a427c909e7c3aba427784ec1f407)

Backport of #15981

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
