### PR TITLE
Remove unused `DNSRecordOracle` class

### DIFF
--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -50,18 +50,6 @@ enum class dState : uint8_t { NODENIAL, INCONCLUSIVE, NXDOMAIN, NXQTYPE, ENT, IN
 std::ostream& operator<<(std::ostream &, vState);
 std::ostream& operator<<(std::ostream &, dState);
 
-class DNSRecordOracle
-{
-public:
-  virtual ~DNSRecordOracle() = default;
-  DNSRecordOracle(const DNSRecordOracle&) = default;
-  DNSRecordOracle(DNSRecordOracle&&) = default;
-  DNSRecordOracle& operator=(const DNSRecordOracle&) = default;
-  DNSRecordOracle& operator=(DNSRecordOracle&&) = default;
-  virtual std::vector<DNSRecord> get(const DNSName& qname, uint16_t qtype) = 0;
-};
-
-
 struct ContentSigPair
 {
   sortedRecords_t records;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
