### PR TITLE
lmdb: optional memory-only freshness check timestamp

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -144,13 +144,13 @@ Only enable this if you are using Lightning Stream.
 -  Default: yes
 
 Always update the domains table in the database when the last notification
-timestamp is modified.
+or the freshness check timestamp are modified.
 If disabled, these timestamps will only be written back to the database when
 other changes to the domain (such as accounts) occur.
 This setting is also available in version 4.9.9.
 
 **Warning**: Running with this flag disabled will cause spurious notifications
-to be sent upon startup, unless a ``flush'' command is sent using
+to be sent upon startup, unless a ``flush`` command is sent using
 :doc:`pdns_control <../manpages/pdns_control.1>` before stopping the
 PowerDNS Authoritative Server.
 

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -343,6 +343,8 @@ private:
   void consolidateDomainInfo(DomainInfo& info) const;
   void writeDomainInfo(const DomainInfo& info);
 
+  void setLastCheckTime(domainid_t domain_id, time_t last_check);
+
   void getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow);
 
   void lookupStart(domainid_t domain_id, const std::string& match, bool dolog);
@@ -364,6 +366,7 @@ private:
   // database.
   struct TransientDomainInfo
   {
+    time_t last_check{};
     uint32_t notified_serial{};
   };
   // Cache of DomainInfo notified_serial values

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -360,19 +360,25 @@ private:
 
   string directBackendCmd_list(std::vector<string>& argv);
 
+  // Transient DomainInfo data, not necessarily synchronized with the
+  // database.
+  struct TransientDomainInfo
+  {
+    uint32_t notified_serial{};
+  };
   // Cache of DomainInfo notified_serial values
-  class SerialCache : public boost::noncopyable
+  class TransientDomainInfoCache : public boost::noncopyable
   {
   public:
-    bool get(domainid_t domainid, uint32_t& serial) const;
+    bool get(domainid_t domainid, TransientDomainInfo& data) const;
     void remove(domainid_t domainid);
-    void update(domainid_t domainid, uint32_t serial);
-    bool pop(domainid_t& domainid, uint32_t& serial);
+    void update(domainid_t domainid, const TransientDomainInfo& data);
+    bool pop(domainid_t& domainid, TransientDomainInfo& data);
 
   private:
-    std::unordered_map<domainid_t, uint32_t> d_serials;
+    std::unordered_map<domainid_t, TransientDomainInfo> d_data;
   };
-  static SharedLockGuarded<SerialCache> s_notified_serial;
+  static SharedLockGuarded<TransientDomainInfoCache> s_transient_domain_info;
 
   // Domain lookup shared state, set by list/lookup, used by get
   struct


### PR DESCRIPTION
### Short description
This is similar to #16154, but this time concerning the domain freshness check timestamp.
This behaviour is controlled by the `lmdb-write-notification-update` setting (which name becomes thus a bit misleading, suggestions welcome, rename it or add a separate setting?)

I think that this more or less fixes (or at least, works around) #13024.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
