### PR TITLE
Do not catch `KeyboardInterrupt` or `SystemExit`

### DIFF
--- a/.github/scripts/clang-tidy-diff.py
+++ b/.github/scripts/clang-tidy-diff.py
@@ -270,7 +270,7 @@ def main():
     print('Writing fixes to ' + args.export_fixes + ' ...')
     try:
       merge_replacement_files(tmpdir, args.export_fixes)
-    except:
+    except Exception:
       sys.stderr.write('Error exporting fixes.\n')
       traceback.print_exc()
 

--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -27,7 +27,7 @@ try:
     import google.protobuf.json_format
     import opentelemetry.proto.trace.v1.trace_pb2
     opentelemetryAvailable = True
-except:
+except Exception:
     opentelemetryAvailable = False
 
 

--- a/regression-tests.api/test_helper.py
+++ b/regression-tests.api/test_helper.py
@@ -48,7 +48,7 @@ class ApiTestCase(unittest.TestCase):
     def assert_success_json(self, result):
         try:
             result.raise_for_status()
-        except:
+        except Exception:
             print(result.content)
             raise
         self.assertEqual(result.headers['Content-Type'], 'application/json')
@@ -60,7 +60,7 @@ class ApiTestCase(unittest.TestCase):
     def assert_success(self, result):
         try:
             result.raise_for_status()
-        except:
+        except Exception:
             print(result.content)
             raise
 

--- a/regression-tests.auth-py/test_ProxyProtocol.py
+++ b/regression-tests.auth-py/test_ProxyProtocol.py
@@ -130,7 +130,7 @@ secondary
     def generateAuthZone(cls, confdir, zonename, zonecontent):
         try:
             os.unlink(os.path.join(confdir, '%s.zone' % zonename))
-        except:
+        except Exception:
             pass
 
     @classmethod

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -377,7 +377,7 @@ class DOHTests(object):
             conn.send('AAAA')
             response = conn.recv(65535)
             self.assertFalse(response)
