### PR TITLE
dnsdist-2.0.x: Backport 16292 - Fix query rules bypass after tagging from a dynblock

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1119,7 +1119,8 @@ static bool applyRulesToQuery(DNSQuestion& dnsQuestion, const timespec& now)
         const auto& tagValue = got->second.tagSettings->d_value;
         dnsQuestion.setTag(tagName, tagValue);
         vinfolog("Query from %s setting tag %s to %s because of dynamic block", dnsQuestion.ids.origRemote.toStringWithPort(), tagName, tagValue);
-        return true;
+        // do not return, the whole point it to set a Tag to be able to do further processing in rules
+        break;
       }
       default:
         updateBlockStats();
@@ -1193,7 +1194,8 @@ static bool applyRulesToQuery(DNSQuestion& dnsQuestion, const timespec& now)
         const auto& tagValue = got->tagSettings->d_value;
         dnsQuestion.setTag(tagName, tagValue);
         vinfolog("Query from %s setting tag %s to %s because of dynamic block", dnsQuestion.ids.origRemote.toStringWithPort(), tagName, tagValue);
-        return true;
+        // do not return, the whole point it to set a Tag to be able to do further processing in rules
+        break;
       }
       default:
         updateBlockStats();

--- a/regression-tests.dnsdist/test_DynBlocksRatio.py
+++ b/regression-tests.dnsdist/test_DynBlocksRatio.py
@@ -66,6 +66,9 @@ class TestDynBlockGroupCacheMissRatioSetTag(DynBlocksTest):
     local dbr = dynBlockRulesGroup()
     dbr:setCacheMissRatio(0.8, %d, "Exceeded cache miss ratio", %d, 20, 0.0, DNSAction.SetTag, 0.0, { tagName='dyn-miss-ratio', tagValue='hit' })
 
+    -- check that the tag is set and query rules executed
+    addAction(AndRule{QNameRule("test-query-rules.cachemissratio-settag.group.dynblocks.tests.powerdns.com."), TagRule('dyn-miss-ratio', 'hit')}, SpoofAction("192.0.2.2"))
+
     -- on a cache miss, and if the cache miss ratio threshold was exceeded, send a REFUSED response
     addCacheMissAction(TagRule('dyn-miss-ratio', 'hit'), RCodeAction(DNSRCode.REFUSED))
 
@@ -128,6 +131,21 @@ class TestDynBlockGroupCacheMissRatioSetTag(DynBlocksTest):
         query = dns.message.make_query('0.' + name, 'A', 'IN')
         expectedResponse = dns.message.make_response(query)
         expectedResponse.answer.append(rrset)
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False, timeout=0.5)
+        self.assertEqual(receivedResponse, expectedResponse)
+
+        # this specific query will match the query rules before triggering a cache miss
+        # so we can check that the tag is correctly set for query rules as well
+        query = dns.message.make_query('test-query-rules.' + name, 'A', 'IN')
+        # dnsdist sets RA = RD for TC responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        queryRulesRRset = dns.rrset.from_text('test-query-rules.' + name,
+                                                60,
+                                                dns.rdataclass.IN,
+                                                dns.rdatatype.A,
+                                                '192.0.2.2')
+        expectedResponse.answer.append(queryRulesRRset)
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False, timeout=0.5)
         self.assertEqual(receivedResponse, expectedResponse)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16292 to rel/dnsdist-2.0.x

In 2.0.0 we introduced the ability to set a tag when a dynamic block matches, making it possible to combine dynamic blocks with existing rules. Unfortunately the implementation turned out to bypass query rules after setting a tag, so the mechanism could only be used with the remaining rules chains (cache hit, cache-miss, cache inserted, self-answered and regular response rules). This commit fixes that to ensure that we can use tags with query rules as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
