### PR TITLE
Auth: Fix misleading description of tcp-control-port argument.

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -222,7 +222,7 @@ static void declareArguments()
   ::arg().set("secondary-check-signature-freshness", "Check signatures in SOA freshness check. Sets DO flag on SOA queries. Outside some very problematic scenarios, say yes here.") = "yes";
 
   ::arg().set("tcp-control-address", "If set, PowerDNS can be controlled over TCP on this address") = "";
-  ::arg().set("tcp-control-port", "If set, PowerDNS can be controlled over TCP on this address") = "53000";
+  ::arg().set("tcp-control-port", "If set, PowerDNS can be controlled over TCP on this port") = "53000";
   ::arg().set("tcp-control-secret", "If set, PowerDNS can be controlled over TCP after passing this secret") = "";
   ::arg().set("tcp-control-range", "If set, remote control of PowerDNS is possible over these networks only") = "127.0.0.0/8, 10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12, ::1/128, fe80::/10";
 


### PR DESCRIPTION
### Short description
Fix a misleading description for tcp-control-port argument.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

