### PR TITLE
dnsdist-2.1.x: Backport 17208 - Apply TCP connections limits to DoQ/DoH3 connections

### DIFF
--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -164,7 +164,7 @@ static ClientActivity& getCurrentClientActivity(const ClientEntry& entry, time_t
   return activity.front();
 }
 
-IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(const ComboAddress& from, bool isTLS)
+IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC)
 {
   const auto& immutable = dnsdist::configuration::getImmutableConfiguration();
   const auto maxConnsPerClient = immutable.d_maxTCPConnectionsPerClient;
@@ -185,21 +185,25 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
     ++activity.tcpConnections;
   };
 
-  auto checkConnectionAllowed = [now, from, maxConnsPerClient, threshold, tcpRate, tlsNewRate, tlsResumedRate, interval, isTLS, &immutable](const ClientEntry& entry) {
+  auto getProtocol = [isQUIC]() -> std::string {
+    return isQUIC ? "QUIC" : "TCP";
+  };
+
+  auto checkConnectionAllowed = [now, from, maxConnsPerClient, threshold, tcpRate, tlsNewRate, tlsResumedRate, interval, isTLS, &immutable, &getProtocol](const ClientEntry& entry) {
     if (entry.d_bannedUntil != 0 && entry.d_bannedUntil >= now) {
-      VERBOSESLOG(infolog("Refusing TCP connection from %s: banned", from.toStringWithPort()),
-                  dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Refusing TCP connection", "reason", Logging::Loggable("banned"), "client.address", Logging::Loggable(from)));
+      VERBOSESLOG(infolog("Refusing %s connection from %s: banned", getProtocol(), from.toStringWithPort()),
+                  dnsdist::logging::getTopLogger("concurrent-connections-manager")->info(Logr::Info, "Refusing connection", "reason", Logging::Loggable("banned"), "protocol", Logging::Loggable(getProtocol()), "client.address", Logging::Loggable(from)));
       return NewConnectionResult::Denied;
     }
     if (maxConnsPerClient > 0 && entry.d_concurrentConnections >= maxConnsPerClient) {
-      VERBOSESLOG(infolog("Refusing TCP connection from %s: too many connections", from.toStringWithPort()),
-                  dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Refusing TCP connection", "reason", Logging::Loggable("too many connections"), "client.address", Logging::Loggable(from)));
+      VERBOSESLOG(infolog("Refusing %s connection from %s: too many connections", getProtocol(), from.toStringWithPort()),
+                  dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Refusing connection", "reason", Logging::Loggable("too many connections"), "protocol", Logging::Loggable(getProtocol()), "client.address", Logging::Loggable(from)));
       return NewConnectionResult::Denied;
     }
     if (!checkTCPConnectionsRate(entry.d_activity, now, tcpRate, tlsNewRate, tlsResumedRate, interval, isTLS)) {
       entry.d_bannedUntil = now + immutable.d_tcpBanDurationForExceedingTCPTLSRate;
-      VERBOSESLOG(infolog("Banning TCP connections from %s for %d seconds: too many new TCP/TLS connections per second", from.toStringWithPort(), immutable.d_tcpBanDurationForExceedingTCPTLSRate),
-                  dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Banning TCP connections from this client", "reason", Logging::Loggable("too many new TCP/TLS connections per second"), "client.address", Logging::Loggable(from), "duration-seconds", Logging::Loggable(immutable.d_tcpBanDurationForExceedingTCPTLSRate)));
+      VERBOSESLOG(infolog("Banning connections from %s for %d seconds: too many new QUIC/TCP/TLS connections per second", from.toStringWithPort(), immutable.d_tcpBanDurationForExceedingTCPTLSRate),
+                  dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Banning connections from this client", "reason", Logging::Loggable("too many new TCP/TLS connections per second"), "client.address", Logging::Loggable(from), "duration-seconds", Logging::Loggable(immutable.d_tcpBanDurationForExceedingTCPTLSRate)));
       return NewConnectionResult::Denied;
     }
 
@@ -211,8 +215,8 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
     if (current < threshold) {
       return NewConnectionResult::Allowed;
     }
-    VERBOSESLOG(infolog("Restricting TCP connection from %s: nearly reaching the maximum number of concurrent TCP connections", from.toStringWithPort()),
-                dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Restricting TCP connections from this client", "reason", Logging::Loggable("nearly reaching the maximum number of concurrent TCP connections"), "client.address", Logging::Loggable(from)));
+    VERBOSESLOG(infolog("Restricting %s connection from %s: nearly reaching the maximum number of concurrent TCP connections", getProtocol(), from.toStringWithPort()),
+                dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Restricting TCP connections from this client", "reason", Logging::Loggable("nearly reaching the maximum number of concurrent TCP connections"), "protocol", Logging::Loggable(getProtocol()), "client.address", Logging::Loggable(from)));
     return NewConnectionResult::Restricted;
   };
 

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.hh
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.hh
@@ -34,7 +34,7 @@ public:
     Denied = 1,
     Restricted = 2,
   };
-  static NewConnectionResult accountNewTCPConnection(const ComboAddress& from, bool isTLS);
+  static NewConnectionResult accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC = false);
   static bool isClientOverThreshold(const ComboAddress& from);
   static void accountTLSNewSession(const ComboAddress& from);
   static void accountTLSResumedSession(const ComboAddress& from);

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1594,7 +1594,7 @@ tcp_tuning:
       lua-name: "setMaxTCPConnectionRatePerClient"
       internal-field-name: "d_maxTCPConnectionsRatePerClient"
       runtime-configurable: false
-      description: "Set the maximum number of new TCP connections that a given client (see ``connections_mask_v4``, ``connections_mask_v6`` and ``connection_mask_v4_port`` to see how clients can be aggregated) can open, per second, over the last ``connection_rate_interval`` minutes. Clients exceeding this rate will not be able to open new TCP connections for ``ban_duration_for_exceeding_tcp_tls_rate`` seconds. See also ``max_tls_new_session_rate_per_client`` and ``max_tls_resumed_session_rate_per_client``"
+      description: "Set the maximum number of new TCP or QUIC connections that a given client (see ``connections_mask_v4``, ``connections_mask_v6`` and ``connection_mask_v4_port`` to see how clients can be aggregated) can open, per second, over the last ``connection_rate_interval`` minutes. Clients exceeding this rate will not be able to open new TCP connections for ``ban_duration_for_exceeding_tcp_tls_rate`` seconds. See also ``max_tls_new_session_rate_per_client`` and ``max_tls_resumed_session_rate_per_client``"
     - name: "connection_rate_interval"
       type: "u64"
       default: "5"

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -11,7 +11,10 @@ Tuning related functions
 
   .. versionadded:: 2.0.0
 
-  Set for how long, in seconds, a client (or range, see :func:`setTCPConnectionsMaskV4`, :func:`setTCPConnectionsMaskV6` and :func:`setTCPConnectionsMaskV4Port` to see how clients can be aggregated) will be prevented from opening a new TCP connection when it has exceeded :func:`setMaxTCPConnectionRatePerClient`, :func:`setMaxTLSNewSessionRatePerClient` or :func:`setMaxTLSResumedSessionRatePerClient`. Default is 10 seconds.
+  .. versionchanged:: 2.0.4
+    QUIC connections are now affected as well
+
+  Set for how long, in seconds, a client (or range, see :func:`setTCPConnectionsMaskV4`, :func:`setTCPConnectionsMaskV6` and :func:`setTCPConnectionsMaskV4Port` to see how clients can be aggregated) will be prevented from opening a new TCP or QUIC connection when it has exceeded :func:`setMaxTCPConnectionRatePerClient`, :func:`setMaxTLSNewSessionRatePerClient` or :func:`setMaxTLSResumedSessionRatePerClient`. Default is 10 seconds.
 
   :param int num: Duration of the ban in seconds
 
@@ -77,13 +80,19 @@ Tuning related functions
 
   .. versionadded:: 2.0.0
 
-  Set the maximum number of new TCP connections that a given client (or range, see :func:`setTCPConnectionsMaskV4`, :func:`setTCPConnectionsMaskV6` and :func:`setTCPConnectionsMaskV4Port` to see how clients can be aggregated) can open, per second, over the last :func:`setTCPConnectionRateInterval` minutes. Clients exceeding this rate will not be able to open new TCP connections for :func:`setBanDurationForExceedingTCPTLSRate` seconds. See also :func:`setMaxTLSNewSessionRatePerClient` and :func:`setMaxTLSResumedSessionRatePerClient`. 0 (the default) means unlimited.
+  .. versionchanged:: 2.0.4
+    QUIC connections are now affected as well
+
+  Set the maximum number of new TCP or QUIC connections that a given client (or range, see :func:`setTCPConnectionsMaskV4`, :func:`setTCPConnectionsMaskV6` and :func:`setTCPConnectionsMaskV4Port` to see how clients can be aggregated) can open, per second, over the last :func:`setTCPConnectionRateInterval` minutes. Clients exceeding this rate will not be able to open new TCP connections for :func:`setBanDurationForExceedingTCPTLSRate` seconds. See also :func:`setMaxTLSNewSessionRatePerClient` and :func:`setMaxTLSResumedSessionRatePerClient`. 0 (the default) means unlimited.
 
   :param int num: Number of new connections per second
 
 .. function:: setMaxTCPConnectionsPerClient(num)
 
-  Set the maximum number of TCP connections per client. 0 (the default) means unlimited.
+  .. versionchanged:: 2.0.4
+    QUIC connections are now affected as well
+
+  Set the maximum number of TCP or QUIC connections per client. 0 (the default) means unlimited.
 
   :param int num:
 

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -30,13 +30,12 @@
 #include "misc.hh"
 #include "sstuff.hh"
 #include "threadname.hh"
-#include "base64.hh"
 
+#include "dnsdist-concurrent-connections.hh"
 #include "dnsdist-dnsparser.hh"
 #include "dnsdist-ecs.hh"
 #include "dnsdist-proxy-protocol.hh"
 #include "dnsdist-tcp.hh"
-#include "dnsdist-random.hh"
 
 #include "doq-common.hh"
 
@@ -60,7 +59,18 @@ public:
   H3Connection(H3Connection&&) = default;
   H3Connection& operator=(const H3Connection&) = delete;
   H3Connection& operator=(H3Connection&&) = default;
-  ~H3Connection() = default;
+  ~H3Connection()
+  {
+    try {
+      /* do not account if we have been moved! */
+      if (d_conn) {
+        dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(d_peer);
+      }
+    }
+    catch (...) {
+      /* in theory it might raise an exception, and we cannot allow it to be uncaught in a dtor */
+    }
+  }
 
   std::shared_ptr<const std::string> getSNI()
   {
@@ -970,6 +980,12 @@ static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientStat
       if (!originalDestinationID) {
         ++frontend.d_doh3InvalidTokensReceived;
         DEBUGLOG("Discarding invalid token");
+        continue;
+      }
+
+      auto connectionResult = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, true, true);
+      if (connectionResult == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied) {
+        DEBUGLOG("Connection not allowed!");
         continue;
       }
 

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -31,11 +31,11 @@
 #include "sstuff.hh"
 #include "threadname.hh"
 
+#include "dnsdist-concurrent-connections.hh"
 #include "dnsdist-dnsparser.hh"
 #include "dnsdist-ecs.hh"
 #include "dnsdist-proxy-protocol.hh"
 #include "dnsdist-tcp.hh"
-#include "dnsdist-random.hh"
 
 #include "doq-common.hh"
 
@@ -59,7 +59,18 @@ public:
   Connection(Connection&&) = default;
   Connection& operator=(const Connection&) = delete;
   Connection& operator=(Connection&&) = default;
-  ~Connection() = default;
+  ~Connection()
+  {
+    try {
+      /* do not account if we have been moved! */
+      if (d_conn) {
+        dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(d_peer);
+      }
+    }
+    catch (...) {
+      /* in theory it might raise an exception, and we cannot allow it to be uncaught in a dtor */
+    }
+  }
 
   std::shared_ptr<const std::string> getSNI()
   {
@@ -761,6 +772,12 @@ static void handleSocketReadable(DOQFrontend& frontend, ClientState& clientState
       if (!originalDestinationID) {
         ++frontend.d_doqInvalidTokensReceived;
         DEBUGLOG("Discarding invalid token");
+        continue;
+      }
+
+      auto connectionResult = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, true, true);
+      if (connectionResult == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied) {
+        DEBUGLOG("Connection not allowed!");
         continue;
       }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17208 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
