### PR TITLE
auth: remove extra 'A' from some AXFR log lines

### DIFF
--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -888,9 +888,6 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
       SLOG(g_log << Logger::Notice << ctx.logPrefix << "starting AXFR" << endl,
            ctx.slog->info(Logr::Notice, "AXFR: starting"));
       rrs = doAxfr(tt, laddr, pdl, ctx);
-      if (!g_slogStructured) {
-        ctx.logPrefix.insert(0, 1, 'A'); // XFR -> AXFR
-      }
       SLOG(g_log << Logger::Notice << ctx.logPrefix << "retrieval finished" << endl,
            ctx.slog->info(Logr::Notice, "AXFR: retrieval finished"));
     }


### PR DESCRIPTION
### Short description

After 509b8f3, an extra 'A' appeared in some AXFR log lines.
```
24 Apr 13:21:55 AAXFR-in zone 'test.com', primary '127.0.0.1', zone committed with serial 2005092501
```
This pull reverses that.
```
24 Apr 13:24:10 AXFR-in zone 'test.com', primary '127.0.0.1', zone committed with serial 2005092501
```

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
