### PR TITLE
dnsdist: Fix clang-tidy warnings

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -280,8 +280,8 @@ static void addDateHeader(PacketBuffer& out)
   time_t timestamp = time(nullptr);
   // apparently someone might be crazy enough to change the locale using Lua (why?)
   // so we have to do extra work just in case
-  auto posixLocale = newlocale(LC_ALL_MASK, "POSIX", nullptr);
-  if (!posixLocale) {
+  auto* posixLocale = newlocale(LC_ALL_MASK, "POSIX", nullptr);
+  if (posixLocale == nullptr) {
     return;
   }
   try {

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -673,6 +673,7 @@ static void processDOH3Query(DOH3UnitUniquePtr&& doh3Unit)
     }
 
     /* On exceptional cases, cpq is moved but returns false above. So we check to make sure. See https://github.com/PowerDNS/pdns/issues/17109 */
+    // NOLINTNEXTLINE(bugprone-use-after-move): the behaviour of a moved std::unique_ptr is actually specified
     if (cpq) {
       unit = cpq->releaseDU();
       unit->status_code = 500;

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -557,6 +557,7 @@ static void processDOQQuery(DOQUnitUniquePtr&& doqUnit)
       return;
     }
     /* On exceptional cases, cpq is moved but returns false above. So we check to make sure. See https://github.com/PowerDNS/pdns/issues/17109 */
+    // NOLINTNEXTLINE(bugprone-use-after-move): the behaviour of a moved std::unique_ptr is actually specified
     if (cpq) {
       unit = cpq->releaseDU();
       handleImmediateResponse(std::move(unit), "DoQ internal error");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
