### PR TITLE
auth: expose backend storage layout version when relevant

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1372,6 +1372,7 @@ stickysidebar
 Stillaway
 Stirnimann
 Stolte
+storageversion
 Storbeck
 Storesund
 stou

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1377,6 +1377,7 @@ stickysidebar
 Stillaway
 Stirnimann
 Stolte
+storageversion
 Storbeck
 Storesund
 stou

--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -122,6 +122,25 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  "/servers/{server_id}/backends/{backend_id}/storageversion":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - $ref: "#/components/parameters/backend_id"
+    get:
+      summary: Return the backend storage version used to store zone data
+      description: This returns a backend-dependent version information. Currently only supported by the LMDB backend
+      tags:
+        - servers
+      responses:
+        "200":
+          description: Storage version number
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StorageVersion"
+        default:
+          $ref: "#/components/responses/Error"
+
   "/servers/{server_id}/cache/flush":
     parameters:
       - $ref: "#/components/parameters/server_id"
@@ -985,6 +1004,13 @@ components:
       in: path
       required: true
       description: The name of the view to update
+    backend_id:
+      name: backend_id
+      in: path
+      required: true
+      description: The name of the backend to query
+      schema:
+        type: string
 
   responses:
     Error:
@@ -1535,3 +1561,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Network"
+          
+    StorageVersion:
+      title: StorageVersion
+      type: object
+      properties:
+        storageversion:
+          type: number
+          description: 'The version number of the backend storage for a zone'

--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: "0.0.22"
+  version: "0.0.23"
   title: PowerDNS Authoritative HTTP API
   license:
     name: MIT
@@ -117,6 +117,25 @@ paths:
       responses:
         "204":
           description: "OK, key was deleted"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/backends/{backend_id}/storageversion":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - $ref: "#/components/parameters/backend_id"
+    get:
+      summary: Return the backend storage version used to store zone data
+      description: This returns a backend-dependent version information. Currently only supported by the LMDB backend
+      tags:
+        - servers
+      responses:
+        "200":
+          description: Storage version number
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StorageVersion"
         default:
           $ref: "#/components/responses/Error"
 
@@ -972,6 +991,13 @@ components:
       in: path
       required: true
       description: The name of the view to update
+    backend_id:
+      name: backend_id
+      in: path
+      required: true
+      description: The name of the backend to query
+      schema:
+        type: string
 
   responses:
     Error:
@@ -1536,3 +1562,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Network"
+          
+    StorageVersion:
+      title: StorageVersion
+      type: object
+      properties:
+        storageversion:
+          type: number
+          description: 'The version number of the backend storage for a zone'

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -755,6 +755,10 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     LMDBLS::s_flag_deleted = mustDo("flag-deleted");
   }
 
+  // The current state of this code only supports one schema version and
+  // requires users to update their schema if outdated.
+  d_currentschema = SCHEMAVERSION;
+
   bool opened = false;
 
   if (s_first) {
@@ -3763,6 +3767,11 @@ void LMDBBackend::flush()
       break; // no more work to do!
     }
   }
+}
+
+int LMDBBackend::getStorageLayoutVersion()
+{
+  return static_cast<int>(d_currentschema);
 }
 
 class LMDBFactory : public BackendFactory

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -359,12 +359,8 @@ void copyIndexDBI(MDB_txn* txn, MDB_dbi sdbi, MDB_dbi tdbi)
 
 }
 
