### PR TITLE
Allow peeking at cache using an env var

### DIFF
--- a/regression-tests.recursor-dnssec/test_RoutingTag.py
+++ b/regression-tests.recursor-dnssec/test_RoutingTag.py
@@ -147,7 +147,9 @@ end
         query = dns.message.make_query(nameECS, 'TXT', 'IN')
         self.sendECSQuery(query, expected2)
 
-        return # remove this line to peek at cache
+        if not "PEEK_AT_CACHE" in os.environ: # set to peek at cache
+            return
+
         rec_controlCmd = [os.environ['RECCONTROL'],
                           '--config-dir=%s' % 'configs/' + self._confdir,
                           'dump-cache', 'x']
@@ -228,7 +230,9 @@ end
         query = dns.message.make_query(nameECS, 'TXT', 'IN')
         self.sendECSQuery(query, expected2)
 
-        return #remove this line to peek at cache
+        if not "PEEK_AT_CACHE" in os.environ: # set to peek at cache
+            return
+
         rec_controlCmd = [os.environ['RECCONTROL'],
                           '--config-dir=%s' % 'configs/' + self._confdir,
                           'dump-cache y']


### PR DESCRIPTION
### Short description
codeql doesn't like unreachable code https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Funreachable-statement

Unreachable code - Code is unreachable

A simple way to make everyone happy (devs who want to peek, linters that believe no code should be dead) is to let devs set a var to peek.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
