### PR TITLE
dnsdist-2.1.x: Backport 17209 - Fix out-of-bounds check for UDP responses from backend

### DIFF
--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -581,7 +581,7 @@ uint16_t DownstreamState::saveState(InternalQueryState&& state)
 
   do {
     uint16_t selectedID = (idOffset++) % idStates.size();
-    IDState& ids = idStates[selectedID];
+    IDState& ids = idStates.at(selectedID);
     auto guard = ids.acquire();
     if (!guard) {
       continue;
@@ -624,7 +624,7 @@ void DownstreamState::restoreState(uint16_t id, InternalQueryState&& state)
     return;
   }
 
-  auto& ids = idStates[id];
+  auto& ids = idStates.at(id);
   auto guard = ids.acquire();
   if (!guard) {
     /* already used */
@@ -663,11 +663,11 @@ std::optional<InternalQueryState> DownstreamState::getState(uint16_t id)
     return result;
   }
 
-  if (id > idStates.size()) {
+  if (id >= idStates.size()) {
     return result;
   }
 
-  auto& ids = idStates[id];
+  auto& ids = idStates.at(id);
   auto guard = ids.acquire();
   if (!guard) {
     return result;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17209 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
