### PR TITLE
auth lmdb: yet another NSEC bug

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -3356,10 +3356,14 @@ bool LMDBBackend::updateEmptyNonTerminals(domainid_t domain_id, set<DNSName>& in
       name.makeUsRelative(info.zone);
       std::string match = order(domain_id, name, QType::ENT);
       MDBOutVal val{};
+      // If the given ENT record actually exists, and has a matching NSEC3
+      // record, check if there are any other records with the same name,
+      // and remove the NSEC3 record if not, to not leave a dangling record.
       if (txn->txn->get(txn->db->rdbi, match, val) == 0) {
         bool hadOrderName = peekAtHasOrderName(val.get<string_view>());
         txn->txn->del(txn->db->rdbi, match);
-        if (hadOrderName) {
+        auto cursor = txn->txn->getCursor(txn->db->rdbi);
+        if (hadOrderName && hasOrphanedNSEC3Record(cursor, domain_id, name)) {
           deleteNSEC3RecordPair(txn, domain_id, name);
         }
       }

--- a/regression-tests/tests/1dyndns-update-delete-ent/command
+++ b/regression-tests/tests/1dyndns-update-delete-ent/command
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+mysqldiff
+
+# add the nested record
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update add deeply.nested.test.dyndns. 3600 A 1.2.3.4
+send
+answer
+!
+
+cleandig deeply.nested.test.dyndns ANY
+cleandig nested.test.dyndns ANY
+mysqldiff 1 "Check ENT record"
+
+# add the intermediate level
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update add nested.test.dyndns. 3600 A 5.6.7.8
+send
+answer
+!
+
+cleandig deeply.nested.test.dyndns ANY
+cleandig nested.test.dyndns ANY
+mysqldiff 2 "Check ENT record disappearance and proper NSEC3 chaining"
+
+# restore zone for the sake of following tests
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update delete deeply.nested.test.dyndns. 3600 A 1.2.3.4
+update delete nested.test.dyndns. 3600 A 5.6.7.8
+send
+answer
+!

--- a/regression-tests/tests/1dyndns-update-delete-ent/description
+++ b/regression-tests/tests/1dyndns-update-delete-ent/description
@@ -1,0 +1,2 @@
+This test adds a nested record to create an empty non-terminal, then
+adds another record causing the empty non-terminal to get removed.

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result
@@ -1,0 +1,42 @@
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+1	test.dyndns.	3600	IN	SOA	ns1.test.dyndns. ahu.example.dyndns. 2026050754 28800 7200 604800 86400
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record
+--- Start: diff start step.1 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600
+> nested.test.dyndns	NULL	NULL	NULL	NULL
+--- End: diff start step.1 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+0	nested.test.dyndns.	3600	IN	A	5.6.7.8
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record disappearance and proper NSEC3 chaining
+--- Start: diff start step.2 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600
+> nested.test.dyndns	A	0	5.6.7.8	3600
+--- End: diff start step.2 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.dnssec
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.dnssec
@@ -1,0 +1,42 @@
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+1	test.dyndns.	3600	IN	SOA	ns1.test.dyndns. ahu.example.dyndns. 2026050754 28800 7200 604800 86400
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record
+--- Start: diff start step.1 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600	'nested deeply'	1
+> nested.test.dyndns	NULL	NULL	NULL	NULL	NULL	1
+--- End: diff start step.1 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+0	nested.test.dyndns.	3600	IN	A	5.6.7.8
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record disappearance and proper NSEC3 chaining
+--- Start: diff start step.2 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600	'nested deeply'	1
+> nested.test.dyndns	A	0	5.6.7.8	3600	'nested'	1
+--- End: diff start step.2 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb
@@ -1,0 +1,42 @@
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+1	test.dyndns.	3600	IN	SOA	ns1.test.dyndns. ahu.example.dyndns. 2026050754 28800 7200 604800 86400
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record
+--- Start: diff start step.1 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600
+> nested.test.dyndns	TYPE0	0		0
+--- End: diff start step.1 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+0	nested.test.dyndns.	3600	IN	A	5.6.7.8
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record disappearance and proper NSEC3 chaining
+--- Start: diff start step.2 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600
+> nested.test.dyndns	A	0	5.6.7.8	3600
+--- End: diff start step.2 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3
@@ -31,7 +31,7 @@ Reply to question for qname='nested.test.dyndns.', qtype=ANY
 Check ENT record disappearance and proper NSEC3 chaining
 --- Start: diff start step.2 ---
 > deeply.nested.test.dyndns	A	0	1.2.3.4	3600	'8os5tdupgih8h9limmlsb3hascs0uu72'	1
-> nested.test.dyndns	A	0	5.6.7.8	3600	''	1
+> nested.test.dyndns	A	0	5.6.7.8	3600	'atlj98b73ejgobef9qob8vjh1utc9hff'	1
 --- End: diff start step.2 ---
 
 Answer:

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3
@@ -1,0 +1,42 @@
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+1	test.dyndns.	3600	IN	SOA	ns1.test.dyndns. ahu.example.dyndns. 2026050754 28800 7200 604800 86400
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record
+--- Start: diff start step.1 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600	'8os5tdupgih8h9limmlsb3hascs0uu72'	1
+> nested.test.dyndns	TYPE0	0		0	'atlj98b73ejgobef9qob8vjh1utc9hff'	1
+--- End: diff start step.1 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+0	nested.test.dyndns.	3600	IN	A	5.6.7.8
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record disappearance and proper NSEC3 chaining
+--- Start: diff start step.2 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600	'8os5tdupgih8h9limmlsb3hascs0uu72'	1
+> nested.test.dyndns	A	0	5.6.7.8	3600	''	1
+--- End: diff start step.2 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-narrow
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-narrow
@@ -1,0 +1,1 @@
+expected_result.lmdb

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-narrow-variant
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-narrow-variant
@@ -1,0 +1,1 @@
+expected_result.lmdb-nsec3-narrow

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-optout
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-optout
@@ -1,0 +1,1 @@
+expected_result.lmdb-nsec3

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-optout-variant
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-optout-variant
@@ -1,0 +1,1 @@
+expected_result.lmdb-nsec3-optout

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-variant
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-nsec3-variant
@@ -1,0 +1,1 @@
+expected_result.lmdb-nsec3

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-variant
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.lmdb-variant
@@ -1,0 +1,1 @@
+expected_result.lmdb

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.narrow
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.narrow
@@ -1,0 +1,42 @@
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+1	test.dyndns.	3600	IN	SOA	ns1.test.dyndns. ahu.example.dyndns. 2026050754 28800 7200 604800 86400
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record
+--- Start: diff start step.1 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600	NULL	1
+> nested.test.dyndns	NULL	NULL	NULL	NULL	NULL	1
+--- End: diff start step.1 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+0	nested.test.dyndns.	3600	IN	A	5.6.7.8
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record disappearance and proper NSEC3 chaining
+--- Start: diff start step.2 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600	NULL	1
+> nested.test.dyndns	A	0	5.6.7.8	3600	NULL	1
+--- End: diff start step.2 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.nsec3
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.nsec3
@@ -1,0 +1,42 @@
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+1	test.dyndns.	3600	IN	SOA	ns1.test.dyndns. ahu.example.dyndns. 2026050754 28800 7200 604800 86400
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record
+--- Start: diff start step.1 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600	'8os5tdupgih8h9limmlsb3hascs0uu72'	1
+> nested.test.dyndns	NULL	NULL	NULL	NULL	'atlj98b73ejgobef9qob8vjh1utc9hff'	1
+--- End: diff start step.1 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+0	deeply.nested.test.dyndns.	3600	IN	A	1.2.3.4
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='deeply.nested.test.dyndns.', qtype=ANY
+0	nested.test.dyndns.	3600	IN	A	5.6.7.8
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='nested.test.dyndns.', qtype=ANY
+Check ENT record disappearance and proper NSEC3 chaining
+--- Start: diff start step.2 ---
+> deeply.nested.test.dyndns	A	0	1.2.3.4	3600	'8os5tdupgih8h9limmlsb3hascs0uu72'	1
+> nested.test.dyndns	A	0	5.6.7.8	3600	'atlj98b73ejgobef9qob8vjh1utc9hff'	1
+--- End: diff start step.2 ---
+
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+

--- a/regression-tests/tests/1dyndns-update-delete-ent/expected_result.nsec3-optout
+++ b/regression-tests/tests/1dyndns-update-delete-ent/expected_result.nsec3-optout
@@ -1,0 +1,1 @@
+expected_result.nsec3

--- a/regression-tests/tests/1dyndns-update-delete-ent/skip.nodyndns
+++ b/regression-tests/tests/1dyndns-update-delete-ent/skip.nodyndns
@@ -1,0 +1,1 @@
+Skip this test if the backend does not support dyndns/rfc2136


### PR DESCRIPTION
### Short description
In the never ending story of trying to keep reliable NSEC3 information in the lmdb storage, it turns out I went a bit overenthusiastic with the scissors and deleted data when I shouldn't have. This was found out and documented in #16816.

This PR adds a test showing the destroyed NSEC chaining in the oracles for lmdb, then fixes the bug and the test oracles become nice again.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
