### PR TITLE
dnsdist: Add an option to forward all queries over UDP first

### DIFF
--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -234,7 +234,7 @@ bool DNSDistPacketCache::get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_
     *keyOut = key;
   }
 
-  if (d_settings.d_parseECS) {
+  if (d_settings.d_parseECS && !subnet) {
     getClientSubnet(dnsQuestion.getData(), dnsQuestion.ids.qname.wirelength(), subnet);
   }
 

--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -80,9 +80,9 @@ bool DNSDistPacketCache::getClientSubnet(const PacketBuffer& packet, size_t qnam
   return false;
 }
 
-bool DNSDistPacketCache::cachedValueMatches(const CacheValue& cachedValue, uint16_t queryFlags, const DNSName& qname, uint16_t qtype, uint16_t qclass, bool receivedOverUDP, bool dnssecOK, const std::optional<Netmask>& subnet) const
+bool DNSDistPacketCache::cachedValueMatches(const CacheValue& cachedValue, uint16_t queryFlags, const DNSName& qname, uint16_t qtype, uint16_t qclass, bool dnssecOK, const std::optional<Netmask>& subnet) const
 {
-  if (cachedValue.queryFlags != queryFlags || cachedValue.dnssecOK != dnssecOK || cachedValue.receivedOverUDP != receivedOverUDP || cachedValue.qtype != qtype || cachedValue.qclass != qclass || cachedValue.qname != qname) {
+  if (cachedValue.queryFlags != queryFlags || cachedValue.dnssecOK != dnssecOK || cachedValue.qtype != qtype || cachedValue.qclass != qclass || cachedValue.qname != qname) {
     return false;
   }
 
@@ -113,7 +113,7 @@ bool DNSDistPacketCache::insertLocked(std::unordered_map<uint32_t, CacheValue>& 
   CacheValue& value = mapIt->second;
   bool wasExpired = value.validity <= newValue.added;
 
-  if (!wasExpired && !cachedValueMatches(value, newValue.queryFlags, newValue.qname, newValue.qtype, newValue.qclass, newValue.receivedOverUDP, newValue.dnssecOK, newValue.subnet)) {
+  if (!wasExpired && !cachedValueMatches(value, newValue.queryFlags, newValue.qname, newValue.qtype, newValue.qclass, newValue.dnssecOK, newValue.subnet)) {
     ++d_insertCollisions;
     return false;
   }
@@ -127,7 +127,7 @@ bool DNSDistPacketCache::insertLocked(std::unordered_map<uint32_t, CacheValue>& 
   return false;
 }
 
-void DNSDistPacketCache::insert(uint32_t key, const std::optional<Netmask>& subnet, uint16_t queryFlags, bool dnssecOK, const DNSName& qname, uint16_t qtype, uint16_t qclass, const PacketBuffer& response, bool receivedOverUDP, uint8_t rcode, std::optional<uint32_t> tempFailureTTL)
+void DNSDistPacketCache::insert(uint32_t key, const std::optional<Netmask>& subnet, uint16_t queryFlags, bool dnssecOK, const DNSName& qname, uint16_t qtype, uint16_t qclass, const PacketBuffer& response, uint8_t rcode, std::optional<uint32_t> tempFailureTTL)
 {
   if (response.size() < sizeof(dnsheader) || response.size() > getMaximumEntrySize()) {
     return;
@@ -151,17 +151,8 @@ void DNSDistPacketCache::insert(uint32_t key, const std::optional<Netmask>& subn
     minTTL = getMinTTL(reinterpret_cast<const char*>(response.data()), response.size(), &seenAuthSOA);
 
     if (minTTL == std::numeric_limits<uint32_t>::max()) {
-      /* no TTL found, we probably don't want to cache this
-         unless it's an empty (no records) truncated answer,
-         and we have been asked to cache these */
-      if (d_settings.d_truncatedTTL == 0) {
-        return;
-      }
-      dnsheader_aligned dh_aligned(response.data());
-      if (dh_aligned->tc == 0) {
-        return;
-      }
-      minTTL = d_settings.d_truncatedTTL;
+      /* no TTL found, we probably don't want to cache this */
+      return;
     }
 
     if (rcode == RCode::NXDomain || (rcode == RCode::NoError && seenAuthSOA)) {
@@ -193,7 +184,6 @@ void DNSDistPacketCache::insert(uint32_t key, const std::optional<Netmask>& subn
   newValue.len = response.size();
   newValue.validity = newValidity;
   newValue.added = now;
-  newValue.receivedOverUDP = receivedOverUDP;
   newValue.dnssecOK = dnssecOK;
   newValue.value = std::string(response.begin(), response.end());
   newValue.subnet = subnet;
@@ -220,7 +210,7 @@ void DNSDistPacketCache::insert(uint32_t key, const std::optional<Netmask>& subn
   }
 }
 
-bool DNSDistPacketCache::get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_t* keyOut, std::optional<Netmask>& subnet, bool dnssecOK, bool receivedOverUDP, uint32_t allowExpired, bool skipAging, bool truncatedOK, bool recordMiss)
+bool DNSDistPacketCache::get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_t* keyOut, std::optional<Netmask>& subnet, bool dnssecOK, uint32_t allowExpired, bool skipAging, bool recordMiss)
 {
   if (dnsQuestion.ids.qtype == QType::AXFR || dnsQuestion.ids.qtype == QType::IXFR) {
     ++d_misses;
@@ -228,7 +218,7 @@ bool DNSDistPacketCache::get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_
   }
 
   const auto& dnsQName = dnsQuestion.ids.qname.getStorage();
-  uint32_t key = getKey(dnsQName, dnsQuestion.ids.qname.wirelength(), dnsQuestion.getData(), receivedOverUDP);
+  uint32_t key = getKey(dnsQName, dnsQuestion.ids.qname.wirelength(), dnsQuestion.getData());
 
   if (keyOut != nullptr) {
     *keyOut = key;
@@ -275,16 +265,9 @@ bool DNSDistPacketCache::get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_
     }
 
     /* check for collision */
-    if (!cachedValueMatches(value, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnsQuestion.ids.qname, dnsQuestion.ids.qtype, dnsQuestion.ids.qclass, receivedOverUDP, dnssecOK, subnet)) {
+    if (!cachedValueMatches(value, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnsQuestion.ids.qname, dnsQuestion.ids.qtype, dnsQuestion.ids.qclass, dnssecOK, subnet)) {
       ++d_lookupCollisions;
       return false;
-    }
-
-    if (!truncatedOK) {
-      dnsheader_aligned dh_aligned(value.value.data());
-      if (dh_aligned->tc != 0) {
-        return false;
-      }
     }
 
     response.resize(value.len);
@@ -491,7 +474,7 @@ uint32_t DNSDistPacketCache::getMinTTL(const char* packet, uint16_t length, bool
   return getDNSPacketMinTTL(packet, length, seenNoDataSOA);
 }
 
-uint32_t DNSDistPacketCache::getKey(const DNSName::string_t& qname, size_t qnameWireLength, const PacketBuffer& packet, bool receivedOverUDP) const
+uint32_t DNSDistPacketCache::getKey(const DNSName::string_t& qname, size_t qnameWireLength, const PacketBuffer& packet) const
 {
   uint32_t result = 0;
   /* skip the query ID */
@@ -515,8 +498,6 @@ uint32_t DNSDistPacketCache::getKey(const DNSName::string_t& qname, size_t qname
       result = burtle(&packet.at(sizeof(dnsheader) + qnameWireLength), packet.size() - (sizeof(dnsheader) + qnameWireLength), result);
     }
   }
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  result = burtle(reinterpret_cast<const unsigned char*>(&receivedOverUDP), sizeof(receivedOverUDP), result);
   return result;
 }
 
@@ -565,7 +546,7 @@ uint64_t DNSDistPacketCache::dump(int fileDesc, bool rawResponse)
           rcode = dnsHeader.rcode;
         }
 
-        fprintf(filePtr.get(), "%s %" PRId64 " %s %s ; ecs %s, rcode %" PRIu8 ", key %" PRIu32 ", length %" PRIu16 ", received over UDP %d, added %" PRId64 ", dnssecOK %d, raw query flags %" PRIu16, value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QClass(value.qclass).toString().c_str(), QType(value.qtype).toString().c_str(), value.subnet ? value.subnet.value().toString().c_str() : "empty", rcode, entry.first, value.len, value.receivedOverUDP ? 1 : 0, static_cast<int64_t>(value.added), value.dnssecOK ? 1 : 0, value.queryFlags);
+        fprintf(filePtr.get(), "%s %" PRId64 " %s %s ; ecs %s, rcode %" PRIu8 ", key %" PRIu32 ", length %" PRIu16 ", added %" PRId64 ", dnssecOK %d, raw query flags %" PRIu16, value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QClass(value.qclass).toString().c_str(), QType(value.qtype).toString().c_str(), value.subnet ? value.subnet.value().toString().c_str() : "empty", rcode, entry.first, value.len, static_cast<int64_t>(value.added), value.dnssecOK ? 1 : 0, value.queryFlags);
 
         if (rawResponse) {
           std::string rawDataResponse = Base64Encode(value.value);

--- a/pdns/dnsdistdist/dnsdist-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-cache.hh
@@ -45,7 +45,6 @@ public:
     uint32_t d_minTTL{0};
     uint32_t d_tempFailureTTL{60};
     uint32_t d_maxNegativeTTL{3600};
-    uint32_t d_truncatedTTL{0};
     uint32_t d_staleTTL{60};
     uint32_t d_shardCount{1};
     bool d_dontAge{false};
@@ -57,9 +56,9 @@ public:
 
   DNSDistPacketCache(CacheSettings settings);
 
-  void insert(uint32_t key, const std::optional<Netmask>& subnet, uint16_t queryFlags, bool dnssecOK, const DNSName& qname, uint16_t qtype, uint16_t qclass, const PacketBuffer& response, bool receivedOverUDP, uint8_t rcode, std::optional<uint32_t> tempFailureTTL);
-  bool get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_t* keyOut, std::optional<Netmask>& subnet, bool dnssecOK, bool receivedOverUDP, uint32_t allowExpired = 0, bool skipAging = false, bool truncatedOK = true, bool recordMiss = true);
-  size_t purgeExpired(size_t upTo, time_t now);
+  void insert(uint32_t key, const std::optional<Netmask>& subnet, uint16_t queryFlags, bool dnssecOK, const DNSName& qname, uint16_t qtype, uint16_t qclass, const PacketBuffer& response, uint8_t rcode, std::optional<uint32_t> tempFailureTTL);
+  bool get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_t* keyOut, std::optional<Netmask>& subnet, bool dnssecOK, uint32_t allowExpired = 0, bool skipAging = false, bool recordMiss = true);
+  size_t purgeExpired(size_t upTo, const time_t now);
   size_t expunge(size_t upTo = 0);
   size_t expungeByName(const DNSName& name, uint16_t qtype = QType::ANY, bool suffixMatch = false);
   size_t expungeByName(const std::vector<DNSName>& names, uint16_t qtype = QType::ANY, bool suffixMatch = false);
@@ -92,7 +91,7 @@ public:
 
   [[nodiscard]] size_t getMaximumEntrySize() const { return d_settings.d_maximumEntrySize; }
 
-  uint32_t getKey(const DNSName::string_t& qname, size_t qnameWireLength, const PacketBuffer& packet, bool receivedOverUDP) const;
+  uint32_t getKey(const DNSName::string_t& qname, size_t qnameWireLength, const PacketBuffer& packet) const;
 
   static uint32_t getMinTTL(const char* packet, uint16_t length, bool* seenNoDataSOA);
   static bool getClientSubnet(const PacketBuffer& packet, size_t qnameWireLength, std::optional<Netmask>& subnet);
@@ -110,7 +109,6 @@ private:
     time_t added{0};
     time_t validity{0};
     uint16_t len{0};
-    bool receivedOverUDP{false};
     bool dnssecOK{false};
   };
 
@@ -143,7 +141,7 @@ private:
     std::atomic<uint64_t> d_entriesCount{0};
   };
 
-  [[nodiscard]] bool cachedValueMatches(const CacheValue& cachedValue, uint16_t queryFlags, const DNSName& qname, uint16_t qtype, uint16_t qclass, bool receivedOverUDP, bool dnssecOK, const std::optional<Netmask>& subnet) const;
+  [[nodiscard]] bool cachedValueMatches(const CacheValue& cachedValue, uint16_t queryFlags, const DNSName& qname, uint16_t qtype, uint16_t qclass, bool dnssecOK, const std::optional<Netmask>& subnet) const;
   [[nodiscard]] uint32_t getShardIndex(uint32_t key) const;
   bool insertLocked(std::unordered_map<uint32_t, CacheValue>& map, uint32_t key, CacheValue& newValue);
 

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -853,6 +853,7 @@ static void loadBinds(const Context& context, const ::rust::Vec<dnsdist::rust::s
         if (bind.tcp.max_concurrent_connections > 0) {
           state->d_tcpConcurrentConnectionsLimit = bind.tcp.max_concurrent_connections;
         }
+        state->d_forwardViaUDPFirst = bind.forward_via_udp_first;
 
         handleAdditionalAddressesForFrontend(context, state, protocol, bind.additional_addresses);
 

--- a/pdns/dnsdistdist/dnsdist-configuration.hh
+++ b/pdns/dnsdistdist/dnsdist-configuration.hh
@@ -195,7 +195,6 @@ struct RuntimeConfiguration
   bool d_applyACLToProxiedClients{false};
   bool d_openTelemetryTracing{false}; // XXX: It would be nice to #ifndef DISABLE_PROTOBUF, but as this is defined in dnsdist-settings-definitions.yml, we can't
   bool d_webServerAllowCrossOriginRequests{false}; // Whether the webserver / API allows cross-origin requests
-  bool d_forwardViaUDPFirst{false};
 };
 
 /* Be careful not to hold on this for too long, it can be invalidated

--- a/pdns/dnsdistdist/dnsdist-configuration.hh
+++ b/pdns/dnsdistdist/dnsdist-configuration.hh
@@ -195,6 +195,7 @@ struct RuntimeConfiguration
   bool d_applyACLToProxiedClients{false};
   bool d_openTelemetryTracing{false}; // XXX: It would be nice to #ifndef DISABLE_PROTOBUF, but as this is defined in dnsdist-settings-definitions.yml, we can't
   bool d_webServerAllowCrossOriginRequests{false}; // Whether the webserver / API allows cross-origin requests
+  bool d_forwardViaUDPFirst{false};
 };
 
 /* Be careful not to hold on this for too long, it can be invalidated

--- a/pdns/dnsdistdist/dnsdist-idstate.hh
+++ b/pdns/dnsdistdist/dnsdist-idstate.hh
@@ -220,10 +220,8 @@ public:
   std::unique_ptr<DOH3Unit> doh3u{nullptr}; // 8
   int32_t d_streamID{-1}; // 4
   uint32_t cacheKey{0}; // 4
-  uint32_t cacheKeyTCP{0}; // 4
   // for the zero-scope feature we need to keep the cache key computed before adding the ECS payload
   uint32_t cacheKeyNoECS{0}; // 4
-  uint32_t cacheKeyNoECSTCP{0}; // 4
   uint32_t ttlCap{0}; // cap the TTL _after_ inserting into the packet cache // 4
   int backendFD{-1}; // 4
   int delayMsec{0};

--- a/pdns/dnsdistdist/dnsdist-idstate.hh
+++ b/pdns/dnsdistdist/dnsdist-idstate.hh
@@ -220,9 +220,10 @@ public:
   std::unique_ptr<DOH3Unit> doh3u{nullptr}; // 8
   int32_t d_streamID{-1}; // 4
   uint32_t cacheKey{0}; // 4
-  uint32_t cacheKeyNoECS{0}; // 4
-  // DoH-only: if we received a TC=1 answer, we had to retry over TCP and thus we need the TCP cache key */
   uint32_t cacheKeyTCP{0}; // 4
+  // for the zero-scope feature we need to keep the cache key computed before adding the ECS payload
+  uint32_t cacheKeyNoECS{0}; // 4
+  uint32_t cacheKeyNoECSTCP{0}; // 4
   uint32_t ttlCap{0}; // cap the TTL _after_ inserting into the packet cache // 4
   int backendFD{-1}; // 4
   int delayMsec{0};

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -53,7 +53,6 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
     getOptionalValue<bool>(vars, "parseECS", settings.d_parseECS);
     getOptionalValue<size_t>(vars, "staleTTL", settings.d_staleTTL);
     getOptionalValue<size_t>(vars, "temporaryFailureTTL", settings.d_tempFailureTTL);
-    getOptionalValue<size_t>(vars, "truncatedTTL", settings.d_truncatedTTL);
     getOptionalValue<bool>(vars, "cookieHashing", cookieHashing);
     getOptionalValue<size_t>(vars, "maximumEntrySize", maximumEntrySize);
 

--- a/pdns/dnsdistdist/dnsdist-lua-configuration-items.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-configuration-items.cc
@@ -84,7 +84,6 @@ static const std::map<std::string, BooleanConfigurationItems> s_booleanConfigIte
   {"setWebserverBindFatal", {[](dnsdist::configuration::RuntimeConfiguration& config, bool newValue) { config.d_webserverBindFatal = newValue; }}},
   {"setProxyProtocolApplyACLToProxiedClients", {[](dnsdist::configuration::RuntimeConfiguration& config, bool newValue) { config.d_applyACLToProxiedClients = newValue; }}},
   {"setAddEDNSToSelfGeneratedResponses", {[](dnsdist::configuration::RuntimeConfiguration& config, bool newValue) { config.d_addEDNSToSelfGeneratedResponses = newValue; }}},
-  {"setForwardViaUDPFirst", {[](dnsdist::configuration::RuntimeConfiguration& config, bool newValue) { config.d_forwardViaUDPFirst = newValue; }}},
 };
 
 static const std::map<std::string, UnsignedIntegerConfigurationItems> s_unsignedIntegerConfigItems{

--- a/pdns/dnsdistdist/dnsdist-lua-configuration-items.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-configuration-items.cc
@@ -84,6 +84,7 @@ static const std::map<std::string, BooleanConfigurationItems> s_booleanConfigIte
   {"setWebserverBindFatal", {[](dnsdist::configuration::RuntimeConfiguration& config, bool newValue) { config.d_webserverBindFatal = newValue; }}},
   {"setProxyProtocolApplyACLToProxiedClients", {[](dnsdist::configuration::RuntimeConfiguration& config, bool newValue) { config.d_applyACLToProxiedClients = newValue; }}},
   {"setAddEDNSToSelfGeneratedResponses", {[](dnsdist::configuration::RuntimeConfiguration& config, bool newValue) { config.d_addEDNSToSelfGeneratedResponses = newValue; }}},
+  {"setForwardViaUDPFirst", {[](dnsdist::configuration::RuntimeConfiguration& config, bool newValue) { config.d_forwardViaUDPFirst = newValue; }}},
 };
 
 static const std::map<std::string, UnsignedIntegerConfigurationItems> s_unsignedIntegerConfigItems{

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -136,13 +136,14 @@ static std::shared_ptr<const Logr::Logger> getLogger(const std::string_view cont
 
 using localbind_t = LuaAssociativeTable<boost::variant<bool, int, std::string, LuaArray<int>, LuaArray<std::string>, LuaAssociativeTable<std::string>, std::shared_ptr<XskSocket>>>;
 
-static void parseLocalBindVars(std::optional<localbind_t>& vars, bool& reusePort, int& tcpFastOpenQueueSize, std::string& interface, std::set<int>& cpus, int& tcpListenQueueSize, uint64_t& maxInFlightQueriesPerConnection, uint64_t& tcpMaxConcurrentConnections, bool& enableProxyProtocol)
+static void parseLocalBindVars(std::optional<localbind_t>& vars, bool& reusePort, int& tcpFastOpenQueueSize, std::string& interface, std::set<int>& cpus, int& tcpListenQueueSize, uint64_t& maxInFlightQueriesPerConnection, uint64_t& tcpMaxConcurrentConnections, bool& enableProxyProtocol, bool& forwardViaUDPFirst)
 {
   if (vars) {
     LuaArray<int> setCpus;
 
     getOptionalValue<bool>(vars, "reusePort", reusePort);
     getOptionalValue<bool>(vars, "enableProxyProtocol", enableProxyProtocol);
+    getOptionalValue<bool>(vars, "forwardViaUDPFirst", forwardViaUDPFirst);
     getOptionalValue<int>(vars, "tcpFastOpenQueueSize", tcpFastOpenQueueSize);
     getOptionalValue<int>(vars, "tcpListenQueueSize", tcpListenQueueSize);
     getOptionalValue<int>(vars, "maxConcurrentTCPConnections", tcpMaxConcurrentConnections);
@@ -820,8 +821,9 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     std::string interface;
     std::set<int> cpus;
     bool enableProxyProtocol = true;
+    bool forwardViaUDPFirst = false;
 
-    parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol);
+    parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol, forwardViaUDPFirst);
 
     auto frontends = dnsdist::configuration::getImmutableConfiguration().d_frontends;
     try {
@@ -848,6 +850,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       if (tcpMaxConcurrentConnections > 0) {
         tcpCS->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConnections;
       }
+      tcpCS->d_forwardViaUDPFirst = forwardViaUDPFirst;
 
 #ifdef HAVE_XSK
       std::shared_ptr<XskSocket> socket;
@@ -892,8 +895,9 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     std::string interface;
     std::set<int> cpus;
     bool enableProxyProtocol = true;
+    bool forwardViaUDPFirst = false;
 
-    parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol);
+    parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol, forwardViaUDPFirst);
 
     try {
       ComboAddress loc(addr, 53);
@@ -909,6 +913,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       if (tcpMaxConcurrentConnections > 0) {
         tcpCS->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConnections;
       }
+      tcpCS->d_forwardViaUDPFirst = forwardViaUDPFirst;
 #ifdef HAVE_XSK
       std::shared_ptr<XskSocket> socket;
       parseXskVars(vars, socket);
@@ -1607,8 +1612,9 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     std::set<int> cpus;
     std::vector<DNSCryptContext::CertKeyPaths> certKeys;
     bool enableProxyProtocol = true;
+    bool forwardViaUDPFirst = false;
 
-    parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol);
+    parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol, forwardViaUDPFirst);
     checkAllParametersConsumed("addDNSCryptBind", vars);
 
     if (certFiles.type() == typeid(std::string) && keyFiles.type() == typeid(std::string)) {
@@ -1661,6 +1667,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       if (tcpMaxConcurrentConnections > 0) {
         clientState->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConnections;
       }
+      clientState->d_forwardViaUDPFirst = forwardViaUDPFirst;
 
       dnsdist::configuration::updateImmutableConfiguration([&clientState](dnsdist::configuration::ImmutableConfiguration& config) {
         config.d_frontends.push_back(std::move(clientState));
@@ -2343,9 +2350,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     std::vector<std::pair<ComboAddress, int>> additionalAddresses;
     bool enableProxyProtocol = true;
     bool padResponses = false;
+    bool forwardViaUDPFirst = false;
 
     if (vars) {
-      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol);
+      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol, forwardViaUDPFirst);
       getOptionalValue<int>(vars, "idleTimeout", frontend->d_idleTimeout);
       getOptionalValue<std::string>(vars, "serverTokens", frontend->d_serverTokens);
       getOptionalValue<std::string>(vars, "provider", frontend->d_tlsContext->d_provider);
@@ -2466,9 +2474,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     std::vector<std::pair<ComboAddress, int>> additionalAddresses;
     bool enableProxyProtocol = true;
     bool padResponses = false;
+    bool forwardViaUDPFirst = false;
 
     if (vars) {
-      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol);
+      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol, forwardViaUDPFirst);
       if (maxInFlightQueriesPerConn > 0) {
         frontend->d_quicheParams.d_maxInFlight = maxInFlightQueriesPerConn;
       }
@@ -2507,6 +2516,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     auto clientState = std::make_shared<ClientState>(frontend->d_local, false, reusePort, tcpFastOpenQueueSize, interface, cpus, enableProxyProtocol, padResponses);
     clientState->doh3Frontend = std::move(frontend);
     clientState->d_additionalAddresses = std::move(additionalAddresses);
+    clientState->d_forwardViaUDPFirst = forwardViaUDPFirst;
 
     dnsdist::configuration::updateImmutableConfiguration([&clientState](dnsdist::configuration::ImmutableConfiguration& config) {
       config.d_frontends.push_back(std::move(clientState));
@@ -2543,9 +2553,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     std::vector<std::pair<ComboAddress, int>> additionalAddresses;
     bool enableProxyProtocol = true;
     bool padResponses = false;
+    bool forwardViaUDPFirst = false;
 
     if (vars) {
-      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol);
+      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections, enableProxyProtocol, forwardViaUDPFirst);
       if (maxInFlightQueriesPerConn > 0) {
         frontend->d_quicheParams.d_maxInFlight = maxInFlightQueriesPerConn;
       }
@@ -2584,6 +2595,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     auto clientState = std::make_shared<ClientState>(frontend->d_local, false, reusePort, tcpFastOpenQueueSize, interface, cpus, enableProxyProtocol, padResponses);
     clientState->doqFrontend = std::move(frontend);
     clientState->d_additionalAddresses = std::move(additionalAddresses);
+    clientState->d_forwardViaUDPFirst = forwardViaUDPFirst;
 
     dnsdist::configuration::updateImmutableConfiguration([&clientState](dnsdist::configuration::ImmutableConfiguration& config) {
       config.d_frontends.push_back(std::move(clientState));
@@ -2914,9 +2926,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     std::vector<std::pair<ComboAddress, int>> additionalAddresses;
     bool enableProxyProtocol = true;
     bool padResponses = false;
+    bool forwardViaUDPFirst = false;
 
     if (vars) {
-      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConns, enableProxyProtocol);
+      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConns, enableProxyProtocol, forwardViaUDPFirst);
 
       getOptionalValue<std::string>(vars, "provider", frontend->d_provider);
       boost::algorithm::to_lower(frontend->d_provider);
@@ -2987,6 +3000,8 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       if (tcpMaxConcurrentConns > 0) {
         clientState->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConns;
       }
+
+      clientState->d_forwardViaUDPFirst = forwardViaUDPFirst;
 
       dnsdist::configuration::updateImmutableConfiguration([&clientState](dnsdist::configuration::ImmutableConfiguration& config) {
         config.d_frontends.push_back(std::move(clientState));

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -2221,6 +2221,8 @@ packet_cache:
       type: "u32"
       default: 0
       description: "On a truncated (TC=1, no records) response from the backend, cache for this amount of seconds. 0, the default, means that truncated answers are not cached"
+      changes:
+        - version_removed: 2.2.0
     - name: "cookie_hashing"
       type: "bool"
       default: "false"

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1282,6 +1282,10 @@ bind:
       type: "String"
       default: ""
       description: "The name of an XSK sockets map to attach to this frontend, if any"
+    - name: "forward_via_udp_first"
+      type: "bool"
+      default: "false"
+      description: "Whether queries received by this frontend over DoTCP, DoT, DoQ and DoH3 should be forwarded to the backend via UDP (unless the backend is TCP-only). If a truncated answer is received, the query will be re-tried over TCP. Queries received over DoUDP and DoH are always forwarded via UDP unless the backend is TCP-only, so this setting has no effect on these frontends."
 
 outgoing_tcp:
   description: "TCP-related settings for backends"
@@ -2145,13 +2149,6 @@ general:
           Keeping ``CAP_SYS_ADMIN`` on kernel 5.8+ for example allows loading eBPF programs and altering eBPF maps at runtime even if the ``kernel.unprivileged_bpf_disabled`` sysctl is set.
           Note that this does not grant the capabilities to the process, doing so might be done by running it as root which we don't advise, or by adding capabilities via the systemd unit file, for example.
           Please also be aware that switching to a different user via ``--uid`` will still drop all capabilities."
-    - name: "forward_via_udp_first"
-      type: "bool"
-      default: "false"
-      lua-name: "setForwardViaUDPFirst"
-      internal-field-name: "d_forwardViaUDPFirst"
-      runtime-configurable: true
-      description: "Whether queries received over DoTCP, DoT, DoQ and DoH3 should be forwarded to the backend via UDP (unless the backend is TCP-only). If a truncated answer is received, the query will be re-tried over TCP."
 
 netmask_group:
   description: "Group of netmasks"

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -2145,6 +2145,13 @@ general:
           Keeping ``CAP_SYS_ADMIN`` on kernel 5.8+ for example allows loading eBPF programs and altering eBPF maps at runtime even if the ``kernel.unprivileged_bpf_disabled`` sysctl is set.
           Note that this does not grant the capabilities to the process, doing so might be done by running it as root which we don't advise, or by adding capabilities via the systemd unit file, for example.
           Please also be aware that switching to a different user via ``--uid`` will still drop all capabilities."
+    - name: "forward_via_udp_first"
+      type: "bool"
+      default: "false"
+      lua-name: "setForwardViaUDPFirst"
+      internal-field-name: "d_forwardViaUDPFirst"
+      runtime-configurable: true
+      description: "Whether queries received over DoTCP, DoT, DoQ and DoH3 should be forwarded to the backend via UDP (unless the backend is TCP-only). If a truncated answer is received, the query will be re-tried over TCP."
 
 netmask_group:
   description: "Group of netmasks"

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -114,15 +114,9 @@ public:
     return d_ci.cs->getTLSFrontend()->d_proxyProtocolOutsideTLS;
   }
 
-  virtual bool forwardViaUDPFirst() const
-  {
-    return false;
-  }
-  virtual std::unique_ptr<DOHUnitInterface> getDOHUnit(uint32_t streamID)
-  {
-    (void)streamID;
-    throw std::runtime_error("Getting a DOHUnit state from a generic TCP/DoT connection is not supported");
-  }
+  virtual bool forwardViaUDPFirst() const;
+
+  virtual std::unique_ptr<DOHUnitInterface> getDOHUnit(uint32_t streamID);
   virtual void restoreDOHUnit(std::unique_ptr<DOHUnitInterface>&&)
   {
     throw std::runtime_error("Restoring a DOHUnit state to a generic TCP/DoT connection is not supported");

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -78,6 +78,7 @@ public:
 
   ~TCPQueryForwardedOverUDP() override = default;
 
+#if defined(HAVE_DNS_OVER_HTTPS)
   [[nodiscard]] std::string getHTTPPath() const override
   {
     throw std::runtime_error("called HTTP method on non DoH query");
@@ -108,11 +109,6 @@ public:
     throw std::runtime_error("called HTTP method on non DoH query");
   }
 
-  [[nodiscard]] std::shared_ptr<TCPQuerySender> getQuerySender() const override
-  {
-    return std::dynamic_pointer_cast<TCPQuerySender>(d_connection);
-  }
-
   void handleUDPResponse(PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& downstream_) override
   {
     std::unique_ptr<DOHUnitInterface> unit(this);
@@ -132,6 +128,12 @@ public:
     gettimeofday(&now, nullptr);
     TCPResponse resp;
     conn->notifyIOError(now, std::move(resp));
+  }
+#endif /* defined(HAVE_DNS_OVER_HTTPS) */
+
+  [[nodiscard]] std::shared_ptr<TCPQuerySender> getQuerySender() const override
+  {
+    return std::dynamic_pointer_cast<TCPQuerySender>(d_connection);
   }
 
 private:

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -67,8 +67,8 @@ std::atomic<uint64_t> g_tcpStatesDumpRequested{0};
 class TCPQueryForwardedOverUDP : public DOHUnitInterface
 {
 public:
-  TCPQueryForwardedOverUDP(const std::shared_ptr<IncomingTCPConnectionState>& connection) :
-    d_connection(connection)
+  TCPQueryForwardedOverUDP(std::shared_ptr<IncomingTCPConnectionState> connection) :
+    d_connection(std::move(connection))
   {
   }
   TCPQueryForwardedOverUDP(const TCPQueryForwardedOverUDP&) = delete;
@@ -104,8 +104,11 @@ public:
     throw std::runtime_error("called HTTP method on non DoH query");
   }
 
-  void setHTTPResponse(uint16_t, PacketBuffer&&, const std::string&) override
+  void setHTTPResponse(uint16_t statusCode, PacketBuffer&& body, const std::string& contentType) override
   {
+    (void)statusCode;
+    (void)body;
+    (void)contentType;
     throw std::runtime_error("called HTTP method on non DoH query");
   }
 
@@ -695,7 +698,8 @@ void IncomingTCPConnectionState::handleResponse(const struct timeval& now, TCPRe
   if (ids.forwardedOverUDP) {
     dnsheader_aligned responseDH(response.d_buffer.data());
 
-    if (responseDH.get()->tc && ids.d_packet && ids.d_packet->size() > ids.d_proxyProtocolPayloadSize && ids.d_packet->size() - ids.d_proxyProtocolPayloadSize > sizeof(dnsheader)) {
+    if (responseDH->tc && ids.d_packet && ids.d_packet->size() > ids.d_proxyProtocolPayloadSize && ids.d_packet->size() - ids.d_proxyProtocolPayloadSize > sizeof(dnsheader)) {
+
       VERBOSESLOG(infolog("Response received from backend %s via UDP, for query received from %s via TCP/DoT, is truncated, retrying over TCP", response.d_ds->getNameWithAddr(), ids.origRemote.toStringWithPort()),
                   getLogger()->info(Logr::Info, "Response received from backend via UDP, for query received via TCP/DoT, is truncated, retrying over TCP"));
 
@@ -882,8 +886,9 @@ void IncomingTCPConnectionState::handleCrossProtocolResponse(const struct timeva
   }
 }
 
-std::unique_ptr<DOHUnitInterface> IncomingTCPConnectionState::getDOHUnit(uint32_t)
+std::unique_ptr<DOHUnitInterface> IncomingTCPConnectionState::getDOHUnit(uint32_t streamID)
 {
+  (void)streamID;
   return std::make_unique<TCPQueryForwardedOverUDP>(shared_from_this());
 }
 

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -990,11 +990,13 @@ IncomingTCPConnectionState::QueryProcessingResult IncomingTCPConnectionState::ha
     dnsQuestion.proxyProtocolValues = make_unique<std::vector<ProxyProtocolValue>>(*d_proxyProtocolValues);
   }
 
+  bool isXFR = false;
   if (dnsQuestion.ids.qtype == QType::AXFR || dnsQuestion.ids.qtype == QType::IXFR) {
     dnsQuestion.ids.skipCache = true;
+    isXFR = true;
   }
 
-  if (forwardViaUDPFirst()) {
+  if (!isXFR && forwardViaUDPFirst()) {
     // if there was no EDNS, we add it with a large buffer size
     // so we can use UDP to talk to the backend.
     const dnsheader_aligned dnsHeader(query.data());
@@ -1079,7 +1081,7 @@ IncomingTCPConnectionState::QueryProcessingResult IncomingTCPConnectionState::ha
     backend->passCrossProtocolQuery(std::move(cpq));
     return QueryProcessingResult::Forwarded;
   }
-  if (!backend->isTCPOnly() && forwardViaUDPFirst()) {
+  if (!isXFR && !backend->isTCPOnly() && forwardViaUDPFirst()) {
     auto unit = getDOHUnit(streamID ? *streamID : 0U);
     if (unit) {
       dnsQuestion.ids.du = std::move(unit);

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -1100,7 +1100,10 @@ IncomingTCPConnectionState::QueryProcessingResult IncomingTCPConnectionState::ha
     if (assignOutgoingUDPQueryToBackend(backend, queryID, dnsQuestion, query)) {
       return QueryProcessingResult::Forwarded;
     }
-    restoreDOHUnit(std::move(dnsQuestion.ids.du));
+    if (streamID) {
+      restoreDOHUnit(std::move(dnsQuestion.ids.du));
+    }
+
     // fallback to the normal flow
   }
 

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -894,7 +894,7 @@ std::unique_ptr<DOHUnitInterface> IncomingTCPConnectionState::getDOHUnit(uint32_
 
 bool IncomingTCPConnectionState::forwardViaUDPFirst() const
 {
-  return dnsdist::configuration::getCurrentRuntimeConfiguration().d_forwardViaUDPFirst;
+  return d_ci.cs != nullptr && d_ci.cs->d_forwardViaUDPFirst;
 }
 
 IncomingTCPConnectionState::QueryProcessingResult IncomingTCPConnectionState::handleQuery(PacketBuffer&& queryIn, const struct timeval& now, std::optional<int32_t> streamID)

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -1006,7 +1006,6 @@ IncomingTCPConnectionState::QueryProcessingResult IncomingTCPConnectionState::ha
     isXFR = true;
   }
 
-#warning TODO: do not use UDP if there was a cache hit for UDP yielding a TC=1
   if (!isXFR && forwardViaUDPFirst()) {
     // if there was no EDNS, we add it with a large buffer size
     // so we can use UDP to talk to the backend.

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -694,7 +694,9 @@ void IncomingTCPConnectionState::handleResponse(const struct timeval& now, TCPRe
     dnsheader_aligned responseDH(response.d_buffer.data());
 
     if (responseDH.get()->tc && ids.d_packet && ids.d_packet->size() > ids.d_proxyProtocolPayloadSize && ids.d_packet->size() - ids.d_proxyProtocolPayloadSize > sizeof(dnsheader)) {
-      vinfolog("Response received from backend %s via UDP, for query received from %s via TCP/DoT, is truncated, retrying over TCP", response.d_ds->getNameWithAddr(), ids.origRemote.toStringWithPort());
+      VERBOSESLOG(infolog("Response received from backend %s via UDP, for query received from %s via TCP/DoT, is truncated, retrying over TCP", response.d_ds->getNameWithAddr(), ids.origRemote.toStringWithPort()),
+                  getLogger()->info(Logr::Info, "Response received from backend via UDP, for query received via TCP/DoT, is truncated, retrying over TCP"));
+
       auto& query = *ids.d_packet;
       dnsdist::PacketMangling::editDNSHeaderFromRawPacket(&query.at(ids.d_proxyProtocolPayloadSize), [origID = ids.origID](dnsheader& header) {
         /* restoring the original ID */
@@ -711,7 +713,8 @@ void IncomingTCPConnectionState::handleResponse(const struct timeval& now, TCPRe
       if (g_tcpclientthreads && g_tcpclientthreads->passCrossProtocolQueryToThread(std::move(cpq))) {
         return;
       }
-      vinfolog("Unable to pass TCP/DoT query to a TCP worker thread after getting a TC response over UDP");
+      VERBOSESLOG(infolog("Unable to pass TCP/DoT query to a TCP worker thread after getting a TC response over UDP"),
+                  getLogger()->info(Logr::Info, "Unable to pass TCP/DoT query to a TCP worker thread after getting a TC response over UDP"));
       notifyIOError(now, std::move(response));
       return;
     }

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -996,6 +996,7 @@ IncomingTCPConnectionState::QueryProcessingResult IncomingTCPConnectionState::ha
     isXFR = true;
   }
 
+#warning TODO: do not use UDP if there was a cache hit for UDP yielding a TC=1
   if (!isXFR && forwardViaUDPFirst()) {
     // if there was no EDNS, we add it with a large buffer size
     // so we can use UDP to talk to the backend.

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -64,6 +64,84 @@
 
 std::atomic<uint64_t> g_tcpStatesDumpRequested{0};
 
+class TCPQueryForwardedOverUDP : public DOHUnitInterface
+{
+public:
+  TCPQueryForwardedOverUDP(const std::shared_ptr<IncomingTCPConnectionState>& connection) :
+    d_connection(connection)
+  {
+  }
+  TCPQueryForwardedOverUDP(const TCPQueryForwardedOverUDP&) = delete;
+  TCPQueryForwardedOverUDP(TCPQueryForwardedOverUDP&&) = delete;
+  TCPQueryForwardedOverUDP& operator=(const TCPQueryForwardedOverUDP&) = delete;
+  TCPQueryForwardedOverUDP& operator=(TCPQueryForwardedOverUDP&&) = delete;
+
+  ~TCPQueryForwardedOverUDP() override = default;
+
+  [[nodiscard]] std::string getHTTPPath() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] const std::string& getHTTPScheme() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] const std::string& getHTTPHost() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] std::string getHTTPQueryString() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] const HeadersMap& getHTTPHeaders() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  void setHTTPResponse(uint16_t, PacketBuffer&&, const std::string&) override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] std::shared_ptr<TCPQuerySender> getQuerySender() const override
+  {
+    return std::dynamic_pointer_cast<TCPQuerySender>(d_connection);
+  }
+
+  void handleUDPResponse(PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& downstream_) override
+  {
+    std::unique_ptr<DOHUnitInterface> unit(this);
+    auto& conn = d_connection;
+    state.du = std::move(unit);
+    TCPResponse resp(std::move(response), std::move(state), nullptr, downstream_);
+    timeval now{};
+    gettimeofday(&now, nullptr);
+    conn->handleResponse(now, std::move(resp));
+  }
+
+  void handleTimeout() override
+  {
+    std::unique_ptr<DOHUnitInterface> unit(this);
+    auto& conn = d_connection;
+    timeval now{};
+    gettimeofday(&now, nullptr);
+    TCPResponse resp;
+    conn->notifyIOError(now, std::move(resp));
+  }
+
+private:
+  // not a weak pointer: the reference counter could otherwise
+  // drop to zero when we can no longer accept new queries and
+  // have nothing to send, because then we are removed from the
+  // I/O multiplexer
+  std::shared_ptr<IncomingTCPConnectionState> d_connection;
+};
+
 IncomingTCPConnectionState::~IncomingTCPConnectionState()
 {
   try {
@@ -251,11 +329,11 @@ void IncomingTCPConnectionState::handleResponseSent(TCPResponse& currentResponse
     return;
   }
 
+  auto& ids = currentResponse.d_idstate;
   --d_currentQueriesCount;
 
   const auto& backend = currentResponse.d_connection ? currentResponse.d_connection->getDS() : currentResponse.d_ds;
   if (!currentResponse.d_idstate.selfGenerated && backend) {
-    auto& ids = currentResponse.d_idstate;
     auto udiff = ids.queryRealTime.udiff();
     VERBOSESLOG(infolog("Got answer from %s, relayed to %s (%s, %d bytes), took %d us", backend->d_config.remote.toStringWithPort(), ids.origRemote.toStringWithPort(), getProtocol().toString(), sentBytes, udiff),
                 ids.getLogger(getLogger())->info(Logr::Info, "Relayed response to client", "backend.name", Logging::Loggable(backend->getName()), "backend.address", Logging::Loggable(backend->d_config.remote), "dns.response.size", Logging::Loggable(sentBytes), "dns.response.latency_us", Logging::Loggable(udiff), "dns.response.rcode", Logging::Loggable(currentResponse.d_cleartextDH.rcode)));
@@ -267,7 +345,6 @@ void IncomingTCPConnectionState::handleResponseSent(TCPResponse& currentResponse
     ::handleResponseSent(ids, udiff, ids.origRemote, backend->d_config.remote, static_cast<unsigned int>(sentBytes), currentResponse.d_cleartextDH, backendProtocol, true);
   }
   else {
-    auto& ids = currentResponse.d_idstate;
     ::handleResponseSent(ids, 0., ids.origRemote, ComboAddress(), static_cast<unsigned int>(currentResponse.d_buffer.size()), currentResponse.d_cleartextDH, ids.protocol, false);
   }
 
@@ -612,6 +689,33 @@ void IncomingTCPConnectionState::handleResponse(const struct timeval& now, TCPRe
   }
 
   std::shared_ptr<IncomingTCPConnectionState> state = shared_from_this();
+  auto& ids = response.d_idstate;
+  if (ids.forwardedOverUDP) {
+    dnsheader_aligned responseDH(response.d_buffer.data());
+
+    if (responseDH.get()->tc && ids.d_packet && ids.d_packet->size() > ids.d_proxyProtocolPayloadSize && ids.d_packet->size() - ids.d_proxyProtocolPayloadSize > sizeof(dnsheader)) {
+      vinfolog("Response received from backend %s via UDP, for query received from %s via TCP/DoT, is truncated, retrying over TCP", response.d_ds->getNameWithAddr(), ids.origRemote.toStringWithPort());
+      auto& query = *ids.d_packet;
+      dnsdist::PacketMangling::editDNSHeaderFromRawPacket(&query.at(ids.d_proxyProtocolPayloadSize), [origID = ids.origID](dnsheader& header) {
+        /* restoring the original ID */
+        header.id = origID;
+        return true;
+      });
+
+      ids.forwardedOverUDP = false;
+      bool proxyProtocolPayloadAdded = ids.d_proxyProtocolPayloadSize > 0;
+      auto cpq = getCrossProtocolQuery(std::move(query), std::move(ids), response.d_ds);
+      /* 'd_packet' buffer moved by InternalQuery constructor, need re-association */
+      cpq->query.d_idstate.d_packet = std::make_unique<PacketBuffer>(cpq->query.d_buffer);
+      cpq->query.d_proxyProtocolPayloadAdded = proxyProtocolPayloadAdded;
+      if (g_tcpclientthreads && g_tcpclientthreads->passCrossProtocolQueryToThread(std::move(cpq))) {
+        return;
+      }
+      vinfolog("Unable to pass TCP/DoT query to a TCP worker thread after getting a TC response over UDP");
+      notifyIOError(now, std::move(response));
+      return;
+    }
+  }
 
   if (!response.isAsync() && response.d_connection && response.d_connection->getDS() && response.d_connection->getDS()->d_config.useProxyProtocol) {
     // if we have added a TCP Proxy Protocol payload to a connection, don't release it to the general pool as no one else will be able to use it anyway
@@ -645,7 +749,6 @@ void IncomingTCPConnectionState::handleResponse(const struct timeval& now, TCPRe
 
   if (!response.isAsync()) {
     try {
-      auto& ids = response.d_idstate;
       std::shared_ptr<DownstreamState> backend = response.d_ds ? response.d_ds : (response.d_connection ? response.d_connection->getDS() : nullptr);
       if (backend == nullptr || !responseContentMatches(response.d_buffer, ids.qname, ids.qtype, ids.qclass, backend, dnsdist::configuration::getCurrentRuntimeConfiguration().d_allowEmptyResponse)) {
         state->terminateClientConnection();
@@ -772,6 +875,16 @@ void IncomingTCPConnectionState::handleCrossProtocolResponse(const struct timeva
     VERBOSESLOG(infolog("Unable to pass a cross-protocol response to the TCP worker thread because we couldn't write to the pipe: %s", e.what()),
                 getLogger()->error(Logr::Info, e.what(), "Unable to pass a cross-protocol response to the TCP worker thread because we couldn't write to the pipe"));
   }
+}
+
+std::unique_ptr<DOHUnitInterface> IncomingTCPConnectionState::getDOHUnit(uint32_t)
+{
+  return std::make_unique<TCPQueryForwardedOverUDP>(shared_from_this());
+}
+
+bool IncomingTCPConnectionState::forwardViaUDPFirst() const
+{
+  return dnsdist::configuration::getCurrentRuntimeConfiguration().d_forwardViaUDPFirst;
 }
 
 IncomingTCPConnectionState::QueryProcessingResult IncomingTCPConnectionState::handleQuery(PacketBuffer&& queryIn, const struct timeval& now, std::optional<int32_t> streamID)
@@ -967,12 +1080,11 @@ IncomingTCPConnectionState::QueryProcessingResult IncomingTCPConnectionState::ha
     return QueryProcessingResult::Forwarded;
   }
   if (!backend->isTCPOnly() && forwardViaUDPFirst()) {
-    if (streamID) {
-      auto unit = getDOHUnit(*streamID);
-      if (unit) {
-        dnsQuestion.ids.du = std::move(unit);
-      }
+    auto unit = getDOHUnit(streamID ? *streamID : 0U);
+    if (unit) {
+      dnsQuestion.ids.du = std::move(unit);
     }
+
     if (assignOutgoingUDPQueryToBackend(backend, queryID, dnsQuestion, query)) {
       return QueryProcessingResult::Forwarded;
     }

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -404,7 +404,6 @@ bool processResponseAfterRules(PacketBuffer& response, DNSResponse& dnsResponse,
     }
     uint32_t cacheKey = dnsResponse.ids.cacheKey;
     if (dnsResponse.ids.protocol == dnsdist::Protocol::DoH && !dnsResponse.ids.forwardedOverUDP) {
-      cacheKey = dnsResponse.ids.cacheKeyTCP;
       // disable zeroScope in that case, as we only have the "no-ECS" cache key for UDP
       zeroScope = false;
     }
@@ -414,7 +413,7 @@ bool processResponseAfterRules(PacketBuffer& response, DNSResponse& dnsResponse,
     }
     {
       auto cacheInsertCloser = dnsResponse.ids.getCloser("packetCacheInsert"); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      dnsResponse.ids.packetCache->insert(cacheKey, zeroScope ? std::nullopt : dnsResponse.ids.subnet, dnsResponse.ids.cacheFlags, dnsResponse.ids.dnssecOK ? *dnsResponse.ids.dnssecOK : false, dnsResponse.ids.qname, dnsResponse.ids.qtype, dnsResponse.ids.qclass, response, dnsResponse.ids.forwardedOverUDP, dnsResponse.getHeader()->rcode, dnsResponse.ids.tempFailureTTL);
+      dnsResponse.ids.packetCache->insert(cacheKey, zeroScope ? std::nullopt : dnsResponse.ids.subnet, dnsResponse.ids.cacheFlags, dnsResponse.ids.dnssecOK ? *dnsResponse.ids.dnssecOK : false, dnsResponse.ids.qname, dnsResponse.ids.qtype, dnsResponse.ids.qclass, response, dnsResponse.getHeader()->rcode, dnsResponse.ids.tempFailureTTL);
     }
     const auto& chains = dnsdist::configuration::getCurrentRuntimeConfiguration().d_ruleChains;
     const auto& cacheInsertedRespRuleActions = dnsdist::rules::getResponseRuleChain(chains, dnsdist::rules::ResponseRuleChain::CacheInsertedResponseRules);
@@ -1182,28 +1181,15 @@ static ServerPolicy::SelectedBackend selectBackendForOutgoingQuery(DNSQuestion& 
   return selectedBackend;
 }
 
-enum class CacheProtocolLookup : uint8_t
-{
-  UDP = 0,
-  TCP = 1,
-};
-
-enum class CacheTruncationPolicy : uint8_t
-{
-  DisallowTruncated = 0,
-  AllowTruncated = 1,
-};
-
 enum class CacheRecordMissPolicy : uint8_t
 {
   DoNotRecordMiss = 0,
   RecordMiss = 1,
 };
 
-
-static std::optional<ProcessQueryResult> doCacheLookup(const ServerPool& serverPool, DNSQuestion& dnsQuestion, uint32_t allowExpired, CacheProtocolLookup udpBasedLookup, CacheTruncationPolicy allowTruncated, CacheRecordMissPolicy recordMiss, uint32_t* cacheKeyOut)
+static std::optional<ProcessQueryResult> doCacheLookup(const ServerPool& serverPool, DNSQuestion& dnsQuestion, uint32_t allowExpired, CacheRecordMissPolicy recordMiss, uint32_t* cacheKeyOut)
 {
-  if (!serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, cacheKeyOut, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, udpBasedLookup == CacheProtocolLookup::UDP, allowExpired, false, allowTruncated == CacheTruncationPolicy::AllowTruncated, recordMiss == CacheRecordMissPolicy::RecordMiss)) {
+  if (!serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, cacheKeyOut, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, allowExpired, false, recordMiss == CacheRecordMissPolicy::RecordMiss)) {
     return std::nullopt;
   }
 
@@ -1224,19 +1210,16 @@ static std::optional<ProcessQueryResult> doCacheLookup(const ServerPool& serverP
 
 static std::optional<ProcessQueryResult> handleCacheLookups(const ServerPool& serverPool, DNSQuestion& dnsQuestion, ServerPolicy::SelectedBackend& selectedBackend, bool zeroScopeLookup, bool& backendLookupDone)
 {
+  if (!serverPool.packetCache || dnsQuestion.ids.skipCache) {
+    return std::nullopt;
+  }
   uint32_t allowExpired = 0;
   if (!selectedBackend && dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL > 0 && (backendLookupDone || !serverPool.hasAtLeastOneServerAvailable())) {
     allowExpired = dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL;
   }
 
   uint32_t* cacheKey = zeroScopeLookup ? &dnsQuestion.ids.cacheKeyNoECS : &dnsQuestion.ids.cacheKey;
-  auto cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, CacheProtocolLookup::UDP, dnsQuestion.overTCP() ? CacheTruncationPolicy::DisallowTruncated : CacheTruncationPolicy::AllowTruncated, CacheRecordMissPolicy::DoNotRecordMiss, cacheKey);
-  if (cacheResult) {
-    return cacheResult;
-  }
-
-  cacheKey = zeroScopeLookup ? &dnsQuestion.ids.cacheKeyNoECSTCP : &dnsQuestion.ids.cacheKeyTCP;
-  cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, CacheProtocolLookup::TCP, CacheTruncationPolicy::DisallowTruncated, zeroScopeLookup ? CacheRecordMissPolicy::DoNotRecordMiss : CacheRecordMissPolicy::RecordMiss, cacheKey);
+  auto cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, zeroScopeLookup ? CacheRecordMissPolicy::DoNotRecordMiss : CacheRecordMissPolicy::RecordMiss, cacheKey);
   if (cacheResult) {
     return cacheResult;
   }
@@ -1309,7 +1292,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
       // we need ECS parsing (parseECS) to be true so we can be sure that the initial incoming query did not have an existing
       // ECS option, which would make it unsuitable for the zero-scope feature.
-      if (useZeroScope && dnsQuestion.ids.packetCache->isECSParsingEnabled()) {
+      if (useZeroScope && serverPool.packetCache && serverPool.packetCache->isECSParsingEnabled()) {
         auto cacheLookupResult = handleCacheLookups(serverPool, dnsQuestion, selectedBackend, true, backendLookupDone);
         if (cacheLookupResult) {
           if (*cacheLookupResult == ProcessQueryResult::SendAnswer) {

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1182,23 +1182,96 @@ static ServerPolicy::SelectedBackend selectBackendForOutgoingQuery(DNSQuestion& 
   return selectedBackend;
 }
 
-static std::optional<ProcessQueryResult> doCacheLookup(const ServerPool& serverPool, DNSQuestion& dnsQuestion, uint32_t allowExpired, bool udpBasedLookup, bool skipAging, bool truncatedOK, bool recordMiss, uint32_t& cacheKeyOut)
+enum class CacheProtocolLookup : uint8_t
 {
-  if (serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, &cacheKeyOut, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, udpBasedLookup, allowExpired, skipAging, truncatedOK, recordMiss)) {
+  UDP = 0,
+  TCP = 1,
+};
 
-    dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion.getMutableData(), [flags = dnsQuestion.ids.origFlags](dnsheader& header) {
-      dnsdist::PacketMangling::restoreFlags(&header, flags);
-      return true;
-    });
+enum class CacheTruncationPolicy : uint8_t
+{
+  DisallowTruncated = 0,
+  AllowTruncated = 1,
+};
 
-    VERBOSESLOG(infolog("Packet cache hit for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size()),
-                      dnsQuestion.getLogger()->info(Logr::Info, "Packet cache hit"));
+enum class CacheRecordMissPolicy : uint8_t
+{
+  DoNotRecordMiss = 0,
+  RecordMiss = 1,
+};
 
-    if (!prepareOutgoingResponse(*dnsQuestion.ids.cs, dnsQuestion, true)) {
-      return ProcessQueryResult::Drop;
-    }
 
-    return ProcessQueryResult::SendAnswer;
+static std::optional<ProcessQueryResult> doCacheLookup(const ServerPool& serverPool, DNSQuestion& dnsQuestion, uint32_t allowExpired, CacheProtocolLookup udpBasedLookup, CacheTruncationPolicy allowTruncated, CacheRecordMissPolicy recordMiss, uint32_t* cacheKeyOut)
+{
+  if (!serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, cacheKeyOut, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, udpBasedLookup == CacheProtocolLookup::UDP, allowExpired, false, allowTruncated == CacheTruncationPolicy::AllowTruncated, recordMiss == CacheRecordMissPolicy::RecordMiss)) {
+    return std::nullopt;
+  }
+
+  dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion.getMutableData(), [flags = dnsQuestion.ids.origFlags](dnsheader& header) {
+    dnsdist::PacketMangling::restoreFlags(&header, flags);
+    return true;
+  });
+
+  VERBOSESLOG(infolog("Packet cache hit for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size()),
+              dnsQuestion.getLogger()->info(Logr::Info, "Packet cache hit"));
+
+  if (!prepareOutgoingResponse(*dnsQuestion.ids.cs, dnsQuestion, true)) {
+    return ProcessQueryResult::Drop;
+  }
+
+  return ProcessQueryResult::SendAnswer;
+}
+
+static std::optional<ProcessQueryResult> handleCacheLookups(const ServerPool& serverPool, DNSQuestion& dnsQuestion, ServerPolicy::SelectedBackend& selectedBackend, bool zeroScopeLookup, bool& backendLookupDone)
+{
+  uint32_t allowExpired = 0;
+  if (!selectedBackend && dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL > 0 && (backendLookupDone || !serverPool.hasAtLeastOneServerAvailable())) {
+    allowExpired = dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL;
+  }
+
+  uint32_t* cacheKey = zeroScopeLookup ? &dnsQuestion.ids.cacheKeyNoECS : &dnsQuestion.ids.cacheKey;
+  auto cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, CacheProtocolLookup::UDP, dnsQuestion.overTCP() ? CacheTruncationPolicy::DisallowTruncated : CacheTruncationPolicy::AllowTruncated, CacheRecordMissPolicy::DoNotRecordMiss, cacheKey);
+  if (cacheResult) {
+    return cacheResult;
+  }
+
+  cacheKey = zeroScopeLookup ? &dnsQuestion.ids.cacheKeyNoECSTCP : &dnsQuestion.ids.cacheKeyTCP;
+  cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, CacheProtocolLookup::TCP, CacheTruncationPolicy::DisallowTruncated, zeroScopeLookup ? CacheRecordMissPolicy::DoNotRecordMiss : CacheRecordMissPolicy::RecordMiss, cacheKey);
+  if (cacheResult) {
+    return cacheResult;
+  }
+
+  if (zeroScopeLookup) {
+    return std::nullopt;
+  }
+
+  VERBOSESLOG(infolog("Packet cache miss for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size()),
+              dnsQuestion.getLogger()->info(Logr::Info, "Packet cache miss"));
+
+  ++dnsdist::metrics::g_stats.cacheMisses;
+
+  // coverity[auto_causes_copy]
+  const auto existingPool = dnsQuestion.ids.poolName;
+  const auto& chains = dnsdist::configuration::getCurrentRuntimeConfiguration().d_ruleChains;
+  const auto& cacheMissRuleActions = dnsdist::rules::getRuleChain(chains, dnsdist::rules::RuleChain::CacheMissRules);
+
+  if (!applyRulesChainToQuery(cacheMissRuleActions, dnsQuestion)) {
+    return ProcessQueryResult::Drop;
+  }
+  if (dnsQuestion.getHeader()->qr) { // something turned it into a response
+    return handleQueryTurnedIntoSelfAnsweredResponse(dnsQuestion);
+  }
+
+  /* let's be nice and allow the selection of a different pool,
+     but no second cache-lookup for you */
+  if (dnsQuestion.ids.poolName != existingPool) {
+    const auto& newServerPool = getPool(dnsQuestion.ids.poolName);
+    dnsQuestion.ids.packetCache = newServerPool.packetCache;
+    selectedBackend = selectBackendForOutgoingQuery(dnsQuestion, newServerPool);
+    backendLookupDone = true;
+  }
+  else {
+    dnsQuestion.ids.packetCache = serverPool.packetCache;
   }
 
   return std::nullopt;
@@ -1226,31 +1299,6 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       backendLookupDone = true;
     }
 
-    /*
-      so what we want to do:
-      - do a UDP based lookup, except if the backend is TCP-only
-      - on a TC=1, mark dnsQuestion so that we do not forward over UDP at it's useless
-      - on a TC=1, if the query was received over UDP-based protocol: -> send TC=1, otherwise continue
-      - on a miss, do a TCP-based lookup
-      - if we have a hit, and the query was received over a TCP-based proto -> send
-      - if we have a hit and the query was received over UDP-based -> check size and send, or truncate
-    */
-
-    bool willBeForwardedOverUDP = !dnsQuestion.overTCP() || dnsQuestion.ids.protocol == dnsdist::Protocol::DoH;
-    if (selectedBackend) {
-      if (selectedBackend->isTCPOnly()) {
-        willBeForwardedOverUDP = false;
-      }
-    }
-    else if (serverPool.isTCPOnly()) {
-      willBeForwardedOverUDP = false;
-    }
-
-    uint32_t allowExpired = 0;
-    if (!selectedBackend && dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL > 0 && (backendLookupDone || !serverPool.hasAtLeastOneServerAvailable())) {
-      allowExpired = dnsdist::configuration::getCurrentRuntimeConfiguration().d_staleCacheEntriesTTL;
-    }
-
     if (serverPool.packetCache && !dnsQuestion.ids.skipCache && !dnsQuestion.ids.dnssecOK) {
       dnsQuestion.ids.dnssecOK = (dnsdist::getEDNSZ(dnsQuestion) & EDNS_HEADER_FLAG_DO) != 0;
     }
@@ -1261,13 +1309,13 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
       // we need ECS parsing (parseECS) to be true so we can be sure that the initial incoming query did not have an existing
       // ECS option, which would make it unsuitable for the zero-scope feature.
-      if (serverPool.packetCache && !dnsQuestion.ids.skipCache && useZeroScope && serverPool.packetCache->isECSParsingEnabled()) {
-        auto cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, willBeForwardedOverUDP, false, true, false, dnsQuestion.ids.cacheKeyNoECS);
-        if (cacheResult) {
-          if (*cacheResult == ProcessQueryResult::SendAnswer) {
+      if (useZeroScope && dnsQuestion.ids.packetCache->isECSParsingEnabled()) {
+        auto cacheLookupResult = handleCacheLookups(serverPool, dnsQuestion, selectedBackend, true, backendLookupDone);
+        if (cacheLookupResult) {
+          if (*cacheLookupResult == ProcessQueryResult::SendAnswer) {
             return sendAnswer(dnsQuestion);
           }
-          return *cacheResult;
+          return *cacheLookupResult;
         }
 
         if (!dnsQuestion.ids.subnet) {
@@ -1283,57 +1331,12 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       }
     }
 
-    if (serverPool.packetCache && !dnsQuestion.ids.skipCache) {
-      /* First lookup, which takes into account how the protocol over which the query will be forwarded.
-         For DoH, this lookup is done with the protocol set to TCP but we will retry over UDP below,
-         therefore we do not record a miss for queries received over DoH and forwarded over TCP
-         yet, as we will do a second-lookup */
-      auto cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH && willBeForwardedOverUDP, false,  true, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH || !willBeForwardedOverUDP, dnsQuestion.ids.protocol == dnsdist::Protocol::DoH ? dnsQuestion.ids.cacheKeyTCP : dnsQuestion.ids.cacheKey);
-      if (cacheResult) {
-        if (*cacheResult == ProcessQueryResult::SendAnswer) {
-          return sendAnswer(dnsQuestion);
-        }
-        return *cacheResult;
+    auto cacheLookupResult = handleCacheLookups(serverPool, dnsQuestion, selectedBackend, false, backendLookupDone);
+    if (cacheLookupResult) {
+      if (*cacheLookupResult == ProcessQueryResult::SendAnswer) {
+        return sendAnswer(dnsQuestion);
       }
-      if (dnsQuestion.ids.protocol == dnsdist::Protocol::DoH && willBeForwardedOverUDP) {
-        /* do a second-lookup for responses received over UDP, but we do not want TC=1 answers */
-        /* we need to be careful to keep the existing cache-key (TCP) */
-        cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, true, false, false, true, dnsQuestion.ids.cacheKey);
-        if (cacheResult) {
-          if (*cacheResult == ProcessQueryResult::SendAnswer) {
-            return sendAnswer(dnsQuestion);
-          }
-          return *cacheResult;
-        }
-      }
-
-      VERBOSESLOG(infolog("Packet cache miss for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size()),
-                  dnsQuestion.getLogger()->info(Logr::Info, "Packet cache miss"));
-
-      ++dnsdist::metrics::g_stats.cacheMisses;
-
-      // coverity[auto_causes_copy]
-      const auto existingPool = dnsQuestion.ids.poolName;
-      const auto& chains = dnsdist::configuration::getCurrentRuntimeConfiguration().d_ruleChains;
-      const auto& cacheMissRuleActions = dnsdist::rules::getRuleChain(chains, dnsdist::rules::RuleChain::CacheMissRules);
-
-      if (!applyRulesChainToQuery(cacheMissRuleActions, dnsQuestion)) {
-        return ProcessQueryResult::Drop;
-      }
-      if (dnsQuestion.getHeader()->qr) { // something turned it into a response
-        return handleQueryTurnedIntoSelfAnsweredResponse(dnsQuestion);
-      }
-      /* let's be nice and allow the selection of a different pool,
-         but no second cache-lookup for you */
-      if (dnsQuestion.ids.poolName != existingPool) {
-        const auto& newServerPool = getPool(dnsQuestion.ids.poolName);
-        dnsQuestion.ids.packetCache = newServerPool.packetCache;
-        selectedBackend = selectBackendForOutgoingQuery(dnsQuestion, newServerPool);
-        backendLookupDone = true;
-      }
-      else {
-        dnsQuestion.ids.packetCache = serverPool.packetCache;
-      }
+      return *cacheLookupResult;
     }
 
     if (!backendLookupDone) {

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1182,6 +1182,28 @@ static ServerPolicy::SelectedBackend selectBackendForOutgoingQuery(DNSQuestion& 
   return selectedBackend;
 }
 
+static std::optional<ProcessQueryResult> doCacheLookup(const ServerPool& serverPool, DNSQuestion& dnsQuestion, uint32_t allowExpired, bool udpBasedLookup, bool skipAging, bool truncatedOK, bool recordMiss, uint32_t& cacheKeyOut)
+{
+  if (serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, &cacheKeyOut, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, udpBasedLookup, allowExpired, skipAging, truncatedOK, recordMiss)) {
+
+    dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion.getMutableData(), [flags = dnsQuestion.ids.origFlags](dnsheader& header) {
+      dnsdist::PacketMangling::restoreFlags(&header, flags);
+      return true;
+    });
+
+    VERBOSESLOG(infolog("Packet cache hit for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size()),
+                      dnsQuestion.getLogger()->info(Logr::Info, "Packet cache hit"));
+
+    if (!prepareOutgoingResponse(*dnsQuestion.ids.cs, dnsQuestion, true)) {
+      return ProcessQueryResult::Drop;
+    }
+
+    return ProcessQueryResult::SendAnswer;
+  }
+
+  return std::nullopt;
+}
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity): refactoring will be done in https://github.com/PowerDNS/pdns/pull/16124
 ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_ptr<DownstreamState>& outgoingBackend)
 {
@@ -1203,6 +1225,16 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       selectedBackend = selectBackendForOutgoingQuery(dnsQuestion, serverPool);
       backendLookupDone = true;
     }
+
+    /*
+      so what we want to do:
+      - do a UDP based lookup, except if the backend is TCP-only
+      - on a TC=1, mark dnsQuestion so that we do not forward over UDP at it's useless
+      - on a TC=1, if the query was received over UDP-based protocol: -> send TC=1, otherwise continue
+      - on a miss, do a TCP-based lookup
+      - if we have a hit, and the query was received over a TCP-based proto -> send
+      - if we have a hit and the query was received over UDP-based -> check size and send, or truncate
+    */
 
     bool willBeForwardedOverUDP = !dnsQuestion.overTCP() || dnsQuestion.ids.protocol == dnsdist::Protocol::DoH;
     if (selectedBackend) {
@@ -1230,16 +1262,12 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
       // we need ECS parsing (parseECS) to be true so we can be sure that the initial incoming query did not have an existing
       // ECS option, which would make it unsuitable for the zero-scope feature.
       if (serverPool.packetCache && !dnsQuestion.ids.skipCache && useZeroScope && serverPool.packetCache->isECSParsingEnabled()) {
-        if (serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, &dnsQuestion.ids.cacheKeyNoECS, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, willBeForwardedOverUDP, allowExpired, false, true, false)) {
-
-          VERBOSESLOG(infolog("Packet cache hit for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size()),
-                      dnsQuestion.getLogger()->info(Logr::Info, "Packet cache hit"));
-
-          if (!prepareOutgoingResponse(*dnsQuestion.ids.cs, dnsQuestion, true)) {
-            return ProcessQueryResult::Drop;
+        auto cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, willBeForwardedOverUDP, false, true, false, dnsQuestion.ids.cacheKeyNoECS);
+        if (cacheResult) {
+          if (*cacheResult == ProcessQueryResult::SendAnswer) {
+            return sendAnswer(dnsQuestion);
           }
-
-          return sendAnswer(dnsQuestion);
+          return *cacheResult;
         }
 
         if (!dnsQuestion.ids.subnet) {
@@ -1260,31 +1288,22 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
          For DoH, this lookup is done with the protocol set to TCP but we will retry over UDP below,
          therefore we do not record a miss for queries received over DoH and forwarded over TCP
          yet, as we will do a second-lookup */
-      if (serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, dnsQuestion.ids.protocol == dnsdist::Protocol::DoH ? &dnsQuestion.ids.cacheKeyTCP : &dnsQuestion.ids.cacheKey, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH && willBeForwardedOverUDP, allowExpired, false, true, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH || !willBeForwardedOverUDP)) {
-
-        dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion.getMutableData(), [flags = dnsQuestion.ids.origFlags](dnsheader& header) {
-          dnsdist::PacketMangling::restoreFlags(&header, flags);
-          return true;
-        });
-
-        VERBOSESLOG(infolog("Packet cache hit for query for %s|%s from %s (%s, %d bytes)", dnsQuestion.ids.qname.toLogString(), QType(dnsQuestion.ids.qtype).toString(), dnsQuestion.ids.origRemote.toStringWithPort(), dnsQuestion.ids.protocol.toString(), dnsQuestion.getData().size()),
-                    dnsQuestion.getLogger()->info(Logr::Info, "Packet cache hit"));
-
-        if (!prepareOutgoingResponse(*dnsQuestion.ids.cs, dnsQuestion, true)) {
-          return ProcessQueryResult::Drop;
+      auto cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH && willBeForwardedOverUDP, false,  true, dnsQuestion.ids.protocol != dnsdist::Protocol::DoH || !willBeForwardedOverUDP, dnsQuestion.ids.protocol == dnsdist::Protocol::DoH ? dnsQuestion.ids.cacheKeyTCP : dnsQuestion.ids.cacheKey);
+      if (cacheResult) {
+        if (*cacheResult == ProcessQueryResult::SendAnswer) {
+          return sendAnswer(dnsQuestion);
         }
-
-        return sendAnswer(dnsQuestion);
+        return *cacheResult;
       }
       if (dnsQuestion.ids.protocol == dnsdist::Protocol::DoH && willBeForwardedOverUDP) {
         /* do a second-lookup for responses received over UDP, but we do not want TC=1 answers */
         /* we need to be careful to keep the existing cache-key (TCP) */
-        if (serverPool.packetCache->get(dnsQuestion, dnsQuestion.getHeader()->id, &dnsQuestion.ids.cacheKey, dnsQuestion.ids.subnet, *dnsQuestion.ids.dnssecOK, true, allowExpired, false, false, true)) {
-          if (!prepareOutgoingResponse(*dnsQuestion.ids.cs, dnsQuestion, true)) {
-            return ProcessQueryResult::Drop;
+        cacheResult = doCacheLookup(serverPool, dnsQuestion, allowExpired, true, false, false, true, dnsQuestion.ids.cacheKey);
+        if (cacheResult) {
+          if (*cacheResult == ProcessQueryResult::SendAnswer) {
+            return sendAnswer(dnsQuestion);
           }
-
-          return sendAnswer(dnsQuestion);
+          return *cacheResult;
         }
       }
 

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -393,6 +393,7 @@ struct ClientState
   bool d_enableProxyProtocol{true}; // the global proxy protocol ACL still applies
   bool d_padResponses{false};
   bool ready{false};
+  bool d_forwardViaUDPFirst{false};
 
   int getSocket() const
   {

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -113,7 +113,7 @@ Listen Sockets
      ``enableProxyProtocol``, ``ktls``, ``library``, ``proxyProtocolOutsideTLS``, ``readAhead``, ``tlsAsyncMode`` options added.
 
   .. versionchanged:: 2.2.0
-     ``padResponses`` and ``ecdheCurves`` options added.
+     ``padResponses``, ``ecdheCurves`` and ``forwardViaUDPFirst`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over HTTPS connections, presenting the specified X.509 certificate. See :doc:`../advanced/tls-certificates-management` for details about the handling of TLS certificates and keys.
   If no certificate (or key) files are specified, listen for incoming DNS over HTTP connections instead.
@@ -166,6 +166,7 @@ Listen Sockets
   * ``proxyProtocolOutsideTLS``: bool - When the use of incoming proxy protocol is enabled, whether the payload is prepended after the start of the TLS session (so inside, meaning it is protected by the TLS layer providing encryption and authentication) or not (outside, meaning it is in clear-text). Default is false which means inside. Note that most third-party software like HAproxy expect the proxy protocol payload to be outside, in clear-text.
   * ``enableProxyProtocol=true``: bool - Whether to expect a proxy protocol v2 header in front of incoming queries coming from an address in :func:`setProxyProtocolACL`. Default is ``true``, meaning that queries are expected to have a proxy protocol payload if they come from an address present in the :func:`setProxyProtocolACL` ACL.
   * ``padResponses``: bool - Whether to pad DNS responses as specified in RFC 7830. Default is ``false``, meaning responses are not padded.
+  * ``forwardViaUDPFirst``: bool - Whether queries received by this frontend over DoTCP should be forwarded to the backend via UDP (unless the backend is TCP-only). If a truncated answer is received, the query will be re-tried over TCP. Default is ``false``.
 
 .. function:: addDOH3Local(address, certFile(s), keyFile(s) [, options])
 
@@ -177,6 +178,7 @@ Listen Sockets
   .. versionchanged:: 2.2.0
      ``padResponses`` option added.
      ``qLogDir`` option added.
+     ``forwardViaUDPFirst`` option added.
 
   Listen on the specified address and UDP port for incoming DNS over HTTP3 connections, presenting the specified X.509 certificate. See :doc:`../advanced/tls-certificates-management` for details about the handling of TLS certificates and keys.
   More information is available in :doc:`../guides/dns-over-http3`.
@@ -199,6 +201,7 @@ Listen Sockets
   * ``keyLogFile``: str - Write the TLS keys in the specified file so that an external program can decrypt TLS exchanges, in the format described in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format.
   * ``padResponses``: bool - Whether to pad DNS responses as specified in RFC 7830. Default is ``false``, meaning responses are not padded.
   * ``qLogDir``: str - Path to directory to store QLOG (QUIC logs) files in. By default QLOG is disabled.
+  * ``forwardViaUDPFirst``: bool - Whether queries received by this frontend over should be forwarded to the backend via UDP (unless the backend is TCP-only). If a truncated answer is received, the query will be re-tried over TCP. Default is false.
 
 .. function:: addDOQLocal(address, certFile(s), keyFile(s) [, options])
 
@@ -210,6 +213,7 @@ Listen Sockets
   .. versionchanged:: 2.2.0
      ``padResponses`` option added.
      ``qLogDir`` option added.
+     ``forwardViaUDPFirst`` option added.
 
   Listen on the specified address and UDP port for incoming DNS over QUIC connections, presenting the specified X.509 certificate.
   See :doc:`../advanced/tls-certificates-management` for details about the handling of TLS certificates and keys.
@@ -233,13 +237,14 @@ Listen Sockets
   * ``keyLogFile``: str - Write the TLS keys in the specified file so that an external program can decrypt TLS exchanges, in the format described in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format.
   * ``padResponses``: bool - Whether to pad DNS responses as specified in RFC 7830. Default is ``false``, meaning responses are not padded.
   * ``qLogDir``: str - Path to directory to store QLOG (QUIC logs) files in. By default QLOG is disabled.
+  * ``forwardViaUDPFirst``: bool - Whether queries received by this frontend over should be forwarded to the backend via UDP (unless the backend is TCP-only). If a truncated answer is received, the query will be re-tried over TCP. Default is ``false``.
 
 .. function:: addTLSLocal(address, certFile(s), keyFile(s) [, options])
 
   .. versionchanged:: 1.9.0
      ``enableProxyProtocol``, ``readAhead`` and ``proxyProtocolOutsideTLS`` options added.
   .. versionchanged:: 2.2.0
-     ``padResponses`` and ``ecdheCurves`` options added.
+     ``padResponses``, ``ecdheCurves`` and ``forwardViaUDPFirst`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate. See :doc:`../advanced/tls-certificates-management` for details about the handling of TLS certificates and keys.
   More information is available at :doc:`../guides/dns-over-tls`.
@@ -283,6 +288,7 @@ Listen Sockets
   * ``proxyProtocolOutsideTLS``: bool - When the use of incoming proxy protocol is enabled, whether the payload is prepended after the start of the TLS session (so inside, meaning it is protected by the TLS layer providing encryption and authentication) or not (outside, meaning it is in clear-text). Default is false which means inside. Note that most third-party software like HAproxy expect the proxy protocol payload to be outside, in clear-text.
   * ``enableProxyProtocol=true``: str - Whether to expect a proxy protocol v2 header in front of incoming queries coming from an address in :func:`setProxyProtocolACL`. Default is ``true``, meaning that queries are expected to have a proxy protocol payload if they come from an address present in the :func:`setProxyProtocolACL` ACL.
   * ``padResponses``: bool - Whether to pad DNS responses as specified in RFC 7830. Default is ``false``, meaning responses are not padded.
+  * ``forwardViaUDPFirst``: bool - Whether queries received by this frontend over should be forwarded to the backend via UDP (unless the backend is TCP-only). If a truncated answer is received, the query will be re-tried over TCP. Default is ``false``.
 
 .. function:: setLocal(address[, options])
 

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -267,6 +267,128 @@ private:
 
 std::shared_ptr<DOH3TCPCrossQuerySender> DOH3CrossProtocolQuery::s_sender = std::make_shared<DOH3TCPCrossQuerySender>();
 
+class DOH3QueryForwardedOverUDP : public DOHUnitInterface
+{
+public:
+  DOH3QueryForwardedOverUDP(DOH3UnitUniquePtr&& unit) :
+    d_unit(std::move(unit))
+  {
+  }
+  DOH3QueryForwardedOverUDP(const DOH3QueryForwardedOverUDP&) = delete;
+  DOH3QueryForwardedOverUDP(DOH3QueryForwardedOverUDP&&) = delete;
+  DOH3QueryForwardedOverUDP& operator=(const DOH3QueryForwardedOverUDP&) = delete;
+  DOH3QueryForwardedOverUDP& operator=(DOH3QueryForwardedOverUDP&&) = delete;
+
+  ~DOH3QueryForwardedOverUDP() override = default;
+
+#if defined(HAVE_DNS_OVER_HTTPS)
+  [[nodiscard]] std::string getHTTPPath() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] const std::string& getHTTPScheme() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] const std::string& getHTTPHost() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] std::string getHTTPQueryString() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] const HeadersMap& getHTTPHeaders() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  void setHTTPResponse(uint16_t statusCode, PacketBuffer&& body, const std::string& contentType) override
+  {
+    (void)statusCode;
+    (void)body;
+    (void)contentType;
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  void handleUDPResponse(PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& downstream_) override
+  {
+    std::unique_ptr<DOHUnitInterface> unit(this);
+    timeval now{};
+    gettimeofday(&now, nullptr);
+    if (state.forwardedOverUDP) {
+      dnsheader_aligned responseDH(response.data());
+
+      if (responseDH->tc && state.d_packet && state.d_packet->size() > state.d_proxyProtocolPayloadSize && state.d_packet->size() - state.d_proxyProtocolPayloadSize > sizeof(dnsheader)) {
+
+        VERBOSESLOG(infolog("Response received from backend %s via UDP, for query received from %s via DoH3, is truncated, retrying over TCP", downstream_->getNameWithAddr(), state.origRemote.toStringWithPort()),
+                    state.getLogger()->info(Logr::Info, "Response received from backend via UDP, for query received via DoH3, is truncated, retrying over TCP"));
+
+        auto& query = *state.d_packet;
+        dnsdist::PacketMangling::editDNSHeaderFromRawPacket(&query.at(state.d_proxyProtocolPayloadSize), [origID = state.origID](dnsheader& header) {
+          /* restoring the original ID */
+          header.id = origID;
+          return true;
+        });
+
+        state.forwardedOverUDP = false;
+        bool proxyProtocolPayloadAdded = state.d_proxyProtocolPayloadSize > 0;
+        this->d_unit->query = std::move(query);
+        this->d_unit->ids = std::move(state);
+        // NOLINTNEXTLINE(bugprone-unused-return-value)
+        unit.release();
+        /* this moves d_unit->ids, careful! */
+        auto cpq = std::make_unique<DOH3CrossProtocolQuery>(std::move(this->d_unit), false);
+        cpq->query.d_proxyProtocolPayloadAdded = proxyProtocolPayloadAdded;
+        /* 'd_packet' buffer has been moved above, need re-association */
+        cpq->query.d_idstate.d_packet = std::make_unique<PacketBuffer>(cpq->query.d_buffer);
+        if (downstream_->passCrossProtocolQuery(std::move(cpq))) {
+          return;
+        }
+
+        cpq->handleInternalError();
+        return;
+      }
+    }
+
+    TCPResponse resp(std::move(response), std::move(state), nullptr, downstream_);
+    DOH3CrossProtocolQuery cpq(std::move(d_unit), true);
+    const auto& sender = cpq.getTCPQuerySender();
+    resp.d_idstate.doh3u = cpq.releaseDU();
+    sender->handleResponse(now, std::move(resp));
+  }
+
+  void handleTimeout() override
+  {
+    DOH3CrossProtocolQuery cpq(std::move(d_unit), true);
+    const auto& sender = cpq.getTCPQuerySender();
+    timeval now{};
+    gettimeofday(&now, nullptr);
+    TCPResponse resp;
+    resp.d_idstate.doh3u = cpq.releaseDU();
+    sender->notifyIOError(now, std::move(resp));
+  }
+#endif /* defined(HAVE_DNS_OVER_HTTPS) */
+
+  [[nodiscard]] std::shared_ptr<TCPQuerySender> getQuerySender() const override
+  {
+    /* have fun using that! */
+    return {};
+  }
+
+  DOH3UnitUniquePtr releaseDU()
+  {
+    return std::move(d_unit);
+  }
+
+private:
+  DOH3UnitUniquePtr d_unit;
+};
+
 static bool tryWriteResponse(H3Connection& conn, const uint64_t streamID, PacketBuffer& response)
 {
   size_t pos = 0;
@@ -604,6 +726,18 @@ static void processDOH3Query(DOH3UnitUniquePtr&& doh3Unit)
     }
     unit->ids.cs = &clientState;
 
+    const bool forwardViaUDPFirst = dnsdist::configuration::getCurrentRuntimeConfiguration().d_forwardViaUDPFirst;
+    if (forwardViaUDPFirst) {
+      // if there was no EDNS, we add it with a large buffer size
+      // so we can use UDP to talk to the backend.
+      const dnsheader_aligned dnsHeader(unit->query.data());
+      if (dnsHeader->arcount == 0U) {
+        if (addEDNS(unit->query, 4096, false, 4096, 0)) {
+          dnsQuestion.ids.ednsAdded = true;
+        }
+      }
+    }
+
     auto result = processQuery(dnsQuestion, downstream);
     if (result == ProcessQueryResult::Drop) {
       unit->status_code = 403;
@@ -653,6 +787,18 @@ static void processDOH3Query(DOH3UnitUniquePtr&& doh3Unit)
     }
 
     unit->ids.origID = htons(queryId);
+
+    if (!downstream->isTCPOnly() && forwardViaUDPFirst) {
+      auto query = std::move(unit->query);
+      dnsQuestion.ids.du = std::make_unique<DOH3QueryForwardedOverUDP>(std::move(unit));
+
+      if (assignOutgoingUDPQueryToBackend(downstream, htons(queryId), dnsQuestion, query)) {
+        return;
+      }
+      unit = DOH3UnitUniquePtr(dynamic_cast<DOH3QueryForwardedOverUDP*>(dnsQuestion.ids.du.get())->releaseDU());
+      unit->query = std::move(query);
+      // fallback to the normal flow
+    }
     unit->tcp = true;
 
     /* this moves unit->ids, careful! */

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -726,8 +726,7 @@ static void processDOH3Query(DOH3UnitUniquePtr&& doh3Unit)
     }
     unit->ids.cs = &clientState;
 
-    const bool forwardViaUDPFirst = dnsdist::configuration::getCurrentRuntimeConfiguration().d_forwardViaUDPFirst;
-    if (forwardViaUDPFirst) {
+    if (clientState.d_forwardViaUDPFirst) {
       // if there was no EDNS, we add it with a large buffer size
       // so we can use UDP to talk to the backend.
       const dnsheader_aligned dnsHeader(unit->query.data());
@@ -788,7 +787,7 @@ static void processDOH3Query(DOH3UnitUniquePtr&& doh3Unit)
 
     unit->ids.origID = htons(queryId);
 
-    if (!downstream->isTCPOnly() && forwardViaUDPFirst) {
+    if (!downstream->isTCPOnly() && clientState.d_forwardViaUDPFirst) {
       auto query = std::move(unit->query);
       dnsQuestion.ids.du = std::make_unique<DOH3QueryForwardedOverUDP>(std::move(unit));
 

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -317,6 +317,9 @@ public:
 
   void handleUDPResponse(PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& downstream_) override
   {
+    /* The caller will NOT free us, so we need to do it ourselves.
+       Our internal d_unit object will be moved in most cases, but not this object.
+    */
     std::unique_ptr<DOHUnitInterface> unit(this);
     timeval now{};
     gettimeofday(&now, nullptr);
@@ -339,8 +342,6 @@ public:
         bool proxyProtocolPayloadAdded = state.d_proxyProtocolPayloadSize > 0;
         this->d_unit->query = std::move(query);
         this->d_unit->ids = std::move(state);
-        // NOLINTNEXTLINE(bugprone-unused-return-value)
-        unit.release();
         /* this moves d_unit->ids, careful! */
         auto cpq = std::make_unique<DOH3CrossProtocolQuery>(std::move(this->d_unit), false);
         cpq->query.d_proxyProtocolPayloadAdded = proxyProtocolPayloadAdded;

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -294,6 +294,9 @@ public:
 
   void handleUDPResponse(PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& downstream_) override
   {
+    /* The caller will NOT free us, so we need to do it ourselves.
+       Our internal d_unit object will be moved in most cases, but not this object.
+    */
     std::unique_ptr<DOHUnitInterface> unit(this);
     timeval now{};
     gettimeofday(&now, nullptr);
@@ -316,8 +319,6 @@ public:
         bool proxyProtocolPayloadAdded = state.d_proxyProtocolPayloadSize > 0;
         this->d_unit->query = std::move(query);
         this->d_unit->ids = std::move(state);
-        // NOLINTNEXTLINE(bugprone-unused-return-value)
-        unit.release();
         /* this moves d_unit->ids, careful! */
         auto cpq = std::make_unique<DOQCrossProtocolQuery>(std::move(this->d_unit), false);
         cpq->query.d_proxyProtocolPayloadAdded = proxyProtocolPayloadAdded;

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -244,6 +244,128 @@ private:
 
 std::shared_ptr<DOQTCPCrossQuerySender> DOQCrossProtocolQuery::s_sender = std::make_shared<DOQTCPCrossQuerySender>();
 
+class QUICQueryForwardedOverUDP : public DOHUnitInterface
+{
+public:
+  QUICQueryForwardedOverUDP(DOQUnitUniquePtr&& unit) :
+    d_unit(std::move(unit))
+  {
+  }
+  QUICQueryForwardedOverUDP(const QUICQueryForwardedOverUDP&) = delete;
+  QUICQueryForwardedOverUDP(QUICQueryForwardedOverUDP&&) = delete;
+  QUICQueryForwardedOverUDP& operator=(const QUICQueryForwardedOverUDP&) = delete;
+  QUICQueryForwardedOverUDP& operator=(QUICQueryForwardedOverUDP&&) = delete;
+
+  ~QUICQueryForwardedOverUDP() override = default;
+
+#if defined(HAVE_DNS_OVER_HTTPS)
+  [[nodiscard]] std::string getHTTPPath() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] const std::string& getHTTPScheme() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] const std::string& getHTTPHost() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] std::string getHTTPQueryString() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  [[nodiscard]] const HeadersMap& getHTTPHeaders() const override
+  {
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  void setHTTPResponse(uint16_t statusCode, PacketBuffer&& body, const std::string& contentType) override
+  {
+    (void)statusCode;
+    (void)body;
+    (void)contentType;
+    throw std::runtime_error("called HTTP method on non DoH query");
+  }
+
+  void handleUDPResponse(PacketBuffer&& response, InternalQueryState&& state, const std::shared_ptr<DownstreamState>& downstream_) override
+  {
+    std::unique_ptr<DOHUnitInterface> unit(this);
+    timeval now{};
+    gettimeofday(&now, nullptr);
+    if (state.forwardedOverUDP) {
+      dnsheader_aligned responseDH(response.data());
+
+      if (responseDH->tc && state.d_packet && state.d_packet->size() > state.d_proxyProtocolPayloadSize && state.d_packet->size() - state.d_proxyProtocolPayloadSize > sizeof(dnsheader)) {
+
+        VERBOSESLOG(infolog("Response received from backend %s via UDP, for query received from %s via DoQ, is truncated, retrying over TCP", downstream_->getNameWithAddr(), state.origRemote.toStringWithPort()),
+                    state.getLogger()->info(Logr::Info, "Response received from backend via UDP, for query received via DoQ, is truncated, retrying over TCP"));
+
+        auto& query = *state.d_packet;
+        dnsdist::PacketMangling::editDNSHeaderFromRawPacket(&query.at(state.d_proxyProtocolPayloadSize), [origID = state.origID](dnsheader& header) {
+          /* restoring the original ID */
+          header.id = origID;
+          return true;
+        });
+
+        state.forwardedOverUDP = false;
+        bool proxyProtocolPayloadAdded = state.d_proxyProtocolPayloadSize > 0;
+        this->d_unit->query = std::move(query);
+        this->d_unit->ids = std::move(state);
+        // NOLINTNEXTLINE(bugprone-unused-return-value)
+        unit.release();
+        /* this moves d_unit->ids, careful! */
+        auto cpq = std::make_unique<DOQCrossProtocolQuery>(std::move(this->d_unit), false);
+        cpq->query.d_proxyProtocolPayloadAdded = proxyProtocolPayloadAdded;
+        /* 'd_packet' buffer has been moved above, need re-association */
+        cpq->query.d_idstate.d_packet = std::make_unique<PacketBuffer>(cpq->query.d_buffer);
+        if (downstream_->passCrossProtocolQuery(std::move(cpq))) {
+          return;
+        }
+
+        cpq->handleInternalError();
+        return;
+      }
+    }
+
+    TCPResponse resp(std::move(response), std::move(state), nullptr, downstream_);
+    DOQCrossProtocolQuery cpq(std::move(d_unit), true);
+    const auto& sender = cpq.getTCPQuerySender();
+    resp.d_idstate.doqu = cpq.releaseDU();
+    sender->handleResponse(now, std::move(resp));
+  }
+
+  void handleTimeout() override
+  {
+    DOQCrossProtocolQuery cpq(std::move(d_unit), true);
+    const auto& sender = cpq.getTCPQuerySender();
+    timeval now{};
+    gettimeofday(&now, nullptr);
+    TCPResponse resp;
+    resp.d_idstate.doqu = cpq.releaseDU();
+    sender->notifyIOError(now, std::move(resp));
+  }
+#endif /* defined(HAVE_DNS_OVER_HTTPS) */
+
+  [[nodiscard]] std::shared_ptr<TCPQuerySender> getQuerySender() const override
+  {
+    /* have fun using that! */
+    return {};
+  }
+
+  DOQUnitUniquePtr releaseDU()
+  {
+    return std::move(d_unit);
+  }
+
+private:
+  DOQUnitUniquePtr d_unit;
+};
+
 static bool tryWriteResponse(Connection& conn, const uint64_t streamID, PacketBuffer& response)
 {
   size_t pos = 0;
@@ -473,6 +595,18 @@ static void processDOQQuery(DOQUnitUniquePtr&& doqUnit)
     }
     unit->ids.cs = &clientState;
 
+    const bool forwardViaUDPFirst = dnsdist::configuration::getCurrentRuntimeConfiguration().d_forwardViaUDPFirst;
+    if (forwardViaUDPFirst) {
+      // if there was no EDNS, we add it with a large buffer size
+      // so we can use UDP to talk to the backend.
+      const dnsheader_aligned dnsHeader(unit->query.data());
+      if (dnsHeader->arcount == 0U) {
+        if (addEDNS(unit->query, 4096, false, 4096, 0)) {
+          dnsQuestion.ids.ednsAdded = true;
+        }
+      }
+    }
+
     auto result = processQuery(dnsQuestion, downstream);
     if (result == ProcessQueryResult::Drop) {
       handleImmediateResponse(std::move(unit), "DoQ dropped query");
@@ -520,6 +654,18 @@ static void processDOQQuery(DOQUnitUniquePtr&& doqUnit)
 
     unit->ids.origID = htons(queryId);
     unit->tcp = true;
+
+    if (!downstream->isTCPOnly() && forwardViaUDPFirst) {
+      auto query = std::move(unit->query);
+      dnsQuestion.ids.du = std::make_unique<QUICQueryForwardedOverUDP>(std::move(unit));
+
+      if (assignOutgoingUDPQueryToBackend(downstream, htons(queryId), dnsQuestion, query)) {
+        return;
+      }
+      unit = DOQUnitUniquePtr(dynamic_cast<QUICQueryForwardedOverUDP*>(dnsQuestion.ids.du.get())->releaseDU());
+      unit->query = std::move(query);
+      // fallback to the normal flow
+    }
 
     /* this moves unit->ids, careful! */
     auto cpq = std::make_unique<DOQCrossProtocolQuery>(std::move(unit), false);

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -595,8 +595,7 @@ static void processDOQQuery(DOQUnitUniquePtr&& doqUnit)
     }
     unit->ids.cs = &clientState;
 
-    const bool forwardViaUDPFirst = dnsdist::configuration::getCurrentRuntimeConfiguration().d_forwardViaUDPFirst;
-    if (forwardViaUDPFirst) {
+    if (clientState.d_forwardViaUDPFirst) {
       // if there was no EDNS, we add it with a large buffer size
       // so we can use UDP to talk to the backend.
       const dnsheader_aligned dnsHeader(unit->query.data());
@@ -655,7 +654,7 @@ static void processDOQQuery(DOQUnitUniquePtr&& doqUnit)
     unit->ids.origID = htons(queryId);
     unit->tcp = true;
 
-    if (!downstream->isTCPOnly() && forwardViaUDPFirst) {
+    if (!downstream->isTCPOnly() && clientState.d_forwardViaUDPFirst) {
       auto query = std::move(unit->query);
       dnsQuestion.ids.du = std::make_unique<QUICQueryForwardedOverUDP>(std::move(unit));
 

--- a/pdns/dnsdistdist/fuzz_dnsdistcache.cc
+++ b/pdns/dnsdistdist/fuzz_dnsdistcache.cc
@@ -54,8 +54,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     unsigned int consumed;
     PacketBuffer vect(data, data + size);
     const DNSName qname(reinterpret_cast<const char*>(data), size, sizeof(dnsheader), false, &qtype, &qclass, &consumed);
-    pcSkipCookies.getKey(qname.getStorage(), consumed, vect, false);
-    pcHashCookies.getKey(qname.getStorage(), consumed, vect, false);
+    pcSkipCookies.getKey(qname.getStorage(), consumed, vect);
+    pcHashCookies.getKey(qname.getStorage(), consumed, vect);
     std::optional<Netmask> subnet;
     DNSDistPacketCache::getClientSubnet(vect, consumed, subnet);
   }

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -523,13 +523,12 @@ BOOST_AUTO_TEST_CASE(test_PacketCache)
   pwR.commit();
 
   bool dnssecOK = true;
-  bool receivedOverUDP = true;
   uint32_t key = 0;
   std::optional<Netmask> subnet;
   ids.queryRealTime.start();
-  DNSQuestion dnsQuestion(ids, query);
-  packetCache->get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
-  packetCache->insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+  DNSQuestion dq(ids, query);
+  packetCache->get(dq, 0, &key, subnet, dnssecOK);
+  packetCache->insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, 0, std::nullopt);
 
   std::string poolName("test-pool");
   auto testPool = ServerPool();

--- a/pdns/dnsdistdist/test-dnsdistpacketcache_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistpacketcache_cc.cc
@@ -19,8 +19,6 @@
 
 BOOST_AUTO_TEST_SUITE(test_dnsdistpacketcache_cc)
 
-static bool receivedOverUDP = true;
-
 static void test_packetcache_simple(bool shuffle)
 {
   const DNSDistPacketCache::CacheSettings settings{
@@ -62,13 +60,13 @@ static void test_packetcache_simple(bool shuffle)
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
       BOOST_CHECK_EQUAL(found, false);
       BOOST_CHECK(!subnet);
 
-      localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+      localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, 0, std::nullopt);
 
-      found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+      found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, 0, true);
       if (found) {
         BOOST_CHECK_EQUAL(dnsQuestion.getData().size(), response.size());
         int match = memcmp(dnsQuestion.getData().data(), response.data(), dnsQuestion.getData().size());
@@ -93,7 +91,7 @@ static void test_packetcache_simple(bool shuffle)
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
       if (found) {
         auto removed = localCache.expungeByName(ids.qname);
         BOOST_CHECK_EQUAL(removed, 1U);
@@ -112,7 +110,7 @@ static void test_packetcache_simple(bool shuffle)
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      if (localCache.get(dnsQuestion, pwQ.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP)) {
+      if (localCache.get(dnsQuestion, pwQ.getHeader()->id, &key, subnet, dnssecOK)) {
         matches++;
       }
     }
@@ -189,13 +187,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSharded)
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
       BOOST_CHECK_EQUAL(found, false);
       BOOST_CHECK(!subnet);
 
-      localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::AAAA, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+      localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::AAAA, QClass::IN, response, 0, std::nullopt);
 
-      found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+      found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, 0, true);
       if (found) {
         BOOST_CHECK_EQUAL(dnsQuestion.getData().size(), response.size());
         int match = memcmp(dnsQuestion.getData().data(), response.data(), dnsQuestion.getData().size());
@@ -220,7 +218,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSharded)
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      if (localCache.get(dnsQuestion, pwQ.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP)) {
+      if (localCache.get(dnsQuestion, pwQ.getHeader()->id, &key, subnet, dnssecOK)) {
         matches++;
       }
     }
@@ -247,76 +245,6 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSharded)
     BOOST_CHECK_EQUAL(localCache.purgeExpired(0, now), 0U);
   }
   catch (const PDNSException& e) {
-    cerr << "Had error: " << e.reason << endl;
-    throw;
-  }
-}
-
-BOOST_AUTO_TEST_CASE(test_PacketCacheTCP)
-{
-  const DNSDistPacketCache::CacheSettings settings{
-    .d_maxEntries = 150000,
-    .d_maxTTL = 86400,
-    .d_minTTL = 1,
-  };
-  DNSDistPacketCache localCache(settings);
-  InternalQueryState ids;
-  ids.qtype = QType::A;
-  ids.qclass = QClass::IN;
-  ids.protocol = dnsdist::Protocol::DoUDP;
-
-  ComboAddress remote;
-  bool dnssecOK = false;
-  try {
-    ids.qname = DNSName("tcp");
-
-    PacketBuffer query;
-    GenericDNSPacketWriter<PacketBuffer> pwQ(query, ids.qname, QType::AAAA, QClass::IN, 0);
-    pwQ.getHeader()->rd = 1;
-
-    PacketBuffer response;
-    GenericDNSPacketWriter<PacketBuffer> pwR(response, ids.qname, QType::AAAA, QClass::IN, 0);
-    pwR.getHeader()->rd = 1;
-    pwR.getHeader()->ra = 1;
-    pwR.getHeader()->qr = 1;
-    pwR.getHeader()->id = pwQ.getHeader()->id;
-    pwR.startRecord(ids.qname, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ANSWER);
-    ComboAddress v6addr("2001:db8::1");
-    pwR.xfrCAWithoutPort(6, v6addr);
-    pwR.commit();
-
-    {
-      /* UDP */
-      uint32_t key = 0;
-      std::optional<Netmask> subnet;
-      DNSQuestion dnsQuestion(ids, query);
-      bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
-      BOOST_CHECK_EQUAL(found, false);
-      BOOST_CHECK(!subnet);
-
-      localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, std::nullopt);
-      found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
-      BOOST_CHECK_EQUAL(found, true);
-      BOOST_CHECK(!subnet);
-    }
-
-    {
-      /* same but over TCP */
-      uint32_t key = 0;
-      std::optional<Netmask> subnet;
-      ids.protocol = dnsdist::Protocol::DoTCP;
-      DNSQuestion dnsQuestion(ids, query);
-      bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, !receivedOverUDP);
-      BOOST_CHECK_EQUAL(found, false);
-      BOOST_CHECK(!subnet);
-
-      localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, std::nullopt);
-      found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
-      BOOST_CHECK_EQUAL(found, true);
-      BOOST_CHECK(!subnet);
-    }
-  }
-  catch (PDNSException& e) {
     cerr << "Had error: " << e.reason << endl;
     throw;
   }
@@ -356,19 +284,19 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheServFailTTL)
     uint32_t key = 0;
     std::optional<Netmask> subnet;
     DNSQuestion dnsQuestion(ids, query);
-    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
     // Insert with failure-TTL of 0 (-> should not enter cache).
-    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::ServFail, std::optional<uint32_t>(0));
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, RCode::ServFail, std::optional<uint32_t>(0));
+    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, 0, true);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
     // Insert with failure-TTL non-zero (-> should enter cache).
-    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::ServFail, std::optional<uint32_t>(300));
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, RCode::ServFail, std::optional<uint32_t>(300));
+    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, 0, true);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_CHECK(!subnet);
   }
@@ -419,18 +347,18 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheNoDataTTL)
     uint32_t key = 0;
     std::optional<Netmask> subnet;
     DNSQuestion dnsQuestion(ids, query);
-    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, name, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, std::nullopt);
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, name, QType::A, QClass::IN, response, RCode::NoError, std::nullopt);
+    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, 0, true);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_CHECK(!subnet);
 
     std::this_thread::sleep_for(std::chrono::seconds(2));
     /* it should have expired by now */
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, 0, true);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
   }
@@ -481,105 +409,24 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheNXDomainTTL)
     uint32_t key = 0;
     std::optional<Netmask> subnet;
     DNSQuestion dnsQuestion(ids, query);
-    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, name, QType::A, QClass::IN, response, receivedOverUDP, RCode::NXDomain, std::nullopt);
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, name, QType::A, QClass::IN, response, RCode::NXDomain, std::nullopt);
+    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, 0, true);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_CHECK(!subnet);
 
     std::this_thread::sleep_for(std::chrono::seconds(2));
     /* it should have expired by now */
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, 0, true);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
   }
   catch (const PDNSException& e) {
     cerr << "Had error: " << e.reason << endl;
     throw;
-  }
-}
-
-BOOST_AUTO_TEST_CASE(test_PacketCacheTruncated)
-{
-  InternalQueryState ids;
-  ids.qtype = QType::A;
-  ids.qclass = QClass::IN;
-  ids.protocol = dnsdist::Protocol::DoUDP;
-  ids.queryRealTime.start(); // does not have to be accurate ("realTime") in tests
-  ids.qname = DNSName("truncated");
-  bool dnssecOK = false;
-  PacketBuffer query;
-  GenericDNSPacketWriter<PacketBuffer> pwQ(query, ids.qname, QType::A, QClass::IN, 0);
-  pwQ.getHeader()->rd = 1;
-
-  PacketBuffer response;
-  GenericDNSPacketWriter<PacketBuffer> pwR(response, ids.qname, QType::A, QClass::IN, 0);
-  pwR.getHeader()->rd = 1;
-  pwR.getHeader()->ra = 0;
-  pwR.getHeader()->qr = 1;
-  pwR.getHeader()->tc = 1;
-  pwR.getHeader()->rcode = RCode::NoError;
-  pwR.getHeader()->id = pwQ.getHeader()->id;
-  pwR.commit();
-
-  uint32_t key = 0;
-  std::optional<Netmask> subnet;
-  DNSQuestion dnsQuestion(ids, query);
-  bool allowTruncated = true;
-
-  {
-    /* truncated answers are not cached by default */
-    const DNSDistPacketCache::CacheSettings settings{
-      .d_maxEntries = 150000,
-      .d_maxTTL = 86400,
-      .d_minTTL = 1,
-      .d_tempFailureTTL = 60,
-      .d_maxNegativeTTL = 1,
-    };
-    DNSDistPacketCache localCache(settings);
-    BOOST_CHECK_EQUAL(localCache.getSize(), 0U);
-
-    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP, 0, false, allowTruncated);
-    BOOST_REQUIRE_EQUAL(found, false);
-    BOOST_CHECK(!subnet);
-
-    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
-
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, false, allowTruncated);
-    BOOST_REQUIRE_EQUAL(found, false);
-  }
-
-  {
-    /* enable caching of truncated answers */
-    const DNSDistPacketCache::CacheSettings settings{
-      .d_maxEntries = 150000,
-      .d_maxTTL = 86400,
-      .d_minTTL = 1,
-      .d_truncatedTTL = 60,
-    };
-    DNSDistPacketCache localCache(settings);
-    BOOST_CHECK_EQUAL(localCache.getSize(), 0U);
-
-    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP, 0, false, allowTruncated);
-    BOOST_REQUIRE_EQUAL(found, false);
-    BOOST_CHECK(!subnet);
-
-    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
-
-    allowTruncated = false;
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, false, allowTruncated);
-    BOOST_REQUIRE_EQUAL(found, false);
-
-    allowTruncated = true;
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, false, allowTruncated);
-    BOOST_REQUIRE_EQUAL(found, true);
-    BOOST_REQUIRE_EQUAL(dnsQuestion.getData().size(), response.size());
-    int match = memcmp(dnsQuestion.getData().data(), response.data(), dnsQuestion.getData().size());
-    BOOST_CHECK_EQUAL(match, 0);
-    BOOST_CHECK(!subnet);
   }
 }
 
