### PR TITLE
Warn about workflows that needs to be backported to release branches

### DIFF
--- a/.github/workflows/build-docker-images-tags.yml
+++ b/.github/workflows/build-docker-images-tags.yml
@@ -8,6 +8,14 @@ on:
     - 'dnsdist-*'
     - 'rec-*'
 
+# Please be aware that this version of the workflow is NOT the one called
+# when someone pushes a tag on a release branch (rel/**)! The version
+# used is the one present in the tag, which in turns should call the
+# version present in the master branch of the reusable workflow defined
+# in .github/workflows/build-docker-images.yml
+# This means that any change to this file will very likely need to be
+# backported to all release branches!!
+
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/build-tags.yml
+++ b/.github/workflows/build-tags.yml
@@ -8,6 +8,14 @@ on:
     - 'dnsdist-*'
     - 'rec-*'
 
+# Please be aware that this version of the workflow is NOT the one called
+# when someone pushes a tag on a release branch (rel/**)! The version
+# used is the one present in the tag, which in turns should call the
+# version present in the master branch of the reusable workflow defined
+# in .github/workflows/build-packages.yml
+# This means that any change to this file will very likely need to be
+# backported to all release branches!!
+
 permissions:
   actions: read
   id-token: write


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We keep getting hurt by changes to these files that need to be backported to release branches, and we only find out when we are about to release because this is the only time the workflows triggered from a tag are actually executed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
