### PR TITLE
feat(dnsdist): Add OT trace for each rule

### DIFF
--- a/regression-tests.dnsdist/test_OpenTelemetryTracing.py
+++ b/regression-tests.dnsdist/test_OpenTelemetryTracing.py
@@ -117,9 +117,11 @@ class DNSDistOpenTelemetryProtobufBaseTest(DNSDistOpenTelemetryProtobufTest):
         funcs = {
             "processQuery",
             "applyRulesToQuery",
+            "Rule: Enable tracing",
             "selectBackendForOutgoingQuery",
             "processResponse",
             "applyRulesToResponse",
+            "Rule: Do PB logging",
         }
 
         if useTCP:
@@ -195,8 +197,8 @@ newServer{address="127.0.0.1:%d"}
 rl = newRemoteLogger('127.0.0.1:%d')
 setOpenTelemetryTracing(true)
 
-addAction(AllRule(), SetTraceAction(true))
-addResponseAction(AllRule(), RemoteLogResponseAction(rl))
+addAction(AllRule(), SetTraceAction(true), {name="Enable tracing"})
+addResponseAction(AllRule(), RemoteLogResponseAction(rl), {name="Do PB logging"})
 """
 
     def testBasic(self):
@@ -260,8 +262,8 @@ newServer{address="127.0.0.1:%d"}
 rl = newRemoteLogger('127.0.0.1:%d')
 setOpenTelemetryTracing(true)
 
-addAction(AllRule(), SetTraceAction(true))
-addResponseAction(AllRule(), RemoteLogResponseAction(rl, nil, false, {}, {}, true))
+addAction(AllRule(), SetTraceAction(true), {name="Enable tracing"})
+addResponseAction(AllRule(), RemoteLogResponseAction(rl, nil, false, {}, {}, true), {name="Do PB logging"})
 """
 
     def testBasic(self):


### PR DESCRIPTION
### Short description

This PR adds a Span for each rule evaluation, this'll allow operators to know what evaluations take a long time. This could be handy for e.g. LuaActions.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
