### PR TITLE
Avoid warning about mixed explicit/implicit returns

### DIFF
--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -395,7 +395,7 @@ class DOHTests(object):
         self.assertEqual(len(lines), 2)
         metrics = lines[1].split()
         self.assertEqual(len(metrics), 15)
-        return int(metrics[metricMap[name]])
+        return int(metrics[self.metricMap[name]])
 
     def testDOHHTTP1(self):
         """


### PR DESCRIPTION
### Short description
Use map for getHTTPCounter

This was identified by https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fmixed-returns

AI was not used for this. I'm using a map because I used one in #16458


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
