### PR TITLE
dnsdist: Fix a crash when OpenTelemetry tracing is enabled

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lbpolicies.hh
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.hh
@@ -24,6 +24,7 @@
 #include <memory>
 #include <optional>
 #include <vector>
+#include <stdexcept>
 
 struct dnsdist_ffi_servers_list_t;
 struct dnsdist_ffi_server_t;
@@ -87,6 +88,9 @@ public:
 
     DownstreamState* operator->() const
     {
+      if (!d_selected.has_value()) {
+        throw std::runtime_error("Trying to access an invalid SelectedBackend");
+      }
       return (*d_backends)[*d_selected].second.get();
     }
 

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1498,7 +1498,7 @@ static ServerPolicy::SelectedBackend selectBackendForOutgoingQuery(DNSQuestion& 
   const auto& servers = serverPool.getServers();
   auto selectedBackend = policy.getSelectedBackend(servers, dnsQuestion);
 
-  if (closer) {
+  if (closer && selectedBackend) {
     closer->setAttribute("backend.name", AnyValue{selectedBackend->getNameWithAddr()});
     closer->setAttribute("backend.id", AnyValue{boost::uuids::to_string(selectedBackend->getID())});
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported by `ylwango613`, many thanks:
"When the operator enables OpenTelemetry tracing (the documented, supported features setOpenTelemetryTracing(true) plus SetTraceAction(true)), every incoming query passes through selectBackendForOutgoingQuery() in pdns/dnsdistdist/dnsdist.cc.

That function unconditionally dereferences the SelectedBackend returned by the load balancing policy in order to attach backend.name and backend.id attributes to the trace span. It does so without first checking that a backend was actually selected. When no backend is available (empty pool, all backends down, or a Lua policy returned std::nullopt), the SelectedBackend wraps an empty std::optional<unsigned int>, and SelectedBackend::operator->() evaluates *d_selected on a disengaged optional. This is undefined behavior, and in practice it terminates the dnsdist process either via a _GLIBCXX_ASSERTIONS abort or via a segmentation fault on a release build."

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
