### PR TITLE
fix(dnsdist): Improve OT parenting

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -522,7 +522,7 @@ bool processResponseAfterRules(PacketBuffer& response, DNSResponse& dnsResponse,
 {
   pdns::trace::dnsdist::Tracer::Closer closer;
   if (auto tracer = dnsResponse.ids.getTracer(); tracer != nullptr && dnsResponse.ids.tracingEnabled) {
-    closer = tracer->openSpan("processResponseAfterRules");
+    closer = tracer->openSpan("processResponseAfterRules", tracer->getLastSpanID());
   }
   bool zeroScope = false;
   if (!fixUpResponse(response, dnsResponse.ids.qname, dnsResponse.ids.origFlags, dnsResponse.ids.ednsAdded, dnsResponse.ids.ecsAdded, dnsResponse.ids.useZeroScope ? &zeroScope : nullptr)) {
@@ -591,7 +591,7 @@ bool processResponse(PacketBuffer& response, DNSResponse& dnsResponse, bool mute
 {
   pdns::trace::dnsdist::Tracer::Closer closer;
   if (auto tracer = dnsResponse.ids.getTracer(); tracer != nullptr && dnsResponse.ids.tracingEnabled) {
-    closer = tracer->openSpan("processResponse", tracer->getRootSpanID());
+    closer = tracer->openSpan("processResponse");
   }
 
   const auto& chains = dnsdist::configuration::getCurrentRuntimeConfiguration().d_ruleChains;
@@ -1836,7 +1836,7 @@ bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& downstrea
 {
   pdns::trace::dnsdist::Tracer::Closer closer;
   if (auto tracer = dnsQuestion.ids.getTracer(); tracer != nullptr && dnsQuestion.ids.tracingEnabled) {
-    closer = tracer->openSpan("assignOutgoingUDPQueryToBackend", tracer->getLastSpanID());
+    closer = tracer->openSpan("assignOutgoingUDPQueryToBackend", tracer->getLastSpanIDForName("processUDPQuery"));
   }
 
   bool doh = dnsQuestion.ids.du != nullptr;


### PR DESCRIPTION
### Short description

This PR fixes the parenting of some of the Spans:

* Response Spans are no longer a child of the receive Spans.
* `assignOutgoingUDPQueryToBackend` is now a child of `processQuery`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
