### PR TITLE
auth 4.9: backport "lmdb: optional memory-only notification timestamps"

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -129,19 +129,20 @@ Defaults to 100 on 32 bit systems, and 16000 on 64 bit systems.
 Instead of deleting items from the database, flag them as deleted in the item's `Lightning Stream <https://doc.powerdns.com/lightningstream>`_ header.
 Only enable this if you are using Lightning Stream.
 
-``lmdb-skip-notification-update``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``lmdb-write-notification-update``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  .. versionadded:: 5.1.0
+  .. versionadded:: 4.9.9
 
 -  Boolean
--  Default: no
+-  Default: yes
 
-Do not update the domains table in the database when the last notification
-timestamp is modified. These timestamps will only be written back to the
-database when other changes to the domain (such as accounts) occur.
+Always update the domains table in the database when the last notification
+timestamp is modified.
+If disabled, these timestamps will only be written back to the database when
+other changes to the domain (such as accounts) occur.
 
-**Warning**: Running with this flag enabled will cause spurious notifications
+**Warning**: Running with this flag disabled will cause spurious notifications
 to be sent upon startup.
 
 ``lmdb-lightning-stream``

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -351,7 +351,7 @@ private:
   bool d_dolog;
   bool d_random_ids;
   bool d_handle_dups;
-  bool d_skip_notification_update;
+  bool d_write_notification_update;
   DTime d_dtime; // used only for logging
   uint64_t d_mapsize;
 };


### PR DESCRIPTION
### Short description
Backport of #16141. Raw diff is quite different due to many changes in 5.0 work (`ZoneName` and `domainid_t` types) not available in 4.9.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
