### PR TITLE
Use `assertIn`

### DIFF
--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1718,8 +1718,8 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         # note that we can't assume anything about the order of the records
         records = get_rrset(data1, 'a.' + name, 'A')['records']
         self.assertEqual(len(records), 2)
-        self.assertTrue(a1 in records)
-        self.assertTrue(a3 in records)
+        self.assertIn(a1, records)
+        self.assertIn(a3, records)
         # get_rrset above has removed the timestamps from data1, fetch the
         # zone again, since we want to ensure the following operations do
         # not change anything.
@@ -1817,9 +1817,9 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         # note that we can't assume anything about the order of the records
         records = get_rrset(data, 'a.' + name, 'A')['records']
         self.assertEqual(len(records), 3)
-        self.assertTrue(a1 in records)
-        self.assertTrue(a2 in records)
-        self.assertTrue(a4 in records)
+        self.assertIn(a1, records)
+        self.assertIn(a2, records)
+        self.assertIn(a4, records)
 
     def test_zone_disable_reenable(self):
         # This also tests that SOA-EDIT-API works.


### PR DESCRIPTION
### Short description
Address some codeql complaints from https://github.com/check-spelling-sandbox/pdns/security/quality/rules/py%2Fimprecise-assert

https://codeql.github.com/codeql-query-help/python/py-imprecise-assert/

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
