### PR TITLE
dnsdist-2.0.x: Backport 17110 - Give TCP thread as default for definition USE_SINGLE_ACCEPTOR_THREAD

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -3345,19 +3345,9 @@ static void startFrontends()
     std::thread udpThreadHandle(udpClientThread, udpStates);
     udpThreadHandle.detach();
   }
-     
-  /* Gives a TCP Thread to DoQ or DoH3 for cross-protocol communication when a request is too big for dnsdist to use UDP so it uses TCP instead */
-  bool needsTCP = !tcpStates.empty();
-  for (const auto& clientState : dnsdist::getFrontends()) {
-     if (clientState->doqFrontend != nullptr || clientState->doh3Frontend != nullptr) {
-        needsTCP = true;
-        break;
-     }
-  }
-     
-  if (needsTCP) {
-    g_tcpclientthreads = std::make_unique<TCPClientCollection>(1, tcpStates);
-  }
+
+  /* Gives TCP client threads by default */
+  g_tcpclientthreads = std::make_unique<TCPClientCollection>(1, tcpStates);
 #endif /* USE_SINGLE_ACCEPTOR_THREAD */
 }
 }

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -3345,7 +3345,17 @@ static void startFrontends()
     std::thread udpThreadHandle(udpClientThread, udpStates);
     udpThreadHandle.detach();
   }
-  if (!tcpStates.empty()) {
+     
+  /* Gives a TCP Thread to DoQ or DoH3 for cross-protocol communication when a request is too big for dnsdist to use UDP so it uses TCP instead */
+  bool needsTCP = !tcpStates.empty();
+  for (const auto& clientState : dnsdist::getFrontends()) {
+     if (clientState->doqFrontend != nullptr || clientState->doh3Frontend != nullptr) {
+        needsTCP = true;
+        break;
+     }
+  }
+     
+  if (needsTCP) {
     g_tcpclientthreads = std::make_unique<TCPClientCollection>(1, tcpStates);
   }
 #endif /* USE_SINGLE_ACCEPTOR_THREAD */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17110 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
