### PR TITLE
dnsdist-2.1.x: Backport of 16939 - fix(dnsdist): Lua config DBR w/ AllowedRCodeRatio

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -973,11 +973,11 @@ void setupLuaInspection(LuaContext& luaCtx)
     }
   });
   // NOLINTNEXTLINE(performance-unnecessary-value-param): optional parameters cannot be passed by const reference
-  luaCtx.registerFunction<void (std::shared_ptr<DynBlockRulesGroup>::*)(std::vector<uint8_t>, double, unsigned int, const std::string&, unsigned int, size_t, std::optional<DNSAction::Action>, std::optional<double>, DynamicActionOptionalParameters)>("setAllowedRCodesRatio", [](std::shared_ptr<DynBlockRulesGroup>& group, std::vector<uint8_t> rcodes, double ratio, unsigned int seconds, const std::string& reason, unsigned int blockDuration, size_t minimumNumberOfResponses, std::optional<DNSAction::Action> action, std::optional<double> warningRatio, DynamicActionOptionalParameters optionalParameters) {
+  luaCtx.registerFunction<void (std::shared_ptr<DynBlockRulesGroup>::*)(LuaArray<uint8_t>, double, unsigned int, const std::string&, unsigned int, size_t, std::optional<DNSAction::Action>, std::optional<double>, DynamicActionOptionalParameters)>("setAllowedRCodesRatio", [](std::shared_ptr<DynBlockRulesGroup>& group, LuaArray<uint8_t> rcodes, double ratio, unsigned int seconds, const std::string& reason, unsigned int blockDuration, size_t minimumNumberOfResponses, std::optional<DNSAction::Action> action, std::optional<double> warningRatio, DynamicActionOptionalParameters optionalParameters) {
     if (group) {
       std::unordered_set<uint8_t> allowed;
       for (const auto rcode : rcodes) {
-        allowed.insert(rcode);
+        allowed.insert(rcode.second);
       }
       DynBlockRulesGroup::DynBlockAllowedRCodesRatioRule rule(std::move(allowed), reason, blockDuration, ratio, warningRatio ? *warningRatio : 0.0, seconds, action ? *action : DNSAction::Action::None, minimumNumberOfResponses);
       parseDynamicActionOptionalParameters("setAllowedRCodesRatio", rule, action, optionalParameters);

--- a/regression-tests.dnsdist/test_DynBlocksRatio.py
+++ b/regression-tests.dnsdist/test_DynBlocksRatio.py
@@ -380,6 +380,23 @@ backends:
         # we need more queries because of the sampling rate!
         self.doTestRCodeRatio(name, dns.rcode.SERVFAIL, 20, 20)
 
+
+class TestDynBlockGroupAllowedRCodesRatioLua(TestDynBlockGroupAllowedRCodesRatioYaml):
+    _yaml_config_template = ""
+    _yaml_config_params = []
+    _config_template = """
+    local dbr = dynBlockRulesGroup()
+    dbr:setAllowedRCodesRatio({DNSRCode.NOERROR}, 0.2, %d, "Exceeded query rate", %d, 20)
+
+    function maintenance()
+	    dbr:apply()
+    end
+
+    newServer{address="127.0.0.1:%d"}
+    """
+    _config_params = ["_dynBlockPeriod", "_dynBlockDuration", "_testServerPort"]
+
+
 class TestDynBlockGroupCacheMissRatio(DynBlocksTest):
 
     # we need this period to be quite long because we request the valid


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16939 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
