### PR TITLE
chores(dnsdist): Replace '%s' with '%d' when formatting integers in our tests

### DIFF
--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -20,8 +20,8 @@ class APITestsBase(DNSDistTest):
     _config_params = ['_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setACL({"127.0.0.1/32", "::1/128"})
-    newServer{address="127.0.0.1:%s", pool={'', 'mypool'}}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", pool={'', 'mypool'}}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
     _expectedMetrics = ['responses', 'servfail-responses', 'queries', 'acl-drops',
@@ -410,9 +410,9 @@ class TestAPIServerDown(APITestsBase):
     __test__ = True
     _config_template = """
     setACL({"127.0.0.1/32", "::1/128"})
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     getServer(0):setDown()
-    webserver("127.0.0.1:%s")
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -512,10 +512,10 @@ class TestAPICustomHeaders(APITestsBase):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     setACL({"127.0.0.1/32", "::1/128"})
-    newServer({address="127.0.0.1:%s"})
-    webserver("127.0.0.1:%s")
+    newServer({address="127.0.0.1:%d"})
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s", customHeaders={["X-Frame-Options"]="", ["X-Custom"]="custom"} })
     """
 
@@ -557,10 +557,10 @@ class TestStatsWithoutAuthentication(APITestsBase):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     setACL({"127.0.0.1/32", "::1/128"})
-    newServer({address="127.0.0.1:%s"})
-    webserver("127.0.0.1:%s")
+    newServer({address="127.0.0.1:%d"})
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s", statsRequireAuthentication=false })
     """
 
@@ -614,10 +614,10 @@ class TestAPIAuth(APITestsBase):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     setACL({"127.0.0.1/32", "::1/128"})
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -681,10 +681,10 @@ class TestAPIACL(APITestsBase):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     setACL({"127.0.0.1/32", "::1/128"})
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s", acl="192.0.2.1"})
     """
 
@@ -715,8 +715,8 @@ class TestAPIWithoutAuthentication(APITestsBase):
     _config_params = ['_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed']
     _config_template = """
     setACL({"127.0.0.1/32", "::1/128"})
-    newServer({address="127.0.0.1:%s"})
-    webserver("127.0.0.1:%s")
+    newServer({address="127.0.0.1:%d"})
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiRequiresAuthentication=false })
     """
 
@@ -771,8 +771,8 @@ class TestCustomLuaEndpoint(APITestsBase):
     __test__ = True
     _config_template = """
     setACL({"127.0.0.1/32", "::1/128"})
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s"})
 
     function customHTTPHandler(req, resp)
@@ -829,8 +829,8 @@ class TestWebConcurrentConnections(APITestsBase):
 
     _config_params = ['_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed', '_maxConns']
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s", maxConcurrentConnections=%d})
     """
 
@@ -874,8 +874,8 @@ class TestAPICustomStatistics(APITestsBase):
 
     _config_params = ['_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     declareMetric("my-custom-metric", "counter", "Number of statistics")
     declareMetric("my-other-metric", "counter", "Another number of statistics")
     declareMetric("my-gauge", "gauge", "Current memory usage")

--- a/regression-tests.dnsdist/test_AXFR.py
+++ b/regression-tests.dnsdist/test_AXFR.py
@@ -12,7 +12,7 @@ class TestAXFR(DNSDistTest):
     # to mix things up.
     _testServerPort = pickAvailablePort()
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     @classmethod

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -12,7 +12,7 @@ class TestAdvancedFixupCase(DNSDistTest):
     _config_template = """
     truncateTC(true)
     fixupCase(true)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedFixupCase(self):
@@ -48,7 +48,7 @@ class TestAdvancedFixupCase(DNSDistTest):
 class TestAdvancedACL(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
     _acl = ['192.0.2.1/32']
 
@@ -71,7 +71,7 @@ class TestAdvancedACL(DNSDistTest):
 class TestAdvancedStringOnlyServer(DNSDistTest):
 
     _config_template = """
-    newServer("127.0.0.1:%s")
+    newServer("127.0.0.1:%d")
     """
 
     def testAdvancedStringOnlyServer(self):
@@ -103,7 +103,7 @@ class TestAdvancedIncludeDir(DNSDistTest):
     _config_template = """
     -- this directory contains a file allowing includedir.advanced.tests.powerdns.com.
     includeDirectory('test-include-dir')
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedIncludeDirAllowed(self):
@@ -148,8 +148,8 @@ class TestStatNodeRespRingSince(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
-    s1 = newServer{address="127.0.0.1:%s"}
+    controlSocket("127.0.0.1:%d")
+    s1 = newServer{address="127.0.0.1:%d"}
     s1:setUp()
     function visitor(node, self, childstat)
         table.insert(nodesSeen, node.fullname)
@@ -234,7 +234,7 @@ class TestAdvancedGetLocalPort(DNSDistTest):
       return DNSAction.Spoof, "port-was-"..port..".local-port.advanced.tests.powerdns.com."
     end
     addAction("local-port.advanced.tests.powerdns.com.", LuaAction(answerBasedOnLocalPort))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedGetLocalPort(self):
@@ -304,7 +304,7 @@ class TestAdvancedGetLocalAddressOnAnyBind(DNSDistTest):
       return DNSAction.Spoof, "address-was-"..dashAddr..".local-address-any.advanced.tests.powerdns.com."
     end
     addAction("local-address-any.advanced.tests.powerdns.com.", LuaAction(answerBasedOnLocalAddress))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addLocal('0.0.0.0:%d')
     addLocal('[::]:%d')
     """
@@ -423,7 +423,7 @@ class TestAdvancedGetLocalAddressOnNonDefaultLoopbackBind(DNSDistTest):
     # address, so we exercise a different code path when we bind on a different address
     # than the default 127.0.0.1 one
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addLocal('127.0.1.19:%d')
     """
     _config_params = ['_testServerPort', '_dnsDistPort']
@@ -469,7 +469,7 @@ class TestAdvancedGetLocalAddressOnNonDefaultLoopbackBind(DNSDistTest):
 class TestAdvancedAllowHeaderOnly(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     setAllowEmptyResponse(true)
     """
 
@@ -530,7 +530,7 @@ class TestAdvancedDropEmptyQueries(DNSDistTest):
 
     _config_template = """
     setDropEmptyQueries(true)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedDropEmptyQueries(self):
@@ -563,7 +563,7 @@ class TestProtocols(DNSDistTest):
 
     addAction("udp.protocols.advanced.tests.powerdns.com.", LuaAction(checkUDP))
     addAction("tcp.protocols.advanced.tests.powerdns.com.", LuaAction(checkTCP))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testProtocolUDP(self):
@@ -617,7 +617,7 @@ class TestCustomMetrics(DNSDistTest):
     declareMetric("my-custom-gauge", "gauge", "Temperature of the tests")
     addAction("declare.metric.advanced.tests.powerdns.com.", LuaAction(declareNewMetric))
     addAction("operations.metric.advanced.tests.powerdns.com.", LuaAction(custommetrics))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDeclareAfterConfig(self):
@@ -704,7 +704,7 @@ class TestDNSQuestionTime(DNSDistTest):
 
     addAction(AllRule(), LuaAction(luaquery))
     addResponseAction(AllRule(), LuaResponseAction(luaresponse))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testQueryTime(self):
@@ -751,7 +751,7 @@ class TestChangeName(DNSDistTest):
 
     addAction('changeName.advanced.tests.powerdns.com', LuaAction(luaChangeNamequery))
     addResponseAction('changeName.advanced.tests.dnsdist.org', LuaResponseAction(luaChangeNameresponse))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testChangeName(self):
@@ -808,9 +808,9 @@ class TestFlagsOnTimeout(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     -- this server is not going to answer, resulting in a timeout
-    newServer{address="192.0.2.1:%s"}:setUp()
+    newServer{address="192.0.2.1:%d"}:setUp()
     """
 
     def testFlags(self):

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -39,58 +39,58 @@ class TestBackendDiscovery(DNSDistTest):
     setMaxTCPClientThreads(1)
 
     -- no SVCB
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
 
     -- SVCB record but no upgrade path available
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
 
     -- SVCB upgrade to DoT, same address, keep the backend, different pool
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', pool={'', 'another-pool'}, autoUpgrade=true, autoUpgradePool='%s', autoUpgradeKeep=true, source='127.0.0.1@lo'}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', pool={'', 'another-pool'}, autoUpgrade=true, autoUpgradePool='%s', autoUpgradeKeep=true, source='127.0.0.1@lo'}:setUp()
 
     -- SVCB upgrade to DoH, same address, do not keep the backend, same pool
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', pool={'another-pool'}, autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', pool={'another-pool'}, autoUpgrade=true, autoUpgradeKeep=false}:setUp()
 
     -- SVCB upgrade to DoT, different address, certificate is valid for the initial address
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
 
     -- SVCB upgrade to DoT, different address, certificate is NOT valid for the initial address
-    newServer{address="127.0.0.2:%s", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.2:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
 
     -- SVCB upgrade to DoT but upgraded port is not reachable
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
 
     -- The SVCB response is not valid
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
 
     -- SVCB upgrade to DoH except the path is not specified
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
 
     -- Connection refused
-    newServer({address="127.0.0.1:%s", caStore='ca.pem', pool={"", "other-pool"}, autoUpgrade=true, source='127.0.0.1@lo'}):setUp()
+    newServer({address="127.0.0.1:%d", caStore='ca.pem', pool={"", "other-pool"}, autoUpgrade=true, source='127.0.0.1@lo'}):setUp()
 
     -- EOF
-    newServer({address="127.0.0.1:%s", caStore='ca.pem', autoUpgrade=true}):setUp()
+    newServer({address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true}):setUp()
 
     -- ServFail
-    newServer({address="127.0.0.1:%s", autoUpgrade=true}):setUp()
+    newServer({address="127.0.0.1:%d", autoUpgrade=true}):setUp()
 
     -- Wrong name
-    newServer({address="127.0.0.1:%s", autoUpgrade=true}):setUp()
+    newServer({address="127.0.0.1:%d", autoUpgrade=true}):setUp()
 
     -- Wrong ID
-    newServer({address="127.0.0.1:%s", autoUpgrade=true}):setUp()
+    newServer({address="127.0.0.1:%d", autoUpgrade=true}):setUp()
 
     -- Too many questions
-    newServer({address="127.0.0.1:%s", autoUpgrade=true}):setUp()
+    newServer({address="127.0.0.1:%d", autoUpgrade=true}):setUp()
 
     -- Bad QName
-    newServer({address="127.0.0.1:%s", autoUpgrade=true}):setUp()
+    newServer({address="127.0.0.1:%d", autoUpgrade=true}):setUp()
 
     -- SVCB upgrade to DoT, same address, no port specified via SVCB
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
 
     -- SVCB upgrade to DoH, same address, no port specified via SVCB
-    newServer{address="127.0.0.1:%s", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
     """
     _verboseMode = True
 

--- a/regression-tests.dnsdist/test_Basics.py
+++ b/regression-tests.dnsdist/test_Basics.py
@@ -6,7 +6,7 @@ from dnsdisttests import DNSDistTest
 class TestBasics(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     truncateTC(true)
     addAction(QTypeRule(DNSQType.ANY), TCAction())
     addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(DNSRCode.REFUSED))

--- a/regression-tests.dnsdist/test_BrokenAnswer.py
+++ b/regression-tests.dnsdist/test_BrokenAnswer.py
@@ -36,7 +36,7 @@ class TestBrokenAnswerECS(DNSDistTest):
     _testServerPort = pickAvailablePort()
     _config_template = """
     setECSSourcePrefixV4(32)
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     """
     @classmethod
     def startResponders(cls):

--- a/regression-tests.dnsdist/test_CacheHitResponses.py
+++ b/regression-tests.dnsdist/test_CacheHitResponses.py
@@ -10,7 +10,7 @@ class TestCacheHitResponses(DNSDistTest):
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
     addCacheHitResponseAction(SuffixMatchNodeRule("dropwhencached.cachehitresponses.tests.powerdns.com."), DropResponseAction())
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDroppedWhenCached(self):
@@ -99,7 +99,7 @@ class TestStaleCacheHitResponses(DNSDistTest):
     setStaleCacheEntriesTTL(600)
     setKey("%s")
     controlSocket("127.0.0.1:%d")
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     function hitCache(dr) if dr:getStaleCacheHit() then return DNSResponseAction.Drop end return DNSResponseAction.None end
     addCacheHitResponseAction(SuffixMatchNodeRule("dropstaleentry.cachehitresponses.tests.powerdns.com."), LuaResponseAction(hitCache))
     """

--- a/regression-tests.dnsdist/test_CacheInsertedResponses.py
+++ b/regression-tests.dnsdist/test_CacheInsertedResponses.py
@@ -12,7 +12,7 @@ class TestCacheInsertedResponses(DNSDistTest):
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
     addCacheInsertedResponseAction(SuffixMatchNodeRule("cacheinsertedresponses.tests.powerdns.com."), LimitTTLResponseAction(%d, %d))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
     _config_params = ['capTTLMax', 'capTTLMin', '_testServerPort']
 
@@ -98,4 +98,3 @@ class TestCacheInsertedResponses(DNSDistTest):
         self.assertEqual(receivedResponse, responseOnMiss)
         self.assertGreater(receivedResponse.answer[0].ttl, initialTTL)
         self.assertLessEqual(receivedResponse.answer[0].ttl, self.capTTLMin)
-

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -2929,8 +2929,8 @@ class TestAPICache(DNSDistTest):
     _webServerAPIKeyHashed = '$scrypt$ln=10,p=1,r=8$9v8JxDfzQVyTpBkTbkUqYg==$bDQzAOHeK1G9UvTPypNhrX48w974ZXbFPtRKS34+aso='
     _config_params = ['_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     pc = newPacketCache(100)
     getPool(""):setCache(pc)
@@ -3161,7 +3161,7 @@ class TestCachingPayloadRanks(DNSDistTest):
     _webServerAPIKeyHashed = '$scrypt$ln=10,p=1,r=8$9v8JxDfzQVyTpBkTbkUqYg==$bDQzAOHeK1G9UvTPypNhrX48w974ZXbFPtRKS34+aso='
     _config_params = ['_webServerPort', '_webServerAPIKeyHashed', '_testServerPort']
     _config_template = """
-    webserver("127.0.0.1:%s")
+    webserver("127.0.0.1:%d")
     setWebserverConfig({apiKey="%s"})
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1, payloadRanks={768, 512, 4096, 1280, 1024, 2048}})
     getPool(""):setCache(pc)

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -24,8 +24,8 @@ class TestCarbon(DNSDistTest):
     s:setUp()
     s = newServer{address="127.0.0.1:5355"}
     s:setUp()
-    carbonServer("127.0.0.1:%s", "%s", %s)
-    carbonServer("127.0.0.1:%s", "%s", %s)
+    carbonServer("127.0.0.1:%d", "%s", %s)
+    carbonServer("127.0.0.1:%d", "%s", %s)
     """
 
     @classmethod

--- a/regression-tests.dnsdist/test_Console.py
+++ b/regression-tests.dnsdist/test_Console.py
@@ -16,7 +16,7 @@ class TestConsoleAllowed(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     newServer{address="127.0.0.1:%d"}
     """
 
@@ -35,7 +35,7 @@ class TestConsoleAllowedV6(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("[::1]:%s")
+    controlSocket("[::1]:%d")
     newServer{address="127.0.0.1:%d"}
     """
 
@@ -56,7 +56,7 @@ class TestConsoleNotAllowed(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     setConsoleACL({'192.0.2.1'})
     newServer{address="127.0.0.1:%d"}
     """
@@ -74,7 +74,7 @@ class TestConsoleNoKey(DNSDistTest):
 
     _config_params = ['_consolePort', '_testServerPort']
     _config_template = """
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     newServer{address="127.0.0.1:%d"}
     """
 
@@ -93,7 +93,7 @@ class TestConsoleConcurrentConnections(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_maxConns']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     newServer{address="127.0.0.1:%d"}
     setConsoleMaximumConcurrentConnections(%d)
     """
@@ -253,7 +253,7 @@ class TestConsoleViaBuiltInClient(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     newServer{address="127.0.0.1:%d"}
     """
 

--- a/regression-tests.dnsdist/test_DNSCrypt.py
+++ b/regression-tests.dnsdist/test_DNSCrypt.py
@@ -46,10 +46,10 @@ class DNSCryptTest(DNSDistTest):
 class TestDNSCrypt(DNSCryptTest):
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     generateDNSCryptCertificate("DNSCryptProviderPrivate.key", "DNSCryptResolver.cert", "DNSCryptResolver.key", %d, %d, %d)
     addDNSCryptBind("127.0.0.1:%d", "%s", "DNSCryptResolver.cert", "DNSCryptResolver.key")
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     function checkDNSCryptUDP(dq)
       if dq:getProtocol() ~= "DNSCrypt UDP" then
@@ -323,7 +323,7 @@ class TestDNSCryptWithCache(DNSCryptTest):
     addDNSCryptBind("127.0.0.1:%d", "%s", "DNSCryptResolver.cert", "DNSCryptResolver.key")
     pc = newPacketCache(5, {maxTTL=86400, minTTL=1, numberOfShards=1})
     getPool(""):setCache(pc)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testCachedSimpleA(self):

--- a/regression-tests.dnsdist/test_DNSParser.py
+++ b/regression-tests.dnsdist/test_DNSParser.py
@@ -118,7 +118,7 @@ class TestDNSParser(DNSDistTest):
 
   addAction(AllRule(), LuaAction(checkQueryPacket))
   addResponseAction(AllRule(), LuaResponseAction(checkResponsePacket))
-  newServer{address="127.0.0.1:%s"}
+  newServer{address="127.0.0.1:%d"}
     """
 
     def testQuestionAndResponse(self):
@@ -212,7 +212,7 @@ class TestDNSRecordParser(DNSDistTest):
   end
 
   addResponseAction(AllRule(), LuaResponseAction(checkResponsePacket))
-  newServer{address="127.0.0.1:%s"}
+  newServer{address="127.0.0.1:%d"}
     """
 
     def testQuestionAndResponseWithParsers(self):

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -27,7 +27,7 @@ class DOHTests(object):
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
     newServer{address="127.0.0.1:%d"}
 
@@ -946,11 +946,11 @@ class DOHSubPathsTests(object):
     _dohServerPort = pickAvailablePort()
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     addAction(AllRule(), SpoofAction("3.4.5.6"))
 
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/PowerDNS" }, {exactPathMatching=false, library='%s'})
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/PowerDNS" }, {exactPathMatching=false, library='%s'})
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_dohLibrary']
 
@@ -1010,8 +1010,8 @@ class DOHAddingECSTests(object):
     _dohServerPort = pickAvailablePort()
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, {library='%s'})
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, {library='%s'})
     setECSOverride(true)
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_dohLibrary']
@@ -1108,8 +1108,8 @@ class DOHOverHTTP(object):
     _serverName = 'tls.tests.dnsdist.org'
     _dohBaseURL = ("http://%s:%d/dns-query" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    addDOHLocal("127.0.0.1:%s", nil, nil, '/dns-query', {library='%s'})
+    newServer{address="127.0.0.1:%d"}
+    addDOHLocal("127.0.0.1:%d", nil, nil, '/dns-query', {library='%s'})
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_dohLibrary']
 
@@ -1185,9 +1185,9 @@ class DOHWithCache(object):
     _dohServerPort = pickAvailablePort()
     _dohBaseURL = ("https://%s:%d/dns-query" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", '/dns-query', {library='%s'})
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", '/dns-query', {library='%s'})
 
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
@@ -1401,9 +1401,9 @@ class DOHWithoutCacheControl(object):
     _dohServerPort = pickAvailablePort()
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, {sendCacheControlHeaders=false, library='%s'})
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, {sendCacheControlHeaders=false, library='%s'})
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_dohLibrary']
 
@@ -1449,9 +1449,9 @@ class DOHFFI(object):
     _customResponseHeader2 = 'user-agent: derp'
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, {customResponseHeaders={["access-control-allow-origin"]="*",["user-agent"]="derp",["UPPERCASE"]="VaLuE"}, keepIncomingHeaders=true, library='%s'})
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, {customResponseHeaders={["access-control-allow-origin"]="*",["user-agent"]="derp",["UPPERCASE"]="VaLuE"}, keepIncomingHeaders=true, library='%s'})
 
     local ffi = require("ffi")
 
@@ -1514,10 +1514,10 @@ class DOHForwardedFor(object):
     _dohServerPort = pickAvailablePort()
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     setACL('192.0.2.1/32')
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, {trustForwardedForHeader=true, library='%s'})
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, {trustForwardedForHeader=true, library='%s'})
     -- Set a maximum number of TCP connections per client, to exercise
     -- that code along with X-Forwarded-For support
     setMaxTCPConnectionsPerClient(2)
