### PR TITLE
dnsdist: Fix invalid `substr()` use in the DNS overlay parser

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -248,7 +248,7 @@ namespace RecordParsers
     }
 
     // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage): length is passed in and used to read data
-    return makeComboAddressFromRaw(4, packet.substr(record.d_contentOffset, record.d_contentOffset + 4).data(), record.d_contentLength);
+    return makeComboAddressFromRaw(4, packet.substr(record.d_contentOffset, record.d_contentLength).data(), record.d_contentLength);
   }
 
   std::optional<ComboAddress> parseAAAARecord(const std::string_view& packet, const DNSPacketOverlay::Record& record)
@@ -258,19 +258,19 @@ namespace RecordParsers
     }
 
     // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage): length is passed in and used to read data
-    return makeComboAddressFromRaw(6, packet.substr(record.d_contentOffset, record.d_contentOffset + 16).data(), record.d_contentLength);
+    return makeComboAddressFromRaw(6, packet.substr(record.d_contentOffset, record.d_contentLength).data(), record.d_contentLength);
   }
 
   std::optional<ComboAddress> parseAddressRecord(const std::string_view& packet, const DNSPacketOverlay::Record& record)
   {
     if (record.d_type == QType::A && record.d_contentLength == 4) {
       // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage): length is passed in and used to read data
-      return makeComboAddressFromRaw(4, packet.substr(record.d_contentOffset, record.d_contentOffset + 4).data(), record.d_contentLength);
+      return makeComboAddressFromRaw(4, packet.substr(record.d_contentOffset, record.d_contentLength).data(), record.d_contentLength);
     }
 
     if (record.d_type == QType::AAAA && record.d_contentLength == 16) {
       // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage): length is passed in and used to read data
-      return makeComboAddressFromRaw(6, packet.substr(record.d_contentOffset, record.d_contentOffset + 16).data(), record.d_contentLength);
+      return makeComboAddressFromRaw(6, packet.substr(record.d_contentOffset, record.d_contentLength).data(), record.d_contentLength);
     }
 
     return {};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`std::basic_string_view<CharT,Traits>::substr`'s second parameter is a length, not an iterator or a position, so the existing code was misusing it and creating a view that potentially expanded outside of the packet. However currently the view is never used to read more than `record.d_contentLength` (we are passing it immediately to `makeComboAddressFromRaw` with `record.d_contentLength` as the length) and `record.d_contentLength` has been validated right before to be either `4` or `16`, so there is no out-of-bounds read.
This issue has been introduced in b6f9a21db93ee25ec665dc5f65e87eb7adebd102 and is not included in any stable release, so no need to backport the fix.

Reported by Nyaz360 in YWH-PGM6095-85, thanks a lot!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
