### PR TITLE
dnsdist: Speed up cache hits by skipping the LB policy when possible

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings.cc
@@ -107,6 +107,8 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
   });
   luaCtx.registerFunction("getECS", &ServerPool::getECS);
   luaCtx.registerFunction("setECS", &ServerPool::setECS);
+  luaCtx.registerFunction("getDisableZeroScope", &ServerPool::getDisableZeroScope);
+  luaCtx.registerFunction("setDisableZeroScope", &ServerPool::setDisableZeroScope);
 
 #ifndef DISABLE_DOWNSTREAM_BINDINGS
   /* DownstreamState */

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -2040,6 +2040,14 @@ pool:
       type: "String"
       default: ""
       description: "The name of the load-balancing policy associated to this pool. If left empty, the global policy will be used"
+    - name: "use_ecs"
+      type: "bool"
+      default: "false"
+      description: "Whether to add EDNS Client Subnet information to the query before looking up into the cache, when all servers from this pool are down. If at least one server is up, the preference of the selected server is used, this parameter is only useful if all the backends in this pool are down and have EDNS Client Subnet enabled, since the queries in the cache will have been inserted with ECS information"
+    - name: "disable_zero_scope"
+      type: "bool"
+      default: "false"
+      description: "Whether to disable the EDNS Client Subnet :doc:`../advanced/zero-scope` feature, which does a cache lookup for an answer valid for all subnets (ECS scope of 0) before adding ECS information to the query and doing the regular lookup, when all servers from this pool are down. If at least one server is up, the preference of the selected server is used, this parameter is only useful if all the backends in this pool are down, have EDNS Client Subnet enabled and zero scope disabled"
 
 custom_load_balancing_policy:
   description: "Settings for a custom load-balancing policy"

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1452,8 +1452,8 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
     if (selectedBackend && selectedBackend->isTCPOnly()) {
       willBeForwardedOverUDP = false;
     }
-    else if (!selectedBackend) {
-      willBeForwardedOverUDP = !serverPool->isTCPOnly();
+    else if (!selectedBackend && serverPool->isTCPOnly()) {
+      willBeForwardedOverUDP = false;
     }
 
     uint32_t allowExpired = 0;

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1441,7 +1441,13 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
     }
     std::shared_ptr<ServerPool> serverPool = getPool(dnsQuestion.ids.poolName);
     dnsQuestion.ids.packetCache = serverPool->packetCache;
-    selectBackendForOutgoingQuery(dnsQuestion, serverPool, selectedBackend);
+
+    bool backendLookupDone = false;
+    if (!dnsQuestion.ids.packetCache || !serverPool->isConsistent()) {
+      selectBackendForOutgoingQuery(dnsQuestion, serverPool, selectedBackend);
+      backendLookupDone = true;
+    }
+
     bool willBeForwardedOverUDP = !dnsQuestion.overTCP() || dnsQuestion.ids.protocol == dnsdist::Protocol::DoH;
     if (selectedBackend && selectedBackend->isTCPOnly()) {
       willBeForwardedOverUDP = false;
@@ -1450,17 +1456,22 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       willBeForwardedOverUDP = !serverPool->isTCPOnly();
     }
 
-    uint32_t allowExpired = selectedBackend ? 0 : dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL;
+    uint32_t allowExpired = 0;
+    if (!selectedBackend && dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL > 0 && (backendLookupDone || !serverPool->hasAtLeastOneServerAvailable())) {
+      allowExpired = dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL;
+    }
 
     if (dnsQuestion.ids.packetCache && !dnsQuestion.ids.skipCache && !dnsQuestion.ids.dnssecOK) {
       dnsQuestion.ids.dnssecOK = (dnsdist::getEDNSZ(dnsQuestion) & EDNS_HEADER_FLAG_DO) != 0;
     }
 
