### PR TITLE
auth: remove dead ldap code

### DIFF
--- a/modules/ldapbackend/powerldap.hh
+++ b/modules/ldapbackend/powerldap.hh
@@ -84,15 +84,10 @@ public:
   void setOption(int option, int value);
 
   void bind(LdapAuthenticator* authenticator);
-  void bind(const string& ldapbinddn = "", const string& ldapsecret = "", int method = LDAP_AUTH_SIMPLE);
-  void simpleBind(const string& ldapbinddn = "", const string& ldapsecret = "");
   SearchResult::Ptr search(const string& base, int scope, const string& filter, const char** attr = 0);
-  void add(const string& dn, LDAPMod* mods[]);
   void modify(const string& dn, LDAPMod* mods[], LDAPControl** scontrols = 0, LDAPControl** ccontrols = 0);
-  void del(const string& dn);
 
   bool getSearchEntry(int msgid, sentry_t& entry, bool dn = false);
-  void getSearchResults(int msgid, sresult_t& result, bool dn = false);
 
   static const string escape(const string& tobe);
 };


### PR DESCRIPTION
### Short description
Remove code which only wastes electrons nowadays.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
