### PR TITLE
auth 4.9: backport "perform axfr immediately when creating an autosecondary domain"

### DIFF
--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -1154,7 +1154,7 @@ void CommunicatorClass::secondaryRefresh(PacketHandler* P)
     TSIGRecordContent trc;
     DNSName tsigkeyname;
     dp.getTSIGDetails(&trc, &tsigkeyname);
-    P->tryAutoPrimarySynchronous(dp, tsigkeyname); // FIXME could use some error logging
+    P->tryAutoPrimarySynchronous(dp, tsigkeyname);
   }
   if (rdomains.empty()) { // if we have priority domains, check them first
     B->getUnfreshSecondaryInfos(&rdomains);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -988,18 +988,17 @@ How MySQLBackend would implement this:
 
 */
 
-int PacketHandler::tryAutoPrimary(const DNSPacket& p)
+int PacketHandler::tryAutoPrimary(const DNSPacket& p) // NOLINT(readability-identifier-length)
+
 {
   if(p.d_tcp) {
     // Do it right now if the client is TCP (rarely happens)
     return tryAutoPrimarySynchronous(p, p.getTSIGKeyname());
   }
-  else {
-    // Queue it if the client is on UDP; the communicator will invoke
-    // tryAutoPrimarySynchronous later.
-    Communicator.addTryAutoPrimaryRequest(p);
-    return RCode::NoError;
-  }
+  // Queue it if the client is on UDP; the communicator will invoke
+  // tryAutoPrimarySynchronous later.
+  Communicator.addTryAutoPrimaryRequest(p);
+  return RCode::NoError;
 }
 
 int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& tsigkeyname)

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -988,19 +988,17 @@ How MySQLBackend would implement this:
 
 */
 
-int PacketHandler::tryAutoPrimary(const DNSPacket& p, const DNSName& tsigkeyname)
+int PacketHandler::tryAutoPrimary(const DNSPacket& p)
 {
-  if(p.d_tcp)
-  {
-    // do it right now if the client is TCP
-    // rarely happens
-    return tryAutoPrimarySynchronous(p, tsigkeyname);
+  if(p.d_tcp) {
+    // Do it right now if the client is TCP (rarely happens)
+    return tryAutoPrimarySynchronous(p, p.getTSIGKeyname());
   }
-  else
-  {
-    // queue it if the client is on UDP
+  else {
+    // Queue it if the client is on UDP; the communicator will invoke
+    // tryAutoPrimarySynchronous later.
     Communicator.addTryAutoPrimaryRequest(p);
-    return 0;
+    return RCode::NoError;
   }
 }
 
@@ -1068,6 +1066,9 @@ int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& 
       meta.push_back(tsigkeyname.toStringNoDot());
       db->setDomainMetadata(p.qdomain, "AXFR-MASTER-TSIG", meta);
     }
+    // Now that we have created the secondary, fetch its contents.
+    di.receivedNotify = true;
+    Communicator.addSecondaryCheckRequest(di, p.getInnerRemote());
   }
   catch(PDNSException& ae) {
     g_log << Logger::Error << "Database error trying to create " << p.qdomain << " for potential autoprimary " << remote << ": " << ae.reason << endl;
@@ -1126,7 +1127,7 @@ int PacketHandler::processNotify(const DNSPacket& p)
   if(!B.getDomainInfo(p.qdomain, di, false) || !di.backend) {
     if(::arg().mustDo("autosecondary")) {
       g_log << Logger::Warning << "Received NOTIFY for " << p.qdomain << " from " << p.getRemoteString() << " for which we are not authoritative, trying autoprimary" << endl;
-      return tryAutoPrimary(p, p.getTSIGKeyname());
+      return tryAutoPrimary(p);
     }
     g_log<<Logger::Notice<<"Received NOTIFY for "<<p.qdomain<<" from "<<p.getRemoteString()<<" for which we are not authoritative (Refused)"<<endl;
     return RCode::Refused;
@@ -1161,7 +1162,7 @@ int PacketHandler::processNotify(const DNSPacket& p)
     di.receivedNotify = true;
     Communicator.addSecondaryCheckRequest(di, p.getInnerRemote());
   }
-  return 0;
+  return RCode::NoError;
 }
 
 static bool validDNSName(const DNSName& name)

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -68,7 +68,7 @@ public:
   static const std::shared_ptr<CDSRecordContent> s_deleteCDSContent;
 
 private:
-  int tryAutoPrimary(const DNSPacket& p, const DNSName& tsigkeyname);
+  int tryAutoPrimary(const DNSPacket& p);
   int processNotify(const DNSPacket& );
   void addRootReferral(DNSPacket& r);
   int doChaosRequest(const DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target) const;


### PR DESCRIPTION
### Short description
Backport of #16636.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