@@ -630,28 +477,12 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize)
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
       BOOST_CHECK_EQUAL(found, false);
       BOOST_CHECK(!subnet);
 
-      packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, std::nullopt);
-      found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
-      BOOST_CHECK_EQUAL(found, true);
-      BOOST_CHECK(!subnet);
-    }
-
-    {
-      /* same but over TCP */
-      uint32_t key = 0;
-      std::optional<Netmask> subnet;
-      ids.protocol = dnsdist::Protocol::DoTCP;
-      DNSQuestion dnsQuestion(ids, query);
-      bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, !receivedOverUDP);
-      BOOST_CHECK_EQUAL(found, false);
-      BOOST_CHECK(!subnet);
-
-      packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, std::nullopt);
-      found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
+      packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, RCode::NoError, std::nullopt);
+      found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, 0, true);
       BOOST_CHECK_EQUAL(found, true);
       BOOST_CHECK(!subnet);
     }
@@ -672,32 +503,17 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize)
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
       BOOST_CHECK_EQUAL(found, false);
       BOOST_CHECK(!subnet);
 
-      packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, std::nullopt);
-      found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
-      BOOST_CHECK_EQUAL(found, false);
-    }
-
-    {
-      /* same but over TCP */
-      uint32_t key = 0;
-      std::optional<Netmask> subnet;
-      ids.protocol = dnsdist::Protocol::DoTCP;
-      DNSQuestion dnsQuestion(ids, query);
-      bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, !receivedOverUDP);
-      BOOST_CHECK_EQUAL(found, false);
-      BOOST_CHECK(!subnet);
-
-      packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, std::nullopt);
-      found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
+      packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, RCode::NoError, std::nullopt);
+      found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, 0, true);
       BOOST_CHECK_EQUAL(found, false);
     }
   }
 
