### PR TITLE
auth, rec: No longer allow passing the api-key as a query argument

### DIFF
--- a/pdns/recursordist/rec-rust-lib/rust/src/web.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/web.rs
@@ -192,18 +192,6 @@ fn api_wrapper(
         }
     }
 
-    if !auth_ok && !ctx.api_ch.is_null() {
-        if let Some(pw) = ctx.api_ch.as_ref() {
-            for kv in &request.vars {
-                cxx::let_cxx_string!(s = &kv.value);
-                if kv.key == "api-key" && pw.matches(&s) {
-                    auth_ok = true;
-                    break;
-                }
-            }
-        }
-    }
-
     if !auth_ok && allow_password {
         auth_ok = compare_authorization(ctx, reqheaders);
         if !auth_ok {

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -166,7 +166,7 @@ void WebServer::apiWrapper(const WebServer::HandlerFunction& handler, HttpReques
     throw HttpUnauthorizedException("X-API-Key");
   }
 
-  bool auth_ok = req->compareHeader("x-api-key", *d_apikey) || d_apikey->matches(req->getvars["api-key"]);
+  bool auth_ok = req->compareHeader("x-api-key", *d_apikey);
 
   if (!auth_ok && allowPassword) {
     if (d_webserverPassword) {


### PR DESCRIPTION
### Short description
As discussed in #16785, do not allow passing the webserver api-key as part of the query string. This had never been documented and was probably only used to speed up the recursor web server development in 2015.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] no idea what I am doing in the rust code