### PR TITLE
rec builder: don't try to copy rust files that are not there

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.debbuild-prepare
+++ b/builder-support/dockerfiles/Dockerfile.debbuild-prepare
@@ -9,7 +9,6 @@ ADD builder/helpers/ /pdns/builder/helpers/
 ADD builder-support/helpers/ /pdns/builder-support/helpers/
 
 @IF [ -n "$M_recursor$M_all" ]
-COPY --from=pdns-recursor /tmp/rust* /tmp
 RUN cd /pdns/builder-support/helpers/ && ./install_rust.sh
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git cmake clang
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends python3-pip ninja-build

--- a/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -16,7 +16,6 @@ ADD builder/helpers/ /pdns/builder/helpers/
 ADD builder-support/helpers/ /pdns/builder-support/helpers/
 
 @IF [ -n "$M_recursor$M_all" ]
-COPY --from=pdns-recursor /tmp/rust* /tmp
 RUN cd /pdns/builder-support/helpers/ && ./install_rust.sh && \
     yum install -y git cmake clang
 RUN cd /pdns/builder-support/helpers/ && ./install_meson.sh


### PR DESCRIPTION
### Short description
Since #16204, there is no rust to copy from the sdist step. `docker build`'s COPY tolerates a wildcard not matching anything, and just continues. `podman build` (really `buildah`) errors out instead. Removing this no-op COPY unbreaks podman builds.

(except recursor 'el-*' builds are still broken after this (on both podman and Docker) because they can't find gnutls, which is what I was actually going to fix/look at before I ran into this.)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
