### PR TITLE
auth: proactive test fix

### DIFF
--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1715,7 +1715,11 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.assert_success(r)
         # verify the zone contents
         data1 = self.get_zone(name)
-        self.assertEqual(get_rrset(data1, 'a.'+name)['records'], [ a1, a3 ])
+        # note that we can't assume anything about the order of the records
+        records = get_rrset(data1, 'a.' + name, 'A')['records']
+        self.assertEqual(len(records), 2)
+        self.assertTrue(a1 in records)
+        self.assertTrue(a3 in records)
         # get_rrset above has removed the timestamps from data1, fetch the
         # zone again, since we want to ensure the following operations do
         # not change anything.


### PR DESCRIPTION
### Short description
One of the tests added in #16589 depends upon the order records will be returned by the backend. Fix this to let it work regardless of that order.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