-        except:
+        except Exception:
             pass
 
     metricMap = {
@@ -1659,7 +1659,7 @@ class DOHFrontendLimits(object):
                 if self._dohLibrary != 'h2o':
                     alpn.append('h2')
                 conns.append(self.openTLSConnection(self._dohServerPort, self._serverName, self._caCert, alpn=alpn))
-            except:
+            except Exception:
                 conns.append(None)
 
         count = 0
@@ -1676,7 +1676,7 @@ class DOHFrontendLimits(object):
                     count = count + 1
                 else:
                     failed = failed + 1
-            except:
+            except Exception:
                 failed = failed + 1
 
         for conn in conns:
@@ -1868,7 +1868,7 @@ class DOHLimits(object):
                 conn.perform_rb()
                 conn.getinfo(pycurl.RESPONSE_CODE)
                 count = count + 1
-            except:
+            except Exception:
                 failed = failed + 1
 
         for conn in conns:

--- a/regression-tests.dnsdist/test_ProxyProtocol.py
+++ b/regression-tests.dnsdist/test_ProxyProtocol.py
@@ -113,7 +113,7 @@ def MockTCPReverseProxyAddingProxyProtocol(listeningPort, forwardingPort, server
                 break
           except socket.timeout:
             break
-          except:
+          except Exception:
             break
 
         incoming.close()

--- a/regression-tests.dnsdist/test_TCPKeepAlive.py
+++ b/regression-tests.dnsdist/test_TCPKeepAlive.py
@@ -60,7 +60,7 @@ class TestTCPKeepAlive(DNSDistTest):
                     break
                 self.assertEqual(expectedResponse, response)
                 count = count + 1
-            except:
+            except Exception:
                 pass
 
         conn.close()
@@ -99,7 +99,7 @@ class TestTCPKeepAlive(DNSDistTest):
                     break
                 self.assertEqual(expectedResponse, response)
                 count = count + 1
-            except:
+            except Exception:
                 pass
 
         conn.close()
@@ -129,7 +129,7 @@ class TestTCPKeepAlive(DNSDistTest):
                     break
                 self.assertEqual(expectedResponse, response)
                 count = count + 1
-            except:
+            except Exception:
                 pass
 
         conn.close()
@@ -153,7 +153,7 @@ class TestTCPKeepAlive(DNSDistTest):
                 if response is None:
                     break
                 count = count + 1
-            except:
+            except Exception:
                 pass
 
         conn.close()
@@ -177,7 +177,7 @@ class TestTCPKeepAlive(DNSDistTest):
                 if response is None:
                     break
                 count = count + 1
-            except:
+            except Exception:
                 pass
 
         conn.close()
@@ -200,7 +200,7 @@ class TestTCPKeepAlive(DNSDistTest):
                 if response is None:
                     break
                 count = count + 1
-            except:
+            except Exception:
                 pass
 
         conn.close()
@@ -240,7 +240,7 @@ class TestTCPKeepAlive(DNSDistTest):
                     break
                 self.assertEqual(expectedResponse, response)
                 count = count + 1
-            except:
+            except Exception:
                 pass
 
         for con in conns:
@@ -292,7 +292,7 @@ class TestTCPKeepAliveNoDownstreamDrop(DNSDistTest):
                 if response is None:
                     break
                 count = count + 1
-            except:
+            except Exception:
                 pass
 
         conn.close()

--- a/regression-tests.dnsdist/test_TCPLimits.py
+++ b/regression-tests.dnsdist/test_TCPLimits.py
@@ -50,7 +50,7 @@ class TestTCPLimits(DNSDistTest):
                 response = self.recvTCPResponseOverConnection(conn)
                 self.assertTrue(response)
                 count = count + 1
-            except:
+            except Exception:
                 pass
 
         # this one should fail
@@ -63,7 +63,7 @@ class TestTCPLimits(DNSDistTest):
                 failed = True
             else:
                 count = count + 1
-        except:
+        except Exception:
             failed = True
 
         conn.close()
@@ -91,7 +91,7 @@ class TestTCPLimits(DNSDistTest):
                     count = count + 1
                 else:
                     failed = failed + 1
-            except:
+            except Exception:
                 failed = failed + 1
 
         for conn in conns:
@@ -172,7 +172,7 @@ class TestTCPLimitsReadIO(DNSDistTest):
                 conn.send(payload[count].to_bytes())
                 count = count + 1
                 time.sleep(0.001)
-            except:
+            except Exception:
                 failed = True
                 break
 
@@ -181,7 +181,7 @@ class TestTCPLimitsReadIO(DNSDistTest):
                 response = self.recvTCPResponseOverConnection(conn)
                 if not response:
                   failed = True
-            except:
+            except Exception:
                 failed = True
 
         conn.close()
@@ -194,7 +194,7 @@ class TestTCPLimitsReadIO(DNSDistTest):
             response = self.recvTCPResponseOverConnection(conn)
             if response is None:
               failed = True
-        except:
+        except Exception:
             failed = True
         finally:
             conn.close()
@@ -391,7 +391,7 @@ class TestTCPFrontendLimits(DNSDistTest):
                     count = count + 1
                 else:
                     failed = failed + 1
-            except:
+            except Exception:
                 failed = failed + 1
 
         for conn in conns:

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -476,7 +476,7 @@ class TestTLSFrontendLimits(DNSDistTest):
         for idx in range(self._maxTCPConnsPerTLSFrontend + 1):
             try:
                 conns.append(self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert))
-            except:
+            except Exception:
                 conns.append(None)
 
         count = 0
@@ -493,7 +493,7 @@ class TestTLSFrontendLimits(DNSDistTest):
                     count = count + 1
                 else:
                     failed = failed + 1
-            except:
+            except Exception:
                 failed = failed + 1
 
         for conn in conns:

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -31,7 +31,7 @@ def have_ipv6():
         sock.bind(('::1', 56581))
         sock.close()
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/regression-tests.recursor-dnssec/test_RecDnstap.py
+++ b/regression-tests.recursor-dnssec/test_RecDnstap.py
@@ -203,7 +203,7 @@ class TestRecursorDNSTap(RecursorTest):
         try:
             try:
                 os.remove(param.path)
-            except:
+            except Exception:
                 pass
             sock.bind(param.path)
             sock.listen(100)
@@ -278,7 +278,7 @@ cname 3600 IN CNAME a.example.
     def getFirstDnstap(self):
         try:
             data = DNSTapServerParameters.queue.get(True, timeout=2.0)
-        except:
+        except Exception:
             data = False
         self.assertTrue(data)
         dnstap = dnstap_pb2.Dnstap()


### PR DESCRIPTION
### Short description
codeql has an opinion on https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fcatch-base-exception

> #### Except block handles 'BaseException'
>All exception classes in Python derive from `BaseException`. `BaseException` has three important subclasses, `Exception` from which all errors and normal exceptions derive, `KeyboardInterrupt` which is raised when the user interrupts the program from the keyboard and `SystemExit` which is raised by the `sys.exit()` function to terminate the program.
>
>Since `KeyboardInterrupt` and `SystemExit` are special they should not be grouped together with other `Exception` classes.
>
>Catching `BaseException`, rather than its subclasses may prevent proper handling of `KeyboardInterrupt` or `SystemExit`. It is easy to catch `BaseException` accidentally as it is caught implicitly by an empty `except:` statement.
>
> ##### Recommendation
>Handle `Exception`, `KeyboardInterrupt` and `SystemExit` separately. Do not use the plain `except:` form.



### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
