### PR TITLE
dnsdist: Fix a data race on concurrent CDB KVS lookups

### DIFF
--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -205,7 +205,7 @@ bool CDBKVStore::reload(const struct stat& st)
 {
   auto newCDB = std::make_unique<CDB>(d_fname);
   {
-    *(d_cdb.write_lock()) = std::move(newCDB);
+    *(d_cdb.lock()) = std::move(newCDB);
   }
   d_mtime = st.st_mtime;
   return true;
@@ -263,7 +263,7 @@ bool CDBKVStore::getValue(const std::string& key, std::string& value)
     }
 
     {
-      auto cdb = d_cdb.read_lock();
+      auto cdb = d_cdb.lock();
       if (*cdb && (*cdb)->findOne(key, value)) {
         return true;
       }
@@ -286,7 +286,7 @@ bool CDBKVStore::keyExists(const std::string& key)
     }
 
     {
-      auto cdb = d_cdb.read_lock();
+      auto cdb = d_cdb.lock();
       if (!*cdb) {
         return false;
       }

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -222,7 +222,7 @@ private:
   void refreshDBIfNeeded(time_t now);
   bool reload(const struct stat& st);
 
-  SharedLockGuarded<std::unique_ptr<CDB>> d_cdb{nullptr};
+  LockGuarded<std::unique_ptr<CDB>> d_cdb{nullptr};
   std::string d_fname;
   time_t d_mtime{0};
   time_t d_nextCheck{0};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Contrary to the assumption that was made by the existing author (me!), `tinycdb` structures are not safe to use concurrently from more than one thread, even for reading, as they hold data related to the current search (current position, mostly).
This will have a performance impact for heavy users of the CDB KVS store, so perhaps a follow-up PR might be needed to have a per-thread CDB instance instead.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
