### PR TITLE
auth lmdb: full support for comments

### DIFF
--- a/modules/lmdbbackend/Makefile.am
+++ b/modules/lmdbbackend/Makefile.am
@@ -1,4 +1,5 @@
-AM_CPPFLAGS += $(LMDB_CFLAGS) $(LIBCRYPTO_INCLUDES)
+AM_CPPFLAGS += $(LMDB_CFLAGS) $(LIBCRYPTO_INCLUDES) -I$(top_srcdir)/ext/protozero/include
+
 
 pkglib_LTLIBRARIES = liblmdbbackend.la
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1244,7 +1244,7 @@ static uint32_t peekAtTtl(const string_view& buffer)
 
 void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, const std::string& match, QType qtype)
 {
-  auto cursor = txn.txn->getCursor(txn.db->dbi);
+  auto cursor = txn.txn->getCursor(txn.db->rdbi);
   MDBOutVal key{};
   MDBOutVal val{};
 
@@ -1381,13 +1381,13 @@ void LMDBBackend::deleteNSEC3RecordPair(const std::shared_ptr<RecordsRWTransacti
   MDBOutVal val{};
 
   auto key = co(domain_id, qname, QType::NSEC3);
-  if (txn->txn->get(txn->db->dbi, key, val) == 0) {
+  if (txn->txn->get(txn->db->rdbi, key, val) == 0) {
     LMDBResourceRecord lrr;
     if (deserializeFromBuffer(val.get<string_view>(), lrr)) {
       DNSName ordername(lrr.content.c_str(), lrr.content.size(), 0, false);
-      txn->txn->del(txn->db->dbi, co(domain_id, ordername, QType::NSEC3));
+      txn->txn->del(txn->db->rdbi, co(domain_id, ordername, QType::NSEC3));
     }
-    txn->txn->del(txn->db->dbi, key);
+    txn->txn->del(txn->db->rdbi, key);
   }
 }
 
@@ -1408,14 +1408,14 @@ void LMDBBackend::writeNSEC3RecordPair(const std::shared_ptr<RecordsRWTransactio
   // same ordername and we have nothing to do, or the ordername has changed and
   // we need to remove the about-to-become-dangling back chain record.
   MDBOutVal val{};
-  if (txn->txn->get(txn->db->dbi, co(domain_id, qname, QType::NSEC3), val) == 0) {
+  if (txn->txn->get(txn->db->rdbi, co(domain_id, qname, QType::NSEC3), val) == 0) {
     LMDBResourceRecord lrr;
     if (deserializeFromBuffer(val.get<string_view>(), lrr)) {
       DNSName prevordername(lrr.content.c_str(), lrr.content.size(), 0, false);
       if (prevordername == ordername) {
         return; // nothing to do! (assuming the other record also exists)
       }
-      txn->txn->del(txn->db->dbi, co(domain_id, prevordername, QType::NSEC3));
+      txn->txn->del(txn->db->rdbi, co(domain_id, prevordername, QType::NSEC3));
     }
   }
 
@@ -1427,14 +1427,14 @@ void LMDBBackend::writeNSEC3RecordPair(const std::shared_ptr<RecordsRWTransactio
   lrr.content = qname.toDNSStringLC();
   std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
   serializeToBuffer(ser, lrr);
-  txn->txn->put_header_in_place(txn->db->dbi, co(domain_id, ordername, QType::NSEC3), ser);
+  txn->txn->put_header_in_place(txn->db->rdbi, co(domain_id, ordername, QType::NSEC3), ser);
 
   // Write qname -> ordername forward chain record with ttl set to 1
   lrr.ttl = 1;
   lrr.content = ordername.toDNSString();
   ser = MDBRWTransactionImpl::stringWithEmptyHeader();
   serializeToBuffer(ser, lrr);
-  txn->txn->put_header_in_place(txn->db->dbi, co(domain_id, qname, QType::NSEC3), ser);
+  txn->txn->put_header_in_place(txn->db->rdbi, co(domain_id, qname, QType::NSEC3), ser);
 }
 
 // Check if the only records found for this particular name are a single NSEC3
@@ -1479,11 +1479,11 @@ bool LMDBBackend::feedRecord(const DNSResourceRecord& r, const DNSName& ordernam
 
   string rrs = MDBRWTransactionImpl::stringWithEmptyHeader();
   MDBOutVal _rrs;
-  if (!d_rwtxn->txn->get(d_rwtxn->db->dbi, matchName, _rrs)) {
+  if (!d_rwtxn->txn->get(d_rwtxn->db->rdbi, matchName, _rrs)) {
     rrs.append(_rrs.get<string>());
   }
   serializeToBuffer(rrs, lrr);
-  d_rwtxn->txn->put_header_in_place(d_rwtxn->db->dbi, matchName, rrs);
+  d_rwtxn->txn->put_header_in_place(d_rwtxn->db->rdbi, matchName, rrs);
 
   if (lrr.hasOrderName) {
     writeNSEC3RecordPair(d_rwtxn, lrr.domain_id, lrr.qname, ordername);
@@ -1503,7 +1503,7 @@ bool LMDBBackend::feedEnts(domainid_t domain_id, map<DNSName, bool>& nonterm)
 
     std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
     serializeToBuffer(ser, lrr);
-    d_rwtxn->txn->put_header_in_place(d_rwtxn->db->dbi, co(domain_id, lrr.qname, QType::ENT), ser);
+    d_rwtxn->txn->put_header_in_place(d_rwtxn->db->rdbi, co(domain_id, lrr.qname, QType::ENT), ser);
   }
   return true;
 }
@@ -1520,7 +1520,7 @@ bool LMDBBackend::feedEnts3(domainid_t domain_id, const DNSName& domain, map<DNS
     lrr.hasOrderName = lrr.auth && !narrow;
     std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
     serializeToBuffer(ser, lrr);
-    d_rwtxn->txn->put_header_in_place(d_rwtxn->db->dbi, co(domain_id, lrr.qname, QType::ENT), ser);
+    d_rwtxn->txn->put_header_in_place(d_rwtxn->db->rdbi, co(domain_id, lrr.qname, QType::ENT), ser);
 
     if (lrr.hasOrderName) {
       ordername = DNSName(toBase32Hex(hashQNameWithSalt(ns3prc, nt.first)));
@@ -1575,7 +1575,7 @@ bool LMDBBackend::replaceRRSet(domainid_t domain_id, const DNSName& qname, const
       }
     }
     else {
-      auto cursor = txn->txn->getCursor(txn->db->dbi);
+      auto cursor = txn->txn->getCursor(txn->db->rdbi);
       MDBOutVal key{};
       MDBOutVal val{};
       bool hadOrderName{false};
@@ -1609,7 +1609,7 @@ bool LMDBBackend::replaceRRSet(domainid_t domain_id, const DNSName& qname, const
     }
     std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
     serializeToBuffer(ser, adjustedRRSet);
-    txn->txn->put_header_in_place(txn->db->dbi, match, ser);
+    txn->txn->put_header_in_place(txn->db->rdbi, match, ser);
   }
 
   if (needCommit)
@@ -1811,7 +1811,7 @@ std::shared_ptr<LMDBBackend::RecordsRWTransaction> LMDBBackend::getRecordsRWTran
   if (!shard.env) {
     shard.env = getMDBEnv((getArg("filename") + "-" + std::to_string(id % s_shards)).c_str(),
                           MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards);
-    shard.dbi = shard.env->openDB("records_v5", MDB_CREATE);
+    shard.rdbi = shard.env->openDB("records_v5", MDB_CREATE);
   }
   auto ret = std::make_shared<RecordsRWTransaction>(shard.env->getRWTransaction());
   ret->db = std::make_shared<RecordsDB>(shard);
@@ -1829,7 +1829,7 @@ std::shared_ptr<LMDBBackend::RecordsROTransaction> LMDBBackend::getRecordsROTran
     }
     shard.env = getMDBEnv((getArg("filename") + "-" + std::to_string(id % s_shards)).c_str(),
                           MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards);
-    shard.dbi = shard.env->openDB("records_v5", MDB_CREATE);
+    shard.rdbi = shard.env->openDB("records_v5", MDB_CREATE);
   }
 
   if (rwtxn) {
@@ -2017,7 +2017,7 @@ void LMDBBackend::lookupStart(domainid_t domain_id, const std::string& match, bo
 {
   d_rotxn = getRecordsROTransaction(domain_id, d_rwtxn);
   d_txnorder = true;
-  d_lookupstate.cursor = std::make_shared<MDBROCursor>(d_rotxn->txn->getCursor(d_rotxn->db->dbi));
+  d_lookupstate.cursor = std::make_shared<MDBROCursor>(d_rotxn->txn->getCursor(d_rotxn->db->rdbi));
 
   // Make sure we start with fresh data
   d_lookupstate.rrset.clear();
@@ -2164,7 +2164,7 @@ bool LMDBBackend::getSerial(DomainInfo& di)
   auto txn = getRecordsROTransaction(di.id);
   compoundOrdername co;
   MDBOutVal val;
-  if (!txn->txn->get(txn->db->dbi, co(di.id, g_rootdnsname, QType::SOA), val)) {
+  if (!txn->txn->get(txn->db->rdbi, co(di.id, g_rootdnsname, QType::SOA), val)) {
     LMDBResourceRecord lrr;
     if (deserializeFromBuffer(val.get<string_view>(), lrr)) {
       if (lrr.content.size() >= sizeof(soatimes)) {
@@ -2350,7 +2350,7 @@ void LMDBBackend::getUnfreshSecondaryInfos(vector<DomainInfo>* domains)
     auto txn2 = getRecordsROTransaction(di.id);
     compoundOrdername co;
     MDBOutVal val;
-    if (!txn2->txn->get(txn2->db->dbi, co(di.id, g_rootdnsname, QType::SOA), val)) {
+    if (!txn2->txn->get(txn2->db->rdbi, co(di.id, g_rootdnsname, QType::SOA), val)) {
       LMDBResourceRecord lrr;
       if (deserializeFromBuffer(val.get<string_view>(), lrr)) {
         if (lrr.content.size() >= sizeof(soatimes)) {
@@ -2723,7 +2723,7 @@ bool LMDBBackend::getBeforeAndAfterNamesAbsolute(domainid_t id, const DNSName& q
   compoundOrdername co;
   auto txn = getRecordsROTransaction(id);
 
-  auto cursor = txn->txn->getCursor(txn->db->dbi);
+  auto cursor = txn->txn->getCursor(txn->db->rdbi);
   MDBOutVal key, val;
 
   string matchkey = co(id, qname, QType::NSEC3);
@@ -2866,7 +2866,7 @@ bool LMDBBackend::getBeforeAndAfterNames(domainid_t domainId, const ZoneName& zo
   compoundOrdername co;
   auto txn = getRecordsROTransaction(domainId);
 
-  auto cursor = txn->txn->getCursor(txn->db->dbi);
+  auto cursor = txn->txn->getCursor(txn->db->rdbi);
   MDBOutVal key, val;
 
   DNSName qname2 = qname.makeRelative(zonename);
@@ -3007,7 +3007,7 @@ bool LMDBBackend::updateDNSSECOrderNameAndAuth(domainid_t domain_id, const DNSNa
   compoundOrdername co;
   string matchkey = co(domain_id, rel);
 
-  auto cursor = txn->txn->getCursor(txn->db->dbi);
+  auto cursor = txn->txn->getCursor(txn->db->rdbi);
   MDBOutVal key, val;
   if (cursor.prefix(matchkey, key, val) != 0) {
     // cout << "Could not find anything"<<endl;
@@ -3100,7 +3100,7 @@ bool LMDBBackend::updateEmptyNonTerminals(domainid_t domain_id, set<DNSName>& in
     // deleteDomainRecords() would do, as we also need to remove
     // NSEC3 records for these ENT, if any.
     {
-      auto cursor = txn->txn->getCursor(txn->db->dbi);
+      auto cursor = txn->txn->getCursor(txn->db->rdbi);
       MDBOutVal key{};
       MDBOutVal val{};
       std::vector<DNSName> names;
@@ -3137,9 +3137,9 @@ bool LMDBBackend::updateEmptyNonTerminals(domainid_t domain_id, set<DNSName>& in
       name.makeUsRelative(info.zone);
       std::string match = order(domain_id, name, QType::ENT);
       MDBOutVal val{};
-      if (txn->txn->get(txn->db->dbi, match, val) == 0) {
+      if (txn->txn->get(txn->db->rdbi, match, val) == 0) {
         bool hadOrderName = peekAtHasOrderName(val.get<string_view>());
-        txn->txn->del(txn->db->dbi, match);
+        txn->txn->del(txn->db->rdbi, match);
         if (hadOrderName) {
           deleteNSEC3RecordPair(txn, domain_id, name);
         }
@@ -3153,7 +3153,7 @@ bool LMDBBackend::updateEmptyNonTerminals(domainid_t domain_id, set<DNSName>& in
     lrr.auth = true;
     std::string ser = MDBRWTransactionImpl::stringWithEmptyHeader();
     serializeToBuffer(ser, lrr);
-    txn->txn->put_header_in_place(txn->db->dbi, order(domain_id, lrr.qname, QType::ENT), ser);
+    txn->txn->put_header_in_place(txn->db->rdbi, order(domain_id, lrr.qname, QType::ENT), ser);
     // cout <<" +"<<name<<endl;
   }
   if (needCommit) {
@@ -3442,7 +3442,7 @@ string LMDBBackend::directBackendCmd_list(std::vector<string>& argv)
         // without disturbing the current get() cursor.
         compoundOrdername order;
         MDBOutVal val{};
-        if (d_rotxn->txn->get(d_rotxn->db->dbi, order(info.id, basename, QType::NSEC3), val) == 0) {
+        if (d_rotxn->txn->get(d_rotxn->db->rdbi, order(info.id, basename, QType::NSEC3), val) == 0) {
           LMDBResourceRecord nsec3rr;
           if (deserializeFromBuffer(val.get<string_view>(), nsec3rr)) {
             DNSName ordername(nsec3rr.content.c_str(), nsec3rr.content.size(), 0, false);

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -34,6 +34,7 @@
 #include "pdns/logger.hh"
 #include "pdns/misc.hh"
 #include "pdns/pdnsexception.hh"
+#include "pdns/sha.hh"
 #include "pdns/uuid-utils.hh"
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
@@ -42,6 +43,8 @@
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/uuid/uuid_serialize.hpp>
+#include <protozero/pbf_reader.hpp>
+#include <protozero/pbf_writer.hpp>
 #include <cstdio>
 #include <cstring>
 #include <lmdb.h>
@@ -889,7 +892,7 @@ void LMDBBackend::openAllTheDatabases()
 
 unsigned int LMDBBackend::getCapabilities()
 {
-  unsigned int caps = CAP_DNSSEC | CAP_DIRECT | CAP_LIST | CAP_CREATE | CAP_SEARCH;
+  unsigned int caps = CAP_DNSSEC | CAP_DIRECT | CAP_LIST | CAP_CREATE | CAP_SEARCH | CAP_COMMENTS;
   if (d_views) {
     caps |= CAP_VIEWS;
   }
@@ -1159,6 +1162,36 @@ static std::string serializeContent(uint16_t qtype, const DNSName& domain, const
 {
   auto drc = DNSRecordContent::make(qtype, QClass::IN, content);
   return drc->serialize(domain, false);
+}
+
+// perhaps this can also create the compound order name for us
+std::pair<std::string, std::string> LMDBBackend::serializeComment(const Comment& comment)
+{
+  compoundOrdername co;
+  auto qname = comment.qname.makeRelative(d_transactiondomain);
+  string key = co(comment.domain_id, qname, comment.qtype);
+
+  // we serialized domain_id, qname, qtype
+  // that leaves us with content, modified_at, account
+
+  string val;
+
+  protozero::pbf_writer val_writer{val};
+  val_writer.add_sfixed64(1, comment.modified_at);
+  val_writer.add_string(2, comment.account);
+  val_writer.add_string(3, comment.content);
+
+  // because of Lightning Stream, we don't want to put all comments for an RRSET in a single LMDB value
+  // because if we did, then after adding one comment on node A and adding one comment on B, the set from one will overwrite
+  // the set from the other, deleting one of the comments.
+  // instead, we use one LMDB key/value per comment. This requires a unique key. Our unique key is the hash of our value.
+  // This makes sure that identical/duplicate comments do not actually duplicate, and that different comments do not
+  // overwrite each other, because their hashes are different.
+  auto hash = pdns::sha256sum(val);
+
+  key.append(hash);
+
+  return {key, val};
 }
 
 static std::shared_ptr<DNSRecordContent> deserializeContentZR(uint16_t qtype, const DNSName& qname, const std::string& content)
@@ -1491,6 +1524,16 @@ bool LMDBBackend::feedRecord(const DNSResourceRecord& r, const DNSName& ordernam
   return true;
 }
 
+// d_rwtxn must be set here
+bool LMDBBackend::feedComment(const Comment& comment)
+{
+  auto [key, val] = serializeComment(comment);
+
+  d_rwtxn->txn->put(d_rwtxn->db->cdbi, key, val);
+
+  return true;
+}
+
 bool LMDBBackend::feedEnts(domainid_t domain_id, map<DNSName, bool>& nonterm)
 {
   LMDBResourceRecord lrr;
@@ -1618,12 +1661,31 @@ bool LMDBBackend::replaceRRSet(domainid_t domain_id, const DNSName& qname, const
   return true;
 }
 
-// NOLINTNEXTLINE(readability-identifier-length)
-bool LMDBBackend::replaceComments([[maybe_unused]] domainid_t domain_id, [[maybe_unused]] const DNSName& qname, [[maybe_unused]] const QType& qt, const vector<Comment>& comments)
+bool LMDBBackend::replaceComments(const domainid_t domain_id, const DNSName& qname, const QType& qtype, const vector<Comment>& comments)
 {
-  // if the vector is empty, good, that's what we do here (LMDB does not store comments)
-  // if it's not, report failure
-  return comments.empty();
+  // delete all existing comments for the RRset
+  // this could be smarter and not del+replace unchanged comments
+  auto cursor = d_rwtxn->txn->getCursor(d_rwtxn->db->cdbi);
+  MDBOutVal key{};
+  MDBOutVal val{};
+
+  compoundOrdername co;
+
+  auto relqname = qname.makeRelative(d_transactiondomain);
+
+  string match = co(domain_id, relqname, qtype);
+
+  if (cursor.prefix(match, key, val) == 0) {
+    do {
+      cursor.del(key);
+    } while (cursor.next(key, val) == 0);
+  }
+
+  for (const auto& comment : comments) {
+    feedComment(comment);
+  }
+
+  return true;
 }
 
 // FIXME: this is not very efficient
@@ -1923,11 +1985,30 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
   return true;
 }
 
+bool LMDBBackend::listComments(domainid_t domain_id)
+{
+  DomainInfo info;
+  if (!findDomain(domain_id, info)) {
+    throw DBException("Domain with id '" + std::to_string(domain_id) + "' not found");
+  }
+
+  d_lookupstate.domain = info.zone;
+  d_lookupstate.submatch.clear();
+  d_lookupstate.comments = true;
+
+  compoundOrdername order;
+  std::string match = order(domain_id);
+
+  lookupStart(domain_id, match, false);
+  return true;
+}
+
 bool LMDBBackend::list(const ZoneName& target, domainid_t domain_id, bool include_disabled)
 {
   d_lookupstate.domain = target;
   d_lookupstate.submatch.clear();
   d_lookupstate.includedisabled = include_disabled;
+  d_lookupstate.comments = false;
 
   compoundOrdername order;
   std::string match = order(domain_id);
@@ -1955,6 +2036,7 @@ bool LMDBBackend::listSubZone(const ZoneName& target, domainid_t domain_id)
   d_lookupstate.domain = std::move(info.zone);
   d_lookupstate.submatch = std::move(relqname);
   d_lookupstate.includedisabled = true;
+  d_lookupstate.comments = false;
 
   compoundOrdername order;
   std::string match = order(domain_id);
@@ -2002,6 +2084,7 @@ void LMDBBackend::lookupInternal(const QType& type, const DNSName& qdomain, doma
   d_lookupstate.domain = std::move(info.zone);
   d_lookupstate.submatch.clear();
   d_lookupstate.includedisabled = include_disabled;
+  d_lookupstate.comments = false;
 
   compoundOrdername order;
   std::string match;
@@ -2019,15 +2102,18 @@ void LMDBBackend::lookupStart(domainid_t domain_id, const std::string& match, bo
 {
   d_rotxn = getRecordsROTransaction(domain_id, d_rwtxn);
   d_txnorder = true;
-  d_lookupstate.cursor = std::make_shared<MDBROCursor>(d_rotxn->txn->getCursor(d_rotxn->db->rdbi));
+  if (d_lookupstate.comments) {
+    d_lookupstate.cursor = std::make_shared<MDBROCursor>(d_rotxn->txn->getCursor(d_rotxn->db->cdbi));
+  }
+  else {
+    d_lookupstate.cursor = std::make_shared<MDBROCursor>(d_rotxn->txn->getCursor(d_rotxn->db->rdbi));
+  }
 
   // Make sure we start with fresh data
   d_lookupstate.rrset.clear();
   d_lookupstate.rrsetpos = 0;
 
-  MDBOutVal key{};
-  MDBOutVal val{};
-  if (d_lookupstate.cursor->prefix(match, key, val) != 0) {
+  if (d_lookupstate.cursor->prefix(match, d_lookupstate.key, d_lookupstate.val) != 0) {
     d_lookupstate.reset(); // will cause get() to fail
     if (dolog) {
       SLOG(g_log << Logger::Warning << "Query " << ((long)(void*)this) << ": " << d_dtime.udiffNoReset() << " us to execute (found nothing)" << endl,
@@ -2044,6 +2130,48 @@ void LMDBBackend::lookupStart(domainid_t domain_id, const std::string& match, bo
 
 bool LMDBBackend::getInternal(DNSName& basename, std::string_view& key)
 {
+  // FIXME: bit of duplication from below here, but much simpler
+  if (d_lookupstate.comments) {
+    if (!d_lookupstate.cursor) {
+      d_rotxn.reset();
+      return false;
+    }
+
+    key = d_lookupstate.key.getNoStripHeader<string_view>();
+    // remove hash from the key so compoundOrdername::get* works
+    key = key.substr(0, key.size() - 256 / 8);
+    if (key.size() == 0) {
+      // removing the hash-sized suffix left us with nothing
+      throw DBException("got invalid serialized comment: key too short");
+    }
+
+    basename = compoundOrdername::getQName(key);
+
+    const auto& val = d_lookupstate.val.get<string>();
+
+    d_lookupstate.comment.domain_id = compoundOrdername::getDomainID(key);
+    d_lookupstate.comment.qname = basename + d_lookupstate.domain.operator const DNSName&();
+    d_lookupstate.comment.qtype = compoundOrdername::getQType(key);
+    try {
+      protozero::pbf_reader message{val};
+      message.next(1);
+      d_lookupstate.comment.modified_at = message.get_sfixed64();
+      message.next(2);
+      d_lookupstate.comment.account = message.get_string();
+      message.next(3);
+      d_lookupstate.comment.content = message.get_string();
+    }
+    catch (protozero::exception& e) {
+      throw DBException(std::string("got invalid serialized comment: ") + e.what());
+    }
+
+    if (d_lookupstate.cursor && d_lookupstate.cursor->next(d_lookupstate.key, d_lookupstate.val) != 0) {
+      d_lookupstate.reset(); // this invalidates cursor and makes us return false on the next round
+    }
+
+    return true;
+  }
+
   for (;;) {
     if (!d_lookupstate.rrset.empty()) {
       if (++d_lookupstate.rrsetpos >= d_lookupstate.rrset.size()) {
@@ -2106,6 +2234,19 @@ bool LMDBBackend::getInternal(DNSName& basename, std::string_view& key)
 
     break;
   }
+
+  return true;
+}
+
+bool LMDBBackend::getComment(Comment& comment) // NOLINT(readability-identifier-length)
+{
+  DNSName basename;
+  std::string_view key;
+
+  if (!getInternal(basename, key)) {
+    return false;
+  }
+  comment = d_lookupstate.comment;
 
   return true;
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1812,6 +1812,7 @@ std::shared_ptr<LMDBBackend::RecordsRWTransaction> LMDBBackend::getRecordsRWTran
     shard.env = getMDBEnv((getArg("filename") + "-" + std::to_string(id % s_shards)).c_str(),
                           MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards);
     shard.rdbi = shard.env->openDB("records_v5", MDB_CREATE);
+    shard.cdbi = shard.env->openDB("comments_v7", MDB_CREATE);
   }
   auto ret = std::make_shared<RecordsRWTransaction>(shard.env->getRWTransaction());
   ret->db = std::make_shared<RecordsDB>(shard);
@@ -1830,6 +1831,7 @@ std::shared_ptr<LMDBBackend::RecordsROTransaction> LMDBBackend::getRecordsROTran
     shard.env = getMDBEnv((getArg("filename") + "-" + std::to_string(id % s_shards)).c_str(),
                           MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards);
     shard.rdbi = shard.env->openDB("records_v5", MDB_CREATE);
+    shard.cdbi = shard.env->openDB("comments_v7", MDB_CREATE);
   }
 
   if (rwtxn) {
@@ -3468,6 +3470,8 @@ bool LMDBBackend::hasCreatedLocalFiles() const
   // not all of them did.
   // But since this information is for the sake of pdnsutil, this is not
   // really a problem.
+  // However, there is a false positive if we make new databases (dbis) inside
+  // existing LMDB files on disk. This is not easy to avoid.
   return MDBDbi::d_creationCount != 0;
 }
 

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -300,6 +300,7 @@ private:
   {
     shared_ptr<MDBEnv> env;
     MDBDbi rdbi; // records
+    MDBDbi cdbi; // comments
   };
 
   struct RecordsROTransaction

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -299,7 +299,7 @@ private:
   struct RecordsDB
   {
     shared_ptr<MDBEnv> env;
-    MDBDbi dbi;
+    MDBDbi rdbi; // records
   };
 
   struct RecordsROTransaction

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -84,6 +84,10 @@ public:
   bool commitTransaction() override;
   bool abortTransaction() override;
   bool feedRecord(const DNSResourceRecord& r, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
+  bool feedComment(const Comment& c) override;
+  bool listComments(domainid_t domain_id) override;
+  bool getComment(Comment& comment) override;
+
   bool feedEnts(domainid_t domain_id, map<DNSName, bool>& nonterm) override;
   bool feedEnts3(domainid_t domain_id, const DNSName& domain, map<DNSName, bool>& nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
   bool replaceRRSet(domainid_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
@@ -361,6 +365,8 @@ private:
   static void deleteNSEC3RecordPair(const std::shared_ptr<RecordsRWTransaction>& txn, domainid_t domain_id, const DNSName& qname);
   void writeNSEC3RecordPair(const std::shared_ptr<RecordsRWTransaction>& txn, domainid_t domain_id, const DNSName& qname, const DNSName& ordername);
 
+  std::pair<std::string, std::string> serializeComment(const Comment& c);
+
   string directBackendCmd_list(std::vector<string>& argv);
 
   // Transient DomainInfo data, not necessarily synchronized with the
@@ -406,6 +412,10 @@ private:
     MDBOutVal val;
     // whether to include disabled records in the results
     bool includedisabled;
+    // whether we are doing comments (false=records, true=comments)
+    bool comments;
+    // comment found by last call to getInternal
+    Comment comment;
 
     void reset()
     {
@@ -414,6 +424,7 @@ private:
       rrset.clear();
       rrsetpos = 0;
       cursor.reset();
+      // comments bool explicitly not reset here, so getInternal can note absence the right way
     }
   } d_lookupstate;
 

--- a/modules/lmdbbackend/meson.build
+++ b/modules/lmdbbackend/meson.build
@@ -6,4 +6,4 @@ module_extras = files(
   'lmdbbackend.hh',
 )
 
-module_deps = [deps, dep_lmdb_safe, dep_lmdb, dep_boost_serialization, dep_libsystemd]
+module_deps = [deps, dep_lmdb_safe, dep_lmdb, dep_boost_serialization, dep_libsystemd, dep_protozero]

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -475,10 +475,7 @@ public:
   virtual bool searchRecords(const string& pattern, size_t maxResults, vector<DNSResourceRecord>& result);
 
   //! Search for comments, returns true if search was done successfully.
-  virtual bool searchComments(const string& /* pattern */, size_t /* maxResults */, vector<Comment>& /* result */)
-  {
-    return false;
-  }
+  virtual bool searchComments(const string& /* pattern */, size_t /* maxResults */, vector<Comment>& /* result */);
 
   virtual void viewList(vector<string>& /* result */)
   {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1,5 +1,6 @@
 #include <cerrno>
 #include <csignal>
+#include <cstdlib>
 #include <fcntl.h>
 #include <fstream>
 #include <iomanip>
@@ -86,6 +87,8 @@ static int activateTSIGKey(vector<string>& cmds, std::string_view synopsis);
 static int activateZoneKey(vector<string>& cmds, std::string_view synopsis);
 static int addAutoprimary(vector<string>& cmds, std::string_view synopsis);
 static int addMeta(vector<string>& cmds, std::string_view synopsis);
+static int addComment(vector<string>& cmds, std::string_view synopsis);
+static int listComments(vector<string>& cmds, std::string_view synopsis);
 static int addRecord(vector<string>& cmds, std::string_view synopsis);
 static int addZoneKey(vector<string>& cmds, std::string_view synopsis);
 static int backendCmd(vector<string>& cmds, std::string_view synopsis);
@@ -282,7 +285,13 @@ static const groupCommandDispatcher rrsetCommands{
     "\tCalculate the NSEC3 hash for NAME in ZONE"}},
    {"replace", {true, replaceRRSet,
     R"(ZONE NAME TYPE [TTL] "CONTENT" ["CONTENT"...])",
-    "\tReplace named rrset from ZONE"}}}
+    "\tReplace named rrset from ZONE"}},
+  {"add-comment", {true, addComment,
+    "ZONE NAME TYPE COMMENT [ACCOUNT]",
+    "\tAdd a comment"}},
+   {"list-comments", {true, listComments,
+     "ZONE",
+     "\tList comments for a zone"}}}
 };
 
 // TSIG-KEY / TSIGKEY
@@ -1877,6 +1886,30 @@ static int listZone(const ZoneName &zone) {
   cout.flush();
   return EXIT_SUCCESS;
 }
+
+static int listComments(const ZoneName &zone) {
+  UtilBackend B; //NOLINT(readability-identifier-length)
+  DomainInfo di; //NOLINT(readability-identifier-length)
+
+  if (! B.getDomainInfo(zone, di)) {
+    cerr << "Zone '" << zone << "' not found!" << endl;
+    return EXIT_FAILURE;
+  }
+  if ((di.backend->getCapabilities() & DNSBackend::CAP_COMMENTS) == 0) {
+    cerr << "Backend for zone '" << zone << "' does not support listing its comments." << endl;
+    return EXIT_FAILURE;
+  }
+
+  Comment comment;
+
+  di.backend->listComments(di.id);
+  while(di.backend->getComment(comment)) {
+    cout<<comment.qname<<"\t"<<comment.qtype<<"\t"<<comment.modified_at<<"\t"<<comment.account<<"\t"<<comment.content<<endl;
+  }
+  return EXIT_SUCCESS;
+}
+
+
 
 // lovingly copied from http://stackoverflow.com/questions/1798511/how-to-avoid-press-enter-with-any-getchar
 static int read1char(){
@@ -4342,6 +4375,60 @@ static int changeSecondaryZonePrimary(vector<string>& cmds, const std::string_vi
     return EXIT_FAILURE;
   }
 }
+
+static int addComment(vector<string>& cmds, const std::string_view synopsis)
+{
+  if(cmds.size() < 4) {
+    return usage(synopsis);
+  }
+
+  UtilBackend B; //NOLINT(readability-identifier-length)
+  DomainInfo di; //NOLINT(readability-identifier-length)
+  ZoneName zone(cmds.at(0));
+  if (!B.getDomainInfo(zone, di)) {
+    cerr << "Zone '" << zone << "' doesn't exist" << endl;
+    return EXIT_FAILURE;
+  }
+
+  Comment comment;
+
+  comment.domain_id = di.id;
+  comment.qname = DNSName(cmds.at(1));
+  comment.qtype = cmds.at(2);
+  comment.content = cmds.at(3);
+  if(cmds.size() > 4) {
+    comment.account = cmds.at(4);
+  }
+  comment.modified_at = time(nullptr);
+
+  if (!comment.qname.isPartOf(zone)) {
+    cerr << "Name \"" << comment.qname.toString() << "\" to add comment to is not part of zone \"" << zone.toString()  << "\"." << endl;
+    return EXIT_FAILURE;
+  }
+
+  di.backend->startTransaction(zone, UnknownDomainID);
+  if (!di.backend->feedComment(comment)) {
+    cerr << "Backend does not support comments" << endl;
+    di.backend->abortTransaction();
+    return EXIT_FAILURE;
+  }
+
+  di.backend->commitTransaction();
+  return EXIT_SUCCESS;
+}
+
+static int listComments(vector<string>& cmds, const std::string_view synopsis)
+{
+  if(cmds.size() != 1) {
+    return usage(synopsis);
+  }
+  if (cmds.at(0) == ".") {
+    cmds.at(0).clear();
+  }
+
+  return listComments(ZoneName(cmds.at(0)));
+}
+
 
 static int addRecord(vector<string>& cmds, const std::string_view synopsis)
 {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -532,13 +532,6 @@ class AuthZones(ZonesApiTestCase, AuthZonesHelperMixin):
             },
         ]
 
-        if is_auth_lmdb():
-            # No comments in LMDB
-            self.create_zone(
-                name=name, rrsets=rrsets, expect_error="Hosting backend does not support editing comments."
-            )
-            return
-
         name, _, data = self.create_zone(name=name, rrsets=rrsets)
         # NS records have been created
         self.assertEqual(len(data["rrsets"]), len(rrsets) + 1)
@@ -2407,11 +2400,7 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
             data=json.dumps(payload),
             headers={"content-type": "application/json"},
         )
-        if is_auth_lmdb():
-            self.assert_error_json(r)  # No comments in LMDB
-            return
-        else:
-            self.assert_success(r)
+        self.assert_success(r)
         # make sure the comments have been set, and that the NS
         # records are still present
         data = self.get_zone(name, rrset_name=name, rrset_type="NS")
@@ -2429,7 +2418,12 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
     def test_zone_comment_delete(self):
         # Test: Delete ONLY comments.
         name, payload, zone = self.create_zone()
-        rrset = {"changetype": "replace", "name": name, "type": "NS", "comments": []}
+        rrset = {
+            "changetype": "replace",
+            "name": name,
+            "type": "NS",
+            "comments": [{"account": "test4", "content": "this should not show up after delete"}],
+        }
         payload = {"rrsets": [rrset]}
         r = self.session.patch(
             self.url("/api/v1/servers/localhost/zones/" + name),
@@ -2437,6 +2431,18 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
             headers={"content-type": "application/json"},
         )
         self.assert_success(r)
+        data = self.get_zone(name)
+        serverset = get_rrset(data, name, "NS")
+        print(serverset)
+        self.assertNotEqual(serverset["records"], [])
+        self.assertNotEqual(serverset["comments"], [])
+
+        payload["rrsets"][0]["comments"] = []
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
         # make sure the NS records are still present
         data = self.get_zone(name)
         serverset = get_rrset(data, name, "NS")
@@ -2444,7 +2450,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.assertNotEqual(serverset["records"], [])
         self.assertEqual(serverset["comments"], [])
 
-    @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
     def test_zone_comment_out_of_range_modified_at(self):
         # Test if a modified_at outside of the 32 bit range throws an error
         name, payload, zone = self.create_zone()
@@ -2463,7 +2468,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.assertEqual(r.status_code, 422)
         self.assert_in_json_error("Key 'modified_at' is not a valid number", r.json())
 
-    @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
     def test_zone_comment_stay_intact(self):
         # Test if comments on an rrset stay intact if the rrset is replaced
         name, payload, zone = self.create_zone()

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -2634,7 +2634,6 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         # should return zone, SOA, ns1, ns2
         self.assertEqual(len(r.json()), 4)
 
-    @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
     def test_search_rr_comment(self):
         name = unique_zone_name()
         rrsets = [


### PR DESCRIPTION
### Short description
WIP. TODO:

- [x] comment search
- [x] comment sorting? (by timestamp) - no, we already group by RRset, so there's not much sorting to be done really
- [x] schema upgrade - not doing it. Should PR some words into the schema table for clarity
- [x] better serialisation (need something stable/canonical; looks like protozero might be it. Alternatively, have my -hash- depend on something simple and stable while the serialisation is at least robust)
- [x] CAP flag?
- [x] squashing
- [x] fix `pdnsutil comment add example.com foobar A 'hello protobuf' petre` -> `
Error: std::string keyConv(const T&) [with T = DNSName; typename std::enable_if<std::is_same<T, DNSName>::value, T>::type* <anonymous> = 0; std::string = std::__cxx11::basic_string<char>] Attempt to serialize an unset DNSName`


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
