### PR TITLE
auth 4.9.x: backport "memory corruption in ODBC" and "odbc tweaks to appease coverity"

### DIFF
--- a/modules/godbcbackend/sodbc.cc
+++ b/modules/godbcbackend/sodbc.cc
@@ -140,8 +140,10 @@ public:
   {
     prepareStatement();
     ODBCParam p;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.ParameterValuePtr = new UDWORD{value};
     p.LenPtr = new SQLLEN{sizeof(UDWORD)};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_INTEGER;
     p.ValueType = SQL_INTEGER;
     return bind(name, p);
@@ -151,8 +153,10 @@ public:
   {
     prepareStatement();
     ODBCParam p;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.ParameterValuePtr = new ULONG{value};
     p.LenPtr = new SQLLEN{sizeof(ULONG)};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_INTEGER;
     p.ValueType = SQL_INTEGER;
     return bind(name, p);
@@ -162,8 +166,10 @@ public:
   {
     prepareStatement();
     ODBCParam p;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.ParameterValuePtr = new unsigned long long{value};
     p.LenPtr = new SQLLEN{sizeof(unsigned long long)};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_BIGINT;
     p.ValueType = SQL_C_UBIGINT;
     return bind(name, p);
@@ -179,10 +185,12 @@ public:
     prepareStatement();
     ODBCParam p;
 
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.ParameterValuePtr = (char*)new char[value.size() + 1];
     value.copy((char*)p.ParameterValuePtr, value.size());
     ((char*)p.ParameterValuePtr)[value.size()] = 0;
     p.LenPtr = new SQLLEN{static_cast<SQLLEN>(value.size())};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_VARCHAR;
     p.ValueType = SQL_C_CHAR;
 
@@ -198,7 +206,9 @@ public:
     ODBCParam p;
 
     p.ParameterValuePtr = NULL;
+    // NOLINTBEGIN(cppcoreguidelines-owning-memory)
     p.LenPtr = new SQLLEN{SQL_NULL_DATA};
+    // NOLINTEND(cppcoreguidelines-owning-memory)
     p.ParameterType = SQL_VARCHAR;
     p.ValueType = SQL_C_CHAR;
 

--- a/modules/godbcbackend/sodbc.cc
+++ b/modules/godbcbackend/sodbc.cc
@@ -85,7 +85,6 @@ public:
     SQLLEN* LenPtr;
     SQLSMALLINT ParameterType;
     SQLSMALLINT ValueType;
-    size_t ParameterAllocSize; // size allocated for ParameterValuePtr, if ParameterType == SQL_INTEGER
   };
 
   vector<ODBCParam> d_req_bind;
@@ -145,7 +144,6 @@ public:
     p.LenPtr = new SQLLEN{sizeof(UDWORD)};
     p.ParameterType = SQL_INTEGER;
     p.ValueType = SQL_INTEGER;
-    p.ParameterAllocSize = sizeof(UDWORD);
     return bind(name, p);
   }
 
@@ -157,7 +155,6 @@ public:
     p.LenPtr = new SQLLEN{sizeof(ULONG)};
     p.ParameterType = SQL_INTEGER;
     p.ValueType = SQL_INTEGER;
-    p.ParameterAllocSize = sizeof(ULONG);
     return bind(name, p);
   }
 
@@ -185,8 +182,7 @@ public:
     p.ParameterValuePtr = (char*)new char[value.size() + 1];
     value.copy((char*)p.ParameterValuePtr, value.size());
     ((char*)p.ParameterValuePtr)[value.size()] = 0;
-    p.LenPtr = new SQLLEN;
-    *(p.LenPtr) = value.size();
+    p.LenPtr = new SQLLEN{static_cast<SQLLEN>(value.size())};
     p.ParameterType = SQL_VARCHAR;
     p.ValueType = SQL_C_CHAR;
 
@@ -202,8 +198,7 @@ public:
     ODBCParam p;
 
     p.ParameterValuePtr = NULL;
-    p.LenPtr = new SQLLEN;
-    *(p.LenPtr) = SQL_NULL_DATA;
+    p.LenPtr = new SQLLEN{SQL_NULL_DATA};
     p.ParameterType = SQL_VARCHAR;
     p.ValueType = SQL_C_CHAR;
 
@@ -270,7 +265,7 @@ public:
         delete[] static_cast<char*>(i.ParameterValuePtr);
       }
       else if (i.ParameterType == SQL_INTEGER) {
-        if (i.ParameterAllocSize == sizeof(UDWORD)) {
+        if (*i.LenPtr == sizeof(UDWORD)) {
           delete static_cast<UDWORD*>(i.ParameterValuePtr);
         }
         else {


### PR DESCRIPTION
### Short description
Backport of #16109 and #16150.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the AI policy, and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
