### PR TITLE
rec: add meson option to not build man pages

### DIFF
--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -618,11 +618,11 @@ endif
 py = import('python')
 python = py.find_installation('python3', modules: 'venv', required: false)
 
-summary('Python', python.found(), bool_yn: true, section: 'Manual Pages')
-summary('Path', python.full_path(), section: 'Manual Pages')
-summary('Version', python.version(), section: 'Manual Pages')
+summary('Python with venv', python.found(), bool_yn: true, section: 'Manual Pages')
 
-if python.found()
+if get_option('man-pages') and python.found()
+  summary('Path', python.full_path(), section: 'Manual Pages')
+  summary('Version', python.version(), section: 'Manual Pages')
   generated_man_pages = []
   foreach tool, info: tools
     if 'manpages' in info
@@ -660,6 +660,8 @@ if python.found()
   else
     summary('Generating man pages', false, section: 'Manual Pages')
   endif
+else
+  summary('Generating man pages', false, section: 'Manual Pages')
 endif
 
 if dep_systemd_prog.found()

--- a/pdns/recursordist/meson_options.txt
+++ b/pdns/recursordist/meson_options.txt
@@ -25,3 +25,4 @@ option('nod', type: 'feature', value: 'enabled', description: 'Enable Newly Obse
 option('libcap', type: 'feature', value: 'auto', description: 'Enable libcap for capabilities handling')
 option('clang-coverage-format', type: 'boolean', value: false, description: 'Whether to generate coverage data in clang format')
 option('tls-gnutls', type: 'feature', value: 'auto', description: 'GnuTLS-based TLS')
+option('man-pages', type: 'boolean', value: true, description: 'Generate man pages')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

dnsdist has similar. The recent update introduced a dependency on python >= 3.12, which is not available everywhere. So it is handy to have an option to skip building man pages.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
