### PR TITLE
dnsdist: Fix a memory leak with OCSP and OpenSSL 3.6.0

### DIFF
--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -376,7 +376,7 @@ int libssl_ocsp_stapling_callback(SSL* ssl, const std::map<int, std::string>& oc
 
   const auto ocsp_resp_size = data->second.size();
   /* the behaviour is alas different in 3.6.0 because of a regression introduced in b1b4b154fd389ac6254d49cfb11aee36c1c51b84:
-     the value passed to SSL_set_tlsext_status_ocsp_resp() is not freed in 3.6.0 as it is in all others OpenSSL versions.
+     the value passed to SSL_set_tlsext_status_ocsp_resp() is not freed in 3.6.0 as it is in all other OpenSSL versions.
      See https://github.com/openssl/openssl/issues/28888 */
 #if OPENSSL_VERSION_NUMBER != 0x30600000L
   /* we need to allocate a copy because OpenSSL will free the pointer passed to SSL_set_tlsext_status_ocsp_resp() */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

See https://github.com/openssl/openssl/issues/28888 I'm not very happy with the fix, but I don't really have a better idea at this point.

Reported by LeakSanitizer:
```
=================================================================
==121188==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1132 byte(s) in 2 object(s) allocated from:
    #0 0x7f9278720cb5 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:67
    #1 0x7f9277f9189e in CRYPTO_malloc (/usr/lib/libcrypto.so.3+0x19189e) (BuildId: 9943e383d1a8a3cdcf8786b70a4abbf903e67661)
    #2 0x561ed5dfcfe8 in libssl_ocsp_stapling_callback(ssl_st*, std::map<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<int>, std::allocator<std::pair<int const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) ../libssl.cc:378
    #3 0x7f92779c965a  (/usr/lib/libssl.so.3+0xb065a) (BuildId: 05d6e27a4ef1635017caf539e4d5b5687767d20b)
    #4 0x7f92779b2b2d  (/usr/lib/libssl.so.3+0x99b2d) (BuildId: 05d6e27a4ef1635017caf539e4d5b5687767d20b)
    #5 0x7f92779b579d  (/usr/lib/libssl.so.3+0x9c79d) (BuildId: 05d6e27a4ef1635017caf539e4d5b5687767d20b)
    #6 0x561ed5f94e44 in OpenSSLTLSConnection::tryHandshake() ../tcpiohandler.cc:375
    #7 0x561ed58d690d in TCPIOHandler::tryHandshake() ../tcpiohandler.hh:369
    #8 0x561ed58d690d in IncomingTCPConnectionState::handleHandshake(timeval const&) ../dnsdist-tcp.cc:1070
    #9 0x561ed593118d in IncomingTCPConnectionState::handleIO() ../dnsdist-tcp.cc:1251
    #10 0x561ed58fc420 in handleIncomingTCPQuery ../dnsdist-tcp.cc:1468
    #11 0x561ed3b21d72 in std::function<void (int, boost::any&)>::operator()(int, boost::any&) const /usr/include/c++/15.2.1/bits/std_function.h:593
    #12 0x561ed3b21d72 in EpollFDMultiplexer::run(timeval*, int) ../epollmplexer.cc:188
    #13 0x561ed591a6e8 in tcpClientThread ../dnsdist-tcp.cc:1698
    #14 0x561ed593d147 in void std::__invoke_impl<void, void (*)(pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >), pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, std::vector<ClientState*, std::allocator<ClientState*> > >(std::__invoke_other, void (*&&)(pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >), pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >&&) /usr/include/c++/15.2.1/bits/invoke.h:63
    #15 0x561ed593d147 in std::__invoke_result<void (*)(pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >), pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, std::vector<ClientState*, std::allocator<ClientState*> > >::type std::__invoke<void (*)(pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >), pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, std::vector<ClientState*, std::allocator<ClientState*> > >(void (*&&)(pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >), pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >&&) /usr/include/c++/15.2.1/bits/invoke.h:98
    #16 0x561ed593d147 in void std::thread::_Invoker<std::tuple<void (*)(pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >), pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, std::vector<ClientState*, std::allocator<ClientState*> > > >::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul, 5ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul, 5ul>) /usr/include/c++/15.2.1/bits/std_thread.h:303
    #17 0x561ed593d147 in std::thread::_Invoker<std::tuple<void (*)(pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >), pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, std::vector<ClientState*, std::allocator<ClientState*> > > >::operator()() /usr/include/c++/15.2.1/bits/std_thread.h:310
    #18 0x561ed593d147 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >&&, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >&&, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >&&, std::vector<ClientState*, std::allocator<ClientState*> >), pdns::channel::Receiver<ConnectionInfo, std::default_delete<ConnectionInfo> >, pdns::channel::Receiver<CrossProtocolQuery, std::default_delete<CrossProtocolQuery> >, pdns::channel::Receiver<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, pdns::channel::Sender<TCPCrossProtocolResponse, std::default_delete<TCPCrossProtocolResponse> >, std::vector<ClientState*, std::allocator<ClientState*> > > > >::_M_run() /usr/include/c++/15.2.1/bits/std_thread.h:255
    #19 0x7f92772e55a3 in execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104
    #20 0x7f927865e11a in asan_thread_start /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:239
    #21 0x7f92766969ca  (/usr/lib/libc.so.6+0x969ca) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)

SUMMARY: AddressSanitizer: 1132 byte(s) leaked in 2 allocation(s).
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
