### PR TITLE
Auth: nested catalogs

### DIFF
--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -119,6 +119,8 @@ or, prior to version 5.0:
   pdnsutil set-catalog example.com catalog.example
   pdnsutil set-kind example.com primary
 
+Since version 5.1.0 a catalog zone can be a member of another catalog.
+
 Setting catalog values is supported in the :doc:`API <http-api/zone>`, by setting the ``catalog`` property in the zone properties.
 Setting the catalog to an empty ``""`` removes the member zone from the catalog it is in.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1366,6 +1366,18 @@ Allow this many DNS queries in a single TCP transaction. 0 means
 unlimited. Note that exchanges related to an AXFR or IXFR are not
 affected by this setting.
 
+.. _setting-member-catalog-group
+
+``member-catalog-group``
+------------------------
+
+-  String
+-  Default: pdns-member-catalog
+
+.. versionadded:: 5.1.0
+
+Catalog group used to signal that a member zone is a catalog.
+
 .. _setting-module-dir:
 
 ``module-dir``

--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -143,8 +143,8 @@ public:
     declare(suffix, "update-serial-query", "", "update domains set notified_serial=? where id=?");
     declare(suffix, "update-lastcheck-query", "", "update domains set last_check=? where id=?");
     declare(suffix, "info-all-primary-query", "", "select d.id, d.name, d.type, d.notified_serial,d.options, d.catalog,r.content from records r join domains d on r.domain_id=d.id and r.name=d.name where r.type='SOA' and r.disabled=0 and d.type in ('MASTER', 'PRODUCER') order by d.id");
-    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type='MASTER' and domains.catalog=? and records.type='SOA' and records.disabled=0");
-    declare(suffix, "info-consumer-members-query", "", "select id, name, options, master from domains where type='SLAVE' and catalog=?");
+    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.type, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type in ('MASTER', 'PRODUCER') and domains.catalog=? and records.type='SOA' and records.disabled=0");
+    declare(suffix, "info-consumer-members-query", "", "select id, name, type, options, master from domains where type in ('SLAVE', 'CONSUMER') and catalog=?");
     declare(suffix, "delete-domain-query", "", "delete from domains where name=?");
     declare(suffix, "delete-zone-query", "", "delete from records where domain_id=?");
     declare(suffix, "delete-rrset-query", "", "delete from records where domain_id=? and name=? and type=?");

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -122,8 +122,8 @@ public:
     declare(suffix, "update-serial-query", "", "update domains set notified_serial=? where id=?");
     declare(suffix, "update-lastcheck-query", "", "update domains set last_check=? where id=?");
     declare(suffix, "info-all-primary-query", "", "select domains.id, domains.name, domains.type, domains.notified_serial, domains.options, domains.catalog, records.content from records join domains on records.domain_id=domains.id and records.name=domains.name where records.type='SOA' and records.disabled=0 and domains.type in ('MASTER', 'PRODUCER') order by domains.id");
-    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type='MASTER' and domains.catalog=? and records.type='SOA' and records.disabled=0");
-    declare(suffix, "info-consumer-members-query", "", "select id, name, options, master from domains where type='SLAVE' and catalog=?");
+    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.type, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type in ('MASTER', 'PRODUCER') and domains.catalog=? and records.type='SOA' and records.disabled=0");
+    declare(suffix, "info-consumer-members-query", "", "select id, name, type, options, master from domains where type in ('SLAVE', 'CONSUMER') and catalog=?");
     declare(suffix, "delete-domain-query", "", "delete from domains where name=?");
     declare(suffix, "delete-zone-query", "", "delete from records where domain_id=?");
     declare(suffix, "delete-rrset-query", "", "delete from records where domain_id=? and name=? and type=?");

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -150,8 +150,8 @@ public:
     declare(suffix, "update-serial-query", "", "update domains set notified_serial=$1 where id=$2");
     declare(suffix, "update-lastcheck-query", "", "update domains set last_check=$1 where id=$2");
     declare(suffix, "info-all-primary-query", "", "select domains.id, domains.name, domains.type, domains.notified_serial, domains.options, domains.catalog, records.content from records join domains on records.domain_id=domains.id and records.name=domains.name where records.type='SOA' and records.disabled=false and domains.type in ('MASTER', 'PRODUCER') order by domains.id");
