### PR TITLE
auth: make lua records immutable by default

### DIFF
--- a/docs/lua-records/index.rst
+++ b/docs/lua-records/index.rst
@@ -216,7 +216,8 @@ they will not function, and will in fact leak the content of the LUA records.
 .. note::
   Under NO circumstances serve LUA records from zones from untrusted sources!
   LUA records will be able to bring down your system and possible take over
-  control of it. Use TSIG on AXFR even from trusted sources!
+  control of it. Use TSIG on AXFR even from trusted sources, and only
+  enable :ref:`setting-enable-lua-record-updates` if needed!
 
 LUA records can be DNSSEC signed, but because they are dynamic, it is not
 possible to combine pre-signed DNSSEC zone and LUA records. In other words,

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -796,6 +796,19 @@ Globally enable the :doc:`LUA records <lua-records/index>` feature.
 
 To use shared LUA states, set this to ``shared``, see :ref:`lua-records-shared-state`.
 
+.. _setting-enable-lua-record-updates:
+
+``enable-lua-record-updates``
+-----------------------------
+
+.. versionadded:: 5.1.0
+
+-  Boolean
+-  Default: no
+
+Allow updating :doc:`LUA records <lua-records/index>` as part of AXFR/IXFR,
+DNS Update or API operations.
+
 .. _setting-entropy-source:
 
 ``entropy-source``

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -43,6 +43,16 @@ If you are using an older version, the old query can be restored using::
 but it is advised to upgrade to a supported version of PostgreSQL whenever
 possible.
 
+LUA record updates no longer allowed by default
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Modifications of :doc:`LUA records <lua-records/index>`, either from AXFR/IXFR,
+DNS Update, or the API, are now only allowed if the new
+:ref:`setting-enable-lua-record-updates` configuration setting is set to
+``yes``.
+Its default value being ``no``, a configuration update will be
+necessary when upgrading to 5.1 in order to allow such updates.
+
 4.9.0 to 5.0.0
 --------------
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -319,6 +319,7 @@ static void declareArguments()
   ::arg().setSwitch("8bit-dns", "Allow 8bit dns queries") = "no";
 #ifdef HAVE_LUA_RECORDS
   ::arg().setSwitch("enable-lua-records", "Process Lua records for all zones (metadata overrides this)") = "no";
+  ::arg().setSwitch("enable-lua-record-updates", "Allow updates to Lua records") = "no";
   ::arg().setSwitch("lua-records-insert-whitespace", "Insert whitespace when combining Lua chunks") = "no";
   ::arg().set("lua-records-exec-limit", "Lua records scripts execution limit (instructions count). Values <= 0 mean no limit") = "1000";
   ::arg().set("lua-health-checks-expire-delay", "Stops doing health checks after the record hasn't been used for that delay (in seconds)") = "3600";

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -568,6 +568,14 @@ void CommunicatorClass::ixfrSuck(const TSIGTriplet& tsig, const ComboAddress& la
           replacement.emplace_back(std::move(rr));
         }
 
+        // Do not perform Lua records updates if not allowed to.
+        if (QType(g.first.second) == QType::LUA) {
+          if (!::arg().mustDo("enable-lua-record-updates")) {
+            SLOG(g_log << Logger::Warning << ctx.logPrefix << "skipping Lua record updates, not allowed" << endl,
+                 ctx.slog->info(Logr::Warning, "IXFR: skipping Lua record updates, not allowed"));
+            continue;
+          }
+        }
         ctx.domain.backend->replaceRRSet(ctx.domain.id, g.first.first.operator const DNSName&() + ctx.domain.zone.operator const DNSName&(), QType(g.first.second), replacement);
       }
       ctx.domain.backend->commitTransaction();
