### PR TITLE
auth: safer lua geoip queries

### DIFF
--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -730,6 +730,7 @@ static string queryGeoIP(const Netmask& addr, GeoIPInterface::GeoIPQueryAttribut
 
 string getGeoForLua(const std::string& ip, int qaint)
 {
+  ReadLock rl(&GeoIPBackend::s_state_lock);
   GeoIPInterface::GeoIPQueryAttribute qa((GeoIPInterface::GeoIPQueryAttribute)qaint);
   try {
     const Netmask addr{ip};

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -41,7 +41,7 @@
 #pragma GCC diagnostic pop
 #include "pdns/logging.hh"
 
-ReadWriteLock GeoIPBackend::s_state_lock;
+SharedLockGuarded<GeoIPBackend::state_t> GeoIPBackend::s_state;
 
 struct GeoIPDNSResourceRecord : DNSResourceRecord
 {
@@ -66,9 +66,6 @@ struct GeoIPDomain
   vector<string> mapping_lookup_formats;
   map<std::string, std::string> custom_mapping;
 };
-
-static vector<GeoIPDomain> s_domains;
-static int s_rc = 0; // refcount - always accessed under lock
 
 const static std::array<string, 7> GeoIP_WEEKDAYS = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"};
 const static std::array<string, 12> GeoIP_MONTHS = {"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"};
@@ -101,7 +98,7 @@ using UniqueDirPtr = std::unique_ptr<DIR, DirPtrDeleter>;
 
 GeoIPBackend::GeoIPBackend(const string& suffix)
 {
-  WriteLock writeLock(&s_state_lock);
+  auto state = s_state.write_lock();
   setArgPrefix("geoip" + suffix);
   if (g_slogStructured) {
     d_slog = g_slog->withName("geoip" + suffix);
@@ -113,16 +110,14 @@ GeoIPBackend::GeoIPBackend(const string& suffix)
     }
     d_dnssec = true;
   }
-  if (s_rc == 0) { // first instance gets to open everything
-    initialize();
+  if (state->instance_count == 0) { // first instance gets to open everything
+    initialize(*state);
   }
-  s_rc++;
+  state->instance_count++;
 }
 
-static vector<std::unique_ptr<GeoIPInterface>> s_geoip_files;
-
 string getGeoForLua(const std::string& ip, int qaint);
-static string queryGeoIP(const Netmask& addr, GeoIPInterface::GeoIPQueryAttribute attribute, GeoIPNetmask& gl);
+static string queryGeoIP(const GeoIPBackend::filevec_t& geoip_files, const Netmask& addr, GeoIPInterface::GeoIPQueryAttribute attribute, GeoIPNetmask& gl);
 
 // validateMappingLookupFormats validates any custom format provided by the
 // user does not use the custom mapping placeholder again, else it would do an
@@ -411,22 +406,22 @@ void GeoIPBackend::loadDomainsFromDirectory(const std::string& dir, vector<GeoIP
   }
 }
 
-void GeoIPBackend::initialize()
+void GeoIPBackend::initialize(state_t& state)
 {
   YAML::Node config;
   vector<GeoIPDomain> tmp_domains;
 
-  s_geoip_files.clear(); // reset pointers
+  state.geoip_files.clear(); // reset pointers
 
   if (getArg("database-files").empty() == false) {
     vector<string> files;
     stringtok(files, getArg("database-files"), " ,\t\r\n");
     for (auto const& file : files) {
-      s_geoip_files.push_back(GeoIPInterface::makeInterface(d_slog, file));
+      state.geoip_files.push_back(GeoIPInterface::makeInterface(d_slog, file));
     }
   }
 
-  if (s_geoip_files.empty()) {
+  if (state.geoip_files.empty()) {
     SLOG(g_log << Logger::Warning << "No GeoIP database files loaded!" << endl,
          d_slog->info(Logr::Warning, "No GeoIP database files loaded"));
   }
@@ -475,8 +470,8 @@ void GeoIPBackend::initialize()
     loadDomainsFromDirectory(domain_dir.as<string>(), tmp_domains);
   }
 
-  s_domains.clear();
-  std::swap(s_domains, tmp_domains);
+  state.domains.clear();
+  std::swap(state.domains, tmp_domains);
 
   extern std::function<std::string(const std::string& ip, int)> g_getGeo;
   g_getGeo = getGeoForLua;
@@ -485,18 +480,18 @@ void GeoIPBackend::initialize()
 GeoIPBackend::~GeoIPBackend()
 {
   try {
-    WriteLock writeLock(&s_state_lock);
-    s_rc--;
-    if (s_rc == 0) { // last instance gets to cleanup
-      s_geoip_files.clear();
-      s_domains.clear();
+    auto state = s_state.write_lock();
+    state->instance_count--;
+    if (state->instance_count == 0) { // last instance gets to cleanup
+      state->geoip_files.clear();
+      state->domains.clear();
     }
   }
   catch (...) {
   }
 }
 
-bool GeoIPBackend::lookup_static(const GeoIPDomain& dom, const DNSName& search, const QType& qtype, const DNSName& qdomain, const Netmask& addr, GeoIPNetmask& gl)
+bool GeoIPBackend::lookup_static(const filevec_t& geoip_files, const GeoIPDomain& dom, const DNSName& search, const QType& qtype, const DNSName& qdomain, const Netmask& addr, GeoIPNetmask& gl)
 {
   const auto& i = dom.records.find(search);
   map<uint16_t, int> cumul_probabilities;
@@ -515,7 +510,7 @@ bool GeoIPBackend::lookup_static(const GeoIPDomain& dom, const DNSName& search, 
         if (rr.weight == 0 || probability_rnd < comp || probability_rnd > (comp + rr.weight))
           continue;
       }
-      const string& content = format2str(rr.content, addr, gl, dom);
+      const string& content = format2str(geoip_files, rr.content, addr, gl, dom);
       if (rr.qtype != QType::ENT && rr.qtype != QType::TXT && content.empty())
         continue;
       d_result.push_back(rr);
@@ -538,7 +533,7 @@ bool GeoIPBackend::lookup_static(const GeoIPDomain& dom, const DNSName& search, 
 
 void GeoIPBackend::lookup(const QType& qtype, const DNSName& qdomain, domainid_t zoneId, DNSPacket* pkt_p)
 {
-  ReadLock rl(&s_state_lock);
+  auto state = s_state.read_lock();
   const GeoIPDomain* dom;
   GeoIPNetmask gl;
   bool found = false;
@@ -548,11 +543,11 @@ void GeoIPBackend::lookup(const QType& qtype, const DNSName& qdomain, domainid_t
 
   d_result.clear();
 
-  if (zoneId >= 0 && zoneId < static_cast<domainid_t>(s_domains.size())) {
-    dom = &(s_domains[zoneId]);
+  if (zoneId >= 0 && zoneId < static_cast<domainid_t>(state->domains.size())) {
+    dom = &(state->domains[zoneId]);
   }
   else {
-    for (const GeoIPDomain& i : s_domains) { // this is arguably wrong, we should probably find the most specific match
+    for (const GeoIPDomain& i : state->domains) { // this is arguably wrong, we should probably find the most specific match
       if (qdomain.isPartOf(i.domain)) {
         dom = &i;
         found = true;
@@ -570,7 +565,7 @@ void GeoIPBackend::lookup(const QType& qtype, const DNSName& qdomain, domainid_t
 
   gl.netmask = 0;
 
-  (void)this->lookup_static(*dom, qdomain, qtype, qdomain, addr, gl);
+  (void)this->lookup_static(state->geoip_files, *dom, qdomain, qtype, qdomain, addr, gl);
 
   const auto& target = (*dom).services.find(qdomain);
   if (target == (*dom).services.end())
@@ -587,7 +582,7 @@ void GeoIPBackend::lookup(const QType& qtype, const DNSName& qdomain, domainid_t
     GeoIPNetmask tmp_gl;
     tmp_gl.netmask = 0;
     // get netmask from geoip backend
-    if (queryGeoIP(addr, GeoIPInterface::Name, tmp_gl) == "unknown") {
+    if (queryGeoIP(state->geoip_files, addr, GeoIPInterface::Name, tmp_gl) == "unknown") {
       if (addr.isIPv6())
         gl.netmask = target->second.netmask6;
       else
@@ -603,10 +598,10 @@ void GeoIPBackend::lookup(const QType& qtype, const DNSName& qdomain, domainid_t
 
   // note that this means the array format won't work with indirect
   for (auto it = node->second.begin(); it != node->second.end(); it++) {
-    sformat = DNSName(format2str(*it, addr, gl, *dom));
+    sformat = DNSName(format2str(state->geoip_files, *it, addr, gl, *dom));
 
     // see if the record can be found
-    if (this->lookup_static((*dom), sformat, qtype, qdomain, addr, gl))
+    if (this->lookup_static(state->geoip_files, (*dom), sformat, qtype, qdomain, addr, gl))
       return;
   }
 
@@ -651,11 +646,11 @@ void GeoIPBackend::lookupEnd()
   d_result.clear();
 }
 
-static string queryGeoIP(const Netmask& addr, GeoIPInterface::GeoIPQueryAttribute attribute, GeoIPNetmask& gl)
+static string queryGeoIP(const GeoIPBackend::filevec_t& geoip_files, const Netmask& addr, GeoIPInterface::GeoIPQueryAttribute attribute, GeoIPNetmask& gl)
 {
   string ret = "unknown";
 
-  for (auto const& gi : s_geoip_files) {
+  for (auto const& gi : geoip_files) {
     string val;
     const string ip = addr.toStringNoMask();
     bool found = false;
@@ -730,12 +725,12 @@ static string queryGeoIP(const Netmask& addr, GeoIPInterface::GeoIPQueryAttribut
 
 string getGeoForLua(const std::string& ip, int qaint)
 {
-  ReadLock rl(&GeoIPBackend::s_state_lock);
+  auto state = GeoIPBackend::s_state.read_lock();
   GeoIPInterface::GeoIPQueryAttribute qa((GeoIPInterface::GeoIPQueryAttribute)qaint);
   try {
     const Netmask addr{ip};
     GeoIPNetmask gl;
-    string res = queryGeoIP(addr, qa, gl);
+    string res = queryGeoIP(state->geoip_files, addr, qa, gl);
     //    cout<<"Result for "<<ip<<" lookup: "<<res<<endl;
     if (qa == GeoIPInterface::ASn && boost::starts_with(res, "as"))
       return res.substr(2);
@@ -750,10 +745,10 @@ string getGeoForLua(const std::string& ip, int qaint)
   return "";
 }
 
-static bool queryGeoLocation(const Netmask& addr, GeoIPNetmask& gl, double& lat, double& lon,
+static bool queryGeoLocation(const GeoIPBackend::filevec_t& geoip_files, const Netmask& addr, GeoIPNetmask& gl, double& lat, double& lon,
                              std::optional<int>& alt, std::optional<int>& prec)
 {
-  for (auto const& gi : s_geoip_files) {
+  for (auto const& gi : geoip_files) {
     string val;
     if (addr.isIPv6()) {
       if (gi->queryLocationV6(gl, addr.toStringNoMask(), lat, lon, alt, prec))
@@ -765,7 +760,7 @@ static bool queryGeoLocation(const Netmask& addr, GeoIPNetmask& gl, double& lat,
   return false;
 }
 
-string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmask& gl, const GeoIPDomain& dom)
+string GeoIPBackend::format2str(const filevec_t& geoip_files, string sformat, const Netmask& addr, GeoIPNetmask& gl, const GeoIPDomain& dom)
 {
   string::size_type cur, last;
   std::optional<int> alt;
@@ -784,7 +779,7 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
     if (!sformat.compare(cur, 3, "%mp")) {
       rep = "unknown";
       for (const auto& lookupFormat : dom.mapping_lookup_formats) {
-        auto it = dom.custom_mapping.find(format2str(lookupFormat, addr, gl, dom));
+        auto it = dom.custom_mapping.find(format2str(geoip_files, lookupFormat, addr, gl, dom));
         if (it != dom.custom_mapping.end()) {
           rep = it->second;
           break;
@@ -792,34 +787,34 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
       }
     }
     else if (!sformat.compare(cur, 3, "%cn")) {
-      rep = queryGeoIP(addr, GeoIPInterface::Continent, tmp_gl);
+      rep = queryGeoIP(geoip_files, addr, GeoIPInterface::Continent, tmp_gl);
     }
     else if (!sformat.compare(cur, 3, "%co")) {
-      rep = queryGeoIP(addr, GeoIPInterface::Country, tmp_gl);
+      rep = queryGeoIP(geoip_files, addr, GeoIPInterface::Country, tmp_gl);
     }
     else if (!sformat.compare(cur, 3, "%cc")) {
-      rep = queryGeoIP(addr, GeoIPInterface::Country2, tmp_gl);
+      rep = queryGeoIP(geoip_files, addr, GeoIPInterface::Country2, tmp_gl);
     }
     else if (!sformat.compare(cur, 3, "%af")) {
       rep = (addr.isIPv6() ? "v6" : "v4");
     }
     else if (!sformat.compare(cur, 3, "%as")) {
-      rep = queryGeoIP(addr, GeoIPInterface::ASn, tmp_gl);
+      rep = queryGeoIP(geoip_files, addr, GeoIPInterface::ASn, tmp_gl);
     }
     else if (!sformat.compare(cur, 3, "%re")) {
-      rep = queryGeoIP(addr, GeoIPInterface::Region, tmp_gl);
+      rep = queryGeoIP(geoip_files, addr, GeoIPInterface::Region, tmp_gl);
     }
     else if (!sformat.compare(cur, 3, "%na")) {
-      rep = queryGeoIP(addr, GeoIPInterface::Name, tmp_gl);
+      rep = queryGeoIP(geoip_files, addr, GeoIPInterface::Name, tmp_gl);
     }
     else if (!sformat.compare(cur, 3, "%ci")) {
-      rep = queryGeoIP(addr, GeoIPInterface::City, tmp_gl);
+      rep = queryGeoIP(geoip_files, addr, GeoIPInterface::City, tmp_gl);
     }
     else if (!sformat.compare(cur, 4, "%loc")) {
       char ns, ew;
       int d1, d2, m1, m2;
       double s1, s2;
-      if (!queryGeoLocation(addr, gl, lat, lon, alt, prec)) {
+      if (!queryGeoLocation(geoip_files, addr, gl, lat, lon, alt, prec)) {
         rep = "";
         tmp_gl.netmask = (addr.isIPv6() ? 128 : 32);
       }
@@ -846,7 +841,7 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
       nrep = 4;
     }
     else if (!sformat.compare(cur, 4, "%lat")) {
-      if (!queryGeoLocation(addr, gl, lat, lon, alt, prec)) {
+      if (!queryGeoLocation(geoip_files, addr, gl, lat, lon, alt, prec)) {
         rep = "";
         tmp_gl.netmask = (addr.isIPv6() ? 128 : 32);
       }
@@ -856,7 +851,7 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
       nrep = 4;
     }
     else if (!sformat.compare(cur, 4, "%lon")) {
-      if (!queryGeoLocation(addr, gl, lat, lon, alt, prec)) {
+      if (!queryGeoLocation(geoip_files, addr, gl, lat, lon, alt, prec)) {
         rep = "";
         tmp_gl.netmask = (addr.isIPv6() ? 128 : 32);
       }
@@ -933,10 +928,10 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
 
 void GeoIPBackend::reload()
 {
-  WriteLock wl(&s_state_lock);
+  auto state = s_state.write_lock();
 
   try {
-    initialize();
+    initialize(*state);
   }
   catch (PDNSException& pex) {
     SLOG(g_log << Logger::Error << "GeoIP backend reload failed: " << pex.reason << endl,
@@ -959,9 +954,9 @@ void GeoIPBackend::rediscover(string* /* status */)
 
 bool GeoIPBackend::getDomainInfo(const ZoneName& domain, DomainInfo& info, bool /* getSerial */)
 {
-  ReadLock rl(&s_state_lock);
+  auto state = s_state.read_lock();
 
-  for (const GeoIPDomain& dom : s_domains) {
+  for (const GeoIPDomain& dom : state->domains) {
     if (dom.domain == domain) {
       SOAData sd;
       this->getSOA(dom.domain, dom.id, sd);
@@ -978,10 +973,10 @@ bool GeoIPBackend::getDomainInfo(const ZoneName& domain, DomainInfo& info, bool 
 
 void GeoIPBackend::getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool /* include_disabled */)
 {
-  ReadLock rl(&s_state_lock);
+  auto state = s_state.read_lock();
 
   DomainInfo di;
-  for (const auto& dom : s_domains) {
+  for (const auto& dom : state->domains) {
     di.id = dom.id;
     di.zone = dom.domain;
     di.kind = DomainInfo::Native;
@@ -1000,8 +995,8 @@ bool GeoIPBackend::getAllDomainMetadata(const ZoneName& name, std::map<std::stri
   if (!d_dnssec)
     return false;
 
-  ReadLock rl(&s_state_lock);
-  for (const GeoIPDomain& dom : s_domains) {
+  auto state = s_state.read_lock();
+  for (const GeoIPDomain& dom : state->domains) {
     if (dom.domain == name) {
       if (hasDNSSECkey(dom.domain)) {
         meta[string("NSEC3NARROW")].push_back("1");
@@ -1018,8 +1013,8 @@ bool GeoIPBackend::getDomainMetadata(const ZoneName& name, const std::string& ki
   if (!d_dnssec)
     return false;
 
-  ReadLock rl(&s_state_lock);
-  for (const GeoIPDomain& dom : s_domains) {
+  auto state = s_state.read_lock();
+  for (const GeoIPDomain& dom : state->domains) {
     if (dom.domain == name) {
       if (hasDNSSECkey(dom.domain)) {
         if (kind == "NSEC3NARROW")
@@ -1037,8 +1032,8 @@ bool GeoIPBackend::getDomainKeys(const ZoneName& name, std::vector<DNSBackend::K
 {
   if (!d_dnssec)
     return false;
-  ReadLock rl(&s_state_lock);
-  for (const GeoIPDomain& dom : s_domains) {
+  auto state = s_state.read_lock();
+  for (const GeoIPDomain& dom : state->domains) {
     if (dom.domain == name) {
       regex_t reg;
       regmatch_t regm[5];
@@ -1081,9 +1076,9 @@ bool GeoIPBackend::removeDomainKey(const ZoneName& name, unsigned int keyId)
 {
   if (!d_dnssec)
     return false;
-  WriteLock rl(&s_state_lock);
+  auto state = s_state.write_lock();
 
-  for (const GeoIPDomain& dom : s_domains) {
+  for (const GeoIPDomain& dom : state->domains) {
     if (dom.domain == name) {
       regex_t reg;
       regmatch_t regm[5];
@@ -1116,10 +1111,10 @@ bool GeoIPBackend::addDomainKey(const ZoneName& name, const KeyData& key, int64_
 {
   if (!d_dnssec)
     return false;
-  WriteLock rl(&s_state_lock);
+  auto state = s_state.write_lock();
   unsigned int nextid = 1;
 
-  for (const GeoIPDomain& dom : s_domains) {
+  for (const GeoIPDomain& dom : state->domains) {
     if (dom.domain == name) {
       regex_t reg;
       regmatch_t regm[5];
@@ -1154,8 +1149,8 @@ bool GeoIPBackend::activateDomainKey(const ZoneName& name, unsigned int keyId)
 {
   if (!d_dnssec)
     return false;
-  WriteLock rl(&s_state_lock);
-  for (const GeoIPDomain& dom : s_domains) {
+  auto state = s_state.write_lock();
+  for (const GeoIPDomain& dom : state->domains) {
     if (dom.domain == name) {
       regex_t reg;
       regmatch_t regm[5];
@@ -1189,8 +1184,8 @@ bool GeoIPBackend::deactivateDomainKey(const ZoneName& name, unsigned int keyId)
 {
   if (!d_dnssec)
     return false;
-  WriteLock rl(&s_state_lock);
-  for (const GeoIPDomain& dom : s_domains) {
+  auto state = s_state.write_lock();
+  for (const GeoIPDomain& dom : state->domains) {
     if (dom.domain == name) {
       regex_t reg;
       regmatch_t regm[5];

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -1082,7 +1082,6 @@ bool GeoIPBackend::removeDomainKey(const ZoneName& name, unsigned int keyId)
   if (!d_dnssec)
     return false;
   WriteLock rl(&s_state_lock);
-  ostringstream path;
 
   for (const GeoIPDomain& dom : s_domains) {
     if (dom.domain == name) {

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -35,14 +35,14 @@
 #include "pdns/dnsbackend.hh"
 #include "pdns/lock.hh"
 
-class GeoIPInterface;
-
 namespace YAML
 {
 class Node;
 };
 
 struct GeoIPDomain;
+
+class GeoIPInterface;
 
 struct GeoIPNetmask
 {
@@ -54,6 +54,18 @@ class GeoIPBackend : public DNSBackend
 public:
   GeoIPBackend(const std::string& suffix = "");
   ~GeoIPBackend() override;
+
+  using filevec_t = std::vector<std::unique_ptr<GeoIPInterface>>;
+  using state_t = struct
+  {
+    unsigned int instance_count{0};
+    std::vector<GeoIPDomain> domains;
+    filevec_t geoip_files;
+  };
+
+  // Needs to be public, for the Lua interface needs to access this outside
+  // of a backend instance.
+  static SharedLockGuarded<state_t> s_state;
 
   unsigned int getCapabilities() override
   {
@@ -84,19 +96,17 @@ public:
   bool publishDomainKey(const ZoneName& name, unsigned int keyId) override;
   bool unpublishDomainKey(const ZoneName& name, unsigned int keyId) override;
 
-  static ReadWriteLock s_state_lock;
-
 private:
-  void initialize();
-  string format2str(string format, const Netmask& addr, GeoIPNetmask& gl, const GeoIPDomain& dom);
+  void initialize(state_t& state);
+  string format2str(const filevec_t& geoip_files, string format, const Netmask& addr, GeoIPNetmask& gl, const GeoIPDomain& dom);
   bool d_dnssec{};
   bool hasDNSSECkey(const ZoneName& name);
-  bool lookup_static(const GeoIPDomain& dom, const DNSName& search, const QType& qtype, const DNSName& qdomain, const Netmask& addr, GeoIPNetmask& gl);
+  bool lookup_static(const filevec_t& geoip_files, const GeoIPDomain& dom, const DNSName& search, const QType& qtype, const DNSName& qdomain, const Netmask& addr, GeoIPNetmask& gl);
   void setupNetmasks(const YAML::Node& domain, GeoIPDomain& dom);
   bool loadDomain(const std::string& origin, const YAML::Node& domain, domainid_t domainID, GeoIPDomain& dom);
   void loadDomainsFromDirectory(const std::string& dir, vector<GeoIPDomain>& domains);
+
   vector<DNSResourceRecord> d_result;
-  vector<GeoIPInterface> d_files;
   std::vector<std::string> d_global_mapping_lookup_formats;
   std::map<std::string, std::string> d_global_custom_mapping;
 };

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -84,9 +84,9 @@ public:
   bool publishDomainKey(const ZoneName& name, unsigned int keyId) override;
   bool unpublishDomainKey(const ZoneName& name, unsigned int keyId) override;
 
-private:
   static ReadWriteLock s_state_lock;
 
+private:
   void initialize();
   string format2str(string format, const Netmask& addr, GeoIPNetmask& gl, const GeoIPDomain& dom);
   bool d_dnssec{};


### PR DESCRIPTION
### Short description
As noticed in #17158, geoip queries performed through Lua operations were run without holding a read lock on the geoip database, and would thus misbehave when a database reload is in progress at the same time.

This PR simply takes the appropriate lock (this requires the visibility of the lock to be widened, though).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
