### PR TITLE
dnsdist-2.1.x: Backport 17037 - Fix invalid TCP rate limiting computation

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -410,6 +410,7 @@ testrunner_SOURCES = \
 	test-delaypipe_hh.cc \
 	test-dns_cc.cc \
 	test-dnscrypt_cc.cc \
+	test-dnsdist-concurrent-connections.cc \
 	test-dnsdist-connections-cache.cc \
 	test-dnsdist-dnsparser.cc \
 	test-dnsdist-ipcrypt2_cc.cc \

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -38,15 +38,15 @@ namespace dnsdist
 {
 
 static constexpr size_t NB_SHARDS = 16U;
-static constexpr time_t BUCKET_VALIDITY_SECONDS{60U};
+static constexpr time_t BUCKET_VALIDITY_SECONDS{60};
 
 struct ClientActivity
 {
-  time_t getStartTime() const
+  [[nodiscard]] time_t getStartTime() const
   {
     return bucketEndTime - BUCKET_VALIDITY_SECONDS;
   }
-  bool isStillValid(time_t now) const
+  [[nodiscard]] bool isStillValid(time_t now) const
   {
     return bucketEndTime > now;
   }
@@ -89,7 +89,7 @@ static std::atomic<time_t> s_nextCleanup{0};
 static AddressAndPortRange getRange(const ComboAddress& from)
 {
   const auto& immutable = dnsdist::configuration::getImmutableConfiguration();
-  return AddressAndPortRange(from, from.isIPv4() ? immutable.d_tcpConnectionsMaskV4 : immutable.d_tcpConnectionsMaskV6, from.isIPv4() && immutable.d_tcpConnectionsMaskV4 == 32 ? immutable.d_tcpConnectionsMaskV4Port : 0);
+  return {from, from.isIPv4() ? immutable.d_tcpConnectionsMaskV4 : immutable.d_tcpConnectionsMaskV6, static_cast<uint8_t>(from.isIPv4() && immutable.d_tcpConnectionsMaskV4 == 32U ? immutable.d_tcpConnectionsMaskV4Port : 0U)};
 }
 
 static size_t getShardID(const AddressAndPortRange& from)
@@ -129,20 +129,20 @@ static bool checkTCPConnectionsRate(const boost::circular_buffer<ClientActivity>
     return true;
   }
   if (maxTCPRate > 0) {
-    auto rate = connectionsSeen / (period * 1.0);
-    if (rate > (maxTCPRate * 1.0)) {
+    auto rate = static_cast<double>(connectionsSeen) / static_cast<double>(period);
+    if (rate > static_cast<double>(maxTCPRate)) {
       return false;
     }
   }
   if (maxTLSNewRate > 0 && isTLS) {
-    auto rate = tlsNewSeen / (period * 1.0);
-    if (rate > (maxTLSNewRate * 1.0)) {
+    auto rate = static_cast<double>(tlsNewSeen) / static_cast<double>(period);
+    if (rate > static_cast<double>(maxTLSNewRate)) {
       return false;
     }
   }
   if (maxTLSResumedRate > 0 && isTLS) {
-    auto rate = tlsResumedSeen / (period * 1.0);
-    if (rate > (maxTLSResumedRate * 1.0)) {
+    auto rate = static_cast<double>(tlsResumedSeen) / static_cast<double>(period);
+    if (rate > (static_cast<double>(maxTLSResumedRate))) {
       return false;
     }
   }
@@ -201,7 +201,7 @@ static ClientActivity& getCurrentClientActivity(const ClientEntry& entry, time_t
   return activity.front();
 }
 
-IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC, std::optional<time_t> now)
+IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC, time_t now)
 {
   const auto& immutable = dnsdist::configuration::getImmutableConfiguration();
   const auto maxConnsPerClient = immutable.d_maxTCPConnectionsPerClient;
@@ -214,14 +214,10 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
     return NewConnectionResult::Allowed;
   }
 
-  if (!now) {
-    now = time(nullptr);
-  }
-
   auto updateActivity = [now](ClientEntry& entry) {
     ++entry.d_concurrentConnections;
-    entry.d_lastSeen = *now;
-    auto& activity = getCurrentClientActivity(entry, *now);
+    entry.d_lastSeen = now;
+    auto& activity = getCurrentClientActivity(entry, now);
     ++activity.tcpConnections;
   };
 
@@ -230,7 +226,7 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
   };
 
   auto checkConnectionAllowed = [now, from, maxConnsPerClient, threshold, tcpRate, tlsNewRate, tlsResumedRate, interval, isTLS, &immutable, &getProtocol](const ClientEntry& entry) {
-    if (entry.d_bannedUntil != 0 && entry.d_bannedUntil >= *now) {
+    if (entry.d_bannedUntil != 0 && entry.d_bannedUntil >= now) {
       VERBOSESLOG(infolog("Refusing %s connection from %s: banned", getProtocol(), from.toStringWithPort()),
                   dnsdist::logging::getTopLogger("concurrent-connections-manager")->info(Logr::Info, "Refusing connection", "reason", Logging::Loggable("banned"), "protocol", Logging::Loggable(getProtocol()), "client.address", Logging::Loggable(from)));
       return NewConnectionResult::Denied;
@@ -240,8 +236,8 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
                   dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Refusing connection", "reason", Logging::Loggable("too many connections"), "protocol", Logging::Loggable(getProtocol()), "client.address", Logging::Loggable(from)));
       return NewConnectionResult::Denied;
     }
-    if (!checkTCPConnectionsRate(entry.d_activity, *now, tcpRate, tlsNewRate, tlsResumedRate, interval, isTLS)) {
-      entry.d_bannedUntil = *now + immutable.d_tcpBanDurationForExceedingTCPTLSRate;
+    if (!checkTCPConnectionsRate(entry.d_activity, now, tcpRate, tlsNewRate, tlsResumedRate, interval, isTLS)) {
+      entry.d_bannedUntil = now + immutable.d_tcpBanDurationForExceedingTCPTLSRate;
       VERBOSESLOG(infolog("Banning connections from %s for %d seconds: too many new QUIC/TCP/TLS connections per second", from.toStringWithPort(), immutable.d_tcpBanDurationForExceedingTCPTLSRate),
                   dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Banning connections from this client", "reason", Logging::Loggable("too many new TCP/TLS connections per second"), "client.address", Logging::Loggable(from), "duration-seconds", Logging::Loggable(immutable.d_tcpBanDurationForExceedingTCPTLSRate)));
       return NewConnectionResult::Denied;
@@ -263,19 +259,19 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
   auto addr = getRange(from);
   {
     auto shardID = getShardID(addr);
-    auto db = s_tcpClientsConnectionMetrics.at(shardID).lock();
-    const auto& entry = db->find(addr);
-    if (entry == db->end()) {
+    auto clients = s_tcpClientsConnectionMetrics.at(shardID).lock();
+    const auto& entry = clients->find(addr);
+    if (entry == clients->end()) {
       ClientEntry newEntry;
       newEntry.d_activity.set_capacity(interval);
       newEntry.d_addr = addr;
       updateActivity(newEntry);
-      db->insert(std::move(newEntry));
+      clients->insert(std::move(newEntry));
       return NewConnectionResult::Allowed;
     }
     auto result = checkConnectionAllowed(*entry);
     if (result != NewConnectionResult::Denied) {
-      db->modify(entry, updateActivity);
+      clients->modify(entry, updateActivity);
     }
     return result;
   }
@@ -293,12 +289,12 @@ bool IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(const ComboA
   auto addr = getRange(from);
   auto shardID = getShardID(addr);
   {
-    auto db = s_tcpClientsConnectionMetrics.at(shardID).lock();
-    auto it = db->find(addr);
-    if (it == db->end()) {
+    auto clients = s_tcpClientsConnectionMetrics.at(shardID).lock();
+    auto clientsIt = clients->find(addr);
+    if (clientsIt == clients->end()) {
       return false;
     }
-    count = it->d_concurrentConnections;
+    count = clientsIt->d_concurrentConnections;
   }
 
   auto current = (100 * count) / maxConnsPerClient;
@@ -310,12 +306,12 @@ void IncomingConcurrentTCPConnectionsManager::banClientFor(const ComboAddress& f
   auto addr = getRange(from);
   auto shardID = getShardID(addr);
   {
-    auto db = s_tcpClientsConnectionMetrics.at(shardID).lock();
-    auto it = db->find(addr);
-    if (it == db->end()) {
+    auto clients = s_tcpClientsConnectionMetrics.at(shardID).lock();
+    auto clientsIt = clients->find(addr);
+    if (clientsIt == clients->end()) {
       return;
     }
-    db->modify(it, [now, seconds](ClientEntry& entry) {
+    clients->modify(clientsIt, [now, seconds](ClientEntry& entry) {
       entry.d_lastSeen = now;
       entry.d_bannedUntil = now + seconds;
     });
@@ -329,12 +325,12 @@ static void editEntryIfPresent(const ComboAddress& from, const std::function<voi
   auto addr = getRange(from);
   auto shardID = getShardID(addr);
   {
-    auto db = s_tcpClientsConnectionMetrics.at(shardID).lock();
-    auto it = db->find(addr);
-    if (it == db->end()) {
+    auto clients = s_tcpClientsConnectionMetrics.at(shardID).lock();
+    auto clientsIt = clients->find(addr);
+    if (clientsIt == clients->end()) {
       return;
     }
-    callback(*it);
+    callback(*clientsIt);
   }
 }
 

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -96,7 +96,7 @@ static bool checkTCPConnectionsRate(const boost::circular_buffer<ClientActivity>
   }
   uint64_t bucketsConsidered = 0;
   uint64_t connectionsSeen = 1U; /* the current one */
-  uint64_t tlsNewSeen = isTLS ? 1U : 0U;
+  uint64_t tlsNewSeen = 0U;
   uint64_t tlsResumedSeen = 0;
   const auto cutOff = static_cast<time_t>(now - (interval * 60)); // interval is in minutes
   for (const auto& entry : activity) {

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -38,17 +38,20 @@ namespace dnsdist
 {
 
 static constexpr size_t NB_SHARDS = 16;
+static constexpr time_t BUCKET_VALIDITY_SECONDS{60};
 
 struct ClientActivity
 {
   uint64_t tcpConnections{0};
   uint64_t tlsNewSessions{0}; /* without resumption */
   uint64_t tlsResumedSessions{0};
+  // the bucket is valid for BUCKET_VALIDITY_SECONDS seconds
   time_t bucketEndTime{0};
 };
 
 struct ClientEntry
 {
+  // we have "interval" buckets, each holding up to 1 minute of traffic
   mutable boost::circular_buffer<ClientActivity> d_activity;
   AddressAndPortRange d_addr;
   mutable uint64_t d_concurrentConnections{0};
@@ -73,7 +76,6 @@ using map_t = boost::multi_index_container<
 
 static std::vector<LockGuarded<map_t>> s_tcpClientsConnectionMetrics{NB_SHARDS};
 static std::atomic<time_t> s_nextCleanup{0};
-static constexpr time_t INACTIVITY_DELAY{60};
 
 static AddressAndPortRange getRange(const ComboAddress& from)
 {
@@ -93,8 +95,8 @@ static bool checkTCPConnectionsRate(const boost::circular_buffer<ClientActivity>
     return true;
   }
   uint64_t bucketsConsidered = 0;
-  uint64_t connectionsSeen = 0;
-  uint64_t tlsNewSeen = 0;
+  uint64_t connectionsSeen = 1U; /* the current one */
+  uint64_t tlsNewSeen = isTLS ? 1U : 0U;
   uint64_t tlsResumedSeen = 0;
   const auto cutOff = static_cast<time_t>(now - (interval * 60)); // interval is in minutes
   for (const auto& entry : activity) {
@@ -106,23 +108,34 @@ static bool checkTCPConnectionsRate(const boost::circular_buffer<ClientActivity>
     tlsNewSeen += entry.tlsNewSessions;
     tlsResumedSeen += entry.tlsResumedSessions;
   }
+
   if (bucketsConsidered == 0) {
     return true;
   }
+  size_t secondsLeftInCurrentBucket{0};
+  if (!activity.empty() && activity.front().bucketEndTime > now) {
+    secondsLeftInCurrentBucket = activity.front().bucketEndTime - now - 1;
+  }
+
+  auto period = (bucketsConsidered * BUCKET_VALIDITY_SECONDS) - secondsLeftInCurrentBucket;
+  if (period == 0) {
+    return true;
+  }
+
   if (maxTCPRate > 0) {
-    auto rate = connectionsSeen / bucketsConsidered;
+    auto rate = connectionsSeen / period;
     if (rate > maxTCPRate) {
       return false;
     }
   }
   if (maxTLSNewRate > 0 && isTLS) {
-    auto rate = tlsNewSeen / bucketsConsidered;
+    auto rate = tlsNewSeen / period;
     if (rate > maxTLSNewRate) {
       return false;
     }
   }
   if (maxTLSResumedRate > 0 && isTLS) {
-    auto rate = tlsResumedSeen / bucketsConsidered;
+    auto rate = tlsResumedSeen / period;
     if (rate > maxTLSResumedRate) {
       return false;
     }
@@ -155,16 +168,24 @@ void IncomingConcurrentTCPConnectionsManager::cleanup(time_t now)
   }
 }
 
+void IncomingConcurrentTCPConnectionsManager::clear()
+{
+  for (auto& shard : s_tcpClientsConnectionMetrics) {
+    auto db = shard.lock();
+    db->clear();
+  }
+}
+
 static ClientActivity& getCurrentClientActivity(const ClientEntry& entry, time_t now)
 {
   auto& activity = entry.d_activity;
   if (activity.empty() || activity.front().bucketEndTime < now) {
-    activity.push_front(ClientActivity{1, 0, 0, now + INACTIVITY_DELAY});
+    activity.push_front(ClientActivity{0U, 0U, 0U, now + BUCKET_VALIDITY_SECONDS});
   }
   return activity.front();
 }
 
-IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC)
+IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC, std::optional<time_t> now)
 {
   const auto& immutable = dnsdist::configuration::getImmutableConfiguration();
   const auto maxConnsPerClient = immutable.d_maxTCPConnectionsPerClient;
@@ -177,11 +198,14 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
     return NewConnectionResult::Allowed;
   }
 
-  auto now = time(nullptr);
+  if (!now) {
+    now = time(nullptr);
+  }
+
   auto updateActivity = [now](ClientEntry& entry) {
     ++entry.d_concurrentConnections;
-    entry.d_lastSeen = now;
-    auto& activity = getCurrentClientActivity(entry, now);
+    entry.d_lastSeen = *now;
+    auto& activity = getCurrentClientActivity(entry, *now);
     ++activity.tcpConnections;
   };
 
@@ -200,8 +224,8 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
                   dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Refusing connection", "reason", Logging::Loggable("too many connections"), "protocol", Logging::Loggable(getProtocol()), "client.address", Logging::Loggable(from)));
       return NewConnectionResult::Denied;
     }
-    if (!checkTCPConnectionsRate(entry.d_activity, now, tcpRate, tlsNewRate, tlsResumedRate, interval, isTLS)) {
-      entry.d_bannedUntil = now + immutable.d_tcpBanDurationForExceedingTCPTLSRate;
+    if (!checkTCPConnectionsRate(entry.d_activity, *now, tcpRate, tlsNewRate, tlsResumedRate, interval, isTLS)) {
+      entry.d_bannedUntil = *now + immutable.d_tcpBanDurationForExceedingTCPTLSRate;
       VERBOSESLOG(infolog("Banning connections from %s for %d seconds: too many new QUIC/TCP/TLS connections per second", from.toStringWithPort(), immutable.d_tcpBanDurationForExceedingTCPTLSRate),
                   dnsdist::logging::getTopLogger("concurrent-tcp-connections-manager")->info(Logr::Info, "Banning connections from this client", "reason", Logging::Loggable("too many new TCP/TLS connections per second"), "client.address", Logging::Loggable(from), "duration-seconds", Logging::Loggable(immutable.d_tcpBanDurationForExceedingTCPTLSRate)));
       return NewConnectionResult::Denied;
@@ -229,8 +253,7 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
       ClientEntry newEntry;
       newEntry.d_activity.set_capacity(interval);
       newEntry.d_addr = addr;
-      newEntry.d_concurrentConnections = 1;
-      newEntry.d_lastSeen = now;
+      updateActivity(newEntry);
       db->insert(std::move(newEntry));
       return NewConnectionResult::Allowed;
     }

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -154,11 +154,11 @@ void IncomingConcurrentTCPConnectionsManager::cleanup(time_t now)
   if (s_nextCleanup.load() > now) {
     return;
   }
-  s_nextCleanup.store(now + 60);
+  s_nextCleanup.store(now + 60U);
 
   const auto& immutable = dnsdist::configuration::getImmutableConfiguration();
   const auto interval = immutable.d_tcpConnectionsRatePerClientInterval;
-  const auto cutOff = static_cast<time_t>(now - (interval * 60)); // interval in minutes
+  const auto cutOff = static_cast<time_t>(now - (interval * 60U)); // interval in minutes
   for (auto& shard : s_tcpClientsConnectionMetrics) {
     auto db = shard.lock();
     auto& index = db->get<TimeTag>();
@@ -180,6 +180,16 @@ void IncomingConcurrentTCPConnectionsManager::clear()
     auto db = shard.lock();
     db->clear();
   }
+}
+
+size_t IncomingConcurrentTCPConnectionsManager::getNumberOfEntries()
+{
+  size_t total = 0;
+  for (auto& shard : s_tcpClientsConnectionMetrics) {
+    auto db = shard.lock();
+    total += db->size();
+  }
+  return total;
 }
 
 static ClientActivity& getCurrentClientActivity(const ClientEntry& entry, time_t now)

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -220,7 +220,7 @@ IncomingConcurrentTCPConnectionsManager::NewConnectionResult IncomingConcurrentT
   };
 
   auto checkConnectionAllowed = [now, from, maxConnsPerClient, threshold, tcpRate, tlsNewRate, tlsResumedRate, interval, isTLS, &immutable, &getProtocol](const ClientEntry& entry) {
-    if (entry.d_bannedUntil != 0 && entry.d_bannedUntil >= now) {
+    if (entry.d_bannedUntil != 0 && entry.d_bannedUntil >= *now) {
       VERBOSESLOG(infolog("Refusing %s connection from %s: banned", getProtocol(), from.toStringWithPort()),
                   dnsdist::logging::getTopLogger("concurrent-connections-manager")->info(Logr::Info, "Refusing connection", "reason", Logging::Loggable("banned"), "protocol", Logging::Loggable(getProtocol()), "client.address", Logging::Loggable(from)));
       return NewConnectionResult::Denied;
@@ -336,7 +336,9 @@ void IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(const C
   }
   editEntryIfPresent(from, [](const ClientEntry& entry) {
     auto& count = entry.d_concurrentConnections;
-    count--;
+    if (count > 0) {
+      count--;
+    }
   });
 }
 

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -37,11 +37,20 @@
 namespace dnsdist
 {
 
-static constexpr size_t NB_SHARDS = 16;
-static constexpr time_t BUCKET_VALIDITY_SECONDS{60};
+static constexpr size_t NB_SHARDS = 16U;
+static constexpr time_t BUCKET_VALIDITY_SECONDS{60U};
 
 struct ClientActivity
 {
+  time_t getStartTime() const
+  {
+    return bucketEndTime - BUCKET_VALIDITY_SECONDS;
+  }
+  bool isStillValid(time_t now) const
+  {
+    return bucketEndTime > now;
+  }
+
   uint64_t tcpConnections{0};
   uint64_t tlsNewSessions{0}; /* without resumption */
   uint64_t tlsResumedSessions{0};
@@ -94,49 +103,46 @@ static bool checkTCPConnectionsRate(const boost::circular_buffer<ClientActivity>
   if (maxTCPRate == 0 && (!isTLS || (maxTLSNewRate == 0 && maxTLSResumedRate == 0))) {
     return true;
   }
-  uint64_t bucketsConsidered = 0;
   uint64_t connectionsSeen = 1U; /* the current one */
   uint64_t tlsNewSeen = 0U;
   uint64_t tlsResumedSeen = 0;
-  const auto cutOff = static_cast<time_t>(now - (interval * 60)); // interval is in minutes
+  time_t firstSeen{};
+  const auto cutOff = static_cast<time_t>(now - (interval * 60U)); // interval is in minutes
   for (const auto& entry : activity) {
-    if (entry.bucketEndTime < cutOff) {
+    if (entry.getStartTime() <= cutOff) {
       continue;
     }
-    ++bucketsConsidered;
+    if (firstSeen == 0 || entry.getStartTime() < firstSeen) {
+      firstSeen = entry.getStartTime();
+    }
     connectionsSeen += entry.tcpConnections;
     tlsNewSeen += entry.tlsNewSessions;
     tlsResumedSeen += entry.tlsResumedSessions;
   }
 
-  if (bucketsConsidered == 0) {
+  if (firstSeen == 0) {
     return true;
   }
-  size_t secondsLeftInCurrentBucket{0};
-  if (!activity.empty() && activity.front().bucketEndTime > now) {
-    secondsLeftInCurrentBucket = activity.front().bucketEndTime - now - 1;
-  }
 
-  auto period = (bucketsConsidered * BUCKET_VALIDITY_SECONDS) - secondsLeftInCurrentBucket;
+  auto period = 1U + (now - firstSeen);
   if (period == 0) {
     return true;
   }
-
   if (maxTCPRate > 0) {
-    auto rate = connectionsSeen / period;
-    if (rate > maxTCPRate) {
+    auto rate = connectionsSeen / (period * 1.0);
+    if (rate > (maxTCPRate * 1.0)) {
       return false;
     }
   }
   if (maxTLSNewRate > 0 && isTLS) {
-    auto rate = tlsNewSeen / period;
-    if (rate > maxTLSNewRate) {
+    auto rate = tlsNewSeen / (period * 1.0);
+    if (rate > (maxTLSNewRate * 1.0)) {
       return false;
     }
   }
   if (maxTLSResumedRate > 0 && isTLS) {
-    auto rate = tlsResumedSeen / period;
-    if (rate > maxTLSResumedRate) {
+    auto rate = tlsResumedSeen / (period * 1.0);
+    if (rate > (maxTLSResumedRate * 1.0)) {
       return false;
     }
   }
@@ -179,7 +185,7 @@ void IncomingConcurrentTCPConnectionsManager::clear()
 static ClientActivity& getCurrentClientActivity(const ClientEntry& entry, time_t now)
 {
   auto& activity = entry.d_activity;
-  if (activity.empty() || activity.front().bucketEndTime < now) {
+  if (activity.empty() || !activity.front().isStillValid(now)) {
     activity.push_front(ClientActivity{0U, 0U, 0U, now + BUCKET_VALIDITY_SECONDS});
   }
   return activity.front();

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.hh
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.hh
@@ -20,7 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-
+#include <ctime>
 #include "iputils.hh"
 
 namespace dnsdist
@@ -34,7 +34,7 @@ public:
     Denied = 1,
     Restricted = 2,
   };
-  static NewConnectionResult accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC = false, std::optional<time_t> now = std::nullopt);
+  static NewConnectionResult accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC = false, time_t now = time(nullptr));
   static bool isClientOverThreshold(const ComboAddress& from);
   static void accountTLSNewSession(const ComboAddress& from);
   static void accountTLSResumedSession(const ComboAddress& from);

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.hh
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.hh
@@ -42,5 +42,6 @@ public:
   static void banClientFor(const ComboAddress& from, time_t now, uint32_t seconds);
   static void cleanup(time_t now);
   static void clear();
+  static size_t getNumberOfEntries();
 };
 }

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.hh
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.hh
@@ -34,12 +34,13 @@ public:
     Denied = 1,
     Restricted = 2,
   };
-  static NewConnectionResult accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC = false);
+  static NewConnectionResult accountNewTCPConnection(const ComboAddress& from, bool isTLS, bool isQUIC = false, std::optional<time_t> now = std::nullopt);
   static bool isClientOverThreshold(const ComboAddress& from);
   static void accountTLSNewSession(const ComboAddress& from);
   static void accountTLSResumedSession(const ComboAddress& from);
   static void accountClosedTCPConnection(const ComboAddress& from);
   static void banClientFor(const ComboAddress& from, time_t now, uint32_t seconds);
   static void cleanup(time_t now);
+  static void clear();
 };
 }

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -529,6 +529,7 @@ test_sources += files(
   src_dir / 'test-dnsdistbackend_cc.cc',
   src_dir / 'test-dnsdistbackoff.cc',
   src_dir / 'test-dnsdist_cc.cc',
+  src_dir / 'test-dnsdist-concurrent-connections.cc',
   src_dir / 'test-dnsdist-connections-cache.cc',
   src_dir / 'test-dnsdist-dnsparser.cc',
   src_dir / 'test-dnsdist-ipcrypt2_cc.cc',

--- a/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
@@ -32,18 +32,35 @@
 
 BOOST_AUTO_TEST_SUITE(test_dnsdist_concurrent_connections)
 
-BOOST_AUTO_TEST_CASE(test_Below_Rate)
+static void initConfiguration(uint64_t maxTCPConnectionsRatePerClient, uint64_t tcpConnectionsRatePerClientInterval, uint64_t maxTCPConnectionsPerClient, uint32_t banDuration)
 {
-  const uint64_t maxTCPConnectionsRatePerClient = 10U;
-  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
-  const uint64_t maxTCPConnectionsPerClient = 1U;
   dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
     config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
     config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
     config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
+    config.d_tcpBanDurationForExceedingTCPTLSRate = banDuration;
   });
+}
 
-  dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
+struct TestFixture
+{
+  TestFixture()
+  {
+    dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
+  }
+  ~TestFixture()
+  {
+    dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
+  }
+};
+
+BOOST_FIXTURE_TEST_CASE(test_Below_Rate, TestFixture)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 10U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 1U;
+  const uint32_t banDuration = 10U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration);
   time_t now = time(nullptr);
 
   /* simulate a client sending up to maxTCPConnectionsRatePerClient every second, for 120 seconds (so 2 buckets) */
@@ -61,16 +78,13 @@ BOOST_AUTO_TEST_CASE(test_Below_Rate)
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_Below_Rate_Skipping_Bucket)
+BOOST_FIXTURE_TEST_CASE(test_Below_Rate_Skipping_Bucket, TestFixture)
 {
   const uint64_t maxTCPConnectionsRatePerClient = 10U;
   const uint64_t tcpConnectionsRatePerClientInterval = 5U;
   const uint64_t maxTCPConnectionsPerClient = 1U;
-  dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
-    config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
-    config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
-    config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
-  });
+  const uint32_t banDuration = 10U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration);
 
   dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
   time_t now = time(nullptr);
@@ -107,16 +121,13 @@ BOOST_AUTO_TEST_CASE(test_Below_Rate_Skipping_Bucket)
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_Above_Rate_After_Being_Below)
+BOOST_FIXTURE_TEST_CASE(test_Above_Rate_After_Being_Below, TestFixture)
 {
   const uint64_t maxTCPConnectionsRatePerClient = 10U;
   const uint64_t tcpConnectionsRatePerClientInterval = 5U;
   const uint64_t maxTCPConnectionsPerClient = 1U;
-  dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
-    config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
-    config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
-    config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
-  });
+  const uint32_t banDuration = 10U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration);
 
   dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
   time_t now = time(nullptr);
@@ -162,19 +173,19 @@ BOOST_AUTO_TEST_CASE(test_Above_Rate_After_Being_Below)
   /* the last one */
   auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
   BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
-  dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+
+  /* check that the ban properly expires (takes a while to go below the rate, though, because we opened a lot of connections during the last minute ) */
+  result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now + std::max(tcpConnectionsRatePerClientInterval * 60U, static_cast<uint64_t>(banDuration)) + 1U);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
 }
 
-BOOST_AUTO_TEST_CASE(test_Above_Max_Concurrent_Connections)
+BOOST_FIXTURE_TEST_CASE(test_Above_Max_Concurrent_Connections, TestFixture)
 {
   const uint64_t maxTCPConnectionsRatePerClient = 10U;
   const uint64_t tcpConnectionsRatePerClientInterval = 5U;
   const uint64_t maxTCPConnectionsPerClient = 1U;
-  dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
-    config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
-    config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
-    config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
-  });
+  const uint32_t banDuration = 10U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration);
 
   dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
   const time_t now = time(nullptr);
@@ -190,18 +201,22 @@ BOOST_AUTO_TEST_CASE(test_Above_Max_Concurrent_Connections)
   auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false);
   BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
   BOOST_REQUIRE(dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+
+  /* now check that we are correctly allowed once at least one existing connections has been closed */
+  dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+  result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+  dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+  BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
 }
 
-BOOST_AUTO_TEST_CASE(test_Above_Max_Connection_Rate)
+BOOST_FIXTURE_TEST_CASE(test_Above_Max_Connection_Rate, TestFixture)
 {
   const uint64_t maxTCPConnectionsRatePerClient = 10U;
   const uint64_t tcpConnectionsRatePerClientInterval = 5U;
   const uint64_t maxTCPConnectionsPerClient = 1U;
-  dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
-    config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
-    config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
-    config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
-  });
+  const uint32_t banDuration = 10U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration);
 
   dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
   const time_t now = time(nullptr);
@@ -217,6 +232,10 @@ BOOST_AUTO_TEST_CASE(test_Above_Max_Connection_Rate)
   /* now go over the top */
   auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
   BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
+
+  /* check that the ban properly expires (takes a while to go below the rate) */
+  result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now + std::max(60U, banDuration) + 1U);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
@@ -117,7 +117,6 @@ BOOST_FIXTURE_TEST_CASE(test_Below_Rate, TestFixture)
   now += 180U;
   dnsdist::IncomingConcurrentTCPConnectionsManager::cleanup(now);
   BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 0U);
-
 }
 
 BOOST_FIXTURE_TEST_CASE(test_Below_Rate_Skipping_Bucket, TestFixture)

--- a/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
@@ -32,13 +32,16 @@
 
 BOOST_AUTO_TEST_SUITE(test_dnsdist_concurrent_connections)
 
-static void initConfiguration(uint64_t maxTCPConnectionsRatePerClient, uint64_t tcpConnectionsRatePerClientInterval, uint64_t maxTCPConnectionsPerClient, uint32_t banDuration)
+static void initConfiguration(uint64_t maxTCPConnectionsRatePerClient, uint64_t tcpConnectionsRatePerClientInterval, uint64_t maxTCPConnectionsPerClient, uint32_t banDuration, uint64_t maxTLSNewSessionsRatePerClient = 0U, uint64_t maxTLSResumedSessionsRatePerClient = 0U, uint32_t maxTCPReadIOsPerQuery = 50U)
 {
   dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
     config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
     config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
     config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
     config.d_tcpBanDurationForExceedingTCPTLSRate = banDuration;
+    config.d_maxTLSNewSessionsRatePerClient = maxTLSNewSessionsRatePerClient;
+    config.d_maxTLSResumedSessionsRatePerClient = maxTLSResumedSessionsRatePerClient;
+    config.d_maxTCPReadIOsPerQuery = maxTCPReadIOsPerQuery;
   });
 }
 
