### PR TITLE
auth: Überbackend code cleanup

### DIFF
--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -1102,18 +1102,6 @@ void UeberBackend::flush()
   }
 }
 
-AtomicCounter UeberBackend::handle::instances(0);
-
-UeberBackend::handle::handle()
-{
-  ++instances;
-}
-
-UeberBackend::handle::~handle()
-{
-  --instances;
-}
-
 // Set d_hinterBackend to the next available backend from the parents list,
 // reset it to nullptr if the whole list has been processed.
 // Invokes lookup on behalf of the newly picked backend if successful.

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -1121,8 +1121,7 @@ bool UeberBackend::handle::get(DNSZoneRecord& record)
 {
   DLOG(SLOG(g_log << "Ueber get() was called for a " << qtype << " record" << endl,
             d_slog->info(Logr::Debug, "get called", "type", Logging::Loggable(qtype))));
-  bool isMore = false;
-  while (d_hinterBackend != nullptr && !(isMore = d_hinterBackend->get(record))) { // this backend is out of answers
+  while (d_hinterBackend != nullptr && !(d_hinterBackend->get(record))) { // this backend is out of answers
     DLOG(SLOG(g_log << "Backend #" << backendIndex << " of " << parent->backends.size()
                     << " out of answers, trying next" << endl,
               d_slog->info(Logr::Debug, "backend out of answers, taking next", "zero-based backend index", Logging::Loggable(backendIndex), "backend count", Logging::Loggable(parent->backends.size()))));

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -747,6 +747,8 @@ UeberBackend::UeberBackend(const string& pname)
   d_negcache_ttl = ::arg().asNum("negquery-cache-ttl");
 
   backends = BackendMakers().all(pname == "key-only");
+
+  d_handle.setParent(this);
 }
 
 // returns -1 for miss, 0 for negative match, 1 for hit
@@ -844,12 +846,7 @@ void UeberBackend::lookup(const QType& qtype, const DNSName& qname, domainid_t z
 
   d_qtype = qtype.getCode();
 
-  d_handle.parent = this;
-  d_handle.backendIndex = 0;
-  d_handle.qtype = s_doANYLookupsOnly ? QType::ANY : qtype;
-  d_handle.qname = qname;
-  d_handle.zoneId = zoneId;
-  d_handle.pkt_p = pkt_p;
+  d_handle.lookup(qtype, qname, zoneId, pkt_p);
 
   if (backends.empty()) {
     SLOG(g_log << Logger::Error << "No database backends available - unable to answer questions." << endl,
@@ -858,9 +855,7 @@ void UeberBackend::lookup(const QType& qtype, const DNSName& qname, domainid_t z
     throw PDNSException("We are stale, please recycle");
   }
 
-  d_question.qtype = d_handle.qtype;
-  d_question.qname = qname;
-  d_question.zoneId = d_handle.zoneId;
+  d_handle.setupQuestion(d_question);
 
   auto cacheResult = cacheHas(d_question, d_answers);
   if (cacheResult == CacheResult::Miss) { // nothing
@@ -1102,14 +1097,30 @@ void UeberBackend::flush()
   }
 }
 
+void UeberBackend::handle::lookup(const QType& qtype, const DNSName& qname, domainid_t zoneId, DNSPacket* pkt_p)
+{
+  d_backendIndex = 0;
+  d_qtype = s_doANYLookupsOnly ? QType::ANY : qtype;
+  d_qname = qname;
+  d_zoneId = zoneId;
+  d_pkt_p = pkt_p;
+}
+
+void UeberBackend::handle::setupQuestion(UeberBackend::Question& question) const
+{
+  question.qtype = d_qtype;
+  question.qname = d_qname;
+  question.zoneId = d_zoneId;
+}
+
 // Set d_hinterBackend to the next available backend from the parents list,
 // reset it to nullptr if the whole list has been processed.
 // Invokes lookup on behalf of the newly picked backend if successful.
 void UeberBackend::handle::selectNextBackend()
 {
-  if (backendIndex < parent->backends.size()) {
-    d_hinterBackend = parent->backends[backendIndex++].get();
-    d_hinterBackend->lookup(qtype, qname, zoneId, pkt_p);
+  if (d_backendIndex < d_parent->backends.size()) {
+    d_hinterBackend = d_parent->backends[d_backendIndex++].get();
+    d_hinterBackend->lookup(d_qtype, d_qname, d_zoneId, d_pkt_p);
     ++(*s_backendQueries);
   }
   else {
@@ -1119,16 +1130,16 @@ void UeberBackend::handle::selectNextBackend()
 
 bool UeberBackend::handle::get(DNSZoneRecord& record)
 {
-  DLOG(SLOG(g_log << "Ueber get() was called for a " << qtype << " record" << endl,
-            d_slog->info(Logr::Debug, "get called", "type", Logging::Loggable(qtype))));
+  DLOG(SLOG(g_log << "Ueber get() was called for a " << d_qtype << " record" << endl,
+            d_slog->info(Logr::Debug, "get called", "type", Logging::Loggable(d_qtype))));
   while (d_hinterBackend != nullptr && !(d_hinterBackend->get(record))) { // this backend is out of answers
-    DLOG(SLOG(g_log << "Backend #" << backendIndex << " of " << parent->backends.size()
+    DLOG(SLOG(g_log << "Backend #" << d_backendIndex << " of " << d_parent->backends.size()
                     << " out of answers, trying next" << endl,
-              d_slog->info(Logr::Debug, "backend out of answers, taking next", "zero-based backend index", Logging::Loggable(backendIndex), "backend count", Logging::Loggable(parent->backends.size()))));
+              d_slog->info(Logr::Debug, "backend out of answers, taking next", "zero-based backend index", Logging::Loggable(d_backendIndex), "backend count", Logging::Loggable(d_parent->backends.size()))));
     selectNextBackend();
     if (d_hinterBackend != nullptr) {
-      DLOG(SLOG(g_log << "Now asking backend #" << backendIndex << endl,
-                d_slog->info(Logr::Debug, "Now asking backend", "index", Logging::Loggable(backendIndex))));
+      DLOG(SLOG(g_log << "Now asking backend #" << d_backendIndex << endl,
+                d_slog->info(Logr::Debug, "Now asking backend", "index", Logging::Loggable(d_backendIndex))));
     }
   }
 
@@ -1140,7 +1151,7 @@ bool UeberBackend::handle::get(DNSZoneRecord& record)
 
   DLOG(SLOG(g_log << "Found an answering backend - will not try another one" << endl,
             d_slog->info(Logr::Debug, "found an answering backend - will not try any other one")));
-  backendIndex = parent->backends.size(); // don't go on to the next backend
+  d_backendIndex = d_parent->backends.size(); // don't go on to the next backend
   return true;
 }
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -844,7 +844,8 @@ void UeberBackend::lookup(const QType& qtype, const DNSName& qname, domainid_t z
 
   d_qtype = qtype.getCode();
 
-  d_handle.i = 0;
+  d_handle.parent = this;
+  d_handle.backendIndex = 0;
   d_handle.qtype = s_doANYLookupsOnly ? QType::ANY : qtype;
   d_handle.qname = qname;
   d_handle.zoneId = zoneId;
@@ -866,8 +867,7 @@ void UeberBackend::lookup(const QType& qtype, const DNSName& qname, domainid_t z
     //      cout<<"UeberBackend::lookup("<<qname<<"|"<<DNSRecordContent::NumberToType(qtype.getCode())<<"): uncached"<<endl;
     d_negcached = d_cached = false;
     d_answers.clear();
-    (d_handle.d_hinterBackend = backends[d_handle.i++].get())->lookup(d_handle.qtype, d_handle.qname, d_handle.zoneId, d_handle.pkt_p);
-    ++(*s_backendQueries);
+    d_handle.selectNextBackend();
   }
   else if (cacheResult == CacheResult::NegativeMatch) {
     //      cout<<"UeberBackend::lookup("<<qname<<"|"<<DNSRecordContent::NumberToType(qtype.getCode())<<"): NEGcached"<<endl;
@@ -881,8 +881,6 @@ void UeberBackend::lookup(const QType& qtype, const DNSName& qname, domainid_t z
     d_cached = true;
     d_cachehandleiter = d_answers.begin();
   }
-
-  d_handle.parent = this;
 }
 
 void UeberBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled)
@@ -1116,27 +1114,38 @@ UeberBackend::handle::~handle()
   --instances;
 }
 
+// Set d_hinterBackend to the next available backend from the parents list,
+// reset it to nullptr if the whole list has been processed.
+// Invokes lookup on behalf of the newly picked backend if successful.
+void UeberBackend::handle::selectNextBackend()
+{
+  if (backendIndex < parent->backends.size()) {
+    d_hinterBackend = parent->backends[backendIndex++].get();
+    d_hinterBackend->lookup(qtype, qname, zoneId, pkt_p);
+    ++(*s_backendQueries);
+  }
+  else {
+    d_hinterBackend = nullptr;
+  }
+}
+
 bool UeberBackend::handle::get(DNSZoneRecord& record)
 {
   DLOG(SLOG(g_log << "Ueber get() was called for a " << qtype << " record" << endl,
             d_slog->info(Logr::Debug, "get called", "type", Logging::Loggable(qtype))));
   bool isMore = false;
-  while (d_hinterBackend != nullptr && !(isMore = d_hinterBackend->get(record))) { // this backend out of answers
-    if (i < parent->backends.size()) {
-      DLOG(SLOG(g_log << "Backend #" << i << " of " << parent->backends.size()
-                      << " out of answers, taking next" << endl,
-                d_slog->info(Logr::Debug, "backend out of answers, taking next", "zero-based backend index", Logging::Loggable(i), "backend count", Logging::Loggable(parent->backends.size()))));
-
-      d_hinterBackend = parent->backends[i++].get();
-      d_hinterBackend->lookup(qtype, qname, zoneId, pkt_p);
-      ++(*s_backendQueries);
-    }
-    else {
-      break;
+  while (d_hinterBackend != nullptr && !(isMore = d_hinterBackend->get(record))) { // this backend is out of answers
+    DLOG(SLOG(g_log << "Backend #" << backendIndex << " of " << parent->backends.size()
+                    << " out of answers, trying next" << endl,
+              d_slog->info(Logr::Debug, "backend out of answers, taking next", "zero-based backend index", Logging::Loggable(backendIndex), "backend count", Logging::Loggable(parent->backends.size()))));
+    selectNextBackend();
+    if (d_hinterBackend != nullptr) {
+      DLOG(SLOG(g_log << "Now asking backend #" << backendIndex << endl,
+                d_slog->info(Logr::Debug, "Now asking backend", "index", Logging::Loggable(backendIndex))));
     }
   }
 
-  if (!isMore && i == parent->backends.size()) {
+  if (d_hinterBackend == nullptr) {
     DLOG(SLOG(g_log << "UeberBackend reached end of backends" << endl,
               d_slog->info(Logr::Debug, "end of backends reached")));
     return false;
@@ -1144,7 +1153,7 @@ bool UeberBackend::handle::get(DNSZoneRecord& record)
 
   DLOG(SLOG(g_log << "Found an answering backend - will not try another one" << endl,
             d_slog->info(Logr::Debug, "found an answering backend - will not try any other one")));
-  i = parent->backends.size(); // don't go on to the next backend
+  backendIndex = parent->backends.size(); // don't go on to the next backend
   return true;
 }
 

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -75,21 +75,24 @@ public:
 
     //! The UeberBackend class where this handle belongs to
     UeberBackend* parent{nullptr};
-    //! The current real backend, which is answering questions
-    DNSBackend* d_hinterBackend{nullptr};
 
     //! DNSPacket who asked this question
     DNSPacket* pkt_p{nullptr};
     DNSName qname;
 
     //! Index of the current backend within the backends vector
-    unsigned int i{0};
+    size_t backendIndex{0};
     QType qtype;
     domainid_t zoneId{UnknownDomainID};
+
+    void selectNextBackend();
 
   private:
     static AtomicCounter instances;
     std::shared_ptr<Logr::Logger> d_slog;
+
+    //! The currently selected real backend, which is answering questions
+    DNSBackend* d_hinterBackend{nullptr};
   };
 
   void lookup(const QType& qtype, const DNSName& qname, domainid_t zoneId, DNSPacket* pkt_p = nullptr);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -68,8 +68,6 @@ public:
   public:
     bool get(DNSZoneRecord& record);
     void lookupEnd() const;
-    handle();
-    ~handle();
 
     void setSLog(Logr::log_t slog) { d_slog = slog; }
 
@@ -88,7 +86,6 @@ public:
     void selectNextBackend();
 
   private:
-    static AtomicCounter instances;
     std::shared_ptr<Logr::Logger> d_slog;
 
     //! The currently selected real backend, which is answering questions

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -62,36 +62,6 @@ public:
       new modules are loaded */
   vector<std::unique_ptr<DNSBackend>> backends;
 
-  //! the very magic handle for UeberBackend questions
-  class handle
-  {
-  public:
-    bool get(DNSZoneRecord& record);
-    void lookupEnd() const;
-
-    void setSLog(Logr::log_t slog) { d_slog = slog; }
-
-    //! The UeberBackend class where this handle belongs to
-    UeberBackend* parent{nullptr};
-
-    //! DNSPacket who asked this question
-    DNSPacket* pkt_p{nullptr};
-    DNSName qname;
-
-    //! Index of the current backend within the backends vector
-    size_t backendIndex{0};
-    QType qtype;
-    domainid_t zoneId{UnknownDomainID};
-
-    void selectNextBackend();
-
-  private:
-    std::shared_ptr<Logr::Logger> d_slog;
-
-    //! The currently selected real backend, which is answering questions
-    DNSBackend* d_hinterBackend{nullptr};
-  };
-
   void lookup(const QType& qtype, const DNSName& qname, domainid_t zoneId, DNSPacket* pkt_p = nullptr);
   /** Read a single record from a lookup(...) result. */
   bool get(DNSZoneRecord& resourceRecord);
@@ -155,13 +125,7 @@ public:
   void flush();
 
 private:
-  handle d_handle;
-  vector<DNSZoneRecord> d_answers;
-  vector<DNSZoneRecord>::const_iterator d_cachehandleiter;
   std::shared_ptr<Logr::Logger> d_slog;
-
-  static std::mutex d_mut;
-  static std::condition_variable d_cond;
 
   struct Question
   {
@@ -169,6 +133,46 @@ private:
     domainid_t zoneId;
     QType qtype;
   } d_question;
+
+  //! the very magic handle for UeberBackend questions
+  class handle
+  {
+  public:
+    void setSLog(Logr::log_t slog) { d_slog = slog; }
+    void setParent(UeberBackend* parent) { d_parent = parent; }
+    void selectNextBackend();
+
+    void setupQuestion(Question& question) const;
+    void lookup(const QType& qtype, const DNSName& qname, domainid_t zoneId, DNSPacket* pkt_p);
+    bool get(DNSZoneRecord& record);
+    void lookupEnd() const;
+
+  private:
+    std::shared_ptr<Logr::Logger> d_slog;
+
+    //! The UeberBackend class where this handle belongs to
+    UeberBackend* d_parent{nullptr};
+
+    //! The currently selected real backend, which is answering questions
+    DNSBackend* d_hinterBackend{nullptr};
+
+    //! Index of the current backend within the backends vector
+    size_t d_backendIndex{0};
+
+    //! DNSPacket who asked this question
+    DNSPacket* d_pkt_p{nullptr};
+    DNSName d_qname;
+
+    QType d_qtype;
+    domainid_t d_zoneId{UnknownDomainID};
+  };
+
+  handle d_handle;
+  vector<DNSZoneRecord> d_answers;
+  vector<DNSZoneRecord>::const_iterator d_cachehandleiter;
+
+  static std::mutex d_mut;
+  static std::condition_variable d_cond;
 
   unsigned int d_cache_ttl, d_negcache_ttl;
   uint16_t d_qtype{0};


### PR DESCRIPTION
### Short description
This apparently simple PR reworks the behaviour of the `handle` internal object of `UeberBackend` to:
- factor the code performing backend selection and `lookup` call.
- make the current backend pointer a private field to guarantee that the above factored logic is the only thing which decides which backend to use.

It is not supposed to introduce any behaviour change. But it will help make further (possibly breaking) changes in `UeberBackend` with confidence.

P.S.: do we really need to keep the `instances` atomic counter? It doesn't seem to be used by anything and its value is not retrievable either.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
