### PR TITLE
Fix builder-support/dockerfiles/Dockerfile.authoritative: remove copy of removed folder auth/systemd

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.authoritative
+++ b/builder-support/dockerfiles/Dockerfile.authoritative
@@ -7,7 +7,7 @@ RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \
 
 # the pdns/ dir is a bit broad, but who cares :)
 ADD configure.ac Makefile.am COPYING INSTALL NOTICE README /pdns-authoritative/
-@EXEC sdist_paths=(build-aux m4 pdns ext docs modules codedocs contrib regression-tests auth/systemd meson meson.build meson_options.txt)
+@EXEC sdist_paths=(build-aux m4 pdns ext docs modules codedocs contrib regression-tests meson meson.build meson_options.txt)
 @EXEC for d in ${sdist_paths[@]} ; do echo "COPY $d /pdns-authoritative/$d" ; done
 ADD builder/helpers/set-configure-ac-version.sh /pdns-authoritative/builder/helpers/
 ADD builder-support/gen-version /pdns-authoritative/builder-support/gen-version


### PR DESCRIPTION
The folder `auth/systemd` was removed in #16671 (although in the original PR it appears as a renaming). This is OK because `pdns.service.in` and `ixfrdist.service.in` are already present and copied from the folder `pdns`.

This PR removes a leftover from `builder-support/dockerfiles/Dockerfile.authoritative` where it is tried for the mentioned folder to be copied into a container for building packages. Since the folder no longer exists, package building fails. See <https://github.com/PowerDNS/pdns/actions/runs/20478713308/job/58860589101>

Test: <https://github.com/romeroalx/pdns/actions/runs/20484014826>

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
