### PR TITLE
auth: only apply backupSelector to the first non-empty group

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -967,13 +967,14 @@ static vector<string> genericIfUp(Logr::log_t slog, const boost::variant<iplist_
     throw std::runtime_error("if{url,port}up health check has not completed yet");
   }
 
-  // Apply backupSelector on all candidates
-  vector<ComboAddress> ret{};
-  for(const auto& unit : candidates) {
-    ret.insert(ret.end(), unit.begin(), unit.end());
+  // Apply backupSelector on all candidates in the first non-empty group
+  vector<ComboAddress> res;
+  for (const auto& unit : candidates) {
+    if (!unit.empty()) {
+      res = useSelector(slog, getOptionValue<string>(options, "backupSelector", "random"), s_lua_record_ctx->bestwho, unit);
+      break;
+    }
   }
-
-  vector<ComboAddress> res = useSelector(slog, getOptionValue<string>(options, "backupSelector", "random"), s_lua_record_ctx->bestwho, ret);
   return convComboAddressListToString(res);
 }
 
@@ -1338,8 +1339,18 @@ static vector<string> lua_ifurlextup(Logr::log_t slog, const vector<pair<int, op
     throw std::runtime_error("ifexturlup health check has not completed yet");
   }
 
-  // Apply backupSelector on all candidates
-  vector<ComboAddress> res = useSelector(slog, getOptionValue<string>(options, "backupSelector", "random"), s_lua_record_ctx->bestwho, candidates);
+  // Apply backupSelector on all candidates in the first non-empty group
+  vector<ComboAddress> first;
+  for (const auto& [count, unitmap] : ipurls) {
+    if (!unitmap.empty()) {
+      first.reserve(unitmap.size());
+      for (const auto& [ipStr, url] : unitmap) {
+        first.emplace_back(ipStr);
+      }
+      break;
+    }
+  }
+  vector<ComboAddress> res = useSelector(slog, getOptionValue<string>(options, "backupSelector", "random"), s_lua_record_ctx->bestwho, first);
   return convComboAddressListToString(res);
 }
 


### PR DESCRIPTION
Example:

    local ips = {{}, {ip_dallas}}, {}, {ip_frankfurt}}
    return ifurlup(url, ips, {selector='all', backupSelector='all'})

The previous behavior results in returning {ip_dallas, ip_frankfurt} if every IP is detected as down. Health checks start out in the down state so every IP is considered down after a server restart or changes to the health check configuration. For GeoDNS configurations, this means GeoDNS doesn't work when the service is first started or if health checks start failing for every server due to a network or configuration issue.

This changes the behavior to returning {ip_dallas} when every IP is down which matches the behavior when every IP is up. It makes much more sense to have the same result for every IP being up and every IP being down.

### Short description

Closes #12789

I've tested this with the GrapheneOS PowerDNS configuration and it's currently deployed on our staging authoritative DNS server as a backport to 5.0.4:

https://dig.ping.pe/grapheneos.org:A:ns1.staging.grapheneos.org

I have an nftables rule added blocking connecting to each of the server IPs for grapheneos.org to trigger the backup selector. Without this change, it would return every single IP as a separate A record from using backupSelector='all'. We've been working around this for a long time by checking the length of the returned array but it would be a lot nicer to have this work in a more logical way where backupSelector matches what selector does when every IP is up.

The configuration change can be seen here:

https://github.com/GrapheneOS/ns1.grapheneos.org/commit/88288bf91aa089cbfd62d3022d1b983c78c19e32

This shows how backupSelector='empty' improved it already by avoiding needing to hard-wire a value based on the largest set of IPs:

https://github.com/GrapheneOS/ns1.grapheneos.org/commit/dadc575e6fa9cb19aff97a5dde4656b4dbece636

It would be possible to make this configurable but I doubt anyone wants the previous behavior.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)