### PR TITLE
rec: add a few fields in protobuf logs: ede, edeText and OpenTelemetryTraceID

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -311,16 +311,16 @@ class PDNSPBConnHandler(object):
         if msg.HasField('edeText'):
             edeText = msg.edeText
 
-        openTelemetryData = "N/A"
+        openTelemetryDataLen = "N/A"
         if opentelemetryAvailable and msg.HasField('openTelemetryData'):
-            openTelemetryData = str(len(msg.openTelemetryData))
+            openTelemetryDataLen = str(len(msg.openTelemetryData))
 
         openTelemetryTraceID = "N/A"
         if msg.HasField('openTelemetryTraceID'):
             openTelemetryTraceID = binascii.hexlify(msg.openTelemetryTraceID)
 
         print('[%s] %s of size %d: %s%s%s -> %s%s(%s) id: %d uuid: %s%s '
-                  'requestorid: %s deviceid: %s devicename: %s serverid: %s nod: %s workerId: %s pcCacheHit: %s outgoingQueries: %s headerFlags: %s ednsVersion: %s ede: %s edeText: %s openTelemetryData: len %s otTraceID: %s' %
+                  'requestorid: %s deviceid: %s devicename: %s serverid: %s nod: %s workerId: %s pcCacheHit: %s outgoingQueries: %s headerFlags: %s ednsVersion: %s ede: %s edeText: %s otTraceID: %s openTelemetryData: len %s' %
               (datestr,
                typestr,
                msg.inBytes,
@@ -345,8 +345,8 @@ class PDNSPBConnHandler(object):
                ednsVersion,
                ede,
                edeText,
-               openTelemetryData,
-               openTelemetryTraceID))
+               openTelemetryTraceID,
+               openTelemetryDataLen))
 
         for mt in msg.meta:
             values = ''

--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -304,12 +304,23 @@ class PDNSPBConnHandler(object):
         if msg.HasField('ednsVersion'):
             ednsVersion = "0x%08X" % socket.ntohl(msg.ednsVersion)
 
+        ede = "N/A"
+        if msg.HasField('ede'):
+            ede = str(msg.ede)
+        edeText = "N/A"
+        if msg.HasField('edeText'):
+            edeText = msg.edeText
+
         openTelemetryData = "N/A"
         if opentelemetryAvailable and msg.HasField('openTelemetryData'):
             openTelemetryData = str(len(msg.openTelemetryData))
 
+        openTelemetryTraceID = "N/A"
+        if msg.HasField('openTelemetryTraceID'):
+            openTelemetryTraceID = binascii.hexlify(msg.openTelemetryTraceID)
+
         print('[%s] %s of size %d: %s%s%s -> %s%s(%s) id: %d uuid: %s%s '
-                  'requestorid: %s deviceid: %s devicename: %s serverid: %s nod: %s workerId: %s pcCacheHit: %s outgoingQueries: %s headerFlags: %s ednsVersion: %s openTelemetryData: len %s' %
+                  'requestorid: %s deviceid: %s devicename: %s serverid: %s nod: %s workerId: %s pcCacheHit: %s outgoingQueries: %s headerFlags: %s ednsVersion: %s ede: %s edeText: %s openTelemetryData: len %s otTraceID: %s' %
               (datestr,
                typestr,
                msg.inBytes,
@@ -332,7 +343,10 @@ class PDNSPBConnHandler(object):
                outgoingQs,
                headerFlags,
                ednsVersion,
-               openTelemetryData))
+               ede,
+               edeText,
+               openTelemetryData,
+               openTelemetryTraceID))
 
         for mt in msg.meta:
             values = ''

--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -193,6 +193,9 @@ message PBDNSMessage {
   optional uint32 headerFlags = 28;             // Flags field in wire format, 16 bits used
   optional uint32 ednsVersion = 29;             // EDNS version and flags in wire format, see https://www.rfc-editor.org/rfc/rfc6891.html#section-6.1.3
   optional bytes openTelemetryData = 30;        // Protobuf encoded Open Telemetry Data, see https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
+  optional uint32 ede = 31;                     // EDNS error code, actually 16 bits
+  optional string edeText = 32;                 // EDNS error text
+  optional bytes openTelemetryTraceID = 33;     // OpenTelemetry TraceID
 }
 
 message PBDNSMessageList {

--- a/pdns/protozero-trace.hh
+++ b/pdns/protozero-trace.hh
@@ -226,6 +226,8 @@ struct InstrumentationScope
 using TraceID = std::array<uint8_t, 16>;
 using SpanID = std::array<uint8_t, 8>;
 
+constexpr TraceID s_emptyTraceID = {};
+
 inline void random(TraceID& trace)
 {
   dns_random(trace.data(), trace.size());

--- a/pdns/protozero.hh
+++ b/pdns/protozero.hh
@@ -104,6 +104,9 @@ namespace ProtoZero
       headerFlags = 28,
       ednsVersion = 29,
       openTelemetryData = 30,
+      ede = 31,
+      edeText = 32,
+      openTelemetryTraceID = 33,
     };
     enum class QuestionField : protozero::pbf_tag_type
     {
@@ -320,6 +323,23 @@ namespace ProtoZero
       if (!data.empty()) {
         add_string(d_message, Field::openTelemetryData, data);
       }
+    }
+
+    void setEDE(const uint16_t ede)
+    {
+      add_uint32(d_message, Field::ede, ede);
+    }
+
+    void setEDEText(const std::string edeText)
+    {
+      if (!edeText.empty()) {
+        add_string(d_message, Field::edeText, edeText);
+      }
+    }
+
+    void setOpenTelemtryTraceID(const std::array<uint8_t, 16>& traceID)
+    {
+      add_bytes(d_message, Field::openTelemetryTraceID, reinterpret_cast<const char*>(traceID.data()), traceID.size()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast): it's the API
     }
 
     void startResponse()

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -1684,7 +1684,7 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
         }
         eee.emplace(EDNSExtendedError{static_cast<uint16_t>(code), std::move(extra)});
 