-  /* now we generate a very big response packet, it should be cached over TCP and UDP (although in practice dnsdist will refuse to cache it for the UDP case)  */
+  /* now we generate a very big response packet, it should be cached (although in practice dnsdist will refuse to cache it for the UDP case)  */
   response.clear();
   {
     GenericDNSPacketWriter<PacketBuffer> pwR(response, ids.qname, QType::AAAA, QClass::IN, 0);
@@ -726,31 +542,15 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheMaximumSize)
     DNSDistPacketCache packetCache(settings);
 
     {
-      /* UDP */
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
       BOOST_CHECK_EQUAL(found, false);
       BOOST_CHECK(!subnet);
 
-      packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, RCode::NoError, std::nullopt);
-      found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
-      BOOST_CHECK_EQUAL(found, true);
-    }
-
-    {
-      /* same but over TCP */
-      uint32_t key = 0;
-      std::optional<Netmask> subnet;
-      ids.protocol = dnsdist::Protocol::DoTCP;
-      DNSQuestion dnsQuestion(ids, query);
-      bool found = packetCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, !receivedOverUDP);
-      BOOST_CHECK_EQUAL(found, false);
-      BOOST_CHECK(!subnet);
-
-      packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, !receivedOverUDP, RCode::NoError, std::nullopt);
-      found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, !receivedOverUDP, 0, true);
+      packetCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, RCode::NoError, std::nullopt);
+      found = packetCache.get(dnsQuestion, queryID, &key, subnet, dnssecOK, 0, true);
       BOOST_CHECK_EQUAL(found, true);
     }
   }
