### PR TITLE
dnsdist: Better handling of nghttp2 errors

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -1245,7 +1245,10 @@ IOState IncomingHTTP2Connection::readHTTPData()
         throw std::runtime_error("Fatal error while passing received data to nghttp2: " + std::string(nghttp2_strerror((int)readlen)));
       }
 
-      nghttp2_session_send(d_session.get());
+      auto sendCode = nghttp2_session_send(d_session.get());
+      if (sendCode != 0) {
+        throw std::runtime_error("Fatal error while flushing HTTP data: " + std::string(nghttp2_strerror(static_cast<int>(sendCode))));
+      }
     }
   }
   catch (const std::exception& e) {

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -403,8 +403,8 @@ void DoHConnectionToBackend::handleReadableIOCallback(int fd, FDMultiplexer::fun
         // cerr<<"nghttp2_session_mem_recv returned "<<readlen<<endl;
         /* as long as we don't require a pause by returning nghttp2_error.NGHTTP2_ERR_PAUSE from a CB,
            all data should be consumed before returning */
-        if (readlen > 0 && static_cast<size_t>(readlen) < conn->d_inPos) {
-          throw std::runtime_error("Fatal error while passing received data to nghttp2: " + std::string(nghttp2_strerror((int)readlen)));
+        if (readlen < 0 || static_cast<size_t>(readlen) < conn->d_inPos) {
+          throw std::runtime_error("Fatal error while passing received data to nghttp2: " + std::string(nghttp2_strerror(static_cast<int>(readlen))));
         }
 
         struct timeval now{
@@ -413,8 +413,10 @@ void DoHConnectionToBackend::handleReadableIOCallback(int fd, FDMultiplexer::fun
         gettimeofday(&now, nullptr);
         conn->d_lastDataReceivedTime = now;
 
-        // cerr<<"after read send"<<endl;
-        nghttp2_session_send(conn->d_session.get());
+        auto sendCode = nghttp2_session_send(conn->d_session.get());
+        if (sendCode != 0) {
+          throw std::runtime_error("Fatal error while flushing HTTP data: " + std::string(nghttp2_strerror(static_cast<int>(sendCode))));
+        }
       }
 
       if (newState == IOState::Done) {

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -403,8 +403,11 @@ void DoHConnectionToBackend::handleReadableIOCallback(int fd, FDMultiplexer::fun
         // cerr<<"nghttp2_session_mem_recv returned "<<readlen<<endl;
         /* as long as we don't require a pause by returning nghttp2_error.NGHTTP2_ERR_PAUSE from a CB,
            all data should be consumed before returning */
-        if (readlen < 0 || static_cast<size_t>(readlen) < conn->d_inPos) {
+        if (readlen < 0) {
           throw std::runtime_error("Fatal error while passing received data to nghttp2: " + std::string(nghttp2_strerror(static_cast<int>(readlen))));
+        }
+        if (static_cast<size_t>(readlen) < conn->d_inPos) {
+          throw std::runtime_error("Data was not entirely processed (" + std::to_string(readlen) + " bytes out of " + std::to_string(conn->d_inPos) + ") while passing received data to nghttp2");
         }
 
         struct timeval now{


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
There are a few cases where an error returned by `nghttp2` could have been silently ignored. Thanks to ilhamaf for reporting this!
As far as I can tell there is no actual impact, except perhaps that we can detect errors/stale connections earlier, but I haven't been able to cause any actual problem introduced by not handling these errors properly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
