### PR TITLE
auth: trim labels faster

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -668,11 +668,19 @@ unsigned int DNSName::countLabels() const
 
 void DNSName::trimToLabels(unsigned int to)
 {
-  for (auto nlabels = countLabels(); nlabels > to; --nlabels) {
-    chopOff();
+  if (to != 0) {
+    for (auto nlabels = countLabels(); nlabels > to; --nlabels) {
+      chopOff();
+    }
+  }
+  else {
+    // If all the labels are to be removed, the result is either empty or
+    // the root zone.
+    if (!empty()) {
+      d_storage = g_rootdnsname.d_storage;
+    }
   }
 }
-
 
 size_t hash_value(DNSName const& d)
 {

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -188,6 +188,14 @@ BOOST_AUTO_TEST_CASE(test_trim) {
 
   DNSName root(".");
   BOOST_CHECK_EQUAL(root.countLabels(), 0U);
+
+  w.trimToLabels(0);
+  BOOST_CHECK(w == root);
+
+  w.clear();
+  BOOST_CHECK(w.empty());
+  w.trimToLabels(0);
+  BOOST_CHECK(w.empty());
 }
 
 BOOST_AUTO_TEST_CASE(test_toolong) {


### PR DESCRIPTION
### Short description
As noticed recently, `trimToLabels(0)` can be implemented in a simpler and faster way than removing all labels one by one.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