@@ -790,9 +590,9 @@ static void threadMangler(unsigned int offset)
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      s_localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      s_localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
 
-      s_localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+      s_localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, 0, std::nullopt);
     }
   }
   catch (PDNSException& e) {
@@ -822,7 +622,7 @@ static void threadReader(unsigned int offset)
       uint32_t key = 0;
       std::optional<Netmask> subnet;
       DNSQuestion dnsQuestion(ids, query);
-      bool found = s_localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+      bool found = s_localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
       if (!found) {
         s_missing++;
       }
@@ -913,7 +713,7 @@ BOOST_AUTO_TEST_CASE(test_PCCollision)
     ComboAddress remote("192.0.2.1");
     ids.queryRealTime.start();
     DNSQuestion dnsQuestion(ids, query);
-    bool found = localCache.get(dnsQuestion, 0, &key, subnetOut, dnssecOK, receivedOverUDP);
+    bool found = localCache.get(dnsQuestion, 0, &key, subnetOut, dnssecOK);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_REQUIRE(subnetOut);
     BOOST_CHECK_EQUAL(subnetOut->toString(), opt.getSource().toString());
@@ -929,10 +729,10 @@ BOOST_AUTO_TEST_CASE(test_PCCollision)
     pwR.addOpt(512, 0, 0, ednsOptions);
     pwR.commit();
 
-    localCache.insert(key, subnetOut, *(getFlagsFromDNSHeader(pwR.getHeader())), dnssecOK, ids.qname, ids.qtype, QClass::IN, response, receivedOverUDP, RCode::NoError, std::nullopt);
+    localCache.insert(key, subnetOut, *(getFlagsFromDNSHeader(pwR.getHeader())), dnssecOK, ids.qname, ids.qtype, QClass::IN, response, RCode::NoError, std::nullopt);
     BOOST_CHECK_EQUAL(localCache.getSize(), 1U);
 
-    found = localCache.get(dnsQuestion, 0, &key, subnetOut, dnssecOK, receivedOverUDP);
+    found = localCache.get(dnsQuestion, 0, &key, subnetOut, dnssecOK);
     BOOST_CHECK_EQUAL(found, true);
     BOOST_REQUIRE(subnetOut);
     BOOST_CHECK_EQUAL(subnetOut->toString(), opt.getSource().toString());
@@ -955,7 +755,8 @@ BOOST_AUTO_TEST_CASE(test_PCCollision)
     ComboAddress remote("192.0.2.1");
     ids.queryRealTime.start();
     DNSQuestion dnsQuestion(ids, query);
-    bool found = localCache.get(dnsQuestion, 0, &secondKey, subnetOut, dnssecOK, receivedOverUDP);
+    subnetOut.reset();
+    bool found = localCache.get(dnsQuestion, 0, &secondKey, subnetOut, dnssecOK);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK_EQUAL(secondKey, key);
     BOOST_REQUIRE(subnetOut);
@@ -985,17 +786,17 @@ BOOST_AUTO_TEST_CASE(test_PCCollision)
           pwFQ.getHeader()->rd = 1;
           pwFQ.getHeader()->qr = false;
           pwFQ.getHeader()->id = 0x42;
-          opt.source = Netmask("10." + std::to_string(idxA) + "." + std::to_string(idxB) + "." + std::to_string(idxC) + "/32");
+          opt.setSource(Netmask("10." + std::to_string(idxA) + "." + std::to_string(idxB) + "." + std::to_string(idxC) + "/32"));
           ednsOptions.clear();
-          ednsOptions.emplace_back(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt));
+          ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
           pwFQ.addOpt(512, 0, 0, ednsOptions);
           pwFQ.commit();
