### PR TITLE
auth: small meson improvements for testing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1054,6 +1054,7 @@ if get_option('unit-tests')
 endif
 
 if get_option('unit-tests-backends')
+  socat = find_program('socat', required: true)
   # Remote Backend Tests #################################################################
   if get_option('module-remote') != 'disabled'
     libpdns_module_remotebackend_test_common = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -1120,6 +1120,7 @@ if get_option('unit-tests-backends')
       test(
         'pdns-auth-backend-' + module,
         start_test_stop,
+        env: {'PDNS_BUILD_PATH': meson.build_root()},
         args: ['5300', module],
         workdir: product_source_dir / 'regression-tests',
         depends: [pdns_auth, pdns_auth_util, sdig, saxfr, pdns_auth_notify, nsec3dig],

--- a/tasks.py
+++ b/tasks.py
@@ -46,6 +46,7 @@ auth_build_deps = [    # FIXME: perhaps we should be stealing these from the deb
     'libyaml-cpp-dev',
     'libzmq3-dev',
     'python3-venv',
+    'socat',
     'sqlite3',
     'unixodbc-dev',
     'cmake',


### PR DESCRIPTION
### Short description

While building the auth and running the regression/unit tests for all the backends. I discovered that `meson` does not check if `socat` is installed.
This is fixed in this commit:

- **fix(auth): Ensure socat is installed when enabling tests**

I then discovered that `PDNS_BUILD_PATH` is not correctly set when running `meson test`. It would be empty, and hence `start-test-stop` would look for the wrong binaries in the wrong place.
This is fixed with this commit:

- **fix(auth): set PDNS_BUILD_PATH when running tests**

Note that not *all* tests run with `meson test` actually succeed from me. But those failures are not related to these changes.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
