### PR TITLE
Fix duplicate key in dict literal

### DIFF
--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -2772,8 +2772,8 @@ A sequence of statistic names, that are prevented from being exported via SNMP, 
 Prefer structured logging when both an old style and a structured log messages is available.
  ''',
         'versionadded': '4.6.0',
-        'versionchanged': ('5.0.0', 'Disabling structured logging is deprecated'),
-        'versionchanged': ('5.1.0', 'Disabling structured logging is not supported'),
+        'versionchanged': [('5.0.0', 'Disabling structured logging is deprecated'),
+                           ('5.1.0', 'Disabling structured logging is not supported')]
     },
     {
         'name' : 'structured_logging_backend',


### PR DESCRIPTION
### Short description

This was identified by https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fduplicate-key-dict-literal

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
