### PR TITLE
plumbing: pass a Logr::logr_t down AXFRRetriever and TSIGTCPVerifier. NFC yet.

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -245,6 +245,7 @@ pdns_server_SOURCES = \
 	lock.hh \
 	logger.cc logger.hh \
 	logging.hh \
+	logr.hh \
 	lua-auth4.cc lua-auth4.hh \
 	lua-base4.cc lua-base4.hh \
 	misc.cc misc.hh \
@@ -741,7 +742,8 @@ ixfrdist_SOURCES = \
 	ixfrdist-web.hh ixfrdist-web.cc \
 	ixfrdist.cc \
 	ixfrutils.cc ixfrutils.hh \
-	logger.cc logger.hh\
+	logger.cc logger.hh \
+	logr.hh \
 	misc.cc misc.hh \
 	mplexer.hh \
 	nsecrecords.cc \
@@ -811,6 +813,7 @@ ixplore_SOURCES = \
 	ixfrutils.cc ixfrutils.hh \
 	ixplore.cc \
 	logger.cc \
+	logr.hh \
 	misc.cc misc.hh \
 	nsecrecords.cc \
 	qtype.cc \
@@ -919,6 +922,7 @@ tsig_tests_SOURCES = \
 	gss_context.cc gss_context.hh \
 	iputils.cc \
 	logger.cc \
+	logr.hh \
 	misc.cc misc.hh \
 	nsecrecords.cc \
 	qtype.cc \
@@ -1379,6 +1383,7 @@ testrunner_SOURCES = \
 	iputils.cc \
 	ixfr.cc ixfr.hh \
 	logger.cc \