@@ -1586,10 +1586,10 @@ class DOHForwardedForNoTrusted(object):
     _dohServerPort = pickAvailablePort()
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     setACL('192.0.2.1/32')
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, {earlyACLDrop=true, library='%s'})
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, {earlyACLDrop=true, library='%s'})
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_dohLibrary']
 
@@ -1642,8 +1642,8 @@ class DOHFrontendLimits(object):
     _skipListeningOnCL = True
     _maxTCPConnsPerDOHFrontend = 5
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, { maxConcurrentTCPConnections=%d, library='%s' })
+    newServer{address="127.0.0.1:%d"}
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { maxConcurrentTCPConnections=%d, library='%s' })
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_maxTCPConnsPerDOHFrontend', '_dohLibrary']
     _alternateListeningAddr = '127.0.0.1'
@@ -1719,8 +1719,8 @@ class Protocols(object):
     end
 
     addAction("protocols.doh.tests.powerdns.com.", LuaAction(checkDOH))
-    newServer{address="127.0.0.1:%s"}
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, {library='%s'})
+    newServer{address="127.0.0.1:%d"}
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, {library='%s'})
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_dohLibrary']
 
@@ -1756,9 +1756,9 @@ class DOHWithPKCS12Cert(object):
     _dohServerPort = pickAvailablePort()
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     cert=newTLSCertificate("%s", {password="%s"})
-    addDOHLocal("127.0.0.1:%s", cert, "", { "/" }, {library='%s'})
+    addDOHLocal("127.0.0.1:%d", cert, "", { "/" }, {library='%s'})
     """
     _config_params = ['_testServerPort', '_serverCert', '_pkcs12Password', '_dohServerPort', '_dohLibrary']
 
@@ -1799,8 +1799,8 @@ class DOHForwardedToTCPOnly(object):
     _dohServerPort = pickAvailablePort()
     _dohBaseURL = ("https://%s:%d/" % (_serverName, _dohServerPort))
     _config_template = """
-    newServer{address="127.0.0.1:%s", tcpOnly=true}
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, {library='%s'})
+    newServer{address="127.0.0.1:%d", tcpOnly=true}
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, {library='%s'})
     """
     _config_params = ['_testServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_dohLibrary']
 

--- a/regression-tests.dnsdist/test_DOH3.py
+++ b/regression-tests.dnsdist/test_DOH3.py
@@ -359,7 +359,7 @@ class TestDOH3GetLocalAddressOnAnyBind(QUICGetLocalAddressOnAnyBindTests, DNSDis
       return DNSAction.Spoof, "address-was-"..dashAddr..".local-address-any.advanced.tests.powerdns.com."
     end
     addAction("local-address-any.quic.tests.powerdns.com.", LuaAction(answerBasedOnLocalAddress))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addDOH3Local("0.0.0.0:%d", "%s", "%s")
     addDOH3Local("[::]:%d", "%s", "%s")
     """

--- a/regression-tests.dnsdist/test_DOQ.py
+++ b/regression-tests.dnsdist/test_DOQ.py
@@ -193,7 +193,7 @@ class TestDOQCertificateReloading(DNSDistTest):
     _doqServerPort = pickAvailablePort()
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
     newServer{address="127.0.0.1:%d"}
 
