### PR TITLE
dnsdist-2.1.x: Backport 17103 - Update our version of Quiche to 0.28.0

### DIFF
--- a/builder-support/helpers/quiche.json
+++ b/builder-support/helpers/quiche.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.26.1",
+  "version": "0.28.0",
   "license": "BSD-2-Clause",
   "publisher": "https://github.com/cloudflare/quiche",
-  "SHA256SUM": "27e49c8bb3bf97876a9d75a3bb343361735443069eda7d3dc9fa1da195f68ed9",
+  "SHA256SUM": "2adb185e8557b3057cee76ba73d8afb20c25e3143a6296a5891ddc9b1fd81192",
   "cargo-based": true
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17103 to dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
