### PR TITLE
dnsdist-2.0.x: Backport 17135 - Also apply UDP socket buffer sizes to backend sockets

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -251,6 +251,7 @@ dnsdist_SOURCES = \
 	dnsdist-tcp-downstream.cc dnsdist-tcp-downstream.hh \
 	dnsdist-tcp-upstream.hh \
 	dnsdist-tcp.cc dnsdist-tcp.hh \
+	dnsdist-udp.cc dnsdist-udp.hh \
 	dnsdist-web.cc dnsdist-web.hh \
 	dnsdist-xsk.cc dnsdist-xsk.hh \
 	dnsdist.cc dnsdist.hh \
@@ -360,6 +361,7 @@ testrunner_SOURCES = \
 	dnsdist-svc.cc dnsdist-svc.hh \
 	dnsdist-tcp-downstream.cc \
 	dnsdist-tcp.cc dnsdist-tcp.hh \
+	dnsdist-udp.cc dnsdist-udp.hh \
 	dnsdist-xsk.cc dnsdist-xsk.hh \
 	dnsdist.hh \
 	dnslabeltext.cc \

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -36,6 +36,7 @@
 #include "dnsdist-rings.hh"
 #include "dnsdist-snmp.hh"
 #include "dnsdist-tcp.hh"
+#include "dnsdist-udp.hh"
 #include "dnsdist-xsk.hh"
 #include "dolog.hh"
 #include "xsk.hh"
@@ -129,6 +130,8 @@ bool DownstreamState::reconnect(bool initialAttempt)
       }
     }
 #endif
+
+    dnsdist::udp::setUDPSocketBufferSizes(fd, dnsdist::udp::Context::Backend, d_config.remote);
 
     if (!IsAnyAddress(d_config.sourceAddr)) {
 #ifdef IP_BIND_ADDRESS_NO_PORT

--- a/pdns/dnsdistdist/dnsdist-udp.cc
+++ b/pdns/dnsdistdist/dnsdist-udp.cc
@@ -1,0 +1,93 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "dnsdist-udp.hh"
+#include "dolog.hh"
+#include "dnsdist-configuration.hh"
+
+namespace dnsdist::udp
+{
+static std::string contextToStr(Context context)
+{
+  if (context == Context::Frontend) {
+    return "frontend";
+  }
+  if (context == Context::Backend) {
+    return "backend";
+  }
+
+  return "";
+}
+
+void setUDPSocketBufferSizes(int socketDesc, Context context, const ComboAddress& addr)
+{
+  const auto& immutableConfig = dnsdist::configuration::getImmutableConfiguration();
+  if (immutableConfig.d_socketUDPSendBuffer > 0) {
+    try {
+      setSocketSendBuffer(socketDesc, immutableConfig.d_socketUDPSendBuffer);
+    }
+    catch (const std::exception& e) {
+      if (context == Context::Frontend) {
+        warnlog(e.what());
+      }
+    }
+  }
+  else {
+    try {
+      auto result = raiseSocketSendBufferToMax(socketDesc);
+      if (result > 0 && context == Context::Frontend) {
+        infolog("Raised send buffer to %u for %s address '%s'", result, contextToStr(context), addr.toStringWithPort());
+      }
+    }
+    catch (const std::exception& e) {
+      if (context == Context::Frontend) {
+        warnlog(e.what());
+      }
+    }
+  }
+
+  if (immutableConfig.d_socketUDPRecvBuffer > 0) {
+    try {
+      setSocketReceiveBuffer(socketDesc, immutableConfig.d_socketUDPRecvBuffer);
+    }
+    catch (const std::exception& e) {
+      if (context == Context::Frontend) {
+        warnlog(e.what());
+      }
+    }
+  }
+  else {
+    try {
+      auto result = raiseSocketReceiveBufferToMax(socketDesc);
+      if (result > 0 && context == Context::Frontend) {
+        infolog("Raised receive buffer to %u for address '%s'", result, addr.toStringWithPort());
+      }
+    }
+    catch (const std::exception& e) {
+      if (context == Context::Frontend) {
+        warnlog(e.what());
+      }
+    }
+  }
+}
+
+} // dnsdist::udp

--- a/pdns/dnsdistdist/dnsdist-udp.hh
+++ b/pdns/dnsdistdist/dnsdist-udp.hh
@@ -1,0 +1,36 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <cstdint>
+#include "iputils.hh"
+
+namespace dnsdist::udp
+{
+enum class Context : uint8_t
+{
+  Frontend,
+  Backend
+};
+
+void setUDPSocketBufferSizes(int socketDesc, Context context, const ComboAddress& addr);
+}

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -68,6 +68,7 @@
 #include "dnsdist-tcp.hh"
 #include "dnsdist-tcp-downstream.hh"
 #include "dnsdist-tcp-upstream.hh"
+#include "dnsdist-udp.hh"
 #include "dnsdist-web.hh"
 #include "dnsdist-xsk.hh"
 
@@ -2665,45 +2666,7 @@ static void setupLocalSocket(ClientState& clientState, const ComboAddress& addr,
   }
 
   if (!tcp) {
-    if (immutableConfig.d_socketUDPSendBuffer > 0) {
-      try {
-        setSocketSendBuffer(socket, immutableConfig.d_socketUDPSendBuffer);
-      }
-      catch (const std::exception& e) {
-        warnlog(e.what());
-      }
-    }
-    else {
-      try {
-        auto result = raiseSocketSendBufferToMax(socket);
-        if (result > 0) {
-          infolog("Raised send buffer to %u for local address '%s'", result, addr.toStringWithPort());
-        }
-      }
-      catch (const std::exception& e) {
-        warnlog(e.what());
-      }
-    }
-
-    if (immutableConfig.d_socketUDPRecvBuffer > 0) {
-      try {
-        setSocketReceiveBuffer(socket, immutableConfig.d_socketUDPRecvBuffer);
-      }
-      catch (const std::exception& e) {
-        warnlog(e.what());
-      }
-    }
-    else {
-      try {
-        auto result = raiseSocketReceiveBufferToMax(socket);
-        if (result > 0) {
-          infolog("Raised receive buffer to %u for local address '%s'", result, addr.toStringWithPort());
-        }
-      }
-      catch (const std::exception& e) {
-        warnlog(e.what());
-      }
-    }
+    dnsdist::udp::setUDPSocketBufferSizes(socket, dnsdist::udp::Context::Frontend, addr);
   }
 
   const std::string& itf = clientState.interface;

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -184,6 +184,7 @@ common_sources += files(
   src_dir / 'dnsdist-systemd.cc',
   src_dir / 'dnsdist-tcp.cc',
   src_dir / 'dnsdist-tcp-downstream.cc',
+  src_dir / 'dnsdist-udp.cc',
   src_dir / 'dnsdist-web.cc',
   src_dir / 'dnsdist-xsk.cc',
   src_dir / 'dnsname.cc',


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17135 to rel/dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
