### PR TITLE
dnsdist-2.0.x: Backport 16503 - `dnsheader_aligned`: Prevent copies

### DIFF
--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -227,6 +227,11 @@ public:
       d_p = &d_h;
     }
   }
+  dnsheader_aligned(const dnsheader_aligned&) = delete;
+  dnsheader_aligned(dnsheader_aligned&&) = delete;
+  dnsheader_aligned& operator=(const dnsheader_aligned&) = delete;
+  dnsheader_aligned& operator=(dnsheader_aligned&&) = delete;
+  ~dnsheader_aligned() = default;
 
   [[nodiscard]] const dnsheader* get() const
   {

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -87,8 +87,7 @@ struct DNSQuestion
     if (data.size() < sizeof(dnsheader)) {
       throw std::runtime_error("Trying to access the dnsheader of a too small (" + std::to_string(data.size()) + ") DNSQuestion buffer");
     }
-    dnsheader_aligned dh(data.data());
-    return dh;
+    return dnsheader_aligned(data.data());
   }
 
   /* this function is not safe against unaligned access, you should


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #16503 to rel/dnsdist-2.0.x

The `dnsheader_aligned` object contains a pointer that references either the `dnsheader` passed to the constructor if it is properly aligned, or the internal `dnsheader` member. In the second case, making a copy would mean we can reference an object that has been destructed, which is a serious problem.

This commit also ensures copy elision is done `DNSQuestion:getHeader`, as otherwise the compiler might refuse to compile.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
