### PR TITLE
auth, rec: smarter memory need computation

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -266,8 +266,15 @@ void MOADNSParser::init(bool query, const std::string_view& packet)
     vector<unsigned char> record;
     bool seenTSIG = false;
     validPacket=true;
-    d_answers.reserve((unsigned int)(d_header.ancount + d_header.nscount + d_header.arcount));
-    for(n=0;n < (unsigned int)(d_header.ancount + d_header.nscount + d_header.arcount); ++n) {
+    unsigned int supposedRecordCount = d_header.ancount + d_header.nscount + d_header.arcount;
+    // No need to reserve more memory for more records than the request can
+    // contain. We could try to be smarter and actually count the records
+    // by doing getDnsrecordheader and skip the payload in a loop, but all
+    // we really want here is to avoid reserving too much memory in case of
+    // maliciously high record counts.
+    auto reserveRecordCount = std::min(1 + (packet.size() - sizeof(dnsheader)) / sizeof(dnsrecordheader), static_cast<size_t>(supposedRecordCount));
+    d_answers.reserve(reserveRecordCount);
+    for (n = 0; n < supposedRecordCount; ++n) {
       DNSRecord dr;
 
       if(n < d_header.ancount)


### PR DESCRIPTION
### Short description
The dns packet parser will attempt to reserve memory for the number of advertized records in the packet. But should the packet be truncated (or incorrect), it does not make sense to reserve memory for more records than can fit the received packet, so compute a better upper bound, without taking too much time to do so.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
