### PR TITLE
contrib: fix spurious "openTelemetry decoding not available" warning

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -145,17 +145,18 @@ class PDNSPBConnHandler(object):
                 self.convertKV(values, key, value)
 
     def printOT(self, msg):
-        if self._printjson and opentelemetryAvailable:
-            if msg.HasField('openTelemetryData'):
-                json_string = None
-                otmsg = opentelemetry.proto.trace.v1.trace_pb2.TracesData()
-                otmsg.ParseFromString(msg.openTelemetryData)
-                values = google.protobuf.json_format.MessageToDict(otmsg, preserving_proto_field_name=True)
-                self.convertIDs(values)
-                json_string = json.dumps(values, indent=True)
-                print("- openTelemetry: " + json_string)
-        else:
-            print("- openTelemetry decoding not available, see the comments in ProtoBuffer.py to make it available.")
+        if self._printjson:
+            if opentelemetryAvailable:
+                if msg.HasField('openTelemetryData'):
+                    json_string = None
+                    otmsg = opentelemetry.proto.trace.v1.trace_pb2.TracesData()
+                    otmsg.ParseFromString(msg.openTelemetryData)
+                    values = google.protobuf.json_format.MessageToDict(otmsg, preserving_proto_field_name=True)
+                    self.convertIDs(values)
+                    json_string = json.dumps(values, indent=True)
+                    print("- openTelemetry: " + json_string)
+                else:
+                    print("- openTelemetry decoding not available, see the comments in ProtoBuffer.py to make it available.")
 
     @staticmethod
     def getAppliedPolicyTypeAsString(polType):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
