### PR TITLE
rec: only store IP (and no port) as local address in cookie store

### DIFF
--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -395,10 +395,10 @@ static bool tcpconnect(const OptLog& log, const ComboAddress& remote, const std:
   // Bind to the same address the cookie is associated with (RFC 9018 section 3 last paragraph)
   ComboAddress localip = localBind ? *localBind : pdns::getQueryLocalAddress(remote.sin4.sin_family, 0);
   if (localBind) {
-    VLOG(log, "Connecting TCP to " << remote.toString() << " with specific local address " << localip.toString() << endl);
+    VLOG(log, "Connecting TCP to " << remote.toStringWithPortExcept(53) << " with specific local address " << localip.toString() << endl);
   }
   else {
-    VLOG(log, "Connecting TCP to " << remote.toString() << " with no specific local address" << endl);
+    VLOG(log, "Connecting TCP to " << remote.toStringWithPortExcept(53) << " with no specific local address" << endl);
   }
 
   try {
@@ -545,6 +545,7 @@ static std::pair<bool, LWResult::Result> incomingCookie(const OptLog& log, const
         VLOG(log, "Client cookie from " << address.toString() << " matched! Storing with localAddress " << localip.toString() << endl);
         ++t_Counters.at(rec::Counter::cookieMatched);
         found->d_localaddress = localip;
+        found->d_localaddress.setPort(0);
         found->d_cookie = received;
         if (found->getSupport() == CookieEntry::Support::Probing) {
           ++t_Counters.at(rec::Counter::cookieProbeSupported);


### PR DESCRIPTION
Otherwise binding a local TCP port will fail, as the stored port is likely still in use do to connections lingering.

Observed when forcing DoT to specific nameservers that support cookies.  In many cases the effect was: see the bind failing and go to the next nameserver, that's likely why it was noticed before.

While there, add a little bit of more detail in trace info.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
