### PR TITLE
auth: deaden dead code

### DIFF
--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -69,15 +69,6 @@ bool Connector::recv(Json& value)
   throw PDNSException("Unknown error while receiving data");
 }
 
-void RemoteBackend::makeErrorAndThrow(Json& value)
-{
-  std::string msg = "Remote process indicated a failure";
-  for (const auto& message : value["log"].array_items()) {
-    msg += " '" + message.string_value() + "'";
-  }
-  throw PDNSException(msg);
-}
-
 /**
  * Standard ctor and dtor
  */

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -219,7 +219,6 @@ private:
 
   bool send(Json& value);
   bool recv(Json& value);
-  static void makeErrorAndThrow(Json& value);
 
   static string asString(const Json& value)
   {


### PR DESCRIPTION
### Short description
Boring PR which removes unused dead code. Did I mention that code is dead? Because it turns out to be dead, which is quite common among dead code.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
