### PR TITLE
auth 4.9: backport "REST API: bring back 404 errors" 

### DIFF
--- a/ext/yahttp/yahttp/router.cpp
+++ b/ext/yahttp/yahttp/router.cpp
@@ -101,7 +101,13 @@ namespace YaHTTP {
       if (matched && !method.empty() && req->method != method) {
          // method did not match, record it though so we can return correct result
          matched = false;
-         seen = true;
+         // The OPTIONS handler registered in pdns/webserver.cc matches every
+         // url, and would cause "not found" errors to always be superseded
+         // with "found, but wrong method" errors, so don't pretend there has
+         // been a match in this case.
+         if (method != "OPTIONS") {
+           seen = true;
+         }
          continue;
       }
       if (matched) {

--- a/regression-tests.api/test_Basics.py
+++ b/regression-tests.api/test_Basics.py
@@ -61,4 +61,13 @@ class TestBasics(ApiTestCase):
         r = self.session.options(self.url("/api/v1/servers/localhost/invalid"))
         self.assertEqual(r.status_code, requests.codes.not_found)
 
+        r = self.session.options(self.url("/api/v1/servers/remotehost"))
+        self.assertEqual(r.status_code, requests.codes.not_found)
+
+        r = self.session.get(self.url("/api/v1/servers/remotehost"))
+        if is_auth():
+            self.assertEqual(r.status_code, requests.codes.not_found)
+        else:
+            self.assertEqual(r.status_code, requests.codes.unauthorized)
+
         print("response", repr(r.headers))


### PR DESCRIPTION
### Short description
Backport of #16059.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
