### PR TITLE
Switch TestRuleMetricsDefault to pass

### DIFF
--- a/regression-tests.dnsdist/test_Metrics.py
+++ b/regression-tests.dnsdist/test_Metrics.py
@@ -178,7 +178,7 @@ class RuleMetricsTest(object):
             self.assertEqual(self.getMetric('rule-servfail'), ruleBefore)
 
 class TestRuleMetricsDefault(RuleMetricsTest, DNSDistTest):
-    None
+    pass
 
 class TestRuleMetricsRecvmmsg(RuleMetricsTest, DNSDistTest):
     # test the metrics with recvmmsg/sendmmsg support enabled as well


### PR DESCRIPTION
### Short description
This was identified by https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fineffectual-statement

The [internet suggests](https://stackoverflow.com/a/47973297):
> While the function [with `None`] will behave identically, it is a bit different since the expression (while constant) will still be evaluated (although immediately discarded).


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
