### PR TITLE
authoritative: Prevent a potential race condition in cache cleaning

### DIFF
--- a/pdns/auth-caches.cc
+++ b/pdns/auth-caches.cc
@@ -31,8 +31,9 @@ extern AuthQueryCache QC;
 uint64_t purgeAuthCaches()
 {
   uint64_t ret = 0;
-  ret += PC.purge();
+  /* Clean query cache before packet cache to avoid potential race condition */
   ret += QC.purge();
+  ret += PC.purge();
   return ret;
 }
 
@@ -40,8 +41,9 @@ uint64_t purgeAuthCaches()
 uint64_t purgeAuthCaches(const std::string& match)
 {
   uint64_t ret = 0;
-  ret += PC.purge(match);
+  /* Clean query cache before packet cache to avoid potential race condition */
   ret += QC.purge(match);
+  ret += PC.purge(match);
   return ret;
 }
 
@@ -49,8 +51,9 @@ uint64_t purgeAuthCaches(const std::string& match)
 uint64_t purgeAuthCachesExact(const DNSName& qname)
 {
   uint64_t ret = 0;
-  ret += PC.purgeExact(qname);
+  /* Clean query cache before packet cache to avoid potential race condition */
   ret += QC.purgeExact(qname);
+  ret += PC.purgeExact(qname);
   return ret;
 }
 


### PR DESCRIPTION
### Short description
Clean query cache before cleaning packet cache.

Otherwise the following situation is possible:

* thread A cleans packet cache
* thread B answers a question for the same name that is being cleaned by A
* since there is no packet cache it populates a packet cache entry from the query cache (which has not yet been cleaned by thread A
* thread A cleans query cache
* the server will return the old packet cache entry until its TTL expires or cache is cleaned again

Switching which cache is cleaned first fixes this race condition.


Closes #16286 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