@@ -53,6 +56,28 @@ struct TestFixture
     dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
   }
 };
+
+BOOST_FIXTURE_TEST_CASE(test_No_Rate_Limiting, TestFixture)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 0U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 0U;
+  const uint32_t banDuration = 10U;
+  /* disable this to completely disable tracking */
+  const uint32_t maxTCPReadIOsPerQuery = 0U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration, 0U, 0U, maxTCPReadIOsPerQuery);
+  const ComboAddress client{"192.0.2.1"};
+  time_t now = time(nullptr);
+
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 0U);
+
+  auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+  dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+  BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 0U);
+}
 
 BOOST_FIXTURE_TEST_CASE(test_Below_Rate, TestFixture)
 {
@@ -76,6 +101,23 @@ BOOST_FIXTURE_TEST_CASE(test_Below_Rate, TestFixture)
     /* one second later */
     now++;
   }
+
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 1U);
+
+  /* should not remove anything */
+  dnsdist::IncomingConcurrentTCPConnectionsManager::cleanup(now);
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 1U);
+
+  /* more than the 60s between two cleanups, but entries should still be valid */
+  now += 120U;
+  dnsdist::IncomingConcurrentTCPConnectionsManager::cleanup(now);
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 1U);
+
+  /* now we should be after interval * 60s, entries should no longer be valid */
+  now += 180U;
+  dnsdist::IncomingConcurrentTCPConnectionsManager::cleanup(now);
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 0U);
+
 }
 
 BOOST_FIXTURE_TEST_CASE(test_Below_Rate_Skipping_Bucket, TestFixture)
