### PR TITLE
regression-tests.dnsdist: detect function absence and report it better

### DIFF
--- a/regression-tests.dnsdist/test_Lua.py
+++ b/regression-tests.dnsdist/test_Lua.py
@@ -101,6 +101,7 @@ class TestLuaFrontendBindings(DNSDistTest):
     -- check that all these methods return nil on a non-existing entry
     functions = { 'getServer', 'getDNSCryptBind', 'getBind', 'getDOQFrontend', 'getDOH3Frontend', 'getDOHFrontend', 'getTLSFrontend'}
     for _, func in ipairs(functions) do
+      assert(_G[func] ~= nil, "function "..func.." not compiled in, cannot test")
       assert(_G[func](42) == nil, "function "..func.." did not return nil as expected")
     end
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
