### PR TITLE
auth: fix a secondary domain type check in bind backend

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1071,10 +1071,13 @@ void Bind2Backend::loadConfig(string* status) // NOLINT(readability-function-cog
         }
         catch (std::system_error& ae) {
           ostringstream msg;
-          if (ae.code().value() == ENOENT && isNew && domain.type == "slave")
+          bool missingNewSecondary = ae.code().value() == ENOENT && isNew && kind == DomainInfo::Secondary;
+          if (missingNewSecondary) {
             msg << " error at " + nowTime() << " no file found for new secondary domain '" << domain.name << "'. Has not been AXFR'd yet";
-          else
+          }
+          else {
             msg << " error at " + nowTime() + " parsing '" << domain.name << "' from file '" << domain.filename << "': " << ae.what();
+          }
 
           if (status != nullptr)
             *status += msg.str();


### PR DESCRIPTION
### Short description
The logic used to report that a new secondary domain had not been AXFR'd yet was only triggering if the domain was marked as `"slave"`, missing the `"secondary"` case. Trivial fix in this PR.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
