### PR TITLE
auth: record contents handling changes

### DIFF
--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -988,7 +988,12 @@ void RecordTextWriter::xfrText(const string& val, bool /* multi */, bool /* lenF
   if(!d_string.empty())
     d_string.append(1,' ');
 
-  d_string.append(val);
+  if (val.empty()) {
+    d_string.append(2, '"');
+  }
+  else {
+    d_string.append(val);
+  }
 }
 
 void RecordTextWriter::xfrUnquotedText(const string& val, bool /* lenField */)

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -642,7 +642,7 @@ void RecordTextReader::xfrText(string& val, bool multi, bool /* lenField */)
             char chr2 = d_string[d_pos + 1];
             char chr3 = d_string[d_pos + 2];
             if (chr2 >= '0' && chr2 <= '9' && chr3 >= '0' && chr3 <= '9') {
-              valid = true;
+              valid = 100 * (chr - '0') + 10 * (chr2 - '0') + chr3 - '0' < 256;
             }
           }
           if (!valid) {
@@ -651,6 +651,12 @@ void RecordTextReader::xfrText(string& val, bool multi, bool /* lenField */)
         }
         // Not advancing d_pos, we'll append the next 1 or 3 characters as
         // part of the regular case.
+      }
+      if (!quoted && d_string[d_pos] == '"') {
+        // Bind allows a non-quoted text to be immediately followed by a
+        // quoted text, without any whitespace in between, so handle this
+        // as a delimiter.
+        break;
       }
       val.append(1, d_string[d_pos]);
       ++d_pos;

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -84,9 +84,9 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
 // non-local name
      (CASE_S(QType::PTR, "ptr.example.com.", "\x03ptr\x07""example\x03""com\x00"))
      (CASE_S(QType::HINFO, "\"i686\" \"Linux\"", "\x04i686\x05Linux"))
-     (BROKEN_CASE_L(QType::HINFO, "i686 \"Linux\"", "\"i686\" \"Linux\"", "\x04i686\x05Linux"))
+     (CASE_L(QType::HINFO, "i686 \"Linux\"", "\"i686\" \"Linux\"", "\x04i686\x05Linux"))
      (CASE_L(QType::HINFO, "\"i686\" Linux", "\"i686\" \"Linux\"", "\x04i686\x05Linux"))
-     (BROKEN_CASE_L(QType::HINFO, "i686 Linux", "\"i686\" \"Linux\"", "\x04i686\x05Linux"))
+     (CASE_L(QType::HINFO, "i686 Linux", "\"i686\" \"Linux\"", "\x04i686\x05Linux"))
 // local name
      (CASE_S(QType::MX, "10 mx.rec.test.", "\x00\x0a\x02mx\xc0\x11"))
 // non-local name

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -100,7 +100,6 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
      (CASE_S(QType::TXT,  "\"\\195\\133LAND ISLANDS\"", "\x0e\xc3\x85LAND ISLANDS"))
      (CASE_S(QType::TXT,  "\"text with DEL in there: \\127\"", "\x19text with DEL in there: \x7f"))
      (CASE_L(QType::TXT, "\"\xc3\x85LAND ISLANDS\"", "\"\\195\\133LAND ISLANDS\"", "\x0e\xc3\x85LAND ISLANDS"))
-     (CASE_S(QType::TXT, "\"nonbreakingtxt\"", "\x0enonbreakingtxt"))
 // local name
      (CASE_S(QType::RP, "admin.rec.test. admin-info.rec.test.", "\x05""admin\x03rec\x04test\x00\x0a""admin-info\x03rec\x04test\x00"))
 // non-local name
@@ -384,6 +383,8 @@ BOOST_AUTO_TEST_CASE(test_record_types_bad_values) {
 // non-local overly large name (256), must be broken
      (ZONE_CASE(QType::CNAME, "123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012."))
      (ZONE_CASE(QType::SOA, "ns.rec.test hostmaster.test.rec 20130512010 3600 3600 604800 120")) // too long serial
+     (ZONE_CASE(QType::TXT, "\\02unlimited")) // incorrect escape
+     (ZONE_CASE(QType::TXT, "\\384excessive")) // incorrect escape
 ;
 
   int n=0;


### PR DESCRIPTION
### Short description
Two small changes to textual data in record contents:
- reading a multiple values record (`HINFO`, `NAPTR`) from text form (bind-style or fed to the API) did not allow values to be unquoted, even if they did not contain spaces. This is now accepted (and fixes two known-to-be-broken unit tests).
- writing a multiple values record, when one of the values is an empty string, well, did output an empty string, leading to confusing error messages. These empty values will now get output as `""` to make them "visible". This is intended to help #5208 where the error message complaining about the bad record did not make enough sense.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [X] realizing that this is a "there be dragons" minefield