### PR TITLE
auth, dnsdist: lost+found, faster

### DIFF
--- a/ext/yahttp/yahttp/cookie.hpp
+++ b/ext/yahttp/yahttp/cookie.hpp
@@ -74,7 +74,7 @@ namespace YaHTTP {
 
     void keyValuePair(const std::string &keyvalue, std::string &key, std::string &value) {
       size_t pos;
-      pos = keyvalue.find("=");
+      pos = keyvalue.find('=');
       if (pos == std::string::npos) throw ParseError("Not a Key-Value pair (cookie)");
       key = std::string(keyvalue.begin(), keyvalue.begin()+pos);
       value = std::string(keyvalue.begin()+pos+1, keyvalue.end());
@@ -115,7 +115,7 @@ namespace YaHTTP {
         if ((npos = cookiestr.find("; ", pos)) == std::string::npos)
           npos = cookiestr.size();
         std::string s = cookiestr.substr(pos, npos-pos);
-        if (s.find("=") != std::string::npos)
+        if (s.find('=') != std::string::npos)
           keyValuePair(s, k, v);
         else
           k = std::move(s);

--- a/ext/yahttp/yahttp/reqresp.cpp
+++ b/ext/yahttp/yahttp/reqresp.cpp
@@ -118,7 +118,7 @@ namespace YaHTTP {
           break;
         }
         // split headers
-        if ((pos1 = line.find(":")) == std::string::npos) {
+        if ((pos1 = line.find(':')) == std::string::npos) {
           throw ParseError("Malformed header line");
         }
         key = line.substr(0, pos1);
@@ -138,7 +138,7 @@ namespace YaHTTP {
         } else {
           if (key == "host" && target->kind == YAHTTP_TYPE_REQUEST) {
             // maybe it contains port?
-            if ((pos1 = value.find(":")) == std::string::npos) {
+            if ((pos1 = value.find(':')) == std::string::npos) {
               target->url.host = value;
             } else {
               target->url.host = value.substr(0, pos1);

--- a/ext/yahttp/yahttp/reqresp.hpp
+++ b/ext/yahttp/yahttp/reqresp.hpp
@@ -258,7 +258,7 @@ public:
     }
     void setup(const std::string& method_, const std::string& url_) {
       this->url.parse(url_);
-      this->headers["host"] = this->url.host.find(":") == std::string::npos ? this->url.host : "[" + this->url.host + "]";
+      this->headers["host"] = this->url.host.find(':') == std::string::npos ? this->url.host : "[" + this->url.host + "]";
       this->method = method_;
       std::transform(this->method.begin(), this->method.end(), this->method.begin(), ::toupper);
       this->headers["user-agent"] = "YaHTTP v1.0";

--- a/ext/yahttp/yahttp/utility.hpp
+++ b/ext/yahttp/yahttp/utility.hpp
@@ -381,8 +381,8 @@ namespace YaHTTP {
       strstr_map_t parameter_map;
       while (pos != std::string::npos) {
         // find next parameter start
-        std::string::size_type nextpos = parameters.find("&", pos);
-        std::string::size_type delim = parameters.find("=", pos);
+        std::string::size_type nextpos = parameters.find('&', pos);
+        std::string::size_type delim = parameters.find('=', pos);
         if (delim > nextpos) {
           delim = nextpos;
         }

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -129,7 +129,7 @@ static bool validateMappingLookupFormats(const vector<string>& formats)
 
   for (const auto& lookupFormat : formats) {
     last = 0;
-    while ((cur = lookupFormat.find("%", last)) != string::npos) {
+    while ((cur = lookupFormat.find('%', last)) != string::npos) {
       if (lookupFormat.compare(cur, 3, "%mp") == 0) {
         return false;
       }

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -74,7 +74,7 @@ bool HttpRequest::compareAuthorization(const CredentialsHolder& credentials) con
     string plain;
     B64Decode(cookie, plain);
 
-    if (auto colon = plain.find(":"); colon != std::string::npos) {
+    if (auto colon = plain.find(':'); colon != std::string::npos) {
       auth_ok = credentials.matches(plain.substr(colon + 1));
     }
   }


### PR DESCRIPTION
### Short description
As advised by clang-tidy, use the single character form of `std::string::find` when we are looking for, well, a single character.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
