### PR TITLE
dnsdist: Stop overriding `dh_fixperms` in Deb packages

### DIFF
--- a/builder-support/debian/dnsdist/debian-bookworm/dnsdist.postinst
+++ b/builder-support/debian/dnsdist/debian-bookworm/dnsdist.postinst
@@ -19,12 +19,12 @@ case "$1" in
     adduser --force-badname --system --home /nonexistent --group \
         --no-create-home --quiet _dnsdist || true
 
-    if [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.conf`" = "root:root" ]; then
+    if [ -e /etc/dnsdist/dnsdist.conf ] && [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.conf`" = "root:root" ]; then
       chown root:_dnsdist /etc/dnsdist/dnsdist.conf
       # Make sure that dnsdist can read it; the default used to be 0600
       chmod g+r /etc/dnsdist/dnsdist.conf
     fi
-    if [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.yml`" = "root:root" ]; then
+    if [ -e /etc/dnsdist/dnsdist.yml ] && [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.yml`" = "root:root" ]; then
       chown root:_dnsdist /etc/dnsdist/dnsdist.yml
       # Make sure that dnsdist can read it; the default used to be 0600
       chmod g+r /etc/dnsdist/dnsdist.yml

--- a/builder-support/debian/dnsdist/debian-bookworm/rules
+++ b/builder-support/debian/dnsdist/debian-bookworm/rules
@@ -95,13 +95,5 @@ override_dh_installexamples:
 override_dh_installinit:
 	# do nothing here. avoids referencing a non-existant init script.
 
-override_dh_fixperms:
-	dh_fixperms
-        # these files often contain passwords. 640 as it is chowned to root:_dnsdist
-	touch debian/dnsdist/etc/dnsdist/dnsdist.conf
-	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.conf
-	touch debian/dnsdist/etc/dnsdist/dnsdist.yml
-	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.yml
-
 override_dh_builddeb:
 	dh_builddeb -- -Zgzip

--- a/builder-support/debian/dnsdist/debian-bullseye/dnsdist.postinst
+++ b/builder-support/debian/dnsdist/debian-bullseye/dnsdist.postinst
@@ -19,12 +19,12 @@ case "$1" in
     adduser --force-badname --system --home /nonexistent --group \
         --no-create-home --quiet _dnsdist || true
 
-    if [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.conf`" = "root:root" ]; then
+    if [ -e /etc/dnsdist/dnsdist.conf ] && [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.conf`" = "root:root" ]; then
       chown root:_dnsdist /etc/dnsdist/dnsdist.conf
       # Make sure that dnsdist can read it; the default used to be 0600
       chmod g+r /etc/dnsdist/dnsdist.conf
     fi
-    if [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.yml`" = "root:root" ]; then
+    if [ -e /etc/dnsdist/dnsdist.yml ] && [ "`stat -c '%U:%G' /etc/dnsdist/dnsdist.yml`" = "root:root" ]; then
       chown root:_dnsdist /etc/dnsdist/dnsdist.yml
       # Make sure that dnsdist can read it; the default used to be 0600
       chmod g+r /etc/dnsdist/dnsdist.yml

--- a/builder-support/debian/dnsdist/debian-bullseye/rules
+++ b/builder-support/debian/dnsdist/debian-bullseye/rules
@@ -89,13 +89,5 @@ override_dh_installexamples:
 override_dh_installinit:
 	# do nothing here. avoids referencing a non-existant init script.
 
-override_dh_fixperms:
-	dh_fixperms
-        # these files often contain passwords. 640 as it is chowned to root:_dnsdist
-	touch debian/dnsdist/etc/dnsdist/dnsdist.conf
-	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.conf
-	touch debian/dnsdist/etc/dnsdist/dnsdist.yml
-	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.yml
-
 override_dh_builddeb:
 	dh_builddeb -- -Zgzip


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This changes prevents the creation of empty `/etc/dnsdist/dnsdist.conf` and `/etc/dnsdist/dnsdist.yml` files, which might prevent a successful loading of existing configuration files.

Test run at https://github.com/rgacogne/pdns/actions/runs/21364333104

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
