### PR TITLE
REST API: normalize record contents received

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -17,6 +17,14 @@ zone display
 Display of records in various :doc:`pdnsutil <manpages/pdnsutil.1>` commands
 will now always contain explicit trailing dots, for consistency.
 
+Record handling in the API
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Record data sent through the API will now be normalized to be closer to their
+actual zone representation.
+As a result of this change, reading back these records may show a different
+representation than expected.
+
 4.9.0 to 5.0.0
 --------------
 

--- a/pdns/dnslabeltext.rl
+++ b/pdns/dnslabeltext.rl
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <string>
+#include <string_view>
 #include "dnsname.hh"
 #include "namespaces.hh"
 #include "dnswriter.hh"
@@ -172,11 +173,11 @@ DNSName::string_t segmentDNSNameRaw(const char* realinput, size_t inputlen)
 
 // Reads an RFC 1035 character string from 'in', puts the resulting bytes in 'out'.
 // Returns the amount of bytes read from 'in'
-size_t parseRFC1035CharString(const std::string &in, std::string &val) {
+size_t parseRFC1035CharString(std::string_view in, std::string &val) {
 
   val.clear();
   val.reserve(in.size());
-  const char *p = in.c_str();
+  const char *p = in.data();
   const char *pe = p + in.size();
   int cs = 0;
   uint8_t escaped_octet = 0;

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -38,6 +38,7 @@
 #include <syslog.h>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <cctype>
 #include <utility>
 #include <vector>
@@ -803,7 +804,7 @@ std::vector<ComboAddress> getResolvers(const std::string& resolvConfPath);
 
 DNSName reverseNameFromIP(const ComboAddress& ip);
 
-size_t parseRFC1035CharString(const std::string &in, std::string &val); // from ragel
+size_t parseRFC1035CharString(std::string_view in, std::string &val); // from ragel
 size_t parseSVCBValueListFromParsedRFC1035CharString(const std::string &in, vector<std::string> &val); // from ragel
 size_t parseSVCBValueList(const std::string &in, vector<std::string> &val);
 

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1377,7 +1377,7 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
         self.assertEqual(r.status_code, 422)
-        self.assertIn('contains an invalid escape', r.json()['error'])
+        self.assertIn('Data field in DNS should start with quote (") at position 9', r.json()['error'])
 
     def test_zone_rr_update_with_escapes(self):
         name, payload, zone = self.create_zone()
@@ -1669,7 +1669,7 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         rrset = {
             'changetype': 'replace',
             'name': name,
-            'type': 'FAFAFA',
+            'type': 'FAFAFAFA', # obviously a FIPv6 address
             'ttl': 3600,
             'records': [
                 {
@@ -1994,7 +1994,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
 #        self.assertIn('You cannot have record(s) under CNAME/DNAME', r.json()['error'])
 
     def test_create_zone_with_leading_space(self):
-        # Actual regression.
         name, payload, zone = self.create_zone()
         rrset = {
             'changetype': 'replace',
@@ -2011,8 +2010,7 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         payload = {'rrsets': [rrset]}
         r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
                                headers={'content-type': 'application/json'})
-        self.assertEqual(r.status_code, 422)
-        self.assertIn('Not in expected format', r.json()['error'])
+        self.assert_success(r)
 
     @unittest.skipIf(is_auth_lmdb(), "No out-of-zone storage in LMDB")
     def test_zone_rr_delete_out_of_zone(self):


### PR DESCRIPTION
### Short description
This is an attempt at fixing #15990. Instead of taking the JSON record content strings as is, they will now be processed a bit to increase the odds of them matching their proper representation and pass validation.

As a side effect, this unbreaks a test labeled as a regression, which is probably something good?

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)