### PR TITLE
auth 5.0: backport "Correctly compute public key exponent length when larger than 255."

### DIFF
--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -941,7 +941,7 @@ void OpenSSLRSADNSCryptoKeyEngine::fromPublicKeyString(const std::string& conten
     if (contentLen < 3) {
       throw runtime_error(getName() + " invalid input size for the public key");
     }
-    const size_t exponentSize = raw[1] * 0xff + raw[2];
+    const size_t exponentSize = (static_cast<size_t>(raw[1])) * 0x100 + raw[2];
     if (contentLen < (exponentSize + 4)) {
       throw runtime_error(getName() + " invalid input size for the public key");
     }


### PR DESCRIPTION
### Short description
Backport of #16810.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
