### PR TITLE
ci: Use `Cargo`'s `dev` profile

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -159,6 +159,7 @@ jobs:
         SANITIZERS: ${{ matrix.sanitizers }}
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
+        CARGO_USE_DEV: 1
       options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     defaults:
       run:
@@ -248,6 +249,7 @@ jobs:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ env.REPO_HOME }}/build-scripts/UBSan.supp"
         UNIT_TESTS: yes
         FUZZING_TARGETS: yes
+        CARGO_USE_DEV: 1
       options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     defaults:
       run:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,7 @@ jobs:
       # for clang-tidy only, not compilation
       CLANG_VERSION: '14'
       REPO_HOME: ${{ github.workspace }}
+      CARGO_USE_DEV: 1
 
     outputs:
       clang-tidy-annotations-auth: ${{ steps.clang-tidy-annotations-auth.outputs.failed }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -59,6 +59,7 @@ jobs:
       COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
       SANITIZERS:
       UNIT_TESTS: no
+      CARGO_USE_DEV: 1
       REPO_HOME: ${{ github.workspace }}
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
@@ -103,6 +104,7 @@ jobs:
       COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
       SANITIZERS:
       UNIT_TESTS: no
+      CARGO_USE_DEV: 1
     steps:
       - uses: PowerDNS/pdns/set-ubuntu-mirror@meta
       - uses: actions/checkout@v5


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Using the `dev` profile means faster builds and more checks.

Untested, let's see if the CI is happy!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
