### PR TITLE
auth: fix geoip_mmdb backend MMDB_open error handling

### DIFF
--- a/modules/geoipbackend/geoipinterface-mmdb.cc
+++ b/modules/geoipbackend/geoipinterface-mmdb.cc
@@ -46,7 +46,7 @@ public:
     else
       throw PDNSException(string("Unsupported mode ") + modeStr + ("for geoipbackend-mmdb"));
     memset(&d_s, 0, sizeof(d_s));
-    if ((ec = MMDB_open(fname.c_str(), flags, &d_s)) < 0)
+    if ((ec = MMDB_open(fname.c_str(), flags, &d_s)) != MMDB_SUCCESS)
       throw PDNSException(string("Cannot open ") + fname + string(": ") + string(MMDB_strerror(ec)));
     d_lang = language;
     g_log << Logger::Debug << "Opened MMDB database " << fname << "(type: " << d_s.metadata.database_type << " version: " << d_s.metadata.binary_format_major_version << "." << d_s.metadata.binary_format_minor_version << ")" << endl;


### PR DESCRIPTION
### Short description

According to [MMDB_open docs], errors from `MMDB_open` should be compared to `MMDB_SUCCESS` (which is 0). All other errors are > 0, which means that existing check never detects errors, causing further queries to fail with error:
```
The MaxMind DB file is in a format this library can't handle
(unknown record size or binary format version)
```
[MMDB_open docs]: https://maxmind.github.io/libmaxminddb/#mmdb_open

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master

---
>Sponsored by [Quad9](https://quad9.net/)