### PR TITLE
auth Lua health checks: more responsiveness

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1,17 +1,19 @@
-#include <boost/format/format_fwd.hpp>
+#include <algorithm>
+#include <condition_variable>
+#include <future>
+#include <random>
 #include <stdexcept>
 #include <thread>
-#include <future>
+#include <tuple>
+#include <utility>
+#include <variant>
 #include <boost/format.hpp>
+#include <boost/format/format_fwd.hpp>
 #include <boost/uuid/string_generator.hpp>
 #include <boost/algorithm/string/erase.hpp>
-#include <utility>
-#include <algorithm>
-#include <random>
+
 #include "misc.hh"
 #include "qtype.hh"
-#include <tuple>
-#include <variant>
 #include "version.hh"
 #include "ext/luawrapper/include/LuaContext.hpp"
 #include "lock.hh"
@@ -245,13 +247,13 @@ private:
       std::chrono::system_clock::time_point checkStart = std::chrono::system_clock::now();
       std::vector<std::future<void>> results;
       std::vector<CheckDesc> toDelete;
-      time_t interval{g_luaHealthChecksInterval};
       {
         // make sure there's no insertion
         auto statuses = d_statuses.read_lock();
         for (auto& it: *statuses) {
           auto& desc = it.first;
           auto& state = it.second;
+          time_t interval{g_luaHealthChecksInterval};
           time_t checkInterval{0};
           auto lastAccess = std::chrono::system_clock::from_time_t(state->lastAccess);
 
@@ -301,10 +303,15 @@ private:
       // set thread name again, in case std::async surprised us by doing work in this thread
       setThreadName("pdns/luaupcheck");
 
-      // Only sleep for 1 second here, even if the health check interval is
-      // larger, in case we get new entries to process in d_statuses in the
-      // meantime.
-      std::this_thread::sleep_for(std::chrono::seconds(1));
+      // Wait for at most one complete check interval, but allow an earlier
+      // wakeup in case more work is being put in d_statuses.
+      {
+        std::unique_lock<std::mutex> lock(d_mutex);
+        auto sleepTime = std::chrono::seconds(g_luaHealthChecksInterval) - (std::chrono::system_clock::now() - checkStart);
+        if (sleepTime > std::chrono::seconds::zero()) {
+          d_condvar.wait_until(lock, std::chrono::system_clock::now() + sleepTime);
+        }
+      }
     }
   }
 
@@ -313,6 +320,9 @@ private:
 
   std::unique_ptr<std::thread> d_checkerThread;
   std::atomic_flag d_checkerThreadStarted;
+
+  std::mutex d_mutex; // used with the condition variable below
+  std::condition_variable d_condvar;
 
   void setStatus(const CheckDesc& cd, bool status)
   {
@@ -387,9 +397,13 @@ int IsUpOracle::isUp(const CheckDesc& cd)
       (*statuses)[cd] = std::make_unique<CheckState>(now);
     }
   }
