### PR TITLE
auth: once again, relax JSON normalization code for record contents

### DIFF
--- a/pdns/dnslabeltext.rl
+++ b/pdns/dnslabeltext.rl
@@ -241,6 +241,76 @@ size_t parseRFC1035CharString(std::string_view in, std::string &val) {
   return counter;
 }
 
+// Similar to above, but allows ( ) ; within quoted parts.
+size_t parseRFC1035CharStringRelaxed(std::string_view in, std::string &val) {
+
+  val.clear();
+  val.reserve(in.size());
+  const char *p = in.data();
+  const char *pe = p + in.size();
+  int cs = 0;
+  uint8_t escaped_octet = 0;
+  // Keeps track of how many chars we read from the source string
+  size_t counter=0;
+
+/* This parses an RFC 1035 char-string, but allows ( ) and ; to occur in
+ * quoted parts.
+ */
+%%{
+  machine dns_text_to_string_r;
+
+  action doEscapedNumber {
+    escaped_octet *= 10;
+    escaped_octet += fc-'0';
+    counter++;
+  }
+
+  action doneEscapedNumber {
+    val += escaped_octet;
+    escaped_octet = 0;
+  }
+
+  action addToVal {
+    val += fc;
+    counter++;
+  }
+
+  action incrementCounter {
+    counter++;
+  }
+
+  # generated rules, define required actions
+  DIGIT = 0x30..0x39;
+  DQUOTE = "\"";
+  HTAB = "\t";
+  SP = " ";
+  WSP = (SP | HTAB)@addToVal;
+  non_special = "!" | 0x23..0x27 | 0x2a..0x3a | 0x3c..0x5b | 0x5d..0x7e;
+  special = 0x28..0x29 | 0x3b;
+  non_digit = 0x21..0x2f | 0x3a..0x7e;
+  dec_octet = ( ( "0" | "1" ) DIGIT{2} ) | ( "2" ( ( 0x30..0x34 DIGIT ) | ( "5" 0x30..0x35 ) ) );
+  escaped = '\\'@incrementCounter ( non_digit$addToVal | dec_octet$doEscapedNumber@doneEscapedNumber );
+  contiguous = ( non_special$addToVal | escaped )+;
+  # rules differ from parseRFC1035CharString starting from here
+  quotedcontiguous = ( non_special$addToVal | special$addToVal | escaped )+;
+  quoted = DQUOTE@incrementCounter ( quotedcontiguous | ( '\\'? WSP ) )* DQUOTE@incrementCounter;
+  char_string = (contiguous | quoted);
+
+  # instantiate machine rules
+  main := char_string;
+  write data;
+  write init;
+}%%
+
+  // silence warnings
+  (void) dns_text_to_string_r_first_final;
+  (void) dns_text_to_string_r_error;
+  (void) dns_text_to_string_r_en_main;
+  %% write exec;
+
+  return counter;
+}
+
 size_t parseSVCBValueListFromParsedRFC1035CharString(const std::string &in, std::vector<std::string> &val) {
   val.clear();
   const char *p = in.c_str();

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -835,10 +835,12 @@ std::vector<ComboAddress> getResolvers(const std::string& resolvConfPath);
 
 DNSName reverseNameFromIP(const ComboAddress& ip);
 
-// The following two routines are generated from Ragel code.
+// The following three routines are generated from Ragel code.
 // Note that parseRFC1035CharString will return zero if the first character
 // being processed is < 0x20, >= 07f, or equal to 0x28, 0x29 or 0x3b.
+// parseRFC1035CharStringRelaxed will too, except within a quoted section.
 size_t parseRFC1035CharString(std::string_view in, std::string &val);
+size_t parseRFC1035CharStringRelaxed(std::string_view in, std::string &val);
 size_t parseSVCBValueListFromParsedRFC1035CharString(const std::string &in, vector<std::string> &val);
 size_t parseSVCBValueList(const std::string &in, vector<std::string> &val);
 

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -297,6 +297,96 @@ BOOST_AUTO_TEST_CASE(test_parseRFC1035CharString)
   BOOST_CHECK_EQUAL(out, expected);
 }
 
