### PR TITLE
auth: fixes for SA 2026-05

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1538,7 +1538,29 @@ BB2DomainInfo Bind2Backend::createDomainEntry(const ZoneName& domain)
 
 bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& /* nameserver */, const string& account)
 {
-  string filename = getArg("autoprimary-destdir") + '/' + domain.toStringNoDot();
+  std::string domainname = domain.toStringNoDot();
+
+  // Reject domain name if it embeds quotes; this may happen if 8bit-dns is
+  // used, and bind currently does not allow for character escapes in zone
+  // names.
+  if (domainname.find_first_of("\"") != std::string::npos) {
+    SLOG(g_log << Logger::Error << d_logprefix
+               << " Unable to accept autosecondary zone '" << domain
+               << "' from autoprimary " << ipAddress
+               << " due to unauthorized characters in domain name for bind configuration file"
+               << endl,
+         d_slog->error(Logr::Error, "unauthorized characters in domain name for bind configuration file", "Unable to accept autosecondary zone", "zone", Logging::Loggable(domain), "autoprimary address", Logging::Loggable(ipAddress)));
+    throw PDNSException("Unauthorized characters in domain name for bind configuration file");
+  }
+
+  string filename = getArg("autoprimary-destdir") + '/';
+  if (domainname.empty()) {
+    filename.append("rootzone.");
+  }
+  else {
+    // Make sure the zone file name does not contain path separators.
+    filename.append(boost::replace_all_copy(domainname, "/", "\\047"));
+  }
 
   SLOG(g_log << Logger::Warning << d_logprefix
              << " Writing bind config zone statement for autosecondary zone '" << domain
@@ -1559,8 +1581,8 @@ bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName
     }
 
     c_of << endl;
-    c_of << "# AutoSecondary zone '" << domain.toString() << "' (added: " << nowTime() << ") (account: " << account << ')' << endl;
-    c_of << "zone \"" << domain.toStringNoDot() << "\" {" << endl;
+    c_of << "# AutoSecondary zone '" << domainname << "' (added: " << nowTime() << ") (account: " << account << ')' << endl;
+    c_of << "zone \"" << domainname << "\" {" << endl;
     c_of << "\ttype secondary;" << endl;
     c_of << "\tfile \"" << filename << "\";" << endl;
     c_of << "\tprimaries { " << ipAddress << "; };" << endl;

--- a/modules/ldapbackend/native.cc
+++ b/modules/ldapbackend/native.cc
@@ -297,7 +297,7 @@ void LdapBackend::lookup_tree(const QType& qtype, const DNSName& qname, DNSPacke
 
   stringtok(parts, toLower(qname.toString()), ".");
   for (auto i = parts.crbegin(); i != parts.crend(); i++) {
-    dn = "dc=" + *i + "," + dn;
+    dn = "dc=" + d_pldap->escape(*i) + "," + dn;
   }
 
   SLOG(g_log << Logger::Debug << d_myname << " Search = basedn: " << dn + getArg("basedn") << ", filter: " << filter << ", qtype: " << qtype.toString() << endl,

--- a/modules/ldapbackend/powerldap.cc
+++ b/modules/ldapbackend/powerldap.cc
@@ -328,22 +328,68 @@ const string PowerLDAP::getError(int rc)
   return ldapGetError(d_ld, rc);
 }
 
-const string PowerLDAP::escape(const string& str)
+// Escape sensitive characters according to the rules in RFC4514, section 2.4
+// and RFC4515, section 3.
+const std::string PowerLDAP::escape(const string& input)
 {
-  string a;
-  string::const_iterator i;
-  char tmp[4];
+  std::string out;
+  std::array<char, 1 + 3> hexbuf{};
+  auto length = input.length();
 
-  for (i = str.begin(); i != str.end(); i++) {
-    // RFC4515 3
-    if ((unsigned char)*i == '*' || (unsigned char)*i == '(' || (unsigned char)*i == ')' || (unsigned char)*i == '\\' || (unsigned char)*i == '\0' || (unsigned char)*i > 127) {
-      snprintf(tmp, sizeof(tmp), "\\%02x", (unsigned char)*i);
-
-      a += tmp;
+  out.reserve(length);
+  for (decltype(length) pos = 0; pos < length; ++pos) {
+    uint8_t chr = static_cast<uint8_t>(input[pos]);
+    // Perform UTF-8 encoding of 8-bit values if needed
+    if (chr >= 0x80) {
+      ::snprintf(hexbuf.data(), hexbuf.size(), "\\%02X",
+                 static_cast<uint8_t>(0xc0 | ((chr >> 6) & 0x3f)));
+      out.append(hexbuf.data());
+      ::snprintf(hexbuf.data(), hexbuf.size(), "\\%02X",
+                 static_cast<uint8_t>(0x80 | (chr & 0x3f)));
+      out.append(hexbuf.data());
     }
-    else
-      a += *i;
+    else {
+      bool escape4514{false};
+      bool escape4515{false};
+      // Characters which need escaping regardless of their position
+      switch (chr) {
+      case '"':
+      case '+':
+      case ',':
+      case ';':
+      case '<':
+      case '>':
+        escape4514 = true;
+        break;
+      case '*':
+      case '(':
+      case ')':
+      case '\\':
+      case '\0':
+        escape4515 = true;
+        break;
+      default:
+        break;
+      }
+      // Characters which need escaping if in first position
+      if (pos == 0) {
+        escape4514 |= chr == ' ' || chr == '#';
+      }
+      // Characters which need escaping if in last position
+      if (pos == length - 1) {
+        escape4514 |= chr == ' ';
+      }
+      if (escape4515) {
+        ::snprintf(hexbuf.data(), hexbuf.size(), "\\%02X", chr);
+        out.append(hexbuf.data());
+      }
+      else {
+        if (escape4514) {
+          out.append(1, '\\');
+        }
+        out.append(1, chr);
+      }
+    }
   }
-
-  return a;
+  return out;
 }

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -201,8 +201,12 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfrUnquote
     d_content.push_back(0);
     return;
   }
-  if(lenField)
+  if (lenField) {
+    if (text.length() > 255) {
+      throw runtime_error("invalid unquoted text length");
+    }
     d_content.push_back(text.length());
+  }
   d_content.insert(d_content.end(), text.c_str(), text.c_str() + text.length());
 }
 
@@ -467,11 +471,14 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfrSvcPara
       break;
     case SvcParam::alpn:
     {
-      uint16_t totalSize = param.getALPN().size(); // All 1 octet size headers for each value
+      size_t totalSize = param.getALPN().size(); // All 1 octet size headers for each value
       for (auto const &a : param.getALPN()) {
         totalSize += a.length();
       }
-      xfr16BitInt(totalSize);
+      if (totalSize > std::numeric_limits<uint16_t>::max()) {
+        throw runtime_error("invalid total length of alpn parameters");
+      }
+      xfr16BitInt(static_cast<uint16_t>(totalSize));
       for (auto const &a : param.getALPN()) {
         xfrUnquotedText(a, true); // will add the 1-byte length field
       }

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -450,6 +450,9 @@ void RecordTextReader::xfrSvcParamKeyVals(set<SvcParam>& val) // NOLINT(readabil
           if (len == 0) {
             throw RecordTextException("ALPN values cannot be empty strings");
           }
+          if (len > 255) {
+            throw RecordTextException("Length of ALPN value goes over 255");
+          }
           if (len > v.length() - spos) {
             throw RecordTextException("Length of ALPN value goes over total length of alpn SVC Param");
           }
@@ -458,6 +461,11 @@ void RecordTextReader::xfrSvcParamKeyVals(set<SvcParam>& val) // NOLINT(readabil
         }
       } else {
         xfrSVCBValueList(value);
+        for (const auto& item : value) {
+          if (item.length() > 255) {
+            throw RecordTextException("Length of SVC value goes over 255");
+          }
+        }
       }
       if (value.empty()) {
         throw RecordTextException("value is required for SVC Param " + k);

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -59,6 +59,9 @@ struct updateContext {
   // Logging-related fields
   std::string msgPrefix;
   std::shared_ptr<Logr::Logger> slog;
+  
+  // forwardPacket-related fields
+  mutable int sock{-1};
 };
 
 static void increaseSerial(const string& soaEditSetting, const updateContext& ctx);
@@ -653,6 +656,22 @@ static uint performUpdate(DNSSECKeeper& dsk, const DNSRecord* rec, updateContext
   return changedRecords;
 }
 
+static void socketCleaner(const updateContext* ctx)
+{
+  if (ctx->sock < 0) {
+    return; // nothing to do
+  }
+
+  try {
+    closesocket(ctx->sock);
+    ctx->sock = -1;
+  }
+  catch (const PDNSException& e) {
+    SLOG(g_log << Logger::Error << "Error closing primary forwarding socket: " << e.reason << endl,
+         ctx->slog->error(Logr::Error, e.reason, "Update: error closing primary forwarding socket"));
+  }
+}
+
 static int forwardPacket(UeberBackend& B, const updateContext& ctx, const DNSPacket& p) // NOLINT(readability-identifier-length)
 {
   vector<string> forward;
@@ -672,108 +691,71 @@ static int forwardPacket(UeberBackend& B, const updateContext& ctx, const DNSPac
       continue;
     }
     auto local = pdns::getQueryLocalAddress(remote.sin4.sin_family, 0);
-    int sock = makeQuerySocket(local, false); // create TCP socket. RFC2136 section 6.2 seems to be ok with this.
-    if (sock < 0) {
+    ctx.sock = makeQuerySocket(local, false); // create TCP socket. RFC2136 section 6.2 seems to be ok with this.
+    if (ctx.sock < 0) {
       SLOG(g_log << Logger::Error << ctx.msgPrefix << "Error creating socket: " << stringerror() << endl,
            ctx.slog->error(Logr::Error, errno, "Update: error creating socket"));
       continue;
     }
 
-    if (connect(sock, (const struct sockaddr*)&remote, remote.getSocklen()) < 0) { // NOLINT(cppcoreguidelines-pro-type-cstyle-cast): less ugly than a reinterpret_cast + const_cast combination which would require a linter annotation anyway
-      SLOG(g_log << Logger::Error << ctx.msgPrefix << "Failed to connect to " << remote.toStringWithPort() << ": " << stringerror() << endl,
-           ctx.slog->error(Logr::Error, errno, "Update: failed to connect", "remote", Logging::Loggable(remote.toStringWithPort())));
-      try {
-        closesocket(sock);
-      }
-      catch (const PDNSException& e) {
-        SLOG(g_log << Logger::Error << "Error closing primary forwarding socket after connect() failed: " << e.reason << endl,
-             ctx.slog->error(Logr::Error, errno, "Update: error closing primary forwarding socket after connect() failed"));
-      }
-      continue;
-    }
+    string buffer;
+    ssize_t recvRes{0};
+    {
+      std::unique_ptr<const updateContext, decltype(&socketCleaner)> guard{&ctx, socketCleaner};
 
-    DNSPacket l_forwardPacket(p);
-    l_forwardPacket.setID(dns_random_uint16());
-    l_forwardPacket.setRemote(&remote);
-    uint16_t len = htons(l_forwardPacket.getString().length());
-    string buffer((const char*)&len, 2); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast): less ugly than a reinterpret_cast which would require a linter annotation anyway
-    buffer.append(l_forwardPacket.getString());
-    if (write(sock, buffer.c_str(), buffer.length()) < 0) {
-      SLOG(g_log << Logger::Error << ctx.msgPrefix << "Unable to forward update message to " << remote.toStringWithPort() << ", error:" << stringerror() << endl,
-           ctx.slog->error(Logr::Error, errno, "Update: unable to forward update message", "remote", Logging::Loggable(remote.toStringWithPort())));
-      try {
-        closesocket(sock);
+      if (connect(ctx.sock, (const struct sockaddr*)&remote, remote.getSocklen()) < 0) { // NOLINT(cppcoreguidelines-pro-type-cstyle-cast): less ugly than a reinterpret_cast + const_cast combination which would require a linter annotation anyway
+        SLOG(g_log << Logger::Error << ctx.msgPrefix << "Failed to connect to " << remote.toStringWithPort() << ": " << stringerror() << endl,
+             ctx.slog->error(Logr::Error, errno, "Update: failed to connect", "remote", Logging::Loggable(remote.toStringWithPort())));
+        continue;
       }
-      catch (const PDNSException& e) {
-        SLOG(g_log << Logger::Error << "Error closing primary forwarding socket after write() failed: " << e.reason << endl,
-             ctx.slog->error(Logr::Error, e.reason, "Update: error closing primary forwarding socket after write() failed"));
-      }
-      continue;
-    }
 
-    int res = waitForData(sock, 10, 0);
-    if (res == 0) {
-      SLOG(g_log << Logger::Error << ctx.msgPrefix << "Timeout waiting for reply from primary at " << remote.toStringWithPort() << endl,
-           ctx.slog->info(Logr::Error, "Update: timeout waiting for reply from primary", "remote", Logging::Loggable(remote.toStringWithPort())));
-      try {
-        closesocket(sock);
+      DNSPacket l_forwardPacket(p);
+      l_forwardPacket.setID(dns_random_uint16());
+      l_forwardPacket.setRemote(&remote);
+      uint16_t len = htons(l_forwardPacket.getString().length());
+      buffer.assign((const char*)&len, 2); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast): less ugly than a reinterpret_cast which would require a linter annotation anyway
+      buffer.append(l_forwardPacket.getString());
+      if (write(ctx.sock, buffer.c_str(), buffer.length()) < 0) {
+        SLOG(g_log << Logger::Error << ctx.msgPrefix << "Unable to forward update message to " << remote.toStringWithPort() << ", error:" << stringerror() << endl,
+             ctx.slog->error(Logr::Error, errno, "Update: unable to forward update message", "remote", Logging::Loggable(remote.toStringWithPort())));
+        continue;
       }
-      catch (const PDNSException& e) {
-        SLOG(g_log << Logger::Error << "Error closing primary forwarding socket after a timeout occurred: " << e.reason << endl,
-             ctx.slog->error(Logr::Error, e.reason, "Update: error closing primary forwarding socket after a timeout occurred"));
-      }
-      continue;
-    }
-    if (res < 0) {
-      SLOG(g_log << Logger::Error << ctx.msgPrefix << "Error waiting for answer from primary at " << remote.toStringWithPort() << ", error:" << stringerror() << endl,
-           ctx.slog->error(Logr::Error, errno, "Update: error waiting for answer from primary", "remote", Logging::Loggable(remote.toStringWithPort())));
-      try {
-        closesocket(sock);
-      }
-      catch (const PDNSException& e) {
-        SLOG(g_log << Logger::Error << "Error closing primary forwarding socket after an error occurred: " << e.reason << endl,
-             ctx.slog->error(Logr::Error, e.reason, "Update: error closing primary forwarding socket after an error occurred"));
-      }
-      continue;
-    }
 
-    std::array<unsigned char, 2> lenBuf{};
-    ssize_t recvRes = recv(sock, lenBuf.data(), lenBuf.size(), 0);
-    if (recvRes < 0 || static_cast<size_t>(recvRes) < lenBuf.size()) {
-      SLOG(g_log << Logger::Error << ctx.msgPrefix << "Could not receive data (length) from primary at " << remote.toStringWithPort() << ", error:" << stringerror() << endl,
-           ctx.slog->error(Logr::Error, errno, "Update: could not receive data (length) from primary", "remote", Logging::Loggable(remote.toStringWithPort())));
-      try {
-        closesocket(sock);
+      int res = waitForData(ctx.sock, 10, 0);
+      if (res == 0) {
+        SLOG(g_log << Logger::Error << ctx.msgPrefix << "Timeout waiting for reply from primary at " << remote.toStringWithPort() << endl,
+             ctx.slog->info(Logr::Error, "Update: timeout waiting for reply from primary", "remote", Logging::Loggable(remote.toStringWithPort())));
+        continue;
       }
-      catch (const PDNSException& e) {
-        SLOG(g_log << Logger::Error << "Error closing primary forwarding socket after recv() failed: " << e.reason << endl,
-             ctx.slog->error(Logr::Error, e.reason, "Update: error closing primary forwarding socket after recv() failed"));
+      if (res < 0) {
+        SLOG(g_log << Logger::Error << ctx.msgPrefix << "Error waiting for answer from primary at " << remote.toStringWithPort() << ", error:" << stringerror() << endl,
+             ctx.slog->error(Logr::Error, errno, "Update: error waiting for answer from primary", "remote", Logging::Loggable(remote.toStringWithPort())));
+        continue;
       }
-      continue;
-    }
-    size_t packetLen = lenBuf[0] * 256 + lenBuf[1];
 
-    buffer.resize(packetLen);
-    recvRes = recv(sock, &buffer.at(0), packetLen, 0);
-    if (recvRes < 0) {
-      SLOG(g_log << Logger::Error << ctx.msgPrefix << "Could not receive data (dnspacket) from primary at " << remote.toStringWithPort() << ", error:" << stringerror() << endl,
-           ctx.slog->error(Logr::Error, errno, "Update: could not receive data (dnspacket) from primary", "remote", Logging::Loggable(remote.toStringWithPort())));
-      try {
-        closesocket(sock);
+      std::array<unsigned char, 2> lenBuf{};
+      recvRes = recv(ctx.sock, lenBuf.data(), lenBuf.size(), 0);
+      if (recvRes < 0 || static_cast<size_t>(recvRes) < lenBuf.size()) {
+        SLOG(g_log << Logger::Error << ctx.msgPrefix << "Could not receive data (length) from primary at " << remote.toStringWithPort() << ", error:" << stringerror() << endl,
+             ctx.slog->error(Logr::Error, errno, "Update: could not receive data (length) from primary", "remote", Logging::Loggable(remote.toStringWithPort())));
+        continue;
       }
-      catch (const PDNSException& e) {
-        SLOG(g_log << Logger::Error << "Error closing primary forwarding socket after recv() failed: " << e.reason << endl,
-             ctx.slog->error(Logr::Error, e.reason, "Update: error closing primary forwarding socket after recv() failed"));
+      size_t packetLen = lenBuf[0] * 256 + lenBuf[1];
+
+      if (packetLen == 0) {
+        SLOG(g_log << Logger::Warning << ctx.msgPrefix << "Empty update sent by primary at " << remote.toStringWithPort() << endl,
+             ctx.slog->info(Logr::Warning, "Update: empty update from primary", "remote", Logging::Loggable(remote.toStringWithPort())));
+        continue;
       }
-      continue;
-    }
-    try {
-      closesocket(sock);
-    }
-    catch (const PDNSException& e) {
-      SLOG(g_log << Logger::Error << "Error closing primary forwarding socket: " << e.reason << endl,
-           ctx.slog->error(Logr::Error, e.reason, "Update: error closing primary forwarding socket"));
-    }
+
+      buffer.resize(packetLen);
+      recvRes = recv(ctx.sock, &buffer.at(0), packetLen, 0);
+      if (recvRes < 0) {
+        SLOG(g_log << Logger::Error << ctx.msgPrefix << "Could not receive data (dnspacket) from primary at " << remote.toStringWithPort() << ", error:" << stringerror() << endl,
+             ctx.slog->error(Logr::Error, errno, "Update: could not receive data (dnspacket) from primary", "remote", Logging::Loggable(remote.toStringWithPort())));
+        continue;
+      }
+    } // socketCleaner scope
 
     try {
       MOADNSParser mdp(false, buffer.data(), static_cast<unsigned int>(recvRes));

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -222,6 +222,7 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. mandatory=alpn", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x00\x00\x02\x00\x01"))
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. no-default-alpn", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x02\x00\x00"))
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. alpn=h3,h2", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x01\x00\x06\x02h3\x02h2"))
+     (BROKEN_CASE_S(QType::SVCB, "1 foo.powerdns.org. alpn=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x01\x00\x06\x02h3\x02h2"))
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. port=53", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x03\x00\x02\x00\x35"))
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. ipv4hint=192.0.2.53,192.0.2.2", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x04\x00\x08\xc0\x00\x02\x35\xc0\x00\x02\x02"))
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. ech=\"aGVsbG8=\"", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x05\x00\x05hello"))


### PR DESCRIPTION
### Short description
All the auth-specific fixes for the 2026-05 advisory. The http-related fixes are in https://github.com/PowerDNS/pdns/pull/17196 and https://github.com/PowerDNS/pdns/pull/17200

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
