### PR TITLE
auth 5.0: backport "m4/pdns_check_libcrypto: fix ecdsa/eddsa includedir"

### DIFF
--- a/m4/pdns_check_libcrypto.m4
+++ b/m4/pdns_check_libcrypto.m4
@@ -55,6 +55,7 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO], [
                     LIBCRYPTO_LIBS=`$PKG_CONFIG libcrypto --libs-only-l 2>/dev/null`
                     LIBCRYPTO_INCLUDES=`$PKG_CONFIG libcrypto --cflags-only-I 2>/dev/null`
                     ssldir=`$PKG_CONFIG libcrypto --variable=prefix 2>/dev/null`
+                    sslincdir=`$PKG_CONFIG libcrypto --variable=includedir 2>/dev/null`
                     found=true
                 fi
             fi
@@ -78,6 +79,7 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO], [
                 LIBCRYPTO_INCLUDES="-I$ssldir/include"
                 LIBCRYPTO_LDFLAGS="-L$ssldir/lib"
                 LIBCRYPTO_LIBS="-lcrypto"
+                sslincdir="$ssldir/include"
                 found=true
                 AC_MSG_RESULT([yes])
                 break

--- a/m4/pdns_check_libcrypto_ecdsa.m4
+++ b/m4/pdns_check_libcrypto_ecdsa.m4
@@ -12,11 +12,11 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO_ECDSA], [
 
   # Find the headers we need for ECDSA
   libcrypto_ecdsa=yes
-  AC_CHECK_HEADER([$ssldir/include/openssl/ecdsa.h], [
+  AC_CHECK_HEADER([$sslincdir/openssl/ecdsa.h], [
     AC_CHECK_DECLS([NID_X9_62_prime256v1, NID_secp384r1], [ : ], [
       libcrypto_ecdsa=no
     ], [AC_INCLUDES_DEFAULT
-#include <$ssldir/include/openssl/evp.h>
+#include <$sslincdir/openssl/evp.h>
     ])
   ], [
     libcrypto_ecdsa=no

--- a/m4/pdns_check_libcrypto_eddsa.m4
+++ b/m4/pdns_check_libcrypto_eddsa.m4
@@ -17,13 +17,13 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO_EDDSA], [
     AC_DEFINE([HAVE_LIBCRYPTO_ED25519], [1], [define to 1 if OpenSSL ed25519 support is available.])
   ], [ : ],
   [AC_INCLUDES_DEFAULT
-  #include <$ssldir/include/openssl/evp.h>])
+  #include <$sslincdir/openssl/evp.h>])
   AC_CHECK_DECLS([NID_ED448], [
     libcrypto_ed448=yes
     AC_DEFINE([HAVE_LIBCRYPTO_ED448], [1], [define to 1 if OpenSSL ed448 support is available.])
   ], [ : ],
   [AC_INCLUDES_DEFAULT
-  #include <$ssldir/include/openssl/evp.h>])
+  #include <$sslincdir/openssl/evp.h>])
 
   AS_IF([test "$libcrypto_ed25519" = "yes" -o "$libcrypto_ed448" = "yes"], [
     AC_DEFINE([HAVE_LIBCRYPTO_EDDSA], [1], [define to 1 if OpenSSL EDDSA support is available.])


### PR DESCRIPTION
### Short description
Backport of #16538 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
