### PR TITLE
rec: harmonize with dnsdist PR #16741 wrt OpenTelemetry instance name

### DIFF
--- a/pdns/protozero-trace.hh
+++ b/pdns/protozero-trace.hh
@@ -748,16 +748,19 @@ struct TracesData
     return data;
   }
 
-  static TracesData boilerPlate(std::string&& service, std::vector<Span>&& spans, const std::vector<KeyValue>& attributes, std::string& serverID)
+  static TracesData boilerPlate(std::string&& service, std::vector<Span>&& spans, const std::vector<KeyValue>& attributes, const std::string& serverID)
   {
     auto& spanAttrs = spans.at(0).attributes;
     spanAttrs.insert(spanAttrs.end(), attributes.begin(), attributes.end());
-    auto host = getHostname();
-    std::string hostname = host.value_or("unset");
     InstrumentationScope scope{
-      .name = "rec", .version = VERSION, .attributes = {{"hostname", {hostname}}, {"server.id", {serverID}}}};
+      .name = "rec", .version = VERSION};
     return TracesData{
-      .resource_spans = {pdns::trace::ResourceSpans{.resource = {.attributes = {{"service.name", {{std::move(service)}}}}}, .scope_spans = {{.scope = std::move(scope), .spans = std::move(spans)}}}}};
+      .resource_spans = {pdns::trace::ResourceSpans{
+        .resource = {
+          .attributes = {
+            {"service.name", {{std::move(service)}}},
+            {"instance", {serverID}}}},
+        .scope_spans = {{.scope = std::move(scope), .spans = std::move(spans)}}}}};
   }
 };
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

- Move `server.id` to a resource attribute and rename it to `instance`.
- Drop `hostname` as `InstrumentationScope` attribute.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
