### PR TITLE
Do not call `sys.exit` with a void return

### DIFF
--- a/docs/generate-docs.py
+++ b/docs/generate-docs.py
@@ -120,4 +120,4 @@ def create_argument_parser():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/docs/generate-man-pages.py
+++ b/docs/generate-man-pages.py
@@ -102,4 +102,4 @@ def create_argument_parser():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()


### PR DESCRIPTION
### Short description
codeql has an opinion of https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fprocedure-return-value-used

> Use of the return value of a procedure
> The return value of a procedure (a function that does not return a value) is used. This is confusing to the reader as the value (None) has no meaning.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
