### PR TITLE
gh actions - build-and-test-all skip build dnsdist arm64 on debian 11

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -846,10 +846,12 @@ jobs:
           fail-on-error: false
 
   swagger-syntax-check:
-    if: ${{ !github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL }}
+    if: ${{ (!github.event.schedule || vars.SCHEDULED_JOBS_BUILD_AND_TEST_ALL) && ! contains(needs.get-runner-container-image.outputs.id, 'debian-11') }}
     runs-on: ubuntu-24.04
+    needs:
+      - get-runner-container-image
     container:
-      image: ghcr.io/powerdns/base-pdns-ci-image/debian-12-pdns-base:master
+      image: "${{ needs.get-runner-container-image.outputs.id }}:${{ needs.get-runner-container-image.outputs.tag }}"
       options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
### Short description
This PR checks if the image used for the container used as runner is based on "debian 11" in `build-and-test-all.yml`, and skips the run of `build-dnsdist` for `arm64` and `swagger-syntax-check` (we were already using a different distro for this job).

Error in CI: <https://github.com/PowerDNS/pdns/actions/runs/20148771420/job/57836257153>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