-          secondKey = pc.getKey(ids.qname.toDNSString(), ids.qname.wirelength(), secondQuery, false);
-          auto pair = colMap.emplace(secondKey, opt.source);
+          secondKey = pc.getKey(ids.qname.getStorage(), ids.qname.wirelength(), secondQuery);
+          auto pair = colMap.emplace(secondKey, opt.getSource());
           total++;
           if (!pair.second) {
             collisions++;
-            cerr<<"Collision between "<<colMap[secondKey].toString()<<" and "<<opt.source.toString()<<" for key "<<secondKey<<endl;
+            cerr<<"Collision between "<<colMap[secondKey].toString()<<" and "<<opt.getSource().toString()<<" for key "<<secondKey<<endl;
             goto done;
           }
         }
@@ -1049,7 +850,7 @@ BOOST_AUTO_TEST_CASE(test_PCDNSSECCollision)
     ids.queryRealTime.start();
     ids.origRemote = remote;
     DNSQuestion dnsQuestion(ids, query);
-    bool found = localCache.get(dnsQuestion, 0, &key, subnetOut, true, receivedOverUDP);
+    bool found = localCache.get(dnsQuestion, 0, &key, subnetOut, true);
     BOOST_CHECK_EQUAL(found, false);
 
     PacketBuffer response;
