### PR TITLE
auth 5.0: backport "perform axfr immediately when creating an autosecondary domain"

### DIFF
--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -1155,7 +1155,7 @@ void CommunicatorClass::secondaryRefresh(PacketHandler* P)
     TSIGRecordContent trc;
     DNSName tsigkeyname;
     dp.getTSIGDetails(&trc, &tsigkeyname);
-    P->tryAutoPrimarySynchronous(dp, tsigkeyname); // FIXME could use some error logging
+    P->tryAutoPrimarySynchronous(dp, tsigkeyname);
   }
   if (rdomains.empty()) { // if we have priority domains, check them first
     B->getUnfreshSecondaryInfos(&rdomains);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1056,18 +1056,17 @@ How SQL backends implement this:
 
 */
 
-int PacketHandler::tryAutoPrimary(const DNSPacket& p)
+int PacketHandler::tryAutoPrimary(const DNSPacket& p) // NOLINT(readability-identifier-length)
+
 {
   if(p.d_tcp) {
     // Do it right now if the client is TCP (rarely happens)
     return tryAutoPrimarySynchronous(p, p.getTSIGKeyname());
   }
-  else {
-    // Queue it if the client is on UDP; the communicator will invoke
-    // tryAutoPrimarySynchronous later.
-    Communicator.addTryAutoPrimaryRequest(p);
-    return RCode::NoError;
-  }
+  // Queue it if the client is on UDP; the communicator will invoke
+  // tryAutoPrimarySynchronous later.
+  Communicator.addTryAutoPrimaryRequest(p);
+  return RCode::NoError;
 }
 
 int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& tsigkeyname)

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1056,19 +1056,17 @@ How SQL backends implement this:
 
 */
 
-int PacketHandler::tryAutoPrimary(const DNSPacket& p, const DNSName& tsigkeyname)
+int PacketHandler::tryAutoPrimary(const DNSPacket& p)
 {
-  if(p.d_tcp)
-  {
-    // do it right now if the client is TCP
-    // rarely happens
-    return tryAutoPrimarySynchronous(p, tsigkeyname);
+  if(p.d_tcp) {
+    // Do it right now if the client is TCP (rarely happens)
+    return tryAutoPrimarySynchronous(p, p.getTSIGKeyname());
   }
-  else
-  {
-    // queue it if the client is on UDP
+  else {
+    // Queue it if the client is on UDP; the communicator will invoke
+    // tryAutoPrimarySynchronous later.
     Communicator.addTryAutoPrimaryRequest(p);
-    return 0;
+    return RCode::NoError;
   }
 }
 
@@ -1137,6 +1135,9 @@ int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& 
       meta.push_back(tsigkeyname.toStringNoDot());
       db->setDomainMetadata(zonename, "AXFR-MASTER-TSIG", meta);
     }
+    // Now that we have created the secondary, fetch its contents.
+    di.receivedNotify = true;
+    Communicator.addSecondaryCheckRequest(di, p.getInnerRemote());
   }
   catch(PDNSException& ae) {
     g_log << Logger::Error << "Database error trying to create " << zonename << " for potential autoprimary " << remote << ": " << ae.reason << endl;
@@ -1196,7 +1197,7 @@ int PacketHandler::processNotify(const DNSPacket& p)
   if(!B.getDomainInfo(zonename, di, false) || di.backend == nullptr) {
     if(::arg().mustDo("autosecondary")) {
       g_log << Logger::Warning << "Received NOTIFY for " << zonename << " from " << p.getRemoteString() << " for which we are not authoritative, trying autoprimary" << endl;
-      return tryAutoPrimary(p, p.getTSIGKeyname());
+      return tryAutoPrimary(p);
     }
     g_log<<Logger::Notice<<"Received NOTIFY for "<<zonename<<" from "<<p.getRemoteString()<<" for which we are not authoritative (Refused)"<<endl;
     return RCode::Refused;
@@ -1231,7 +1232,7 @@ int PacketHandler::processNotify(const DNSPacket& p)
     di.receivedNotify = true;
     Communicator.addSecondaryCheckRequest(di, p.getInnerRemote());
   }
-  return 0;
+  return RCode::NoError;
 }
 
 static bool validDNSName(const DNSName& name)

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -69,7 +69,7 @@ public:
   static const std::shared_ptr<CDSRecordContent> s_deleteCDSContent;
 
 private:
-  int tryAutoPrimary(const DNSPacket& p, const DNSName& tsigkeyname);
+  int tryAutoPrimary(const DNSPacket& p);
   int processNotify(const DNSPacket& );
   void addRootReferral(DNSPacket& r);
   int doChaosRequest(const DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target) const;


### PR DESCRIPTION
### Short description
Backport of #16636. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
