### PR TITLE
dnsdist-2.1: Backport 17369 - Fix a crash when OpenTelemetry tracing is enabled

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lbpolicies.hh
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.hh
@@ -24,6 +24,7 @@
 #include <memory>
 #include <optional>
 #include <vector>
+#include <stdexcept>
 
 struct dnsdist_ffi_servers_list_t;
 struct dnsdist_ffi_server_t;
@@ -87,6 +88,9 @@ public:
 
     DownstreamState* operator->() const
     {
+      if (!d_selected.has_value()) {
+        throw std::runtime_error("Trying to access an invalid SelectedBackend");
+      }
       return (*d_backends)[*d_selected].second.get();
     }
 

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1490,7 +1490,7 @@ static ServerPolicy::SelectedBackend selectBackendForOutgoingQuery(DNSQuestion& 
   const auto& servers = serverPool.getServers();
   auto selectedBackend = policy.getSelectedBackend(servers, dnsQuestion);
 
-  if (closer) {
+  if (closer && selectedBackend) {
     closer->setAttribute("backend.name", AnyValue{selectedBackend->getNameWithAddr()});
     closer->setAttribute("backend.id", AnyValue{boost::uuids::to_string(selectedBackend->getID())});
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17369 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
