### PR TITLE
Clarify the documentation regarding lmdb-shards-map-size

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -122,8 +122,9 @@ Defaults to 100 on 32 bit systems, and 16000 on 64 bit systems.
 
   .. versionchanged:: 5.1.0
 
-From version 5.1.0 onwards, this settings only applies to the main database
-file; shards use :ref:`settings-lmdb-shards-map-size` instead.
+From version 5.1.0 onwards, the size of the main database and the
+size of the shard databases can be set independently.
+In order to set a different size for the shard databases, use :ref:`settings-lmdb-shards-map-size`.
 
 .. _settings-lmdb-shards-map-size:
 


### PR DESCRIPTION
This aligns the note in the `lmdb-map-size` section better with how `lmdb-map-size` and `lmdb-shards-map-size` actually interact.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Old text suggests that `lmdb-map-size` no longer applies to the shard databases:

> From version 5.1.0 onwards, this settings **only applies to the main database file**; shards use [lmdb-shards-map-size](https://doc.powerdns.com/authoritative/backends/lmdb.html#settings-lmdb-shards-map-size) instead.

but the default is that it still applies to both:

> Size, in megabytes, of each LMDB shard database. This number can be increased later, but never decreased. **If set to zero (which is its default value), the same value as [lmdb-map-size](https://doc.powerdns.com/authoritative/backends/lmdb.html#settings-lmdb-map-size) will be used**.

Hence the proposed change that focuses on the new ability to set the sizes independently, without the "only applies to" part.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

