### PR TITLE
Fix try/except/as notation

### DIFF
--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -434,7 +434,7 @@ e 3600 IN A 192.0.2.42
                 soa = zone.get_soa()
                 if soa.serial == serial and soa.mname == dns.name.from_text('ns.zone.rpz.'):
                     return # we found what we expected
-            except e as FileNotFoundError:
+            except FileNotFoundError as e:
                 pass
             attempts = attempts + incr
             time.sleep(incr)


### PR DESCRIPTION
### Short description

The python notation appears backwards and python wasn't happy: https://github.com/PowerDNS/pdns/actions/runs/19200740735/job/54888429023?pr=16456#step:11:588
- introduced in #15336

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
