### PR TITLE
Remove unused variable

### DIFF
--- a/regression-tests.dnsdist/dnscrypt.py
+++ b/regression-tests.dnsdist/dnscrypt.py
@@ -208,7 +208,6 @@ class DNSCryptClient(object):
             raise Exception("Invalid encrypted response: invalid padding")
 
         idx -= 1
-        paddingLen = len(cleartextBytes) - idx
 
         return cleartext[:idx+1]
 


### PR DESCRIPTION
It was introduced (unused) in b8db58a230959585880e15c097851c5139d90f45

codeql doesn't approve

https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Funused-local-variable
Unused local variable - Local variable is defined but not used


### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
