### PR TITLE
Use `with open(...) as f:` to ensure file is always closed

### DIFF
--- a/.github/scripts/clang-tidy-diff.py
+++ b/.github/scripts/clang-tidy-diff.py
@@ -99,7 +99,8 @@ def merge_replacement_files(tmpdir, mergefile):
   mergekey = "Diagnostics"
   merged = []
   for replacefile in glob.iglob(os.path.join(tmpdir, '*.yaml')):
-    content = yaml.safe_load(open(replacefile, 'r'))
+    with open(replacefile, 'r') as f:
+      content = yaml.safe_load(f)
     if not content:
       continue # Skip empty files.
     merged.extend(content.get(mergekey, []))

--- a/.github/scripts/clang-tidy.py
+++ b/.github/scripts/clang-tidy.py
@@ -48,8 +48,8 @@ def main():
     gh_step_summary = os.getenv("GITHUB_STEP_SUMMARY")
     if gh_step_summary:
         # Print Markdown summary
-        summary_fp = open(gh_step_summary, "a", encoding="utf-8")
-        print("### clang-tidy summary", file=summary_fp)
+        with open(gh_step_summary, "a", encoding="utf-8") as summary_fp:
+            print("### clang-tidy summary", file=summary_fp)
 
     fixes = fixes["Diagnostics"]
     have_warnings = False

--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -89,31 +89,28 @@ def write_dockerfile (os, os_version, release):
         pkg = 'dnsdist'
         cmd = 'dnsdist'
 
-    f = open('{}{}.{}-{}'.format(g_dockerfile, release, os, os_version), 'w')
-
-    # This comment was in the template for the `--nobest` part but that makes
-    # the template look even more different than the final output, so:
-    #
-    # > When should the logic be in the code and when in the template? :shrug:
-    # > I prefer it to be in the code but I also do not want to add extra vars
-    # > and logic to the code unless necessary.
-    f.write(tpl.render({ "os": os,
-                         "os_image": os_image,
-                         "os_version": os_version,
-                         "release": release,
-                         "cmd": cmd,
-                         "pkg": pkg }))
-    f.close()
+    with open('{}{}.{}-{}'.format(g_dockerfile, release, os, os_version), 'w') as f:
+        # This comment was in the template for the `--nobest` part but that makes
+        # the template look even more different than the final output, so:
+        #
+        # > When should the logic be in the code and when in the template? :shrug:
+        # > I prefer it to be in the code but I also do not want to add extra vars
+        # > and logic to the code unless necessary.
+        f.write(tpl.render({ "os": os,
+                            "os_image": os_image,
+                            "os_version": os_version,
+                            "release": release,
+                            "cmd": cmd,
+                            "pkg": pkg }))
 
 
 def write_list_file (os, os_version, release):
     tpl = g_env.get_template('pdns-list.jinja2')
 
-    f = open('pdns.list.{}.{}-{}'.format(release, os, os_version), 'w')
-    f.write(tpl.render({ "os": os,
-                         "os_version": os_version,
-                         "release": release }))
-    f.close()
+    with open('pdns.list.{}.{}-{}'.format(release, os, os_version), 'w') as f:
+        f.write(tpl.render({ "os": os,
+                            "os_version": os_version,
+                            "release": release }))
 
 
 def write_pkg_pin_file (release):
@@ -124,9 +121,8 @@ def write_pkg_pin_file (release):
     elif release.startswith('dnsdist-'):
         pkg = 'dnsdist'
 
-    f = open('pkg-pin', 'w')
-    f.write(tpl.render({ "pkg": pkg }))
-    f.close()
+    with open('pkg-pin', 'w') as f:
+       f.write(tpl.render({ "pkg": pkg }))
 
 
 def write_release_files (release):

--- a/pdns/keyroller/setup.py
+++ b/pdns/keyroller/setup.py
@@ -29,8 +29,9 @@ def exists(fname):
 # README file and 2) it's easier to type in the README file than to put a raw
 # string in below ...
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname),
-                'r', encoding='utf-8').read()
+    with open(os.path.join(os.path.dirname(__file__), fname),
+              'r', encoding='utf-8') as f:
+        return f.read()
 
 
 version = os.environ.get('BUILDER_VERSION', '0.0.0')

--- a/regression-tests.recursor-dnssec/test_RoutingTag.py
+++ b/regression-tests.recursor-dnssec/test_RoutingTag.py
@@ -64,10 +64,9 @@ ecs-add-for=0.0.0.0/0
 
     def setRoutingTag(self, tag):
         # This value is picked up by the gettag()
-        file = open('tagfile', 'w')
-        if tag:
-            file.write(tag)
-        file.close();
+        with open('tagfile', 'w') as file:
+            if tag:
+                file.write(tag)
 
     @classmethod
     def startResponders(cls):

--- a/regression-tests/bulktest-to-json.py
+++ b/regression-tests/bulktest-to-json.py
@@ -13,12 +13,13 @@ for fname in glob.glob('testresults-*.xml'):
 	vars['tag'] = tag
 	varnames.update(vars.keys())
 	stats=dict()
-	for line in open(fname):
-		if line.startswith('&lt;'):
-			sname = line.split(';')[4][:-3]
-			sval = line.split(';')[8][:-3]
-			stats[sname]=sval
-			statnames.add(sname)
+	with open(fname) as f
+		for line in f:
+			if line.startswith('&lt;'):
+				sname = line.split(';')[4][:-3]
+				sval = line.split(';')[8][:-3]
+				stats[sname]=sval
+				statnames.add(sname)
 	# print fname, vars, stats
 	runs.append(dict(vars.items()+stats.items()))
 


### PR DESCRIPTION
### Short description
Codeql does not like https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Ffile-not-closed

> #### File is not always closed
>When a file is opened, it should always be closed.
>
>A file opened for writing that is not closed when the application exits may result in data loss, where not all of the data written may be saved to the file. A file opened for reading or writing that is not closed may also use up file descriptors, which is a resource leak that in long running applications could lead to a failure to open additional files.
>
>##### Recommendation
>Ensure that opened files are always closed, including when an exception could be raised. The best practice is often to use a `with` statement to automatically clean up resources. ...

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
