### PR TITLE
auth 5.0: backport "use less inefficient code in web server"

### DIFF
--- a/ext/yahttp/yahttp/reqresp.cpp
+++ b/ext/yahttp/yahttp/reqresp.cpp
@@ -201,20 +201,25 @@ namespace YaHTTP {
             if (buffer.size() < chunk_size+2 || buffer.at(chunk_size+1) != '\n') return false; // expect newline after carriage return
             crlf=2;
           } else if (buffer.at(chunk_size) != '\n') return false;
-          if (bodybuf.str().length() + chunk_size > maxbody) {
+          if (bodysize + chunk_size > maxbody) {
             throw ParseError("Chunked body is too large");
           }
           std::string tmp = buffer.substr(0, chunk_size);
           buffer.erase(buffer.begin(), buffer.begin()+chunk_size+crlf);
           bodybuf << tmp;
+          bodysize += chunk_size;
           chunk_size = 0;
           if (buffer.size() == 0) break; // just in case
         }
       } else {
-        if (bodybuf.str().length() + buffer.length() > maxbody)
+        if (bodysize + buffer.length() > maxbody) {
           bodybuf << buffer.substr(0, maxbody - bodybuf.str().length());
-        else
+          bodysize = maxbody;
+        }
+        else {
           bodybuf << buffer;
+          bodysize += buffer.length();
+        }
         buffer = "";
       }
     }

--- a/ext/yahttp/yahttp/reqresp.hpp
+++ b/ext/yahttp/yahttp/reqresp.hpp
@@ -313,7 +313,8 @@ public:
     std::ostringstream bodybuf; //<! buffer for body
     size_t maxbody; //<! maximum size of body
     size_t minbody; //<! minimum size of body
-    size_t headersize;                 
+    size_t headersize;
+    size_t bodysize;
     bool hasBody; //<! are we expecting body
 
     void keyValuePair(const std::string &keyvalue, std::string &key, std::string &value); //<! key value pair parser helper
@@ -325,28 +326,27 @@ public:
       hasBody = false;
       buffer = "";
       headersize = 0;
+      bodysize = 0;
       this->target->initialize();
     }; //<! Initialize the parser for target and clear state
     bool feed(const std::string& somedata); //<! Feed data to the parser
     bool ready() {
      return (chunked == true && state == 3) || // if it's chunked we get end of data indication
              (chunked == false && state > 1 &&  
-               (!hasBody || 
-                 (bodybuf.str().size() <= maxbody && 
-                  bodybuf.str().size() >= minbody)
-               )
-             ); 
+               (!hasBody || (bodysize <= maxbody && bodysize >= minbody))); 
     }; //<! whether we have received enough data
     void finalize() {
       bodybuf.flush();
       if (ready()) {
+        std::string body = bodybuf.str();
         strstr_map_t::iterator cpos = target->headers.find("content-type");
         if (cpos != target->headers.end() && Utility::iequals(cpos->second, "application/x-www-form-urlencoded", 32)) {
-          target->postvars = Utility::parseUrlParameters(bodybuf.str());
+          target->postvars = Utility::parseUrlParameters(body);
         }
-        target->body = bodybuf.str();
+        target->body = std::move(body);
       }
       bodybuf.str("");
+      bodysize = 0;
       this->target = NULL;
     }; //<! finalize and release target
   };


### PR DESCRIPTION
### Short description
Backport of #17284.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
