### PR TITLE
auth: get rid of a "may be uninitialized" warning.

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2734,7 +2734,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
         cacheNeeded = (operations & ((1U << PRUNE) | (1U << EXTEND))) != 0;
       }
 
-      applyResult result;
+      applyResult result{ABORT};
       std::vector<DNSResourceRecord> rrset;
       switch (operationType) {
       case DELETE:


### PR DESCRIPTION
### Short description
I just noticed, when building auth with `-Og`, that gcc warned about a local variable which may not be initialized. This is not the case due to the surrounding logic, but it doesn't hurt to use a safe value as initializer.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
