### PR TITLE
dnsdist: Document that flushing the cache is allowed in read-only mode

### DIFF
--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -469,7 +469,7 @@ webserver:
     - name: "api_read_write"
       type: "bool"
       default: "false"
-      description: "Allow modifications via the API. Optionally saving these changes to disk. Modifications done via the API will not be written to the configuration by default and will not persist after a reload"
+      description: "Allow modifications of the configuration via the API. Optionally saving these changes to disk. Modifications done via the API will not be written to the configuration by default and will not persist after a reload. Note that flushing the content of the packet cache via DELETE requests is still allowed even if the API is read-only"
 
 console:
   description: "Console-related settings"

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -404,11 +404,12 @@ Webserver configuration
 
 .. function:: setAPIWritable(allow [,dir])
 
-  Allow modifications via the API.
+  Allow modifications of the configuration via the API.
   Optionally saving these changes to disk.
-  Modifications done via the API will not be written to the configuration by default and will not persist after a reload
+  Modifications done via the API will not be written to the configuration by default and will not persist after a reload.
+  Note that flushing the content of the packet cache via DELETE requests is still allowed even if the API is read-only.
 
-  :param bool allow: Set to true to allow modification through the API
+  :param bool allow: Set to true to allow modification of the configuration through the API
   :param str dir: A valid directory where the configuration files will be written by the API.
 
 .. function:: setWebserverConfig(options)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
As reported by Prasanna Dabi (thanks!) one might expect that a read-only API would not allow the flushing of the packet cache. This is not the case, the read-only flag controls whether the API is allowed to alter the configuration, but flushing the content of the packet cache is always allowed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
