### PR TITLE
rec aggressive nsec test: increase entry count so we hit the 8192 byte limit on 32 bit systems too

### DIFF
--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -1143,7 +1143,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_very_big_replace)
   rec.d_ttl = now.tv_sec + 10;
   rec.setContent(getRecordContent(QType::NSEC3, "1 0 500 ab HASG==== A RRSIG NSEC3"));
   std::vector<std::shared_ptr<const RRSIGRecordContent>> sigs;
-  for (auto i = 0; i < 100; i++) {
+  for (auto i = 0; i < 200; i++) {
     auto rrsig = std::make_shared<RRSIGRecordContent>("NSEC3 5 3 10 20370101000000 20370101000000 24567 dummy. data");
     sigs.emplace_back(std::move(rrsig));
   }


### PR DESCRIPTION

### Short description
The size estimate for 100 entries on a 32 bit system is 7265 bytes, smaller than the configured (default) 8192 limit.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
