### PR TITLE
dnsdist: Fix 'warning: struct `UnusedStruct` is never constructed' warning

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-pre-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-pre-in.rs
@@ -3,10 +3,6 @@ use serde::{Deserialize, Serialize};
 mod helpers;
 use helpers::*;
 
-// Suppresses "Deserialize unused" warning
-#[derive(Deserialize, Serialize)]
-struct UnusedStruct {}
-
 #[derive(Debug)]
 pub struct ValidationError {
     msg: String,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
```
warning: struct `UnusedStruct` is never constructed
  --> src/lib.rs:10:8
   |
10 | struct UnusedStruct {}
   |        ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

The warning that this struct was introduced to fix seems to be gone anyway.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
