### PR TITLE
Fix[docs]: "real-remote" is always a CIDR-netmask

### DIFF
--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -209,7 +209,7 @@ Query:
 
 .. code-block:: json
 
-    {"method":"lookup", "parameters":{"qtype":"ANY", "qname":"www.example.com.", "remote":"192.0.2.24", "local":"192.0.2.1", "real-remote":"192.0.2.24", "zone-id":-1}}
+    {"method":"lookup", "parameters":{"qtype":"ANY", "qname":"www.example.com.", "remote":"192.0.2.24", "local":"192.0.2.1", "real-remote":"192.0.2.0/24", "zone-id":-1}}
 
 Response:
 
@@ -227,7 +227,7 @@ Query:
     GET /dnsapi/lookup/www.example.com./ANY HTTP/1.1
     X-RemoteBackend-remote: 192.0.2.24
     X-RemoteBackend-local: 192.0.2.1
-    X-RemoteBackend-real-remote: 192.0.2.24
+    X-RemoteBackend-real-remote: 192.0.2.0/24
     X-RemoteBackend-zone-id: -1
 
 Response:


### PR DESCRIPTION
### Short description

- Update the "real-remote" example in the remote backend lookup. It is always a CIDR netmask and not a pure IP-address.
- Update it for both JSON/RPC and HTTP/RPC examples.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code (not applicable)
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code (not applicable) (not applicable)
- [ ] added or modified regression test(s) (not applicable)
- [ ] added or modified unit test(s) (not applicable)