@@ -963,6 +971,15 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
     map<DNSName, bool> nonterm;
 
     for (DNSResourceRecord& rr : rrs) { // NOLINT(readability-identifier-length)
+      // Do not perform Lua records updates if not allowed to.
+      if (rr.qtype.getCode() == QType::LUA) {
+        if (!::arg().mustDo("enable-lua-record-updates")) {
+          SLOG(g_log << Logger::Warning << ctx.logPrefix << "skipping Lua record updates, not allowed" << endl,
+               ctx.slog->info(Logr::Warning, "AXFR: skipping Lua record updates, not allowed"));
+          continue;
+        }
+      }
+
       if (!ctx.isPresigned) {
         if (rr.qtype.getCode() == QType::RRSIG) {
           continue;

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -505,6 +505,36 @@ void CommunicatorClass::ixfrSuck(const TSIGTriplet& tsig, const ComboAddress& la
     ctx.numDeltas = deltas.size();
     //    cout<<"Got "<<deltas.size()<<" deltas from serial "<<ctx.domain.serial<<", applying.."<<endl;
 
+    // Do not perform Lua records updates if not allowed to.
+    if (!::arg().mustDo("enable-lua-record-updates")) {
+      bool foundLua{false};
+      for (const auto& d : deltas) { // NOLINT(readability-identifier-length)
+        for (const auto& rec : d.first) {
+          if (rec.d_type == QType::LUA) {
+            foundLua = true;
+            break;
+          }
+        }
+        if (foundLua) {
+          break;
+        }
+        for (const auto& rec : d.second) {
+          if (rec.d_type == QType::LUA) {
+            foundLua = true;
+            break;
+          }
+        }
+        if (foundLua) {
+          break;
+        }
+      }
+      if (foundLua) {
+        SLOG(g_log << Logger::Warning << ctx.logPrefix << "refused as it contains Lua record updates" << endl,
+             ctx.slog->info(Logr::Warning, "IXFR: refused as it contains Lua record updates"));
+        return;
+      }
+    }
+
     for (const auto& d : deltas) { // NOLINT(readability-identifier-length)
       const auto& remove = d.first;
       const auto& add = d.second;
@@ -566,15 +596,6 @@ void CommunicatorClass::ixfrSuck(const TSIGTriplet& tsig, const ComboAddress& la
           }
 
           replacement.emplace_back(std::move(rr));
-        }
-
-        // Do not perform Lua records updates if not allowed to.
-        if (QType(g.first.second) == QType::LUA) {
-          if (!::arg().mustDo("enable-lua-record-updates")) {
-            SLOG(g_log << Logger::Warning << ctx.logPrefix << "skipping Lua record updates, not allowed" << endl,
-                 ctx.slog->info(Logr::Warning, "IXFR: skipping Lua record updates, not allowed"));
-            continue;
-          }
         }
         ctx.domain.backend->replaceRRSet(ctx.domain.id, g.first.first.operator const DNSName&() + ctx.domain.zone.operator const DNSName&(), QType(g.first.second), replacement);
       }
@@ -924,6 +945,16 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
       }
     }
 
+    // Do not perform Lua records updates if not allowed to.
+    if (!::arg().mustDo("enable-lua-record-updates")) {
+      for (DNSResourceRecord& drr : rrs) {
+        if (drr.qtype.getCode() == QType::LUA) {
+          SLOG(g_log << Logger::Warning << ctx.logPrefix << "refused as it contains Lua record updates" << endl,
+               ctx.slog->info(Logr::Warning, "AXFR: refused as it contains Lua record updates"));
+          return;
+        }
+      }
+    }
     transaction = ctx.domain.backend->startTransaction(domain, ctx.domain.id);
     SLOG(g_log << Logger::Info << ctx.logPrefix << "storage transaction started" << endl,
          ctx.slog->info(Logr::Info, "AXFR: storage transaction started"));
@@ -971,15 +1002,6 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
     map<DNSName, bool> nonterm;
 
     for (DNSResourceRecord& rr : rrs) { // NOLINT(readability-identifier-length)
-      // Do not perform Lua records updates if not allowed to.
-      if (rr.qtype.getCode() == QType::LUA) {
-        if (!::arg().mustDo("enable-lua-record-updates")) {
-          SLOG(g_log << Logger::Warning << ctx.logPrefix << "skipping Lua record updates, not allowed" << endl,
-               ctx.slog->info(Logr::Warning, "AXFR: skipping Lua record updates, not allowed"));
-          continue;
-        }
-      }
-
       if (!ctx.isPresigned) {
         if (rr.qtype.getCode() == QType::RRSIG) {
           continue;

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -932,6 +932,17 @@ static uint8_t updateRecords(const MOADNSParser::answers_t& answers, DNSSECKeepe
   for (const auto& rec : answers) {
     if (rec.d_place == DNSResourceRecord::AUTHORITY) {
       anyRecordProcessed = true;
+
+      // Reject Lua record updates unless explicitly allowed, regardless of any
+      // other policy.
+      if (QType(dnsRecord->d_type) == QType::LUA) {
+        if (!::arg().mustDo("enable-lua-record-updates")) {
+          SLOG(g_log << Logger::Warning << ctx.msgPrefix << "Refusing update for " << dnsRecord->d_name << "/" << QType(dnsRecord->d_type).toString() << ": Not permitted by global settings" << endl,
+               ctx.slog->info(Logr::Warning, "Update: refusing record update, not permitted by global settings", "name", Logging::Loggable(dnsRecord->d_name), "type", Logging::Loggable(dnsRecord->d_type)));
+          continue;
+        }
+      }
+
       /* see if it's permitted by policy */
       if (update_policy_lua != nullptr) {
         if (!update_policy_lua->updatePolicy(rec.d_name, QType(rec.d_type), ctx.di.zone.operator const DNSName&(), packet)) {

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -923,6 +923,18 @@ static uint8_t updatePrereqCheck323(const MOADNSParser::answers_t& answers, cons
 
 static uint8_t updateRecords(const MOADNSParser::answers_t& answers, DNSSECKeeper& dsk, uint& changedRecords, const std::unique_ptr<AuthLua4>& update_policy_lua, DNSPacket& packet, updateContext& ctx)
 {
+  // Reject the complete update if it contains Lua records, unless explicitly
+  // allowed, regardless of any other policy.
+  if (!::arg().mustDo("enable-lua-record-updates")) {
+    for (const auto& rec : answers) {
+      if (QType(rec.d_type) == QType::LUA) {
+        SLOG(g_log << Logger::Warning << ctx.msgPrefix << "Refusing update due to Lua record " << rec.d_name << ": Not permitted by global settings" << endl,
+             ctx.slog->info(Logr::Warning, "Update: refusing update due to Lua record, not permitted by global settings", "name", Logging::Loggable(rec.d_name)));
+        return RCode::Refused;
+      }
+    }
+  }
+
   vector<const DNSRecord*> cnamesToAdd;
   vector<const DNSRecord*> nonCnamesToAdd;
   vector<const DNSRecord*> nsRRtoDelete;
@@ -932,16 +944,6 @@ static uint8_t updateRecords(const MOADNSParser::answers_t& answers, DNSSECKeepe
   for (const auto& rec : answers) {
     if (rec.d_place == DNSResourceRecord::AUTHORITY) {
       anyRecordProcessed = true;
-
-      // Reject Lua record updates unless explicitly allowed, regardless of any
-      // other policy.
-      if (QType(dnsRecord->d_type) == QType::LUA) {
-        if (!::arg().mustDo("enable-lua-record-updates")) {
-          SLOG(g_log << Logger::Warning << ctx.msgPrefix << "Refusing update for " << dnsRecord->d_name << "/" << QType(dnsRecord->d_type).toString() << ": Not permitted by global settings" << endl,
-               ctx.slog->info(Logr::Warning, "Update: refusing record update, not permitted by global settings", "name", Logging::Loggable(dnsRecord->d_name), "type", Logging::Loggable(dnsRecord->d_type)));
-          continue;
-        }
-      }
 
       /* see if it's permitted by policy */
       if (update_policy_lua != nullptr) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1753,9 +1753,9 @@ static bool checkNewRecords(HttpResponse* resp, vector<DNSResourceRecord>& recor
   std::vector<std::pair<DNSResourceRecord, string>> errors;
 
   // Do not perform Lua records updates if not allowed to.
-  for (const auto& rec : records) {
-    if (rec.qtype == QType::LUA) {
-      if (!::arg().mustDo("enable-lua-record-updates")) {
+  if (!::arg().mustDo("enable-lua-record-updates")) {
+    for (const auto& rec : records) {
+      if (rec.qtype == QType::LUA) {
         errors.emplace_back(std::make_pair(rec, std::string("update of Lua records is not allowed")));
       }
     }
@@ -2578,8 +2578,8 @@ enum applyResult
 static applyResult applyDelete(const DomainInfo& domainInfo, DNSName& qname, QType& qtype, bool returnRRset, std::vector<DNSResourceRecord>& rrset)
 {
   // Do not perform Lua records deletions if not allowed to.
-  if (qtype == QType::LUA) {
-    if (!::arg().mustDo("enable-lua-record-updates")) {
+  if (!::arg().mustDo("enable-lua-record-updates")) {
+    if (qtype == QType::LUA) {
       throw ApiException("Update of Lua records is not allowed");
     }
   }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1752,6 +1752,15 @@ static bool checkNewRecords(HttpResponse* resp, vector<DNSResourceRecord>& recor
 {
   std::vector<std::pair<DNSResourceRecord, string>> errors;
 
+  // Do not perform Lua records updates if not allowed to.
+  for (const auto& rec : records) {
+    if (rec.qtype == QType::LUA) {
+      if (!::arg().mustDo("enable-lua-record-updates")) {
+        errors.emplace_back(std::make_pair(rec, std::string("update of Lua records is not allowed")));
+      }
+    }
+  }
+
   Check::checkRRSet({}, records, zone, flags, errors);
   if (errors.empty()) {
     return true;
@@ -2568,6 +2577,12 @@ enum applyResult
 // Apply a DELETE changetype.
 static applyResult applyDelete(const DomainInfo& domainInfo, DNSName& qname, QType& qtype, bool returnRRset, std::vector<DNSResourceRecord>& rrset)
 {
+  // Do not perform Lua records deletions if not allowed to.
+  if (qtype == QType::LUA) {
+    if (!::arg().mustDo("enable-lua-record-updates")) {
+      throw ApiException("Update of Lua records is not allowed");
+    }
+  }
   // Delete all matching qname/qtype RRs (and implicitly, comments).
   if (!domainInfo.backend->replaceRRSet(domainInfo.id, qname, qtype, {})) {
     throw ApiException("Hosting backend does not support editing records.");

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -291,7 +291,11 @@ if daemon == "authoritative":
         run_check_call(PDNSUTIL_CMD + ["load-zone", zone, ZONE_DIR + zone])
 
     run_check_call(PDNSUTIL_CMD + ["secure-zone", "powerdnssec.org"])
-    servercmd = [pdns_server] + common_args + ["--no-shuffle", "--dnsupdate=yes", "--cache-ttl=0", "--api=yes"]
+    servercmd = (
+        [pdns_server]
+        + common_args
+        + ["--no-shuffle", "--dnsupdate=yes", "--cache-ttl=0", "--api=yes", "--enable-lua-record-updates"]
+    )
 
 else:
     conf_dir = "rec-conf.d"


### PR DESCRIPTION
### Short description
We are receiving countless reports that "omg Lua records can contain arbitrary code, and AXFR can update them". Well, yes, that's the point, and if your usage does not require Lua records or XFR, you don't need to enable them.

This PR introduces a global `enable-lua-record-updates` setting, which defaults to false. When set to false, modifications of Lua records (including their deletion) from XFR, DNS update and the API are not allowed; they will be ignored (with a warning in the logs) in XFR and DNS update, and will return an error in the API.

Lua records can still get modified using `pdnsutil` or direct backend storage modification.

Feel free to bikeshed the name of the setting!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
