### PR TITLE
docs: fix markup for list of "Important Notes"

### DIFF
--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -240,6 +240,7 @@ Uses the YYYYMMDDSS format for SOA serial numbers. The "inception day" is determ
 - Otherwise, the serial remains unchanged.
 
 **Important Notes**:
+
 - Avoid using SS=00 in backend zones, as it may prevent proper zone transfers (AXFR/IXFR) to secondaries.
 - Serial overflow can occur if more than 99 updates are made in a single day.
 - This logic is not safe for zones with non-PowerDNS secondaries, as updates may not be detected reliably.


### PR DESCRIPTION
### Short description
This had me confused while reading, because the list wasn't rendered as list (but as a paragraph) and I wondered why starting with 00 would increase the chance of overflow...

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [N/A] compiled this code
- [N/A] tested this code
- [N/A] included documentation (including possible behaviour changes)
- [N/A] documented the code
- [N/A] added or modified regression test(s)
- [N/A] added or modified unit test(s)