### PR TITLE
ci: Error when clang tidy fails

### DIFF
--- a/.github/scripts/clang-tidy-diff.py
+++ b/.github/scripts/clang-tidy-diff.py
@@ -51,7 +51,7 @@ else:
     import queue as queue
 
 
-def run_tidy(task_queue, lock, timeout):
+def run_tidy(task_queue, lock, timeout, failed_files):
     watchdog = None
     while True:
         command = task_queue.get()
@@ -63,6 +63,14 @@ def run_tidy(task_queue, lock, timeout):
                 watchdog.start()
 
             stdout, stderr = proc.communicate()
+            if proc.returncode != 0:
+                if proc.returncode < 0:
+                    msg = "Terminated by signal %d : %s\n" % (
+                        -proc.returncode,
+                        " ".join(command),
+                    )
+                    stderr += msg.encode("utf-8")
+                failed_files.append(command)
 
             with lock:
                 sys.stdout.write(stdout.decode("utf-8") + "\n")
@@ -82,9 +90,9 @@ def run_tidy(task_queue, lock, timeout):
             task_queue.task_done()
 
 
-def start_workers(max_tasks, tidy_caller, task_queue, lock, timeout):
+def start_workers(max_tasks, tidy_caller, arguments):
     for _ in range(max_tasks):
-        t = threading.Thread(target=tidy_caller, args=(task_queue, lock, timeout))
+        t = threading.Thread(target=tidy_caller, args=arguments)
         t.daemon = True
         t.start()
 
@@ -219,8 +227,12 @@ def main():
     # A lock for console output.
     lock = threading.Lock()
 
+     # List of files with a non-zero return code.
+    failed_files = []
     # Run a pool of clang-tidy workers.
-    start_workers(max_task_count, run_tidy, task_queue, lock, args.timeout)
+    start_workers(
+        max_task_count, run_tidy, (task_queue, lock, args.timeout, failed_files)
+    )
 
     # Form the common args list.
     common_clang_tidy_args = []
@@ -263,8 +275,12 @@ def main():
 
         task_queue.put(command)
 
+    # Application return code
+    return_code = 0
     # Wait for all threads to be done.
     task_queue.join()
+    if failed_files:
+        return_code = 1
 
     if yaml and args.export_fixes:
         print("Writing fixes to " + args.export_fixes + " ...")
@@ -273,10 +289,11 @@ def main():
         except Exception:
             sys.stderr.write("Error exporting fixes.\n")
             traceback.print_exc()
+            return_code = 1
 
     if tmpdir:
         shutil.rmtree(tmpdir)
-
+    sys.exit(return_code)
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/clang-tidy-diff.py
+++ b/.github/scripts/clang-tidy-diff.py
@@ -227,12 +227,10 @@ def main():
     # A lock for console output.
     lock = threading.Lock()
 
-     # List of files with a non-zero return code.
+    # List of files with a non-zero return code.
     failed_files = []
     # Run a pool of clang-tidy workers.
-    start_workers(
-        max_task_count, run_tidy, (task_queue, lock, args.timeout, failed_files)
-    )
+    start_workers(max_task_count, run_tidy, (task_queue, lock, args.timeout, failed_files))
 
     # Form the common args list.
     common_clang_tidy_args = []
@@ -294,6 +292,7 @@ def main():
     if tmpdir:
         shutil.rmtree(tmpdir)
     sys.exit(return_code)
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/helpers.py
+++ b/.github/scripts/helpers.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 
 import git
 import yaml
@@ -43,6 +44,6 @@ def index_compdb(file_contents):
     """Index the compilation database."""
     result = set()
     for item in file_contents:
-        filename = os.path.join(item["directory"], item["file"])
+        filename = os.path.normpath(os.path.join(item["directory"], item["file"]))
         result.add(filename)
     return result


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR makes the clang-tidy step fail when `clang-tidy` failed to execute properly, for example if the configuration is broken, or at least one modified C/C++ file is invalid enough (meaning compilation would have failed in the other steps anyway). This will hopefully prevent a silent failure from `clang-tidy` from occurring again because of a configuration file becoming invalid after an upgrade in the future.

I added a second commit that normalizes the path to the compilation database, properly dealing with any `..` components that are common when building with `meson`, for example. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
