### PR TITLE
auth 5.0: backport "Prevent a potential race condition in cache cleaning"

### DIFF
--- a/pdns/auth-caches.cc
+++ b/pdns/auth-caches.cc
@@ -31,8 +31,9 @@ extern AuthQueryCache QC;
 uint64_t purgeAuthCaches()
 {
   uint64_t ret = 0;
-  ret += PC.purge();
+  /* Clean query cache before packet cache to avoid potential race condition */
   ret += QC.purge();
+  ret += PC.purge();
   return ret;
 }
 
@@ -40,8 +41,9 @@ uint64_t purgeAuthCaches()
 uint64_t purgeAuthCaches(const std::string& match)
 {
   uint64_t ret = 0;
-  ret += PC.purge(match);
+  /* Clean query cache before packet cache to avoid potential race condition */
   ret += QC.purge(match);
+  ret += PC.purge(match);
   return ret;
 }
 
@@ -49,8 +51,9 @@ uint64_t purgeAuthCaches(const std::string& match)
 uint64_t purgeAuthCachesExact(const DNSName& qname)
 {
   uint64_t ret = 0;
-  ret += PC.purgeExact(qname);
+  /* Clean query cache before packet cache to avoid potential race condition */
   ret += QC.purgeExact(qname);
+  ret += PC.purgeExact(qname);
   return ret;
 }
 


### PR DESCRIPTION
### Short description
Backport of #16287.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