-        if (packetWriter.size() < maxanswersize && (maxanswersize - packetWriter.size()) >= (EDNSOptionCodeSize + EDNSOptionLengthSize + sizeof(eee->infoCode) + eee->extraText.size())) {
+        if (packetWriter.size() < maxanswersize && (maxanswersize - packetWriter.size()) >= (EDNSOptionCodeSize + EDNSOptionLengthSize + sizeof(EDNSExtendedError::code) + eee->extraText.size())) {
           returnedEdnsOptions.emplace_back(EDNSOptionCode::EXTENDEDERROR, makeEDNSExtendedErrorOptString(*eee));
         }
       }

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -1618,6 +1618,7 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
       }
     }
 
+    std::optional<EDNSExtendedError> eee;
     if (haveEDNS) {
       auto state = resolver.getValidationState();
       if (comboWriter->d_extendedErrorCode || resolver.d_extendedError || (SyncRes::s_addExtendedResolutionDNSErrors && vStateIsBogus(state))) {
@@ -1681,13 +1682,10 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
             throw std::runtime_error("Bogus validation state not handled: " + vStateToString(state));
           }
         }
+        eee.emplace(EDNSExtendedError{static_cast<uint16_t>(code), std::move(extra)});
 
-        EDNSExtendedError eee;
-        eee.infoCode = static_cast<uint16_t>(code);
-        eee.extraText = std::move(extra);
-
-        if (packetWriter.size() < maxanswersize && (maxanswersize - packetWriter.size()) >= (EDNSOptionCodeSize + EDNSOptionLengthSize + sizeof(eee.infoCode) + eee.extraText.size())) {
-          returnedEdnsOptions.emplace_back(EDNSOptionCode::EXTENDEDERROR, makeEDNSExtendedErrorOptString(eee));
+        if (packetWriter.size() < maxanswersize && (maxanswersize - packetWriter.size()) >= (EDNSOptionCodeSize + EDNSOptionLengthSize + sizeof(eee->infoCode) + eee->extraText.size())) {
+          returnedEdnsOptions.emplace_back(EDNSOptionCode::EXTENDEDERROR, makeEDNSExtendedErrorOptString(*eee));
         }
       }
 
@@ -1750,6 +1748,10 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
       pbMessage.setValidationState(resolver.getValidationState());
       // See if we want to store the policyTags into the PC
       addPolicyTagsToPBMessageIfNeeded(*comboWriter, pbMessage);
