### PR TITLE
rec: backport 16155 to 5.3.x: add builder-support/helpers/update-rust-library-version.py

### DIFF
--- a/builder-support/helpers/update-rust-library-version.py
+++ b/builder-support/helpers/update-rust-library-version.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+"""Update the Rust library version in the Cargo.toml file to keep it in sync with the product version."""
+
+import shutil
+import sys
+import tempfile
+
+def main():
+    if len(sys.argv) != 4:
+        print(f'Usage: {sys.argv[0]} <path/to/Cargo.toml> <package name> <version to set>')
+        sys.exit(1)
+
+    file_name = sys.argv[1]
+    package_name = sys.argv[2]
+    version = sys.argv[3]
+
+    with tempfile.NamedTemporaryFile(mode='w+t', encoding='utf-8', delete=False) as generated_fp:
+        with open(file_name, 'r', encoding='utf-8') as cargo_file:
+            in_rust_package_section = False
+            for line in cargo_file:
+                if line.startswith('['):
+                    in_rust_package_section = False
+                elif line == f'name = "{package_name}"\n':
+                    in_rust_package_section = True
+                elif in_rust_package_section and line.startswith("version ="):
+                    generated_fp.write(f"version = \"{version}\"\n")
+                    continue
+                generated_fp.write(line)
+    shutil.move(generated_fp.name, file_name)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Partial backport of #16155

Was missing from #16380

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
