### PR TITLE
auth: trivial microoptimization

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -683,7 +683,7 @@ bool DNSSECKeeper::getTSIGForAccess(const ZoneName& zone, const ComboAddress& /*
 {
   vector<string> keynames;
   d_keymetadb->getDomainMetadata(zone, "AXFR-MASTER-TSIG", keynames);
-  keyname->trimToLabels(0);
+  keyname->clear();
 
   // XXX FIXME this should check for a specific primary!
   for(const string& dbkey :  keynames) {

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -195,7 +195,7 @@ static bool rrsigncomp(const DNSZoneRecord& a, const DNSZoneRecord& b)
 
 static bool getBestAuthFromSet(const set<ZoneName>& authSet, const DNSName& name, ZoneName& signer)
 {
-  signer.trimToLabels(0);
+  signer.clear();
   ZoneName sname(name);
   do {
     for (const auto& auth : authSet) {


### PR DESCRIPTION
### Short description
When clearing a `DNSName` object, use `clear` instead of `trimToLabels(0)`, which achieves the same result, but more slowly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
