### PR TITLE
dnsdist-2.1.x: Backport 17213 - Prevent ID overflow in outgoing TCP connections

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -230,7 +230,7 @@ void DoHConnectionToBackend::handleTimeout(const struct timeval& now, bool write
 bool DoHConnectionToBackend::reachedMaxStreamID() const
 {
   const uint32_t maximumStreamID = (static_cast<uint32_t>(1) << 31) - 1;
-  return d_highestStreamID == maximumStreamID;
+  return d_highestStreamID >= maximumStreamID;
 }
 
 bool DoHConnectionToBackend::reachedMaxConcurrentQueries() const

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -924,6 +924,18 @@ bool TCPConnectionToBackend::isXFRFinished(const TCPResponse& response, TCPQuery
   return done;
 }
 
+bool TCPConnectionToBackend::reachedMaxStreamID() const
+{
+  /* TCP/DoT has only 2^16 usable identifiers, DoH has 2^32 */
+  const uint32_t maximumStreamID = std::numeric_limits<uint16_t>::max() - 1;
+  if (d_highestStreamID >= maximumStreamID) {
+    return true;
+  }
+
+  /* pending queries will need IDs, so we need to take them into account as well */
+  return (d_pendingQueries.size() >= (maximumStreamID - d_highestStreamID));
+}
+
 std::shared_ptr<const Logr::Logger> ConnectionToBackend::getLogger() const
 {
   auto logger = dnsdist::logging::getTopLogger("outgoing-tcp-connection")->withValues("fresh_connection", Logging::Loggable(d_fresh), "tcp_fast_open", Logging::Loggable(d_enableFastOpen), "proxy_protocol_payload_sent", Logging::Loggable(d_proxyProtocolPayloadSent), "downstream_failures", Logging::Loggable(d_downstreamFailures), "highest_stream_id", Logging::Loggable(d_highestStreamID), "queries_count", Logging::Loggable(d_queries), "io_state", Logging::Loggable(d_ioState ? d_ioState->getState() : "empty"));

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -241,12 +241,7 @@ public:
     return d_state == State::idle && d_pendingQueries.size() == 0 && d_pendingResponses.size() == 0;
   }
 
-  bool reachedMaxStreamID() const override
-  {
-    /* TCP/DoT has only 2^16 usable identifiers, DoH has 2^32 */
-    const uint32_t maximumStreamID = std::numeric_limits<uint16_t>::max() - 1;
-    return d_highestStreamID == maximumStreamID;
-  }
+  bool reachedMaxStreamID() const override;
 
   bool reachedMaxConcurrentQueries() const override
   {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17213 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
