### PR TITLE
Hardened DoH3 internal error handling for cpq

### DIFF
--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -661,10 +661,13 @@ static void processDOH3Query(DOH3UnitUniquePtr&& doh3Unit)
     if (downstream->passCrossProtocolQuery(std::move(cpq))) {
       return;
     }
-    // NOLINTNEXTLINE(bugprone-use-after-move): it was only moved if the call succeeded
-    unit = cpq->releaseDU();
-    unit->status_code = 500;
-    handleImmediateResponse(std::move(unit), "DoH3 internal error");
+
+    /* On exceptional cases, cpq is moved but returns false above. So we check to make sure. See https://github.com/PowerDNS/pdns/issues/17109 */
+    if (cpq) {
+      unit = cpq->releaseDU();
+      unit->status_code = 500;
+      handleImmediateResponse(std::move(unit), "DoH3 internal error");
+    }
     return;
   }
   catch (const std::exception& e) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Added a check for cpq before releasing DU to handle exceptional cases.

Barely does a fix for https://github.com/PowerDNS/pdns/issues/17109, where instead of a segfault, nothing happens and the client making the DoH3 DNS request is left hanging. At least, dnsdist keeps running.

Also related to #17114

### NOTE
I initially submitted this as a potential security issue in YesWeHack and it got marked as informative, and I got permission to post it publicly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
