### PR TITLE
dnsdist: Do not create `dnsdist.yml` in RPM system configuration directory

### DIFF
--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -145,8 +145,7 @@ install -d %{buildroot}/%{_sysconfdir}/dnsdist
 install -Dm644 %{_libdir}/libdnsdist-quiche.so %{buildroot}/%{_libdir}/libdnsdist-quiche.so
 %{__mv} %{buildroot}%{_sysconfdir}/dnsdist/dnsdist.conf-dist %{buildroot}%{_sysconfdir}/dnsdist/dnsdist.conf
 chmod 0640 %{buildroot}/%{_sysconfdir}/dnsdist/dnsdist.conf
-%{__mv} %{buildroot}%{_sysconfdir}/dnsdist/dnsdist.yml-dist %{buildroot}%{_sysconfdir}/dnsdist/dnsdist.yml
-chmod 0640 %{buildroot}/%{_sysconfdir}/dnsdist/dnsdist.yml
+chmod 0640 %{buildroot}/%{_sysconfdir}/dnsdist/dnsdist.yml-dist
 
 %{__install } -d %{buildroot}/%{_sharedstatedir}/%{name}
 
@@ -189,6 +188,6 @@ systemctl daemon-reload ||:
 %{_mandir}/man1/*
 %dir %{_sysconfdir}/dnsdist
 %attr(-, root, dnsdist) %config(noreplace) %{_sysconfdir}/%{name}/dnsdist.conf
-%attr(-, root, dnsdist) %config(noreplace) %{_sysconfdir}/%{name}/dnsdist.yml
+%attr(-, root, dnsdist) %config(noreplace) %{_sysconfdir}/%{name}/dnsdist.yml-dist
 %dir %attr(-,dnsdist,dnsdist) %{_sharedstatedir}/%{name}
 %{_unitdir}/dnsdist*


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
DNSdist now looks for a `dnsdist.yml` file first, which means that any existing `dnsdist.conf` would no longer be taken into account if we create a default `dnsdist.yml`. Let's install a sample YAML configuration file in `dnsdist.yml-dist` instead.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
