### PR TITLE
auth: minor docs tweaks

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -352,7 +352,7 @@ paths:
   '/servers/{server_id}/zones/{zone_id}/rectify':
     put:
       summary: 'Rectify the zone data.'
-      description: 'This does not take into account the API-RECTIFY metadata. Fails on secondary zones and zones that do not have DNSSEC.'
+      description: 'This does not take into account the API-RECTIFY metadata. Fails on secondary zones.'
       operationId: rectifyZone
       tags:
         - zones


### PR DESCRIPTION
### Short description
Prompted by #16548, update the documention for the rectify endpoint, it will not fail on zones where DNSSEC is not enabled. 

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
