### PR TITLE
auth: fixes to AXFR in Bind backend

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -287,26 +287,10 @@ bool Bind2Backend::abortTransaction()
   return true;
 }
 
-static bool ciEqual(const string& lhs, const string& rhs)
-{
-  if (lhs.size() != rhs.size()) {
-    return false;
-  }
-
-  string::size_type pos = 0;
-  const string::size_type epos = lhs.size();
-  for (; pos < epos; ++pos) {
-    if (dns_tolower(lhs[pos]) != dns_tolower(rhs[pos])) {
-      return false;
-    }
-  }
-  return true;
-}
-
 /** does domain end on suffix? Is smart about "wwwds9a.nl" "ds9a.nl" not matching */
 static bool endsOn(const string& domain, const string& suffix)
 {
-  if (suffix.empty() || ciEqual(domain, suffix)) {
+  if (suffix.empty() || pdns_iequals(domain, suffix)) {
     return true;
   }
 

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -290,23 +290,28 @@ bool Bind2Backend::abortTransaction()
 /** does domain end on suffix? Is smart about "wwwds9a.nl" "ds9a.nl" not matching */
 static bool endsOn(const string& domain, const string& suffix)
 {
-  if (suffix.empty() || pdns_iequals(domain, suffix)) {
-    return true;
-  }
-
   if (domain.size() <= suffix.size()) {
     return false;
   }
 
   string::size_type dpos = domain.size() - suffix.size() - 1;
-  string::size_type spos = 0;
-
   if (domain[dpos++] != '.') {
     return false;
   }
+  // That dot might have been escaped. So we now need to count how many '\'
+  // characters we can find in a row before it; if their number is odd, the
+  // dot is escaped and we are not a proper suffix.
+  size_t slashes{0};
+  while (dpos >= 2 + slashes && domain.at(dpos - 2 - slashes) == '\\') {
+    ++slashes;
+  }
+  if ((slashes % 2) != 0) {
+    return false;
+  }
 
+  string::size_type spos = 0;
   for (; dpos < domain.size(); ++dpos, ++spos) {
-    if (dns_tolower(domain[dpos]) != dns_tolower(suffix[spos])) {
+    if (!pdns_iequals_ch(domain[dpos], suffix[spos])) {
       return false;
     }
   }
@@ -319,15 +324,16 @@ static void stripDomainSuffix(string* qname, const ZoneName& zonename)
 {
   std::string domain = zonename.operator const DNSName&().toString();
 
+  if (domain.empty()) {
+    return;
+  }
+  if (pdns_iequals(*qname, domain)) {
+    *qname = "@";
+    return;
+  }
   if (endsOn(*qname, domain)) {
-    if (toLower(*qname) == toLower(domain)) {
-      *qname = "@";
-    }
-    else {
-      if ((*qname)[qname->size() - domain.size() - 1] == '.') {
-        qname->resize(qname->size() - domain.size() - 1);
-      }
-    }
+    auto prefix = qname->size() - domain.size();
+    qname->resize(prefix - 1); // also strip dot
   }
 }
 

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -314,26 +314,21 @@ static bool endsOn(const string& domain, const string& suffix)
   return true;
 }
 
-/** strips a domain suffix from a domain, returns true if it stripped */
-static bool stripDomainSuffix(string* qname, const ZoneName& zonename)
+/** strips a domain suffix from a domain */
+static void stripDomainSuffix(string* qname, const ZoneName& zonename)
 {
   std::string domain = zonename.operator const DNSName&().toString();
 
-  if (!endsOn(*qname, domain)) {
-    return false;
-  }
-
-  if (toLower(*qname) == toLower(domain)) {
-    *qname = "@";
-  }
-  else {
-    if ((*qname)[qname->size() - domain.size() - 1] != '.') {
-      return false;
+  if (endsOn(*qname, domain)) {
+    if (toLower(*qname) == toLower(domain)) {
+      *qname = "@";
     }
-
-    qname->resize(qname->size() - domain.size() - 1);
+    else {
+      if ((*qname)[qname->size() - domain.size() - 1] == '.') {
+        qname->resize(qname->size() - domain.size() - 1);
+      }
+    }
   }
-  return true;
 }
 
 bool Bind2Backend::feedRecord(const DNSResourceRecord& rr, const DNSName& /* ordername */, bool /* ordernameIsNSEC3 */)
@@ -370,7 +365,7 @@ bool Bind2Backend::feedRecord(const DNSResourceRecord& rr, const DNSName& /* ord
   case QType::DNAME:
   case QType::NS:
     stripDomainSuffix(&content, d_transaction_qname);
-    // fallthrough
+    [[fallthrough]];
   default:
     if (d_of && *d_of) {
       *d_of << qname << "\t" << rr.ttl << "\t" << rr.qtype.toString() << "\t" << content << endl;


### PR DESCRIPTION
### Short description
I had these cleanups lying around for a while. Then while tinkering, I noticed that the code responsible for rewriting some record contents as relative-form whenever possible would not correctly handle escaped dots in labels, and would then produce a Bind file with a trailing slash, which would lead to a parse error when the zone gets reloaded.

The last commit of this PR hardens the code to prevent this situation from occurring.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
