### PR TITLE
auth: Use the proper size after processing a proxy protocol payload

### DIFF
--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -297,9 +297,11 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
   }
   if(sock==-1)
     throw PDNSException("poll betrayed us! (should not happen)");
-  
-  DLOG(SLOG(g_log<<"Received a packet " << len <<" bytes long from "<< remote.toString()<<endl,
-            d_slog->info(Logr::Debug, "Received a packet", "remote", Logging::Loggable(remote), "size", Logging::Loggable(len))));
+
+  buffer.resize(len);
+
+  DLOG(SLOG(g_log<<"Received a packet " << buffer.size() <<" bytes long from "<< remote.toString()<<endl,
+            d_slog->info(Logr::Debug, "Received a packet", "remote", Logging::Loggable(remote), "size", Logging::Loggable(buffer.size()))));
 
   BOOST_STATIC_ASSERT(offsetof(sockaddr_in, sin_port) == offsetof(sockaddr_in6, sin6_port));
 
@@ -327,9 +329,8 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
     bool proxyProto, tcp;
     std::vector<ProxyProtocolValue> ppvalues;
 
-    buffer.resize(len);
     ssize_t used = parseProxyHeader(buffer, proxyProto, psource, pdestination, tcp, ppvalues);
-    if (used <= 0 || (size_t) used > g_proxyProtocolMaximumSize || (len - used) > DNSPacket::s_udpTruncationThreshold) {
+    if (used <= 0 || (size_t) used > g_proxyProtocolMaximumSize || (buffer.size() - used) > DNSPacket::s_udpTruncationThreshold) {
       S.inc("corrupt-packets");
       S.ringAccount("remotes-corrupt", packet.d_remote);
       return false;
@@ -342,7 +343,7 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
     packet.d_inner_remote.reset();
   }
 
-  if(packet.parse(&buffer.at(0), (size_t) len)<0) {
+  if (packet.parse(buffer.data(), buffer.size()) < 0) {
     S.inc("corrupt-packets");
     S.ringAccount("remotes-corrupt", packet.getInnerRemote());
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported in #YWH-PGM6095-116. While it is a bug, I don't believe it is a security issue because I'm not aware of any implementation actually releasing the memory unless `shrink_to_fit()` is called, and even then it's not always the case. The content of the memory contains part of the existing query and it is still owned by this buffer so there is no information disclosure.

Thanks to bksparajuli for reporting this!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
