### PR TITLE
recursor el-* build: depend on gnutls

### DIFF
--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -25,6 +25,7 @@ BuildRequires: libcap-devel
 BuildRequires: libcurl-devel
 BuildRequires: libsodium-devel
 BuildRequires: net-snmp-devel
+BuildRequires: gnutls-devel
 BuildRequires: openssl-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel


### PR DESCRIPTION
### Short description
recursor el-* builds are broken since #16232 because the meson config expects gnutls and our spec files did not install it. This PR installs the gnutls dep. An alternative solution would be to not depend on gnutls. The choice in this PR mirrors the one made in dnsdist.

sidenote: recursor's version.cc does not mention openssl or gnutls, like `dnsdist --version` does do

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
