### PR TITLE
auth: minor lmdb fixes (for the 42nd time)

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1076,7 +1076,7 @@ void serializeToBuffer(std::string& buffer, const LMDBBackend::LMDBResourceRecor
 
   // Reserve space to store the size of the resource record + the content of the resource
   // record + a few other things.
-  buffer.reserve(buffer.size() + sizeof(len) + len + sizeof(value.ttl) + sizeof(value.auth) + sizeof(value.disabled) + sizeof(value.hasOrderName));
+  buffer.reserve(buffer.size() + serialize_prefix_size + len + serialize_trailing_size);
 
   // Store the size of the resource record (in host order).
   // NOLINTNEXTLINE.
@@ -1108,7 +1108,7 @@ static inline size_t deserializeRRFromBuffer(const string_view& str, LMDBBackend
 {
   const auto* data = str.data();
   uint16_t len;
-  if (str.size() < sizeof(len)) {
+  if (str.size() < serialize_prefix_size) {
     return 0;
   }
   memcpy(&len, data, sizeof(len));


### PR DESCRIPTION
### Short description
I left a possibly uninitialized variable in a theoretical code path, so better fix it to appease static analyzers.
And some sugar while I was reading through the serialization/deserialization code again.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
