### PR TITLE
auth-backend tests: make more diskspace on the github runner

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -409,7 +409,7 @@ jobs:
         LDAPHOST: ldap://ldapserver/
         ODBCINI: /github/home/.odbc.ini
         AUTH_BACKEND_IP_ADDR: "172.17.0.1"
-      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0 -v /:/hostroot
     strategy:
       matrix:
         include:
@@ -513,6 +513,7 @@ jobs:
         run: |
           python3 -m venv ${REPO_HOME}/.venv
           . ${REPO_HOME}/.venv/bin/activate && pip install -r ${REPO_HOME}/meson/requirements.txt
+      - run: ${{ env.INV_CMD }} github-more-diskspace
       - run: ${{ env.INV_CMD }} install-clang-runtime
       - run: ${{ env.INV_CMD }} install-auth-test-deps -b ${{ matrix.backend }}
       - run: ${{ env.INV_CMD }} test-auth-backend -b ${{ matrix.backend }}

--- a/tasks.py
+++ b/tasks.py
@@ -1487,6 +1487,16 @@ RUN apt-get update && apt-get install -y {package_name}={package_version}*
 
     c.run(f'docker build . -t test-build-{product_name}-{distro_release}:latest -f /tmp/Dockerfile')
 
+@task
+def github_more_diskspace(c):
+    c.run('df -h / /hostroot')
+    for path in ['/usr/local/lib/android',
+              '/usr/local/.ghcup',
+              '/usr/share/dotnet',
+              '/usr/share/swift']:
+              c.sudo(f'rm -rf {path} /hostroot{path}')
+    c.run('df -h / /hostroot')
+
 # this is run always
 def setup():
     if '/usr/lib/ccache' not in os.environ['PATH']:


### PR DESCRIPTION
### Short description
There are two parts to this:

* expose the host root to the container
* cleanup from tasks.py

The method is small, and thus easy to copy to other runs that need it.
If we teach our pdns-ci image about it, perhaps the inv call could even go away (we'd just need the mountpoint then) but I'm not sure that is worth the complexity.

The path dir in tasks.py can likely be expanded.
Finding more candidates is easy with https://github.com/Habbie/github-runner-diskspace/

The tasks.py task tries to clean up both in `/` and `/hostroot`. I did not actually test it outside of Docker.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
