### PR TITLE
Backport 17252 to rec-5.2.x: increase entry count so we hit the 8192 byte limit on 32 bit systems too

### DIFF
--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -1143,7 +1143,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_very_big_replace)
   rec.d_ttl = now.tv_sec + 10;
   rec.setContent(getRecordContent(QType::NSEC3, "1 0 500 ab HASG==== A RRSIG NSEC3"));
   std::vector<std::shared_ptr<const RRSIGRecordContent>> sigs;
-  for (auto i = 0; i < 100; i++) {
+  for (auto i = 0; i < 200; i++) {
     auto rrsig = std::make_shared<RRSIGRecordContent>("NSEC3 5 3 10 20370101000000 20370101000000 24567 dummy. data");
     sigs.emplace_back(std::move(rrsig));
   }


### PR DESCRIPTION

(cherry picked from commit 7b77faf16e72c169ad046629d7567afd6fe28ed8)

Backport of #17252 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
