### PR TITLE
add ubuntu-resolute build target

### DIFF
--- a/builder-support/debian/dnsdist/debian-bookworm/control
+++ b/builder-support/debian/dnsdist/debian-bookworm/control
@@ -5,7 +5,9 @@ Maintainer: PowerDNS.COM BV <powerdns.support.sales@powerdns.com>
 Uploaders: PowerDNS.COM BV <powerdns.support.sales@powerdns.com>
 Build-Depends: debhelper (>= 10),
                clang,
-               libboost-all-dev,
+               libboost-dev,
+               libboost-container-dev,
+               libboost-test-dev,
                libbpf-dev [linux-any],
                libcap-dev,
                libcdb-dev,

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-resolute
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-resolute
@@ -1,0 +1,28 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+FROM ubuntu:resolute AS dist-base
+
+ARG BUILDER_CACHE_BUSTER=
+ARG APT_URL
+RUN apt-get update && apt-get -y dist-upgrade
+
+@INCLUDE Dockerfile.debbuild-prepare
+
+@IF [ -n "$M_authoritative$M_all" ]
+ADD builder-support/debian/authoritative/debian-buster/ pdns-${BUILDER_VERSION}/debian/
+@ENDIF
+
+@IF [ -n "$M_recursor$M_all" ]
+ADD builder-support/debian/recursor/debian-buster/ pdns-recursor-${BUILDER_VERSION}/debian/
+@ENDIF
+
+@IF [ -n "$M_dnsdist$M_all" ]
+ADD builder-support/debian/dnsdist/debian-bookworm/ dnsdist-${BUILDER_VERSION}/debian/
+@ENDIF
+
+@INCLUDE Dockerfile.debbuild
+
+# Do a test install and verify
+# Can be skipped with skiptests=1 in the environment
+# @EXEC [ "$skiptests" = "" ] && include Dockerfile.debtest


### PR DESCRIPTION
### Short description
~~Builds auth/rec/dnsdist. Binaries not yet tested. Commit titled HACK needs to go/be improved.~~

builds all now. Still contains a hack (documented in commit message) but that's due to a meson quirk.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
