### PR TITLE
dnsproxy: drop bogus endianness workaround

### DIFF
--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -256,10 +256,6 @@ void DNSProxy::mainloop()
       memcpy(&dHead, &buffer[0], sizeof(dHead));
       {
         auto conntrack = d_conntrack.lock();
-        if (BYTE_ORDER == BIG_ENDIAN) {
-          // this is needed because spoof ID down below does not respect the native byteorder
-          dHead.id = (256 * (uint16_t)buffer[1]) + (uint16_t)buffer[0];
-        }
 
         auto iter = conntrack->find(dHead.id ^ d_xor);
         if (iter == conntrack->end()) {


### PR DESCRIPTION
### Short description
While I'm sure this byte swap made sense at one time, I suspect other code has changed to be less picky about byte order, and today removing the swap makes ALIAS resolving work on s390x without breaking it on amd64.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
