### PR TITLE
REST API: bring back 404 errors

### DIFF
--- a/ext/yahttp/yahttp/router.cpp
+++ b/ext/yahttp/yahttp/router.cpp
@@ -101,7 +101,13 @@ namespace YaHTTP {
       if (matched && !method.empty() && req->method != method) {
          // method did not match, record it though so we can return correct result
          matched = false;
-         seen = true;
+         // The OPTIONS handler registered in pdns/webserver.cc matches every
+         // url, and would cause "not found" errors to always be superseded
+         // with "found, but wrong method" errors, so don't pretend there has
+         // been a match in this case.
+         if (method != "OPTIONS") {
+           seen = true;
+         }
          continue;
       }
       if (matched) {

--- a/regression-tests.api/test_Basics.py
+++ b/regression-tests.api/test_Basics.py
@@ -61,4 +61,13 @@ class TestBasics(ApiTestCase):
         r = self.session.options(self.url("/api/v1/servers/localhost/invalid"))
         self.assertEqual(r.status_code, requests.codes.not_found)
 
+        r = self.session.options(self.url("/api/v1/servers/remotehost"))
+        self.assertEqual(r.status_code, requests.codes.not_found)
+
+        r = self.session.get(self.url("/api/v1/servers/remotehost"))
+        if is_auth():
+            self.assertEqual(r.status_code, requests.codes.not_found)
+        else:
+            self.assertEqual(r.status_code, requests.codes.unauthorized)
+
         print("response", repr(r.headers))


### PR DESCRIPTION
### Short description
Changes to the `YaHTTP` component in 4.9 introduced changes in the "router" part to return `405 Method Not Allowed` when matching an url but not the HTTP method, instead of having every url handler having to check for the method and throw an `HttpMethodNotAllowedException`.

That was a very good idea, except that the `OPTIONS` handler we use is registered against `/<*url>` and therefore always matches. Because of this, trying to access a non-existent url would always return `405 Method Not Allowed` instead of `404 Not Found`.

This trivial PR special-cases the `OPTIONS` match to let 404 errors take precedence over 405.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
