### PR TITLE
Remove boost < 1.54 leftovers

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1478,9 +1478,7 @@ BB2DomainInfo Bind2Backend::createDomainEntry(const ZoneName& domain, const stri
   { // Find a free zone id nr.
     auto state = s_state.read_lock();
     if (!state->empty()) {
-      // older (1.53) versions of boost have an expression for s_state.rbegin()
-      // that is ambiguous in C++17. So construct it explicitly
-      newid = boost::make_reverse_iterator(state->end())->d_id + 1;
+      newid = state->rbegin()->d_id + 1;
     }
   }
 

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -23,9 +23,7 @@
 #include "config.h"
 #endif
 #include <boost/version.hpp>
-#if BOOST_VERSION >= 105400
 #include <boost/container/static_vector.hpp>
-#endif
 #include "dnswriter.hh"
 #include "misc.hh"
 #include "dnsparser.hh"


### PR DESCRIPTION
### Short description
We require Boost >= 1.54 to build. Therefore, we can drop constructs written to accomodate older versions.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
