### PR TITLE
dnsdist-2.1.x: Backport 17216 - Prevent division by zero when computing DNSCrypt padding

### DIFF
--- a/pdns/dnsdistdist/dnscrypt.cc
+++ b/pdns/dnsdistdist/dnscrypt.cc
@@ -698,10 +698,10 @@ int DNSCryptQuery::encryptResponse(PacketBuffer& response, size_t maxResponseSiz
   }
 
   size_t requiredSize = sizeof(responseHeader) + DNSCRYPT_MAC_SIZE + response.size();
-  size_t maxSize = std::min(maxResponseSize, requiredSize + DNSCRYPT_MAX_RESPONSE_PADDING_SIZE);
   if (requiredSize > maxResponseSize) {
     return ENOBUFS;
   }
+  size_t maxSize = std::min(maxResponseSize, requiredSize + DNSCRYPT_MAX_RESPONSE_PADDING_SIZE);
   uint16_t paddingSize = computePaddingSize(requiredSize, maxSize);
   requiredSize += paddingSize;
 

--- a/pdns/dnsdistdist/dnscrypt.cc
+++ b/pdns/dnsdistdist/dnscrypt.cc
@@ -639,6 +639,9 @@ uint16_t DNSCryptQuery::computePaddingSize(uint16_t unpaddedLen, size_t maxLen) 
   if (d_pair == nullptr) {
     throw std::runtime_error("Trying to compute the padding size from an invalid DNSCrypt query");
   }
+  if (unpaddedLen > maxLen) {
+    throw std::runtime_error("Trying to compute the padding size for an oversized content");
+  }
 
   DNSCryptNonceType nonce;
   memcpy(nonce.data(), d_header.clientNonce.data(), d_header.clientNonce.size());
@@ -696,6 +699,9 @@ int DNSCryptQuery::encryptResponse(PacketBuffer& response, size_t maxResponseSiz
 
   size_t requiredSize = sizeof(responseHeader) + DNSCRYPT_MAC_SIZE + response.size();
   size_t maxSize = std::min(maxResponseSize, requiredSize + DNSCRYPT_MAX_RESPONSE_PADDING_SIZE);
+  if (requiredSize > maxResponseSize) {
+    return ENOBUFS;
+  }
   uint16_t paddingSize = computePaddingSize(requiredSize, maxSize);
   requiredSize += paddingSize;
 

--- a/pdns/dnsdistdist/test-dnscrypt_cc.cc
+++ b/pdns/dnsdistdist/test-dnscrypt_cc.cc
@@ -180,6 +180,48 @@ BOOST_AUTO_TEST_CASE(DNSCryptEncryptedQueryValid)
   BOOST_CHECK(mdp.d_qtype == QType::AAAA);
 }
 
+BOOST_AUTO_TEST_CASE(DNSCryptEncryptResponse)
+{
+  DNSCryptPrivateKey resolverPrivateKey;
+  DNSCryptCert resolverCert;
+  DNSCryptCertSignedData::ResolverPublicKeyType providerPublicKey;
+  DNSCryptCertSignedData::ResolverPrivateKeyType providerPrivateKey;
+  time_t now = time(nullptr);
+  DNSCryptContext::generateProviderKeys(providerPublicKey, providerPrivateKey);
+  DNSCryptContext::generateCertificate(1, now, oneDayFromNow(now), DNSCryptExchangeVersion::VERSION1, providerPrivateKey, resolverPrivateKey, resolverCert);
+  auto ctx = std::make_shared<DNSCryptContext>("2.name", resolverCert, resolverPrivateKey);
+
+  DNSCryptPrivateKey clientPrivateKey;
+  DNSCryptPublicKeyType clientPublicKey;
+  DNSCryptContext::generateResolverKeyPair(clientPrivateKey, clientPublicKey);
+
+  DNSCryptClientNonceType clientNonce{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x08, 0x09, 0x0A, 0x0B};
+
+  DNSName name("www.powerdns.com.");
+  PacketBuffer plainQuery;
+  GenericDNSPacketWriter<PacketBuffer> packetWriter(plainQuery, name, QType::AAAA, QClass::IN, 0);
+  packetWriter.getHeader()->rd = 1;
+
+  plainQuery.resize(4096U);
+  int res = ctx->encryptQuery(plainQuery, 8192, clientPublicKey, clientPrivateKey, clientNonce, false, std::make_shared<DNSCryptCert>(resolverCert));
+
+  BOOST_CHECK_EQUAL(res, 0);
+
+  std::shared_ptr<DNSCryptQuery> query = std::make_shared<DNSCryptQuery>(ctx);
+
+  query->parsePacket(plainQuery, false, now);
+
+  BOOST_CHECK_EQUAL(query->isValid(), true);
+  BOOST_CHECK_EQUAL(query->isEncrypted(), true);
+
+  PacketBuffer response;
+  GenericDNSPacketWriter<PacketBuffer> responseWriter(response, name, QType::AAAA, QClass::IN, 0);
+  packetWriter.getHeader()->rd = 1;
+  response.resize(4049U);
+
+  query->encryptResponse(response, 4096U, false);
+}
+
 // valid encrypted query with not enough room
 BOOST_AUTO_TEST_CASE(DNSCryptEncryptedQueryValidButShort)
 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17216 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
