### PR TITLE
dnsdist: Clean QUIC stream-related data after errors

### DIFF
--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -748,6 +748,8 @@ static void processH3HeaderEvent(ClientState& clientState, DOH3Frontend& fronten
     ++clientState.nonCompliantQueries;
     ++frontend.d_errorResponses;
     h3_send_response(conn, streamID, 400, msg);
+    conn.d_streamBuffers.erase(streamID);
+    conn.d_headersBuffers.erase(streamID);
   };
 
   auto& headers = conn.d_headersBuffers.at(streamID);
@@ -892,8 +894,11 @@ static void processH3Events(ClientState& clientState, DOH3Frontend& frontend, H3
     }
     case QUICHE_H3_EVENT_FINISHED:
     case QUICHE_H3_EVENT_RESET:
-    case QUICHE_H3_EVENT_PRIORITY_UPDATE:
+      conn.d_headersBuffers.erase(streamID);
+      conn.d_streamBuffers.erase(streamID);
+      break;
     case QUICHE_H3_EVENT_GOAWAY:
+    case QUICHE_H3_EVENT_PRIORITY_UPDATE:
       break;
     }
 

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -647,6 +647,7 @@ static void handleReadableStream(DOQFrontend& frontend, ClientState& clientState
       ++dnsdist::metrics::g_stats.nonCompliantQueries;
       ++clientState.nonCompliantQueries;
       quiche_conn_stream_shutdown(conn.d_conn.get(), streamID, QUICHE_SHUTDOWN_WRITE, static_cast<uint64_t>(DOQ_Error_Codes::DOQ_PROTOCOL_ERROR));
+      conn.d_streamBuffers.erase(streamID);
       return;
     }
 
@@ -660,6 +661,7 @@ static void handleReadableStream(DOQFrontend& frontend, ClientState& clientState
     ++dnsdist::metrics::g_stats.nonCompliantQueries;
     ++clientState.nonCompliantQueries;
     quiche_conn_stream_shutdown(conn.d_conn.get(), streamID, QUICHE_SHUTDOWN_WRITE, static_cast<uint64_t>(DOQ_Error_Codes::DOQ_PROTOCOL_ERROR));
+    conn.d_streamBuffers.erase(streamID);
     return;
   }
 
@@ -669,6 +671,7 @@ static void handleReadableStream(DOQFrontend& frontend, ClientState& clientState
     ++dnsdist::metrics::g_stats.nonCompliantQueries;
     ++clientState.nonCompliantQueries;
     quiche_conn_stream_shutdown(conn.d_conn.get(), streamID, QUICHE_SHUTDOWN_WRITE, static_cast<uint64_t>(DOQ_Error_Codes::DOQ_PROTOCOL_ERROR));
+    conn.d_streamBuffers.erase(streamID);
     return;
   }
   DEBUGLOG("Dispatching query");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
