### PR TITLE
dnsdist: Use `DNSName` in `StatNode` to avoid encoding issues

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dynblocks.hh
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.hh
@@ -65,6 +65,7 @@ struct dnsdist_ffi_stat_node_t
   {
   }
 
+  mutable std::string fullname;
   const StatNode& node;
   const StatNode::Stat& self;
   const StatNode::Stat& children;

--- a/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
@@ -66,9 +66,11 @@ unsigned int dnsdist_ffi_stat_node_get_labels_count(const dnsdist_ffi_stat_node_
 
 void dnsdist_ffi_stat_node_get_full_name_raw(const dnsdist_ffi_stat_node_t* node, const char** name, size_t* nameSize)
 {
-  const auto& storage = node->node.fullname;
-  *name = storage.c_str();
-  *nameSize = storage.size();
+  if (node->fullname.empty()) {
+    node->fullname = node->node.fullname.toString();
+  }
+  *name = node->fullname.c_str();
+  *nameSize = node->fullname.size();
 }
 
 unsigned int dnsdist_ffi_stat_node_get_children_count(const dnsdist_ffi_stat_node_t* node)

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -902,7 +902,7 @@ void setupLuaInspection(LuaContext& luaCtx)
                                                               [](const StatNode& node) -> unsigned int {
                                                                 return node.size();
                                                               });
-  luaCtx.registerMember("fullname", &StatNode::fullname);
+  luaCtx.registerMember<std::string(StatNode::*)>(std::string("fullname"), [](const StatNode& node) -> std::string { return node.fullname.toString(); });
   luaCtx.registerMember("labelsCount", &StatNode::labelsCount);
   luaCtx.registerMember("servfails", &StatNode::Stat::servfails);
   luaCtx.registerMember("nxdomains", &StatNode::Stat::nxdomains);

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -902,7 +902,13 @@ void setupLuaInspection(LuaContext& luaCtx)
                                                               [](const StatNode& node) -> unsigned int {
                                                                 return node.size();
                                                               });
-  luaCtx.registerMember<std::string(StatNode::*)>(std::string("fullname"), [](const StatNode& node) -> std::string { return node.fullname.toString(); });
+  luaCtx.registerMember<std::string(StatNode::*)>(std::string("fullname"), [](const StatNode& node) -> std::string {
+    /* we are not using toLogString() because we want:
+       - an empty string for empty
+       - trailing dots otherwise
+    */
+    return !node.fullname.empty() ? node.fullname.toString() : "";
+  });
   luaCtx.registerMember("labelsCount", &StatNode::labelsCount);
   luaCtx.registerMember("servfails", &StatNode::Stat::servfails);
   luaCtx.registerMember("nxdomains", &StatNode::Stat::nxdomains);

--- a/pdns/statnode.cc
+++ b/pdns/statnode.cc
@@ -57,7 +57,7 @@ void StatNode::submit(const DNSName& domain, int rcode, unsigned int bytes, bool
   }
 
   auto last = tmp.end() - 1;
-  children[*last].submit(last, tmp.begin(), "", rcode, bytes, remote, 1, hit, samplingRate);
+  children[*last].submit(last, tmp.begin(), g_rootdnsname, rcode, bytes, remote, 1, hit, samplingRate);
 }
 
 static uint64_t adjustForSampling(uint32_t count, size_t samplingRate)
@@ -76,7 +76,7 @@ static uint64_t adjustForSampling(uint32_t count, size_t samplingRate)
    www.powerdns.com. 
 */
 
