### PR TITLE
recursor: Fix lua addRecord function implementation

### DIFF
--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -132,10 +132,20 @@ void RecursorLua4::DNSQuestion::setRecords(const vector<pair<int, DNSRecord>>& a
   }
 }
 
-void RecursorLua4::DNSQuestion::addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, std::optional<int> ttl, std::optional<DNSName> name)
+void RecursorLua4::DNSQuestion::addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, std::optional<int> ttl, RecursorLua4::DNSQuestion::OptDNSNameOrString name)
 {
-  DNSRecord dnsRecord;
-  dnsRecord.d_name = name.value_or(qname);
+  DNSRecord dnsRecord{};
+  if (name) {
+    if (const auto* ptr = boost::get<std::string>(&*name)) {
+      dnsRecord.d_name = DNSName(*ptr);
+    }
+    else {
+      dnsRecord.d_name = *boost::get<DNSName>(&*name);
+    }
+  }
+  else {
+    dnsRecord.d_name = qname;
+  }
   dnsRecord.d_ttl = ttl.value_or(3600);
   dnsRecord.d_type = type;
   dnsRecord.d_place = place;
@@ -143,7 +153,7 @@ void RecursorLua4::DNSQuestion::addRecord(uint16_t type, const std::string& cont
   records.push_back(std::move(dnsRecord));
 }
 
-void RecursorLua4::DNSQuestion::addAnswer(uint16_t type, const std::string& content, std::optional<int> ttl, std::optional<DNSName> name)
+void RecursorLua4::DNSQuestion::addAnswer(uint16_t type, const std::string& content, std::optional<int> ttl, OptDNSNameOrString name)
 {
   addRecord(type, content, DNSResourceRecord::ANSWER, ttl, std::move(name));
 }

--- a/pdns/recursordist/lua-recursor4.cc
+++ b/pdns/recursordist/lua-recursor4.cc
@@ -132,10 +132,10 @@ void RecursorLua4::DNSQuestion::setRecords(const vector<pair<int, DNSRecord>>& a
   }
 }
 
-void RecursorLua4::DNSQuestion::addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, std::optional<int> ttl, std::optional<string> name)
+void RecursorLua4::DNSQuestion::addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, std::optional<int> ttl, std::optional<DNSName> name)
 {
   DNSRecord dnsRecord;
-  dnsRecord.d_name = name ? DNSName(*name) : qname;
+  dnsRecord.d_name = name.value_or(qname);
   dnsRecord.d_ttl = ttl.value_or(3600);
   dnsRecord.d_type = type;
   dnsRecord.d_place = place;
@@ -143,7 +143,7 @@ void RecursorLua4::DNSQuestion::addRecord(uint16_t type, const std::string& cont
   records.push_back(std::move(dnsRecord));
 }
 
-void RecursorLua4::DNSQuestion::addAnswer(uint16_t type, const std::string& content, std::optional<int> ttl, std::optional<string> name)
+void RecursorLua4::DNSQuestion::addAnswer(uint16_t type, const std::string& content, std::optional<int> ttl, std::optional<DNSName> name)
 {
   addRecord(type, content, DNSResourceRecord::ANSWER, ttl, std::move(name));
 }

--- a/pdns/recursordist/lua-recursor4.hh
+++ b/pdns/recursordist/lua-recursor4.hh
@@ -136,8 +136,9 @@ public:
     bool isTcp;
     vState validationState{vState::Indeterminate};
 
-    void addAnswer(uint16_t type, const std::string& content, std::optional<int> ttl, std::optional<DNSName> name);
-    void addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, std::optional<int> ttl, std::optional<DNSName> name);
+    using OptDNSNameOrString = std::optional<boost::variant<std::string, DNSName>>;
+    void addAnswer(uint16_t type, const std::string& content, std::optional<int> ttl, OptDNSNameOrString name);
+    void addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, std::optional<int> ttl, OptDNSNameOrString name);
     [[nodiscard]] vector<pair<int, DNSRecord>> getRecords() const;
     [[nodiscard]] std::optional<dnsheader> getDH() const;
     [[nodiscard]] vector<pair<uint16_t, string>> getEDNSOptions() const;

--- a/pdns/recursordist/lua-recursor4.hh
+++ b/pdns/recursordist/lua-recursor4.hh
@@ -136,8 +136,8 @@ public:
     bool isTcp;
     vState validationState{vState::Indeterminate};
 
