### PR TITLE
Use map for getAppliedPolicyTypeAsString

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -38,6 +38,15 @@ class PDNSPBConnHandler(object):
         self._oturl = oturl
         self._printjson = printjson
 
+    messageTypeToStringMap = {
+        dnsmessage_pb2.PBDNSMessage.UNKNOWN: 'Unknown',
+        dnsmessage_pb2.PBDNSMessage.QNAME: 'QName',
+        dnsmessage_pb2.PBDNSMessage.CLIENTIP: 'Client IP',
+        dnsmessage_pb2.PBDNSMessage.RESPONSEIP: 'Response IP',
+        dnsmessage_pb2.PBDNSMessage.NSDNAME: 'NS DName',
+        dnsmessage_pb2.PBDNSMessage.NSIP: 'NS IP',
+    }
+
     def run(self):
         while True:
             data = self._conn.recv(2)
@@ -150,18 +159,8 @@ class PDNSPBConnHandler(object):
 
     @staticmethod
     def getAppliedPolicyTypeAsString(polType):
-        if polType == dnsmessage_pb2.PBDNSMessage.UNKNOWN:
-            return 'Unknown'
-        elif polType == dnsmessage_pb2.PBDNSMessage.QNAME:
-            return 'QName'
-        elif polType == dnsmessage_pb2.PBDNSMessage.CLIENTIP:
-            return 'Client IP'
-        elif polType == dnsmessage_pb2.PBDNSMessage.RESPONSEIP:
-            return 'Response IP'
-        elif polType == dnsmessage_pb2.PBDNSMessage.NSDNAME:
-            return 'NS DName'
-        elif polType == dnsmessage_pb2.PBDNSMessage.NSIP:
-            return 'NS IP'
+        try:
+            return messageTypeToStringMap.get(polType, "Unrecognized")
 
     @staticmethod
     def getEventAsString(event):


### PR DESCRIPTION
### Short description

Use map for getAppliedPolicyTypeAsString

This was identified by https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fmixed-returns

AI was not used for this. Habbie suggested a map.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
