### PR TITLE
dnsdist: Harden the Lua FFI interface against misuse

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -60,12 +60,15 @@ typedef enum {
 
 /* Unless specified otherwise, functions taking a dnsdist_ffi_dnsquestion_t* can be used with a dnsdist_ffi_response_t* pointer as well */
 
+/* addr will point to a buffer holding an IPv4 (4 bytes) or IPv6 address (16 bytes). addrSize will be updated to the amount of bytes contained into addr */
 void dnsdist_ffi_dnsquestion_get_localaddr(const dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnsquestion_get_local_port(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsquestion_is_remote_v6(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_is_remote_v6(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__((visibility("default")));
+/* addr will point to a buffer holding an IPv4 (4 bytes) or IPv6 address (16 bytes). addrSize will be updated to the amount of bytes contained into addr */
 void dnsdist_ffi_dnsquestion_get_remoteaddr(const dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnsquestion_get_remote_port(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-const char* dnsdist_ffi_dnsquestion_get_incoming_interface(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_incoming_interface(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__((visibility("default")));
+/* qname will point to a read-only buffer holding the DNS name in wire format (at most 255 bytes). qnameSize will be updated to the amount of bytes in qname. Note that the buffer will be invalidated if any function altering the query is called, so don't hold unto it */
 void dnsdist_ffi_dnsquestion_get_qname_raw(const dnsdist_ffi_dnsquestion_t* dq, const char** qname, size_t* qnameSize) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_get_qname_hash(const dnsdist_ffi_dnsquestion_t* dq, size_t init) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnsquestion_get_qtype(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
@@ -73,9 +76,12 @@ uint16_t dnsdist_ffi_dnsquestion_get_qclass(const dnsdist_ffi_dnsquestion_t* dq)
 uint16_t dnsdist_ffi_dnsquestion_get_id(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 int dnsdist_ffi_dnsquestion_get_rcode(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 /* dnsdist_ffi_dnsquestion_get_header has been deprecated since 2.1.0 */
-void* dnsdist_ffi_dnsquestion_get_header(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+void* dnsdist_ffi_dnsquestion_get_header(const dnsdist_ffi_dnsquestion_t* dq) __attribute__((visibility("default")));
+/* buffer MUST be big enough to hold a DNS header (12 bytes) */
 bool dnsdist_ffi_dnsquestion_get_header_copy(const dnsdist_ffi_dnsquestion_t* dq, char* buffer, size_t buffer_size) __attribute__((visibility("default")));
+/* buffer MUST hold a DNS header (12 bytes) */
 bool dnsdist_ffi_dnsquestion_set_header(const dnsdist_ffi_dnsquestion_t* dq, const char* buffer) __attribute__ ((visibility ("default")));
+/* Return a pointer to the raw query bytes. Note that the buffer will be invalidated if any function altering the query is called, so don't hold unto it */
 const unsigned char* dnsdist_ffi_dnsquestion_get_data(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnsquestion_get_len(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_get_size(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
@@ -91,10 +97,14 @@ bool dnsdist_ffi_dnsquestion_is_temp_failure_ttl_set(const dnsdist_ffi_dnsquesti
 uint32_t dnsdist_ffi_dnsquestion_get_temp_failure_ttl(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsquestion_get_do(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 uint8_t dnsdist_ffi_dnsquestion_get_edns_version(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
-uint8_t dnsdist_ffi_dnsquestion_get_edns_extended_rcode(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_get_sni(const dnsdist_ffi_dnsquestion_t* dq, const char** sni, size_t* sniSize) __attribute__ ((visibility ("default")));
+uint8_t dnsdist_ffi_dnsquestion_get_edns_extended_rcode(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__((visibility("default")));
+/* sni will be updated to point to a buffer containing the SNI in wire format, and sniSize will contain the number of bytes in the buffer pointed to by sni */
+void dnsdist_ffi_dnsquestion_get_sni(const dnsdist_ffi_dnsquestion_t* dq, const char** sni, size_t* sniSize) __attribute__((visibility("default")));
+/* return a pointer to a NULL-terminated string containing the value of the corresponding tag, if any. Note that the string will be invalidated as soon as the tags are altered in any way, so don't hold unto it */
 const char* dnsdist_ffi_dnsquestion_get_tag(const dnsdist_ffi_dnsquestion_t* dq, const char* label) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dq, const char* label, char* buffer, size_t bufferSize) __attribute__ ((visibility ("default")));
+/* bufferSize must be set to the size of buffer. If a tag exists for the key passed in label, and buffer is big enough to contain the value of the tag, the content of the value is copied into buffer and the amount of bytes copied is returned */
+size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dq, const char* label, char* buffer, size_t bufferSize) __attribute__((visibility("default")));
+/* buffer MUST be large enough to hold a MAC address (6 bytes), and bufferSize should be set to the size of buffer */
 size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dq, void* buffer, size_t bufferSize) __attribute__ ((visibility ("default")));
 uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 
@@ -312,7 +322,7 @@ void dnsdist_ffi_dnsresponse_meta_add_int64_value_to_key(dnsdist_ffi_dnsresponse
 void dnsdist_ffi_dnsresponse_meta_end_key(dnsdist_ffi_dnsresponse_t* dnsResponse) __attribute__ ((visibility ("default")));
 
 /* ====================================================================================================================================
-   /!\ the functions below this line cannot be passed a dnsdist_ffi_dnsresponse_t* pointer in place of a dnsdist_ffi_dnsquestion_t* /!\
+   /!\ the functions below this line MUST NOT be passed a dnsdist_ffi_dnsresponse_t* pointer in place of a dnsdist_ffi_dnsquestion_t* /!\
    ==========================================================================================================)========================= */
 
 /* this function adds a new key to the raw meta buffer. It can only be called with the same key on a given query once, and dnsdist_ffi_dnsquestion_meta_end_key should always be called after values have been added */
@@ -324,6 +334,7 @@ void dnsdist_ffi_dnsquestion_meta_add_int64_value_to_key(dnsdist_ffi_dnsquestion
 /* this function should never be called if dnsdist_ffi_dnsquestion_meta_begin_key has not been called first */
 void dnsdist_ffi_dnsquestion_meta_end_key(dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 
+/* addr will point to a buffer holding an IPv4 (4 bytes) or IPv6 address (16 bytes). addrSize will be updated to the amount of bytes contained into addr */
 void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize, uint8_t bits) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_ednsoption_t** out) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dq, const char* str, size_t strSize) __attribute__ ((visibility ("default")));

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -58,11 +58,12 @@ typedef enum {
  dnsdist_ffi_protocol_type_doh = 5,
 } dnsdist_ffi_protocol_type;
 
+/* Unless specified otherwise, functions taking a dnsdist_ffi_dnsquestion_t* can be used with a dnsdist_ffi_response_t* pointer as well */
+
 void dnsdist_ffi_dnsquestion_get_localaddr(const dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnsquestion_get_local_port(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsquestion_is_remote_v6(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsquestion_get_remoteaddr(const dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize, uint8_t bits) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnsquestion_get_remote_port(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 const char* dnsdist_ffi_dnsquestion_get_incoming_interface(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsquestion_get_qname_raw(const dnsdist_ffi_dnsquestion_t* dq, const char** qname, size_t* qnameSize) __attribute__ ((visibility ("default")));
@@ -94,19 +95,9 @@ uint8_t dnsdist_ffi_dnsquestion_get_edns_extended_rcode(const dnsdist_ffi_dnsque
 void dnsdist_ffi_dnsquestion_get_sni(const dnsdist_ffi_dnsquestion_t* dq, const char** sni, size_t* sniSize) __attribute__ ((visibility ("default")));
 const char* dnsdist_ffi_dnsquestion_get_tag(const dnsdist_ffi_dnsquestion_t* dq, const char* label) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dq, const char* label, char* buffer, size_t bufferSize) __attribute__ ((visibility ("default")));
-const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-const char* dnsdist_ffi_dnsquestion_get_http_scheme(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dq, void* buffer, size_t bufferSize) __attribute__ ((visibility ("default")));
 uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 
-// returns the length of the resulting 'out' array. 'out' is not set if the length is 0
-size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_ednsoption_t** out) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_get_http_headers(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_http_header_t** out) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_tag_t** out) __attribute__ ((visibility ("default")));
-
-void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dq, const char* str, size_t strSize) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsquestion_set_rcode(dnsdist_ffi_dnsquestion_t* dq, int rcode) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsquestion_set_len(dnsdist_ffi_dnsquestion_t* dq, uint16_t len) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsquestion_set_skip_cache(dnsdist_ffi_dnsquestion_t* dq, bool skipCache) __attribute__ ((visibility ("default")));
@@ -127,10 +118,6 @@ void dnsdist_ffi_dnsquestion_set_http_response(dnsdist_ffi_dnsquestion_t* ref, u
 
 void dnsdist_ffi_dnsquestion_set_extended_dns_error(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t infoCode, const char* extraText, size_t extraTextSize) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsquestion_add_extended_dns_error(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t infoCode, const char* extraText, size_t extraTextSize) __attribute__ ((visibility ("default")));
-
-size_t dnsdist_ffi_dnsquestion_get_trailing_data(dnsdist_ffi_dnsquestion_t* dq, const char** out) __attribute__ ((visibility ("default")));
-
-bool dnsdist_ffi_dnsquestion_set_trailing_data(dnsdist_ffi_dnsquestion_t* dq, const char* data, size_t dataLen) __attribute__ ((visibility ("default")));
 
 void dnsdist_ffi_dnsquestion_send_trap(dnsdist_ffi_dnsquestion_t* dq, const char* reason, size_t reasonLen) __attribute__ ((visibility ("default")));
 
@@ -172,9 +159,7 @@ void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dr, u
 bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dr, const char* initialName, size_t initialNameSize) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsresponse_get_stale_cache_hit(const dnsdist_ffi_dnsresponse_t* dnsResponse) __attribute__ ((visibility ("default")));
 uint8_t dnsdist_ffi_dnsresponse_get_restart_count(const dnsdist_ffi_dnsresponse_t* dnsResponse) __attribute__ ((visibility ("default")));
-
-bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsresponse_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsresponse_set_async(dnsdist_ffi_dnsresponse_t* dnsResponse, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));
 
 bool dnsdist_ffi_resume_from_async(uint16_t asyncID, uint16_t queryID, const char* tag, size_t tagSize, const char* tagValue, size_t tagValueSize, bool useCache) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_drop_from_async(uint16_t asyncID, uint16_t queryID) __attribute__ ((visibility ("default")));
@@ -191,8 +176,6 @@ typedef struct dnsdist_ffi_proxy_protocol_value {
 size_t dnsdist_ffi_generate_proxy_protocol_payload(size_t addrSize, const void* srcAddr, const void* dstAddr, uint16_t srcPort, uint16_t dstPort, bool tcp, size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, size_t outSize) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi_dnsquestion_t* dq, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, const size_t outSize) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsquestion_add_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values) __attribute__ ((visibility ("default")));
-// returns the length of the resulting 'out' array. 'out' is not set if the length is 0. Note that the return value will get invalidated as soon as a new value is added via dnsdist_ffi_dnsquestion_add_proxy_protocol_values().
-size_t dnsdist_ffi_dnsquestion_get_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_proxy_protocol_value_t** out) __attribute__((visibility("default")));
 
 typedef struct dnsdist_ffi_domain_list_t dnsdist_ffi_domain_list_t;
 typedef struct dnsdist_ffi_address_list_t dnsdist_ffi_address_list_t;
@@ -319,6 +302,19 @@ void dnsdist_ffi_svc_record_parameters_free(dnsdist_ffi_svc_record_parameters* p
 
 bool dnsdist_ffi_dnsquestion_generate_svc_response(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_svc_record_parameters** parametersList, size_t parametersListSize, uint32_t ttl) __attribute__ ((visibility ("default")));
 
+/* this function adds a new key to the raw meta buffer. It can only be called with the same key on a given query once, and dnsdist_ffi_dnsresponse_meta_end_key should always be called after values have been added */
+void dnsdist_ffi_dnsresponse_meta_begin_key(dnsdist_ffi_dnsresponse_t* dnsResponse, const char* key, size_t keyLen) __attribute__ ((visibility ("default")));
+/* this function should never be called if dnsdist_ffi_dnsresponse_meta_begin_key has not been called first */
+void dnsdist_ffi_dnsresponse_meta_add_str_value_to_key(dnsdist_ffi_dnsresponse_t* dnsResponse, const char* value, size_t valueLen) __attribute__ ((visibility ("default")));
+/* this function should never be called if dnsdist_ffi_dnsresponse_meta_begin_key has not been called first */
+void dnsdist_ffi_dnsresponse_meta_add_int64_value_to_key(dnsdist_ffi_dnsresponse_t* dnsResponse, int64_t value) __attribute__ ((visibility ("default")));
+/* this function should never be called if dnsdist_ffi_dnsresponse_meta_begin_key has not been called first */
+void dnsdist_ffi_dnsresponse_meta_end_key(dnsdist_ffi_dnsresponse_t* dnsResponse) __attribute__ ((visibility ("default")));
+
+/* ====================================================================================================================================
+   /!\ the functions below this line cannot be passed a dnsdist_ffi_dnsresponse_t* pointer in place of a dnsdist_ffi_dnsquestion_t* /!\
+   ==========================================================================================================)========================= */
+
 /* this function adds a new key to the raw meta buffer. It can only be called with the same key on a given query once, and dnsdist_ffi_dnsquestion_meta_end_key should always be called after values have been added */
 void dnsdist_ffi_dnsquestion_meta_begin_key(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* key, size_t keyLen) __attribute__ ((visibility ("default")));
 /* this function should never be called if dnsdist_ffi_dnsquestion_meta_begin_key has not been called first */
@@ -328,11 +324,18 @@ void dnsdist_ffi_dnsquestion_meta_add_int64_value_to_key(dnsdist_ffi_dnsquestion
 /* this function should never be called if dnsdist_ffi_dnsquestion_meta_begin_key has not been called first */
 void dnsdist_ffi_dnsquestion_meta_end_key(dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 
-/* this function adds a new key to the raw meta buffer. It can only be called with the same key on a given query once, and dnsdist_ffi_dnsresponse_meta_end_key should always be called after values have been added */
-void dnsdist_ffi_dnsresponse_meta_begin_key(dnsdist_ffi_dnsresponse_t* dnsResponse, const char* key, size_t keyLen) __attribute__ ((visibility ("default")));
-/* this function should never be called if dnsdist_ffi_dnsresponse_meta_begin_key has not been called first */
-void dnsdist_ffi_dnsresponse_meta_add_str_value_to_key(dnsdist_ffi_dnsresponse_t* dnsResponse, const char* value, size_t valueLen) __attribute__ ((visibility ("default")));
-/* this function should never be called if dnsdist_ffi_dnsresponse_meta_begin_key has not been called first */
-void dnsdist_ffi_dnsresponse_meta_add_int64_value_to_key(dnsdist_ffi_dnsresponse_t* dnsResponse, int64_t value) __attribute__ ((visibility ("default")));
-/* this function should never be called if dnsdist_ffi_dnsresponse_meta_begin_key has not been called first */
-void dnsdist_ffi_dnsresponse_meta_end_key(dnsdist_ffi_dnsresponse_t* dnsResponse) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize, uint8_t bits) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_ednsoption_t** out) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dq, const char* str, size_t strSize) __attribute__ ((visibility ("default")));
+// returns the length of the resulting 'out' array. 'out' is not set if the length is 0
+size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_tag_t** out) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_http_scheme(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_http_headers(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_http_header_t** out) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_trailing_data(dnsdist_ffi_dnsquestion_t* dq, const char** out) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_set_trailing_data(dnsdist_ffi_dnsquestion_t* dq, const char* data, size_t dataLen) __attribute__ ((visibility ("default")));
+// returns the length of the resulting 'out' array. 'out' is not set if the length is 0. Note that the return value will get invalidated as soon as a new value is added via dnsdist_ffi_dnsquestion_add_proxy_protocol_values().
+size_t dnsdist_ffi_dnsquestion_get_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_proxy_protocol_value_t** out) __attribute__((visibility("default")));
+bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -78,9 +78,9 @@ int dnsdist_ffi_dnsquestion_get_rcode(const dnsdist_ffi_dnsquestion_t* dq) __att
 /* dnsdist_ffi_dnsquestion_get_header has been deprecated since 2.1.0 */
 void* dnsdist_ffi_dnsquestion_get_header(const dnsdist_ffi_dnsquestion_t* dq) __attribute__((visibility("default")));
 /* buffer MUST be big enough to hold a DNS header (12 bytes) */
-bool dnsdist_ffi_dnsquestion_get_header_copy(const dnsdist_ffi_dnsquestion_t* dq, char* buffer, size_t buffer_size) __attribute__((visibility("default")));
+bool dnsdist_ffi_dnsquestion_get_header_copy(const dnsdist_ffi_dnsquestion_t* dnsQuestion, char* buffer, size_t buffer_size) __attribute__((visibility("default")));
 /* buffer MUST hold a DNS header (12 bytes) */
-bool dnsdist_ffi_dnsquestion_set_header(const dnsdist_ffi_dnsquestion_t* dq, const char* buffer) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_set_header(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* buffer) __attribute__ ((visibility ("default")));
 /* Return a pointer to the raw query bytes. Note that the buffer will be invalidated if any function altering the query is called, so don't hold unto it */
 const unsigned char* dnsdist_ffi_dnsquestion_get_data(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 uint16_t dnsdist_ffi_dnsquestion_get_len(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
@@ -336,10 +336,10 @@ void dnsdist_ffi_dnsquestion_meta_end_key(dnsdist_ffi_dnsquestion_t* dnsQuestion
 
 /* addr will point to a buffer holding an IPv4 (4 bytes) or IPv6 address (16 bytes). addrSize will be updated to the amount of bytes contained into addr */
 void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize, uint8_t bits) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_ednsoption_t** out) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_ednsoption_t** out) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dq, const char* str, size_t strSize) __attribute__ ((visibility ("default")));
 // returns the length of the resulting 'out' array. 'out' is not set if the length is 0
-size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_tag_t** out) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_tag_t** out) __attribute__ ((visibility ("default")));
 const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
 const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -100,7 +100,7 @@ uint8_t dnsdist_ffi_dnsquestion_get_edns_version(const dnsdist_ffi_dnsquestion_t
 uint8_t dnsdist_ffi_dnsquestion_get_edns_extended_rcode(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__((visibility("default")));
 /* sni will be updated to point to a buffer containing the SNI in wire format, and sniSize will contain the number of bytes in the buffer pointed to by sni */
 void dnsdist_ffi_dnsquestion_get_sni(const dnsdist_ffi_dnsquestion_t* dq, const char** sni, size_t* sniSize) __attribute__((visibility("default")));
-/* return a pointer to a NULL-terminated string containing the value of the corresponding tag, if any. Note that the string will be invalidated as soon as the tags are altered in any way, so don't hold unto it */
+/* return a pointer to a NUL-terminated string containing the value of the corresponding tag, if any. Note that the string will be invalidated as soon as the tags are altered in any way, so don't hold unto it */
 const char* dnsdist_ffi_dnsquestion_get_tag(const dnsdist_ffi_dnsquestion_t* dq, const char* label) __attribute__ ((visibility ("default")));
 /* bufferSize must be set to the size of buffer. If a tag exists for the key passed in label, and buffer is big enough to contain the value of the tag, the content of the value is copied into buffer and the amount of bytes copied is returned */
 size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dq, const char* label, char* buffer, size_t bufferSize) __attribute__((visibility("default")));

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -61,86 +61,86 @@ typedef enum {
 /* Unless specified otherwise, functions taking a dnsdist_ffi_dnsquestion_t* can be used with a dnsdist_ffi_response_t* pointer as well */
 
 /* addr will point to a buffer holding an IPv4 (4 bytes) or IPv6 address (16 bytes). addrSize will be updated to the amount of bytes contained into addr */
-void dnsdist_ffi_dnsquestion_get_localaddr(const dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
-uint16_t dnsdist_ffi_dnsquestion_get_local_port(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_get_localaddr(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnsquestion_get_local_port(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsquestion_is_remote_v6(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__((visibility("default")));
 /* addr will point to a buffer holding an IPv4 (4 bytes) or IPv6 address (16 bytes). addrSize will be updated to the amount of bytes contained into addr */
-void dnsdist_ffi_dnsquestion_get_remoteaddr(const dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
-uint16_t dnsdist_ffi_dnsquestion_get_remote_port(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_get_remoteaddr(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnsquestion_get_remote_port(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 const char* dnsdist_ffi_dnsquestion_get_incoming_interface(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__((visibility("default")));
 /* qname will point to a read-only buffer holding the DNS name in wire format (at most 255 bytes). qnameSize will be updated to the amount of bytes in qname. Note that the buffer will be invalidated if any function altering the query is called, so don't hold unto it */
-void dnsdist_ffi_dnsquestion_get_qname_raw(const dnsdist_ffi_dnsquestion_t* dq, const char** qname, size_t* qnameSize) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_get_qname_hash(const dnsdist_ffi_dnsquestion_t* dq, size_t init) __attribute__ ((visibility ("default")));
-uint16_t dnsdist_ffi_dnsquestion_get_qtype(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-uint16_t dnsdist_ffi_dnsquestion_get_qclass(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-uint16_t dnsdist_ffi_dnsquestion_get_id(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-int dnsdist_ffi_dnsquestion_get_rcode(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_get_qname_raw(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char** qname, size_t* qnameSize) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_qname_hash(const dnsdist_ffi_dnsquestion_t* dnsQuestion, size_t init) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnsquestion_get_qtype(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnsquestion_get_qclass(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnsquestion_get_id(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+int dnsdist_ffi_dnsquestion_get_rcode(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 /* dnsdist_ffi_dnsquestion_get_header has been deprecated since 2.1.0 */
-void* dnsdist_ffi_dnsquestion_get_header(const dnsdist_ffi_dnsquestion_t* dq) __attribute__((visibility("default")));
+void* dnsdist_ffi_dnsquestion_get_header(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__((visibility("default")));
 /* buffer MUST be big enough to hold a DNS header (12 bytes) */
 bool dnsdist_ffi_dnsquestion_get_header_copy(const dnsdist_ffi_dnsquestion_t* dnsQuestion, char* buffer, size_t buffer_size) __attribute__((visibility("default")));
 /* buffer MUST hold a DNS header (12 bytes) */
 bool dnsdist_ffi_dnsquestion_set_header(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* buffer) __attribute__ ((visibility ("default")));
 /* Return a pointer to the raw query bytes. Note that the buffer will be invalidated if any function altering the query is called, so don't hold unto it */
-const unsigned char* dnsdist_ffi_dnsquestion_get_data(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-uint16_t dnsdist_ffi_dnsquestion_get_len(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_get_size(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsquestion_set_size(dnsdist_ffi_dnsquestion_t* dq, size_t newSize) __attribute__ ((visibility ("default")));
-uint8_t dnsdist_ffi_dnsquestion_get_opcode(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsquestion_get_tcp(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-dnsdist_ffi_protocol_type dnsdist_ffi_dnsquestion_get_protocol(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsquestion_get_skip_cache(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsquestion_get_use_ecs(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsquestion_get_ecs_override(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-uint16_t dnsdist_ffi_dnsquestion_get_ecs_prefix_length(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsquestion_is_temp_failure_ttl_set(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-uint32_t dnsdist_ffi_dnsquestion_get_temp_failure_ttl(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+const unsigned char* dnsdist_ffi_dnsquestion_get_data(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnsquestion_get_len(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_size(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_set_size(dnsdist_ffi_dnsquestion_t* dnsQuestion, size_t newSize) __attribute__ ((visibility ("default")));
+uint8_t dnsdist_ffi_dnsquestion_get_opcode(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_get_tcp(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+dnsdist_ffi_protocol_type dnsdist_ffi_dnsquestion_get_protocol(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_get_skip_cache(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_get_use_ecs(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_get_ecs_override(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+uint16_t dnsdist_ffi_dnsquestion_get_ecs_prefix_length(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_is_temp_failure_ttl_set(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+uint32_t dnsdist_ffi_dnsquestion_get_temp_failure_ttl(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsquestion_get_do(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 uint8_t dnsdist_ffi_dnsquestion_get_edns_version(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 uint8_t dnsdist_ffi_dnsquestion_get_edns_extended_rcode(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__((visibility("default")));
 /* sni will be updated to point to a buffer containing the SNI in wire format, and sniSize will contain the number of bytes in the buffer pointed to by sni */
-void dnsdist_ffi_dnsquestion_get_sni(const dnsdist_ffi_dnsquestion_t* dq, const char** sni, size_t* sniSize) __attribute__((visibility("default")));
+void dnsdist_ffi_dnsquestion_get_sni(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char** sni, size_t* sniSize) __attribute__((visibility("default")));
 /* return a pointer to a NUL-terminated string containing the value of the corresponding tag, if any. Note that the string will be invalidated as soon as the tags are altered in any way, so don't hold unto it */
-const char* dnsdist_ffi_dnsquestion_get_tag(const dnsdist_ffi_dnsquestion_t* dq, const char* label) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_tag(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label) __attribute__ ((visibility ("default")));
 /* bufferSize must be set to the size of buffer. If a tag exists for the key passed in label, and buffer is big enough to contain the value of the tag, the content of the value is copied into buffer and the amount of bytes copied is returned */
-size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dq, const char* label, char* buffer, size_t bufferSize) __attribute__((visibility("default")));
+size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label, char* buffer, size_t bufferSize) __attribute__((visibility("default")));
 /* buffer MUST be large enough to hold a MAC address (6 bytes), and bufferSize should be set to the size of buffer */
-size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dq, void* buffer, size_t bufferSize) __attribute__ ((visibility ("default")));
-uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dnsQuestion, void* buffer, size_t bufferSize) __attribute__ ((visibility ("default")));
+uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 
-void dnsdist_ffi_dnsquestion_set_rcode(dnsdist_ffi_dnsquestion_t* dq, int rcode) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_len(dnsdist_ffi_dnsquestion_t* dq, uint16_t len) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_skip_cache(dnsdist_ffi_dnsquestion_t* dq, bool skipCache) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_use_ecs(dnsdist_ffi_dnsquestion_t* dq, bool useECS) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_ecs_override(dnsdist_ffi_dnsquestion_t* dq, bool ecsOverride) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_ecs_prefix_length(dnsdist_ffi_dnsquestion_t* dq, uint16_t ecsPrefixLength) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_temp_failure_ttl(dnsdist_ffi_dnsquestion_t* dq, uint32_t tempFailureTTL) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_unset_temp_failure_ttl(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_tag(dnsdist_ffi_dnsquestion_t* dq, const char* label, const char* value) __attribute__((visibility("default")));
-void dnsdist_ffi_dnsquestion_unset_tag(dnsdist_ffi_dnsquestion_t* dq, const char* label) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_tag_raw(dnsdist_ffi_dnsquestion_t* dq, const char* label, const char* value, size_t valueSize) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_rcode(dnsdist_ffi_dnsquestion_t* dnsQuestion, int rcode) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_len(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t len) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_skip_cache(dnsdist_ffi_dnsquestion_t* dnsQuestion, bool skipCache) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_use_ecs(dnsdist_ffi_dnsquestion_t* dnsQuestion, bool useECS) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_ecs_override(dnsdist_ffi_dnsquestion_t* dnsQuestion, bool ecsOverride) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_ecs_prefix_length(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t ecsPrefixLength) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_temp_failure_ttl(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint32_t tempFailureTTL) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_unset_temp_failure_ttl(dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_tag(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label, const char* value) __attribute__((visibility("default")));
+void dnsdist_ffi_dnsquestion_unset_tag(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_tag_raw(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label, const char* value, size_t valueSize) __attribute__ ((visibility ("default")));
 
-void dnsdist_ffi_dnsquestion_set_requestor_id(dnsdist_ffi_dnsquestion_t* dq, const char* value, size_t valueSize) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_device_id(dnsdist_ffi_dnsquestion_t* dq, const char* value, size_t valueSize) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_device_name(dnsdist_ffi_dnsquestion_t* dq, const char* value, size_t valueSize) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_requestor_id(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* value, size_t valueSize) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_device_id(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* value, size_t valueSize) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_device_name(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* value, size_t valueSize) __attribute__ ((visibility ("default")));
 
-void dnsdist_ffi_dnsquestion_set_http_response(dnsdist_ffi_dnsquestion_t* ref, uint16_t statusCode, const char* body, size_t bodyLen, const char* contentType) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_http_response(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t statusCode, const char* body, size_t bodyLen, const char* contentType) __attribute__ ((visibility ("default")));
 
 void dnsdist_ffi_dnsquestion_set_extended_dns_error(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t infoCode, const char* extraText, size_t extraTextSize) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_dnsquestion_add_extended_dns_error(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t infoCode, const char* extraText, size_t extraTextSize) __attribute__ ((visibility ("default")));
 
-void dnsdist_ffi_dnsquestion_send_trap(dnsdist_ffi_dnsquestion_t* dq, const char* reason, size_t reasonLen) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_send_trap(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* reason, size_t reasonLen) __attribute__ ((visibility ("default")));
 
 // the content of values should contain raw DNS record data ('\192\000\002\001' for A, '\034this text has a comma at the end,' for TXT, etc)
-void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_raw_value_t* values, size_t valuesCount) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_raw_value_t* values, size_t valuesCount) __attribute__ ((visibility ("default")));
 // the content of values should contain raw IPv4 or IPv6 addresses in network byte-order
-void dnsdist_ffi_dnsquestion_spoof_addrs(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_raw_value_t* values, size_t valuesCount) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_spoof_addrs(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_raw_value_t* values, size_t valuesCount) __attribute__ ((visibility ("default")));
 // spoof raw response. will just replace qid to match question
-void dnsdist_ffi_dnsquestion_spoof_packet(dnsdist_ffi_dnsquestion_t* dq, const char* rawresponse, size_t len) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_spoof_packet(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* rawresponse, size_t len) __attribute__ ((visibility ("default")));
 
 /* decrease the returned TTL but _after_ inserting the original response into the packet cache */
-void dnsdist_ffi_dnsquestion_set_max_returned_ttl(dnsdist_ffi_dnsquestion_t* dq, uint32_t max) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsquestion_set_restartable(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_max_returned_ttl(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint32_t max) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_set_restartable(dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 
 bool dnsdist_ffi_dnsquestion_set_alternate_name(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* alternateName, size_t alternateNameSize, const char* tag, size_t tagSize, const char* tagValue, size_t tagValueSize, const char* formerNameTagName, size_t formerNameTagSize) __attribute__ ((visibility ("default")));
 
@@ -149,8 +149,8 @@ typedef struct dnsdist_ffi_server_t dnsdist_ffi_server_t;
 
 size_t dnsdist_ffi_servers_list_get_count(const dnsdist_ffi_servers_list_t* list) __attribute__ ((visibility ("default")));
 void dnsdist_ffi_servers_list_get_server(const dnsdist_ffi_servers_list_t* list, size_t idx, const dnsdist_ffi_server_t** out) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_servers_list_chashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dq, size_t hash) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_servers_list_whashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dq, size_t hash) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_servers_list_chashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dnsQuestion, size_t hash) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_servers_list_whashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dnsQuestion, size_t hash) __attribute__ ((visibility ("default")));
 
 uint64_t dnsdist_ffi_server_get_outstanding(const dnsdist_ffi_server_t* server) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_server_is_up(const dnsdist_ffi_server_t* server) __attribute__ ((visibility ("default")));
@@ -160,13 +160,13 @@ int dnsdist_ffi_server_get_weight(const dnsdist_ffi_server_t* server) __attribut
 int dnsdist_ffi_server_get_order(const dnsdist_ffi_server_t* server) __attribute__ ((visibility ("default")));
 double dnsdist_ffi_server_get_latency(const dnsdist_ffi_server_t* server) __attribute__ ((visibility ("default")));
 
-void dnsdist_ffi_dnsresponse_set_min_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t min) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsresponse_set_max_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t max) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsresponse_limit_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t min, uint32_t max) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsresponse_set_min_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t min) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsresponse_set_max_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t max) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsresponse_limit_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t min, uint32_t max) __attribute__ ((visibility ("default")));
 /* decrease the returned TTL but _after_ inserting the original response into the packet cache */
-void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t max) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dr, uint16_t qtype) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dr, const char* initialName, size_t initialNameSize) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t max) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dnsResponse, uint16_t qtype) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dnsResponse, const char* initialName, size_t initialNameSize) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsresponse_get_stale_cache_hit(const dnsdist_ffi_dnsresponse_t* dnsResponse) __attribute__ ((visibility ("default")));
 uint8_t dnsdist_ffi_dnsresponse_get_restart_count(const dnsdist_ffi_dnsresponse_t* dnsResponse) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsresponse_set_async(dnsdist_ffi_dnsresponse_t* dnsResponse, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));
@@ -184,7 +184,7 @@ typedef struct dnsdist_ffi_proxy_protocol_value {
 } dnsdist_ffi_proxy_protocol_value_t;
 
 size_t dnsdist_ffi_generate_proxy_protocol_payload(size_t addrSize, const void* srcAddr, const void* dstAddr, uint16_t srcPort, uint16_t dstPort, bool tcp, size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, size_t outSize) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi_dnsquestion_t* dq, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, const size_t outSize) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values, void* out, const size_t outSize) __attribute__ ((visibility ("default")));
 bool dnsdist_ffi_dnsquestion_add_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value_t* values) __attribute__ ((visibility ("default")));
 
 typedef struct dnsdist_ffi_domain_list_t dnsdist_ffi_domain_list_t;
@@ -335,18 +335,18 @@ void dnsdist_ffi_dnsquestion_meta_add_int64_value_to_key(dnsdist_ffi_dnsquestion
 void dnsdist_ffi_dnsquestion_meta_end_key(dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
 
 /* addr will point to a buffer holding an IPv4 (4 bytes) or IPv6 address (16 bytes). addrSize will be updated to the amount of bytes contained into addr */
-void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize, uint8_t bits) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dnsQuestion, const void** addr, size_t* addrSize, uint8_t bits) __attribute__ ((visibility ("default")));
 size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_ednsoption_t** out) __attribute__ ((visibility ("default")));
-void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dq, const char* str, size_t strSize) __attribute__ ((visibility ("default")));
+void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* str, size_t strSize) __attribute__ ((visibility ("default")));
 // returns the length of the resulting 'out' array. 'out' is not set if the length is 0
 size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_tag_t** out) __attribute__ ((visibility ("default")));
-const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-const char* dnsdist_ffi_dnsquestion_get_http_scheme(dnsdist_ffi_dnsquestion_t* dq) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_get_http_headers(dnsdist_ffi_dnsquestion_t* ref, const dnsdist_ffi_http_header_t** out) __attribute__ ((visibility ("default")));
-size_t dnsdist_ffi_dnsquestion_get_trailing_data(dnsdist_ffi_dnsquestion_t* dq, const char** out) __attribute__ ((visibility ("default")));
-bool dnsdist_ffi_dnsquestion_set_trailing_data(dnsdist_ffi_dnsquestion_t* dq, const char* data, size_t dataLen) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+const char* dnsdist_ffi_dnsquestion_get_http_scheme(dnsdist_ffi_dnsquestion_t* dnsQuestion) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_http_headers(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_http_header_t** out) __attribute__ ((visibility ("default")));
+size_t dnsdist_ffi_dnsquestion_get_trailing_data(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char** out) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_set_trailing_data(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* data, size_t dataLen) __attribute__ ((visibility ("default")));
 // returns the length of the resulting 'out' array. 'out' is not set if the length is 0. Note that the return value will get invalidated as soon as a new value is added via dnsdist_ffi_dnsquestion_add_proxy_protocol_values().
 size_t dnsdist_ffi_dnsquestion_get_proxy_protocol_values(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_proxy_protocol_value_t** out) __attribute__((visibility("default")));
-bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));
+bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs) __attribute__ ((visibility ("default")));

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -114,7 +114,7 @@ uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t*
   return static_cast<uint64_t>(std::round(dnsQuestion->dq->ids.queryRealTime.udiff()));
 }
 
-static bool checkDNSQuestionType(const std::string_view& functionName, const dnsdist_ffi_dnsquestion_t* dnsQuestion)
+static bool checkDNSQuestionType(const char* functionName, const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
   if (dnsQuestion->objectType != dnsdist::lua::ffi::ObjectType::Question) {
     VERBOSESLOG(infolog("Error: calling FFI function %s with a wrong type", functionName),
@@ -124,7 +124,7 @@ static bool checkDNSQuestionType(const std::string_view& functionName, const dns
   return true;
 }
 
-static bool checkDNSResponseType(const std::string_view& functionName, const dnsdist_ffi_dnsresponse_t* dnsResponse)
+static bool checkDNSResponseType(const char* functionName, const dnsdist_ffi_dnsresponse_t* dnsResponse)
 {
   if (dnsResponse->objectType != dnsdist::lua::ffi::ObjectType::Response) {
     VERBOSESLOG(infolog("Error: calling FFI function %s with a wrong type", functionName),
@@ -136,6 +136,7 @@ static bool checkDNSResponseType(const std::string_view& functionName, const dns
 
 void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dnsQuestion, const void** addr, size_t* addrSize, uint8_t bits)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return;
   }
@@ -361,6 +362,7 @@ size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dnsQ
 
 const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return nullptr;
   }
@@ -385,6 +387,7 @@ const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dns
 
 const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return nullptr;
   }
@@ -409,6 +412,7 @@ const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestio
 
 const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return nullptr;
   }
@@ -433,6 +437,7 @@ const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dns
 
 const char* dnsdist_ffi_dnsquestion_get_http_scheme(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return nullptr;
   }
@@ -468,6 +473,7 @@ static void fill_edns_option(const EDNSOptionViewValue& value, dnsdist_ffi_ednso
 // returns the length of the resulting 'out' array. 'out' is not set if the length is 0
 size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_ednsoption_t** out)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return 0U;
   }
@@ -506,6 +512,7 @@ size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dnsQu
 size_t dnsdist_ffi_dnsquestion_get_http_headers([[maybe_unused]] dnsdist_ffi_dnsquestion_t* dnsQuestion, [[maybe_unused]] const dnsdist_ffi_http_header_t** out)
 {
 #if defined(HAVE_DNS_OVER_HTTPS) || defined(HAVE_DNS_OVER_HTTP3)
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return 0U;
   }
@@ -559,6 +566,7 @@ size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dnsQuest
   if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || dnsQuestion->dq->ids.qTag == nullptr || dnsQuestion->dq->ids.qTag->empty()) {
     return 0;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return 0U;
   }
@@ -586,6 +594,7 @@ size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dnsQuest
 
 void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* str, size_t strSize)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return;
   }
@@ -739,6 +748,7 @@ void dnsdist_ffi_dnsquestion_set_device_name(dnsdist_ffi_dnsquestion_t* dnsQuest
 
 size_t dnsdist_ffi_dnsquestion_get_trailing_data(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char** out)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return 0U;
   }
@@ -910,6 +920,7 @@ void dnsdist_ffi_dnsresponse_set_max_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse,
 void dnsdist_ffi_dnsresponse_limit_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t min, uint32_t max)
 {
   if (dnsResponse != nullptr && dnsResponse->dr != nullptr) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     if (!checkDNSResponseType(__func__, dnsResponse)) {
       return;
     }
@@ -921,6 +932,7 @@ void dnsdist_ffi_dnsresponse_limit_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, u
 void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t max)
 {
   if (dnsResponse != nullptr && dnsResponse->dr != nullptr) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     if (!checkDNSResponseType(__func__, dnsResponse)) {
       return;
     }
@@ -931,6 +943,7 @@ void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dns
 void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dnsResponse, uint16_t qtype)
 {
   if (dnsResponse != nullptr && dnsResponse->dr != nullptr) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     if (!checkDNSResponseType(__func__, dnsResponse)) {
       return;
     }
@@ -943,6 +956,7 @@ bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dnsResponse, cons
   if (dnsResponse == nullptr || dnsResponse->dr == nullptr || initialName == nullptr || initialNameSize == 0) {
     return false;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSResponseType(__func__, dnsResponse)) {
     return false;
   }
@@ -969,6 +983,7 @@ bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dnsResponse, cons
 
 bool dnsdist_ffi_dnsresponse_get_stale_cache_hit(const dnsdist_ffi_dnsresponse_t* dnsResponse)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSResponseType(__func__, dnsResponse)) {
     return false;
   }
@@ -977,6 +992,7 @@ bool dnsdist_ffi_dnsresponse_get_stale_cache_hit(const dnsdist_ffi_dnsresponse_t
 
 uint8_t dnsdist_ffi_dnsresponse_get_restart_count(const dnsdist_ffi_dnsresponse_t* dnsResponse)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSResponseType(__func__, dnsResponse)) {
     return 0U;
   }
@@ -985,6 +1001,7 @@ uint8_t dnsdist_ffi_dnsresponse_get_restart_count(const dnsdist_ffi_dnsresponse_
 
 bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return false;
   }
@@ -1006,6 +1023,7 @@ bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dnsQuestion, u
 
 bool dnsdist_ffi_dnsresponse_set_async(dnsdist_ffi_dnsresponse_t* dnsResponse, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSResponseType(__func__, dnsResponse)) {
     return false;
   }
@@ -1366,6 +1384,7 @@ size_t dnsdist_ffi_dnsquestion_get_proxy_protocol_values(dnsdist_ffi_dnsquestion
     return 0;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return 0U;
   }
@@ -2578,6 +2597,7 @@ void dnsdist_ffi_dnsquestion_meta_begin_key([[maybe_unused]] dnsdist_ffi_dnsques
   if (dnsQuestion == nullptr || key == nullptr || keyLen == 0) {
     return;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return;
   }
@@ -2601,6 +2621,7 @@ void dnsdist_ffi_dnsquestion_meta_add_str_value_to_key([[maybe_unused]] dnsdist_
   if (dnsQuestion == nullptr || value == nullptr || valueLen == 0) {
     return;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return;
   }
@@ -2621,6 +2642,7 @@ void dnsdist_ffi_dnsquestion_meta_add_int64_value_to_key([[maybe_unused]] dnsdis
   if (dnsQuestion == nullptr) {
     return;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return;
   }
@@ -2641,6 +2663,7 @@ void dnsdist_ffi_dnsquestion_meta_end_key([[maybe_unused]] dnsdist_ffi_dnsquesti
   if (dnsQuestion == nullptr) {
     return;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return;
   }
@@ -2671,6 +2694,7 @@ void dnsdist_ffi_dnsresponse_meta_begin_key([[maybe_unused]] dnsdist_ffi_dnsresp
     return;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSResponseType(__func__, dnsResponse)) {
     return;
   }
@@ -2695,6 +2719,7 @@ void dnsdist_ffi_dnsresponse_meta_add_str_value_to_key([[maybe_unused]] dnsdist_
     return;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSResponseType(__func__, dnsResponse)) {
     return;
   }
@@ -2716,6 +2741,7 @@ void dnsdist_ffi_dnsresponse_meta_add_int64_value_to_key([[maybe_unused]] dnsdis
     return;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSResponseType(__func__, dnsResponse)) {
     return;
   }
@@ -2737,6 +2763,7 @@ void dnsdist_ffi_dnsresponse_meta_end_key([[maybe_unused]] dnsdist_ffi_dnsrespon
     return;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   if (!checkDNSResponseType(__func__, dnsResponse)) {
     return;
   }

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -114,8 +114,7 @@ uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t*
   return static_cast<uint64_t>(std::round(dnsQuestion->dq->ids.queryRealTime.udiff()));
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-static bool checkDNSQuestionType(const char functionName[], const dnsdist_ffi_dnsquestion_t* dnsQuestion)
+static bool checkDNSQuestionType(const std::string_view& functionName, const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
   if (dnsQuestion->objectType != dnsdist::lua::ffi::ObjectType::Question) {
     VERBOSESLOG(infolog("Error: calling FFI function %s with a wrong type", functionName),
@@ -557,7 +556,7 @@ size_t dnsdist_ffi_dnsquestion_get_http_headers([[maybe_unused]] dnsdist_ffi_dns
 
 size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_tag_t** out)
 {
-  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || dnsQuestion->dq->ids.qTag == nullptr || dnsQuestion->dq->ids.qTag->size() == 0) {
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || dnsQuestion->dq->ids.qTag == nullptr || dnsQuestion->dq->ids.qTag->empty()) {
     return 0;
   }
   if (!checkDNSQuestionType(__func__, dnsQuestion)) {
@@ -1456,7 +1455,7 @@ size_t dnsdist_ffi_packetcache_get_domain_list_by_addr(const char* poolName, con
   }
 
   auto domains = pool.packetCache->getDomainsContainingRecords(caAddr);
-  if (domains.size() == 0) {
+  if (domains.empty()) {
     return 0;
   }
 
@@ -1507,7 +1506,7 @@ size_t dnsdist_ffi_packetcache_get_address_list_by_domain(const char* poolName, 
   }
 
   auto addresses = pool.packetCache->getRecordsForDomain(name);
-  if (addresses.size() == 0) {
+  if (addresses.empty()) {
     return 0;
   }
 
@@ -2511,7 +2510,7 @@ void dnsdist_ffi_svc_record_parameters_add_ipv4_hint(dnsdist_ffi_svc_record_para
     return;
   }
   try {
-    parameters->parameters.ipv4hints.emplace_back(ComboAddress(std::string(value, valueLen)));
+    parameters->parameters.ipv4hints.emplace_back(std::string(value, valueLen));
   }
   catch (const std::exception& exp) {
     SLOG(errlog("Exception in dnsdist_ffi_svc_record_parameters_add_ipv4_hint: %s", exp.what()),
@@ -2533,7 +2532,7 @@ void dnsdist_ffi_svc_record_parameters_add_ipv6_hint(dnsdist_ffi_svc_record_para
     return;
   }
   try {
-    parameters->parameters.ipv6hints.emplace_back(ComboAddress(std::string(value, valueLen)));
+    parameters->parameters.ipv6hints.emplace_back(std::string(value, valueLen));
   }
   catch (const std::exception& exp) {
     SLOG(errlog("Exception in dnsdist_ffi_svc_record_parameters_add_ipv6_hint: %s", exp.what()),

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -136,6 +136,7 @@ static bool checkDNSResponseType(const char* functionName, const dnsdist_ffi_dns
 
 void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize, uint8_t bits)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay): __func__ is what it is
   if (!checkDNSQuestionType(__func__, dq)) {
     return;
   }

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -42,39 +42,39 @@ static std::shared_ptr<const Logr::Logger> getLogger(const std::string_view from
   return dnsdist::logging::getTopLogger("lua-ffi-script")->withValues("lua.ffi.function", Logging::Loggable(fromFunction));
 }
 
-uint16_t dnsdist_ffi_dnsquestion_get_qtype(const dnsdist_ffi_dnsquestion_t* dq)
+uint16_t dnsdist_ffi_dnsquestion_get_qtype(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->ids.qtype;
+  return dnsQuestion->dq->ids.qtype;
 }
 
-uint16_t dnsdist_ffi_dnsquestion_get_qclass(const dnsdist_ffi_dnsquestion_t* dq)
+uint16_t dnsdist_ffi_dnsquestion_get_qclass(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->ids.qclass;
+  return dnsQuestion->dq->ids.qclass;
 }
 
-uint16_t dnsdist_ffi_dnsquestion_get_id(const dnsdist_ffi_dnsquestion_t* dq)
+uint16_t dnsdist_ffi_dnsquestion_get_id(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  if (dq == nullptr) {
+  if (dnsQuestion == nullptr) {
     return 0;
   }
-  return ntohs(dq->dq->getHeader()->id);
+  return ntohs(dnsQuestion->dq->getHeader()->id);
 }
 
-static void dnsdist_ffi_comboaddress_to_raw(const ComboAddress& ca, const void** addr, size_t* addrSize)
+static void dnsdist_ffi_comboaddress_to_raw(const ComboAddress& caAddr, const void** addr, size_t* addrSize)
 {
-  if (ca.isIPv4()) {
-    *addr = &ca.sin4.sin_addr.s_addr;
-    *addrSize = sizeof(ca.sin4.sin_addr.s_addr);
+  if (caAddr.isIPv4()) {
+    *addr = &caAddr.sin4.sin_addr.s_addr;
+    *addrSize = sizeof(caAddr.sin4.sin_addr.s_addr);
   }
   else {
-    *addr = &ca.sin6.sin6_addr.s6_addr;
-    *addrSize = sizeof(ca.sin6.sin6_addr.s6_addr);
+    *addr = &caAddr.sin6.sin6_addr.s6_addr;
+    *addrSize = sizeof(caAddr.sin6.sin6_addr.s6_addr);
   }
 }
 
-void dnsdist_ffi_dnsquestion_get_localaddr(const dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize)
+void dnsdist_ffi_dnsquestion_get_localaddr(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const void** addr, size_t* addrSize)
 {
-  dnsdist_ffi_comboaddress_to_raw(dq->dq->ids.origDest, addr, addrSize);
+  dnsdist_ffi_comboaddress_to_raw(dnsQuestion->dq->ids.origDest, addr, addrSize);
 }
 
 bool dnsdist_ffi_dnsquestion_is_remote_v6(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
@@ -86,18 +86,18 @@ bool dnsdist_ffi_dnsquestion_is_remote_v6(const dnsdist_ffi_dnsquestion_t* dnsQu
   return dnsQuestion->dq->ids.origRemote.isIPv6();
 }
 
-void dnsdist_ffi_dnsquestion_get_remoteaddr(const dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize)
+void dnsdist_ffi_dnsquestion_get_remoteaddr(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const void** addr, size_t* addrSize)
 {
-  dnsdist_ffi_comboaddress_to_raw(dq->dq->ids.origRemote, addr, addrSize);
+  dnsdist_ffi_comboaddress_to_raw(dnsQuestion->dq->ids.origRemote, addr, addrSize);
 }
 
-size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dq, void* buffer, size_t bufferSize)
+size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dnsQuestion, void* buffer, size_t bufferSize)
 {
-  if (dq == nullptr) {
+  if (dnsQuestion == nullptr) {
     return 0;
   }
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  auto ret = dnsdist::MacAddressesCache::get(dq->dq->ids.origRemote, reinterpret_cast<unsigned char*>(buffer), bufferSize);
+  auto ret = dnsdist::MacAddressesCache::get(dnsQuestion->dq->ids.origRemote, reinterpret_cast<unsigned char*>(buffer), bufferSize);
   if (ret != 0) {
     return 0;
   }
@@ -105,13 +105,13 @@ size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dq,
   return 6;
 }
 
-uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t* dq)
+uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  if (dq == nullptr) {
+  if (dnsQuestion == nullptr) {
     return 0;
   }
 
-  return static_cast<uint64_t>(std::round(dq->dq->ids.queryRealTime.udiff()));
+  return static_cast<uint64_t>(std::round(dnsQuestion->dq->ids.queryRealTime.udiff()));
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
@@ -125,8 +125,7 @@ static bool checkDNSQuestionType(const char functionName[], const dnsdist_ffi_dn
   return true;
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-static bool checkDNSResponseType(const char functionName[], const dnsdist_ffi_dnsresponse_t* dnsResponse)
+static bool checkDNSResponseType(const std::string_view& functionName, const dnsdist_ffi_dnsresponse_t* dnsResponse)
 {
   if (dnsResponse->objectType != dnsdist::lua::ffi::ObjectType::Response) {
     VERBOSESLOG(infolog("Error: calling FFI function %s with a wrong type", functionName),
@@ -136,24 +135,24 @@ static bool checkDNSResponseType(const char functionName[], const dnsdist_ffi_dn
   return true;
 }
 
-void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize, uint8_t bits)
+void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dnsQuestion, const void** addr, size_t* addrSize, uint8_t bits)
 {
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return;
   }
 
-  dq->maskedRemote = Netmask(dq->dq->ids.origRemote, bits).getMaskedNetwork();
-  dnsdist_ffi_comboaddress_to_raw(dq->maskedRemote, addr, addrSize);
+  dnsQuestion->maskedRemote = Netmask(dnsQuestion->dq->ids.origRemote, bits).getMaskedNetwork();
+  dnsdist_ffi_comboaddress_to_raw(dnsQuestion->maskedRemote, addr, addrSize);
 }
 
-uint16_t dnsdist_ffi_dnsquestion_get_local_port(const dnsdist_ffi_dnsquestion_t* dq)
+uint16_t dnsdist_ffi_dnsquestion_get_local_port(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->ids.origDest.getPort();
+  return dnsQuestion->dq->ids.origDest.getPort();
 }
 
-uint16_t dnsdist_ffi_dnsquestion_get_remote_port(const dnsdist_ffi_dnsquestion_t* dq)
+uint16_t dnsdist_ffi_dnsquestion_get_remote_port(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->ids.origRemote.getPort();
+  return dnsQuestion->dq->ids.origRemote.getPort();
 }
 
 const char* dnsdist_ffi_dnsquestion_get_incoming_interface(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
@@ -164,31 +163,31 @@ const char* dnsdist_ffi_dnsquestion_get_incoming_interface(const dnsdist_ffi_dns
   return dnsQuestion->dq->ids.cs->interface.c_str();
 }
 
-void dnsdist_ffi_dnsquestion_get_qname_raw(const dnsdist_ffi_dnsquestion_t* dq, const char** qname, size_t* qnameSize)
+void dnsdist_ffi_dnsquestion_get_qname_raw(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char** qname, size_t* qnameSize)
 {
-  const auto& storage = dq->dq->ids.qname.getStorage();
+  const auto& storage = dnsQuestion->dq->ids.qname.getStorage();
   *qname = storage.data();
   *qnameSize = storage.size();
 }
 
-size_t dnsdist_ffi_dnsquestion_get_qname_hash(const dnsdist_ffi_dnsquestion_t* dq, size_t init)
+size_t dnsdist_ffi_dnsquestion_get_qname_hash(const dnsdist_ffi_dnsquestion_t* dnsQuestion, size_t init)
 {
-  return dq->dq->ids.qname.hash(init);
+  return dnsQuestion->dq->ids.qname.hash(init);
 }
 
-int dnsdist_ffi_dnsquestion_get_rcode(const dnsdist_ffi_dnsquestion_t* dq)
+int dnsdist_ffi_dnsquestion_get_rcode(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->getHeader()->rcode;
+  return dnsQuestion->dq->getHeader()->rcode;
 }
 
-void* dnsdist_ffi_dnsquestion_get_header(const dnsdist_ffi_dnsquestion_t* dq)
+void* dnsdist_ffi_dnsquestion_get_header(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->getMutableHeader();
+  return dnsQuestion->dq->getMutableHeader();
 }
 
-const unsigned char* dnsdist_ffi_dnsquestion_get_data(const dnsdist_ffi_dnsquestion_t* dq)
+const unsigned char* dnsdist_ffi_dnsquestion_get_data(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->getData().data();
+  return dnsQuestion->dq->getData().data();
 }
 
 bool dnsdist_ffi_dnsquestion_get_header_copy(const dnsdist_ffi_dnsquestion_t* dnsQuestion, char* buffer, size_t buffer_size)
@@ -215,20 +214,20 @@ bool dnsdist_ffi_dnsquestion_set_header(const dnsdist_ffi_dnsquestion_t* dnsQues
   return true;
 }
 
-uint16_t dnsdist_ffi_dnsquestion_get_len(const dnsdist_ffi_dnsquestion_t* dq)
+uint16_t dnsdist_ffi_dnsquestion_get_len(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->getData().size();
+  return dnsQuestion->dq->getData().size();
 }
 
-size_t dnsdist_ffi_dnsquestion_get_size(const dnsdist_ffi_dnsquestion_t* dq)
+size_t dnsdist_ffi_dnsquestion_get_size(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->getData().size();
+  return dnsQuestion->dq->getData().size();
 }
 
-bool dnsdist_ffi_dnsquestion_set_size(dnsdist_ffi_dnsquestion_t* dq, size_t newSize)
+bool dnsdist_ffi_dnsquestion_set_size(dnsdist_ffi_dnsquestion_t* dnsQuestion, size_t newSize)
 {
   try {
-    dq->dq->getMutableData().resize(newSize);
+    dnsQuestion->dq->getMutableData().resize(newSize);
     return true;
   }
   catch (const std::exception& e) {
@@ -236,20 +235,20 @@ bool dnsdist_ffi_dnsquestion_set_size(dnsdist_ffi_dnsquestion_t* dq, size_t newS
   }
 }
 
-uint8_t dnsdist_ffi_dnsquestion_get_opcode(const dnsdist_ffi_dnsquestion_t* dq)
+uint8_t dnsdist_ffi_dnsquestion_get_opcode(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->getHeader()->opcode;
+  return dnsQuestion->dq->getHeader()->opcode;
 }
 
-bool dnsdist_ffi_dnsquestion_get_tcp(const dnsdist_ffi_dnsquestion_t* dq)
+bool dnsdist_ffi_dnsquestion_get_tcp(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->overTCP();
+  return dnsQuestion->dq->overTCP();
 }
 
-dnsdist_ffi_protocol_type dnsdist_ffi_dnsquestion_get_protocol(const dnsdist_ffi_dnsquestion_t* dq)
+dnsdist_ffi_protocol_type dnsdist_ffi_dnsquestion_get_protocol(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  if (dq != nullptr) {
-    auto proto = dq->dq->getProtocol();
+  if (dnsQuestion != nullptr) {
+    auto proto = dnsQuestion->dq->getProtocol();
     if (proto == dnsdist::Protocol::DoUDP) {
       return dnsdist_ffi_protocol_type_doudp;
     }
@@ -272,35 +271,35 @@ dnsdist_ffi_protocol_type dnsdist_ffi_dnsquestion_get_protocol(const dnsdist_ffi
   return dnsdist_ffi_protocol_type_doudp;
 }
 
-bool dnsdist_ffi_dnsquestion_get_skip_cache(const dnsdist_ffi_dnsquestion_t* dq)
+bool dnsdist_ffi_dnsquestion_get_skip_cache(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->ids.skipCache;
+  return dnsQuestion->dq->ids.skipCache;
 }
 
-bool dnsdist_ffi_dnsquestion_get_use_ecs(const dnsdist_ffi_dnsquestion_t* dq)
+bool dnsdist_ffi_dnsquestion_get_use_ecs(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->useECS;
+  return dnsQuestion->dq->useECS;
 }
 
-bool dnsdist_ffi_dnsquestion_get_ecs_override(const dnsdist_ffi_dnsquestion_t* dq)
+bool dnsdist_ffi_dnsquestion_get_ecs_override(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->ecsOverride;
+  return dnsQuestion->dq->ecsOverride;
 }
 
-uint16_t dnsdist_ffi_dnsquestion_get_ecs_prefix_length(const dnsdist_ffi_dnsquestion_t* dq)
+uint16_t dnsdist_ffi_dnsquestion_get_ecs_prefix_length(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->ecsPrefixLength;
+  return dnsQuestion->dq->ecsPrefixLength;
 }
 
-bool dnsdist_ffi_dnsquestion_is_temp_failure_ttl_set(const dnsdist_ffi_dnsquestion_t* dq)
+bool dnsdist_ffi_dnsquestion_is_temp_failure_ttl_set(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  return dq->dq->ids.tempFailureTTL != std::nullopt;
+  return dnsQuestion->dq->ids.tempFailureTTL != std::nullopt;
 }
 
-uint32_t dnsdist_ffi_dnsquestion_get_temp_failure_ttl(const dnsdist_ffi_dnsquestion_t* dq)
+uint32_t dnsdist_ffi_dnsquestion_get_temp_failure_ttl(const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  if (dq->dq->ids.tempFailureTTL) {
-    return *dq->dq->ids.tempFailureTTL;
+  if (dnsQuestion->dq->ids.tempFailureTTL) {
+    return *dnsQuestion->dq->ids.tempFailureTTL;
   }
   return 0;
 }
@@ -322,137 +321,137 @@ uint8_t dnsdist_ffi_dnsquestion_get_edns_extended_rcode(const dnsdist_ffi_dnsque
   return rcode ? *rcode : 0U;
 }
 
-void dnsdist_ffi_dnsquestion_get_sni(const dnsdist_ffi_dnsquestion_t* dq, const char** sni, size_t* sniSize)
+void dnsdist_ffi_dnsquestion_get_sni(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char** sni, size_t* sniSize)
 {
-  *sniSize = dq->dq->sni.size();
-  *sni = dq->dq->sni.c_str();
+  *sniSize = dnsQuestion->dq->sni.size();
+  *sni = dnsQuestion->dq->sni.c_str();
 }
 
-const char* dnsdist_ffi_dnsquestion_get_tag(const dnsdist_ffi_dnsquestion_t* dq, const char* label)
+const char* dnsdist_ffi_dnsquestion_get_tag(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label)
 {
   const char* result = nullptr;
 
-  if (dq != nullptr && dq->dq != nullptr && dq->dq->ids.qTag != nullptr) {
-    const auto it = dq->dq->ids.qTag->find(label);
-    if (it != dq->dq->ids.qTag->cend()) {
-      result = it->second.c_str();
+  if (dnsQuestion != nullptr && dnsQuestion->dq != nullptr && dnsQuestion->dq->ids.qTag != nullptr) {
+    const auto tagIt = dnsQuestion->dq->ids.qTag->find(label);
+    if (tagIt != dnsQuestion->dq->ids.qTag->cend()) {
+      result = tagIt->second.c_str();
     }
   }
 
   return result;
 }
 
-size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dq, const char* label, char* buffer, size_t bufferSize)
+size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label, char* buffer, size_t bufferSize)
 {
-  if (dq == nullptr || dq->dq == nullptr || dq->dq->ids.qTag == nullptr || label == nullptr || buffer == nullptr || bufferSize == 0) {
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || dnsQuestion->dq->ids.qTag == nullptr || label == nullptr || buffer == nullptr || bufferSize == 0) {
     return 0;
   }
 
-  const auto it = dq->dq->ids.qTag->find(label);
-  if (it == dq->dq->ids.qTag->cend()) {
+  const auto tagIt = dnsQuestion->dq->ids.qTag->find(label);
+  if (tagIt == dnsQuestion->dq->ids.qTag->cend()) {
     return 0;
   }
 
-  if (it->second.size() > bufferSize) {
+  if (tagIt->second.size() > bufferSize) {
     return 0;
   }
 
-  memcpy(buffer, it->second.c_str(), it->second.size());
-  return it->second.size();
+  memcpy(buffer, tagIt->second.c_str(), tagIt->second.size());
+  return tagIt->second.size();
 }
 
-const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dq)
+const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return nullptr;
   }
 
-  if (!dq->httpPath) {
-    if (dq->dq->ids.du) {
+  if (!dnsQuestion->httpPath) {
+    if (dnsQuestion->dq->ids.du) {
 #if defined(HAVE_DNS_OVER_HTTPS)
-      dq->httpPath = dq->dq->ids.du->getHTTPPath();
+      dnsQuestion->httpPath = dnsQuestion->dq->ids.du->getHTTPPath();
 #endif /* HAVE_DNS_OVER_HTTPS */
     }
-    else if (dq->dq->ids.doh3u) {
+    else if (dnsQuestion->dq->ids.doh3u) {
 #if defined(HAVE_DNS_OVER_HTTP3)
-      dq->httpPath = dq->dq->ids.doh3u->getHTTPPath();
+      dnsQuestion->httpPath = dnsQuestion->dq->ids.doh3u->getHTTPPath();
 #endif /* HAVE_DNS_OVER_HTTP3 */
     }
   }
-  if (dq->httpPath) {
-    return dq->httpPath->c_str();
+  if (dnsQuestion->httpPath) {
+    return dnsQuestion->httpPath->c_str();
   }
   return nullptr;
 }
 
-const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestion_t* dq)
+const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return nullptr;
   }
 
-  if (!dq->httpQueryString) {
-    if (dq->dq->ids.du) {
+  if (!dnsQuestion->httpQueryString) {
+    if (dnsQuestion->dq->ids.du) {
 #ifdef HAVE_DNS_OVER_HTTPS
-      dq->httpQueryString = dq->dq->ids.du->getHTTPQueryString();
+      dnsQuestion->httpQueryString = dnsQuestion->dq->ids.du->getHTTPQueryString();
 #endif /* HAVE_DNS_OVER_HTTPS */
     }
-    else if (dq->dq->ids.doh3u) {
+    else if (dnsQuestion->dq->ids.doh3u) {
 #if defined(HAVE_DNS_OVER_HTTP3)
-      dq->httpQueryString = dq->dq->ids.doh3u->getHTTPQueryString();
+      dnsQuestion->httpQueryString = dnsQuestion->dq->ids.doh3u->getHTTPQueryString();
 #endif /* HAVE_DNS_OVER_HTTP3 */
     }
   }
-  if (dq->httpQueryString) {
-    return dq->httpQueryString->c_str();
+  if (dnsQuestion->httpQueryString) {
+    return dnsQuestion->httpQueryString->c_str();
   }
   return nullptr;
 }
 
-const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dq)
+const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return nullptr;
   }
 
-  if (!dq->httpHost) {
-    if (dq->dq->ids.du) {
+  if (!dnsQuestion->httpHost) {
+    if (dnsQuestion->dq->ids.du) {
 #ifdef HAVE_DNS_OVER_HTTPS
-      dq->httpHost = dq->dq->ids.du->getHTTPHost();
+      dnsQuestion->httpHost = dnsQuestion->dq->ids.du->getHTTPHost();
 #endif /* HAVE_DNS_OVER_HTTPS */
     }
-    else if (dq->dq->ids.doh3u) {
+    else if (dnsQuestion->dq->ids.doh3u) {
 #if defined(HAVE_DNS_OVER_HTTP3)
-      dq->httpHost = dq->dq->ids.doh3u->getHTTPHost();
+      dnsQuestion->httpHost = dnsQuestion->dq->ids.doh3u->getHTTPHost();
 #endif /* HAVE_DNS_OVER_HTTP3 */
     }
   }
-  if (dq->httpHost) {
-    return dq->httpHost->c_str();
+  if (dnsQuestion->httpHost) {
+    return dnsQuestion->httpHost->c_str();
   }
   return nullptr;
 }
 
-const char* dnsdist_ffi_dnsquestion_get_http_scheme(dnsdist_ffi_dnsquestion_t* dq)
+const char* dnsdist_ffi_dnsquestion_get_http_scheme(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return nullptr;
   }
 
-  if (!dq->httpScheme) {
-    if (dq->dq->ids.du) {
+  if (!dnsQuestion->httpScheme) {
+    if (dnsQuestion->dq->ids.du) {
 #ifdef HAVE_DNS_OVER_HTTPS
-      dq->httpScheme = dq->dq->ids.du->getHTTPScheme();
+      dnsQuestion->httpScheme = dnsQuestion->dq->ids.du->getHTTPScheme();
 #endif /* HAVE_DNS_OVER_HTTPS */
     }
-    else if (dq->dq->ids.doh3u) {
+    else if (dnsQuestion->dq->ids.doh3u) {
 #if defined(HAVE_DNS_OVER_HTTP3)
-      dq->httpScheme = dq->dq->ids.doh3u->getHTTPScheme();
+      dnsQuestion->httpScheme = dnsQuestion->dq->ids.doh3u->getHTTPScheme();
 #endif /* HAVE_DNS_OVER_HTTP3 */
     }
   }
-  if (dq->httpScheme) {
-    return dq->httpScheme->c_str();
+  if (dnsQuestion->httpScheme) {
+    return dnsQuestion->httpScheme->c_str();
   }
   return nullptr;
 }
@@ -505,52 +504,52 @@ size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dnsQu
   return totalCount;
 }
 
-size_t dnsdist_ffi_dnsquestion_get_http_headers([[maybe_unused]] dnsdist_ffi_dnsquestion_t* ref, [[maybe_unused]] const dnsdist_ffi_http_header_t** out)
+size_t dnsdist_ffi_dnsquestion_get_http_headers([[maybe_unused]] dnsdist_ffi_dnsquestion_t* dnsQuestion, [[maybe_unused]] const dnsdist_ffi_http_header_t** out)
 {
 #if defined(HAVE_DNS_OVER_HTTPS) || defined(HAVE_DNS_OVER_HTTP3)
-  if (!checkDNSQuestionType(__func__, ref)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return 0U;
   }
 
-  const auto processHeaders = [&ref](const std::unordered_map<std::string, std::string>& headers) {
+  const auto processHeaders = [&dnsQuestion](const std::unordered_map<std::string, std::string>& headers) {
     if (headers.empty()) {
       return;
     }
-    ref->httpHeaders = std::make_unique<std::unordered_map<std::string, std::string>>(headers);
-    if (!ref->httpHeadersVect) {
-      ref->httpHeadersVect = std::make_unique<std::vector<dnsdist_ffi_http_header_t>>();
+    dnsQuestion->httpHeaders = std::make_unique<std::unordered_map<std::string, std::string>>(headers);
+    if (!dnsQuestion->httpHeadersVect) {
+      dnsQuestion->httpHeadersVect = std::make_unique<std::vector<dnsdist_ffi_http_header_t>>();
     }
-    ref->httpHeadersVect->clear();
-    ref->httpHeadersVect->resize(ref->httpHeaders->size());
+    dnsQuestion->httpHeadersVect->clear();
+    dnsQuestion->httpHeadersVect->resize(dnsQuestion->httpHeaders->size());
     size_t pos = 0;
-    for (const auto& header : *ref->httpHeaders) {
-      ref->httpHeadersVect->at(pos).name = header.first.c_str();
-      ref->httpHeadersVect->at(pos).value = header.second.c_str();
+    for (const auto& header : *dnsQuestion->httpHeaders) {
+      dnsQuestion->httpHeadersVect->at(pos).name = header.first.c_str();
+      dnsQuestion->httpHeadersVect->at(pos).value = header.second.c_str();
       ++pos;
     }
   };
 
 #if defined(HAVE_DNS_OVER_HTTPS)
-  if (ref->dq->ids.du) {
-    const auto& headers = ref->dq->ids.du->getHTTPHeaders();
+  if (dnsQuestion->dq->ids.du) {
+    const auto& headers = dnsQuestion->dq->ids.du->getHTTPHeaders();
     processHeaders(headers);
   }
 #endif /* HAVE_DNS_OVER_HTTPS */
 #if defined(HAVE_DNS_OVER_HTTP3)
-  if (ref->dq->ids.doh3u) {
-    const auto& headers = ref->dq->ids.doh3u->getHTTPHeaders();
+  if (dnsQuestion->dq->ids.doh3u) {
+    const auto& headers = dnsQuestion->dq->ids.doh3u->getHTTPHeaders();
     processHeaders(headers);
   }
 #endif /* HAVE_DNS_OVER_HTTP3 */
 
-  if (!ref->httpHeadersVect) {
+  if (!dnsQuestion->httpHeadersVect) {
     return 0;
   }
 
-  if (!ref->httpHeadersVect->empty()) {
-    *out = ref->httpHeadersVect->data();
+  if (!dnsQuestion->httpHeadersVect->empty()) {
+    *out = dnsQuestion->httpHeadersVect->data();
   }
-  return ref->httpHeadersVect->size();
+  return dnsQuestion->httpHeadersVect->size();
 #else /* HAVE_DNS_OVER_HTTPS || HAVE_DNS_OVER_HTTP3 */
   return 0;
 #endif /* HAVE_DNS_OVER_HTTPS || HAVE_DNS_OVER_HTTP3 */
@@ -586,33 +585,33 @@ size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dnsQuest
   return dnsQuestion->tagsVect->size();
 }
 
-void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dq, const char* str, size_t strSize)
+void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* str, size_t strSize)
 {
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return;
   }
-  dq->result = std::string(str, strSize);
+  dnsQuestion->result = std::string(str, strSize);
 }
 
-void dnsdist_ffi_dnsquestion_set_http_response([[maybe_unused]] dnsdist_ffi_dnsquestion_t* ref, [[maybe_unused]] uint16_t statusCode, [[maybe_unused]] const char* body, [[maybe_unused]] size_t bodyLen, [[maybe_unused]] const char* contentType)
+void dnsdist_ffi_dnsquestion_set_http_response([[maybe_unused]] dnsdist_ffi_dnsquestion_t* dnsQuestion, [[maybe_unused]] uint16_t statusCode, [[maybe_unused]] const char* body, [[maybe_unused]] size_t bodyLen, [[maybe_unused]] const char* contentType)
 {
 #if defined(HAVE_DNS_OVER_HTTPS)
-  if (ref->dq->ids.du) {
+  if (dnsQuestion->dq->ids.du) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): C API
     PacketBuffer bodyVect(body, body + bodyLen);
-    ref->dq->ids.du->setHTTPResponse(statusCode, std::move(bodyVect), contentType);
-    dnsdist::PacketMangling::editDNSHeaderFromPacket(ref->dq->getMutableData(), [](dnsheader& header) {
+    dnsQuestion->dq->ids.du->setHTTPResponse(statusCode, std::move(bodyVect), contentType);
+    dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion->dq->getMutableData(), [](dnsheader& header) {
       header.qr = true;
       return true;
     });
   }
 #endif
 #if defined(HAVE_DNS_OVER_HTTP3)
-  if (ref->dq->ids.doh3u) {
+  if (dnsQuestion->dq->ids.doh3u) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): C API
     PacketBuffer bodyVect(body, body + bodyLen);
-    ref->dq->ids.doh3u->setHTTPResponse(statusCode, std::move(bodyVect), contentType);
-    dnsdist::PacketMangling::editDNSHeaderFromPacket(ref->dq->getMutableData(), [](dnsheader& header) {
+    dnsQuestion->dq->ids.doh3u->setHTTPResponse(statusCode, std::move(bodyVect), contentType);
+    dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion->dq->getMutableData(), [](dnsheader& header) {
       header.qr = true;
       return true;
     });
@@ -647,130 +646,130 @@ void dnsdist_ffi_dnsquestion_add_extended_dns_error(dnsdist_ffi_dnsquestion_t* d
   }
 }
 
-void dnsdist_ffi_dnsquestion_set_rcode(dnsdist_ffi_dnsquestion_t* dq, int rcode)
+void dnsdist_ffi_dnsquestion_set_rcode(dnsdist_ffi_dnsquestion_t* dnsQuestion, int rcode)
 {
-  dnsdist::PacketMangling::editDNSHeaderFromPacket(dq->dq->getMutableData(), [rcode](dnsheader& header) {
+  dnsdist::PacketMangling::editDNSHeaderFromPacket(dnsQuestion->dq->getMutableData(), [rcode](dnsheader& header) {
     header.rcode = rcode;
     header.qr = true;
     return true;
   });
 }
 
-void dnsdist_ffi_dnsquestion_set_len(dnsdist_ffi_dnsquestion_t* dq, uint16_t len)
+void dnsdist_ffi_dnsquestion_set_len(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t len)
 {
-  dq->dq->getMutableData().resize(len);
+  dnsQuestion->dq->getMutableData().resize(len);
 }
 
-void dnsdist_ffi_dnsquestion_set_skip_cache(dnsdist_ffi_dnsquestion_t* dq, bool skipCache)
+void dnsdist_ffi_dnsquestion_set_skip_cache(dnsdist_ffi_dnsquestion_t* dnsQuestion, bool skipCache)
 {
-  dq->dq->ids.skipCache = skipCache;
+  dnsQuestion->dq->ids.skipCache = skipCache;
 }
 
-void dnsdist_ffi_dnsquestion_set_use_ecs(dnsdist_ffi_dnsquestion_t* dq, bool useECS)
+void dnsdist_ffi_dnsquestion_set_use_ecs(dnsdist_ffi_dnsquestion_t* dnsQuestion, bool useECS)
 {
-  dq->dq->useECS = useECS;
+  dnsQuestion->dq->useECS = useECS;
 }
 
-void dnsdist_ffi_dnsquestion_set_ecs_override(dnsdist_ffi_dnsquestion_t* dq, bool ecsOverride)
+void dnsdist_ffi_dnsquestion_set_ecs_override(dnsdist_ffi_dnsquestion_t* dnsQuestion, bool ecsOverride)
 {
-  dq->dq->ecsOverride = ecsOverride;
+  dnsQuestion->dq->ecsOverride = ecsOverride;
 }
 
-void dnsdist_ffi_dnsquestion_set_ecs_prefix_length(dnsdist_ffi_dnsquestion_t* dq, uint16_t ecsPrefixLength)
+void dnsdist_ffi_dnsquestion_set_ecs_prefix_length(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t ecsPrefixLength)
 {
-  dq->dq->ecsPrefixLength = ecsPrefixLength;
+  dnsQuestion->dq->ecsPrefixLength = ecsPrefixLength;
 }
 
-void dnsdist_ffi_dnsquestion_set_temp_failure_ttl(dnsdist_ffi_dnsquestion_t* dq, uint32_t tempFailureTTL)
+void dnsdist_ffi_dnsquestion_set_temp_failure_ttl(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint32_t tempFailureTTL)
 {
-  dq->dq->ids.tempFailureTTL = tempFailureTTL;
+  dnsQuestion->dq->ids.tempFailureTTL = tempFailureTTL;
 }
 
-void dnsdist_ffi_dnsquestion_unset_temp_failure_ttl(dnsdist_ffi_dnsquestion_t* dq)
+void dnsdist_ffi_dnsquestion_unset_temp_failure_ttl(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  dq->dq->ids.tempFailureTTL = std::nullopt;
+  dnsQuestion->dq->ids.tempFailureTTL = std::nullopt;
 }
 
-void dnsdist_ffi_dnsquestion_set_tag(dnsdist_ffi_dnsquestion_t* dq, const char* label, const char* value)
+void dnsdist_ffi_dnsquestion_set_tag(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label, const char* value)
 {
-  dq->dq->setTag(label, value);
+  dnsQuestion->dq->setTag(label, value);
 }
 
-void dnsdist_ffi_dnsquestion_unset_tag(dnsdist_ffi_dnsquestion_t* dq, const char* label)
+void dnsdist_ffi_dnsquestion_unset_tag(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label)
 {
-  dq->dq->unsetTag(label);
+  dnsQuestion->dq->unsetTag(label);
 }
 
-void dnsdist_ffi_dnsquestion_set_tag_raw(dnsdist_ffi_dnsquestion_t* dq, const char* label, const char* value, size_t valueSize)
+void dnsdist_ffi_dnsquestion_set_tag_raw(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* label, const char* value, size_t valueSize)
 {
-  dq->dq->setTag(label, std::string(value, valueSize));
+  dnsQuestion->dq->setTag(label, std::string(value, valueSize));
 }
 
-void dnsdist_ffi_dnsquestion_set_requestor_id(dnsdist_ffi_dnsquestion_t* dq, const char* value, size_t valueSize)
+void dnsdist_ffi_dnsquestion_set_requestor_id(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* value, size_t valueSize)
 {
-  if (dq == nullptr || dq->dq == nullptr || value == nullptr) {
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || value == nullptr) {
     return;
   }
-  if (!dq->dq->ids.d_protoBufData) {
-    dq->dq->ids.d_protoBufData = std::make_unique<InternalQueryState::ProtoBufData>();
+  if (!dnsQuestion->dq->ids.d_protoBufData) {
+    dnsQuestion->dq->ids.d_protoBufData = std::make_unique<InternalQueryState::ProtoBufData>();
   }
-  dq->dq->ids.d_protoBufData->d_requestorID = std::string(value, valueSize);
+  dnsQuestion->dq->ids.d_protoBufData->d_requestorID = std::string(value, valueSize);
 }
 
-void dnsdist_ffi_dnsquestion_set_device_id(dnsdist_ffi_dnsquestion_t* dq, const char* value, size_t valueSize)
+void dnsdist_ffi_dnsquestion_set_device_id(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* value, size_t valueSize)
 {
-  if (dq == nullptr || dq->dq == nullptr || value == nullptr) {
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || value == nullptr) {
     return;
   }
-  if (!dq->dq->ids.d_protoBufData) {
-    dq->dq->ids.d_protoBufData = std::make_unique<InternalQueryState::ProtoBufData>();
+  if (!dnsQuestion->dq->ids.d_protoBufData) {
+    dnsQuestion->dq->ids.d_protoBufData = std::make_unique<InternalQueryState::ProtoBufData>();
   }
-  dq->dq->ids.d_protoBufData->d_deviceID = std::string(value, valueSize);
+  dnsQuestion->dq->ids.d_protoBufData->d_deviceID = std::string(value, valueSize);
 }
 
-void dnsdist_ffi_dnsquestion_set_device_name(dnsdist_ffi_dnsquestion_t* dq, const char* value, size_t valueSize)
+void dnsdist_ffi_dnsquestion_set_device_name(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* value, size_t valueSize)
 {
-  if (dq == nullptr || dq->dq == nullptr || value == nullptr) {
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || value == nullptr) {
     return;
   }
-  if (!dq->dq->ids.d_protoBufData) {
-    dq->dq->ids.d_protoBufData = std::make_unique<InternalQueryState::ProtoBufData>();
+  if (!dnsQuestion->dq->ids.d_protoBufData) {
+    dnsQuestion->dq->ids.d_protoBufData = std::make_unique<InternalQueryState::ProtoBufData>();
   }
-  dq->dq->ids.d_protoBufData->d_deviceName = std::string(value, valueSize);
+  dnsQuestion->dq->ids.d_protoBufData->d_deviceName = std::string(value, valueSize);
 }
 
-size_t dnsdist_ffi_dnsquestion_get_trailing_data(dnsdist_ffi_dnsquestion_t* dq, const char** out)
+size_t dnsdist_ffi_dnsquestion_get_trailing_data(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char** out)
 {
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return 0U;
   }
-  dq->trailingData = dq->dq->getTrailingData();
-  if (!dq->trailingData.empty()) {
-    *out = dq->trailingData.data();
+  dnsQuestion->trailingData = dnsQuestion->dq->getTrailingData();
+  if (!dnsQuestion->trailingData.empty()) {
+    *out = dnsQuestion->trailingData.data();
   }
 
-  return dq->trailingData.size();
+  return dnsQuestion->trailingData.size();
 }
 
-bool dnsdist_ffi_dnsquestion_set_trailing_data(dnsdist_ffi_dnsquestion_t* dq, const char* data, size_t dataLen)
+bool dnsdist_ffi_dnsquestion_set_trailing_data(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* data, size_t dataLen)
 {
-  return dq->dq->setTrailingData(std::string(data, dataLen));
+  return dnsQuestion->dq->setTrailingData(std::string(data, dataLen));
 }
 
-void dnsdist_ffi_dnsquestion_send_trap(dnsdist_ffi_dnsquestion_t* dq, const char* reason, size_t reasonLen)
+void dnsdist_ffi_dnsquestion_send_trap(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* reason, size_t reasonLen)
 {
   if (g_snmpAgent != nullptr && dnsdist::configuration::getImmutableConfiguration().d_snmpTrapsEnabled) {
-    g_snmpAgent->sendDNSTrap(*dq->dq, std::string(reason, reasonLen));
+    g_snmpAgent->sendDNSTrap(*dnsQuestion->dq, std::string(reason, reasonLen));
   }
 }
 
-void dnsdist_ffi_dnsquestion_spoof_packet(dnsdist_ffi_dnsquestion_t* dq, const char* raw, size_t len)
+void dnsdist_ffi_dnsquestion_spoof_packet(dnsdist_ffi_dnsquestion_t* dnsQuestion, const char* raw, size_t len)
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-  dnsdist::self_answers::generateAnswerFromRawPacket(*dq->dq, PacketBuffer(raw, raw + len));
+  dnsdist::self_answers::generateAnswerFromRawPacket(*dnsQuestion->dq, PacketBuffer(raw, raw + len));
 }
 
-void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_raw_value_t* values, size_t valuesCount)
+void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_raw_value_t* values, size_t valuesCount)
 {
   std::vector<std::string> data;
   data.reserve(valuesCount);
@@ -781,10 +780,10 @@ void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dq, const dnsd
   }
 
   dnsdist::ResponseConfig config{};
-  dnsdist::self_answers::generateAnswerFromRDataEntries(*dq->dq, data, std::nullopt, config);
+  dnsdist::self_answers::generateAnswerFromRDataEntries(*dnsQuestion->dq, data, std::nullopt, config);
 }
 
-void dnsdist_ffi_dnsquestion_spoof_addrs(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_raw_value_t* values, size_t valuesCount)
+void dnsdist_ffi_dnsquestion_spoof_addrs(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_raw_value_t* values, size_t valuesCount)
 {
   std::vector<ComboAddress> data;
   data.reserve(valuesCount);
@@ -813,23 +812,24 @@ void dnsdist_ffi_dnsquestion_spoof_addrs(dnsdist_ffi_dnsquestion_t* dq, const dn
   }
 
   dnsdist::ResponseConfig config{};
-  dnsdist::self_answers::generateAnswerFromIPAddresses(*dq->dq, data, config);
+  dnsdist::self_answers::generateAnswerFromIPAddresses(*dnsQuestion->dq, data, config);
 }
 
-void dnsdist_ffi_dnsquestion_set_max_returned_ttl(dnsdist_ffi_dnsquestion_t* dq, uint32_t max)
+void dnsdist_ffi_dnsquestion_set_max_returned_ttl(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint32_t max)
 {
-  if (dq != nullptr && dq->dq != nullptr) {
-    dq->dq->ids.ttlCap = max;
+  if (dnsQuestion != nullptr && dnsQuestion->dq != nullptr) {
+    dnsQuestion->dq->ids.ttlCap = max;
   }
 }
 
-bool dnsdist_ffi_dnsquestion_set_restartable(dnsdist_ffi_dnsquestion_t* dq)
+bool dnsdist_ffi_dnsquestion_set_restartable(dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
-  if (dq == nullptr || dq->dq == nullptr) {
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr) {
+    // NOLINTNEXTLINE(readability-simplify-boolean-expr)
     return false;
   }
 
-  dq->dq->ids.d_packet = std::make_unique<PacketBuffer>(dq->dq->getData());
+  dnsQuestion->dq->ids.d_packet = std::make_unique<PacketBuffer>(dnsQuestion->dq->getData());
   return true;
 }
 
@@ -843,9 +843,9 @@ void dnsdist_ffi_servers_list_get_server(const dnsdist_ffi_servers_list_t* list,
   *out = &list->ffiServers.at(idx);
 }
 
-size_t dnsdist_ffi_servers_list_chashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dq, size_t hash)
+size_t dnsdist_ffi_servers_list_chashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dnsQuestion, size_t hash)
 {
-  (void)dq;
+  (void)dnsQuestion;
   auto serverPosition = chashedFromHash(list->servers, hash);
   if (!serverPosition) {
     throw std::runtime_error("Unable to find servers in server list");
@@ -853,9 +853,9 @@ size_t dnsdist_ffi_servers_list_chashed(const dnsdist_ffi_servers_list_t* list, 
   return *serverPosition;
 }
 
-size_t dnsdist_ffi_servers_list_whashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dq, size_t hash)
+size_t dnsdist_ffi_servers_list_whashed(const dnsdist_ffi_servers_list_t* list, const dnsdist_ffi_dnsquestion_t* dnsQuestion, size_t hash)
 {
-  (void)dq;
+  (void)dnsQuestion;
   auto serverPosition = whashedFromHash(list->servers, hash);
   if (!serverPosition) {
     throw std::runtime_error("Unable to find servers in server list");
@@ -898,66 +898,66 @@ const char* dnsdist_ffi_server_get_name_with_addr(const dnsdist_ffi_server_t* se
   return server->server->getNameWithAddr().c_str();
 }
 
-void dnsdist_ffi_dnsresponse_set_min_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t min)
+void dnsdist_ffi_dnsresponse_set_min_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t min)
 {
-  dnsdist_ffi_dnsresponse_limit_ttl(dr, min, std::numeric_limits<uint32_t>::max());
+  dnsdist_ffi_dnsresponse_limit_ttl(dnsResponse, min, std::numeric_limits<uint32_t>::max());
 }
 
-void dnsdist_ffi_dnsresponse_set_max_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t max)
+void dnsdist_ffi_dnsresponse_set_max_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t max)
 {
-  dnsdist_ffi_dnsresponse_limit_ttl(dr, 0, max);
+  dnsdist_ffi_dnsresponse_limit_ttl(dnsResponse, 0, max);
 }
 
-void dnsdist_ffi_dnsresponse_limit_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t min, uint32_t max)
+void dnsdist_ffi_dnsresponse_limit_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t min, uint32_t max)
 {
-  if (dr != nullptr && dr->dr != nullptr) {
-    if (!checkDNSResponseType(__func__, dr)) {
+  if (dnsResponse != nullptr && dnsResponse->dr != nullptr) {
+    if (!checkDNSResponseType(__func__, dnsResponse)) {
       return;
     }
 
-    dnsdist::PacketMangling::restrictDNSPacketTTLs(dr->dr->getMutableData(), min, max);
+    dnsdist::PacketMangling::restrictDNSPacketTTLs(dnsResponse->dr->getMutableData(), min, max);
   }
 }
 
-void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t max)
+void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dnsResponse, uint32_t max)
 {
-  if (dr != nullptr && dr->dr != nullptr) {
-    if (!checkDNSResponseType(__func__, dr)) {
+  if (dnsResponse != nullptr && dnsResponse->dr != nullptr) {
+    if (!checkDNSResponseType(__func__, dnsResponse)) {
       return;
     }
-    dr->dr->ids.ttlCap = max;
+    dnsResponse->dr->ids.ttlCap = max;
   }
 }
 
-void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dr, uint16_t qtype)
+void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dnsResponse, uint16_t qtype)
 {
-  if (dr != nullptr && dr->dr != nullptr) {
-    if (!checkDNSResponseType(__func__, dr)) {
+  if (dnsResponse != nullptr && dnsResponse->dr != nullptr) {
+    if (!checkDNSResponseType(__func__, dnsResponse)) {
       return;
     }
-    clearDNSPacketRecordTypes(dr->dr->getMutableData(), std::unordered_set<QType>{qtype});
+    clearDNSPacketRecordTypes(dnsResponse->dr->getMutableData(), std::unordered_set<QType>{qtype});
   }
 }
 
-bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dr, const char* initialName, size_t initialNameSize)
+bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dnsResponse, const char* initialName, size_t initialNameSize)
 {
-  if (dr == nullptr || dr->dr == nullptr || initialName == nullptr || initialNameSize == 0) {
+  if (dnsResponse == nullptr || dnsResponse->dr == nullptr || initialName == nullptr || initialNameSize == 0) {
     return false;
   }
-  if (!checkDNSResponseType(__func__, dr)) {
+  if (!checkDNSResponseType(__func__, dnsResponse)) {
     return false;
   }
 
   try {
     DNSName parsed(initialName, initialNameSize, 0, false);
 
-    if (!dnsdist::changeNameInDNSPacket(dr->dr->getMutableData(), dr->dr->ids.qname, parsed)) {
+    if (!dnsdist::changeNameInDNSPacket(dnsResponse->dr->getMutableData(), dnsResponse->dr->ids.qname, parsed)) {
       return false;
     }
 
     // set qname to new one
-    dr->dr->ids.qname = std::move(parsed);
-    dr->dr->ids.skipCache = true;
+    dnsResponse->dr->ids.qname = std::move(parsed);
+    dnsResponse->dr->ids.skipCache = true;
   }
   catch (const std::exception& e) {
     VERBOSESLOG(infolog("Error rebasing packet on a new DNSName: %s", e.what()),
@@ -984,14 +984,14 @@ uint8_t dnsdist_ffi_dnsresponse_get_restart_count(const dnsdist_ffi_dnsresponse_
   return dnsResponse->dr->ids.restartCount;
 }
 
-bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs)
+bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dnsQuestion, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs)
 {
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return false;
   }
   try {
-    dq->dq->asynchronous = true;
-    return dnsdist::suspendQuery(*dq->dq, asyncID, queryID, timeoutMs);
+    dnsQuestion->dq->asynchronous = true;
+    return dnsdist::suspendQuery(*dnsQuestion->dq, asyncID, queryID, timeoutMs);
   }
   catch (const std::exception& e) {
     VERBOSESLOG(infolog("Error in dnsdist_ffi_dnsquestion_set_async: %s", e.what()),
@@ -1321,7 +1321,7 @@ size_t dnsdist_ffi_generate_proxy_protocol_payload(const size_t addrSize, const 
   }
 }
 
-size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi_dnsquestion_t* dq, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value* values, void* out, const size_t outSize)
+size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi_dnsquestion_t* dnsQuestion, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value* values, void* out, const size_t outSize)
 {
   std::vector<ProxyProtocolValue> valuesVect;
   if (valuesCount > 0) {
@@ -1332,7 +1332,7 @@ size_t dnsdist_ffi_dnsquestion_generate_proxy_protocol_payload(const dnsdist_ffi
     }
   }
 
-  std::string payload = makeProxyHeader(dq->dq->overTCP(), dq->dq->ids.origRemote, dq->dq->ids.origDest, valuesVect);
+  std::string payload = makeProxyHeader(dnsQuestion->dq->overTCP(), dnsQuestion->dq->ids.origRemote, dnsQuestion->dq->ids.origDest, valuesVect);
   if (payload.size() > outSize) {
     return 0;
   }
@@ -1404,6 +1404,7 @@ const char* dnsdist_ffi_domain_list_get(const dnsdist_ffi_domain_list_t* list, s
 
 void dnsdist_ffi_domain_list_free(dnsdist_ffi_domain_list_t* list)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   delete list;
 }
 
@@ -1418,6 +1419,7 @@ const char* dnsdist_ffi_address_list_get(const dnsdist_ffi_address_list_t* list,
 
 void dnsdist_ffi_address_list_free(dnsdist_ffi_address_list_t* list)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   delete list;
 }
 
@@ -1427,9 +1429,9 @@ size_t dnsdist_ffi_packetcache_get_domain_list_by_addr(const char* poolName, con
     return 0;
   }
 
-  ComboAddress ca;
+  ComboAddress caAddr;
   try {
-    ca = ComboAddress(addr);
+    caAddr = ComboAddress(addr);
   }
   catch (const std::exception& e) {
     VERBOSESLOG(infolog("Error parsing address passed to dnsdist_ffi_packetcache_get_domain_list_by_addr: %s", e.what()),
@@ -1453,7 +1455,7 @@ size_t dnsdist_ffi_packetcache_get_domain_list_by_addr(const char* poolName, con
     return 0;
   }
 
-  auto domains = pool.packetCache->getDomainsContainingRecords(ca);
+  auto domains = pool.packetCache->getDomainsContainingRecords(caAddr);
   if (domains.size() == 0) {
     return 0;
   }
@@ -1721,6 +1723,7 @@ const char* dnsdist_ffi_ring_entry_get_mac_address(const dnsdist_ffi_ring_entry_
 
 void dnsdist_ffi_ring_entry_list_free(dnsdist_ffi_ring_entry_list_t* list)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   delete list;
 }
 
@@ -1755,14 +1758,14 @@ size_t dnsdist_ffi_ring_get_entries(dnsdist_ffi_ring_entry_list_t** out)
 
   for (const auto& shard : g_rings.d_shards) {
     {
-      auto ql = shard->queryRing.lock();
-      for (const auto& entry : *ql) {
+      auto queryRingLock = shard->queryRing.lock();
+      for (const auto& entry : *queryRingLock) {
         addRingEntryToList(list, now, entry);
       }
     }
     {
-      auto rl = shard->respRing.lock();
-      for (const auto& entry : *rl) {
+      auto responseRingLock = shard->respRing.lock();
+      for (const auto& entry : *responseRingLock) {
         addRingEntryToList(list, now, entry);
       }
     }
@@ -1780,9 +1783,9 @@ size_t dnsdist_ffi_ring_get_entries_by_addr(const char* addr, dnsdist_ffi_ring_e
   if (out == nullptr || addr == nullptr) {
     return 0;
   }
-  ComboAddress ca;
+  ComboAddress caAddr;
   try {
-    ca = ComboAddress(addr);
+    caAddr = ComboAddress(addr);
   }
   catch (const std::exception& e) {
     VERBOSESLOG(infolog("Unable to convert address in dnsdist_ffi_ring_get_entries_by_addr: %s", e.what()),
@@ -1796,15 +1799,15 @@ size_t dnsdist_ffi_ring_get_entries_by_addr(const char* addr, dnsdist_ffi_ring_e
   }
 
   auto list = std::make_unique<dnsdist_ffi_ring_entry_list_t>();
-  struct timespec now{};
+  timespec now{};
   gettime(&now);
 
   auto compare = ComboAddress::addressOnlyEqual();
   for (const auto& shard : g_rings.d_shards) {
     {
-      auto ql = shard->queryRing.lock();
-      for (const auto& entry : *ql) {
-        if (!compare(entry.requestor, ca)) {
+      auto queryRingLock = shard->queryRing.lock();
+      for (const auto& entry : *queryRingLock) {
+        if (!compare(entry.requestor, caAddr)) {
           continue;
         }
 
@@ -1812,9 +1815,9 @@ size_t dnsdist_ffi_ring_get_entries_by_addr(const char* addr, dnsdist_ffi_ring_e
       }
     }
     {
-      auto rl = shard->respRing.lock();
-      for (const auto& entry : *rl) {
-        if (!compare(entry.requestor, ca)) {
+      auto responseRingLock = shard->respRing.lock();
+      for (const auto& entry : *responseRingLock) {
+        if (!compare(entry.requestor, caAddr)) {
           continue;
         }
 
@@ -1840,12 +1843,12 @@ size_t dnsdist_ffi_ring_get_entries_by_mac(const char* addr, dnsdist_ffi_ring_en
   return 0;
 #else
   auto list = std::make_unique<dnsdist_ffi_ring_entry_list_t>();
-  struct timespec now{};
+  timespec now{};
   gettime(&now);
 
   for (const auto& shard : g_rings.d_shards) {
-    auto ql = shard->queryRing.lock();
-    for (const auto& entry : *ql) {
+    auto queryRingLock = shard->queryRing.lock();
+    for (const auto& entry : *queryRingLock) {
       if (memcmp(addr, entry.macaddress.data(), entry.macaddress.size()) != 0) {
         continue;
       }
@@ -1874,6 +1877,7 @@ bool dnsdist_ffi_network_endpoint_new(const char* path, size_t pathSize, dnsdist
   }
   try {
     dnsdist::NetworkEndpoint endpoint(std::string(path, pathSize));
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     *out = new dnsdist_ffi_network_endpoint_t{std::move(endpoint)};
     return true;
   }
@@ -1899,6 +1903,7 @@ bool dnsdist_ffi_network_endpoint_send(const dnsdist_ffi_network_endpoint_t* end
 
 void dnsdist_ffi_network_endpoint_free(dnsdist_ffi_network_endpoint_t* endpoint)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   delete endpoint;
 }
 
@@ -1915,6 +1920,7 @@ bool dnsdist_ffi_dnspacket_parse(const char* packet, size_t packetSize, dnsdist_
 
   try {
     dnsdist::DNSPacketOverlay overlay(std::string_view(packet, packetSize));
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     *out = new dnsdist_ffi_dnspacket_t{std::move(overlay)};
     return true;
   }
@@ -2125,9 +2131,8 @@ bool dnsdist_ffi_dnspacket_parse_cname_record(const char* raw, const dnsdist_ffi
 
 void dnsdist_ffi_dnspacket_free(dnsdist_ffi_dnspacket_t* packet)
 {
-  if (packet != nullptr) {
-    delete packet;
-  }
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+  delete packet;
 }
 
 bool dnsdist_ffi_metric_declare(const char* name, size_t nameLen, const char* type, const char* description, const char* customName)

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -31,7 +31,6 @@
 #include "dnsdist-metrics.hh"
 #include "dnsdist-lua-network.hh"
 #include "dnsdist-lua.hh"
-#include "dnsdist-ecs.hh"
 #include "dnsdist-rings.hh"
 #include "dnsdist-self-answers.hh"
 #include "dnsdist-svc.hh"
@@ -97,6 +96,7 @@ size_t dnsdist_ffi_dnsquestion_get_mac_addr(const dnsdist_ffi_dnsquestion_t* dq,
   if (dq == nullptr) {
     return 0;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   auto ret = dnsdist::MacAddressesCache::get(dq->dq->ids.origRemote, reinterpret_cast<unsigned char*>(buffer), bufferSize);
   if (ret != 0) {
     return 0;
@@ -114,7 +114,8 @@ uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t*
   return static_cast<uint64_t>(std::round(dq->dq->ids.queryRealTime.udiff()));
 }
 
-static bool checkDNSQuestionType(const char* functionName, const dnsdist_ffi_dnsquestion_t* dnsQuestion)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+static bool checkDNSQuestionType(const char functionName[], const dnsdist_ffi_dnsquestion_t* dnsQuestion)
 {
   if (dnsQuestion->objectType != dnsdist::lua::ffi::ObjectType::Question) {
     VERBOSESLOG(infolog("Error: calling FFI function %s with a wrong type", functionName),
@@ -124,7 +125,8 @@ static bool checkDNSQuestionType(const char* functionName, const dnsdist_ffi_dns
   return true;
 }
 
-static bool checkDNSResponseType(const char* functionName, const dnsdist_ffi_dnsresponse_t* dnsResponse)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+static bool checkDNSResponseType(const char functionName[], const dnsdist_ffi_dnsresponse_t* dnsResponse)
 {
   if (dnsResponse->objectType != dnsdist::lua::ffi::ObjectType::Response) {
     VERBOSESLOG(infolog("Error: calling FFI function %s with a wrong type", functionName),
@@ -136,7 +138,6 @@ static bool checkDNSResponseType(const char* functionName, const dnsdist_ffi_dns
 
 void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize, uint8_t bits)
 {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay): __func__ is what it is
   if (!checkDNSQuestionType(__func__, dq)) {
     return;
   }
@@ -252,19 +253,19 @@ dnsdist_ffi_protocol_type dnsdist_ffi_dnsquestion_get_protocol(const dnsdist_ffi
     if (proto == dnsdist::Protocol::DoUDP) {
       return dnsdist_ffi_protocol_type_doudp;
     }
-    else if (proto == dnsdist::Protocol::DoTCP) {
+    if (proto == dnsdist::Protocol::DoTCP) {
       return dnsdist_ffi_protocol_type_dotcp;
     }
-    else if (proto == dnsdist::Protocol::DNSCryptUDP) {
+    if (proto == dnsdist::Protocol::DNSCryptUDP) {
       return dnsdist_ffi_protocol_type_dnscryptudp;
     }
-    else if (proto == dnsdist::Protocol::DNSCryptTCP) {
+    if (proto == dnsdist::Protocol::DNSCryptTCP) {
       return dnsdist_ffi_protocol_type_dnscrypttcp;
     }
-    else if (proto == dnsdist::Protocol::DoT) {
+    if (proto == dnsdist::Protocol::DoT) {
       return dnsdist_ffi_protocol_type_dot;
     }
-    else if (proto == dnsdist::Protocol::DoH) {
+    if (proto == dnsdist::Protocol::DoH) {
       return dnsdist_ffi_protocol_type_doh;
     }
   }
@@ -467,13 +468,13 @@ static void fill_edns_option(const EDNSOptionViewValue& value, dnsdist_ffi_ednso
 }
 
 // returns the length of the resulting 'out' array. 'out' is not set if the length is 0
-size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_ednsoption_t** out)
+size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_ednsoption_t** out)
 {
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return 0U;
   }
 
-  auto ednsOptions = parseEDNSOptions(*(dq->dq));
+  auto ednsOptions = parseEDNSOptions(*(dnsQuestion->dq));
   if (!ednsOptions) {
     return 0;
   }
@@ -483,22 +484,22 @@ size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dq, c
     totalCount += option.second.values.size();
   }
 
-  if (!dq->ednsOptionsVect) {
-    dq->ednsOptionsVect = std::make_unique<std::vector<dnsdist_ffi_ednsoption_t>>();
+  if (!dnsQuestion->ednsOptionsVect) {
+    dnsQuestion->ednsOptionsVect = std::make_unique<std::vector<dnsdist_ffi_ednsoption_t>>();
   }
-  dq->ednsOptionsVect->clear();
-  dq->ednsOptionsVect->resize(totalCount);
+  dnsQuestion->ednsOptionsVect->clear();
+  dnsQuestion->ednsOptionsVect->resize(totalCount);
   size_t pos = 0;
   for (const auto& option : *ednsOptions) {
     for (const auto& entry : option.second.values) {
-      fill_edns_option(entry, dq->ednsOptionsVect->at(pos));
-      dq->ednsOptionsVect->at(pos).optionCode = option.first;
+      fill_edns_option(entry, dnsQuestion->ednsOptionsVect->at(pos));
+      dnsQuestion->ednsOptionsVect->at(pos).optionCode = option.first;
       pos++;
     }
   }
 
   if (totalCount > 0) {
-    *out = dq->ednsOptionsVect->data();
+    *out = dnsQuestion->ednsOptionsVect->data();
   }
 
   return totalCount;
@@ -555,34 +556,34 @@ size_t dnsdist_ffi_dnsquestion_get_http_headers([[maybe_unused]] dnsdist_ffi_dns
 #endif /* HAVE_DNS_OVER_HTTPS || HAVE_DNS_OVER_HTTP3 */
 }
 
-size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_tag_t** out)
+size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dnsQuestion, const dnsdist_ffi_tag_t** out)
 {
-  if (dq == nullptr || dq->dq == nullptr || dq->dq->ids.qTag == nullptr || dq->dq->ids.qTag->size() == 0) {
+  if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || dnsQuestion->dq->ids.qTag == nullptr || dnsQuestion->dq->ids.qTag->size() == 0) {
     return 0;
   }
-  if (!checkDNSQuestionType(__func__, dq)) {
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return 0U;
   }
 
-  if (!dq->tagsVect) {
-    dq->tagsVect = std::make_unique<std::vector<dnsdist_ffi_tag_t>>();
+  if (!dnsQuestion->tagsVect) {
+    dnsQuestion->tagsVect = std::make_unique<std::vector<dnsdist_ffi_tag_t>>();
   }
-  dq->tagsVect->clear();
-  dq->tagsVect->resize(dq->dq->ids.qTag->size());
+  dnsQuestion->tagsVect->clear();
+  dnsQuestion->tagsVect->resize(dnsQuestion->dq->ids.qTag->size());
   size_t pos = 0;
 
-  for (const auto& tag : *dq->dq->ids.qTag) {
-    auto& entry = dq->tagsVect->at(pos);
+  for (const auto& tag : *dnsQuestion->dq->ids.qTag) {
+    auto& entry = dnsQuestion->tagsVect->at(pos);
     entry.name = tag.first.c_str();
     entry.value = tag.second.c_str();
     ++pos;
   }
 
-  if (!dq->tagsVect->empty()) {
-    *out = dq->tagsVect->data();
+  if (!dnsQuestion->tagsVect->empty()) {
+    *out = dnsQuestion->tagsVect->data();
   }
 
-  return dq->tagsVect->size();
+  return dnsQuestion->tagsVect->size();
 }
 
 void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dq, const char* str, size_t strSize)
@@ -707,7 +708,7 @@ void dnsdist_ffi_dnsquestion_set_tag_raw(dnsdist_ffi_dnsquestion_t* dq, const ch
 
 void dnsdist_ffi_dnsquestion_set_requestor_id(dnsdist_ffi_dnsquestion_t* dq, const char* value, size_t valueSize)
 {
-  if (!dq || !dq->dq || !value) {
+  if (dq == nullptr || dq->dq == nullptr || value == nullptr) {
     return;
   }
   if (!dq->dq->ids.d_protoBufData) {
@@ -718,7 +719,7 @@ void dnsdist_ffi_dnsquestion_set_requestor_id(dnsdist_ffi_dnsquestion_t* dq, con
 
 void dnsdist_ffi_dnsquestion_set_device_id(dnsdist_ffi_dnsquestion_t* dq, const char* value, size_t valueSize)
 {
-  if (!dq || !dq->dq || !value) {
+  if (dq == nullptr || dq->dq == nullptr || value == nullptr) {
     return;
   }
   if (!dq->dq->ids.d_protoBufData) {
@@ -729,7 +730,7 @@ void dnsdist_ffi_dnsquestion_set_device_id(dnsdist_ffi_dnsquestion_t* dq, const 
 
 void dnsdist_ffi_dnsquestion_set_device_name(dnsdist_ffi_dnsquestion_t* dq, const char* value, size_t valueSize)
 {
-  if (!dq || !dq->dq || !value) {
+  if (dq == nullptr || dq->dq == nullptr || value == nullptr) {
     return;
   }
   if (!dq->dq->ids.d_protoBufData) {
@@ -775,6 +776,7 @@ void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dq, const dnsd
   data.reserve(valuesCount);
 
   for (size_t idx = 0; idx < valuesCount; idx++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     data.emplace_back(values[idx].value, values[idx].size);
   }
 
@@ -788,19 +790,23 @@ void dnsdist_ffi_dnsquestion_spoof_addrs(dnsdist_ffi_dnsquestion_t* dq, const dn
   data.reserve(valuesCount);
 
   for (size_t idx = 0; idx < valuesCount; idx++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     if (values[idx].size == 4) {
-      sockaddr_in sin;
+      sockaddr_in sin{};
       sin.sin_family = AF_INET;
       sin.sin_port = 0;
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       memcpy(&sin.sin_addr.s_addr, values[idx].value, sizeof(sin.sin_addr.s_addr));
       data.emplace_back(&sin);
     }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     else if (values[idx].size == 16) {
-      sockaddr_in6 sin6;
+      sockaddr_in6 sin6{};
       sin6.sin6_family = AF_INET6;
       sin6.sin6_port = 0;
       sin6.sin6_scope_id = 0;
       sin6.sin6_flowinfo = 0;
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       memcpy(&sin6.sin6_addr.s6_addr, values[idx].value, sizeof(sin6.sin6_addr.s6_addr));
       data.emplace_back(&sin6);
     }
@@ -1007,14 +1013,14 @@ bool dnsdist_ffi_dnsresponse_set_async(dnsdist_ffi_dnsresponse_t* dnsResponse, u
 
   try {
     dnsResponse->dr->asynchronous = true;
-    auto dr = dynamic_cast<DNSResponse*>(dnsResponse->dr);
-    if (!dr) {
+    auto* drPtr = dnsResponse->dr;
+    if (drPtr == nullptr) {
       VERBOSESLOG(infolog("Passed a DNSQuestion instead of a DNSResponse to dnsdist_ffi_dnsresponse_set_async"),
                   getLogger(__func__)->info(Logr::Info, "Passed a DNSQuestion instead of a DNSResponse"));
       return false;
     }
 
-    return dnsdist::suspendResponse(*dr, asyncID, queryID, timeoutMs);
+    return dnsdist::suspendResponse(*drPtr, asyncID, queryID, timeoutMs);
   }
   catch (const std::exception& e) {
     VERBOSESLOG(infolog("Error in dnsdist_ffi_dnsresponse_set_async: %s", e.what()),
@@ -1188,7 +1194,7 @@ bool dnsdist_ffi_drop_from_async(uint16_t asyncID, uint16_t queryID)
     return false;
   }
 
-  struct timeval now;
+  timeval now{};
   gettimeofday(&now, nullptr);
   TCPResponse tresponse(std::move(query->query));
   sender->notifyIOError(now, std::move(tresponse));
@@ -1215,6 +1221,7 @@ bool dnsdist_ffi_set_answer_from_async(uint16_t asyncID, uint16_t queryID, const
   dnsheader_aligned alignedHeader(query->query.d_buffer.data());
   auto oldID = alignedHeader->id;
   query->query.d_buffer.clear();
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,cppcoreguidelines-pro-bounds-pointer-arithmetic)
   query->query.d_buffer.insert(query->query.d_buffer.begin(), raw, raw + rawSize);
 
   dnsdist::PacketMangling::editDNSHeaderFromPacket(query->query.d_buffer, [oldID](dnsheader& header) {
@@ -1226,6 +1233,7 @@ bool dnsdist_ffi_set_answer_from_async(uint16_t asyncID, uint16_t queryID, const
   return dnsdist::queueQueryResumptionEvent(std::move(query));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 static constexpr char s_lua_ffi_code[] = R"FFICodeContent(
   local ffi = require("ffi")
   local C = ffi.C
@@ -1240,6 +1248,7 @@ static constexpr char s_lua_ffi_code[] = R"FFICodeContent(
 
 const char* getLuaFFIWrappers()
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   return s_lua_ffi_code;
 }
 
@@ -1269,13 +1278,16 @@ void setupLuaFFIPerThreadContext(LuaContext& luaCtx)
 size_t dnsdist_ffi_generate_proxy_protocol_payload(const size_t addrSize, const void* srcAddr, const void* dstAddr, const uint16_t srcPort, const uint16_t dstPort, const bool tcp, const size_t valuesCount, const dnsdist_ffi_proxy_protocol_value* values, void* out, const size_t outSize)
 {
   try {
-    ComboAddress src, dst;
+    ComboAddress src;
+    ComboAddress dst;
     if (addrSize != sizeof(src.sin4.sin_addr) && addrSize != sizeof(src.sin6.sin6_addr.s6_addr)) {
       return 0;
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     src = makeComboAddressFromRaw(addrSize == sizeof(src.sin4.sin_addr) ? 4 : 6, reinterpret_cast<const char*>(srcAddr), addrSize);
     src.sin4.sin_port = htons(srcPort);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     dst = makeComboAddressFromRaw(addrSize == sizeof(dst.sin4.sin_addr) ? 4 : 6, reinterpret_cast<const char*>(dstAddr), addrSize);
     dst.sin4.sin_port = htons(dstPort);
 

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -114,8 +114,32 @@ uint64_t dnsdist_ffi_dnsquestion_get_elapsed_us(const dnsdist_ffi_dnsquestion_t*
   return static_cast<uint64_t>(std::round(dq->dq->ids.queryRealTime.udiff()));
 }
 
+static bool checkDNSQuestionType(const char* functionName, const dnsdist_ffi_dnsquestion_t* dnsQuestion)
+{
+  if (dnsQuestion->objectType != dnsdist::lua::ffi::ObjectType::Question) {
+    VERBOSESLOG(infolog("Error: calling FFI function %s with a wrong type", functionName),
+                getLogger(functionName)->info(Logr::Info, "Error: calling FFI function with a wrong type"));
+    return false;
+  }
+  return true;
+}
+
+static bool checkDNSResponseType(const char* functionName, const dnsdist_ffi_dnsresponse_t* dnsResponse)
+{
+  if (dnsResponse->objectType != dnsdist::lua::ffi::ObjectType::Response) {
+    VERBOSESLOG(infolog("Error: calling FFI function %s with a wrong type", functionName),
+                getLogger(functionName)->info(Logr::Info, "Error: calling FFI function with a wrong type"));
+    return false;
+  }
+  return true;
+}
+
 void dnsdist_ffi_dnsquestion_get_masked_remoteaddr(dnsdist_ffi_dnsquestion_t* dq, const void** addr, size_t* addrSize, uint8_t bits)
 {
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return;
+  }
+
   dq->maskedRemote = Netmask(dq->dq->ids.origRemote, bits).getMaskedNetwork();
   dnsdist_ffi_comboaddress_to_raw(dq->maskedRemote, addr, addrSize);
 }
@@ -337,6 +361,10 @@ size_t dnsdist_ffi_dnsquestion_get_tag_raw(const dnsdist_ffi_dnsquestion_t* dq, 
 
 const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dq)
 {
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return nullptr;
+  }
+
   if (!dq->httpPath) {
     if (dq->dq->ids.du) {
 #if defined(HAVE_DNS_OVER_HTTPS)
@@ -357,6 +385,10 @@ const char* dnsdist_ffi_dnsquestion_get_http_path(dnsdist_ffi_dnsquestion_t* dq)
 
 const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestion_t* dq)
 {
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return nullptr;
+  }
+
   if (!dq->httpQueryString) {
     if (dq->dq->ids.du) {
 #ifdef HAVE_DNS_OVER_HTTPS
@@ -377,6 +409,10 @@ const char* dnsdist_ffi_dnsquestion_get_http_query_string(dnsdist_ffi_dnsquestio
 
 const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dq)
 {
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return nullptr;
+  }
+
   if (!dq->httpHost) {
     if (dq->dq->ids.du) {
 #ifdef HAVE_DNS_OVER_HTTPS
@@ -397,6 +433,10 @@ const char* dnsdist_ffi_dnsquestion_get_http_host(dnsdist_ffi_dnsquestion_t* dq)
 
 const char* dnsdist_ffi_dnsquestion_get_http_scheme(dnsdist_ffi_dnsquestion_t* dq)
 {
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return nullptr;
+  }
+
   if (!dq->httpScheme) {
     if (dq->dq->ids.du) {
 #ifdef HAVE_DNS_OVER_HTTPS
@@ -428,6 +468,10 @@ static void fill_edns_option(const EDNSOptionViewValue& value, dnsdist_ffi_ednso
 // returns the length of the resulting 'out' array. 'out' is not set if the length is 0
 size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_ednsoption_t** out)
 {
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return 0U;
+  }
+
   auto ednsOptions = parseEDNSOptions(*(dq->dq));
   if (!ednsOptions) {
     return 0;
@@ -462,6 +506,10 @@ size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dq, c
 size_t dnsdist_ffi_dnsquestion_get_http_headers([[maybe_unused]] dnsdist_ffi_dnsquestion_t* ref, [[maybe_unused]] const dnsdist_ffi_http_header_t** out)
 {
 #if defined(HAVE_DNS_OVER_HTTPS) || defined(HAVE_DNS_OVER_HTTP3)
+  if (!checkDNSQuestionType(__func__, ref)) {
+    return 0U;
+  }
+
   const auto processHeaders = [&ref](const std::unordered_map<std::string, std::string>& headers) {
     if (headers.empty()) {
       return;
@@ -511,6 +559,9 @@ size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dq, cons
   if (dq == nullptr || dq->dq == nullptr || dq->dq->ids.qTag == nullptr || dq->dq->ids.qTag->size() == 0) {
     return 0;
   }
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return 0U;
+  }
 
   if (!dq->tagsVect) {
     dq->tagsVect = std::make_unique<std::vector<dnsdist_ffi_tag_t>>();
@@ -535,6 +586,9 @@ size_t dnsdist_ffi_dnsquestion_get_tag_array(dnsdist_ffi_dnsquestion_t* dq, cons
 
 void dnsdist_ffi_dnsquestion_set_result(dnsdist_ffi_dnsquestion_t* dq, const char* str, size_t strSize)
 {
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return;
+  }
   dq->result = std::string(str, strSize);
 }
 
@@ -685,6 +739,9 @@ void dnsdist_ffi_dnsquestion_set_device_name(dnsdist_ffi_dnsquestion_t* dq, cons
 
 size_t dnsdist_ffi_dnsquestion_get_trailing_data(dnsdist_ffi_dnsquestion_t* dq, const char** out)
 {
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return 0U;
+  }
   dq->trailingData = dq->dq->getTrailingData();
   if (!dq->trailingData.empty()) {
     *out = dq->trailingData.data();
@@ -847,6 +904,10 @@ void dnsdist_ffi_dnsresponse_set_max_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t
 void dnsdist_ffi_dnsresponse_limit_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t min, uint32_t max)
 {
   if (dr != nullptr && dr->dr != nullptr) {
+    if (!checkDNSResponseType(__func__, dr)) {
+      return;
+    }
+
     dnsdist::PacketMangling::restrictDNSPacketTTLs(dr->dr->getMutableData(), min, max);
   }
 }
@@ -854,6 +915,9 @@ void dnsdist_ffi_dnsresponse_limit_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t m
 void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dr, uint32_t max)
 {
   if (dr != nullptr && dr->dr != nullptr) {
+    if (!checkDNSResponseType(__func__, dr)) {
+      return;
+    }
     dr->dr->ids.ttlCap = max;
   }
 }
@@ -861,6 +925,9 @@ void dnsdist_ffi_dnsresponse_set_max_returned_ttl(dnsdist_ffi_dnsresponse_t* dr,
 void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dr, uint16_t qtype)
 {
   if (dr != nullptr && dr->dr != nullptr) {
+    if (!checkDNSResponseType(__func__, dr)) {
+      return;
+    }
     clearDNSPacketRecordTypes(dr->dr->getMutableData(), std::unordered_set<QType>{qtype});
   }
 }
@@ -868,6 +935,9 @@ void dnsdist_ffi_dnsresponse_clear_records_type(dnsdist_ffi_dnsresponse_t* dr, u
 bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dr, const char* initialName, size_t initialNameSize)
 {
   if (dr == nullptr || dr->dr == nullptr || initialName == nullptr || initialNameSize == 0) {
+    return false;
+  }
+  if (!checkDNSResponseType(__func__, dr)) {
     return false;
   }
 
@@ -893,16 +963,25 @@ bool dnsdist_ffi_dnsresponse_rebase(dnsdist_ffi_dnsresponse_t* dr, const char* i
 
 bool dnsdist_ffi_dnsresponse_get_stale_cache_hit(const dnsdist_ffi_dnsresponse_t* dnsResponse)
 {
+  if (!checkDNSResponseType(__func__, dnsResponse)) {
+    return false;
+  }
   return dnsResponse->dr->ids.staleCacheHit;
 }
 
 uint8_t dnsdist_ffi_dnsresponse_get_restart_count(const dnsdist_ffi_dnsresponse_t* dnsResponse)
 {
+  if (!checkDNSResponseType(__func__, dnsResponse)) {
+    return 0U;
+  }
   return dnsResponse->dr->ids.restartCount;
 }
 
 bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs)
 {
+  if (!checkDNSQuestionType(__func__, dq)) {
+    return false;
+  }
   try {
     dq->dq->asynchronous = true;
     return dnsdist::suspendQuery(*dq->dq, asyncID, queryID, timeoutMs);
@@ -919,11 +998,15 @@ bool dnsdist_ffi_dnsquestion_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t a
   return false;
 }
 
-bool dnsdist_ffi_dnsresponse_set_async(dnsdist_ffi_dnsquestion_t* dq, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs)
+bool dnsdist_ffi_dnsresponse_set_async(dnsdist_ffi_dnsresponse_t* dnsResponse, uint16_t asyncID, uint16_t queryID, uint32_t timeoutMs)
 {
+  if (!checkDNSResponseType(__func__, dnsResponse)) {
+    return false;
+  }
+
   try {
-    dq->dq->asynchronous = true;
-    auto dr = dynamic_cast<DNSResponse*>(dq->dq);
+    dnsResponse->dr->asynchronous = true;
+    auto dr = dynamic_cast<DNSResponse*>(dnsResponse->dr);
     if (!dr) {
       VERBOSESLOG(infolog("Passed a DNSQuestion instead of a DNSResponse to dnsdist_ffi_dnsresponse_set_async"),
                   getLogger(__func__)->info(Logr::Info, "Passed a DNSQuestion instead of a DNSResponse"));
@@ -1269,6 +1352,10 @@ size_t dnsdist_ffi_dnsquestion_get_proxy_protocol_values(dnsdist_ffi_dnsquestion
 {
   if (dnsQuestion == nullptr || dnsQuestion->dq == nullptr || !dnsQuestion->dq->proxyProtocolValues || out == nullptr) {
     return 0;
+  }
+
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
+    return 0U;
   }
 
   dnsQuestion->proxyProtocolValuesVect = std::make_unique<std::vector<dnsdist_ffi_proxy_protocol_value_t>>(dnsQuestion->dq->proxyProtocolValues->size());
@@ -2474,6 +2561,9 @@ void dnsdist_ffi_dnsquestion_meta_begin_key([[maybe_unused]] dnsdist_ffi_dnsques
   if (dnsQuestion == nullptr || key == nullptr || keyLen == 0) {
     return;
   }
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
+    return;
+  }
 
   if (dnsQuestion->pbfWriter.valid()) {
     VERBOSESLOG(infolog("Error in dnsdist_ffi_dnsquestion_meta_begin_key: the previous key has not been ended"),
@@ -2494,6 +2584,9 @@ void dnsdist_ffi_dnsquestion_meta_add_str_value_to_key([[maybe_unused]] dnsdist_
   if (dnsQuestion == nullptr || value == nullptr || valueLen == 0) {
     return;
   }
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
+    return;
+  }
 
   if (!dnsQuestion->pbfMetaValueWriter.valid()) {
     VERBOSESLOG(infolog("Error in dnsdist_ffi_dnsquestion_meta_add_str_value_to_key: trying to add a value without starting a key"),
@@ -2511,6 +2604,9 @@ void dnsdist_ffi_dnsquestion_meta_add_int64_value_to_key([[maybe_unused]] dnsdis
   if (dnsQuestion == nullptr) {
     return;
   }
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
+    return;
+  }
 
   if (!dnsQuestion->pbfMetaValueWriter.valid()) {
     VERBOSESLOG(infolog("Error in dnsdist_ffi_dnsquestion_meta_add_int64_value_to_key: trying to add a value without starting a key"),
@@ -2526,6 +2622,9 @@ void dnsdist_ffi_dnsquestion_meta_end_key([[maybe_unused]] dnsdist_ffi_dnsquesti
 {
 #if !defined(DISABLE_PROTOBUF)
   if (dnsQuestion == nullptr) {
+    return;
+  }
+  if (!checkDNSQuestionType(__func__, dnsQuestion)) {
     return;
   }
 
@@ -2555,6 +2654,10 @@ void dnsdist_ffi_dnsresponse_meta_begin_key([[maybe_unused]] dnsdist_ffi_dnsresp
     return;
   }
 
+  if (!checkDNSResponseType(__func__, dnsResponse)) {
+    return;
+  }
+
   if (dnsResponse->pbfWriter.valid()) {
     VERBOSESLOG(infolog("Error in dnsdist_ffi_dnsresponse_meta_begin_key: the previous key has not been ended"),
                 getLogger(__func__)->info(Logr::Info, "Error ending meta key for response : the previous key has not been ended"));
@@ -2575,6 +2678,10 @@ void dnsdist_ffi_dnsresponse_meta_add_str_value_to_key([[maybe_unused]] dnsdist_
     return;
   }
 
+  if (!checkDNSResponseType(__func__, dnsResponse)) {
+    return;
+  }
+
   if (!dnsResponse->pbfMetaValueWriter.valid()) {
     VERBOSESLOG(infolog("Error in dnsdist_ffi_dnsresponse_meta_add_str_value_to_key: trying to add a value without starting a key"),
                 getLogger(__func__)->info(Logr::Info, "Error adding meta value: the key has not been started"));
@@ -2592,6 +2699,10 @@ void dnsdist_ffi_dnsresponse_meta_add_int64_value_to_key([[maybe_unused]] dnsdis
     return;
   }
 
+  if (!checkDNSResponseType(__func__, dnsResponse)) {
+    return;
+  }
+
   if (!dnsResponse->pbfMetaValueWriter.valid()) {
     VERBOSESLOG(infolog("Error in dnsdist_ffi_dnsresponse_meta_add_int64_value_to_key: trying to add a value without starting a key"),
                 getLogger(__func__)->info(Logr::Info, "Error adding meta value: the key has not been started"));
@@ -2606,6 +2717,10 @@ void dnsdist_ffi_dnsresponse_meta_end_key([[maybe_unused]] dnsdist_ffi_dnsrespon
 {
 #if !defined(DISABLE_PROTOBUF)
   if (dnsResponse == nullptr) {
+    return;
+  }
+
+  if (!checkDNSResponseType(__func__, dnsResponse)) {
     return;
   }
 

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.hh
@@ -45,6 +45,15 @@ struct LuaContext::Pusher<dnsdist_ffi_dnsquestion_t*>
   }
 };
 
+namespace dnsdist::lua::ffi
+{
+enum class ObjectType : uint64_t
+{
+  Question = 1,
+  Response = 2,
+};
+}
+
 struct dnsdist_ffi_dnsquestion_t
 {
   dnsdist_ffi_dnsquestion_t(DNSQuestion* dq_) :
@@ -53,6 +62,7 @@ struct dnsdist_ffi_dnsquestion_t
   }
 
   DNSQuestion* dq{nullptr};
+  const dnsdist::lua::ffi::ObjectType objectType{dnsdist::lua::ffi::ObjectType::Question};
   ComboAddress maskedRemote;
   std::string trailingData;
   std::optional<std::string> result{std::nullopt};
@@ -94,6 +104,7 @@ struct dnsdist_ffi_dnsresponse_t
   }
 
   DNSResponse* dr{nullptr};
+  const dnsdist::lua::ffi::ObjectType objectType{dnsdist::lua::ffi::ObjectType::Response};
   std::optional<std::string> result{std::nullopt};
 #if !defined(DISABLE_PROTOBUF)
   protozero::pbf_writer pbfWriter{};
@@ -101,6 +112,9 @@ struct dnsdist_ffi_dnsresponse_t
   protozero::pbf_writer pbfMetaValueWriter{};
 #endif /* DISABLE_PROTOBUF */
 };
+
+static_assert(offsetof(dnsdist_ffi_dnsresponse_t, dr) == offsetof(dnsdist_ffi_dnsquestion_t, dq), "The DNSQuestion object in dnsdist_ffi_dnsquestion_t and DNSResponse object in dnsdist_ffi_dnsresponse_t must have the same offset");
+static_assert(offsetof(dnsdist_ffi_dnsresponse_t, objectType) == offsetof(dnsdist_ffi_dnsquestion_t, objectType), "The object type in dnsdist_ffi_dnsquestion_t and dnsdist_ffi_dnsresponse_t must have the same offset");
 
 // dnsdist_ffi_server_t is a lightuserdata
 template <>

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.hh
@@ -49,8 +49,8 @@ namespace dnsdist::lua::ffi
 {
 enum class ObjectType : uint64_t
 {
-  Question = 1,
-  Response = 2,
+  Question = 0xaa55aa55,
+  Response = 0x55aa55aa,
 };
 }
 
@@ -113,8 +113,8 @@ struct dnsdist_ffi_dnsresponse_t
 #endif /* DISABLE_PROTOBUF */
 };
 
-static_assert(offsetof(dnsdist_ffi_dnsresponse_t, dr) == offsetof(dnsdist_ffi_dnsquestion_t, dq), "The DNSQuestion object in dnsdist_ffi_dnsquestion_t and DNSResponse object in dnsdist_ffi_dnsresponse_t must have the same offset");
-static_assert(offsetof(dnsdist_ffi_dnsresponse_t, objectType) == offsetof(dnsdist_ffi_dnsquestion_t, objectType), "The object type in dnsdist_ffi_dnsquestion_t and dnsdist_ffi_dnsresponse_t must have the same offset");
+static_assert(offsetof(dnsdist_ffi_dnsresponse_t, dr) == offsetof(dnsdist_ffi_dnsquestion_t, dq), "The DNSQuestion object in dnsdist_ffi_dnsquestion_t and DNSResponse object in dnsdist_ffi_dnsresponse_t must be located at the same offset");
+static_assert(offsetof(dnsdist_ffi_dnsresponse_t, objectType) == offsetof(dnsdist_ffi_dnsquestion_t, objectType), "The object type in dnsdist_ffi_dnsquestion_t and dnsdist_ffi_dnsresponse_t must be located at the same offset");
 
 // dnsdist_ffi_server_t is a lightuserdata
 template <>

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -1195,4 +1195,29 @@ BOOST_AUTO_TEST_CASE(test_set_altername_name)
   BOOST_CHECK(dnsdist_ffi_dnsquestion_set_alternate_name(&lightDQ, target.getStorage().data(), target.getStorage().size(), tag.data(), tag.size(), nullptr, 0, nullptr, 0));
 }
 
+BOOST_AUTO_TEST_CASE(query_response_pointer_mismatch)
+{
+  InternalQueryState ids;
+  ids.origRemote = ComboAddress("192.0.2.1:4242");
+  ids.origDest = ComboAddress("192.0.2.255:53");
+  ids.qtype = QType::A;
+  ids.qclass = QClass::IN;
+  ids.protocol = dnsdist::Protocol::DoUDP;
+  ids.qname = DNSName("www.powerdns.com.");
+  ids.queryRealTime.start();
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, ids.qname, QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+  pwQ.getHeader()->id = htons(42);
+
+  DNSResponse dnsResponse(ids, query, nullptr);
+  dnsdist_ffi_dnsresponse_t lightDR(&dnsResponse);
+
+  const char* buffer = nullptr;
+  size_t bufferSize = 0;
+  dnsdist_ffi_dnsquestion_get_masked_remoteaddr(reinterpret_cast<dnsdist_ffi_dnsquestion_t*>(&lightDR), reinterpret_cast<const void**>(&buffer), &bufferSize, 16);
+  BOOST_CHECK(buffer == nullptr);
+  BOOST_CHECK_EQUAL(bufferSize, 0U);
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -59,9 +59,9 @@ BOOST_AUTO_TEST_CASE(test_Query)
   pwQ.getHeader()->rd = 1;
   pwQ.getHeader()->id = htons(42);
 
-  DNSQuestion dq(ids, query);
-  dnsdist_ffi_dnsquestion_t lightDQ(&dq);
-  const auto initialData = dq.getData();
+  DNSQuestion dnsQuestion(ids, query);
+  dnsdist_ffi_dnsquestion_t lightDQ(&dnsQuestion);
+  const auto initialData = dnsQuestion.getData();
 
   {
     // dnsdist_ffi_dnsquestion_get_qtype
@@ -83,6 +83,7 @@ BOOST_AUTO_TEST_CASE(test_Query)
     // dnsdist_ffi_dnsquestion_get_localaddr, dnsdist_ffi_dnsquestion_get_local_port
     const char* buffer = nullptr;
     size_t bufferSize = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     dnsdist_ffi_dnsquestion_get_localaddr(&lightDQ, reinterpret_cast<const void**>(&buffer), &bufferSize);
     BOOST_REQUIRE(buffer != nullptr);
     BOOST_REQUIRE_EQUAL(bufferSize, sizeof(ids.origDest.sin4.sin_addr.s_addr));
@@ -94,6 +95,7 @@ BOOST_AUTO_TEST_CASE(test_Query)
     // dnsdist_ffi_dnsquestion_get_remoteaddr, dnsdist_ffi_dnsquestion_get_remote_port
     const char* buffer = nullptr;
     size_t bufferSize = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     dnsdist_ffi_dnsquestion_get_remoteaddr(&lightDQ, reinterpret_cast<const void**>(&buffer), &bufferSize);
     BOOST_REQUIRE(buffer != nullptr);
     BOOST_REQUIRE_EQUAL(bufferSize, sizeof(ids.origRemote.sin4.sin_addr.s_addr));
@@ -107,6 +109,7 @@ BOOST_AUTO_TEST_CASE(test_Query)
     // dnsdist_ffi_dnsquestion_get_masked_remoteaddr
     const char* buffer = nullptr;
     size_t bufferSize = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     dnsdist_ffi_dnsquestion_get_masked_remoteaddr(&lightDQ, reinterpret_cast<const void**>(&buffer), &bufferSize, 16);
     BOOST_REQUIRE(buffer != nullptr);
     auto masked = Netmask(ids.origRemote, 16).getMaskedNetwork();
@@ -115,16 +118,15 @@ BOOST_AUTO_TEST_CASE(test_Query)
   }
 
   {
-    const char* buffer[6];
-    size_t bufferSize = 6;
+    std::array<char, 6> buffer{};
 
     // invalid
-    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_mac_addr(nullptr, buffer, 0), 0U);
+    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_mac_addr(nullptr, buffer.data(), 0), 0U);
     // too small
-    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_mac_addr(&lightDQ, buffer, 0), 0U);
+    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_mac_addr(&lightDQ, buffer.data(), 0), 0U);
 
     // we will not find the corresponding MAC address in /proc/net/arp, unfortunately, especially not on !linux
-    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_mac_addr(&lightDQ, buffer, bufferSize), 0U);
+    BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_mac_addr(&lightDQ, buffer.data(), buffer.size()), 0U);
   }
 
   {
@@ -144,6 +146,7 @@ BOOST_AUTO_TEST_CASE(test_Query)
 
     const char* buffer = nullptr;
     size_t bufferSize = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     dnsdist_ffi_dnsquestion_get_remoteaddr(&lightDQ, reinterpret_cast<const void**>(&buffer), &bufferSize);
     BOOST_REQUIRE(buffer != nullptr);
     BOOST_REQUIRE_EQUAL(bufferSize, sizeof(ids.origRemote.sin6.sin6_addr.s6_addr));
@@ -212,7 +215,7 @@ BOOST_AUTO_TEST_CASE(test_Query)
 
     BOOST_CHECK(static_cast<uint8_t>(dnsdist_ffi_dnsquestion_get_protocol(&lightDQ)) == dnsdist::Protocol(dnsdist::Protocol::DoUDP).toNumber());
     for (const auto protocol : {dnsdist::Protocol::DoUDP, dnsdist::Protocol::DoTCP, dnsdist::Protocol::DNSCryptUDP, dnsdist::Protocol::DNSCryptTCP, dnsdist::Protocol::DoT, dnsdist::Protocol::DoH}) {
-      dq.ids.protocol = protocol;
+      dnsQuestion.ids.protocol = protocol;
       BOOST_CHECK(static_cast<uint8_t>(dnsdist_ffi_dnsquestion_get_protocol(&lightDQ)) == protocol);
     }
   }
@@ -278,20 +281,21 @@ BOOST_AUTO_TEST_CASE(test_Query)
   }
 
   {
-    dq.getMutableData() = initialData;
-    const auto oldData = dq.getData();
+    dnsQuestion.getMutableData() = initialData;
+    const auto oldData = dnsQuestion.getData();
     std::vector<dnsdist_ffi_raw_value> values;
-    ComboAddress v4("192.0.2.1");
-    ComboAddress v6("[2001:db8::42]");
+    ComboAddress v4Addr("192.0.2.1");
+    ComboAddress v6Addr("[2001:db8::42]");
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    values.push_back({reinterpret_cast<const char*>(&v4.sin4.sin_addr.s_addr), sizeof(v4.sin4.sin_addr.s_addr)});
+    values.push_back({reinterpret_cast<const char*>(&v4Addr.sin4.sin_addr.s_addr), sizeof(v4Addr.sin4.sin_addr.s_addr)});
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    values.push_back({reinterpret_cast<const char*>(&v6.sin6.sin6_addr.s6_addr), sizeof(v6.sin6.sin6_addr.s6_addr)});
+    values.push_back({reinterpret_cast<const char*>(&v6Addr.sin6.sin6_addr.s6_addr), sizeof(v6Addr.sin6.sin6_addr.s6_addr)});
 
     dnsdist_ffi_dnsquestion_spoof_addrs(&lightDQ, values.data(), values.size());
-    BOOST_CHECK(dq.getData().size() > oldData.size());
+    BOOST_CHECK(dnsQuestion.getData().size() > oldData.size());
 
-    MOADNSParser mdp(false, reinterpret_cast<const char*>(dq.getData().data()), dq.getData().size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    MOADNSParser mdp(false, reinterpret_cast<const char*>(dnsQuestion.getData().data()), dnsQuestion.getData().size());
     BOOST_CHECK_EQUAL(mdp.d_qname, ids.qname);
     BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
     /* only the A has been added since the query was not ANY */
@@ -304,7 +308,7 @@ BOOST_AUTO_TEST_CASE(test_Query)
     BOOST_CHECK_EQUAL(mdp.d_answers.at(0).d_class, QClass::IN);
     BOOST_CHECK_EQUAL(mdp.d_answers.at(0).d_name, ids.qname);
 
-    dq.getMutableData() = oldData;
+    dnsQuestion.getMutableData() = oldData;
   }
 
   {
@@ -333,14 +337,16 @@ BOOST_AUTO_TEST_CASE(test_Query)
 
     dnsdist_ffi_dnsquestion_set_tag(&lightDQ, tagName.c_str(), tagValue.c_str());
 
-    auto got = dnsdist_ffi_dnsquestion_get_tag(&lightDQ, tagName.c_str());
+    const auto* got = dnsdist_ffi_dnsquestion_get_tag(&lightDQ, tagName.c_str());
     BOOST_CHECK(got != nullptr);
     BOOST_CHECK_EQUAL(got, tagValue.c_str());
 
     const dnsdist_ffi_tag_t* tags = nullptr;
     BOOST_CHECK_EQUAL(dnsdist_ffi_dnsquestion_get_tag_array(nullptr, nullptr), 0U);
     BOOST_REQUIRE_EQUAL(dnsdist_ffi_dnsquestion_get_tag_array(&lightDQ, &tags), 1U);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): it's the API
     BOOST_CHECK_EQUAL(std::string(tags[0].name), tagName.c_str());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): it's the API
     BOOST_CHECK_EQUAL(std::string(tags[0].value), tagValue.c_str());
 
     dnsdist_ffi_dnsquestion_unset_tag(&lightDQ, tagName.c_str());
@@ -433,10 +439,10 @@ BOOST_AUTO_TEST_CASE(test_Response)
   pwR.getHeader()->id = htons(42);
 
   ComboAddress dsAddr("192.0.2.1:53");
-  auto ds = std::make_shared<DownstreamState>(dsAddr);
+  auto downstream = std::make_shared<DownstreamState>(dsAddr);
 
-  DNSResponse dr(ids, response, ds);
-  dnsdist_ffi_dnsresponse_t lightDR(&dr);
+  DNSResponse dnsResponse(ids, response, downstream);
+  dnsdist_ffi_dnsresponse_t lightDR(&dnsResponse);
 
   {
     dnsdist_ffi_dnsresponse_set_min_ttl(&lightDR, 42);
@@ -479,8 +485,8 @@ BOOST_AUTO_TEST_CASE(test_Response)
 BOOST_AUTO_TEST_CASE(test_Server)
 {
   ComboAddress dsAddr("192.0.2.1:53");
-  auto ds = std::make_shared<DownstreamState>(dsAddr);
-  dnsdist_ffi_server_t server(ds);
+  auto downstream = std::make_shared<DownstreamState>(dsAddr);
+  dnsdist_ffi_server_t server(downstream);
 
   BOOST_CHECK_EQUAL(dnsdist_ffi_server_get_outstanding(&server), 0U);
   BOOST_CHECK_EQUAL(dnsdist_ffi_server_is_up(&server), false);
@@ -520,9 +526,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCache)
   uint32_t key = 0;
   std::optional<Netmask> subnet;
   ids.queryRealTime.start();
-  DNSQuestion dq(ids, query);
-  packetCache->get(dq, 0, &key, subnet, dnssecOK, receivedOverUDP);
-  packetCache->insert(key, subnet, *(getFlagsFromDNSHeader(dq.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
+  DNSQuestion dnsQuestion(ids, query);
+  packetCache->get(dnsQuestion, 0, &key, subnet, dnssecOK, receivedOverUDP);
+  packetCache->insert(key, subnet, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnssecOK, ids.qname, QType::A, QClass::IN, response, receivedOverUDP, 0, std::nullopt);
 
   std::string poolName("test-pool");
   auto testPool = ServerPool();
@@ -603,8 +609,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCache)
 
 BOOST_AUTO_TEST_CASE(test_ProxyProtocol)
 {
-  ComboAddress v4("192.0.2.1");
-  ComboAddress v6("[2001:db8::42]");
+  ComboAddress v4Addr("192.0.2.1");
+  ComboAddress v6Addr("[2001:db8::42]");
 
   std::vector<dnsdist_ffi_proxy_protocol_value> values;
   values.push_back({"test-value", 10U, 1U});
@@ -614,18 +620,18 @@ BOOST_AUTO_TEST_CASE(test_ProxyProtocol)
 
   {
     // too small buffer
-    auto got = dnsdist_ffi_generate_proxy_protocol_payload(sizeof(v4.sin4.sin_addr.s_addr), &v4.sin4.sin_addr.s_addr, &v4.sin4.sin_addr.s_addr, 4242U, 53U, true, values.size(), values.data(), output.data(), 0);
+    auto got = dnsdist_ffi_generate_proxy_protocol_payload(sizeof(v4Addr.sin4.sin_addr.s_addr), &v4Addr.sin4.sin_addr.s_addr, &v4Addr.sin4.sin_addr.s_addr, 4242U, 53U, true, values.size(), values.data(), output.data(), 0);
     BOOST_CHECK_EQUAL(got, 0U);
   }
 
   {
     // invalid address size
-    auto got = dnsdist_ffi_generate_proxy_protocol_payload(0U, &v4.sin4.sin_addr.s_addr, &v4.sin4.sin_addr.s_addr, 4242U, 53U, true, values.size(), values.data(), output.data(), 0);
+    auto got = dnsdist_ffi_generate_proxy_protocol_payload(0U, &v4Addr.sin4.sin_addr.s_addr, &v4Addr.sin4.sin_addr.s_addr, 4242U, 53U, true, values.size(), values.data(), output.data(), 0);
     BOOST_CHECK_EQUAL(got, 0U);
   }
 
   {
-    auto got = dnsdist_ffi_generate_proxy_protocol_payload(sizeof(v4.sin4.sin_addr.s_addr), &v4.sin4.sin_addr.s_addr, &v4.sin4.sin_addr.s_addr, 4242U, 53U, true, values.size(), values.data(), output.data(), output.size());
+    auto got = dnsdist_ffi_generate_proxy_protocol_payload(sizeof(v4Addr.sin4.sin_addr.s_addr), &v4Addr.sin4.sin_addr.s_addr, &v4Addr.sin4.sin_addr.s_addr, 4242U, 53U, true, values.size(), values.data(), output.data(), output.size());
     BOOST_CHECK_EQUAL(got, 41U);
   }
 }
@@ -740,12 +746,12 @@ BOOST_AUTO_TEST_CASE(test_PacketOverlay)
   pwR.getHeader()->ra = 1;
   pwR.getHeader()->id = htons(42);
   pwR.startRecord(target, QType::A, 7200, QClass::IN, DNSResourceRecord::ANSWER);
-  ComboAddress v4("192.0.2.1");
-  pwR.xfrCAWithoutPort(4, v4);
+  ComboAddress v4Addr("192.0.2.1");
+  pwR.xfrCAWithoutPort(4, v4Addr);
   pwR.commit();
   pwR.startRecord(target, QType::AAAA, 7200, QClass::IN, DNSResourceRecord::ADDITIONAL);
-  ComboAddress v6("2001:db8::1");
-  pwR.xfrCAWithoutPort(6, v6);
+  ComboAddress v6Addr("2001:db8::1");
+  pwR.xfrCAWithoutPort(6, v6Addr);
   pwR.commit();
   pwR.addOpt(4096, 0, 0);
   pwR.commit();
@@ -755,7 +761,9 @@ BOOST_AUTO_TEST_CASE(test_PacketOverlay)
 
   dnsdist_ffi_dnspacket_t* packet = nullptr;
   // invalid packet
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   BOOST_CHECK(!dnsdist_ffi_dnspacket_parse(reinterpret_cast<const char*>(response.data()), response.size() - 1, &packet));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   BOOST_REQUIRE(dnsdist_ffi_dnspacket_parse(reinterpret_cast<const char*>(response.data()), response.size(), &packet));
   BOOST_REQUIRE(packet != nullptr);
 
@@ -763,7 +771,7 @@ BOOST_AUTO_TEST_CASE(test_PacketOverlay)
   size_t qnameSize = 0;
 
   // invalid parameters
-  dnsdist_ffi_dnspacket_get_qname_raw(nullptr, nullptr, 0);
+  dnsdist_ffi_dnspacket_get_qname_raw(nullptr, nullptr, nullptr);
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_qtype(nullptr), 0U);
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_qclass(nullptr), 0U);
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_qtype(packet), QType::A);
@@ -786,12 +794,15 @@ BOOST_AUTO_TEST_CASE(test_PacketOverlay)
     parsedName.resize(1024);
 
     // too small
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_name_at_offset_raw(reinterpret_cast<const char*>(response.data()), response.size(), sizeof(dnsheader), parsedName.data(), 1U), 0U);
     // invalid parameters
     BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_name_at_offset_raw(nullptr, 0, sizeof(dnsheader), parsedName.data(), parsedName.size()), 0U);
     // invalid packet
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_name_at_offset_raw(reinterpret_cast<const char*>(response.data()), sizeof(dnsheader) + 2, sizeof(dnsheader), parsedName.data(), parsedName.size()), 0U);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto parsedNameSize = dnsdist_ffi_dnspacket_get_name_at_offset_raw(reinterpret_cast<const char*>(response.data()), response.size(), sizeof(dnsheader), parsedName.data(), parsedName.size());
     BOOST_REQUIRE_GT(parsedNameSize, 0U);
     BOOST_REQUIRE_EQUAL(parsedNameSize, target.wirelength());
@@ -800,7 +811,7 @@ BOOST_AUTO_TEST_CASE(test_PacketOverlay)
 
   const char* name = nullptr;
   size_t nameSize = 0;
-  dnsdist_ffi_dnspacket_get_record_name_raw(nullptr, 0, nullptr, 0);
+  dnsdist_ffi_dnspacket_get_record_name_raw(nullptr, 0, nullptr, nullptr);
   BOOST_REQUIRE(name == nullptr);
 
   // invalid parameters
@@ -819,7 +830,7 @@ BOOST_AUTO_TEST_CASE(test_PacketOverlay)
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_type(packet, 0), QType::A);
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_class(packet, 0), QClass::IN);
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_ttl(packet, 0), 7200U);
-  BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_content_length(packet, 0), sizeof(v4.sin4.sin_addr.s_addr));
+  BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_content_length(packet, 0), sizeof(v4Addr.sin4.sin_addr.s_addr));
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_content_offset(packet, 0), 42U);
 
   // second record
@@ -830,7 +841,7 @@ BOOST_AUTO_TEST_CASE(test_PacketOverlay)
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_type(packet, 1), QType::AAAA);
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_class(packet, 1), QClass::IN);
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_ttl(packet, 1), 7200U);
-  BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_content_length(packet, 1), sizeof(v6.sin6.sin6_addr.s6_addr));
+  BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_content_length(packet, 1), sizeof(v6Addr.sin6.sin6_addr.s6_addr));
   BOOST_CHECK_EQUAL(dnsdist_ffi_dnspacket_get_record_content_offset(packet, 1), 58U);
 
   dnsdist_ffi_dnspacket_free(packet);
@@ -838,14 +849,14 @@ BOOST_AUTO_TEST_CASE(test_PacketOverlay)
 
 BOOST_AUTO_TEST_CASE(test_RingBuffers)
 {
-  dnsheader dh;
-  memset(&dh, 0, sizeof(dh));
-  dh.id = htons(42);
-  dh.rd = 1;
-  dh.ancount = htons(1);
-  dh.nscount = htons(1);
-  dh.arcount = htons(1);
-  dh.rcode = RCode::NXDomain;
+  dnsheader ourHeader{};
+  memset(&ourHeader, 0, sizeof(ourHeader));
+  ourHeader.id = htons(42);
+  ourHeader.rd = 1;
+  ourHeader.ancount = htons(1);
+  ourHeader.nscount = htons(1);
+  ourHeader.arcount = htons(1);
+  ourHeader.rcode = RCode::NXDomain;
   DNSName qname("rings.luaffi.powerdns.com.");
   ComboAddress requestor1("192.0.2.1");
   ComboAddress backend("192.0.2.42");
@@ -854,7 +865,7 @@ BOOST_AUTO_TEST_CASE(test_RingBuffers)
   dnsdist::Protocol protocol = dnsdist::Protocol::DoUDP;
   dnsdist::Protocol outgoingProtocol = dnsdist::Protocol::DoUDP;
   unsigned int responseTime = 0;
-  struct timespec now;
+  timespec now{};
   gettime(&now);
 
   g_rings.reset();
@@ -865,8 +876,8 @@ BOOST_AUTO_TEST_CASE(test_RingBuffers)
   g_rings.init(config);
   BOOST_CHECK_EQUAL(g_rings.getNumberOfQueryEntries(), 0U);
 
-  g_rings.insertQuery(now, requestor1, qname, qtype, size, dh, protocol);
-  g_rings.insertResponse(now, requestor1, DNSName(qname), qtype, responseTime, size, dh, backend, outgoingProtocol);
+  g_rings.insertQuery(now, requestor1, qname, qtype, size, ourHeader, protocol);
+  g_rings.insertResponse(now, requestor1, DNSName(qname), qtype, responseTime, size, ourHeader, backend, outgoingProtocol);
 
   dnsdist_ffi_ring_entry_list_t* list = nullptr;
 
@@ -1215,6 +1226,7 @@ BOOST_AUTO_TEST_CASE(query_response_pointer_mismatch)
 
   const char* buffer = nullptr;
   size_t bufferSize = 0;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   dnsdist_ffi_dnsquestion_get_masked_remoteaddr(reinterpret_cast<dnsdist_ffi_dnsquestion_t*>(&lightDR), reinterpret_cast<const void**>(&buffer), &bufferSize, 16);
   BOOST_CHECK(buffer == nullptr);
   BOOST_CHECK_EQUAL(bufferSize, 0U);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We are getting a fair amount of AI-assisted reports involving misuse of the Lua FFI API. While this API was always designed to be fast, leaving a lot of opportunities to hold it wrong, we can harden it against at least one common case: passing a `dnsresponse` object to a function expecting a `dnsquestion` or the other way around.
Several reporters suggested the use of RTTI for that but the cost is far from negligible. This PR uses `offsetof` and an additional `uint64` (for alignment) field to detect this kind of misuse.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
