### PR TITLE
Broader exception catching around stoi usage

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -3377,8 +3377,8 @@ string LMDBBackend::directBackendCmd(const string& query)
       try {
         pdns::checked_stoi_into(id, argv[3]);
       }
-      catch (const std::out_of_range& e) {
-        return "ID out of range\n";
+      catch (const std::logic_error&) {
+        return "ill-formed ID\n";
       }
 
       if (genChangeDomain(id, [](DomainInfo& /* di */) {})) {

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -441,7 +441,7 @@ void fillSOAData(const string& content, SOAData& soaData)
     pdns::checked_stoi_into(soaData.expire, parts.at(5));
     pdns::checked_stoi_into(soaData.minimum, parts.at(6));
   }
-  catch (const std::out_of_range& oor) {
-    throw PDNSException("Out of range exception parsing '" + content + "'");
+  catch (const std::logic_error& exc) {
+    throw PDNSException("exception parsing '" + content + "': " + exc.what());
   }
 }

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -432,11 +432,7 @@ try
     {
       s_wednserrors++;
     }
-    catch(std::out_of_range &e)
-    {
-      s_wednserrors++;
-    }
-    catch(std::exception& e)
+    catch(std::exception&)
     {
       s_wednserrors++;
     }

--- a/pdns/json.cc
+++ b/pdns/json.cc
@@ -38,8 +38,8 @@ static inline int intFromJsonInternal(const Json& container, const std::string& 
   if (val.is_string()) {
     try {
       return std::stoi(val.string_value());
-    } catch (std::out_of_range&) {
-      throw JsonException("Key '" + string(key) + "' is out of range");
+    } catch (std::logic_error&) {
+      throw JsonException("Key '" + string(key) + "' is not a valid number");
     }
   }
 
@@ -88,8 +88,8 @@ static inline double doubleFromJsonInternal(const Json& container, const std::st
   if (val.is_string()) {
     try {
       return std::stod(val.string_value());
-    } catch (std::out_of_range&) {
-      throw JsonException("Value for key '" + string(key) + "' is out of range");
+    } catch (std::logic_error&) {
+      throw JsonException("Value for key '" + string(key) + "' is not a valid number");
     }
   }
 

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -720,7 +720,7 @@ int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret)
         auto tmpPort = pdns::checked_stoi<uint16_t>(addr.substr(pos + 2));
         port = std::make_optional(tmpPort);
       }
-      catch (const std::out_of_range&) {
+      catch (const std::logic_error&) {
         return -1;
       }
     }

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -366,7 +366,7 @@ void Resolver::getSoaSerial(const ComboAddress& ipport, const DNSName &domain, u
   try {
     *serial = pdns::checked_stoi<uint32_t>(parts[2]);
   }
-  catch(const std::out_of_range& oor) {
+  catch(const std::logic_error&) {
     throw ResolverException("Query to '" + ipport.toLogString() + "' for SOA of '" + domain.toLogString() + "' produced an unparseable serial");
   }
 }

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1271,9 +1271,9 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
         try {
           pdns::checked_stoi_into(serial, parts[2]);
         }
-        catch(const std::out_of_range& oor) {
+        catch(const std::logic_error& exc) {
           SLOG(g_log<<Logger::Warning<<logPrefix<<"invalid serial in IXFR query"<<endl,
-               slog->info(Logr::Warning, "IXFR: invalid serial in query", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+               slog->error(Logr::Warning, exc.what(), "IXFR: invalid serial in query", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
           outpacket->setRcode(RCode::FormErr);
           sendPacket(outpacket,outsock);
           return 0;

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -138,7 +138,7 @@ unsigned int ZoneParserTNG::makeTTLFromZone(const string& str)
   try {
     pdns::checked_stoi_into(val, str);
   }
-  catch (const std::out_of_range& oor) {
+  catch (const std::logic_error&) {
     throw PDNSException("Unable to parse time specification '"+str+"' "+getLineOfFile());
   }
 

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -2461,7 +2461,7 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
             headers={"content-type": "application/json"},
         )
         self.assertEqual(r.status_code, 422)
-        self.assert_in_json_error("Key 'modified_at' is out of range", r.json())
+        self.assert_in_json_error("Key 'modified_at' is not a valid number", r.json())
 
     @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
     def test_zone_comment_stay_intact(self):


### PR DESCRIPTION
### Short description
Users of `std::stoi` and its variants (including `pdns::checked_stoi`) will check for `std::out_of_range`, but if the data to convert does not start with a digit, the exception raised will be `std::invalid_argument`.

Both exceptions derive from `std::logic_error`, so this PR changes the `catch` blocks to use `std::logic_error` instead.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