@@ -236,7 +236,7 @@ class TestDOQGetLocalAddressOnAnyBind(QUICGetLocalAddressOnAnyBindTests, DNSDist
       return DNSAction.Spoof, "address-was-"..dashAddr..".local-address-any.advanced.tests.powerdns.com."
     end
     addAction("local-address-any.quic.tests.powerdns.com.", LuaAction(answerBasedOnLocalAddress))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addDOQLocal("0.0.0.0:%d", "%s", "%s")
     addDOQLocal("[::]:%d", "%s", "%s")
     """

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -138,8 +138,8 @@ class TestDnstapOverRemoteLogger(DNSDistTest):
       return DNSAction.None, ""
     end
 
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
-    rl = newRemoteLogger('127.0.0.1:%s')
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
+    rl = newRemoteLogger('127.0.0.1:%d')
 
     addAction(AllRule(), DnstapLogAction("a.server", rl, alterDnstapQuery))				-- Send dnstap message before lookup
 
@@ -610,7 +610,7 @@ class TestDnstapOverFrameStreamUnixLogger(DNSDistTest):
     _fstrmLoggerCounter = 0
     _config_params = ['_testServerPort', '_fstrmLoggerAddress', '_dohServerPort', '_serverCert', '_serverKey', '_doh3ServerPort', '_serverCert', '_serverKey']
     _config_template = """
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     fslu = newFrameStreamUnixLogger('%s')
 
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, {})
@@ -821,8 +821,8 @@ class TestDnstapOverFrameStreamTcpLogger(DNSDistTest):
     _fstrmLoggerCounter = 0
     _config_params = ['_testServerPort', '_fstrmLoggerPort']
     _config_template = """
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
-    fslu = newFrameStreamTcpLogger('127.0.0.1:%s')
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
+    fslu = newFrameStreamTcpLogger('127.0.0.1:%d')
 
     addAction(AllRule(), DnstapLogAction("a.server", fslu))
     """

