### PR TITLE
rec: limit size of incoming web request.

### DIFF
--- a/pdns/recursordist/rec-rust-lib/rust/src/web.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/web.rs
@@ -38,6 +38,7 @@ use http_body_util::{BodyExt, Full};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{body::Incoming as IncomingBody, header, Method, Request, Response, StatusCode};
+use hyper::body::Body;
 use hyper_util::rt::TokioIo;
 use pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
 use std::str::FromStr;
@@ -278,6 +279,7 @@ struct Context {
     acl: cxx::UniquePtr<rustmisc::NetmaskGroup>,
     logger: cxx::SharedPtr<rustmisc::Logger>,
     loglevel: rustmisc::LogLevel,
+    max_request_size: u64,
 }
 
 // Serve a file
@@ -619,6 +621,55 @@ async fn process_request(
         if let Some(func) = apifunc {
             let reqheaders = rust_request.headers().clone();
             if rust_request.method() == Method::POST || rust_request.method() == Method::PUT {
+                let body_size = rust_request.size_hint().upper();
+                // From observation, hyper handles invalid or missing content length in a safe way
+                // by making the value 0. The actual body collect() is limited by the promised
+                // content length in the request
+                if body_size.is_none_or(|x| x > ctx.max_request_size) {
+                    let mut body = vec![];
+                    let status = StatusCode::PAYLOAD_TOO_LARGE; // 413
+                    if let Some(reason) = status.canonical_reason() {
+                        body = reason.as_bytes().to_vec();
+                    }
+                    if ctx.loglevel != rustmisc::LogLevel::None {
+                        let version = format!("{:?}", version);
+                        rustmisc::log(
+                            &my_logger,
+                            rustweb::Priority::Warning,
+                            "Request",
+                            &vec![
+                                rustmisc::KeyValue {
+                                    key: "remote".to_string(),
+                                    value: remote.to_string(),
+                                },
+                                rustmisc::KeyValue {
+                                    key: "method".to_string(),
+                                    value: method.to_string(),
+                                },
+                                rustmisc::KeyValue {
+                                    key: "urlpath".to_string(),
+                                    value: path.to_string(),
+                                },
+                                rustmisc::KeyValue {
+                                    key: "HTTPVersion".to_string(),
+                                    value: version,
+                                },
+                                rustmisc::KeyValue {
+                                    key: "status".to_string(),
+                                    value: status.as_u16().to_string(),
+                                },
+                                rustmisc::KeyValue {
+                                    key: "respsize".to_string(),
+                                    value: body.len().to_string(),
+                                },
+                            ],
+                        );
+                    }
+                    let rust_response = rust_response
+                        .status(status)
+                        .body(full(body))?;
+                    return Ok(rust_response);
+                }
                 request.body = rust_request.collect().await?.to_bytes().to_vec();
             }
             // This calls indirectly into C++
@@ -889,6 +940,7 @@ pub fn serveweb(
     acl: cxx::UniquePtr<rustmisc::NetmaskGroup>,
     logger: cxx::SharedPtr<rustmisc::Logger>,
     loglevel: rustmisc::LogLevel,
+    max_request_size: u64,
 ) -> Result<(), std::io::Error> {
     // Context, atomically reference counted
     let ctx = Arc::new(Context {
@@ -897,6 +949,7 @@ pub fn serveweb(
         acl,
         logger,
         loglevel,
+        max_request_size,
     });
 
     // We use a single thread to handle all the requests, letting the runtime abstracts from this
@@ -1196,6 +1249,7 @@ mod rustweb {
             acl: UniquePtr<NetmaskGroup>,
             logger: SharedPtr<Logger>,
             loglevel: LogLevel,
+            max_request_size: u64,
         ) -> Result<()>;
     }
 

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -3302,26 +3302,26 @@ This field is ignored if :ref:`setting-yaml-webservice.listen` is set.
  """,
     },
     {
-        'name': 'max_request_size',
-        'section': 'webservice',
-        'type': LType.Uint64,
-        'oldname': 'webserver-max-request-size',
-        'default': '2',
-        'help': 'Maximum size for webserver requests in megabytes',
-        'doc': '''
+        "name": "max_request_size",
+        "section": "webservice",
+        "type": LType.Uint64,
+        "oldname": "webserver-max-request-size",
+        "default": "2",
+        "help": "Maximum size for webserver requests in megabytes",
+        "doc": """
 Maximum size of incoming webserver requests in megabytes.
- ''',
-        'versionadded': '5.5.0',
+ """,
+        "versionadded": "5.5.0",
     },
     {
-        'name': 'write_pid',
-        'section': 'recursor',
-        'type': LType.Bool,
-        'default': 'true',
-        'help': 'Write a PID file',
-        'doc': '''
+        "name": "write_pid",
+        "section": "recursor",
+        "type": LType.Bool,
+        "default": "true",
+        "help": "Write a PID file",
+        "doc": """
 If a PID file should be written to :ref:`setting-socket-dir`
- ''',
+ """,
     },
     {
         "name": "x_dnssec_names",

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -3302,14 +3302,26 @@ This field is ignored if :ref:`setting-yaml-webservice.listen` is set.
  """,
     },
     {
-        "name": "write_pid",
-        "section": "recursor",
-        "type": LType.Bool,
-        "default": "true",
-        "help": "Write a PID file",
-        "doc": """
+        'name': 'max_request_size',
+        'section': 'webservice',
+        'type': LType.Uint64,
+        'oldname': 'webserver-max-request-size',
+        'default': '2',
+        'help': 'Maximum size for webserver requests in megabytes',
+        'doc': '''
+Maximum size of incoming webserver requests in megabytes.
+ ''',
+        'versionadded': '5.5.0',
+    },
+    {
+        'name': 'write_pid',
+        'section': 'recursor',
+        'type': LType.Bool,
+        'default': 'true',
+        'help': 'Write a PID file',
+        'doc': '''
 If a PID file should be written to :ref:`setting-socket-dir`
- """,
+ ''',
     },
     {
         "name": "x_dnssec_names",

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -1201,7 +1201,7 @@ void serveRustWeb()
   // This function returns after having created the web server object that handles the requests.
   // That object and its runtime are associated with a Posix thread that waits until all tasks are
   // done, which normally never happens. See rec-rust-lib/rust/src/web.rs for details
-  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel);
+  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel, arg().asNum("webserver-max-request-size") * 1024 * 1024);
 }
 
 static void fromCxxToRust(const HttpResponse& cxxresp, pdns::rust::web::rec::Response& rustResponse)

