### PR TITLE
dnsdist: Make the round-robin LB policy internal counter atomic

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lbpolicies.cc
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.cc
@@ -244,7 +244,7 @@ std::optional<ServerPolicy::SelectedServerPosition> roundrobin(const ServerPolic
     return std::nullopt;
   }
 
-  static unsigned int counter;
+  static std::atomic<unsigned int> counter{0};
 
   size_t serverIdx = (counter++) % servers.size();
   auto currentServer = servers.at(serverIdx);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise TSAN is rightfully complaining that there is a data race because several threads are updating at the same time. While the impact of this counter being corrupted is almost zero, and there is an actual overhead to making it atomic, I believe this is the only correct way to ensure the expected behaviour of this policy.
The only point that really puzzles me is why we are only seeing this now? Perhaps the refactoring done in https://github.com/PowerDNS/pdns/pull/15924 exposed the race, that was otherwise hidden in the noise of copying shared pointers around?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
