### PR TITLE
dnsdist-2.1.x: Backport 17151 - Fix handling of long HTTP/2 Date headers, handle non-POSIX locales

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -272,6 +272,21 @@ IncomingHTTP2Connection::IncomingHTTP2Connection(ConnectionInfo&& connectionInfo
   sess = nullptr;
 }
 
+static void addDateHeader(PacketBuffer& out)
+{
+  static const std::string dateformat("Date: %a, %d %h %Y %T GMT\r\n");
+  timebuf_t date_header{};
+  struct tm tmval{};
+  time_t timestamp = time(nullptr);
+  // we do not call setlocale(), and according to https://en.cppreference.com/w/cpp/locale/setlocale.html:
+  // "During program startup, the equivalent of std::setlocale(LC_ALL, "C"); is executed before any user code is run.""
+  size_t date_header_written = strftime(date_header.data(), date_header.size(), dateformat.data(), gmtime_r(&timestamp, &tmval));
+
+  if (date_header_written > 0 && date_header_written <= date_header.size()) {
+    out.insert(out.end(), date_header.begin(), date_header.begin() + date_header_written);
+  }
+}
+
 bool IncomingHTTP2Connection::checkALPN()
 {
   constexpr std::array<uint8_t, 2> h2ALPN{'h', '2'};
@@ -286,19 +301,12 @@ bool IncomingHTTP2Connection::checkALPN()
   }
 
   static const std::string data0("HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: Close\r\n");
+  d_out.insert(d_out.end(), data0.begin(), data0.end());
 
-  std::array<char, 64> date_header{};
-  static const std::string dateformat("Date: %a, %d %h %Y %T GMT\r\n");
-  struct tm tmval{};
-  time_t timestamp = time(nullptr);
-  size_t date_header_written = strftime(date_header.data(), date_header.size(), dateformat.data(), gmtime_r(&timestamp, &tmval));
+  addDateHeader(d_out);
 
   static const std::string data2("\r\n<html><body>This server implements RFC 8484 - DNS Queries over HTTP, and requires HTTP/2 in accordance with section 5.2 of the RFC.</body></html>\r\n");
 
-  d_out.insert(d_out.end(), data0.begin(), data0.end());
-  if (date_header_written > 0 && date_header_written <= date_header.size()) {
-    d_out.insert(d_out.end(), date_header.begin(), date_header.begin() + date_header_written);
-  }
   d_out.insert(d_out.end(), data2.begin(), data2.end());
   writeToSocket(false);
 

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -278,13 +278,23 @@ static void addDateHeader(PacketBuffer& out)
   timebuf_t date_header{};
   struct tm tmval{};
   time_t timestamp = time(nullptr);
-  // we do not call setlocale(), and according to https://en.cppreference.com/w/cpp/locale/setlocale.html:
-  // "During program startup, the equivalent of std::setlocale(LC_ALL, "C"); is executed before any user code is run.""
-  size_t date_header_written = strftime(date_header.data(), date_header.size(), dateformat.data(), gmtime_r(&timestamp, &tmval));
-
-  if (date_header_written > 0 && date_header_written <= date_header.size()) {
-    out.insert(out.end(), date_header.begin(), date_header.begin() + date_header_written);
+  // apparently someone might be crazy enough to change the locale using Lua (why?)
+  // so we have to do extra work just in case
+  auto posixLocale = newlocale(LC_ALL_MASK, "POSIX", nullptr);
+  if (!posixLocale) {
+    return;
   }
+  try {
+    size_t date_header_written = strftime_l(date_header.data(), date_header.size(), dateformat.data(), gmtime_r(&timestamp, &tmval), posixLocale);
+
+    if (date_header_written > 0 && date_header_written <= date_header.size()) {
+      out.insert(out.end(), date_header.begin(), date_header.begin() + date_header_written);
+    }
+  }
+  catch (...) {
+  }
+
+  freelocale(posixLocale);
 }
 
 bool IncomingHTTP2Connection::checkALPN()

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -287,17 +287,18 @@ bool IncomingHTTP2Connection::checkALPN()
 
   static const std::string data0("HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: Close\r\n");
 
-  std::array<char, 40> data1{};
+  std::array<char, 64> date_header{};
   static const std::string dateformat("Date: %a, %d %h %Y %T GMT\r\n");
   struct tm tmval{};
   time_t timestamp = time(nullptr);
-  size_t len = strftime(data1.data(), data1.size(), dateformat.data(), gmtime_r(&timestamp, &tmval));
-  assert(len != 0);
+  size_t date_header_written = strftime(date_header.data(), date_header.size(), dateformat.data(), gmtime_r(&timestamp, &tmval));
 
   static const std::string data2("\r\n<html><body>This server implements RFC 8484 - DNS Queries over HTTP, and requires HTTP/2 in accordance with section 5.2 of the RFC.</body></html>\r\n");
 
   d_out.insert(d_out.end(), data0.begin(), data0.end());
-  d_out.insert(d_out.end(), data1.begin(), data1.begin() + len);
+  if (date_header_written > 0 && date_header_written <= date_header.size()) {
+    d_out.insert(d_out.end(), date_header.begin(), date_header.begin() + date_header_written);
+  }
   d_out.insert(d_out.end(), data2.begin(), data2.end());
   writeToSocket(false);
 

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import base64
+from datetime import datetime
 import os
 import subprocess
 import time
@@ -64,6 +65,9 @@ class DOHTests(object):
     addDOHLocal("127.0.0.1:%d", "%s", "%s", { "/", "/coffee", "/PowerDNS", "/PowerDNS2", "/PowerDNS-999" }, {customResponseHeaders={["access-control-allow-origin"]="*",["user-agent"]="derp",["UPPERCASE"]="VaLuE"}, keepIncomingHeaders=true, library='%s'})
     dohFE = getDOHFrontend(0)
     dohFE:setResponsesMap({newDOHResponseMapEntry('^/coffee$', 418, 'C0FFEE', {['FoO']='bar'})})
+
+    -- check that the HTTP Date header is fine even if someone messes with the locale
+    os.setlocale('fr_FR')
     """
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_serverName', '_dohServerPort', '_dohServerPort', '_serverCert', '_serverKey', '_dohLibrary']
     _verboseMode = True
@@ -426,11 +430,13 @@ class DOHTests(object):
         self.assertEqual(self.getHTTPCounter("http/2"), http2)
 
         dateFound = False
+        expectedDatePrefix = datetime.now().strftime("%a, %d %h %Y")
         for header in responseHeaders.decode().splitlines(False):
             values = header.split(':')
             key = values[0]
             if key.lower() == 'date':
                 dateFound = True
+                self.assertTrue(values[1].strip().startswith(expectedDatePrefix))
                 break
         self.assertTrue(dateFound)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17151 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
