### PR TITLE
dnsdist: Fix reentry issue in TCP downstream I/O on macOS/BSD

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -379,7 +379,6 @@ void DoHConnectionToBackend::handleReadableIOCallback(int fd, FDMultiplexer::fun
   if (conn->d_inIOCallback) {
     return;
   }
-  conn->d_inIOCallback = true;
   dnsdist::tcp::HandlingIOGuard handlingIOGuard(conn->d_inIOCallback);
   IOStateGuard ioGuard(conn->d_ioState);
   do {

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -322,8 +322,8 @@ void TCPConnectionToBackend::handleReconnectionAttempt(std::shared_ptr<TCPConnec
         if (conn->d_state == State::sendingQueryToBackend) {
           /* we need to edit this query so it has the correct ID */
           auto query = std::move(conn->d_currentQuery);
-          uint16_t id = conn->d_highestStreamID;
-          prepareQueryForSending(query.d_query, id, ConnectionState::needProxy);
+          uint16_t streamId = conn->d_highestStreamID;
+          prepareQueryForSending(query.d_query, streamId, ConnectionState::needProxy);
           conn->d_currentQuery = std::move(query);
         }
 
@@ -340,8 +340,8 @@ void TCPConnectionToBackend::handleReconnectionAttempt(std::shared_ptr<TCPConnec
               TCPResponse response(std::move(pending.second.d_query));
               pending.second.d_sender->notifyIOError(now, std::move(response));
             }
-            catch (const std::exception& e) {
-              vinfolog("Got an exception while notifying: %s", e.what());
+            catch (const std::exception& exp) {
+              vinfolog("Got an exception while notifying: %s", exp.what());
             }
             catch (...) {
               vinfolog("Got exception while notifying");
@@ -369,7 +369,7 @@ void TCPConnectionToBackend::handleReconnectionAttempt(std::shared_ptr<TCPConnec
         connectionDied = false;
       }
     }
-    catch (const std::exception& e) {
+    catch (const std::exception& exp) {
       // reconnect might throw on failure, let's ignore that, we just need to know
       // it failed
     }

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -275,6 +275,7 @@ private:
 
   static void handleIO(std::shared_ptr<TCPConnectionToBackend>& conn, const struct timeval& now);
   static void handleIOCallback(int fd, FDMultiplexer::funcparam_t& param);
+  static void handleReconnectionAttempt(std::shared_ptr<TCPConnectionToBackend>& conn, const struct timeval& now, IOStateGuard& ioGuard, IOState& iostate, bool& reconnected, bool& connectionDied);
   static IOState queueNextQuery(std::shared_ptr<TCPConnectionToBackend>& conn);
   static IOState sendQuery(std::shared_ptr<TCPConnectionToBackend>& conn, const struct timeval& now);
   static bool isXFRFinished(const TCPResponse& response, TCPQuery& query);

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -302,6 +302,8 @@ private:
   size_t d_currentPos{0};
   uint16_t d_responseSize{0};
   State d_state{State::idle};
+  bool d_handlingIO{false};
+  bool d_lastIOBlocked{false};
 };
 
 void setTCPDownstreamMaxIdleConnectionsPerBackend(uint64_t max);

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -1207,7 +1207,6 @@ void IncomingTCPConnectionState::handleIO()
   if (d_handlingIO) {
     return;
   }
-  d_handlingIO = true;
   dnsdist::tcp::HandlingIOGuard reentryGuard(d_handlingIO);
 
   // why do we loop? Because the TLS layer does buffering, and thus can have data ready to read

--- a/pdns/dnsdistdist/dnsdist-tcp.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp.hh
@@ -314,6 +314,7 @@ public:
   HandlingIOGuard(bool& handlingIO) :
     d_handlingIO(handlingIO)
   {
+    d_handlingIO = true;
   }
   HandlingIOGuard(const HandlingIOGuard&) = delete;
   HandlingIOGuard(HandlingIOGuard&&) = delete;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Based on the work done by @karelbilek in https://github.com/PowerDNS/pdns/pull/16079, many thanks!

Fixes #16072 at least on my FreeBSD tests.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)

