### PR TITLE
auth: technical depth reduction in rectifyZone

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -865,7 +865,6 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
     bool doent{true};
     uint32_t maxent = ::arg().asNum("max-ent-entries");
 
-  dononterm:;
     std::unordered_map<DNSName,RecordStatus>::const_iterator it;
     for (const auto& qname: qnames) {
       bool auth{true};
@@ -963,7 +962,107 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
         for(const auto& nt : nonterm) {
           qnames.insert(nt.first);
         }
-        goto dononterm;
+      }
+    }
+
+    if (doent) {
+      for (const auto& qname: qnames) {
+        bool auth{true};
+        DNSName ordername;
+        auto shorter(qname);
+
+        if (realrr) {
+          do {
+            if (nsset.count(shorter) != 0) {
+              auth = false;
+              break;
+            }
+          } while (shorter.chopOff());
+        } else {
+          auth = nonterm.find(qname)->second;
+        }
+
+        if (haveNSEC3) { // NSEC3
+          if (nsec3set.count(qname) != 0) {
+            if (!narrow) {
+              ordername = DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname)));
+            }
+            if (!realrr && !isOptOut) {
+              auth = true;
+            }
+          }
+        }
+        else if (realrr && securedZone) { // NSEC
+          ordername = qname.makeRelative(zone);
+        }
+
+        it = rss.find(qname);
+        if (it == rss.end() || it->second.update || it->second.auth != auth || it->second.ordername != ordername) {
+          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, auth, QType::ANY, haveNSEC3 && !narrow);
+          ++updates;
+        }
+
+        if (realrr) {
+          if (dsnames.count(qname) != 0) {
+            sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, true, QType::DS, haveNSEC3 && !narrow);
+            ++updates;
+          }
+          if (!auth || nsset.count(qname) != 0) {
+            ordername.clear();
+            if (isOptOut && dsnames.count(qname) == 0) {
+              sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::NS, haveNSEC3 && !narrow);
+              ++updates;
+            }
+            sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::A, haveNSEC3 && !narrow);
+            ++updates;
+            sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::AAAA, haveNSEC3 && !narrow);
+            ++updates;
+          }
+
+          if (doent) {
+            shorter = qname;
+            while(shorter != zone.operator const DNSName&() && shorter.chopOff()) {
+              if (qnames.count(shorter) == 0) {
+                if (maxent == 0) {
+                  SLOG(g_log<<Logger::Warning<<"Zone '"<<zone<<"' has too many empty non terminals."<<endl,
+                       d_slog->info(Logr::Warning, "Too many empty non terminals in zone", "zone", Logging::Loggable(zone)));
+                  insnonterm.clear();
+                  delnonterm.clear();
+                  doent = false;
+                  break;
+                }
+
+                if (delnonterm.count(shorter) == 0 && nonterm.count(shorter) == 0) {
+                  insnonterm.insert(shorter);
+                }
+                else {
+                  delnonterm.erase(shorter);
+                }
+
+                if (nonterm.count(shorter) == 0) {
+                  nonterm.insert(pair<DNSName, bool>(shorter, auth));
+                  --maxent;
+                } else if (auth) {
+                  nonterm[shorter] = true;
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (realrr) {
+        //cerr<<"Total: "<<nonterm.size()<<" Insert: "<<insnonterm.size()<<" Delete: "<<delnonterm.size()<<endl;
+        if (!insnonterm.empty() || !delnonterm.empty() || !doent) {
+          sd.db->updateEmptyNonTerminals(sd.domain_id, insnonterm, delnonterm, !doent);
+        }
+        if (doent) {
+          realrr = false;
+          qnames.clear();
+          for(const auto& nt : nonterm) {
+            qnames.insert(nt.first);
+          }
+        }
       }
     }
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -861,56 +861,56 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
   try {
     sd.db->rectifyZoneHook(sd.domain_id, true);
 
-    bool realrr=true;
-    bool doent=true;
+    bool realrr{true};
+    bool doent{true};
     uint32_t maxent = ::arg().asNum("max-ent-entries");
 
   dononterm:;
     std::unordered_map<DNSName,RecordStatus>::const_iterator it;
     for (const auto& qname: qnames) {
-      bool auth=true;
+      bool auth{true};
       DNSName ordername;
       auto shorter(qname);
 
-      if(realrr) {
+      if (realrr) {
         do {
-          if(nsset.count(shorter)) {
-            auth=false;
+          if (nsset.count(shorter) != 0) {
+            auth = false;
             break;
           }
-        } while(shorter.chopOff());
+        } while (shorter.chopOff());
       } else {
-        auth=nonterm.find(qname)->second;
+        auth = nonterm.find(qname)->second;
       }
 
-      if(haveNSEC3) { // NSEC3
-        if(nsec3set.count(qname)) {
-          if(!narrow) {
-            ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname)));
+      if (haveNSEC3) { // NSEC3
+        if (nsec3set.count(qname) != 0) {
+          if (!narrow) {
+            ordername = DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname)));
           }
-          if(!realrr && !isOptOut) {
-            auth=true;
+          if (!realrr && !isOptOut) {
+            auth = true;
           }
         }
       }
       else if (realrr && securedZone) { // NSEC
-        ordername=qname.makeRelative(zone);
+        ordername = qname.makeRelative(zone);
       }
 
       it = rss.find(qname);
-      if(it == rss.end() || it->second.update || it->second.auth != auth || it->second.ordername != ordername) {
+      if (it == rss.end() || it->second.update || it->second.auth != auth || it->second.ordername != ordername) {
         sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, auth, QType::ANY, haveNSEC3 && !narrow);
         ++updates;
       }
 
-      if(realrr) {
-        if (dsnames.count(qname)) {
+      if (realrr) {
+        if (dsnames.count(qname) != 0) {
           sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, true, QType::DS, haveNSEC3 && !narrow);
           ++updates;
         }
-        if (!auth || nsset.count(qname)) {
+        if (!auth || nsset.count(qname) != 0) {
           ordername.clear();
-          if(isOptOut && !dsnames.count(qname)){
+          if (isOptOut && dsnames.count(qname) == 0) {
             sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::NS, haveNSEC3 && !narrow);
             ++updates;
           }
@@ -920,31 +920,31 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
           ++updates;
         }
 
-        if(doent) {
-          shorter=qname;
-          while(shorter!=zone.operator const DNSName&() && shorter.chopOff()) {
-            if(!qnames.count(shorter)) {
-              if(!(maxent)) {
+        if (doent) {
+          shorter = qname;
+          while(shorter != zone.operator const DNSName&() && shorter.chopOff()) {
+            if (qnames.count(shorter) == 0) {
+              if (maxent == 0) {
                 SLOG(g_log<<Logger::Warning<<"Zone '"<<zone<<"' has too many empty non terminals."<<endl,
                      d_slog->info(Logr::Warning, "Too many empty non terminals in zone", "zone", Logging::Loggable(zone)));
                 insnonterm.clear();
                 delnonterm.clear();
-                doent=false;
+                doent = false;
                 break;
               }
 
-              if (!delnonterm.count(shorter) && !nonterm.count(shorter)) {
+              if (delnonterm.count(shorter) == 0 && nonterm.count(shorter) == 0) {
                 insnonterm.insert(shorter);
               }
               else {
                 delnonterm.erase(shorter);
               }
 
-              if (!nonterm.count(shorter)) {
+              if (nonterm.count(shorter) == 0) {
                 nonterm.insert(pair<DNSName, bool>(shorter, auth));
                 --maxent;
               } else if (auth) {
-                nonterm[shorter]=true;
+                nonterm[shorter] = true;
               }
             }
           }
@@ -952,15 +952,15 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
       }
     }
 
-    if(realrr) {
+    if (realrr) {
       //cerr<<"Total: "<<nonterm.size()<<" Insert: "<<insnonterm.size()<<" Delete: "<<delnonterm.size()<<endl;
-      if(!insnonterm.empty() || !delnonterm.empty() || !doent) {
+      if (!insnonterm.empty() || !delnonterm.empty() || !doent) {
         sd.db->updateEmptyNonTerminals(sd.domain_id, insnonterm, delnonterm, !doent);
       }
-      if(doent) {
-        realrr=false;
+      if (doent) {
+        realrr = false;
         qnames.clear();
-        for(const auto& nt :  nonterm){
+        for(const auto& nt : nonterm) {
           qnames.insert(nt.first);
         }
         goto dononterm;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -764,7 +764,6 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
   ostringstream infostream;
   DNSResourceRecord rr;
   set<DNSName> qnames, nsset, dsnames, insnonterm, delnonterm;
-  std::unordered_map<DNSName,bool> nonterm;
   vector<DNSResourceRecord> rrs;
   std::unordered_map<DNSName,RecordStatus> rss;
 
@@ -861,6 +860,7 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
   try {
     sd.db->rectifyZoneHook(sd.domain_id, true);
 
+    std::unordered_map<DNSName,bool> nonterm;
     bool doent{true};
     uint32_t maxent = ::arg().asNum("max-ent-entries");
 
@@ -945,20 +945,12 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
     if (!insnonterm.empty() || !delnonterm.empty() || !doent) {
       sd.db->updateEmptyNonTerminals(sd.domain_id, insnonterm, delnonterm, !doent);
     }
-    if (doent) {
-      qnames.clear();
-      for(const auto& nt : nonterm) {
-        qnames.insert(nt.first);
-      }
-    }
+    qnames.clear();
 
     if (doent) {
-      for (const auto& qname: qnames) {
-        bool auth{true};
+      for (const auto& nt : nonterm) { // NOLINT(readability-identifier-length)
+        auto [qname, auth] = nt;
         DNSName ordername;
-        auto shorter(qname);
-
-        auth = nonterm.find(qname)->second;
 
         if (haveNSEC3) { // NSEC3
           if (nsec3set.count(qname) != 0) {

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -861,7 +861,6 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
   try {
     sd.db->rectifyZoneHook(sd.domain_id, true);
 
-    bool realrr{true};
     bool doent{true};
     uint32_t maxent = ::arg().asNum("max-ent-entries");
 
@@ -871,28 +870,21 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
       DNSName ordername;
       auto shorter(qname);
 
-      if (realrr) {
-        do {
-          if (nsset.count(shorter) != 0) {
-            auth = false;
-            break;
-          }
-        } while (shorter.chopOff());
-      } else {
-        auth = nonterm.find(qname)->second;
-      }
+      do {
+        if (nsset.count(shorter) != 0) {
+          auth = false;
+          break;
+        }
+      } while (shorter.chopOff());
 
       if (haveNSEC3) { // NSEC3
         if (nsec3set.count(qname) != 0) {
           if (!narrow) {
             ordername = DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname)));
           }
-          if (!realrr && !isOptOut) {
-            auth = true;
-          }
         }
       }
-      else if (realrr && securedZone) { // NSEC
+      else if (securedZone) { // NSEC
         ordername = qname.makeRelative(zone);
       }
 
@@ -902,66 +894,61 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
         ++updates;
       }
 
-      if (realrr) {
-        if (dsnames.count(qname) != 0) {
-          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, true, QType::DS, haveNSEC3 && !narrow);
+      if (dsnames.count(qname) != 0) {
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, true, QType::DS, haveNSEC3 && !narrow);
+        ++updates;
+      }
+      if (!auth || nsset.count(qname) != 0) {
+        ordername.clear();
+        if (isOptOut && dsnames.count(qname) == 0) {
+          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::NS, haveNSEC3 && !narrow);
           ++updates;
         }
-        if (!auth || nsset.count(qname) != 0) {
-          ordername.clear();
-          if (isOptOut && dsnames.count(qname) == 0) {
-            sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::NS, haveNSEC3 && !narrow);
-            ++updates;
-          }
-          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::A, haveNSEC3 && !narrow);
-          ++updates;
-          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::AAAA, haveNSEC3 && !narrow);
-          ++updates;
-        }
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::A, haveNSEC3 && !narrow);
+        ++updates;
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::AAAA, haveNSEC3 && !narrow);
+        ++updates;
+      }
 
-        if (doent) {
-          shorter = qname;
-          while(shorter != zone.operator const DNSName&() && shorter.chopOff()) {
-            if (qnames.count(shorter) == 0) {
-              if (maxent == 0) {
-                SLOG(g_log<<Logger::Warning<<"Zone '"<<zone<<"' has too many empty non terminals."<<endl,
-                     d_slog->info(Logr::Warning, "Too many empty non terminals in zone", "zone", Logging::Loggable(zone)));
-                insnonterm.clear();
-                delnonterm.clear();
-                doent = false;
-                break;
-              }
+      if (doent) {
+        shorter = qname;
+        while(shorter != zone.operator const DNSName&() && shorter.chopOff()) {
+          if (qnames.count(shorter) == 0) {
+            if (maxent == 0) {
+              SLOG(g_log<<Logger::Warning<<"Zone '"<<zone<<"' has too many empty non terminals."<<endl,
+                   d_slog->info(Logr::Warning, "Too many empty non terminals in zone", "zone", Logging::Loggable(zone)));
+              insnonterm.clear();
+              delnonterm.clear();
+              doent = false;
+              break;
+            }
 
-              if (delnonterm.count(shorter) == 0 && nonterm.count(shorter) == 0) {
-                insnonterm.insert(shorter);
-              }
-              else {
-                delnonterm.erase(shorter);
-              }
+            if (delnonterm.count(shorter) == 0 && nonterm.count(shorter) == 0) {
+              insnonterm.insert(shorter);
+            }
+            else {
+              delnonterm.erase(shorter);
+            }
 
-              if (nonterm.count(shorter) == 0) {
-                nonterm.insert(pair<DNSName, bool>(shorter, auth));
-                --maxent;
-              } else if (auth) {
-                nonterm[shorter] = true;
-              }
+            if (nonterm.count(shorter) == 0) {
+              nonterm.insert(pair<DNSName, bool>(shorter, auth));
+              --maxent;
+            } else if (auth) {
+              nonterm[shorter] = true;
             }
           }
         }
       }
     }
 
-    if (realrr) {
-      //cerr<<"Total: "<<nonterm.size()<<" Insert: "<<insnonterm.size()<<" Delete: "<<delnonterm.size()<<endl;
-      if (!insnonterm.empty() || !delnonterm.empty() || !doent) {
-        sd.db->updateEmptyNonTerminals(sd.domain_id, insnonterm, delnonterm, !doent);
-      }
-      if (doent) {
-        realrr = false;
-        qnames.clear();
-        for(const auto& nt : nonterm) {
-          qnames.insert(nt.first);
-        }
+    //cerr<<"Total: "<<nonterm.size()<<" Insert: "<<insnonterm.size()<<" Delete: "<<delnonterm.size()<<endl;
+    if (!insnonterm.empty() || !delnonterm.empty() || !doent) {
+      sd.db->updateEmptyNonTerminals(sd.domain_id, insnonterm, delnonterm, !doent);
+    }
+    if (doent) {
+      qnames.clear();
+      for(const auto& nt : nonterm) {
+        qnames.insert(nt.first);
       }
     }
 
@@ -971,97 +958,23 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
         DNSName ordername;
         auto shorter(qname);
 
-        if (realrr) {
-          do {
-            if (nsset.count(shorter) != 0) {
-              auth = false;
-              break;
-            }
-          } while (shorter.chopOff());
-        } else {
-          auth = nonterm.find(qname)->second;
-        }
+        auth = nonterm.find(qname)->second;
 
         if (haveNSEC3) { // NSEC3
           if (nsec3set.count(qname) != 0) {
             if (!narrow) {
               ordername = DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname)));
             }
-            if (!realrr && !isOptOut) {
+            if (!isOptOut) {
               auth = true;
             }
           }
-        }
-        else if (realrr && securedZone) { // NSEC
-          ordername = qname.makeRelative(zone);
         }
 
         it = rss.find(qname);
         if (it == rss.end() || it->second.update || it->second.auth != auth || it->second.ordername != ordername) {
           sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, auth, QType::ANY, haveNSEC3 && !narrow);
           ++updates;
-        }
-
-        if (realrr) {
-          if (dsnames.count(qname) != 0) {
-            sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, true, QType::DS, haveNSEC3 && !narrow);
-            ++updates;
-          }
-          if (!auth || nsset.count(qname) != 0) {
-            ordername.clear();
-            if (isOptOut && dsnames.count(qname) == 0) {
-              sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::NS, haveNSEC3 && !narrow);
-              ++updates;
-            }
-            sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::A, haveNSEC3 && !narrow);
-            ++updates;
-            sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::AAAA, haveNSEC3 && !narrow);
-            ++updates;
-          }
-
-          if (doent) {
-            shorter = qname;
-            while(shorter != zone.operator const DNSName&() && shorter.chopOff()) {
-              if (qnames.count(shorter) == 0) {
-                if (maxent == 0) {
-                  SLOG(g_log<<Logger::Warning<<"Zone '"<<zone<<"' has too many empty non terminals."<<endl,
-                       d_slog->info(Logr::Warning, "Too many empty non terminals in zone", "zone", Logging::Loggable(zone)));
-                  insnonterm.clear();
-                  delnonterm.clear();
-                  doent = false;
-                  break;
-                }
-
-                if (delnonterm.count(shorter) == 0 && nonterm.count(shorter) == 0) {
-                  insnonterm.insert(shorter);
-                }
-                else {
-                  delnonterm.erase(shorter);
-                }
-
-                if (nonterm.count(shorter) == 0) {
-                  nonterm.insert(pair<DNSName, bool>(shorter, auth));
-                  --maxent;
-                } else if (auth) {
-                  nonterm[shorter] = true;
-                }
-              }
-            }
-          }
-        }
-      }
-
-      if (realrr) {
-        //cerr<<"Total: "<<nonterm.size()<<" Insert: "<<insnonterm.size()<<" Delete: "<<delnonterm.size()<<endl;
-        if (!insnonterm.empty() || !delnonterm.empty() || !doent) {
-          sd.db->updateEmptyNonTerminals(sd.domain_id, insnonterm, delnonterm, !doent);
-        }
-        if (doent) {
-          realrr = false;
-          qnames.clear();
-          for(const auto& nt : nonterm) {
-            qnames.insert(nt.first);
-          }
         }
       }
     }


### PR DESCRIPTION
### Short description
While being in that routine for $REASONS, I couldn't help but notice there is block of 100 lines of code which (often) runs twice, duo to a `goto` statement at its end.

But unrolling the loop, and then cleaning each copy according to the state of the `realrr` variable (which says whether we are in the first or second loop) allows the second loop to shrink down to about 25 lines and become much more readable.

And then this allows us to not have to rebuild the container being operated on, for the second pass, as we can directly operate on the source of the second refill and save a bunch of memory copies and container searches.

Probably easier to review on a commit-by-commit, in order to help following the changes. Or you can trust me blindly (only to regret this later eventually).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
