### PR TITLE
codeql PEP8 first argument should be self

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -307,6 +307,11 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - uses: astral-sh/ruff-action@v4.0.0
+    - name: Check Python formatting
+      uses: astral-sh/ruff-action@v4.0.0
       with:
         args: 'format --check --diff'
+    - name: Check method variables
+      uses: astral-sh/ruff-action@v4.0.0
+      with:
+        args: 'check --select N805'

--- a/regression-tests.auth-py/clientsubnetoption.py
+++ b/regression-tests.auth-py/clientsubnetoption.py
@@ -149,6 +149,7 @@ class ClientSubnetOption(dns.edns.Option):
         file.write(data)
         return None
 
+    @classmethod
     def from_wire(cls, otype, wire, current, olen):
         """Read EDNS packet as defined in draft-vandergaast-edns-client-subnet-01.
 
@@ -175,8 +176,6 @@ class ClientSubnetOption(dns.edns.Option):
             raise Exception("Returned a family other then IPv4 or IPv6")
 
         return cls(ip, mask, scope, otype)
-
-    from_wire = classmethod(from_wire)
 
     # needed in 2.0.0..
     @classmethod

--- a/regression-tests.common/paddingoption.py
+++ b/regression-tests.common/paddingoption.py
@@ -22,6 +22,7 @@ class PaddingOption(dns.edns.Option):
         file.write(bytes(self.numberOfBytes))
         return None
 
+    @classmethod
     def from_wire(cls, otype, wire, current, olen):
         """Read EDNS packet as defined in rfc7830.
 
@@ -32,8 +33,6 @@ class PaddingOption(dns.edns.Option):
         numberOfBytes = olen
 
         return cls(numberOfBytes)
-
-    from_wire = classmethod(from_wire)
 
     # needed in 2.0.0
     @classmethod
@@ -50,7 +49,7 @@ class PaddingOption(dns.edns.Option):
     def __eq__(self, other):
         if not isinstance(other, PaddingOption):
             return False
-        return self.numberOfBytes == numberOfBytes
+        return self.numberOfBytes == other.numberOfBytes
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/regression-tests.dnsdist/clientsubnetoption.py
+++ b/regression-tests.dnsdist/clientsubnetoption.py
@@ -149,6 +149,7 @@ class ClientSubnetOption(dns.edns.Option):
         file.write(data)
         return None
 
+    @classmethod
     def from_wire(cls, otype, wire, current, olen):
         """Read EDNS packet as defined in draft-vandergaast-edns-client-subnet-01.
 
@@ -175,8 +176,6 @@ class ClientSubnetOption(dns.edns.Option):
             raise Exception("Returned a family other then IPv4 or IPv6")
 
         return cls(ip, mask, scope, otype)
-
-    from_wire = classmethod(from_wire)
 
     # needed in 2.0.0..
     @classmethod

--- a/regression-tests.dnsdist/cookiesoption.py
+++ b/regression-tests.dnsdist/cookiesoption.py
@@ -35,6 +35,7 @@ class CookiesOption(dns.edns.Option):
         file.write(data)
         return None
 
+    @classmethod
     def from_wire(cls, otype, wire, current, olen):
         """Read EDNS packet as defined in draft-ietf-dnsop-cookies-09.
 
@@ -53,8 +54,6 @@ class CookiesOption(dns.edns.Option):
             server = None
 
         return cls(client, server)
-
-    from_wire = classmethod(from_wire)
 
     # needed in 2.0.0
     @classmethod

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -236,6 +236,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.id = request.id ^ 42
         return response.to_wire()
 
+    @staticmethod
     def TooManyQuestionsCallback(request):
         response = dns.message.make_response(request)
         response.question.append(response.question[0])

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -220,6 +220,7 @@ class TestBackendDiscovery(DNSDistTest):
     def EOFCallback(request):
         return None
 
