### PR TITLE
rec: keep cache warm for a list of names

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -663,6 +663,7 @@ Kaminsky
 Kaseorg
 Kdhcp
 Kdhcpdupdate
+keepwarm
 Kees
 Kerkhof
 KEYBITS

--- a/pdns/recursordist/rec-keepwarm.hh
+++ b/pdns/recursordist/rec-keepwarm.hh
@@ -1,0 +1,100 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <ctime>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/tag.hpp>
+#include <utility>
+
+#include "dnsname.hh"
+#include "qtype.hh"
+
+namespace rec
+{
+using namespace ::boost::multi_index;
+
+struct KeepWarmEntry
+{
+  KeepWarmEntry(DNSName name, QType qtype, time_t ttd = 0) : d_qname(std::move(name)), d_ttd(ttd), d_qtype(qtype) {}
+  DNSName d_qname;
+  time_t d_ttd;
+  uint16_t d_qtype;
+};
+
+class KeepWarm
+{
+public:
+  struct QNameQTypeTag
+  {
+  };
+
+  struct TTDTag
+  {
+  };
+
+  using Queue = multi_index_container<
+    KeepWarmEntry,
+    indexed_by<ordered_unique<tag<QNameQTypeTag>,
+                              composite_key<KeepWarmEntry,
+                                            member<KeepWarmEntry, DNSName, &KeepWarmEntry::d_qname>,
+                                            member<KeepWarmEntry, uint16_t, &KeepWarmEntry::d_qtype>>>,
+               ordered_non_unique<tag<TTDTag>, member<KeepWarmEntry, time_t, &KeepWarmEntry::d_ttd>, std::less<>>>>;
+
+  [[nodiscard]] const Queue& get() const
+  {
+    return d_queue;
+  }
+  void modifyTTD(const DNSName& qname, uint16_t qtype, uint32_t ttd)
+  {
+      auto item = d_queue.find(std::tie(qname, qtype));
+      if (item != d_queue.end()) {
+        d_queue.modify(item, [ttd](rec::KeepWarmEntry& entry) { entry.d_ttd = ttd; });
+      }
+    
+  }
+  void emplace(const DNSName& name, uint16_t qtype)
+  {
+    d_queue.emplace(name, qtype);
+  }
+  Queue::iterator erase(Queue::iterator iter)
+  {
+    return d_queue.erase(iter);
+  }
+  Queue::iterator begin()
+  {
+    return d_queue.begin();
+  }
+  Queue::iterator end()
+  {
+    return d_queue.end();
+  }
+
+private:
+  Queue d_queue;
+};
+}

--- a/pdns/recursordist/rec-keepwarm.hh
+++ b/pdns/recursordist/rec-keepwarm.hh
@@ -40,7 +40,8 @@ using namespace ::boost::multi_index;
 
 struct KeepWarmEntry
 {
-  KeepWarmEntry(DNSName name, QType qtype, time_t ttd = 0) : d_qname(std::move(name)), d_ttd(ttd), d_qtype(qtype) {}
+  KeepWarmEntry(DNSName name, QType qtype, time_t ttd = 0) :
+    d_qname(std::move(name)), d_ttd(ttd), d_qtype(qtype) {}
   DNSName d_qname;
   time_t d_ttd;
   uint16_t d_qtype;
@@ -71,11 +72,11 @@ public:
   }
   void modifyTTD(KeepWarmEntry& entry, uint32_t ttd)
   {
-      auto item = d_queue.find(std::tie(entry.d_qname, entry.d_qtype));
-      if (item != d_queue.end()) {
-        d_queue.modify(item, [ttd](rec::KeepWarmEntry& entry) { entry.d_ttd = ttd; });
-      }
-      entry.d_ttd = ttd; 
+    auto item = d_queue.find(std::tie(entry.d_qname, entry.d_qtype));
+    if (item != d_queue.end()) {
+      d_queue.modify(item, [ttd](rec::KeepWarmEntry& entryLambda) { entryLambda.d_ttd = ttd; });
+    }
+    entry.d_ttd = ttd;
   }
   void emplace(const DNSName& name, uint16_t qtype)
   {

--- a/pdns/recursordist/rec-keepwarm.hh
+++ b/pdns/recursordist/rec-keepwarm.hh
@@ -69,13 +69,13 @@ public:
   {
     return d_queue;
   }
-  void modifyTTD(const DNSName& qname, uint16_t qtype, uint32_t ttd)
+  void modifyTTD(KeepWarmEntry& entry, uint32_t ttd)
   {
-      auto item = d_queue.find(std::tie(qname, qtype));
+      auto item = d_queue.find(std::tie(entry.d_qname, entry.d_qtype));
       if (item != d_queue.end()) {
         d_queue.modify(item, [ttd](rec::KeepWarmEntry& entry) { entry.d_ttd = ttd; });
       }
-    
+      entry.d_ttd = ttd; 
   }
   void emplace(const DNSName& name, uint16_t qtype)
   {
@@ -92,6 +92,10 @@ public:
   Queue::iterator end()
   {
     return d_queue.end();
+  }
+  [[nodiscard]] size_t size() const
+  {
+    return d_queue.size();
   }
 
 private:

--- a/pdns/recursordist/rec-lua-conf.cc
+++ b/pdns/recursordist/rec-lua-conf.cc
@@ -433,6 +433,7 @@ public:
 void loadRecursorLuaConfig(const std::string& fname, ProxyMapping& proxyMapping, LuaConfigItems& newLuaConfig) // NOLINT(readability-function-cognitive-complexity)
 {
   LuaConfigItems lci;
+  lci.keepWarm = newLuaConfig.keepWarm;
   if (g_slog) {
     lci.d_slog = g_slog->withName("luaconfig");
   }

--- a/pdns/recursordist/rec-lua-conf.hh
+++ b/pdns/recursordist/rec-lua-conf.hh
@@ -142,6 +142,7 @@ public:
   ProtobufExportConfig outgoingProtobufExportConfig;
   FrameStreamExportConfig frameStreamExportConfig;
   FrameStreamExportConfig nodFrameStreamExportConfig;
+  std::vector<std::pair<DNSName, QType>> keepWarm;
   std::shared_ptr<Logr::Logger> d_slog;
   /* we need to increment this every time the configuration
      is reloaded, so we know if we need to reload the protobuf

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -127,6 +127,7 @@ bool RecThreadInfo::s_weDistributeQueries; // if true, 1 or more threads listen 
 unsigned int RecThreadInfo::s_numDistributorThreads;
 unsigned int RecThreadInfo::s_numUDPWorkerThreads;
 unsigned int RecThreadInfo::s_numTCPWorkerThreads;
+unsigned int RecThreadInfo::s_numTaskThreads;
 thread_local unsigned int RecThreadInfo::t_id{RecThreadInfo::TID_NOT_INITED};
 
 pdns::RateLimitedLog g_rateLimitedLogger;
@@ -2254,6 +2255,7 @@ static int serviceMain(Logr::log_t log)
 
   RecThreadInfo::setNumDistributorThreads(::arg().asNum("distributor-threads"));
   RecThreadInfo::setNumUDPWorkerThreads(::arg().asNum("threads"));
+  RecThreadInfo::setNumTaskThreads(::arg().asNum("taskthreads"));
   if (RecThreadInfo::numUDPWorkers() < 1) {
     log->info(Logr::Warning, "Asked to run with 0 threads, raising to 1 instead");
     RecThreadInfo::setNumUDPWorkerThreads(1);

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2608,17 +2608,18 @@ static void houseKeepingWork(Logr::log_t log)
       pruneCookies(now.tv_sec - 3000);
     });
 
-    // By default, refresh at 80% of max-cache-ttl with a minimum period of 10s
+    // By default, refresh at 80% of lowest TTL seen in the result with a minimum period of 10s
     const unsigned int minRootRefreshInterval = 10;
     static PeriodicTask rootUpdateTask{"rootUpdateTask", std::max(SyncRes::s_maxcachettl * 8 / 10, minRootRefreshInterval)};
     rootUpdateTask.runIfDue(now, [now, &log, minRootRefreshInterval]() {
       int res = 0;
+      uint32_t minttl = SyncRes::s_maxcachettl;
       if (!g_regressionTestMode) {
-        res = SyncRes::getRootNS(now, nullptr, 0, log);
+        res = SyncRes::getRootNS(now, nullptr, 0, log, minttl);
       }
       if (res == 0) {
         // Success, go back to the default period
-        rootUpdateTask.setPeriod(std::max(SyncRes::s_maxcachettl * 8 / 10, minRootRefreshInterval));
+        rootUpdateTask.setPeriod(std::max(minttl * 8 / 10, minRootRefreshInterval));
       }
       else {
         // On failure, go to the middle of the remaining period (initially 80% / 8 = 10%) and shorten the interval on each

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -40,6 +40,7 @@
 #include "threadname.hh"
 #include "version.hh"
 #include "ws-recursor.hh"
+#include "rec-keepwarm.hh"
 
 #ifdef NOD_ENABLED
 #include "nod.hh"
@@ -2454,68 +2455,103 @@ static void handleRCC(int fileDesc, FDMultiplexer::funcparam_t& /* var */)
 static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>& luaconfsLocal)
 {
   auto log = g_slog->withName("cachewarmer");
-  time_t wait = 60;
 
-  for (const auto& [qname, qtype] : luaconfsLocal->keepWarm) {
-    SyncRes resolver(now);
-    resolver.setQNameMinimization(true);
-    resolver.setCacheOnly(true);
-    resolver.setDoDNSSEC(g_dnssecmode != DNSSECMode::Off);
-    resolver.setDNSSECValidationRequested(g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate);
-    std::vector<DNSRecord> ret;
-    int res = -1;
-    const std::string msg = "Exception while resolving";
-    try {
-      res = resolver.beginResolve(qname, qtype, QClass::IN, ret, 0);
-    }
-    catch (const PDNSException& e) {
-      log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("PDNSException"));
-      ret.clear();
-    }
-    catch (const ImmediateServFailException& e) {
-      log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("ImmediateServFailException"));
-      ret.clear();
-    }
-    catch (const PolicyHitException& e) {
-      log->info(Logr::Warning, msg, "exception", Logging::Loggable("PolicyHitException"));
-      ret.clear();
-    }
-    catch (const std::exception& e) {
-      log->error(Logr::Warning, e.what(), msg, "exception", Logging::Loggable("std::exception"));
-      ret.clear();
-    }
-    catch (...) {
-      log->info(Logr::Warning, msg);
-      ret.clear();
-    }
+  static LockGuarded<rec::KeepWarm> s_keepwarm;
+  static uint64_t lastgeneration = 0;
 
-    if (res == RCode::NoError && ret.size() > 0) {
-      uint32_t minttl = std::numeric_limits<uint32_t>::max();
-      for (const auto& record : ret) {
-        minttl = std::min(minttl, record.d_ttl);
+  auto lock = s_keepwarm.lock();
+
+  if (lastgeneration != luaconfsLocal->generation) {
+    lastgeneration = luaconfsLocal->generation;
+    for (const auto& [qname, qtype] : luaconfsLocal->keepWarm) {
+      lock->emplace(qname, qtype);
+    }
+    std::set<std::pair<DNSName, QType>> all;
+    std::copy(luaconfsLocal->keepWarm.begin(), luaconfsLocal->keepWarm.end(), std::inserter(all, all.end()));
+    for (auto iter = lock->begin(); iter != lock->end();) {
+      if (all.count({iter->d_qname, QType(iter->d_qtype)}) == 0) {
+        iter = lock->erase(iter);
       }
-      if (minttl > 5) {
-        wait = std::min(wait, static_cast<time_t>(minttl - 5));
-        continue;
+      else {
+        ++iter;
       }
-      wait = std::min(wait, static_cast<time_t>(1));
-    }
-
-    NegCache::NegCacheEntry negEntry;
-    bool inNegCache = g_negCache->get(qname, qtype, now, negEntry, false);
-    if (!inNegCache) {
-      log->info(Logr::Debug, "Absent or expiring and not in negache, pushing task", "qname", Logging::Loggable(qname),
-                "qtype", Logging::Loggable(qtype),
-                "res", Logging::Loggable(res), "size", Logging::Loggable(ret.size()));
-      // Work to be done
-      pushAlmostExpiredTask(qname, qtype, now.tv_sec + 60, ComboAddress("255.255.255.255"), true);
-      wait = std::min(wait, static_cast<time_t>(1));
-    }
-    else {
-      auto expiring = negEntry.d_ttd - now.tv_sec;
-      wait = std::min(wait, expiring);
     }
   }
+
+  std::vector<rec::KeepWarmEntry> toBeHandled;
+
+  auto& sidx = lock->get().template get<rec::KeepWarm::TTDTag>();
+  auto siter = sidx.begin();
+
+  const int batchSize = 100;
+  const time_t specialTime = 1;
+  const time_t cooldown = 60;
+  const time_t almost = 5;
+  for (int i = 0; i < batchSize && siter != sidx.end(); i++, siter++) {
+    if (siter->d_ttd > now.tv_sec + almost) {
+      break;
+    }
+    toBeHandled.emplace_back(*siter);
+  }
+
+
+  for (auto& element : toBeHandled) {
+    if (element.d_ttd == specialTime) {
+      SyncRes resolver(now);
+      resolver.setQNameMinimization(true);
+      resolver.setCacheOnly(true);
+      resolver.setDoDNSSEC(g_dnssecmode != DNSSECMode::Off);
+      resolver.setDNSSECValidationRequested(g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate);
+      std::vector<DNSRecord> ret;
+      const std::string msg = "Exception while resolving";
+      try {
+        resolver.beginResolve(element.d_qname, element.d_qtype, QClass::IN, ret, 0);
+      }
+      catch (const PDNSException& e) {
+        log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("PDNSException"));
+        ret.clear();
+      }
+      catch (const ImmediateServFailException& e) {
+        log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("ImmediateServFailException"));
+        ret.clear();
+      }
+      catch (const PolicyHitException& e) {
+        log->info(Logr::Warning, msg, "exception", Logging::Loggable("PolicyHitException"));
+        ret.clear();
+      }
+      catch (const std::exception& e) {
+        log->error(Logr::Warning, e.what(), msg, "exception", Logging::Loggable("std::exception"));
+        ret.clear();
+      }
+      catch (...) {
+        log->info(Logr::Warning, msg);
+        ret.clear();
+      }
+
+      uint32_t minttl = cooldown; // If no records found, either it did not resolve at all, or it did
+                                  // not resolve yet. In both cases, pace the work.
+      if (ret.size() > 0) {
+        minttl = std::numeric_limits<uint32_t>::max();
+        for (const auto& record : ret) {
+          minttl = std::min(minttl, record.d_ttl);
+        }
+      }
+      lock->modifyTTD(element.d_qname, element.d_qtype, now.tv_sec + minttl);
+    }
+    else if (element.d_ttd == 0 || element.d_ttd <= now.tv_sec + almost) {
+      pushAlmostExpiredTask(element.d_qname, element.d_qtype, now.tv_sec + cooldown, ComboAddress("255.255.255.255"), true);
+        lock->modifyTTD(element.d_qname, element.d_qtype, specialTime);
+    }
+  }
+
+  time_t wait = cooldown;
+  siter = sidx.begin();
+  if (siter != sidx.end()) {
+    wait = siter->d_ttd - now.tv_sec - 1;
+    wait = std::max(static_cast<time_t>(1), wait);
+    wait = std::min(static_cast<time_t>(cooldown), wait);
+  }
+
   log->info(Logr::Debug, "Wait", "interval", Logging::Loggable(wait));
   return wait;
 }

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -99,7 +99,6 @@ LockGuarded<std::shared_ptr<NetmaskGroup>> g_initialAllowNotifyFrom; // new thre
 LockGuarded<std::shared_ptr<notifyset_t>> g_initialAllowNotifyFor; // new threads need this to be setup
 LockGuarded<std::shared_ptr<OpenTelemetryTraceConditions>> g_initialOpenTelemetryConditions; // new threads need this to be setup
 static time_t s_statisticsInterval;
-static std::atomic<uint32_t> s_counter;
 int g_argc;
 char** g_argv;
 static string s_structured_logger_backend;
@@ -2452,6 +2451,75 @@ static void handleRCC(int fileDesc, FDMultiplexer::funcparam_t& /* var */)
   }
 }
 
