### PR TITLE
auth meson: reset binary names to original

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -130,7 +130,7 @@ jobs:
           echo "normalized-branch-name=$BRANCH_NAME" | tr "/" "-" >> "$GITHUB_ENV"
           mkdir -p /opt/pdns-auth/bin
           for i in $(find . -maxdepth 1 -type f -executable); do cp ${i} /opt/pdns-auth/bin/; done
-          mkdir -p /opt/pdns-auth/sbin; mv /opt/pdns-auth/bin/pdns-auth /opt/pdns-auth/sbin/
+          mkdir -p /opt/pdns-auth/sbin; mv /opt/pdns-auth/bin/pdns_server /opt/pdns-auth/sbin/
       - if: ${{ matrix.builder == 'meson' }}
         name: Store the binaries
         uses: actions/upload-artifact@v5 # this takes 30 seconds, maybe we want to tar
@@ -389,7 +389,7 @@ jobs:
       - run: ${{ env.INV_CMD }} install-clang-runtime
       - run: ${{ env.INV_CMD }} install-auth-test-deps -b ${{ matrix.backend }}
       - run: ${{ env.INV_CMD }} test-api auth -b ${{ matrix.backend }}
-      - run: ${{ env.INV_CMD }} generate-coverage-info /opt/pdns-auth/sbin/pdns-auth 'auth' $GITHUB_WORKSPACE
+      - run: ${{ env.INV_CMD }} generate-coverage-info /opt/pdns-auth/sbin/pdns_server 'auth' $GITHUB_WORKSPACE
         if: ${{ env.COVERAGE == 'yes' }}
       - name: Coveralls Parallel auth API ${{ matrix.backend }}
         if: ${{ env.COVERAGE == 'yes' }}
@@ -522,7 +522,7 @@ jobs:
       - run: ${{ env.INV_CMD }} install-clang-runtime
       - run: ${{ env.INV_CMD }} install-auth-test-deps -b ${{ matrix.backend }}
       - run: ${{ env.INV_CMD }} test-auth-backend -b ${{ matrix.backend }}
-      - run: ${{ env.INV_CMD }} generate-coverage-info /opt/pdns-auth/sbin/pdns-auth 'auth' $GITHUB_WORKSPACE
+      - run: ${{ env.INV_CMD }} generate-coverage-info /opt/pdns-auth/sbin/pdns_server 'auth' $GITHUB_WORKSPACE
         if: ${{ env.COVERAGE == 'yes' }}
       - name: Coveralls Parallel auth backend ${{ matrix.backend }}
         if: ${{ env.COVERAGE == 'yes' }}

--- a/auth/systemd/pdns.service.in
+++ b/auth/systemd/pdns.service.in
@@ -1,13 +1,13 @@
 [Unit]
 Description=@Description@
-Documentation=man:pdns-auth(1)
-Documentation=man:pdns-auth-control(1)
+Documentation=man:pdns_server(1)
+Documentation=man:pdns_control(1)
 Documentation=https://doc.powerdns.com
 Wants=network-online.target
 After=network-online.target mysql.service mysqld.service postgresql.service slapd.service mariadb.service time-sync.target
 
 [Service]
-ExecStart=@StaticBinDir@/pdns-auth @ConfigName@ @SocketDir@ --guardian=no --daemon=no --disable-syslog --log-timestamp=no --write-pid=no
+ExecStart=@StaticBinDir@/pdns_server @ConfigName@ @SocketDir@ --guardian=no --daemon=no --disable-syslog --log-timestamp=no --write-pid=no
 SyslogIdentifier=@SyslogIdentifier@
 User=@ServiceUser@
 Group=@ServiceGroup@

--- a/meson.build
+++ b/meson.build
@@ -231,13 +231,13 @@ if dep_systemd_prog.found()
   auth_service_conf_general.merge_from(auth_service_conf)
   auth_service_conf_general.set('Description', 'PowerDNS Authoritative Server')
   auth_service_conf_general.set('ConfigName', '')
