### PR TITLE
feat(dnsdist): Add `prepend` and `append` methods to Lua DNSName

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings.cc
@@ -34,6 +34,7 @@
 
 #include "dolog.hh"
 #include "xsk.hh"
+#include <variant>
 
 void setupLuaBindingsLogging(LuaContext& luaCtx)
 {
@@ -492,6 +493,22 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
   /* DNSName */
   luaCtx.registerFunction("isPartOf", &DNSName::isPartOf);
   luaCtx.registerFunction<bool (DNSName::*)()>("chopOff", [](DNSName& name) { return name.chopOff(); });
+  luaCtx.registerFunction<void (DNSName::*)(const std::variant<DNSName, std::string>&)>("append", [](DNSName& name, const std::variant<DNSName, std::string>& labels) {
+    if (std::holds_alternative<DNSName>(labels)) {
+      name += std::get<DNSName>(labels);
+    }
+    if (std::holds_alternative<string>(labels)) {
+      name += DNSName(std::get<std::string>(labels));
+    }
+  });
+  luaCtx.registerFunction<void (DNSName::*)(const std::variant<DNSName, std::string>&)>("prepend", [](DNSName& name, const std::variant<DNSName, std::string>& labels) {
+    if (std::holds_alternative<DNSName>(labels)) {
+      name = std::get<DNSName>(labels) + name;
+    }
+    if (std::holds_alternative<string>(labels)) {
+      name = DNSName(std::get<std::string>(labels)) + name;
+    }
+  });
   luaCtx.registerFunction<unsigned int (DNSName::*)() const>("countLabels", [](const DNSName& name) { return name.countLabels(); });
   luaCtx.registerFunction<size_t (DNSName::*)() const>("hash", [](const DNSName& name) { return name.hash(); });
   luaCtx.registerFunction<size_t (DNSName::*)() const>("wirelength", [](const DNSName& name) { return name.wirelength(); });

--- a/pdns/dnsdistdist/docs/reference/dnsname.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsname.rst
@@ -79,3 +79,21 @@ Functions and methods of a ``DNSName``
   .. method:: DNSName:wirelength() -> int
 
     Returns the length in bytes of the DNSName as it would be on the wire.
+
+  .. method:: DNSName:append(labels: [DNSName,string])
+
+    .. versionadded:: 2.2.0
+
+    Append ``labels`` to the DNSName. ``labels`` can be a string or DNSName containing one or more labels.
+
+    .. codeblock:: lua
+      local n = newDNSName("example.com")
+      n:append("example") -- n is now "example.com.example"
+      local other_name = newDNSName("foobar.invalid")
+      n:append(other_name) -- n is now "example.com.example.foobar.invalid")
+
+  .. method:: DNSName:prepend(labels: [DNSName,string])
+
+    .. versionadded:: 2.2.0
+
+    Prepend ``labels`` to the DNSName. ``labels`` can be a string or DNSName containing one or more labels.

--- a/regression-tests.dnsdist/test_CheckConfig.py
+++ b/regression-tests.dnsdist/test_CheckConfig.py
@@ -78,3 +78,32 @@ class TestCheckConfig(unittest.TestCase):
         """
         configTemplate = "blablabla"
         self.tryDNSDist(configTemplate, False)
+
+    def testDNSNameLuaFuncs(self):
+        """
+        CheckConfig: DNSName related functions
+        """
+        configTemplate = """
+        local myName = newDNSName("foo")
+        myName:prepend("bar")
+        if myName:toString() ~= "bar.foo." then
+          print("DNSName:prepend(string) failed")
+          os.exit(1)
+        end
+        myName:prepend(newDNSName("baz"))
+        if myName:toString() ~= "baz.bar.foo." then
+          print("DNSName:prepend(DNSName) failed")
+          os.exit(1)
+        end
+        myName:append("bar")
+        if myName:toString() ~= "baz.bar.foo.bar." then
+          print("DNSName:append(string) failed")
+          os.exit(1)
+        end
+        myName:append(newDNSName("baz"))
+        if myName:toString() ~= "baz.bar.foo.bar.baz." then
+          print("DNSName:append(DNSName) failed")
+          os.exit(1)
+        end
+        """
+        self.tryDNSDist(configTemplate)


### PR DESCRIPTION
### Short description

This adds 2 convenience functions to dnsdist's Lua bindings for `DNSName` to easily append en prepend labels.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
