### PR TITLE
rec: backport 16167 to rec-5.3.x: Update the Rust library version when generating a tarball

### DIFF
--- a/pdns/recursordist/meson-dist-script.sh
+++ b/pdns/recursordist/meson-dist-script.sh
@@ -5,6 +5,11 @@ echo PWD=$(pwd)
 echo MESON_SOURCE_ROOT=$MESON_SOURCE_ROOT
 echo MESON_PROJECT_DIST_ROOT=$MESON_PROJECT_DIST_ROOT
 
+if [ -z "${BUILDER_VERSION}" ]; then
+    echo "BUILDER_VERSION is not set" >&2
+    exit 1
+fi
+
 cd "$MESON_PROJECT_DIST_ROOT"
 
 # Get all symlinks
@@ -25,6 +30,8 @@ echo Running autoreconf -vi so distfile is still usable for autotools building
 # Run autoconf for people using autotools to build, this creates a configure sc
 autoreconf -vi
 rm -rf "$MESON_PROJECT_DIST_ROOT"/autom4te.cache
+echo Updating the version of the Rust library to ${BUILDER_VERSION}
+"$MESON_SOURCE_ROOT"/../../builder-support/helpers/update-rust-library-version.py "$MESON_PROJECT_DIST_ROOT"/rec-rust-lib/rust/Cargo.toml recrust ${BUILDER_VERSION}
 
 cd "$MESON_PROJECT_BUILD_ROOT"
 

--- a/pdns/recursordist/rec-rust-lib/rust/Cargo.toml
+++ b/pdns/recursordist/rec-rust-lib/rust/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "recrust"
-# Convention: major/minor is equal to rec's major/minor
-version = "5.3.0"
 edition = "2021"
+# Convention: major/minor is equal to rec's major/minor
+# Note that this line will be automatically updated to the value
+# BUILDER_VERSION when a release tarball is built
+# See builder-support/helpers/update-rust-library-version.py
+# called from meson-dist-script.sh
+version = "5.3.0"
 
 [lib]
 name = "recrust"


### PR DESCRIPTION
Backport of #16167 

(cherry picked from commit 927320a746425547865918cc273454b10f29308f)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
