### PR TITLE
dnsdist: Handle the new YAML example configuration file in our packages

### DIFF
--- a/builder-support/debian/dnsdist/debian-bookworm/dnsdist.examples
+++ b/builder-support/debian/dnsdist/debian-bookworm/dnsdist.examples
@@ -1,1 +1,2 @@
 dnsdist.conf
+dnsdist.yml

--- a/builder-support/debian/dnsdist/debian-bookworm/dnsdist.postinst
+++ b/builder-support/debian/dnsdist/debian-bookworm/dnsdist.postinst
@@ -24,6 +24,11 @@ case "$1" in
       # Make sure that dnsdist can read it; the default used to be 0600
       chmod g+r /etc/dnsdist/dnsdist.conf
     fi
+    if [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.yml`" = "root:root" ]; then
+      chown root:_dnsdist /etc/dnsdist/dnsdist.yml
+      # Make sure that dnsdist can read it; the default used to be 0600
+      chmod g+r /etc/dnsdist/dnsdist.yml
+    fi
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/builder-support/debian/dnsdist/debian-bookworm/rules
+++ b/builder-support/debian/dnsdist/debian-bookworm/rules
@@ -87,8 +87,10 @@ endif
 
 override_dh_installexamples:
 	cp dnsdist.conf-dist dnsdist.conf
+	cp dnsdist.yml-dist dnsdist.yml
 	dh_installexamples
 	rm -f dnsdist.conf
+	rm -f dnsdist.yml
 
 override_dh_installinit:
 	# do nothing here. avoids referencing a non-existant init script.
@@ -98,6 +100,8 @@ override_dh_fixperms:
         # these files often contain passwords. 640 as it is chowned to root:_dnsdist
 	touch debian/dnsdist/etc/dnsdist/dnsdist.conf
 	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.conf
+	touch debian/dnsdist/etc/dnsdist/dnsdist.yml
+	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.yml
 
 override_dh_builddeb:
 	dh_builddeb -- -Zgzip

--- a/builder-support/debian/dnsdist/debian-bullseye/dnsdist.examples
+++ b/builder-support/debian/dnsdist/debian-bullseye/dnsdist.examples
@@ -1,1 +1,2 @@
 dnsdist.conf
+dnsdist.yml

--- a/builder-support/debian/dnsdist/debian-bullseye/dnsdist.postinst
+++ b/builder-support/debian/dnsdist/debian-bullseye/dnsdist.postinst
@@ -24,6 +24,11 @@ case "$1" in
       # Make sure that dnsdist can read it; the default used to be 0600
       chmod g+r /etc/dnsdist/dnsdist.conf
     fi
+    if [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.yml`" = "root:root" ]; then
+      chown root:_dnsdist /etc/dnsdist/dnsdist.yml
+      # Make sure that dnsdist can read it; the default used to be 0600
+      chmod g+r /etc/dnsdist/dnsdist.yml
+    fi
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/builder-support/debian/dnsdist/debian-bullseye/rules
+++ b/builder-support/debian/dnsdist/debian-bullseye/rules
@@ -81,8 +81,10 @@ endif
 
 override_dh_installexamples:
 	cp dnsdist.conf-dist dnsdist.conf
+	cp dnsdist.yml-dist dnsdist.yml
 	dh_installexamples
 	rm -f dnsdist.conf
+	rm -f dnsdist.yml
 
 override_dh_installinit:
 	# do nothing here. avoids referencing a non-existant init script.
@@ -92,6 +94,8 @@ override_dh_fixperms:
         # these files often contain passwords. 640 as it is chowned to root:_dnsdist
 	touch debian/dnsdist/etc/dnsdist/dnsdist.conf
 	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.conf
+	touch debian/dnsdist/etc/dnsdist/dnsdist.yml
+	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.yml
 
 override_dh_builddeb:
 	dh_builddeb -- -Zgzip

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -145,6 +145,8 @@ install -d %{buildroot}/%{_sysconfdir}/dnsdist
 install -Dm644 %{_libdir}/libdnsdist-quiche.so %{buildroot}/%{_libdir}/libdnsdist-quiche.so
 %{__mv} %{buildroot}%{_sysconfdir}/dnsdist/dnsdist.conf-dist %{buildroot}%{_sysconfdir}/dnsdist/dnsdist.conf
 chmod 0640 %{buildroot}/%{_sysconfdir}/dnsdist/dnsdist.conf
+%{__mv} %{buildroot}%{_sysconfdir}/dnsdist/dnsdist.yml-dist %{buildroot}%{_sysconfdir}/dnsdist/dnsdist.yml
+chmod 0640 %{buildroot}/%{_sysconfdir}/dnsdist/dnsdist.yml
 
 %{__install } -d %{buildroot}/%{_sharedstatedir}/%{name}
 
@@ -187,5 +189,6 @@ systemctl daemon-reload ||:
 %{_mandir}/man1/*
 %dir %{_sysconfdir}/dnsdist
 %attr(-, root, dnsdist) %config(noreplace) %{_sysconfdir}/%{name}/dnsdist.conf
+%attr(-, root, dnsdist) %config(noreplace) %{_sysconfdir}/%{name}/dnsdist.yml
 %dir %attr(-,dnsdist,dnsdist) %{_sharedstatedir}/%{name}
 %{_unitdir}/dnsdist*


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We are now providing a `dnsdist.yml` sample configuration file, so it needs to be properly handled by the RPM and Debian installation processes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
