### PR TITLE
dnsdist-1.9.x: Backport 16536 - Raise the maximum number of descriptors to 1M

### DIFF
--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -20,7 +20,7 @@ StartLimitInterval=0
 
 # Tuning
 TasksMax=8192
-LimitNOFILE=16384
+LimitNOFILE=1000000
 # Note: increasing the amount of lockable memory is required to use eBPF support
 # LimitMEMLOCK=infinity
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16536 to rel/dnsdist-1.9.x

When running under systemd there is a cap on the number of open file or socket descriptors that we can have at a given time. We used to set this to 16k which was a large enough value for most installations, but now that people are deploying DNSdist to offer DoT/DoH/DoQ/DoH3 to large numbers of users we are regularly getting complaints that the default value is too low. On the other hand I'm not aware of any case where having a cap actually prevented an issue where we would be opening too many descriptors. Therefore this commit is raising the default value to 1 millions, a large enough values for even very large setups dealing with > 100k incoming connections at a time.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
