### PR TITLE
dnsdist: Do not oversize the received buffer with `recvmmsg`

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1309,8 +1309,8 @@ static bool isUDPQueryAcceptable(ClientState& clientState, const struct msghdr* 
     /* message was too large for our buffer */
     VERBOSESLOG(infolog("Dropping message too large for our buffer"),
                 dnsdist::logging::getTopLogger("udp-query")->info(Logr::Info, "Dropping query from client that is too large for our buffer", "client.address", Logging::Loggable(remote), "destination.address", Logging::Loggable(dest), "frontend.address", Logging::Loggable(clientState.local)));
-    ++clientState.nonCompliantQueries;
     ++dnsdist::metrics::g_stats.nonCompliantQueries;
+    ++clientState.nonCompliantQueries;
     return false;
   }
 
@@ -2313,8 +2313,8 @@ static void MultipleMessagesUDPClientThread(ClientState* clientState)
 
       if ((msgh->msg_flags & MSG_TRUNC) != 0) {
         /* message was too large for our buffer */
-        ++clientState->nonCompliantQueries;
         ++dnsdist::metrics::g_stats.nonCompliantQueries;
+        ++clientState->nonCompliantQueries;
         continue;
       }
 

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -2287,7 +2287,7 @@ static void MultipleMessagesUDPClientThread(ClientState* clientState)
 
     /* block until we have at least one message ready, but return
        as many as possible to save the syscall costs */
-    msgsGot = recvmmsg(clientState->udpFD, msgVec.data(), vectSize, MSG_WAITFORONE | MSG_TRUNC, nullptr);
+    msgsGot = recvmmsg(clientState->udpFD, msgVec.data(), vectSize, MSG_WAITFORONE, nullptr);
     if (msgsGot <= 0) {
       int savederrno = errno;
       VERBOSESLOG(infolog("Getting UDP messages via recvmmsg() failed with: %s", stringerror(savederrno)),
@@ -2308,6 +2308,13 @@ static void MultipleMessagesUDPClientThread(ClientState* clientState)
       if (static_cast<size_t>(got) < sizeof(struct dnsheader)) {
         ++dnsdist::metrics::g_stats.nonCompliantQueries;
         ++clientState->nonCompliantQueries;
+        continue;
+      }
+
+      if ((msgh->msg_flags & MSG_TRUNC) != 0) {
+        /* message was too large for our buffer */
+        ++clientState->nonCompliantQueries;
+        ++dnsdist::metrics::g_stats.nonCompliantQueries;
         continue;
       }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Passing `MSG_TRUNC` to `recvmmsg` causes the Linux kernel to report the real size of the datagram even if it was longer than the passed buffer, which is not what we want here as it would be wasteful to resize our internal buffer to this size.

This was reported by komaku in #YWH-PGM6095-172, many thanks!.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
