### PR TITLE
auth: stricter handing of the Lua DNS update policy

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -83,24 +83,6 @@ PacketHandler::PacketHandler():B(g_programname), d_dk(&B)
     d_pdl = std::make_unique<AuthLua4>(::arg()["lua-global-include-dir"]);
     d_pdl->loadFile(fname);
   }
-  fname = ::arg()["lua-dnsupdate-policy-script"];
-  if (fname.empty())
-  {
-    d_update_policy_is_lua = false;
-    d_update_policy_lua = nullptr;
-  }
-  else
-  {
-    d_update_policy_is_lua = true;
-    try {
-      d_update_policy_lua = std::make_unique<AuthLua4>();
-      d_update_policy_lua->loadFile(fname);
-    }
-    catch (const std::runtime_error& e) {
-      g_log<<Logger::Warning<<"Failed to load update policy - disabling: "<<e.what()<<endl;
-      d_update_policy_lua = nullptr;
-    }
-  }
 }
 
 UeberBackend *PacketHandler::getBackend()

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -86,10 +86,12 @@ PacketHandler::PacketHandler():B(g_programname), d_dk(&B)
   fname = ::arg()["lua-dnsupdate-policy-script"];
   if (fname.empty())
   {
+    d_update_policy_is_lua = false;
     d_update_policy_lua = nullptr;
   }
   else
   {
+    d_update_policy_is_lua = true;
     try {
       d_update_policy_lua = std::make_unique<AuthLua4>();
       d_update_policy_lua->loadFile(fname);

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -138,6 +138,7 @@ private:
   bool d_doExpandALIAS;
   bool d_doResolveAcrossZones;
   bool d_dnssec{false};
+  bool d_update_policy_is_lua{false};
   SOAData d_sd;
   std::unique_ptr<AuthLua4> d_pdl;
   std::unique_ptr<AuthLua4> d_update_policy_lua;

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -138,10 +138,8 @@ private:
   bool d_doExpandALIAS;
   bool d_doResolveAcrossZones;
   bool d_dnssec{false};
-  bool d_update_policy_is_lua{false};
   SOAData d_sd;
   std::unique_ptr<AuthLua4> d_pdl;
-  std::unique_ptr<AuthLua4> d_update_policy_lua;
   std::unique_ptr<AuthLua4> s_LUA;
   UeberBackend B; // every thread an own instance
   DNSSECKeeper d_dk; // B is shared with DNSSECKeeper

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -985,7 +985,13 @@ int PacketHandler::processUpdate(DNSPacket& packet)
   g_log << Logger::Info << ctx.msgPrefix << "Processing started." << endl;
 
   // if there is policy, we delegate all checks to it
-  if (this->d_update_policy_lua == nullptr) {
+  if (d_update_policy_is_lua) {
+    if (d_update_policy_lua == nullptr) {
+      // The policy failed to load earlier.
+      return RCode::Refused;
+    }
+  }
+  else {
     if (!isUpdateAllowed(B, ctx, packet)) {
       return RCode::Refused;
     }


### PR DESCRIPTION
### Short description
If the Lua DNS update policy script can not be loaded, we log a message saying that DNS updates will be refused, but what actually happens is that the code falls back to the "there is no Lua policy script" mode, and will accept the non-Lua settings to decide whether to allow the update or not, despite the documentation (and the log message!) pretending this won't be the case.

So:
- really disable DNS Updates if a Lua policy is configured but fails to load
- actually only load the policy when processing Update queries, rather than for every DNS query.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
