### PR TITLE
dnsdist-2.0.x: Backport 16002 - Update Cloudflare's Quiche to 0.24.5 in our packages

### DIFF
--- a/builder-support/helpers/quiche.json
+++ b/builder-support/helpers/quiche.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.24.4",
+  "version": "0.24.5",
   "license": "BSD-2-Clause",
   "publisher": "https://github.com/cloudflare/quiche",
-  "SHA256SUM": "b5f740e79728a34f5843dbce6c119fc24cbac186bd12402c2b786c570efdb193"
+  "SHA256SUM": "7d2dff9ac5b9a53eb32d98af9b5fae944dcc7176a9fcfe1877f682b1ec935663"
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16002 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
