### PR TITLE
common: Check boundary in getUnquotedText() as we do in getText()

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -543,11 +543,13 @@ string PacketReader::getText(bool multi, bool lenField)
 
 string PacketReader::getUnquotedText(bool lenField)
 {
-  uint16_t stop_at;
-  if(lenField)
+  uint16_t stop_at{};
+  if (lenField) {
     stop_at = static_cast<uint8_t>(d_content.at(d_pos)) + d_pos + 1;
-  else
+  }
+  else {
     stop_at = d_recordlen;
+  }
 
   /* think unsigned overflow */
   if (stop_at < d_pos) {
@@ -560,8 +562,9 @@ string PacketReader::getUnquotedText(bool lenField)
     throw std::out_of_range("getUnquotedText: length exceeds record boundary");
   }
 
-  if(stop_at == d_pos)
+  if (stop_at == d_pos) {
     return "";
+  }
 
   d_pos++;
   string ret(d_content.substr(d_pos, stop_at-d_pos));

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -554,6 +554,12 @@ string PacketReader::getUnquotedText(bool lenField)
     throw std::out_of_range("getUnquotedText out of record range");
   }
 
+  /* Validate against record boundary */
+  const uint16_t recordEnd = d_startrecordpos + d_recordlen;
+  if (stop_at > recordEnd) {
+    throw std::out_of_range("getUnquotedText: length exceeds record boundary");
+  }
+
   if(stop_at == d_pos)
     return "";
 


### PR DESCRIPTION
From YWH-PGM6095-137, thanks to h72. We still stay inside the packet, so no security issue.

Followup to #17077

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
