### PR TITLE
Meson: Add missing libcurl dep for sdig

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -726,6 +726,7 @@ if get_option('tools')
     },
     'sdig': {
       'main': src_dir / 'sdig.cc',
+      'deps-extra': dep_libcurl,
       'manpages': ['sdig.1'],
     },
     'calidns': {


### PR DESCRIPTION
### Short description
There is an error linking sdig currently if you attempt to build tools without lua records as it will miss linking libcurl. This change will ensure linking of libcurl happens for sdig if it is found in the current environment.

To reproduce:
```
git clone https://github.com/PowerDNS/pdns.git
cd pdns
meson setup build -Dtools=true -Dlua-records=false
meson compile -C build
```

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
