### PR TITLE
luawrapper: correct lua_pop argument

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -123,7 +123,7 @@ public:
           lua_gettable(lua, -2);
           /* if not found, return false */
           if (lua_isnil(lua, -1)) {
-            lua_pop(lua, -2);
+            lua_pop(lua, 2);
             lua_pushboolean(lua, false);
             return 1;
           }


### PR DESCRIPTION
### Short description
a negative argument to `_pop` has defined behaviour but never
does what the user expects.

Note that none of this matters as Lua will adjust the stack to
the 1 top item, which is the pushed boolean, after `return 1`

but I get confused every time I read the negative version

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
