### PR TITLE
Small cleanup of `EDNSSubnetOpts`

### DIFF
--- a/pdns/ednssubnet.cc
+++ b/pdns/ednssubnet.cc
@@ -51,7 +51,7 @@ bool EDNSSubnetOpts::getFromString(const char* options, unsigned int len, EDNSSu
   esow.family = ntohs(esow.family);
 
   ComboAddress address;
-  unsigned int octetsin = esow.sourcePrefixLength > 0 ? (((esow.sourcePrefixLength - 1) >> 3) + 1) : 0;
+  size_t octetsin = esow.sourcePrefixLength > 0U ? (((esow.sourcePrefixLength - 1) >> 3) + 1) : 0U;
 
   if (esow.family == 1) {
     if (len != sizeof(esow) + octetsin) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The existing code was relying on implicit integer conversion rules, which was correct but brittle, so let's explicitly check that the source is non-zero.

Reported by Aayush Khanal in YWH-PGM6095-141, thanks!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
