### PR TITLE
lmdb: allow different mapsize values for main and shards

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -120,6 +120,23 @@ Size, in megabytes, of each LMDB database.
 This number can be increased later, but never decreased.
 Defaults to 100 on 32 bit systems, and 16000 on 64 bit systems.
 
+  .. versionchanged:: 5.1.0
+
+From version 5.1.0 onwards, this settings only applies to the main database
+file; shards use :ref:`settings-lmdb-shards-map-size` instead.
+
+.. _settings-lmdb-shards-map-size:
+
+``lmdb-shards-map-size``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+  .. versionadded:: 5.1.0
+
+Size, in megabytes, of each LMDB shard database.
+This number can be increased later, but never decreased.
+If set to zero (which is its default value), the same value as
+:ref:`settings-lmdb-map-size` will be used.
+
 .. _settings-lmdb-flag-deleted:
 
 ``lmdb-flag-deleted``

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -424,5 +424,6 @@ private:
   bool d_views;
   bool d_write_notification_update;
   DTime d_dtime; // used only for logging
-  uint64_t d_mapsize;
+  uint64_t d_mapsize_main;
+  uint64_t d_mapsize_shards;
 };


### PR DESCRIPTION
### Short description
Following a recent discussion, it _might_ be helpful in some setups to use distinct `map-size` values for the lmdb "main" and "shard" files.

This PoC PR:
- makes the existing `map-size` setting only controlling "main".
- adds a new `shards-map-size` setting controlling "shard".
- make the default value of that new setting be zero, in which case the same value as `map-size` is used.

This should make the change transparent to existing configurations, which will not need to be modified to keep working.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code (quickly)
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
