### PR TITLE
dnsdist-2.0.x: Backport 15902 - Fix QType rate dynamic block with YAML

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -143,6 +143,18 @@ static uint8_t strToRCode(const std::string& context, const std::string& paramet
   return *rcode;
 }
 
+static uint16_t strToQType(const std::string& context, const std::string& parameterName, const ::rust::String& qtype_rust_string)
+{
+  auto qtype_str = std::string(qtype_rust_string);
+  boost::to_lower(qtype_str);
+  QType qtype;
+  qtype = std::string(qtype_str);
+  if (qtype.getCode() == 0) {
+    return checkedConversionFromStr<uint8_t>(context, parameterName, qtype_rust_string);
+  }
+  return qtype;
+}
+
 static std::optional<std::string> loadContentFromConfigurationFile(const std::string& fileName)
 {
   /* no check on the file size, don't do this with just any file! */
@@ -647,7 +659,7 @@ static void loadDynamicBlockConfiguration(const dnsdist::rust::settings::Dynamic
           ruleParams.d_tagSettings->d_name = std::string(rule.tag_name);
           ruleParams.d_tagSettings->d_value = std::string(rule.tag_value);
         }
-        dbrgObj->setRCodeRate(checkedConversionFromStr<int>("dynamic-rules.rules.qtype_rate", "qtype", rule.qtype), std::move(ruleParams));
+        dbrgObj->setQTypeRate(strToQType("dynamic-rules.rules.qtype_rate", "qtype", rule.qtype), std::move(ruleParams));
       }
       else if (rule.rule_type == "cache-miss-ratio") {
         DynBlockRulesGroup::DynBlockCacheMissRatioRule ruleParams(std::string(rule.comment), rule.action_duration, rule.ratio, rule.warning_ratio, rule.seconds, rule.action.empty() ? DNSAction::Action::None : DNSAction::typeFromString(std::string(rule.action)), rule.minimum_number_of_responses, rule.minimum_global_cache_hit_ratio);

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -146,9 +146,8 @@ static uint8_t strToRCode(const std::string& context, const std::string& paramet
 static uint16_t strToQType(const std::string& context, const std::string& parameterName, const ::rust::String& qtype_rust_string)
 {
   auto qtype_str = std::string(qtype_rust_string);
-  boost::to_lower(qtype_str);
   QType qtype;
-  qtype = std::string(qtype_str);
+  qtype = qtype_str;
   if (qtype.getCode() == 0) {
     return checkedConversionFromStr<uint8_t>(context, parameterName, qtype_rust_string);
   }

--- a/regression-tests.dnsdist/test_DynBlocksGroup.py
+++ b/regression-tests.dnsdist/test_DynBlocksGroup.py
@@ -28,6 +28,55 @@ class TestDynBlockGroupQPS(DynBlocksTest):
         name = 'qrate.group.dynblocks.tests.powerdns.com.'
         self.doTestQRate(name)
 
+class TestDynBlockGroupQTypeRate(DynBlocksTest):
+
+    _config_template = """
+    local dbr = dynBlockRulesGroup()
+    dbr:setQTypeRate(DNSQType.ANY, %d, %d, "Exceeded qtype rate", %d)
+
+    function maintenance()
+	    dbr:apply()
+    end
+    setDynBlocksAction(DNSAction.Refused)
+    newServer{address="127.0.0.1:%d"}
+    """
+    _config_params = ['_dynBlockANYQPS', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort']
+
+    def testDynBlocksQTypeRate(self):
+        """
+        Dyn Blocks (Group): QType Rate
+        """
+        name = 'qtype-rate.group.dynblocks.tests.powerdns.com.'
+        self.doTestQTypeRate(name)
+
+class TestDynBlockGroupQTypeRateYAML(DynBlocksTest):
+
+    _yaml_config_template = """---
+dynamic_rules:
+  - name: "Block client generating too many ANY queries"
+    rules:
+      - type: "qtype-rate"
+        rate: %d
+        seconds: %d
+        action_duration: %d
+        comment: "Exceeded ANY rate"
+        action: "Refused"
+        qtype: "ANY"
+
+backends:
+  - address: "127.0.0.1:%d"
+    protocol: Do53
+"""
+    _config_params = []
+    _yaml_config_params = ['_dynBlockANYQPS', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort']
+
+    def testDynBlocksQTypeRate(self):
+        """
+        Dyn Blocks (Group / YAML): QType Rate
+        """
+        name = 'qtype-rate-yaml.group.dynblocks.tests.powerdns.com.'
+        self.doTestQTypeRate(name)
+
 class TestDynBlockGroupQPSRefused(DynBlocksTest):
 
     _config_template = """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #15902 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