@@ -1063,13 +864,13 @@ BOOST_AUTO_TEST_CASE(test_PCDNSSECCollision)
     pwR.addOpt(512, 0, EDNS_HEADER_FLAG_DO);
     pwR.commit();
 
-    localCache.insert(key, subnetOut, *(getFlagsFromDNSHeader(pwR.getHeader())), /* DNSSEC OK is set */ true, ids.qname, ids.qtype, QClass::IN, response, receivedOverUDP, RCode::NoError, std::nullopt);
+    localCache.insert(key, subnetOut, *(getFlagsFromDNSHeader(pwR.getHeader())), /* DNSSEC OK is set */ true, ids.qname, ids.qtype, QClass::IN, response, RCode::NoError, std::nullopt);
     BOOST_CHECK_EQUAL(localCache.getSize(), 1U);
 
-    found = localCache.get(dnsQuestion, 0, &key, subnetOut, false, receivedOverUDP);
+    found = localCache.get(dnsQuestion, 0, &key, subnetOut, false);
     BOOST_CHECK_EQUAL(found, false);
 
-    found = localCache.get(dnsQuestion, 0, &key, subnetOut, true, receivedOverUDP);
+    found = localCache.get(dnsQuestion, 0, &key, subnetOut, true);
     BOOST_CHECK_EQUAL(found, true);
   }
 }