--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -12,8 +12,8 @@ class TestDynBlockQPS(DynBlocksTest):
     function maintenance()
 	    addDynBlocks(exceedQRate(%d, %d), "Exceeded query rate", %d)
     end
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
     _config_params = ['_dynBlockQPS', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
@@ -32,7 +32,7 @@ class TestDynBlockQPSRefused(DynBlocksTest):
 	    addDynBlocks(exceedQRate(%d, %d), "Exceeded query rate", %d)
     end
     setDynBlocksAction(DNSAction.Refused)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksQRate(self):
@@ -49,7 +49,7 @@ class TestDynBlockQPSActionRefused(DynBlocksTest):
 	    addDynBlocks(exceedQRate(%d, %d), "Exceeded query rate", %d, DNSAction.Refused)
     end
     setDynBlocksAction(DNSAction.Drop)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksQRate(self):
@@ -66,7 +66,7 @@ class TestDynBlockQPSActionNXD(DynBlocksTest):
 	    addDynBlocks(exceedQRate(%d, %d), "Exceeded query rate", %d, DNSAction.Nxdomain)
     end
     setDynBlocksAction(DNSAction.Drop)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksQRate(self):
@@ -88,7 +88,7 @@ class TestDynBlockQPSActionTruncated(DNSDistTest):
 	    addDynBlocks(exceedQRate(%d, %d), "Exceeded query rate", %d, DNSAction.Truncate)
     end
     setDynBlocksAction(DNSAction.Drop)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksQRate(self):
@@ -191,7 +191,7 @@ class TestDynBlockAllowlist(DynBlocksTest):
     end
     addAction("allowlisted-test.dynblocks.tests.powerdns.com.", LuaAction(spoofrule))
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAllowlisted(self):

--- a/regression-tests.dnsdist/test_DynBlocksEBPF.py
+++ b/regression-tests.dnsdist/test_DynBlocksEBPF.py
@@ -27,8 +27,8 @@ class TestDynBlockEBPFQPS(DynBlocksTest):
     bpf:unblock(newCA("2001:DB8::42"))
     bpf:unblockQName(newDNSName("powerdns.com."), 255)
 
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
     _config_params = ['_dynBlockQPS', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']

--- a/regression-tests.dnsdist/test_DynBlocksGroup.py
+++ b/regression-tests.dnsdist/test_DynBlocksGroup.py
@@ -15,7 +15,7 @@ class TestDynBlockGroupQPS(DynBlocksTest):
     function maintenance()
 	    dbr:apply()
     end
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     webserver("127.0.0.1:%s")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
@@ -87,7 +87,7 @@ class TestDynBlockGroupQPSRefused(DynBlocksTest):
 	    dbr:apply()
     end
     setDynBlocksAction(DNSAction.Refused)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksQRate(self):
@@ -107,7 +107,7 @@ class TestDynBlockGroupQPSActionRefused(DynBlocksTest):
 	    dbr:apply()
     end
     setDynBlocksAction(DNSAction.Drop)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksQRate(self):
@@ -128,7 +128,7 @@ class TestDynBlockGroupExcluded(DynBlocksTest):
 	    dbr:apply()
     end
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testExcluded(self):
@@ -185,7 +185,7 @@ class TestDynBlockGroupExcludedViaNMG(DynBlocksTest):
 	    dbr:apply()
     end
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testExcluded(self):
@@ -238,8 +238,8 @@ class TestDynBlockGroupNoOp(DynBlocksTest):
 	    dbr:apply()
     end
 
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
     _config_params = ['_dynBlockQPS', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
@@ -299,8 +299,8 @@ class TestDynBlockGroupWarning(DynBlocksTest):
 	    dbr:apply()
     end
 
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
     _config_params = ['_dynBlockQPS', '_dynBlockPeriod', '_dynBlockDuration', '_dynBlockWarningQPS', '_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']

--- a/regression-tests.dnsdist/test_DynBlocksRatio.py
+++ b/regression-tests.dnsdist/test_DynBlocksRatio.py
@@ -20,7 +20,7 @@ class TestDynBlockGroupServFailsRatio(DynBlocksTest):
 	    dbr:apply()
     end
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksServFailRatio(self):
@@ -44,7 +44,7 @@ class TestDynBlockGroupCacheMissRatio(DynBlocksTest):
 	    dbr:apply()
     end
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     local pc = newPacketCache(1000, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
     """
@@ -76,7 +76,7 @@ class TestDynBlockGroupCacheMissRatioSetTag(DynBlocksTest):
 	    dbr:apply()
     end
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     local pc = newPacketCache(1000, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
     """

--- a/regression-tests.dnsdist/test_DynBlocksResponseBytes.py
+++ b/regression-tests.dnsdist/test_DynBlocksResponseBytes.py
@@ -14,11 +14,11 @@ class TestDynBlockResponseBytes(DynBlocksTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_dynBlockBytesPerSecond', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     function maintenance()
 	    addDynBlocks(exceedRespByterate(%d, %d), "Exceeded response byterate", %d)
     end
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksResponseByteRate(self):
@@ -36,7 +36,7 @@ class TestDynBlockGroupResponseBytes(DynBlocksTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_dynBlockBytesPerSecond', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     local dbr = dynBlockRulesGroup()
     dbr:setResponseByteRate(%d, %d, "Exceeded query rate", %d)
 
@@ -44,7 +44,7 @@ class TestDynBlockGroupResponseBytes(DynBlocksTest):
 	    dbr:apply()
     end
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksResponseByteRate(self):

--- a/regression-tests.dnsdist/test_DynBlocksServFail.py
+++ b/regression-tests.dnsdist/test_DynBlocksServFail.py
@@ -12,7 +12,7 @@ class TestDynBlockServFails(DynBlocksTest):
     function maintenance()
 	    addDynBlocks(exceedServFails(%d, %d), "Exceeded servfail rate", %d)
     end
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksServFailRate(self):
@@ -30,7 +30,7 @@ class TestDynBlockServFailsCached(DynBlocksTest):
     function maintenance()
 	    addDynBlocks(exceedServFails(%d, %d), "Exceeded servfail rate", %d)
     end
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksServFailRateCached(self):
@@ -103,7 +103,7 @@ class TestDynBlockGroupServFails(DynBlocksTest):
 	    dbr:apply()
     end
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDynBlocksServFailRate(self):

--- a/regression-tests.dnsdist/test_EBPF.py
+++ b/regression-tests.dnsdist/test_EBPF.py
@@ -26,7 +26,7 @@ class TestSimpleEBPF(DNSDistTest):
 
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     newServer{address="127.0.0.1:%d"}
 
     bpf = newBPFFilter({ipv4MaxItems=10, ipv6MaxItems=10, qnamesMaxItems=10})

--- a/regression-tests.dnsdist/test_EDE.py
+++ b/regression-tests.dnsdist/test_EDE.py
@@ -6,7 +6,7 @@ from dnsdisttests import DNSDistTest, pickAvailablePort
 class TestBasics(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
 

--- a/regression-tests.dnsdist/test_EDNSOptions.py
+++ b/regression-tests.dnsdist/test_EDNSOptions.py
@@ -105,7 +105,7 @@ class TestEDNSOptions(EDNSOptionsBase):
 
     addAction(AllRule(), LuaAction(testEDNSOptions))
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
     _config_params = ['_ednsTestFunction', '_testServerPort']
 
@@ -263,7 +263,7 @@ class TestEDNSOptionsAddingECS(EDNSOptionsBase):
     addAction(AllRule(), LuaAction(testEDNSOptions))
     addResponseAction("ednsoptions-ecs.tests.powerdns.com.", LuaResponseAction(testEDNSOptionsInResponses))
 
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     """
     _config_params = ['_ednsTestFunction', '_testServerPort']
 
@@ -559,7 +559,7 @@ class TestEDNSOptionsLuaFFI(DNSDistTest):
 
     addAction(AllRule(), LuaFFIAction(testEDNSOptions))
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testWithoutEDNSFFI(self):

--- a/regression-tests.dnsdist/test_EDNSSelfGenerated.py
+++ b/regression-tests.dnsdist/test_EDNSSelfGenerated.py
@@ -24,7 +24,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
 
     setPayloadSizeOnSelfGeneratedAnswers(1042)
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testNoEDNS(self):
@@ -287,7 +287,7 @@ class TestEDNSSelfGeneratedDisabled(DNSDistTest):
 
     setPayloadSizeOnSelfGeneratedAnswers(1042)
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testWithEDNSNoDO(self):

--- a/regression-tests.dnsdist/test_EdnsClientSubnet.py
+++ b/regression-tests.dnsdist/test_EdnsClientSubnet.py
@@ -14,7 +14,7 @@ class TestEdnsClientSubnetNoOverride(DNSDistTest):
 
     _config_template = """
     truncateTC(true)
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     """
 
     def testWithoutEDNS(self):
@@ -311,7 +311,7 @@ class TestEdnsClientSubnetOverride(DNSDistTest):
     setECSOverride(true)
     setECSSourcePrefixV4(24)
     setECSSourcePrefixV6(56)
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     """
 
     def testWithoutEDNS(self):
@@ -671,7 +671,7 @@ class TestECSDisabledByRuleOrLua(DNSDistTest):
     setECSOverride(false)
     setECSSourcePrefixV4(16)
     setECSSourcePrefixV6(16)
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     addAction(SuffixMatchNodeRule("disabled.ecsrules.tests.powerdns.com."), SetDisableECSAction())
     function disableECSViaLua(dq)
         dq.useECS = false
@@ -764,7 +764,7 @@ class TestECSOverrideSetByRuleOrLua(DNSDistTest):
     setECSOverride(false)
     setECSSourcePrefixV4(24)
     setECSSourcePrefixV6(56)
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     addAction(SuffixMatchNodeRule("overridden.ecsrules.tests.powerdns.com."), SetECSOverrideAction(true))
     function overrideECSViaLua(dq)
         dq.ecsOverride = true
@@ -863,7 +863,7 @@ class TestECSPrefixLengthSetByRuleOrLua(DNSDistTest):
     setECSOverride(false)
     setECSSourcePrefixV4(24)
     setECSSourcePrefixV6(56)
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     addAction(SuffixMatchNodeRule("overriddenprefixlength.ecsrules.tests.powerdns.com."), SetECSPrefixLengthAction(32, 128))
     function overrideECSPrefixLengthViaLua(dq)
         dq.ecsPrefixLength = 32
@@ -965,7 +965,7 @@ class TestECSPrefixSetByRule(DNSDistTest):
     setECSOverride(false)
     setECSSourcePrefixV4(32)
     setECSSourcePrefixV6(128)
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     addAction(SuffixMatchNodeRule("setecsaction.ecsrules.tests.powerdns.com."), SetECSAction("192.0.2.1/32"))
     """
 

--- a/regression-tests.dnsdist/test_HealthChecks.py
+++ b/regression-tests.dnsdist/test_HealthChecks.py
@@ -19,7 +19,7 @@ class HealthCheckTest(DNSDistTest):
     _config_template = """
     setKey("%s")
     controlSocket("127.0.0.1:%d")
-    webserver("127.0.0.1:%s")
+    webserver("127.0.0.1:%d")
     setWebserverConfig({apiKey="%s"})
     newServer{address="127.0.0.1:%d"}
     """
@@ -108,7 +108,7 @@ class TestHealthCheckForcedUP(HealthCheckTest):
     _config_template = """
     setKey("%s")
     controlSocket("127.0.0.1:%d")
-    webserver("127.0.0.1:%s")
+    webserver("127.0.0.1:%d")
     setWebserverConfig({apiKey="%s"})
     srv = newServer{address="127.0.0.1:%d"}
     srv:setUp()
@@ -132,7 +132,7 @@ class TestHealthCheckForcedDown(HealthCheckTest):
     _config_template = """
     setKey("%s")
     controlSocket("127.0.0.1:%d")
-    webserver("127.0.0.1:%s")
+    webserver("127.0.0.1:%d")
     setWebserverConfig({apiKey="%s"})
     srv = newServer{address="127.0.0.1:%d"}
     srv:setDown()
@@ -157,7 +157,7 @@ class TestHealthCheckCustomName(HealthCheckTest):
     _config_template = """
     setKey("%s")
     controlSocket("127.0.0.1:%d")
-    webserver("127.0.0.1:%s")
+    webserver("127.0.0.1:%d")
     setWebserverConfig({apiKey="%s"})
     srv = newServer{address="127.0.0.1:%d", checkName='%s'}
     """
@@ -181,7 +181,7 @@ class TestHealthCheckCustomNameNoAnswer(HealthCheckTest):
     _config_template = """
     setKey("%s")
     controlSocket("127.0.0.1:%d")
-    webserver("127.0.0.1:%s")
+    webserver("127.0.0.1:%d")
     setWebserverConfig({apiKey="%s"})
     srv = newServer{address="127.0.0.1:%d", checkName='powerdns.com.'}
     """
@@ -207,7 +207,7 @@ class TestHealthCheckCustomFunction(HealthCheckTest):
     _config_template = """
     setKey("%s")
     controlSocket("127.0.0.1:%d")
-    webserver("127.0.0.1:%s")
+    webserver("127.0.0.1:%d")
     setWebserverConfig({apiKey="%s"})
 
     function myHealthCheckFunction(qname, qtype, qclass, dh)
@@ -245,12 +245,12 @@ class TestLazyHealthChecks(HealthCheckTest):
     setKey("%s")
     controlSocket("127.0.0.1:%d")
 
-    newServer{address="127.0.0.1:%s", healthCheckMode='lazy', checkInterval=1, lazyHealthCheckFailedInterval=1, lazyHealthCheckThreshold=10, lazyHealthCheckSampleSize=100,  lazyHealthCheckMinSampleCount=10, lazyHealthCheckMode='TimeoutOrServFail', pool=''}
+    newServer{address="127.0.0.1:%d", healthCheckMode='lazy', checkInterval=1, lazyHealthCheckFailedInterval=1, lazyHealthCheckThreshold=10, lazyHealthCheckSampleSize=100,  lazyHealthCheckMinSampleCount=10, lazyHealthCheckMode='TimeoutOrServFail', pool=''}
 
-    newServer{address="127.0.0.1:%s", tls='openssl', caStore='ca.pem', subjectAddr='127.0.0.1', healthCheckMode='lazy', checkInterval=1, lazyHealthCheckFailedInterval=1, lazyHealthCheckThreshold=10, lazyHealthCheckSampleSize=100,  lazyHealthCheckMinSampleCount=10, lazyHealthCheckMode='TimeoutOrServFail', pool='dot'}
+    newServer{address="127.0.0.1:%d", tls='openssl', caStore='ca.pem', subjectAddr='127.0.0.1', healthCheckMode='lazy', checkInterval=1, lazyHealthCheckFailedInterval=1, lazyHealthCheckThreshold=10, lazyHealthCheckSampleSize=100,  lazyHealthCheckMinSampleCount=10, lazyHealthCheckMode='TimeoutOrServFail', pool='dot'}
     addAction('dot.lazy.test.powerdns.com.', PoolAction('dot'))
 
-    newServer{address="127.0.0.1:%s", tls='openssl', dohPath='/dns-query', caStore='ca.pem', subjectAddr='127.0.0.1', healthCheckMode='lazy', checkInterval=1, lazyHealthCheckFailedInterval=1, lazyHealthCheckThreshold=10, lazyHealthCheckSampleSize=100,  lazyHealthCheckMinSampleCount=10, lazyHealthCheckMode='TimeoutOrServFail', pool='doh'}
+    newServer{address="127.0.0.1:%d", tls='openssl', dohPath='/dns-query', caStore='ca.pem', subjectAddr='127.0.0.1', healthCheckMode='lazy', checkInterval=1, lazyHealthCheckFailedInterval=1, lazyHealthCheckThreshold=10, lazyHealthCheckSampleSize=100,  lazyHealthCheckMinSampleCount=10, lazyHealthCheckMode='TimeoutOrServFail', pool='doh'}
     addAction('doh.lazy.test.powerdns.com.', PoolAction('doh'))
     """
     _verboseMode = True
@@ -598,7 +598,7 @@ class TestServerStateChange(HealthCheckTest):
     _config_template = """
     setKey("%s")
     controlSocket("127.0.0.1:%d")
-    webserver("127.0.0.1:%s")
+    webserver("127.0.0.1:%d")
     setWebserverConfig({apiKey="%s"})
     srv = newServer{address="127.0.0.1:%d",maxCheckFailures=1,checkTimeout=1000,checkInterval=1,rise=1}
     srv:setAuto(false)

--- a/regression-tests.dnsdist/test_Lua.py
+++ b/regression-tests.dnsdist/test_Lua.py
@@ -13,7 +13,7 @@ class TestLuaThread(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
     counter = 0
     function threadmessage(cmd, data)
@@ -44,7 +44,7 @@ class TestLuaThread(DNSDistTest):
 
 class TestLuaDNSHeaderBindings(DNSDistTest):
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     function checkTCSet(dq)
       local tc = dq.dh:getTC()
@@ -193,7 +193,7 @@ class TestLuaError(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
     debug = nil
     """

--- a/regression-tests.dnsdist/test_Metrics.py
+++ b/regression-tests.dnsdist/test_Metrics.py
@@ -11,11 +11,11 @@ from dnsdisttests import DNSDistTest, pickAvailablePort
 class RuleMetricsTest(object):
 
     _config_template = """
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
-    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/"})
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl" })
+    addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/"})
 
-    newServer{address="127.0.0.1:%s", pool={'', 'cache'}}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", pool={'', 'cache'}}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({apiKey="%s"})
 
     addAction('rcode-nxdomain.metrics.tests.powerdns.com', RCodeAction(DNSRCode.NXDOMAIN))

--- a/regression-tests.dnsdist/test_OCSP.py
+++ b/regression-tests.dnsdist/test_OCSP.py
@@ -115,9 +115,9 @@ class TestBrokenOCSPStaplingDoH(DNSDistOCSPStaplingTest):
     _dohWithNGHTTP2ServerPort = pickAvailablePort()
     _dohWithH2OServerPort = pickAvailablePort()
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { ocspResponses={"%s"}, library='nghttp2'})
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { ocspResponses={"%s"}, library='h2o'})
@@ -145,13 +145,13 @@ class TestOCSPStaplingTLSGnuTLS(DNSDistOCSPStaplingTest):
     _caKey = 'ca.key'
     _tlsServerPort = pickAvailablePort()
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
     -- generate an OCSP response file for our certificate, valid one day
     generateOCSPResponse('%s', '%s', '%s', '%s', 1, 0)
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="gnutls", ocspResponses={"%s"}})
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="gnutls", ocspResponses={"%s"}})
     """
     _config_params = ['_testServerPort', '_consoleKeyB64', '_consolePort', '_serverCert', '_caCert', '_caKey', '_ocspFile', '_tlsServerPort', '_serverCert', '_serverKey', '_ocspFile']
 
@@ -188,11 +188,11 @@ class TestBrokenOCSPStaplingTLSGnuTLS(DNSDistOCSPStaplingTest):
     _ocspFile = '/dev/null'
     _tlsServerPort = pickAvailablePort()
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="gnutls", ocspResponses={"%s"}})
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="gnutls", ocspResponses={"%s"}})
     """
     _config_params = ['_testServerPort', '_consoleKeyB64', '_consolePort', '_tlsServerPort', '_serverCert', '_serverKey', '_ocspFile']
 
@@ -216,13 +216,13 @@ class TestOCSPStaplingTLSOpenSSL(DNSDistOCSPStaplingTest):
     _caKey = 'ca.key'
     _tlsServerPort = pickAvailablePort()
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
     -- generate an OCSP response file for our certificate, valid one day
     generateOCSPResponse('%s', '%s', '%s', '%s', 1, 0)
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl", ocspResponses={"%s"}})
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl", ocspResponses={"%s"}})
     """
     _config_params = ['_testServerPort', '_consoleKeyB64', '_consolePort', '_serverCert', '_caCert', '_caKey', '_ocspFile', '_tlsServerPort', '_serverCert', '_serverKey', '_ocspFile']
 
@@ -259,11 +259,11 @@ class TestBrokenOCSPStaplingTLSOpenSSL(DNSDistOCSPStaplingTest):
     _ocspFile = '/dev/null'
     _tlsServerPort = pickAvailablePort()
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl", ocspResponses={"%s"}})
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl", ocspResponses={"%s"}})
     """
     _config_params = ['_testServerPort', '_consoleKeyB64', '_consolePort', '_tlsServerPort', '_serverCert', '_serverKey', '_ocspFile']
 

--- a/regression-tests.dnsdist/test_OutgoingDOH.py
+++ b/regression-tests.dnsdist/test_OutgoingDOH.py
@@ -275,8 +275,8 @@ class TestOutgoingDOHOpenSSL(DNSDistTest, OutgoingDOHTests):
     setKey("%s")
     controlSocket("127.0.0.1:%d")
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='%s', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', pool={'', 'cache'}, keyLogFile="/tmp/dohkeys"}:setUp()
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='%s', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', pool={'', 'cache'}, keyLogFile="/tmp/dohkeys"}:setUp()
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
 
     pc = newPacketCache(100)
@@ -319,8 +319,8 @@ class TestOutgoingDOHGnuTLS(DNSDistTest, OutgoingDOHTests):
     setKey("%s")
     controlSocket("127.0.0.1:%d")
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='%s', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', pool={'', 'cache'}}:setUp()
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='%s', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', pool={'', 'cache'}}:setUp()
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
 
     pc = newPacketCache(100)
@@ -421,8 +421,8 @@ class TestOutgoingDOHOpenSSLWrongCertName(DNSDistTest, BrokenOutgoingDOHTests):
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='openssl', validateCertificates=true, caStore='ca.pem', subjectName='not-powerdns.com', dohPath='/dns-query'}:setUp()
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='openssl', validateCertificates=true, caStore='ca.pem', subjectName='not-powerdns.com', dohPath='/dns-query'}:setUp()
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -441,8 +441,8 @@ class TestOutgoingDOHGnuTLSWrongCertName(DNSDistTest, BrokenOutgoingDOHTests):
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='not-powerdns.com', dohPath='/dns-query'}:setUp()
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='not-powerdns.com', dohPath='/dns-query'}:setUp()
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -466,8 +466,8 @@ class TestOutgoingDOHOpenSSLWrongCertNameButNoCheck(DNSDistTest, OutgoingDOHTest
     setKey("%s")
     controlSocket("127.0.0.1:%d")
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='%s', validateCertificates=false, caStore='ca.pem', subjectName='not-powerdns.com', dohPath='/dns-query', pool={'', 'cache'}}:setUp()
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='%s', validateCertificates=false, caStore='ca.pem', subjectName='not-powerdns.com', dohPath='/dns-query', pool={'', 'cache'}}:setUp()
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
 
     pc = newPacketCache(100)
@@ -497,8 +497,8 @@ class TestOutgoingDOHGnuTLSWrongCertNameButNoCheck(DNSDistTest, OutgoingDOHTests
     setKey("%s")
     controlSocket("127.0.0.1:%d")
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='%s', validateCertificates=false, caStore='ca.pem', subjectName='not-powerdns.com', dohPath='/dns-query', pool={'', 'cache'}}:setUp()
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='%s', validateCertificates=false, caStore='ca.pem', subjectName='not-powerdns.com', dohPath='/dns-query', pool={'', 'cache'}}:setUp()
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
 
     pc = newPacketCache(100)
