### PR TITLE
auth: include serial (that is, SOA record) while sending a notify

### DIFF
--- a/pdns/auth-primarycommunicator.cc
+++ b/pdns/auth-primarycommunicator.cc
@@ -303,10 +303,9 @@ void CommunicatorClass::sendNotification(int sock, const ZoneName& domain, const
 
 
   if (SOAData soaData; ueber->getSOAUncached(domain, soaData)) {
-    DNSSECKeeper dnssecKeeper;
+    DNSSECKeeper dnssecKeeper(ueber);
     auto editedSOA = makeEditedDNSZRFromSOAData(dnssecKeeper, soaData, DNSResourceRecord::ANSWER);
     auto soaContent = editedSOA.dr.getContent();
-    cerr << soaData.serial << ' ' << soaContent->getZoneRepresentation() << endl;
     pwriter.startRecord(domain.operator const DNSName&(), QType::SOA, soaData.ttl, QClass::IN, DNSResourceRecord::ANSWER);
     soaContent->toPacket(pwriter);
     pwriter.commit();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This fixes #16129. I'm setting it to Draft status as I:

1. I'm not at home in the auth code
2. A test is missing. I went looking to extend an existing test, but failed to find an existing test testing notify. This might be related to point 1.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
