### PR TITLE
contrib/ProtobufLogger.py: Fix syntax error that crept in with 16458

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -159,8 +159,7 @@ class PDNSPBConnHandler(object):
 
     @staticmethod
     def getAppliedPolicyTypeAsString(polType):
-        try:
-            return messageTypeToStringMap.get(polType, "Unrecognized")
+        return messageTypeToStringMap.get(polType, "Unrecognized")
 
     @staticmethod
     def getEventAsString(event):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
