### PR TITLE
dnsdist: Check record length before calling the visitor function

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -1350,13 +1350,12 @@ bool visitDNSPacket(const std::string_view& packet, const std::function<bool(uin
       uint32_t dnsttl = reader.get32BitInt();
       uint16_t contentLength = reader.get16BitInt();
       uint16_t pos = reader.getPosition();
+      reader.skip(contentLength);
 
       bool done = visitor(section, dnsclass, dnstype, dnsttl, contentLength, &packet.at(pos));
       if (done) {
         return true;
       }
-
-      reader.skip(contentLength);
     }
   }
   catch (...) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
