### PR TITLE
dnsdist-1.9.x: Backport of #16242 -  Fix handling of large XSK frames

### DIFF
--- a/pdns/xsk.cc
+++ b/pdns/xsk.cc
@@ -709,7 +709,7 @@ uint32_t XskPacket::getFrameLen() const noexcept
 
 size_t XskPacket::getCapacity() const noexcept
 {
-  return frameSize;
+  return frameSize - getDataOffset();
 }
 
 void XskPacket::changeDirectAndUpdateChecksum() noexcept


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16242 to rel/dnsdist-1.9.x

There was a bug in the way we were computing the remaining capacity of a XSK frame, because we forgot to account for the network headers. This caused some XSK responses to be discarded by the kernel (`tx_invalid_descs`) because there was not enough space left in the frame (less than `XDP_PACKET_HEADROOM`).

Thanks to `ednaq` for reporting this via ou YesWeHack program.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
