### PR TITLE
auth 4.9: backport "lua: one more bad case of createForward"

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -947,13 +947,13 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
             // 1-2-3-4 with any prefix (e.g. ip-foo-bar-1-2-3-4)
             string ret;
             for (size_t index=4; index > 0; index--) {
-              auto octet = ip_parts.at(ip_parts.size() - index);
-              auto octetVal = std::stol(octet); // may throw
-              if (octetVal >= 0 && octetVal <= 255) {
-                ret += octet + ".";
-              } else {
+              const auto octet = ip_parts.at(ip_parts.size() - index);
+              size_t octetLength{0};
+              auto octetVal = pdns::checked_stoi<uint8_t>(octet, &octetLength); // may throw
+              if (octetLength != octet.length()) { // trailing chars after number
                 return allZerosIP;
               }
+              ret += std::to_string(octetVal) + ".";
             }
             ret.resize(ret.size() - 1); // remove trailing dot after last octet
             return ret;
@@ -973,7 +973,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
         return allZerosIP;
       } catch (const PDNSException &e) {
         return allZerosIP;
-      } catch (const std::exception &) { // thrown by std::stol
+      } catch (const std::exception &) { // thrown by pdns::checked_stoi
         return allZerosIP;
       }
     });

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -842,6 +842,9 @@ static vector<string> genericIfUp(const boost::variant<iplist_t, ipunitlist_t>& 
   return convComboAddressListToString(res);
 }
 
+static string allZerosIP{"0.0.0.0"};
+static string allZerosIP6{"::"};
+
 static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cognitive-complexity)
 {
   lua.writeFunction("latlon", []() {
@@ -916,7 +919,6 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
       return std::string("error");
     });
   lua.writeFunction("createForward", []() {
-      static string allZerosIP{"0.0.0.0"};
       try {
         DNSName rel{s_lua_record_ctx->qname.makeRelative(s_lua_record_ctx->zone)};
 
@@ -977,7 +979,6 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
     });
 
   lua.writeFunction("createForward6", []() {
-      static string allZerosIP{"::"};
       try {
         DNSName rel{s_lua_record_ctx->qname.makeRelative(s_lua_record_ctx->zone)};
 
@@ -1015,9 +1016,9 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
             return address.toString();
           }
         }
-        return allZerosIP;
+        return allZerosIP6;
       } catch (const PDNSException &e) {
-        return allZerosIP;
+        return allZerosIP6;
       }
     });
   lua.writeFunction("createReverse6", [](const string &format, boost::optional<std::unordered_map<string,string>> excp){
@@ -1081,7 +1082,7 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
   lua.writeFunction("filterForward", [](const string& address, NetmaskGroup& nmg, boost::optional<string> fallback) -> vector<string> {
       ComboAddress ca(address);
 
-      if (nmg.match(ComboAddress(address))) {
+      if (nmg.match(ca)) {
         return {address};
       } else {
         if (fallback) {
@@ -1093,9 +1094,9 @@ static void setupLuaRecords(LuaContext& lua) // NOLINT(readability-function-cogn
         }
 
         if (ca.isIPv4()) {
-          return {string("0.0.0.0")};
+          return {allZerosIP};
         } else {
-          return {string("::")};
+          return {allZerosIP6};
         }
       }
     });

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -1005,6 +1005,7 @@ createforward6.example.org.                 3600 IN NS   ns2.example.org.
                 "1-2-3-4": "1.2.3.4",
                 "1-2-3-4.foo": "1.2.3.4",
                 "1-2-3-4.foo.bar": "0.0.0.0",
+                "1-2-3-4aa.foo.bar": "0.0.0.0",
                 "1-2-3-4.foo.bar.baz": "0.0.0.0",
                 "1-2-3-4.foo.bar.baz.quux": "0.0.0.0",
                 "ip-1-2-3-4": "1.2.3.4",


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17126. A lot of hand-editing due to major changes post 5.0 in the way the lua functions are set up.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
