### PR TITLE
auth regress: Fix PDNS_BUILD_PATH for non-meson builds

### DIFF
--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -9,7 +9,7 @@ MAKE=${MAKE:-make}
 
 if [ -z "$PDNS_BUILD_PATH" ]; then
   # PDNS_BUILD_PATH is unset or empty. Assume an autotools build.
-  PDNS_BUILD_PATH=${PWD}/..
+  PDNS_BUILD_PATH=${PWD}/../pdns
 fi
 
 export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns_server}

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -6,7 +6,7 @@ fi
 
 if [ -z "$PDNS_BUILD_PATH" ]; then
   # PDNS_BUILD_PATH is unset or empty. Assume an autotools build.
-  PDNS_BUILD_PATH=${PWD}/..
+  PDNS_BUILD_PATH=${PWD}/../pdns
 fi
 
 export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns_server}


### PR DESCRIPTION
### Short description
Buglet crept in in last change, and broke manual run of `start-stop-tests` in `regression-tests/`.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
