### PR TITLE
dnsdist: Fix build error when only protobuf is enabled

### DIFF
--- a/pdns/dnsdistdist/dnsdist-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-protobuf.cc
@@ -27,6 +27,7 @@
 #include "base64.hh"
 #include "dnsdist.hh"
 #include "dnsdist-protobuf.hh"
+#include "dolog.hh"
 #include "protozero.hh"
 
 DNSDistProtoBufMessage::DNSDistProtoBufMessage(const DNSQuestion& dnsquestion) :


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Since ba78a38a7a2349ec73fa2a66b552eb2234b42007 the build fails with:
```
../dnsdist-protobuf.cc: In member function ‘void DNSDistProtoBufMessage::serialize(std::string&) const’:
../dnsdist-protobuf.cc:205:7: error: ‘vinfolog’ was not declared in this scope
  205 |       vinfolog("Error while parsing the RRs from a response packet to add them to the protobuf message: %s", exp.what());
      |       ^~~~~~~~
```
because of a missing header.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
