### PR TITLE
dnsdist-1.9.x: Backport 15899 - Fix flaky Proxy Protocol regression test

### DIFF
--- a/regression-tests.dnsdist/test_ProxyProtocol.py
+++ b/regression-tests.dnsdist/test_ProxyProtocol.py
@@ -375,6 +375,7 @@ class TestProxyProtocol(ProxyProtocolTest):
 
       new_conn_before = self.getServerStats()[0]['tcpNewConnections']
       reused_conn_before = self.getServerStats()[0]['tcpReusedConnections']
+      max_conn_before = self.getServerStats()[0]['tcpMaxConcurrentConnections']
 
       conn = self.openTCPConnection(2.0)
       data = query.to_wire()
@@ -406,7 +407,10 @@ class TestProxyProtocol(ProxyProtocolTest):
       server = self.getServerStats()[0]
       self.assertEqual(server['tcpNewConnections'], new_conn_before + 1)
       self.assertEqual(server['tcpReusedConnections'], reused_conn_before + 9)
-      self.assertEqual(server['tcpMaxConcurrentConnections'], 1)
+      # we can only check that we did not open more than one new connection
+      # compared to the connections that existed before, because connections
+      # triggered by a different test can still be around
+      self.assertLessEqual(server['tcpMaxConcurrentConnections'], max_conn_before + 1)
 
     def testProxyTCPSeveralQueriesWithRandomTLVOnSameConnection(self):
       """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16899 to rel/dnsdist-1.9.x

We can only check that we did not open more than one new connection compared to the connections that existed before, because connections triggered by a different test can still be around. This seems to be happening on a regular basis on slow runners with few CPU cores.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
