### PR TITLE
dnsdist-2.1.x: Backport 17256 - Make code boost-1.91 compatible

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3193,7 +3193,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         customName = std::optional(*optCustomName);
       }
       if (!customName) {
-        std::optional<declare_metric_opts_t> vars = {boost::get<declare_metric_opts_t>(opts.value())};
+        std::optional<declare_metric_opts_t> vars{boost::get<declare_metric_opts_t>(opts.value())};
         getOptionalValue<std::string>(vars, "customName", customName);
         getOptionalValue<bool>(vars, "withLabels", withLabels);
         checkAllParametersConsumed("declareMetric", vars);
@@ -3217,7 +3217,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       step = *custom_step;
     }
     else {
-      std::optional<update_metric_opts_t> vars = {boost::get<update_metric_opts_t>(incOpts)};
+      std::optional<update_metric_opts_t> vars{boost::get<update_metric_opts_t>(incOpts)};
       getOptionalValue<uint64_t>(vars, "step", step);
       getOptionalValue<LuaAssociativeTable<std::string>>(vars, "labels", labels);
       checkAllParametersConsumed("incMetric", vars);
@@ -3240,7 +3240,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       step = *custom_step;
     }
     else {
-      std::optional<update_metric_opts_t> vars = {boost::get<update_metric_opts_t>(decOpts)};
+      std::optional<update_metric_opts_t> vars{boost::get<update_metric_opts_t>(decOpts)};
       getOptionalValue<uint64_t>(vars, "step", step);
       getOptionalValue<LuaAssociativeTable<std::string>>(vars, "labels", labels);
       checkAllParametersConsumed("decMetric", vars);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17256 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
