### PR TITLE
WIP: Allow config option to disable serving RRs after SOA EXPIRE time has elapsed

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -274,6 +274,8 @@ static void declareArguments()
   ::arg().set("domain-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "";
   ::arg().set("zone-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "60";
 
+  ::arg().setSwitch("serve-after-expire", "Continue to serve RRs even when the SOA expire has elapsed") = "on";
+
   ::arg().set("trusted-notification-proxy", "IP address of incoming notification proxy") = "";
   ::arg().set("secondary-do-renotify", "If this secondary should send out notifications after receiving zone transfers from a primary") = "no";
   ::arg().set("forward-notify", "IP addresses to forward received notifications to regardless of primary or secondary settings") = "";

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -274,7 +274,7 @@ static void declareArguments()
   ::arg().set("domain-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "";
   ::arg().set("zone-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "60";
 
-  ::arg().setSwitch("serve-after-expire", "Continue to serve RRs even when the SOA expire has elapsed") = "on";
+  ::arg().setSwitch("serve-after-soa-expire", "Continue to serve RRs even when the SOA expire has elapsed") = "on";
 
   ::arg().set("trusted-notification-proxy", "IP address of incoming notification proxy") = "";
   ::arg().set("secondary-do-renotify", "If this secondary should send out notifications after receiving zone transfers from a primary") = "no";

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -274,7 +274,7 @@ static void declareArguments()
   ::arg().set("domain-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "";
   ::arg().set("zone-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "60";
 
-  ::arg().setSwitch("serve-after-soa-expire", "Continue to serve RRs even when the SOA expire has elapsed") = "on";
+  ::arg().setSwitch("serve-after-soa-expire", "Continue to serve RRs even when the SOA expire has elapsed. When set to \"off\", this will delete the corresponding zone data from the secondary when the SOA expire has elapsed") = "on";
 
   ::arg().set("trusted-notification-proxy", "IP address of incoming notification proxy") = "";
   ::arg().set("secondary-do-renotify", "If this secondary should send out notifications after receiving zone transfers from a primary") = "no";

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -250,9 +250,19 @@ void Resolver::checkDomainExpired(const DNSName& domain)
   if(!B.getSOAUncached(domain, sd)) return; // We never had an SOA recieved from the server, so just skip the check.
   uint32_t expire = sd.expire;
 
-  if (currentUnixTime < (expire + last_check)) return; // Check if the EXPIRE has elapsed. If no, return (do nothing)
-  // <SQL execute (using currently used backend) "DELETE FROM records WHERE domain_id=${domain_id} AND NOT type='SOA'">
 
+  g_log << "Domain " << domain.toLogString() << " expired. Deleting domain records.";
+  
+  di.backend->startTransaction((ZoneName&)domain, UnknownDomainID);
+  try {
+    if(!di.backend->deleteDomain((ZoneName&)domain)) {
+      throw PDNSException("Failed to delete domain '" + domain.toLogString() + "'");
+    }
+    di.backend->commitTransaction();
+  } catch (...) {
+    di.backend->abortTransaction();
+    throw;
+  }
 }
 
 bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *theirSerial, uint32_t *theirInception, uint32_t *theirExpire, uint16_t* id)

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -273,17 +273,24 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
   *id=mdp.d_header.id;
   *domain = mdp.d_qname;
 
-  if(domain->empty())
+  if(domain->empty()) {
+    CheckDomainExpired(domain);
     throw ResolverException("SOA query to '" + remote->toLogString() + "' produced response without domain name (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
 
-  if(mdp.d_answers.empty())
+  if(mdp.d_answers.empty()) {
     throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' produced no results (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
+    CheckDomainExpired(domain);
+  }
 
-  if(mdp.d_qtype != QType::SOA)
+  if(mdp.d_qtype != QType::SOA) {
+    CheckDomainExpired(domain);
     throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' returned wrong record type");
+  }
 
-  if(mdp.d_header.rcode != 0)
+  if(mdp.d_header.rcode != 0) {
+    CheckDomainExpired(domain);
     throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' returned Rcode " + RCode::to_s(mdp.d_header.rcode));
+  }
 
   *theirInception = *theirExpire = 0;
   bool gotSOA=false;

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -233,14 +233,14 @@ namespace pdns {
 
 void Resolver::checkDomainExpired(const DNSName& domain)
 {
-  if (::arg().mustDo("serve-after-expire") {
+  if (::arg().mustDo("serve-after-expire")) {
     return;
   }
   time_t currentUnixTime = time(nullptr);
   // Get the "last_check" time for the domain "domain"
   
   //! TODO GET THE BACKEND WORKING
-  UeberBackend B();  //NOLINT(readability-identifier-length)
+  UeberBackend B;  //NOLINT(readability-identifier-length)
   //UtilBackend B; //NOLINT(readability-identifier-length)
   DomainInfo di;
   if (!B.getDomainInfo(domain, di)){
@@ -305,22 +305,22 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
   *domain = mdp.d_qname;
 
   if(domain->empty()) {
-    checkDomainExpired(domain);
+    checkDomainExpired(*domain);
     throw ResolverException("SOA query to '" + remote->toLogString() + "' produced response without domain name (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
   }
 
   if(mdp.d_answers.empty()) {
-    checkDomainExpired(domain);
+    checkDomainExpired(*domain);
     throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' produced no results (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
   }
 
   if(mdp.d_qtype != QType::SOA) {
-    checkDomainExpired(domain);
+    checkDomainExpired(*domain);
     throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' returned wrong record type");
   }
 
   if(mdp.d_header.rcode != 0) {
-    checkDomainExpired(domain);
+    checkDomainExpired(*domain);
     throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' returned Rcode " + RCode::to_s(mdp.d_header.rcode));
   }
 

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -231,15 +231,16 @@ namespace pdns {
   } // namespace resolver
 } // namespace pdns
 
-void Resolver::checkDomainExpired(DNSName* domain) {
-  if (::arg()["serve-after-expire"] == "on") return; // Config option should be "off" for this function to run
-  // Get the current time
-  time_t currentUnixTime = time(NULL);
-  if (currentUnixTime < 0) return; // Time could not be checked, so skip the expire check
+void Resolver::checkDomainExpired(const DNSName& domain)
+{
+  if (::arg().mustDo("serve-after-expire") {
+    return;
+  }
+  time_t currentUnixTime = time(nullptr);
   // Get the "last_check" time for the domain "domain"
   
   //! TODO GET THE BACKEND WORKING
-  UeberBackend B("default");  //NOLINT(readability-identifier-length)
+  UeberBackend B();  //NOLINT(readability-identifier-length)
   //UtilBackend B; //NOLINT(readability-identifier-length)
   DomainInfo di;
   if (!B.getDomainInfo(domain, di)){

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -237,20 +237,15 @@ void Resolver::checkDomainExpired(const DNSName& domain)
     return;
   }
   time_t currentUnixTime = time(nullptr);
-  // Get the "last_check" time for the domain "domain"
   
-  //! TODO GET THE BACKEND WORKING
   UeberBackend B;  //NOLINT(readability-identifier-length)
-  //UtilBackend B; //NOLINT(readability-identifier-length)
   DomainInfo di;
-  if (!B.getDomainInfo(domain, di)){
-    // If you get this to print, well fucking done.
-    cerr << "WTF? We just asked for an SOA for a zone that is not in the database" << endl;
+  if (!B.getDomainInfo((ZoneName&)domain, di)){
+    g_log << "ERROR: We just asked for an SOA for a zone that is not in the database." << endl;
     return;
   }
   time_t last_check = di.last_check;
   
-  // Get SOA EXPIRE time
   SOAData sd;
   if(!B.getSOAUncached(domain, sd)) return; // We never had an SOA recieved from the server, so just skip the check.
   uint32_t expire = sd.expire;

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -274,21 +274,22 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
   *domain = mdp.d_qname;
 
   if(domain->empty()) {
-    CheckDomainExpired(domain);
+    checkDomainExpired(domain);
     throw ResolverException("SOA query to '" + remote->toLogString() + "' produced response without domain name (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
+  }
 
   if(mdp.d_answers.empty()) {
     throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' produced no results (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
-    CheckDomainExpired(domain);
+    checkDomainExpired(domain);
   }
 
   if(mdp.d_qtype != QType::SOA) {
-    CheckDomainExpired(domain);
+    checkDomainExpired(domain);
     throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' returned wrong record type");
   }
 
   if(mdp.d_header.rcode != 0) {
-    CheckDomainExpired(domain);
+    checkDomainExpired(domain);
     throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' returned Rcode " + RCode::to_s(mdp.d_header.rcode));
   }
 

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -229,6 +229,33 @@ namespace pdns {
   } // namespace resolver
 } // namespace pdns
 
+void Resolver::checkDomainExpired(DNSName* domain) {
+  if (::arg()["serve-after-expire"] == "on") return; // Config option should be "off" for this function to run
+  // Get the current time
+  time_t currentUnixTime = time(NULL);
+  if (currentUnixTime < 0) return; // Time could not be checked, so skip the expire check 
+/*
+  for (auto& backend : backends) {
+    // Do not risk passing variant zones to variant-unaware backends.
+    if (domain.hasVariant() && (backend->getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
+      continue;
+    }
+    if (backend->getDomainInfo(domain, domainInfo, getSerial)) {
+      return true;
+    }
+  }
+  return false;
+*/
+  // <SQL execute (using currently used backend) "SELECT id as domain_id, last_check FROM domains WHERE name = ${domain.toString()}">
+  // <SQL execute (using currently used backend) "SELECT content FROM records WHERE type='SOA'" and export EXPIRE (index 5) from the record as soa_expire
+  // If at any point bullshit data or no data is returned, just return.
+
+  // if (currentUnixTime < (soa_expire + last_check)) return; // Check if the EXPIRE has elapsed. If no, return (do nothing)
+  // <SQL execute (using currently used backend) "DELETE FROM records WHERE domain_id=${domain_id} AND NOT type='SOA'">
+
+  // Maybe add a HINFO record to indicate that this domain was automatically removed?
+}
+
 bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *theirSerial, uint32_t *theirInception, uint32_t *theirExpire, uint16_t* id)
 {
   auto fds = std::make_unique<struct pollfd[]>(locals.size());

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -253,7 +253,6 @@ void Resolver::checkDomainExpired(DNSName* domain) {
   // if (currentUnixTime < (soa_expire + last_check)) return; // Check if the EXPIRE has elapsed. If no, return (do nothing)
   // <SQL execute (using currently used backend) "DELETE FROM records WHERE domain_id=${domain_id} AND NOT type='SOA'">
 
-  // Maybe add a HINFO record to indicate that this domain was automatically removed?
 }
 
 bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *theirSerial, uint32_t *theirInception, uint32_t *theirExpire, uint16_t* id)

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -306,8 +306,8 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
   }
 
   if(mdp.d_answers.empty()) {
-    throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' produced no results (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
     checkDomainExpired(domain);
+    throw ResolverException("Query to '" + remote->toLogString() + "' for SOA of '" + domain->toLogString() + "' produced no results (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
   }
 
   if(mdp.d_qtype != QType::SOA) {

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -51,7 +51,7 @@
 #include "gss_context.hh"
 #include "namespaces.hh"
 
-#include "dnsbackend.hh"
+#include "ueberbackend.hh"
 
 using pdns::resolver::parseResult;
 
@@ -244,12 +244,15 @@ void Resolver::checkDomainExpired(const DNSName& domain)
     g_log << "ERROR: We just asked for an SOA for a zone that is not in the database." << endl;
     return;
   }
+
+  if (!di.last_check) return;
   time_t last_check = di.last_check;
   
   SOAData sd;
-  if(!B.getSOAUncached(domain, sd)) return; // We never had an SOA recieved from the server, so just skip the check.
-  uint32_t expire = sd.expire;
+  if(!B.getSOAUncached((ZoneName&)domain, sd)) return;
+  uint64_t expire = (uint64_t)sd.expire;
 
+  if ((uint64_t)currentUnixTime - (uint64_t)last_check < expire) return;
 
   g_log << "Domain " << domain.toLogString() << " expired. Deleting domain records.";
   
@@ -310,7 +313,6 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
   *domain = mdp.d_qname;
 
   if(domain->empty()) {
-    checkDomainExpired(*domain);
     throw ResolverException("SOA query to '" + remote->toLogString() + "' produced response without domain name (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
   }
 

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -310,9 +310,11 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
 
   MOADNSParser mdp(false, (char*)buf, err);
   *id=mdp.d_header.id;
+  DNSName domain_copy = *domain;
   *domain = mdp.d_qname;
 
   if(domain->empty()) {
+    checkDomainExpired(domain_copy);
     throw ResolverException("SOA query to '" + remote->toLogString() + "' produced response without domain name (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
   }
 

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -51,6 +51,8 @@
 #include "gss_context.hh"
 #include "namespaces.hh"
 
+#include "dnsbackend.hh"
+
 using pdns::resolver::parseResult;
 
 int makeQuerySocket(const ComboAddress& local, bool udpOrTCP, bool nonLocalBind)
@@ -233,24 +235,26 @@ void Resolver::checkDomainExpired(DNSName* domain) {
   if (::arg()["serve-after-expire"] == "on") return; // Config option should be "off" for this function to run
   // Get the current time
   time_t currentUnixTime = time(NULL);
-  if (currentUnixTime < 0) return; // Time could not be checked, so skip the expire check 
-/*
-  for (auto& backend : backends) {
-    // Do not risk passing variant zones to variant-unaware backends.
-    if (domain.hasVariant() && (backend->getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
-      continue;
-    }
-    if (backend->getDomainInfo(domain, domainInfo, getSerial)) {
-      return true;
-    }
+  if (currentUnixTime < 0) return; // Time could not be checked, so skip the expire check
+  // Get the "last_check" time for the domain "domain"
+  
+  //! TODO GET THE BACKEND WORKING
+  UeberBackend B("default");  //NOLINT(readability-identifier-length)
+  //UtilBackend B; //NOLINT(readability-identifier-length)
+  DomainInfo di;
+  if (!B.getDomainInfo(domain, di)){
+    // If you get this to print, well fucking done.
+    cerr << "WTF? We just asked for an SOA for a zone that is not in the database" << endl;
+    return;
   }
-  return false;
-*/
-  // <SQL execute (using currently used backend) "SELECT id as domain_id, last_check FROM domains WHERE name = ${domain.toString()}">
-  // <SQL execute (using currently used backend) "SELECT content FROM records WHERE type='SOA'" and export EXPIRE (index 5) from the record as soa_expire
-  // If at any point bullshit data or no data is returned, just return.
+  time_t last_check = di.last_check;
+  
+  // Get SOA EXPIRE time
+  SOAData sd;
+  if(!B.getSOAUncached(domain, sd)) return; // We never had an SOA recieved from the server, so just skip the check.
+  uint32_t expire = sd.expire;
 
-  // if (currentUnixTime < (soa_expire + last_check)) return; // Check if the EXPIRE has elapsed. If no, return (do nothing)
+  if (currentUnixTime < (expire + last_check)) return; // Check if the EXPIRE has elapsed. If no, return (do nothing)
   // <SQL execute (using currently used backend) "DELETE FROM records WHERE domain_id=${domain_id} AND NOT type='SOA'">
 
 }

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -233,11 +233,11 @@ namespace pdns {
 
 void Resolver::checkDomainExpired(const DNSName& domain)
 {
-  if (::arg().mustDo("serve-after-expire")) {
+  if (::arg().mustDo("serve-after-soa-expire")) {
     return;
   }
   time_t currentUnixTime = time(nullptr);
-  
+
   UeberBackend B;  //NOLINT(readability-identifier-length)
   DomainInfo di;
   if (!B.getDomainInfo((ZoneName&)domain, di)){
@@ -247,7 +247,7 @@ void Resolver::checkDomainExpired(const DNSName& domain)
 
   if (!di.last_check) return;
   time_t last_check = di.last_check;
-  
+
   SOAData sd;
   if(!B.getSOAUncached((ZoneName&)domain, sd)) return;
   uint64_t expire = (uint64_t)sd.expire;
@@ -255,7 +255,7 @@ void Resolver::checkDomainExpired(const DNSName& domain)
   if ((uint64_t)currentUnixTime - (uint64_t)last_check < expire) return;
 
   g_log << "Domain " << domain.toLogString() << " expired. Deleting domain records.";
-  
+
   di.backend->startTransaction((ZoneName&)domain, UnknownDomainID);
   try {
     if(!di.backend->deleteDomain((ZoneName&)domain)) {

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -66,6 +66,7 @@ public:
   uint16_t sendResolve(const ComboAddress& remote, const ComboAddress& local, const DNSName &domain, int type, int *localsock, bool dnssecOk=false,
     const DNSName& tsigkeyname=DNSName(), const DNSName& tsigalgorithm=DNSName(), const string& tsigsecret="");
 
+  void checkDomainExpired(DNSName* domain);
   //! see if we got a SOA response from our sendResolve
   bool tryGetSOASerial(DNSName *theirDomain, ComboAddress* remote, uint32_t* theirSerial, uint32_t* theirInception, uint32_t* theirExpire, uint16_t* id);
   

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -66,7 +66,7 @@ public:
   uint16_t sendResolve(const ComboAddress& remote, const ComboAddress& local, const DNSName &domain, int type, int *localsock, bool dnssecOk=false,
     const DNSName& tsigkeyname=DNSName(), const DNSName& tsigalgorithm=DNSName(), const string& tsigsecret="");
 
-  void checkDomainExpired(DNSName* domain);
+  void checkDomainExpired(const DNSName& domain);
   //! see if we got a SOA response from our sendResolve
   bool tryGetSOASerial(DNSName *theirDomain, ComboAddress* remote, uint32_t* theirSerial, uint32_t* theirInception, uint32_t* theirExpire, uint16_t* id);
   


### PR DESCRIPTION
This pull request aims to allow PowerDNS to comply with RFC 1034, section 4.3.5, specifically the following two lines:
> If the secondary finds it impossible to perform a serial check for the EXPIRE interval,
> it must assume that its copy of the zone is obsolete and discard it.

Since I do not want to introduce breaking changes, the default behaviour will be as it is now (not removing obsolete RRs), and it will require manual intervention (editing the config file) for PowerDNS to change the behaviour.

Fixes: #11185 (was also a problem with other backends)

Author's matrix: @erents:dapperepoging.nl
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
