### PR TITLE
Convert metrics_table.py to a module

### DIFF
--- a/pdns/recursordist/metrics.py
+++ b/pdns/recursordist/metrics.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import metrics_table
 
 # default: 'type': uint64
 # ptype: "'counter' (vs gauge')
@@ -31,9 +32,7 @@ def dedashForSNMP(name):
     ret = ret.replace('Nsec', 'NSEC')
     return ret
 
-# read table
-with open(srcdir + '/metrics_table.py', mode='r', encoding="utf-8") as file:
-    table = eval(file.read())
+table = metrics_table.table
 
 #
 # We create various files in the srcdir but copy them into the builddir if needed to satisfy meson

--- a/pdns/recursordist/metrics_table.py
+++ b/pdns/recursordist/metrics_table.py
@@ -24,7 +24,7 @@
 #   }
 #
 
-[
+table = [
     {
         'name': 'questions',
         'lambda': '[] { return g_Counters.sum(rec::Counter::qcounter); }',


### PR DESCRIPTION
### Short description
This was identified by https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fineffectual-statement
Fix suggested by dwfreed (who is not an AI, at least to my knowledge)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
