### PR TITLE
rec and auth: Implement an cors flag to set allowed origin in webserver

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1366,7 +1366,7 @@ Allow this many DNS queries in a single TCP transaction. 0 means
 unlimited. Note that exchanges related to an AXFR or IXFR are not
 affected by this setting.
 
-.. _setting-member-catalog-group
+.. _setting-member-catalog-group:
 
 ``member-catalog-group``
 ------------------------
@@ -2254,6 +2254,17 @@ Ignored if ``webserver-address`` is set to a UNIX domain socket.
 -  Default: no
 
 If the webserver should print arguments.
+
+.. _setting-webserver-allow-cross-origin-requests:
+
+``webserver-allow-cross-origin-requests``
+-----------------------------------------
+.. versionadded:: 5.1.0
+
+-  Boolean
+-  Default: no
+
+If the webserver should allow cross origin requests.
 
 .. _setting-write-pid:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -2261,10 +2261,10 @@ If the webserver should print arguments.
 -----------------------------------------
 .. versionadded:: 5.1.0
 
--  Boolean
--  Default: no
+-  String
+-  Default: empty
 
-If the webserver should allow cross origin requests.
+The value if the access-control-allow-origin HTTP header to include. This header is not inluded if the value is empty.
 
 .. _setting-write-pid:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -2255,16 +2255,16 @@ Ignored if ``webserver-address`` is set to a UNIX domain socket.
 
 If the webserver should print arguments.
 
-.. _setting-webserver-allow-cross-origin-requests:
+.. _setting-webserver-cross-origin-request-header:
 
-``webserver-allow-cross-origin-requests``
+``webserver-cross-origin-request_header``
 -----------------------------------------
 .. versionadded:: 5.1.0
 
 -  String
 -  Default: empty
 
-The value if the access-control-allow-origin HTTP header to include. This header is not inluded if the value is empty.
+The value if the access-control-allow-origin HTTP header to include. This header is not included if the value is empty.
 
 .. _setting-write-pid:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -2257,7 +2257,7 @@ If the webserver should print arguments.
 
 .. _setting-webserver-cross-origin-request-header:
 
-``webserver-cross-origin-request_header``
+``webserver-cross-origin-request-header``
 -----------------------------------------
 .. versionadded:: 5.1.0
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -11,6 +11,12 @@ upgrade notes if your version is older than 3.4.2.
 5.0.0 to 5.1.0
 --------------
 
+Cross origin requests
+^^^^^^^^^^^^^^^^^^^^^
+
+The embedded webserver now does not include a ``access-control-allow-origin: *`` header by default.
+See :ref:`setting-webserver-allow-cross-origin-requests`.
+
 zone display
 ^^^^^^^^^^^^
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -14,7 +14,7 @@ upgrade notes if your version is older than 3.4.2.
 Cross origin requests
 ^^^^^^^^^^^^^^^^^^^^^
 
-The embedded webserver now does not include a ``access-control-allow-origin: *`` header by default.
+The embedded webserver now no longer includes a ``access-control-allow-origin: *`` header by default.
 See :ref:`setting-webserver-cross-origin-request-header`.
 
 zone display

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -15,7 +15,7 @@ Cross origin requests
 ^^^^^^^^^^^^^^^^^^^^^
 
 The embedded webserver now does not include a ``access-control-allow-origin: *`` header by default.
-See :ref:`setting-webserver-allow-cross-origin-requests`.
+See :ref:`setting-webserver-cross-origin-request-header`.
 
 zone display
 ^^^^^^^^^^^^

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -255,6 +255,7 @@ static void declareArguments()
   ::arg().set("webserver-max-concurrent-connections", "Webserver/API maximum concurrent connections allowed") = "100";
   ::arg().set("webserver-connection-timeout", "Webserver/API request/response timeout in seconds") = "5";
   ::arg().setSwitch("webserver-hash-plaintext-credentials", "Whether to hash passwords and api keys supplied in plaintext, to prevent keeping the plaintext version in memory at runtime") = "no";
+  ::arg().setSwitch("allow-cross-origin-requests", "If the webserver should allow cross origin requests") = "no";
 
   ::arg().setSwitch("query-logging", "Hint backends that queries should be logged") = "no";
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -255,7 +255,7 @@ static void declareArguments()
   ::arg().set("webserver-max-concurrent-connections", "Webserver/API maximum concurrent connections allowed") = "100";
   ::arg().set("webserver-connection-timeout", "Webserver/API request/response timeout in seconds") = "5";
   ::arg().setSwitch("webserver-hash-plaintext-credentials", "Whether to hash passwords and api keys supplied in plaintext, to prevent keeping the plaintext version in memory at runtime") = "no";
