### PR TITLE
dnsdist: The dynamic block tag name is set via `tagName`, not `tagKey`

### DIFF
--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1822,7 +1822,7 @@ faster than the existing rules.
 
     Options:
 
-    * ``tagKey``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
+    * ``tagName``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
     * ``tagValue``: str - If ``action`` is set to ``DNSAction.SetTag``, the value of the tag that will be set. Default is an empty string.
 
   .. method:: DynBlockRulesGroup:setMasks(v4, v6, port)
@@ -1860,7 +1860,7 @@ faster than the existing rules.
 
     Options:
 
-    * ``tagKey``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
+    * ``tagName``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
     * ``tagValue``: str - If ``action`` is set to ``DNSAction.SetTag``, the value of the tag that will be set. Default is an empty string
 
   .. method:: DynBlockRulesGroup:setNewBlockInsertedHook(hook)
@@ -1900,7 +1900,7 @@ faster than the existing rules.
 
     Options:
 
-    * ``tagKey``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
+    * ``tagName``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
     * ``tagValue``: str - If ``action`` is set to ``DNSAction.SetTag``, the value of the tag that will be set. Default is an empty string
 
   .. method:: DynBlockRulesGroup:setRCodeRatio(rcode, ratio, seconds, reason, blockingTime, minimumNumberOfResponses [, action [, warningRate, [options]]])
@@ -1927,7 +1927,7 @@ faster than the existing rules.
 
     Options:
 
-    * ``tagKey``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
+    * ``tagName``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
     * ``tagValue``: str - If ``action`` is set to ``DNSAction.SetTag``, the value of the tag that will be set. Default is an empty string
 
   .. method:: DynBlockRulesGroup:setQTypeRate(qtype, rate, seconds, reason, blockingTime [, action [, warningRate, [options]]])
@@ -1951,7 +1951,7 @@ faster than the existing rules.
 
     Options:
 
-    * ``tagKey``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
+    * ``tagName``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
     * ``tagValue``: str - If ``action`` is set to ``DNSAction.SetTag``, the value of the tag that will be set. Default is an empty string
 
   .. method:: DynBlockRulesGroup:setResponseByteRate(rate, seconds, reason, blockingTime [, action [, warningRate, [options]]])
@@ -1977,7 +1977,7 @@ faster than the existing rules.
 
     Options:
 
-    * ``tagKey``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
+    * ``tagName``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
     * ``tagValue``: str - If ``action`` is set to ``DNSAction.SetTag``, the value of the tag that will be set. Default is an empty string
 
   .. method:: DynBlockRulesGroup:setSuffixMatchRule(seconds, reason, blockingTime, action, visitor, [options])
@@ -2009,7 +2009,7 @@ faster than the existing rules.
 
     Options:
 
-    * ``tagKey``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
+    * ``tagName``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
     * ``tagValue``: str - If ``action`` is set to ``DNSAction.SetTag``, the value of the tag that will be set. Default is an empty string
 
   .. method:: DynBlockRulesGroup:setSuffixMatchRuleFFI(seconds, reason, blockingTime, action , visitor, [options])
@@ -2032,7 +2032,7 @@ faster than the existing rules.
 
     Options:
 
-    * ``tagKey``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
+    * ``tagName``: str - If ``action`` is set to ``DNSAction.SetTag``, the name of the tag that will be set
     * ``tagValue``: str - If ``action`` is set to ``DNSAction.SetTag``, the value of the tag that will be set. Default is an empty string
 
   .. method:: DynBlockRulesGroup:apply()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
