### PR TITLE
auth rfc2136: more code cleanup

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -861,7 +861,7 @@ static uint8_t updatePrereqCheck323(MOADNSParser& mdp, const updateContext& ctx)
         if (rec.qtype == rrSet.second) {
           foundRR++;
           for (auto& rrItem : *vec) {
-            rrItem.ttl = rec.ttl; // The compare one line below also compares TTL, so we make them equal because TTL is not user within prerequisite checks.
+            rrItem.ttl = rec.ttl; // The comparison on the next line also compares TTL, so we make them equal because TTL is not used within prerequisite checks.
             if (rrItem == rec) {
               matchRR++;
             }
@@ -958,7 +958,7 @@ static uint8_t updateRecords(MOADNSParser& mdp, DNSSECKeeper& dsk, uint& changed
     while (ctx.di.backend->get(rec)) {
       nsRRInZone.push_back(rec);
     }
-    if (nsRRInZone.size() > nsRRtoDelete.size()) { // only delete if the NS's we delete are less then what we have in the zone (3.4.2.4)
+    if (nsRRInZone.size() > nsRRtoDelete.size()) { // only delete if the NS's we delete are less than what we have in the zone (3.4.2.4)
       for (auto& inZone : nsRRInZone) {
         for (auto& resrec : nsRRtoDelete) {
           if (inZone.getZoneRepresentation() == resrec->getContent()->getZoneRepresentation()) {


### PR DESCRIPTION
### Short description
All these NSEC operations look identical, but they are all subtly different. However there is some readability gains in reworking the logic a bit and factoring the computation of the order name.

Better reviewed on a per-commit basis.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] failed to avoid sarcasm in commit messages