### PR TITLE
Fix Boost system lib dependency: it is no longer available since 1.89

### DIFF
--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -22,7 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 m4_define([_BOOST_SERIAL], [m4_translit([
-# serial 38
+# serial 39
 ], [#
 ], [])])
 
@@ -226,7 +226,7 @@ AC_LANG_POP([C++])dnl
   AC_CACHE_CHECK([for Boost's header version],
     [boost_cv_lib_version],
     [m4_pattern_allow([^BOOST_LIB_VERSION$])dnl
-     _BOOST_SED_CPP([[/^boost-lib-version = /{s///;s/[\" ]//g;p;q;}]],
+     _BOOST_SED_CPP([[/^.*boost-lib-version = /{s///;s/[\" ]//g;p;q;}]],
                     [#include <boost/version.hpp>
 boost-lib-version = BOOST_LIB_VERSION],
     [boost_cv_lib_version=`cat conftest.i`])])
@@ -622,6 +622,13 @@ BOOST_DEFUN([Bind],
 [BOOST_FIND_HEADER([boost/bind.hpp])])
 
 
+# BOOST_CAST()
+# ------------
+# Look for Boost.Cast
+BOOST_DEFUN([Cast],
+[BOOST_FIND_HEADER([boost/cast.hpp])])
+
+
 # BOOST_CHRONO([PREFERRED-RT-OPT], [ERROR_ON_UNUSABLE])
 # --------------
 # Look for Boost.Chrono.
@@ -787,6 +794,15 @@ fi
 LIBS=$boost_context_save_LIBS
 LDFLAGS=$boost_context_save_LDFLAGS
 ])# BOOST_CONTEXT
+
+
+# BOOST_CONVERSION()
+# ------------------
+# Look for Boost.Conversion (cast / lexical_cast)
+BOOST_DEFUN([Conversion],
+[BOOST_FIND_HEADER([boost/cast.hpp])
+BOOST_FIND_HEADER([boost/lexical_cast.hpp])
+])# BOOST_CONVERSION
 
 
 # BOOST_COROUTINE([PREFERRED-RT-OPT], [ERROR_ON_UNUSABLE])
@@ -1316,11 +1332,16 @@ BOOST_DEFUN([String_Algo],
 # --------------------------------
 # Look for Boost.System.  For the documentation of PREFERRED-RT-OPT, see the
 # documentation of BOOST_FIND_LIB above.  This library was introduced in Boost
-# 1.35.0.
+# 1.35.0 and is header only since 1.70.
 BOOST_DEFUN([System],
-[BOOST_FIND_LIB([system], [$1],
+[
+if test $boost_major_version -ge 170; then
+  BOOST_FIND_HEADER([boost/system/error_code.hpp])
+else
+  BOOST_FIND_LIB([system], [$1],
                 [boost/system/error_code.hpp],
                 [boost::system::error_code e; e.clear();], [], [], [$2])
+fi
 ])# BOOST_SYSTEM
 
 


### PR DESCRIPTION
To do that, partly sync with upstream boost.m4

Should fix #15972

(cherry picked from commit e096f48218dd2ea82fc907ff62e4cbced121ca8b)

Backport of #15991 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
