### PR TITLE
auth 5.0: backport "Give backends the ability to perform extra actions during zone rectify".

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1150,7 +1150,7 @@ static std::shared_ptr<DNSRecordContent> deserializeContentZR(uint16_t qtype, co
 #define StringView string
 #endif
 
-void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match)
+void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match, QType qtype)
 {
   auto cursor = txn.txn->getCursor(txn.db->dbi);
   MDBOutVal key{};
@@ -1158,7 +1158,9 @@ void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, const std::stri
 
   if (cursor.prefix(match, key, val) == 0) {
     do {
-      cursor.del(key);
+      if (qtype == QType::ANY || compoundOrdername::getQType(key.getNoStripHeader<StringView>()) == qtype) {
+        cursor.del(key);
+      }
     } while (cursor.next(key, val) == 0);
   }
 }
@@ -3276,6 +3278,25 @@ bool LMDBBackend::hasCreatedLocalFiles() const
   // But since this information is for the sake of pdnsutil, this is not
   // really a problem.
   return MDBDbi::d_creationCount != 0;
+}
+
+// Hook for rectifyZone operation.
+// Before the operation starts, we forcibly remove all NSEC3 records from the
+// domain, since logic flaws in older versions may have left us with dangling
+// records. The appropriate records will be regenerated with
+// updateDNSSECOrderNameAndAuth() calls anyway.
+void LMDBBackend::rectifyZoneHook(domainid_t domain_id, bool before) const
+{
+  if (!before) {
+    return;
+  }
+
+  if (!d_rwtxn) {
+    throw DBException("rectifyZoneHook invoked outside of a transaction");
+  }
+
+  compoundOrdername order;
+  LMDBBackend::deleteDomainRecords(*d_rwtxn, order(domain_id), QType::NSEC3);
 }
 
 class LMDBFactory : public BackendFactory

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -171,6 +171,8 @@ public:
 
   bool hasCreatedLocalFiles() const override;
 
+  void rectifyZoneHook(domainid_t domain_id, bool before) const override;
+
   // functions to use without constructing a backend object
   static std::pair<uint32_t, uint32_t> getSchemaVersionAndShards(std::string& filename);
   static bool upgradeToSchemav5(std::string& filename);
@@ -335,7 +337,7 @@ private:
   std::shared_ptr<RecordsROTransaction> getRecordsROTransaction(domainid_t id, const std::shared_ptr<LMDBBackend::RecordsRWTransaction>& rwtxn = nullptr);
   int genChangeDomain(const ZoneName& domain, const std::function<void(DomainInfo&)>& func);
   int genChangeDomain(domainid_t id, const std::function<void(DomainInfo&)>& func);
-  static void deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match);
+  static void deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match, QType qtype = QType::ANY);
 
   bool findDomain(const ZoneName& domain, DomainInfo& info) const;
   bool findDomain(domainid_t domainid, DomainInfo& info) const;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -855,6 +855,8 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
   if (doTransaction)
     sd.db->startTransaction(zone, UnknownDomainID);
 
+  sd.db->rectifyZoneHook(sd.domain_id, true);
+
   bool realrr=true;
   bool doent=true;
   int updates=0;
@@ -966,6 +968,8 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
       goto dononterm;
     }
   }
+
+  sd.db->rectifyZoneHook(sd.domain_id, false);
 
   if (doTransaction)
     sd.db->commitTransaction();

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -513,6 +513,10 @@ public:
     return false;
   }
 
+  virtual void rectifyZoneHook(domainid_t /*domain_id*/, bool /*before*/) const
+  {
+  }
+
   const string& getPrefix() { return d_prefix; };
 
 protected:


### PR DESCRIPTION
### Short description
Backport of #15894, needed to fix #16499.
 
### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
