### PR TITLE
auth 4.9: backport "fixes to AXFR in Bind backend"

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -308,8 +308,8 @@ bool Bind2Backend::feedRecord(const DNSResourceRecord& rr, const DNSName& /* ord
   case QType::CNAME:
   case QType::DNAME:
   case QType::NS:
-    stripDomainSuffix(&content, d_transaction_qname.toString());
-    // fallthrough
+    stripDomainSuffix(&content, d_transaction_qname);
+    [[fallthrough]];
   default:
     if (d_of && *d_of) {
       *d_of << qname << "\t" << rr.ttl << "\t" << rr.qtype.toString() << "\t" << content << endl;

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -333,23 +333,20 @@ static bool endsOn(const string &domain, const string &suffix)
 }
 
 /** strips a domain suffix from a domain, returns true if it stripped */
-bool stripDomainSuffix(string *qname, const string &domain)
+void stripDomainSuffix(string *qname, const DNSName &zonename)
 {
-  if (!endsOn(*qname, domain)) {
-    return false;
-  }
+  std::string domain = zonename.toString();
 
-  if (toLower(*qname) == toLower(domain)) {
-    *qname="@";
-  }
-  else {
-    if ((*qname)[qname->size() - domain.size() - 1] != '.') {
-      return false;
+  if (endsOn(*qname, domain)) {
+    if (toLower(*qname) == toLower(domain)) {
+      *qname = "@";
     }
-
-    qname->resize(qname->size() - domain.size()-1);
+    else {
+      if ((*qname)[qname->size() - domain.size() - 1] == '.') {
+        qname->resize(qname->size() - domain.size() - 1);
+      }
+    }
   }
-  return true;
 }
 
 // returns -1 in case if error, 0 if no data is available, 1 if there is. In the first two cases, errno is set

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -306,25 +306,30 @@ string nowTime()
 }
 
 /** does domain end on suffix? Is smart about "wwwds9a.nl" "ds9a.nl" not matching */
-static bool endsOn(const string &domain, const string &suffix)
+static bool endsOn(const string& domain, const string& suffix)
 {
-  if( suffix.empty() || pdns_iequals(domain, suffix) ) {
-    return true;
-  }
-
-  if(domain.size() <= suffix.size()) {
+  if (domain.size() <= suffix.size()) {
     return false;
   }
 
   string::size_type dpos = domain.size() - suffix.size() - 1;
-  string::size_type spos = 0;
-
   if (domain[dpos++] != '.') {
     return false;
   }
+  // That dot might have been escaped. So we now need to count how many '\'
+  // characters we can find in a row before it; if their number is odd, the
+  // dot is escaped and we are not a proper suffix.
+  size_t slashes{0};
+  while (dpos >= 2 + slashes && domain.at(dpos - 2 - slashes) == '\\') {
+    ++slashes;
+  }
+  if ((slashes % 2) != 0) {
+    return false;
+  }
 
-  for(; dpos < domain.size(); ++dpos, ++spos) {
-    if (dns_tolower(domain[dpos]) != dns_tolower(suffix[spos])) {
+  string::size_type spos = 0;
+  for (; dpos < domain.size(); ++dpos, ++spos) {
+    if (!pdns_iequals_ch(domain[dpos], suffix[spos])) {
       return false;
     }
   }
@@ -332,20 +337,21 @@ static bool endsOn(const string &domain, const string &suffix)
   return true;
 }
 
-/** strips a domain suffix from a domain, returns true if it stripped */
+/** strips a domain suffix from a domain */
 void stripDomainSuffix(string *qname, const DNSName &zonename)
 {
   std::string domain = zonename.toString();
 
+  if (domain.empty()) {
+    return;
+  }
+  if (pdns_iequals(*qname, domain)) {
+    *qname = "@";
+    return;
+  }
   if (endsOn(*qname, domain)) {
-    if (toLower(*qname) == toLower(domain)) {
-      *qname = "@";
-    }
-    else {
-      if ((*qname)[qname->size() - domain.size() - 1] == '.') {
-        qname->resize(qname->size() - domain.size() - 1);
-      }
-    }
+    auto prefix = qname->size() - domain.size();
+    qname->resize(prefix - 1); // also strip dot
   }
 }
 

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -305,26 +305,10 @@ string nowTime()
   return {buffer.data()};
 }
 
-static bool ciEqual(const string& lhs, const string& rhs)
-{
-  if (lhs.size() != rhs.size()) {
-    return false;
-  }
-
-  string::size_type pos = 0;
-  const string::size_type epos = lhs.size();
-  for (; pos < epos; ++pos) {
-    if (dns_tolower(lhs[pos]) != dns_tolower(rhs[pos])) {
-      return false;
-    }
-  }
-  return true;
-}
-
 /** does domain end on suffix? Is smart about "wwwds9a.nl" "ds9a.nl" not matching */
 static bool endsOn(const string &domain, const string &suffix)
 {
-  if( suffix.empty() || ciEqual(domain, suffix) ) {
+  if( suffix.empty() || pdns_iequals(domain, suffix) ) {
     return true;
   }
 

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -86,7 +86,7 @@ namespace OpenSSL
 string nowTime();
 string unquotify(const string &item);
 string humanDuration(time_t passed);
-bool stripDomainSuffix(string *qname, const string &domain);
+void stripDomainSuffix(string *qname, const DNSName &zonename);
 void stripLine(string &line);
 std::optional<string> getHostname();
 std::string getCarbonHostName();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17152. Most of the changes of the original PR are in `pdns/misc.cc` rather than `modules/bindbackend/bindbackend2.cc` in 4.9, and had to be manually applied.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