-    void addAnswer(uint16_t type, const std::string& content, std::optional<int> ttl, std::optional<string> name);
-    void addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, std::optional<int> ttl, std::optional<string> name);
+    void addAnswer(uint16_t type, const std::string& content, std::optional<int> ttl, std::optional<DNSName> name);
+    void addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, std::optional<int> ttl, std::optional<DNSName> name);
     [[nodiscard]] vector<pair<int, DNSRecord>> getRecords() const;
     [[nodiscard]] std::optional<dnsheader> getDH() const;
     [[nodiscard]] vector<pair<uint16_t, string>> getEDNSOptions() const;

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -1091,14 +1091,11 @@ end
         self.assertEqual(res.answer, expectedAnswerRecords)
 
 
-class AddRecordRecusrorTest(RecursorTest):
-    """Test addRecord can add SOA to authority section.
-    """
+class RecursorAddRecordTest(RecursorTest):
+    "Test addRecord in recursor"
 
-    _confdir = "AddRecordRecusror"
+    _confdir = "RecursorAddRecord"
     _soa = "ns1.example. admin.example. 2026033101 3600 1200 604800 60"
-    _config_template = """
-    """
     _lua_dns_script_file = f"""
     local PLACE_AUTHORITY = 2
 
@@ -1118,10 +1115,10 @@ class AddRecordRecusrorTest(RecursorTest):
     end
     """
 
-    def testAddRecord4AuthSeection(self):
+    def testAddRecord4AuthSection(self):
         """addRecord: NXDOMAIN response with SOA in authority section"""
         expectedAuthority = dns.rrset.from_text(
-            "example.", 3600, dns.rdataclass.IN, "SOA", AddRecordRecusrorTest._soa
+            "example.", 3600, dns.rdataclass.IN, "SOA", RecursorAddRecordTest._soa
         )
         query = dns.message.make_query("nxd-addrecord.example.", "A")
 

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -1092,22 +1092,54 @@ end
 
 
 class RecursorAddRecordTest(RecursorTest):
-    "Test addRecord in recursor"
+    """Test that addRecord works as expected with different pdns.place'es
+    and accepts 'name' argument as a string or DNSName
+    """
 
     _confdir = "RecursorAddRecord"
-    _soa = "ns1.example. admin.example. 2026033101 3600 1200 604800 60"
+    _soa_1 = "ns.example. admin.example. 2026033101 3600 1200 604800 60"
+    _soa_2 = "ns.example. admin.example. 1970010101 3600 1200 604800 60"
     _lua_dns_script_file = f"""
-    local PLACE_AUTHORITY = 2
 
+    -- preresolve handles 3 names, all use addRecord in different capacity:
+    -- - nxdomain-addrecord-as-dnsname.example. - returns NXDOMAIN, uses addRecord with
+    --   name argument as DNSName
+    -- - nxdomain-addrecord-as-string.example. - returns NXDOMAIN, uses addRecord with
+    --   name argument as string
+    -- - addrecord-as-string.example. returns A, uses addRecord to use a different
+    --   pdns.place
+    --
     function preresolve(dq)
-      if dq.qname == newDN("nxd-addrecord.example.") then
+      if dq.qname == newDN("nxdomain-addrecord-as-dnsname.example.") then
         dq.rcode = pdns.NXDOMAIN
         dq:addRecord(
           pdns.SOA,
-          "{_soa}",
-          PLACE_AUTHORITY,
+          "{_soa_1}",
+          pdns.place.AUTHORITY,
           3600,
           newDN("example.")
+        )
+        return true
+      end
+      if dq.qname == newDN("nxdomain-addrecord-as-string.example.") then
+        dq.rcode = pdns.NXDOMAIN
+        dq:addRecord(
+          pdns.SOA,
+          "{_soa_2}",
+          pdns.place.AUTHORITY,
+          3600,
+          "example."
+        )
+        return true
+      end
+      if dq.qname == newDN("addrecord-as-string.example.") then
+        dq.rcode = pdns.NOERROR
+        dq:addRecord(
+          pdns.A,
+          "192.0.2.1",
+          pdns.place.ANSWER,
+          60,
+          "addrecord-as-string.example."
         )
         return true
       end
@@ -1115,12 +1147,14 @@ class RecursorAddRecordTest(RecursorTest):
     end
     """
 
