### PR TITLE
dnsdist: update docs for `DNSQuestion::setExtendedDNSError`

### DIFF
--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -315,14 +315,18 @@ This state can be modified from the various hooks.
     :param int code: The EDNS option code
     :param string data: The EDNS option raw data
 
-  .. method:: DNSQuestion:setExtendedDNSError(infoCode [, extraText])
+  .. method:: DNSQuestion:setExtendedDNSError(infoCode [, extraText [, clearExistingEntries]])
 
     .. versionadded:: 1.9.0
+
+    .. versionchanged:: 2.1.0
+      ``clearExistingEntries`` optional parameter added.
 
       Set an Extended DNS Error status that will be added to the response corresponding to the current query.
 
     :param int infoCode: The EDNS Extended DNS Error code
     :param string extraText: The optional EDNS Extended DNS Error extra text
+    :param bool clearExistingEntries: Whether to clear existing EDNS Extended DNS Error codes, default true
 
   .. method:: DNSQuestion:setHTTPResponse(status, body, contentType="")
 


### PR DESCRIPTION
### Short description
PR #16680 introduced new parameter for `setExtendedDNSError` - `clearExistingEntries`. Docs were added for actions, but not for the lua function, which was changed together with the actions.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

---
>Sponsored by [Quad9](https://quad9.net/)