### PR TITLE
feat: Add DRIP records (HHIT and BRID)

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -371,6 +371,14 @@ boilerplate_conv(HTTPS,
                  }
                  )
 
+boilerplate_conv(HHIT,
+                 conv.xfrBlob(d_data);
+                 )
+
+boilerplate_conv(BRID,
+                 conv.xfrBlob(d_data);
+                 )
+
 boilerplate_conv(SMIMEA,
                  conv.xfr8BitInt(d_certusage);
                  conv.xfr8BitInt(d_selector);
@@ -833,6 +841,16 @@ std::shared_ptr<SVCBBaseRecordContent> HTTPSRecordContent::clone() const
 
 /* SVCB end */
 
+std::shared_ptr<DRIPBaseRecordContent> HHITRecordContent::clone() const
+{
+  return {std::make_shared<HHITRecordContent>(*this)};
+}
+
+std::shared_ptr<DRIPBaseRecordContent> BRIDRecordContent::clone() const
+{
+  return {std::make_shared<BRIDRecordContent>(*this)};
+}
+
 boilerplate_conv(TKEY,
                  conv.xfrName(d_algo);
                  conv.xfr32BitInt(d_inception);
@@ -963,6 +981,8 @@ static void reportOtherTypes(const ReportIsOnlyCallableByReportAllTypes& guard)
    OPENPGPKEYRecordContent::report(guard);
    SVCBRecordContent::report(guard);
    HTTPSRecordContent::report(guard);
+   HHITRecordContent::report(guard);
+   BRIDRecordContent::report(guard);
    DLVRecordContent::report(guard);
    DNSRecordContent::regist(QClass::ANY, QType::TSIG, &TSIGRecordContent::make, &TSIGRecordContent::make, "TSIG");
    DNSRecordContent::regist(QClass::ANY, QType::TKEY, &TKEYRecordContent::make, &TKEYRecordContent::make, "TKEY");

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -95,7 +95,9 @@ bool DNSResourceRecord::operator==(const DNSResourceRecord& rhs) const
     std::tie(rhs.qname, rhs.qtype, rcontent, rhs.ttl);
 }
 
+//NOLINTBEGIN
 boilerplate_conv(A, conv.xfrIP(d_ip));
+//NOLINTEND
 
 ARecordContent::ARecordContent(uint32_t ip)
 {
@@ -141,6 +143,7 @@ void ARecordContent::doRecordCheck(const DNSRecord& dr)
     throw MOADNSException("Wrong size for A record ("+std::to_string(dr.d_clen)+")");
 }
 
+//NOLINTBEGIN
 boilerplate_conv(AAAA, conv.xfrIP6(d_ip6); );
 
 boilerplate_conv(NS, conv.xfrName(d_content, true));
@@ -171,6 +174,7 @@ boilerplate_conv(RP,
 boilerplate_conv(OPT,
                    conv.xfrBlob(d_data)
                  );
+//NOLINTEND
 
 #ifdef HAVE_LUA_RECORDS
 
@@ -217,6 +221,7 @@ void OPTRecordContent::getData(vector<pair<uint16_t, string> >& options) const
   }
 }
 