-  // Now that we have given it work to do, make sure the checker thread runs.
+  // Now that we have given it work to do, make sure the checker thread runs,
+  // and notify it if it had already been running.
   if (!d_checkerThreadStarted.test_and_set()) {
     d_checkerThread = std::make_unique<std::thread>([this] { return checkThread(); });
+  }
+  else {
+    d_condvar.notify_all();
   }
   // If explicitly asked to fail on incomplete checks, report this (as
   // a negative value).

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -361,9 +361,6 @@ private:
 //NOLINTNEXTLINE(readability-identifier-length)
 int IsUpOracle::isUp(const CheckDesc& cd)
 {
-  if (!d_checkerThreadStarted.test_and_set()) {
-    d_checkerThread = std::make_unique<std::thread>([this] { return checkThread(); });
-  }
   time_t now = time(nullptr);
   {
     auto statuses = d_statuses.read_lock();
@@ -386,6 +383,10 @@ int IsUpOracle::isUp(const CheckDesc& cd)
     if (statuses->find(cd) == statuses->end()) {
       (*statuses)[cd] = std::make_unique<CheckState>(now);
     }
+  }
+  // Now that we have given it work to do, make sure the checker thread runs.
+  if (!d_checkerThreadStarted.test_and_set()) {
+    d_checkerThread = std::make_unique<std::thread>([this] { return checkThread(); });
   }
   // If explicitly asked to fail on incomplete checks, report this (as
   // a negative value).

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -301,7 +301,10 @@ private:
       // set thread name again, in case std::async surprised us by doing work in this thread
       setThreadName("pdns/luaupcheck");
 
-      std::this_thread::sleep_until(checkStart + std::chrono::seconds(interval));
+      // Only sleep for 1 second here, even if the health check interval is
+      // larger, in case we get new entries to process in d_statuses in the
+      // meantime.
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     }
   }
 

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -116,12 +116,12 @@ usa-ext      IN    LUA    A   ( ";include('config')                         "
                                 "{{EUEips, USAips}}, settings)              ")
 
 usa-unreachable IN LUA    A   ( ";settings={{stringmatch='Programming in Lua', minimumFailures=2}} "
-                                "USAips={{'{prefix}.103', '192.168.42.105'}}"
+                                "USAips={{'{prefix}.103', '192.168.42.106'}}"
                                 "return ifurlup('http://www.lua.org:8080/', "
                                 "USAips, settings)                          ")
 
 usa-slowcheck IN   LUA    A   ( ";settings={{stringmatch='Programming in Lua', interval=8}} "
-                                "USAips={{'{prefix}.103', '192.168.42.105'}}"
+                                "USAips={{'{prefix}.103', '192.168.42.107'}}"
                                 "return ifurlup('http://www.lua.org:8080/', "
                                 "USAips, settings)                          ")
 
@@ -1415,7 +1415,7 @@ lua-health-checks-interval=5
         Simple ifurlup() test with minimumFailures option set.
         """
         reachable = ["{prefix}.103".format(prefix=self._PREFIX)]
-        unreachable = ["192.168.42.105"]
+        unreachable = ["192.168.42.106"]
         ips = reachable + unreachable
         all_rrs = []
         reachable_rrs = []
@@ -1435,12 +1435,12 @@ lua-health-checks-interval=5
 
         # The above request being sent at time T, the following events occur:
         # T+00: results computed using backupSelector as no data available yet
-        # T+00: checker thread starts
-        # T+02: 192.168.42.105 found down, first time, still kept up
-        # T+05: checker thread wakes up, decides to skip 192.168.42.105 check,
+        # T+00: checker thread starts (if it was not running already)
+        # T+02: 192.168.42.106 found down, first time, still kept up
+        # T+05: checker thread wakes up, decides to skip 192.168.42.106 check,
         #       as its last update time was T+02, hence no check until T+07
-        # T+10: checker thread wakes up
-        # T+12: 192.168.42.105 found down, second time, finally marked down
+        # T+10: checker thread wakes up, performs the 192.168.42.106 check
+        # T+12: 192.168.42.106 found down, second time, finally marked down
 
         # Due to minimumFailures set, there should be no error yet.
         time.sleep(5)
@@ -1462,7 +1462,7 @@ lua-health-checks-interval=5
         Simple ifurlup() test with interval option set.
         """
         reachable = ["{prefix}.103".format(prefix=self._PREFIX)]
-        unreachable = ["192.168.42.105"]
+        unreachable = ["192.168.42.107"]
         ips = reachable + unreachable
         all_rrs = []
         reachable_rrs = []


### PR DESCRIPTION
### Short description
The current state of the health check thread is to check for statuses checks to launch, every `lua-health-checks-interval` seconds.

This design has two issues:
- if the thread runs before its work list is filled, then the checks won't be started until `lua-health-checks-interval` seconds, which will be noticeable if this value is large (as noticed in #16369).
- processing Lua records causing new health checks to be started won't cause them to be noticed and work on until the thread wakes up from its `lua-health-checks-interval` seconds sleep.

This PR attempts to address this in two commits:
- the checker thread was always being started (if not running already) before adding checks to its work list, creating a race where the thread could run, notice its list of checks is empty, and go to sleep, after which its check job is immediately added.
- because further check requests can occur at any time, let it wake up every second to check for more work to do.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
