### PR TITLE
auth: logic botch in ldap backend

### DIFF
--- a/modules/ldapbackend/native.cc
+++ b/modules/ldapbackend/native.cc
@@ -100,10 +100,10 @@ bool LdapBackend::list(const ZoneName& target, domainid_t domain_id, bool /* inc
   }
   catch (LDAPNoConnection& lnc) {
     g_log << Logger::Warning << d_myname << " Connection to LDAP lost, trying to reconnect" << endl;
-    if (reconnect())
-      this->list(target, domain_id);
-    else
-      throw PDNSException("Failed to reconnect to LDAP server");
+    if (reconnect()) {
+      return this->list(target, domain_id);
+    }
+    throw PDNSException("Failed to reconnect to LDAP server");
   }
   catch (LDAPException& le) {
     g_log << Logger::Error << d_myname << " Unable to get zone " << target << " from LDAP directory: " << le.what() << endl;
@@ -183,10 +183,11 @@ void LdapBackend::lookup(const QType& qtype, const DNSName& qname, domainid_t zo
   }
   catch (LDAPNoConnection& lnc) {
     g_log << Logger::Warning << d_myname << " Connection to LDAP lost, trying to reconnect" << endl;
-    if (reconnect())
+    if (reconnect()) {
       this->lookup(qtype, qname, zoneid, dnspkt);
-    else
-      throw PDNSException("Failed to reconnect to LDAP server");
+      return;
+    }
+    throw PDNSException("Failed to reconnect to LDAP server");
   }
   catch (LDAPException& le) {
     g_log << Logger::Error << d_myname << " Unable to search LDAP directory: " << le.what() << endl;
@@ -413,10 +414,10 @@ bool LdapBackend::getDomainInfo(const ZoneName& domain, DomainInfo& info, bool /
   }
   catch (LDAPNoConnection& lnc) {
     g_log << Logger::Warning << d_myname << " Connection to LDAP lost, trying to reconnect" << endl;
-    if (reconnect())
-      this->getDomainInfo(domain, info);
-    else
-      throw PDNSException("Failed to reconnect to LDAP server");
+    if (reconnect()) {
+      return this->getDomainInfo(domain, info);
+    }
+    throw PDNSException("Failed to reconnect to LDAP server");
   }
   catch (LDAPException& le) {
     g_log << Logger::Error << d_myname << " Unable to search LDAP directory: " << le.what() << endl;

--- a/modules/ldapbackend/primary.cc
+++ b/modules/ldapbackend/primary.cc
@@ -44,10 +44,10 @@ void LdapBackend::getUpdatedPrimaries(vector<DomainInfo>& domains, std::unordere
   }
   catch (LDAPNoConnection& lnc) {
     g_log << Logger::Warning << d_myname << " Connection to LDAP lost, trying to reconnect" << endl;
-    if (reconnect())
-      this->getUpdatedPrimaries(domains, catalogs, catalogHashes);
-    else
-      throw PDNSException("Failed to reconnect to LDAP server");
+    if (reconnect()) {
+      return this->getUpdatedPrimaries(domains, catalogs, catalogHashes);
+    }
+    throw PDNSException("Failed to reconnect to LDAP server");
   }
   catch (LDAPException& le) {
     g_log << Logger::Error << d_myname << " Unable to search LDAP directory: " << le.what() << endl;
@@ -92,10 +92,11 @@ void LdapBackend::setNotified(domainid_t id, uint32_t serial)
   }
   catch (LDAPNoConnection& lnc) {
     g_log << Logger::Warning << d_myname << " Connection to LDAP lost, trying to reconnect" << endl;
-    if (reconnect())
+    if (reconnect()) {
       this->setNotified(id, serial);
-    else
-      throw PDNSException("Failed to reconnect to LDAP server");
+      return;
+    }
+    throw PDNSException("Failed to reconnect to LDAP server");
   }
   catch (LDAPException& le) {
     g_log << Logger::Error << d_myname << " Unable to search LDAP directory: " << le.what() << endl;
@@ -129,10 +130,11 @@ void LdapBackend::setNotified(domainid_t id, uint32_t serial)
   }
   catch (LDAPNoConnection& lnc) {
     g_log << Logger::Warning << d_myname << " Connection to LDAP lost, trying to reconnect" << endl;
-    if (reconnect())
+    if (reconnect()) {
       this->setNotified(id, serial);
-    else
-      throw PDNSException("Failed to reconnect to LDAP server");
+      return;
+    }
+    throw PDNSException("Failed to reconnect to LDAP server");
   }
   catch (LDAPException& le) {
     g_log << Logger::Error << d_myname << " Unable to search LDAP directory: " << le.what() << endl;


### PR DESCRIPTION
### Short description
The `getDomainInfo` method in the LDAP backend will reinvoke itself, if the connection to the LDAP server was lost but could be reactivated.

However, instead of simply returning with the results of the new call, it will happily continue with the regular result parsing logic. Except that the local `result` variable, at this point, contains garbage, since the LDAP request could not succeed.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
