### PR TITLE
auth, rec webservers: recognize Accept: */* header

### DIFF
--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1241,8 +1241,7 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         name, payload, zone = self.create_zone(nameservers=['ns1.foo.com.', 'ns2.foo.com.'], soa_edit_api='')
         # export it
         r = self.session.get(
-            self.url("/api/v1/servers/localhost/zones/" + name + "/export"),
-            headers={'accept': '*/*'}
+            self.url("/api/v1/servers/localhost/zones/" + name + "/export")
         )
         data = r.text.strip().split("\n")
         expected_data = [name + '\t3600\tIN\tNS\tns1.foo.com.',


### PR DESCRIPTION
### Short description
The common webserver code tries to pick the best format for its output according to the `Accept` and `Content-Type` headers. But if `Accept` contains `*/*`, then it should allow any kind of output.

Note that we do not handle q-factor weighting in the `Accept` header yet.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
