### PR TITLE
dnsdist: Refactor the FFI "alternate name" interface

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -139,6 +139,8 @@ void dnsdist_ffi_dnsquestion_spoof_packet(dnsdist_ffi_dnsquestion_t* dq, const c
 void dnsdist_ffi_dnsquestion_set_max_returned_ttl(dnsdist_ffi_dnsquestion_t* dq, uint32_t max) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsquestion_set_restartable(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 
+bool dnsdist_ffi_dnsquestion_set_alternate_name(dnsdist_ffi_dnsquestion_t* dq, const char* alternateName, size_t alternateNameSize, const char* tag, size_t tagSize, const char* tagValue, size_t tagValueSize, const char* formerNameTagName, size_t formerNameTagSize) __attribute__ ((visibility ("default")));
+
 typedef struct dnsdist_ffi_servers_list_t dnsdist_ffi_servers_list_t;
 typedef struct dnsdist_ffi_server_t dnsdist_ffi_server_t;
 

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -934,6 +934,46 @@ bool dnsdist_ffi_set_rcode_from_async(uint16_t asyncID, uint16_t queryID, uint8_
   return dnsdist::queueQueryResumptionEvent(std::move(query));
 }
 
+static bool setAlternateName(PacketBuffer& packet, InternalQueryState& ids, std::string_view alternateName, std::string_view tag, std::string_view tagValue, std::string_view formerNameTagName)
+{
+  const DNSName originalName = ids.qname;
+  try {
+    DNSName parsed(alternateName.data(), alternateName.size(), 0, false);
+
+    // edit qname in query packet
+    if (!dnsdist::changeNameInDNSPacket(packet, originalName, parsed)) {
+      return false;
+    }
+    if (ids.d_packet) {
+      *ids.d_packet = packet;
+    }
+    // set qname to new one
+    ids.qname = std::move(parsed);
+  }
+  catch (const std::exception& e) {
+    vinfolog("Error rebasing packet on a new DNSName: %s", e.what());
+    return false;
+  }
+
+  // save existing qname in tag
+  if (!formerNameTagName.empty()) {
+    if (!ids.qTag) {
+      ids.qTag = std::make_unique<QTag>();
+    }
+    (*ids.qTag)[std::string(formerNameTagName)] = originalName.getStorage();
+  }
+
+  if (!tag.empty()) {
+    if (!ids.qTag) {
+      ids.qTag = std::make_unique<QTag>();
+    }
+    (*ids.qTag)[std::string(tag)] = tagValue;
+  }
+
+  ids.skipCache = true;
+  return true;
+}
+
 bool dnsdist_ffi_resume_from_async_with_alternate_name(uint16_t asyncID, uint16_t queryID, const char* alternateName, size_t alternateNameSize, const char* tag, size_t tagSize, const char* tagValue, size_t tagValueSize, const char* formerNameTagName, size_t formerNameTagSize)
 {
   if (!dnsdist::g_asyncHolder) {
@@ -947,57 +987,40 @@ bool dnsdist_ffi_resume_from_async_with_alternate_name(uint16_t asyncID, uint16_
   }
 
   auto& ids = query->query.d_idstate;
-  DNSName originalName = ids.qname;
-
-  try {
-    DNSName parsed(alternateName, alternateNameSize, 0, false);
-
-    PacketBuffer initialPacket;
-    if (query->d_isResponse) {
-      if (!ids.d_packet) {
-        return false;
-      }
-      initialPacket = std::move(*ids.d_packet);
-    }
-    else {
-      initialPacket = std::move(query->query.d_buffer);
-    }
-
-    // edit qname in query packet
-    if (!dnsdist::changeNameInDNSPacket(initialPacket, originalName, parsed)) {
+  PacketBuffer packet;
+  if (query->d_isResponse) {
+    if (!ids.d_packet) {
       return false;
     }
-    if (query->d_isResponse) {
-      query->d_isResponse = false;
-    }
-    query->query.d_buffer = std::move(initialPacket);
-    // set qname to new one
-    ids.qname = std::move(parsed);
+    packet = std::move(*ids.d_packet);
   }
-  catch (const std::exception& e) {
-    vinfolog("Error rebasing packet on a new DNSName: %s", e.what());
+  else {
+    packet = std::move(query->query.d_buffer);
+  }
+
+  auto wasOK = setAlternateName(packet, ids, std::string_view(alternateName, alternateNameSize), std::string_view(tag, tagSize), std::string_view(tagValue, tagValueSize), std::string_view(formerNameTagName, formerNameTagSize));
+  if (!wasOK) {
     return false;
   }
 
-  // save existing qname in tag
-  if (formerNameTagName != nullptr && formerNameTagSize > 0) {
-    if (!ids.qTag) {
-      ids.qTag = std::make_unique<QTag>();
-    }
-    (*ids.qTag)[std::string(formerNameTagName, formerNameTagSize)] = originalName.getStorage();
+  if (query->d_isResponse) {
+    query->d_isResponse = false;
   }
-
-  if (tag != nullptr && tagSize > 0) {
-    if (!ids.qTag) {
-      ids.qTag = std::make_unique<QTag>();
-    }
-    (*ids.qTag)[std::string(tag, tagSize)] = std::string(tagValue, tagValueSize);
-  }
-
-  ids.skipCache = true;
+  query->query.d_buffer = std::move(packet);
 
   // resume as query
   return dnsdist::queueQueryResumptionEvent(std::move(query));
+}
+
+bool dnsdist_ffi_dnsquestion_set_alternate_name(dnsdist_ffi_dnsquestion_t* dq, const char* alternateName, size_t alternateNameSize, const char* tag, size_t tagSize, const char* tagValue, size_t tagValueSize, const char* formerNameTagName, size_t formerNameTagSize)
+{
+  if (dq == nullptr || dq->dq == nullptr || alternateName == nullptr || alternateNameSize == 0) {
+    return false;
+  }
+
+  auto& ids = dq->dq->ids;
+  auto& packet = dq->dq->getMutableData();
+  return setAlternateName(packet, ids, std::string_view(alternateName, alternateNameSize), std::string_view(tag, tagSize), std::string_view(tagValue, tagValueSize), std::string_view(formerNameTagName, formerNameTagSize));
 }
 
 bool dnsdist_ffi_drop_from_async(uint16_t asyncID, uint16_t queryID)

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -1037,7 +1037,6 @@ BOOST_AUTO_TEST_CASE(test_SVC_Generation)
 #if !defined(DISABLE_PROTOBUF)
 BOOST_AUTO_TEST_CASE(test_meta_values)
 {
-
   InternalQueryState ids;
   ids.origRemote = ComboAddress("192.0.2.1:4242");
   ids.origDest = ComboAddress("192.0.2.255:53");
@@ -1121,5 +1120,48 @@ BOOST_AUTO_TEST_CASE(test_meta_values)
   }
 }
 #endif /* DISABLE_PROTOBUF */
+
+BOOST_AUTO_TEST_CASE(test_set_altername_name)
+{
+  const DNSName initialQName("www.powerdns.com.");
+  InternalQueryState ids;
+  ids.origRemote = ComboAddress("192.0.2.1:4242");
+  ids.origDest = ComboAddress("192.0.2.255:53");
+  ids.qtype = QType::A;
+  ids.qclass = QClass::IN;
+  ids.protocol = dnsdist::Protocol::DoUDP;
+  ids.qname = initialQName;
+  ids.queryRealTime.start();
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, ids.qname, QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+  pwQ.getHeader()->id = htons(42);
+
+  DNSQuestion dnsQuestion(ids, query);
+  dnsdist_ffi_dnsquestion_t lightDQ(&dnsQuestion);
+
+  {
+    /* check invalid parameters */
+    dnsdist_ffi_dnsquestion_set_alternate_name(nullptr, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0);
+    dnsdist_ffi_dnsquestion_set_alternate_name(&lightDQ, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0);
+    dnsdist_ffi_dnsquestion_set_alternate_name(&lightDQ, "alternate", 0, nullptr, 0, nullptr, 0, nullptr, 0);
+  }
+
+  const std::string tag("alternate-name-tag");
+  const std::string tagValue("alternate-name-tag-value");
+  const std::string formerTagName("alternate-name-former-value");
+  const DNSName target("new.target.net.");
+  BOOST_REQUIRE(dnsdist_ffi_dnsquestion_set_alternate_name(&lightDQ, target.getStorage().data(), target.getStorage().size(), tag.data(), tag.size(), tagValue.data(), tagValue.size(), formerTagName.data(), formerTagName.size()));
+
+  BOOST_CHECK_EQUAL(ids.qname.toString(), target.toString());
+  BOOST_CHECK_EQUAL(ids.skipCache, true);
+  BOOST_REQUIRE(ids.qTag != nullptr);
+  BOOST_CHECK_EQUAL(ids.qTag->at(tag), tagValue);
+  BOOST_CHECK_EQUAL(ids.qTag->at(formerTagName), initialQName.getStorage());
+
+  MOADNSParser mdp(false, reinterpret_cast<const char*>(dnsQuestion.getData().data()), dnsQuestion.getData().size());
+  BOOST_CHECK_EQUAL(mdp.d_qname, target);
+  BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+}
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
So we can use it without making the query asynchronous when we don't have to.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
