### PR TITLE
dnsdist-2.0.x: Backport 16090 - Fix access to frontends while in client mode

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -2484,10 +2484,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
 #ifdef HAVE_DNS_OVER_QUIC
-  luaCtx.writeFunction("getDOQFrontend", [client](uint64_t index) {
+  luaCtx.writeFunction("getDOQFrontend", [client](uint64_t index) -> boost::optional<std::shared_ptr<DOQFrontend>> {
     boost::optional<std::shared_ptr<DOQFrontend>> result{boost::none};
     if (client) {
-      return result;
+      return std::shared_ptr<DOQFrontend>();
     }
     setLuaNoSideEffect();
     try {
@@ -2566,10 +2566,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
 #ifdef HAVE_DNS_OVER_HTTP3
-  luaCtx.writeFunction("getDOH3Frontend", [client](uint64_t index) {
+  luaCtx.writeFunction("getDOH3Frontend", [client](uint64_t index) -> boost::optional<std::shared_ptr<DOH3Frontend>> {
     boost::optional<std::shared_ptr<DOH3Frontend>> result{boost::none};
     if (client) {
-      return result;
+      return std::shared_ptr<DOH3Frontend>();
     }
     setLuaNoSideEffect();
     try {
@@ -2635,10 +2635,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #endif
   });
 
-  luaCtx.writeFunction("getDOHFrontend", [client]([[maybe_unused]] uint64_t index) {
+  luaCtx.writeFunction("getDOHFrontend", [client]([[maybe_unused]] uint64_t index) -> boost::optional<std::shared_ptr<DOHFrontend>> {
     boost::optional<std::shared_ptr<DOHFrontend>> result{boost::none};
     if (client) {
-      return result;
+      return std::shared_ptr<DOHFrontend>();
     }
 #ifdef HAVE_DNS_OVER_HTTPS
     setLuaNoSideEffect();
@@ -2865,8 +2865,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 #endif
   });
 
-  luaCtx.writeFunction("getTLSFrontend", []([[maybe_unused]] uint64_t index) {
+  luaCtx.writeFunction("getTLSFrontend", [client]([[maybe_unused]] uint64_t index) -> boost::optional<std::shared_ptr<TLSFrontend>> {
     boost::optional<std::shared_ptr<TLSFrontend>> result{boost::none};
+    if (client) {
+      return std::shared_ptr<TLSFrontend>();
+    }
 #ifdef HAVE_DNS_OVER_TLS
     setLuaNoSideEffect();
     try {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16090 to rel/dnsdist-2.0.x

Since 2.0 we return `nil` instead of an object containing a `NULL` pointer when the requested object does not exist, to make it possible to check the validity of the returned object from `Lua`. It makes sense in all contexts except when we are in client mode, because then accessing the object in the remaining parts of the configuration will trigger an error. Our DNS over HTTPS documentation itself contains such a Lua configuration snippet, which is now broken. This commit reverts back to sending an object containg a `NULL` pointer when accessing the frontends in the client mode case.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