-    def testAddRecord4AuthSection(self):
-        """addRecord: NXDOMAIN response with SOA in authority section"""
+    def testAddRecord4NXDOMAINAuthSectionUseDNSName(self):
+        """test that addRecord can add AUTHORITY section to NXDOMAIN
+        providing name argument as an DNSName instance"""
+
         expectedAuthority = dns.rrset.from_text(
-            "example.", 3600, dns.rdataclass.IN, "SOA", RecursorAddRecordTest._soa
+            "example.", 3600, dns.rdataclass.IN, "SOA", RecursorAddRecordTest._soa_1
         )
-        query = dns.message.make_query("nxd-addrecord.example.", "A")
+        query = dns.message.make_query("nxdomain-addrecord-as-dnsname.example.", "A")
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
@@ -1129,3 +1163,38 @@ class RecursorAddRecordTest(RecursorTest):
             self.assertEqual(len(res.answer), 0)
             self.assertEqual(len(res.authority), 1)
             self.assertEqual(res.authority[0], expectedAuthority)
+
+    def testAddRecord4NXDOMAINAuthSectionUseString(self):
+        """test that addRecord can add AUTHORITY section to NXDOMAIN
+        providing name argument as a string"""
+
+        expectedAuthority = dns.rrset.from_text(
+            "example.", 3600, dns.rdataclass.IN, "SOA", RecursorAddRecordTest._soa_2
+        )
+        query = dns.message.make_query("nxdomain-addrecord-as-string.example.", "A")
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+            self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+            self.assertEqual(len(res.answer), 0)
+            self.assertEqual(len(res.authority), 1)
+            self.assertEqual(res.authority[0], expectedAuthority)
+
+    def testAddRecord4NOERROR_A_WithStringAsName(self):
+        """also check a simple case when we use addRecord to generate simple
+        NOERROR's ANSWER section
+        """
+
+        qname = "addrecord-as-string.example."
+        query = dns.message.make_query(qname, "A")
+        expected = [
+            dns.rrset.from_text(qname, 0, dns.rdataclass.IN, "A", "192.0.2.1"),
+        ]
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+            self.assertRcodeEqual(res, dns.rcode.NOERROR)
+            self.assertEqual(len(res.answer), 1)
+            self.assertEqual(len(res.authority), 0)
+            self.assertResponseMatches(query, expected, res)

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -1089,3 +1089,46 @@ end
         self.assertEqual(len(res.authority), 0)
         self.assertEqual(len(res.additional), 0)
         self.assertEqual(res.answer, expectedAnswerRecords)
+
+
+class AddRecordRecusrorTest(RecursorTest):
+    """Test addRecord can add SOA to authority section.
+    """
+
+    _confdir = "AddRecordRecusror"
+    _soa = "ns1.example. admin.example. 2026033101 3600 1200 604800 60"
+    _config_template = """
+    """
+    _lua_dns_script_file = f"""
+    local PLACE_AUTHORITY = 2
+
+    function preresolve(dq)
+      if dq.qname == newDN("nxd-addrecord.example.") then
+        dq.rcode = pdns.NXDOMAIN
+        dq:addRecord(
+          pdns.SOA,
+          "{_soa}",
+          PLACE_AUTHORITY,
+          3600,
+          newDN("example.")
+        )
+        return true
+      end
+      return false
+    end
+    """
+
+    def testAddRecord4AuthSeection(self):
+        """addRecord: NXDOMAIN response with SOA in authority section"""
+        expectedAuthority = dns.rrset.from_text(
+            "example.", 3600, dns.rdataclass.IN, "SOA", AddRecordRecusrorTest._soa
+        )
+        query = dns.message.make_query("nxd-addrecord.example.", "A")
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+            self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+            self.assertEqual(len(res.answer), 0)
+            self.assertEqual(len(res.authority), 1)
+            self.assertEqual(res.authority[0], expectedAuthority)


### PR DESCRIPTION
### Short description
If addRecord is called in recursor, recursor errors with the following message in logs:
```
msg="Exception in resolver context" error="[string \"chunk\"]:6: Unable to convert parameter from userdata to N5boost8optionalINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE
stack traceback:
	[C]: in function 'addRecord'
	[string \"chunk\"]:6: in function <[string \"chunk\"]:2>" subsystem="syncres" level="0" prio="Error" tid="2" ts="1774655562.434" ecs="" exception="std::exception" mtid="2" proto="udp" qname="test.example.com" qtype="A" remote="127.0.0.1:42431"
```

I filed a bug that has details on how to reproduce: #17052 
This PR fixes this problem

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
