### PR TITLE
Fix OpenTelemetry Trace names for Span Kinds

### DIFF
--- a/pdns/dnsdistdist/dnsdist-opentelemetry.cc
+++ b/pdns/dnsdistdist/dnsdist-opentelemetry.cc
@@ -66,7 +66,7 @@ TracesData Tracer::getTracesData()
           .span_id = preActivationTrace.span_id,
           .parent_span_id = preActivationTrace.parent_span_id,
           .name = preActivationTrace.name,
-          .kind = pdns::trace::Span::SpanKind::SPAN_KINSERVER,
+          .kind = pdns::trace::Span::SpanKind::SPAN_KIND_SERVER,
           .start_time_unix_nano = preActivationTrace.start_time_unix_nano,
           .end_time_unix_nano = preActivationTrace.end_time_unix_nano,
         });
@@ -123,7 +123,7 @@ SpanID Tracer::addSpan([[maybe_unused]] const std::string& name, [[maybe_unused]
       .span_id = spanID,
       .parent_span_id = parentSpanID,
       .name = name,
-      .kind = pdns::trace::Span::SpanKind::SPAN_KINSERVER,
+      .kind = pdns::trace::Span::SpanKind::SPAN_KIND_SERVER,
       .start_time_unix_nano = pdns::trace::timestamp(),
     });
     return spanID;

--- a/pdns/protozero-trace.hh
+++ b/pdns/protozero-trace.hh
@@ -435,20 +435,20 @@ struct Span
   {
     // Unspecified. Do NOT use as default.
     // Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED.
-    SPAN_KINUNSPECIFIED = 0,
+    SPAN_KIND_UNSPECIFIED = 0,
     // Indicates that the span represents an internal operation within an application,
     // as opposed to an operation happening at the boundaries. Default value.
-    SPAN_KININTERNAL = 1,
+    SPAN_KIND_INTERNAL = 1,
     // Indicates that the span covers server-side handling of an RPC or other
     // remote network request.
-    SPAN_KINSERVER = 2,
+    SPAN_KIND_SERVER = 2,
     // Indicates that the span describes a request to some remote service.
-    SPAN_KINCLIENT = 3,
+    SPAN_KIND_CLIENT = 3,
     // Indicates that the span describes a producer sending a message to a broker.
     // Unlike CLIENT and SERVER, there is often no direct critical path latency relationship
     // between producer and consumer spans. A PRODUCER span ends when the message was accepted
     // by the broker while the logical processing of the message might span a much longer time.
-    SPAN_KINPRODUCER = 4,
+    SPAN_KIND_PRODUCER = 4,
     // Indicates that the span describes consumer receiving a message from a broker.
     // Like the PRODUCER kind, there is often no direct critical path latency relationship
     // between producer and consumer spans.
@@ -457,7 +457,7 @@ struct Span
   // Distinguishes between spans generated in a particular context. For example,
   // two spans with the same name may be distinguished using `CLIENT` (caller)
   // and `SERVER` (callee) to identify queueing latency associated with the span.
-  SpanKind kind{Span::SpanKind::SPAN_KINUNSPECIFIED}; // = 6
+  SpanKind kind{Span::SpanKind::SPAN_KIND_UNSPECIFIED}; // = 6
   // start_time_unix_nano is the start time of the span. On the client side, this is the time
   // kept by the local machine where the span execution starts. On the server side, this
   // is the time when the server's application handler starts running.
@@ -597,7 +597,7 @@ struct Span
     trace_state.clear(); // 3
     parent_span_id.clear(); // 4
     name.clear(); // 5
-    kind = SpanKind::SPAN_KINUNSPECIFIED; // 6
+    kind = SpanKind::SPAN_KIND_UNSPECIFIED; // 6
     start_time_unix_nano = 0; // 7
     end_time_unix_nano = 0; // 8
     attributes.clear(); // 9

--- a/pdns/test-protozero-trace.cc
+++ b/pdns/test-protozero-trace.cc
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(traces1)
     .span_id = {0xEE, 0xE1, 0x9B, 0x7E, 0xC3, 0xC1, 0xB1, 0x74},
     .parent_span_id = {0xEE, 0xE1, 0x9B, 0x7E, 0xC3, 0xC1, 0xB1, 0x73},
     .name = "I'm a server span",
-    .kind = pdns::trace::Span::SpanKind::SPAN_KINSERVER,
+    .kind = pdns::trace::Span::SpanKind::SPAN_KIND_SERVER,
     .start_time_unix_nano = 1544712660000000000UL,
     .end_time_unix_nano = 1544712661000000000UL,
     .attributes = {{"my.span.attr", {"some value"}}}};
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(traces2)
     .span_id = {0xEE, 0xE1, 0x9B, 0x7E, 0xC3, 0xC1, 0xB1, 0x74},
     .parent_span_id = {0xEE, 0xE1, 0x9B, 0x7E, 0xC3, 0xC1, 0xB1, 0x73},
     .name = "I'm a server span",
-    .kind = pdns::trace::Span::SpanKind::SPAN_KINSERVER,
+    .kind = pdns::trace::Span::SpanKind::SPAN_KIND_SERVER,
     .start_time_unix_nano = 1544712660000000000UL,
     .end_time_unix_nano = 1544712661000000000UL,
     .attributes = {{"my.span.attr", {"some value"}}, {"attr2", {1.0}}},


### PR DESCRIPTION
### Short description

This PR fixes the names for the OT Trace Span Kinds that we use internally. Additionally, it also uses the `Server` kind on all dnsdist produced Spans.

- **fix(dnsdist): Set SpanKind::Server for every span**
- **fix(OT): correctly name the SpanKinds**

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
