### PR TITLE
all: Fix two cases of lacking/wrong max size compares (YWH-PGM6095-90)

### DIFF
--- a/ext/yahttp/yahttp/reqresp.cpp
+++ b/ext/yahttp/yahttp/reqresp.cpp
@@ -40,7 +40,19 @@ namespace YaHTTP {
   }
 
   template <class T>
-  bool AsyncLoader<T>::feed(const std::string& somedata) {
+  bool AsyncLoader<T>::feed(const std::string& somedata)
+  {
+    if (state < 2) {
+      headersize += somedata.length(); // maye include some body data, we don't know yet...
+      if (headersize > target->max_header_size) {
+        if (target->kind == YAHTTP_TYPE_REQUEST) {
+          throw ParseError("Request header too large");
+        }
+        else {
+          throw ParseError("Response header too large");
+        }
+      }
+    }
     buffer.append(somedata);
     while(state < 2) {
       int cr=0;
@@ -155,8 +167,8 @@ namespace YaHTTP {
         maxbody = minbody;
       }
       if (minbody < 1) return true; // guess there isn't anything left.
-      if (target->kind == YAHTTP_TYPE_REQUEST && static_cast<ssize_t>(minbody) > target->max_request_size) throw ParseError("Max request body size exceeded");
-      else if (target->kind == YAHTTP_TYPE_RESPONSE && static_cast<ssize_t>(minbody) > target->max_response_size) throw ParseError("Max response body size exceeded");
+      if (target->kind == YAHTTP_TYPE_REQUEST && minbody > target->max_request_size) throw ParseError("Max request body size exceeded");
+      else if (target->kind == YAHTTP_TYPE_RESPONSE && minbody > target->max_response_size) throw ParseError("Max response body size exceeded");
     }
 
     if (maxbody == 0) hasBody = false;

--- a/ext/yahttp/yahttp/reqresp.hpp
+++ b/ext/yahttp/yahttp/reqresp.hpp
@@ -20,6 +20,10 @@ namespace funcptr = boost;
 
 #include <algorithm>
 
+#ifndef YAHTTP_MAX_HEADER_SIZE
+#define YAHTTP_MAX_HEADER_SIZE (100 * 1024)
+#endif
+
 #ifndef YAHTTP_MAX_REQUEST_SIZE
 #define YAHTTP_MAX_REQUEST_SIZE 2097152
 #endif
@@ -108,6 +112,7 @@ namespace YaHTTP {
 #endif
       max_request_size = YAHTTP_MAX_REQUEST_SIZE;
       max_response_size = YAHTTP_MAX_RESPONSE_SIZE;
+      max_header_size = YAHTTP_MAX_HEADER_SIZE;
       url = "";
       method = "";
       statusText = "";
@@ -130,6 +135,7 @@ protected:
       this->parameters = rhs.parameters; this->getvars = rhs.getvars;
       this->body = rhs.body; this->max_request_size = rhs.max_request_size;
       this->max_response_size = rhs.max_response_size; this->version = rhs.version;
+      this->max_header_size = rhs.max_header_size;
 #ifdef HAVE_CPP_FUNC_PTR
       this->renderer = rhs.renderer;
 #endif
@@ -143,6 +149,7 @@ protected:
       this->parameters = rhs.parameters; this->getvars = rhs.getvars;
       this->body = rhs.body; this->max_request_size = rhs.max_request_size;
       this->max_response_size = rhs.max_response_size; this->version = rhs.version;
+      this->max_header_size = rhs.max_header_size;
 #ifdef HAVE_CPP_FUNC_PTR
       this->renderer = rhs.renderer;
 #endif
@@ -166,8 +173,9 @@ public:
 
     std::string body; //<! the actual content
 
-    ssize_t max_request_size; //<! maximum size of request
-    ssize_t max_response_size;  //<! maximum size of response
+    size_t max_request_size; //<! maximum size of request
+    size_t max_response_size; //<! maximum size of response
+    size_t max_header_size; //<! maximum size of headers
     bool is_multipart; //<! if the request is multipart, prevents Content-Length header
 #ifdef HAVE_CPP_FUNC_PTR
     funcptr::function<size_t(const HTTPBase*,std::ostream&,bool)> renderer; //<! rendering function
@@ -305,6 +313,7 @@ public:
     std::ostringstream bodybuf; //<! buffer for body
     size_t maxbody; //<! maximum size of body
     size_t minbody; //<! minimum size of body
+    size_t headersize;                 
     bool hasBody; //<! are we expecting body
 
     void keyValuePair(const std::string &keyvalue, std::string &key, std::string &value); //<! key value pair parser helper
@@ -315,6 +324,7 @@ public:
       pos = 0; state = 0; this->target = target_;
       hasBody = false;
       buffer = "";
+      headersize = 0;
       this->target->initialize();
     }; //<! Initialize the parser for target and clear state
     bool feed(const std::string& somedata); //<! Feed data to the parser


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

#YWH-PGM6095-108
CVE-2026-33260 

For rec on <= 5.2.x is affected, newer rec uses Rust code.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
