### PR TITLE
dnsdist: don't increment in a potential macro argument

### DIFF
--- a/pdns/dnsdistdist/dnsdist-crypto.cc
+++ b/pdns/dnsdistdist/dnsdist-crypto.cc
@@ -287,8 +287,8 @@ void Nonce::increment()
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   auto* ptr = reinterpret_cast<uint32_t*>(value.data());
-  uint32_t count = htonl(*ptr);
-  *ptr = ntohl(++count);
+  uint32_t count = htonl(*ptr) + 1;
+  *ptr = ntohl(count);
 }
 
 #else


### PR DESCRIPTION
Fixes g++ 8: ../dnsdist-crypto.cc:291:16: warning: operation on 'count' may be undefined [-Wsequence-point]

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
