### PR TITLE
Improve reading of operator expression

### DIFF
--- a/pdns/dnsdistdist/html/local.js
+++ b/pdns/dnsdistdist/html/local.js
@@ -158,16 +158,16 @@ $(document).ready(function() {
                 if(!gdata["cpu-sys-msec"]) 
                     gdata=data;
 
-                var cpu=((1.0*data["cpu-sys-msec"]+1.0*data["cpu-user-msec"] - 1.0*gdata["cpu-sys-msec"]-1.0*gdata["cpu-user-msec"])/10.0);
+                var cpu=((1*data["cpu-sys-msec"] + 1*data["cpu-user-msec"]) - (1*gdata["cpu-sys-msec"] + 1*gdata["cpu-user-msec"]))/10.0;
 
                 $("#cpu").text(cpu.toFixed(2));
                 var qps=1.0*data["queries"]-1.0*gdata["queries"];
                 $("#qps").text(qps.toFixed(2));
                 $("#server-policy").text(data["server-policy"]);
 
-                var servfailps=1.0*data["servfail-responses"]-1.0*gdata["servfail-responses"];
+                var servfailps=(1*data["servfail-responses"]) - (1*gdata["servfail-responses"]);
 
-                var totpcache=1.0*data["cache-hits"]-1.0*gdata["cache-hits"]+1.0*data["cache-misses"]-1.0*gdata["cache-misses"];
+                var totpcache=(1*data["cache-hits"] + 1*data["cache-misses"]) - (1*gdata["cache-hits"] + 1*gdata["cache-misses"]);
                 var hitrate=0;
                 if(totpcache > 0) {
                     hitrate=100.0*(data["cache-hits"]-1.0*gdata["cache-hits"])/totpcache;


### PR DESCRIPTION
### Short description
codeql has an opinion of https://github.com/check-spelling-sandbox/pdns/security/quality/rules/js%2Fwhitespace-contradicts-precedence

specifically, it doesn't like this line:
https://github.com/PowerDNS/pdns/blob/93edc7bd31032e0b40d948d259e5fa038c145324/pdns/dnsdistdist/html/local.js#L161

I think that there's no value in using `1.0*` over `1*` -- afaict the goal is to coerce a string to a number.

I'm suggesting rewriting things with parentheses in other places:
- there's no need for the outer parenthesis set for `var cpu=(...)`
- while parentheses aren't needed to cause `*` operations to bind higher than `+` or `-` operations, I think it's easier to read and have parallelism if the items are added pairwise and then subtracted as a set instead of summing two items and subtracting two items.
- maintaining the same parallelism for cpu (sys+user) as for cache (hits+misses) over data and gdata

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
