### PR TITLE
auth 5.0: backport CI fix

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.authoritative
+++ b/builder-support/dockerfiles/Dockerfile.authoritative
@@ -7,7 +7,7 @@ RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \
 
 # the pdns/ dir is a bit broad, but who cares :)
 ADD configure.ac Makefile.am COPYING INSTALL NOTICE README /pdns-authoritative/
-@EXEC sdist_paths=(build-aux m4 pdns ext docs modules codedocs contrib regression-tests auth/systemd meson meson.build meson_options.txt)
+@EXEC sdist_paths=(build-aux m4 pdns ext docs modules codedocs contrib regression-tests meson meson.build meson_options.txt)
 @EXEC for d in ${sdist_paths[@]} ; do echo "COPY $d /pdns-authoritative/$d" ; done
 ADD builder/helpers/set-configure-ac-version.sh /pdns-authoritative/builder/helpers/
 ADD builder-support/gen-version /pdns-authoritative/builder-support/gen-version


### PR DESCRIPTION
## Short description
backport of commit d69f70b313c44d865c934a02cc81ffd3b5500a88

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