@@ -210,6 +252,39 @@ BOOST_FIXTURE_TEST_CASE(test_Above_Max_Concurrent_Connections, TestFixture)
   BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
 }
 
+BOOST_FIXTURE_TEST_CASE(test_Max_Concurrent_Connections_Overload_Threshold, TestFixture)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 0U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 100U;
+  const uint32_t banDuration = 10U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration);
+  const auto overloadThreshold = dnsdist::configuration::getImmutableConfiguration().d_tcpConnectionsOverloadThreshold;
+  BOOST_REQUIRE_GT(overloadThreshold, 0U);
+
+  dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
+  const time_t now = time(nullptr);
+
+  const ComboAddress client{"192.0.2.1"};
+  for (size_t idx = 0; idx < maxTCPConnectionsPerClient * overloadThreshold / 100.0; idx++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+  }
+
+  /* now go over the top */
+  auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Restricted);
+  BOOST_REQUIRE(dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+
+  /* now check that we are correctly allowed once at least one existing connections has been closed */
+  dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+  result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+  dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+  BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+}
+
 BOOST_FIXTURE_TEST_CASE(test_Above_Max_Connection_Rate, TestFixture)
 {
   const uint64_t maxTCPConnectionsRatePerClient = 10U;
@@ -236,6 +311,87 @@ BOOST_FIXTURE_TEST_CASE(test_Above_Max_Connection_Rate, TestFixture)
   /* check that the ban properly expires (takes a while to go below the rate) */
   result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now + std::max(60U, banDuration) + 1U);
   BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_TLS_New_Without_TCP_Rate_Limiting, TestFixture)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 0U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 0U;
