### PR TITLE
rec docs: describe followCNAMERecords better

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/hooks.rst
+++ b/pdns/recursordist/docs/lua-scripting/hooks.rst
@@ -302,16 +302,16 @@ dq.followupPrefix to the same prefix as used with
 
 Follow up actions
 -----------------
-When modifying queries, it might be needed that the Recursor does some extra work after the function returns.
+When modifying queries, it might be needed that the :program:`Recursor` does some extra work after the function returns.
 The :attr:`dq.followupFunction <DNSQuestion.followupFunction>` can be set in this case.
 
 .. _cnamechainresolution:
 
 CNAME chain resolution
 ^^^^^^^^^^^^^^^^^^^^^^
-It may be useful to return a CNAME record for Lua, and then have the PowerDNS Recursor continue resolving that CNAME.
-This can be achieved by setting dq.followupFunction to ``followCNAMERecords`` and dq.followupDomain to "www.powerdns.com".
-PowerDNS will do the rest.
+It may be useful to return a ``CNAME`` record for Lua, and then have :program:`Recursor` continue resolving that ``CNAME``.
+This can be achieved by adding or setting a ``CNAME`` record and setting :attr:`dq.followupFunction <DNSQuestion.followupFunction>` to ``"followCNAMERecords"``.
+:program:`Recursor` will inspect the current records and resolve the ``CNAME`` found.
 
 .. _udpqueryresponse:
 

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -702,6 +702,9 @@ int followCNAMERecords(vector<DNSRecord>& ret, const QType qtype, int rcode)
 {
   vector<DNSRecord> resolved;
   DNSName target;
+  // Docs do not specify *which* CNAME is picked. We take the first
+  // and do not mind the section. Maybe the last in the answer section
+  // would be what users expect?
   for (const DNSRecord& record : ret) {
     if (record.d_type == QType::CNAME) {
       auto rec = getRR<CNAMERecordContent>(record);


### PR DESCRIPTION
While working on this, I noted it is underspecified *which* CNAME record is followed, but that is for some other time.

Fixes #17030

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