-  ::arg().setSwitch("webserver-allow-cross-origin-requests", "If the webserver should allow cross origin requests") = "no";
+  ::arg().set("webserver-allow-cross-origin-requests", "Webserver cross origin request header value") = "";
 
   ::arg().setSwitch("query-logging", "Hint backends that queries should be logged") = "no";
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -255,7 +255,7 @@ static void declareArguments()
   ::arg().set("webserver-max-concurrent-connections", "Webserver/API maximum concurrent connections allowed") = "100";
   ::arg().set("webserver-connection-timeout", "Webserver/API request/response timeout in seconds") = "5";
   ::arg().setSwitch("webserver-hash-plaintext-credentials", "Whether to hash passwords and api keys supplied in plaintext, to prevent keeping the plaintext version in memory at runtime") = "no";
-  ::arg().set("webserver-cross-origin-request_header", "Webserver cross origin request header value") = "";
+  ::arg().set("webserver-cross-origin-request-header", "Webserver cross origin request header value") = "";
 
   ::arg().setSwitch("query-logging", "Hint backends that queries should be logged") = "no";
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -255,7 +255,7 @@ static void declareArguments()
   ::arg().set("webserver-max-concurrent-connections", "Webserver/API maximum concurrent connections allowed") = "100";
   ::arg().set("webserver-connection-timeout", "Webserver/API request/response timeout in seconds") = "5";
   ::arg().setSwitch("webserver-hash-plaintext-credentials", "Whether to hash passwords and api keys supplied in plaintext, to prevent keeping the plaintext version in memory at runtime") = "no";
-  ::arg().set("webserver-allow-cross-origin-requests", "Webserver cross origin request header value") = "";
+  ::arg().set("webserver-cross-origin-request_header", "Webserver cross origin request header value") = "";
 
   ::arg().setSwitch("query-logging", "Hint backends that queries should be logged") = "no";
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -255,7 +255,7 @@ static void declareArguments()
   ::arg().set("webserver-max-concurrent-connections", "Webserver/API maximum concurrent connections allowed") = "100";
   ::arg().set("webserver-connection-timeout", "Webserver/API request/response timeout in seconds") = "5";
   ::arg().setSwitch("webserver-hash-plaintext-credentials", "Whether to hash passwords and api keys supplied in plaintext, to prevent keeping the plaintext version in memory at runtime") = "no";
-  ::arg().setSwitch("allow-cross-origin-requests", "If the webserver should allow cross origin requests") = "no";
+  ::arg().setSwitch("webserver-allow-cross-origin-requests", "If the webserver should allow cross origin requests") = "no";
 
   ::arg().setSwitch("query-logging", "Hint backends that queries should be logged") = "no";
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -22,6 +22,8 @@ New settings
 - The :ref:`setting-yaml-outgoing.max_bytesperq` setting has been introduced to limit the amount of incoming bytes per client query.
 - The :ref:`setting-yaml-recordcache.max_entry_size` setting has been introduced to limit the maximum size of a stored record set.
 - The :ref:`setting-yaml-packetcache.max_entry_size` setting has been introduced to limit the maximum size of a packet cache entry.
+- The :ref:`setting-yaml-webservice.allow_cross_origin_requests` setting has been introduced, default ``false``. This is a change of behaviour, as older versions do allow cross origin requests.
+
 
 5.3.0 to 5.4.0
 ---------------

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -22,7 +22,7 @@ New settings
 - The :ref:`setting-yaml-outgoing.max_bytesperq` setting has been introduced to limit the amount of incoming bytes per client query.
 - The :ref:`setting-yaml-recordcache.max_entry_size` setting has been introduced to limit the maximum size of a stored record set.
 - The :ref:`setting-yaml-packetcache.max_entry_size` setting has been introduced to limit the maximum size of a packet cache entry.
-- The :ref:`setting-yaml-webservice.allow_cross_origin_requests` setting has been introduced, default is not set. This is a change of behaviour, as older versions do set the access-control-allow-origin header.
+- The :ref:`setting-yaml-webservice.cross_origin_request_header` setting has been introduced, default is not set. This is a change of behaviour, as older versions do set the access-control-allow-origin header.
 
 
 5.3.0 to 5.4.0

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -22,7 +22,7 @@ New settings
 - The :ref:`setting-yaml-outgoing.max_bytesperq` setting has been introduced to limit the amount of incoming bytes per client query.
 - The :ref:`setting-yaml-recordcache.max_entry_size` setting has been introduced to limit the maximum size of a stored record set.
 - The :ref:`setting-yaml-packetcache.max_entry_size` setting has been introduced to limit the maximum size of a packet cache entry.
