### PR TITLE
auth: one more configuration sanity check

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -844,6 +844,7 @@ Forward DNS updates sent to a secondary to the primary.
 ------------------
 
 -  IP addresses, separated by commas
+-  Default: empty
 
 IP addresses to forward received notifications to regardless of primary
 or secondary settings.

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -776,6 +776,14 @@ static void mainthread()
       exit(1); // NOLINT(concurrency-mt-unsafe) we're single threaded at this point
     }
   }
+  // - configurations involving communicator threads need at least one
+  //   such thread configured
+  if (::arg().mustDo("primary") || ::arg().mustDo("secondary") || !::arg()["forward-notify"].empty()) {
+    if (::arg().asNum("retrieval-threads", 1) <= 0) {
+      g_log << Logger::Error << R"(Error: primary or secondary operation requires "retrieval-threads" to be set to a nonzero value.)" << endl;
+      exit(1); // NOLINT(concurrency-mt-unsafe) we're single threaded at this point
+    }
+  }
   // (no more checks yet)
 
   PC.setTTL(::arg().asNum("cache-ttl"));


### PR DESCRIPTION
### Short description
Refuse to start if the (mis)configuration involves communicator threads but their number is configured to zero.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
