### PR TITLE
dnsdist: Allow selecting a specific version of Lua with meson

### DIFF
--- a/pdns/dnsdistdist/meson/lua/meson.build
+++ b/pdns/dnsdistdist/meson/lua/meson.build
@@ -12,6 +12,9 @@ endif
 
 if not dep_lua.found() and (opt_lua == 'auto' or opt_lua == 'lua')
   variants = [
+    'lua5.4',
+    'lua-5.4',
+    'lua54',
     'lua5.3',
     'lua-5.3',
     'lua53',
@@ -30,6 +33,10 @@ if not dep_lua.found() and (opt_lua == 'auto' or opt_lua == 'lua')
       break
     endif
   endforeach
+endif
+
+if not dep_lua.found() and opt_lua != 'lua' and opt_lua.startswith('lua')
+  dep_lua = dependency(opt_lua, version: '>= 5.1', required: false)
 endif
 
 if not dep_lua.found()

--- a/pdns/dnsdistdist/meson_options.txt
+++ b/pdns/dnsdistdist/meson_options.txt
@@ -5,7 +5,7 @@ option('libsodium', type: 'feature', value: 'auto', description: 'Enable libsodi
 option('libcrypto', type: 'feature', value: 'auto', description: 'Enable OpenSSL libcrypto)')
 option('libcrypto-path', type: 'string', value: '', description: 'Custom path to find OpenSSL libcrypto')
 option('tls-gnutls', type: 'feature', value: 'auto', description: 'GnuTLS-based TLS')
-option('lua', type: 'combo', choices: ['auto', 'luajit', 'lua'], value: 'auto', description: 'Lua implementation to use')
+option('lua', type: 'combo', choices: ['auto', 'luajit', 'lua', 'lua51', 'lua-5.1', 'lua5.1', 'lua52', 'lua-5.2', 'lua5.2', 'lua53', 'lua-5.3', 'lua5.3', 'lua54', 'lua-5.4', 'lua5.4'], value: 'auto', description: 'Lua implementation to use')
 option('hardening', type: 'feature', value: 'auto', description: 'Compiler security checks')
 option('hardening-experimental-cf', type: 'combo', choices: ['disabled', 'full', 'branch', 'return', 'check'], value: 'disabled', description: 'Control Flow hardening')
 option('hardening-experimental-scp', type: 'feature', value: 'disabled', description: 'Stack Clash Protection')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
While at it, I also added the option to explicitly select Lua 5.4 in addition to 5.1, 5.2 and 5.3.

We might want to apply the same change to auth and rec.

Fixes https://github.com/PowerDNS/pdns/issues/16249

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
