### PR TITLE
dnsdist: Build our Rust lib in `dev` profile when `CARGO_USE_DEV` is set

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
@@ -11,9 +11,18 @@ export CARGO="${CARGO:-$_defaultCARGO}"
 mytarget=${CARGO_TARGET_DIR-target}
 #echo "mytarget=${mytarget}"
 
-$CARGO build --release $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml --locked
+CARGO_PROFILE="--release"
+if [ -n "${CARGO_USE_DEV}" ]; then
+    CARGO_PROFILE=""
+fi
 
-cp -p target/$RUSTC_TARGET_ARCH/release/libdnsdist_rust.a $builddir/dnsdist-rust-lib/rust/libdnsdist_rust.a
+$CARGO build ${CARGO_PROFILE} $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml --locked
+
+if [ -n "${CARGO_USE_DEV}" ]; then
+    cp -p target/$RUSTC_TARGET_ARCH/debug/libdnsdist_rust.a $builddir/dnsdist-rust-lib/rust/libdnsdist_rust.a
+else
+    cp -p target/$RUSTC_TARGET_ARCH/release/libdnsdist_rust.a $builddir/dnsdist-rust-lib/rust/libdnsdist_rust.a
+fi
 
 cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/dnsdist-rust/src/lib.rs.h $srcdir/lib.rs.h
 cp -p $mytarget/$RUSTC_TARGET_ARCH/cxxbridge/dnsdist-rust/src/lib.rs.h $builddir/dnsdist-rust-lib/rust/lib.rs.h


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It is roughly halving the compile time in my tests, and comes with more checks (see https://doc.rust-lang.org/cargo/reference/profiles.html#dev) so I find it useful to be able to explicitly request building using the `dev` profile. The default remains to build in `release` mode for performance, of course.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
