### PR TITLE
dnsdist-2.0.x: Backport 15931- Speed up response content matching

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -292,7 +292,7 @@ bool responseContentMatches(const PacketBuffer& response, const DNSName& qname, 
       return false;
     }
 
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-bounds-pointer-arithmetic)
     const std::string_view packetView(reinterpret_cast<const char*>(response.data() + sizeof(dnsheader)), response.size() - sizeof(dnsheader));
     if (qname.matches(packetView)) {
       size_t pos = sizeof(dnsheader) + qname.wirelength();

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -294,7 +294,7 @@ bool responseContentMatches(const PacketBuffer& response, const DNSName& qname, 
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-bounds-pointer-arithmetic)
     const std::string_view packetView(reinterpret_cast<const char*>(response.data() + sizeof(dnsheader)), response.size() - sizeof(dnsheader));
-    if (qname.matches(packetView)) {
+    if (qname.matchesUncompressedName(packetView)) {
       size_t pos = sizeof(dnsheader) + qname.wirelength();
       rqtype = response.at(pos) * 256 + response.at(pos + 1);
       rqclass = response.at(pos + 2) * 256 + response.at(pos + 3);

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -285,12 +285,22 @@ bool responseContentMatches(const PacketBuffer& response, const DNSName& qname, 
     return false;
   }
 
-  uint16_t rqtype{};
-  uint16_t rqclass{};
-  DNSName rqname;
   try {
+    uint16_t rqtype{};
+    uint16_t rqclass{};
+    if (response.size() < (sizeof(dnsheader) + qname.wirelength() + sizeof(rqtype) + sizeof(rqclass))) {
+      return false;
+    }
+
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    rqname = DNSName(reinterpret_cast<const char*>(response.data()), response.size(), sizeof(dnsheader), false, &rqtype, &rqclass);
+    const std::string_view packetView(reinterpret_cast<const char*>(response.data() + sizeof(dnsheader)), response.size() - sizeof(dnsheader));
+    if (qname.matches(packetView)) {
+      size_t pos = sizeof(dnsheader) + qname.wirelength();
+      rqtype = response.at(pos) * 256 + response.at(pos + 1);
+      rqclass = response.at(pos + 2) * 256 + response.at(pos + 3);
+      return rqtype == qtype && rqclass == qclass;
+    }
+    return false;
   }
   catch (const std::exception& e) {
     if (remote && !response.empty() && static_cast<size_t>(response.size()) > sizeof(dnsheader)) {
@@ -302,8 +312,6 @@ bool responseContentMatches(const PacketBuffer& response, const DNSName& qname, 
     }
     return false;
   }
-
-  return rqtype == qtype && rqclass == qclass && rqname == qname;
 }
 
 static void restoreFlags(struct dnsheader* dnsHeader, uint16_t origFlags)

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -740,6 +740,7 @@ bool DNSName::matches(const std::string_view& wire_uncompressed) const
 
   const auto* our = d_storage.cbegin();
   const auto* other = wire_uncompressed.cbegin();
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   for (; our != d_storage.cend() && other != wire_uncompressed.cend(); ++our, ++other) {
     if (dns_tolower(*other) != dns_tolower(*our)) {
       return false;

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -732,22 +732,13 @@ bool DNSName::RawLabelsVisitor::empty() const
   return d_position == 0;
 }
 
-bool DNSName::matches(const std::string_view& wire_uncompressed) const
+bool DNSName::matchesUncompressedName(const std::string_view& wire_uncompressed) const
 {
   if (wire_uncompressed.empty() != empty() || wire_uncompressed.size() < d_storage.size()) {
     return false;
   }
 
-  const auto* our = d_storage.cbegin();
-  const auto* other = wire_uncompressed.cbegin();
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-  for (; our != d_storage.cend() && other != wire_uncompressed.cend(); ++our, ++other) {
-    if (dns_tolower(*other) != dns_tolower(*our)) {
-      return false;
-    }
-  }
-
-  return our == d_storage.cend();
+  return pdns_ilexicographical_compare_three_way(std::string_view(wire_uncompressed.data(), d_storage.size()), d_storage) == 0;
 }
 
 #if defined(PDNS_AUTH) // [

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -738,15 +738,15 @@ bool DNSName::matches(const std::string_view& wire_uncompressed) const
     return false;
   }
 
-  const auto* us = d_storage.cbegin();
-  const auto* p = wire_uncompressed.cbegin();
-  for (; us != d_storage.cend() && p != wire_uncompressed.cend(); ++us, ++p) {
-    if (dns_tolower(*p) != dns_tolower(*us)) {
+  const auto* our = d_storage.cbegin();
+  const auto* other = wire_uncompressed.cbegin();
+  for (; our != d_storage.cend() && other != wire_uncompressed.cend(); ++our, ++other) {
+    if (dns_tolower(*other) != dns_tolower(*our)) {
       return false;
     }
   }
 
-  return us == d_storage.cend();
+  return our == d_storage.cend();
 }
 
 #if defined(PDNS_AUTH) // [

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -732,6 +732,23 @@ bool DNSName::RawLabelsVisitor::empty() const
   return d_position == 0;
 }
 
+bool DNSName::matches(const std::string_view& wire_uncompressed) const
+{
+  if (wire_uncompressed.empty() != empty() || wire_uncompressed.size() < d_storage.size()) {
+    return false;
+  }
+
+  const auto* us = d_storage.cbegin();
+  const auto* p = wire_uncompressed.cbegin();
+  for (; us != d_storage.cend() && p != wire_uncompressed.cend(); ++us, ++p) {
+    if (dns_tolower(*p) != dns_tolower(*us)) {
+      return false;
+    }
+  }
+
+  return us == d_storage.cend();
+}
+
 #if defined(PDNS_AUTH) // [
 std::ostream & operator<<(std::ostream &ostr, const ZoneName& zone)
 {

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -112,8 +112,8 @@ public:
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name? Note that name.isPartOf(name).
   inline bool operator==(const DNSName& rhs) const; //!< DNS-native comparison (case insensitive) - empty compares to empty
   bool operator!=(const DNSName& other) const { return !(*this == other); }
-  // !< DNS-native (case insensitive) comparison against raw data in wire format. The view has to start with the DNS name, but does not have to contain only a DNS name. For example passing a view of a DNS packet starting just after the DNS header is OK.
-  bool matches(const std::string_view& wire_uncompressed) const;
+  // !< DNS-native (case insensitive) comparison against raw data in (uncompressed) wire format. The view has to start with the DNS name, but does not have to contain only a DNS name. Roughly, passing a view of a DNS packet starting just after the DNS header is OK, everything else is not because any names present later in the packet might be compressed.
+  bool matchesUncompressedName(const std::string_view& wire_uncompressed) const;
 
   std::string toString(const std::string& separator=".", const bool trailing=true) const;              //!< Our human-friendly, escaped, representation
   void toString(std::string& output, const std::string& separator=".", const bool trailing=true) const;

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -112,7 +112,8 @@ public:
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name? Note that name.isPartOf(name).
   inline bool operator==(const DNSName& rhs) const; //!< DNS-native comparison (case insensitive) - empty compares to empty
   bool operator!=(const DNSName& other) const { return !(*this == other); }
-  bool matches(const std::string_view& wire_uncompressed) const; // DNS-native (case insensitive) comparison against raw data in wire format
+  // !< DNS-native (case insensitive) comparison against raw data in wire format. The view has to start with the DNS name, but does not have to contain only a DNS name. For example passing a view of a DNS packet starting just after the DNS header is OK.
+  bool matches(const std::string_view& wire_uncompressed) const;
 
   std::string toString(const std::string& separator=".", const bool trailing=true) const;              //!< Our human-friendly, escaped, representation
   void toString(std::string& output, const std::string& separator=".", const bool trailing=true) const;

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -112,6 +112,7 @@ public:
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name? Note that name.isPartOf(name).
   inline bool operator==(const DNSName& rhs) const; //!< DNS-native comparison (case insensitive) - empty compares to empty
   bool operator!=(const DNSName& other) const { return !(*this == other); }
+  bool matches(const std::string_view& wire_uncompressed) const; // DNS-native (case insensitive) comparison against raw data in wire format
 
   std::string toString(const std::string& separator=".", const bool trailing=true) const;              //!< Our human-friendly, escaped, representation
   void toString(std::string& output, const std::string& separator=".", const bool trailing=true) const;

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -379,20 +379,38 @@ inline bool operator<(const struct timespec& lhs, const struct timespec& rhs)
 }
 
 
-inline bool pdns_ilexicographical_compare(const std::string& a, const std::string& b)  __attribute__((pure));
-inline bool pdns_ilexicographical_compare(const std::string& a, const std::string& b)
+inline int pdns_ilexicographical_compare_three_way(std::string_view a, std::string_view b)  __attribute__((pure));
+inline int pdns_ilexicographical_compare_three_way(std::string_view a, std::string_view b)
 {
-  const unsigned char *aPtr = (const unsigned char*)a.c_str(), *bPtr = (const unsigned char*)b.c_str();
+  const unsigned char *aPtr = (const unsigned char*)a.data(), *bPtr = (const unsigned char*)b.data();
   const unsigned char *aEptr = aPtr + a.length(), *bEptr = bPtr + b.length();
   while(aPtr != aEptr && bPtr != bEptr) {
-    if ((*aPtr != *bPtr) && (dns_tolower(*aPtr) - dns_tolower(*bPtr)))
-      return (dns_tolower(*aPtr) - dns_tolower(*bPtr)) < 0;
+    if (*aPtr != *bPtr) {
+      if (int rc = dns_tolower(*aPtr) - dns_tolower(*bPtr); rc != 0) {
+        return rc;
+      }
+    }
     aPtr++;
     bPtr++;
   }
-  if(aPtr == aEptr && bPtr == bEptr) // strings are equal (in length)
-    return false;
-  return aPtr == aEptr; // true if first string was shorter
+  // At this point, one of the strings has been completely processed.
+  // Either both have the same length, and they are equal, or one of them
+  // is larger, and compares as higher.
+  if (aPtr == aEptr) {
+    if (bPtr != bEptr) {
+      return -1; // a < b
+    }
+  }
+  else {
+    return 1; // a > b
+  }
+  return 0; // a == b
+}
+
+inline bool pdns_ilexicographical_compare(const std::string& a, const std::string& b)  __attribute__((pure));
+inline bool pdns_ilexicographical_compare(const std::string& a, const std::string& b)
+{
+  return pdns_ilexicographical_compare_three_way(a, b) < 0;
 }
 
 inline bool pdns_iequals(const std::string& a, const std::string& b) __attribute__((pure));
@@ -401,15 +419,7 @@ inline bool pdns_iequals(const std::string& a, const std::string& b)
   if (a.length() != b.length())
     return false;
 
-  const char *aPtr = a.c_str(), *bPtr = b.c_str();
-  const char *aEptr = aPtr + a.length();
-  while(aPtr != aEptr) {
-    if((*aPtr != *bPtr) && (dns_tolower(*aPtr) != dns_tolower(*bPtr)))
-      return false;
-    aPtr++;
-    bPtr++;
-  }
-  return true;
+  return pdns_ilexicographical_compare_three_way(a, b) == 0;
 }
 
 inline bool pdns_iequals_ch(const char a, const char b) __attribute__((pure));

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -1038,7 +1038,7 @@ BOOST_AUTO_TEST_CASE(test_raw_data_comparison) {
   GenericDNSPacketWriter<PacketBuffer> packetWriter(query, aroot, QType::A, QClass::IN, 0);
 
   {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-bounds-pointer-arithmetic)
     const std::string_view raw(reinterpret_cast<const char*>(query.data()) + sizeof(dnsheader), query.size() - sizeof(dnsheader));
     BOOST_CHECK(aroot.matches(raw));
 

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -1040,24 +1040,24 @@ BOOST_AUTO_TEST_CASE(test_raw_data_comparison) {
   {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-bounds-pointer-arithmetic)
     const std::string_view raw(reinterpret_cast<const char*>(query.data()) + sizeof(dnsheader), query.size() - sizeof(dnsheader));
-    BOOST_CHECK(aroot.matches(raw));
+    BOOST_CHECK(aroot.matchesUncompressedName(raw));
 
     const DNSName differentCase("A.RooT-Servers.NET");
-    BOOST_CHECK(differentCase.matches(raw));
+    BOOST_CHECK(differentCase.matchesUncompressedName(raw));
 
     const DNSName broot("b.root-servers.net");
-    BOOST_CHECK(!(broot.matches(raw)));
+    BOOST_CHECK(!(broot.matchesUncompressedName(raw)));
 
     /* last character differs */
     const DNSName notaroot("a.root-servers.nes");
-    BOOST_CHECK(!(notaroot.matches(raw)));
+    BOOST_CHECK(!(notaroot.matchesUncompressedName(raw)));
   }
 
   {
     /* too short */
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-bounds-pointer-arithmetic)
     const std::string_view raw(reinterpret_cast<const char*>(query.data() + sizeof(dnsheader)), aroot.wirelength() - 1);
-    BOOST_CHECK(!(aroot.matches(raw)));
+    BOOST_CHECK(!(aroot.matchesUncompressedName(raw)));
   }
 }
 

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -1042,7 +1042,7 @@ BOOST_AUTO_TEST_CASE(test_raw_data_comparison) {
     const std::string_view raw(reinterpret_cast<const char*>(query.data()) + sizeof(dnsheader), query.size() - sizeof(dnsheader));
     BOOST_CHECK(aroot.matches(raw));
 
-    DNSName differentCase("A.RooT-Servers.NET");
+    const DNSName differentCase("A.RooT-Servers.NET");
     BOOST_CHECK(differentCase.matches(raw));
 
     const DNSName broot("b.root-servers.net");

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -1038,6 +1038,7 @@ BOOST_AUTO_TEST_CASE(test_raw_data_comparison) {
   GenericDNSPacketWriter<PacketBuffer> packetWriter(query, aroot, QType::A, QClass::IN, 0);
 
   {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     const std::string_view raw(reinterpret_cast<const char*>(query.data()) + sizeof(dnsheader), query.size() - sizeof(dnsheader));
     BOOST_CHECK(aroot.matches(raw));
 
@@ -1054,6 +1055,7 @@ BOOST_AUTO_TEST_CASE(test_raw_data_comparison) {
 
   {
     /* too short */
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-bounds-pointer-arithmetic)
     const std::string_view raw(reinterpret_cast<const char*>(query.data() + sizeof(dnsheader)), aroot.wirelength() - 1);
     BOOST_CHECK(!(aroot.matches(raw)));
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR backports:
- `pdns_ilexicographical_compare_three_way` and
- #15931 
to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