-bool LMDBBackend::upgradeToSchemav5(std::string& filename)
+bool LMDBBackend::upgradeToSchemav5(std::string& filename, uint32_t currentSchemaVersion, uint32_t shardCount)
 {
-  auto currentSchemaVersionAndShards = getSchemaVersionAndShards(filename);
-  uint32_t currentSchemaVersion = currentSchemaVersionAndShards.first;
-  uint32_t shards = currentSchemaVersionAndShards.second;
-
   if (currentSchemaVersion != 3 && currentSchemaVersion != 4) {
     throw std::runtime_error("upgrade to v5 requested but current schema is not v3 or v4, stopping");
   }
@@ -399,7 +395,7 @@ bool LMDBBackend::upgradeToSchemav5(std::string& filename)
 #endif
 
   std::cerr << "migrating shards" << std::endl;
-  for (uint32_t i = 0; i < shards; i++) {
+  for (uint32_t i = 0; i < shardCount; i++) {
     string shardfile = filename + "-" + std::to_string(i);
     if (access(shardfile.c_str(), F_OK) < 0) {
       if (errno == ENOENT) {
@@ -647,7 +643,7 @@ bool LMDBBackend::upgradeToSchemav5(std::string& filename)
   return true;
 }
 
-bool LMDBBackend::upgradeToSchemav6(std::string& /* filename */)
+bool LMDBBackend::upgradeToSchemav6(std::string& /* filename */, uint32_t /* currentSchemaVersion */, uint32_t /* shardCount */)
 {
   // a v6 reader can read v5 databases just fine
   // so this function currently does nothing
@@ -766,9 +762,8 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     if (s_first) {
       auto filename = getArg("filename");
 
-      auto currentSchemaVersionAndShards = getSchemaVersionAndShards(filename);
-      uint32_t currentSchemaVersion = currentSchemaVersionAndShards.first;
-      // std::cerr<<"current schema version: "<<currentSchemaVersion<<", shards="<<currentSchemaVersionAndShards.second<<std::endl;
+      auto [currentSchemaVersion, shardCount] = getSchemaVersionAndShards(filename);
+      // std::cerr<<"current schema version: "<<currentSchemaVersion<<", shards="<<shardCount<<std::endl;
 
       if (getArgAsNum("schema-version") != SCHEMAVERSION) {
         throw std::runtime_error("This version of the lmdbbackend only supports schema version 6. Configuration demands a lower version. Not starting up.");
@@ -784,14 +779,14 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
       }
 
       if (currentSchemaVersion == 3 || currentSchemaVersion == 4) {
-        if (!upgradeToSchemav5(filename)) {
+        if (!upgradeToSchemav5(filename, currentSchemaVersion, shardCount)) {
           throw std::runtime_error("Failed to perform LMDB schema version upgrade from v4 to v5");
         }
         currentSchemaVersion = 5;
       }
 
       if (currentSchemaVersion == 5) {
-        if (!upgradeToSchemav6(filename)) {
+        if (!upgradeToSchemav6(filename, currentSchemaVersion, shardCount)) {
           throw std::runtime_error("Failed to perform LMDB schema version upgrade from v5 to v6");
         }
         currentSchemaVersion = 6;

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -368,12 +368,8 @@ void copyIndexDBI(MDB_txn* txn, MDB_dbi sdbi, MDB_dbi tdbi)
 
 }
 
-bool LMDBBackend::upgradeToSchemav5(std::string& filename)
+bool LMDBBackend::upgradeToSchemav5(std::string& filename, uint32_t currentSchemaVersion, uint32_t shardCount)
 {
-  auto currentSchemaVersionAndShards = getSchemaVersionAndShards(filename);
-  uint32_t currentSchemaVersion = currentSchemaVersionAndShards.first;
-  uint32_t shards = currentSchemaVersionAndShards.second;
-
   if (currentSchemaVersion != 3 && currentSchemaVersion != 4) {
     throw std::runtime_error("upgrade to v5 requested but current schema is not v3 or v4, stopping");
   }
@@ -409,7 +405,7 @@ bool LMDBBackend::upgradeToSchemav5(std::string& filename)
 
   try {
     std::cerr << "migrating shards" << std::endl;
-    for (uint32_t i = 0; i < shards; i++) {
+    for (uint32_t i = 0; i < shardCount; i++) {
       string shardfile = filename + "-" + std::to_string(i);
       if (access(shardfile.c_str(), F_OK) < 0) {
         if (errno == ENOENT) {
@@ -657,7 +653,7 @@ bool LMDBBackend::upgradeToSchemav5(std::string& filename)
   return true;
 }
 
-bool LMDBBackend::upgradeToSchemav6(std::string& /* filename */)
+bool LMDBBackend::upgradeToSchemav6(std::string& /* filename */, uint32_t /* currentSchemaVersion */, uint32_t /* shardCount */)
 {
   // a v6 reader can read v5 databases just fine
   // so this function currently does nothing
@@ -776,9 +772,8 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     if (s_first) {
       auto filename = getArg("filename");
 
-      auto currentSchemaVersionAndShards = getSchemaVersionAndShards(filename);
-      uint32_t currentSchemaVersion = currentSchemaVersionAndShards.first;
-      // std::cerr<<"current schema version: "<<currentSchemaVersion<<", shards="<<currentSchemaVersionAndShards.second<<std::endl;
+      auto [currentSchemaVersion, shardCount] = getSchemaVersionAndShards(filename);
+      // std::cerr<<"current schema version: "<<currentSchemaVersion<<", shards="<<shardCount<<std::endl;
 
       if (getArgAsNum<uint32_t>("schema-version") != SCHEMAVERSION) {
         throw std::runtime_error("This version of the lmdbbackend only supports schema version 6. Configuration demands a lower version. Not starting up.");
@@ -794,14 +789,14 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
       }
 
       if (currentSchemaVersion == 3 || currentSchemaVersion == 4) {
-        if (!upgradeToSchemav5(filename)) {
+        if (!upgradeToSchemav5(filename, currentSchemaVersion, shardCount)) {
           throw std::runtime_error("Failed to perform LMDB schema version upgrade from v4 to v5");
         }
         currentSchemaVersion = 5;
       }
 
       if (currentSchemaVersion == 5) {
-        if (!upgradeToSchemav6(filename)) {
+        if (!upgradeToSchemav6(filename, currentSchemaVersion, shardCount)) {
           throw std::runtime_error("Failed to perform LMDB schema version upgrade from v5 to v6");
         }
         currentSchemaVersion = 6;

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -765,6 +765,10 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     LMDBLS::s_flag_deleted = mustDo("flag-deleted");
   }
 
+  // The current state of this code only supports one schema version and
+  // requires users to update their schema if outdated.
+  d_currentschema = SCHEMAVERSION;
+
   bool opened = false;
 
   if (s_first) {
@@ -3744,6 +3748,18 @@ void LMDBBackend::flush()
       break; // no more work to do!
     }
   }
+}
+
+std::string LMDBBackend::getStorageLayoutVersion(bool verbose)
+{
+  std::ostringstream ostr;
+
+  ostr << std::to_string(d_currentschema);
+  if (verbose) {
+    ostr << endl;
+    ostr << "Built against LMDB library version " << MDB_VERSION_MAJOR << "." << MDB_VERSION_MINOR << "." << MDB_VERSION_PATCH;
+  }
+  return ostr.str();
 }
 
 class LMDBFactory : public BackendFactory

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -181,8 +181,8 @@ public:
 
   // functions to use without constructing a backend object
   static std::pair<uint32_t, uint32_t> getSchemaVersionAndShards(std::string& filename);
-  static bool upgradeToSchemav5(std::string& filename);
-  static bool upgradeToSchemav6(std::string& filename);
+  static bool upgradeToSchemav5(std::string& filename, uint32_t currentSchemaVersion, uint32_t shardCount);
+  static bool upgradeToSchemav6(std::string& filename, uint32_t currentSchemaVersion, uint32_t shardCount);
 
 private:
   struct compoundOrdername

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -172,6 +172,8 @@ public:
 
   void flush() override;
 
+  int getStorageLayoutVersion() override;
+
   // other
   string directBackendCmd(const string& query) override;
 
@@ -443,6 +445,7 @@ private:
   bool d_views;
   bool d_write_notification_update;
   bool d_split_domains_table;
+  uint32_t d_currentschema;
   DTime d_dtime; // used only for logging
   uint64_t d_mapsize_main;
   uint64_t d_mapsize_shards;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -172,6 +172,8 @@ public:
 
   void flush() override;
 
+  std::string getStorageLayoutVersion(bool verbose) override;
+
   // other
   string directBackendCmd(const string& query) override;
 
@@ -452,6 +454,7 @@ private:
   bool d_views;
   bool d_write_notification_update;
   bool d_split_domains_table;
+  uint32_t d_currentschema;
   DTime d_dtime; // used only for logging
   uint64_t d_mapsize_main;
   uint64_t d_mapsize_shards;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -533,6 +533,10 @@ public:
   {
   }
 
+  // Return the level/version of the storage layout used by this backend
+  // (values being obviously backend-specific).
+  virtual int getStorageLayoutVersion() { return -1; };
+
 protected:
   bool mustDo(const string& key);
   const string& getArg(const string& key);

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -534,6 +534,10 @@ public:
   {
   }
 
+  // Return the level/version of the storage layout used by this backend
+  // (values being obviously backend-specific).
+  virtual std::string getStorageLayoutVersion(bool /* verbose */) { return ""; };
+
 protected:
   bool mustDo(const string& key);
   const string& getArg(const string& key);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3838,7 +3838,12 @@ static std::unique_ptr<DNSBackend> getBackendByName(const std::string& name)
 
 static int lmdbGetBackendVersion([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
 {
-  cout << "6" << endl; // FIXME this should reuse the constant from lmdbbackend but that is currently a #define in a .cc
+  if (auto lmdbBackend = getBackendByName("lmdb"); lmdbBackend) {
+    cout << std::to_string(lmdbBackend->getStorageLayoutVersion()) << endl;
+  }
+  else {
+    cout << "LMDB backend not configured." << endl;
+  }
   return 0;
 }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3823,6 +3823,17 @@ static int addOrSetMeta(const ZoneName& zone, const string& kind, const vector<s
   return 0;
 }
 
+static std::unique_ptr<DNSBackend> getBackendByName(const std::string& name)
+{
+  for (auto& backend : BackendMakers().all()) {
+    if (backend->getPrefix() == name) {
+      return std::move(backend);
+    }
+  }
+
+  return nullptr;
+}
+
 // Command handlers
 
 static int lmdbGetBackendVersion([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
@@ -5623,17 +5634,8 @@ static int B2BMigrate(vector<string>& cmds, const std::string_view synopsis)
     return 1;
   }
 
-  unique_ptr<DNSBackend> src{nullptr};
-  unique_ptr<DNSBackend> tgt{nullptr};
-
-  for (auto& backend : BackendMakers().all()) {
-    if (backend->getPrefix() == cmds.at(0)) {
-       src = std::move(backend);
-    }
-    else if (backend->getPrefix() == cmds.at(1)) {
-       tgt = std::move(backend);
-    }
-  }
+  unique_ptr<DNSBackend> src = getBackendByName(cmds.at(0));
+  unique_ptr<DNSBackend> tgt = getBackendByName(cmds.at(1));
 
   if (src == nullptr) {
     cerr << "Unknown source backend '" << cmds.at(0) << "'" << endl;
@@ -5694,13 +5696,7 @@ static int backendCmd(vector<string>& cmds, const std::string_view synopsis)
     return usage(synopsis);
   }
 
-  std::unique_ptr<DNSBackend> matchingBackend{nullptr};
-
-  for (auto& backend : BackendMakers().all()) {
-    if (backend->getPrefix() == cmds.at(0)) {
-      matchingBackend = std::move(backend);
-    }
-  }
+  std::unique_ptr<DNSBackend> matchingBackend = getBackendByName(cmds.at(0));
 
   if (matchingBackend == nullptr) {
     cerr << "Unknown backend '" << cmds.at(0) << "'" << endl;
@@ -5734,13 +5730,7 @@ static int backendLookup(vector<string>& cmds, const std::string_view synopsis)
     return usage(synopsis);
   }
 
-  std::unique_ptr<DNSBackend> matchingBackend{nullptr};
-
-  for (auto& backend : BackendMakers().all()) {
-    if (backend->getPrefix() == cmds.at(0)) {
-      matchingBackend = std::move(backend);
-    }
-  }
+  std::unique_ptr<DNSBackend> matchingBackend = getBackendByName(cmds.at(0));
 
   if (matchingBackend == nullptr) {
     cerr << "Unknown backend '" << cmds.at(0) << "'" << endl;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3862,14 +3862,12 @@ static std::unique_ptr<DNSBackend> getBackendByName(const std::string& name)
 
 static int lmdbGetBackendVersion([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
 {
-#ifdef HAVE_LMDB
-  cout << "6" << endl; // FIXME this should reuse the constant from lmdbbackend but that is currently a #define in a .cc
-  if (g_verbose) {
-    cout << "Built against LMDB library version " << MDB_VERSION_MAJOR << "." << MDB_VERSION_MINOR << "." << MDB_VERSION_PATCH << endl;
+  if (auto lmdbBackend = getBackendByName("lmdb"); lmdbBackend) {
+    cout << lmdbBackend->getStorageLayoutVersion(g_verbose) << endl;
   }
-#else
-  cerr<<"LMDB support not enabled"<<endl;
-#endif
+  else {
+    cout << "LMDB backend not configured." << endl;
+  }
   return 0;
 }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3847,6 +3847,17 @@ static int addOrSetMeta(const ZoneName& zone, const string& kind, const vector<s
   return 0;
 }
 
+static std::unique_ptr<DNSBackend> getBackendByName(const std::string& name)
+{
+  for (auto& backend : BackendMakers().all()) {
+    if (backend->getPrefix() == name) {
+      return std::move(backend);
+    }
+  }
+
+  return nullptr;
+}
+
 // Command handlers
 
 static int lmdbGetBackendVersion([[maybe_unused]] vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)
@@ -5650,17 +5661,8 @@ static int B2BMigrate(vector<string>& cmds, const std::string_view synopsis)
     return 1;
   }
 
-  unique_ptr<DNSBackend> src{nullptr};
-  unique_ptr<DNSBackend> tgt{nullptr};
-
-  for (auto& backend : BackendMakers().all()) {
-    if (backend->getPrefix() == cmds.at(0)) {
-       src = std::move(backend);
-    }
-    else if (backend->getPrefix() == cmds.at(1)) {
-       tgt = std::move(backend);
-    }
-  }
+  unique_ptr<DNSBackend> src = getBackendByName(cmds.at(0));
+  unique_ptr<DNSBackend> tgt = getBackendByName(cmds.at(1));
 
   if (src == nullptr) {
     cerr << "Unknown source backend '" << cmds.at(0) << "'" << endl;
@@ -5738,13 +5740,7 @@ static int backendCmd(vector<string>& cmds, const std::string_view synopsis)
     return usage(synopsis);
   }
 
-  std::unique_ptr<DNSBackend> matchingBackend{nullptr};
-
-  for (auto& backend : BackendMakers().all()) {
-    if (backend->getPrefix() == cmds.at(0)) {
-      matchingBackend = std::move(backend);
-    }
-  }
+  std::unique_ptr<DNSBackend> matchingBackend = getBackendByName(cmds.at(0));
 
   if (matchingBackend == nullptr) {
     cerr << "Unknown backend '" << cmds.at(0) << "'" << endl;
@@ -5778,13 +5774,7 @@ static int backendLookup(vector<string>& cmds, const std::string_view synopsis)
     return usage(synopsis);
   }
 
-  std::unique_ptr<DNSBackend> matchingBackend{nullptr};
-
-  for (auto& backend : BackendMakers().all()) {
-    if (backend->getPrefix() == cmds.at(0)) {
-      matchingBackend = std::move(backend);
-    }
-  }
+  std::unique_ptr<DNSBackend> matchingBackend = getBackendByName(cmds.at(0));
 
   if (matchingBackend == nullptr) {
     cerr << "Unknown backend '" << cmds.at(0) << "'" << endl;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2016,6 +2016,30 @@ static void apiServerAutoprimariesPOST(HttpRequest* req, HttpResponse* resp)
   resp->status = 201;
 }
 
+static void apiServerBackendStorageVersion(HttpRequest* req, HttpResponse* resp)
+{
+  const std::string backendName = req->parameters["id"];
+  UeberBackend backend;
+  for (auto& onebackend : backend.backends) {
+    if (onebackend->getPrefix() == backendName) {
+      auto version = onebackend->getStorageLayoutVersion();
+      if (version < 0) {
+        throw ApiException("Storage layout version not available");
+      }
+
+      if (req->accept_json) {
+        resp->setJsonBody(Json::object{{"storageversion", version}});
+      }
+      else {
+        resp->headers["Content-Type"] = "text/plain; charset=us-ascii";
+        resp->body = std::to_string(version);
+      }
+      return;
+    }
+  }
+  throw ApiException("Unknown backend");
+}
+
 // create new zone
 static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
 {
@@ -3344,6 +3368,7 @@ void AuthWebServer::webThread(Logr::log_t slog)
       d_ws->registerApiHandler("/api/v1/servers/localhost/autoprimaries/<ip>/<nameserver>", &apiServerAutoprimaryDetailDELETE, "DELETE");
       d_ws->registerApiHandler("/api/v1/servers/localhost/autoprimaries", &apiServerAutoprimariesGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/autoprimaries", &apiServerAutoprimariesPOST, "POST");
+      d_ws->registerApiHandler("/api/v1/servers/localhost/backends/<id>/storageversion", apiServerBackendStorageVersion, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/networks", apiServerNetworksGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/networks/<ip>/<prefixlen>", apiServerNetworksGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/networks/<ip>/<prefixlen>", apiServerNetworksPUT, "PUT");

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2113,6 +2113,30 @@ static void apiServerAutoprimariesPOST(HttpRequest* req, HttpResponse* resp)
   resp->status = 201;
 }
 
+static void apiServerBackendStorageVersion(HttpRequest* req, HttpResponse* resp)
+{
+  const std::string backendName = req->parameters["id"];
+  UeberBackend backend;
+  for (auto& onebackend : backend.backends) {
+    if (onebackend->getPrefix() == backendName) {
+      std::string version = onebackend->getStorageLayoutVersion(false);
+      if (version.empty()) {
+        throw ApiException("Storage layout version not available");
+      }
+
+      if (req->accept_json) {
+        resp->setJsonBody(Json::object{{"storageversion", version}});
+      }
+      else {
+        resp->headers["Content-Type"] = "text/plain; charset=us-ascii";
+        resp->body = std::move(version);
+      }
+      return;
+    }
+  }
+  throw ApiException("Unknown backend");
+}
+
 // create new zone
 static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
 {
@@ -3471,6 +3495,7 @@ void AuthWebServer::webThread(Logr::log_t slog)
       d_ws->registerApiHandler("/api/v1/servers/localhost/autoprimaries/<ip>/<nameserver>", &apiServerAutoprimaryDetailDELETE, "DELETE");
       d_ws->registerApiHandler("/api/v1/servers/localhost/autoprimaries", &apiServerAutoprimariesGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/autoprimaries", &apiServerAutoprimariesPOST, "POST");
+      d_ws->registerApiHandler("/api/v1/servers/localhost/backends/<id>/storageversion", apiServerBackendStorageVersion, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/networks", apiServerNetworksGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/networks/<ip>/<prefixlen>", apiServerNetworksGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/networks/<ip>/<prefixlen>", apiServerNetworksPUT, "PUT");

--- a/regression-tests.api/test_Backends.py
+++ b/regression-tests.api/test_Backends.py
@@ -1,0 +1,19 @@
+from __future__ import print_function
+import json
+import operator
+import unittest
+import requests.exceptions
+from test_helper import ApiTestCase, is_auth, is_auth_lmdb, BACKEND
+
+
+@unittest.skipIf(not is_auth(), "Not applicable")
+class AuthBackends(ApiTestCase):
+    def test_storage_version(self):
+        # Require a json answer to GET
+        self.session.headers["Content-Type"] = "application/json"
+        r = self.session.get(self.url("/api/v1/servers/localhost/backends/" + BACKEND + "/storageversion"))
+        if is_auth_lmdb():
+            self.assertEqual(r.status_code, 200)
+            self.assertGreater(r.json()["storageversion"], 5)
+        else:
+            self.assertEqual(r.status_code, 422)

--- a/regression-tests.api/test_Backends.py
+++ b/regression-tests.api/test_Backends.py
@@ -1,0 +1,19 @@
+from __future__ import print_function
+import json
+import operator
+import unittest
+import requests.exceptions
+from test_helper import ApiTestCase, is_auth, is_auth_lmdb, BACKEND
+
+
+@unittest.skipIf(not is_auth(), "Not applicable")
+class AuthBackends(ApiTestCase):
+    def test_storage_version(self):
+        # Require a json answer to GET
+        self.session.headers["Content-Type"] = "application/json"
+        r = self.session.get(self.url("/api/v1/servers/localhost/backends/" + BACKEND + "/storageversion"))
+        if is_auth_lmdb():
+            self.assertEqual(r.status_code, 200)
+            self.assertGreater(int(r.json()["storageversion"]), 5)
+        else:
+            self.assertEqual(r.status_code, 422)


### PR DESCRIPTION
### Short description
This PR adds some plumbing for backends to be able to report a "storage version number", whatever that means on a per-backend basis. This data, when available, is made available through the HTTP API via a currently undocumented endpoint.

The LMDB backend implements this to return the schema version currently used for the given zone.

The lack of documentation is intentional, for I am not sure this is something useful to users at this point.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
