### PR TITLE
Remove some `boost::optional` leftovers

### DIFF
--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -33,9 +33,10 @@
 #include <arpa/inet.h>
 
 #include <iostream>
-#include <optional>
 #include <string>
 #include <vector>
+#include <boost/optional.hpp>
+
 #include "qtype.hh"
 #include "dns.hh"
 #include "misc.hh"

--- a/pdns/dnsproxy.hh
+++ b/pdns/dnsproxy.hh
@@ -24,6 +24,8 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <boost/optional.hpp>
+
 #include "dnspacket.hh"
 #include "lock.hh"
 #include "iputils.hh"

--- a/pdns/ednsextendederror.hh
+++ b/pdns/ednsextendederror.hh
@@ -20,6 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
+#include <cstdint>
+
 #include "namespaces.hh"
 
 struct EDNSExtendedError

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1757,7 +1757,7 @@ public:
     tree.insert(netmask).second = positive;
   }
 
-  void addMasks(const NetmaskGroup& group, boost::optional<bool> positive)
+  void addMasks(const NetmaskGroup& group, std::optional<bool> positive)
   {
     for (const auto& entry : group.tree) {
       addMask(entry.first, positive ? *positive : entry.second);

--- a/pdns/logging.hh
+++ b/pdns/logging.hh
@@ -30,7 +30,6 @@
 #include <memory>
 #include <string>
 #include <sstream>
-#include <boost/optional.hpp>
 
 #include "logr.hh"
 #include "dnsname.hh"

--- a/pdns/logr.hh
+++ b/pdns/logr.hh
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <map>

--- a/pdns/namespaces.hh
+++ b/pdns/namespaces.hh
@@ -21,7 +21,6 @@
  */
 #pragma once
 
-#include <boost/optional.hpp>
 #include <iostream>
 #include <map>
 #include <memory>

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -20,6 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
+
+#include <cstdint>
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -26,7 +26,6 @@
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index/key_extractors.hpp>
-#include <boost/optional.hpp>
 #include "dnsparser.hh"
 #include "dnsname.hh"
 #include "dns.hh"

--- a/pdns/recursordist/recpacketcache.hh
+++ b/pdns/recursordist/recpacketcache.hh
@@ -30,7 +30,6 @@
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index/key_extractors.hpp>
-#include <boost/optional.hpp>
 
 #include "packetcache.hh"
 #include "validate.hh"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
