### PR TITLE
rec: Prevent dist failure if cargo is in a non-default location

### DIFF
--- a/pdns/recursordist/meson-dist-script.sh
+++ b/pdns/recursordist/meson-dist-script.sh
@@ -15,9 +15,7 @@ fi
 
 if [ -z "${CARGO}" ]; then
     echo PATH=$PATH
-    ls -l /usr/bin/cargo
     export CARGO=/usr/bin/cargo
-    #exit 1
 fi
 
 cd "$MESON_PROJECT_DIST_ROOT"
@@ -62,7 +60,7 @@ echo Updating the version of the Rust library to ${BUILDER_VERSION}
 # Unfortunately we cannot use --offline because for some reason cargo-update wants
 # to check all dependencies even though we are telling it exactly what to update
 cd "$MESON_PROJECT_DIST_ROOT"/rec-rust-lib/rust/
-ls -l /usr/bin/cargo
+
 echo $CARGO update --verbose --precise ${BUILDER_VERSION} recrust
 $CARGO update --verbose --precise ${BUILDER_VERSION} recrust
 cd "$MESON_PROJECT_BUILD_ROOT"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

We run with -e, so ls -l /usr/bin/cargo will cause failure of the whole script

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
