### PR TITLE
auth: smarter bind zone file freshness check

### DIFF
--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -162,6 +162,9 @@ public:
   bool d_nsec3zone{false};
   NSEC3PARAMRecordContent d_nsec3param;
 
+  // Sugar for the main filename. Only use if d_fileinfo is NOT empty!
+  const std::string& main_filename() const { return d_fileinfo.front().first; }
+
 private:
   static time_t getCtime(const std::string&);
   time_t d_checkinterval{0};

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -90,6 +90,7 @@ void ZoneParserTNG::stackFile(const std::string& fname)
   filestate fs(fp, fname);
   d_filestates.push(fs);
   d_fromfile = true;
+  d_fileset.emplace_back(std::make_pair(fname, st.st_ctime));
 }
 
 ZoneParserTNG::~ZoneParserTNG()

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -58,6 +58,7 @@ public:
     d_defaultttl = ttl;
     d_havespecificttl = true;
   }
+  std::vector<std::pair<std::string, time_t>> getFileset() const { return d_fileset; }
 private:
   bool getLine();
   bool getTemplateLine();
@@ -91,4 +92,5 @@ private:
   bool d_generateEnabled{true};
   bool d_upgradeContent;
   bool d_templateCounterWrapped{false};
+  std::vector<std::pair<std::string, time_t>> d_fileset;
 };


### PR DESCRIPTION
### Short description
As mentioned in #469, if you use a bind zone file which includes other file, and use a nonzero value of `bind-check-interval` in order to reload the zone when it changes, the check only concerns the first zone files, and changes to any included files are not noticed.

This PR fixes this by:
- making a list of all the included files.
- ~~checking it twice, PowerDNS is coming to town.~~
- checking the modified time of all these files when the check gets triggered.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
