### PR TITLE
dnsdist: Add missing dependencies to our Rust's lib

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
@@ -1,6 +1,9 @@
 sources = files(
   'dnsdist-settings-generator.py',
+  '../dnsdist-actions-definitions.yml',
+  '../dnsdist-selectors-definitions.yml',
   '../dnsdist-settings-definitions.yml',
+  '../dnsdist-response-actions-definitions.yml',
   'dnsdist-configuration-yaml-items-pre-in.cc',
   'rust-pre-in.rs',
   'rust-middle-in.rs',


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We do use the selectors and actions definition to generate the YAML settings parsing parts of the Rust library, so it needs to be re-generated if these change.
This is probably not a problem for anyone that isn't developing on dnsdist so I'm not sure it's worth backporting.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
