### PR TITLE
rec: include logr.hh in bridge.hh

### DIFF
--- a/pdns/recursordist/rec-rust-lib/rust/src/bridge.hh
+++ b/pdns/recursordist/rec-rust-lib/rust/src/bridge.hh
@@ -25,13 +25,10 @@
 
 #include "rust/cxx.h"
 #include "credentials.hh"
+#include "logr.hh"
 
 class NetmaskGroup;
 union ComboAddress;
-namespace Logr
-{
-class Logger;
-}
 
 namespace pdns::rust::misc
 {


### PR DESCRIPTION
Not doing so results in creating shared pointer to an incomplete class, which does not work for all compilers/c++ libs.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
