### PR TITLE
dnsdist: Fix XSK configuration via YAML

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1214,7 +1214,7 @@ bool loadConfigurationFromFile(const std::string& fileName, [[maybe_unused]] boo
 
 #if defined(HAVE_XSK)
     for (const auto& xskEntry : globalConfig.xsk) {
-      auto map = std::shared_ptr<XSKMap>();
+      auto map = std::make_shared<XSKMap>();
       for (size_t counter = 0; counter < xskEntry.queues; ++counter) {
         auto socket = std::make_shared<XskSocket>(xskEntry.frames, std::string(xskEntry.interface), counter, std::string(xskEntry.map_path));
         dnsdist::xsk::g_xsk.push_back(socket);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The XSK map was not properly allocated, triggering a crash when trying to load a YAML configuration file with XSK support.

I tried adding a regression test but this is not easy: even with sudo mode (required to create the `umem` object) creating the BPF map is not trivial. I'll do a follow-up PR later.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
