### PR TITLE
rec docs: ComboAddress has no == operator, don't suggest it has

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/comboaddress.rst
+++ b/pdns/recursordist/docs/lua-scripting/comboaddress.rst
@@ -18,9 +18,9 @@ To compare the address (so not the port) of two :class:`ComboAddresses` instance
 
     a = newCA("[::1]:56")
     b = newCA("[::1]:53")
-    a == b                       -- false, reference mismatch
-    a:toString() == b:toString() -- false, port mismatch
-    a:equal(b)                   -- true
+    a == b                                       -- false, reference mismatch
+    a:toStringWithPort() == b:toStringWithPort() -- false, port mismatch
+    a:equal(b)                                   -- true
 
 To convert an address to human-friendly representation, use :meth:`:toString <ComboAddress:toString>` or :meth:`:toStringWithPort <ComboAddress:toStringWithPort()>`.
 To get only the port number, use :meth:`:getPort() <ComboAddress:getPort>`.
@@ -35,7 +35,7 @@ To get only the port number, use :meth:`:getPort() <ComboAddress:getPort>`.
 
   An object representing an IP address and port tuple.
 
-  .. method:: ComboAddress:equal(comboaddress) -> bool
+  .. method:: ComboAddress:equal(ComboAddress) -> bool
 
       Compare the address to another :class:`ComboAddress` object. The port numbers are *not* relevant.
 

--- a/pdns/recursordist/docs/lua-scripting/comboaddress.rst
+++ b/pdns/recursordist/docs/lua-scripting/comboaddress.rst
@@ -10,16 +10,17 @@ Make a :class:`ComboAddress` with:
 
     newCA("::1")
 
-A :class:`ComboAddress` can be compared against a NetmaskGroup with the :meth:`NetMaskGroup:match` function.
+A :class:`ComboAddress` object can be compared against a :class:`NetMaskGroup` object with the :meth:`NetMaskGroup:match` function.
 
-To compare the address (so not the port) of two ComboAddresses, use :meth:`:equal <ComboAddress:equal>`:
+To compare the address (so not the port) of two :class:`ComboAddresses` instances, use :meth:`:equal <ComboAddress:equal>`:
 
 .. code-block:: Lua
 
     a = newCA("[::1]:56")
     b = newCA("[::1]:53")
-    a == b     -- false, port mismatch
-    a:equal(b) -- true
+    a == b                       -- false, reference mismatch
+    a:toString() == b:toString() -- false, port mismatch
+    a:equal(b)                   -- true
 
 To convert an address to human-friendly representation, use :meth:`:toString <ComboAddress:toString>` or :meth:`:toStringWithPort <ComboAddress:toStringWithPort()>`.
 To get only the port number, use :meth:`:getPort() <ComboAddress:getPort>`.
@@ -33,6 +34,10 @@ To get only the port number, use :meth:`:getPort() <ComboAddress:getPort>`.
 .. class:: ComboAddress
 
   An object representing an IP address and port tuple.
+
+  .. method:: ComboAddress:equal(comboaddress) -> bool
+
+      Compare the address to another :class:`ComboAddress` object. The port numbers are *not* relevant.
 
   .. method:: ComboAddress:getPort() -> int
 


### PR DESCRIPTION
Fixes #16128
Plus some general improvements.
One day we should make the Lua classes docs for all three products (more) consistent.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
