### PR TITLE
dnsdist: Fix micro-benchmarks compilation

### DIFF
--- a/pdns/dnsdistdist/bench-dnsdist-rings_cc.cc
+++ b/pdns/dnsdistdist/bench-dnsdist-rings_cc.cc
@@ -46,8 +46,12 @@ auto simpleRings = std::vector<ringInfo>{
 TEST_CASE("Rings/insert")
 {
   for (auto const ringInfo : simpleRings) {
+    Rings::RingsConfiguration config;
+    config.capacity = ringInfo.maxEntries;
+    config.numberOfShards = ringInfo.numberOfShards;
+    config.nbLockTries = ringInfo.nbLockTries;
     Rings rings;
-    rings.init(ringInfo.maxEntries, ringInfo.numberOfShards, ringInfo.nbLockTries);
+    rings.init(config);
 
     dnsheader dnsheader{};
     memset(&dnsheader, 0, sizeof(dnsheader));

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -624,6 +624,7 @@ if get_option('benchmark')
         dep_ffi_interface,
         dep_lua,
         dep_protozero,
+        dep_libsystemd,
       ],
     }
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
