### PR TITLE
Do not mutate default values

### DIFF
--- a/modules/remotebackend/pdns_unittest.py
+++ b/modules/remotebackend/pdns_unittest.py
@@ -113,7 +113,9 @@ class Handler(pdns.remotebackend.Handler):
                 domain['meta'][kind] = value
             self.result = True
 
-    def do_adddomainkey(self, name='', key={}, **kwargs):
+    def do_adddomainkey(self, name='', key=None, **kwargs):
+        if key is None:
+            key = {}
         domain = self.get_domain(name)
         if domain:
             k_id = len(domain['keys']) + 1

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -993,7 +993,9 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         except subprocess.CalledProcessError as exc:
             raise AssertionError('openssl pkcs12 failed (%d): %s' % (exc.returncode, exc.output))
 
-    def checkMessageProxyProtocol(self, receivedProxyPayload, source, destination, isTCP, values=[], v6=False, sourcePort=None, destinationPort=None):
+    def checkMessageProxyProtocol(self, receivedProxyPayload, source, destination, isTCP, values=None, v6=False, sourcePort=None, destinationPort=None):
+        if values is None:
+            values = []
         proxy = ProxyProtocol()
         self.assertTrue(proxy.parseHeader(receivedProxyPayload))
         self.assertEqual(proxy.version, 0x02)


### PR DESCRIPTION
### Short description
codeql has a strong opinion about https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fmodification-of-default-value

> #### Modification of parameter with default
>The default value of a parameter is computed once when the function is created, not for every invocation. The "pre-computed" value is then used for every subsequent call to the function. Consequently, if you modify the default value for a parameter this "modified" default value is used for the parameter in future calls to the function. This means that the function may not behave as expected in future calls and also makes the function more difficult to understand.
>
> ##### Recommendation
>If a parameter has a default value, do not modify the default value. When you use a mutable object as a default value, you should use a placeholder value instead of modifying the default value. This is a particular problem when you work with lists and dictionaries but there are standard methods of avoiding modifying the default parameter (see References).
>
> ##### Example
> [ elided for compactness ]
> The recommended workaround is use a placeholder value. That is, define the function with a default of `default=None`, check if the parameter is `None` and then set the parameter to a list.
>
> ##### References
>* Effbot: [Default Parameter Values in Python](https://web.archive.org/web/20201112004749/http://effbot.org/zone/default-values.htm).
>* Python Language Reference: [Function definitions](http://docs.python.org/3/reference/compound_stmts.html#function-definitions).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
