### PR TITLE
auth: let pdnsutil work with lua backend

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -700,6 +700,8 @@ static void loadMainConfig(const std::string& configdir)
   ::arg().set("max-include-depth", "Maximum nested $INCLUDE depth when loading a zone from a file")="20";
   ::arg().setSwitch("upgrade-unknown-types","Transparently upgrade known TYPExxx records. Recommended to keep off, except for PowerDNS upgrades until data sources are cleaned up")="no";
   ::arg().setSwitch("views", "Enable views (variants) of zones, for backends which support them") = "no";
+  // Needed by Lua backend
+  ::arg().set("lua-global-include-dir", "Include *.lua files from this directory into Lua contexts") = "";
   ::arg().laxFile(configname);
 
   // FIXME520: remove when branching 5.2


### PR DESCRIPTION
### Short description
As reported in #17364, since commit 8401755f1428fd6526bf7a1c102e1135873a6b40, users of the Lua2 backend must declare the `lua-global-include-dir` configuration setting.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
