### PR TITLE
dnsdist: Add missing `noexcept` on move ctors/assignment operators

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -978,22 +978,13 @@ struct DoHClientCollection::DoHWorkerThread
   {
   }
 
-  DoHWorkerThread(pdns::channel::Sender<CrossProtocolQuery>&& sender) :
+  DoHWorkerThread(pdns::channel::Sender<CrossProtocolQuery>&& sender) noexcept :
     d_sender(std::move(sender))
   {
   }
 
-  DoHWorkerThread(DoHWorkerThread&& rhs) :
-    d_sender(std::move(rhs.d_sender))
-  {
-  }
-
-  DoHWorkerThread& operator=(DoHWorkerThread&& rhs)
-  {
-    d_sender = std::move(rhs.d_sender);
-    return *this;
-  }
-
+  DoHWorkerThread(DoHWorkerThread&& rhs) noexcept = default;
+  DoHWorkerThread& operator=(DoHWorkerThread&& rhs) noexcept = default;
   DoHWorkerThread(const DoHWorkerThread& rhs) = delete;
   DoHWorkerThread& operator=(const DoHWorkerThread&) = delete;
 

--- a/pdns/dnsdistdist/dnsdist-tcp.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp.hh
@@ -38,7 +38,7 @@ struct ConnectionInfo
     remote(remote_), cs(cs_), fd(-1)
   {
   }
-  ConnectionInfo(ConnectionInfo&& rhs) :
+  ConnectionInfo(ConnectionInfo&& rhs) noexcept :
     remote(rhs.remote), cs(rhs.cs), fd(rhs.fd), d_restricted(rhs.d_restricted)
   {
     rhs.cs = nullptr;
@@ -48,7 +48,7 @@ struct ConnectionInfo
   ConnectionInfo(const ConnectionInfo& rhs) = delete;
   ConnectionInfo& operator=(const ConnectionInfo& rhs) = delete;
 
-  ConnectionInfo& operator=(ConnectionInfo&& rhs)
+  ConnectionInfo& operator=(ConnectionInfo&& rhs) noexcept
   {
     remote = rhs.remote;
     cs = rhs.cs;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
