### PR TITLE
dnsdist: Lua FFI response actions are passed a `dnsdist_ffi_dnsresponse_t`

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -337,6 +337,7 @@ DNSR
 dnsrecord
 dnsreplay
 dnsresourcerecord
+dnsresponse
 dnsscan
 dnsscope
 dnssec

--- a/pdns/dnsdistdist/dnsdist-response-actions-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-response-actions-definitions.yml
@@ -105,7 +105,7 @@ Subsequent rules are processed after this action"
       default: ""
       description: "The path to a file containing the code of the Lua function"
 - name: "LuaFFI"
-  description: "Invoke a Lua function that accepts a pointer to a ``dnsdist_ffi_dnsquestion_t`` object, whose bindings are defined in ``dnsdist-lua-ffi-interface.h``. The function should return a :ref:`DNSResponseAction`. If the Lua code fails, ``ServFail`` is returned"
+  description: "Invoke a Lua function that accepts a pointer to a ``dnsdist_ffi_dnsresponse_t`` object, whose bindings are defined in ``dnsdist-lua-ffi-interface.h``. The function should return a :ref:`DNSResponseAction`. If the Lua code fails, ``ServFail`` is returned"
   skip-cpp: true
   skip-rust: true
   parameters:
@@ -122,7 +122,7 @@ Subsequent rules are processed after this action"
       default: ""
       description: "The path to a file containing the code of the Lua function"
 - name: "LuaFFIPerThread"
-  description: "Invoke a Lua function that accepts a pointer to a ``dnsdist_ffi_dnsquestion_t`` object, whose bindings are defined in ``dnsdist-lua-ffi-interface.h``. The function should return a :ref:`DNSResponseAction`. If the Lua code fails, ``ServFail`` is returned.
+  description: "Invoke a Lua function that accepts a pointer to a ``dnsdist_ffi_dnsresponse_t`` object, whose bindings are defined in ``dnsdist-lua-ffi-interface.h``. The function should return a :ref:`DNSResponseAction`. If the Lua code fails, ``ServFail`` is returned.
 The function will be invoked in a per-thread Lua state, without access to the global Lua state. All constants (:ref:`DNSQType`, :ref:`DNSRCode`, ...) are available in that per-thread context, as well as all FFI functions. Objects and their bindings that are not usable in a FFI context (:class:`DNSQuestion`, :class:`DNSDistProtoBufMessage`, :class:`PacketCache`, ...) are not available."
   parameters:
     - name: "code"

--- a/pdns/dnsdistdist/docs/reference/actions.rst
+++ b/pdns/dnsdistdist/docs/reference/actions.rst
@@ -241,7 +241,7 @@ The following actions exist.
 
 .. function:: LuaFFIPerThreadResponseAction(function)
 
-  Invoke a Lua FFI function that accepts a pointer to a ``dnsdist_ffi_dnsquestion_t`` object, whose bindings are defined in ``dnsdist-lua-ffi-interface.h``.
+  Invoke a Lua FFI function that accepts a pointer to a ``dnsdist_ffi_dnsresponse_t`` object, whose bindings are defined in ``dnsdist-lua-ffi-interface.h``.
 
   The ``function`` should return a :ref:`DNSResponseAction`. If the Lua code fails, ServFail is returned.
 
@@ -253,7 +253,7 @@ The following actions exist.
 
 .. function:: LuaFFIResponseAction(function)
 
-  Invoke a Lua FFI function that accepts a pointer to a ``dnsdist_ffi_dnsquestion_t`` object, whose bindings are defined in ``dnsdist-lua-ffi-interface.h``.
+  Invoke a Lua FFI function that accepts a pointer to a ``dnsdist_ffi_dnsresponse_t`` object, whose bindings are defined in ``dnsdist-lua-ffi-interface.h``.
 
   The ``function`` should return a :ref:`DNSResponseAction`. If the Lua code fails, ServFail is returned.
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Many thanks to Mehtab Zafar for reporting this!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
