### PR TITLE
rec: Fix a typo in the documention of `pdns_features`

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/features.rst
+++ b/pdns/recursordist/docs/lua-scripting/features.rst
@@ -11,6 +11,6 @@ Currently, the following keys are defined:
 
 .. code-block:: Lua
                 
-    pdns_feature["PR8001_devicename"] = true
+    pdns_features["PR8001_devicename"] = true
 
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
