### PR TITLE
Remove unnecessary udp query

### DIFF
--- a/regression-tests.recursor-dnssec/test_Malformed.py
+++ b/regression-tests.recursor-dnssec/test_Malformed.py
@@ -111,7 +111,6 @@ outgoing:
     def testHeaderOnlyAnswer(self):
         # Case: rec gets a header-only answer
         query = dns.message.make_query('headeronly.malformed.example.', 'A')
-        res = self.sendUDPQuery(query)
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             res = sender(query)


### PR DESCRIPTION
### Short description
CodeQL Quality complained "Variable defined multiple times". This change removes the first instance which was a bad copy+paste from another test.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
