### PR TITLE
Backport 16936 to rec 5.4.x: drop QR=0 responses from auths

### DIFF
--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -817,6 +817,15 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
   try {
     lwr->d_tcbit = 0;
     MOADNSParser mdp(false, reinterpret_cast<const char*>(buf.data()), buf.size());
+
+    // RFC 1035 Section 4.1.1: QR must be 1 for responses
+    if (!mdp.d_header.qr) {
+      lwr->d_rcode = RCode::ServFail;
+      lwr->d_validpacket = false;
+      t_Counters.at(rec::Counter::serverParseError)++;
+      return LWResult::Result::PermanentError;
+    }
+
     lwr->d_aabit = mdp.d_header.aa;
     lwr->d_tcbit = mdp.d_header.tc;
     lwr->d_rcode = mdp.d_header.rcode;

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -3073,7 +3073,7 @@ retryWithName:
       if (pident->domain.empty() && !d_waiter.key->domain.empty() && pident->type == 0 && d_waiter.key->type != 0 && pident->id == d_waiter.key->id && d_waiter.key->remote == pident->remote) {
         pident->domain = d_waiter.key->domain;
         pident->type = d_waiter.key->type;
-        goto retryWithName; // note that this only passes on an error, lwres will still reject the packet NOLINT(cppcoreguidelines-avoid-goto)
+        goto retryWithName; // note that this only passes on an error, lwres still should reject the packet NOLINT(cppcoreguidelines-avoid-goto)
       }
     }
     t_Counters.at(rec::Counter::unexpectedCount)++; // if we made it here, it really is an unexpected answer

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -3021,8 +3021,13 @@ static void handleUDPServerResponse(int fileDesc, FDMultiplexer::funcparam_t& va
   pident->id = dnsheader.id;
   pident->fd = fileDesc;
 
-  if (!dnsheader.qr && g_logCommonErrors) {
-    g_slogout->info(Logr::Error, "Not taking data from question on outgoing socket", "from", Logging::Loggable(fromaddr));
+  if (!dnsheader.qr) {
+    // RFC 1035 Section 4.1.1: QR=0 means query, not response. Discard.
+    if (g_logCommonErrors) {
+      g_slogout->info(Logr::Error, "Not taking data from question on outgoing socket", "from", Logging::Loggable(fromaddr));
+    }
+    t_Counters.at(rec::Counter::unexpectedCount)++;
+    return;
   }
 
   if (dnsheader.qdcount == 0U || // UPC, Nominum, very old BIND on FormErr, NSD

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -3030,29 +3030,22 @@ static void handleUDPServerResponse(int fileDesc, FDMultiplexer::funcparam_t& va
     return;
   }
 
-  if (dnsheader.qdcount == 0U || // UPC, Nominum, very old BIND on FormErr, NSD
-      dnsheader.qr == 0U) { // one weird server
-    pident->domain.clear();
-    pident->type = 0;
+  try {
+    if (len > signed_sizeof_sdnsheader) {
+      pident->domain = DNSName(reinterpret_cast<const char*>(packet.data()), static_cast<int>(len), static_cast<int>(sizeof(dnsheader)), false, &pident->type); // don't copy this from above - we need to do the actual read  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    }
+    else {
+      // len == sizeof(dnsheader), only header case
+      // We will do a full scan search later to see if we can match this reply even without a domain
+      pident->domain.clear();
+      pident->type = 0;
+    }
   }
-  else {
-    try {
-      if (len > signed_sizeof_sdnsheader) {
-        pident->domain = DNSName(reinterpret_cast<const char*>(packet.data()), static_cast<int>(len), static_cast<int>(sizeof(dnsheader)), false, &pident->type); // don't copy this from above - we need to do the actual read  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-      }
-      else {
-        // len == sizeof(dnsheader), only header case
-        // We will do a full scan search later to see if we can match this reply even without a domain
-        pident->domain.clear();
-        pident->type = 0;
-      }
-    }
-    catch (std::exception& e) {
-      // Parse error, continue waiting for other packets
-      t_Counters.at(rec::Counter::serverParseError)++; // won't be fed to lwres.cc, so we have to increment
-      g_slogudpin->error(Logr::Warning, e.what(), "Error in packet from remote nameserver", "from", Logging::Loggable(fromaddr));
-      return;
-    }
+  catch (std::exception& e) {
+    // Parse error, continue waiting for other packets
+    t_Counters.at(rec::Counter::serverParseError)++; // won't be fed to lwres.cc, so we have to increment
+    g_slogudpin->error(Logr::Warning, e.what(), "Error in packet from remote nameserver", "from", Logging::Loggable(fromaddr));
+    return;
   }
 
   if (!pident->domain.empty()) {

--- a/regression-tests.recursor-dnssec/test_Malformed.py
+++ b/regression-tests.recursor-dnssec/test_Malformed.py
@@ -1,0 +1,169 @@
+import dns
+import os
+import time
+import subprocess
+
+from twisted.internet.protocol import Factory
+from twisted.internet.protocol import Protocol
+from twisted.internet.protocol import DatagramProtocol
+from twisted.internet import reactor
+
+from recursortests import RecursorTest
+
+malformedReactorRunning = False
+
+class MalformedTest(RecursorTest):
+    _confdir = 'Malformed'
+    _config_template = """
+recursor:
+  forward_zones:
+  - zone: malformed.example
+    forwarders: [%s.27]
+  devonly_regression_test_mode: true
+packetcache:
+  disable: true
+logging:
+    quiet: false
+    common_errors: true
+outgoing:
+    dont_throttle_netmasks: ['127.0.0.27']
+""" % (os.environ['PREFIX'])
+
+    @classmethod
+    def generateRecursorConfig(cls, confdir):
+        super(MalformedTest, cls).generateRecursorYamlConfig(confdir)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setUpSockets()
+
+        cls.startResponders()
+
+        confdir = os.path.join('configs', cls._confdir)
+        cls.createConfigDir(confdir)
+
+        cls.generateRecursorConfig(confdir)
+        cls.startRecursor(confdir, cls._recursorPort)
+
+        print("Launching tests..")
+
+    @classmethod
+    def startResponders(cls):
+        global malformedReactorRunning
+        print("Launching responders..")
+
+        address1 = cls._PREFIX + '.27'
+        port = 53
+
+        if not malformedReactorRunning:
+            reactor.listenUDP(port, UDPResponder(), interface=address1)
+            reactor.listenTCP(port, TCPFactory(), interface=address1)
+            malformedReactorRunning = True
+
+        cls.startReactor()
+
+    def getCache(self, name):
+        rec_controlCmd = [os.environ['RECCONTROL'],
+                          '--config-dir=%s' % 'configs/' + self._confdir,
+                          'dump-cache',
+                          '-']
+        try:
+            ret = subprocess.check_output(rec_controlCmd, stderr=subprocess.STDOUT, text=True)
+            for i in ret.splitlines():
+                pieces = i.split(' ')
+                #print(pieces)
+                if pieces[0] == name:
+                    return pieces
+            return []
+
+        except subprocess.CalledProcessError as e:
+            print(e.output)
+            raise
+
+    def testOKAnswer(self):
+        # Case: rec gets a proper answer
+        query = dns.message.make_query('proper.malformed.example.', 'A')
+        expected = dns.rrset.from_text('proper.malformed.example.', 15, dns.rdataclass.IN, 'A', '127.0.0.1')
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+            self.assertRcodeEqual(res, dns.rcode.NOERROR)
+            self.assertRRsetInAnswer(res, expected)
+
+    def testQR0Answer(self):
+        # Case: rec gets a QR=0 answer
+        query = dns.message.make_query('qr0.malformed.example.', 'A')
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+            self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
+
+    def testQR0PoisonAnswer(self):
+        # Case: rec gets a QR=0 answer
+        query = dns.message.make_query('qr0poison.malformed.example.', 'A')
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+            lines = self.getCache("qr0poison.malformed.example")
+            self.assertEqual(lines, [])
+            self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
+
+    def testHeaderOnlyAnswer(self):
+        # Case: rec gets a header-only answer
+        query = dns.message.make_query('headeronly.malformed.example.', 'A')
+        res = self.sendUDPQuery(query)
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+            self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
+
+class UDPResponder(DatagramProtocol):
+
+    def question(self, datagram, tcp=False):
+        request = dns.message.from_wire(datagram)
+
+        response = dns.message.make_response(request)
+        response.flags = dns.flags.AA + dns.flags.QR
+
+        question = request.question[0]
+
+        # Case: send proper answer back
+        if question.name == dns.name.from_text('proper.malformed.example.') and question.rdtype == dns.rdatatype.A:
+            answer = dns.rrset.from_text('proper.malformed.example.', 15, dns.rdataclass.IN, 'A', '127.0.0.1')
+            response.answer.append(answer)
+
+        # Case: send qr=0 answer back
+        elif question.name == dns.name.from_text('qr0.malformed.example.') and question.rdtype == dns.rdatatype.A:
+            answer = dns.rrset.from_text('qr0.malformed.example.', 15, dns.rdataclass.IN, 'A', '127.0.0.1')
+            response.answer.append(answer)
+            response.flags &= ~dns.flags.QR
+
+        # Case: send qr=0 poison answer back
+        elif question.name == dns.name.from_text('qr0poison.malformed.example.') and question.rdtype == dns.rdatatype.A:
+            answer = dns.rrset.from_text('www.poision.example.', 15, dns.rdataclass.IN, 'A', '127.0.0.1')
+            response.answer.append(answer)
+            response.flags &= ~dns.flags.QR
+
+        # Case: send header only back
+        elif dns.name.from_text('headeronly.malformed.example.') and question.rdtype == dns.rdatatype.A:
+            response.question = []
+            response.use_edns(False)
+        else:
+            self.assertEqual(0, 1)
+        return response.to_wire()
+
+    def datagramReceived(self, datagram, address):
+        response = self.question(datagram)
+        self.transport.write(response, address)
+
+class TCPResponder(Protocol):
+    def dataReceived(self, data):
+        handler = UDPResponder()
+        response = handler.question(data[2:], True)
+        length = len(response)
+        header = length.to_bytes(2, 'big')
+        self.transport.write(header + response)
+
+class TCPFactory(Factory):
+    def buildProtocol(self, addr):
+        return TCPResponder()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #16936 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
