### PR TITLE
dnsdist-2.0.x: Backport 16180 - Fix release builds by updating the locked Rust lib version

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.dnsdist
+++ b/builder-support/dockerfiles/Dockerfile.dnsdist
@@ -2,7 +2,8 @@ FROM alpine:3.21 AS dnsdist
 ARG BUILDER_CACHE_BUSTER=
 
 RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \
-                       libtool file boost-dev ragel python3 py3-yaml git libedit-dev bash meson
+                       libtool file boost-dev ragel python3 py3-yaml git libedit-dev \
+                       bash meson cargo
 
 COPY . /dnsdist/
 WORKDIR /dnsdist/

--- a/pdns/dnsdistdist/meson-dist-script.sh
+++ b/pdns/dnsdistdist/meson-dist-script.sh
@@ -46,6 +46,16 @@ meson compile rust-lib-sources
 cp -vp dnsdist-rust-lib/*.cc dnsdist-rust-lib/*.hh "$MESON_PROJECT_DIST_ROOT"/dnsdist-rust-lib/
 cp -vp "$MESON_SOURCE_ROOT"/dnsdist-rust-lib/rust/src/lib.rs "$MESON_PROJECT_DIST_ROOT"/dnsdist-rust-lib/rust/src/
 
+echo Updating the version of the Rust library to ${BUILDER_VERSION}
+"$MESON_SOURCE_ROOT"/../../builder-support/helpers/update-rust-library-version.py "$MESON_PROJECT_DIST_ROOT"/dnsdist-rust-lib/rust/Cargo.toml dnsdist-rust ${BUILDER_VERSION}
+# Update the version of the Rust library in Cargo.lock as well,
+# This needs to be done AFTER the sources of the Rust library have been generated
+# Unfortunately we cannot use --offline because for some reason cargo-update wants
+# to check all dependencies even though we are telling it exactly what to update
+cd "$MESON_PROJECT_DIST_ROOT"/dnsdist-rust-lib/rust/
+cargo update --verbose --precise ${BUILDER_VERSION} dnsdist-rust
+cd "$MESON_PROJECT_BUILD_ROOT"
+
 # Generate man pages
 meson compile man-pages
 cp -vp *.1 "$MESON_PROJECT_DIST_ROOT"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16180 to rel/dnsdist-2.0.x

Since we are now dynamically setting the version of our internal Rust library when generating the release tarball, `cargo` needs to update the `Cargo.lock` file to reflect the new version, which is not possible if we are passing `--locked`:
```
error: the lock file /pdns/dnsdist-2.1.0-alpha0.870.master.gc64b979bc/dnsdist-rust-lib/rust/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```
This commit fixes that also updating the `Cargo.lock` file when generating the release tarball so that `cargo` no longer needs to update the `Cargo.lock`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
