### PR TITLE
auth 4.9: fetch all zone records before any output in "zone list".

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1079,7 +1079,7 @@ static int listZone(const DNSName &zone) {
   std::vector<DNSResourceRecord> records;
   DNSResourceRecord rr;
 
-  di.backend->list(zone, di.id);
+  di.backend->list(zone, di.id); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   while(di.backend->get(rr)) {
     if(rr.qtype.getCode() != QType::ENT) {
       if ( (rr.qtype.getCode() == QType::NS || rr.qtype.getCode() == QType::SRV || rr.qtype.getCode() == QType::MX || rr.qtype.getCode() == QType::CNAME) && !rr.content.empty() && rr.content[rr.content.size()-1] != '.') {


### PR DESCRIPTION
### Short description
This is a backport of a very specific commit in #15999: the change which makes `pdnsutil list-zone` fetch the complete zone data before outputting anything.

This sucks because this will require the whole zone to be held in memory, but should the output ever get stalled (because piped into a slow or unresponsive consumer), we do not risk being stuck in the middle of a database query. For most backends this would be harmless, but with LMDB and its copy-on-write operation, this means that there is a read transaction getting stuck, and as such the data storage of all outdated records can't be reclaimed until this transaction is completed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master (although not in the same form, see description)
