### PR TITLE
dnsdist: Refactor access to DNS headers from Lua

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dnsquestion.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsquestion.cc
@@ -34,15 +34,16 @@ std::string DNSQuestion::getTrailingData() const
 
 bool DNSQuestion::setTrailingData(const std::string& tail)
 {
+  auto& mutableData = getMutableData();
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  const char* message = reinterpret_cast<const char*>(this->data.data());
-  const uint16_t messageLen = getDNSPacketLength(message, this->data.size());
-  this->data.resize(messageLen);
+  const char* message = reinterpret_cast<const char*>(mutableData.data());
+  const uint16_t messageLen = getDNSPacketLength(message, mutableData.size());
+  mutableData.resize(messageLen);
   if (!tail.empty()) {
     if (!hasRoomFor(tail.size())) {
       return false;
     }
-    this->data.insert(this->data.end(), tail.begin(), tail.end());
+    mutableData.insert(mutableData.end(), tail.begin(), tail.end());
   }
   return true;
 }
@@ -74,7 +75,7 @@ std::shared_ptr<const Logr::Logger> DNSResponse::getThisLogger(std::shared_ptr<c
     return d_logger;
   }
   auto logger = DNSQuestion::getThisLogger(std::move(parent));
-  if (data.size() >= sizeof(dnsheader)) {
+  if (getData().size() >= sizeof(dnsheader)) {
     const auto header = getHeader();
     logger = logger->withValues("dns.response.rcode", Logging::Loggable(header->rcode));
   }
@@ -82,7 +83,7 @@ std::shared_ptr<const Logr::Logger> DNSResponse::getThisLogger(std::shared_ptr<c
     logger = logger->withValues("backend.protocol", Logging::Loggable(d_downstream->getProtocol()), "backend.name", Logging::Loggable(d_downstream->getName()), "backend.address", Logging::Loggable(d_downstream->d_config.remote));
   }
   const double udiff = ids.queryRealTime.udiff();
-  logger = logger->withValues("dns.response.latency_us", Logging::Loggable(udiff), "dns.response.size", Logging::Loggable(data.size()));
+  logger = logger->withValues("dns.response.latency_us", Logging::Loggable(udiff), "dns.response.size", Logging::Loggable(getData().size()));
   return logger;
 }
 

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
@@ -99,7 +99,7 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
   luaCtx.registerMember<dnsheader*(DNSQuestion::*)>(
     "dh",
     [](const DNSQuestion& dnsQuestion) -> dnsheader* {
-      return dnsQuestion.getMutableHeader();
+      return const_cast<DNSQuestion&>(dnsQuestion).getMutableHeader();
     },
     [](DNSQuestion& dnsQuestion, const dnsheader* dnsHeader) {
       dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion.getMutableData(), [&dnsHeader](dnsheader& header) {
@@ -185,6 +185,15 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
       return {};
     }
     return EDNSOptionViewsToValues(*ednsOptions);
+  });
+  luaCtx.registerFunction<dnsheader (DNSQuestion::*)() const>("getHeader", [](const DNSQuestion& dnsQuestion) -> dnsheader {
+    return *(dnsQuestion.getHeader());
+  });
+  luaCtx.registerFunction<void (DNSQuestion::*)(dnsheader)>("setHeader", [](DNSQuestion& dnsQuestion, dnsheader newHeader) {
+    dnsQuestion.editHeader([&newHeader](dnsheader& header) -> bool {
+      header = newHeader;
+      return true;
+    });
   });
   luaCtx.registerFunction<std::string (DNSQuestion::*)(void) const>("getTrailingData", [](const DNSQuestion& dnsQuestion) {
     return dnsQuestion.getTrailingData();
@@ -488,7 +497,7 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
   luaCtx.registerMember<dnsheader*(DNSResponse::*)>(
     "dh",
     [](const DNSResponse& dnsResponse) -> dnsheader* {
-      return dnsResponse.getMutableHeader();
+      return const_cast<DNSResponse&>(dnsResponse).getMutableHeader();
     },
     [](DNSResponse& dnsResponse, const dnsheader* dnsHeader) {
       dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsResponse.getMutableData(), [&dnsHeader](dnsheader& header) {
@@ -534,6 +543,15 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
       return {};
     }
     return EDNSOptionViewsToValues(*ednsOptions);
+  });
+  luaCtx.registerFunction<dnsheader (DNSResponse::*)() const>("getHeader", [](const DNSResponse& dnsQuestion) -> dnsheader {
+    return *(dnsQuestion.getHeader());
+  });
+  luaCtx.registerFunction<void (DNSResponse::*)(dnsheader)>("setHeader", [](DNSResponse& dnsQuestion, dnsheader newHeader) {
+    dnsQuestion.editHeader([&newHeader](dnsheader& header) -> bool {
+      header = newHeader;
+      return true;
+    });
   });
   luaCtx.registerFunction<std::string (DNSResponse::*)(void) const>("getTrailingData", [](const DNSResponse& dnsQuestion) {
     return dnsQuestion.getTrailingData();

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -71,7 +71,11 @@ uint16_t dnsdist_ffi_dnsquestion_get_qtype(const dnsdist_ffi_dnsquestion_t* dq) 
 uint16_t dnsdist_ffi_dnsquestion_get_qclass(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnsquestion_get_id(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 int dnsdist_ffi_dnsquestion_get_rcode(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+/* dnsdist_ffi_dnsquestion_get_header has been deprecated since 2.1.0 */
 void* dnsdist_ffi_dnsquestion_get_header(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_get_header_copy(const dnsdist_ffi_dnsquestion_t* dq, char* buffer, size_t buffer_size) __attribute__((visibility("default")));
+bool dnsdist_ffi_dnsquestion_set_header(const dnsdist_ffi_dnsquestion_t* dq, const char* buffer) __attribute__ ((visibility ("default")));
+const unsigned char* dnsdist_ffi_dnsquestion_get_data(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnsquestion_get_len(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_get_size(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsquestion_set_size(dnsdist_ffi_dnsquestion_t* dq, size_t newSize) __attribute__ ((visibility ("default")));

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -160,6 +160,35 @@ void* dnsdist_ffi_dnsquestion_get_header(const dnsdist_ffi_dnsquestion_t* dq)
   return dq->dq->getMutableHeader();
 }
 
+const unsigned char* dnsdist_ffi_dnsquestion_get_data(const dnsdist_ffi_dnsquestion_t* dq)
+{
+  return dq->dq->getData().data();
+}
+
+bool dnsdist_ffi_dnsquestion_get_header_copy(const dnsdist_ffi_dnsquestion_t* dnsQuestion, char* buffer, size_t buffer_size)
+{
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || buffer == nullptr || buffer_size < sizeof(dnsheader)) {
+    return false;
+  }
+
+  const auto aligned = dnsQuestion->dq->getHeader();
+  memcpy(buffer, aligned.get(), sizeof(dnsheader));
+  return true;
+}
+
+bool dnsdist_ffi_dnsquestion_set_header(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* buffer)
+{
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || buffer == nullptr) {
+    return false;
+  }
+
+  dnsQuestion->dq->editHeader([&buffer](dnsheader& header) -> bool {
+    memcpy(&header, buffer, sizeof(dnsheader));
+    return true;
+  });
+  return true;
+}
+
 uint16_t dnsdist_ffi_dnsquestion_get_len(const dnsdist_ffi_dnsquestion_t* dq)
 {
   return dq->dq->getData().size();

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -84,26 +84,26 @@ struct DNSQuestion
 
   const dnsheader_aligned getHeader() const
   {
-    if (data.size() < sizeof(dnsheader)) {
-      throw std::runtime_error("Trying to access the dnsheader of a too small (" + std::to_string(data.size()) + ") DNSQuestion buffer");
+    if (getData().size() < sizeof(dnsheader)) {
+      throw std::runtime_error("Trying to access the dnsheader of a too small (" + std::to_string(getData().size()) + ") DNSQuestion buffer");
     }
-    return dnsheader_aligned(data.data());
+    return dnsheader_aligned(getData().data());
   }
 
   /* this function is not safe against unaligned access, you should
-     use editHeader() instead, but we need it for the Lua bindings */
-  dnsheader* getMutableHeader() const
+     use editHeader() instead, but we need it for the deprecated Lua bindings */
+  dnsheader* getMutableHeader()
   {
-    if (data.size() < sizeof(dnsheader)) {
-      throw std::runtime_error("Trying to access the dnsheader of a too small (" + std::to_string(data.size()) + ") DNSQuestion buffer");
+    if (getData().size() < sizeof(dnsheader)) {
+      throw std::runtime_error("Trying to access the dnsheader of a too small (" + std::to_string(getData().size()) + ") DNSQuestion buffer");
     }
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return reinterpret_cast<dnsheader*>(data.data());
+    return reinterpret_cast<dnsheader*>(getMutableData().data());
   }
 
   bool hasRoomFor(size_t more) const
   {
-    return data.size() <= getMaximumSize() && (getMaximumSize() - data.size()) >= more;
+    return getData().size() <= getMaximumSize() && (getMaximumSize() - getData().size()) >= more;
   }
 
   size_t getMaximumSize() const
@@ -192,6 +192,7 @@ struct DNSQuestion
 protected:
   virtual std::shared_ptr<const Logr::Logger> getThisLogger(std::shared_ptr<const Logr::Logger> parent) const;
 
+  /* do not access the data field directly: use getData() or getMutableData() */
   PacketBuffer& data;
   std::shared_ptr<const Logr::Logger> d_logger;
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -21,6 +21,9 @@ This state can be modified from the various hooks.
 
   .. attribute:: dh
 
+    .. versionchanged:: 2.1.0
+      This attribute is now deprecated, :meth:`DNSQuestion.getHeader` and :meth:`DNSQuestion.setHeader` should be used instead.
+
     The :ref:`DNSHeader` of this query.
 
   .. attribute:: ecsOverride
@@ -33,7 +36,7 @@ This state can be modified from the various hooks.
 
   .. attribute:: len
 
-    The length of the data starting at :attr:`DNSQuestion.dh`, including any trailing bytes following the DNS message.
+    The length of the data returned by :meth:`DNSQuestion.getContent`, including any trailing bytes following the DNS message.
 
   .. attribute:: localaddr
 
@@ -76,7 +79,7 @@ This state can be modified from the various hooks.
 
   .. attribute:: size
 
-    The total size of the buffer starting at :attr:`DNSQuestion.dh`.
+    The total size of the buffer returned by :attr:`DNSQuestion.getContent`.
 
   .. attribute:: skipCache
 
@@ -126,6 +129,12 @@ This state can be modified from the various hooks.
      Return the amount of time that has elapsed since the query was received.
 
      :returns: A double indicating elapsed time in microseconds
+
+  .. method:: getHeader() -> :ref:`DNSHeader`
+
+    .. versionadded:: 2.1.0
+
+    The :ref:`DNSHeader` of this query.
 
   .. method:: getHTTPHeaders() -> table
 
@@ -287,6 +296,12 @@ This state can be modified from the various hooks.
     :param int infoCode: The EDNS Extended DNS Error code
     :param string extraText: The optional EDNS Extended DNS Error extra text
     :param bool clearExistingEntries: Whether to clear existing EDNS Extended DNS Error codes, default true
+
+  .. method:: setHeader(header)
+
+    .. versionadded:: 2.1.0
+
+    Set a new :ref:`DNSHeader` for this query.
 
   .. method:: setHTTPResponse(status, body, contentType="")
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -22,9 +22,9 @@ This state can be modified from the various hooks.
   .. attribute:: dh
 
     .. versionchanged:: 2.1.0
-      This attribute is now deprecated, :meth:`DNSQuestion.getHeader` and :meth:`DNSQuestion.setHeader` should be used instead.
+      This attribute is now deprecated and will be removed in 2.2.0, :meth:`DNSQuestion.getHeader` and :meth:`DNSQuestion.setHeader` should be used instead.
 
-    The :ref:`DNSHeader` of this query.
+    The :class:`DNSHeader` of this query.
 
   .. attribute:: ecsOverride
 
@@ -79,7 +79,7 @@ This state can be modified from the various hooks.
 
   .. attribute:: size
 
-    The total size of the buffer returned by :attr:`DNSQuestion.getContent`.
+    The total size of the buffer returned by :meth:`DNSQuestion.getContent`.
 
   .. attribute:: skipCache
 
@@ -130,11 +130,11 @@ This state can be modified from the various hooks.
 
      :returns: A double indicating elapsed time in microseconds
 
-  .. method:: getHeader() -> :ref:`DNSHeader`
+  .. method:: getHeader() -> DNSHeader
 
     .. versionadded:: 2.1.0
 
-    The :ref:`DNSHeader` of this query.
+    The :class:`DNSHeader` of this query.
 
   .. method:: getHTTPHeaders() -> table
 
@@ -301,7 +301,7 @@ This state can be modified from the various hooks.
 
     .. versionadded:: 2.1.0
 
-    Set a new :ref:`DNSHeader` for this query.
+    Set a new :class:`DNSHeader` for this query.
 
   .. method:: setHTTPResponse(status, body, contentType="")
 

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -22,6 +22,8 @@ New:
     open_telemetry_tracing:
       enabled: true
 
+The use of :attr:`DNSQuestion.dh` is now deprecated and strongly discouraged as it has proven to be error-prone. :meth:`DNSQuestion.getHeader` and :meth:`DNSQuestion.setHeader` should be used instead.
+
 2.0.x to 2.1.0
 --------------
 

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -167,6 +167,21 @@ BOOST_AUTO_TEST_CASE(test_Query)
   }
 
   {
+    // dnsdist_ffi_dnsquestion_get_header_copy
+    dnsheader copy{};
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    BOOST_REQUIRE(dnsdist_ffi_dnsquestion_get_header_copy(&lightDQ, reinterpret_cast<char*>(&copy), sizeof(copy)));
+    BOOST_CHECK(memcmp(&copy, pwQ.getHeader(), sizeof(dnsheader)) == 0);
+  }
+
+  {
+    // dnsdist_ffi_dnsquestion_get_data
+    const auto* data = dnsdist_ffi_dnsquestion_get_data(&lightDQ);
+    BOOST_REQUIRE(data != nullptr);
+    BOOST_CHECK(memcmp(data, query.data(), query.size()) == 0);
+  }
+
+  {
     // dnsdist_ffi_dnsquestion_get_len, dnsdist_ffi_dnsquestion_get_size
     BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_len(&lightDQ), query.size());
     BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_size(&lightDQ), query.size());

--- a/regression-tests.dnsdist/test_Async.py
+++ b/regression-tests.dnsdist/test_Async.py
@@ -531,7 +531,7 @@ class TestAsyncFFI(DNSDistTest, AsyncTests):
       print('in passQueryToAsyncFilter')
       local timeout = 500 -- 500 ms
 
-      local queryPtr = C.dnsdist_ffi_dnsquestion_get_header(dq)
+      local queryPtr = C.dnsdist_ffi_dnsquestion_get_data(dq)
       local querySize = C.dnsdist_ffi_dnsquestion_get_len(dq)
 
       -- we need to take a copy, as we can no longer touch that data after calling set_async
@@ -549,7 +549,7 @@ class TestAsyncFFI(DNSDistTest, AsyncTests):
       print('in passResponseToAsyncFilter')
       local timeout = 500 -- 500 ms
 
-      local responsePtr = C.dnsdist_ffi_dnsquestion_get_header(dr)
+      local responsePtr = C.dnsdist_ffi_dnsquestion_get_data(dr)
       local responseSize = C.dnsdist_ffi_dnsquestion_get_len(dr)
 
       -- we need to take a copy, as we can no longer touch that data after calling set_async
@@ -673,7 +673,7 @@ class TestAsyncLua(DNSDistTest, AsyncTests):
       local timeout = 500 -- 500 ms
 
       local buffer = dq:getContent()
-      local id = dq.dh:getID()
+      local id = dq:getHeader():getID()
       dq:suspend(asyncID, id, timeout)
       asyncResponderEndpoint:send(buffer)
 
@@ -685,7 +685,7 @@ class TestAsyncLua(DNSDistTest, AsyncTests):
       local timeout = 500 -- 500 ms
 
       local buffer = dr:getContent()
-      local id = dr.dh:getID()
+      local id = dr:getHeader():getID()
       dr:suspend(asyncID, id, timeout)
       asyncResponderEndpoint:send(buffer)
 

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -54,7 +54,9 @@ class DOHTests(object):
         end
         if foundct then
           dq:setHTTPResponse(200, 'It works!', 'text/plain')
-          dq.dh:setQR(true)
+          local header = dq:getHeader()
+          header:setQR(true)
+          dq:setHeader(header)
           return DNSAction.HeaderModify
         end
       end
@@ -1061,7 +1063,9 @@ query_rules:
         end
         if foundct then
           dq:setHTTPResponse(200, 'It works!', 'text/plain')
-          dq.dh:setQR(true)
+          local header = dq:getHeader()
+          header:setQR(true)
+          dq:setHeader(header)
           return DNSAction.HeaderModify
         end
       end

--- a/regression-tests.dnsdist/test_DOH3.py
+++ b/regression-tests.dnsdist/test_DOH3.py
@@ -56,7 +56,9 @@ class TestDOH3(DOH3Common, QUICTests, DNSDistTest):
         end
         if foundct then
           dq:setHTTPResponse(200, 'It works!', 'text/plain')
-          dq.dh:setQR(true)
+          local header = dq:getHeader()
+          header:setQR(true)
+          dq:setHeader(header)
           return DNSAction.HeaderModify
         end
       end

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -137,8 +137,10 @@ class TestDnstapOverRemoteLogger(DNSDistTest):
     end
 
     function luaFunc(dq)
-      dq.dh:setQR(true)
-      dq.dh:setRCode(DNSRCode.NXDOMAIN)
+      local header = dq:getHeader()
+      header:setQR(true)
+      header:setRCode(DNSRCode.NXDOMAIN)
+      dq:setHeader(header)
       return DNSAction.None, ""
     end
 
@@ -334,8 +336,10 @@ class TestDnstapOverRemoteLoggerPool(DNSDistTest):
     end
 
     function luaFunc(dq)
-      dq.dh:setQR(true)
-      dq.dh:setRCode(DNSRCode.NXDOMAIN)
+      local header = dq:getHeader()
+      header:setQR(true)
+      header:setRCode(DNSRCode.NXDOMAIN)
+      dq:setHeader(header)
       return DNSAction.None, ""
     end
 

--- a/regression-tests.dnsdist/test_Lua.py
+++ b/regression-tests.dnsdist/test_Lua.py
@@ -48,7 +48,7 @@ class TestLuaDNSHeaderBindings(DNSDistTest):
     newServer{address="127.0.0.1:%d"}
 
     function checkTCSet(dq)
-      local tc = dq.dh:getTC()
+      local tc = dq:getHeader():getTC()
       if not tc then
         return DNSAction.Spoof, 'tc-not-set.check-tc.lua-dnsheaders.tests.powerdns.com.'
       end

--- a/regression-tests.dnsdist/test_LuaFFI.py
+++ b/regression-tests.dnsdist/test_LuaFFI.py
@@ -353,10 +353,10 @@ class TestLuaFFIHeader(DNSDistTest):
 
     -- check that the AA bit is clear, set the rcode to REFUSED otherwise
     function checkAAResponseAction(dr)
-      local header_void = ffi.C.dnsdist_ffi_dnsquestion_get_header(dr)
-      local header = ffi.cast("unsigned char *", header_void)
+      local header_ptr = ffi.new("char [12]")
+      ffi.C.dnsdist_ffi_dnsquestion_get_header_copy(dr, header_ptr, 12)
       -- get AA
-      local aa = bit.band(header[2], bit.lshift(1, 2)) ~= 0
+      local aa = bit.band(header_ptr[2], bit.lshift(1, 2)) ~= 0
       if aa then
           ffi.C.dnsdist_ffi_dnsquestion_set_rcode(dr, DNSRCode.REFUSED)
           -- prevent subsequent rules from being applied
@@ -367,10 +367,11 @@ class TestLuaFFIHeader(DNSDistTest):
 
     -- set the AA bit to 1
     function setAAResponseAction(dr)
-      local header_void = ffi.C.dnsdist_ffi_dnsquestion_get_header(dr)
-      local header = ffi.cast("unsigned char *", header_void)
+      local header_ptr = ffi.new("char [12]")
+      ffi.C.dnsdist_ffi_dnsquestion_get_header_copy(dr, header_ptr, 12)
       -- set AA=1
-      header[2] = bit.bor(header[2], bit.lshift(1, 2))
+      header_ptr[2] = bit.bor(header_ptr[2], bit.lshift(1, 2))
+      ffi.C.dnsdist_ffi_dnsquestion_set_header(dr, header_ptr)
       return DNSResponseAction.None
     end
 

--- a/regression-tests.dnsdist/test_Spoofing.py
+++ b/regression-tests.dnsdist/test_Spoofing.py
@@ -655,7 +655,9 @@ class TestSpoofingLuaSpoof(DNSDistTest):
         elseif dq.qtype == DNSQType.TXT then
              return DNSAction.SpoofRaw, "\\003aaa\\004bbbb\\011ccccccccccc"
         elseif dq.qtype == DNSQType.SRV then
-            dq.dh:setAA(true)
+            local header = dq:getHeader()
+            header:setAA(true)
+            dq:setHeader(header)
             return DNSAction.SpoofRaw, "\\000\\000\\000\\000\\255\\255\\003srv\\008powerdns\\003com\\000"
         end
         return DNSAction.None, ""
@@ -833,7 +835,9 @@ class TestSpoofingLuaSpoofMulti(DNSDistTest):
             dq:spoof({ "\\003aaa\\004bbbb", "\\011ccccccccccc" })
             return DNSAction.HeaderModify
         elseif dq.qtype == DNSQType.SRV then
-            dq.dh:setAA(true)
+            local header = dq:getHeader()
+            header:setAA(true)
+            dq:setHeader(header)
             dq:spoof({ "\\000\\000\\000\\000\\255\\255\\004srv1\\008powerdns\\003com\\000","\\000\\000\\000\\000\\255\\255\\004srv2\\008powerdns\\003com\\000" })
             return DNSAction.HeaderModify
         end

--- a/regression-tests.dnsdist/test_Tags.py
+++ b/regression-tests.dnsdist/test_Tags.py
@@ -24,12 +24,16 @@ class TestTags(DNSDistTest):
     addAction(TagRule("dns"), SpoofAction("1.2.3.100"))
 
     function responseHandlerSetTC(dr)
-      dr.dh:setTC(true)
+      local header = dr:getHeader()
+      header:setTC(true)
+      dr:setHeader(header)
       return DNSResponseAction.HeaderModify, ""
     end
 
     function responseHandlerUnsetQR(dr)
-      dr.dh:setQR(false)
+      local header = dr:getHeader()
+      header:setQR(false)
+      dr:setHeader(header)
       return DNSResponseAction.HeaderModify, ""
     end
 

--- a/regression-tests.dnsdist/test_Yaml.py
+++ b/regression-tests.dnsdist/test_Yaml.py
@@ -91,7 +91,7 @@ response_rules:
           name: "Match responses on RD=0 (inline)"
           function_code: |
             return function(dr)
-              local rd = dr.dh:getRD()
+              local rd = dr:getHeader():getRD()
               if not rd then
                 return true
               end


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The existing interface is error-prone: it provides a pointer to a buffer that might get invalidated if the user keeps it around for too long. The new interface makes it clear when the modification is actually performed, and there is no dangling pointer.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
