### PR TITLE
dnsdist: Upgrade h2o to 2.2.6-pdns3

### DIFF
--- a/builder-support/helpers/h2o.json
+++ b/builder-support/helpers/h2o.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.2.6-pdns2",
+  "version": "2.2.6-pdns3",
   "license": "MIT",
   "publisher": "https://github.com/h2o/h2o",
-  "SHA256SUM": "e25959c3f9a102e7a332ca0bb8b3f533eb14919d5a60ca999730c2ebee4b548f"
+  "SHA256SUM": "c37b2184169f41a2d10bacb8a2b0e90df238b7a172478ddc77e7077754e0ab17"
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The new version of `h2o` adds mitigation against the MadeYouReset / CVE-2025-8671 attack.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
