### PR TITLE
feat(dnsdist): Add instance field to OT Trace messages

### DIFF
--- a/pdns/dnsdistdist/dnsdist-actions-factory.cc
+++ b/pdns/dnsdistdist/dnsdist-actions-factory.cc
@@ -29,6 +29,7 @@
 
 #include "config.h"
 #include "dnsdist-configuration.hh"
+#include "dnsdist-opentelemetry.hh"
 #include "dnsdist.hh"
 #include "dnsdist-async.hh"
 #include "dnsdist-dnsparser.hh"
@@ -1741,6 +1742,7 @@ public:
     tracer->setRootSpanAttribute("query.qtype", AnyValue{QType(dnsquestion->ids.qtype).toString()});
     tracer->setRootSpanAttribute("query.remote.address", AnyValue{dnsquestion->ids.origRemote.toString()});
     tracer->setRootSpanAttribute("query.remote.port", AnyValue{dnsquestion->ids.origRemote.getPort()});
+    tracer->setTraceAttribute("instance", AnyValue{dnsdist::configuration::getCurrentRuntimeConfiguration().d_server_id});
 
     if (d_sendDownstreamTraceparent) {
       dnsquestion->ids.sendTraceParentToDownstreamID = d_traceparentOptionCode;

--- a/pdns/dnsdistdist/dnsdist-opentelemetry.cc
+++ b/pdns/dnsdistdist/dnsdist-opentelemetry.cc
@@ -21,7 +21,6 @@
  */
 
 #include "dnsdist-opentelemetry.hh"
-#include "misc.hh"
 #include "dnsdist-ecs.hh"
 
 #include <memory>
@@ -33,10 +32,6 @@
 
 namespace pdns::trace::dnsdist
 {
-
-#ifndef DISABLE_PROTOBUF
-static const KeyValue hostnameAttr{.key = "hostname", .value = {getHostname().value_or("")}};
-#endif
 
 TracesData Tracer::getTracesData()
 {
@@ -58,8 +53,6 @@ TracesData Tracer::getTracesData()
                             .attributes = {data->d_attributes.cbegin(), data->d_attributes.cend()},
                           },
                           .spans = {}}}}}};
-
-    otTrace.resource_spans.at(0).scope_spans.at(0).scope.attributes.push_back(hostnameAttr);
 
     for (auto const& span : data->d_spans) {
       otTrace.resource_spans.at(0).scope_spans.at(0).spans.push_back(

--- a/pdns/dnsdistdist/test-dnsdist-opentelemetry_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdist-opentelemetry_cc.cc
@@ -152,12 +152,10 @@ BOOST_AUTO_TEST_CASE(traceAttributes)
   BOOST_CHECK_EQUAL(trace.resource_spans.at(0).resource.attributes.at(0).key, "service.name");
 
   // Check if we have a hostname
-  BOOST_CHECK_EQUAL(trace.resource_spans.at(0).scope_spans.at(0).scope.attributes.size(), 2U);
+  BOOST_CHECK_EQUAL(trace.resource_spans.at(0).scope_spans.at(0).scope.attributes.size(), 1U);
 
   BOOST_CHECK_EQUAL(trace.resource_spans.at(0).scope_spans.at(0).scope.attributes.at(0).key, "foo");
   BOOST_CHECK_EQUAL(trace.resource_spans.at(0).scope_spans.at(0).scope.attributes.at(0).value, AnyValue{"bar"});
-
-  BOOST_CHECK_EQUAL(trace.resource_spans.at(0).scope_spans.at(0).scope.attributes.at(1).key, "hostname");
 }
 
 BOOST_AUTO_TEST_CASE(spanAttributes)
@@ -200,11 +198,11 @@ BOOST_AUTO_TEST_CASE(getOTProtobuf)
 {
   auto tracer = pdns::trace::dnsdist::Tracer::getTracer();
   auto data = tracer->getOTProtobuf();
-  BOOST_TEST(data.size() >= 100U);
+  BOOST_TEST(data.size() >= 50U);
 
   tracer->setTraceAttribute("foo", AnyValue{"bar"});
   data = tracer->getOTProtobuf();
-  BOOST_TEST(data.size() >= 110U);
+  BOOST_TEST(data.size() >= 60U);
 }
 
 BOOST_AUTO_TEST_CASE(setTraceID)

--- a/regression-tests.dnsdist/test_OpenTelemetryTracing.py
+++ b/regression-tests.dnsdist/test_OpenTelemetryTracing.py
@@ -104,7 +104,7 @@ class DNSDistOpenTelemetryProtobufTest(test_Protobuf.DNSDistProtobufTest):
                 "attributes"
             ]
         ]
-        self.assertListEqual(msg_scope_attr_keys, ["hostname"])
+        self.assertListEqual(msg_scope_attr_keys, ["instance"])
 
         root_span_attr_keys = [
             v["key"]


### PR DESCRIPTION
### Short description

This PR ensures there is an `instance` field set to the DNSDist server id in OpenTelemetry Trace messages.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
