### PR TITLE
Fix `with open(...) as f:`

### DIFF
--- a/regression-tests/bulktest-to-json.py
+++ b/regression-tests/bulktest-to-json.py
@@ -13,7 +13,7 @@ for fname in glob.glob('testresults-*.xml'):
 	vars['tag'] = tag
 	varnames.update(vars.keys())
 	stats=dict()
-	with open(fname) as f
+	with open(fname) as f:
 		for line in f:
 			if line.startswith('&lt;'):
 				sname = line.split(';')[4][:-3]


### PR DESCRIPTION
### Short description
- Fixes the only instance in #16500 that I messed up

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