-void StatNode::submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const std::string& domain, int rcode, unsigned int bytes, const std::optional<ComboAddress>& remote, unsigned int count, bool hit, size_t samplingRate)
+void StatNode::submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const DNSName& domain, int rcode, unsigned int bytes, const std::optional<ComboAddress>& remote, unsigned int count, bool hit, size_t samplingRate)
 {
   //  cerr<<"Submit called for domain='"<<domain<<"': ";
   //  for(const std::string& n :  labels) 
@@ -93,13 +93,8 @@ void StatNode::submit(std::vector<string>::const_iterator end, std::vector<strin
 
   if (end == begin) {
     if (fullname.empty()) {
-      size_t needed = name.size() + 1 + domain.size();
-      if (fullname.capacity() < needed) {
-        fullname.reserve(needed);
-      }
-      fullname = name;
-      fullname.append(".");
-      fullname.append(domain);
+      fullname = domain;
+      fullname.prependRawLabel(name);
       labelsCount = count;
     }
     //    cerr<<"Hit the end, set our fullname to '"<<fullname<<"'"<<endl<<endl;
@@ -128,13 +123,8 @@ void StatNode::submit(std::vector<string>::const_iterator end, std::vector<strin
   }
   else {
     if (fullname.empty()) {
-      size_t needed = name.size() + 1 + domain.size();
-      if (fullname.capacity() < needed) {
-        fullname.reserve(needed);
-      }
-      fullname = name;
-      fullname.append(".");
-      fullname.append(domain);
+      fullname = domain;
+      fullname.prependRawLabel(name);
       labelsCount = count;
     }
     //    cerr<<"Not yet end, set our fullname to '"<<fullname<<"', recursing"<<endl;

--- a/pdns/statnode.hh
+++ b/pdns/statnode.hh
@@ -61,7 +61,7 @@ public:
 
   Stat s;
   std::string name;
-  std::string fullname;
+  DNSName fullname;
   uint8_t labelsCount{0};
 
   void submit(const DNSName& domain, int rcode, uint32_t bytes, bool hit, const std::optional<ComboAddress>& remote, size_t samplingRate);
@@ -77,7 +77,7 @@ public:
   }
 
 private:
-  void submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const std::string& domain, int rcode, uint32_t bytes, const std::optional<ComboAddress>& remote, unsigned int count, bool hit, size_t samplingRate);
+  void submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const DNSName& domain, int rcode, uint32_t bytes, const std::optional<ComboAddress>& remote, unsigned int count, bool hit, size_t samplingRate);
 
   using children_t = std::map<std::string, StatNode, CIStringCompare>;
   children_t children;

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -149,18 +149,8 @@ class TestStatNodeRespRingSince(DNSDistTest):
         Advanced: StatNodeRespRing with optional since parameter
 
         """
-        name = "statnodesince.advanced.tests.powerdns.com."
-        query = dns.message.make_query(name, "A", "IN")
-        response = dns.message.make_response(query)
-        rrset = dns.rrset.from_text(name, 1, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
-        response.answer.append(rrset)
-
-        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEqual(query, receivedQuery)
-        self.assertEqual(response, receivedResponse)
+        queryRaw = b"\315m\001\000\000\001\000\000\000\000\000\000\016stat\x2enodesince\badvanced\005tests\bpowerdns\003com\000\000\001\000\001"
+        (_, _) = self.sendUDPQuery(queryRaw, response=None, rawQuery=True, useQueue=False)
 
         self.sendConsoleCommand("nodesSeen = {}")
         self.sendConsoleCommand("statNodeRespRing(visitor)")
@@ -170,7 +160,7 @@ class TestStatNodeRespRingSince(DNSDistTest):
         nodes = nodes.strip("\n")
         self.assertEqual(
             nodes,
-            """statnodesince.advanced.tests.powerdns.com.
+            """stat\\.nodesince.advanced.tests.powerdns.com.
 advanced.tests.powerdns.com.
 tests.powerdns.com.
 powerdns.com.
@@ -185,7 +175,7 @@ com.""",
         nodes = nodes.strip("\n")
         self.assertEqual(
             nodes,
-            """statnodesince.advanced.tests.powerdns.com.
+            """stat\\.nodesince.advanced.tests.powerdns.com.
 advanced.tests.powerdns.com.
 tests.powerdns.com.
 powerdns.com.
@@ -202,7 +192,7 @@ com.""",
         nodes = nodes.strip("\n")
         self.assertEqual(
             nodes,
-            """statnodesince.advanced.tests.powerdns.com.
+            """stat\\.nodesince.advanced.tests.powerdns.com.
 advanced.tests.powerdns.com.
 tests.powerdns.com.
 powerdns.com.
@@ -225,7 +215,7 @@ com.""",
         nodes = nodes.strip("\n")
         self.assertEqual(
             nodes,
-            """statnodesince.advanced.tests.powerdns.com.
+            """stat\\.nodesince.advanced.tests.powerdns.com.
 advanced.tests.powerdns.com.
 tests.powerdns.com.
 powerdns.com.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
