### PR TITLE
auth: loosen check in NotificationQueue::removeIf

### DIFF
--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -78,7 +78,7 @@ class NotificationQueue
 public:
   void add(const ZoneName& domain, const string& ipstring, time_t delay = 0)
   {
-    const ComboAddress ipaddress(ipstring);
+    const ComboAddress ipaddress(ipstring); // may not contain a port number
     add(domain, ipaddress, delay);
   }
 
@@ -98,7 +98,7 @@ public:
   {
     for (auto i = d_nqueue.begin(); i != d_nqueue.end(); ++i) {
       ComboAddress stQueued{i->ip};
-      if (i->id == id && stQueued == remote && i->domain == domain) {
+      if (i->id == id && ComboAddress::addressOnlyEqual()(stQueued, remote) && i->domain == domain) {
         d_nqueue.erase(i);
         return true;
       }


### PR DESCRIPTION
### Short description
Prior to commit 792548c400dfc4db8f48781dabb783f3eccf89a3, the check in `removeIf` was only matching on hostnames (and other data); with that commit, the check became a `ComboAddress` equality test, which also requires port values to match.

This PR loosens the check by ~~allowing a `ComboAddress` with port not set (i.e. with a value of zero) to match against any other `ComboAddress` with the same hostname, regardless of its port~~ restoring the previous behaviour of ignoring port numbers.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)