### PR TITLE
dnsdist: Prevent copies of OT closers

### DIFF
--- a/pdns/dnsdistdist/dnsdist-idstate.cc
+++ b/pdns/dnsdistdist/dnsdist-idstate.cc
@@ -112,13 +112,13 @@ InternalQueryState::~InternalQueryState()
 
 std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getCloser([[maybe_unused]] const std::string_view& name, [[maybe_unused]] const SpanID& parentSpanID)
 {
-  std::optional<pdns::trace::dnsdist::Tracer::Closer> ret(std::nullopt);
+  std::optional<pdns::trace::dnsdist::Tracer::Closer> ret{std::nullopt};
 #ifndef DISABLE_PROTOBUF
   // getTracer returns a Tracer when tracing is globally enabled
   // tracingEnabled tells us whether or not tracing is enabled for this query
   // Should tracing be disabled, *but* we have not processed query rules, we will still return a closer if tracing is globally enabled
   if (auto tracer = getTracer(); tracer != nullptr && (tracingEnabled || !rulesAppliedToQuery)) {
-    ret = std::optional<pdns::trace::dnsdist::Tracer::Closer>(d_OTTracer->openSpan(std::string(name), parentSpanID));
+    ret = d_OTTracer->openSpan(std::string(name), parentSpanID);
   }
 #endif
   return ret;
@@ -126,11 +126,11 @@ std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getClose
 
 std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getCloser([[maybe_unused]] const std::string_view& name, [[maybe_unused]] const std::string_view& parentSpanName)
 {
-  std::optional<pdns::trace::dnsdist::Tracer::Closer> ret(std::nullopt);
+  std::optional<pdns::trace::dnsdist::Tracer::Closer> ret{std::nullopt};
 #ifndef DISABLE_PROTOBUF
   if (auto tracer = getTracer(); tracer != nullptr) {
     auto parentSpanID = d_OTTracer->getLastSpanIDForName(std::string(parentSpanName));
-    return getCloser(name, parentSpanID);
+    ret = getCloser(name, parentSpanID);
   }
 #endif
   return ret;
@@ -138,10 +138,10 @@ std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getClose
 
 std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getCloser([[maybe_unused]] const std::string_view& name)
 {
-  std::optional<pdns::trace::dnsdist::Tracer::Closer> ret(std::nullopt);
+  std::optional<pdns::trace::dnsdist::Tracer::Closer> ret{std::nullopt};
 #ifndef DISABLE_PROTOBUF
   if (auto tracer = getTracer(); tracer != nullptr) {
-    return getCloser(std::string(name), tracer->getLastSpanID());
+    ret = getCloser(std::string(name), tracer->getLastSpanID());
   }
 #endif
   return ret;
@@ -149,7 +149,7 @@ std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getClose
 
 std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getRulesCloser([[maybe_unused]] const std::string_view& ruleName, [[maybe_unused]] const std::string& ruleType)
 {
-  std::optional<pdns::trace::dnsdist::Tracer::Closer> ret(std::nullopt);
+  std::optional<pdns::trace::dnsdist::Tracer::Closer> ret{std::nullopt};
 #ifndef DISABLE_PROTOBUF
   static const std::string prefix = "Rule: ";
   // getTracer returns a Tracer when tracing is globally enabled
@@ -158,7 +158,7 @@ std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getRules
   if (auto tracer = getTracer(); tracer != nullptr && (tracingEnabled || !rulesAppliedToQuery)) {
     auto parentSpanID = tracer->getLastSpanID();
     auto name = ruleType + prefix + std::string(ruleName);
-    ret = std::optional<pdns::trace::dnsdist::Tracer::Closer>(tracer->openSpan(name, parentSpanID));
+    ret = tracer->openSpan(name, parentSpanID);
   }
 #endif
   return ret;

--- a/pdns/dnsdistdist/dnsdist-opentelemetry.hh
+++ b/pdns/dnsdistdist/dnsdist-opentelemetry.hh
@@ -214,11 +214,30 @@ public:
         d_tracer->closeSpan(d_spanID);
       }
 #endif
-    };
-    Closer(const Closer&) = default;
-    Closer& operator=(const Closer&) = default;
-    Closer& operator=(Closer&&) noexcept = default;
-    Closer(Closer&&) = default;
+    }
+    Closer(const Closer&) = delete;
+    Closer& operator=(const Closer&) = delete;
+    Closer& operator=(Closer&& rhs) noexcept
+    {
+#ifndef DISABLE_PROTOBUF
+      this->d_tracer = std::move(rhs.d_tracer);
+      this->d_spanID = rhs.d_spanID;
+      /* we wouldn't want to close it twice */
+      rhs.d_tracer.reset();
+      rhs.d_spanID.clear();
+#endif
+      return *this;
+    }
+    Closer(Closer&& rhs)
+    {
+#ifndef DISABLE_PROTOBUF
+      this->d_tracer = std::move(rhs.d_tracer);
+      this->d_spanID = rhs.d_spanID;
+      /* we wouldn't want to close it twice */
+      rhs.d_tracer.reset();
+      rhs.d_spanID.clear();
+#endif
+    }
 
     /**
      * @brief Get the SpanID


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Moving them is OK, duplicating them isn't otherwise we might close the same span several times which is bad.

This might prevent this issue that popped on CI:
```
2026-03-17T08:54:12.2188750Z === configs/dnsdist_TestOutgoingTLSOpenSSLYamlTraceparent.log ===
2026-03-17T08:54:12.2190218Z msg="dnsdist 0.0.0-git1 comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it according to the terms of the GPL version 2" subsystem="setup" level="0" prio="Info" ts="1773737020.400"
2026-03-17T08:54:12.2191499Z msg="Raised send buffer size" subsystem="setup" level="0" prio="Info" ts="1773737020.425" frontend.address="127.0.0.1:12494" network.send_buffer_size="212992"
2026-03-17T08:54:12.2192416Z msg="Raised receive buffer size" subsystem="setup" level="0" prio="Info" ts="1773737020.425" buffer_size="1048576" frontend.address="127.0.0.1:12494"
2026-03-17T08:54:12.2193200Z msg="Listening on Do53 frontend" subsystem="setup" level="0" prio="Info" ts="1773737020.425" frontend.address="127.0.0.1:12494"
2026-03-17T08:54:12.2194351Z msg="Allowing queries from" subsystem="setup" level="0" prio="Info" ts="1773737020.425" acl="10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.168.0.0/16, ::1/128, fc00::/7, fe80::/10"
2026-03-17T08:54:12.2195650Z msg="Allowing console connections from" subsystem="setup" level="0" prio="Info" ts="1773737020.425" acl="127.0.0.0/8, ::1/128"
2026-03-17T08:54:12.2196689Z msg="Webserver launched" subsystem="webserver" level="0" prio="Info" ts="1773737020.427" network.local.address="127.0.0.1:12136"
2026-03-17T08:54:12.2198054Z msg="Setting initial status for backend" subsystem="backend" level="0" prio="Info" ts="1773737020.433" backend.address="127.0.0.1:12139" backend.health_check.status="up" backend.name="" backend.protocol="DoT"
2026-03-17T08:54:12.2209390Z dnsdist: ../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist-opentelemetry.cc:176: void pdns::trace::dnsdist::Tracer::closeSpan(const SpanID &): Assertion `data->d_spanIDStack.back() == spanID' failed.
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
