### PR TITLE
dnsdist: Better performance when using `recvmmsg`

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -2240,7 +2240,7 @@ static void MultipleMessagesUDPClientThread(ClientState* clientState)
   for (;;) {
 
     /* reset the IO vector, since it's also used to send the vector of responses
-       to avoid having to copy the data around
+       to avoid having to copy the data around.
        No need to reset the parts that have not been used, though. */
     for (int idx = 0; idx < msgsGot; idx++) {
       auto& slot = recvData[idx];


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

`recvmmsg` and `sendmmsg` are Linux-specific syscalls to receive and send multiple messages on a socket via a single call, which in theory improves performance a lot, especially with the speculative execution vulnerabilities mitigations making syscalls expensive.
We had several reports that turning this feature on in DNSdist did not really improve performance, which is quite unexpected. Looking at a CPU profile in `perf`, we were spending an awful lot of time resizing buffers that did not need to be resized most of the time because they had not been used. This commit ensures that we only resize and reset buffers for slots that have been used in the previous round.

With that I'm getting a nice performance boost from using `recvmmsg` and `sendmmsg` while processing 80k QPS at 100% cache-hit ratio from a single thread: the CPU usage shrinks by roughly 15%.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
