### PR TITLE
dnsdist: Handle escaped values in YAML SpoofRaw parameters

### DIFF
--- a/pdns/dnsdistdist/dnsdist-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-actions-definitions.yml
@@ -459,19 +459,7 @@ are processed after this action"
       description: "The length of the DNS packet"
 - name: "SpoofRaw"
   description: |
-               Forge a response with the specified raw bytes as record data
-               .. code-block:: Lua
-
-                 -- select queries for the 'raw.powerdns.com.' name and TXT type, and answer with both a "aaa" "bbbb" and "ccc" TXT record:
-                 addAction(AndRule({QNameRule('raw.powerdns.com.'), QTypeRule(DNSQType.TXT)}), SpoofRawAction({"\003aaa\004bbbb", "\003ccc"}))
-                 -- select queries for the 'raw-srv.powerdns.com.' name and SRV type, and answer with a '0 0 65535 srv.powerdns.com.' SRV record, setting the AA bit to 1 and the TTL to 3600s
-                 addAction(AndRule({QNameRule('raw-srv.powerdns.com.'), QTypeRule(DNSQType.SRV)}), SpoofRawAction("\000\000\000\000\255\255\003srv\008powerdns\003com\000", { aa=true, ttl=3600 }))
-                 -- select reverse queries for '127.0.0.1' and answer with 'localhost'
-                 addAction(AndRule({QNameRule('1.0.0.127.in-addr.arpa.'), QTypeRule(DNSQType.PTR)}), SpoofRawAction("\009localhost\000"))
-                 -- rfc8482: Providing Minimal-Sized Responses to DNS Queries That Have QTYPE=ANY via HINFO of value "rfc8482"
-                 addAction(QTypeRule(DNSQType.ANY), SpoofRawAction("\007rfc\056\052\056\050\000", { typeForAny=DNSQType.HINFO }))
-
-               :func:`DNSName:toDNSString` is convenient for converting names to wire format for passing to ``SpoofRawAction``.
+               Forge a response with the specified raw bytes as record data. Non-character values should be encoded in the ``\DDD`` format where ``DDD`` is the decimal value. For example to wire content of an A record containing ``1.2.3.4`` should be encoded as ``\001\002\003\004``.
 
                ``sdig dumpluaraw`` and ``pdnsutil raw-lua-from-content`` from PowerDNS can generate raw answers for you:
 

--- a/pdns/dnsdistdist/dnsdist-rules.cc
+++ b/pdns/dnsdistdist/dnsdist-rules.cc
@@ -143,7 +143,7 @@ std::shared_ptr<QClassRule> getQClassSelector(const std::string& qclassStr, uint
 {
   QClass qclass(qclassCode);
   if (!qclassStr.empty()) {
-    qclass = QClass(std::string(qclassStr));
+    qclass = QClass(boost::to_upper_copy(std::string(qclassStr)));
   }
 
   return std::make_shared<QClassRule>(qclass);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixes the issue reported in https://github.com/PowerDNS/pdns/issues/16649 I'm not 100% happy with having to do the escaping in our code, but I don't really see any other option at the moment.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
