### PR TITLE
dnsdist: Do not keep stale cache entries around for empty pools

### DIFF
--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -1152,6 +1152,11 @@ void ServerPool::setECS(bool useECS)
   updateConsistency();
 }
 
+bool ServerPool::shouldKeepStaleData() const
+{
+  return !getServers().empty() && countServers(true) == 0;
+}
+
 namespace dnsdist::backend
 {
 void registerNewBackend(std::shared_ptr<DownstreamState>& backend)

--- a/pdns/dnsdistdist/dnsdist-server-pool.hh
+++ b/pdns/dnsdistdist/dnsdist-server-pool.hh
@@ -64,6 +64,7 @@ struct ServerPool
   size_t poolLoad() const;
   size_t countServers(bool upOnly) const;
   bool hasAtLeastOneServerAvailable() const;
+  bool shouldKeepStaleData() const;
   const ServerPolicy::NumberedServerVector& getServers() const;
   void addServer(std::shared_ptr<DownstreamState>& server);
   void removeServer(std::shared_ptr<DownstreamState>& server);

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -2426,7 +2426,7 @@ static void maintThread()
            has all its backends down) */
         if (packetCache->keepStaleData() && !iter->second) {
           /* so far all pools had at least one backend up */
-          if (pool.countServers(true) == 0) {
+          if (pool.shouldKeepStaleData()) {
             iter->second = true;
           }
         }

--- a/pdns/dnsdistdist/test-dnsdistserverpool.cc
+++ b/pdns/dnsdistdist/test-dnsdistserverpool.cc
@@ -59,6 +59,7 @@ BOOST_AUTO_TEST_CASE(test_ServerPoolBasics)
   BOOST_CHECK_EQUAL(pool.countServers(true), 0U);
   BOOST_CHECK_EQUAL(pool.countServers(false), 0U);
   BOOST_CHECK_EQUAL(pool.poolLoad(), 0U);
+  BOOST_CHECK(!pool.shouldKeepStaleData());
 
   {
     const auto& servers = pool.getServers();
@@ -76,6 +77,7 @@ BOOST_AUTO_TEST_CASE(test_ServerPoolBasics)
     BOOST_CHECK(!pool.hasAtLeastOneServerAvailable());
     BOOST_CHECK_EQUAL(pool.countServers(true), 0U);
     BOOST_CHECK_EQUAL(pool.countServers(false), 1U);
+    BOOST_CHECK(pool.shouldKeepStaleData());
 
     BOOST_CHECK_EQUAL(pool.poolLoad(), 0U);
     {
@@ -88,11 +90,13 @@ BOOST_AUTO_TEST_CASE(test_ServerPoolBasics)
     BOOST_CHECK(pool.hasAtLeastOneServerAvailable());
     BOOST_CHECK_EQUAL(pool.countServers(true), 1U);
     BOOST_CHECK_EQUAL(pool.countServers(false), 1U);
+    BOOST_CHECK(!pool.shouldKeepStaleData());
 
     /* now remove it */
     pool.removeServer(ds);
     BOOST_CHECK_EQUAL(pool.countServers(true), 0U);
     BOOST_CHECK_EQUAL(pool.countServers(false), 0U);
+    BOOST_CHECK(!pool.shouldKeepStaleData());
     {
       const auto& servers = pool.getServers();
       BOOST_CHECK(servers.empty());


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported in https://github.com/PowerDNS/pdns/issues/16713

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
