### PR TITLE
pdnsutil: make "zone list" record sorting optional

### DIFF
--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -22,6 +22,7 @@ Options
 -v, --verbose           Be more verbose
 -f, --force             Force an action
 -q, --quiet             Be quiet
+-s, --sort              Sort output when applicable
 --config-name <NAME>    Virtual configuration name
 --config-dir <DIR>      Location of pdns.conf. Default is /etc/powerdns.
 
@@ -217,7 +218,9 @@ zone increase-serial *ZONE*
 
 zone list *ZONE*
 
-    Show all records for *ZONE*.
+    Show all records for *ZONE*. Passing --sort or -s will sort the records
+    according to their name, but may require a lot of memory and processor
+    time on huge zones.
 
 zone list-all *KIND*
 

--- a/regression-tests.nobackend/gsqlite3-corrupted-record/command
+++ b/regression-tests.nobackend/gsqlite3-corrupted-record/command
@@ -26,7 +26,7 @@ echo "UPDATE records SET name='this-name-turns-out-to-be-an-invalid-dns-name-bec
 echo "UPDATE records SET ordername='..' WHERE name='never.bug.less';" | sqlite3 pdns.sqlite3 2>&1
 
 # Check that pdnsutil zone list doesn't show the invalid records
-$PDNSUTIL $ARGS zone list bug.less
+$PDNSUTIL -s $ARGS zone list bug.less
 
 # Check that pdnsutil zone check reports the invalid records
 $PDNSUTIL $ARGS zone check bug.less

--- a/regression-tests.nobackend/lmdb-schema-upgrade/command
+++ b/regression-tests.nobackend/lmdb-schema-upgrade/command
@@ -24,7 +24,7 @@ EOF
   for zone in $(grep 'zone ' "${rootPath}/../../regression-tests/named.conf"  | cut -f2 -d\" | grep -v '^nztest.com$')
   do
     if [ "$zone" != "." ]; then
-      $PDNSUTIL -q --config-dir="${workdir}" --config-name=lmdb list-zone $zone
+      $PDNSUTIL -q --config-dir="${workdir}" --config-name=lmdb --sort list-zone $zone
     fi
   done
   rm -r $workdir

--- a/regression-tests/mysqldiff
+++ b/regression-tests/mysqldiff
@@ -52,7 +52,7 @@ lmdb)
     # Maybe we should add a pdnsutil backend-cmd to retrieve these results in
     # same format as the mysql query...
     $PDNSUTIL --config-dir=. --config-name=$backend \
-        list-zone $zonewithvariant | grep -vwF SOA \
+        --sort zone list $zonewithvariant | grep -vwF SOA \
         > ${testsdir}/${testname}/$step
     ;;
 esac

--- a/regression-tests/tests/pdnsutil-zone-handling/command
+++ b/regression-tests/tests/pdnsutil-zone-handling/command
@@ -6,7 +6,7 @@
 # --enable-verbose-logging removed.
 
 pdnsutil_wrapper() {
-$PDNSUTIL --config-dir=. --config-name=$backend "$@" 2>&1 | egrep -v 'destructor'
+$PDNSUTIL --config-dir=. --config-name=$backend --sort "$@" 2>&1 | egrep -v 'destructor'
 }
 
 ZONE=bug.less


### PR DESCRIPTION
### Short description
Sorting is nice but keeping all the records in memory does not play nice with huge zones containing millions of records. Make it an option.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