@@ -1115,7 +916,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheInspection)
       pwR.commit();
     }
 
-    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, 0, std::nullopt);
     BOOST_CHECK_EQUAL(localCache.getSize(), key);
   }
 
@@ -1157,7 +958,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheInspection)
       pwR.commit();
     }
 
-    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, 0, std::nullopt);
     BOOST_CHECK_EQUAL(localCache.getSize(), key);
   }
 
@@ -1180,7 +981,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheInspection)
     pwR.addOpt(4096, 0, 0);
     pwR.commit();
 
-    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, 0, std::nullopt);
     BOOST_CHECK_EQUAL(localCache.getSize(), key);
   }
 
@@ -1210,7 +1011,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheInspection)
       pwR.commit();
     }
 
-    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, 0, std::nullopt);
     BOOST_CHECK_EQUAL(localCache.getSize(), key);
   }
 
@@ -1234,7 +1035,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheInspection)
       pwR.commit();
     }
 
-    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+    localCache.insert(key++, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, qname, QType::A, QClass::IN, response, 0, std::nullopt);
     BOOST_CHECK_EQUAL(localCache.getSize(), key);
   }
 
@@ -1356,12 +1157,12 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheXFR)
     uint32_t key = 0;
     std::optional<Netmask> subnet;
     DNSQuestion dnsQuestion(ids, query);
-    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
     BOOST_CHECK_EQUAL(found, false);
     BOOST_CHECK(!subnet);
 
-    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, ids.qtype, ids.qclass, response, receivedOverUDP, 0, std::nullopt);
-    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, receivedOverUDP, 0, true);
+    localCache.insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, ids.qtype, ids.qclass, response, 0, std::nullopt);
+    found = localCache.get(dnsQuestion, pwR.getHeader()->id, &key, subnet, dnssecOK, 0, true);
     BOOST_CHECK_EQUAL(found, false);
   }
 }
