### PR TITLE
auth 5.0: fetch all zone records before any output in "zone list".

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1671,13 +1671,12 @@ static int listZone(const ZoneName &zone) {
     return EXIT_FAILURE;
   }
 
-  di.backend->list(zone, di.id);
+  std::vector<DNSResourceRecord> records;
   DNSResourceRecord rr;
-  cout<<"$ORIGIN ."<<endl;
-  std::ostream::sync_with_stdio(false);
 
+  di.backend->list(zone, di.id);
   while(di.backend->get(rr)) {
-    if(rr.qtype.getCode() != 0) {
+    if(rr.qtype.getCode() != QType::ENT) {
       switch (rr.qtype.getCode()) {
       case QType::ALIAS:
       case QType::CNAME:
@@ -1689,9 +1688,14 @@ static int listZone(const ZoneName &zone) {
         }
         break;
       }
-
-      cout<<rr.qname<<"\t"<<rr.ttl<<"\tIN\t"<<rr.qtype.toString()<<"\t"<<rr.content<<"\n";
+      records.emplace_back(rr);
     }
+  }
+
+  cout<<"$ORIGIN ."<<endl;
+  std::ostream::sync_with_stdio(false);
+  for (const auto& rec : records) {
+    std::cout<<rec.qname<<"\t"<<rec.ttl<<"\tIN\t"<<rec.qtype.toString()<<"\t"<<rec.content<<std::endl;
   }
   cout.flush();
   return EXIT_SUCCESS;


### PR DESCRIPTION
### Short description
This is a backport of a very specific commit in #15999: the change which makes pdnsutil list-zone fetch the complete zone data before outputting anything.

This sucks because this will require the whole zone to be held in memory, but should the output ever get stalled (because piped into a slow or unresponsive consumer), we do not risk being stuck in the middle of a database query. For most backends this would be harmless, but with LMDB and its copy-on-write operation, this means that there is a read transaction getting stuck, and as such the data storage of all outdated records can't be reclaimed until this transaction is completed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master (although not in the same form, see description)
