### PR TITLE
GH actions - build-and-test-all.yml - build dnsdist: add back install-build-deps step

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -258,6 +258,8 @@ jobs:
         with:
           venv-parent: ${{ env.REPO_HOME }}
           working-directory: .
+      - run: ${{ env.INV_CMD }} install-dnsdist-build-deps $([ "$(. /etc/os-release && echo $VERSION_CODENAME)" = "bullseye" ] && echo "--skipXDP=True")
+        working-directory: .
       - run: ${{ env.INV_CMD }} install-clang
         working-directory: .
       - run: ${{ env.INV_CMD }} install-lld-linker-if-needed


### PR DESCRIPTION
### Short description
Adds a step to install build dependencies in `build-and-test-all.yml` to the `build-dnsdist` job in the same way that is done for `auth` and `recursor`. 

Fixes (when backported): <https://github.com/PowerDNS/pdns/actions/runs/21177012599/job/60908513454>

Test: <https://github.com/romeroalx/pdns/actions/runs/21201901598>

Needs to be backported to rel/dnsdist:2.0.x and `rel/dnsdist/1.9.x`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
