### PR TITLE
auth 5.0: backport "api: relax zone name check in view removal "

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2742,17 +2742,15 @@ static void apiServerViewsGET(HttpRequest* req, HttpResponse* resp)
 // POST /views/<view> + name in json adds ZoneName "name" to view "view"
 static void apiServerViewsPOST(HttpRequest* req, HttpResponse* resp)
 {
-  UeberBackend backend;
-  DomainInfo domainInfo;
   const auto& document = req->json();
+  // We can't use a ZoneData object here, as the zone being added to the
+  // view may not exist yet.
   ZoneName zonename = apiNameToZoneName(stringFromJson(document, "name"));
 
-  if (!backend.getDomainInfo(zonename, domainInfo)) {
-    throw ApiException("Zone " + zonename.toString() + " does not exist");
-  }
   std::string view{req->parameters["view"]};
 
-  if (!domainInfo.backend->viewAddZone(view, zonename)) {
+  UeberBackend backend;
+  if (!backend.viewAddZone(view, zonename)) {
     throw ApiException("Failed to add " + zonename.toString() + " to view " + view);
   }
   // Notify zone cache of the new association
@@ -2776,6 +2774,7 @@ static void apiServerViewsDELETE(HttpRequest* req, HttpResponse* resp)
   // We can't use a ZoneData object here, as the zone being removed from the
   // view may no longer exist.
   ZoneName zoneName(apiZoneIdToName(req->parameters["id"]));
+
   std::string view{req->parameters["view"]};
 
   UeberBackend backend;


### PR DESCRIPTION
### Short description
Backport of #16352.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
