### PR TITLE
auth: odbc tweaks to appease coverity

### DIFF
--- a/modules/godbcbackend/sodbc.cc
+++ b/modules/godbcbackend/sodbc.cc
@@ -140,8 +140,10 @@ public:
   {
     prepareStatement();
     ODBCParam p;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.ParameterValuePtr = new UDWORD{value};
     p.LenPtr = new SQLLEN{sizeof(UDWORD)};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_INTEGER;
     p.ValueType = SQL_INTEGER;
     return bind(name, p);
@@ -151,8 +153,10 @@ public:
   {
     prepareStatement();
     ODBCParam p;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.ParameterValuePtr = new ULONG{value};
     p.LenPtr = new SQLLEN{sizeof(ULONG)};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_INTEGER;
     p.ValueType = SQL_INTEGER;
     return bind(name, p);
@@ -162,8 +166,10 @@ public:
   {
     prepareStatement();
     ODBCParam p;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.ParameterValuePtr = new unsigned long long{value};
     p.LenPtr = new SQLLEN{sizeof(unsigned long long)};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_BIGINT;
     p.ValueType = SQL_C_UBIGINT;
     return bind(name, p);
@@ -179,10 +185,12 @@ public:
     prepareStatement();
     ODBCParam p;
 
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.ParameterValuePtr = (char*)new char[value.size() + 1];
     value.copy((char*)p.ParameterValuePtr, value.size());
     ((char*)p.ParameterValuePtr)[value.size()] = 0;
     p.LenPtr = new SQLLEN{static_cast<SQLLEN>(value.size())};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_VARCHAR;
     p.ValueType = SQL_C_CHAR;
 
@@ -198,7 +206,9 @@ public:
     ODBCParam p;
 
     p.ParameterValuePtr = NULL;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.LenPtr = new SQLLEN{SQL_NULL_DATA};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_VARCHAR;
     p.ValueType = SQL_C_CHAR;
 


### PR DESCRIPTION
### Short description
The changes in #16109 introduced a new field in a struct, which I had been lazy to only initialize when it matters; but doing this triggers the wrath of Coverity.

While working on silencing this (by performing proper initialization in all cases), I noticed that this extra field was actually mostly duplicating an existing field. Therefore it is simpler to remove that field addition and use the value of the other one (which may be modified by query results, but not in the case which matters to us).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
