### PR TITLE
ci: Add check for builder submodule

### DIFF
--- a/.github/workflows/check-submodules.yml
+++ b/.github/workflows/check-submodules.yml
@@ -1,0 +1,19 @@
+name: Check if the builder submodule is modified
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'builder'
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    name: Builder submodule check
+    steps:
+      - run: |
+          echo "The builder/ submodule was modified in this PR" >> "${GITHUB_STEP_SUMMARY}"
+          exit 1


### PR DESCRIPTION
### Short description

This adds a check that fails when the builder submodule is modified.

I'll add a commit that modifies the submodule to test this after.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)