### PR TITLE
LMDB: try to reduce the cost of the LS header

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -850,10 +850,10 @@ public:
 
     return put_raw(dbi, key, val, flags);
   }
-  // Return an empty string with reserved space for a LSheader without extra
-  // bytes at its beginning.
+  // Return an empty string with reserved space for a LSheader (without any
+  // extension blocks) at its beginning.
   // This string should only be appended to, not assigned!
-  static std::string stringWithHeader()
+  static std::string stringWithEmptyHeader()
   {
     std::string result(LMDBLS::LS_MIN_HEADER_SIZE, '\0');
     return result;

--- a/ext/lmdb-safe/lmdb-typed.hh
+++ b/ext/lmdb-safe/lmdb-typed.hh
@@ -774,7 +774,7 @@ public:
         }
       }
 #ifndef DNSDIST
-      std::string ser = MDBRWTransactionImpl::stringWithHeader();
+      std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
       serializeToBuffer(ser, value);
       (*d_txn)->put_header_in_place(d_parent->d_main, itemId, ser, flags);
 #else

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1300,14 +1300,14 @@ void LMDBBackend::writeNSEC3RecordPair(const std::shared_ptr<RecordsRWTransactio
   // Write ordername -> qname back chain record with ttl set to 0
   lrr.ttl = 0;
   lrr.content = qname.toDNSStringLC();
-  std::string ser = MDBRWTransactionImpl::stringWithHeader();
+  std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
   serializeToBuffer(ser, lrr);
   txn->txn->put_header_in_place(txn->db->dbi, co(domain_id, ordername, QType::NSEC3), ser);
 
   // Write qname -> ordername forward chain record with ttl set to 1
   lrr.ttl = 1;
   lrr.content = ordername.toDNSString();
-  ser = MDBRWTransactionImpl::stringWithHeader();
+  ser = MDBRWTransactionImpl::stringWithEmptyHeader();
   serializeToBuffer(ser, lrr);
   txn->txn->put_header_in_place(txn->db->dbi, co(domain_id, qname, QType::NSEC3), ser);
 }
@@ -1352,7 +1352,7 @@ bool LMDBBackend::feedRecord(const DNSResourceRecord& r, const DNSName& ordernam
   compoundOrdername co;
   string matchName = co(lrr.domain_id, lrr.qname, lrr.qtype.getCode());
 
-  string rrs = MDBRWTransactionImpl::stringWithHeader();
+  string rrs = MDBRWTransactionImpl::stringWithEmptyHeader();
   MDBOutVal _rrs;
   if (!d_rwtxn->txn->get(d_rwtxn->db->dbi, matchName, _rrs)) {
     rrs.append(_rrs.get<string>());
@@ -1376,7 +1376,7 @@ bool LMDBBackend::feedEnts(domainid_t domain_id, map<DNSName, bool>& nonterm)
     lrr.auth = nt.second;
     lrr.hasOrderName = false;
 
-    std::string ser = MDBRWTransactionImpl::stringWithHeader();
+    std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
     serializeToBuffer(ser, lrr);
     d_rwtxn->txn->put_header_in_place(d_rwtxn->db->dbi, co(domain_id, lrr.qname, QType::ENT), ser);
   }
@@ -1393,7 +1393,7 @@ bool LMDBBackend::feedEnts3(domainid_t domain_id, const DNSName& domain, map<DNS
     lrr.ttl = 0;
     lrr.auth = nt.second;
     lrr.hasOrderName = lrr.auth && !narrow;
-    std::string ser = MDBRWTransactionImpl::stringWithHeader();
+    std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
     serializeToBuffer(ser, lrr);
     d_rwtxn->txn->put_header_in_place(d_rwtxn->db->dbi, co(domain_id, lrr.qname, QType::ENT), ser);
 
@@ -1478,7 +1478,7 @@ bool LMDBBackend::replaceRRSet(domainid_t domain_id, const DNSName& qname, const
 
       adjustedRRSet.emplace_back(lrr);
     }
-    std::string ser = MDBRWTransactionImpl::stringWithHeader();
+    std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
     serializeToBuffer(ser, adjustedRRSet);
     txn->txn->put_header_in_place(txn->db->dbi, match, ser);
   }
@@ -1604,7 +1604,7 @@ bool LMDBBackend::viewAddZone(const string& view, const ZoneName& zone)
   auto txn = d_tdomains->getEnv()->getRWTransaction();
 
   string key = view + string(1, (char)0) + keyConv(zone.operator const DNSName&());
-  std::string val = MDBRWTransactionImpl::stringWithHeader();
+  std::string val = MDBRWTransactionImpl::stringWithEmptyHeader();
   val.append(zone.getVariant()); // variant goes here
 
   txn->put_header_in_place(d_tviews, key, val);
@@ -2904,7 +2904,7 @@ bool LMDBBackend::updateDNSSECOrderNameAndAuth(domainid_t domain_id, const DNSNa
       newRRs.push_back(std::move(lrr));
     }
     if (changed) {
-      std::string ser = MDBRWTransactionImpl::stringWithHeader();
+      std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
       serializeToBuffer(ser, newRRs);
       cursor.put_header_in_place(key, ser);
     }
@@ -3008,7 +3008,7 @@ bool LMDBBackend::updateEmptyNonTerminals(domainid_t domain_id, set<DNSName>& in
     lrr.qname = name.makeRelative(info.zone);
     lrr.ttl = 0;
     lrr.auth = true;
-    std::string ser = MDBRWTransactionImpl::stringWithHeader();
+    std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
     serializeToBuffer(ser, lrr);
     txn->txn->put_header_in_place(txn->db->dbi, order(domain_id, lrr.qname, QType::ENT), ser);
     // cout <<" +"<<name<<endl;


### PR DESCRIPTION
### Short description
For Lightning Stream compatibility/operation, all records in our LMDB databases contain a hidden (to the database consumer) header, which is prepended to the data at write time. Which means a temporary buffer needs to be created with the header and a copy of the data to write.

This PR allows the database users to have some awareness of this, and prepare room for the header themselves, so that the header can be set up in place rather than having to perform the data copy.

This is implemented in 3 independent commits:
- the first commit reworks the data serialization interfaces to no longer return a `std::string`, but instead take one as argument, and only append to it, preserving its preexisting content.
- the second commit adds specific cursor and transaction interfaces to use with data containing room for the header. These interfaces update the header in-place and then perform the write as usual. It also introduces an interface to return a would-be empty string, which contains space for the header, and can be used by append-only code.
- the third commit seizes the opportunity to use the changes from the previous commit to build data buffers with room for the header whenever possible.

This addresses the ``make LS header prepending cheaper by reusing a buffer'' point in #12663 (but not the way it was thought of at that time).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
