### PR TITLE
Backport 16993 to rec 5.4.x: Fix serialization of cached authority records 

### DIFF
--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -1045,12 +1045,13 @@ void MemRecursorCache::getRecordSet(T& message, U recordSet)
     for (const auto& authRec : *recordSet->d_authorityRecs) {
       protozero::pbf_builder<PBAuthRecord> auth(message, PBCacheEntry::repeated_message_authRecord);
       auth.add_bytes(PBAuthRecord::required_bytes_name, authRec.d_name.toString());
-      auth.add_bytes(PBAuthRecord::required_bytes_rdata, authRec.getContent()->serialize(authRec.d_name, true));
       auth.add_uint32(PBAuthRecord::required_uint32_type, authRec.d_type);
       auth.add_uint32(PBAuthRecord::required_uint32_class, authRec.d_class);
       auth.add_uint32(PBAuthRecord::required_uint32_ttl, authRec.d_ttl);
       auth.add_uint32(PBAuthRecord::required_uint32_place, authRec.d_place);
       auth.add_uint32(PBAuthRecord::required_uint32_clen, authRec.d_clen);
+      /* content needs to be done last otherwise we have a problem when deserializing because we don't know the correct type! */
+      auth.add_bytes(PBAuthRecord::required_bytes_rdata, authRec.getContent()->serialize(authRec.d_name, true));
     }
   }
   message.add_bytes(PBCacheEntry::required_bytes_authZone, recordSet->d_authZone.toString());

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -1301,7 +1301,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
   dr.d_name = DNSName("hi");
   dr.d_type = QType::AAAA;
   dr.d_ttl = 3600;
-  dr.setContent(std::make_shared<ARecordContent>(ComboAddress("1::2:3:4")));
+  dr.setContent(std::make_shared<AAAARecordContent>(ComboAddress("1::2:3:4")));
   authRecords.emplace_back(dr);
 
   std::vector<std::shared_ptr<const RRSIGRecordContent>> signatures;
@@ -1327,18 +1327,18 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheDumpAndRestore)
   const MemRecursorCache::Extra authAddress{ComboAddress{"::2"}, true};
   const time_t ttl_time = 90;
 
+  const size_t expected = 100;
+
+  for (size_t counter = 0; counter < expected; ++counter) {
+    DNSName a = DNSName("hello ") + DNSName(std::to_string(counter));
+    BOOST_CHECK_EQUAL(DNSName(a.toString()), a);
+
+    MRC.replace(now, a, QType(QType::A), rset0, signatures, authRecords, true, authZone, std::nullopt, MemRecursorCache::NOTAG, vState::Insecure, authAddress, false, ttl_time);
+  }
+
+  BOOST_CHECK_EQUAL(MRC.size(), expected);
+
   auto checker = [&] {
-    const size_t expected = 100;
-
-    for (size_t counter = 0; counter < expected; ++counter) {
-      DNSName a = DNSName("hello ") + DNSName(std::to_string(counter));
-      BOOST_CHECK_EQUAL(DNSName(a.toString()), a);
-
-      MRC.replace(now, a, QType(QType::A), rset0, signatures, authRecords, true, authZone, std::nullopt, MemRecursorCache::NOTAG, vState::Insecure, authAddress, false, ttl_time);
-    }
-
-    BOOST_CHECK_EQUAL(MRC.size(), expected);
-
     size_t matches = 0;
 
     for (size_t counter = 0; counter < expected + 10; counter++) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #16993

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
