### PR TITLE
auth and rec: Allow selecting a specific version of Lua with meson

### DIFF
--- a/meson/lua-records/meson.build
+++ b/meson/lua-records/meson.build
@@ -3,7 +3,7 @@ opt_lua_records = get_option('lua-records')
 dep_libcurl = dependency('libcurl', version: '>= 7.21.3', required: opt_lua_records)
 conf.set('HAVE_LIBCURL', dep_libcurl.found(), description: 'Whether we have libcurl')
 
-opt_lua_enabled = opt_lua in ['auto', 'luajit', 'lua']
+opt_lua_enabled = opt_lua in ['auto', 'luajit', 'lua', 'lua51', 'lua-5.1', 'lua5.1', 'lua52', 'lua-5.2', 'lua5.2', 'lua53', 'lua-5.3', 'lua5.3', 'lua54', 'lua-5.4', 'lua5.4']
 
 if not opt_lua_enabled
   error('Lua records require Lua, make sure it is enabled')

--- a/meson/lua/meson.build
+++ b/meson/lua/meson.build
@@ -12,6 +12,9 @@ endif
 
 if not dep_lua.found() and (opt_lua == 'auto' or opt_lua == 'lua')
   variants = [
+    'lua5.4',
+    'lua-5.4',
+    'lua54',
     'lua5.3',
     'lua-5.3',
     'lua53',
@@ -30,6 +33,10 @@ if not dep_lua.found() and (opt_lua == 'auto' or opt_lua == 'lua')
       break
     endif
   endforeach
+endif
+
+if not dep_lua.found() and opt_lua != 'lua' and opt_lua.startswith('lua')
+  dep_lua = dependency(opt_lua, version: '>= 5.1', required: false)
 endif
 
 if not dep_lua.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('lua', type: 'combo', choices: ['auto', 'luajit', 'lua'], value: 'auto', description: 'Lua implementation to use')
+option('lua', type: 'combo', choices: ['auto', 'luajit', 'lua', 'lua51', 'lua-5.1', 'lua5.1', 'lua52', 'lua-5.2', 'lua5.2', 'lua53', 'lua-5.3', 'lua5.3', 'lua54', 'lua-5.4', 'lua5.4'], value: 'auto', description: 'Lua implementation to use')
 option('hardening', type: 'feature', value: 'auto', description: 'Compiler security checks')
 option('hardening-experimental-cf', type: 'combo', choices: ['disabled', 'full', 'branch', 'return', 'check'], value: 'disabled', description: 'Control Flow hardening')
 option('hardening-experimental-scp', type: 'feature', value: 'disabled', description: 'Stack Clash Protection')

--- a/pdns/recursordist/meson_options.txt
+++ b/pdns/recursordist/meson_options.txt
@@ -1,4 +1,4 @@
-option('lua', type: 'combo', choices: ['auto', 'luajit', 'lua'], value: 'auto', description: 'Lua implementation to use')
+option('lua', type: 'combo', choices: ['auto', 'luajit', 'lua', 'lua51', 'lua-5.1', 'lua5.1', 'lua52', 'lua-5.2', 'lua5.2', 'lua53', 'lua-5.3', 'lua5.3', 'lua54', 'lua-5.4', 'lua5.4'], value: 'auto', description: 'Lua implementation to use')
 option('hardening', type: 'feature', value: 'auto', description: 'Compiler security checks')
 option('hardening-experimental-cf', type: 'combo', choices: ['disabled', 'full', 'branch', 'return', 'check'], value: 'disabled', description: 'Control Flow hardening')
 option('hardening-experimental-scp', type: 'feature', value: 'disabled', description: 'Stack Clash Protection')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Same change as dnsdist.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
