### PR TITLE
dnsdist: fix a few signed vs unsigned compare warnings in tests

### DIFF
--- a/pdns/dnsdistdist/test-dnsdistedns.cc
+++ b/pdns/dnsdistdist/test-dnsdistedns.cc
@@ -234,9 +234,9 @@ BOOST_AUTO_TEST_CASE(test_locateEDNSOptRR)
     pw.getHeader()->rd = 1;
     pw.addOpt(1232, 0, 0);
     pw.commit();
-    BOOST_CHECK_EQUAL(locateEDNSOptRR(packet, &optStart, &optLen, &last), 0U);
+    BOOST_CHECK_EQUAL(locateEDNSOptRR(packet, &optStart, &optLen, &last), 0);
     BOOST_CHECK_EQUAL(optStart, 29);
-    BOOST_CHECK_EQUAL(optLen, 11);
+    BOOST_CHECK_EQUAL(optLen, 11U);
     BOOST_CHECK(last);
 
     // Make only a header, should error, as there is no question section but QDCOUNT=1
@@ -277,9 +277,9 @@ BOOST_AUTO_TEST_CASE(test_locateEDNSOptRR)
     pw.commit();
     pw.startRecord(DNSName("notroot"), QType::OPT, 3600, QClass::IN, DNSResourceRecord::Place::ADDITIONAL, false);
     pw.commit();
-    BOOST_CHECK_EQUAL(locateEDNSOptRR(packet, &optStart, &optLen, &last), 0U);
+    BOOST_CHECK_EQUAL(locateEDNSOptRR(packet, &optStart, &optLen, &last), 0);
     BOOST_CHECK_EQUAL(optStart, 29);
-    BOOST_CHECK_EQUAL(optLen, 11);
+    BOOST_CHECK_EQUAL(optLen, 11U);
     BOOST_CHECK(!last);
   }
 }
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE(addEDNSPadding)
     // A packet where padding *should* be added
     auto packetWithEDNSNoPadding = getPacket(true, defaultEdnsBufSize, 0);
     BOOST_CHECK(dnsdist::edns::addEDNSPadding(packetWithEDNSNoPadding, defaultEdnsBufSize));
-    BOOST_CHECK_EQUAL(packetWithEDNSNoPadding.size() % 468, 0);
+    BOOST_CHECK_EQUAL(packetWithEDNSNoPadding.size() % 468, 0U);
   }
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
