### PR TITLE
auth: correctly delete ENT records from the API

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2537,7 +2537,7 @@ static void replaceZoneRecords(const DomainInfo& domainInfo, const ZoneName& zon
   }
   if (!new_records.empty() && ent_present) {
     QType qt_ent{QType::ENT};
-    if (!domainInfo.backend->replaceRRSet(domainInfo.id, qname, qt_ent, new_records)) {
+    if (!domainInfo.backend->replaceRRSet(domainInfo.id, qname, qt_ent, {})) {
       throw ApiException("Hosting backend does not support editing records.");
     }
   }


### PR DESCRIPTION
### Short description
When a rrset gets replaced from the API, the processing logic checks for an existing `ENT` record with the same name, and if so, attempts to delete it.

However, a mistake in the logic, not only causes the ENT record **not** to be deleted (until the zone gets rectified, so for zones with `API-RECTIFY` metadata set, this does not live enough to get noticed), but also creates an `ENT` rrset with the exact same contents as the rrset to write. So much for the non-terminal being empty...

This one-liner PR correctly invokes the backends' `replaceRRSet' method to cause the `ENT` records to correctly get deleted, prior to the insertion of the actual RRset.

(this bug exists in 4.7 onwards, I have not checked older releases)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