-  auth_service_conf_general.set('SocketDir', enable_socket_dir ? '--socket-dir=%t/pdns-auth' : '')
-  auth_service_conf_general.set('SyslogIdentifier', 'pdns-auth')
-  auth_service_conf_general.set('RuntimeDirectory', 'pdns-auth')
+  auth_service_conf_general.set('SocketDir', enable_socket_dir ? '--socket-dir=%t/pdns' : '')
+  auth_service_conf_general.set('SyslogIdentifier', 'pdns')
+  auth_service_conf_general.set('RuntimeDirectory', 'pdns')
 
   configure_file(
-    input: 'auth' / 'systemd' / 'pdns-auth.service.in',
-    output: 'pdns-auth.service',
+    input: 'auth' / 'systemd' / 'pdns.service.in',
+    output: 'pdns.service',
     configuration: auth_service_conf_general,
   )
 
@@ -245,13 +245,13 @@ if dep_systemd_prog.found()
   auth_service_conf_instance.merge_from(auth_service_conf)
   auth_service_conf_instance.set('Description', 'PowerDNS Authoritative Server %i')
   auth_service_conf_instance.set('ConfigName', '--config-name=%i')
-  auth_service_conf_instance.set('SocketDir', enable_socket_dir ? '--socket-dir=%t/pdns-auth-%i' : '')
-  auth_service_conf_instance.set('SyslogIdentifier', 'pdns-auth-%i')
-  auth_service_conf_instance.set('RuntimeDirectory', have_systemd_percent_t ? 'pdns-auth-%i' : 'pdns-auth')
+  auth_service_conf_instance.set('SocketDir', enable_socket_dir ? '--socket-dir=%t/pdns-%i' : '')
+  auth_service_conf_instance.set('SyslogIdentifier', 'pdns-%i')
+  auth_service_conf_instance.set('RuntimeDirectory', have_systemd_percent_t ? 'pdns-%i' : 'pdns')
 
   configure_file(
-    input: 'auth' / 'systemd' / 'pdns-auth.service.in',
-    output: 'pdns-auth@.service',
+    input: 'auth' / 'systemd' / 'pdns.service.in',
+    output: 'pdns@.service',
     configuration: auth_service_conf_instance,
   )
 
