### PR TITLE
rec: optimize dns64 PTR processing (#YWH-PGM6095-280)

### DIFF
--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -800,6 +800,24 @@ int getFakeAAAARecords(const DNSName& qname, ComboAddress prefix, vector<DNSReco
   return rcode;
 }
 
+static std::pair<uint8_t, bool> parseNibble(const std::string& label)
+{
+  if (label.size() != 1) {
+    return {0, false};
+  }
+  auto digit = label[0];
+  if (digit >= '0' && digit <= '9') {
+    return {digit - '0', true};
+  }
+  if (digit >= 'a' && digit <= 'f') {
+    return {digit - 'a' + 10, true};
+  }
+  if (digit >= 'A' && digit <= 'F') {
+    return {digit - 'A' + 10, true};
+  }
+  return {0, false};
+}
+
 int getFakePTRRecords(const DNSName& qname, vector<DNSRecord>& ret)
 {
   /* qname has a reverse ordered IPv6 address, need to extract the underlying IPv4 address from it
@@ -813,8 +831,16 @@ int getFakePTRRecords(const DNSName& qname, vector<DNSRecord>& ret)
 
   string newquery;
   for (size_t octet = 0; octet < 4; ++octet) {
-    newquery += std::to_string(stoll(parts[octet * 2], nullptr, 16) + 16 * stoll(parts[octet * 2 + 1], nullptr, 16));
-    newquery.append(1, '.');
+    auto [value1, valid1] = parseNibble(parts[octet * 2]);
+    if (!valid1) {
+      return RCode::ServFail;
+    }
+    auto [value2, valid2] = parseNibble(parts[(octet * 2) + 1]);
+    if (!valid2) {
+      return RCode::ServFail;
+    }
+    newquery += std::to_string(value1 + (value2 * 16));
+    newquery += '.';
   }
   newquery += "in-addr.arpa.";
 


### PR DESCRIPTION
And return ServFail on malformed DNS64 PTR queries

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
