### PR TITLE
auth 5.0: backport "lmdb: optional memory-only notification timestamps"

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -133,19 +133,20 @@ Defaults to 100 on 32 bit systems, and 16000 on 64 bit systems.
 Instead of deleting items from the database, flag them as deleted in the item's `Lightning Stream <https://doc.powerdns.com/lightningstream>`_ header.
 Only enable this if you are using Lightning Stream.
 
-``lmdb-skip-notification-update``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``lmdb-write-notification-update``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  .. versionadded:: 5.1.0
+  .. versionadded:: 5.0.1
 
 -  Boolean
--  Default: no
+-  Default: yes
 
-Do not update the domains table in the database when the last notification
-timestamp is modified. These timestamps will only be written back to the
-database when other changes to the domain (such as accounts) occur.
+Always update the domains table in the database when the last notification
+timestamp is modified.
+If disabled, these timestamps will only be written back to the database when
+other changes to the domain (such as accounts) occur.
 
-**Warning**: Running with this flag enabled will cause spurious notifications
+**Warning**: Running with this flag disabled will cause spurious notifications
 to be sent upon startup.
 
 ``lmdb-lightning-stream``

--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -133,6 +133,21 @@ Defaults to 100 on 32 bit systems, and 16000 on 64 bit systems.
 Instead of deleting items from the database, flag them as deleted in the item's `Lightning Stream <https://doc.powerdns.com/lightningstream>`_ header.
 Only enable this if you are using Lightning Stream.
 
+``lmdb-skip-notification-update``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  .. versionadded:: 5.1.0
+
+-  Boolean
+-  Default: no
+
+Do not update the domains table in the database when the last notification
+timestamp is modified. These timestamps will only be written back to the
+database when other changes to the domain (such as accounts) occur.
+
+**Warning**: Running with this flag enabled will cause spurious notifications
+to be sent upon startup.
+
 ``lmdb-lightning-stream``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -722,7 +722,7 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     throw std::runtime_error(std::string("Unable to parse the 'map-size' LMDB value: ") + e.what());
   }
 
-  d_skip_notification_update = mustDo("skip-notification-update");
+  d_write_notification_update = mustDo("write-notification-update");
 
   if (mustDo("lightning-stream")) {
     d_random_ids = true;
@@ -1170,7 +1170,7 @@ bool LMDBBackend::findDomain(domainid_t domainid, DomainInfo& info) const
 void LMDBBackend::consolidateDomainInfo(DomainInfo& info) const
 {
   // Update the notified_serial value if we have a cached value in memory.
-  if (d_skip_notification_update) {
+  if (!d_write_notification_update) {
     auto container = s_notified_serial.read_lock();
     container->get(info.id, info.notified_serial);
   }
@@ -1178,7 +1178,7 @@ void LMDBBackend::consolidateDomainInfo(DomainInfo& info) const
 
 void LMDBBackend::writeDomainInfo(const DomainInfo& info)
 {
-  if (d_skip_notification_update) {
+  if (!d_write_notification_update) {
     uint32_t last_notified_serial{0};
     auto container = s_notified_serial.write_lock();
     container->get(info.id, last_notified_serial);
@@ -2296,7 +2296,7 @@ void LMDBBackend::getUpdatedPrimaries(vector<DomainInfo>& updatedDomains, std::u
 
 void LMDBBackend::setNotified(domainid_t domain_id, uint32_t serial)
 {
-  if (!d_skip_notification_update) {
+  if (d_write_notification_update) {
     genChangeDomain(domain_id, [serial](DomainInfo& info) {
       info.notified_serial = serial;
     });
@@ -2308,7 +2308,6 @@ void LMDBBackend::setNotified(domainid_t domain_id, uint32_t serial)
     auto container = s_notified_serial.write_lock();
     container->update(info.id, serial);
   }
-  // else throw something? this should be a "can't happen" situation.
 }
 
 class getCatalogMembersReturnFalseException : std::runtime_error
@@ -3248,7 +3247,7 @@ public:
     declare(suffix, "random-ids", "Numeric IDs inside the database are generated randomly instead of sequentially", "no");
     declare(suffix, "map-size", "LMDB map size in megabytes", (sizeof(void*) == 4) ? "100" : "16000");
     declare(suffix, "flag-deleted", "Flag entries on deletion instead of deleting them", "no");
-    declare(suffix, "skip-notification-update", "Do not update domain table upon notification", "no");
+    declare(suffix, "write-notification-update", "Do not update domain table upon notification", "yes");
     declare(suffix, "lightning-stream", "Run in Lightning Stream compatible mode", "no");
   }
   DNSBackend* make(const string& suffix = "") override

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -337,6 +337,9 @@ private:
   int genChangeDomain(domainid_t id, const std::function<void(DomainInfo&)>& func);
   static void deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match);
 
+  bool findDomain(const ZoneName& domain, DomainInfo& info);
+  bool findDomain(domainid_t domainid, DomainInfo& info);
+
   void getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow);
 
   void lookupStart(domainid_t domain_id, const std::string& match, bool dolog);

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -384,7 +384,7 @@ private:
   bool d_random_ids;
   bool d_handle_dups;
   bool d_views;
-  bool d_skip_notification_update;
+  bool d_write_notification_update;
   DTime d_dtime; // used only for logging
   uint64_t d_mapsize;
 };


### PR DESCRIPTION
### Short description
Backport of #16141. Raw diff is slightly different due to lmdb performance changes (#15864) not having been backported.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