+  const uint64_t maxTLSNewSessionsRatePerClient = 1U;
+  const uint32_t banDuration = 10U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration, maxTLSNewSessionsRatePerClient);
+  const ComboAddress client{"192.0.2.1"};
+  time_t now = time(nullptr);
+
+  /* TCP (not TLS) connections should not be rate-limited */
+  for (size_t counter = 0U; counter < 20U; counter++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  }
+
+  /* TLS ones should be rate-limited, but resumed sessions are OK */
+  for (size_t counter = 0U; counter < 20U; counter++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, true, false, now);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountTLSResumedSession(client);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  }
+
+  /* TLS ones should be rate-limited, only two NEW sessions allowed (because we need to establish the connection to see if it is resumed or not, we are off by one) */
+  for (size_t counter = 0U; counter < 2U; counter++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, true, false, now);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountTLSNewSession(client);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  }
+  auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, true, false, now);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_TLS_Resumed_Without_TCP_Rate_Limiting, TestFixture)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 0U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 0U;
+  const uint64_t maxTLSNewSessionsRatePerClient = 0U;
+  const uint64_t maxTLSResumedSessionsRatePerClient = 1U;
+  const uint32_t banDuration = 10U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration, maxTLSNewSessionsRatePerClient, maxTLSResumedSessionsRatePerClient);
+  const ComboAddress client{"192.0.2.1"};
+  time_t now = time(nullptr);
+
+  /* TCP (not TLS) connections should not be rate-limited */
+  for (size_t counter = 0U; counter < 20U; counter++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  }
+
+  /* TLS ones should be rate-limited, but NEW sessions are OK (don't ask) */
+  for (size_t counter = 0U; counter < 20U; counter++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, true, false, now);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountTLSNewSession(client);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  }
+
+  /* only two resumed sessions allowed (because we need to establish the connection to see if it is resumed or not, we are off by one) */
+  for (size_t counter = 0U; counter < 2U; counter++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, true, false, now);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountTLSResumedSession(client);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  }
+  auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, true, false, now);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
@@ -51,15 +51,120 @@ BOOST_AUTO_TEST_CASE(test_Below_Rate)
     const ComboAddress client{"192.0.2.1"};
     for (size_t idx = 0; idx < maxTCPConnectionsRatePerClient; idx++) {
       auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
-      BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+      BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
       dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
     }
