### PR TITLE
ECS Scope Preservation and NODATA‑Scoped Caching for Incoming EDNS Subnet

### DIFF
--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -791,6 +791,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
 #endif /* HAVE_FSTRM */
 
   lwr->d_records.clear();
+  lwr->d_ednsECScope.reset();
   try {
     lwr->d_tcbit = 0;
     MOADNSParser mdp(false, reinterpret_cast<const char*>(buf.data()), buf.size());
@@ -848,6 +849,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
                               "incoming", Logging::Loggable(reso.getSource()));
               return LWResult::Result::Spoofed;
             }
+            lwr->d_ednsECScope = reso.getScopePrefixLength();
             /* rfc7871 states that 0 "indicate[s] that the answer is suitable for all addresses in FAMILY",
                so we might want to still pass the information along to be able to differentiate between
                IPv4 and IPv6. Still I'm pretty sure it doesn't matter in real life, so let's not duplicate

--- a/pdns/recursordist/lwres.hh
+++ b/pdns/recursordist/lwres.hh
@@ -77,6 +77,7 @@ public:
   bool d_validpacket{false};
   bool d_aabit{false}, d_tcbit{false};
   bool d_haveEDNS{false};
+  std::optional<uint8_t> d_ednsECScope;
 };
 
 class EDNSSubnetOpts;

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -96,6 +96,7 @@ std::unique_ptr<nod::UniqueResponseDB> g_udrDBp;
 std::atomic<bool> statsWanted;
 uint32_t g_disthashseed;
 bool g_useIncomingECS;
+bool g_returnIncomingECS;
 static shared_ptr<NetmaskGroup> g_initialProxyProtocolACL;
 static shared_ptr<std::set<ComboAddress>> g_initialProxyProtocolExceptions;
 std::optional<ComboAddress> g_dns64Prefix{std::nullopt};
@@ -1842,6 +1843,8 @@ static int initSyncRes(Logr::log_t log)
   SyncRes::parseEDNSSubnetAllowlist(::arg()["edns-subnet-allow-list"]);
   SyncRes::parseEDNSSubnetAddFor(::arg()["ecs-add-for"]);
   g_useIncomingECS = ::arg().mustDo("use-incoming-edns-subnet");
+  g_returnIncomingECS = ::arg().mustDo("return-incoming-edns-subnet");
+  g_ECSScopeZeroOnNoRecord = ::arg().mustDo("ecs-scope-zero-on-no-record");
   SyncRes::s_outAnyToTcp = ::arg().mustDo("out-any-to-tcp");
   return 0;
 }

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -228,6 +228,8 @@ extern thread_local std::unique_ptr<UDPClientSocks> t_udpclientsocks;
 extern thread_local std::shared_ptr<NetmaskGroup> t_proxyProtocolACL;
 extern thread_local std::shared_ptr<std::set<ComboAddress>> t_proxyProtocolExceptions;
 extern bool g_useIncomingECS;
+extern bool g_returnIncomingECS;
+extern bool g_ECSScopeZeroOnNoRecord;
 extern std::optional<ComboAddress> g_dns64Prefix;
 extern DNSName g_dns64PrefixReverse;
 extern uint64_t g_latencyStatSize;

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -870,6 +870,19 @@ found, the recursor fallbacks to sending 127.0.0.1.
     'versionadded': '4.1.0'
     },
     {
+        'name' : 'scope_zero_on_no_record',
+        'section' : 'ecs',
+        'oldname' : 'ecs-scope-zero-on-no-record',
+        'type' : LType.Bool,
+        'default' : 'true',
+        'help' : 'Force ECS scope to zero in responses (including negative answers)',
+        'doc' : '''
+When enabled, the recursor will force the ECS scope prefix-length to 0 in responses, even if the authoritative response contained a different scope.
+When disabled, the authoritative scope will be preserved when available, including for NODATA/SOA responses.
+Responses carrying a non-zero scope are not inserted into the packet cache.
+ ''',
+    },
+    {
         'name' : 'edns_bufsize',
         'section' : 'outgoing',
         'oldname' : 'edns-outgoing-bufsize',
@@ -3133,6 +3146,17 @@ See :ref:`setting-unique-response-ignore-list`.
         'doc' : '''
 Whether to process and pass along a received EDNS Client Subnet to authoritative servers.
 The ECS information will only be sent for netmasks and domains listed in :ref:`setting-edns-subnet-allow-list` and will be truncated if the received scope exceeds :ref:`setting-ecs-ipv4-bits` for IPv4 or :ref:`setting-ecs-ipv6-bits` for IPv6.
+ ''',
+    },
+    {
+        'name' : 'return_incoming_edns_subnet',
+        'section' : 'incoming',
+        'type' : LType.Bool,
+        'default' : 'true',
+        'help' : 'Return EDNS Client Subnet information in responses to clients',
+        'doc' : '''
+When enabled, responses to clients that sent an EDNS Client Subnet option will include an ECS option in the reply (assuming :ref:`setting-use-incoming-edns-subnet` is also enabled).
+Disabling this prevents ECS from being echoed back to downstream resolvers.
  ''',
     },
     {

--- a/pdns/recursordist/recursor_cache.hh
+++ b/pdns/recursordist/recursor_cache.hh
@@ -104,9 +104,9 @@ public:
     bool d_tcp{false};
   };
 
-  [[nodiscard]] time_t get(time_t, const DNSName& qname, QType qtype, Flags flags, vector<DNSRecord>* res, const ComboAddress& who, const OptTag& routingTag = NOTAG, SigRecs* signatures = nullptr, AuthRecs* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr, Extra* extra = nullptr);
+  [[nodiscard]] time_t get(time_t, const DNSName& qname, QType qtype, Flags flags, vector<DNSRecord>* res, const ComboAddress& who, const OptTag& routingTag = NOTAG, SigRecs* signatures = nullptr, AuthRecs* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr, Extra* extra = nullptr, uint8_t* ecsScope = nullptr);
 
-  void replace(time_t, const DNSName& qname, QType qtype, const vector<DNSRecord>& content, const SigRecsVec& signatures, const AuthRecsVec& authorityRecs, bool auth, const DNSName& authZone, const std::optional<Netmask>& ednsmask = std::nullopt, const OptTag& routingTag = NOTAG, vState state = vState::Indeterminate, const std::optional<Extra>& extra = std::nullopt, bool refresh = false, time_t ttl_time = time(nullptr));
+  void replace(time_t, const DNSName& qname, QType qtype, const vector<DNSRecord>& content, const SigRecsVec& signatures, const AuthRecsVec& authorityRecs, bool auth, const DNSName& authZone, const std::optional<Netmask>& ednsmask = std::nullopt, const OptTag& routingTag = NOTAG, vState state = vState::Indeterminate, const std::optional<Extra>& extra = std::nullopt, bool refresh = false, time_t ttl_time = time(nullptr), uint8_t ecsScope = 0);
 
   void doPrune(time_t now, size_t keep);
   uint64_t doDump(int fileDesc, size_t maxCacheEntries);
@@ -186,6 +186,7 @@ private:
     QType d_qtype; // 2
     mutable vState d_state{vState::Indeterminate}; // 1
     bool d_auth; // 1
+    uint8_t d_ecsScope{0};
     mutable bool d_submitted{false}; // 1, whether this entry has been queued for refetch
     bool d_tooBig{false}; // 1
     bool d_tcp{false}; // 1 was entry received over TCP?
@@ -387,7 +388,7 @@ private:
   static Entries getEntries(MapCombo::LockedContent& map, const DNSName& qname, QType qtype, const OptTag& rtag);
   static cache_t::const_iterator getEntryUsingECSIndex(MapCombo::LockedContent& map, time_t now, const DNSName& qname, QType qtype, bool requireAuth, const ComboAddress& who, bool serveStale);
 
-  static time_t handleHit(time_t now, MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, SigRecs* signatures, AuthRecs* authorityRecs, bool* variable, std::optional<vState>& state, bool* wasAuth, DNSName* authZone, Extra* extra);
+  static time_t handleHit(time_t now, MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, SigRecs* signatures, AuthRecs* authorityRecs, bool* variable, std::optional<vState>& state, bool* wasAuth, DNSName* authZone, Extra* extra, uint8_t* ecsScope);
   static void updateStaleEntry(time_t now, OrderedTagIterator_t& entry);
   static void handleServeStaleBookkeeping(time_t, bool, OrderedTagIterator_t&);
 };

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -26,6 +26,7 @@
 #include "dns.hh"
 #include "qtype.hh"
 #include <vector>
+#include <optional>
 #include <set>
 #include <unordered_set>
 #include <map>
@@ -443,6 +444,11 @@ public:
     return d_wasOutOfBand;
   }
 
+  const std::optional<uint8_t>& getAnswerECSScope() const
+  {
+    return d_answerECSScope;
+  }
+
   struct timeval getNow() const
   {
     return d_now;
@@ -713,6 +719,8 @@ private:
   size_t countSupportedDS(const dsset_t& dsSet, const string& prefix);
 
   void handleNewTarget(const std::string& prefix, const DNSName& qname, const DNSName& newtarget, QType qtype, std::vector<DNSRecord>& ret, int& rcode, unsigned int depth, const std::vector<DNSRecord>& recordsFromAnswer, vState& state);
+  void mergeAnswerECSScope(uint8_t scope);
+  void mergeAnswerECSScope(const std::optional<uint8_t>& scope);
 
   void handlePolicyHit(const std::string& prefix, const DNSName& qname, QType qtype, vector<DNSRecord>& ret, bool& done, int& rcode, unsigned int depth);
   unsigned int getAdjustedRecursionBound() const;
@@ -738,6 +746,7 @@ private:
   ostringstream d_trace;
   shared_ptr<RecursorLua4> d_pdl;
   std::optional<Netmask> d_outgoingECSNetwork;
+  std::optional<uint8_t> d_answerECSScope;
   std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>> d_outgoingProtobufServers;
   std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> d_frameStreamServers;
   boost::optional<const boost::uuids::uuid&> d_initialRequestId;

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -268,6 +268,7 @@ void setLWResult(LWResult* res, int rcode, bool aa, bool tc, bool edns, bool val
   res->d_aabit = aa;
   res->d_tcbit = tc;
   res->d_haveEDNS = edns;
+  res->d_ednsECScope.reset();
   res->d_validpacket = validpacket;
 }
 


### PR DESCRIPTION
**Options**
1. `ecs-scope-zero-on-no-record` (`scope_zero_on_no_record`), default **true**
   - Meaning: when enabled, the recursor forces ECS scope to **0** for NODATA responses (including CNAME‑chain NODATA), regardless of the authoritative scope.
   - When disabled, the authoritative scope is preserved when available.
   - **Note:** when `scope_zero_on_no_record=false` and the authoritative scope is **0**, negative caching remains **global** (negcache is not ECS‑aware), so there is no ECS scoping effect in that case.

2. `return-incoming-edns-subnet` (`return_incoming_edns_subnet`), default **true**
   - Meaning: when enabled (and `use-incoming-edns-subnet` is enabled), the recursor echoes an ECS option back to the client.
   - Purpose: returning ECS in the response conveys the applicable scope, so downstream resolvers and caches can avoid reusing a subnet‑specific answer for unrelated clients. This prevents incorrect upstream/downstream cache reuse.

**Record Cache (ECS scope preservation)**
1. **Record cache entries now store ECS scope**
   - Added `d_ecsScope` to `MemRecursorCache::CacheEntry`.
   - `replace()` writes scope into the cache entry (only when the entry is ECS‑specific).
   - `get()` and `handleHit()` return the stored scope via an output parameter.

2. **Cache hits now propagate ECS scope back to the response path**
   - `SyncRes::doCacheCheck()` and `SyncRes::doCNAMECacheCheck()` read ECS scope from record cache hits and set `d_answerECSScope`, so cached answers return the correct scope.

3. **Cache dump/load includes ECS scope**
   - `PBCacheEntry` now carries `optional_uint32_ecsScope` so ECS scope survives `getRecordSets()` / `putRecordSets()`.

**Negative Cache (NODATA + ECS)**
1. **Avoid global negcache pollution for ECS‑specific NODATA**
   - In `SyncRes::processRecords()`, when `scope_zero_on_no_record=false` and the authoritative NODATA response contains a **non‑zero** ECS scope, we skip inserting the NODATA entry into `negcache`.
   - This avoids a global negative cache entry that would incorrectly apply to all scopes.

**Response ECS Scope when `scope_zero_on_no_record=true`**
1. **Scope forced to 0 only for true NODATA**
   - In `pdns_recursor.cc`, ECS scope is forced to 0 only when the final response is NODATA (NoError with no relevant RRSet for the requested QTYPE), including CNAME‑chain NODATA.
   - Other responses keep the authoritative scope.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Preserves authoritative ECS scope across record cache hits, returns ECS to downstream clients, and avoids global caching of ECS‑specific NODATA responses.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
