### PR TITLE
dnsdist: Backport 16392 to dnsdist-2.0.x: Make version number in rust lib confirm to Rust specifics

### DIFF
--- a/builder-support/helpers/update-rust-library-version.py
+++ b/builder-support/helpers/update-rust-library-version.py
@@ -15,7 +15,7 @@ def main():
     package_name = sys.argv[2]
     version = sys.argv[3]
 
-    # convert the serial so that it conforms to Rust rules: x.x.x-whatever
+    # convert the version so that it conforms to Rust rules: x.x.x-whatever
     version = re.sub(r'([0-9]+\.[0-9]+\.[0-9]+)\.', r'\1-', version)
     with tempfile.NamedTemporaryFile(mode='w+t', encoding='utf-8', delete=False) as generated_fp:
         with open(file_name, 'r', encoding='utf-8') as cargo_file:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #16392

You can see the failure in https://github.com/PowerDNS/pdns/actions/runs/18928845190 (rec is fixed in the meantime).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
