### PR TITLE
ci: Check return status of rec unit test run when using meson

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -932,10 +932,11 @@ def ci_rec_run_unit_tests(c, meson=False):
         logfile = 'meson-logs/testlog.txt'
         res = c.run(f'meson test --verbose -t {suite_timeout_sec}', warn=True)
     else:
+        logfile = 'test-suite.log'
         res = c.run('make check', warn=True)
-        if res.exited != 0:
-          c.run('cat test-suite.log')
-          raise UnexpectedExit(res)
+    if res.exited != 0:
+        c.run(f'cat {logfile}', warn=True)
+        raise UnexpectedExit(res)
 
 @task
 def ci_dnsdist_run_unit_tests(c, builder):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

In noticed recursor meson unit test run failure (while working on something else) but did they not report as such due to a logic error in the workflow.

(I also forced failure on all other unit tests runners and they report correctly).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
