### PR TITLE
auth: always send a response for {A,I}XFR requests

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -689,10 +689,14 @@ int TCPNameserver::doAXFR(const ZoneName &targetZone, std::unique_ptr<DNSPacket>
     if (algorithm != g_gsstsigdnsname) {
       if(!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
         g_log<<Logger::Warning<<logPrefix<<"TSIG key not found"<<endl;
+        outpacket->setRcode(RCode::NotAuth);
+        sendPacket(outpacket,outsock);
         return 0;
       }
       if (B64Decode(tsig64, tsigsecret) == -1) {
         g_log<<Logger::Error<<logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl;
+        outpacket->setRcode(RCode::ServFail);
+        sendPacket(outpacket,outsock);
         return 0;
       }
     }
@@ -1295,10 +1299,14 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock)
       }
       if (!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
         g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << target << "' not found" << endl;
+        outpacket->setRcode(RCode::NotAuth);
+        sendPacket(outpacket,outsock);
         return 0;
       }
       if (B64Decode(tsig64, tsigsecret) == -1) {
         g_log<<Logger::Error<<logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl;
+        outpacket->setRcode(RCode::ServFail);
+        sendPacket(outpacket,outsock);
         return 0;
       }
     }


### PR DESCRIPTION
### Short description
In both AXFR and IXFR processing, if a TSIG key is used but the key is not found, or fails to base64 decode, a message will be logged but no response will be sent. These situations are apparently "can't happen", so this probably doesn't matter much in real life, but I think these conditions deserve a reply anyway. I have opted for `NotAuth` if the key is not found, `ServFail` if it is found but is not valid base64 - better ideas welcome.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] no idea what I am doing