### PR TITLE
auth 4.9: backport "stricter handing of the Lua DNS update policy"

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -80,23 +80,6 @@ PacketHandler::PacketHandler():B(g_programname), d_dk(&B)
     d_pdl = std::make_unique<AuthLua4>();
     d_pdl->loadFile(fname); // XXX exception handling?
   }
-  fname = ::arg()["lua-dnsupdate-policy-script"];
-  if (fname.empty())
-  {
-    d_update_policy_is_lua = false;
-    d_update_policy_lua = nullptr;
-  }
-  else
-  {
-    d_update_policy_is_lua = true;
-    d_update_policy_lua = std::make_unique<AuthLua4>();
-    try {
-      d_update_policy_lua->loadFile(fname);
-    }
-    catch (const std::runtime_error&) {
-      d_update_policy_lua = nullptr;
-    }
-  }
 }
 
 UeberBackend *PacketHandler::getBackend()

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -83,10 +83,12 @@ PacketHandler::PacketHandler():B(g_programname), d_dk(&B)
   fname = ::arg()["lua-dnsupdate-policy-script"];
   if (fname.empty())
   {
+    d_update_policy_is_lua = false;
     d_update_policy_lua = nullptr;
   }
   else
   {
+    d_update_policy_is_lua = true;
     d_update_policy_lua = std::make_unique<AuthLua4>();
     try {
       d_update_policy_lua->loadFile(fname);

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -114,10 +114,8 @@ private:
   bool d_doDNAME;
   bool d_doExpandALIAS;
   bool d_dnssec{false};
-  bool d_update_policy_is_lua{false};
   SOAData d_sd;
   std::unique_ptr<AuthLua4> d_pdl;
-  std::unique_ptr<AuthLua4> d_update_policy_lua;
   std::unique_ptr<AuthLua4> s_LUA;
   UeberBackend B; // every thread an own instance
   DNSSECKeeper d_dk; // B is shared with DNSSECKeeper

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -114,6 +114,7 @@ private:
   bool d_doDNAME;
   bool d_doExpandALIAS;
   bool d_dnssec{false};
+  bool d_update_policy_is_lua{false};
   SOAData d_sd;
   std::unique_ptr<AuthLua4> d_pdl;
   std::unique_ptr<AuthLua4> d_update_policy_lua;

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -653,9 +653,15 @@ int PacketHandler::processUpdate(DNSPacket& p) {
   g_log<<Logger::Info<<msgPrefix<<"Processing started."<<endl;
 
   // if there is policy, we delegate all checks to it
-  if (d_update_policy_is_lua) {
-    if (d_update_policy_lua == nullptr) {
-      // The policy failed to load earlier.
+  string fname = ::arg()["lua-dnsupdate-policy-script"];
+  std::unique_ptr<AuthLua4> update_policy_lua;
+  if (!fname.empty()) {
+    try {
+      update_policy_lua = std::make_unique<AuthLua4>();
+      update_policy_lua->loadFile(fname);
+    }
+    catch (const std::runtime_error& e) {
+      g_log<<Logger::Warning<<"Failed to load update policy - disabling: "<<e.what()<<endl;
       return RCode::Refused;
     }
   }
@@ -891,8 +897,8 @@ int PacketHandler::processUpdate(DNSPacket& p) {
       const DNSRecord *rr = &answer.first;
       if (rr->d_place == DNSResourceRecord::AUTHORITY) {
         /* see if it's permitted by policy */
-        if (this->d_update_policy_lua != nullptr) {
-          if (this->d_update_policy_lua->updatePolicy(rr->d_name, QType(rr->d_type), di.zone, p) == false) {
+        if (update_policy_lua != nullptr) {
+          if (update_policy_lua->updatePolicy(rr->d_name, QType(rr->d_type), di.zone, p) == false) {
             g_log<<Logger::Warning<<msgPrefix<<"Refusing update for " << rr->d_name << "/" << QType(rr->d_type).toString() << ": Not permitted by policy"<<endl;
             continue;
           } else {

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -653,8 +653,13 @@ int PacketHandler::processUpdate(DNSPacket& p) {
   g_log<<Logger::Info<<msgPrefix<<"Processing started."<<endl;
 
   // if there is policy, we delegate all checks to it
-  if (this->d_update_policy_lua == nullptr) {
-
+  if (d_update_policy_is_lua) {
+    if (d_update_policy_lua == nullptr) {
+      // The policy failed to load earlier.
+      return RCode::Refused;
+    }
+  }
+  else {
     // Check permissions - IP based
     vector<string> allowedRanges;
     B.getDomainMetadata(p.qdomain, "ALLOW-DNSUPDATE-FROM", allowedRanges);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #16831.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
