### PR TITLE
rec: don't use a vector of string for internal pubsuffixlist

### DIFF
--- a/pdns/recursordist/mkpubsuffixcc
+++ b/pdns/recursordist/mkpubsuffixcc
@@ -10,9 +10,9 @@ trap "rm -f $temp" 0 1 2 3 15
 set -e
 curl -o $temp -s -S https://publicsuffix.org/list/public_suffix_list.dat
 (echo "#include \"pubsuffix.hh\""
- echo "const std::vector<std::string> g_pubsuffix = {";
+ echo "const std::string g_pubsuffix = ";
 	for a in $(grep -v "//" "$temp" | grep \\. | egrep "^[.0-9a-z-]*$")
 	do
-		echo \"$a\",
+		echo \"$a\\\\n\"
 	done
-echo "};") > "$1"
+echo ";") > "$1"

--- a/pdns/recursordist/pubsuffix.hh
+++ b/pdns/recursordist/pubsuffix.hh
@@ -25,7 +25,7 @@
 #include <vector>
 
 extern std::vector<std::vector<std::string>> g_pubs;
-extern const std::vector<std::string> g_pubsuffix;
+extern const std::string g_pubsuffix;
 
 /* initialize the g_pubs variable with the public suffix list,
    using the file passed in parameter if any, or the built-in


### PR DESCRIPTION
The construct

`std::vector<std::string> x  { not even that many string literals };`

blows up with some compilers. Worst I have seen is (with not even 8k strings): g++12 develops a resident size of 26G.

This just creates a (blank line and comments stripped) in-memory version of the file that is fed to the same code as an external file.

Problem noted by @wojas.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
