### PR TITLE
auth dumresp: fix fd leak

### DIFF
--- a/pdns/dumresp.cc
+++ b/pdns/dumresp.cc
@@ -100,6 +100,7 @@ try
 }
 catch(const std::exception& e) {
   cerr<<"TCP connection handler got an exception: "<<e.what()<<endl;
+  close(sock);
 }
 
 static void tcpAcceptor(const ComboAddress local)


### PR DESCRIPTION
### Short description
As mentioned in #16365, if an exception is raised, a socket is leaked.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
