### PR TITLE
store debug.traceback function before user can hide it from us

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -67,6 +67,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #define LUACONTEXT_GLOBAL_EQ "e5ddced079fc405aa4937b386ca387d2"
+#define LUACONTEXT_DEBUG_TRACEBACK "8d143f0add7ad7fa323d0d1d12f3f114" // I would prefer a lightuserdata in the registry index
 #define EQ_FUNCTION_NAME "__eq"
 #define TOSTRING_FUNCTION_NAME "__tostring"
 
@@ -113,7 +114,12 @@ public:
         if (openDefaultLibs)
             luaL_openlibs(mState);
 
-         writeGlobalEq();
+        writeGlobalEq();
+        lua_pushliteral(mState, LUACONTEXT_DEBUG_TRACEBACK); // ref
+        lua_getglobal(mState, "debug"); // ref, debug
+        lua_getfield(mState, -1, "traceback"); // ref, debug, traceback
+        lua_remove(mState, -2); // ref, traceback
+        lua_settable(mState, LUA_REGISTRYINDEX); // []
     }
 
     void writeGlobalEq() {
@@ -1418,9 +1424,8 @@ private:
     }
     
     static int gettraceback(lua_State* L) {
-        lua_getglobal(L, "debug"); // stack: error, debug library
-        lua_getfield(L, -1, "traceback"); // stack: error, debug library, debug.traceback function
-        lua_remove(L, -2); // stack: error, debug.traceback function
+        lua_pushliteral(L, LUACONTEXT_DEBUG_TRACEBACK); // stack: error, ref
+        lua_rawget(L, LUA_REGISTRYINDEX); // stack: error, debug.traceback
         lua_pushstring(L, ""); // stack: error, debug.traceback, ""
         lua_pushinteger(L, 2); // stack: error, debug.traceback, "", 2
         lua_call(L, 2, 1); // stack: error, traceback

--- a/regression-tests.dnsdist/test_Lua.py
+++ b/regression-tests.dnsdist/test_Lua.py
@@ -184,3 +184,22 @@ class TestLuaPoolBindings(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=response)
             self.assertEqual(receivedResponse, response)
+
+class TestLuaError(DNSDistTest):
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
+
+    _config_params = ['_consoleKeyB64', '_consolePort']
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%s")
+
+    debug = nil
+    """
+
+    def testLuaError(self):
+        """
+        LuaError: Test exception handling while debug module is obscured
+        """
+        res = self.sendConsoleCommand('error("expected" .. " " .. "error")')
+        self.assertIn('expected error', res)


### PR DESCRIPTION
### Short description
> needs some cleanup and perhaps a test. Also has a comment pointing to another bug we've never hit.

all done

related to #15173

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
