### PR TITLE
dnsdist: Don't start the NetworkListener thread in config check mode

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings-network.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-network.cc
@@ -26,7 +26,7 @@
 #include "dnsdist-lua-network.hh"
 #include "dolog.hh"
 
-void setupLuaBindingsNetwork(LuaContext& luaCtx, bool client)
+void setupLuaBindingsNetwork(LuaContext& luaCtx, bool client, bool configCheck)
 {
   luaCtx.writeFunction("newNetworkEndpoint", [client](const std::string& path) {
     if (client) {
@@ -93,8 +93,8 @@ void setupLuaBindingsNetwork(LuaContext& luaCtx, bool client)
     });
   });
 
-  luaCtx.registerFunction<void (std::shared_ptr<dnsdist::NetworkListener>::*)()>("start", [client](std::shared_ptr<dnsdist::NetworkListener>& listener) {
-    if (client) {
+  luaCtx.registerFunction<void (std::shared_ptr<dnsdist::NetworkListener>::*)()>("start", [client, configCheck](std::shared_ptr<dnsdist::NetworkListener>& listener) {
+    if (client || configCheck) {
       return;
     }
 

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3298,7 +3298,7 @@ void setupLuaBindingsOnly(LuaContext& luaCtx, bool client, bool configCheck)
   setupLuaBindingsDNSQuestion(luaCtx);
   setupLuaBindingsKVS(luaCtx, client);
   setupLuaBindingsLogging(luaCtx);
-  setupLuaBindingsNetwork(luaCtx, client);
+  setupLuaBindingsNetwork(luaCtx, client, configCheck);
   setupLuaBindingsPacketCache(luaCtx, client);
   setupLuaBindingsProtoBuf(luaCtx, client, configCheck);
   setupLuaBindingsRings(luaCtx, client);

--- a/pdns/dnsdistdist/dnsdist-lua.hh
+++ b/pdns/dnsdistdist/dnsdist-lua.hh
@@ -52,7 +52,7 @@ void setupLuaBindingsDNSParser(LuaContext& luaCtx);
 void setupLuaBindingsDNSQuestion(LuaContext& luaCtx);
 void setupLuaBindingsKVS(LuaContext& luaCtx, bool client);
 void setupLuaBindingsLogging(LuaContext& luaCtx);
-void setupLuaBindingsNetwork(LuaContext& luaCtx, bool client);
+void setupLuaBindingsNetwork(LuaContext& luaCtx, bool client, bool configCheck);
 void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client);
 void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck);
 void setupLuaBindingsRings(LuaContext& luaCtx, bool client);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Not only is this useless, there is a risk of race if the thread is not created quickly enough, so when the main thread reaches the end of the configuration and exits the new thread tries to access an object that has been freed.
This happens a lot on slow runners with few CPU cores available.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