--- a/regression-tests.api/test_Basics.py
+++ b/regression-tests.api/test_Basics.py
@@ -1,7 +1,8 @@
 import requests
 import socket
 import time
-from test_helper import ApiTestCase, is_auth
+import unittest
+from test_helper import ApiTestCase, is_auth, is_recursor
 
 
 class TestBasics(ApiTestCase):
@@ -34,6 +35,17 @@ class TestBasics(ApiTestCase):
         status = resp.splitlines(0)[0]
         if b"400" in status:
             raise Exception("Got unwanted response: %s" % status)
+
+    @unittest.skipIf(not is_recursor(), "Only applicable to recursors (for now)")
+    def test_big_request(self):
+        payload = bytearray(10000000)
+        url = '/api/v1/servers/localhost/zones'
+        r = self.session.post(
+            self.url(url),
+            data=payload,
+            headers={"content-type": "application/json"})
+        self.assertEqual(r.status_code, 413)
+
 
     def test_cors(self):
         r = self.session.options(self.url("/api/v1/servers/localhost"))

--- a/regression-tests.api/test_Basics.py
+++ b/regression-tests.api/test_Basics.py
@@ -39,13 +39,9 @@ class TestBasics(ApiTestCase):
     @unittest.skipIf(not is_recursor(), "Only applicable to recursors (for now)")
     def test_big_request(self):
         payload = bytearray(10000000)
-        url = '/api/v1/servers/localhost/zones'
-        r = self.session.post(
-            self.url(url),
-            data=payload,
-            headers={"content-type": "application/json"})
+        url = "/api/v1/servers/localhost/zones"
+        r = self.session.post(self.url(url), data=payload, headers={"content-type": "application/json"})
         self.assertEqual(r.status_code, 413)
-
 
     def test_cors(self):
         r = self.session.options(self.url("/api/v1/servers/localhost"))


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Only applies to rec-5.3.x and newer, as older ones do not use the Rust webservice implementation.

YWH-PGM6095-96, CVE-2026-33256 affected 5.3.5, 5.4.0

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
