### PR TITLE
auth, rec: typos

### DIFF
--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -272,7 +272,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
             g_zoneCache.add(zone.first, d.id);
           }
           else {
-            g_log << Logger::Error << logPrefix << "new zone '" << zone.first << "' does not exists and was not inserted in the zone-cache" << endl;
+            g_log << Logger::Error << logPrefix << "new zone '" << zone.first << "' does not exist and was not inserted in the zone-cache" << endl;
           }
         }
         else {

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -812,7 +812,7 @@ static void setupNODThread(Logr::log_t log)
       g_nodDBp->setCacheDir(::arg()["new-domain-history-dir"]);
     }
     catch (const PDNSException& e) {
-      log->error(Logr::Error, e.reason, "new-domain-history-dir is not readable or does not exists", "dir", Logging::Loggable(::arg()["new-domain-history-dir"]));
+      log->error(Logr::Error, e.reason, "new-domain-history-dir is not readable or does not exist", "dir", Logging::Loggable(::arg()["new-domain-history-dir"]));
       _exit(1);
     }
     if (!g_nodDBp->init()) {


### PR DESCRIPTION
### Short description
`does not exists` -> `does not exist`

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