+static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>& luaconfsLocal)
+{
+  auto log = g_slog->withName("cachewarmer");
+  time_t wait = 60;
+
+  for (const auto& [qname, qtype] : luaconfsLocal->keepWarm) {
+    SyncRes resolver(now);
+    resolver.setQNameMinimization(true);
+    resolver.setCacheOnly(true);
+    resolver.setDoDNSSEC(g_dnssecmode != DNSSECMode::Off);
+    resolver.setDNSSECValidationRequested(g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate);
+    std::vector<DNSRecord> ret;
+    int res = -1;
+    const std::string msg = "Exception while resolving";
+    try {
+      res = resolver.beginResolve(qname, qtype, QClass::IN, ret, 0);
+    }
+    catch (const PDNSException& e) {
+      log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("PDNSException"));
+      ret.clear();
+    }
+    catch (const ImmediateServFailException& e) {
+      log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("ImmediateServFailException"));
+      ret.clear();
+    }
+    catch (const PolicyHitException& e) {
+      log->info(Logr::Warning, msg, "exception", Logging::Loggable("PolicyHitException"));
+      ret.clear();
+    }
+    catch (const std::exception& e) {
+      log->error(Logr::Warning, e.what(), msg, "exception", Logging::Loggable("std::exception"));
+      ret.clear();
+    }
+    catch (...) {
+      log->info(Logr::Warning, msg);
+      ret.clear();
+    }
+
+    if (res == RCode::NoError && ret.size() > 0) {
+      uint32_t minttl = std::numeric_limits<uint32_t>::max();
+      for (const auto& record : ret) {
+        minttl = std::min(minttl, record.d_ttl);
+      }
+      if (minttl > 5) {
+        wait = std::min(wait, static_cast<time_t>(minttl - 5));
+        continue;
+      }
+      wait = std::min(wait, static_cast<time_t>(1));
+    }
+
+    NegCache::NegCacheEntry negEntry;
+    bool inNegCache = g_negCache->get(qname, qtype, now, negEntry, false);
+    if (!inNegCache) {
+      log->info(Logr::Debug, "Absent or expiring and not in negache, pushing task", "qname", Logging::Loggable(qname),
+                "qtype", Logging::Loggable(qtype),
+                "res", Logging::Loggable(res), "size", Logging::Loggable(ret.size()));
+      // Work to be done
+      pushAlmostExpiredTask(qname, qtype, now.tv_sec + 60, ComboAddress("255.255.255.255"), true);
+      wait = std::min(wait, static_cast<time_t>(1));
+    }
+    else {
+      auto expiring = negEntry.d_ttd - now.tv_sec;
+      wait = std::min(wait, expiring);
+    }
+  }
+  log->info(Logr::Debug, "Wait", "interval", Logging::Loggable(wait));
+  return wait;
+}
+
 class PeriodicTask
 {
 public:
@@ -2530,6 +2598,12 @@ static void houseKeepingWork(Logr::log_t log)
   // Below are the thread specific tasks for the handler and the taskThread
   // Likley a few handler tasks could be moved to the taskThread
   if (info.isTaskThread()) {
+    static PeriodicTask keepWarmTask{"KeepWarmTask", 1};
+    keepWarmTask.runIfDue(now, [now, &luaconfsLocal] {
+      auto actionRequired = keepCacheWarm(now, luaconfsLocal);
+      keepWarmTask.setPeriod(actionRequired);
+    });
+
     // TaskQueue is run always
     runTasks(10, g_logCommonErrors);
 
@@ -2735,6 +2809,13 @@ static void recLoop()
 
   auto& threadInfo = RecThreadInfo::self();
 
+  static std::atomic<uint32_t> s_counter;
+
+  // Use primes, it avoid not being scheduled in cases where the counter has a regular pattern.
+  // We want to call handler thread often, it gets scheduled about 2 times per second on an idle recursor
+  constexpr uint32_t handlerAndTaskInterval = 11;
+  constexpr uint32_t otherInterval = 499;
+
   while (!RecursorControlChannel::stop) {
     try {
       while (g_multiTasker->schedule(g_now)) {
@@ -2743,7 +2824,7 @@ static void recLoop()
 
       // Use primes, it avoid not being scheduled in cases where the counter has a regular pattern.
       // We want to call handler thread often, it gets scheduled about 2 times per second
-      if (((threadInfo.isHandler() || threadInfo.isTaskThread()) && s_counter % 11 == 0) || s_counter % 499 == 0) {
+      if (((threadInfo.isHandler() || threadInfo.isTaskThread()) && s_counter % handlerAndTaskInterval == 0) || s_counter % otherInterval == 0) {
         timeval start{};
         Utility::gettimeofday(&start);
         g_multiTasker->makeThread(houseKeeping, nullptr);
@@ -2784,7 +2865,7 @@ static void recLoop()
       }
       runLuaMaintenance(threadInfo, last_lua_maintenance, luaMaintenanceInterval);
 
-      auto timeoutUsec = g_multiTasker->nextWaiterDelayUsec(500000);
+      auto timeoutUsec = g_multiTasker->nextWaiterDelayUsec(1000000U / handlerAndTaskInterval / 2);
       t_fdm->run(&g_now, static_cast<int>(timeoutUsec / 1000));
       // 'run' updates g_now for us
     }

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2518,7 +2518,7 @@ static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>
         log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("ImmediateServFailException"));
         ret.clear();
       }
-      catch (const PolicyHitException& e) {
+      catch (const PolicyHitException&) {
         log->info(Logr::Warning, msg, "exception", Logging::Loggable("PolicyHitException"));
         ret.clear();
       }
@@ -2533,18 +2533,18 @@ static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>
 
       uint32_t minttl = cooldown; // If no records found, either it did not resolve at all, or it did
                                   // not resolve yet. In both cases, pace the work.
-      if (ret.size() > 0) {
+      if (!ret.empty()) {
         minttl = std::numeric_limits<uint32_t>::max();
         bool haveAnswerRecord = false;
         for (const auto& record : ret) {
           if (record.d_place == DNSResourceRecord::ANSWER) {
-	    haveAnswerRecord = true;
+            haveAnswerRecord = true;
           }
           minttl = std::min(minttl, record.d_ttl);
         }
         if (haveAnswerRecord && !haveFinalAnswer(element.d_qname, element.d_qtype, res, ret)) {
           // Common cause: a record in the CNAME chain expired, setting the minttl will trigger a task push below
-	  minttl = 0;
+          minttl = 0;
         }
       }
       lock->modifyTTD(element, now.tv_sec + minttl);
@@ -2858,7 +2858,7 @@ static void recLoop()
 
   static std::atomic<uint32_t> s_counter;
 
-  // Use primes, it avoid not being scheduled in cases where the counter has a regular pattern.
+  // Use primes, they avoid not being scheduled in cases where the counter shows a regular pattern.
   // We want to call handler thread often, it gets scheduled about 2 times per second on an idle recursor
   constexpr uint32_t handlerAndTaskInterval = 11;
   constexpr uint32_t otherInterval = 499;

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2482,20 +2482,20 @@ static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>
 
   std::vector<rec::KeepWarmEntry> toBeHandled;
 
-  auto& sidx = lock->get().template get<rec::KeepWarm::TTDTag>();
+  const auto& sidx = lock->get().template get<rec::KeepWarm::TTDTag>();
   auto siter = sidx.begin();
 
-  const int batchSize = 100;
+  const auto batchSize = std::min(static_cast<size_t>(1000), lock->size());
   const time_t specialTime = 1;
   const time_t cooldown = 60;
   const time_t almost = 5;
-  for (int i = 0; i < batchSize && siter != sidx.end(); i++, siter++) {
+  for (size_t i = 0; i < batchSize && siter != sidx.end(); i++, siter++) {
+
     if (siter->d_ttd > now.tv_sec + almost) {
       break;
     }
     toBeHandled.emplace_back(*siter);
   }
-
 
   for (auto& element : toBeHandled) {
     if (element.d_ttd == specialTime) {
@@ -2505,9 +2505,10 @@ static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>
       resolver.setDoDNSSEC(g_dnssecmode != DNSSECMode::Off);
       resolver.setDNSSECValidationRequested(g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate);
       std::vector<DNSRecord> ret;
+      int res = -1;
       const std::string msg = "Exception while resolving";
       try {
-        resolver.beginResolve(element.d_qname, element.d_qtype, QClass::IN, ret, 0);
+        res = resolver.beginResolve(element.d_qname, element.d_qtype, QClass::IN, ret, 0);
       }
       catch (const PDNSException& e) {
         log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("PDNSException"));
@@ -2534,15 +2535,23 @@ static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>
                                   // not resolve yet. In both cases, pace the work.
       if (ret.size() > 0) {
         minttl = std::numeric_limits<uint32_t>::max();
+        bool haveAnswerRecord = false;
         for (const auto& record : ret) {
+          if (record.d_place == DNSResourceRecord::ANSWER) {
+	    haveAnswerRecord = true;
+          }
           minttl = std::min(minttl, record.d_ttl);
         }
+        if (haveAnswerRecord && !haveFinalAnswer(element.d_qname, element.d_qtype, res, ret)) {
+          // Common cause: a record in the CNAME chain expired, setting the minttl will trigger a task push below
+	  minttl = 0;
+        }
       }
-      lock->modifyTTD(element.d_qname, element.d_qtype, now.tv_sec + minttl);
+      lock->modifyTTD(element, now.tv_sec + minttl);
     }
-    else if (element.d_ttd == 0 || element.d_ttd <= now.tv_sec + almost) {
+    if (element.d_ttd <= now.tv_sec + almost) { // include non-initialized (0) case
       pushAlmostExpiredTask(element.d_qname, element.d_qtype, now.tv_sec + cooldown, ComboAddress("255.255.255.255"), true);
-        lock->modifyTTD(element.d_qname, element.d_qtype, specialTime);
+      lock->modifyTTD(element, specialTime);
     }
   }
 
@@ -2643,7 +2652,7 @@ static void houseKeepingWork(Logr::log_t log)
     });
 
     // TaskQueue is run always
-    runTasks(10, g_logCommonErrors);
+    runTasks(100, g_logCommonErrors);
 
     static PeriodicTask ztcTask{"ZTC", 60};
     static map<DNSName, RecZoneToCache::State> ztcStates;

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2454,20 +2454,85 @@ static void handleRCC(int fileDesc, FDMultiplexer::funcparam_t& /* var */)
   }
 }
 
+static uint32_t keepWarmResolve(const timeval& now, const rec::KeepWarmEntry& element, time_t cooldown, Logr::log_t log)
+{
+  SyncRes resolver(now);
+  resolver.setQNameMinimization(true);
+  resolver.setCacheOnly(true);
+  resolver.setDoDNSSEC(g_dnssecmode != DNSSECMode::Off);
+  resolver.setDNSSECValidationRequested(g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate);
+  int res = -1;
+  std::vector<DNSRecord> ret;
+  const std::string msg = "Exception while resolving";
+  try {
+    // we're only checking the cache here
+    res = resolver.beginResolve(element.d_qname, element.d_qtype, QClass::IN, ret, 0);
+  }
+  catch (const PDNSException& e) {
+    log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("PDNSException"));
+    ret.clear();
+  }
+  catch (const ImmediateServFailException& e) {
+    log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("ImmediateServFailException"));
+    ret.clear();
+  }
+  catch (const PolicyHitException&) {
+    log->info(Logr::Warning, msg, "exception", Logging::Loggable("PolicyHitException"));
+    ret.clear();
+  }
+  catch (const std::exception& e) {
+    log->error(Logr::Warning, e.what(), msg, "exception", Logging::Loggable("std::exception"));
+    ret.clear();
+  }
+  catch (...) {
+    log->info(Logr::Warning, msg);
+    ret.clear();
+  }
+  uint32_t minttl = cooldown;
+
+  // If no records found, either it did not resolve at all
+  // (e.g. NXDOMAIN or NODATA), or it did not resolve yet because
+  // the task did not run yet. In both cases, pace the work by
+  // putting furter processing to the future.
+
+  if (!ret.empty()) {
+    minttl = std::numeric_limits<uint32_t>::max();
+    bool haveAnswerRecord = false;
+    for (const auto& record : ret) {
+      if (record.d_place == DNSResourceRecord::ANSWER) {
+        haveAnswerRecord = true;
+      }
+      minttl = std::min(minttl, record.d_ttl);
+    }
+    if (haveAnswerRecord && !haveFinalAnswer(element.d_qname, element.d_qtype, res, ret)) {
+      // Common cause: a record in the CNAME chain expired, setting the minttl will trigger a task push below
+      minttl = 0;
+    }
+  }
+  return minttl;
+}
+
 static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>& luaconfsLocal)
 {
   auto log = g_slog->withName("cachewarmer");
 
+  // The current list of names/qtypes we are keeping warm
   static LockGuarded<rec::KeepWarm> s_keepwarm;
   static uint64_t lastgeneration = 0;
 
   auto lock = s_keepwarm.lock();
 
   if (lastgeneration != luaconfsLocal->generation) {
+    // We need to update the list of names/qtypes. We do that by first adding the pairs from the new
+    // config to the list. This will *not* replace existing equivalent entries, so the TTD
+    // information of existing names/qtypes is not overwritten.
     lastgeneration = luaconfsLocal->generation;
     for (const auto& [qname, qtype] : luaconfsLocal->keepWarm) {
       lock->emplace(qname, qtype);
     }
+    // Next, we remove the entries no longer in the config from the current list of names/qtypes.
+    // We use a helper set that is built once, as looking up these entries in a set is much quicker
+    // than walking a vector all the time.
     std::set<std::pair<DNSName, QType>> all;
     std::copy(luaconfsLocal->keepWarm.begin(), luaconfsLocal->keepWarm.end(), std::inserter(all, all.end()));
     for (auto iter = lock->begin(); iter != lock->end();) {
@@ -2480,13 +2545,13 @@ static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>
     }
   }
 
+  // Take a max of batchSize entries to be handle
+  const auto batchSize = std::min(static_cast<size_t>(1000), lock->size());
   std::vector<rec::KeepWarmEntry> toBeHandled;
-
   const auto& sidx = lock->get().template get<rec::KeepWarm::TTDTag>();
   auto siter = sidx.begin();
 
-  const auto batchSize = std::min(static_cast<size_t>(1000), lock->size());
-  const time_t specialTime = 1;
+  const time_t specialTime = 1; // A task was pushed, we should check the result
   const time_t cooldown = 60;
   const time_t almost = 5;
   for (size_t i = 0; i < batchSize && siter != sidx.end(); i++, siter++) {
@@ -2498,69 +2563,22 @@ static time_t keepCacheWarm(const timeval& now, LocalStateHolder<LuaConfigItems>
   }
 
   for (auto& element : toBeHandled) {
-    if (element.d_ttd == specialTime) {
-      SyncRes resolver(now);
-      resolver.setQNameMinimization(true);
-      resolver.setCacheOnly(true);
-      resolver.setDoDNSSEC(g_dnssecmode != DNSSECMode::Off);
-      resolver.setDNSSECValidationRequested(g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate);
-      std::vector<DNSRecord> ret;
-      int res = -1;
-      const std::string msg = "Exception while resolving";
-      try {
-        res = resolver.beginResolve(element.d_qname, element.d_qtype, QClass::IN, ret, 0);
-      }
-      catch (const PDNSException& e) {
-        log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("PDNSException"));
-        ret.clear();
-      }
-      catch (const ImmediateServFailException& e) {
-        log->error(Logr::Warning, e.reason, msg, "exception", Logging::Loggable("ImmediateServFailException"));
-        ret.clear();
-      }
-      catch (const PolicyHitException&) {
-        log->info(Logr::Warning, msg, "exception", Logging::Loggable("PolicyHitException"));
-        ret.clear();
-      }
-      catch (const std::exception& e) {
-        log->error(Logr::Warning, e.what(), msg, "exception", Logging::Loggable("std::exception"));
-        ret.clear();
-      }
-      catch (...) {
-        log->info(Logr::Warning, msg);
-        ret.clear();
-      }
-
-      uint32_t minttl = cooldown; // If no records found, either it did not resolve at all, or it did
-                                  // not resolve yet. In both cases, pace the work.
-      if (!ret.empty()) {
-        minttl = std::numeric_limits<uint32_t>::max();
-        bool haveAnswerRecord = false;
-        for (const auto& record : ret) {
-          if (record.d_place == DNSResourceRecord::ANSWER) {
-            haveAnswerRecord = true;
-          }
-          minttl = std::min(minttl, record.d_ttl);
-        }
-        if (haveAnswerRecord && !haveFinalAnswer(element.d_qname, element.d_qtype, res, ret)) {
-          // Common cause: a record in the CNAME chain expired, setting the minttl will trigger a task push below
-          minttl = 0;
-        }
-      }
+    if (element.d_ttd == specialTime) { // a task was pushed and potentially ran, we need to check if it returned a result
+      auto minttl = keepWarmResolve(now, element, cooldown, log);
       lock->modifyTTD(element, now.tv_sec + minttl);
     }
     if (element.d_ttd <= now.tv_sec + almost) { // include non-initialized (0) case
       pushAlmostExpiredTask(element.d_qname, element.d_qtype, now.tv_sec + cooldown, ComboAddress("255.255.255.255"), true);
-      lock->modifyTTD(element, specialTime);
+      lock->modifyTTD(element, specialTime); // we have pushed a task, next iteration will check result
     }
   }
 
   time_t wait = cooldown;
   siter = sidx.begin();
   if (siter != sidx.end()) {
-    wait = siter->d_ttd - now.tv_sec - 1;
-    wait = std::max(static_cast<time_t>(1), wait);
-    wait = std::min(static_cast<time_t>(cooldown), wait);
+    wait = siter->d_ttd - now.tv_sec - 1; // wake up just before the ttd arrives of the first task.
+    wait = std::max(static_cast<time_t>(1), wait); // but sleep at least a second
+    wait = std::min(static_cast<time_t>(cooldown), wait); // and don't sleep longer than cooldown time, for config updates
   }
 
   log->info(Logr::Debug, "Wait", "interval", Logging::Loggable(wait));

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -439,7 +439,7 @@ public:
 
   static unsigned int numTaskThreads()
   {
-    return 1;
+    return s_numTaskThreads;
   }
 
   static unsigned int numUDPWorkers()
@@ -480,6 +480,11 @@ public:
   static void setNumDistributorThreads(unsigned int n)
   {
     s_numDistributorThreads = n;
+  }
+
+  static void setNumTaskThreads(unsigned int n)
+  {
+    s_numTaskThreads = n;
   }
 
   static unsigned int numRecursorThreads()
@@ -589,6 +594,7 @@ private:
   static unsigned int s_numDistributorThreads;
   static unsigned int s_numUDPWorkerThreads;
   static unsigned int s_numTCPWorkerThreads;
+  static unsigned int s_numTaskThreads;
 };
 
 struct ThreadMSG

--- a/pdns/recursordist/rec-rust-lib/cxxsupport.cc
+++ b/pdns/recursordist/rec-rust-lib/cxxsupport.cc
@@ -546,7 +546,7 @@ static void processLine(const std::string& arg, FieldMap& map, bool mainFile)
   ::rust::String section;
   ::rust::String fieldname;
   ::rust::String type_name;
-  pdns::rust::settings::rec::Value rustvalue = {false, 0, 0.0, "", {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}};
+  pdns::rust::settings::rec::Value rustvalue = {false, 0, 0.0, "", {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}};
   if (pdns::settings::rec::oldKVToBridgeStruct(var, val, section, fieldname, type_name, rustvalue)) {
     auto overriding = !mainFile && !incremental && !simpleRustType(type_name);
     auto [existing, inserted] = map.emplace(std::pair{std::pair{section, fieldname}, pdns::rust::settings::rec::OldStyle{section, fieldname, var, std::move(type_name), rustvalue, overriding}});
@@ -663,23 +663,24 @@ std::string pdns::settings::rec::defaultsToYaml(bool postProcess)
     rustvalue.u64_val = 24;
     map.emplace(std::pair{std::pair{section, name}, pdns::rust::settings::rec::OldStyle{section, name, name, type, std::move(rustvalue), false}});
   };
-  def("dnssec", "trustanchors", "Vec<TrustAnchor>");
   def("dnssec", "negative_trustanchors", "Vec<NegativeTrustAnchor>");
   def("dnssec", "trustanchorfile", "String");
   def("dnssec", "trustanchorfile_interval", "u64");
-  def("logging", "protobuf_servers", "Vec<ProtobufServer>");
-  def("logging", "outgoing_protobuf_servers", "Vec<ProtobufServer>");
+  def("dnssec", "trustanchors", "Vec<TrustAnchor>");
+  def("incoming", "proxymappings", "Vec<ProxyMapping>");
   def("logging", "dnstap_framestream_servers", "Vec<DNSTapFrameStreamServer>");
   def("logging", "dnstap_nod_framestream_servers", "Vec<DNSTapNODFrameStreamServer>");
   def("logging", "opentelemetry_trace_conditions", "Vec<OpenTelemetryTraceCondition>");
-  def("recursor", "rpzs", "Vec<RPZ>");
-  def("recursor", "sortlists", "Vec<SortList>");
+  def("logging", "outgoing_protobuf_servers", "Vec<ProtobufServer>");
+  def("logging", "protobuf_servers", "Vec<ProtobufServer>");
+  def("recordcache", "keepwarm", "Vec<QNameAndQType>");
   def("recordcache", "zonetocaches", "Vec<ZoneToCache>");
   def("recursor", "allowed_additional_qtypes", "Vec<AllowedAdditionalQType>");
-  def("incoming", "proxymappings", "Vec<ProxyMapping>");
   def("recursor", "forwarding_catalog_zones", "Vec<ForwardingCatalogZone>");
-  def("webservice", "listen", "Vec<IncomingWSConfig>");
+  def("recursor", "rpzs", "Vec<RPZ>");
+  def("recursor", "sortlists", "Vec<SortList>");
   def("recursor", "tls_configurations", "Vec<OutgoingTLSConfiguration>");
+  def("webservice", "listen", "Vec<IncomingWSConfig>");
   // End of should be generated XXX
 
   // Convert the map to a vector, as CXX does not have any dictionary like support.

--- a/pdns/recursordist/rec-rust-lib/cxxsupport.cc
+++ b/pdns/recursordist/rec-rust-lib/cxxsupport.cc
@@ -1348,6 +1348,13 @@ void fromRustToLuaConfig(const rust::Vec<pdns::rust::settings::rec::ForwardingCa
   }
 }
 
