### PR TITLE
Tolerate promtool failing with exit code 3

### DIFF
--- a/regression-tests.dnsdist/test_Prometheus.py
+++ b/regression-tests.dnsdist/test_Prometheus.py
@@ -94,7 +94,7 @@ class TestPrometheus(DNSDistTest):
         except subprocess.CalledProcessError as exc:
             raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, process.output))
 
-        # promtool returns 3 because of the "_total" suffix warnings
+        # promtool may return 3 because of the "_total" suffix warnings
         if not process.returncode in [0, 3]:
           raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, output))
 

--- a/regression-tests.ixfrdist/test_Stats.py
+++ b/regression-tests.ixfrdist/test_Stats.py
@@ -60,7 +60,7 @@ webserver-address: %s
         except subprocess.CalledProcessError as exc:
             raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, process.output))
 
-        # promtool returns 3 because of the "_total" suffix warnings
+        # promtool may return 3 because of the "_total" suffix warnings
         if not process.returncode in [0, 3]:
           raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, output))
 

--- a/regression-tests.recursor-dnssec/test_Prometheus.py
+++ b/regression-tests.recursor-dnssec/test_Prometheus.py
@@ -29,7 +29,7 @@ class RecPrometheusTest(RecursorTest):
         except subprocess.CalledProcessError as exc:
             raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, process.output))
 
-        # promtool returns 3 because of the "_total" suffix warnings
+        # promtool may return 3 because of the "_total" suffix warnings
         if not process.returncode in [0, 3]:
           raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, output))
 


### PR DESCRIPTION
### Short description
codeql doesn't like "Commented-out code", saying "Commented-out code makes the remaining code more difficult to read."

https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fcommented-out-code

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
