### PR TITLE
auth: dnsupdate handling buglet

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -947,7 +947,7 @@ static uint8_t updateRecords(const MOADNSParser::answers_t& answers, DNSSECKeepe
       if (rec.d_class == QClass::NONE && rec.d_type == QType::NS && rec.d_name == ctx.di.zone.operator const DNSName&()) {
         nsRRtoDelete.push_back(&rec);
       }
-      else if (rec.d_class == QClass::IN && rec.d_ttl > 0) {
+      else if (rec.d_class == QClass::IN) {
         if (rec.d_type == QType::CNAME) {
           cnamesToAdd.push_back(&rec);
         }


### PR DESCRIPTION
### Short description
Sending a CNAME record with a TTL of zero as part of a DNS Update would cause the CNAME name unicity check to be bypassed, allowing for a given record name to point to both CNAME and non-CNAME records after the update.

Reported by "ibfavas" through the YesWeHack program.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