-    if (dnsQuestion.useECS && ((selectedBackend && selectedBackend->d_config.useECS) || (!selectedBackend && serverPool->getECS()))) {
+    const bool useECS = dnsQuestion.useECS && ((selectedBackend && selectedBackend->d_config.useECS) || (!selectedBackend && serverPool->getECS()));
+    if (useECS) {
+      const bool useZeroScope = (selectedBackend && !selectedBackend->d_config.disableZeroScope) || (!selectedBackend && !serverPool->getDisableZeroScope());
       // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
       // we need ECS parsing (parseECS) to be true so we can be sure that the initial incoming query did not have an existing
       // ECS option, which would make it unsuitable for the zero-scope feature.
-      if (dnsQuestion.ids.packetCache && !dnsQuestion.ids.skipCache && (!selectedBackend || !selectedBackend->d_config.disableZeroScope) && dnsQuestion.ids.packetCache->isECSParsingEnabled()) {
+      if (dnsQuestion.ids.packetCache && !dnsQuestion.ids.skipCache && useZeroScope && dnsQuestion.ids.packetCache->isECSParsingEnabled()) {
         if (dnsQuestion.ids.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, &dnsQuestion.ids.cacheKeyNoECS, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, willBeForwardedOverUDP, allowExpired, false, true, false)) {
 
           vinfolog("Packet cache hit for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size());
@@ -1543,7 +1554,12 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
         serverPool = getPool(dnsQuestion.ids.poolName);
         dnsQuestion.ids.packetCache = serverPool->packetCache;
         selectBackendForOutgoingQuery(dnsQuestion, serverPool, selectedBackend);
+        backendLookupDone = true;
       }
+    }
+
+    if (!backendLookupDone) {
+      selectBackendForOutgoingQuery(dnsQuestion, serverPool, selectedBackend);
     }
 
     if (!selectedBackend) {

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1449,10 +1449,12 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
     }
 
     bool willBeForwardedOverUDP = !dnsQuestion.overTCP() || dnsQuestion.ids.protocol == dnsdist::Protocol::DoH;
-    if (selectedBackend && selectedBackend->isTCPOnly()) {
-      willBeForwardedOverUDP = false;
+    if (selectedBackend) {
+      if (selectedBackend->isTCPOnly()) {
+        willBeForwardedOverUDP = false;
+      }
     }
-    else if (!selectedBackend && serverPool->isTCPOnly()) {
+    else if (serverPool->isTCPOnly()) {
       willBeForwardedOverUDP = false;
     }
 

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -951,9 +951,18 @@ struct ServerPool
     return d_useECS;
   }
 
-  void setECS(bool useECS)
+  void setECS(bool useECS);
+
+  bool getDisableZeroScope() const
   {
-    d_useECS = useECS;
+    return d_disableZeroScope;
+  }
+
+  void setDisableZeroScope(bool disable);
+
+  bool isConsistent() const
+  {
+    return d_isConsistent;
   }
 
   std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
@@ -961,6 +970,7 @@ struct ServerPool
 
   size_t poolLoad();
   size_t countServers(bool upOnly);
+  bool hasAtLeastOneServerAvailable();
   const std::shared_ptr<const ServerPolicy::NumberedServerVector> getServers();
   void addServer(shared_ptr<DownstreamState>& server);
   void removeServer(shared_ptr<DownstreamState>& server);
@@ -971,9 +981,13 @@ struct ServerPool
   }
 
 private:
+  void updateConsistency();
+
   SharedLockGuarded<std::shared_ptr<const ServerPolicy::NumberedServerVector>> d_servers;
   bool d_useECS{false};
   bool d_tcpOnly{false};
+  bool d_disableZeroScope{false};
+  bool d_isConsistent{true};
 };
 
 enum ednsHeaderFlags

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -987,6 +987,13 @@ Servers that are not assigned to a specific pool get assigned to the default poo
 
     Returns the :class:`PacketCache` for this pool or nil.
 
+  .. method:: ServerPool:getDisableZeroScope()
+
+    .. versionadded:: 2.0.1
+
+    Whether dnsdist will disable the EDNS Client Subnet :doc:`../advanced/zero-scope` feature when looking up into the cache,
+    when all servers from this pool are down.
+
   .. method:: ServerPool:getECS()
 
     Whether dnsdist will add EDNS Client Subnet information to the query before looking up into the cache,
@@ -998,9 +1005,12 @@ Servers that are not assigned to a specific pool get assigned to the default poo
 
     :param PacketCache cache: The new cache to add to the pool
 
-  .. method:: ServerPool:unsetCache()
+  .. method:: ServerPool:setDisableZeroScope(disable)
 
-    Removes the cache from this pool.
+    .. versionadded:: 2.0.1
+
+    Set to true if dnsdist should disable the EDNS Client Subnet :doc:`../advanced/zero-scope` feature when looking up into the cache,
+    when all servers from this pool are down.
 
   .. method:: ServerPool:setECS()
 
@@ -1009,6 +1019,10 @@ Servers that are not assigned to a specific pool get assigned to the default poo
     selected server is used, this parameter is only useful if all the backends in this pool are down
     and have EDNS Client Subnet enabled, since the queries in the cache will have been inserted with
     ECS information. Default is false.
+
+  .. method:: ServerPool:unsetCache()
+
+    Removes the cache from this pool.
 
 PacketCache
 ~~~~~~~~~~~

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -2267,13 +2267,17 @@ class TestCachingECSWithoutPoolECS(DNSDistTest):
 
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
-    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
+    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_testServerPort']
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
     setKey("%s")
     controlSocket("127.0.0.1:%d")
     newServer{address="127.0.0.1:%d", useClientSubnet=true}
+    -- add a second server without ECS, which will never be used
+    -- but makes the pool inconsistent
+    newServer{address="127.0.0.1:%d", useClientSubnet=false}:setDown()
+    getPool(""):setECS(false)
     """
 
     def testCached(self):
@@ -2325,10 +2329,10 @@ class TestCachingECSWithPoolECS(DNSDistTest):
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
-    getPool(""):setECS(true)
     setKey("%s")
     controlSocket("127.0.0.1:%d")
     newServer{address="127.0.0.1:%d", useClientSubnet=true}
+    getPool(""):setECS(true)
     """
 
     def testCached(self):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to execute the load-balancing policy to select a backend before doing the cache lookup, because in some corner cases the selected backend might have settings that impact our cache lookup. In practice most configurations have a consistent set of settings for all servers in a given pool, so it makes no sense to waste CPU cycles selecting a
backend if we are going to get a hit from the cache.
This PR adds a bit of code to check if a pool is in a consistent state, and if it is it delays the execution of the load-balancing policy to after the cache lookup, skipping it entirely for cache hits.

Needs more testing.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
