### PR TITLE
dnsdist: Fix two documentation nits

### DIFF
--- a/pdns/dnsdistdist/dnsdist-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-actions-definitions.yml
@@ -420,9 +420,7 @@ are processed after this action"
     - name: remote_loggers
       type: "Vec<String>"
       default: ""
-      description: |
-        The names of all the loggers that should be sent the protobuf messages that includes the tracing information.
-        This message will be sent once dnsdist is finished with the DNS transaction (i.e. the response has been sent, the query was dropped, or when a timeout occured).
+      description: "The names of all the loggers that should be sent the protobuf messages that includes the tracing information. This message will be sent once dnsdist is finished with the DNS transaction (i.e. the response has been sent, the query was dropped, or when a timeout occured)."
     - name: "use_incoming_traceid"
       type: "bool"
       default: "false"

--- a/pdns/dnsdistdist/docs/reference/dnsname.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsname.rst
@@ -86,7 +86,8 @@ Functions and methods of a ``DNSName``
 
     Append ``labels`` to the DNSName. ``labels`` can be a string or DNSName containing one or more labels.
 
-    .. codeblock:: lua
+    .. code-block:: lua
+
       local n = newDNSName("example.com")
       n:append("example") -- n is now "example.com.example"
       local other_name = newDNSName("foobar.invalid")


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
