### PR TITLE
More zone names in error messages

### DIFF
--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -251,7 +251,7 @@ string DLNotifyRetrieveHandler(const vector<string>& parts, Utility::pid_t /* pp
   try {
     domain = ZoneName(parts[1]);
   } catch (...) {
-    return "Failed to parse zone as valid DNS name";
+    return "Failed to parse '" + parts[1] + "' as a valid zone name";
   }
 
   ComboAddress primary_ip;
@@ -299,7 +299,7 @@ string DLNotifyHostHandler(const vector<string>& parts, Utility::pid_t /* ppid *
   try {
     domain = ZoneName(parts[1]);
   } catch (...) {
-    return "Failed to parse zone as valid DNS name";
+    return "Failed to parse '" + parts[1] + "' as a valid zone name";
   }
 
   try {
@@ -346,12 +346,12 @@ string DLNotifyHandler(const vector<string>& parts, Utility::pid_t /* ppid */)
     try {
       domain = ZoneName(parts[1]);
     } catch (...) {
-      return "Failed to parse zone as valid DNS name";
+      return "Failed to parse '" + parts[1] + "' as a valid zone name";
     }
     if(!Communicator.notifyDomain(domain, &B)) {
-      return "Failed to add to the queue - see log";
+      return "Failed to add " + domain.toLogString() + " to the queue - see log";
     }
-    return "Added to queue";
+    return "Added " + domain.toLogString() + " to queue";
   }
 }
 

--- a/regression-tests.nobackend/supermaster-signed/expected_result
+++ b/regression-tests.nobackend/supermaster-signed/expected_result
@@ -3,6 +3,6 @@ Imported TSIG key tsig.com hmac-md5
 Set 'example.com' meta TSIG-ALLOW-AXFR = tsig.com
 Set 'test.com' meta TSIG-ALLOW-AXFR = tsig.com
 Set 'example.com' meta AXFR-MASTER-TSIG = tsig.com
-Added to queue
+Added test.com to queue
 Received notification response with error from 127.0.0.2:53: Query Refused
 For: 'test.com'

--- a/regression-tests.nobackend/supermaster-unsigned/expected_result
+++ b/regression-tests.nobackend/supermaster-unsigned/expected_result
@@ -1,3 +1,3 @@
 Set 'example.com' meta ALLOW-AXFR-FROM = 127.0.0.2
 Set 'test.com' meta ALLOW-AXFR-FROM = 127.0.0.2
-Added to queue
+Added test.com to queue


### PR DESCRIPTION
### Short description
This is an updated version of #12154, adding zone names in error messages, see that PR description for use case and details.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
