### PR TITLE
Correctly display APL DNS records with IPv4 addresses ending in .0

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -774,12 +774,15 @@ string APLRecordContent::getZoneRepresentation(bool /* noDot */) const {
     if (ard->d_family == APL_FAMILY_IPV4) { // IPv4
       s_family = std::to_string(APL_FAMILY_IPV4);
       ca = ComboAddress();
-      memcpy(&ca.sin4.sin_addr.s_addr, ard->d_ip.d_ip4, sizeof(ca.sin4.sin_addr.s_addr));
+      memset(&ca.sin4.sin_addr.s_addr, 0, sizeof(ca.sin4.sin_addr.s_addr));
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      memcpy(&ca.sin4.sin_addr.s_addr, ard->d_ip.d_ip4, ard->d_afdlength);
     } else if (ard->d_family == APL_FAMILY_IPV6) { // IPv6
       s_family = std::to_string(APL_FAMILY_IPV6);
       ca = ComboAddress();
       ca.sin4.sin_family = AF_INET6;
       memset(&ca.sin6.sin6_addr.s6_addr, 0, sizeof(ca.sin6.sin6_addr.s6_addr));
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       memcpy(&ca.sin6.sin6_addr.s6_addr, ard->d_ip.d_ip6, ard->d_afdlength);
     } else {
       throw MOADNSException("Asked to decode APL record but got unknown Address Family");


### PR DESCRIPTION
### Short description
APL records do not include trailing zero bytes, and we compute the "AFDPART" accordingly. However, when computing a text representation of the record, the IPv4 code boldly assumes AFDPART is zero and all four bytes of the IPv4 address have been initialized.
This PR applies the same logic as for IPv6, making sure to only use known-to-be-valid bytes to form the address.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