+    @staticmethod
     def ServFailCallback(request):
         response = dns.message.make_response(request)
         response.set_rcode(dns.rcode.SERVFAIL)

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -128,6 +128,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.answer.append(rrset)
         return response.to_wire()
 
+    @staticmethod
     def UpgradeDoTCallback(request):
         response = dns.message.make_response(request)
         rrset = dns.rrset.from_text(

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -225,6 +225,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.set_rcode(dns.rcode.SERVFAIL)
         return response.to_wire()
 
+    @staticmethod
     def WrongNameCallback(request):
         query = dns.message.make_query("not-the-right-one.", dns.rdatatype.SVCB)
         response = dns.message.make_response(query)

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -175,6 +175,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.answer.append(rrset)
         return response.to_wire()
 
+    @staticmethod
     def UpgradeDoTDifferentAddr2Callback(request):
         response = dns.message.make_response(request)
         rrset = dns.rrset.from_text(

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -151,6 +151,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.additional.append(rrset)
         return response.to_wire()
 
+    @staticmethod
     def UpgradeDoHCallback(request):
         response = dns.message.make_response(request)
         rrset = dns.rrset.from_text(

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -231,6 +231,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.id = request.id
         return response.to_wire()
 
+    @staticmethod
     def WrongIDCallback(request):
         response = dns.message.make_response(request)
         response.id = request.id ^ 42

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -260,6 +260,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.answer.append(rrset)
         return response.to_wire()
 
+    @staticmethod
     def UpgradeDoHNoPortCallback(request):
         response = dns.message.make_response(request)
         rrset = dns.rrset.from_text(

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -187,6 +187,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.answer.append(rrset)
         return response.to_wire()
 
+    @staticmethod
     def UpgradeDoTUnreachableCallback(request):
         response = dns.message.make_response(request)
         rrset = dns.rrset.from_text(

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -120,6 +120,7 @@ class TestBackendDiscovery(DNSDistTest):
     def NoSVCCallback(request):
         return dns.message.make_response(request).to_wire()
 
+    @staticmethod
     def NoUpgradePathCallback(request):
         response = dns.message.make_response(request)
         rrset = dns.rrset.from_text(

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -205,6 +205,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.question = []
         return response.to_wire()
 
+    @staticmethod
     def UpgradeDoHMissingPathCallback(request):
         response = dns.message.make_response(request)
         rrset = dns.rrset.from_text(

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -117,6 +117,7 @@ class TestBackendDiscovery(DNSDistTest):
     """
     _verboseMode = True
 
+    @staticmethod
     def NoSVCCallback(request):
         return dns.message.make_response(request).to_wire()
 

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -199,6 +199,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.answer.append(rrset)
         return response.to_wire()
 
+    @staticmethod
     def BrokenResponseCallback(request):
         response = dns.message.make_response(request)
         response.use_edns(edns=False)

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -241,6 +241,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.question.append(response.question[0])
         return response.to_wire()
 
+    @staticmethod
     def BadQNameCallback(request):
         response = dns.message.make_response(request)
         wire = bytearray(response.to_wire())

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -163,6 +163,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.answer.append(rrset)
         return response.to_wire()
 
+    @staticmethod
     def UpgradeDoTDifferentAddr1Callback(request):
         response = dns.message.make_response(request)
         rrset = dns.rrset.from_text(

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -217,6 +217,7 @@ class TestBackendDiscovery(DNSDistTest):
         response.answer.append(rrset)
         return response.to_wire()
 
+    @staticmethod
     def EOFCallback(request):
         return None
 

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -248,6 +248,7 @@ class TestBackendDiscovery(DNSDistTest):
         wire[12] = 0xFF
         return wire
 
+    @staticmethod
     def UpgradeDoTNoPortCallback(request):
         response = dns.message.make_response(request)
         rrset = dns.rrset.from_text(

--- a/regression-tests.dnsdist/test_OutgoingDOH.py
+++ b/regression-tests.dnsdist/test_OutgoingDOH.py
@@ -776,6 +776,7 @@ class TestOutgoingDOHXForwarded(DNSDistTest):
     """
     _verboseMode = True
 
+    @staticmethod
     def callback(request, headersList, fromQueue, toQueue, conn):
         if str(request.question[0].name) == "a.root-servers.net.":
             # do not check headers on health-check queries

--- a/regression-tests.dnsdist/test_OutgoingDOH.py
+++ b/regression-tests.dnsdist/test_OutgoingDOH.py
@@ -672,6 +672,7 @@ class TestOutgoingDOHBrokenResponsesGnuTLS(DNSDistTest, OutgoingDOHBrokenRespons
     """
     _verboseMode = True
 
+    @staticmethod
     def callback(request, headers, fromQueue, toQueue, conn):
 
         if str(request.question[0].name) == "500-status.broken-responses.outgoing-doh.test.powerdns.com.":

--- a/regression-tests.dnsdist/test_OutgoingDOH.py
+++ b/regression-tests.dnsdist/test_OutgoingDOH.py
@@ -617,6 +617,7 @@ class TestOutgoingDOHBrokenResponsesOpenSSL(DNSDistTest, OutgoingDOHBrokenRespon
     addAction(SuffixMatchNodeRule(smn), PoolAction('cache'))
     """
 
+    @staticmethod
     def callback(request, headers, fromQueue, toQueue, conn):
 
         if str(request.question[0].name) == "500-status.broken-responses.outgoing-doh.test.powerdns.com.":

--- a/regression-tests.recursor-dnssec/clientsubnetoption.py
+++ b/regression-tests.recursor-dnssec/clientsubnetoption.py
@@ -149,7 +149,7 @@ class ClientSubnetOption(dns.edns.Option):
         file.write(data)
         return None
 
-    def from_wire(cls, otype, wire, current, olen):
+    def from_wire(self, otype, wire, current, olen):
         """Read EDNS packet as defined in draft-vandergaast-edns-client-subnet-01.
 
         Returns:
@@ -174,7 +174,7 @@ class ClientSubnetOption(dns.edns.Option):
         else:
             raise Exception("Returned a family other then IPv4 or IPv6")
 
-        return cls(ip, mask, scope, otype)
+        return self(ip, mask, scope, otype)
 
     from_wire = classmethod(from_wire)
 

--- a/regression-tests.recursor-dnssec/extendederrors.py
+++ b/regression-tests.recursor-dnssec/extendederrors.py
@@ -27,6 +27,7 @@ class ExtendedErrorOption(dns.edns.Option):
         file.write(data)
         return None
 
+    @classmethod
     def from_wire(cls, otype, wire, current, olen):
         """Read EDNS packet.
 
@@ -44,8 +45,6 @@ class ExtendedErrorOption(dns.edns.Option):
             extra = b""
 
         return cls(code, extra)
-
-    from_wire = classmethod(from_wire)
 
     # needed in 2.0.0
     @classmethod

--- a/regression-tests.recursor-dnssec/test_KeepOpenTCP.py
+++ b/regression-tests.recursor-dnssec/test_KeepOpenTCP.py
@@ -30,7 +30,8 @@ auth-zones=authzone.example=configs/%s/authzone.zone"""
             )
         super(KeepOpenTCPTest, cls).generateRecursorConfig(confdir)
 
-    def sendTCPQueryKeepOpen(cls, sock, query, timeout=2.0):
+    @staticmethod
+    def sendTCPQueryKeepOpen(sock, query, timeout=2.0):
         try:
             wire = query.to_wire()
             sock.send(struct.pack("!H", len(wire)))


### PR DESCRIPTION
### Short description
codeql complains (per [PEP8](https://peps.python.org/pep-0008/#function-and-method-arguments)) when the first argument to methods is not `self`: https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fnot-named-self

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
