### PR TITLE
chore: Add invoke tasks to configure with meson for development

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -571,31 +571,113 @@ def ci_auth_configure_autotools(c):
         c.run('cat config.log')
         raise UnexpectedExit(res)
 
+AUTH_CONFIGURE_MESON_ALL_BACKENDS_STATIC = " ".join([
+    "-D module-bind=static",
+    "-D module-geoip=static",
+    "-D module-gmysql=static",
+    "-D module-godbc=static",
+    "-D module-gpgsql=static",
+    "-D module-gsqlite3=static",
+    "-D module-ldap=static",
+    "-D module-lmdb=static",
+    "-D module-lua2=static",
+    "-D module-pipe=static",
+    "-D module-remote=static",
+    "-D module-remote-zeromq=true",
+    "-D module-tinydns=static"])
+
+AUTH_CONFIGURE_MESON_LEAST_BACKENDS_STATIC = " ".join([
+    "-D module-bind=static",
+    "-D module-gsqlite3=static",
+    "-D module-remote=static"])
+
+AUTH_CONFIGURE_MESON_TOOLS = " ".join([
+    "-D tools=true",
+    "-D tools-ixfrdist=true"])
+
+AUTH_CONFIGURE_MESON_FEATURES = " ".join([
+    "-D dns-over-tls=enabled",
+    "-D experimental-pkcs11=enabled",
+    "-D experimental-gss-tsig=enabled"])
+
+@task(help={
+    'features': 'What feature-set to build, one of "full" or "least". The former builds all backends, the latter only bind, gsqlite3 and remote',
+    'build_dir': 'Where Meson should configure into',
+    'clang': 'Use clang instead of GCC',
+    'ccache': 'Use ccache',
+    'tools': 'Build all tools (sdig, ixfrdist, etc.)',
+    'unit_tests': 'Enable unit tests',
+    'coverage': 'Create code coverage files',
+})
+def dev_auth_configure_meson(c, features, build_dir="build", clang=False, ccache=False, tools=True, unit_tests=False, coverage=False):
+    additional_ld_flags = ''
+    unittests=''
+    cc = 'gcc'
+    cxx = 'g++'
+    if clang:
+        additional_ld_flags += '-fuse-ld=lld '
+        cc = 'clang'
+        cxx = 'clang++'
+
+    os.environ['COMPILER'] = cc
+
+    if ccache:
+        cc = f'ccache {cc}'
+        cxx = f'ccache {cxx}'
+    if unit_tests:
+        unittests = '-D unit-tests=true'
+
+    cflags = " ".join([get_cflags()])
+    cxxflags = " ".join([get_cxxflags()])
+
+    tools_opts = ""
+    if tools:
+      tools_opts = AUTH_CONFIGURE_MESON_TOOLS
+
+    features_set = ""
+    if features == 'full':
+      features_set = AUTH_CONFIGURE_MESON_FEATURES
+      backend_opts = AUTH_CONFIGURE_MESON_ALL_BACKENDS_STATIC
+    elif features == 'least':
+      backend_opts = AUTH_CONFIGURE_MESON_LEAST_BACKENDS_STATIC
+    else:
+        raise KeyError(f'features should be one of "full" or "least", not "{features}"')
+
+    if coverage:
+        os.environ['COVERAGE'] = 'yes'
+
+    reconf_opt = "--reconfigure" if os.path.exists(build_dir) else ""
+
+    env = " ".join([
+        f"CC='{cc}'",
+        f"CXX='{cxx}'",
+        f'CFLAGS="{cflags}"',
+        f'LDFLAGS="{additional_ld_flags}"',
+        f'CXXFLAGS="{cxxflags}"',
+    ])
+    c.run(" ".join([
+        f'{env} meson setup {build_dir}',
+        reconf_opt,
+        features_set,
+        tools_opts,
+        backend_opts,
+        unittests,
+        "-D hardening-fortify-source=auto",
+        "-D auto-var-init=pattern",
+        get_coverage(meson=True),
+        get_sanitizers(meson=True)
+    ]))
+
 def ci_auth_configure_meson(c, build_dir):
     unittests = get_unit_tests(meson=True, auth=True)
     fuzz_targets = get_fuzzing_targets(meson=True)
     configure_cmd = " ".join([
         "LDFLAGS='-L/usr/local/lib -Wl,-rpath,/usr/local/lib'",
         get_base_configure_cmd_meson(build_dir),
-        "-D module-bind=static",
-        "-D module-geoip=static",
-        "-D module-gmysql=static",
-        "-D module-godbc=static",
-        "-D module-gpgsql=static",
-        "-D module-gsqlite3=static",
-        "-D module-ldap=static",
-        "-D module-lmdb=static",
-        "-D module-lua2=static",
-        "-D module-pipe=static",
-        "-D module-remote=static",
-        "-D module-remote-zeromq=true",
-        "-D module-tinydns=static",
-        "-D tools=true",
-        "-D dns-over-tls=enabled",
-        "-D experimental-pkcs11=enabled",
-        "-D experimental-gss-tsig=enabled",
         "-D prefix=/opt/pdns-auth",
-        "-D tools-ixfrdist=true",
+        AUTH_CONFIGURE_MESON_FEATURES,
+        AUTH_CONFIGURE_MESON_ALL_BACKENDS_STATIC,
+        AUTH_CONFIGURE_MESON_TOOLS,
         unittests,
         fuzz_targets
     ])


### PR DESCRIPTION
### Short description

I got tired of figuring out options to pass to meson. Now you can configure the products locally with `inv dev-{PRODUCT}-configure-meson {full|least}`.

There are some options you can pass, to e.g. enable unit tests, coverage, clang. See `inv --help dev-{PRODUCT}-configure-meson`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
