### PR TITLE
dnsdist: Subnets excluded from dynamic rules should not count towards thresholds

### DIFF
--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -692,10 +692,16 @@ dynamic_rules:
       type: "u8"
       default: "32"
       description: "Number of bits to keep for IPv4 addresses"
+      changes:
+        - version: "2.1.0"
+          content: "Queries and corresponding responses coming from an excluded (``excluded_ranges``) client no longer count towards the thresholds for the aggregated subnet the client belongs to"
     - name: "mask_ipv6"
       type: "u8"
       default: "64"
       description: "Number of bits to keep for IPv6 addresses. In some scenarios it might make sense to block a whole /64 IPv6 range instead of a single address, for example"
+      changes:
+        - version: "2.1.0"
+          content: "Queries and corresponding responses coming from an excluded (``excluded_ranges``) client no longer count towards the thresholds for the aggregated subnet the client belongs to"
     - name: "mask_port"
       type: u8
       default: "0"

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1883,6 +1883,9 @@ faster than the existing rules.
 
     .. versionadded:: 1.7.0
 
+    .. versionchanged:: 2.1.0
+      Queries and corresponding responses coming from an excluded (see :meth:`DynBlockRulesGroup::excludeRange`) client no longer count towards the thresholds for the aggregated subnet the client belongs to.
+
     Set the number of bits to keep in the IP address when inserting a block. The default is 32 for IPv4 and 128 for IPv6, meaning
     that only the exact address is blocked, but in some scenarios it might make sense to block a whole /64 IPv6 range instead of a
     single address, for example.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Until now we only looked at whether a subnet was excluded from dynamic rules when deciding to insert a block. This introduced an issue when the dynamic rules were configured to group clients into subnets via the `setMasks` directive, because then queries received from an excluded client were still counted towards the thresholds for the final subnet. For example, when grouping IPv4 clients into `/24` subnets and excluding `192.0.2.1`, we would end up blocking the whole `192.0.2.0/24` subnet if the number of queries or responses received from `192.0.2.1` were over the threshold.
From now on excluded subnets will no longer count toward the thresholds.

Closes https://github.com/PowerDNS/pdns/issues/14583

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
