### PR TITLE
rec: only check cookie if we sent one out (YWH-PGM6095-134)

### DIFF
--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -544,7 +544,7 @@ static std::pair<bool, LWResult::Result> incomingCookie(const OptLog& log, const
     if (EDNSCookiesOpt received; received.makeFromString(opt->second)) {
       cookieFoundInReply = true;
       VLOG(log, "Received cookie info back from " << address.toString() << ": " << received.toDisplayString() << endl);
-      if (received.getClient() == cookieSentOut->getClient()) {
+      if (cookieSentOut && received.getClient() == cookieSentOut->getClient()) {
         VLOG(log, "Client cookie from " << address.toString() << " matched! Storing with localAddress " << localip.toString() << endl);
         ++t_Counters.at(rec::Counter::cookieMatched);
         found->d_localaddress = localip;
@@ -870,7 +870,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
           }
         }
       }
-      if (g_cookies && !*chained) {
+      if (g_cookies && cookieSentOut && !*chained) {
         auto [done, result] = incomingCookie(log, address, localip, *now, cookieSentOut, edo, doTCP, *lwr, cookieFoundInReply);
         if (done) {
           return result;


### PR DESCRIPTION
A server might sent us a cookie when we diod not sent out one, leading to a dereference of an absent optional value.

This is YWH-PGM6095-134
CVE-2026-33262

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