@@ -523,8 +523,8 @@ class TestOutgoingDOHBrokenResponsesOpenSSL(DNSDistTest, OutgoingDOHBrokenRespon
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='openssl', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', pool={'', 'cache'}}:setUp()
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='openssl', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', pool={'', 'cache'}}:setUp()
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
 
     pc = newPacketCache(100)
@@ -565,8 +565,8 @@ class TestOutgoingDOHBrokenResponsesGnuTLS(DNSDistTest, OutgoingDOHBrokenRespons
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query'}:setUp()
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query'}:setUp()
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
     _verboseMode = True
@@ -603,7 +603,7 @@ class TestOutgoingDOHProxyProtocol(DNSDistTest):
     _config_params = ['_tlsBackendPort']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', useProxyProtocol=true}:setUp()
+    newServer{address="127.0.0.1:%d", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', useProxyProtocol=true}:setUp()
     """
     _verboseMode = True
 
@@ -649,7 +649,7 @@ class TestOutgoingDOHXForwarded(DNSDistTest):
     _config_params = ['_tlsBackendPort']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', addXForwardedHeaders=true}
+    newServer{address="127.0.0.1:%d", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', addXForwardedHeaders=true}
     """
     _verboseMode = True
 

--- a/regression-tests.dnsdist/test_OutgoingTLS.py
+++ b/regression-tests.dnsdist/test_OutgoingTLS.py
@@ -143,8 +143,8 @@ class TestOutgoingTLSOpenSSL(DNSDistTest, OutgoingTLSTests):
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='openssl', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', keyLogFile="/tmp/dotkeys"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='openssl', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', keyLogFile="/tmp/dotkeys"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -219,8 +219,8 @@ class TestOutgoingTLSGnuTLS(DNSDistTest, OutgoingTLSTests):
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com'}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com'}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -240,8 +240,8 @@ class TestOutgoingTLSOpenSSLWrongCertName(DNSDistTest, BrokenOutgoingTLSTests):
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='openssl', validateCertificates=true, caStore='ca.pem', subjectName='not-powerdns.com'}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='openssl', validateCertificates=true, caStore='ca.pem', subjectName='not-powerdns.com'}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -260,8 +260,8 @@ class TestOutgoingTLSGnuTLSWrongCertName(DNSDistTest, BrokenOutgoingTLSTests):
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='not-powerdns.com'}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='not-powerdns.com'}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -280,8 +280,8 @@ class TestOutgoingTLSOpenSSLWrongCertNameButNoCheck(DNSDistTest, OutgoingTLSTest
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='openssl', validateCertificates=false, caStore='ca.pem', subjectName='not-powerdns.com'}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='openssl', validateCertificates=false, caStore='ca.pem', subjectName='not-powerdns.com'}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 
@@ -300,8 +300,8 @@ class TestOutgoingTLSGnuTLSWrongCertNameButNoCheck(DNSDistTest, OutgoingTLSTests
     _config_params = ['_tlsBackendPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
     setMaxTCPClientThreads(1)
-    newServer{address="127.0.0.1:%s", tls='gnutls', validateCertificates=false, caStore='ca.pem', subjectName='not-powerdns.com'}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", tls='gnutls', validateCertificates=false, caStore='ca.pem', subjectName='not-powerdns.com'}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 

--- a/regression-tests.dnsdist/test_Prometheus.py
+++ b/regression-tests.dnsdist/test_Prometheus.py
@@ -16,8 +16,8 @@ class TestPrometheus(DNSDistTest):
     _webServerAPIKeyHashed = '$scrypt$ln=10,p=1,r=8$9v8JxDfzQVyTpBkTbkUqYg==$bDQzAOHeK1G9UvTPypNhrX48w974ZXbFPtRKS34+aso='
     _config_params = ['_testServerPort', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -254,8 +254,8 @@ class TestProtobuf(DNSDistProtobufTest):
       return DNSAction.None, ""				-- continue to the next rule
     end
 
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
-    rl = newRemoteLogger('127.0.0.1:%s')
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
+    rl = newRemoteLogger('127.0.0.1:%d')
 
     addAction(AllRule(), LuaAction(alterLuaFirst))							-- Add tags to DNSQuery first
 
@@ -418,7 +418,7 @@ class TestProtobuf(DNSDistProtobufTest):
 class TestProtobufMetaTags(DNSDistProtobufTest):
     _config_params = ['_testServerPort', '_protobufServerPort']
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     rl = newRemoteLogger('127.0.0.1:%d')
 
     local ffi = require("ffi")
@@ -565,7 +565,7 @@ class TestProtobufMetaTags(DNSDistProtobufTest):
 class TestProtobufExtendedDNSErrorTags(DNSDistProtobufTest):
     _config_params = ['_testServerPort', '_protobufServerPort']
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     rl = newRemoteLogger('127.0.0.1:%d')
 
     addAction(AllRule(), RemoteLogAction(rl, nil, {serverID='dnsdist-server-1'}))
@@ -623,7 +623,7 @@ class TestProtobufExtendedDNSErrorTags(DNSDistProtobufTest):
 class TestProtobufCacheHit(DNSDistProtobufTest):
     _config_params = ['_testServerPort', '_protobufServerPort']
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     rl = newRemoteLogger('127.0.0.1:%d')
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
@@ -698,7 +698,7 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
     newServer{address="127.0.0.1:%d"}
     rl = newRemoteLogger('127.0.0.1:%d')
 
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl" })
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { '/dns-query' }, { keepIncomingHeaders=true, library='nghttp2' })
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { '/dns-query' }, { keepIncomingHeaders=true, library='h2o' })
 
@@ -860,9 +860,9 @@ class TestProtobufMetaProxy(DNSDistProtobufTest):
 class TestProtobufIPCipher(DNSDistProtobufTest):
     _config_params = ['_testServerPort', '_protobufServerPort', '_protobufServerID', '_protobufServerID']
     _config_template = """
-    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    newServer{address="127.0.0.1:%d", useClientSubnet=true}
     key = makeIPCipherKey("some 16-byte key")
-    rl = newRemoteLogger('127.0.0.1:%s')
+    rl = newRemoteLogger('127.0.0.1:%d')
     addAction(AllRule(), RemoteLogAction(rl, nil, {serverID='%s', ipEncryptKey=key})) -- Send protobuf message before lookup
     addResponseAction(AllRule(), RemoteLogResponseAction(rl, nil, true, {serverID='%s', ipEncryptKey=key})) -- Send protobuf message after lookup
 

--- a/regression-tests.dnsdist/test_ProxyProtocol.py
+++ b/regression-tests.dnsdist/test_ProxyProtocol.py
@@ -1236,7 +1236,7 @@ class TestDOHWithOutgoingProxyProtocol(DNSDistDOHTest):
     _dohWithH2OBaseURL = ("https://%s:%d/dns-query" % (_serverName, _dohWithH2OServerPort))
     _proxyResponderPort = proxyResponderPort
     _config_template = """
-    newServer{address="127.0.0.1:%s", useProxyProtocol=true}
+    newServer{address="127.0.0.1:%d", useProxyProtocol=true}
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { '/dns-query' }, { trustForwardedForHeader=true, library='nghttp2' })
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { '/dns-query' }, { trustForwardedForHeader=true, library='h2o' })
     setACL( { "::1/128", "127.0.0.0/8" } )