-    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type='MASTER' and domains.catalog=$1 and records.type='SOA' and records.disabled=false");
-    declare(suffix, "info-consumer-members-query", "", "select id, name, options, master from domains where type='SLAVE' and catalog=$1");
+    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.type, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type in ('MASTER', 'PRODUCER') and domains.catalog=$1 and records.type='SOA' and records.disabled=false");
+    declare(suffix, "info-consumer-members-query", "", "select id, name, type, options, master from domains where type in ('SLAVE', 'CONSUMER') and catalog=$1");
     declare(suffix, "delete-domain-query", "", "delete from domains where name=$1");
     declare(suffix, "delete-zone-query", "", "delete from records where domain_id=$1");
     declare(suffix, "delete-rrset-query", "", "delete from records where domain_id=$1 and name=$2 and type=$3");

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -135,8 +135,8 @@ public:
     declare(suffix, "update-serial-query", "", "update domains set notified_serial=:serial where id=:domain_id");
     declare(suffix, "update-lastcheck-query", "", "update domains set last_check=:last_check where id=:domain_id");
     declare(suffix, "info-all-primary-query", "", "select domains.id, domains.name, domains.type, domains.notified_serial, domains.options, domains.catalog, records.content from records join domains on records.domain_id=domains.id and records.name=domains.name where records.type='SOA' and records.disabled=0 and domains.type in ('MASTER', 'PRODUCER') order by domains.id");
