### PR TITLE
dnsdist: Fix outgoing TLS session cache cleanup

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -420,6 +420,7 @@ testrunner_SOURCES = \
 	test-dnsdist-ipcrypt2_cc.cc \
 	test-dnsdist-lua-ffi.cc \
 	test-dnsdist-opentelemetry_cc.cc \
+	test-dnsdist-session-cache.cc \
 	test-dnsdist-xsk.cc \
 	test-dnsdist_cc.cc \
 	test-dnsdistasync.cc \

--- a/pdns/dnsdistdist/dnsdist-session-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-session-cache.cc
@@ -50,6 +50,10 @@ void TLSSessionCache::putSessions(const boost::uuids::uuid& backendID, time_t no
   }
 
   const auto& runtimeConfig = dnsdist::configuration::getCurrentRuntimeConfiguration();
+  if (runtimeConfig.d_tlsSessionCacheMaxSessionsPerBackend == 0) {
+    return;
+  }
+
   for (auto& session : sessions) {
     auto& entry = data->d_sessions[backendID];
     if (entry.d_sessions.size() >= runtimeConfig.d_tlsSessionCacheMaxSessionsPerBackend) {

--- a/pdns/dnsdistdist/dnsdist-session-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-session-cache.cc
@@ -31,7 +31,7 @@ void TLSSessionCache::cleanup(time_t now, LockGuardedHolder<TLSSessionCache::Cac
   time_t cutOff = now - runtimeConfig.d_tlsSessionCacheSessionValidity;
 
   for (auto it = data->d_sessions.begin(); it != data->d_sessions.end();) {
-    if (it->second.d_lastUsed < cutOff || it->second.d_sessions.size() == 0) {
+    if (it->second.d_lastUsed < cutOff || it->second.d_sessions.empty()) {
       it = data->d_sessions.erase(it);
     }
     else {

--- a/pdns/dnsdistdist/dnsdist-session-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-session-cache.cc
@@ -28,10 +28,10 @@ TLSSessionCache g_sessionCache;
 void TLSSessionCache::cleanup(time_t now, LockGuardedHolder<TLSSessionCache::CacheData>& data)
 {
   const auto& runtimeConfig = dnsdist::configuration::getCurrentRuntimeConfiguration();
-  time_t cutOff = now + runtimeConfig.d_tlsSessionCacheSessionValidity;
+  time_t cutOff = now - runtimeConfig.d_tlsSessionCacheSessionValidity;
 
   for (auto it = data->d_sessions.begin(); it != data->d_sessions.end();) {
-    if (it->second.d_lastUsed > cutOff || it->second.d_sessions.size() == 0) {
+    if (it->second.d_lastUsed < cutOff || it->second.d_sessions.size() == 0) {
       it = data->d_sessions.erase(it);
     }
     else {

--- a/pdns/dnsdistdist/dnsdist-session-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-session-cache.hh
@@ -31,10 +31,6 @@
 class TLSSessionCache
 {
 public:
-  TLSSessionCache()
-  {
-  }
-
   void putSessions(const boost::uuids::uuid& backendID, time_t now, std::vector<std::unique_ptr<TLSSession>>&& sessions);
   std::unique_ptr<TLSSession> getSession(const boost::uuids::uuid& backendID, time_t now);
 

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -549,6 +549,7 @@ test_sources += files(
   src_dir / 'test-dnsdistrules_cc.cc',
   src_dir / 'test-dnsdistsvc_cc.cc',
   src_dir / 'test-dnsdistserverpool.cc',
+  src_dir / 'test-dnsdist-session-cache.cc',
   src_dir / 'test-dnsdisttcp_cc.cc',
   src_dir / 'test-dnsdist-xsk.cc',
   src_dir / 'test-dnsparser_cc.cc',

--- a/pdns/dnsdistdist/test-dnsdist-session-cache.cc
+++ b/pdns/dnsdistdist/test-dnsdist-session-cache.cc
@@ -1,0 +1,86 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include "dnsdist-session-cache.hh"
+#include "dnsdist-configuration.hh"
+
+class MockTLSSession : public TLSSession
+{
+public:
+  ~MockTLSSession() override = default;
+};
+
+BOOST_AUTO_TEST_SUITE(test_dnsdist_session_cache)
+
+BOOST_AUTO_TEST_CASE(test_No_Rate_Limiting)
+{
+  TLSSessionCache cache{};
+  const auto backendID1 = getUniqueID();
+  const auto backendID2 = getUniqueID();
+  auto now = time(nullptr);
+
+  BOOST_REQUIRE_EQUAL(cache.getSize(), 0U);
+
+  /* store one session */
+  std::vector<std::unique_ptr<TLSSession>> sessions;
+  sessions.push_back(std::make_unique<MockTLSSession>());
+  cache.putSessions(backendID1, now, std::move(sessions));
+  BOOST_REQUIRE_EQUAL(cache.getSize(), 1U);
+
+  /* we can retrieve it */
+  auto session = cache.getSession(backendID1, now);
+  BOOST_REQUIRE(session != nullptr);
+  BOOST_REQUIRE_EQUAL(cache.getSize(), 0U);
+
+  /* but only once */
+  session = cache.getSession(backendID1, now);
+  BOOST_REQUIRE(session == nullptr);
+  BOOST_REQUIRE_EQUAL(cache.getSize(), 0U);
+
+  /* add a new session */
+  sessions.clear();
+  sessions.push_back(std::make_unique<MockTLSSession>());
+  cache.putSessions(backendID1, now, std::move(sessions));
+  BOOST_REQUIRE_EQUAL(cache.getSize(), 1U);
+
+  /* wait until the session expires */
+  const auto& runtimeConfig = dnsdist::configuration::getCurrentRuntimeConfiguration();
+  now += std::max(runtimeConfig.d_tlsSessionCacheSessionValidity, runtimeConfig.d_tlsSessionCacheCleanupDelay) + 1;
+
+  /* trigger cache cleaning by inserting a session for a different backend */
+  sessions.clear();
+  sessions.push_back(std::make_unique<MockTLSSession>());
+  cache.putSessions(backendID2, now, std::move(sessions));
+  BOOST_REQUIRE_EQUAL(cache.getSize(), 1U);
+
+  session = cache.getSession(backendID1, now);
+  BOOST_REQUIRE(session == nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The logic to compute the cut off time was wrong, leading to outgoing TLS resumption tickets to not be properly cleaned up.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