--- a/regression-tests.dnsdist/test_RecordsCount.py
+++ b/regression-tests.dnsdist/test_RecordsCount.py
@@ -8,7 +8,7 @@ class TestRecordsCountOnlyOneAR(DNSDistTest):
 
     _config_template = """
     addAction(NotRule(RecordsCountRule(DNSSection.Additional, 1, 1)), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testRecordsCountRefuseEmptyAR(self):
@@ -82,7 +82,7 @@ class TestRecordsCountMoreThanOneLessThanFour(DNSDistTest):
     _config_template = """
     addAction(RecordsCountRule(DNSSection.Answer, 2, 3), AllowAction())
     addAction(AllRule(), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testRecordsCountRefuseOneAN(self):
@@ -160,7 +160,7 @@ class TestRecordsCountNothingInNS(DNSDistTest):
     _config_template = """
     addAction(RecordsCountRule(DNSSection.Authority, 0, 0), AllowAction())
     addAction(AllRule(), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testRecordsCountRefuseNS(self):
@@ -217,7 +217,7 @@ class TestRecordsCountNoOPTInAR(DNSDistTest):
 
     _config_template = """
     addAction(NotRule(RecordsTypeCountRule(DNSSection.Additional, DNSQType.OPT, 0, 0)), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testRecordsCountRefuseOPTinAR(self):

--- a/regression-tests.dnsdist/test_Responses.py
+++ b/regression-tests.dnsdist/test_Responses.py
@@ -8,7 +8,7 @@ from dnsdisttests import DNSDistTest
 class TestResponseRuleNXDelayed(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addResponseAction(RCodeRule(DNSRCode.NXDOMAIN), DelayResponseAction(1000))
     """
 
@@ -58,7 +58,7 @@ class TestResponseRuleERCode(DNSDistTest):
 
     _extraStartupSleep = 1
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addResponseAction(ERCodeRule(DNSRCode.BADVERS), DelayResponseAction(1000))
     """
 
@@ -109,7 +109,7 @@ class TestResponseRuleERCode(DNSDistTest):
 class TestResponseRuleQNameDropped(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addResponseAction("drop.responses.tests.powerdns.com.", DropResponseAction())
     """
 
@@ -152,7 +152,7 @@ class TestResponseRuleQNameDropped(DNSDistTest):
 class TestResponseRuleQNameAllowed(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addResponseAction("allow.responses.tests.powerdns.com.", AllowResponseAction())
     addResponseAction(AllRule(), DropResponseAction())
     """
@@ -198,7 +198,7 @@ class TestResponseRuleEditTTL(DNSDistTest):
     _ttl = 5
     _config_params = ['_testServerPort', '_ttl']
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     function editTTLCallback(section, class, type, ttl)
       return %d
@@ -255,7 +255,7 @@ class TestResponseRuleLimitTTL(DNSDistTest):
       return DNSResponseAction.None, ""
     end
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     addResponseAction("min.responses.tests.powerdns.com.", SetMinTTLResponseAction(highttl))
     addResponseAction("max.responses.tests.powerdns.com.", SetMaxTTLResponseAction(lowttl))
@@ -354,7 +354,7 @@ class TestSetReducedTTL(DNSDistTest):
     _config_params = ['_percentage', '_testServerPort']
     _config_template = """
     addResponseAction(AllRule(), SetReducedTTLResponseAction(%d))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testLimitTTL(self):
@@ -383,7 +383,7 @@ class TestSetReducedTTL(DNSDistTest):
 class TestResponseLuaActionReturnSyntax(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     function customDelay(dr)
       return DNSResponseAction.Delay, "1000"
     end
@@ -445,7 +445,7 @@ class TestResponseClearRecordsType(DNSDistTest):
       return DNSResponseAction.HeaderModify, ""
     end
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     addResponseAction("ffi.clear-records-type.responses.tests.powerdns.com.", LuaFFIResponseAction(luafct))
     addResponseAction("clear-records-type.responses.tests.powerdns.com.", ClearRecordTypesResponseAction(DNSQType.AAAA))
@@ -511,7 +511,7 @@ class TestResponseRewriteServFail(DNSDistTest):
 
     _config_params = ['_testServerPort']
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     function rewriteServFail(dq)
       if dq.rcode == DNSRCode.SERVFAIL then
@@ -571,7 +571,7 @@ class TestResponseRewriteServFail(DNSDistTest):
 class TestAdvancedSetEDNSOptionResponseAction(DNSDistTest):
     _config_template = """
     addResponseAction(AllRule(), SetEDNSOptionResponseAction(10, "deadbeefdeadc0de"))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedSetEDNSOptionResponse(self):

--- a/regression-tests.dnsdist/test_RestartQuery.py
+++ b/regression-tests.dnsdist/test_RestartQuery.py
@@ -183,16 +183,16 @@ class TestRestartCount(DNSDistTest):
     _config_params = ['_testServer1Port', '_testServer2Port', '_testServer3Port', '_testServer4Port']
     _config_template = """
     MaxRestart = 2
-    s0 = newServer{name="s0", address="127.0.0.1:%s"}
+    s0 = newServer{name="s0", address="127.0.0.1:%d"}
     s0:setUp()
     s0:addPool("pool0")
-    s1 = newServer{name="s1", address="127.0.0.1:%s"}
+    s1 = newServer{name="s1", address="127.0.0.1:%d"}
     s1:setUp()
     s1:addPool("pool1")
-    s2 = newServer{name="s2", address="127.0.0.1:%s"}
+    s2 = newServer{name="s2", address="127.0.0.1:%d"}
     s2:setUp()
     s2:addPool("pool2")
-    s3 = newServer{name="s3", address="127.0.0.1:%s"}
+    s3 = newServer{name="s3", address="127.0.0.1:%d"}
     s3:setUp()
     s3:addPool("pool3")
     function makeQueryRestartable(dq) dq:setRestartable() return DNSAction.None end

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -8,7 +8,7 @@ from dnsdisttests import DNSDistTest, pickAvailablePort
 class TestRoutingPoolRouting(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s", pool="real"}
+    newServer{address="127.0.0.1:%d", pool="real"}
     addAction(SuffixMatchNodeRule("poolaction.routing.tests.powerdns.com"), PoolAction("real"))
     -- by default PoolAction stops the processing so the second rule should not be executed
     addAction(SuffixMatchNodeRule("poolaction.routing.tests.powerdns.com"), PoolAction("not-real"))
@@ -82,7 +82,7 @@ class TestRoutingPoolRouting(DNSDistTest):
 
 class TestRoutingQPSPoolRouting(DNSDistTest):
     _config_template = """
-    newServer{address="127.0.0.1:%s", pool="regular"}
+    newServer{address="127.0.0.1:%d", pool="regular"}
     addAction(SuffixMatchNodeRule("qpspoolaction.routing.tests.powerdns.com"), QPSPoolAction(10, "regular"))
     """
 
@@ -172,9 +172,9 @@ class TestRoutingRoundRobinLB(RoundRobinTest, DNSDistTest):
     _config_params = ['_testServerPort', '_testServer2Port']
     _config_template = """
     setServerPolicy(roundrobin)
-    s1 = newServer{address="127.0.0.1:%s"}
+    s1 = newServer{address="127.0.0.1:%d"}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s"}
+    s2 = newServer{address="127.0.0.1:%d"}
     s2:setUp()
     """
 
@@ -250,9 +250,9 @@ class TestRoutingRoundRobinLBOneDown(DNSDistTest):
     _config_params = ['_testServerPort', '_testServer2Port']
     _config_template = """
     setServerPolicy(roundrobin)
-    s1 = newServer{address="127.0.0.1:%s"}
+    s1 = newServer{address="127.0.0.1:%d"}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s"}
+    s2 = newServer{address="127.0.0.1:%d"}
     s2:setDown()
     """
 
@@ -303,9 +303,9 @@ class TestRoutingRoundRobinLBAllDown(DNSDistTest):
     _config_template = """
     setServerPolicy(roundrobin)
     setRoundRobinFailOnNoServer(true)
-    s1 = newServer{address="127.0.0.1:%s"}
+    s1 = newServer{address="127.0.0.1:%d"}
     s1:setDown()
-    s2 = newServer{address="127.0.0.1:%s"}
+    s2 = newServer{address="127.0.0.1:%d"}
     s2:setDown()
     """
 
@@ -348,9 +348,9 @@ class TestRoutingLuaFFIPerThreadRoundRobinLB(RoundRobinTest, DNSDistTest):
       end
     ]])
 
-    s1 = newServer{address="127.0.0.1:%s"}
+    s1 = newServer{address="127.0.0.1:%d"}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s"}
+    s2 = newServer{address="127.0.0.1:%d"}
     s2:setUp()
 
     function atExit()
@@ -399,9 +399,9 @@ class TestRoutingCustomLuaRoundRobinLB(RoundRobinTest, DNSDistTest):
     end
     setServerPolicy(newServerPolicy("custom lua round robin policy", luaroundrobin))
 
-    s1 = newServer{address="127.0.0.1:%s"}
+    s1 = newServer{address="127.0.0.1:%d"}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s"}
+    s2 = newServer{address="127.0.0.1:%d"}
     s2:setUp()
     """
 
@@ -435,9 +435,9 @@ class TestRoutingOrder(DNSDistTest):
     _config_params = ['_testServerPort', '_testServer2Port']
     _config_template = """
     setServerPolicy(firstAvailable)
-    s1 = newServer{address="127.0.0.1:%s", order=2}
+    s1 = newServer{address="127.0.0.1:%d", order=2}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s", order=1}
+    s2 = newServer{address="127.0.0.1:%d", order=1}
     s2:setUp()
     """
 
@@ -501,9 +501,9 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
     _config_params = ['_testServerPort', '_testServer2Port']
     _config_template = """
     setServerPolicy(firstAvailable)
-    s1 = newServer{address="127.0.0.1:%s", order=2}
+    s1 = newServer{address="127.0.0.1:%d", order=2}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s", order=1, qps=10}
+    s2 = newServer{address="127.0.0.1:%d", order=1, qps=10}
     s2:setUp()
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
@@ -613,7 +613,7 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
 class TestRoutingNoServer(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s", pool="real"}
+    newServer{address="127.0.0.1:%d", pool="real"}
     setServFailWhenNoServer(true)
     """
 
@@ -653,9 +653,9 @@ class TestRoutingWRandom(DNSDistTest):
     setWeightedBalancingFactor(1.5)
     -- this is the default, but let's ensure we can reset it to the initial value
     setWeightedBalancingFactor(0)
-    s1 = newServer{address="127.0.0.1:%s", weight=1}
+    s1 = newServer{address="127.0.0.1:%d", weight=1}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s", weight=2}
+    s2 = newServer{address="127.0.0.1:%d", weight=2}
     s2:setUp()
     """
 
@@ -726,11 +726,11 @@ class TestRoutingHighValueWRandom(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_testServer2Port']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     setServerPolicy(wrandom)
-    s1 = newServer{address="127.0.0.1:%s", weight=2000000000}
+    s1 = newServer{address="127.0.0.1:%d", weight=2000000000}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s", weight=2000000000}
+    s2 = newServer{address="127.0.0.1:%d", weight=2000000000}
     s2:setUp()
     """
 
@@ -817,9 +817,9 @@ class TestRoutingWHashed(DNSDistTest):
     setWeightedBalancingFactor(1.5)
     -- this is the default, but let's ensure we can reset it to the initial value
     setWeightedBalancingFactor(0)
-    s1 = newServer{address="127.0.0.1:%s", weight=1}
+    s1 = newServer{address="127.0.0.1:%d", weight=1}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s", weight=1}
+    s2 = newServer{address="127.0.0.1:%d", weight=1}
     s2:setUp()
     """
 
@@ -898,9 +898,9 @@ class TestRoutingCHashed(DNSDistTest):
     setConsistentHashingBalancingFactor(1.5)
     -- this is the default, but let's ensure we can reset it to the initial value
     setConsistentHashingBalancingFactor(0)
-    s1 = newServer{address="127.0.0.1:%s", weight=1000}
+    s1 = newServer{address="127.0.0.1:%d", weight=1000}
     s1:setUp()
-    s2 = newServer{address="127.0.0.1:%s", weight=1000}
+    s2 = newServer{address="127.0.0.1:%d", weight=1000}
     s2:setUp()
     """
 
@@ -985,7 +985,7 @@ class TestRoutingLuaFFILBNoServer(DNSDistTest):
     end
     setServerPolicyLuaFFI("luaffipolicy", luaffipolicy)
 
-    s1 = newServer{address="127.0.0.1:%s"}
+    s1 = newServer{address="127.0.0.1:%d"}
     s1:setDown()
     """
     _verboseMode = True
@@ -1050,13 +1050,13 @@ class TestRoutingOrderedWRandUntag(DNSDistTest):
     setKey("%s")
     controlSocket("127.0.0.1:%d")
     setServerPolicy(orderedWrandUntag)
-    s11 = newServer{name="s11", address="127.0.0.1:%s", order=1, weight=1}
+    s11 = newServer{name="s11", address="127.0.0.1:%d", order=1, weight=1}
     s11:setUp()
-    s12 = newServer{name="s12", address="127.0.0.1:%s", order=1, weight=2}
+    s12 = newServer{name="s12", address="127.0.0.1:%d", order=1, weight=2}
     s12:setUp()
-    s21 = newServer{name="s21", address="127.0.0.1:%s", order=2, weight=1}
+    s21 = newServer{name="s21", address="127.0.0.1:%d", order=2, weight=1}
     s21:setUp()
-    s22 = newServer{name="s22", address="127.0.0.1:%s", order=2, weight=2}
+    s22 = newServer{name="s22", address="127.0.0.1:%d", order=2, weight=2}
     s22:setUp()
     function setServerState(name, flag)
         for _, s in ipairs(getServers()) do

--- a/regression-tests.dnsdist/test_RulesActions.py
+++ b/regression-tests.dnsdist/test_RulesActions.py
@@ -16,7 +16,7 @@ class TestAdvancedAllow(DNSDistTest):
     addAction(AllRule(), NoneAction())
     addAction(QNameSuffixRule("allowed.advanced.tests.powerdns.com."), AllowAction())
     addAction(AllRule(), DropAction())
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedAllow(self):
@@ -63,7 +63,7 @@ class TestAdvancedRemoveRD(DNSDistTest):
 
     _config_template = """
     addAction("norecurse.advanced.tests.powerdns.com.", SetNoRecurseAction())
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedNoRD(self):
@@ -126,7 +126,7 @@ class TestAdvancedAddCD(DNSDistTest):
 
     _config_template = """
     addAction("setcd.advanced.tests.powerdns.com.", SetDisableValidationAction())
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedSetCD(self):
@@ -189,7 +189,7 @@ class TestAdvancedClearRD(DNSDistTest):
 
     _config_template = """
     addAction("clearrd.advanced.tests.powerdns.com.", SetNoRecurseAction())
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedClearRD(self):
@@ -253,7 +253,7 @@ class TestAdvancedDelay(DNSDistTest):
 
     _config_template = """
     addAction(AllRule(), DelayAction(1000))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDelayed(self):
@@ -294,7 +294,7 @@ class TestAdvancedAndNot(DNSDistTest):
 
     _config_template = """
     addAction(AndRule({NotRule(QTypeRule("A")), TCPRule(false)}), RCodeAction(DNSRCode.NOTIMP))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
     def testAOverUDPReturnsNotImplementedCanary(self):
         """
@@ -363,7 +363,7 @@ class TestAdvancedOr(DNSDistTest):
 
     _config_template = """
     addAction(OrRule({QTypeRule("A"), TCPRule(false)}), RCodeAction(DNSRCode.NOTIMP))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
     def testAAAAOverUDPReturnsNotImplemented(self):
         """
@@ -423,7 +423,7 @@ class TestAdvancedOr(DNSDistTest):
 class TestAdvancedLogAction(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addAction(AllRule(), LogAction("dnsdist.log", false))
     """
     def testAdvancedLogAction(self):
@@ -456,7 +456,7 @@ class TestAdvancedLogAction(DNSDistTest):
 class TestAdvancedDNSSEC(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addAction(DNSSECRule(), DropAction())
     """
     def testAdvancedDNSSECDrop(self):
@@ -492,7 +492,7 @@ class TestAdvancedDNSSEC(DNSDistTest):
 class TestAdvancedQClass(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addAction(QClassRule(DNSClass.CHAOS), DropAction())
     """
     def testAdvancedQClassChaosDrop(self):
@@ -535,7 +535,7 @@ class TestAdvancedQClass(DNSDistTest):
 class TestAdvancedOpcode(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addAction(OpcodeRule(DNSOpcode.Notify), DropAction())
     """
     def testAdvancedOpcodeNotifyDrop(self):
@@ -580,7 +580,7 @@ class TestAdvancedOpcode(DNSDistTest):
 class TestAdvancedNonTerminalRule(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s", pool="real"}
+    newServer{address="127.0.0.1:%d", pool="real"}
     addAction(AllRule(), SetDisableValidationAction())
     addAction(AllRule(), PoolAction("real"))
     addAction(AllRule(), DropAction())
@@ -619,7 +619,7 @@ class TestAdvancedRestoreFlagsOnSelfResponse(DNSDistTest):
     _config_template = """
     addAction(AllRule(), SetDisableValidationAction())
     addAction(AllRule(), SpoofAction("192.0.2.1"))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedRestoreFlagsOnSpoofResponse(self):
@@ -653,7 +653,7 @@ class TestAdvancedQPS(DNSDistTest):
 
     _config_template = """
     addAction("qps.advanced.tests.powerdns.com", QPSAction(10))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedQPSLimit(self):
@@ -702,7 +702,7 @@ class TestAdvancedQPSNone(DNSDistTest):
     _config_template = """
     addAction("qpsnone.advanced.tests.powerdns.com", QPSAction(100))
     addAction(AllRule(), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedQPSNone(self):
@@ -730,7 +730,7 @@ class TestAdvancedNMGRule(DNSDistTest):
     allowed = newNMG()
     allowed:addMask("192.0.2.1/32")
     addAction(NotRule(NetmaskGroupRule(allowed)), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedNMGRule(self):
@@ -759,7 +759,7 @@ class TestAdvancedNMGAddNMG(DNSDistTest):
     oneNMG:addNMG(anotherNMG)
     addAction(NotRule(NetmaskGroupRule(oneNMG)), DropAction())
     addAction(AllRule(), SpoofAction('192.0.2.1'))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedNMGRuleAddNMG(self):
@@ -786,7 +786,7 @@ class TestAdvancedNMGRuleFromString(DNSDistTest):
 
     _config_template = """
     addAction(NotRule(NetmaskGroupRule('192.0.2.1')), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedNMGRule(self):
@@ -808,7 +808,7 @@ class TestAdvancedNMGRuleFromMultipleStrings(DNSDistTest):
 
     _config_template = """
     addAction(NotRule(NetmaskGroupRule({'192.0.2.1', '192.0.2.128/25'})), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedNMGRule(self):
@@ -831,7 +831,7 @@ class TestDSTPortRule(DNSDistTest):
     _config_params = ['_dnsDistPort', '_testServerPort']
     _config_template = """
     addAction(DSTPortRule(%d), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testDSTPortRule(self):
@@ -857,7 +857,7 @@ class TestAdvancedLabelsCountRule(DNSDistTest):
 
     _config_template = """
     addAction(QNameLabelsCountRule(5,6), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedLabelsCountRule(self):
@@ -912,7 +912,7 @@ class TestAdvancedWireLengthRule(DNSDistTest):
 
     _config_template = """
     addAction(QNameWireLengthRule(54,56), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedWireLengthRule(self):
@@ -972,7 +972,7 @@ class TestAdvancedLuaDO(DNSDistTest):
         return DNSAction.None, ""
     end
     addAction(AllRule(), LuaAction(nxDOLua))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testNxDOViaLua(self):
@@ -1017,7 +1017,7 @@ class TestAdvancedLuaRefused(DNSDistTest):
         return DNSAction.Refused, ""
     end
     addAction(AllRule(), LuaAction(refuse))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testRefusedViaLua(self):
@@ -1050,7 +1050,7 @@ class TestAdvancedLuaActionReturnSyntax(DNSDistTest):
         return DNSAction.Refused
     end
     addAction(AllRule(), LuaAction(refuse))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testRefusedWithEmptyRule(self):
@@ -1086,7 +1086,7 @@ class TestAdvancedLuaTruncated(DNSDistTest):
         return DNSAction.None, ""
     end
     addAction(AllRule(), LuaAction(trunc))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testTCViaLua(self):
@@ -1125,7 +1125,7 @@ class TestAdvancedRD(DNSDistTest):
 
     _config_template = """
     addAction(RDRule(), RCodeAction(DNSRCode.REFUSED))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedRDRefused(self):
@@ -1177,7 +1177,7 @@ class TestAdvancedLuaTempFailureTTL(DNSDistTest):
       return DNSAction.None, ""
     end
     addAction(AllRule(), LuaAction(testAction))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testTempFailureTTLBinding(self):
@@ -1206,7 +1206,7 @@ class TestAdvancedLuaTempFailureTTL(DNSDistTest):
 class TestAdvancedEDNSOptionRule(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addAction(EDNSOptionRule(EDNSOptionCode.ECS), DropAction())
     """
 
@@ -1263,7 +1263,7 @@ class TestAdvancedEDNSOptionRule(DNSDistTest):
 class TestAdvancedEDNSVersionRule(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     addAction(EDNSVersionRule(0), ERCodeAction(DNSRCode.BADVERS))
     """
 
@@ -1328,8 +1328,8 @@ class TestSetRules(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
-    newServer{address="127.0.0.1:%s"}
+    controlSocket("127.0.0.1:%d")
+    newServer{address="127.0.0.1:%d"}
     addAction(AllRule(), SpoofAction("192.0.2.1"))
     """
 
@@ -1394,8 +1394,8 @@ class TestRmRules(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
-    newServer{address="127.0.0.1:%s"}
+    controlSocket("127.0.0.1:%d")
+    newServer{address="127.0.0.1:%d"}
     addAction(AllRule(), SpoofAction("192.0.2.1"), {name='myFirstRule', uuid='090736ca-2fb6-41e7-a836-58efaca3d71e'})
     addAction(AllRule(), SpoofAction("192.0.2.1"), {name='mySecondRule'})
     addResponseAction(AllRule(), AllowResponseAction(), {name='myFirstResponseRule', uuid='745a03b5-89e0-4eee-a6bf-c9700b0d31f0'})
@@ -1431,7 +1431,7 @@ class TestRmRules(DNSDistTest):
 class TestAdvancedContinueAction(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s", pool="mypool"}
+    newServer{address="127.0.0.1:%d", pool="mypool"}
     addAction("nocontinue.continue-action.advanced.tests.powerdns.com.", PoolAction("mypool"))
     addAction("continue.continue-action.advanced.tests.powerdns.com.", ContinueAction(PoolAction("mypool")))
     addAction(AllRule(), SetDisableValidationAction())
@@ -1485,7 +1485,7 @@ class TestAdvancedNegativeAndSOA(DNSDistTest):
     addAction("nxd.negativeandsoa.advanced.tests.powerdns.com.", NegativeAndSOAAction(true, "auth.", 42, "mname", "rname", 5, 4, 3, 2, 1))
     addAction("nodata.negativeandsoa.advanced.tests.powerdns.com.", NegativeAndSOAAction(false, "another-auth.", 42, "mname", "rname", 1, 2, 3, 4, 5))
     setPayloadSizeOnSelfGeneratedAnswers(%d)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
     _config_params = ['_selfGeneratedPayloadSize', '_testServerPort']
 
@@ -1576,7 +1576,7 @@ class TestAdvancedNegativeAndSOAAuthSection(DNSDistTest):
     addAction("nxd.negativeandsoa.advanced.tests.powerdns.com.", NegativeAndSOAAction(true, "auth.", 42, "mname", "rname", 5, 4, 3, 2, 1, { soaInAuthoritySection=true }))
     addAction("nodata.negativeandsoa.advanced.tests.powerdns.com.", NegativeAndSOAAction(false, "another-auth.", 42, "mname", "rname", 1, 2, 3, 4, 5, { soaInAuthoritySection=true }))
     setPayloadSizeOnSelfGeneratedAnswers(%d)
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
     _config_params = ['_selfGeneratedPayloadSize', '_testServerPort']
 
@@ -1681,7 +1681,7 @@ class TestAdvancedLuaRule(DNSDistTest):
     addAction(AllRule(), SetTagAction('a-tag', 'a-value'))
     addAction(LuaRule(luarulefunction), RCodeAction(DNSRCode.NOTIMP))
     addAction(AllRule(), RCodeAction(DNSRCode.REFUSED))
-    -- newServer{address="127.0.0.1:%s"}
+    -- newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedLuaRule(self):
@@ -1716,7 +1716,7 @@ class TestAdvancedSetEDNSOptionAction(DNSDistTest):
 
     _config_template = """
     addAction(AllRule(), SetEDNSOptionAction(10, "deadbeefdeadc0de"))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testAdvancedSetEDNSOption(self):
@@ -1829,7 +1829,7 @@ class TestAdvancedLuaGetContent(DNSDistTest):
         return DNSAction.None, ""
     end
     addAction(AllRule(), LuaAction(accessContentLua))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testGetContentViaLua(self):

--- a/regression-tests.dnsdist/test_SNMP.py
+++ b/regression-tests.dnsdist/test_SNMP.py
@@ -18,7 +18,7 @@ class TestSNMP(DNSDistTest):
     _snmpOID = '1.3.6.1.4.1.43315.3'
     _queriesSent = 0
     _config_template = """
-    newServer{address="127.0.0.1:%s", name="servername"}
+    newServer{address="127.0.0.1:%d", name="servername"}
     snmpAgent(true)
     setVerboseHealthChecks(true)
     """
@@ -73,7 +73,7 @@ class TestSNMP(DNSDistTest):
         ## state
         self.assertEqual(str(results['1.3.6.1.4.1.43315.3.2.1.8.0']), "up")
         ## address
-        self.assertEqual(str(results['1.3.6.1.4.1.43315.3.2.1.9.0']), ("127.0.0.1:%s" % (self._testServerPort)))
+        self.assertEqual(str(results['1.3.6.1.4.1.43315.3.2.1.9.0']), ("127.0.0.1:%d" % (self._testServerPort)))
         ## pools
         self.assertEqual(str(results['1.3.6.1.4.1.43315.3.2.1.10.0']), "")
         ## queries

--- a/regression-tests.dnsdist/test_SVCB.py
+++ b/regression-tests.dnsdist/test_SVCB.py
@@ -23,7 +23,7 @@ class TestSVCB(DNSDistTest):
     local httpsSVC = { newSVCRecordParameters(1, ".", { mandatory={"port"}, alpn={ "h2" }, noDefaultAlpn=true, port=8002, ipv4hint={ "192.0.2.2" }, ipv6hint={ "2001:db8::2" }}) }
     addAction(AndRule{QTypeRule(65), SuffixMatchNodeRule("https.svcb.tests.powerdns.com.")}, SpoofSVCAction(httpsSVC))
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testBasic(self):
@@ -186,7 +186,7 @@ class TestSVCBViaFFI(DNSDistTest):
 
     addAction(AndRule{QTypeRule(65), SuffixMatchNodeRule("https.svcb.tests.powerdns.com.")}, LuaFFIAction(httpsSVC))
 
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testBasic(self):

--- a/regression-tests.dnsdist/test_SelfAnsweredResponses.py
+++ b/regression-tests.dnsdist/test_SelfAnsweredResponses.py
@@ -10,7 +10,7 @@ class TestSelfAnsweredResponses(DNSDistTest):
     addSelfAnsweredResponseAction(AndRule({SuffixMatchNodeRule("udp.selfanswered.tests.powerdns.com."), NotRule(MaxQPSRule(1))}), DropResponseAction())
     addAction(SuffixMatchNodeRule("tcp.selfanswered.tests.powerdns.com."), SpoofAction("192.0.2.1"))
     addSelfAnsweredResponseAction(AndRule({SuffixMatchNodeRule("tcp.selfanswered.tests.powerdns.com."), NotRule(MaxQPSRule(1))}), DropResponseAction())
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testSelfAnsweredUDP(self):

--- a/regression-tests.dnsdist/test_Spoofing.py
+++ b/regression-tests.dnsdist/test_Spoofing.py
@@ -21,7 +21,7 @@ class TestSpoofingSpoof(DNSDistTest):
     addAction(AndRule{SuffixMatchNodeRule("multiraw.spoofing.tests.powerdns.com"), QTypeRule(DNSQType.A)}, SpoofRawAction({"\\192\\000\\002\\001", "\\192\\000\\002\\002"}))
     -- rfc8482
     addAction(AndRule{SuffixMatchNodeRule("raw-any.spoofing.tests.powerdns.com"), QTypeRule(DNSQType.ANY)}, SpoofRawAction("\\007rfc\\056\\052\\056\\050\\000", { typeForAny=DNSQType.HINFO }))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testSpoofActionA(self):
@@ -538,7 +538,7 @@ class TestSpoofingLuaSpoof(DNSDistTest):
     addAction("luaspoof1.spoofing.tests.powerdns.com.", LuaAction(spoof1rule))
     addAction("luaspoof2.spoofing.tests.powerdns.com.", LuaAction(spoof2rule))
     addAction("lua-raw.spoofing.tests.powerdns.com.", LuaAction(spoofrawrule))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testLuaSpoofA(self):
@@ -740,7 +740,7 @@ class TestSpoofingLuaSpoofMulti(DNSDistTest):
 
     addAction("luaspoof1multi.spoofing.tests.powerdns.com.", LuaAction(spoof1multirule))
     addAction("lua-raw-multi.spoofing.tests.powerdns.com.", LuaAction(spoofrawmultirule))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testLuaSpoofMultiA(self):
@@ -898,7 +898,7 @@ class TestSpoofingLuaFFISpoofMulti(DNSDistTest):
     end
 
     addAction("lua-raw-multi.ffi-spoofing.tests.powerdns.com.", LuaFFIAction(spoofrawmultirule))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
     _verboseMode = True
 
@@ -960,7 +960,7 @@ class TestSpoofingLuaWithStatistics(DNSDistTest):
         end
     end
     addAction("luaspoofwithstats.spoofing.tests.powerdns.com.", LuaAction(spoof1rule))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
 
     def testLuaSpoofBasedOnStatistics(self):
@@ -1039,7 +1039,7 @@ class TestSpoofingLuaSpoofPacket(DNSDistTest):
     end
 
     addAction("lua-raw-packet.ffi-spoofing.tests.powerdns.com.", LuaFFIAction(spoofpacketffi))
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
     """
     _verboseMode = True
 

--- a/regression-tests.dnsdist/test_TCPFastOpen.py
+++ b/regression-tests.dnsdist/test_TCPFastOpen.py
@@ -23,8 +23,8 @@ class TestBrokenTCPFastOpen(DNSDistTest):
     _webServerAPIKeyHashed = '$scrypt$ln=10,p=1,r=8$9v8JxDfzQVyTpBkTbkUqYg==$bDQzAOHeK1G9UvTPypNhrX48w974ZXbFPtRKS34+aso='
     _config_params = ['_testServerPort', '_testServerRetries', '_webServerPort', '_webServerBasicAuthPasswordHashed', '_webServerAPIKeyHashed']
     _config_template = """
-    newServer{address="127.0.0.1:%s", useClientSubnet=true, tcpFastOpen=true, retries=%d }
-    webserver("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d", useClientSubnet=true, tcpFastOpen=true, retries=%d }
+    webserver("127.0.0.1:%d")
     setWebserverConfig({password="%s", apiKey="%s"})
     """
 

--- a/regression-tests.dnsdist/test_TCPKeepAlive.py
+++ b/regression-tests.dnsdist/test_TCPKeepAlive.py
@@ -21,11 +21,11 @@ class TestTCPKeepAlive(DNSDistTest):
     _maxTCPConnsPerClient = 100
     _maxTCPConnDuration = 99
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    setTCPRecvTimeout(%s)
-    setMaxTCPQueriesPerConnection(%s)
-    setMaxTCPConnectionsPerClient(%s)
-    setMaxTCPConnectionDuration(%s)
+    newServer{address="127.0.0.1:%d"}
+    setTCPRecvTimeout(%d)
+    setMaxTCPQueriesPerConnection(%d)
+    setMaxTCPConnectionsPerClient(%d)
+    setMaxTCPConnectionDuration(%d)
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
     addAction("largernumberofconnections.tcpka.tests.powerdns.com.", SetSkipCacheAction())
@@ -261,11 +261,11 @@ class TestTCPKeepAliveNoDownstreamDrop(DNSDistTest):
     _maxTCPConnsPerClient = 3
     _maxTCPConnDuration = 99
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    setTCPRecvTimeout(%s)
-    setMaxTCPQueriesPerConnection(%s)
-    setMaxTCPConnectionsPerClient(%s)
-    setMaxTCPConnectionDuration(%s)
+    newServer{address="127.0.0.1:%d"}
+    setTCPRecvTimeout(%d)
+    setMaxTCPQueriesPerConnection(%d)
+    setMaxTCPConnectionsPerClient(%d)
+    setMaxTCPConnectionDuration(%d)
     -- create the pool named "nosuchpool"
     getPool("nosuchpool")
     addAction("nodownstream-drop.tcpka.tests.powerdns.com.", PoolAction("nosuchpool"))

--- a/regression-tests.dnsdist/test_TCPOnly.py
+++ b/regression-tests.dnsdist/test_TCPOnly.py
@@ -6,7 +6,7 @@ from dnsdisttests import DNSDistTest
 class TestTCPOnly(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s", tcpOnly=true}
+    newServer{address="127.0.0.1:%d", tcpOnly=true}
     """
 
     def testUDP(self):

--- a/regression-tests.dnsdist/test_TCPShort.py
+++ b/regression-tests.dnsdist/test_TCPShort.py
@@ -24,8 +24,8 @@ class TestTCPShort(DNSDistTest):
     _tlsServerPort = pickAvailablePort()
     _tcpSendTimeout = 60
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    addTLSLocal("127.0.0.1:%s", "%s", "%s")
+    newServer{address="127.0.0.1:%d"}
+    addTLSLocal("127.0.0.1:%d", "%s", "%s")
     setTCPSendTimeout(%d)
     """
     _config_params = ['_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_tcpSendTimeout']

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -278,10 +278,10 @@ class TestOpenSSL(DNSDistTest, TLSTests):
     _tlsServerPort = pickAvailablePort()
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
-    newServer{address="127.0.0.1:%s"}
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
+    newServer{address="127.0.0.1:%d"}
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl" })
     addAction(SNIRule("powerdns.com"), SpoofAction("1.2.3.4"))
     """
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey']
@@ -307,10 +307,10 @@ class TestGnuTLS(DNSDistTest, TLSTests):
     _tlsServerPort = pickAvailablePort()
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
-    newServer{address="127.0.0.1:%s"}
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="gnutls" })
+    newServer{address="127.0.0.1:%d"}
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="gnutls" })
     addAction(SNIRule("powerdns.com"), SpoofAction("1.2.3.4"))
     """
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey']
@@ -384,9 +384,9 @@ class TestDOTWithCache(DNSDistTest):
     _caCert = 'ca.pem'
     _tlsServerPort = pickAvailablePort()
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
-    addTLSLocal("127.0.0.1:%s", "%s", "%s")
+    addTLSLocal("127.0.0.1:%d", "%s", "%s")
 
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
@@ -458,8 +458,8 @@ class TestTLSFrontendLimits(DNSDistTest):
     _tcpIdleTimeout = 2
     _maxTCPConnsPerTLSFrontend = 5
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl", maxConcurrentTCPConnections=%d })
+    newServer{address="127.0.0.1:%d"}
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl", maxConcurrentTCPConnections=%d })
     """
     _config_params = ['_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_maxTCPConnsPerTLSFrontend']
     _alternateListeningAddr = '127.0.0.1'
@@ -524,8 +524,8 @@ class TestProtocols(DNSDistTest):
     end
 
     addAction("protocols.tls.tests.powerdns.com.", LuaAction(checkDOT))
-    newServer{address="127.0.0.1:%s"}
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
+    newServer{address="127.0.0.1:%d"}
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl" })
     """
     _config_params = ['_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey']
 
@@ -557,10 +557,10 @@ class TestPKCSTLSCertificate(DNSDistTest, TLSTests):
     _tlsServerPort = pickAvailablePort()
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
-    newServer{address="127.0.0.1:%s"}
+    controlSocket("127.0.0.1:%d")
+    newServer{address="127.0.0.1:%d"}
     cert=newTLSCertificate("%s", {password="%s"})
-    addTLSLocal("127.0.0.1:%s", cert, "", { provider="openssl" })
+    addTLSLocal("127.0.0.1:%d", cert, "", { provider="openssl" })
     addAction(SNIRule("powerdns.com"), SpoofAction("1.2.3.4"))
     """
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_serverCert', '_pkcsPassphrase', '_tlsServerPort']
@@ -586,10 +586,10 @@ class TestOpenSSLTLSTicketsKeyCallback(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
-    newServer{address="127.0.0.1:%s"}
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl" })
+    newServer{address="127.0.0.1:%d"}
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl" })
 
     lastKey = ""
     lastKeyLen = 0
@@ -627,10 +627,10 @@ class TestGnuTLSTLSTicketsKeyCallback(DNSDistTest):
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey']
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
 
-    newServer{address="127.0.0.1:%s"}
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="gnutls" })
+    newServer{address="127.0.0.1:%d"}
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="gnutls" })
 
     lastKey = ""
     lastKeyLen = 0

--- a/regression-tests.dnsdist/test_TLSSessionResumption.py
+++ b/regression-tests.dnsdist/test_TLSSessionResumption.py
@@ -71,7 +71,7 @@ class TestNoTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
     _dohWithH2OServerPort = pickAvailablePort()
     _numberOfKeys = 0
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d, numberOfStoredSessions=0, sessionTickets=false, library='nghttp2' })
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d, numberOfStoredSessions=0, sessionTickets=false, library='h2o' })
@@ -98,8 +98,8 @@ class TestTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
     _numberOfKeys = 5
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
-    newServer{address="127.0.0.1:%s"}
+    controlSocket("127.0.0.1:%d")
+    newServer{address="127.0.0.1:%d"}
 
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d, library='nghttp2' })
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/" }, { numberOfTicketsKeys=%d, library='h2o' })
@@ -193,9 +193,9 @@ class TestNoTLSSessionResumptionDOT(DNSDistTLSSessionResumptionTest):
     _tlsServerPort = pickAvailablePort()
     _numberOfKeys = 0
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { numberOfTicketsKeys=%d, numberOfStoredSessions=0, sessionTickets=false })
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { numberOfTicketsKeys=%d, numberOfStoredSessions=0, sessionTickets=false })
     """
     _config_params = ['_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_numberOfKeys']
 
@@ -217,9 +217,9 @@ class TestTLSSessionResumptionDOT(DNSDistTLSSessionResumptionTest):
     _config_template = """
     setKey("%s")
     controlSocket("127.0.0.1:%s")
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
-    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl", numberOfTicketsKeys=%d })
+    addTLSLocal("127.0.0.1:%d", "%s", "%s", { provider="openssl", numberOfTicketsKeys=%d })
     """
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey', '_numberOfKeys']
 

--- a/regression-tests.dnsdist/test_Tags.py
+++ b/regression-tests.dnsdist/test_Tags.py
@@ -6,7 +6,7 @@ from dnsdisttests import DNSDistTest
 class TestTags(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     function lol(dq)
       return DNSAction.None, ""
@@ -215,7 +215,7 @@ class TestTags(DNSDistTest):
 class TestSetTagAction(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     addAction(AllRule(), SetTagAction("dns", "value1"))
     addAction("tag-me-dns-2.tags.tests.powerdns.com.", SetTagAction("dns", "value2"))
@@ -274,7 +274,7 @@ class TestSetTagAction(DNSDistTest):
 class TestSetTag(DNSDistTest):
 
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     function dqset(dq)
       dq:setTag("dns", "value1")

--- a/regression-tests.dnsdist/test_TeeAction.py
+++ b/regression-tests.dnsdist/test_TeeAction.py
@@ -18,7 +18,7 @@ class TestTeeAction(DNSDistTest):
     _fromTeeProxyQueue = Queue()
     _config_template = """
     setKey("%s")
