### PR TITLE
dnsdist-1.9.x: Backport 16042 - Don't increment in a potential macro argument

### DIFF
--- a/pdns/dnsdistdist/dnsdist-crypto.cc
+++ b/pdns/dnsdistdist/dnsdist-crypto.cc
@@ -287,8 +287,8 @@ void Nonce::increment()
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   auto* ptr = reinterpret_cast<uint32_t*>(value.data());
-  uint32_t count = htonl(*ptr);
-  *ptr = ntohl(++count);
+  uint32_t count = htonl(*ptr) + 1;
+  *ptr = ntohl(count);
 }
 
 #else


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16042 to rel/dnsdist-1.9.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
