### PR TITLE
Remove unused assignment

### DIFF
--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -292,7 +292,7 @@ class TestLuaRecords(BaseLuaTest):
                     dns.rrset.from_text('selfweighted.example.org.', 0, dns.rdataclass.IN, 'A',
                                         '{prefix}.102'.format(prefix=self._PREFIX))]
         query = dns.message.make_query('selfweighted.example.org', 'A')
-        res = self.sendUDPQuery(query)
+        self.sendUDPQuery(query)
 
         # wait for health checks to happen
         time.sleep(3)
@@ -532,7 +532,7 @@ class TestLuaRecords(BaseLuaTest):
         expected = [dns.rrset.from_text('ifurlextup.example.org.', 0, dns.rdataclass.IN, dns.rdatatype.A, '192.168.0.3')]
 
         query = dns.message.make_query('ifurlextup.example.org', 'A')
-        res = self.sendUDPQuery(query)
+        self.sendUDPQuery(query)
 
         # wait for health checks to happen
         time.sleep(5)

--- a/regression-tests.dnsdist/test_TCPFastOpen.py
+++ b/regression-tests.dnsdist/test_TCPFastOpen.py
@@ -59,7 +59,7 @@ class TestBrokenTCPFastOpen(DNSDistTest):
                 continue
 
             (datalen,) = struct.unpack("!H", data)
-            data = conn.recv(datalen)
+            conn.recv(datalen)
             conn.close()
             continue
 

--- a/regression-tests.recursor-dnssec/test_Additionals.py
+++ b/regression-tests.recursor-dnssec/test_Additionals.py
@@ -30,8 +30,8 @@ class AdditionalsDefaultTest(RecursorTest):
         self.assertMatchingRRSIGInAnswer(res, expected)
         self.assertAdditionalEmpty(res)
         # fill the cache
-        res = self.sendUDPQuery(query2)
-        res = self.sendUDPQuery(query3)
+        self.sendUDPQuery(query2)
+        self.sendUDPQuery(query3)
         # query 1 again
         res = self.sendUDPQuery(query1)
         self.assertMessageIsAuthenticated(res)

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -943,7 +943,7 @@ class OutgoingProtobufWithECSMappingTest(TestRecursorProtobuf):
         # So make sure we have the . DNSKEY in cache
         query = dns.message.make_query('.', 'A', want_dnssec=True)
         query.flags |= dns.flags.RD
-        res = self.sendUDPQuery(query)
+        self.sendUDPQuery(query)
         time.sleep(1)
         self.emptyProtoBufQueue()
 
@@ -1226,7 +1226,7 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
 
           self.checkNoRemainingMessage()
           # Again to check PC case
-          res = sender(query)
+          sender(query)
           #time.sleep(1)
           self.checkNoRemainingMessage()
 


### PR DESCRIPTION
### Short description
codeql doesn't like unused assignments: https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fmultiple-definition
(It confusingly calls them multiple definitions, but whatever)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
