### PR TITLE
Backport 16011 to rec-5.3.x: Path.unlink(True) requires python 3.8, rewrite so it works on older versions

### DIFF
--- a/pdns/recursordist/rec-rust-lib/generate.py
+++ b/pdns/recursordist/rec-rust-lib/generate.py
@@ -792,6 +792,12 @@ def gen_newstyle_docs(srcdir, argentries):
 
 RUNTIME = '*runtime determined*'
 
+def unlinkMissingOK(path):
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
 def generate():
     """Read table, validate and generate C++, Rust and .rst files"""
     srcdir = '.'
@@ -841,11 +847,11 @@ def generate():
         gen_newstyle_docs(srcdir, entries)
     # Remove cxx generated files, they need to be re-generated after a table change and the rust dependency tracking does
     # not do that in some cases.
-    Path(gendir, 'rust', 'librecrust.a').unlink(True)
-    Path(gendir, 'rust', 'lib.rs.h').unlink(True)
-    Path(gendir, 'rust', 'web.rs.h').unlink(True)
-    Path(gendir, 'rust', 'cxx.h').unlink(True)
-    Path(gendir, 'rust', 'misc.rs.h').unlink(True)
+    unlinkMissingOK(Path(gendir, 'rust', 'librecrust.a'))
+    unlinkMissingOK(Path(gendir, 'rust', 'lib.rs.h'))
+    unlinkMissingOK(Path(gendir, 'rust', 'web.rs.h'))
+    unlinkMissingOK(Path(gendir, 'rust', 'cxx.h'))
+    unlinkMissingOK(Path(gendir, 'rust', 'misc.rs.h'))
     # Path.walk exists only in very recent versions of Python
     # With meson, target is in toplevel build dir
     # With autotools, target exists in rec-rust-lib/rust and this Python script is executed with cwd rec-rust-lib


### PR DESCRIPTION

(cherry picked from commit 7f587167886f1c9e5417f7e622d9737af9409091)

Backport of #16011 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
