### PR TITLE
build-packages: fix el-10 builds. Make macro systemd_requires optional

### DIFF
--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -50,11 +50,11 @@ BuildRequires: net-snmp-devel
 
 %if 0%{?suse_version}
 Requires(pre): shadow
-%systemd_requires
+%{?systemd_requires}
 %endif
 Requires(pre): shadow-utils
 BuildRequires: fstrm-devel
-%systemd_requires
+%{?systemd_requires}
 %if ( "%{_arch}" != "aarch64" && 0%{?rhel} >= 8 ) || ( "%{_arch}" == "aarch64" && 0%{?rhel} >= 9 )
 BuildRequires: libbpf-devel
 BuildRequires: libxdp-devel

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -48,7 +48,7 @@ BuildRequires: libatomic
 %endif
 
 Requires(pre): shadow-utils
-%systemd_requires
+%{?systemd_requires}
 
 %description
 PowerDNS Recursor is a non authoritative/recursing DNS server. Use this


### PR DESCRIPTION
### Short description
This PR marks the macro `systemd_requires` used when building RPM packages as optional (use only if present). This macro has been discontinued for recent versions, as can be seen for [SUSE](https://en.opensuse.org/openSUSE:Systemd_packaging_guidelines#Runtime_requirements) and [Fedora](https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_dependencies_on_the_systemd_package) (here is where it is suggested to use the conditional)

Fixes `el-10` builds: <https://github.com/PowerDNS/pdns/actions/runs/21160187392/job/60853134558#step:3:3013>

Test: <https://github.com/romeroalx/pdns/actions/runs/21169758238>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
