### PR TITLE
auth: fix stupid logic error in lmdb-write-update-notification=no

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2284,8 +2284,8 @@ void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::
     }
 
     for (auto& [k, v] : zonemap) {
+      consolidateDomainInfo(v);
       if (allow(v)) {
-        consolidateDomainInfo(v);
         domains->push_back(std::move(v));
       }
     }
@@ -2296,8 +2296,8 @@ void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::
       di.id = iter.getID();
       di.backend = this;
 
+      consolidateDomainInfo(di);
       if (allow(di)) {
-        consolidateDomainInfo(di);
         domains->push_back(di);
       }
     }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -3530,7 +3530,7 @@ public:
     declare(suffix, "map-size", "main LMDB map size in megabytes", (sizeof(void*) == 4) ? "100" : "16000");
     declare(suffix, "shards-map-size", "shard LMDB map size in megabytes, zero to use the same size as main", "0");
     declare(suffix, "flag-deleted", "Flag entries on deletion instead of deleting them", "no");
-    declare(suffix, "write-notification-update", "Do not update domain table upon notification", "yes");
+    declare(suffix, "write-notification-update", "Update domain table upon notification", "yes");
     declare(suffix, "lightning-stream", "Run in Lightning Stream compatible mode", "no");
   }
   DNSBackend* make(const string& suffix = "") override


### PR DESCRIPTION
### Short description
The `getAllDomainsFiltered` routine needs to make sure it is passing up-to-date `DomainInfo` data to the filter routine, otherwise it may make a bad decision due to data not being consistent.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] pulled a lot of hair trying to track this bug down
- [X] shat brick once I saw it