### PR TITLE
auth: meson: fix missing symbols for dynamic backends

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -458,6 +458,21 @@ if dep_pkcs11.found()
   )
 endif
 
+# Needs link_whole, so the symbols are put into pdns_server and pdnsutil, and
+# dynamically loaded backends can use the symbols from their host program (uses
+# export_dynamic).
+libpdns_sqlbackend = declare_dependency(
+  link_whole: static_library(
+    'pdns-sqlbackend',
+    sources: files(
+      src_dir / 'backends' / 'gsql' / 'gsqlbackend.cc',
+      src_dir / 'backends' / 'gsql' / 'gsqlbackend.hh',
+      src_dir / 'backends' / 'gsql' / 'ssql.hh',
+    ),
+    dependencies: deps,
+  )
+)
+
 # This needs to be link_whole'd because it's needed by auth backends.
 libpdns_ssqlite3 = dependency('', required: false)
 if dep_sqlite3.found()
@@ -497,9 +512,6 @@ common_sources += files(
   src_dir / 'auth-zonecache.hh',
   src_dir / 'axfr-retriever.cc',
   src_dir / 'axfr-retriever.hh',
-  src_dir / 'backends' / 'gsql' / 'gsqlbackend.cc', # TODO Move to a separate module.
-  src_dir / 'backends' / 'gsql' / 'gsqlbackend.hh', # TODO Move to a separate module.
-  src_dir / 'backends' / 'gsql' / 'ssql.hh',        # TODO Move to a separate module.
   src_dir / 'base32.cc',
   src_dir / 'base32.hh',
   src_dir / 'base64.cc',
@@ -697,6 +709,7 @@ tools = {
       libpdns_gettime,
       libpdns_signers_openssl,
       libpdns_signers_sodium,
+      libpdns_sqlbackend,
     ],
     'manpages': ['pdns_server.1'],
     'install_dir': get_option('sbindir'),
@@ -710,6 +723,7 @@ tools = {
       libpdns_ssqlite3,
       libpdns_signers_openssl,
       libpdns_signers_sodium,
+      libpdns_sqlbackend,
     ],
     'manpages': ['pdnsutil.1'],
   },


### PR DESCRIPTION

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Auth backends can be built as dynamic libraries. In the autoconf build, such backends expect pdns_server to provide all symbols they need (including sqlite3 for gsqlite3, gsqlbackend* for the gsql*backends, bindlexer for the bindbackend).

Previously gsqlbackend.cc was in common_sources, thus libpdns-common.
While pdns_server and pdnsutil link libpdns-common, they do so using link_with. This commit moves gsqlbackend.cc into a libpdns-sqlbackend, which gets linked using link_whole. Thus the symbols appear in pdns_server and pdnsutil and are not discarded.

Addresses parts of #13987.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