-    controlSocket("127.0.0.1:%s")
+    controlSocket("127.0.0.1:%d")
     newServer{address="127.0.0.1:%d"}
     addAction(QTypeRule(DNSQType.A), TeeAction("127.0.0.1:%d", true))
     addAction(QTypeRule(DNSQType.AAAA), TeeAction("127.0.0.1:%d", false))

--- a/regression-tests.dnsdist/test_Trailing.py
+++ b/regression-tests.dnsdist/test_Trailing.py
@@ -12,7 +12,7 @@ class TestTrailingDataToBackend(DNSDistTest):
     _testServerPort = pickAvailablePort()
     _verboseMode = True
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     function replaceTrailingData(dq)
         local success = dq:setTrailingData("ABC")
@@ -172,7 +172,7 @@ class TestTrailingDataToBackend(DNSDistTest):
 class TestTrailingDataToDnsdist(DNSDistTest):
     _verboseMode = True
     _config_template = """
-    newServer{address="127.0.0.1:%s"}
+    newServer{address="127.0.0.1:%d"}
 
     addAction(AndRule({QNameRule("dropped.trailing.tests.powerdns.com."), TrailingDataRule()}), DropAction())
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
These have been bothering me for a long time. I was hoping we would be fixing them little by little but we are actually copy/pasting the wrong formatters to new tests, so I'm biting the bullet now.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
