### PR TITLE
Remove horrible unused argument with default value

### DIFF
--- a/pdns/keyroller/pdnsapi/metadata.py
+++ b/pdns/keyroller/pdnsapi/metadata.py
@@ -1,5 +1,5 @@
 class ZoneMetadata:
-    def __init__(self, kind, metadata, type="Metadata"):
+    def __init__(self, kind, metadata):
         self.kind = kind
         if not isinstance(metadata, list):
             raise Exception('metadata must be a list, not a {}'.format(type(metadata)))


### PR DESCRIPTION
### Short description

The unused argument shadows a built-in function that's needed by the function.

Codeql hates this code https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fcall-to-non-callable and I absolutely sympathize.

I understand that there isn't working test coverage for this, but I believe this can be safely reviewed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
