### PR TITLE
dnsdist: Compress DNS names when changing the name in a packet

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -132,7 +132,7 @@ bool changeNameInDNSPacket(PacketBuffer& initialPacket, const DNSName& from, con
     pw.startRecord(rrname, ah.d_type, ah.d_ttl, ah.d_class, place, true);
     if (nameOnlyTypes.count(ah.d_type)) {
       rrname = pr.getName();
-      pw.xfrName(rrname);
+      pw.xfrName(rrname, true);
     }
     else if (noNameTypes.count(ah.d_type)) {
       pr.xfrBlob(blob);
@@ -147,13 +147,13 @@ bool changeNameInDNSPacket(PacketBuffer& initialPacket, const DNSName& from, con
       auto prio = pr.get16BitInt();
       rrname = pr.getName();
       pw.xfr16BitInt(prio);
-      pw.xfrName(rrname);
+      pw.xfrName(rrname, true);
     }
     else if (ah.d_type == QType::SOA) {
       auto mname = pr.getName();
-      pw.xfrName(mname);
+      pw.xfrName(mname, true);
       auto rname = pr.getName();
-      pw.xfrName(rname);
+      pw.xfrName(rname, true);
       /* serial */
       pw.xfr32BitInt(pr.get32BitInt());
       /* refresh */
@@ -173,7 +173,7 @@ bool changeNameInDNSPacket(PacketBuffer& initialPacket, const DNSName& from, con
       /* port */
       pw.xfr16BitInt(pr.get16BitInt());
       auto target = pr.getName();
-      pw.xfrName(target);
+      pw.xfrName(target, true);
     }
     else {
       /* sorry, unsafe type */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise the resulting packet might be bigger than needed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