@@ -1498,10 +1299,10 @@ static void test_packetcache_shuffle(
     std::optional<Netmask> subnet;
     uint32_t key = 0;
     DNSQuestion dnsQuestion(ids, query);
-    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
     BOOST_CHECK_EQUAL(found, false);
 
-    localCache.insert(key, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, ids.qname, testqtype, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+    localCache.insert(key, std::nullopt, *getFlagsFromDNSHeader(pwQ.getHeader()), dnssecOK, ids.qname, testqtype, QClass::IN, response, 0, std::nullopt);
   }
 
   // now prepare all the possible permutations and save them, to compare later
@@ -1561,7 +1362,7 @@ static void test_packetcache_shuffle(
     uint32_t key = 0;
     std::optional<Netmask> subnet;
     DNSQuestion dnsQuestion(ids, query);
-    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+    bool found = localCache.get(dnsQuestion, 0, &key, subnet, dnssecOK);
     BOOST_CHECK_EQUAL(found, true);
 
     bool hit = false;

--- a/regression-tests.dnsdist/quictests.py
+++ b/regression-tests.dnsdist/quictests.py
@@ -229,6 +229,7 @@ class QUICWithCacheTests(object):
         # one UDP, one TCP
         self.assertEqual(after - before, 2)
 
+
 class QUICGetLocalAddressOnAnyBindTests(object):
     def testGetLocalAddressOnAnyBind(self):
         """

--- a/regression-tests.dnsdist/quictests.py
+++ b/regression-tests.dnsdist/quictests.py
@@ -149,6 +149,10 @@ class QUICWithCacheTests(object):
         rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.AAAA, "::1")
         response.answer.append(rrset)
 
+        before = 0
+        for key in self._responsesCounter:
+            before += self._responsesCounter[key]
+
         # first query to fill the cache
         (receivedQuery, receivedResponse) = self.sendQUICQuery(query, response=response)
         self.assertTrue(receivedQuery)
@@ -161,12 +165,69 @@ class QUICWithCacheTests(object):
             (_, receivedResponse) = self.sendQUICQuery(query, response=None, useQueue=False)
             self.assertEqual(receivedResponse, response)
 
-        total = 0
+        after = 0
         for key in self._responsesCounter:
-            total += self._responsesCounter[key]
+            after += self._responsesCounter[key]
 
-        self.assertEqual(total, 1)
+        self.assertEqual(after - before, 1)
 
+    def testTruncation(self):
+        """
+        QUIC cache: Truncation over UDP
+        """
+        # the query is first forwarded over UDP, leading to a TC=1 answer from the
+        # backend, then over TCP
+        name = "truncated-udp.doq-with-cache.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        query.id = 42
+        expectedQuery = dns.message.make_query(name, "A", "IN", use_edns=True, payload=4096)
+        expectedQuery.id = 42
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response.answer.append(rrset)
+
+        before = 0
+        for key in self._responsesCounter:
+            before += self._responsesCounter[key]
+
+        # first response is a TC=1
+        tcResponse = dns.message.make_response(query)
+        tcResponse.flags |= dns.flags.TC
+        self._toResponderQueue.put(tcResponse, True, 2.0)
+
+        (receivedQuery, receivedResponse) = self.sendQUICQuery(query, response=response)
+        # first query, received by the responder over UDP
+        self.assertTrue(receivedQuery)
+        receivedQuery.id = expectedQuery.id
+        self.assertEqual(expectedQuery, receivedQuery)
+        self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
+
+        # check the response
+        self.assertTrue(receivedResponse)
+        self.assertEqual(response, receivedResponse)
+
+        # check the second query, received by the responder over TCP
+        receivedQuery = self._fromResponderQueue.get(True, 2.0)
+        self.assertTrue(receivedQuery)
+        receivedQuery.id = expectedQuery.id
+        self.assertEqual(expectedQuery, receivedQuery)
+        self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
+
+        # now check the cache for a QUIC query
+        (receivedQuery, receivedResponse) = self.sendQUICQuery(query, response=None, useQueue=False)
+        self.assertEqual(response, receivedResponse)
+
+        # The TC=1 answer received over UDP will not be cached, because we currently do not cache answers with no records (no TTL)
+        # The TCP one should, however
+        (_, receivedResponse) = self.sendTCPQuery(expectedQuery, response=None, useQueue=False)
+        self.assertEqual(response, receivedResponse)
+
+        after = 0
+        for key in self._responsesCounter:
+            after += self._responsesCounter[key]
+
+        # one UDP, one TCP
+        self.assertEqual(after - before, 2)
 
 class QUICGetLocalAddressOnAnyBindTests(object):
     def testGetLocalAddressOnAnyBind(self):

--- a/regression-tests.dnsdist/test_Async.py
+++ b/regression-tests.dnsdist/test_Async.py
@@ -153,9 +153,8 @@ class AsyncTests(object):
             "sendDOQQueryWrapper",
         ):
             sender = getattr(self, method)
-            if method != "sendDOTQueryWrapper" and method != "sendDOQQueryWrapper":
+            if method in ['sendUDPQuery', 'sendDOHWithNGHTTP2QueryWrapper']:
                 # first time to fill the cache
-                # disabled for DoT since it was already filled via TCP
                 (receivedQuery, receivedResponse) = sender(query, response)
                 receivedQuery.id = query.id
                 self.assertEqual(query, receivedQuery)

--- a/regression-tests.dnsdist/test_Async.py
+++ b/regression-tests.dnsdist/test_Async.py
@@ -153,7 +153,7 @@ class AsyncTests(object):
             "sendDOQQueryWrapper",
         ):
             sender = getattr(self, method)
-            if method in ['sendUDPQuery', 'sendDOHWithNGHTTP2QueryWrapper']:
+            if method in ["sendUDPQuery", "sendDOHWithNGHTTP2QueryWrapper"]:
                 # first time to fill the cache
                 (receivedQuery, receivedResponse) = sender(query, response)
                 receivedQuery.id = query.id

--- a/regression-tests.dnsdist/test_CacheHitResponses.py
+++ b/regression-tests.dnsdist/test_CacheHitResponses.py
@@ -54,16 +54,7 @@ class TestCacheHitResponses(DNSDistTest):
 
         self.assertEqual(total, 2)
 
-        # TCP should not be cached
-        # first query to fill the cache
-        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(receivedResponse, response)
-
-        # now the result should be cached, and so dropped
+        # TCP should be cached as well, and so dropped
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
         self.assertEqual(receivedResponse, None)
 
@@ -82,7 +73,7 @@ class TestCacheHitResponses(DNSDistTest):
             total += self._responsesCounter[key]
             TestCacheHitResponses._responsesCounter[key] = 0
 
-        self.assertEqual(total, 2)
+        self.assertEqual(total, 1)
 
 
 class TestStaleCacheHitResponses(DNSDistTest):

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -57,15 +57,7 @@ class TestCaching(DNSDistTest):
 
         self.assertEqual(total, 1)
 
-        # TCP should not be cached
-        # first query to fill the cache
-        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(receivedResponse, response)
-
+        # TCP should be cached
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
             self.assertEqual(receivedResponse, response)
@@ -75,7 +67,7 @@ class TestCaching(DNSDistTest):
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEqual(total, 1)
+        self.assertEqual(total, 0)
 
     def testEmptyTruncated(self):
         """
@@ -128,14 +120,7 @@ class TestCaching(DNSDistTest):
 
         self.assertEqual(total, 1)
 
-        # TCP should not be cached
-        # first query to fill the cache
-        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(receivedResponse, response)
+        # TCP should be cached
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
@@ -146,7 +131,7 @@ class TestCaching(DNSDistTest):
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEqual(total, 1)
+        self.assertEqual(total, 0)
 
     def testSkipCache(self):
         """
@@ -539,14 +524,7 @@ class TestCaching(DNSDistTest):
 
         self.assertEqual(total, 1)
 
-        # TCP should not be cached
-        # first query to fill the cache
-        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(receivedResponse, response)
+        # TCP should be cached
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
@@ -557,7 +535,7 @@ class TestCaching(DNSDistTest):
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEqual(total, 1)
+        self.assertEqual(total, 0)
 
     def testCacheDifferentCookies(self):
         """
@@ -731,15 +709,7 @@ class TestCachingHashingCookies(DNSDistTest):
 
         self.assertEqual(total, 1)
 
-        # TCP should not be cached
-        # first query to fill the cache
-        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(receivedResponse, response)
-
+        # TCP should be cached
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
             self.assertEqual(receivedResponse, response)
@@ -749,7 +719,7 @@ class TestCachingHashingCookies(DNSDistTest):
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEqual(total, 1)
+        self.assertEqual(total, 0)
 
     def testCacheDifferentCookies(self):
         """
@@ -2448,7 +2418,7 @@ class TestCachingECSWithoutPoolECS(DNSDistTest):
         response.answer.append(rrset)
 
         # first query to fill the cache
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
@@ -2499,7 +2469,7 @@ class TestCachingECSWithPoolECS(DNSDistTest):
         response.answer.append(rrset)
 
         # first query to fill the cache
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
@@ -2668,7 +2638,7 @@ class TestCachingScopeZero(DNSDistTest):
         scopedResponse.answer.append(rrset)
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, scopedResponse)
             receivedQuery.id = expectedQuery.id
@@ -2683,6 +2653,8 @@ class TestCachingScopeZero(DNSDistTest):
 
         query = dns.message.make_query(name, "AAAA", "IN")
         query.flags &= dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.answer.append(rrset)
         # next query FROM A DIFFERENT CLIENT since RD is now set should STILL hit the cache
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
@@ -2704,7 +2676,7 @@ class TestCachingScopeZero(DNSDistTest):
         scopedResponse.answer.append(rrset)
         # this query has ECS, it should NOT be able to use the scope-zero cached entry since the hash will be
         # different
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, scopedResponse)
             receivedQuery.id = expectedQuery.id
@@ -2743,7 +2715,7 @@ class TestCachingScopeZero(DNSDistTest):
         scopedResponse2.use_edns(edns=True, payload=4096, options=[ecsoResponse2])
         scopedResponse2.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, scopedResponse)
             receivedQuery.id = expectedQuery.id
@@ -2761,7 +2733,7 @@ class TestCachingScopeZero(DNSDistTest):
         expectedResponse = dns.message.make_response(query)
         expectedResponse.answer.append(rrset)
         # next query FROM A DIFFERENT CLIENT since RD is now set should NOT hit the cache
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, scopedResponse2)
             receivedQuery.id = expectedQuery2.id
@@ -2786,7 +2758,7 @@ class TestCachingScopeZero(DNSDistTest):
         response = dns.message.make_response(query)
         response.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = expectedQuery.id
@@ -2804,7 +2776,7 @@ class TestCachingScopeZero(DNSDistTest):
         response = dns.message.make_response(query)
         response.answer.append(rrset)
         # next query FROM A DIFFERENT CLIENT since RD is now set should NOT hit the cache
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = expectedQuery2.id
@@ -2875,7 +2847,7 @@ class TestCachingScopeZeroButNoSubnetcheck(DNSDistTest):
         scopedResponse.answer.append(rrset)
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, scopedResponse)
             receivedQuery.id = expectedQuery.id
@@ -2893,7 +2865,7 @@ class TestCachingScopeZeroButNoSubnetcheck(DNSDistTest):
         response = dns.message.make_response(query)
         response.answer.append(rrset)
         # next query FROM A DIFFERENT CLIENT since RD is now set should NOT hit the cache
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = expectedQuery2.id
@@ -2929,7 +2901,7 @@ class TestCachingAlteredHeader(DNSDistTest):
         rrset = dns.rrset.from_text(name, 60, dns.rdataclass.IN, dns.rdatatype.A, "192.0.2.1")
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
@@ -2984,7 +2956,7 @@ class TestCachingBackendSettingRD(DNSDistTest):
         rrset = dns.rrset.from_text(name, 60, dns.rdataclass.IN, dns.rdatatype.A, "192.0.2.1")
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
@@ -3007,7 +2979,7 @@ class TestCachingBackendSettingRD(DNSDistTest):
         rrset = dns.rrset.from_text(name, 60, dns.rdataclass.IN, dns.rdatatype.A, "192.0.2.1")
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
@@ -3224,48 +3196,11 @@ class TestCachingOfVeryLargeAnswers(DNSDistTest):
 
         self.assertEqual(total, 1)
 
-        # UDP should not be cached, dnsdist has a hard limit to 4096 bytes for UDP
-        # actually we will never get an answer, because dnsdist will not be able to get it from the backend
-        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
-        self.assertTrue(receivedQuery)
-        self.assertFalse(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-
-
-class TestCacheEmptyTC(DNSDistTest):
-    _truncated_ttl = 42
-    _config_template = """
-    pc = newPacketCache(100, {maxTTL=86400, minTTL=1, truncatedTTL=%d})
-    getPool(""):setCache(pc)
-    newServer{address="127.0.0.1:%d"}
-    """
-    _config_params = ["_truncated_ttl", "_testServerPort"]
-
-    def testEmptyTruncated(self):
-        """
-        Cache: Empty TC=1 should be cached
-        """
-        name = "cache-empty-tc.cache.tests.powerdns.com."
-        query = dns.message.make_query(name, "AAAA", "IN")
-        response = dns.message.make_response(query)
-        response.flags |= dns.flags.TC
-
-        # first to fill the cache
-        for method in ("sendUDPQuery", "sendTCPQuery"):
-            sender = getattr(self, method)
-            (receivedQuery, receivedResponse) = sender(query, response)
-            self.assertTrue(receivedQuery)
-            self.assertTrue(receivedResponse)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(receivedResponse, response)
-
-        # now it should be cached
-        for method in ("sendUDPQuery", "sendTCPQuery"):
-            sender = getattr(self, method)
-            (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEqual(receivedResponse, response)
+        # UDP should get a TC=1 via the cache, dnsdist has a hard limit to 4096 bytes for UDP
+        tcResponse = dns.message.make_response(query)
+        tcResponse.flags |= dns.flags.TC
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, tcResponse)
 
 
 class TestCachingPayloadRanks(DNSDistTest):

--- a/regression-tests.dnsdist/test_DOH3.py
+++ b/regression-tests.dnsdist/test_DOH3.py
@@ -3,7 +3,7 @@ import dns
 
 from dnsdisttests import DNSDistTest
 from dnsdisttests import pickAvailablePort
-from quictests import QUICTests, QUICACLTests, QUICGetLocalAddressOnAnyBindTests, QUICXFRTests, QUICTooLargeTests
+from quictests import QUICTests, QUICWithCacheTests, QUICACLTests, QUICGetLocalAddressOnAnyBindTests, QUICXFRTests, QUICTooLargeTests
 
 
 class DOH3Common(object):
@@ -332,6 +332,48 @@ response_rules:
       type: "Drop"
     """
     _yaml_config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
+
+
+class TestDOH3WithCache(DOH3Common, QUICWithCacheTests, DNSDistTest):
+    _serverKey = "server.key"
+    _serverCert = "server.chain"
+    _serverName = "tls.tests.dnsdist.org"
+    _caCert = "ca.pem"
+    _doqServerPort = pickAvailablePort()
+    _dohBaseURL = "https://%s:%d/" % (_serverName, _doqServerPort)
+    _config_template = """
+    newServer{address="127.0.0.1:%d"}
+
+    addDOH3Local("127.0.0.1:%d", "%s", "%s")
+
+    pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
+    getPool(""):setCache(pc)
+
+    setForwardViaUDPFirst(true)
+    """
+    _config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
+
+
+class TestDOH3WithCacheAndBBR(DOH3Common, QUICWithCacheTests, DNSDistTest):
+    _serverKey = "server.key"
+    _serverCert = "server.chain"
+    _serverName = "tls.tests.dnsdist.org"
+    _caCert = "ca.pem"
+    _doqServerPort = pickAvailablePort()
+    _dohBaseURL = "https://%s:%d/" % (_serverName, _doqServerPort)
+    _config_template = """
+    newServer{address="127.0.0.1:%d"}
+
+    -- As of Quiche 0.24.7 BBR is no longer supported, but we should not choke on it
+    -- see https://github.com/cloudflare/quiche/issues/2342
+    addDOH3Local("127.0.0.1:%d", "%s", "%s", {congestionControlAlgo="bbr"})
+
+    pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
+    getPool(""):setCache(pc)
+
+    setForwardViaUDPFirst(true)
+    """
+    _config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
 
 
 class TestDOH3ACL(DOH3Common, QUICACLTests, DNSDistTest):

--- a/regression-tests.dnsdist/test_DOH3.py
+++ b/regression-tests.dnsdist/test_DOH3.py
@@ -344,12 +344,10 @@ class TestDOH3WithCache(DOH3Common, QUICWithCacheTests, DNSDistTest):
     _config_template = """
     newServer{address="127.0.0.1:%d"}
 
-    addDOH3Local("127.0.0.1:%d", "%s", "%s")
+    addDOH3Local("127.0.0.1:%d", "%s", "%s", {forwardViaUDPFirst=true})
 
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
-
-    setForwardViaUDPFirst(true)
     """
     _config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
 
@@ -366,12 +364,10 @@ class TestDOH3WithCacheAndBBR(DOH3Common, QUICWithCacheTests, DNSDistTest):
 
     -- As of Quiche 0.24.7 BBR is no longer supported, but we should not choke on it
     -- see https://github.com/cloudflare/quiche/issues/2342
-    addDOH3Local("127.0.0.1:%d", "%s", "%s", {congestionControlAlgo="bbr"})
+    addDOH3Local("127.0.0.1:%d", "%s", "%s", {congestionControlAlgo="bbr", forwardViaUDPFirst=true})
 
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
-
-    setForwardViaUDPFirst(true)
     """
     _config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
 

--- a/regression-tests.dnsdist/test_DOH3.py
+++ b/regression-tests.dnsdist/test_DOH3.py
@@ -3,7 +3,14 @@ import dns
 
 from dnsdisttests import DNSDistTest
 from dnsdisttests import pickAvailablePort
-from quictests import QUICTests, QUICWithCacheTests, QUICACLTests, QUICGetLocalAddressOnAnyBindTests, QUICXFRTests, QUICTooLargeTests
+from quictests import (
+    QUICTests,
+    QUICWithCacheTests,
+    QUICACLTests,
+    QUICGetLocalAddressOnAnyBindTests,
+    QUICXFRTests,
+    QUICTooLargeTests,
+)
 
 
 class DOH3Common(object):

--- a/regression-tests.dnsdist/test_DOQ.py
+++ b/regression-tests.dnsdist/test_DOQ.py
@@ -154,12 +154,10 @@ class TestDOQWithCache(DOQCommon, QUICWithCacheTests, DNSDistTest):
     _config_template = """
     newServer{address="127.0.0.1:%d"}
 
-    addDOQLocal("127.0.0.1:%d", "%s", "%s")
+    addDOQLocal("127.0.0.1:%d", "%s", "%s", {forwardViaUDPFirst=true})
 
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
-
-    setForwardViaUDPFirst(true)
     """
     _config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
 
@@ -175,12 +173,10 @@ class TestDOQWithCacheAndBBR(DOQCommon, QUICWithCacheTests, DNSDistTest):
 
     -- As of Quiche 0.24.7 BBR is no longer supported, but we should not choke on it
     -- see https://github.com/cloudflare/quiche/issues/2342
-    addDOQLocal("127.0.0.1:%d", "%s", "%s", {congestionControlAlgo="bbr"})
+    addDOQLocal("127.0.0.1:%d", "%s", "%s", {congestionControlAlgo="bbr", forwardViaUDPFirst=true})
 
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
-
-    setForwardViaUDPFirst(true)
     """
     _config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
 

--- a/regression-tests.dnsdist/test_DOQ.py
+++ b/regression-tests.dnsdist/test_DOQ.py
@@ -158,6 +158,8 @@ class TestDOQWithCache(DOQCommon, QUICWithCacheTests, DNSDistTest):
 
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
+
+    setForwardViaUDPFirst(true)
     """
     _config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
 
@@ -177,6 +179,8 @@ class TestDOQWithCacheAndBBR(DOQCommon, QUICWithCacheTests, DNSDistTest):
 
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
+
+    setForwardViaUDPFirst(true)
     """
     _config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
 

--- a/regression-tests.dnsdist/test_DynBlocksServFail.py
+++ b/regression-tests.dnsdist/test_DynBlocksServFail.py
@@ -47,13 +47,14 @@ class TestDynBlockServFailsCached(DynBlocksTest):
             print(method, "()")
             sender = getattr(self, method)
 
-            # fill the cache
-            (receivedQuery, receivedResponse) = sender(query, expectedResponse)
-            receivedQuery.id = query.id
-            self.assertEqual(query, receivedQuery)
-            self.assertEqual(expectedResponse, receivedResponse)
+            if method == 'sendUDPQuery':
+                # fill the cache
+                (receivedQuery, receivedResponse) = sender(query, expectedResponse)
+                receivedQuery.id = query.id
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(expectedResponse, receivedResponse)
 
-            waitForMaintenanceToRun()
+                waitForMaintenanceToRun()
 
             # we should NOT be dropped!
             (_, receivedResponse) = sender(query, response=None)

--- a/regression-tests.dnsdist/test_DynBlocksServFail.py
+++ b/regression-tests.dnsdist/test_DynBlocksServFail.py
@@ -47,7 +47,7 @@ class TestDynBlockServFailsCached(DynBlocksTest):
             print(method, "()")
             sender = getattr(self, method)
 
-            if method == 'sendUDPQuery':
+            if method == "sendUDPQuery":
                 # fill the cache
                 (receivedQuery, receivedResponse) = sender(query, expectedResponse)
                 receivedQuery.id = query.id

--- a/regression-tests.dnsdist/test_EDE.py
+++ b/regression-tests.dnsdist/test_EDE.py
@@ -54,7 +54,7 @@ class TestBasics(DNSDistTest):
 
         response.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
@@ -79,7 +79,7 @@ class TestBasics(DNSDistTest):
         rrset = dns.rrset.from_text(name, 60, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, backendResponse)
             receivedQuery.id = query.id
@@ -112,7 +112,7 @@ class TestBasics(DNSDistTest):
         rrset = dns.rrset.from_text(name, 60, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, backendResponse)
             receivedQuery.id = query.id
@@ -144,7 +144,7 @@ class TestBasics(DNSDistTest):
         rrset = dns.rrset.from_text(name, 60, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, backendResponse)
             receivedQuery.id = query.id
@@ -276,7 +276,7 @@ class TestMultipleEDE(DNSDistTest):
         rrset = dns.rrset.from_text(name, 60, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, backendResponse)
             receivedQuery.id = query.id
@@ -309,7 +309,7 @@ class TestMultipleEDE(DNSDistTest):
         rrset = dns.rrset.from_text(name, 60, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
         expectedResponse.answer.append(rrset)
 
-        for method in ("sendUDPQuery", "sendTCPQuery"):
+        for method in ["sendUDPQuery"]:
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, backendResponse)
             receivedQuery.id = query.id

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -723,12 +723,6 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
         receivedQuery.id = query.id
         self.assertEqual(query, receivedQuery)
         self.assertEqual(receivedResponse, response)
-        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -750,12 +744,6 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
         receivedQuery.id = query.id
         self.assertEqual(query, receivedQuery)
         self.assertEqual(receivedResponse, response)
-        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -763,7 +751,7 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
                 (_, receivedResponse) = sender(query, response=None, useQueue=False)
                 self.assertEqual(receivedResponse, response)
 
-        # 4 queries should made it through, 2 UDP and 2 TCP
+        # 2 queries should made it through, 2 UDP
         # for k,v in self._responsesCounter.items():
         #    print(k)
         #    print(v)
@@ -773,8 +761,8 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
         self.assertEqual(self._responsesCounter["UDP Responder 2"], 2)
         if "TCP Responder" in self._responsesCounter:
             self.assertEqual(self._responsesCounter["TCP Responder"], 0)
-        self.assertEqual(self._responsesCounter["TCP Responder 2"], 2)
-
+        if "TCP Responder 2" in self._responsesCounter:
+            self.assertEqual(self._responsesCounter["TCP Responder 2"], 0)
 
 class TestRoutingNoServer(DNSDistTest):
     _config_template = """

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -764,6 +764,7 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
         if "TCP Responder 2" in self._responsesCounter:
             self.assertEqual(self._responsesCounter["TCP Responder 2"], 0)
 
+
 class TestRoutingNoServer(DNSDistTest):
     _config_template = """
     newServer{address="127.0.0.1:%d", pool="real"}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is a very rough draft!

This PR adds an option to forward queries to Do53 backends via UDP, no matter the protocol over which the query was received, and only fallback to TCP if the response is truncated. This is a big change from the current behaviour where dnsdist forwards via TCP if the query was received over Do53 TCP, DoT, DoQ or DoH3, and a lot of tests and documentation sections have to be updated. This should significantly reduce our latency for queries received over protocols other than Do53 UDP and DoH.
 
This PR also stops separating packet-cache entries depending on the protocol they were received over: we now check the size of the entry against what the client supports (looking at the EDNS UDP buffer size when available) and send a truncated answer if the cached entry is too large without having to hit the backend. This should improve our cache-hit ratio.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
