### PR TITLE
Backport #16973: Change OT Trace YAML config to a struct

### DIFF
--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1850,6 +1850,18 @@ structured_logging:
         Add a field "instance" to each log line with the value of ``general.server_id``.
       version_added: 2.1.0
 
+open_telemetry_tracing:
+  category: "logging.open_telemetry_tracing"
+  description: "OpenTelemetry Trace settings"
+  parameters:
+    - name: "enabled"
+      type: "bool"
+      default: "false"
+      runtime-configurable: true
+      lua-name: "setOpenTelemetryTracing"
+      internal-field-name: "d_openTelemetryTracing"
+      description: "Set to true to enable OpenTelemetry tracing. When true, the :func:`DNSQuestion:setTrace` makes the query store tracing information (see :doc:`OpenTelemetry tracing <ottrace>`). When this setting is false, no tracing information is gathered at all."
+
 logging:
   description: "Logging settings"
   parameters:
@@ -1924,12 +1936,8 @@ logging:
       type: "StructuredLoggingConfiguration"
       default: true
     - name: "open_telemetry_tracing"
-      type: "bool"
-      default: "false"
-      lua-name: "setOpenTelemetryTracing"
-      internal-field-name: "d_openTelemetryTracing"
-      runtime-configurable: true
-      description: "Set to true to enable OpenTelemetry tracing. When true, the :func:`DNSQuestion:setTrace` makes the query store tracing information (see :doc:`OpenTelemetry tracing <ottrace>`). When this setting is false, no tracing information is gathered at all."
+      type: "OpenTelemetryTracingConfiguration"
+      default: true
 
 general:
   description: "General settings"

--- a/pdns/dnsdistdist/docs/reference/ottrace.rst
+++ b/pdns/dnsdistdist/docs/reference/ottrace.rst
@@ -7,7 +7,7 @@ OpenTelemetry Tracing
 
 Since version 2.1.0, when :program:`dnsdist` is built with ProtoBuf support, sent messages (using e.g. :func:`RemoteLogResponseAction`) can contain `OpenTelemetry traces <https://opentelemetry.io/docs/concepts/signals/traces>`__ data.
 
-To enable tracing, use :func:`setOpenTelemetryTracing(true) <setOpenTelemetryTracing>` in your configuration, or ``logging.open_telemetry_tracing`` to ``true`` in your:ref:`YAML Logging Configuration <yaml-settings-LoggingConfiguration>`.
+To enable tracing, use :func:`setOpenTelemetryTracing(true) <setOpenTelemetryTracing>` in your configuration, or ``logging.open_telemetry_tracing.enabled`` to ``true`` in your :ref:`YAML Logging Configuration <yaml-settings-LoggingConfiguration>`.
 It is also possible to call :func:`setOpenTelemetryTracing` at runtime.
 Once enabled, Rules can be used to turn on tracing on a per-query basis.
 
@@ -27,7 +27,8 @@ When sending the trace in this way, the Protobuf message is essentially empty ap
 .. code-block:: yaml
 
    logging:
-     open_telemetry_tracing: true
+     open_telemetry_tracing:
+       enabled: true
    remote_logging:
      protobuf_loggers:
        - name: pblog
@@ -48,7 +49,8 @@ Should you only want to receive the trace, including a fully filled Protobuf mes
 .. code-block:: yaml
 
    logging:
-     open_telemetry_tracing: true
+     open_telemetry_tracing:
+       enabled: true
    remote_logging:
      protobuf_loggers:
        - name: pblog

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -1,6 +1,27 @@
 Upgrade Guide
 =============
 
+2.1.0-beta2 to 2.1.0
+--------------------
+
+The :doc:`reference/ottrace` YAML configuration has changed.
+It is now a structure with a single ``enabled`` field.
+
+Old:
+
+.. code-block:: yaml
+
+  logging:
+    open_telemetry_tracing: true
+
+New:
+
+.. code-block:: yaml
+
+  logging:
+    open_telemetry_tracing:
+      enabled: true
+
 2.0.x to 2.1.0
 --------------
 

--- a/regression-tests.dnsdist/test_OpenTelemetryTracing.py
+++ b/regression-tests.dnsdist/test_OpenTelemetryTracing.py
@@ -220,7 +220,8 @@ class TestOpenTelemetryTracingBaseYAML(DNSDistOpenTelemetryProtobufBaseTest):
     ]
     _yaml_config_template = """---
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: 127.0.0.1:%d
@@ -306,7 +307,8 @@ class TestOpenTelemetryTracingBaseDelayYAML(DNSDistOpenTelemetryProtobufBaseTest
     ]
     _yaml_config_template = """---
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: 127.0.0.1:%d
@@ -397,7 +399,8 @@ class TestOpenTelemetryTracingUseIncomingYAML(DNSDistOpenTelemetryProtobufBaseTe
     ]
     _yaml_config_template = """---
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: 127.0.0.1:%d
@@ -475,7 +478,8 @@ class DNSDistOpenTelemetryProtobufEnabledButUnsetYAML(
     _yaml_config_template = """---
 
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: 127.0.0.1:%d
@@ -524,7 +528,8 @@ class DNSDistOpenTelemetryProtobufEnabledSetButTurnedOffYAML(
 
     _yaml_config_template = """---
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: 127.0.0.1:%d
@@ -589,7 +594,8 @@ class TestOpenTelemetryTracingBaseYAMLIncludedRemoteLoggerDropped(
     ]
     _yaml_config_template = """---
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: 127.0.0.1:%d
@@ -687,7 +693,8 @@ class TestOpenTelemetryTracingBaseYAMLIncludedRemoteLoggerSpoofed(
     ]
     _yaml_config_template = """---
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: 127.0.0.1:%d
@@ -759,7 +766,8 @@ class TestOpenTelemetryTracingStripIncomingTraceParent(
     ]
     _yaml_config_template = """---
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: 127.0.0.1:%d
@@ -866,7 +874,8 @@ class TestOpenTelemetryTracingSendTraceparentDownstream(
     ]
     _yaml_config_template = """---
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: 127.0.0.1:%d

--- a/regression-tests.dnsdist/test_OutgoingTLS.py
+++ b/regression-tests.dnsdist/test_OutgoingTLS.py
@@ -318,7 +318,8 @@ class TestOutgoingTLSGnuTLSWrongCertNameButNoCheck(DNSDistTest, OutgoingTLSTests
 class TestOutgoingTLSOpenSSLYamlTraceparent(TestOutgoingTLSOpenSSLYaml):
     _yaml_config_template = """---
 logging:
-  open_telemetry_tracing: true
+  open_telemetry_tracing:
+    enabled: true
 
 backends:
   - address: "127.0.0.1:%d"


### PR DESCRIPTION

### Short description

This'll allow us to add more trace feature configuration in the future and it mirrors the `structured_logging` config. Backport of #16973.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] checked that this code was merged to master
