### PR TITLE
pdns/sstuff: convert mapped IPv4 addresses for ACL

### DIFF
--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -121,7 +121,13 @@ public:
   {
     ComboAddress remote;
     if (getRemote(remote)) {
-      return netmaskGroup.match(remote);
+      if (netmaskGroup.match(remote)) {
+        return true;
+      }
+
+      if (remote.isMappedIPv4()) {
+        return netmaskGroup.match(remote.mapToIPv4());
+      }
     }
 
     return false;

--- a/regression-tests.auth-py/test_acl.py
+++ b/regression-tests.auth-py/test_acl.py
@@ -1,0 +1,82 @@
+import requests
+from authtests import AuthTest
+
+class TestBasic(AuthTest):
+    _config_template = """
+    launch = {backend}
+    webserver = yes
+    webserver-address = 127.0.0.1
+    webserver-port = 8053
+    webserver-allow-from = 127.0.0.1
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestBasic, cls).setUpClass()
+
+    def test_basic(self):
+        r = requests.get('http://127.0.0.1:8053')
+        self.assertEqual(r.status_code, 200)
+
+class TestDualStack(AuthTest):
+    _config_template = """
+    launch = {backend}
+    webserver = yes
+    webserver-address = [::]
+    webserver-port = 8053
+    webserver-allow-from = 127.0.0.1
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestDualStack, cls).setUpClass()
+
+    def test_ds(self):
+        r = requests.get('http://127.0.0.1:8053')
+        self.assertEqual(r.status_code, 200)
+
+class TestDualStackBackwardsCompat(AuthTest):
+    _config_template = """
+    launch = {backend}
+    webserver = yes
+    webserver-address = [::]
+    webserver-port = 8053
+    webserver-allow-from = ::ffff:127.0.0.1
+    """
+
+    def test_ds_compat(self):
+        r = requests.get('http://127.0.0.1:8053')
+        self.assertEqual(r.status_code, 200)
+
+class TestUnauthorized(AuthTest):
+    _config_template = """
+    launch = {backend}
+    webserver = yes
+    webserver-address = 127.0.0.1
+    webserver-port = 8053
+    webserver-allow-from = 224.0.0.0
+    """
+
+    def test_unauthorized(self):
+        try:
+            requests.get('http://127.0.0.1:8053')
+            self.fail()
+        except requests.exceptions.ConnectionError:
+            pass
+
+class TestUnauthorizedDualStack(AuthTest):
+    _config_template = """
+    launch = {backend}
+    webserver = yes
+    webserver-address = [::]
+    webserver-port = 8053
+    webserver-allow-from = 224.0.0.0
+    """
+
+    def test_unauthorized(self):
+        try:
+            requests.get('http://127.0.0.1:8053')
+            self.fail()
+        except requests.exceptions.ConnectionError:
+            pass
+


### PR DESCRIPTION
When a mapped address does not get converted, ACLs do not match as expected. For example ::ffff:127.0.0.1 did not match the ACL 127.0.0.1.

Fixes #16537

---

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)


Note: I added the tests to auth-py instead of api because the setup is seemingly a bit different. The API tests are not supporting the custom config from what I can tell, which I need for these tests.