-- The :ref:`setting-yaml-webservice.allow_cross_origin_requests` setting has been introduced, default ``false``. This is a change of behaviour, as older versions do allow cross origin requests.
+- The :ref:`setting-yaml-webservice.allow_cross_origin_requests` setting has been introduced, default is not set. This is a change of behaviour, as older versions do set the access-control-allow-origin header.
 
 
 5.3.0 to 5.4.0

--- a/pdns/recursordist/rec-rust-lib/rust/src/web.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/web.rs
@@ -176,8 +176,8 @@ fn api_wrapper(
     allow_password: bool,
 ) {
     // security headers
-    if !ctx.allow_cross_origin_requests.is_empty()  {
-        if let Ok(value) = header::HeaderValue::from_str(&ctx.allow_cross_origin_requests) {
+    if !ctx.cross_origin_request_header.is_empty()  {
+        if let Ok(value) = header::HeaderValue::from_str(&ctx.cross_origin_request_header) {
             headers.insert(
                 header::ACCESS_CONTROL_ALLOW_ORIGIN,
                 value,
@@ -284,7 +284,7 @@ struct Context {
     logger: cxx::SharedPtr<rustmisc::Logger>,
     loglevel: rustmisc::LogLevel,
     max_request_size: u64,
-    allow_cross_origin_requests: String,
+    cross_origin_request_header: String,
 }
 
 // Serve a file
@@ -460,10 +460,10 @@ fn collect_options(
     response.status = 200;
     methods.push(Method::OPTIONS.to_string());
 
-    if !ctx.allow_cross_origin_requests.is_empty() {
+    if !ctx.cross_origin_request_header.is_empty() {
         response.headers.push(rustweb::KeyValue {
             key: String::from("access-control-allow-origin"),
-            value: String::from(ctx.allow_cross_origin_requests.clone()),
+            value: String::from(ctx.cross_origin_request_header.clone()),
         });
     }
 
@@ -951,7 +951,7 @@ pub fn serveweb(
     logger: cxx::SharedPtr<rustmisc::Logger>,
     loglevel: rustmisc::LogLevel,
     max_request_size: u64,
-    allow_cross_origin_requests: String,
+    cross_origin_request_header: String,
 ) -> Result<(), std::io::Error> {
     // Context, atomically reference counted
     let ctx = Arc::new(Context {
@@ -961,7 +961,7 @@ pub fn serveweb(
         logger,
         loglevel,
         max_request_size,
-        allow_cross_origin_requests,
+        cross_origin_request_header,
     });
 
     // We use a single thread to handle all the requests, letting the runtime abstracts from this
@@ -1262,7 +1262,7 @@ mod rustweb {
             logger: SharedPtr<Logger>,
             loglevel: LogLevel,
             max_request_size: u64,
-            allow_cross_origin_requests: String,
+            cross_origin_request_header: String,
         ) -> Result<()>;
     }
 

--- a/pdns/recursordist/rec-rust-lib/rust/src/web.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/web.rs
@@ -176,10 +176,18 @@ fn api_wrapper(
     allow_password: bool,
 ) {
     // security headers
-    headers.insert(
-        header::ACCESS_CONTROL_ALLOW_ORIGIN,
-        header::HeaderValue::from_static("*"),
-    );
+    if ctx.allow_cross_origin_requests {
+        if let Some(origin) = reqheaders.get("origin") {
+            headers.insert(
+                header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                origin.clone(),
+            );
+            headers.insert(
+                header::VARY,
+                header::HeaderValue::from_static("Origin"),
+            );
+        }
+    }
 
     // XXX AUDIT!
 
@@ -280,6 +288,7 @@ struct Context {
     logger: cxx::SharedPtr<rustmisc::Logger>,
     loglevel: rustmisc::LogLevel,
     max_request_size: u64,
+    allow_cross_origin_requests: bool,
 }
 
 // Serve a file
@@ -415,7 +424,9 @@ fn matcher(
 
 // This constructs the answer to an OPTIONS query
 fn collect_options(
+    ctx: &Context,
     path: &str,
+    reqheaders: &header::HeaderMap,
     response: &mut rustweb::Response,
     my_logger: &cxx::SharedPtr<rustmisc::Logger>,
 ) {
@@ -453,10 +464,22 @@ fn collect_options(
     }
     response.status = 200;
     methods.push(Method::OPTIONS.to_string());
-    response.headers.push(rustweb::KeyValue {
-        key: String::from("access-control-allow-origin"),
-        value: String::from("*"),
-    });
+
+    if ctx.allow_cross_origin_requests {
+        if let Some(origin) = reqheaders.get("origin") { // keys are lowercased
+            if let Ok(origin_str) = origin.to_str() {
+                response.headers.push(rustweb::KeyValue {
+                    key: String::from("access-control-allow-origin"),
+                    value: origin_str.to_string(),
+                });
+                response.headers.push(rustweb::KeyValue {
+                    key: String::from("Vary"),
+                    value: String::from("Origin"),
+                });
+            }
+        }
+    }
+
     response.headers.push(rustweb::KeyValue {
         key: String::from("access-control-allow-headers"),
         value: String::from("Content-Type, X-API-Key"),
@@ -601,7 +624,7 @@ async fn process_request(
     let version = rust_request.version().to_owned();
 
     if method == Method::OPTIONS {
-        collect_options(&path, &mut response, &my_logger);
+        collect_options(&ctx, &path, &rust_request.headers(), &mut response, &my_logger);
     } else {
         // Find the right function implementing what the request wants
         let mut matchmethod = method.clone();
@@ -941,6 +964,7 @@ pub fn serveweb(
     logger: cxx::SharedPtr<rustmisc::Logger>,
     loglevel: rustmisc::LogLevel,
     max_request_size: u64,
+    allow_cross_origin_requests: bool,
 ) -> Result<(), std::io::Error> {
     // Context, atomically reference counted
     let ctx = Arc::new(Context {
@@ -950,6 +974,7 @@ pub fn serveweb(
         logger,
         loglevel,
         max_request_size,
+        allow_cross_origin_requests,
     });
 
     // We use a single thread to handle all the requests, letting the runtime abstracts from this
@@ -1250,6 +1275,7 @@ mod rustweb {
             logger: SharedPtr<Logger>,
             loglevel: LogLevel,
             max_request_size: u64,
+            allow_cross_origin_requests: bool,
         ) -> Result<()>;
     }
 

--- a/pdns/recursordist/rec-rust-lib/rust/src/web.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/web.rs
@@ -176,11 +176,13 @@ fn api_wrapper(
     allow_password: bool,
 ) {
     // security headers
-    if ctx.allow_cross_origin_requests {
-        headers.insert(
-            header::ACCESS_CONTROL_ALLOW_ORIGIN,
-            header::HeaderValue::from_static("*"),
-        );
+    if !ctx.allow_cross_origin_requests.is_empty()  {
+        if let Ok(value) = header::HeaderValue::from_str(&ctx.allow_cross_origin_requests) {
+            headers.insert(
+                header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                value,
+            );
+        }
     }
 
     // XXX AUDIT!
@@ -282,7 +284,7 @@ struct Context {
     logger: cxx::SharedPtr<rustmisc::Logger>,
     loglevel: rustmisc::LogLevel,
     max_request_size: u64,
-    allow_cross_origin_requests: bool,
+    allow_cross_origin_requests: String,
 }
 
 // Serve a file
@@ -458,10 +460,10 @@ fn collect_options(
     response.status = 200;
     methods.push(Method::OPTIONS.to_string());
 
-    if ctx.allow_cross_origin_requests {
+    if !ctx.allow_cross_origin_requests.is_empty() {
         response.headers.push(rustweb::KeyValue {
             key: String::from("access-control-allow-origin"),
-            value: String::from("*"),
+            value: String::from(ctx.allow_cross_origin_requests.clone()),
         });
     }
 
@@ -949,7 +951,7 @@ pub fn serveweb(
     logger: cxx::SharedPtr<rustmisc::Logger>,
     loglevel: rustmisc::LogLevel,
     max_request_size: u64,
-    allow_cross_origin_requests: bool,
+    allow_cross_origin_requests: String,
 ) -> Result<(), std::io::Error> {
     // Context, atomically reference counted
     let ctx = Arc::new(Context {
@@ -1260,7 +1262,7 @@ mod rustweb {
             logger: SharedPtr<Logger>,
             loglevel: LogLevel,
             max_request_size: u64,
-            allow_cross_origin_requests: bool,
+            allow_cross_origin_requests: String,
         ) -> Result<()>;
     }
 

--- a/pdns/recursordist/rec-rust-lib/rust/src/web.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/web.rs
@@ -177,16 +177,10 @@ fn api_wrapper(
 ) {
     // security headers
     if ctx.allow_cross_origin_requests {
-        if let Some(origin) = reqheaders.get("origin") {
-            headers.insert(
-                header::ACCESS_CONTROL_ALLOW_ORIGIN,
-                origin.clone(),
-            );
-            headers.insert(
-                header::VARY,
-                header::HeaderValue::from_static("Origin"),
-            );
-        }
+        headers.insert(
+            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            header::HeaderValue::from_static("*"),
+        );
     }
 
     // XXX AUDIT!
@@ -426,7 +420,6 @@ fn matcher(
 fn collect_options(
     ctx: &Context,
     path: &str,
-    reqheaders: &header::HeaderMap,
     response: &mut rustweb::Response,
     my_logger: &cxx::SharedPtr<rustmisc::Logger>,
 ) {
@@ -466,18 +459,10 @@ fn collect_options(
     methods.push(Method::OPTIONS.to_string());
 
     if ctx.allow_cross_origin_requests {
-        if let Some(origin) = reqheaders.get("origin") { // keys are lowercased
-            if let Ok(origin_str) = origin.to_str() {
-                response.headers.push(rustweb::KeyValue {
-                    key: String::from("access-control-allow-origin"),
-                    value: origin_str.to_string(),
-                });
-                response.headers.push(rustweb::KeyValue {
-                    key: String::from("Vary"),
-                    value: String::from("Origin"),
-                });
-            }
-        }
+        response.headers.push(rustweb::KeyValue {
+            key: String::from("access-control-allow-origin"),
+            value: String::from("*"),
+        });
     }
 
     response.headers.push(rustweb::KeyValue {
@@ -624,7 +609,7 @@ async fn process_request(
     let version = rust_request.version().to_owned();
 
     if method == Method::OPTIONS {
-        collect_options(&ctx, &path, &rust_request.headers(), &mut response, &my_logger);
+        collect_options(&ctx, &path, &mut response, &my_logger);
     } else {
         // Find the right function implementing what the request wants
         let mut matchmethod = method.clone();

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -276,7 +276,7 @@ Static pre-shared authentication key for access to the REST API. Since 4.6.0 the
         "versionchanged": ("4.6.0", "This setting now accepts a hashed and salted version."),
     },
     {
-        "name": "cross_origin_request_heaer",
+        "name": "cross_origin_request_header",
         "section": "webservice",
         "type": LType.String,
         "default": "",

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -278,11 +278,11 @@ Static pre-shared authentication key for access to the REST API. Since 4.6.0 the
     {
         "name": "allow_cross_origin_requests",
         "section": "webservice",
-        "type": LType.Bool,
-        "default": "false",
-        "help": "Whether the webserver allows cross-origin HTTP requests",
+        "type": LType.String,
+        "default": "",
+        "help": "Value of access-control-allow-origin HTTP header",
         "doc": """
-Whether the webserver allows cross-origin HTTP requests. This might allow a malicious website to read metrics provided by the API if a user’s browser has valid credentials cached for the webserver while the user visits the malicious website.
+Whether the webserver allows cross-origin HTTP requests. If set, the access-control-cross-origin HTTP header is included with the given value. This might allow a malicious website to read metrics provided by the API if a user’s browser has valid credentials cached for the webserver while the user visits the malicious website.
  """,
         "versionadded": "5.5.0",
     },

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -276,6 +276,17 @@ Static pre-shared authentication key for access to the REST API. Since 4.6.0 the
         "versionchanged": ("4.6.0", "This setting now accepts a hashed and salted version."),
     },
     {
+        "name": "allow_cross_origin_requests",
+        "section": "webservice",
+        "type": LType.Bool,
+        "default": "false",
+        "help": "Whether the webserver allows cross-origin HTTP requests",
+        "doc": """
+Whether the webserver allows cross-origin HTTP requests. This might allow a malicious website to read metrics provided by the API if a user’s browser has valid credentials cached for the webserver while the user visits the malicious website.
+ """,
+        "versionadded": "5.5.0",
+    },
+    {
         "name": "auth_zones",
         "section": "recursor",
         "type": LType.ListAuthZones,

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -276,7 +276,7 @@ Static pre-shared authentication key for access to the REST API. Since 4.6.0 the
         "versionchanged": ("4.6.0", "This setting now accepts a hashed and salted version."),
     },
     {
-        "name": "allow_cross_origin_requests",
+        "name": "cross_origin_request_heaer",
         "section": "webservice",
         "type": LType.String,
         "default": "",

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -1203,7 +1203,7 @@ void serveRustWeb()
   // This function returns after having created the web server object that handles the requests.
   // That object and its runtime are associated with a Posix thread that waits until all tasks are
   // done, which normally never happens. See rec-rust-lib/rust/src/web.rs for details
-  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel, arg().asNum("webserver-max-request-size") * 1024ULL * 1024ULL, arg().mustDo("allow-cross-origin-requests"));
+  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel, arg().asNum("webserver-max-request-size") * 1024ULL * 1024ULL, arg()["allow-cross-origin-requests"]);
 }
 
 static void fromCxxToRust(const HttpResponse& cxxresp, pdns::rust::web::rec::Response& rustResponse)

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -1203,7 +1203,7 @@ void serveRustWeb()
   // This function returns after having created the web server object that handles the requests.
   // That object and its runtime are associated with a Posix thread that waits until all tasks are
   // done, which normally never happens. See rec-rust-lib/rust/src/web.rs for details
-  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel, arg().asNum("webserver-max-request-size") * 1024 * 1024);
+  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel, arg().asNum("webserver-max-request-size") * 1024ULL * 1024ULL, arg().mustDo("allow-cross-origin-requests"));
 }
 
 static void fromCxxToRust(const HttpResponse& cxxresp, pdns::rust::web::rec::Response& rustResponse)

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -1203,7 +1203,7 @@ void serveRustWeb()
   // This function returns after having created the web server object that handles the requests.
   // That object and its runtime are associated with a Posix thread that waits until all tasks are
   // done, which normally never happens. See rec-rust-lib/rust/src/web.rs for details
-  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel, arg().asNum("webserver-max-request-size") * 1024ULL * 1024ULL, arg()["allow-cross-origin-requests"]);
+  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel, arg().asNum("webserver-max-request-size") * 1024ULL * 1024ULL, arg()["cross-origin-request-header"]);
 }
 
 static void fromCxxToRust(const HttpResponse& cxxresp, pdns::rust::web::rec::Response& rustResponse)

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -145,8 +145,15 @@ void WebServer::registerBareHandler(const string& url, const HandlerFunction& ha
   YaHTTP::Router::Map(method, url, std::move(f));
 }
 
-void WebServer::apiWrapper(const WebServer::HandlerFunction& handler, HttpRequest* req, HttpResponse* resp, bool allowPassword) {
-  resp->headers["access-control-allow-origin"] = "*";
+void WebServer::apiWrapper(const WebServer::HandlerFunction& handler, HttpRequest* req, HttpResponse* resp, bool allowPassword)
+{
+  if (d_allow_cross_origin_requests) {
+    const auto origin = req->headers.find("Origin");
+    if (origin != req->headers.end()) {
+      resp->headers["access-control-allow-origin"] = origin->second;
+      resp->headers["Vary"] = "Origin"; // prevents cached data to be used for a different Origin
+    }
+  }
 
   if (!d_apikey) {
     SLOG(g_log<<Logger::Error<<req->logprefix<<"HTTP API Request \"" << req->url.path << "\": Authentication failed, API Key missing in config" << endl,
@@ -604,7 +611,7 @@ WebServer::WebServer(std::shared_ptr<ConcurrentConnectionManager> ccm, string li
   d_maxbodysize(static_cast<ssize_t>(2 * 1024 * 1024))
 
 {
-    YaHTTP::Router::Map("OPTIONS", "/<*url>", [](YaHTTP::Request *req, YaHTTP::Response *resp) {
+    YaHTTP::Router::Map("OPTIONS", "/<*url>", [&allowCors = d_allow_cross_origin_requests](YaHTTP::Request *req, YaHTTP::Response *resp) {
       // look for url in routes
       bool seen = false;
       std::vector<std::string> methods;
@@ -626,7 +633,13 @@ WebServer::WebServer(std::shared_ptr<ConcurrentConnectionManager> ccm, string li
           return;
        }
        methods.emplace_back("OPTIONS");
-       resp->headers["access-control-allow-origin"] = "*";
+       if (allowCors) {
+         const auto origin = req->headers.find("Origin");
+         if (origin != req->headers.end()) {
+           resp->headers["access-control-allow-origin"] = origin->second;
+           resp->headers["Vary"] = "Origin"; // prevents cached data to be used for a different Origin
+         }
+       }
        resp->headers["access-control-allow-headers"] = "Content-Type, X-API-Key";
        resp->headers["access-control-allow-methods"] = boost::algorithm::join(methods, ", ");
        resp->headers["access-control-max-age"] = "3600";

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -147,8 +147,8 @@ void WebServer::registerBareHandler(const string& url, const HandlerFunction& ha
 
 void WebServer::apiWrapper(const WebServer::HandlerFunction& handler, HttpRequest* req, HttpResponse* resp, bool allowPassword)
 {
-  if (d_allow_cross_origin_requests) {
-      resp->headers["access-control-allow-origin"] = "*";
+  if (!d_allow_cross_origin_requests.empty()) {
+    resp->headers["access-control-allow-origin"] = d_allow_cross_origin_requests;
   }
 
   if (!d_apikey) {
@@ -629,8 +629,8 @@ WebServer::WebServer(std::shared_ptr<ConcurrentConnectionManager> ccm, string li
           return;
        }
        methods.emplace_back("OPTIONS");
-       if (allowCors) {
-         resp->headers["access-control-allow-origin"] = "*";
+       if (!allowCors.empty()) {
+         resp->headers["access-control-allow-origin"] = allowCors;
        }
        resp->headers["access-control-allow-headers"] = "Content-Type, X-API-Key";
        resp->headers["access-control-allow-methods"] = boost::algorithm::join(methods, ", ");

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -147,8 +147,8 @@ void WebServer::registerBareHandler(const string& url, const HandlerFunction& ha
 
 void WebServer::apiWrapper(const WebServer::HandlerFunction& handler, HttpRequest* req, HttpResponse* resp, bool allowPassword)
 {
-  if (!d_allow_cross_origin_requests.empty()) {
-    resp->headers["access-control-allow-origin"] = d_allow_cross_origin_requests;
+  if (!d_cross_origin_request_header.empty()) {
+    resp->headers["access-control-allow-origin"] = d_cross_origin_request_header;
   }
 
   if (!d_apikey) {
@@ -607,7 +607,7 @@ WebServer::WebServer(std::shared_ptr<ConcurrentConnectionManager> ccm, string li
   d_maxbodysize(static_cast<ssize_t>(2 * 1024 * 1024))
 
 {
-    YaHTTP::Router::Map("OPTIONS", "/<*url>", [&allowCors = d_allow_cross_origin_requests](YaHTTP::Request *req, YaHTTP::Response *resp) {
+    YaHTTP::Router::Map("OPTIONS", "/<*url>", [&allowCors = d_cross_origin_request_header](YaHTTP::Request *req, YaHTTP::Response *resp) {
       // look for url in routes
       bool seen = false;
       std::vector<std::string> methods;

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -148,11 +148,7 @@ void WebServer::registerBareHandler(const string& url, const HandlerFunction& ha
 void WebServer::apiWrapper(const WebServer::HandlerFunction& handler, HttpRequest* req, HttpResponse* resp, bool allowPassword)
 {
   if (d_allow_cross_origin_requests) {
-    const auto origin = req->headers.find("Origin");
-    if (origin != req->headers.end()) {
-      resp->headers["access-control-allow-origin"] = origin->second;
-      resp->headers["Vary"] = "Origin"; // prevents cached data to be used for a different Origin
-    }
+      resp->headers["access-control-allow-origin"] = "*";
   }
 
   if (!d_apikey) {
@@ -634,11 +630,7 @@ WebServer::WebServer(std::shared_ptr<ConcurrentConnectionManager> ccm, string li
        }
        methods.emplace_back("OPTIONS");
        if (allowCors) {
-         const auto origin = req->headers.find("Origin");
-         if (origin != req->headers.end()) {
-           resp->headers["access-control-allow-origin"] = origin->second;
-           resp->headers["Vary"] = "Origin"; // prevents cached data to be used for a different Origin
-         }
+         resp->headers["access-control-allow-origin"] = "*";
        }
        resp->headers["access-control-allow-headers"] = "Content-Type, X-API-Key";
        resp->headers["access-control-allow-methods"] = boost::algorithm::join(methods, ", ");

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -284,9 +284,9 @@ public:
     return d_loglevel;
   };
 
-  void setAllowCrossOriginRequests(const std::string& value)
+  void setCrossOriginRequestHeader(const std::string& value)
   {
-    d_allow_cross_origin_requests = value;
+    d_cross_origin_request_header = value;
   }
 
   std::shared_ptr<Logr::Logger> d_slog;
@@ -315,7 +315,7 @@ protected:
   int d_connectiontimeout{5}; // in seconds
 
   NetmaskGroup d_acl;
-  std::string d_allow_cross_origin_requests;
+  std::string d_cross_origin_request_header;
 
   const string d_logprefix = "[webserver] ";
 

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -284,6 +284,11 @@ public:
     return d_loglevel;
   };
 
+  void setAllowCrossOriginRequests(bool value)
+  {
+    d_allow_cross_origin_requests = value;
+  }
+
   std::shared_ptr<Logr::Logger> d_slog;
 
 protected:
@@ -310,6 +315,7 @@ protected:
   int d_connectiontimeout{5}; // in seconds
 
   NetmaskGroup d_acl;
+  bool d_allow_cross_origin_requests{false};
 
   const string d_logprefix = "[webserver] ";
 

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -284,7 +284,7 @@ public:
     return d_loglevel;
   };
 
-  void setAllowCrossOriginRequests(bool value)
+  void setAllowCrossOriginRequests(const std::string& value)
   {
     d_allow_cross_origin_requests = value;
   }
@@ -315,7 +315,7 @@ protected:
   int d_connectiontimeout{5}; // in seconds
 
   NetmaskGroup d_acl;
-  bool d_allow_cross_origin_requests{false};
+  std::string d_allow_cross_origin_requests;
 
   const string d_logprefix = "[webserver] ";
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -116,7 +116,7 @@ AuthWebServer::AuthWebServer() :
     d_ws->setMaxBodySize(::arg().asNum("webserver-max-bodysize"));
     d_ws->setConnectionTimeout(::arg().asNum("webserver-connection-timeout"));
 
-    d_ws->setAllowCrossOriginRequests(arg()["webserver-allow-cross-origin-requests"]);
+    d_ws->setCrossOriginRequestHeader(arg()["webserver-cross-origin-request-header"]);
     d_ws->bind();
   }
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -116,7 +116,7 @@ AuthWebServer::AuthWebServer() :
     d_ws->setMaxBodySize(::arg().asNum("webserver-max-bodysize"));
     d_ws->setConnectionTimeout(::arg().asNum("webserver-connection-timeout"));
 
-    d_ws->setAllowCrossOriginRequests(arg().mustDo("webserver-allow-cross-origin-requests"));
+    d_ws->setAllowCrossOriginRequests(arg()["webserver-allow-cross-origin-requests"]);
     d_ws->bind();
   }
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -116,6 +116,7 @@ AuthWebServer::AuthWebServer() :
     d_ws->setMaxBodySize(::arg().asNum("webserver-max-bodysize"));
     d_ws->setConnectionTimeout(::arg().asNum("webserver-connection-timeout"));
 
+    d_ws->setAllowCrossOriginRequests(arg().mustDo("allow-cross-origin-requests"));
     d_ws->bind();
   }
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -116,7 +116,7 @@ AuthWebServer::AuthWebServer() :
     d_ws->setMaxBodySize(::arg().asNum("webserver-max-bodysize"));
     d_ws->setConnectionTimeout(::arg().asNum("webserver-connection-timeout"));
 
-    d_ws->setAllowCrossOriginRequests(arg().mustDo("allow-cross-origin-requests"));
+    d_ws->setAllowCrossOriginRequests(arg().mustDo("webserver-allow-cross-origin-requests"));
     d_ws->bind();
   }
 }

--- a/regression-tests.api/test_Basics.py
+++ b/regression-tests.api/test_Basics.py
@@ -48,7 +48,7 @@ class TestBasics(ApiTestCase):
         # look for CORS headers
 
         self.assertEqual(r.status_code, requests.codes.ok)
-        self.assertEqual(r.headers["access-control-allow-origin"], "*")
+        self.assertNotIn("access-control-allow-origin", r.headers)
         self.assertEqual(r.headers["access-control-allow-headers"], "Content-Type, X-API-Key")
         self.assertEqual(r.headers["access-control-allow-methods"], "GET, OPTIONS")
 
@@ -56,7 +56,7 @@ class TestBasics(ApiTestCase):
 
         r = self.session.options(self.url("/api/v1/servers/localhost/zones/test"))
         self.assertEqual(r.status_code, requests.codes.ok)
-        self.assertNotIn("access-control-allow-origin"], r.headers)
+        self.assertNotIn("access-control-allow-origin", r.headers)
         self.assertEqual(r.headers["access-control-allow-headers"], "Content-Type, X-API-Key")
         if is_auth():
             self.assertEqual(r.headers["access-control-allow-methods"], "GET, PATCH, PUT, DELETE, OPTIONS")

--- a/regression-tests.api/test_Basics.py
+++ b/regression-tests.api/test_Basics.py
@@ -56,7 +56,7 @@ class TestBasics(ApiTestCase):
 
         r = self.session.options(self.url("/api/v1/servers/localhost/zones/test"))
         self.assertEqual(r.status_code, requests.codes.ok)
-        self.assertEqual(r.headers["access-control-allow-origin"], "*")
+        self.assertNotIn("access-control-allow-origin"], r.headers)
         self.assertEqual(r.headers["access-control-allow-headers"], "Content-Type, X-API-Key")
         if is_auth():
             self.assertEqual(r.headers["access-control-allow-methods"], "GET, PATCH, PUT, DELETE, OPTIONS")


### PR DESCRIPTION
With this PR, we default to not allowing cross origin requests. This is an extra safety belt that dnsdist already has.

Both yahttphhtp and Rust webserver cases implemted.

Docs and tests missing, hence draft

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
