### PR TITLE
auth: remove and delete dead code which turns out to be dead and also not alive

### DIFF
--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -194,7 +194,6 @@ public:
   void lookupEnd() override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled = false) override;
 
-  static DNSBackend* maker();
   static std::mutex s_startup_lock;
 
   void setStale(domainid_t domain_id) override;

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -249,18 +249,6 @@ string PipeBackend::directBackendCmd(const string& query)
   return oss.str();
 }
 
-//! For the dynamic loader
-DNSBackend* PipeBackend::maker()
-{
-  try {
-    return new PipeBackend();
-  }
-  catch (...) {
-    g_log << Logger::Error << kBackendId << " Unable to instantiate a pipebackend!" << endl;
-    return nullptr;
-  }
-}
-
 PipeBackend::~PipeBackend()
 {
   cleanup();

--- a/modules/pipebackend/pipebackend.hh
+++ b/modules/pipebackend/pipebackend.hh
@@ -56,7 +56,6 @@ public:
   bool list(const ZoneName& target, domainid_t domain_id, bool include_disabled = false) override;
   bool get(DNSResourceRecord& r) override;
   string directBackendCmd(const string& query) override;
-  static DNSBackend* maker();
 
 private:
   void launch();

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -1011,17 +1011,6 @@ void RemoteBackend::setFresh(domainid_t domain_id)
   }
 }
 
-DNSBackend* RemoteBackend::maker()
-{
-  try {
-    return new RemoteBackend();
-  }
-  catch (...) {
-    g_log << Logger::Error << kBackendId << " Unable to instantiate a remotebackend!" << endl;
-    return nullptr;
-  };
-}
-
 class RemoteBackendFactory : public BackendFactory
 {
 public:

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -208,8 +208,6 @@ public:
   void setStale(domainid_t domain_id) override;
   void setFresh(domainid_t domain_id) override;
 
-  static DNSBackend* maker();
-
 private:
   int build();
   std::unique_ptr<Connector> connector;


### PR DESCRIPTION
### Short description
Dynamic loading of backends nowadays relies upon the constructor of a global variable to setup things, the `maker` methods are not used anymore.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
