### PR TITLE
meson: Add missing checks for `TLS_client_method`, `gnutls_transport_set_fastopen`

### DIFF
--- a/meson/gnutls/meson.build
+++ b/meson/gnutls/meson.build
@@ -7,6 +7,7 @@ if dep_gnutls.found()
     'gnutls_session_set_verify_cert',
     'gnutls_session_get_verify_cert_status',
     'gnutls_alpn_set_protocols',
+    'gnutls_transport_set_fastopen',
   ]
 
   foreach func: funcs

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -25,6 +25,7 @@ if dep_libssl.found()
     'SSL_get0_next_proto_negotiated',
     'SSL_CTX_set_alpn_select_cb',
     'SSL_CTX_use_cert_and_key',
+    'TLS_client_method',
   ]
 
   foreach func: funcs

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -1051,6 +1051,7 @@ private:
 
 #ifdef HAVE_GNUTLS
 #include <gnutls/gnutls.h>
+#include <gnutls/socket.h>
 #include <gnutls/x509.h>
 
 static void safe_memory_lock([[maybe_unused]] void* data, [[maybe_unused]] size_t size)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
