### PR TITLE
auth: yet another boring autoconf regression

### DIFF
--- a/regression-tests.auth-py/runtests
+++ b/regression-tests.auth-py/runtests
@@ -15,7 +15,7 @@ mkdir -p configs
 
 if [ -z "$PDNS_BUILD_PATH" ]; then
   # PDNS_BUILD_PATH is unset or empty. Assume an autotools build.
-  PDNS_BUILD_PATH=${PWD}/..
+  PDNS_BUILD_PATH=${PWD}/../pdns
 fi
 export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns_server}
 export PDNSUTIL=${PDNSUTIL:-$PDNS_BUILD_PATH/pdnsutil}


### PR DESCRIPTION
### Short description
I missed one `PDNS_BUILD_PATH` in need of fixing after the meson binary name changes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