-    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type='MASTER' and domains.catalog=:catalog and records.type='SOA' and records.disabled=0");
-    declare(suffix, "info-consumer-members-query", "", "select id, name, options, master from domains where type='SLAVE' and catalog=:catalog");
+    declare(suffix, "info-producer-members-query", "", "select domains.id, domains.name, domains.type, domains.options from records join domains on records.domain_id=domains.id and records.name=domains.name where domains.type in ('MASTER', 'PRODUCER') and domains.catalog=:catalog and records.type='SOA' and records.disabled=0");
+    declare(suffix, "info-consumer-members-query", "", "select id, name, type, options, master from domains where type in ('SLAVE', 'CONSUMER') and catalog=:catalog");
     declare(suffix, "delete-domain-query", "", "delete from domains where name=:domain");
     declare(suffix, "delete-zone-query", "", "delete from records where domain_id=:domain_id");
     declare(suffix, "delete-rrset-query", "", "delete from records where domain_id=:domain_id and name=:qname and type=:qtype");

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2457,8 +2457,15 @@ bool LMDBBackend::getCatalogMembers(const ZoneName& catalog, vector<CatalogInfo>
 
   try {
     getAllDomainsFiltered(&scratch, [this, &catalog, &members, &type](DomainInfo& di) {
-      if ((type == CatalogInfo::CatalogType::Producer && di.kind != DomainInfo::Primary) || (type == CatalogInfo::CatalogType::Consumer && di.kind != DomainInfo::Secondary) || di.catalog != catalog) {
+      if ((type == CatalogInfo::CatalogType::Producer && !di.isPrimaryType()) || (type == CatalogInfo::CatalogType::Consumer && !di.isSecondaryType()) || di.catalog != catalog) {
         return false;
+      }
+
+      if (di.isCatalogType() && di.zone == di.catalog) {
+        SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " catalog '" << di.zone << "' cannot be a member of itself" << endl,
+             d_slog->info(Logr::Warning, "catalog cannot be a member of itself", "catalog", Logging::Loggable(di.zone)));
+        members.clear();
+        throw getCatalogMembersReturnFalseException();
       }
 
       CatalogInfo ci;
@@ -2467,6 +2474,9 @@ bool LMDBBackend::getCatalogMembers(const ZoneName& catalog, vector<CatalogInfo>
       ci.d_primaries = di.primaries;
       try {
         ci.fromJson(di.options, type);
+        if (di.isCatalogType()) {
+          ci.addGroup(g_memberCatalogGroup);
+        }
       }
       catch (const std::runtime_error& e) {
         SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " options '" << di.options << "' for zone '" << di.zone << "' is no valid JSON: " << e.what() << endl,

--- a/pdns/auth-catalogzone.cc
+++ b/pdns/auth-catalogzone.cc
@@ -117,7 +117,7 @@ std::string CatalogInfo::toJson() const
 void CatalogInfo::updateCatalogHash(CatalogHashMap& hashes, const DomainInfo& di)
 {
   CatalogInfo ci;
-  hashes[di.catalog].process(std::to_string(di.id) + di.zone.toLogString());
+  hashes[di.catalog].process(std::to_string(di.id) + di.zone.toLogString() + DomainInfo::getKindString(di.kind));
   if (ci.parseJson(di.options, CatalogType::Producer)) {
     hashes[di.catalog].process(ci.d_doc["producer"].dump());
   }

--- a/pdns/auth-catalogzone.hh
+++ b/pdns/auth-catalogzone.hh
@@ -58,6 +58,7 @@ public:
   void fromJson(const std::string& json, CatalogType type);
   std::string toJson() const;
   void setType(CatalogType type) { d_type = type; }
+  void addGroup(const std::string& group) { d_group.insert(group); }
 
   static void updateCatalogHash(CatalogHashMap& hashes, const DomainInfo& di);
   DNSName getUnique() const { return DNSName(toBase32Hex(hashQNameWithSalt(std::to_string(d_id), 0, DNSName(d_zone)))); } // salt with domain id to detect recreated zones
@@ -81,3 +82,5 @@ private:
 
   bool parseJson(const std::string& json, CatalogType type);
 };
+
+extern std::string g_memberCatalogGroup;

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -119,6 +119,7 @@ bool g_doGssTSIG;
 bool g_views;
 bool g_slogStructured{false};
 static Logger::Urgency s_logUrgency;
+std::string g_memberCatalogGroup;
 typedef Distributor<DNSPacket, DNSPacket, PacketHandler> DNSDistributor;
 
 ArgvMap theArg;
@@ -341,6 +342,7 @@ static void declareArguments()
   ::arg().setSwitch("consistent-backends", "Assume individual zones are not divided over backends. Send only ANY lookup operations to the backend to reduce the number of lookups") = "yes";
 
   ::arg().set("default-catalog-zone", "Catalog zone to assign newly created primary zones (via the API) to") = "";
+  ::arg().set("member-catalog-group", "Catalog group used to signal that a member zone is a catalog") = "pdns-member-catalog";
 
 #ifdef ENABLE_GSS_TSIG
   ::arg().setSwitch("enable-gss-tsig", "Enable GSS TSIG processing") = "no";
@@ -779,6 +781,7 @@ static void mainthread()
   g_doGssTSIG = ::arg().mustDo("enable-gss-tsig");
 #endif
   g_views = ::arg().mustDo("views");
+  g_memberCatalogGroup = ::arg()["member-catalog-group"];
 
   DNSPacket::s_udpTruncationThreshold = std::max(512, ::arg().asNum("udp-truncation-threshold"));
   DNSPacket::s_doEDNSSubnetProcessing = ::arg().mustDo("edns-subnet-processing");

--- a/pdns/auth-primarycommunicator.cc
+++ b/pdns/auth-primarycommunicator.cc
@@ -193,7 +193,7 @@ void CommunicatorClass::getUpdatedProducers(UeberBackend* B, vector<DomainInfo>&
         DNSResourceRecord rr;
         makeIncreasedSOARecord(sd, "EPOCH", "", rr, d_slog);
         di.backend->startTransaction(sd.zonename, UnknownDomainID);
-        if (!di.backend->replaceRRSet(di.id, rr.qname, rr.qtype, vector<DNSResourceRecord>(1, rr))) {
+        if (!di.backend->replaceRRSet(di.id, rr.qname, rr.qtype, {rr})) {
           di.backend->abortTransaction();
           throw PDNSException("backend hosting producer zone '" + sd.zonename.toLogString() + "' does not support editing records");
         }

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -137,6 +137,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
         CatalogInfo ciDB = *db;
         if (ciDB.d_unique.empty() || ciXFR.d_unique == ciDB.d_unique) { // update
           bool doOptions{false};
+          bool doType{false};
 
           if (ciDB.d_unique.empty()) { // set unique
             SLOG(g_log << Logger::Warning << ctx.logPrefix << "set unique, zone '" << ciXFR.d_zone << "' is now a member" << endl,
@@ -155,6 +156,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
           if (ciXFR.d_group != ciDB.d_group) { // update group
             SLOG(g_log << Logger::Warning << ctx.logPrefix << "update group for zone '" << ciXFR.d_zone << "' to '" << boost::join(ciXFR.d_group, ", ") << "'" << endl,
                  ctx.slog->info(Logr::Warning, "Catalog-Zone: update group", "zone", Logging::Loggable(ciXFR.d_zone), "group", Logging::Loggable(boost::join(ciXFR.d_group, ", ")))); // can't apply Logging::IterLoggable on set
+            doType = !empty(g_memberCatalogGroup) && ((ciXFR.d_group.count(g_memberCatalogGroup) != 0) != (ciDB.d_group.count(g_memberCatalogGroup) != 0));
             ciDB.d_group = ciXFR.d_group;
             doOptions = true;
           }
@@ -169,6 +171,19 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
             SLOG(g_log << Logger::Warning << ctx.logPrefix << "update options for zone '" << ciXFR.d_zone << "'" << endl,
                  ctx.slog->info(Logr::Warning, "Catalog-Zone: update options", "zone", Logging::Loggable(ciXFR.d_zone)));
             ctx.domain.backend->setOptions(ciXFR.d_zone, ciDB.toJson());
+          }
+
+          if (doType) { // update zone type
+            if (doTransaction && (inTransaction = ctx.domain.backend->startTransaction(ctx.domain.zone))) {
+              SLOG(g_log << Logger::Warning << ctx.logPrefix << "backend transaction started" << endl,
+                   ctx.slog->info(Logr::Warning, "Catalog-Zone: backend transaction started"));
+              doTransaction = false;
+            }
+
+            DomainInfo::DomainKind kind = ciXFR.d_group.count(g_memberCatalogGroup) != 0 ? DomainInfo::Consumer : DomainInfo::Secondary;
+            SLOG(g_log << Logger::Warning << ctx.logPrefix << "update type to '" << DomainInfo::getKindString(kind) << "' for zone '" << ciXFR.d_zone << "'" << endl,
+                 ctx.slog->info(Logr::Warning, "Catalog-Zone: update type", "zone", Logging::Loggable(ciXFR.d_zone), "type", Logging::Loggable(kind)));
+            ctx.domain.backend->setKind(ciXFR.d_zone, kind);
           }
 
           if (ctx.domain.primaries != ciDB.d_primaries) { // update primaries
@@ -277,7 +292,8 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
 
         SLOG(g_log << Logger::Warning << ctx.logPrefix << "create zone '" << ciCreate.d_zone << "'" << endl,
              ctx.slog->info(Logr::Warning, "Catalog-Zone: create zone", "zone", Logging::Loggable(ciCreate.d_zone)));
-        ctx.domain.backend->createDomain(ciCreate.d_zone, DomainInfo::Secondary, ciCreate.d_primaries, "");
+        d.kind = !empty(g_memberCatalogGroup) && ciCreate.d_group.count(g_memberCatalogGroup) != 0 ? DomainInfo::Consumer : DomainInfo::Secondary;
+        ctx.domain.backend->createDomain(ciCreate.d_zone, d.kind, ciCreate.d_primaries, "");
 
         ctx.domain.backend->setPrimaries(ciCreate.d_zone, ctx.domain.primaries);
         ctx.domain.backend->setOptions(ciCreate.d_zone, ciCreate.toJson());
@@ -471,7 +487,7 @@ static bool catalogProcess(const XFRContext& ctx, vector<DNSResourceRecord>& rrs
     return false;
   }
 
-  // Get catalog ifo from db
+  // Get catalog info from db
   if (!ctx.domain.backend->getCatalogMembers(ctx.domain.zone, fromDB, CatalogInfo::CatalogType::Consumer)) {
     return false;
   }

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -539,7 +539,7 @@ void GSQLBackend::getUnfreshSecondaryInfos(vector<DomainInfo>* unfreshDomains)
 void GSQLBackend::getUpdatedPrimaries(vector<DomainInfo>& updatedDomains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes)
 {
   /*
-    list all domains that need notifications for which we are promary, and insert into
+    list all domains that need notifications for which we are primary, and insert into
     updatedDomains: id, name, notified_serial, serial
   */
 
@@ -581,6 +581,8 @@ void GSQLBackend::getUpdatedPrimaries(vector<DomainInfo>& updatedDomains, std::u
       continue;
     }
 
+    di.kind = DomainInfo::stringToKind(row[2]);
+
     try {
       pdns::checked_stoi_into(di.id, row[0]);
     }
@@ -594,24 +596,27 @@ void GSQLBackend::getUpdatedPrimaries(vector<DomainInfo>& updatedDomains, std::u
       di.catalog = ZoneName(row[5]);
     }
     catch (const std::runtime_error& e) {
-      SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " zone name '" << row[5] << "' is not a valid DNS name: " << e.what() << endl,
-           d_slog->error(Logr::Warning, e.what(), "zone name is not a valid DNS name", "zone", Logging::Loggable(row[5])));
+      SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " catalog name '" << row[5] << "' is not a valid DNS name: " << e.what() << endl,
+           d_slog->error(Logr::Warning, e.what(), "catalog name is not a valid DNS name", "zone", Logging::Loggable(row[5])));
       continue;
     }
     catch (PDNSException& ae) {
-      SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " zone name '" << row[5] << "' is not a valid DNS name: " << ae.reason << endl,
-           d_slog->error(Logr::Warning, ae.reason, "zone name is not a valid DNS name", "zone", Logging::Loggable(row[5])));
+      SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " catalog name '" << row[5] << "' is not a valid DNS name: " << ae.reason << endl,
+           d_slog->error(Logr::Warning, ae.reason, "catalog name is not a valid DNS name", "zone", Logging::Loggable(row[5])));
       continue;
     }
 
-    if (pdns_iequals(row[2], "PRODUCER")) {
+    if (di.kind == DomainInfo::Producer) {
       catalogs.insert(di.zone.operator const DNSName&());
       catalogHashes[di.zone].process("");
-      continue; // Producer freshness check is performed elsewhere
+      if (di.catalog.empty()) {
+        continue; // Producer is no catalog member, freshness check is performed elsewhere
+      }
     }
-    else if (!pdns_iequals(row[2], "MASTER")) {
+    else if (di.kind != DomainInfo::Primary) {
       SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " type '" << row[2] << "' for zone '" << di.zone << "' is no primary type" << endl,
            d_slog->info(Logr::Warning, "zone type is not fit for a primary", "zone", Logging::Loggable(di.zone), "type", Logging::Loggable(row[2])));
+      continue;
     }
 
     try {
@@ -624,6 +629,10 @@ void GSQLBackend::getUpdatedPrimaries(vector<DomainInfo>& updatedDomains, std::u
       SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " catalog hash update failed'" << row[4] << "' for zone '" << di.zone << "' member of '" << di.catalog << "': " << e.what() << endl,
            d_slog->error(Logr::Warning, e.what(), "catalog hash update failed", "zone", Logging::Loggable(di.zone), "catalog", Logging::Loggable(di.catalog)));
       continue;
+    }
+
+    if (di.kind == DomainInfo::Producer) {
+      continue; // Producer is a catalog member, freshness check is performed elsewhere
     }
 
     try {
@@ -692,12 +701,12 @@ bool GSQLBackend::getCatalogMembers(const ZoneName& catalog, vector<CatalogInfo>
   }
 
   members.reserve(d_result.size());
-  for (const auto& row : d_result) { // id, zone, options, [master]
+  for (const auto& row : d_result) { // id, zone, type, options, [master]
     if (type == CatalogInfo::CatalogType::Producer) {
-      ASSERT_ROW_COLUMNS("info-producer/consumer-members-query", row, 3);
+      ASSERT_ROW_COLUMNS("info-producer/consumer-members-query", row, 4);
     }
     else {
-      ASSERT_ROW_COLUMNS("info-producer/consumer-members-query", row, 4);
+      ASSERT_ROW_COLUMNS("info-producer/consumer-members-query", row, 5);
     }
 
     CatalogInfo ci;
@@ -718,6 +727,16 @@ bool GSQLBackend::getCatalogMembers(const ZoneName& catalog, vector<CatalogInfo>
       return false;
     }
 
+    auto kind = DomainInfo::stringToKind(row[2]);
+    auto isCatalog = kind == DomainInfo::Producer || kind == DomainInfo::Consumer;
+
+    if (isCatalog && ci.d_zone == catalog) {
+      SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " catalog '" << ci.d_zone << "' cannot be a member of itself" << endl,
+           d_slog->info(Logr::Warning, "catalog cannot be a member of itself", "catalog", Logging::Loggable(ci.d_zone)));
+      members.clear();
+      return false;
+    }
+
     try {
       pdns::checked_stoi_into(ci.d_id, row[0]);
     }
@@ -729,18 +748,21 @@ bool GSQLBackend::getCatalogMembers(const ZoneName& catalog, vector<CatalogInfo>
     }
 
     try {
-      ci.fromJson(row[2], type);
+      ci.fromJson(row[3], type);
+      if (isCatalog) {
+        ci.addGroup(g_memberCatalogGroup);
+      }
     }
     catch (const std::runtime_error& e) {
-      SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " options '" << row[2] << "' for zone '" << ci.d_zone << "' is no valid JSON: " << e.what() << endl,
-           d_slog->error(Logr::Warning, e.what(), "catalog 'options' field is not valid JSON", "zone", Logging::Loggable(ci.d_zone), "field", Logging::Loggable(row[2])));
+      SLOG(g_log << Logger::Warning << __PRETTY_FUNCTION__ << " options '" << row[3] << "' for zone '" << ci.d_zone << "' is no valid JSON: " << e.what() << endl,
+           d_slog->error(Logr::Warning, e.what(), "catalog 'options' field is not valid JSON", "zone", Logging::Loggable(ci.d_zone), "field", Logging::Loggable(row[3])));
       members.clear();
       return false;
     }
 
-    if (row.size() >= 4) { // Consumer only
+    if (type == CatalogInfo::CatalogType::Consumer) { // Consumer only
       vector<string> primaries;
-      stringtok(primaries, row[3], ", \t");
+      stringtok(primaries, row[4], ", \t");
       for (const auto& m : primaries) {
         try {
           ci.d_primaries.emplace_back(m, 53);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -56,6 +56,7 @@ AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;
 uint16_t g_maxNSEC3Iterations{0};
+std::string g_memberCatalogGroup;
 
 namespace po = boost::program_options;
 po::variables_map g_vm;

--- a/regression-tests/backends/bind-master
+++ b/regression-tests/backends/bind-master
@@ -2,7 +2,7 @@ case $context in
     bind)
         backend=bind
         cat > pdns-bind.conf << __EOF__
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=bind
 bind-config=./named.conf
 bind-ignore-broken-records=yes
@@ -20,7 +20,7 @@ __EOF__
         rm -f dnssec.sqlite3
         backend=bind
         cat > pdns-bind.conf << __EOF__
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=bind
 bind-config=./named.conf
 bind-ignore-broken-records=yes

--- a/regression-tests/backends/bind-slave
+++ b/regression-tests/backends/bind-slave
@@ -37,6 +37,6 @@
 		--retrieval-threads=1  --config-name=bind-slave \
 		--dnsupdate=yes \
 		--cache-ttl=$cachettl --no-config --dname-processing --bind-dnssec-db=./dnssec-slave.sqlite3 \
-		--module-dir=./modules &
+		--module-dir="$PDNS_MODULE_PATH" &
 	echo 'waiting for zones to be loaded'
 	bindwait bind-slave

--- a/regression-tests/backends/geoip-master
+++ b/regression-tests/backends/geoip-master
@@ -118,7 +118,7 @@ EOF
 		# generate pdns.conf for pdnsutil
 		backend=geoip
 		cat > pdns-geoip.conf <<EOF
-module-dir=./modules
+module-dir=$PDNS_MODULE_PATH
 launch=geoip
 geoip-zones-file=$testsdir/geo.yaml
 geoip-database-files=$geoipdatabase
@@ -138,7 +138,7 @@ EOF
 			--cache-ttl=$cachettl --dname-processing --no-config \
 			--distributor-threads=1 \
                         --geoip-zones-file=$testsdir/geo.yaml --geoip-database-files="$geoipdatabase" \
-                        --module-dir="$PDNS_BUILD_PATH/modules" --edns-subnet-processing=yes \
+                        --edns-subnet-processing=yes \
 			$geoipkeydir &
 		;;
 

--- a/regression-tests/backends/gmysql-master
+++ b/regression-tests/backends/gmysql-master
@@ -41,6 +41,11 @@ __EOF__
 			$PDNSUTIL --config-dir=. --config-name=gmysql load-zone catalog.invalid zones/catalog.invalid
 			$PDNSUTIL --config-dir=. --config-name=gmysql set-kind catalog.invalid producer
 
+			$PDNSUTIL --config-dir=. --config-name=gmysql load-zone catalog2.invalid zones/catalog2.invalid
+			$PDNSUTIL --config-dir=. --config-name=gmysql set-kind catalog2.invalid producer
+			$PDNSUTIL --config-dir=. --config-name=gmysql set-catalog catalog2.invalid catalog.invalid
+			$PDNSUTIL --config-dir=. --config-name=gmysql set-catalog minimal.com catalog2.invalid
+
 			$PDNSUTIL --config-dir=. --config-name=gmysql set-option test.com producer coo other-catalog.invalid
 			$PDNSUTIL --config-dir=. --config-name=gmysql set-option test.com producer unique 123
 			$PDNSUTIL --config-dir=. --config-name=gmysql set-option tsig.com producer group pdns-group-x pdns-group-y

--- a/regression-tests/backends/gmysql-master
+++ b/regression-tests/backends/gmysql-master
@@ -17,7 +17,7 @@ case $context in
 			"$GMYSQLDB"
 
 		cat > pdns-gmysql.conf << __EOF__
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=gmysql
 gmysql-dbname=$GMYSQLDB
 gmysql-user=$GMYSQLUSER

--- a/regression-tests/backends/gmysql-slave
+++ b/regression-tests/backends/gmysql-slave
@@ -70,7 +70,7 @@ __EOF__
 	# setup catalog zone
 	if [ $zones -ne 1 ] # detect root tests
 	then
-		zones=$((zones+1))
+		zones=$((zones+2))
 		$PDNSUTIL --config-dir=. --config-name=gmysql2 create-secondary-zone catalog.invalid 127.0.0.1:$port
 		$PDNSUTIL --config-dir=. --config-name=gmysql2 set-kind catalog.invalid consumer
 

--- a/regression-tests/backends/gmysql-slave
+++ b/regression-tests/backends/gmysql-slave
@@ -13,7 +13,7 @@
 
 	backend=gmysql2
 	cat > pdns-gmysql2.conf << __EOF__
-module-dir=./modules
+module-dir=$PDNS_MODULE_PATH
 launch=gmysql
 gmysql-dbname=$GMYSQL2DB
 gmysql-user=$GMYSQL2USER

--- a/regression-tests/backends/godbc_mssql-master
+++ b/regression-tests/backends/godbc_mssql-master
@@ -17,7 +17,7 @@ case $context in
 		# actually terminates
 		tosql gsqlite | grep -v -E '(COMMIT|TRANSACTION)' | awk '1;!(NR%98){print "go"}' | cat - <(echo go) /dev/null | $BSQLODBC
 		cat > pdns-godbc_mssql.conf << __EOF__
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=godbc
 godbc-datasource=$GODBC_MSSQL_DSN
 godbc-username=$GODBC_MSSQL_USERNAME

--- a/regression-tests/backends/godbc_mssql-slave
+++ b/regression-tests/backends/godbc_mssql-slave
@@ -7,7 +7,7 @@
 	$ISQL < ../modules/godbcbackend/schema.mssql.sql
 	backend=godbc2
 	cat > pdns-godbc2.conf << __EOF__
-module-dir=./modules
+module-dir=$PDNS_MODULE_PATH
 launch=godbc
 godbc-datasource=$GODBC_MSSQL2_DSN
 godbc-username=$GODBC_MSSQL2_USERNAME

--- a/regression-tests/backends/godbc_sqlite3-master
+++ b/regression-tests/backends/godbc_sqlite3-master
@@ -7,12 +7,12 @@ case $context in
 		echo 'ANALYZE; PRAGMA journal_mode=WAL;' | sqlite3 pdns.sqlite3
 
 		cat > pdns-godbc_sqlite3.conf << __EOF__
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=godbc
 godbc-datasource=$GODBC_SQLITE3_DSN
 
 __EOF__
-		${PDNSSERVER:-../pdns/pdns_server} --module-dir=./modules/ --launch=gsqlite3 --config | grep query= | perl -pe 's/^# gsqlite3/godbc/; s/:\w+/?/g' >> pdns-godbc_sqlite3.conf
+		${PDNSSERVER:-../pdns/pdns_server} --launch=gsqlite3 --config | grep query= | perl -pe 's/^# gsqlite3/godbc/; s/:\w+/?/g' >> pdns-godbc_sqlite3.conf
 
 		gsql_master godbc_sqlite3 nodyndns
 		;;

--- a/regression-tests/backends/gpgsql-master
+++ b/regression-tests/backends/gpgsql-master
@@ -12,7 +12,7 @@ case $context in
                 psql --user="$GPGSQLUSER" -c "ANALYZE" "$GPGSQLDB"
 
 		cat > pdns-gpgsql.conf << __EOF__
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=gpgsql
 gpgsql-dbname=$GPGSQLDB
 gpgsql-user=$GPGSQLUSER

--- a/regression-tests/backends/gpgsql-slave
+++ b/regression-tests/backends/gpgsql-slave
@@ -8,7 +8,7 @@
 
 	backend=gpgsql2
 	cat > pdns-gpgsql2.conf << __EOF__
-module-dir=./modules
+module-dir=$PDNS_MODULE_PATH
 launch=gpgsql
 gpgsql-dbname=$GPGSQL2DB
 gpgsql-user=$GPGSQL2USER

--- a/regression-tests/backends/gsqlite3-master
+++ b/regression-tests/backends/gsqlite3-master
@@ -8,7 +8,7 @@ case $context in
 		echo ANALYZE\; | sqlite3 pdns.sqlite3
 
 		cat > pdns-gsqlite3.conf << __EOF__
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=gsqlite3
 gsqlite3-database=pdns.sqlite3
 consistent-backends

--- a/regression-tests/backends/gsqlite3-slave
+++ b/regression-tests/backends/gsqlite3-slave
@@ -4,7 +4,7 @@
 
 	backend=gsqlite32
 	cat > pdns-gsqlite32.conf << __EOF__
-module-dir=./modules
+module-dir=$PDNS_MODULE_PATH
 launch=gsqlite3
 gsqlite3-database=pdns.sqlite32
 gsqlite3-pragma-synchronous=0

--- a/regression-tests/backends/ldap-master
+++ b/regression-tests/backends/ldap-master
@@ -18,7 +18,7 @@ __EOF__
 
 		backend=ldap
 		cat > pdns-ldap.conf << __EOF__
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=ldap
 ldap-basedn=$LDAPBASEDN
 ldap-binddn=$LDAPUSER

--- a/regression-tests/backends/lmdb-master
+++ b/regression-tests/backends/lmdb-master
@@ -12,7 +12,7 @@ case $_context in
     lmdb | lmdb-nodnssec | lmdb-nsec3 | lmdb-nsec3-optout | lmdb-nsec3-narrow)
         backend=lmdb
         cat > pdns-lmdb.conf << __EOF__
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=lmdb
 lmdb-filename=./pdns.lmdb
 lmdb-random-ids=yes

--- a/regression-tests/backends/lmdb-master
+++ b/regression-tests/backends/lmdb-master
@@ -85,6 +85,11 @@ __EOF__
             $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb load-zone catalog.invalid zones/catalog.invalid
             $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-kind catalog.invalid producer
 
+            $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb load-zone catalog2.invalid zones/catalog2.invalid
+            $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-kind catalog2.invalid producer
+            $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-catalog catalog2.invalid catalog.invalid
+            $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-catalog minimal.com$plusvariant catalog2.invalid
+
             $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-options-json test.com$plusvariant '{"producer":{"coo":"other-catalog.invalid","unique":"123"}}'
             $RUNWRAPPER_PDNSUTIL $PDNSUTIL --config-dir=. --config-name=lmdb set-options-json tsig.com$plusvariant '{"producer":{"group":["pdns-group-x","pdns-group-y"]}}'
         fi

--- a/regression-tests/backends/lmdb-slave
+++ b/regression-tests/backends/lmdb-slave
@@ -47,7 +47,7 @@ __EOF__
         # setup catalog zone
         if [ $zones -ne 1 ] # detect root tests
         then
-                zones=$((zones+1))
+                zones=$((zones+2))
                 $PDNSUTIL --config-dir=. --config-name=lmdb2 create-secondary-zone catalog.invalid 127.0.0.1:$port
                 $PDNSUTIL --config-dir=. --config-name=lmdb2 set-kind catalog.invalid consumer
 

--- a/regression-tests/backends/lmdb-slave
+++ b/regression-tests/backends/lmdb-slave
@@ -1,7 +1,7 @@
         context=${context}-presigned-lmdb
         backend=lmdb2
         cat > pdns-lmdb2.conf << __EOF__
-module-dir=./modules
+module-dir=$PDNS_MODULE_PATH
 launch=lmdb
 lmdb-filename=./pdns2.lmdb
 __EOF__

--- a/regression-tests/backends/lua2-master
+++ b/regression-tests/backends/lua2-master
@@ -24,7 +24,7 @@ case $context in
 		# generate pdns.conf for pdnsutil
 		backend=lua2
 		cat > pdns-lua2.conf <<EOF
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=lua2
 lua2-filename=$testsdir/$luascript
 lua2-api=2
@@ -36,7 +36,7 @@ EOF
 			--cache-ttl=$cachettl --dname-processing --no-config \
 			--distributor-threads=1 --zone-cache-refresh-interval=$interval \
 			--allow-axfr-ips=0.0.0.0/0,::/0 \
-			--lua2-filename=$testsdir/$luascript --lua2-api=2 --module-dir=./modules &
+			--lua2-filename=$testsdir/$luascript --lua2-api=2 &
 		;;
 
 	*)

--- a/regression-tests/backends/remote-master
+++ b/regression-tests/backends/remote-master
@@ -90,7 +90,7 @@ case $context in
 		# generate pdns.conf for pdnsutil
 		backend=remote
 		cat > pdns-remote.conf <<EOF
-module-dir=$PDNS_BUILD_PATH/modules
+module-dir=$PDNS_MODULE_PATH
 launch=remote
 remote-connection-string=$connstr,timeout=10000
 EOF
@@ -123,7 +123,7 @@ EOF
 			--cache-ttl=$cachettl --dname-processing --no-config \
 			--distributor-threads=1 \
 			--dnsupdate=yes --zone-cache-refresh-interval=0 \
-			--remote-connection-string="$connstr" $remote_add_param --module-dir="$PDNS_BUILD_PATH/modules" &
+			--remote-connection-string="$connstr" $remote_add_param &
 		;;
 
 	*)

--- a/regression-tests/backends/tinydns-master
+++ b/regression-tests/backends/tinydns-master
@@ -4,7 +4,7 @@ case $context in
 			--no-shuffle --launch=tinydns \
 		 --cache-ttl=$cachettl --dname-processing --no-config \
 			--dnsupdate=yes \
-			--tinydns-dbfile=../modules/tinydnsbackend/data.cdb --module-dir="$PDNS_BUILD_PATH/modules" &
+			--tinydns-dbfile=../modules/tinydnsbackend/data.cdb --module-dir="$PDNS_MODULE_PATH" &
 		skipreasons="nodnssec noent nodyndns nometa noaxfr noalias"
 		;;
 

--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -10,6 +10,9 @@ MAKE=${MAKE:-make}
 if [ -z "$PDNS_BUILD_PATH" ]; then
   # PDNS_BUILD_PATH is unset or empty. Assume an autotools build.
   PDNS_BUILD_PATH=${PWD}/../pdns
+  PDNS_MODULE_PATH=${PDNS_MODULE_PATH:-$PWD/modules}
+else
+  PDNS_MODULE_PATH=${PDNS_MODULE_PATH:-$PDNS_BUILD_PATH/modules}
 fi
 
 export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns_server}

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -7,6 +7,9 @@ fi
 if [ -z "$PDNS_BUILD_PATH" ]; then
   # PDNS_BUILD_PATH is unset or empty. Assume an autotools build.
   PDNS_BUILD_PATH=${PWD}/../pdns
+  PDNS_MODULE_PATH=${PDNS_MODULE_PATH:-$PWD/modules}
+else
+  PDNS_MODULE_PATH=${PDNS_MODULE_PATH:-$PDNS_BUILD_PATH/modules}
 fi
 
 export PDNS=${PDNS:-$PDNS_BUILD_PATH/pdns_server}

--- a/regression-tests/tests/zone-variants/expected_result.lmdb
+++ b/regression-tests/tests/zone-variants/expected_result.lmdb
@@ -22,6 +22,7 @@ No keys for zone '.'.
 ..myroot
 2.0.192.in-addr.arpa
 catalog.invalid
+catalog2.invalid
 cdnskey-cds-test.com
 cryptokeys.org
 delegated.dnssec-parent.com

--- a/regression-tests/zones/catalog2.invalid
+++ b/regression-tests/zones/catalog2.invalid
@@ -1,0 +1,10 @@
+$TTL 3600
+$ORIGIN catalog2.invalid.
+@		IN	SOA	ns1.zone.invalid. hostmaster.zone.invalid. (  1
+			1M ; refresh
+			30S ; retry
+			1W ; expire
+			1D ; default_ttl
+			)
+
+@		IN	NS	ns1.zone.invalid.


### PR DESCRIPTION
### Short description
"One catalog to rule them all"

Make it possible for catalog zones to be a member of an other catalog. A group property is used to signal if a member is a catalog.

And one commit to unbreak the regression tests for dynmodules.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
