### PR TITLE
Version selector for PDNS Lightning Stream Enterprise in docs

### DIFF
--- a/website/docs.powerdns.com/index.html
+++ b/website/docs.powerdns.com/index.html
@@ -249,7 +249,7 @@
                 'lightningstream-versions'
             );
             loadVersionSelector(
-                '/lightningstream-enterprise/',
+                '/lightningstream-enterprise',
                 'lightningstream-enterprise-versions'
             )
 


### PR DESCRIPTION
### Short description

Adds a separate version selector to the docs site for Lightning Stream Enterprise. To differentiate both version selectors (open source and enterprise) both get a heading. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
