### PR TITLE
rec: give better error mesage on api-dir not set

### DIFF
--- a/pdns/recursordist/rec-rust-lib/generate.py
+++ b/pdns/recursordist/rec-rust-lib/generate.py
@@ -295,6 +295,8 @@ def gen_cxx_defineoldsettings(file, entries):
     """Generate C++ code to declare old-style settings"""
     file.write("void pdns::settings::rec::defineOldStyleSettings()\n{\n")
     for entry in entries:
+        if "skip-old" in entry:
+            continue
         helptxt = quote(entry["help"])
         oldname = quote(entry["oldname"])
         if entry["type"] == LType.Bool:

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -65,11 +65,19 @@ std::optional<uint64_t> productServerStatisticsFetch(const std::string& name)
   return getStatByName(name);
 }
 
-static void apiWriteConfigFile(const string& filebasename, const string& content)
+static void checkApiDirSet()
 {
   if (::arg()["api-config-dir"].empty()) {
+    if (g_yamlSettings) {
+      throw ApiException("Config option webservice.api_dir must be set");
+    }
     throw ApiException("Config Option \"api-config-dir\" must be set");
   }
+}
+
+static void apiWriteConfigFile(const string& filebasename, const string& content)
+{
+  checkApiDirSet();
 
   string filename = ::arg()["api-config-dir"] + "/" + filebasename;
   if (g_yamlSettings) {
@@ -243,9 +251,7 @@ static void fillZone(const DNSName& zonename, HttpResponse* resp)
 
 static void doCreateZone(const Json& document)
 {
-  if (::arg()["api-config-dir"].empty()) {
-    throw ApiException("Config Option \"api-config-dir\" must be set");
-  }
+  checkApiDirSet();
 
   const DNSName zone = apiNameToDNSName(stringFromJson(document, "name"));
   const string zonename = zone.toString();
@@ -347,9 +353,7 @@ static void doCreateZone(const Json& document)
 
 static bool doDeleteZone(const DNSName& zonename)
 {
-  if (::arg()["api-config-dir"].empty()) {
-    throw ApiException("Config Option \"api-config-dir\" must be set");
-  }
+  checkApiDirSet();
 
   string filename;
   if (g_yamlSettings) {
@@ -372,9 +376,7 @@ static bool doDeleteZone(const DNSName& zonename)
 
 static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
 {
-  if (::arg()["api-config-dir"].empty()) {
-    throw ApiException("Config Option \"api-config-dir\" must be set");
-  }
+  checkApiDirSet();
 
   Json document = req->json();
 


### PR DESCRIPTION
We currently always report old-style setting name.

Plus skip irrelevant settings when generating the settings table as some settings are Lua or YAML only.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
