### PR TITLE
dnsdist-2.0.x: Backport 15737 - dnsdist-resolver: Fix a bug when we get new IPs for a server

### DIFF
--- a/dockerdata/dnsdist-resolver.lua
+++ b/dockerdata/dnsdist-resolver.lua
@@ -15,7 +15,6 @@ _M.verbose = false
 -- key = name
 -- value = {address, serverObject} (should make these named members)
 local ourservers = {}
-local ourcount = {}
 
 -- Global variable for store results for getAddressInfo() function
 local resout = {}
@@ -109,39 +108,21 @@ function _M.maintenance()
             end
         end
 
-        -- init our current count
-        if ourcount[name] == nil then
-            ourcount[name] = #ips
-        end
-
-        -- increase our current count if necessary
-        if #ips > ourcount[name] then
-            ourcount[name] = #ips
-            if _M.verbose then
-                infolog("increasing count to " .. ourcount[name] .. " for " .. name)
+        -- remove servers if they are no longer present
+        for ourserver, server in pairs(ourservers) do
+            -- check if we match the prefix and the ip is gone
+            if ourserver:find(name, 1, true) == 1 and has_value(ips, server[1]) == false then
+                if _M.verbose then
+                    infolog("ip address not found anymore " .. server[1])
+                end
+                removeServer(ourserver)
             end
         end
-
-        -- remove servers when we've lost ips
-        if #ips < ourcount[name] then
-            for ourserver, server in pairs(ourservers) do
-                -- check if we match the prefix and the ip is gone
-                if ourserver:find(name, 1, true) == 1 and has_value(ips, server[1]) == false then
-                    ourcount[name] = #ips
-                    if _M.verbose then
-                        infolog("ip address not found anymore " .. server[1])
-                        infolog("decreasing count to " .. ourcount[name])
-                    end
-                    removeServer(ourserver)
-                end
-            end
-        else
-            for _, ip in ipairs(ips) do
-                -- it has IPs
-                if _M.servers[name] ~= nil then
-                    -- we want this server
-                    setServer(name, ip)
-                end
+        for _, ip in ipairs(ips) do
+            -- it has IPs
+            if _M.servers[name] ~= nil then
+                -- we want this server
+                setServer(name, ip)
             end
         end
     end


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #15737 to rel/dnsdist-2.0.x

The `dnsdist-resolver` script regularly checks the IPs corresponding to a backend `hostname`, and updates our backend accordingly:
- if an IP we previously received vanishes, it removes the backend corresponding to that IP
- if a new IP shows up, it adds a new backend

The existing code tries to avoid some work by keeping track of the number of IPs associated to a given server, skipping the comparisons of recently received IPs to existing ones if the number did not change. This unfortunately does not work well if we get the same number of IPs but with different IPs in the set.
This caused some backends to never get removed and stay along as ghosts, as well as some new IPs to never be picked up.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
