### PR TITLE
dnsdist: Only install dnsdist.yml-dist if yaml support was enabled

### DIFF
--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -819,11 +819,14 @@ install_data(
   install_dir : get_option('sysconfdir'),
   follow_symlinks: true
 )
-install_data(
-  'dnsdist.yml-dist',
-  install_dir : get_option('sysconfdir'),
-  follow_symlinks: true
-)
+
+if get_option('yaml').enabled()
+  install_data(
+    'dnsdist.yml-dist',
+    install_dir : get_option('sysconfdir'),
+    follow_symlinks: true
+  )
+endif
 
 if python_venv.found()
   html_docs = custom_target(


### PR DESCRIPTION
### Short description
I am testing dnsdist-2.1 git in Gentoo and noticed that meson now installs `/etc/dnsdist/dnsdist.yml` by default. There's no point to have this when yaml support was not enabled and I can easily remove it in our package install, but figured we could just as well do this correctly in dnsdist itself. A bit of reading about checking meson features and here we are.
Verified by building Gentoo's dnsdist-9999 (aka git master) and not getting `dnsdist.yml` installed any longer.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
