### PR TITLE
auth, rec: redact more configuration secrets in the /config endpoint

### DIFF
--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -100,13 +100,33 @@ void apiServerDetail(HttpRequest* /* req */, HttpResponse* resp)
   resp->setJsonBody(getServerDetail());
 }
 
+static bool shouldBeRedacted(const std::string& setting)
+{
+  // auth, rec: webserver-password
+  if (boost::ends_with(setting, "-password")) {
+    return true;
+  }
+  // auth, rec: api-key
+  if (boost::ends_with(setting, "api-key")) {
+    return true;
+  }
+#ifdef PDNS_AUTH // [
+  // auth: {edns-cookie,tcp-control}-secret
+  if (boost::ends_with(setting, "-secret")) {
+    return true;
+  }
+#endif // ]
+  return false;
+}
+
 void apiServerConfig(HttpRequest* /* req */, HttpResponse* resp)
 {
   const vector<string>& items = ::arg().list();
   string value;
   Json::array doc;
   for (const string& item : items) {
-    if (item.find("password") != string::npos || item.find("api-key") != string::npos) {
+    // Prevent sensitive configuration values from being leaked
+    if (shouldBeRedacted(item)) {
       value = "***";
     }
     else {


### PR DESCRIPTION
### Short description
This PR makes sure `edns-cookie-secret` and `tcp-control-secret` values won't be available through the `/api/v1/servers/localhost/config` API endpoint.

The way the code gets modified will also affect recursor, but should not change anything in behaviour for it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