+BOOST_AUTO_TEST_CASE(test_parseRFC1035CharStringRelaxed)
+{
+  string in;
+  string out;
+  string expected;
+  size_t amount;
+
+  // Same tests as for parseRFC1035CharString
+
+  in = "foobar123";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, "foobar123");
+
+  in = "foobar123\\,bazquux456";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, "foobar123,bazquux456");
+
+  in = string("\"")+string(16262, 'A')+string("\"");
+  expected = string(16262, 'A');
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, expected);
+
+  in = "hello\\044world\\002";
+  expected = "hello,world\x02";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, expected);
+
+  in = "\"hello\\044world\"";
+  expected = "hello,world";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, expected);
+
+  // Here we'll only read until the space
+  in = "hello world";
+  expected = "hello";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, 5U);
+  BOOST_CHECK_EQUAL(out, expected);
+
+  // \032 is a space, but it is read because it is escaped
+  in = "hello\\032world";
+  expected = "hello world";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, expected);
+
+  in = "\"hello\\032world\"";
+  expected = "hello world";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, expected);
+
+  in = "\"hello\\032world XXXX\"";
+  expected = "hello world XXXX";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, expected);
+
+  // From draft-ietf-dnsop-svcb-https-03
+  expected = R"FOO(part1,part2,part3\,part4\\)FOO";
+  in = R"FOO("part1,part2,part3\\,part4\\\\)FOO";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, expected);
+
+  in = R"FOO(part1\,\p\a\r\t2\044part3\092,part4\092\\)FOO";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, expected);
+
+  // Specific checks for ( ) ;
+
+  in = "\"();etc\"";
+  expected = "();etc";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, in.size());
+  BOOST_CHECK_EQUAL(out, expected);
+
+  in = ";login";
+  expected = "";
+  amount = parseRFC1035CharStringRelaxed(in, out);
+  BOOST_CHECK_EQUAL(amount, 0);
+  BOOST_CHECK_EQUAL(out, expected);
+}
+
 BOOST_AUTO_TEST_CASE(test_parseSVCBValueList)
 {
   vector<string> out;

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -299,10 +299,10 @@ BOOST_AUTO_TEST_CASE(test_parseRFC1035CharString)
 
 BOOST_AUTO_TEST_CASE(test_parseRFC1035CharStringRelaxed)
 {
-  string in;
+  string in; // NOLINT(readability-identifier-length)
   string out;
   string expected;
-  size_t amount;
+  size_t amount{0};
 
   // Same tests as for parseRFC1035CharString
 
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(test_parseRFC1035CharStringRelaxed)
   BOOST_CHECK_EQUAL(amount, in.size());
   BOOST_CHECK_EQUAL(out, expected);
 
-  in = "\"hello\\044world\"";
+  in = R"("hello\044world")";
   expected = "hello,world";
   amount = parseRFC1035CharStringRelaxed(in, out);
   BOOST_CHECK_EQUAL(amount, in.size());
@@ -348,13 +348,13 @@ BOOST_AUTO_TEST_CASE(test_parseRFC1035CharStringRelaxed)
   BOOST_CHECK_EQUAL(amount, in.size());
   BOOST_CHECK_EQUAL(out, expected);
 
-  in = "\"hello\\032world\"";
+  in = R"("hello\032world")";
   expected = "hello world";
   amount = parseRFC1035CharStringRelaxed(in, out);
   BOOST_CHECK_EQUAL(amount, in.size());
   BOOST_CHECK_EQUAL(out, expected);
 
-  in = "\"hello\\032world XXXX\"";
+  in = R"("hello\032world XXXX")";
   expected = "hello world XXXX";
   amount = parseRFC1035CharStringRelaxed(in, out);
   BOOST_CHECK_EQUAL(amount, in.size());

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -662,9 +662,9 @@ static std::string normalizeJsonString(const std::string& jsonContent)
     std::string chunk;
     // Preserve quotes in the result if the chunk is quoted.
     bool quote = input[pos] == '"';
-    auto chunksize = parseRFC1035CharString(input.substr(pos), chunk);
+    auto chunksize = parseRFC1035CharStringRelaxed(input.substr(pos), chunk);
     if (chunksize == 0) {
-      // Found one of (  ) ; \x7f
+      // Found one of (  ) ; (non-quoted) or a non-printable character
       if (input[pos] < ' ' || input[pos] >= 0x7f) {
         std::stringstream hexstr;
         hexstr << std::hex << static_cast<unsigned char>(input[pos]);

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1605,6 +1605,30 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.assertEqual(r.status_code, 422)
         self.assertIn("Not in expected format (parsed as", r.json()["error"])
 
+    def test_zone_rr_update_with_semicolon(self):
+        name, payload, zone = self.create_zone()
+        # do a replace (= update)
+        recname = "well-formed-txt." + name
+        content = '"v=DMARC1; p=none"'
+        rrset = {
+            "changetype": "replace",
+            "name": recname,
+            "type": "txt",
+            "ttl": 3600,
+            "records": [{"content": content, "disabled": False}],
+        }
+        payload = {"rrsets": [rrset]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+        self.assert_success(r)
+        # verify that the new record has been correctly processed and the \000
+        # escape is unchanged
+        data = self.get_zone(name)
+        self.assertEqual(get_rrset(data, recname, "TXT")["records"][0]["content"], content)
+
     def test_zone_rr_update_with_escapes(self):
         name, payload, zone = self.create_zone()
         # do a replace (= update)


### PR DESCRIPTION
### Short description
As mentioned in #17368, the recent addition of normalization for the RRset contents fed through the API will reject semicolons in valid `TXT` records.

This PR replaces the use of `parseRFC1035CharString` in this code path with a slightly different `parseRFC1035CharStringRelaxed`. The only difference between these routines is that the relaxed form will now accept `(` `)` and `;`, if they occur within a `"`-quoted part.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [X] added or modified unit test(s)
