### PR TITLE
auth: only perform secpoll checks when they make sense

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -890,8 +890,9 @@ static void mainthread()
     DP->go();
   }
 
+  bool performSecPoll{true};
   try {
-    doSecPoll(slog, true);
+    performSecPoll = doSecPoll(slog, true);
   }
   catch (...) {
   }
@@ -1017,13 +1018,15 @@ static void mainthread()
       }
     }
 
-    secpollSince += sleeptime;
-    if (secpollSince >= secpollInterval) {
-      secpollSince = 0;
-      try {
-        doSecPoll(slog, false);
-      }
-      catch (...) {
+    if (performSecPoll) {
+      secpollSince += sleeptime;
+      if (secpollSince >= secpollInterval) {
+        secpollSince = 0;
+        try {
+          performSecPoll = doSecPoll(slog, false);
+        }
+        catch (...) {
+        }
       }
     }
   }

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -29,11 +29,12 @@ extern StatBag S;
 
 /** Do an actual secpoll for the current version
  * @param first bool that tells if this is the first secpoll run since startup
+ * @return whether polling should continue
  */
-void doSecPoll(Logr::log_t slog, bool first)
+bool doSecPoll(Logr::log_t slog, bool first)
 {
   if(::arg()["security-poll-suffix"].empty())
-    return;
+    return false;
 
   struct timeval now;
   gettimeofday(&now, nullptr);
@@ -56,7 +57,7 @@ void doSecPoll(Logr::log_t slog, bool first)
   if (res == RCode::NXDomain && !isReleaseVersion(pkgv)) {
     SLOG(g_log<<Logger::Warning<<"Not validating response for security status update, this is a non-release version"<<endl,
          slog->info(Logr::Warning, "Not validating response for security status update, this is a non-release version"));
-    return;
+    return false;
   }
 
   string security_message;
@@ -67,7 +68,7 @@ void doSecPoll(Logr::log_t slog, bool first)
     S.set("security-status", security_status);
     SLOG(g_log<<Logger::Warning<<"Failed to retrieve security status update for '" + pkgv + "' on '"+ query + "': "<<pe.reason<<endl,
          slog->error(Logr::Warning, pe.reason, "Failed to retrieve security status update", "package", Logging::Loggable(pkgv), "query", Logging::Loggable(query)));
-    return;
+    return true;
   }
 
 
@@ -86,4 +87,5 @@ void doSecPoll(Logr::log_t slog, bool first)
     SLOG(g_log<<Logger::Error<<"PowerDNS Security Update Mandatory: "<<g_security_message<<endl,
          slog->info(Logr::Error, "PowerDNS Security Update Mandatory", "status", Logging::Loggable(g_security_message)));
   }
+  return true;
 }

--- a/pdns/secpoll-auth.hh
+++ b/pdns/secpoll-auth.hh
@@ -24,4 +24,4 @@
 #include "namespaces.hh"
 #include "stubresolver.hh"
 
-void doSecPoll(Logr::log_t slog, bool first);
+bool doSecPoll(Logr::log_t slog, bool first);


### PR DESCRIPTION
### Short description
Once we've warned we're a non-release version, it is not necessary to keep polling. This PR adds the ability to the secpoll code to tell whether it should run again in the future, or not. If secpoll is disabled or we find out there are no results and this is a non-release version, we stop performing further checks.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
