### PR TITLE
rec: silence rust warning

### DIFF
--- a/pdns/recursordist/rec-rust-lib/rust-preamble-in.rs
+++ b/pdns/recursordist/rec-rust-lib/rust-preamble-in.rs
@@ -22,6 +22,9 @@
 
 // This file (rust-preamble-in.rs) is included at the start of lib.rs
 
+// rustc complains serde Serialize/Deserialize are not used on toplevel, while they *are* used plenty
+// in mod recsettings. Disable the warning for the line below only.
+#[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
 
 mod helpers;
@@ -33,10 +36,6 @@ use bridge::*;
 mod misc;
 
 mod web; // leaving this out causes link issues
-
-// Suppresses "Deserialize unused" warning
-#[derive(Deserialize, Serialize)]
-struct UnusedStruct {}
 
 trait Validate {
     fn validate(&self) -> Result<(), ValidationError>;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Explanation in the code comment. The warning does not happen in dnsdist as it defines structs with Serialization on top-level.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
