### PR TITLE
Update lua2.rst: dns_get_all_domains() args and notes update

### DIFF
--- a/docs/backends/lua2.rst
+++ b/docs/backends/lua2.rst
@@ -127,7 +127,7 @@ NOTES:
  is required if you want to be able to enable the zone cache or to search
  records.
  It is also required if you want to serve a zone **without a SOA in _another_ backend**: if you
- don't list your zone here pdns server will reject it (as unknown zone) and the requests will
+ don't list your zone here, pdns server will not recognize the zone as valid (and will treat it as unknown), causing the requests to
  never reach lua2 backend.
 
 ``dns_get_domain_metadata(domain, kind)``


### PR DESCRIPTION
1. It requires `DNSName, domaininfo` pair instead of `string, domaininfo`
2. The function is definitely not optimal if one uses lua2 backend to serve a zone, since without it pdns will ignore the zone and requets will never reach this backend. Figuring this out __was__ painful.

### Short description
Fixing misleading documentation. :-(

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
