### PR TITLE
dnsdist: add fast path to roundrobin load balancing policy

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lbpolicies.cc
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.cc
@@ -244,6 +244,14 @@ std::optional<ServerPolicy::SelectedServerPosition> roundrobin(const ServerPolic
     return std::nullopt;
   }
 
+  static unsigned int counter;
+
+  size_t serverIdx = (counter++) % servers.size();
+  auto currentServer = servers.at(serverIdx);
+  if (currentServer.second->isUp()) {
+    return currentServer.first;
+  }
+
   vector<size_t> candidates;
   candidates.reserve(servers.size());
 
@@ -262,8 +270,7 @@ std::optional<ServerPolicy::SelectedServerPosition> roundrobin(const ServerPolic
     }
   }
 
-  static unsigned int counter;
-  return candidates.at((counter++) % candidates.size());
+  return candidates.at(counter % candidates.size());
 }
 
 std::optional<ServerPolicy::SelectedServerPosition> orderedWrandUntag(const ServerPolicy::NumberedServerVector& servers, const DNSQuestion* dnsQuestion)


### PR DESCRIPTION
### Short description
There is no need to collect all servers that are up when the current server is already a good candidate. This avoids needless heap allocation and deallocation in the vast majority of cases.
Passes the existing tests. Result of discussion in #16234 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