+//NOLINTBEGIN
 boilerplate_conv(TSIG,
                  conv.xfrName(d_algoName);
                  conv.xfr48BitInt(d_time);
@@ -230,11 +235,13 @@ boilerplate_conv(TSIG,
                  conv.xfr16BitInt(size);
                  if (size>0) conv.xfrBlobNoSpaces(d_otherData, size);
                  );
+//NOLINTEND
 
 MXRecordContent::MXRecordContent(uint16_t preference, DNSName  mxname):  d_preference(preference), d_mxname(std::move(mxname))
 {
 }
 
+//NOLINTBEGIN
 boilerplate_conv(MX,
                  conv.xfr16BitInt(d_preference);
                  conv.xfrName(d_mxname, true);
@@ -295,22 +302,26 @@ boilerplate_conv(NAPTR,
                  conv.xfrText(d_flags);        conv.xfrText(d_services);         conv.xfrText(d_regexp);
                  conv.xfrName(d_replacement);
                  )
+//NOLINTEND
 
 
 SRVRecordContent::SRVRecordContent(uint16_t preference, uint16_t weight, uint16_t port, DNSName  target)
 : d_weight(weight), d_port(port), d_target(std::move(target)), d_preference(preference)
 {}
 
+//NOLINTBEGIN
 boilerplate_conv(SRV,
                  conv.xfr16BitInt(d_preference);   conv.xfr16BitInt(d_weight);   conv.xfr16BitInt(d_port);
                  conv.xfrName(d_target);
                  )
+//NOLINTEND
 
 SOARecordContent::SOARecordContent(DNSName  mname, DNSName  rname, const struct soatimes& st)
 : d_mname(std::move(mname)), d_rname(std::move(rname)), d_st(st)
 {
 }
 
+//NOLINTBEGIN
 boilerplate_conv(SOA,
                  conv.xfrName(d_mname, true);
                  conv.xfrName(d_rname, true);
@@ -470,6 +481,7 @@ boilerplate_conv(L64,
 boilerplate_conv(LP,
                  conv.xfr16BitInt(d_preference);
                  conv.xfrName(d_fqdn, false);)
+//NOLINTEND
 
 /* EUI48 start */
 void EUI48RecordContent::report(const ReportIsOnlyCallableByReportAllTypes& /* unused */)
@@ -851,6 +863,7 @@ std::shared_ptr<DRIPBaseRecordContent> BRIDRecordContent::clone() const
   return {std::make_shared<BRIDRecordContent>(*this)};
 }
 
+//NOLINTBEGIN
 boilerplate_conv(TKEY,
                  conv.xfrName(d_algo);
                  conv.xfr32BitInt(d_inception);
@@ -875,6 +888,7 @@ boilerplate_conv(CAA,
                  conv.xfrUnquotedText(d_tag, true);
                  conv.xfrText(d_value, true, false); /* no lenField */
                 )
+//NOLINTEND
 
 static uint16_t makeTag(const std::string& data)
 {

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -716,6 +716,30 @@ public:
   std::shared_ptr<SVCBBaseRecordContent> clone() const override;
 };
 
+class DRIPBaseRecordContent : public DNSKEYRecordContent
+{
+public:
+  [[nodiscard]] size_t sizeEstimate() const override
+  {
+    return sizeof(*this) + d_data.size();
+  }
+  virtual std::shared_ptr<DRIPBaseRecordContent> clone() const = 0;
+protected:
+  string d_data;
+};
+
+class HHITRecordContent : public DRIPBaseRecordContent {
+public:
+  includeboilerplate(HHIT);
+  std::shared_ptr<DRIPBaseRecordContent> clone() const override;
+};
+
+class BRIDRecordContent : public DRIPBaseRecordContent {
+public:
+  includeboilerplate(BRID);
+  std::shared_ptr<DRIPBaseRecordContent> clone() const override;
+};
+
 class RRSIGRecordContent : public DNSRecordContent
 {
 public:

--- a/pdns/qtype.cc
+++ b/pdns/qtype.cc
@@ -76,6 +76,8 @@ const map<const string, uint16_t> QType::names = {
   {"ZONEMD", 63},
   {"SVCB", 64},
   {"HTTPS", 65},
+  {"HHIT", 67},
+  {"BRID", 68},
   {"SPF", 99},
   {"NID", 104},
   {"L32", 105},

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -120,6 +120,8 @@ public:
     ZONEMD = 63,
     SVCB = 64,
     HTTPS = 65,
+    HHIT = 67,
+    BRID = 68,
     SPF = 99,
     NID = 104,
     L32 = 105,

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -259,6 +259,11 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
      (CASE_L(QType::SVCB, R"XXX(16 foo.example.org. alpn=f\\\092oo\092,bar,h2)XXX", R"XXX(16 foo.example.org. alpn=f\\\\oo\\,bar,h2)XXX", "\x00\x10\3foo\7example\3org\x00\x00\x01\x00\x0c\x08\x66\\oo,bar\x02h2"))
      // END SVCB draft test vectors
 
+     (CASE_S(QType::HHIT, "1234abcd", "\xd7\x6d\xf8\x69\xb7\x1d"))
+     (CASE_L(QType::HHIT, "1234 abcd", "1234abcd", "\xd7\x6d\xf8\x69\xb7\x1d"))
+     (CASE_S(QType::BRID, "1234abcd", "\xd7\x6d\xf8\x69\xb7\x1d"))
+     (CASE_L(QType::BRID, "1234 abcd", "1234abcd", "\xd7\x6d\xf8\x69\xb7\x1d"))
+
      (CASE_S(QType::SPF, "\"v=spf1 a:mail.rec.test ~all\"", "\x1bv=spf1 a:mail.rec.test ~all"))
 
      (CASE_S(QType::NID, "15 0123:4567:89AB:CDEF", "\x00\x0F\x01\x23\x45\x67\x89\xab\xcd\xef"))


### PR DESCRIPTION

### Short description
This PR adds support for the HHIT and BRID records defined in [draft-ietf-drip-registries-33](https://www.ietf.org/archive/id/draft-ietf-drip-registries-33.html).

These are (from our perspective) simple Base64 encoded blobs. The blobs themselves encode CBOR data that we can ignore.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
