### PR TITLE
fix(dnsdist): Fix builds on aarch64

### DIFF
--- a/pdns/dnsdistdist/dnsdist-ipcrypt2.hh
+++ b/pdns/dnsdistdist/dnsdist-ipcrypt2.hh
@@ -26,7 +26,9 @@
 #include <string>
 
 #include "iputils.hh"
+#ifdef HAVE_IPCRYPT2
 #include "ipcrypt2.h"
+#endif
 
 namespace pdns::ipcrypt2
 {
@@ -55,7 +57,9 @@ public:
   [[nodiscard]] ComboAddress encrypt(const ComboAddress& address) const;
 
 private:
+#ifdef HAVE_IPCRYPT2
   std::unique_ptr<struct IPCryptPFX> d_ipcryptCtxPfx;
+#endif
   IPCryptMethod d_method;
 };
 }


### PR DESCRIPTION
### Short description

Followup to #16321, that PR was incomplete. I've tested the full build on aarch64.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
