### PR TITLE
auth: harden xfr*BitInt writers

### DIFF
--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -134,6 +134,9 @@ template <typename Container> void GenericDNSPacketWriter<Container>::addOpt(con
 
 template <typename Container> void GenericDNSPacketWriter<Container>::xfr48BitInt(uint64_t val)
 {
+  if ((val >> 48) != 0) {
+    throw runtime_error("Value too large to fit in 48 bits");
+  }
   std::array<unsigned char, 6> bytes;
   uint16_t theLeft = htons((val >> 32)&0xffffU);
   uint32_t theRight = htonl(val & 0xffffffffU);
@@ -148,23 +151,32 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfrNodeOrL
   d_content.insert(d_content.end(), val.content, val.content + sizeof(val.content));
 }
 
-template <typename Container> void GenericDNSPacketWriter<Container>::xfr32BitInt(uint32_t val)
+template <typename Container> void GenericDNSPacketWriter<Container>::xfr32BitInt(uint64_t val)
 {
-  uint32_t rval=htonl(val);
+  if (val > std::numeric_limits<uint32_t>::max()) {
+    throw runtime_error("Value too large to fit in 32 bits");
+  }
+  uint32_t rval=htonl(static_cast<uint32_t>(val));
   uint8_t* ptr=reinterpret_cast<uint8_t*>(&rval);
   d_content.insert(d_content.end(), ptr, ptr+4);
 }
 
-template <typename Container> void GenericDNSPacketWriter<Container>::xfr16BitInt(uint16_t val)
+template <typename Container> void GenericDNSPacketWriter<Container>::xfr16BitInt(uint64_t val)
 {
-  uint16_t rval=htons(val);
+  if (val > std::numeric_limits<uint16_t>::max()) {
+    throw runtime_error("Value too large to fit in 16 bits");
+  }
+  uint16_t rval=htons(static_cast<uint16_t>(val));
   uint8_t* ptr=reinterpret_cast<uint8_t*>(&rval);
   d_content.insert(d_content.end(), ptr, ptr+2);
 }
 
-template <typename Container> void GenericDNSPacketWriter<Container>::xfr8BitInt(uint8_t val)
+template <typename Container> void GenericDNSPacketWriter<Container>::xfr8BitInt(uint64_t val)
 {
-  d_content.push_back(val);
+  if (val > std::numeric_limits<uint8_t>::max()) {
+    throw runtime_error("Value too large to fit in 8 bits");
+  }
+  d_content.push_back(static_cast<uint8_t>(val));
 }
 
 

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -87,8 +87,8 @@ public:
 
   void xfr48BitInt(uint64_t val);
   void xfrNodeOrLocatorID(const NodeOrLocatorID& val);
-  void xfr32BitInt(uint32_t val);
-  void xfr16BitInt(uint16_t val);
+  void xfr32BitInt(uint64_t val);
+  void xfr16BitInt(uint64_t val);
   void xfrType(uint16_t val)
   {
     xfr16BitInt(val);
@@ -125,7 +125,7 @@ public:
     xfr32BitInt(val);
   }
 
-  void xfr8BitInt(uint8_t val);
+  void xfr8BitInt(uint64_t val);
 
   void xfrName(const DNSName& name, bool compress=false);
   void xfrText(const string& text, bool multi=false, bool lenField=true);


### PR DESCRIPTION
### Short description
Following the recent SA, this widens the type of the data passed to `xfr16BitInt` and `xfr8BitInt` so that we can check for out-of-range values in a single place. Of course, we want to keep the existing beforehand checks, as they will provide more precise information.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
