### PR TITLE
auth: add default-soa-edit-api setting for API zone creation

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -483,6 +483,22 @@ Use this soa-edit value for all signed zones if no
 :ref:`metadata-soa-edit` metadata value is set.
 Overrides :ref:`setting-default-soa-edit`
 
+.. _setting-default-soa-edit-api:
+
+``default-soa-edit-api``
+------------------------
+
+-  String
+-  Default: DEFAULT
+
+.. versionadded:: 5.2.0
+
+The default :ref:`metadata-soa-edit-api` metadata value for zones created via
+the API when the zone creation request does not include the ``soa_edit_api`` field.
+Set to empty string to disable automatic SOA serial updates via the API.
+
+See :ref:`metadata-soa-edit-api` for the list of possible values.
+
 .. _setting-default-soa-mail:
 
 ``default-soa-mail``

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -265,6 +265,7 @@ static void declareArguments()
   ::arg().set("default-soa-content", "Default SOA content") = "a.misconfigured.dns.server.invalid hostmaster.@ 0 10800 3600 604800 3600";
   ::arg().set("default-soa-edit", "Default SOA-EDIT value") = "";
   ::arg().set("default-soa-edit-signed", "Default SOA-EDIT value for signed zones") = "";
+  ::arg().set("default-soa-edit-api", "Default SOA-EDIT-API value for new zones") = "DEFAULT";
   ::arg().set("dnssec-key-cache-ttl", "Seconds to cache DNSSEC keys from the database") = "30";
   ::arg().set("domain-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "";
   ::arg().set("zone-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "60";

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2094,7 +2094,10 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
 
   try {
     // will be overridden by updateDomainSettingsFromDocument, if given in document.
-    domainInfo.backend->setDomainMetadataOne(zonename, "SOA-EDIT-API", "DEFAULT");
+    const string defaultSOAEditAPI = ::arg()["default-soa-edit-api"];
+    if (!defaultSOAEditAPI.empty()) {
+      domainInfo.backend->setDomainMetadataOne(zonename, "SOA-EDIT-API", defaultSOAEditAPI);
+    }
 
     for (auto& resourceRecord : new_records) {
       resourceRecord.domain_id = static_cast<int>(domainInfo.id);

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -73,6 +73,7 @@ views
 AUTH_COMMON_TPL = """
 module-dir=../regression-tests/modules
 default-soa-edit=INCEPTION-INCREMENT
+default-soa-edit-api=EPOCH
 launch+=bind
 bind-config=bindbackend.conf
 loglevel=5


### PR DESCRIPTION
### Short description
Add a configurable default-soa-edit-api setting that sets the SOA-EDIT-API metadata for zones created via the API when the zone creation request does not include the soa_edit_api field.

Closes: #6173

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)