### PR TITLE
auth 4.9: backport "some pdns_control love"

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -90,6 +90,12 @@ Over this socket, instructions can be sent using the ``pdns_control``
 program. The control socket is called ``pdns.controlsocket`` and is
 created inside the :ref:`setting-socket-dir`.
 
+The controlsocket is created only if
+:ref:`setting-tcp-control-address` is configured. Access to the socket can be
+further restricted to the networks listed in
+:ref:`setting-tcp-control-range`, and to require a password set in
+:ref:`setting-tcp-control-secret`.
+
 .. _running-pdnscontrol:
 
 ``pdns_control``

--- a/pdns/dynlistener.cc
+++ b/pdns/dynlistener.cc
@@ -242,7 +242,7 @@ string DynListener::getLine()
         }
         string password(mesg.data());
         boost::trim(password);
-        if(password.empty() || password!=arg()["tcp-control-secret"]) {
+        if(password.empty() || !constantTimeStringEquals(password, arg()["tcp-control-secret"])) {
           g_log<<Logger::Error<<"Wrong password on TCP control socket"<<endl;
           writen2(d_client, "Wrong password");
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17130. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
