### PR TITLE
Stricter timestamp checks

### DIFF
--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -124,6 +124,13 @@ void RecordTextReader::xfrTime(uint32_t &val)
     throw RecordTextException("unable to parse '"+std::to_string(itmp)+"' into a valid time at position "+std::to_string(d_pos)+" in '"+d_string+"'");
   }
 
+  // Note tm_mon is still in 1..12 range at this point
+  if (tm.tm_sec < 0 || tm.tm_sec > 60 || tm.tm_min < 0 || tm.tm_min > 59 ||
+      tm.tm_hour < 0 || tm.tm_hour > 23 || tm.tm_mday < 0 || tm.tm_mday > 31 ||
+      tm.tm_mon < 1 || tm.tm_mon > 12) {
+    throw RecordTextException("invalid time specification '"+std::to_string(itmp)+"' at position "+std::to_string(d_pos)+" in '"+d_string+"'");
+  }
+
   tm.tm_year-=1900;
   tm.tm_mon-=1;
   // coverity[store_truncates_time_t]

--- a/pdns/unix_utility.cc
+++ b/pdns/unix_utility.cc
@@ -239,9 +239,10 @@ time_t Utility::timegm(struct tm *const t)
   time_t  i;
   time_t years = t->tm_year - 70;
 
+  // We allow for some benign out-of-range values
   if (t->tm_sec>60) { t->tm_min += t->tm_sec/60; t->tm_sec%=60; }
   if (t->tm_min>60) { t->tm_hour += t->tm_min/60; t->tm_min%=60; }
-  if (t->tm_hour>60) { t->tm_mday += t->tm_hour/60; t->tm_hour%=60; }
+  if (t->tm_hour>24) { t->tm_mday += t->tm_hour/24; t->tm_hour%=24; }
   if (t->tm_mon>11) { t->tm_year += t->tm_mon/12; t->tm_mon%=12; }
 
   while (t->tm_mday>spm[1+t->tm_mon]) {


### PR DESCRIPTION
### Short description
This adds stricter timestamp checks when reading them from the wire, and also fixes an embarrassing math bug.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
