### PR TITLE
dnsdist: Fix the use of compression for SRV and DNAME targets

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -132,7 +132,8 @@ bool changeNameInDNSPacket(PacketBuffer& initialPacket, const DNSName& from, con
     pw.startRecord(rrname, ah.d_type, ah.d_ttl, ah.d_class, place, true);
     if (nameOnlyTypes.count(ah.d_type)) {
       rrname = pr.getName();
-      pw.xfrName(rrname, true);
+      // compression is not allowed for DNAME target per rfc6672 section 2.5
+      pw.xfrName(rrname, ah.d_type != QType::DNAME);
     }
     else if (noNameTypes.count(ah.d_type)) {
       pr.xfrBlob(blob);
@@ -173,7 +174,11 @@ bool changeNameInDNSPacket(PacketBuffer& initialPacket, const DNSName& from, con
       /* port */
       pw.xfr16BitInt(pr.get16BitInt());
       auto target = pr.getName();
-      pw.xfrName(target, true);
+      /* Compression is not allowed per rfc2782:
+         "Unless and until permitted by future standards action,
+         name compression is not to be used for this field."
+      */
+      pw.xfrName(target, false);
     }
     else {
       /* sorry, unsafe type */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