-    BOOST_CHECK(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
 
     /* one second later */
     now++;
   }
 }
+
+BOOST_AUTO_TEST_CASE(test_Below_Rate_Skipping_Bucket)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 10U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 1U;
+  dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
+    config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
+    config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
+    config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
+  });
+
+  dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
+  time_t now = time(nullptr);
+
+  /* simulate a client sending up to maxTCPConnectionsRatePerClient for 60 seconds */
+  for (size_t elapsed = 0; elapsed < 60U; elapsed++) {
+    const ComboAddress client{"192.0.2.1"};
+    for (size_t idx = 0; idx < maxTCPConnectionsRatePerClient; idx++) {
+      auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+      BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+      dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    }
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+
+    /* one second later */
+    now++;
+  }
+
+  /* nothing for one minute */
+  now += 60U;
+
+  /* than twice maxTCPConnectionsRatePerClient for 60 seconds, should be OK since it is averaged over 3 minutes */
+  for (size_t elapsed = 0; elapsed < 60U; elapsed++) {
+    const ComboAddress client{"192.0.2.1"};
+    for (size_t idx = 0; idx < (maxTCPConnectionsRatePerClient * 2U); idx++) {
+      auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+      BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+      dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    }
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+
+    /* one second later */
+    now++;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_Above_Rate_After_Being_Below)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 10U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 1U;
+  dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
+    config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
+    config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
+    config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
+  });
+
+  dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
+  time_t now = time(nullptr);
+  const ComboAddress client{"192.0.2.1"};
+
+  /* simulate a client creating only one connection per minute for tcpConnectionsRatePerClientInterval minutes */
+  for (size_t elapsed = 0; elapsed < tcpConnectionsRatePerClientInterval; elapsed++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+
+    /* one MINUTE later */
+    now += 60U;
+  }
+
+  /* now 4 * maxTCPConnectionsRatePerClient connections per second for 60 seconds */
+  for (size_t elapsed = 0; elapsed < 60U; elapsed++) {
+    for (size_t idx = 0; idx < (4U * maxTCPConnectionsRatePerClient); idx++) {
+      auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+      BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+      dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    }
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+
+    /* one second later */
+    now++;
+  }
+
+  /* go back to the last second of the last bucket */
+  now--;
+
+  /* 596 new connections should bring us over the top, since the first bucket of one connection per minute
+     is no longer valid, so we have 4 buckets at 1 connection per minute + 1 bucket at 4 * maxTCPConnectionsRatePerClient connections per second
+     so 4 + (4 * maxTCPConnectionsRatePerClient * 60) = 2404, and the budget is maxTCPConnectionsRatePerClient * 60 * interval = 3000
+  */
+  for (size_t count = 0; count < (maxTCPConnectionsRatePerClient * 60U * tcpConnectionsRatePerClientInterval) - (tcpConnectionsRatePerClientInterval - 1U + (4U * maxTCPConnectionsRatePerClient * 60U)); count++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  }
+  /* the last one */
+  auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
+  dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+}
+
 BOOST_AUTO_TEST_CASE(test_Above_Max_Concurrent_Connections)
 {
   const uint64_t maxTCPConnectionsRatePerClient = 10U;
@@ -77,14 +182,14 @@ BOOST_AUTO_TEST_CASE(test_Above_Max_Concurrent_Connections)
   const ComboAddress client{"192.0.2.1"};
   for (size_t idx = 0; idx < maxTCPConnectionsPerClient; idx++) {
     auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
-    BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
   }
-  BOOST_CHECK(dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  BOOST_REQUIRE(dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
 
   /* now go over the top */
   auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false);
-  BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
-  BOOST_CHECK(dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
+  BOOST_REQUIRE(dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
 }
 
 BOOST_AUTO_TEST_CASE(test_Above_Max_Connection_Rate)
@@ -104,14 +209,14 @@ BOOST_AUTO_TEST_CASE(test_Above_Max_Connection_Rate)
   const ComboAddress client{"192.0.2.1"};
   for (size_t idx = 0; idx < maxTCPConnectionsRatePerClient; idx++) {
     auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
-    BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
     dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
   }
-  BOOST_CHECK(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+  BOOST_REQUIRE(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
 
   /* now go over the top */
   auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
-  BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
@@ -1,0 +1,117 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include "dnsdist-concurrent-connections.hh"
+#include "dnsdist-configuration.hh"
+
+BOOST_AUTO_TEST_SUITE(test_dnsdist_concurrent_connections)
+
+BOOST_AUTO_TEST_CASE(test_Below_Rate)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 10U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 1U;
+  dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
+    config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
+    config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
+    config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
+  });
+
+  dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
+  time_t now = time(nullptr);
+
+  /* simulate a client sending up to maxTCPConnectionsRatePerClient every second, for 120 seconds (so 2 buckets) */
+  for (size_t elapsed = 0; elapsed < 120U; elapsed++) {
+    const ComboAddress client{"192.0.2.1"};
+    for (size_t idx = 0; idx < maxTCPConnectionsRatePerClient; idx++) {
+      auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+      BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+      dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+    }
+    BOOST_CHECK(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+
+    /* one second later */
+    now++;
+  }
+}
+BOOST_AUTO_TEST_CASE(test_Above_Max_Concurrent_Connections)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 10U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 1U;
+  dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
+    config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
+    config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
+    config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
+  });
+
+  dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
+  const time_t now = time(nullptr);
+
+  const ComboAddress client{"192.0.2.1"};
+  for (size_t idx = 0; idx < maxTCPConnectionsPerClient; idx++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+    BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+  }
+  BOOST_CHECK(dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+
+  /* now go over the top */
+  auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false);
+  BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
+  BOOST_CHECK(dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+}
+
+BOOST_AUTO_TEST_CASE(test_Above_Max_Connection_Rate)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 10U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 1U;
+  dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
+    config.d_maxTCPConnectionsPerClient = maxTCPConnectionsPerClient;
+    config.d_maxTCPConnectionsRatePerClient = maxTCPConnectionsRatePerClient;
+    config.d_tcpConnectionsRatePerClientInterval = tcpConnectionsRatePerClientInterval;
+  });
+
+  dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
+  const time_t now = time(nullptr);
+
+  const ComboAddress client{"192.0.2.1"};
+  for (size_t idx = 0; idx < maxTCPConnectionsRatePerClient; idx++) {
+    auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+    BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+    dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+  }
+  BOOST_CHECK(!dnsdist::IncomingConcurrentTCPConnectionsManager::isClientOverThreshold(client));
+
+  /* now go over the top */
+  auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+  BOOST_CHECK(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
@@ -32,6 +32,7 @@
 
 BOOST_AUTO_TEST_SUITE(test_dnsdist_concurrent_connections)
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 static void initConfiguration(uint64_t maxTCPConnectionsRatePerClient, uint64_t tcpConnectionsRatePerClientInterval, uint64_t maxTCPConnectionsPerClient, uint32_t banDuration, uint64_t maxTLSNewSessionsRatePerClient = 0U, uint64_t maxTLSResumedSessionsRatePerClient = 0U, uint32_t maxTCPReadIOsPerQuery = 50U)
 {
   dnsdist::configuration::updateImmutableConfiguration([&](dnsdist::configuration::ImmutableConfiguration& config) {
@@ -55,6 +56,10 @@ struct TestFixture
   {
     dnsdist::IncomingConcurrentTCPConnectionsManager::clear();
   }
+  TestFixture(const TestFixture&) = default;
+  TestFixture(TestFixture&&) = default;
+  TestFixture& operator=(const TestFixture&) = default;
+  TestFixture& operator=(TestFixture&&) = default;
 };
 
 BOOST_FIXTURE_TEST_CASE(test_No_Rate_Limiting, TestFixture)
@@ -265,7 +270,7 @@ BOOST_FIXTURE_TEST_CASE(test_Max_Concurrent_Connections_Overload_Threshold, Test
   const time_t now = time(nullptr);
 
   const ComboAddress client{"192.0.2.1"};
-  for (size_t idx = 0; idx < maxTCPConnectionsPerClient * overloadThreshold / 100.0; idx++) {
+  for (size_t idx = 0; idx < static_cast<size_t>(static_cast<double>(maxTCPConnectionsPerClient) * overloadThreshold / 100.0); idx++) {
     auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
     BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
   }

--- a/regression-tests.dnsdist/test_TCPLimits.py
+++ b/regression-tests.dnsdist/test_TCPLimits.py
@@ -239,7 +239,7 @@ class TestTCPLimitsConnectionRate(DNSDistTest):
         # if we are unlucky a few of our connections fell into a different bucket,
         # which is more likely if the test runner is slow, so let's allow up to
         # self._maxConnectionRate * 2
-        for idx in range(self._maxConnectionRate):
+        for idx in range(self._maxConnectionRate + 1):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
             if receivedQuery is None and receivedResponse is None:
                 blocked = True
@@ -293,7 +293,7 @@ class TestTCPLimitsTLSNewSessionRate(DNSDistTest):
         # if we are unlucky a few of our connections fell into a different bucket,
         # which is more likely if the test runner is slow, so let's allow up to
         # _maxNewTLSSessionRate * 2 + 1
-        for idx in range(self._maxNewTLSSessionRate):
+        for idx in range(self._maxNewTLSSessionRate + 1):
             try:
                 self.sendDOTQueryWrapper(query, response=None, useQueue=False)
             except ConnectionResetError:
@@ -361,8 +361,8 @@ class TestTCPLimitsTLSResumedSessionRate(DNSDistTest):
         blocked = False
         # if we are unlucky a few of our connections fell into a different bucket,
         # which is more likely if the test runner is slow, so let's allow up to
-        # self._maxResumedTLSSessionRate * 2 = 2
-        for idx in range(self._maxResumedTLSSessionRate):
+        # self._maxResumedTLSSessionRate * 2 + 2
+        for idx in range(self._maxResumedTLSSessionRate + 1):
             try:
                 conn = self.openTLSConnection(
                     self._tlsServerPort, self._serverName, self._caCert, timeout=1, sslctx=sslctx, session=session

--- a/regression-tests.dnsdist/test_TCPLimits.py
+++ b/regression-tests.dnsdist/test_TCPLimits.py
@@ -234,10 +234,19 @@ class TestTCPLimitsConnectionRate(DNSDistTest):
             receivedQuery.id = query.id
             self.assertEqual(receivedQuery, query)
             self.assertEqual(receivedResponse, response)
-        # the next one should be past the max rate
-        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEqual(receivedQuery, None)
-        self.assertEqual(receivedResponse, None)
+
+        blocked = False
+        # if we are unlucky a few of our connections fell into a different bucket,
+        # which is more likely if the test runner is slow, so let's allow up to
+        # self._maxConnectionRate * 2
+        for idx in range(self._maxConnectionRate):
+            (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+            if receivedQuery is None and receivedResponse is None:
+                blocked = True
+                break
+
+        if not blocked:
+            self.fail()
 
 class TestTCPLimitsTLSNewSessionRate(DNSDistTest):
     # separate test suite because we get banned for a few seconds
@@ -280,12 +289,20 @@ class TestTCPLimitsTLSNewSessionRate(DNSDistTest):
             self.assertEqual(receivedQuery, query)
             self.assertEqual(receivedResponse, response)
 
-        try:
-            # the next one should be past the max rate
-            self.sendDOTQueryWrapper(query, response=None, useQueue=False)
+        blocked = False
+        # if we are unlucky a few of our connections fell into a different bucket,
+        # which is more likely if the test runner is slow, so let's allow up to
+        # _maxNewTLSSessionRate * 2 + 1
+        for idx in range(self._maxNewTLSSessionRate):
+            try:
+                self.sendDOTQueryWrapper(query, response=None, useQueue=False)
+            except ConnectionResetError:
+                blocked = True
+                break
+
+        if not blocked:
             self.fail()
-        except ConnectionResetError:
-          pass
+
 
 class TestTCPLimitsTLSResumedSessionRate(DNSDistTest):
     # separate test suite because we get banned for a few seconds
@@ -341,14 +358,24 @@ class TestTCPLimitsTLSResumedSessionRate(DNSDistTest):
             else:
                 self.assertTrue(conn.session_reused)
 
-        try:
-            # the next one should be past the max rate
-            conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert, timeout=1, sslctx=sslctx, session=session)
-            self.sendTCPQueryOverConnection(conn, query, response=response, timeout=1)
-            self.recvTCPResponseOverConnection(conn, useQueue=True, timeout=1)
+        blocked = False
+        # if we are unlucky a few of our connections fell into a different bucket,
+        # which is more likely if the test runner is slow, so let's allow up to
+        # self._maxResumedTLSSessionRate * 2 = 2
+        for idx in range(self._maxResumedTLSSessionRate):
+            try:
+                conn = self.openTLSConnection(
+                    self._tlsServerPort, self._serverName, self._caCert, timeout=1, sslctx=sslctx, session=session
+                )
+                self.sendTCPQueryOverConnection(conn, query, response=response, timeout=1)
+                self.recvTCPResponseOverConnection(conn, useQueue=True, timeout=1)
+            except ConnectionResetError:
+                blocked = True
+                break
+
+        if not blocked:
             self.fail()
-        except ConnectionResetError:
-          pass
+
 
 class TestTCPFrontendLimits(DNSDistTest):
 

--- a/regression-tests.dnsdist/test_TCPLimits.py
+++ b/regression-tests.dnsdist/test_TCPLimits.py
@@ -228,8 +228,8 @@ class TestTCPLimitsConnectionRate(DNSDistTest):
         query = dns.message.make_query(name, 'A', 'IN')
         response = dns.message.make_response(query)
 
-        # _maxConnectionRate connections in a row
-        for idx in range(self._maxConnectionRate):
+        # _maxConnectionRate connections in a row (minus one because startResponders opens a TCP connection to see if dnsdist is running)
+        for idx in range(self._maxConnectionRate - 1):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response=response)
             receivedQuery.id = query.id
             self.assertEqual(receivedQuery, query)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17037 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
