### PR TITLE
feat(dnsdist): Allow cache expunging with multiple names

### DIFF
--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -22,6 +22,7 @@
 #include <cinttypes>
 
 #include "dnsdist.hh"
+#include "dnsname.hh"
 #include "dolog.hh"
 #include "dnsparser.hh"
 #include "dnsdist-cache.hh"
@@ -29,6 +30,7 @@
 #include "ednssubnet.hh"
 #include "packetcache.hh"
 #include "base64.hh"
+#include "qtype.hh"
 
 DNSDistPacketCache::DNSDistPacketCache(CacheSettings settings) :
   d_settings(std::move(settings))
@@ -426,6 +428,35 @@ size_t DNSDistPacketCache::expungeByName(const DNSName& name, uint16_t qtype, bo
       const CacheValue& value = it->second;
 
       if ((value.qname == name || (suffixMatch && value.qname.isPartOf(name))) && (qtype == QType::ANY || qtype == value.qtype)) {
+        it = map->erase(it);
+        --shard.d_entriesCount;
+        ++removed;
+      }
+      else {
+        ++it;
+      }
+    }
+  }
+
+  return removed;
+}
+
+size_t DNSDistPacketCache::expungeByName(const std::vector<DNSName>& names, uint16_t qtype, bool suffixMatch)
+{
+  size_t removed = 0;
+
+  for (auto& shard : d_shards) {
+    auto map = shard.d_map.write_lock();
+
+    for (auto it = map->begin(); it != map->end();) {
+      const CacheValue& value = it->second;
+
+      if (std::find_if(names.cbegin(), names.cend(),
+                       [&value, &qtype, &suffixMatch](const DNSName& name) {
+                         return (
+                           (value.qname == name || (suffixMatch && value.qname.isPartOf(name))) && (qtype == QType::ANY || value.qtype == qtype));
+                       })
+          != names.cend()) {
         it = map->erase(it);
         --shard.d_entriesCount;
         ++removed;

--- a/pdns/dnsdistdist/dnsdist-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-cache.hh
@@ -62,6 +62,7 @@ public:
   size_t purgeExpired(size_t upTo, time_t now);
   size_t expunge(size_t upTo = 0);
   size_t expungeByName(const DNSName& name, uint16_t qtype = QType::ANY, bool suffixMatch = false);
+  size_t expungeByName(const std::vector<DNSName>& names, uint16_t qtype = QType::ANY, bool suffixMatch = false);
   [[nodiscard]] bool isFull();
   [[nodiscard]] string toString();
   [[nodiscard]] uint64_t getSize();

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -130,16 +130,37 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
     }
     return static_cast<size_t>(0);
   });
-  luaCtx.registerFunction<void (std::shared_ptr<DNSDistPacketCache>::*)(const boost::variant<DNSName, string>& dname, std::optional<uint16_t> qtype, std::optional<bool> suffixMatch)>("expungeByName", [](std::shared_ptr<DNSDistPacketCache>& cache, const boost::variant<DNSName, string>& dname, std::optional<uint16_t> qtype, std::optional<bool> suffixMatch) {
+  luaCtx.registerFunction<void (std::shared_ptr<DNSDistPacketCache>::*)(const boost::variant<LuaArray<DNSName>, LuaArray<string>, DNSName, string>& dname, std::optional<uint16_t> qtype, std::optional<bool> suffixMatch)>("expungeByName", [](std::shared_ptr<DNSDistPacketCache>& cache, const boost::variant<LuaArray<DNSName>, LuaArray<string>, DNSName, string>& dname, std::optional<uint16_t> qtype, std::optional<bool> suffixMatch) {
+    if (cache == nullptr) {
+      return;
+    }
     DNSName qname;
+    vector<DNSName> qnames;
     if (dname.type() == typeid(DNSName)) {
       qname = boost::get<DNSName>(dname);
     }
-    if (dname.type() == typeid(string)) {
+    else if (dname.type() == typeid(string)) {
       qname = DNSName(boost::get<string>(dname));
     }
-    if (cache) {
+    else if (dname.type() == typeid(LuaArray<DNSName>)) {
+      auto qnamesArr = boost::get<LuaArray<DNSName>>(dname);
+      qnames.reserve(qnamesArr.size());
+      for (auto const& qnameVal : qnamesArr) {
+        qnames.push_back(qnameVal.second);
+      }
+    }
+    else if (dname.type() == typeid(LuaArray<string>)) {
+      auto strArr = boost::get<LuaArray<string>>(dname);
+      qnames.reserve(strArr.size());
+      for (auto const& strVal : strArr) {
+        qnames.push_back(DNSName(strVal.second));
+      }
+    }
+    if (qnames.empty()) {
       g_outputBuffer += "Expunged " + std::to_string(cache->expungeByName(qname, qtype ? *qtype : QType(QType::ANY).getCode(), suffixMatch ? *suffixMatch : false)) + " records\n";
+    }
+    else {
+      g_outputBuffer += "Expunged " + std::to_string(cache->expungeByName(qnames, qtype ? *qtype : QType(QType::ANY).getCode(), suffixMatch ? *suffixMatch : false)) + " records\n";
     }
   });
   luaCtx.registerFunction<void (std::shared_ptr<DNSDistPacketCache>::*)() const>("printStats", [](const std::shared_ptr<DNSDistPacketCache>& cache) {

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1189,9 +1189,12 @@ See :doc:`../guides/cache` for a how to.
     .. versionchanged:: 1.6.0
       ``name`` can now also be a string
 
+    .. versionchanged:: 2.2.0
+      ``name`` can now also be a list of strings or DNSNames
+
     Remove entries matching ``name`` and type from the cache.
 
-    :param DNSName name: The name to expunge
+    :param string,[string],DNSName,[DNSName] name: The name(s) to expunge
     :param int qtype: The type to expunge, can be a pre-defined :ref:`DNSQType`
     :param bool suffixMatch: When set to true, remove all entries under ``name``
 

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 import base64
 import time
-import dns
+
 import clientsubnetoption
 import cookiesoption
+import dns
 import requests
 from dnsdisttests import DNSDistTest, pickAvailablePort
 
@@ -1441,6 +1442,91 @@ class TestCacheManagement(DNSDistTest):
 
         self.assertEqual(total, misses)
 
+    def testCacheExpungeByMultipleName(self):
+        """
+        Cache: Expunge by multiple names
+
+        """
+        misses = 0
+        ttl = 600
+        name = "expungebynames.cache.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, ttl, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response.answer.append(rrset)
+
+        name2 = "expungebynamesother.cache.tests.powerdns.com."
+        query2 = dns.message.make_query(name2, "A", "IN")
+        response2 = dns.message.make_response(query2)
+        rrset2 = dns.rrset.from_text(name2, ttl, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response2.answer.append(rrset2)
+
+        # Miss
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+        misses += 1
+
+        # next queries should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        # cache another entry
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query2.id
+        self.assertEqual(query2, receivedQuery)
+        self.assertEqual(response2, receivedResponse)
+        misses += 1
+
+        # queries for name and name 2 should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response2)
+
+        # remove cached entries from name
+        self.sendConsoleCommand(
+            'getPool(""):getCache():expungeByName({newDNSName("' + name + '"), newDNSName("' + name2 + '")})'
+        )
+
+        # Miss for name
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+        misses += 1
+
+        # Miss for name2
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query2.id
+        self.assertEqual(query2, receivedQuery)
+        self.assertEqual(response2, receivedResponse)
+        misses += 1
+
+        # next queries for name should hit the cache again
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        # queries for name2 should still hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response2)
+
+        total = 0
+        for key in self._responsesCounter:
+            total += self._responsesCounter[key]
+
+        self.assertEqual(total, misses)
+
     def testCacheExpungeByNameAndType(self):
         """
         Cache: Expunge by name and type
@@ -1490,6 +1576,78 @@ class TestCacheManagement(DNSDistTest):
 
         # remove cached entries from name A
         self.sendConsoleCommand('getPool(""):getCache():expungeByName(newDNSName("' + name + '"), DNSQType.A)')
+
+        # Miss for name A
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+        misses += 1
+
+        # next queries for name A should hit the cache again
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        # queries for name AAAA should still hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response2)
+
+        total = 0
+        for key in self._responsesCounter:
+            total += self._responsesCounter[key]
+        self.assertEqual(total, misses)
+
+    def testCacheExpungeByNamesAndType(self):
+        """
+        Cache: Expunge by names and type
+
+        """
+        misses = 0
+        ttl = 600
+        name = "expungebynamesandtype.cache.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, ttl, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response.answer.append(rrset)
+
+        query2 = dns.message.make_query(name, "AAAA", "IN")
+        response2 = dns.message.make_response(query2)
+        rrset2 = dns.rrset.from_text(name, ttl, dns.rdataclass.IN, dns.rdatatype.AAAA, "::1")
+        response2.answer.append(rrset2)
+
+        # Miss
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+        misses += 1
+
+        # next queries should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        # cache another entry
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query2.id
+        self.assertEqual(query2, receivedQuery)
+        self.assertEqual(response2, receivedResponse)
+        misses += 1
+
+        # queries for name A and AAAA should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response2)
+
+        # remove cached entries from name A
+        self.sendConsoleCommand('getPool(""):getCache():expungeByName({newDNSName("' + name + '")}, DNSQType.A)')
 
         # Miss for name A
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
@@ -1589,6 +1747,82 @@ class TestCacheManagement(DNSDistTest):
 
         self.assertEqual(total, misses)
 
+    def testCacheExpungeByNamesAndSuffix(self):
+        """
+        Cache: Expunge by names
+
+        """
+        misses = 0
+        ttl = 600
+        name = "expungebynames.suffix-names.cache.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, ttl, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response.answer.append(rrset)
+
+        name2 = "expungebynames.suffix-namesother.cache.tests.powerdns.com."
+        query2 = dns.message.make_query(name2, "A", "IN")
+        response2 = dns.message.make_response(query2)
+        rrset2 = dns.rrset.from_text(name2, ttl, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response2.answer.append(rrset2)
+
+        # Miss
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+        misses += 1
+
+        # next queries should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        # cache another entry
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query2.id
+        self.assertEqual(query2, receivedQuery)
+        self.assertEqual(response2, receivedResponse)
+        misses += 1
+
+        # queries for name and name 2 should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response2)
+
+        # remove cached entries from name
+        self.sendConsoleCommand(
+            'getPool(""):getCache():expungeByName({newDNSName("suffix-names.cache.tests.powerdns.com.")}, DNSQType.ANY, true)'
+        )
+
+        # Miss for name
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+        misses += 1
+
+        # next queries for name should hit the cache again
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        # queries for name2 should still hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response2)
+
+        total = 0
+        for key in self._responsesCounter:
+            total += self._responsesCounter[key]
+
+        self.assertEqual(total, misses)
+
     def testCacheExpungeByNameAndTypeAndSuffix(self):
         """
         Cache: Expunge by name and type
@@ -1639,6 +1873,80 @@ class TestCacheManagement(DNSDistTest):
         # remove cached entries from name A
         self.sendConsoleCommand(
             'getPool(""):getCache():expungeByName(newDNSName("suffixtype.cache.tests.powerdns.com."), DNSQType.A, true)'
+        )
+
+        # Miss for name A
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+        misses += 1
+
+        # next queries for name A should hit the cache again
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        # queries for name AAAA should still hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response2)
+
+        total = 0
+        for key in self._responsesCounter:
+            total += self._responsesCounter[key]
+        self.assertEqual(total, misses)
+
+    def testCacheExpungeByNamesAndTypeAndSuffix(self):
+        """
+        Cache: Expunge by names and type and suffix
+
+        """
+        misses = 0
+        ttl = 600
+        name = "expungebynamesandtype.suffixnamestype.cache.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, ttl, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response.answer.append(rrset)
+
+        query2 = dns.message.make_query(name, "AAAA", "IN")
+        response2 = dns.message.make_response(query2)
+        rrset2 = dns.rrset.from_text(name, ttl, dns.rdataclass.IN, dns.rdatatype.AAAA, "::1")
+        response2.answer.append(rrset2)
+
+        # Miss
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
+        misses += 1
+
+        # next queries should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        # cache another entry
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query2.id
+        self.assertEqual(query2, receivedQuery)
+        self.assertEqual(response2, receivedResponse)
+        misses += 1
+
+        # queries for name A and AAAA should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response)
+
+        (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
+        self.assertEqual(receivedResponse, response2)
+
+        # remove cached entries from name A
+        self.sendConsoleCommand(
+            'getPool(""):getCache():expungeByName({newDNSName("suffixnamestype.cache.tests.powerdns.com.")}, DNSQType.A, true)'
         )
 
         # Miss for name A


### PR DESCRIPTION
### Short description

Now one can pass a list of DNSNames or strings to `expungeByName`.

Closes: #7157
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
