### PR TITLE
pdnsutil: possibly helpful backend-cmd help

### DIFF
--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -239,6 +239,10 @@ string PipeBackend::directBackendCmd(const string& query)
   if (d_abiVersion < 5)
     return "not supported on ABI version " + std::to_string(d_abiVersion) + " (use ABI version 5 or later)\n";
 
+  if (query.empty()) {
+    return "";
+  }
+
   try {
     launch();
     ostringstream oss;

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -2276,29 +2276,33 @@ bool GSQLBackend::replaceComments(const domainid_t domain_id, const DNSName& qna
 
 string GSQLBackend::directBackendCmd(const string &query)
 {
- try {
-   ostringstream out;
+  if (query.empty()) {
+    return "";
+  }
 
-   auto stmt = d_db->prepare(query,0);
+  try {
+    ostringstream out;
 
-   reconnectIfNeeded();
+    auto stmt = d_db->prepare(query,0);
 
-   stmt->execute();
+    reconnectIfNeeded();
 
-   SSqlStatement::row_t row;
+    stmt->execute();
 
-   while(stmt->hasNextRow()) {
-     stmt->nextRow(row);
-     for(const auto& col: row)
-       out<<"\'"<<col<<"\'\t";
-     out<<endl;
-   }
+    SSqlStatement::row_t row;
 
-   return out.str();
- }
- catch (SSqlException &e) {
-   throw PDNSException("GSQLBackend unable to execute direct command query '" + query + "': "+e.txtReason());
- }
+    while(stmt->hasNextRow()) {
+      stmt->nextRow(row);
+      for(const auto& col: row)
+        out<<"\'"<<col<<"\'\t";
+      out<<endl;
+    }
+
+    return out.str();
+  }
+  catch (SSqlException &e) {
+    throw PDNSException("GSQLBackend unable to execute direct command query '" + query + "': "+e.txtReason());
+  }
 }
 
 string GSQLBackend::pattern2SQLPattern(const string &pattern)

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -5531,7 +5531,7 @@ static int B2BMigrate(vector<string>& cmds, const std::string_view synopsis)
 
 static int backendCmd(vector<string>& cmds, const std::string_view synopsis)
 {
-  if (cmds.size() < 2) {
+  if (cmds.empty()) {
     return usage(synopsis);
   }
 
@@ -5553,11 +5553,17 @@ static int backendCmd(vector<string>& cmds, const std::string_view synopsis)
     return 1;
   }
 
-  for (auto i = next(begin(cmds), 1); i != end(cmds); ++i) {
-    if (cmds.size() != 2 && !g_quiet) {
-      cerr << "== " << *i << endl;
+  if (cmds.size() == 1) {
+    // get usage synposis from backend, if available
+    cout << matchingBackend->directBackendCmd("");
+  }
+  else {
+    for (auto i = next(begin(cmds), 1); i != end(cmds); ++i) {
+      if (cmds.size() != 2 && !g_quiet) {
+        cerr << "== " << *i << endl;
+      }
+      cout << matchingBackend->directBackendCmd(*i);
     }
-    cout << matchingBackend->directBackendCmd(*i);
   }
 
   return 0;


### PR DESCRIPTION
### Short description
At the moment, if one invokes `pdnsutil backend-cmd $backendname` with no actual commands to perform, you get a syntax error and the synopsis of `pdnsutil backend-cmd`.

However, the LMDB backend has code to display a short but much more useful help message in this case.

So let pdnsutil pass no commands to the backends, and let the backends handle that - either doing nothing or giving some information.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
