### PR TITLE
rec: skip ZONEMD records in RPZs

### DIFF
--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -267,7 +267,7 @@ static shared_ptr<const SOARecordContent> loadRPZFromServer(Logr::log_t plogger,
   // coverity[store_truncates_time_t]
   while (axfr.getChunk(nop, &chunk, (axfrStart + axfrTimeout - axfrNow)) != 0) {
     for (auto& dnsRecord : chunk) {
-      if (dnsRecord.d_type == QType::NS || dnsRecord.d_type == QType::TSIG) {
+      if (dnsRecord.d_type == QType::NS || dnsRecord.d_type == QType::TSIG || dnsRecord.d_type == QType::ZONEMD) {
         continue;
       }
 
@@ -362,7 +362,7 @@ std::shared_ptr<const SOARecordContent> loadRPZFromFile(const std::string& fname
         zone->setDomain(domain);
         soaRecord = std::move(dnsRecord);
       }
-      else if (dnsRecord.d_type == QType::NS) {
+      else if (dnsRecord.d_type == QType::NS || dnsRecord.d_type == QType::ZONEMD) {
         continue;
       }
       else {
@@ -642,7 +642,7 @@ static bool RPZTrackerIteration(RPZTrackerParams& params, const DNSName& zoneNam
       }
 
       for (const auto& resourceRecord : add) { // should always contain the new SOA
-        if (resourceRecord.d_type == QType::NS) {
+        if (resourceRecord.d_type == QType::NS || resourceRecord.d_type == QType::ZONEMD) {
           continue;
         }
         if (resourceRecord.d_type == QType::SOA) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

They appear at the apex and are interpreted as custom records, which causes spurious matches to (maybe absent) custom records. Strictly speaking they should not be there (https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-dns-rpz-00#section-2 only mentions NS SOA and DNSSEC related as special), but it makes sense to exclude ZONEMD.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
