### PR TITLE
docs: link algorithm rollover from DNSSEC operational instructions

### DIFF
--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -6,6 +6,7 @@ Several How to's describe operational practices with DNSSEC:
 -  :doc:`../guides/kskroll`
 -  :doc:`../guides/kskrollcdnskey`
 -  :doc:`../guides/zskroll`
+-  :doc:`../guides/algoroll`
 
 Below, frequently used commands are described:
 


### PR DESCRIPTION
### Short description

I probably would've missed it anyway, because that section of the document has strong "motivational / introductory text" vibes which make my brain auto-skip it, but at least there's a chance now.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [N/A] compiled this code
- [N/A] tested this code
- [N/A] included documentation (including possible behaviour changes)
- [N/A] documented the code
- [N/A] added or modified regression test(s)
- [N/A] added or modified unit test(s)