### PR TITLE
dnsdist: Reuse the vector of packets between XSK recv rounds

### DIFF
--- a/pdns/dnsdistdist/dnsdist-xsk.cc
+++ b/pdns/dnsdistdist/dnsdist-xsk.cc
@@ -133,13 +133,14 @@ void XskRouter(std::shared_ptr<XskSocket> xsk)
   const auto& fds = xsk->getDescriptors();
   // list of workers that need to be notified
   std::set<int> needNotify;
+  std::vector<XskPacket> packets;
   while (true) {
     try {
       auto ready = xsk->wait(-1);
       dnsdist::configuration::refreshLocalRuntimeConfiguration();
       // descriptor 0 gets incoming AF_XDP packets
       if ((fds.at(0).revents & POLLIN) != 0) {
-        auto packets = xsk->recv(64, &failed);
+        xsk->recv(packets, 64, &failed);
         dnsdist::metrics::g_stats.nonCompliantQueries += failed;
         for (auto& packet : packets) {
           const auto dest = packet.getToAddr();

--- a/pdns/dnsdistdist/xsk.hh
+++ b/pdns/dnsdistdist/xsk.hh
@@ -137,7 +137,7 @@ public:
   // add as many packets as possible to the rx queue for sending */
   void send(std::vector<XskPacket>& packets);
   // look at incoming packets in rx, return them if parsing succeeeded
-  [[nodiscard]] std::vector<XskPacket> recv(uint32_t recvSizeMax, uint32_t* failedCount);
+  void recv(std::vector<XskPacket>& packets, uint32_t recvSizeMax, uint32_t* failedCount);
   void addWorker(std::shared_ptr<XskWorker> worker);
   void addWorkerRoute(const std::shared_ptr<XskWorker>& worker, const ComboAddress& dest);
   void removeWorkerRoute(const ComboAddress& dest);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The existing code was allocating a new vector for every call to `XskSocket::recv()` which was just silly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
