### PR TITLE
gh actions build-packages: fix pattern for the download-artifacts action and publication issues

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -343,7 +343,7 @@ jobs:
       - name: Download packages
         uses: actions/download-artifact@v4
         with:
-          pattern: "${{ inputs.product }}-${{ matrix.os }}-*-${{ matrix.architecture }}"
+          pattern: "${{ inputs.product }}-${{ matrix.os }}-${{ needs.build.outputs.version }}-${{ matrix.architecture }}"
       - name: Normalize package name
         id: normalize-name
         run: |
@@ -388,6 +388,7 @@ jobs:
   upload-src-files:
     needs: [prepare, build, provenance-src, provenance-pkgs]
     continue-on-error: true
+    if: ${{ needs.prepare.outputs.publish-packages == 'yes' }}
     name: Upload source and other files
     runs-on: ubuntu-24.04
     strategy:
@@ -413,7 +414,7 @@ jobs:
       - name: Download packages
         uses: actions/download-artifact@v4
         with:
-          pattern: "${{ inputs.product }}-${{ matrix.os }}-*-${{ matrix.architecture }}"
+          pattern: "${{ inputs.product }}-${{ matrix.os }}-${{ needs.build.outputs.version }}-${{ matrix.architecture }}"
       - name: Normalize package name
         id: normalize-name
         run: |
@@ -446,6 +447,7 @@ jobs:
     needs: [build, provenance-src, provenance-pkgs]
     name: Upload provenance files
     continue-on-error: true
+    if: ${{ needs.prepare.outputs.publish-packages == 'yes' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -465,7 +467,7 @@ jobs:
       - name: Download provenance files
         uses: actions/download-artifact@v4
         with:
-          pattern: "${{ inputs.product }}-*.intoto.jsonl"
+          pattern: "${{ inputs.product }}-${{ needs.build.outputs.version }}-*.intoto.jsonl"
       - name: Normalize package name
         id: normalize-name
         run: |


### PR DESCRIPTION
### Short description
This PR fixes the pattern used in `download-artifacts` to make it more complete. Issue found when running `build-packages-daily-releases.yml` ([here](https://github.com/PowerDNS/pdns/actions/runs/18896122375/job/53938210304#step:5:13))

In addition, there are cases where another job has published the version that was being published ([see error](https://github.com/PowerDNS/pdns/actions/runs/18798499970/job/53643796800#step:5:20)). A retry mechanism is added to avoid this.

Finally, the process of uploading files is split into two steps: uploading an artifact and creating the file object, and the internal `chunk-size` is set the same for File and DEB objects as it is for RPMs.

Test: <https://github.com/romeroalx/pdns/actions/runs/18901704327>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
