### PR TITLE
dnsdist: Stop using `random()` to bench rules

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-rules.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-rules.cc
@@ -522,7 +522,7 @@ void setupLuaRuleChainsManagement(LuaContext& luaCtx)
       entry.ids.qclass = QClass::IN;
       entry.ids.protocol = dnsdist::Protocol::DoUDP;
       entry.ids.origRemote = ComboAddress("127.0.0.1");
-      entry.ids.origRemote.sin4.sin_addr.s_addr = random();
+      entry.ids.origRemote.sin4.sin_addr.s_addr = dns_random_uint32();
       entry.ids.queryRealTime.start();
       GenericDNSPacketWriter<PacketBuffer> writer(entry.packet, entry.ids.qname, entry.ids.qtype);
       items.push_back(std::move(entry));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This makes Coverity (CID 500050) and probably other tools very unhappy.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
