### PR TITLE
More metaprogramming sugar

### DIFF
--- a/pdns/logging.hh
+++ b/pdns/logging.hh
@@ -154,7 +154,24 @@ struct IterLoggable : public Logr::Loggable
       else {
         first = false;
       }
-      oss << *i;
+      if constexpr (std::is_same_v<typename T::value_type, std::string>) {
+        oss << *i;
+      }
+      else if constexpr (is_toStructuredLogString_available<typename T::value_type>::value) {
+        oss << i->toStructuredLogString();
+      }
+      else if constexpr (is_toLogString_available<typename T::value_type>::value) {
+        oss << i->toLogString();
+      }
+      else if constexpr (is_toString_available<typename T::value_type>::value) {
+        oss << i->toString();
+      }
+      else if constexpr (is_to_string_available<typename T::value_type>::value) {
+        oss << std::to_string(*i);
+      }
+      else {
+        oss << *i;
+      }
     }
     return oss.str();
   }


### PR DESCRIPTION
### Short description
This innocent-looking PR gives `Logging::IterLoggable` the ability to work on the same types as `Logging::Loggable`, instead of only those which can be fed a `strstream`.

I need this for the Auth structured logging work, this allows `Logging::IterLoggable` to be used with a `std::vector<ComboAddress>`.

(I was considering using "my C++ metaprogramming is more hurtful than yours" as the PR title but that would risk ending up in the documentation changelogs 🤣 )

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