@@ -672,7 +672,7 @@ subdir('modules')
 config_h = configure_file(configuration: conf, output: 'config.h')
 
 tools = {
-  'pdns-auth': {
+  'pdns_server': {
     'main': src_dir / 'auth-main.cc',
     'export-dynamic': true,
     'deps-extra': [
@@ -684,7 +684,7 @@ tools = {
     ],
     'manpages': ['pdns_server.1'],
   },
-  'pdns-auth-util': {
+  'pdnsutil': {
     'main': src_dir / 'pdnsutil.cc',
     'export-dynamic': true,
     'files-extra': libpdns_bind_dnssec_schema_gen,
@@ -696,15 +696,15 @@ tools = {
     ],
     'manpages': ['pdnsutil.1'],
   },
-  'pdns-auth-control': {
+  'pdns_control': {
     'main': src_dir / 'dynloader.cc',
     'manpages': ['pdns_control.1'],
   },
-  'pdns-zone2sql': {
+  'zone2sql': {
     'main': src_dir / 'zone2sql.cc',
     'manpages': ['zone2sql.1'],
   },
-  'pdns-zone2json': {
+  'zone2json': {
     'main': src_dir / 'zone2json.cc',
     'manpages': ['zone2json.1'],
   },
@@ -712,7 +712,7 @@ tools = {
 
 if get_option('module-ldap') != 'disabled'
   tools += {
-    'pdns-zone2ldap': {
+    'zone2ldap': {
       'main': src_dir / 'zone2ldap.cc',
       'manpages': ['zone2ldap.1'],
     }
@@ -721,7 +721,7 @@ endif
 
 if get_option('tools')
   tools += {
-    'pdns-auth-notify': {
+    'pdns_notify': {
       'main': src_dir / 'notify.cc',
       'manpages': ['pdns_notify.1'],
     },
@@ -1137,7 +1137,7 @@ if get_option('unit-tests-backends')
         env: {'PDNS_BUILD_PATH': meson.build_root()},
         args: ['5300', module],
         workdir: product_source_dir / 'regression-tests',
-        depends: [pdns_auth, pdns_auth_util, sdig, saxfr, pdns_auth_notify, nsec3dig],
+        depends: [pdns_server, pdnsutil, sdig, saxfr, pdns_notify, nsec3dig],
         is_parallel: false,
       )
     endif

--- a/regression-tests.auth-py/runtests
+++ b/regression-tests.auth-py/runtests
@@ -15,18 +15,12 @@ mkdir -p configs
 
 if [ -z "$PDNS_BUILD_PATH" ]; then
   # PDNS_BUILD_PATH is unset or empty. Assume an autotools build.
-  PDNS_BUILD_PATH=.
-
-  export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
-  export PDNSUTIL=${PDNSUTIL:-${PWD}/../pdns/pdnsutil}
-  export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
-  export PDNS_MODULE_DIR=${PDNS_MODULE_DIR:-${PWD}/modules}
-else
-  export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns-auth}
-  export PDNSUTIL=${PDNSUTIL:-$PDNS_BUILD_PATH/pdns-auth-util}
-  export PDNSCONTROL=${PDNSCONTROL:-$PDNS_BUILD_PATH/pdns-auth-control}
-  export PDNS_MODULE_DIR=${PDNS_MODULE_DIR:-$PDNS_BUILD_PATH/modules}
+  PDNS_BUILD_PATH=${PWD}/..
 fi
+export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns_server}
+export PDNSUTIL=${PDNSUTIL:-$PDNS_BUILD_PATH/pdnsutil}
+export PDNSCONTROL=${PDNSCONTROL:-$PDNS_BUILD_PATH/pdns_control}
+export PDNS_MODULE_DIR=${PDNS_MODULE_DIR:-$PDNS_BUILD_PATH/modules}
 
 export PREFIX=127.0.0
 

--- a/regression-tests/README.md
+++ b/regression-tests/README.md
@@ -45,7 +45,7 @@ compatible XML report.
 
 If you used meson to build, export `PDNS_BUILD_PATH` and point it to your
 build directory. Also make sure you configured with `-Dtools=true`, and have
-built `pdns-auth`, `pdns-auth-util`, `zone2sql` and `sdig`.
+built `pdns_server`, `pdnsutil`, `zone2sql` and `sdig`.
 Example for invoking the tests:
 
 ```sh

--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -9,36 +9,22 @@ MAKE=${MAKE:-make}
 
 if [ -z "$PDNS_BUILD_PATH" ]; then
   # PDNS_BUILD_PATH is unset or empty. Assume an autotools build.
-  PDNS_BUILD_PATH=.
-
-  export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
-  export PDNS2=${PDNS2:-${PWD}/../pdns/pdns_server}
-  export PDNSRECURSOR=${PDNSRECURSOR:-${PWD}/../pdns/recursordist/pdns_recursor}
-  export RECCONTROL=${RECCONTROL:-${PWD}/../pdns/recursordist/rec_control}
-  export SDIG=${SDIG:-${PWD}/../pdns/sdig}
-  export NOTIFY=${NOTIFY:-${PWD}/../pdns/pdns_notify}
-  export NSEC3DIG=${NSEC3DIG:-${PWD}/../pdns/nsec3dig}
-  export SAXFR=${SAXFR:-${PWD}/../pdns/saxfr}
-  export ZONE2SQL=${ZONE2SQL:-${PWD}/../pdns/zone2sql}
-  export ZONE2JSON=${ZONE2JSON:-${PWD}/../pdns/zone2json}
-  export ZONE2LDAP=${ZONE2LDAP:-${PWD}/../pdns/zone2ldap}
-  export PDNSUTIL=${PDNSUTIL:-${PWD}/../pdns/pdnsutil}
-  export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
-else
-  export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns-auth}
-  export PDNS2=${PDNS2:-$PDNS_BUILD_PATH/pdns-auth}
-  export PDNSRECURSOR=${PDNSRECURSOR:-$PDNS_BUILD_PATH/pdns/recursordist/pdns_recursor}
-  export RECCONTROL=${RECCONTROL:-$PDNS_BUILD_PATH/pdns/recursordist/rec_control}
-  export SDIG=${SDIG:-$PDNS_BUILD_PATH/sdig}
-  export NOTIFY=${NOTIFY:-$PDNS_BUILD_PATH/pdns-auth-notify}
-  export NSEC3DIG=${NSEC3DIG:-$PDNS_BUILD_PATH/nsec3dig}
-  export SAXFR=${SAXFR:-$PDNS_BUILD_PATH/saxfr}
-  export ZONE2SQL=${ZONE2SQL:-$PDNS_BUILD_PATH/pdns-zone2sql}
-  export ZONE2JSON=${ZONE2JSON:-$PDNS_BUILD_PATH/pdns-zone2json}
-  export ZONE2LDAP=${ZONE2LDAP:-$PDNS_BUILD_PATH/pdns-zone2ldap}
-  export PDNSUTIL=${PDNSUTIL:-$PDNS_BUILD_PATH/pdns-auth-util}
-  export PDNSCONTROL=${PDNSCONTROL:-$PDNS_BUILD_PATH/pdns-auth-control}
+  PDNS_BUILD_PATH=${PWD}/..
 fi
+
+export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns_server}
+export PDNS2=${PDNS2:-$PDNS_BUILD_PATH/pdns_server}
+export PDNSRECURSOR=${PDNSRECURSOR:-$PDNS_BUILD_PATH/pdns/recursordist/pdns_recursor}
+export RECCONTROL=${RECCONTROL:-$PDNS_BUILD_PATH/pdns/recursordist/rec_control}
+export SDIG=${SDIG:-$PDNS_BUILD_PATH/sdig}
+export NOTIFY=${NOTIFY:-$PDNS_BUILD_PATH/pdns_notify}
+export NSEC3DIG=${NSEC3DIG:-$PDNS_BUILD_PATH/nsec3dig}
+export SAXFR=${SAXFR:-$PDNS_BUILD_PATH/saxfr}
+export ZONE2SQL=${ZONE2SQL:-$PDNS_BUILD_PATH/zone2sql}
+export ZONE2JSON=${ZONE2JSON:-$PDNS_BUILD_PATH/zone2json}
+export ZONE2LDAP=${ZONE2LDAP:-$PDNS_BUILD_PATH/zone2ldap}
+export PDNSUTIL=${PDNSUTIL:-$PDNS_BUILD_PATH/pdnsutil}
+export PDNSCONTROL=${PDNSCONTROL:-$PDNS_BUILD_PATH/pdns_control}
 
 unset _JAVA_OPTIONS
 

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -6,36 +6,22 @@ fi
 
 if [ -z "$PDNS_BUILD_PATH" ]; then
   # PDNS_BUILD_PATH is unset or empty. Assume an autotools build.
-  PDNS_BUILD_PATH=.
-
-  export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
-  export PDNS2=${PDNS2:-${PWD}/../pdns/pdns_server}
-  export PDNSRECURSOR=${PDNSRECURSOR:-${PWD}/../pdns/recursordist/pdns_recursor}
-  export RECCONTROL=${RECCONTROL:-${PWD}/../pdns/recursordist/rec_control}
-  export SDIG=${SDIG:-${PWD}/../pdns/sdig}
-  export NOTIFY=${NOTIFY:-${PWD}/../pdns/pdns_notify}
-  export NSEC3DIG=${NSEC3DIG:-${PWD}/../pdns/nsec3dig}
-  export SAXFR=${SAXFR:-${PWD}/../pdns/saxfr}
-  export ZONE2SQL=${ZONE2SQL:-${PWD}/../pdns/zone2sql}
-  export ZONE2LDAP=${ZONE2LDAP:-${PWD}/../pdns/zone2ldap}
-  export ZONE2JSON=${ZONE2JSON:-${PWD}/../pdns/zone2json}
-  export PDNSUTIL=${PDNSUTIL:-${PWD}/../pdns/pdnsutil}
-  export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
-else
-  export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns-auth}
-  export PDNS2=${PDNS2:-$PDNS_BUILD_PATH/pdns-auth}
-  export PDNSRECURSOR=${PDNSRECURSOR:-$PDNS_BUILD_PATH/pdns/recursordist/pdns_recursor}
-  export RECCONTROL=${RECCONTROL:-$PDNS_BUILD_PATH/pdns/recursordist/rec_control}
-  export SDIG=${SDIG:-$PDNS_BUILD_PATH/sdig}
-  export NOTIFY=${NOTIFY:-$PDNS_BUILD_PATH/pdns-auth-notify}
-  export NSEC3DIG=${NSEC3DIG:-$PDNS_BUILD_PATH/nsec3dig}
-  export SAXFR=${SAXFR:-$PDNS_BUILD_PATH/saxfr}
-  export ZONE2SQL=${ZONE2SQL:-$PDNS_BUILD_PATH/pdns-zone2sql}
-  export ZONE2JSON=${ZONE2JSON:-$PDNS_BUILD_PATH/pdns-zone2json}
-  export ZONE2LDAP=${ZONE2LDAP:-$PDNS_BUILD_PATH/pdns-zone2ldap}
-  export PDNSUTIL=${PDNSUTIL:-$PDNS_BUILD_PATH/pdns-auth-util}
-  export PDNSCONTROL=${PDNSCONTROL:-$PDNS_BUILD_PATH/pdns-auth-control}
+  PDNS_BUILD_PATH=${PWD}/..
 fi
+
+export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns_server}
+export PDNS2=${PDNS2:-$PDNS_BUILD_PATH/pdns_server}
+export PDNSRECURSOR=${PDNSRECURSOR:-$PDNS_BUILD_PATH/pdns/recursordist/pdns_recursor}
+export RECCONTROL=${RECCONTROL:-$PDNS_BUILD_PATH/pdns/recursordist/rec_control}
+export SDIG=${SDIG:-$PDNS_BUILD_PATH/sdig}
+export NOTIFY=${NOTIFY:-$PDNS_BUILD_PATH/pdns_notify}
+export NSEC3DIG=${NSEC3DIG:-$PDNS_BUILD_PATH/nsec3dig}
+export SAXFR=${SAXFR:-$PDNS_BUILD_PATH/saxfr}
+export ZONE2SQL=${ZONE2SQL:-$PDNS_BUILD_PATH/zone2sql}
+export ZONE2JSON=${ZONE2JSON:-$PDNS_BUILD_PATH/zone2json}
+export ZONE2LDAP=${ZONE2LDAP:-$PDNS_BUILD_PATH/zone2ldap}
+export PDNSUTIL=${PDNSUTIL:-$PDNS_BUILD_PATH/pdnsutil}
+export PDNSCONTROL=${PDNSCONTROL:-$PDNS_BUILD_PATH/pdns_control}
 
 export RESOLVERIP=${RESOLVERIP:-8.8.8.8}
 export FIX_TESTS=${FIX_TESTS:-NO}

--- a/tasks.py
+++ b/tasks.py
@@ -1010,7 +1010,7 @@ def test_api(c, product, backend=''):
             c.run(f'PDNSRECURSOR=/opt/pdns-recursor/sbin/pdns_recursor ./runtests recursor {backend}')
     elif product == 'auth':
         with c.cd('regression-tests.api'):
-            c.run(f'PDNSSERVER=/opt/pdns-auth/sbin/pdns-auth PDNSUTIL=/opt/pdns-auth/bin/pdns-auth-util SDIG=/opt/pdns-auth/bin/sdig MYSQL_HOST={auth_backend_ip_addr} PGHOST={auth_backend_ip_addr} PGPORT=5432 ./runtests authoritative {backend}')
+            c.run(f'PDNSSERVER=/opt/pdns-auth/sbin/pdns_server PDNSUTIL=/opt/pdns-auth/bin/pdnsutil SDIG=/opt/pdns-auth/bin/sdig MYSQL_HOST={auth_backend_ip_addr} PGHOST={auth_backend_ip_addr} PGPORT=5432 ./runtests authoritative {backend}')
     else:
         raise Failure('unknown product')
 
@@ -1159,7 +1159,7 @@ def setup_softhsm(c):
 
 @task
 def test_auth_backend(c, backend):
-    pdns_auth_env_vars = f'PDNS=/opt/pdns-auth/sbin/pdns-auth PDNS2=/opt/pdns-auth/sbin/pdns-auth SDIG=/opt/pdns-auth/bin/sdig NOTIFY=/opt/pdns-auth/bin/pdns-auth-notify NSEC3DIG=/opt/pdns-auth/bin/nsec3dig SAXFR=/opt/pdns-auth/bin/saxfr ZONE2SQL=/opt/pdns-auth/bin/pdns-zone2sql ZONE2LDAP=/opt/pdns-auth/bin/pdns-zone2ldap ZONE2JSON=/opt/pdns-auth/bin/pdns-zone2json PDNSUTIL=/opt/pdns-auth/bin/pdns-auth-util PDNSCONTROL=/opt/pdns-auth/bin/pdns-auth-control PDNSSERVER=/opt/pdns-auth/sbin/pdns-auth SDIG=/opt/pdns-auth/bin/sdig GMYSQLHOST={auth_backend_ip_addr} GMYSQL2HOST={auth_backend_ip_addr} MYSQL_HOST={auth_backend_ip_addr} PGHOST={auth_backend_ip_addr} PGPORT=5432'
+    pdns_auth_env_vars = f'PDNS=/opt/pdns-auth/sbin/pdns_server PDNS2=/opt/pdns-auth/sbin/pdns_server SDIG=/opt/pdns-auth/bin/sdig NOTIFY=/opt/pdns-auth/bin/pdns_notify NSEC3DIG=/opt/pdns-auth/bin/nsec3dig SAXFR=/opt/pdns-auth/bin/saxfr ZONE2SQL=/opt/pdns-auth/bin/zone2sql ZONE2LDAP=/opt/pdns-auth/bin/zone2ldap ZONE2JSON=/opt/pdns-auth/bin/zone2json PDNSUTIL=/opt/pdns-auth/bin/pdnsutil PDNSCONTROL=/opt/pdns-auth/bin/pdns_control PDNSSERVER=/opt/pdns-auth/sbin/pdns_server SDIG=/opt/pdns-auth/bin/sdig GMYSQLHOST={auth_backend_ip_addr} GMYSQL2HOST={auth_backend_ip_addr} MYSQL_HOST={auth_backend_ip_addr} PGHOST={auth_backend_ip_addr} PGPORT=5432'
     backend_env_vars = ''
 
     if backend == 'remote':
@@ -1206,7 +1206,7 @@ def test_auth_backend(c, backend):
             pdns_auth_env_vars += ' context=noipv6'
         with c.cd('regression-tests.nobackend'):
             c.run(f'{pdns_auth_env_vars} ./runtests')
-        c.run('/opt/pdns-auth/bin/pdns-auth-util test-algorithms')
+        c.run('/opt/pdns-auth/bin/pdnsutil test-algorithms')
         return
 
 @task


### PR DESCRIPTION
### Short description
in draft until tests pass. Will probably squash then.

There is a lot of repetition in this patch, because there is a lot of repetition in test scripts for finding the binaries. Some refactoring seems obvious, but this PR is simple on purpose so we can backport it to `rel/auth-5.0.x`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
