### PR TITLE
rec: be more consistent in logging source and remote

### DIFF
--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -1173,7 +1173,8 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
 
     resolver.d_slog = resolver.d_slog->withValues("qname", Logging::Loggable(comboWriter->d_mdp.d_qname),
                                                   "qtype", Logging::Loggable(QType(comboWriter->d_mdp.d_qtype)),
-                                                  "remote", Logging::Loggable(comboWriter->getRemote()),
+                                                  "remote", Logging::Loggable(comboWriter->d_remote),
+                                                  "source", Logging::Loggable(comboWriter->d_source),
                                                   "proto", Logging::Loggable(comboWriter->d_tcp ? "tcp" : "udp"),
                                                   "ecs", Logging::Loggable(comboWriter->d_ednssubnet.getSource().empty() ? "" : comboWriter->d_ednssubnet.getSource().toString()),
                                                   "mtid", Logging::Loggable(g_multiTasker->getTid()));
@@ -1801,7 +1802,7 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
       }
     }
     else {
-      bool hadError = sendResponseOverTCP(comboWriter, packet);
+      bool hadError = sendResponseOverTCP(comboWriter, packet, g_slogtcpin);
       finishTCPReply(comboWriter, hadError, true);
       tcpGuard.setHandled();
     }
@@ -2640,7 +2641,7 @@ static void handleNewUDPQuestion(int fileDesc, FDMultiplexer::funcparam_t& /* va
         else if (dnsheader->opcode != static_cast<unsigned>(Opcode::Query) && dnsheader->opcode != static_cast<unsigned>(Opcode::Notify)) {
           t_Counters.at(rec::Counter::ignoredCount)++;
           if (g_logCommonErrors) {
-            g_slogudpin->info(Logr::Error, "Ignoring unsupported opcode server socket", "remote", Logging::Loggable(fromaddr), "opcode", Logging::Loggable(Opcode::to_s(dnsheader->opcode)));
+            g_slogudpin->info(Logr::Error, "Ignoring unsupported opcode on server socket", "remote", Logging::Loggable(fromaddr), "opcode", Logging::Loggable(Opcode::to_s(dnsheader->opcode)));
           }
         }
         else if (dnsheader->qdcount == 0U) {

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -89,15 +89,6 @@ struct DNSComboWriter
     d_socket = sock;
   }
 
-  // get a string representation of the client address, including proxy info if applicable
-  string getRemote() const
-  {
-    if (d_source == d_remote) {
-      return d_source.toStringWithPort();
-    }
-    return d_source.toStringWithPort() + " (proxied by " + d_remote.toStringWithPort() + ")";
-  }
-
   std::vector<ProxyProtocolValue> d_proxyProtocolValues;
   MOADNSParser d_mdp;
   struct timeval d_now;
@@ -287,7 +278,7 @@ inline MT_t* getMT()
 
 /* this function is called with both a string and a vector<uint8_t> representing a packet */
 template <class T>
-static bool sendResponseOverTCP(const std::unique_ptr<DNSComboWriter>& comboWriter, const T& packet)
+static bool sendResponseOverTCP(const std::unique_ptr<DNSComboWriter>& comboWriter, const T& packet, Logr::log_t log)
 {
   std::array<uint8_t, 2> buf{};
   buf[0] = packet.size() / 256;
@@ -303,14 +294,14 @@ static bool sendResponseOverTCP(const std::unique_ptr<DNSComboWriter>& comboWrit
   bool hadError = true;
 
   if (wret == 0) {
-    g_log << Logger::Warning << "EOF writing TCP answer to " << comboWriter->getRemote() << endl;
+    log->info(Logr::Warning, "EOF writing TCP answer", "remote", Logging::Loggable(comboWriter->d_remote), "source", Logging::Loggable(comboWriter->d_source));
   }
   else if (wret < 0) {
     int err = errno;
-    g_log << Logger::Warning << "Error writing TCP answer to " << comboWriter->getRemote() << ": " << stringerror(err) << endl;
+    log->error(Logr::Warning, err, "Error writing TCP", "remote", Logging::Loggable(comboWriter->d_remote), "source", Logging::Loggable(comboWriter->d_source));
   }
   else if ((unsigned int)wret != 2 + packet.size()) {
-    g_log << Logger::Warning << "Oops, partial answer sent to " << comboWriter->getRemote() << " for " << comboWriter->d_mdp.d_qname << " (size=" << (2 + packet.size()) << ", sent " << wret << ")" << endl;
+    log->info(Logr::Warning, "Partial answer sent", "remote", Logging::Loggable(comboWriter->d_remote), "source", Logging::Loggable(comboWriter->d_source), "size", Logging::Loggable(2 + packet.size()), "sent", Logging::Loggable(wret));
   }
   else {
     hadError = false;

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -150,7 +150,7 @@ static void sendErrorOverTCP(std::unique_ptr<DNSComboWriter>& comboWriter, int r
   header.cd = comboWriter->d_mdp.d_header.cd;
   header.rcode = rcode;
 
-  sendResponseOverTCP(comboWriter, packet);
+  sendResponseOverTCP(comboWriter, packet, g_slogtcpin);
 }
 
 void finishTCPReply(std::unique_ptr<DNSComboWriter>& comboWriter, bool hadError, bool updateInFlight)
@@ -413,14 +413,14 @@ static void doProcessTCPQuestion(std::unique_ptr<DNSComboWriter>& comboWriter, s
   if (comboWriter->d_mdp.d_header.qr) {
     t_Counters.at(rec::Counter::ignoredCount)++;
     if (g_logCommonErrors) {
-      g_slogtcpin->info(Logr::Error, "Ignoring answer from TCP client on server socket", "remote", Logging::Loggable(comboWriter->getRemote()));
+      g_slogtcpin->info(Logr::Error, "Ignoring answer from TCP client on server socket", "remote", Logging::Loggable(comboWriter->d_remote), "source", Logging::Loggable(comboWriter->d_source));
     }
     return;
   }
   if (comboWriter->d_mdp.d_header.opcode != static_cast<unsigned>(Opcode::Query) && comboWriter->d_mdp.d_header.opcode != static_cast<unsigned>(Opcode::Notify)) {
     t_Counters.at(rec::Counter::ignoredCount)++;
     if (g_logCommonErrors) {
-      g_slogtcpin->info(Logr::Error, "Ignoring unsupported opcode from TCP client", "remote", Logging::Loggable(comboWriter->getRemote()), "opcode", Logging::Loggable(Opcode::to_s(comboWriter->d_mdp.d_header.opcode)));
+      g_slogtcpin->info(Logr::Error, "Ignoring unsupported opcode from TCP client", "remote", Logging::Loggable(comboWriter->d_remote), "source", Logging::Loggable(comboWriter->d_source), "opcode", Logging::Loggable(Opcode::to_s(comboWriter->d_mdp.d_header.opcode)));
     }
     sendErrorOverTCP(comboWriter, RCode::NotImp);
     tcpGuard.keep();
@@ -429,7 +429,7 @@ static void doProcessTCPQuestion(std::unique_ptr<DNSComboWriter>& comboWriter, s
   if (dnsheader->qdcount == 0U) {
     t_Counters.at(rec::Counter::emptyQueriesCount)++;
     if (g_logCommonErrors) {
-      g_slogtcpin->info(Logr::Error, "Ignoring empty (qdcount == 0) query on server socket", "remote", Logging::Loggable(comboWriter->getRemote()));
+      g_slogtcpin->info(Logr::Error, "Ignoring empty (qdcount == 0) query on server socket", "remote", Logging::Loggable(comboWriter->d_remote), "source", Logging::Loggable(comboWriter->d_source));
     }
     sendErrorOverTCP(comboWriter, RCode::NotImp);
     tcpGuard.keep();
@@ -468,7 +468,7 @@ static void doProcessTCPQuestion(std::unique_ptr<DNSComboWriter>& comboWriter, s
         }
 
         auto answerMatch = comboWriter->d_eventTrace.add(RecEventTrace::AnswerSent);
-        bool hadError = sendResponseOverTCP(comboWriter, response);
+        bool hadError = sendResponseOverTCP(comboWriter, response, g_slogtcpin);
         finishTCPReply(comboWriter, hadError, false);
         struct timeval now{};
         Utility::gettimeofday(&now, nullptr);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Hinted at by #17230, there are some remains of old-style logging that need to be fixed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
