### PR TITLE
rec: zonemd null pointer dereference on non-standard schemes (#YWH-PGM6095-156)

### DIFF
--- a/pdns/test-zonemd_cc.cc
+++ b/pdns/test-zonemd_cc.cc
@@ -105,4 +105,9 @@ BOOST_AUTO_TEST_CASE(test_zonemd13)
   testZoneMD("xxx", "zonemd1.zone", false, false, false);
 }
 
+BOOST_AUTO_TEST_CASE(test_zonemd14)
+{
+  testZoneMD("example", "zonemd-invalidscheme.zone", false, true, false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/zonemd.cc
+++ b/pdns/zonemd.cc
@@ -261,7 +261,7 @@ void pdns::ZoneMD::verify(bool& validationDone, bool& validationOK)
   // Final verify
   for (const auto& record : d_zonemdRecords) {
     auto zonemd = record.second.record;
-    if (zonemd->d_hashalgo == 1) {
+    if (zonemd->d_hashalgo == 1 && sha384digest) {
       validationDone = true;
       auto computed = sha384digest->digest();
       if (constantTimeStringEquals(zonemd->d_digest, computed)) {
@@ -269,7 +269,7 @@ void pdns::ZoneMD::verify(bool& validationDone, bool& validationOK)
         break; // Per RFC: a single succeeding validation is enough
       }
     }
-    else if (zonemd->d_hashalgo == 2) {
+    else if (zonemd->d_hashalgo == 2 && sha512digest) {
       validationDone = true;
       auto computed = sha512digest->digest();
       if (constantTimeStringEquals(zonemd->d_digest, computed)) {

--- a/regression-tests/zones/zonemd-invalidscheme.zone
+++ b/regression-tests/zones/zonemd-invalidscheme.zone
@@ -1,0 +1,23 @@
+example.      86400  IN  SOA     ns1 admin 2026032604 (
+                                 1800 900 604800 86400 )
+example.      86400  IN  NS      ns1.example.
+example.      86400  IN  NS      ns2.example.
+example.      86400  IN  ZONEMD  2026032604 1 1 (
+                                 62e6cf51b02e54b9
+                                 b5f967d547ce4313
+                                 6792901f9f88e637
+                                 493daaf401c92c27
+                                 9dd10f0edb1c56f8
+                                 080211f8480ee306 )
+example.      86400  IN  ZONEMD  2026032604 2 2 (
+                                 08cfa1115c7b948c
+                                 4163a901270395ea
+                                 226a930cd2cbcf2f
+                                 a9a5e6eb85f37c8a
+                                 4e114d884e66f176
+                                 eab121cb02db7d65
+                                 2e0cc4827e7a3204
+                                 f166b47e5613fd27 )
+ns1.example.  3600   IN  A       203.0.113.63
+ns2.example.  86400  IN  TXT     "This example has multiple digests"
+NS2.EXAMPLE.  3600   IN  AAAA    2001:db8::63


### PR DESCRIPTION

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

YWH-PGM6095-156
CVE-2026-33601 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
