### PR TITLE
rec-5.3.x: Backport 16748 - build-packages: fix el-10 builds

### DIFF
--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -45,11 +45,11 @@ BuildRequires: net-snmp-devel
 
 %if 0%{?suse_version}
 Requires(pre): shadow
-%systemd_requires
+%{?systemd_requires}
 %endif
 Requires(pre): shadow-utils
 BuildRequires: fstrm-devel
-%systemd_requires
+%{?systemd_requires}
 %if ( "%{_arch}" != "aarch64" && 0%{?rhel} >= 8 ) || ( "%{_arch}" == "aarch64" && 0%{?rhel} >= 9 )
 BuildRequires: libbpf-devel
 BuildRequires: libxdp-devel

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -47,7 +47,7 @@ BuildRequires: libatomic
 %endif
 
 Requires(pre): shadow-utils
-%systemd_requires
+%{?systemd_requires}
 
 %description
 PowerDNS Recursor is a non authoritative/recursing DNS server. Use this


### PR DESCRIPTION
### Short description
Backports #16748 to rel/rec-5.3.x

Fixes: <https://github.com/PowerDNS/pdns/actions/runs/21158546572/job/60848211224>

Test: <https://github.com/romeroalx/pdns/actions/runs/21176763462>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
