### PR TITLE
dnsdist: Fix OPT rdlen computation when adding ECS

### DIFF
--- a/pdns/dnsdistdist/dnsdist-ecs.cc
+++ b/pdns/dnsdistdist/dnsdist-ecs.cc
@@ -520,7 +520,11 @@ static bool addECSToExistingOPT(PacketBuffer& packet, size_t maximumSize, const 
     return false;
   }
 
-  uint16_t newRDLen = oldRDLen + newECSOption.size();
+  const uint32_t computedRDLen = static_cast<uint32_t>(oldRDLen) + newECSOption.size();
+  if (computedRDLen > std::numeric_limits<uint16_t>::max()) {
+    return false;
+  }
+  const auto newRDLen = static_cast<uint16_t>(computedRDLen);
   packet.at(optRDLenPosition) = newRDLen / 256;
   packet.at(optRDLenPosition + 1) = newRDLen % 256;
 
@@ -610,6 +614,11 @@ bool handleEDNSClientSubnet(PacketBuffer& packet, const size_t maximumSize, cons
     }
 
     return replaceEDNSClientSubnetOption(packet, maximumSize, optRDPosition + ecsOptionStartPosition, ecsOptionSize, optRDPosition, newECSOption);
+  }
+
+  if (res != ENOENT) {
+    /* something is wrong */
+    return false;
   }
 
   /* we have an EDNS OPT RR but no existing ECS option */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If an incoming query has a very large EDNS OPT rdata length, but not the corresponding bytes, the existing code could have wrapped around to a small value after adding ECS. We would then send an invalid OPT record with some trailing bytes. The query would have been discarded by the backend but that's not very nice, let's drop it early AND make sure we don't wrap around.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
