### PR TITLE
auth 4.9: backport "add missing catch block for STL exceptions in createForward"

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -970,6 +970,8 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
         return allZerosIP;
       } catch (const PDNSException &e) {
         return allZerosIP;
+      } catch (const std::exception &) { // thrown by std::stol
+        return allZerosIP;
       }
     });
 

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -1016,6 +1016,7 @@ createforward6.example.org.                 3600 IN NS   ns2.example.org.
                 "ip4041424": "0.0.0.0",
                 "ip-441424": "0.0.0.0",
                 "ip-5abcdef": "0.0.0.0",
+                "some-text-with-more-than-five-dashes": "0.0.0.0",
                 "host64-22-33-44": "64.22.33.44",
                 "2.2.2.2": "0.0.0.0"   # filtered
             }),


### PR DESCRIPTION
### Short description
Backport of #16564.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
