### PR TITLE
auth: SortA API RRs by content if name and type are equal

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -509,7 +509,7 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
            the records and comments below */
         if (rrA.qname == rrB.qname) {
           if (rrA.qtype == rrB.qtype) {
-            return rrB.content < rrA.content;
+            return rrB.content > rrA.content;
           }
           return rrB.qtype < rrA.qtype;
         }
@@ -532,7 +532,7 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
            the records and comments below */
         if (rrA.qname == rrB.qname) {
           if (rrA.qtype == rrB.qtype) {
-            return rrB.content < rrA.content;
+            return rrB.content > rrA.content;
           }
           return rrB.qtype < rrA.qtype;
         }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -52,7 +52,6 @@ def eq_zone_rrsets(rrsets, expected):
 
     assert data_got == data_expected, "%r != %r" % (data_got, data_expected)
 
-
 def assert_eq_rrsets(rrsets, expected):
     """Assert rrsets sets are equal, ignoring sort order."""
     key = lambda rrset: (rrset['name'], rrset['type'])
@@ -368,6 +367,67 @@ class AuthZones(ZonesApiTestCase, AuthZonesHelperMixin):
         name, payload, data = self.create_zone(name=name, rrsets=[rrset])
         # check our record has appeared
         self.assertEqual(get_rrset(data, name, 'A')['records'], rrset['records'])
+
+    def test_create_zone_with_records_ordered(self):
+        name = unique_zone_name()
+        rrset_a = {
+            "name": name,
+            "type": "A",
+            "ttl": 3600,
+            "records": [
+                # The contents are not lexographically ordered when creating
+                {
+                    "content": "4.3.2.1",
+                    "disabled": False,
+                },
+                {
+                    "content": "127.0.0.1",
+                    "disabled": False,
+                },
+            ],
+        }
+
+        rrset_ns = {
+            "name": "foo." + name,
+            "type": "NS",
+            "ttl": 3600,
+            "records": [
+                # The contents are not lexographically ordered when creating
+                {
+                    "content": "ns2.example.com.",
+                    "disabled": False,
+                },
+                {
+                    "content": "ns1.example.net.",
+                    "disabled": False,
+                }
+            ],
+        }
+
+        name, payload, data = self.create_zone(name=name, rrsets=[rrset_a, rrset_ns])
+        # check our record has appeared
+        self.assertEqual(get_rrset(data, name, 'A')['records'], [
+            # The content should be lexographically ordered when retrieving
+            {
+                "content": "127.0.0.1",
+                "disabled": False,
+            },
+            {
+                "content": "4.3.2.1",
+                "disabled": False,
+            },
+        ])
+
+        self.assertEqual(get_rrset(data, rrset_ns['name'], 'NS')['records'], [
+            {
+                "content": "ns1.example.net.",
+                "disabled": False,
+            },
+            {
+                "content": "ns2.example.com.",
+                "disabled": False,
+            }
+        ])
 
     def test_create_zone_with_wildcard_records(self):
         name = unique_zone_name()


### PR DESCRIPTION
### Short description
This rebases #11140 onto master, fixes that PR's issue that content was sorted in reverse and adds a test.

Closes: #11140

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
