### PR TITLE
dnsdist: allow building wth gcc8, which needs -lstdc++fs as link argument

### DIFF
--- a/pdns/dnsdistdist/meson/compiler-setup/meson.build
+++ b/pdns/dnsdistdist/meson/compiler-setup/meson.build
@@ -15,3 +15,8 @@ add_project_arguments(
 
 cxx = meson.get_compiler('cpp')
 system = target_machine.system()
+
+if cxx.get_id() == 'gcc' and cxx.version().version_compare('>=8.0,<9.0')
+  add_global_link_arguments('-lstdc++fs', language: ['c', 'cpp'])
+endif
+


### PR DESCRIPTION
Per https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#iso.2014.filesystemts

Tested on OpenBSD amd64 using gcc8.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