+void fromRustToLuaConfig(const rust::Vec<pdns::rust::settings::rec::QNameAndQType>& keepwarm, std::vector<std::pair<DNSName, QType>>& lua)
+{
+  for (const auto& warm : keepwarm) {
+    lua.emplace_back(DNSName(std::string(warm.qname)), QType::chartocode(std::string(warm.qtype).data()));
+  }
+}
+
 void fromRustToOTTraceConditions(const rust::Vec<pdns::rust::settings::rec::OpenTelemetryTraceCondition>& settings, OpenTelemetryTraceConditions& conditions)
 {
   for (const auto& setting : settings) {
@@ -1400,6 +1407,7 @@ void pdns::settings::rec::fromBridgeStructToLuaConfig(const pdns::rust::settings
   fromRustToLuaConfig(settings.recursor.forwarding_catalog_zones, luaConfig.catalogzones);
   fromRustToLuaConfig(settings.incoming.proxymappings, proxyMapping);
   fromRustToOTTraceConditions(settings.logging.opentelemetry_trace_conditions, conditions);
+  fromRustToLuaConfig(settings.recordcache.keepwarm, luaConfig.keepWarm);
 }
 
 // Return true if an item that's (also) a Lua config item is set

--- a/pdns/recursordist/rec-rust-lib/docs-new-preamble-in.rst
+++ b/pdns/recursordist/rec-rust-lib/docs-new-preamble-in.rst
@@ -698,6 +698,26 @@ A :ref:`setting-yaml-logging.opentelemetry_trace_conditions` section contains a 
 
 See :ref:`opentelemetry_tracing` for an explanation how to use OpenTelemetry Trace Conditions.
 
+QNameAndQType
+^^^^^^^^^^^^^^
+
+As of version 5.5.0, a QNameAndType is defined as
+
+.. code-block:: yaml
+
+   qname: a DNS name
+   qtype: a text representation of aQType, default is A.
+
+A :ref:`setting-yaml-recordcache.keepwarm` section contains a sequence of `QNameAndQType`_, for example:
+
+.. code-block:: yaml
+
+  recordcache:
+    keepwarm:
+      - qname: www.example.com
+      - qname: www.example.com
+        qtype: AAAA
+
 The YAML settings
 -----------------
 

--- a/pdns/recursordist/rec-rust-lib/generate.py
+++ b/pdns/recursordist/rec-rust-lib/generate.py
@@ -119,9 +119,9 @@ class LType(Enum):
     ListSubnets = auto()
     ListTrustAnchors = auto()
     ListZoneToCaches = auto()
+    ListQNameAndQTypes = auto()
     String = auto()
     Uint64 = auto()
-
 
 listOfStringTypes = (LType.ListSocketAddresses, LType.ListStrings, LType.ListSubnets, LType.ListAddressAndInterfaces)
 listOfStructuredTypes = (
@@ -141,6 +141,7 @@ listOfStructuredTypes = (
     LType.ListIncomingWSConfigs,
     LType.ListOutgoingTLSConfigurations,
     LType.ListOpenTelemetryTraceConditions,
+    LType.ListQNameAndQTypes,
 )
 
 
@@ -219,6 +220,8 @@ def get_newdoc_typename(typ):
         return "Sequence of `OpenTelemetryTraceCondition`_"
     if typ == LType.ListAddressAndInterfaces:
         return "Sequence of address or address@interface_"
+    if typ == LType.ListQNameAndQTypes:
+        return "Sequence of `QNameAndQType`_"
     return "Unknown2" + str(typ)
 
 

--- a/pdns/recursordist/rec-rust-lib/generate.py
+++ b/pdns/recursordist/rec-rust-lib/generate.py
@@ -123,6 +123,7 @@ class LType(Enum):
     String = auto()
     Uint64 = auto()
 
+
 listOfStringTypes = (LType.ListSocketAddresses, LType.ListStrings, LType.ListSubnets, LType.ListAddressAndInterfaces)
 listOfStructuredTypes = (
     LType.ListAuthZones,

--- a/pdns/recursordist/rec-rust-lib/rust-bridge-in.rs
+++ b/pdns/recursordist/rec-rust-lib/rust-bridge-in.rs
@@ -384,6 +384,15 @@ struct OpenTelemetryTraceCondition {
     traceid_only: bool,
 }
 
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct QNameAndQType {
+    #[serde(default, skip_serializing_if = "crate::is_default")]
+    qname: String,
+    #[serde(default = "crate::def_qnameandqtype_qtype", skip_serializing_if = "crate::def_value_equals_qnameqtype_qtype")]
+    qtype: String,
+}
+
 // Two structs used to generated YAML based on a vector of name to value mappings
 // Cannot use Enum as CXX has only very basic Enum support
 struct Value {

--- a/pdns/recursordist/rec-rust-lib/rust-bridge-in.rs
+++ b/pdns/recursordist/rec-rust-lib/rust-bridge-in.rs
@@ -417,6 +417,7 @@ struct Value {
     vec_incomingwsconfig_val: Vec<IncomingWSConfig>,
     vec_outgoingtlsconfiguration_val: Vec<OutgoingTLSConfiguration>,
     vec_opentelemetrytracecondition_val: Vec<OpenTelemetryTraceCondition>,
+    vec_qnameandqtype_val: Vec<QNameAndQType>,
 }
 
 struct OldStyle {

--- a/pdns/recursordist/rec-rust-lib/rust/src/bridge.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/bridge.rs
@@ -801,7 +801,6 @@ impl IncomingWSConfig {
 }
 
 impl OutgoingTLSConfiguration {
-
     fn to_yaml_map(&self) -> serde_yaml::Value {
         let mut map = serde_yaml::Mapping::new();
         inserts(&mut map, "name", &self.name);
@@ -898,6 +897,13 @@ impl OpenTelemetryTraceCondition {
 }
 
 impl QNameAndQType {
+    fn to_yaml_map(&self) -> serde_yaml::Value {
+        let mut map = serde_yaml::Mapping::new();
+        inserts(&mut map, "qname", &self.qname);
+        inserts(&mut map, "qtype", &self.qtype);
+        serde_yaml::Value::Mapping(map)
+    }
+
     pub fn validate(&self, field: &str) -> Result<(), ValidationError> {
         if self.qname.is_empty() {
             let msg = format!("{}: value may not be empty", field);
@@ -1249,6 +1255,13 @@ pub fn map_to_yaml_string(vec: &Vec<OldStyle>) -> Result<String, serde_yaml::Err
                     "Vec<OpenTelemetryTraceCondition>" => {
                         let mut seq = serde_yaml::Sequence::new();
                         for element in &entry.value.vec_opentelemetrytracecondition_val {
+                            seq.push(element.to_yaml_map());
+                        }
+                        serde_yaml::Value::Sequence(seq)
+                    }
+                    "Vec<QNameAndQType>" => {
+                        let mut seq = serde_yaml::Sequence::new();
+                        for element in &entry.value.vec_qnameandqtype_val {
                             seq.push(element.to_yaml_map());
                         }
                         serde_yaml::Value::Sequence(seq)

--- a/pdns/recursordist/rec-rust-lib/rust/src/bridge.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/bridge.rs
@@ -897,6 +897,18 @@ impl OpenTelemetryTraceCondition {
     }
 }
 
+impl QNameAndQType {
+    pub fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        if self.qname.is_empty() {
+            let msg = format!("{}: value may not be empty", field);
+            return Err(ValidationError { msg });
+        }
+        validate_qtype(&(field.to_string() + ".qtype"), &self.qtype)?;
+        Ok(())
+    }
+}
+
+
 #[allow(clippy::ptr_arg)] //# Avoids creating a rust::Slice object on the C++ side.
 pub fn validate_auth_zones(field: &str, vec: &Vec<AuthZone>) -> Result<(), ValidationError> {
     validate_vec(field, vec, |field, element| element.validate(field))
@@ -1421,6 +1433,14 @@ pub fn def_pb_strategy() -> String {
 
 pub fn def_value_equals_pb_strategy(value: &String) -> bool {
     &def_pb_strategy() == value
+}
+
+pub fn def_qnameandqtype_qtype() -> String {
+    String::from("A")
+}
+
+pub fn def_value_equals_qnameqtype_qtype(value: &String) -> bool {
+    &def_qnameandqtype_qtype() == value
 }
 
 pub fn validate_dnssec(dnssec: &recsettings::Dnssec) -> Result<(), ValidationError> {

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -3708,8 +3708,11 @@ A DoT connection is matched against the subnets lists (using the remote IP) and 
         "default": "",
         "help": "Sequence of QNameAndQType",
         "doc": """
-        List of names to keep warm in the cache
-        """,
+List of names (optionally with type) to keep warm in the cache.
+The list is maintained on a best-effort basis using asynchronous tasks.
+If the number of names on the list is too high for :program:`Recursor` to maintain updated, the metric ``taskqueue-expired`` grows and ``taskqueue-size`` will never be zero.
+In that case try increasing :ref:`setting-taskthreads`.
+""",
         "skip-old": "No equivalent old style setting",
         "versionadded": "5.5.0",
         "runtime": ["reload-lua-config", "reload-yaml"],

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -2964,9 +2964,9 @@ Maximum number of idle outgoing TCP/DoT connections per thread, 0 means do not k
         "section": "recursor",
         "type": LType.Uint64,
         "default": "2",
-        "help": "Launch this number of threads",
+        "help": "Launch this number of worker threads",
         "doc": """
-Spawn this number of threads on startup.
+Spawn this number of worker threads on startup.
  """,
     },
     {
@@ -2979,6 +2979,17 @@ Spawn this number of threads on startup.
 Spawn this number of TCP processing threads on startup.
  """,
         "versionadded": "5.0.0",
+    },
+    {
+        "name": "taskthreads",
+        "section": "recursor",
+        "type": LType.Uint64,
+        "default": "1",
+        "help": "Launch this number of async task threads",
+        "doc": """
+Spawn this number of asynchronous task threads on startup.
+ """,
+        "versionadded": "5.5.0",
     },
     {
         "name": "trace",

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -3690,4 +3690,17 @@ A DoT connection is matched against the subnets lists (using the remote IP) and 
         "versionadded": "5.4.0",
         "runtime": ["reload-lua-config", "reload-yaml"],
     },
+    {
+        "name": "keepwarm",
+        "section": "recordcache",
+        "type": LType.ListQNameAndQTypes,
+        "default": "",
+        "help": "Sequence of QNameAndQType",
+        "doc": """
+        List of names to keep warm in the cache
+        """,
+        "skip-old": "No equivalent old style setting",
+        "versionadded": "5.5.0",
+        "runtime": ["reload-lua-config", "reload-yaml"],
+    },
 ]

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -120,7 +120,8 @@ static void resolveInternal(const struct timeval& now, bool logErrors, const pdn
   auto log = g_slog->withName("taskq")->withValues("name", Logging::Loggable(task.d_qname), "qtype", Logging::Loggable(QType(task.d_qtype).toString()), "netmask", Logging::Loggable(task.d_netmask.empty() ? "" : task.d_netmask.toString()));
   const string msg = "Exception while running a background ResolveTask";
   SyncRes resolver(now);
-  resolver.setRefreshAlmostExpired(task.d_refreshMode);
+  resolver.setRefreshAlmostExpired(task.d_refreshMode != pdns::ResolveTask::RefreshMode::None);
+  resolver.setForcedRefresh(task.d_refreshMode == pdns::ResolveTask::RefreshMode::Forced);
   resolver.setQuerySource(task.d_netmask);
   if (forceNoQM) {
     resolver.setQNameMinimization(false);
@@ -248,14 +249,14 @@ bool runTaskOnce(bool logErrors)
   return true;
 }
 
-void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline, const Netmask& netmask)
+void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline, const Netmask& netmask, bool force)
 {
   if (SyncRes::isUnsupported(qtype)) {
     auto log = g_slog->withName("taskq")->withValues("name", Logging::Loggable(qname), "qtype", Logging::Loggable(QType(qtype).toString()), "netmask", Logging::Loggable(netmask.empty() ? "" : netmask.toString()));
     log->error(Logr::Error, "Cannot push task", "qtype unsupported");
     return;
   }
-  pdns::ResolveTask task{qname, qtype, deadline, true, resolve, {}, {}, netmask};
+  pdns::ResolveTask task{qname, qtype, deadline, force ? pdns::ResolveTask::ResolveTask::Forced : pdns::ResolveTask::RefreshMode::Refresh, resolve, {}, {}, netmask};
   if (s_taskQueue.lock()->queue.push(std::move(task))) {
     ++s_almost_expired_tasks.pushed;
   }
@@ -269,7 +270,7 @@ void pushResolveTask(const DNSName& qname, uint16_t qtype, time_t now, time_t de
     return;
   }
   auto func = forceQMOff ? resolveForceNoQM : resolve;
-  pdns::ResolveTask task{qname, qtype, deadline, false, func, {}, {}, {}};
+  pdns::ResolveTask task{qname, qtype, deadline, pdns::ResolveTask::RefreshMode::None, func, {}, {}, {}};
   auto lock = s_taskQueue.lock();
   bool inserted = lock->rateLimitSet.insert(now, task);
   if (inserted) {
@@ -287,7 +288,7 @@ bool pushTryDoTTask(const DNSName& qname, uint16_t qtype, const ComboAddress& ip
     return false;
   }
 
-  pdns::ResolveTask task{qname, qtype, deadline, false, tryDoT, ipAddress, nsname, {}};
+  pdns::ResolveTask task{qname, qtype, deadline, pdns::ResolveTask::RefreshMode::None, tryDoT, ipAddress, nsname, {}};
   bool pushed = s_taskQueue.lock()->queue.push(std::move(task));
   if (pushed) {
     ++s_almost_expired_tasks.pushed;

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -130,7 +130,7 @@ static void resolveInternal(const struct timeval& now, bool logErrors, const pdn
   bool exceptionOccurred = true;
   vector<DNSRecord> ret;
   try {
-    log->info(Logr::Debug, "resolving", "refresh", Logging::Loggable(task.d_refreshMode));
+    log->info(Logr::Debug, "resolving", "refreshMode", Logging::Loggable(task.d_refreshMode));
     int res = resolver.beginResolve(task.d_qname, QType(task.d_qtype), QClass::IN, ret);
     exceptionOccurred = false;
     log->info(Logr::Debug, "done", "rcode", Logging::Loggable(res), "records", Logging::Loggable(ret.size()));
@@ -155,7 +155,7 @@ static void resolveInternal(const struct timeval& now, bool logErrors, const pdn
     log->error(Logr::Warning, msg, "Unexpected exception");
   }
   if (exceptionOccurred) {
-    if (task.d_refreshMode) {
+    if (task.d_refreshMode != 0) {
       ++s_almost_expired_tasks.exceptions;
     }
     else {
@@ -163,7 +163,7 @@ static void resolveInternal(const struct timeval& now, bool logErrors, const pdn
     }
   }
   else {
-    if (task.d_refreshMode) {
+    if (task.d_refreshMode != 0) {
       ++s_almost_expired_tasks.run;
     }
     else {

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -120,13 +120,14 @@ static void resolveInternal(const struct timeval& now, bool logErrors, const pdn
   auto log = g_slog->withName("taskq")->withValues("name", Logging::Loggable(task.d_qname), "qtype", Logging::Loggable(QType(task.d_qtype).toString()), "netmask", Logging::Loggable(task.d_netmask.empty() ? "" : task.d_netmask.toString()));
   const string msg = "Exception while running a background ResolveTask";
   SyncRes resolver(now);
-  vector<DNSRecord> ret;
   resolver.setRefreshAlmostExpired(task.d_refreshMode);
   resolver.setQuerySource(task.d_netmask);
   if (forceNoQM) {
     resolver.setQNameMinimization(false);
   }
+
   bool exceptionOccurred = true;
+  vector<DNSRecord> ret;
   try {
     log->info(Logr::Debug, "resolving", "refresh", Logging::Loggable(task.d_refreshMode));
     int res = resolver.beginResolve(task.d_qname, QType(task.d_qtype), QClass::IN, ret);
@@ -186,7 +187,6 @@ static void tryDoT(const struct timeval& now, bool logErrors, const pdns::Resolv
   const string msg = "Exception while running a background tryDoT task";
   SyncRes resolver(now);
   vector<DNSRecord> ret;
-  resolver.setRefreshAlmostExpired(false);
   bool exceptionOccurred = true;
   try {
     log->info(Logr::Debug, "trying DoT");

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -35,7 +35,7 @@ struct ResolveTask;
 }
 void runTasks(size_t max, bool logErrors);
 bool runTaskOnce(bool logErrors);
-void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline, const Netmask& netmask);
+void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline, const Netmask& netmask, bool force = false);
 void pushResolveTask(const DNSName& qname, uint16_t qtype, time_t now, time_t deadline, bool forceQMOff);
 bool pushTryDoTTask(const DNSName& qname, uint16_t qtype, const ComboAddress& ipAddress, time_t deadline, const DNSName& nsname);
 void taskQueueClear();

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2121,6 +2121,7 @@ RecursorControlChannel::Answer luaconfig(bool broadcast)
     // We might have a lua config file, but also process dynamic YAML parts if applicable, currently those are:
     // - the OT trace conditions
     // - the outgoing TLS config
+    // - keepWarm entries
     try {
       if (yamlstat == pdns::settings::rec::YamlSettingsStatus::OK) {
         // YAML read above succeeded
@@ -2128,6 +2129,7 @@ RecursorControlChannel::Answer luaconfig(bool broadcast)
         LuaConfigItems dummyLuaConfig; // we do not use the converted from YAML LuaConfigItems, but the "real thing"
         pdns::settings::rec::fromBridgeStructToLuaConfig(settings, dummyLuaConfig, dummyProxyMapping, conditions);
         TCPOutConnectionManager::setupOutgoingTLSConfigTables(settings);
+        lci.keepWarm = dummyLuaConfig.keepWarm; // XXX
       }
       if (!::arg()["lua-config-file"].empty()) {
         loadRecursorLuaConfig(::arg()["lua-config-file"], proxyMapping, lci); // will bump generation

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2130,6 +2130,8 @@ RecursorControlChannel::Answer luaconfig(bool broadcast)
         pdns::settings::rec::fromBridgeStructToLuaConfig(settings, dummyLuaConfig, dummyProxyMapping, conditions);
         TCPOutConnectionManager::setupOutgoingTLSConfigTables(settings);
         lci.keepWarm = dummyLuaConfig.keepWarm; // XXX
+        auto generation = g_luaconfs.getLocal()->generation;
+        lci.generation = generation + 1;
       }
       if (!::arg()["lua-config-file"].empty()) {
         loadRecursorLuaConfig(::arg()["lua-config-file"], proxyMapping, lci); // will bump generation

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2129,7 +2129,7 @@ RecursorControlChannel::Answer luaconfig(bool broadcast)
         LuaConfigItems dummyLuaConfig; // we do not use the converted from YAML LuaConfigItems, but the "real thing"
         pdns::settings::rec::fromBridgeStructToLuaConfig(settings, dummyLuaConfig, dummyProxyMapping, conditions);
         TCPOutConnectionManager::setupOutgoingTLSConfigTables(settings);
-        lci.keepWarm = dummyLuaConfig.keepWarm; // XXX
+        lci.keepWarm = dummyLuaConfig.keepWarm;
         auto generation = g_luaconfs.getLocal()->generation;
         lci.generation = generation + 1;
       }

--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -421,7 +421,7 @@ time_t MemRecursorCache::fakeTTD(MemRecursorCache::OrderedTagIterator_t& entry, 
     const uint32_t deadline = forcedRefresh(flags) ? origTTL / 2 : origTTL * SyncRes::s_refresh_ttlperc / 100;
     // coverity[store_truncates_time_t]
     const bool almostExpired = static_cast<uint32_t>(ttl) <= deadline;
-    if (almostExpired && qname != g_rootdnsname) {
+    if (almostExpired /* && qname != g_rootdnsname */) {
       if (refresh(flags)) {
         return -1;
       }

--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -421,7 +421,7 @@ time_t MemRecursorCache::fakeTTD(MemRecursorCache::OrderedTagIterator_t& entry, 
     const uint32_t deadline = forcedRefresh(flags) ? origTTL / 2 : origTTL * SyncRes::s_refresh_ttlperc / 100;
     // coverity[store_truncates_time_t]
     const bool almostExpired = static_cast<uint32_t>(ttl) <= deadline;
-    if (almostExpired /* && qname != g_rootdnsname */) {
+    if (almostExpired) {
       if (refresh(flags)) {
         return -1;
       }

--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -408,21 +408,21 @@ bool MemRecursorCache::entryMatches(MemRecursorCache::OrderedTagIterator_t& entr
 }
 
 // Fake a cache miss if more than refreshTTLPerc of the original TTL has passed
-time_t MemRecursorCache::fakeTTD(MemRecursorCache::OrderedTagIterator_t& entry, const DNSName& qname, QType qtype, time_t ret, time_t now, uint32_t origTTL, bool refresh)
+time_t MemRecursorCache::fakeTTD(MemRecursorCache::OrderedTagIterator_t& entry, const DNSName& qname, QType qtype, time_t ret, time_t now, uint32_t origTTL, MemRecursorCache::Flags flags)
 {
   time_t ttl = ret - now;
   // If we are checking an entry being served stale in refresh mode,
   // we always consider it stale so a real refresh attempt will be
   // kicked by SyncRes
-  if (refresh && entry->d_servedStale > 0) {
+  if (refresh(flags) && entry->d_servedStale > 0) {
     return -1;
   }
-  if (ttl > 0 && SyncRes::s_refresh_ttlperc > 0) {
-    const uint32_t deadline = origTTL * SyncRes::s_refresh_ttlperc / 100;
+  if (ttl > 0 && (forcedRefresh(flags) || SyncRes::s_refresh_ttlperc > 0)) {
+    const uint32_t deadline = forcedRefresh(flags) ? origTTL / 2 : origTTL * SyncRes::s_refresh_ttlperc / 100;
     // coverity[store_truncates_time_t]
     const bool almostExpired = static_cast<uint32_t>(ttl) <= deadline;
     if (almostExpired && qname != g_rootdnsname) {
-      if (refresh) {
+      if (refresh(flags)) {
         return -1;
       }
       // We do not want to refresh auth NS entries, as it could lead to ghost domains if an entry
@@ -441,7 +441,6 @@ time_t MemRecursorCache::fakeTTD(MemRecursorCache::OrderedTagIterator_t& entry, 
 time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qtype, Flags flags, vector<DNSRecord>* res, const ComboAddress& who, const OptTag& routingTag, SigRecs* signatures, AuthRecs* authorityRecs, bool* variable, vState* state, bool* wasAuth, DNSName* fromAuthZone, Extra* extra) // NOLINT(readability-function-cognitive-complexity)
 {
   bool requireAuth = (flags & RequireAuth) != 0;
-  bool refresh = (flags & Refresh) != 0;
   bool serveStale = (flags & ServeStale) != 0;
 
   std::optional<vState> cachedState{std::nullopt};
@@ -495,7 +494,7 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qtype
       if (cachedState && ret > now) {
         ptrAssign(state, *cachedState);
       }
-      return fakeTTD(entry, qname, qtype, ret, now, origTTL, refresh);
+      return fakeTTD(entry, qname, qtype, ret, now, origTTL, flags);
     }
     return -1;
   }
@@ -541,7 +540,7 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qtype
         if (cachedState && ttd > now) {
           ptrAssign(state, *cachedState);
         }
-        return fakeTTD(firstIndexIterator, qname, qtype, ttd, now, origTTL, refresh);
+        return fakeTTD(firstIndexIterator, qname, qtype, ttd, now, origTTL, flags);
       }
       return -1;
     }
@@ -587,7 +586,7 @@ time_t MemRecursorCache::get(time_t now, const DNSName& qname, const QType qtype
       if (cachedState && ttd > now) {
         ptrAssign(state, *cachedState);
       }
-      return fakeTTD(firstIndexIterator, qname, qtype, ttd, now, origTTL, refresh);
+      return fakeTTD(firstIndexIterator, qname, qtype, ttd, now, origTTL, flags);
     }
   }
   return -1;

--- a/pdns/recursordist/recursor_cache.hh
+++ b/pdns/recursordist/recursor_cache.hh
@@ -74,7 +74,17 @@ public:
   static constexpr Flags RequireAuth = 1 << 0;
   static constexpr Flags Refresh = 1 << 1;
   static constexpr Flags ServeStale = 1 << 2;
+  static constexpr Flags ForcedRefresh = 1 << 3;
 
+  static bool refresh(Flags flags)
+  {
+    return (flags & Refresh) != 0;
+  }
+
+  static bool forcedRefresh(Flags flags)
+  {
+    return (flags & Refresh) != 0;
+  }
   // The type used to pass auth record data to replace(); If the vector is non-empty, the cache will
   // store a shared pointer to the copied data. The shared pointer will be returned by get().  There
   // are optimizations: an empty vector will be stored as a nullptr, but get() will return a pointer
@@ -381,7 +391,7 @@ private:
     return d_maps.at(qname.hash() % d_maps.size());
   }
 
-  static time_t fakeTTD(OrderedTagIterator_t& entry, const DNSName& qname, QType qtype, time_t ret, time_t now, uint32_t origTTL, bool refresh);
+  static time_t fakeTTD(OrderedTagIterator_t& entry, const DNSName& qname, QType qtype, time_t ret, time_t now, uint32_t origTTL, Flags flags);
 
   static bool entryMatches(OrderedTagIterator_t& entry, QType qtype, bool requireAuth, const ComboAddress& who);
   static Entries getEntries(MapCombo::LockedContent& map, const DNSName& qname, QType qtype, const OptTag& rtag);

--- a/pdns/recursordist/recursor_cache.hh
+++ b/pdns/recursordist/recursor_cache.hh
@@ -83,7 +83,7 @@ public:
 
   static bool forcedRefresh(Flags flags)
   {
-    return (flags & Refresh) != 0;
+    return (flags & ForcedRefresh) != 0;
   }
   // The type used to pass auth record data to replace(); If the vector is non-empty, the cache will
   // store a shared pointer to the copied data. The shared pointer will be returned by get().  There

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -462,7 +462,7 @@ static inline void accountAuthLatency(uint64_t usec, int family)
 }
 
 SyncRes::SyncRes(const struct timeval& now) :
-  d_authzonequeries(0), d_outqueries(0), d_tcpoutqueries(0), d_dotoutqueries(0), d_throttledqueries(0), d_timeouts(0), d_unreachables(0), d_bytesReceived(0), d_totUsec(0), d_fixednow(now), d_now(now), d_cacheonly(false), d_doDNSSEC(false), d_doEDNS0(false), d_qNameMinimization(s_qnameminimization), d_lm(s_lm)
+  d_authzonequeries(0), d_outqueries(0), d_tcpoutqueries(0), d_dotoutqueries(0), d_throttledqueries(0), d_timeouts(0), d_unreachables(0), d_bytesReceived(0), d_totUsec(0), d_fixednow(now), d_now(now), d_cacheonly(false), d_doDNSSEC(false), d_qNameMinimization(s_qnameminimization), d_lm(s_lm)
 {
   d_validationContext.d_nsec3IterationsRemainingQuota = s_maxnsec3iterationsperq > 0 ? s_maxnsec3iterationsperq : std::numeric_limits<decltype(d_validationContext.d_nsec3IterationsRemainingQuota)>::max();
 }
@@ -6343,7 +6343,6 @@ int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigne
   }
   SyncRes resolver(now);
   resolver.d_prefix = "[getRootNS]";
-  resolver.setDoEDNS0(true);
   resolver.setUpdatingRootNS();
   resolver.setDoDNSSEC(g_dnssecmode != DNSSECMode::Off);
   resolver.setDNSSECValidationRequested(g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate);

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -2369,7 +2369,8 @@ void SyncRes::getBestNSFromCache(const DNSName& qname, const QType qtype, vector
       /* let's prevent an infinite loop */
       if (!d_updatingRootNS) {
         auto log = g_slog->withName("housekeeping");
-        getRootNS(d_now, d_asyncResolve, depth, log);
+        uint32_t dummy{};
+        getRootNS(d_now, d_asyncResolve, depth, log, dummy);
       }
     }
   } while (subdomain.chopOff());
@@ -6347,7 +6348,7 @@ int directResolve(const DNSName& qname, const QType qtype, const QClass qclass, 
   return res;
 }
 
-int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigned int depth, Logr::log_t log)
+int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigned int depth, Logr::log_t log, uint32_t& minttl)
 {
   if (::arg()["hint-file"] == "no-refresh") {
     return 0;
@@ -6390,6 +6391,10 @@ int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigne
   }
 
   if (res == 0) {
+    minttl = SyncRes::s_maxcachettl;
+    for (const auto& record : ret) {
+      minttl = std::min(minttl, record.d_ttl);
+    }
     log->info(Logr::Debug, "Refreshed . records");
   }
   else {

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -462,7 +462,12 @@ static inline void accountAuthLatency(uint64_t usec, int family)
 }
 
 SyncRes::SyncRes(const struct timeval& now) :
-  d_authzonequeries(0), d_outqueries(0), d_tcpoutqueries(0), d_dotoutqueries(0), d_throttledqueries(0), d_timeouts(0), d_unreachables(0), d_bytesReceived(0), d_totUsec(0), d_fixednow(now), d_now(now), d_cacheonly(false), d_doDNSSEC(false), d_qNameMinimization(s_qnameminimization), d_lm(s_lm)
+  d_fixednow(now),
+  d_now(now),
+  d_doDNSSEC(g_dnssecmode != DNSSECMode::Off),
+  d_DNSSECValidationRequested(g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate),
+  d_qNameMinimization(s_qnameminimization),
+  d_lm(s_lm)
 {
   d_validationContext.d_nsec3IterationsRemainingQuota = s_maxnsec3iterationsperq > 0 ? s_maxnsec3iterationsperq : std::numeric_limits<decltype(d_validationContext.d_nsec3IterationsRemainingQuota)>::max();
 }
@@ -6344,8 +6349,6 @@ int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigne
   SyncRes resolver(now);
   resolver.d_prefix = "[getRootNS]";
   resolver.setUpdatingRootNS();
-  resolver.setDoDNSSEC(g_dnssecmode != DNSSECMode::Off);
-  resolver.setDNSSECValidationRequested(g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate);
   resolver.setAsyncCallback(std::move(asyncCallback));
   resolver.setRefreshAlmostExpired(true);
 

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -1797,7 +1797,7 @@ unsigned int SyncRes::getAdjustedRecursionBound() const
   return bound;
 }
 
-static bool haveFinalAnswer(const DNSName& qname, QType qtype, int res, const vector<DNSRecord>& ret)
+bool haveFinalAnswer(const DNSName& qname, QType qtype, int res, const vector<DNSRecord>& ret)
 {
   if (res != RCode::NoError) {
     return false;

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -1861,134 +1861,134 @@ int SyncRes::doResolveNoQNameMinimization(const DNSName& qname, const QType qtyp
     if (d_serveStale) {
       LOG(prefix << qname << ": Restart, with serve-stale enabled" << endl);
     }
-    // This is a difficult way of expressing "this is a normal query", i.e. not getRootNS.
-    if (!d_updatingRootNS || qtype.getCode() != QType::NS || !qname.isRoot()) {
-      DNSName authname(qname);
-      const auto iter = getBestAuthZone(&authname);
 
-      if (d_cacheonly) {
-        if (iter != t_sstorage.domainmap->end()) {
-          if (iter->second.isAuth()) {
-            LOG(prefix << qname << ": Cache only lookup for '" << qname << "|" << qtype << "', in auth zone" << endl);
-            ret.clear();
-            d_wasOutOfBand = doOOBResolve(qname, qtype, ret, depth, prefix, res);
-            if (fromCache != nullptr) {
-              *fromCache = d_wasOutOfBand;
-            }
-            return res;
-          }
-        }
-      }
+    // Originally this was all skipped for root refresh cases, but we now have a generic solution
+    // for that via forcedRefresh
+    DNSName authname(qname);
+    const auto iter = getBestAuthZone(&authname);
 
-      bool wasForwardedOrAuthZone = false;
-      bool wasAuthZone = false;
-      bool wasForwardRecurse = false;
-
+    if (d_cacheonly) {
       if (iter != t_sstorage.domainmap->end()) {
-        wasForwardedOrAuthZone = true;
-
         if (iter->second.isAuth()) {
-          wasAuthZone = true;
+          LOG(prefix << qname << ": Cache only lookup for '" << qname << "|" << qtype << "', in auth zone" << endl);
+          ret.clear();
+          d_wasOutOfBand = doOOBResolve(qname, qtype, ret, depth, prefix, res);
+          if (fromCache != nullptr) {
+            *fromCache = d_wasOutOfBand;
+          }
+          return res;
         }
-        else if (iter->second.shouldRecurse()) {
-          wasForwardRecurse = true;
+      }
+    }
+
+    bool wasForwardedOrAuthZone = false;
+    bool wasAuthZone = false;
+    bool wasForwardRecurse = false;
+
+    if (iter != t_sstorage.domainmap->end()) {
+      wasForwardedOrAuthZone = true;
+
+      if (iter->second.isAuth()) {
+        wasAuthZone = true;
+      }
+      else if (iter->second.shouldRecurse()) {
+        wasForwardRecurse = true;
+      }
+    }
+
+    /* When we are looking for a DS, we want to the non-CNAME cache check first
+       because we can actually have a DS (from the parent zone) AND a CNAME (from
+       the child zone), and what we really want is the DS */
+    if (qtype != QType::DS && doCNAMECacheCheck(qname, qtype, ret, depth, prefix, res, context, wasAuthZone, wasForwardRecurse, loop == 1)) { // will reroute us if needed
+      d_wasOutOfBand = wasAuthZone;
+      // Here we have an issue. If we were prevented from going out to the network (cache-only was set, possibly because we
+      // are in QM Step0) we might have a CNAME but not the corresponding target.
+      // It means that we will sometimes go to the next steps when we are in fact done, but that's fine since
+      // we will get the records from the cache, resulting in a small overhead.
+      // This might be a real problem if we had a RPZ hit, though, because we do not want the processing to continue, since
+      // RPZ rules will not be evaluated anymore (we already matched).
+      bool stoppedByPolicyHit = d_appliedPolicy.wasHit();
+      if (stoppedByPolicyHit && d_appliedPolicy.d_kind == DNSFilterEngine::PolicyKind::Custom && d_appliedPolicy.d_custom) {
+        // if the custom RPZ record was a CNAME we still need a full chase
+        // tested by unit test test_following_cname_chain_with_rpz
+        if (!d_appliedPolicy.d_custom->empty() && d_appliedPolicy.d_custom->at(0)->getType() == QType::CNAME) {
+          stoppedByPolicyHit = false;
+        }
+      }
+      if (fromCache != nullptr && (!d_cacheonly || stoppedByPolicyHit)) {
+        *fromCache = true;
+      }
+      /* Apply Post filtering policies */
+
+      if (d_wantsRPZ && !d_appliedPolicy.wasHit()) {
+        auto luaLocal = g_luaconfs.getLocal();
+        if (luaLocal->dfe.getPostPolicy(ret, d_discardedPolicies, d_appliedPolicy)) {
+          mergePolicyTags(d_policyTags, d_appliedPolicy.getTags());
+          bool done = false;
+          handlePolicyHit(prefix, qname, qtype, ret, done, res, depth);
+          if (done && fromCache != nullptr) {
+            *fromCache = true;
+          }
+        }
+      }
+      // This handles the case mentioned above: if the full CNAME chain leading to the answer was
+      // constructed from the cache, indicate that.
+      if (fromCache != nullptr && !*fromCache && haveFinalAnswer(qname, qtype, res, ret)) {
+        *fromCache = true;
+      }
+      return res;
+    }
+
+    if (doCacheCheck(qname, authname, wasForwardedOrAuthZone, wasAuthZone, wasForwardRecurse, qtype, ret, depth, prefix, res, context)) {
+      // we done
+      d_wasOutOfBand = wasAuthZone;
+      if (fromCache != nullptr) {
+        *fromCache = true;
+      }
+
+      if (d_wantsRPZ && !d_appliedPolicy.wasHit()) {
+        auto luaLocal = g_luaconfs.getLocal();
+        if (luaLocal->dfe.getPostPolicy(ret, d_discardedPolicies, d_appliedPolicy)) {
+          mergePolicyTags(d_policyTags, d_appliedPolicy.getTags());
+          bool done = false;
+          handlePolicyHit(prefix, qname, qtype, ret, done, res, depth);
         }
       }
 
-      /* When we are looking for a DS, we want to the non-CNAME cache check first
-         because we can actually have a DS (from the parent zone) AND a CNAME (from
-         the child zone), and what we really want is the DS */
-      if (qtype != QType::DS && doCNAMECacheCheck(qname, qtype, ret, depth, prefix, res, context, wasAuthZone, wasForwardRecurse, loop == 1)) { // will reroute us if needed
-        d_wasOutOfBand = wasAuthZone;
-        // Here we have an issue. If we were prevented from going out to the network (cache-only was set, possibly because we
-        // are in QM Step0) we might have a CNAME but not the corresponding target.
-        // It means that we will sometimes go to the next steps when we are in fact done, but that's fine since
-        // we will get the records from the cache, resulting in a small overhead.
-        // This might be a real problem if we had a RPZ hit, though, because we do not want the processing to continue, since
-        // RPZ rules will not be evaluated anymore (we already matched).
-        bool stoppedByPolicyHit = d_appliedPolicy.wasHit();
-        if (stoppedByPolicyHit && d_appliedPolicy.d_kind == DNSFilterEngine::PolicyKind::Custom && d_appliedPolicy.d_custom) {
-          // if the custom RPZ record was a CNAME we still need a full chase
-          // tested by unit test test_following_cname_chain_with_rpz
-          if (!d_appliedPolicy.d_custom->empty() && d_appliedPolicy.d_custom->at(0)->getType() == QType::CNAME) {
-            stoppedByPolicyHit = false;
-          }
-        }
-        if (fromCache != nullptr && (!d_cacheonly || stoppedByPolicyHit)) {
-          *fromCache = true;
-        }
-        /* Apply Post filtering policies */
+      return res;
+    }
 
-        if (d_wantsRPZ && !d_appliedPolicy.wasHit()) {
-          auto luaLocal = g_luaconfs.getLocal();
-          if (luaLocal->dfe.getPostPolicy(ret, d_discardedPolicies, d_appliedPolicy)) {
-            mergePolicyTags(d_policyTags, d_appliedPolicy.getTags());
-            bool done = false;
-            handlePolicyHit(prefix, qname, qtype, ret, done, res, depth);
-            if (done && fromCache != nullptr) {
-              *fromCache = true;
-            }
-          }
-        }
-        // This handles the case mentioned above: if the full CNAME chain leading to the answer was
-        // constructed from the cache, indicate that.
-        if (fromCache != nullptr && !*fromCache && haveFinalAnswer(qname, qtype, res, ret)) {
-          *fromCache = true;
-        }
-        return res;
+    /* if we have not found a cached DS (or denial of), now is the time to look for a CNAME */
+    if (qtype == QType::DS && doCNAMECacheCheck(qname, qtype, ret, depth, prefix, res, context, wasAuthZone, wasForwardRecurse, loop == 1)) { // will reroute us if needed
+      d_wasOutOfBand = wasAuthZone;
+      // Here we have an issue. If we were prevented from going out to the network (cache-only was set, possibly because we
+      // are in QM Step0) we might have a CNAME but not the corresponding target.
+      // It means that we will sometimes go to the next steps when we are in fact done, but that's fine since
+      // we will get the records from the cache, resulting in a small overhead.
+      // This might be a real problem if we had a RPZ hit, though, because we do not want the processing to continue, since
+      // RPZ rules will not be evaluated anymore (we already matched).
+      const bool stoppedByPolicyHit = d_appliedPolicy.wasHit();
+
+      if (fromCache != nullptr && (!d_cacheonly || stoppedByPolicyHit)) {
+        *fromCache = true;
       }
+      /* Apply Post filtering policies */
 
-      if (doCacheCheck(qname, authname, wasForwardedOrAuthZone, wasAuthZone, wasForwardRecurse, qtype, ret, depth, prefix, res, context)) {
-        // we done
-        d_wasOutOfBand = wasAuthZone;
-        if (fromCache != nullptr) {
-          *fromCache = true;
-        }
-
-        if (d_wantsRPZ && !d_appliedPolicy.wasHit()) {
-          auto luaLocal = g_luaconfs.getLocal();
-          if (luaLocal->dfe.getPostPolicy(ret, d_discardedPolicies, d_appliedPolicy)) {
-            mergePolicyTags(d_policyTags, d_appliedPolicy.getTags());
-            bool done = false;
-            handlePolicyHit(prefix, qname, qtype, ret, done, res, depth);
+      if (d_wantsRPZ && !stoppedByPolicyHit) {
+        auto luaLocal = g_luaconfs.getLocal();
+        if (luaLocal->dfe.getPostPolicy(ret, d_discardedPolicies, d_appliedPolicy)) {
+          mergePolicyTags(d_policyTags, d_appliedPolicy.getTags());
+          bool done = false;
+          handlePolicyHit(prefix, qname, qtype, ret, done, res, depth);
+          if (done && fromCache != nullptr) {
+            *fromCache = true;
           }
         }
-
-        return res;
       }
-
-      /* if we have not found a cached DS (or denial of), now is the time to look for a CNAME */
-      if (qtype == QType::DS && doCNAMECacheCheck(qname, qtype, ret, depth, prefix, res, context, wasAuthZone, wasForwardRecurse, loop == 1)) { // will reroute us if needed
-        d_wasOutOfBand = wasAuthZone;
-        // Here we have an issue. If we were prevented from going out to the network (cache-only was set, possibly because we
-        // are in QM Step0) we might have a CNAME but not the corresponding target.
-        // It means that we will sometimes go to the next steps when we are in fact done, but that's fine since
-        // we will get the records from the cache, resulting in a small overhead.
-        // This might be a real problem if we had a RPZ hit, though, because we do not want the processing to continue, since
-        // RPZ rules will not be evaluated anymore (we already matched).
-        const bool stoppedByPolicyHit = d_appliedPolicy.wasHit();
-
-        if (fromCache != nullptr && (!d_cacheonly || stoppedByPolicyHit)) {
-          *fromCache = true;
-        }
-        /* Apply Post filtering policies */
-
-        if (d_wantsRPZ && !stoppedByPolicyHit) {
-          auto luaLocal = g_luaconfs.getLocal();
-          if (luaLocal->dfe.getPostPolicy(ret, d_discardedPolicies, d_appliedPolicy)) {
-            mergePolicyTags(d_policyTags, d_appliedPolicy.getTags());
-            bool done = false;
-            handlePolicyHit(prefix, qname, qtype, ret, done, res, depth);
-            if (done && fromCache != nullptr) {
-              *fromCache = true;
-            }
-          }
-        }
-        if (fromCache != nullptr && !*fromCache && haveFinalAnswer(qname, qtype, res, ret)) {
-          *fromCache = true;
-        }
-        return res;
+      if (fromCache != nullptr && !*fromCache && haveFinalAnswer(qname, qtype, res, ret)) {
+        *fromCache = true;
       }
+      return res;
     }
 
     if (d_cacheonly) {
@@ -2505,6 +2505,9 @@ bool SyncRes::doCNAMECacheCheck(const DNSName& qname, const QType qtype, vector<
   if (d_refresh) {
     flags |= MemRecursorCache::Refresh;
   }
+  if (d_forcedRefresh) {
+    flags |= MemRecursorCache::ForcedRefresh;
+  }
   if (d_serveStale) {
     flags |= MemRecursorCache::ServeStale;
   }
@@ -2956,6 +2959,9 @@ bool SyncRes::doCacheCheck(const DNSName& qname, const DNSName& authname, bool w
   }
   if (d_refresh) {
     flags |= MemRecursorCache::Refresh;
+  }
+  if (d_forcedRefresh) {
+    flags |= MemRecursorCache::ForcedRefresh;
   }
 
   MemRecursorCache::Extra extra;
@@ -6351,6 +6357,7 @@ int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigne
   resolver.setUpdatingRootNS();
   resolver.setAsyncCallback(std::move(asyncCallback));
   resolver.setRefreshAlmostExpired(true);
+  resolver.setForcedRefresh(true);
 
   const string msg = "Failed to update . records";
   vector<DNSRecord> ret;

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -235,7 +235,7 @@ public:
   struct EDNSStatus
   {
     EDNSStatus(const ComboAddress& arg) :
-      address(arg) {}
+      address(arg) { }
     ComboAddress address;
     time_t ttd{0};
     enum EDNSMode : uint8_t
@@ -368,6 +368,13 @@ public:
   {
     auto old = d_refresh;
     d_refresh = doit;
+    return old;
+  }
+
+  bool setForcedRefresh(bool doit)
+  {
+    auto old = d_forcedRefresh;
+    d_forcedRefresh = doit;
     return old;
   }
 
@@ -769,6 +776,7 @@ private:
   bool d_queryReceivedOverTCP{false};
   bool d_followCNAME{true};
   bool d_refresh{false};
+  bool d_forcedRefresh{false};
   bool d_serveStale{false};
 
   LogMode d_lm;
@@ -930,7 +938,7 @@ class ImmediateServFailException
 {
 public:
   ImmediateServFailException(string reason_) :
-    reason(std::move(reason_)) {};
+    reason(std::move(reason_)) { };
 
   string reason; //! Print this to tell the user what went wrong
 };

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -78,10 +78,17 @@ using NsSet = std::unordered_map<DNSName, pair<vector<ComboAddress>, bool>>;
 
 extern std::unique_ptr<NegCache> g_negCache;
 
-class SyncRes : public boost::noncopyable
+class SyncRes
 {
 public:
-  enum LogMode
+  SyncRes();
+  ~SyncRes() = default;
+  SyncRes(const SyncRes&) = delete;
+  SyncRes(SyncRes&&) = delete;
+  SyncRes& operator=(const SyncRes&) = delete;
+  SyncRes& operator=(SyncRes&&) = delete;
+
+  enum LogMode : uint8_t
   {
     LogNone,
     Log,
@@ -593,18 +600,18 @@ public:
   std::shared_ptr<Logr::Logger> d_slog = g_slog->withName("syncres");
   std::optional<EDNSExtendedError> d_extendedError;
 
-  unsigned int d_authzonequeries;
-  unsigned int d_outqueries;
-  unsigned int d_tcpoutqueries;
-  unsigned int d_dotoutqueries;
-  unsigned int d_throttledqueries;
-  unsigned int d_timeouts;
-  unsigned int d_unreachables;
-  unsigned int d_bytesReceived;
-  unsigned int d_totUsec;
+  unsigned int d_authzonequeries{0};
+  unsigned int d_outqueries{0};
+  unsigned int d_tcpoutqueries{0};
+  unsigned int d_dotoutqueries{0};
+  unsigned int d_throttledqueries{0};
+  unsigned int d_timeouts{0};
+  unsigned int d_unreachables{0};
+  unsigned int d_bytesReceived{0};
+  unsigned int d_totUsec{0};
   unsigned int d_maxdepth{0};
   // Initialized only once, as opposed to d_now which gets updated after outgoing requests
-  struct timeval d_fixednow;
+  const struct timeval d_fixednow;
 
 private:
   ComboAddress d_requestor;
@@ -749,15 +756,15 @@ private:
   /* When d_cacheonly is set to true, we will only check the cache.
    * This is set when the RD bit is unset in the incoming query
    */
-  bool d_cacheonly;
+  bool d_cacheonly{false};
   bool d_doDNSSEC;
-  bool d_DNSSECValidationRequested{false};
+  bool d_DNSSECValidationRequested;
   bool d_requireAuthData{true};
   bool d_updatingRootNS{false};
   bool d_wantsRPZ{true};
   bool d_wasOutOfBand{false};
   bool d_wasVariable{false};
-  bool d_qNameMinimization{false};
+  bool d_qNameMinimization;
   bool d_qNameMinimizationFallbackMode{false};
   bool d_queryReceivedOverTCP{false};
   bool d_followCNAME{true};

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -180,7 +180,7 @@ public:
   static size_t getNSSpeedTable(size_t maxSize, std::string& ret);
   static size_t putIntoNSSpeedTable(const std::string& ret);
 
-  static int getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigned int depth, Logr::log_t);
+  static int getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigned int depth, Logr::log_t, uint32_t& minttl);
   static void addDontQuery(const std::string& mask)
   {
     if (!s_dontQuery) {

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -383,11 +383,6 @@ public:
     return d_qNameMinimizationFallbackMode;
   }
 
-  void setDoEDNS0(bool state = true)
-  {
-    d_doEDNS0 = state;
-  }
-
   void setDoDNSSEC(bool state = true)
   {
     d_doDNSSEC = state;
@@ -757,7 +752,6 @@ private:
   bool d_cacheonly;
   bool d_doDNSSEC;
   bool d_DNSSECValidationRequested{false};
-  bool d_doEDNS0{true};
   bool d_requireAuthData{true};
   bool d_updatingRootNS{false};
   bool d_wantsRPZ{true};

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -235,7 +235,7 @@ public:
   struct EDNSStatus
   {
     EDNSStatus(const ComboAddress& arg) :
-      address(arg) { }
+      address(arg) {}
     ComboAddress address;
     time_t ttd{0};
     enum EDNSMode : uint8_t
@@ -938,7 +938,7 @@ class ImmediateServFailException
 {
 public:
   ImmediateServFailException(string reason_) :
-    reason(std::move(reason_)) { };
+    reason(std::move(reason_)) {};
 
   string reason; //! Print this to tell the user what went wrong
 };

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -1013,4 +1013,3 @@ struct ThreadTimes
     return *this;
   }
 };
-

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -990,6 +990,7 @@ bool primeHints(time_t now = time(nullptr));
 
 using timebuf_t = std::array<char, 64>;
 const char* isoDateTimeMillis(const struct timeval& tval, timebuf_t& buf);
+bool haveFinalAnswer(const DNSName& qname, QType qtype, int res, const vector<DNSRecord>& ret);
 
 struct WipeCacheResult
 {
@@ -1012,3 +1013,4 @@ struct ThreadTimes
     return *this;
   }
 };
+

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -52,8 +52,15 @@ struct ResolveTask
   uint16_t d_qtype;
   // Deadline is not part of index and not used by operator<()
   time_t d_deadline;
-  // Whether to run this task in regular mode (false) or in the mode that refreshes almost expired tasks
-  bool d_refreshMode;
+  // Whether to run this task in normal mode (None) or in the mode that refreshes almost expired
+  // rrsets (Regular) or in Forced Mode
+  enum RefreshMode : uint8_t
+  {
+    None,
+    Refresh,
+    Forced
+  };
+  RefreshMode d_refreshMode;
   // Use a function pointer as comparing std::functions is a nuisance
   using TaskFunction = void (*)(const struct timeval& now, bool logErrors, const ResolveTask& task);
   TaskFunction d_func;
@@ -122,7 +129,7 @@ private:
                               composite_key<ResolveTask,
                                             member<ResolveTask, DNSName, &ResolveTask::d_qname>,
                                             member<ResolveTask, uint16_t, &ResolveTask::d_qtype>,
-                                            member<ResolveTask, bool, &ResolveTask::d_refreshMode>,
+                                            member<ResolveTask, ResolveTask::RefreshMode, &ResolveTask::d_refreshMode>,
                                             member<ResolveTask, ResolveTask::TaskFunction, &ResolveTask::d_func>,
                                             member<ResolveTask, ComboAddress, &ResolveTask::d_ip>,
                                             member<ResolveTask, Netmask, &ResolveTask::d_netmask>>>,

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -240,7 +240,6 @@ void initSR(std::unique_ptr<SyncRes>& sr, bool dnssec, bool debug, time_t fakeNo
   initSR(debug);
 
   sr = std::make_unique<SyncRes>(now);
-  sr->setDoEDNS0(true);
   if (dnssec) {
     sr->setDoDNSSEC(dnssec);
   }

--- a/regression-tests.recursor-dnssec/test_KeepWarm.py
+++ b/regression-tests.recursor-dnssec/test_KeepWarm.py
@@ -1,0 +1,59 @@
+import dns
+import os
+import time
+from recursortests import RecursorTest
+
+
+class KeepWarmTest(RecursorTest):
+    _confdir = "KeepWarm"
+    _auth_zones = RecursorTest._default_auth_zones
+
+    _config_template = """
+recursor:
+    taskthreads: 2 # not actually needed, but just to cover the non-default case
+recordcache:
+  keepwarm:
+    - qname: secure.example
+    - qname: cname-to-secure.insecure.example.
+    - qname: nonexistent.secure.example
+"""
+
+    @classmethod
+    def generateRecursorConfig(cls, confdir):
+        super(KeepWarmTest, cls).generateRecursorYamlConfig(confdir)
+
+    @classmethod
+    def startRecursor(cls, confdir, port):
+        super(KeepWarmTest, cls).startRecursor(confdir, port)
+        # we want to delay a bit, as the tasks are run asynchronously. This is a race of course...
+        time.sleep(2)
+
+    def testCacheContent(self):
+        confdir = os.path.join("configs", self._confdir)
+        ret = self.recControl(confdir, "dump-cache", "-", "r")
+        found = 0
+        for i in ret.splitlines():
+            pieces = i.split(" ")
+            if len(pieces) == 14:
+                # print(pieces)
+                if pieces[0] == "secure.example." and pieces[4] == "A":
+                    found += 1
+                elif pieces[0] == "cname-to-secure.insecure.example." and pieces[4] == "CNAME":
+                    found += 1
+                elif pieces[0] == "host1.secure.example." and pieces[4] == "A":
+                    found += 1
+
+        self.assertEqual(found, 3)
+
+    def testNegCacheContent(self):
+        confdir = os.path.join("configs", self._confdir)
+        ret = self.recControl(confdir, "dump-cache", "-", "n")
+        found = 0
+        for i in ret.splitlines():
+            pieces = i.split(" ")
+            if len(pieces) == 10:
+                print(pieces)
+                if pieces[0] == "nonexistent.secure.example." and pieces[3] == "TYPE0":
+                    found += 1
+
+        self.assertEqual(found, 1)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This is different from [refresh-on-ttl-perc](https://docs.powerdns.com/recursor/yamlsettings.html#recordcache-refresh-on-ttl-perc) as it does not require a name/qtype to be queried to kick the refresh.

List is a `keepwarm` key in the `recordcache` section. Value is a list, for example:
```
recordcache:
  keepwarm:
    - qname: google.com
    - qname: microsoft.com
```

If you have lots of names in the list you'll see `taskqueue-expired` grow and  `taskqueue-size` never hitting zero. In that case increase the new `recursor.taskthreads` setting.

<strike>Draft as tests and docs are missing.</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
