### PR TITLE
fix(protozero): Always initialize SpanID and TraceID to zero

### DIFF
--- a/pdns/protozero-trace.hh
+++ b/pdns/protozero-trace.hh
@@ -231,7 +231,7 @@ struct InstrumentationScope
 
 struct TraceID : public std::array<uint8_t, 16>
 {
-  TraceID() :
+  constexpr TraceID() :
     array{} {};
   TraceID(const std::initializer_list<uint8_t>& arg) :
     array{}
@@ -262,11 +262,11 @@ struct TraceID : public std::array<uint8_t, 16>
     this->fill(0);
   }
 };
-const TraceID s_emptyTraceID = {};
+constexpr TraceID s_emptyTraceID = {};
 
 struct SpanID : public std::array<uint8_t, 8>
 {
-  SpanID() :
+  constexpr SpanID() :
     array{} {};
   SpanID(const std::initializer_list<uint8_t>& arg) :
     array{}
@@ -297,7 +297,7 @@ struct SpanID : public std::array<uint8_t, 8>
     this->fill(0);
   }
 };
-const SpanID s_emptySpanID = {};
+constexpr SpanID s_emptySpanID = {};
 
 inline void fill(TraceID& trace, const std::string& data)
 {


### PR DESCRIPTION
### Short description

Should fix CID-493276 and CID-493277.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
