### PR TITLE
rec: backport 16188 to rec-5.3.x: Fix release builds by updating the locked Rust lib version

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.recursor
+++ b/builder-support/dockerfiles/Dockerfile.recursor
@@ -3,7 +3,7 @@ ARG BUILDER_CACHE_BUSTER=
 
 RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \
                        libtool file boost-dev curl openssl-dev ragel python3 \
-                       flex bison git bash jq meson
+                       flex bison git bash jq meson cargo
 
 COPY . /pdns-recursor
 WORKDIR /pdns-recursor

--- a/pdns/recursordist/meson-dist-script.sh
+++ b/pdns/recursordist/meson-dist-script.sh
@@ -40,6 +40,16 @@ cp -vp pubsuffix.cc "$MESON_PROJECT_DIST_ROOT"
 meson compile rec-rust-sources
 cp -vp "$MESON_SOURCE_ROOT"/rec-rust-lib/rust/src/lib.rs "$MESON_PROJECT_DIST_ROOT"/rec-rust-lib/rust/src/
 
+echo Updating the version of the Rust library to ${BUILDER_VERSION}
+"$MESON_SOURCE_ROOT"/../../builder-support/helpers/update-rust-library-version.py "$MESON_PROJECT_DIST_ROOT"/rec-rust-lib/rust/Cargo.toml recrust ${BUILDER_VERSION}
+# Update the version of the Rust library in Cargo.lock as well,
+# This needs to be done AFTER the sources of the Rust library have been generated
+# Unfortunately we cannot use --offline because for some reason cargo-update wants
+# to check all dependencies even though we are telling it exactly what to update
+cd "$MESON_PROJECT_DIST_ROOT"/rec-rust-lib/rust/
+cargo update --verbose --precise ${BUILDER_VERSION} recrust
+cd "$MESON_PROJECT_BUILD_ROOT"
+
 # Generate man pages
 meson compile man-pages
 cp -vp *.1 "$MESON_PROJECT_DIST_ROOT"


### PR DESCRIPTION
Compare #16180 for dnsdist

(cherry picked from commit 3726ae66eabe2ec0861ce2408f3fcb9c8f2cbd54)

Backport of #16188

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
