### PR TITLE
dead code tells no tales

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -300,20 +300,6 @@ private:
     state->weight = weight;
   }
 
-  void setDown(const ComboAddress& rem, const std::string& url=std::string(), const opts_t& opts = opts_t())
-  {
-    //NOLINTNEXTLINE(readability-identifier-length)
-    CheckDesc cd{rem, url, opts};
-    setStatus(cd, false);
-  }
-
-  void setUp(const ComboAddress& rem, const std::string& url=std::string(), const opts_t& opts = opts_t())
-  {
-    CheckDesc cd{rem, url, opts};
-
-    setStatus(cd, true);
-  }
-
   void setDown(const CheckDesc& cd)
   {
     setStatus(cd, false);


### PR DESCRIPTION
### Short description
Found out the Lua checker changes in 5.0 had made these two routines dead weight.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