+      if (eee) {
+        pbMessage.setEDE(eee->infoCode);
+        pbMessage.setEDEText(eee->extraText);
+      }
 
       // Take s snap of the current protobuf buffer state to store in the PC
       pbDataForCache = boost::make_optional(RecursorPacketCache::PBData{
@@ -1862,6 +1864,10 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
         auto otTrace = pdns::trace::TracesData::boilerPlate("rec", comboWriter->d_mdp.d_qname.toLogString() + '/' + QType(comboWriter->d_mdp.d_qtype).toString(), resolver.d_eventTrace.convertToOT(resolver.d_otTrace));
         string otData = otTrace.encode();
         pbMessage.setOpenTelemetryData(otData);
+      }
+      // Currently only set if an OT trace is generated
+      if (resolver.d_otTrace.trace_id != pdns::trace::s_emptyTraceID) {
+        pbMessage.setOpenTelemtryTraceID(resolver.d_otTrace.trace_id);
       }
       if (comboWriter->d_logResponse) {
         protobufLogResponse(pbMessage);
@@ -2268,7 +2274,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
     RecursorPacketCache::OptPBData pbData{boost::none};
     if (t_protobufServers.servers) {
       if (logQuery && !(luaconfsLocal->protobufExportConfig.taggedOnly && policyTags.empty())) {
-        protobufLogQuery(luaconfsLocal, uniqueId, source, destination, mappedSource, ednssubnet.getSource(), false, question.size(), qname, qtype, qclass, policyTags, requestorId, deviceId, deviceName, meta, ednsVersion, *dnsheader);
+        protobufLogQuery(luaconfsLocal, uniqueId, source, destination, mappedSource, ednssubnet.getSource(), false, question.size(), qname, qtype, qclass, policyTags, requestorId, deviceId, deviceName, meta, ednsVersion, *dnsheader, otTrace.trace_id);
       }
     }
 

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -625,7 +625,7 @@ bool checkFrameStreamExport(LocalStateHolder<LuaConfigItems>& luaconfsLocal, con
 #endif
 void getQNameAndSubnet(const std::string& question, DNSName* dnsname, uint16_t* qtype, uint16_t* qclass,
                        bool& foundECS, EDNSSubnetOpts* ednssubnet, EDNSOptionViewMap* options, boost::optional<uint32_t>& ednsVersion);
-void protobufLogQuery(LocalStateHolder<LuaConfigItems>& luaconfsLocal, const boost::uuids::uuid& uniqueId, const ComboAddress& remote, const ComboAddress& local, const ComboAddress& mappedSource, const Netmask& ednssubnet, bool tcp, size_t len, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::unordered_set<std::string>& policyTags, const std::string& requestorId, const std::string& deviceId, const std::string& deviceName, const std::map<std::string, RecursorLua4::MetaValue>& meta, const boost::optional<uint32_t>& ednsVersion, const dnsheader& header);
+void protobufLogQuery(LocalStateHolder<LuaConfigItems>& luaconfsLocal, const boost::uuids::uuid& uniqueId, const ComboAddress& remote, const ComboAddress& local, const ComboAddress& mappedSource, const Netmask& ednssubnet, bool tcp, size_t len, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::unordered_set<std::string>& policyTags, const std::string& requestorId, const std::string& deviceId, const std::string& deviceName, const std::map<std::string, RecursorLua4::MetaValue>& meta, const boost::optional<uint32_t>& ednsVersion, const dnsheader& header, const pdns::trace::TraceID& traceID);
 bool isAllowNotifyForZone(DNSName qname);
 bool checkForCacheHit(bool qnameParsed, unsigned int tag, const string& data,
                       DNSName& qname, uint16_t& qtype, uint16_t& qclass,

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -274,7 +274,7 @@ static void doProtobufLogQuery(bool logQuery, LocalStateHolder<LuaConfigItems>& 
 {
   try {
     if (logQuery && !(luaconfsLocal->protobufExportConfig.taggedOnly && comboWriter->d_policyTags.empty())) {
-      protobufLogQuery(luaconfsLocal, comboWriter->d_uuid, comboWriter->d_source, comboWriter->d_destination, comboWriter->d_mappedSource, comboWriter->d_ednssubnet.getSource(), true, conn->qlen, qname, qtype, qclass, comboWriter->d_policyTags, comboWriter->d_requestorId, comboWriter->d_deviceId, comboWriter->d_deviceName, comboWriter->d_meta, ednsVersion, *dnsheader);
+      protobufLogQuery(luaconfsLocal, comboWriter->d_uuid, comboWriter->d_source, comboWriter->d_destination, comboWriter->d_mappedSource, comboWriter->d_ednssubnet.getSource(), true, conn->qlen, qname, qtype, qclass, comboWriter->d_policyTags, comboWriter->d_requestorId, comboWriter->d_deviceId, comboWriter->d_deviceName, comboWriter->d_meta, ednsVersion, *dnsheader, comboWriter->d_otTrace.trace_id);
     }
   }
   catch (const std::exception& e) {

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -290,7 +290,8 @@ class TestRecursorProtobuf(RecursorTest):
         self.assertEqual(msg.deviceName, deviceName)
 
     def checkProtobufEDE(self, msg, ede, edeText):
-        self.assertTrue((ede == '') == (not msg.HasField('ede')))
+        print(msg)
+        self.assertTrue((ede == 0) == (not msg.HasField('ede')))
         self.assertTrue((edeText == '') == (not msg.HasField('edeText')))
         self.assertEqual(msg.ede, ede)
         self.assertEqual(msg.edeText, edeText)
@@ -384,7 +385,7 @@ event-trace-enabled=4
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
         self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
         self.checkProtobufOT(msg, True, True)
-        self.checkProtobufEDE(msg, '', '')
+        self.checkProtobufEDE(msg, 0, '')
         self.checkNoRemainingMessage()
 
     def testCNAME(self):
@@ -415,7 +416,7 @@ event-trace-enabled=4
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, 'a.example.', 15, checkTTL=False)
         self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
         self.checkProtobufOT(msg, True, True)
-        self.checkProtobufEDE(msg, '', '')
+        self.checkProtobufEDE(msg, 0, '')
         self.checkNoRemainingMessage()
 
 class ProtobufProxyMappingTest(TestRecursorProtobuf):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fields are added if available. At the moment, the availability of a `TraceID` is coupled to OT Trace data being generated. 
We might want to record a `openTelemetryTraceID` into the protobuf without  generating or including the OT Trace into the PB. That is for a later PR.

Tagging @neilcook. Once approved, the `dnsmessage.proto` changes should be copied to https://github.com/PowerDNS/dnsmessage

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
