### PR TITLE
[boring] Remove explicit constructor duplicating default initialization.

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -879,7 +879,6 @@ boilerplate_conv(TKEY,
                  conv.xfr16BitInt(d_othersize);
                  if (d_othersize>0) conv.xfrBlobNoSpaces(d_other, d_othersize);
                  )
-TKEYRecordContent::TKEYRecordContent() { d_othersize = 0; } // fix CID#1288932
 
 boilerplate_conv(URI,
                  conv.xfr16BitInt(d_priority);

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -1221,7 +1221,7 @@ private:
 class TKEYRecordContent : public DNSRecordContent
 {
 public:
-  TKEYRecordContent();
+  TKEYRecordContent() = default;
   includeboilerplate(TKEY)
   [[nodiscard]] size_t sizeEstimate() const override
   {


### PR DESCRIPTION
### Short description
While looking at some code, I couldn't help but notice that the `TKEYRecordContent` has a constructor duplicating the class default initializers. It is now redundant and can get removed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
