### PR TITLE
auth 4.9: backport "webserver: correctly split the basic authorization cookie"

### DIFF
--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -67,10 +67,9 @@ bool HttpRequest::compareAuthorization(const CredentialsHolder& credentials) con
     string plain;
     B64Decode(cookie, plain);
 
-    vector<string> cparts;
-    stringtok(cparts, plain, ":");
-
-    auth_ok = (cparts.size() == 2 && credentials.matches(cparts[1].c_str()));
+    if (auto colon = plain.find(":"); colon != std::string::npos) {
+      auth_ok = credentials.matches(plain.substr(colon + 1));
+    }
   }
   return auth_ok;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17149.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
