### PR TITLE
dnsdist: SpoofAction: clarify what gets spoofed

### DIFF
--- a/pdns/dnsdistdist/dnsdist-actions-factory.cc
+++ b/pdns/dnsdistdist/dnsdist-actions-factory.cc
@@ -901,15 +901,21 @@ public:
 
   string toString() const override
   {
-    string ret = "spoof in ";
+    string ret = "spoof ";
     if (!d_cname.empty()) {
-      ret += d_cname.toString() + " ";
+      ret += "CNAME " + d_cname.toString() + " ";
     }
     if (!d_rawResponses.empty()) {
       ret += "raw bytes ";
     }
     else {
       for (const auto& addr : d_addrs) {
+        if (addr.isIPv4()) {
+          ret += "A ";
+        }
+        else if (addr.isIPv6()) {
+          ret += "AAAA ";
+        }
         ret += addr.toString() + " ";
       }
     }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Previously SpoofAction was described as "spoof in <ip addr>". The "in" in there confused me (is that "IN" or just nothing?), so I decided to replace "in" with the type that gets spoofed.

Example:
* old: `spoof in 0.0.0.0 ::`
* new: `spoof A 0.0.0.0 AAAA ::`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
