### PR TITLE
dnsdist: Fix passing a numeric value to the YAML QType selector

### DIFF
--- a/pdns/dnsdistdist/dnsdist-selectors-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-selectors-definitions.yml
@@ -340,6 +340,7 @@ Set the ``source`` parameter to ``false`` to match against destination address i
   parameters:
     - name: "qtype"
       type: "String"
+      default: ""
       description: "The qtype, as a string"
     - name: "numeric_value"
       type: "u16"

--- a/regression-tests.dnsdist/test_Spoofing.py
+++ b/regression-tests.dnsdist/test_Spoofing.py
@@ -603,7 +603,7 @@ query_rules:
           suffixes:
             - "multiraw.spoofing.tests.powerdns.com"
         - type: "QType"
-          qtype: "A"
+          numeric_value: 1
     action:
       type: "SpoofRaw"
       answers:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixes https://github.com/PowerDNS/pdns/issues/16994

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
