### PR TITLE
rec: add a regresion test for defpol handling

### DIFF
--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -1051,6 +1051,42 @@ class RPZCNameChainCustomTest(RPZRecursorTest):
                 self.assertRRsetInAnswer(res, dns.rrset.from_text('cname-custom-a.example.', 0, dns.rdataclass.IN, 'CNAME', 'cname-custom-a-target.example.'))
                 self.assertRRsetInAnswer(res, dns.rrset.from_text('cname-custom-a-target.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.103'))
 
+class RPZCustomDefpolTest(RPZRecursorTest):
+    """
+    This test makes sure that the recursor applies defpol to hits and follows the CNAME
+    """
+
+    _PREFIX = os.environ['PREFIX']
+    _confdir = 'RPZCustomDefpol'
+    _lua_config_file = """
+    rpzFile('configs/%s/zone.rpz', { policyName="zone.rpz.", defpol=Policy.Custom, defcontent="a.secure.example"})
+    """ % (_confdir)
+    _config_template = ""
+
+    @classmethod
+    def generateRecursorConfig(cls, confdir):
+        rpzFilePath = os.path.join(confdir, 'zone.rpz')
+        with open(rpzFilePath, 'w') as rpzZone:
+            rpzZone.write("""$ORIGIN zone.rpz.
+@ 3600 IN SOA {soa}
+hit.example IN CNAME .
+""".format(soa=cls._SOA))
+
+        super(RPZCustomDefpolTest, cls).generateRecursorConfig(confdir)
+
+    def testRPDefpol(self):
+        # two times to check the cache
+        for _ in range(2):
+            query = dns.message.make_query('hit.example.', 'A', want_dnssec=True)
+            for method in ("sendUDPQuery", "sendTCPQuery"):
+                sender = getattr(self, method)
+                res = sender(query)
+                self.assertRcodeEqual(res, dns.rcode.NOERROR)
+                # the RPZ CNAME record is not signed
+                self.assertEqual(len(res.answer), 3)
+                self.assertRRsetInAnswer(res, dns.rrset.from_text('hit.example.', 0, dns.rdataclass.IN, 'CNAME', 'a.secure.example.'))
+                self.assertRRsetInAnswer(res, dns.rrset.from_text('a.secure.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.20', '192.0.2.22'))
+
 class RPZFileModByLuaRecursorTest(RPZRecursorTest):
     """
     This test makes sure that we correctly load RPZ zones from a file while being modified by Lua callbacks


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

`RPZFile` case only, but `RPZPrimary` uses the same code.
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