+	logr.hh \
 	lua-auth4.hh lua-auth4.cc \
 	lua-base4.hh lua-base4.cc \
 	misc.cc \

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -593,7 +593,7 @@ static vector<DNSResourceRecord> doAxfr(const TSIGTriplet& tt, const ComboAddres
 {
   uint16_t axfr_timeout = ::arg().asNum("axfr-fetch-timeout");
   vector<DNSResourceRecord> rrs;
-  AXFRRetriever retriever(ctx.remote, ctx.domain.zone, tt, (laddr.sin4.sin_family == 0) ? nullptr : &laddr, ((size_t)::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024, axfr_timeout);
+  AXFRRetriever retriever(nullptr /* TEMPORARY PLUMBING */, ctx.remote, ctx.domain.zone, tt, (laddr.sin4.sin_family == 0) ? nullptr : &laddr, ((size_t)::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024, axfr_timeout);
   Resolver::res_t recs;
   bool first = true;
   bool firstNSEC3{true};

--- a/pdns/axfr-retriever.cc
+++ b/pdns/axfr-retriever.cc
@@ -29,13 +29,14 @@
 
 using pdns::resolver::parseResult;
 
-AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
+AXFRRetriever::AXFRRetriever(Logr::log_t slog,
+                             const ComboAddress& remote,
                              const ZoneName& domain,
                              const TSIGTriplet& tsigConf,
                              const ComboAddress* laddr,
                              size_t maxReceivedBytes,
                              uint16_t timeout) :
-  d_buf(65536), d_tsigVerifier(tsigConf, remote, d_trc), d_maxReceivedBytes(maxReceivedBytes)
+  d_tsigVerifier(slog, tsigConf, remote, d_trc), d_buf(65536), d_maxReceivedBytes(maxReceivedBytes)
 {
   ComboAddress local;
   if (laddr != nullptr) {

--- a/pdns/axfr-retriever.hh
+++ b/pdns/axfr-retriever.hh
@@ -24,12 +24,14 @@
 
 #include "iputils.hh"
 #include "dnsname.hh"
+#include "logr.hh"
 #include "resolver.hh"
 
 class AXFRRetriever : public boost::noncopyable
 {
   public:
-    AXFRRetriever(const ComboAddress& remote,
+    AXFRRetriever(Logr::log_t slog,
+                  const ComboAddress& remote,
                   const ZoneName& zone,
                   const TSIGTriplet& tt = TSIGTriplet(),
                   const ComboAddress* laddr = NULL,
@@ -43,13 +45,13 @@ class AXFRRetriever : public boost::noncopyable
     int getLength(uint16_t timeout);
     void timeoutReadn(uint16_t bytes, uint16_t timeoutsec=10);
 
+    TSIGTCPVerifier d_tsigVerifier;
     std::vector<char> d_buf;
     string d_domain;
     int d_sock;
     int d_soacount;
     ComboAddress d_remote;
     TSIGRecordContent d_trc;
-    TSIGTCPVerifier d_tsigVerifier;
 
     size_t d_receivedBytes{0};
     size_t d_maxReceivedBytes;

--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -142,7 +142,7 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord>>> getIXFRDeltas(const ComboAddr
 
   pw.commit();
   TSIGRecordContent trc;
-  TSIGTCPVerifier tsigVerifier(tt, primary, trc);
+  TSIGTCPVerifier tsigVerifier(nullptr /* TEMPORARY PLUMBING */, tt, primary, trc);
   if(!tt.algo.empty()) {
     TSIGHashEnum the;
     getTSIGHashEnum(tt.algo, the);

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -517,7 +517,7 @@ static void updateThread(const string& workdir, const uint16_t& keep, const uint
       uint32_t soaTTL = 0;
       records_t records;
       try {
-        AXFRRetriever axfr(primary, domain, tt, &local);
+        AXFRRetriever axfr(nullptr /* no structured logging */, primary, domain, tt, &local);
         uint32_t nrecords=0;
         Resolver::res_t nop;
         vector<DNSRecord> chunk;

--- a/pdns/ixplore.cc
+++ b/pdns/ixplore.cc
@@ -145,7 +145,7 @@ int main(int argc, char** argv) {
       cout<<"Could not load zone from disk: "<<e.what()<<endl;
       cout << "Retrieving latest from primary " << primary.toStringWithPort() << endl;
       ComboAddress local = primary.sin4.sin_family == AF_INET ? ComboAddress("0.0.0.0") : ComboAddress("::");
-      AXFRRetriever axfr(primary, zone, tt, &local);
+      AXFRRetriever axfr(nullptr /* no structured logging */, primary, zone, tt, &local);
       unsigned int nrecords=0;
       Resolver::res_t nop;
       vector<DNSRecord> chunk;

--- a/pdns/recursordist/rec-xfr.cc
+++ b/pdns/recursordist/rec-xfr.cc
@@ -183,7 +183,7 @@ static shared_ptr<const SOARecordContent> loadZoneFromServer(Logr::log_t plogger
     local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0);
   }
 
-  AXFRRetriever axfr(primary, zoneName, tsigTriplet, &local, maxReceivedBytes, axfrTimeout);
+  AXFRRetriever axfr(logger, primary, zoneName, tsigTriplet, &local, maxReceivedBytes, axfrTimeout);
   unsigned int nrecords = 0;
   Resolver::res_t nop;
   vector<DNSRecord> chunk;

--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -146,7 +146,7 @@ pdns::ZoneMD::Result ZoneData::getByAXFR(const RecZoneToCache::Config& config, p
     local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0);
   }
 
-  AXFRRetriever axfr(primary, d_zone, tsigTriplet, &local, maxReceivedBytes, axfrTimeout);
+  AXFRRetriever axfr(d_log, primary, d_zone, tsigTriplet, &local, maxReceivedBytes, axfrTimeout);
   Resolver::res_t nop;
   vector<DNSRecord> chunk;
   time_t axfrStart = time(nullptr);

--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -252,7 +252,7 @@ static shared_ptr<const SOARecordContent> loadRPZFromServer(Logr::log_t plogger,
     local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0);
   }
 
-  AXFRRetriever axfr(primary, zoneName, tsigTriplet, &local, maxReceivedBytes, axfrTimeout);
+  AXFRRetriever axfr(logger, primary, zoneName, tsigTriplet, &local, maxReceivedBytes, axfrTimeout);
   unsigned int nrecords = 0;
   Resolver::res_t nop;
   vector<DNSRecord> chunk;

--- a/pdns/tsig-tests.cc
+++ b/pdns/tsig-tests.cc
@@ -64,7 +64,7 @@ try
   tt.name=keyname;
   tt.algo=g_hmacmd5dnsname;
   tt.secret=key;
-  AXFRRetriever axfr(dest, ZoneName("b.aa"), tt);
+  AXFRRetriever axfr(nullptr, dest, ZoneName("b.aa"), tt);
   vector<DNSResourceRecord> res;
   while(axfr.getChunk(res)) {
   }

--- a/pdns/tsigverifier.hh
+++ b/pdns/tsigverifier.hh
@@ -3,15 +3,17 @@
 
 #include "dnsrecords.hh"
 #include "iputils.hh"
+#include "logr.hh"
 
 class TSIGTCPVerifier
 {
 public:
-  TSIGTCPVerifier(const TSIGTriplet& tt, const ComboAddress& remote, TSIGRecordContent& trc): d_tt(tt), d_remote(remote), d_trc(trc)
+  TSIGTCPVerifier(Logr::log_t slog, const TSIGTriplet& tt, const ComboAddress& remote, TSIGRecordContent& trc): d_slog(slog), d_tt(tt), d_remote(remote), d_trc(trc)
   {
   }
   bool check(const string& data, const MOADNSParser& mdp);
 private:
+  Logr::log_t d_slog;
   const TSIGTriplet& d_tt;
   const ComboAddress& d_remote;
   TSIGRecordContent& d_trc;


### PR DESCRIPTION
### Short description
This is a small part of the "structured logging for Auth" work, which affects recursor, hence a separate PR.

In order to have structured logging down the deepest bowels of the TSIG verification code, I need to pass down a structured logger object, and this affects the `AXFRRetriever` class, which is used by both auth and rec.

The `TEMPORARY PLUMBING` comments mark places which will be replaced with a valid object as part of the "structured logging in Auth" work, and are thus expected to be short-lived.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code (well, the GH actions did)
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] intentionally opened this PR on @omoerbeek 's day off