### PR TITLE
Backport 17005 to rec-5.4.x: continue processing response Policies if a discared policy is hit

### DIFF
--- a/pdns/recursordist/filterpo.cc
+++ b/pdns/recursordist/filterpo.cc
@@ -348,7 +348,7 @@ bool DNSFilterEngine::getPostPolicy(const DNSRecord& record, const std::unordere
     }
     const auto& zoneName = zone->getName();
     if (discardedPolicies.find(zoneName) != discardedPolicies.end()) {
-      return false;
+      continue;
     }
 
     if (zone->findResponsePolicy(address, pol)) {

--- a/pdns/recursordist/test-filterpo_cc.cc
+++ b/pdns/recursordist/test-filterpo_cc.cc
@@ -832,6 +832,24 @@ BOOST_AUTO_TEST_CASE(test_multiple_filter_policies_order)
     BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::None);
     BOOST_CHECK(matchingPolicy.d_kind == DNSFilterEngine::PolicyKind::NoAction);
   }
+
+  {
+    /* blocked A in the response, except 1 is disabled, so 2 should match */
+    DNSRecord dr;
+    dr.d_type = QType::A;
+    dr.setContent(DNSRecordContent::make(QType::A, QClass::IN, responseIP.toString()));
+    const auto matchingPolicy = dfe.getPostPolicy({dr}, {{zone1->getName(), true}}, DNSFilterEngine::maximumPriority);
+    BOOST_CHECK(matchingPolicy.d_type == DNSFilterEngine::PolicyType::ResponseIP);
+    BOOST_CHECK(matchingPolicy.d_kind == DNSFilterEngine::PolicyKind::Custom);
+    auto records = matchingPolicy.getCustomRecords(bad, QType::A);
+    BOOST_CHECK_EQUAL(records.size(), 1U);
+    const auto& record = records.at(0);
+    BOOST_CHECK(record.d_type == QType::CNAME);
+    BOOST_CHECK(record.d_class == QClass::IN);
+    auto content = getRR<CNAMERecordContent>(record);
+    BOOST_CHECK(content != nullptr);
+    BOOST_CHECK_EQUAL(content->getTarget().toString(), "response2a.example.net.");
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_mask_to_rpz)


### PR DESCRIPTION
(cherry picked from commit 77e12e9e7c33aee4f7a2977e7b30f596a1d2841d)

Backport of #17005 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
