### PR TITLE
Try to improve the constant-timeness of CredentialsHolder::matches()

### DIFF
--- a/pdns/credentials.cc
+++ b/pdns/credentials.cc
@@ -393,11 +393,9 @@ bool CredentialsHolder::matches(const std::string& password) const
   }
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   uint32_t fallback = burtle(reinterpret_cast<const unsigned char*>(password.data()), password.size(), d_fallbackHashPerturb);
-  if (fallback != d_fallbackHash) {
-    return false;
-  }
-
-  return constantTimeStringEquals(password, d_credentials.getString());
+  bool criterion1 = fallback == d_fallbackHash;
+  bool criterion2 = constantTimeStringEquals(password, d_credentials.getString());
+  return criterion2 && criterion1;
 }
 
 bool CredentialsHolder::isHashingAvailable()


### PR DESCRIPTION
### Short description
The credentials matching logic tries hard to use a constant-time function. But if the passwords are not hashed, there is a hash computation performed first, which will cause the constant-time comparison to be skipped, most of the time.

This PR tries to force both operations to run before deciding whether to accept or reject the password.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
