### PR TITLE
auth views: perform character set validation of view names

### DIFF
--- a/docs/views.rst
+++ b/docs/views.rst
@@ -85,6 +85,10 @@ that view, as their variantless contents.
 Only one variant per zone may appear in a view; setting a new zone variant will
 replace the previous one in the view.
 
+View names are case-sensitive and may be composed of letters, digits, spaces,
+as well as `-` (dash), `.` (dot) and `_` (underscore). They are not allowed to
+start with a dot or a space.
+
 Resolution Algorithm
 --------------------
 

--- a/pdns/check-zone.cc
+++ b/pdns/check-zone.cc
@@ -28,6 +28,31 @@
 namespace Check
 {
 
+bool validateViewName(std::string_view name, std::string& error)
+{
+  if (name.empty()) {
+    error = "Empty view names are not allowed";
+    return false;
+  }
+
+  if (auto pos = name.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890 _-."); pos != std::string_view::npos) {
+    error = std::string("View name contains forbidden character '") + name[pos] + "' at position " + std::to_string(pos);
+    return false;
+  }
+
+  if (name[0] == '.') {
+    error = "View names are not allowed to start with a dot";
+    return false;
+  }
+
+  if (name[0] == ' ') {
+    error = "View names are not allowed to start with a space";
+    return false;
+  }
+
+  return true;
+}
+
 void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecord>& allrrs, const ZoneName& zone, vector<pair<DNSResourceRecord, string>>& errors)
 {
   // QTypes that MUST NOT have multiple records of the same type in a given RRset.

--- a/pdns/check-zone.hh
+++ b/pdns/check-zone.hh
@@ -20,8 +20,19 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+// These validation/verification routines are used by both pdnsutil and
+// the pdns_server REST API.
+// They build error messages, if any, into an object provided by the caller
+// (preferrably a container if it makes sense to report multiple errors);
+// it's up to each caller to decide how to report such errors.
+
 namespace Check
 {
+
+// Validate a view name. Although view names never appear on the wire, we
+// restrict them to [a-zA-Z0-9-_. ], with empty names or names with leading
+// whitespace or a leading dot forbidden.
+bool validateViewName(std::string_view name, std::string& error);
 
 // Returns the list of errors found for new records which violate RRset
 // constraints.

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -5440,6 +5440,11 @@ static int listView(vector<string>& cmds, const std::string_view synopsis)
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
 
+  if ((B.getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
+    cerr << "None of the configured backends support views." << endl;
+    return 1;
+  }
+
   vector<ZoneName> ret;
   B.viewListZones(cmds.at(0), ret);
 
@@ -5456,6 +5461,12 @@ static int listViews(vector<string>& cmds, const std::string_view synopsis)
   }
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
+
+  if ((B.getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
+    // Don't complain about the lack of view support in this case, but
+    // don't list anything either.
+    return 0;
+  }
 
   vector<string> ret;
   B.viewList(ret);
@@ -5474,7 +5485,17 @@ static int viewAddZone(vector<string>& cmds, const std::string_view synopsis)
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
 
+  if ((B.getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
+    cerr << "None of the configured backends support views." << endl;
+    return 1;
+  }
+
   string view{cmds.at(0)};
+  string error;
+  if (!Check::validateViewName(view, error)) {
+    cerr << error << "." << endl;
+    return 1;
+  }
   ZoneName zone{cmds.at(1)};
   if (!B.viewAddZone(view, zone)) {
     cerr<<"Operation failed."<<endl;
@@ -5498,7 +5519,17 @@ static int viewDelZone(vector<string>& cmds, const std::string_view synopsis)
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
 
+  if ((B.getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
+    cerr << "None of the configured backends support views." << endl;
+    return 1;
+  }
+
   string view{cmds.at(0)};
+  string error;
+  if (!Check::validateViewName(view, error)) {
+    cerr << error << "." << endl;
+    return 1;
+  }
   ZoneName zone{cmds.at(1)};
   if (!B.viewDelZone(view, zone)) {
     cerr<<"Operation failed."<<endl;
@@ -5514,6 +5545,11 @@ static int listNetwork(vector<string>& cmds, const std::string_view synopsis)
   }
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
+
+  if ((B.getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
+    cerr << "None of the configured backends support views." << endl;
+    return 1;
+  }
 
   vector<pair<Netmask, string> > ret;
 
@@ -5532,6 +5568,11 @@ static int setNetwork(vector<string>& cmds, const std::string_view synopsis)
   }
 
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
+
+  if ((B.getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
+    cerr << "None of the configured backends support views." << endl;
+    return 1;
+  }
 
   Netmask net{cmds.at(0)};
   string view{};

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2826,6 +2826,10 @@ static void apiServerViewsPOST(HttpRequest* req, HttpResponse* resp)
     throw ApiException("Zone " + zonename.toString() + " does not exist");
   }
   std::string view{req->parameters["view"]};
+  std::string error;
+  if (!Check::validateViewName(view, error)) {
+    throw ApiException(error);
+  }
 
   if (!domainInfo.backend->viewAddZone(view, zonename)) {
     throw ApiException("Failed to add " + zonename.toString() + " to view " + view);
@@ -2850,6 +2854,10 @@ static void apiServerViewsDELETE(HttpRequest* req, HttpResponse* resp)
 {
   ZoneData zoneData{req};
   std::string view{req->parameters["view"]};
+  std::string error;
+  if (!Check::validateViewName(view, error)) {
+    throw ApiException(error);
+  }
 
   if (!zoneData.domainInfo.backend->viewDelZone(view, zoneData.zoneName)) {
     throw ApiException("Failed to remove " + zoneData.zoneName.toString() + " from view " + view);

--- a/regression-tests/tests/views-management/expected_result
+++ b/regression-tests/tests/views-management/expected_result
@@ -1,1 +1,1 @@
-Operation failed.
+None of the configured backends support views.


### PR DESCRIPTION
### Short description
Although view names never end up on the wire, they need to be usable with the REST API, so we need to reject a few characters (such as `/`).

This PR adds view name validation to `pdnsutil` and the REST API, and updates the documentation to mention the allowed characters for view names.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
