### PR TITLE
auth: memory corruption in ODBC

### DIFF
--- a/modules/godbcbackend/sodbc.cc
+++ b/modules/godbcbackend/sodbc.cc
@@ -85,6 +85,7 @@ public:
     SQLLEN* LenPtr;
     SQLSMALLINT ParameterType;
     SQLSMALLINT ValueType;
+    size_t ParameterAllocSize; // size allocated for ParameterValuePtr, if ParameterType == SQL_INTEGER
   };
 
   vector<ODBCParam> d_req_bind;
@@ -144,6 +145,7 @@ public:
     p.LenPtr = new SQLLEN{sizeof(UDWORD)};
     p.ParameterType = SQL_INTEGER;
     p.ValueType = SQL_INTEGER;
+    p.ParameterAllocSize = sizeof(UDWORD);
     return bind(name, p);
   }
 
@@ -155,6 +157,7 @@ public:
     p.LenPtr = new SQLLEN{sizeof(ULONG)};
     p.ParameterType = SQL_INTEGER;
     p.ValueType = SQL_INTEGER;
+    p.ParameterAllocSize = sizeof(ULONG);
     return bind(name, p);
   }
 
@@ -262,12 +265,23 @@ public:
     SQLCloseCursor(d_statement); // hack, this probably violates some state transitions
 
     for (auto& i : d_req_bind) {
-      if (i.ParameterType == SQL_VARCHAR)
-        delete[] (char*)i.ParameterValuePtr;
-      else if (i.ParameterType == SQL_INTEGER)
-        delete (ULONG*)i.ParameterValuePtr;
-      else if (i.ParameterType == SQL_C_UBIGINT)
-        delete (unsigned long long*)i.ParameterValuePtr;
+      // NOLINTBEGIN(cppcoreguidelines-owning-memory)
+      if (i.ParameterType == SQL_VARCHAR) {
+        delete[] static_cast<char*>(i.ParameterValuePtr);
+      }
+      else if (i.ParameterType == SQL_INTEGER) {
+        if (i.ParameterAllocSize == sizeof(UDWORD)) {
+          delete static_cast<UDWORD*>(i.ParameterValuePtr);
+        }
+        else {
+          delete static_cast<ULONG*>(i.ParameterValuePtr);
+        }
+      }
+      else if (i.ParameterType == SQL_C_UBIGINT) {
+        delete static_cast<unsigned long long*>(i.ParameterValuePtr);
+      }
+      // NOLINTEND(cppcoreguidelines-owning-memory)
+
       delete i.LenPtr;
     }
     d_req_bind.clear();


### PR DESCRIPTION
### Short description
@omoerbeek pointed me to a spurious auth test failure in the CI, which I have not been able to reproduce. However, building with sanitizers and running the tests again showed that in the ODBC module, `delete` was invoked on the wrong type and thus with a size not matching the size used by the matching `new`. This is caused by the `SQL_INTEGER` parameters being allocated either as `UDWORD` or `ULONG` which do not have the same size (at least on 64-bit platforms).

This PR tries to fix this by remembering the size used for allocation in this case, and invoking `delete` with either a `UDWORD *` or a `ULONG *` cast, whichever matches the size.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
