### PR TITLE
dnsdist: add MMDB KV store

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -821,6 +821,7 @@ Mischan
 mjt
 mkuchar
 mmdb
+MMDBKV
 mnordhoff
 MOADNS
 Modderman

--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -19,6 +19,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#include "dnsdist-lua-types.hh"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -19,7 +19,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include "dnsdist-lua-types.hh"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -31,6 +30,7 @@
 #include "dnsdist-configuration.hh"
 #include "dnsdist-frontend.hh"
 #include "dnsdist-metrics.hh"
+#include "dnsdist-lua-types.hh"
 
 #ifndef DISABLE_CARBON
 #include "dolog.hh"

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -47,7 +47,9 @@
 #include "dnsdist-xsk.hh"
 #include "fstrm_logger.hh"
 #include "iputils.hh"
+#ifdef HAVE_MMDB
 #include "mmdb.hh"
+#endif
 #include "remote_logger.hh"
 #include "remote_logger_pool.hh"
 #include "xsk.hh"

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -47,9 +47,7 @@
 #include "dnsdist-xsk.hh"
 #include "fstrm_logger.hh"
 #include "iputils.hh"
-#ifdef HAVE_MMDB
 #include "mmdb.hh"
-#endif
 #include "remote_logger.hh"
 #include "remote_logger_pool.hh"
 #include "xsk.hh"
@@ -75,12 +73,7 @@ struct Context
 
 using XSKMap = std::vector<std::shared_ptr<XskSocket>>;
 
-using RegisteredTypes = std::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<dnsdist::rust::settings::DNSSelector>, std::shared_ptr<dnsdist::rust::settings::DNSActionWrapper>, std::shared_ptr<dnsdist::rust::settings::DNSResponseActionWrapper>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>
-#ifdef HAVE_MMDB
-                                     ,
-                                     std::shared_ptr<MMDB>
-#endif
-                                     >;
+using RegisteredTypes = std::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<dnsdist::rust::settings::DNSSelector>, std::shared_ptr<dnsdist::rust::settings::DNSActionWrapper>, std::shared_ptr<dnsdist::rust::settings::DNSResponseActionWrapper>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>, std::shared_ptr<MMDB>>;
 static LockGuarded<std::unordered_map<std::string, RegisteredTypes>> s_registeredTypesMap;
 static std::atomic<bool> s_inConfigCheckMode;
 static std::atomic<bool> s_inClientMode;
@@ -1403,12 +1396,7 @@ bool loadConfigurationFromFile(const std::string& fileName, [[maybe_unused]] boo
 void addLuaBindingsForYAMLObjects([[maybe_unused]] LuaContext& luaCtx)
 {
 #if defined(HAVE_YAML_CONFIGURATION)
-  using ReturnValue = std::optional<boost::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction>, std::shared_ptr<DNSResponseAction>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>
-#ifdef HAVE_MMDB
-                                                   ,
-                                                   std::shared_ptr<MMDB>
-#endif
-                                                   >>;
+  using ReturnValue = std::optional<boost::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction>, std::shared_ptr<DNSResponseAction>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>, std::shared_ptr<MMDB>>>;
 
   luaCtx.writeFunction("getObjectFromYAMLConfiguration", [](const std::string& name) -> ReturnValue {
     auto map = s_registeredTypesMap.lock();

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -2039,9 +2039,9 @@ void registerKVSObjects([[maybe_unused]] const KeyValueStoresConfiguration& conf
     else {
       std::vector<std::pair<int, std::string>> params;
       params.reserve(mmdb.query_params.size());
-      int i = 1;
+      int idx = 1;
       for (const auto& param : mmdb.query_params) {
-        params.emplace_back(i++, param);
+        params.emplace_back(idx++, param);
       }
       queryParams = params;
     }

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -28,6 +28,7 @@
 #include "dnsdist-configuration.hh"
 #include "logging.hh"
 #include "logr.hh"
+#include "mmdb.hh"
 
 #if defined(HAVE_YAML_CONFIGURATION)
 #include "base64.hh"
@@ -71,7 +72,12 @@ struct Context
 
 using XSKMap = std::vector<std::shared_ptr<XskSocket>>;
 
-using RegisteredTypes = std::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<dnsdist::rust::settings::DNSSelector>, std::shared_ptr<dnsdist::rust::settings::DNSActionWrapper>, std::shared_ptr<dnsdist::rust::settings::DNSResponseActionWrapper>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>>;
+using RegisteredTypes = std::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<dnsdist::rust::settings::DNSSelector>, std::shared_ptr<dnsdist::rust::settings::DNSActionWrapper>, std::shared_ptr<dnsdist::rust::settings::DNSResponseActionWrapper>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>
+#ifdef HAVE_MMDB
+                                     ,
+                                     std::shared_ptr<MMDB>
+#endif
+                                     >;
 static LockGuarded<std::unordered_map<std::string, RegisteredTypes>> s_registeredTypesMap;
 static std::atomic<bool> s_inConfigCheckMode;
 static std::atomic<bool> s_inClientMode;
@@ -1394,7 +1400,12 @@ bool loadConfigurationFromFile(const std::string& fileName, [[maybe_unused]] boo
 void addLuaBindingsForYAMLObjects([[maybe_unused]] LuaContext& luaCtx)
 {
 #if defined(HAVE_YAML_CONFIGURATION)
-  using ReturnValue = std::optional<boost::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction>, std::shared_ptr<DNSResponseAction>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>>>;
+  using ReturnValue = std::optional<boost::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction>, std::shared_ptr<DNSResponseAction>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>
+#ifdef HAVE_MMDB
+                                                   ,
+                                                   std::shared_ptr<MMDB>
+#endif
+                                                   >>;
 
   luaCtx.writeFunction("getObjectFromYAMLConfiguration", [](const std::string& name) -> ReturnValue {
     auto map = s_registeredTypesMap.lock();
@@ -1435,6 +1446,11 @@ void addLuaBindingsForYAMLObjects([[maybe_unused]] LuaContext& luaCtx)
     if (auto* ptr = std::get_if<std::shared_ptr<XSKMap>>(&item->second)) {
       return ReturnValue(*ptr);
     }
+#ifdef HAVE_MMDB
+    if (auto* ptr = std::get_if<std::shared_ptr<MMDB>>(&item->second)) {
+      return ReturnValue(*ptr);
+    }
+#endif
 
     return std::nullopt;
   });
@@ -1698,7 +1714,7 @@ std::shared_ptr<DNSSelector> getNetmaskGroupSelector(const NetmaskGroupSelectorC
 
 std::shared_ptr<DNSActionWrapper> getKeyValueStoreLookupAction([[maybe_unused]] const KeyValueStoreLookupActionConfiguration& config)
 {
-#if defined(HAVE_LMDB) || defined(HAVE_CDB)
+#if defined(HAVE_LMDB) || defined(HAVE_CDB) || defined(HAVE_MMDB)
   auto kvs = dnsdist::configuration::yaml::getRegisteredTypeByName<KeyValueStore>(std::string(config.kvs_name));
   if (!kvs && !(dnsdist::configuration::yaml::s_inClientMode || dnsdist::configuration::yaml::s_inConfigCheckMode)) {
     throw std::runtime_error("Unable to find the key-value store named '" + std::string(config.kvs_name) + "'");
@@ -1716,7 +1732,7 @@ std::shared_ptr<DNSActionWrapper> getKeyValueStoreLookupAction([[maybe_unused]] 
 
 std::shared_ptr<DNSActionWrapper> getKeyValueStoreRangeLookupAction([[maybe_unused]] const KeyValueStoreRangeLookupActionConfiguration& config)
 {
-#if defined(HAVE_LMDB) || defined(HAVE_CDB)
+#if defined(HAVE_LMDB) || defined(HAVE_CDB) || defined(HAVE_MMDB)
   auto kvs = dnsdist::configuration::yaml::getRegisteredTypeByName<KeyValueStore>(std::string(config.kvs_name));
   if (!kvs && !(dnsdist::configuration::yaml::s_inClientMode || dnsdist::configuration::yaml::s_inConfigCheckMode)) {
     throw std::runtime_error("Unable to find the key-value store named '" + std::string(config.kvs_name) + "'");
@@ -1734,7 +1750,7 @@ std::shared_ptr<DNSActionWrapper> getKeyValueStoreRangeLookupAction([[maybe_unus
 
 std::shared_ptr<DNSSelector> getKeyValueStoreLookupSelector([[maybe_unused]] const KeyValueStoreLookupSelectorConfiguration& config)
 {
-#if defined(HAVE_LMDB) || defined(HAVE_CDB)
+#if defined(HAVE_LMDB) || defined(HAVE_CDB) || defined(HAVE_MMDB)
   auto kvs = dnsdist::configuration::yaml::getRegisteredTypeByName<KeyValueStore>(std::string(config.kvs_name));
   if (!kvs && !(dnsdist::configuration::yaml::s_inClientMode || dnsdist::configuration::yaml::s_inConfigCheckMode)) {
     throw std::runtime_error("Unable to find the key-value store named '" + std::string(config.kvs_name) + "'");
@@ -1752,7 +1768,7 @@ std::shared_ptr<DNSSelector> getKeyValueStoreLookupSelector([[maybe_unused]] con
 
 std::shared_ptr<DNSSelector> getKeyValueStoreRangeLookupSelector([[maybe_unused]] const KeyValueStoreRangeLookupSelectorConfiguration& config)
 {
-#if defined(HAVE_LMDB) || defined(HAVE_CDB)
+#if defined(HAVE_LMDB) || defined(HAVE_CDB) || defined(HAVE_MMDB)
   auto kvs = dnsdist::configuration::yaml::getRegisteredTypeByName<KeyValueStore>(std::string(config.kvs_name));
   if (!kvs && !(dnsdist::configuration::yaml::s_inClientMode || dnsdist::configuration::yaml::s_inConfigCheckMode)) {
     throw std::runtime_error("Unable to find the key-value store named '" + std::string(config.kvs_name) + "'");
@@ -2005,7 +2021,7 @@ void registerDnstapLogger([[maybe_unused]] const DnstapLoggerConfiguration& conf
 
 void registerKVSObjects([[maybe_unused]] const KeyValueStoresConfiguration& config)
 {
-#if defined(HAVE_LMDB) || defined(HAVE_CDB)
+#if defined(HAVE_LMDB) || defined(HAVE_CDB) || defined(HAVE_MMDB)
   bool createObjects = !dnsdist::configuration::yaml::s_inClientMode && !dnsdist::configuration::yaml::s_inConfigCheckMode;
 #if defined(HAVE_LMDB)
   for (const auto& lmdb : config.lmdb) {
@@ -2019,6 +2035,29 @@ void registerKVSObjects([[maybe_unused]] const KeyValueStoresConfiguration& conf
     dnsdist::configuration::yaml::registerType<KeyValueStore>(store, cdb.name);
   }
 #endif /* defined(HAVE_CDB) */
+#if defined(HAVE_MMDB)
+  for (const auto& mmdb : config.mmdb) {
+    auto definedMmdb = dnsdist::configuration::yaml::getRegisteredTypeByName<MMDB>(mmdb.mmdb);
+    if (!definedMmdb) {
+      throw std::runtime_error("Unable to find a MMDB named " + std::string(mmdb.mmdb));
+    }
+    LuaTypeOrArrayOf<std::string> queryParams;
+    if (!mmdb.query_param.empty()) {
+      queryParams = std::string(mmdb.query_param);
+    }
+    else {
+      std::vector<std::pair<int, std::string>> params;
+      params.reserve(mmdb.query_params.size());
+      int i = 1;
+      for (const auto& param : mmdb.query_params) {
+        params.emplace_back(i++, param);
+      }
+      queryParams = params;
+    }
+    auto store = createObjects ? std::shared_ptr<KeyValueStore>(std::make_shared<MMDBKVStore>(definedMmdb, queryParams)) : std::shared_ptr<KeyValueStore>();
+    dnsdist::configuration::yaml::registerType<KeyValueStore>(store, mmdb.name);
+  }
+#endif /* defined(HAVE_MMDB) */
   for (const auto& key : config.lookup_keys.source_ip_keys) {
     auto lookup = createObjects ? std::shared_ptr<KeyValueLookupKey>(std::make_shared<KeyValueLookupKeySourceIP>(key.v4_mask, key.v6_mask, key.include_port)) : std::shared_ptr<KeyValueLookupKey>();
     dnsdist::configuration::yaml::registerType<KeyValueLookupKey>(lookup, key.name);
@@ -2035,7 +2074,16 @@ void registerKVSObjects([[maybe_unused]] const KeyValueStoresConfiguration& conf
     auto lookup = createObjects ? std::shared_ptr<KeyValueLookupKey>(std::make_shared<KeyValueLookupKeyTag>(std::string(key.tag))) : std::shared_ptr<KeyValueLookupKey>();
     dnsdist::configuration::yaml::registerType<KeyValueLookupKey>(lookup, key.name);
   }
-#endif /* defined(HAVE_LMDB) || defined(HAVE_CDB) */
+#endif /* defined(HAVE_LMDB) || defined(HAVE_CDB) || defined(HAVE_MMDB) */
+}
+
+void registerMMDBObjects([[maybe_unused]] const ::rust::Vec<MmdbConfiguration>& config)
+{
+#ifdef HAVE_MMDB
+  for (const auto& mmdb : config) {
+    dnsdist::configuration::yaml::registerType<MMDB>(std::make_shared<MMDB>(std::string(mmdb.file_name), mmdb.mmap ? "mmap" : ""), mmdb.name);
+  }
+#endif
 }
 
 void registerNMGObjects(const ::rust::Vec<NetmaskGroupConfiguration>& nmgs)

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -47,6 +47,7 @@
 #include "dnsdist-xsk.hh"
 #include "fstrm_logger.hh"
 #include "iputils.hh"
+#include "mmdb.hh"
 #include "remote_logger.hh"
 #include "remote_logger_pool.hh"
 #include "xsk.hh"

--- a/pdns/dnsdistdist/dnsdist-configuration.hh
+++ b/pdns/dnsdistdist/dnsdist-configuration.hh
@@ -32,6 +32,7 @@
 #include "credentials.hh"
 #include "dnsdist-actions.hh"
 #include "dnsdist-carbon.hh"
+#include "dnsdist-lua-types.hh"
 #include "dnsdist-query-count.hh"
 #include "dnsdist-rule-chains.hh"
 #include "dnsdist-server-pool.hh"

--- a/pdns/dnsdistdist/dnsdist-console-completion.cc
+++ b/pdns/dnsdistdist/dnsdist-console-completion.cc
@@ -186,6 +186,9 @@ static std::vector<dnsdist::console::completion::ConsoleKeyword> s_consoleKeywor
 #ifdef HAVE_LMDB
   {"newLMDBKVStore", true, "fname, dbName [, noLock]", "Return a new KeyValueStore object associated to the corresponding LMDB database"},
 #endif
+#ifdef HAVE_MMDB
+  {"newMMDBKVStore", true, "mmdb, queryParams", "Return a new KeyValueStore object associated to the corresponding MMDB database"},
+#endif
   {"newNMG", true, "", "Returns a NetmaskGroup"},
   {"newPacketCache", true, "maxEntries[, maxTTL=86400, minTTL=0, temporaryFailureTTL=60, staleTTL=60, dontAge=false, shuffle=false, numberOfShards=1, deferrableInsertLock=true, options={}]", "return a new Packet Cache"},
   {"newQPSLimiter", true, "rate, burst", "configure a QPS limiter with that rate and that burst capacity"},
@@ -199,6 +202,9 @@ static std::vector<dnsdist::console::completion::ConsoleKeyword> s_consoleKeywor
   {"NoneAction", true, "", "Does nothing. Subsequent rules are processed after this action"},
   {"NotRule", true, "selector", "Matches the traffic if the selector rule does not match"},
   {"OpcodeRule", true, "code", "Matches queries with opcode code. code can be directly specified as an integer, or one of the built-in DNSOpcodes"},
+#ifdef HAVE_MMDB
+  {"openMMDB", true, "name, [, options]", "Open a MMDB database and return a reference to it"},
+#endif
   {"OrRule", true, "selectors", "Matches the traffic if one or more of the selectors rules does match"},
   {"PoolAction", true, "poolname [, stop]", "set the packet into the specified pool"},
   {"PoolAvailableRule", true, "poolname", "Check whether a pool has any servers available to handle queries"},

--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -21,9 +21,12 @@
  */
 
 #include "dnsdist-kvs.hh"
+#include "dnsdist-lua-types.hh"
 #include "dolog.hh"
 
+#include <limits.h>
 #include <sys/stat.h>
+#include <boost/variant.hpp>
 
 std::vector<std::string> KeyValueLookupKeySourceIP::getKeys(const ComboAddress& addr)
 {
@@ -304,37 +307,87 @@ bool CDBKVStore::keyExists(const std::string& key)
 #endif /* HAVE_CDB */
 
 #ifdef HAVE_MMDB
+
+#include "ext/json11/json11.hpp"
+
+std::shared_ptr<const Logr::Logger> MMDBKVStore::getLogger() const
+{
+  return dnsdist::logging::getTopLogger("mmdb-key-value-store")->withValues("path", Logging::Loggable(d_mmdb->file_name()));
+}
+
+json11::Json MMDBKVStore::parseAny(const LuaAny& any)
+{
+  if (any.type() == typeid(std::string)) {
+    return json11::Json(boost::get<std::string>(any));
+  }
+  else if (any.type() == typeid(int64_t)) {
+    auto val = boost::get<int64_t>(any);
+    if (val > static_cast<int64_t>(INT_MAX) || val < static_cast<int64_t>(INT_MIN)) {
+      SLOG(warnlog("Error while retrieving a value from MMDB database: integer overflow. Returning null."),
+           getLogger()->error(Logr::Warning, "", "Error while retrieving a value from MMDB database: integer overflow. Returning null."));
+      return json11::Json();
+    }
+    else {
+      return json11::Json(static_cast<int>(val));
+    }
+  }
+  else if (any.type() == typeid(uint64_t)) {
+    auto val = boost::get<uint64_t>(any);
+    if (val > static_cast<uint64_t>(INT_MAX)) {
+      SLOG(warnlog("Error while retrieving a value from MMDB database: integer overflow. Returning null."),
+           getLogger()->error(Logr::Warning, "", "Error while retrieving a value from MMDB database: integer overflow. Returning null."));
+      return json11::Json();
+    }
+    else {
+      return json11::Json(static_cast<int>(val));
+    }
+  }
+  else if (any.type() == typeid(double)) {
+    return json11::Json(boost::get<double>(any));
+  }
+  else if (any.type() == typeid(bool)) {
+    return json11::Json(boost::get<bool>(any));
+  }
+  else if (any.type() == typeid(LuaArray<LuaAny>)) {
+    auto luaArray = boost::get<LuaArray<LuaAny>>(any);
+    std::vector<json11::Json> array;
+    array.reserve(luaArray.size());
+    for (auto& kv : luaArray) {
+      array.emplace_back(parseAny(kv.second));
+    }
+    return json11::Json(array);
+  }
+  else if (any.type() == typeid(LuaAssociativeTable<LuaAny>)) {
+    auto luaTable = boost::get<LuaAssociativeTable<LuaAny>>(any);
+    std::unordered_map<std::string, json11::Json> map(luaTable.size());
+    for (auto& kv : luaTable) {
+      map.emplace(kv.first, parseAny(kv.second));
+    }
+    return json11::Json(map);
+  }
+  else {
+    return json11::Json();
+  }
+}
+
 bool MMDBKVStore::keyExists(const std::string& key)
 {
   auto addr = makeComboAddressFromRaw(key.size() == sizeof(in_addr) ? 4 : 6, key);
   return d_mmdb->exists(addr);
 }
-
 bool MMDBKVStore::getValue(const std::string& key, std::string& value)
 {
-  auto address = makeComboAddressFromRaw(key.size() == sizeof(in_addr) ? 4 : 6, key);
-  if (d_field == "country") {
-    return d_mmdb->queryCountry(value, address);
+  auto addr = makeComboAddressFromRaw(key.size() == sizeof(in_addr) ? 4 : 6, key);
+  LuaAny ret;
+  bool result = d_mmdb->query(ret, d_queryParams, addr);
+  if (ret.type() == typeid(std::string)) {
+    value = boost::get<std::string>(ret);
+    return result;
   }
-  else if (d_field == "continent") {
-    return d_mmdb->queryContinent(value, address);
-  }
-  else if (d_field == "asn") {
-    return d_mmdb->queryAS(value, address);
-  }
-  else if (d_field == "asnum") {
-    return d_mmdb->queryASN(value, address);
-  }
-  else if (d_field == "city") {
-    return d_mmdb->queryCity(value, address, "en");
-  }
-  else {
-    return false;
-  }
-}
 
-bool MMDBKVStore::reload()
-{
-  return true;
+  json11::Json json = parseAny(ret);
+  json.dump(value);
+
+  return result;
 }
 #endif // HAVE_MMDB

--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -302,3 +302,39 @@ bool CDBKVStore::keyExists(const std::string& key)
 }
 
 #endif /* HAVE_CDB */
+
+#ifdef HAVE_MMDB
+bool MMDBKVStore::keyExists(const std::string& key)
+{
+  auto addr = makeComboAddressFromRaw(key.size() == sizeof(in_addr) ? 4 : 6, key);
+  return d_mmdb->exists(addr);
+}
+
+bool MMDBKVStore::getValue(const std::string& key, std::string& value)
+{
+  auto address = makeComboAddressFromRaw(key.size() == sizeof(in_addr) ? 4 : 6, key);
+  if (d_field == "country") {
+    return d_mmdb->queryCountry(value, address);
+  }
+  else if (d_field == "continent") {
+    return d_mmdb->queryContinent(value, address);
+  }
+  else if (d_field == "asn") {
+    return d_mmdb->queryAS(value, address);
+  }
+  else if (d_field == "asnum") {
+    return d_mmdb->queryASN(value, address);
+  }
+  else if (d_field == "city") {
+    return d_mmdb->queryCity(value, address, "en");
+  }
+  else {
+    return false;
+  }
+}
+
+bool MMDBKVStore::reload()
+{
+  return true;
+}
+#endif // HAVE_MMDB

--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -20,13 +20,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <climits>
+#include <sys/stat.h>
+
 #include "dnsdist-kvs.hh"
 #include "dnsdist-lua-types.hh"
 #include "dolog.hh"
-
-#include <limits.h>
-#include <sys/stat.h>
-#include <boost/variant.hpp>
 
 std::vector<std::string> KeyValueLookupKeySourceIP::getKeys(const ComboAddress& addr)
 {

--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -318,56 +318,50 @@ std::shared_ptr<const Logr::Logger> MMDBKVStore::getLogger() const
 json11::Json MMDBKVStore::parseAny(const LuaAny& any)
 {
   if (any.type() == typeid(std::string)) {
-    return json11::Json(boost::get<std::string>(any));
+    return boost::get<std::string>(any);
   }
-  else if (any.type() == typeid(int64_t)) {
+  if (any.type() == typeid(int64_t)) {
     auto val = boost::get<int64_t>(any);
     if (val > static_cast<int64_t>(INT_MAX) || val < static_cast<int64_t>(INT_MIN)) {
-      SLOG(warnlog("Error while retrieving a value from MMDB database: integer overflow. Returning null."),
-           getLogger()->error(Logr::Warning, "", "Error while retrieving a value from MMDB database: integer overflow. Returning null."));
-      return json11::Json();
+      VERBOSESLOG(warnlog("Error while retrieving a value from MMDB database: integer overflow. Returning null."),
+                  getLogger()->info(Logr::Warning, "Error while retrieving a value from MMDB database: integer overflow. Returning null."));
+      return {};
     }
-    else {
-      return json11::Json(static_cast<int>(val));
-    }
+    return static_cast<int>(val);
   }
-  else if (any.type() == typeid(uint64_t)) {
+  if (any.type() == typeid(uint64_t)) {
     auto val = boost::get<uint64_t>(any);
     if (val > static_cast<uint64_t>(INT_MAX)) {
-      SLOG(warnlog("Error while retrieving a value from MMDB database: integer overflow. Returning null."),
-           getLogger()->error(Logr::Warning, "", "Error while retrieving a value from MMDB database: integer overflow. Returning null."));
-      return json11::Json();
+      VERBOSESLOG(warnlog("Error while retrieving a value from MMDB database: integer overflow. Returning null."),
+                  getLogger()->info(Logr::Warning, "Error while retrieving a value from MMDB database: integer overflow. Returning null."));
+      return {};
     }
-    else {
-      return json11::Json(static_cast<int>(val));
-    }
+    return static_cast<int>(val);
   }
-  else if (any.type() == typeid(double)) {
-    return json11::Json(boost::get<double>(any));
+  if (any.type() == typeid(double)) {
+    return boost::get<double>(any);
   }
-  else if (any.type() == typeid(bool)) {
-    return json11::Json(boost::get<bool>(any));
+  if (any.type() == typeid(bool)) {
+    return boost::get<bool>(any);
   }
-  else if (any.type() == typeid(LuaArray<LuaAny>)) {
+  if (any.type() == typeid(LuaArray<LuaAny>)) {
     auto luaArray = boost::get<LuaArray<LuaAny>>(any);
     std::vector<json11::Json> array;
     array.reserve(luaArray.size());
-    for (auto& kv : luaArray) {
-      array.emplace_back(parseAny(kv.second));
+    for (auto& keyValue : luaArray) {
+      array.emplace_back(parseAny(keyValue.second));
     }
-    return json11::Json(array);
+    return array;
   }
-  else if (any.type() == typeid(LuaAssociativeTable<LuaAny>)) {
+  if (any.type() == typeid(LuaAssociativeTable<LuaAny>)) {
     auto luaTable = boost::get<LuaAssociativeTable<LuaAny>>(any);
     std::unordered_map<std::string, json11::Json> map(luaTable.size());
-    for (auto& kv : luaTable) {
-      map.emplace(kv.first, parseAny(kv.second));
+    for (auto& [key, value] : luaTable) {
+      map.emplace(key, parseAny(value));
     }
-    return json11::Json(map);
+    return map;
   }
-  else {
-    return json11::Json();
-  }
+  return {};
 }
 
 bool MMDBKVStore::keyExists(const std::string& key)

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -244,7 +244,7 @@ class MMDBKVStore : public KeyValueStore
 {
 public:
   MMDBKVStore(const std::shared_ptr<MMDB>& mmdb, const LuaTypeOrArrayOf<std::string>& queryParams) :
-    d_mmdb(mmdb), d_originalParams(queryParams), d_queryParams(MMDB::convertParams(d_originalParams)) {};
+    d_mmdb(mmdb), d_originalParams(queryParams), d_queryParams(MMDBQueryParams(d_originalParams)) {};
 
   bool keyExists(const std::string& key) override;
   bool getValue(const std::string& key, std::string& value) override;
@@ -259,6 +259,6 @@ private:
 
   std::shared_ptr<MMDB> d_mmdb;
   const LuaTypeOrArrayOf<std::string> d_originalParams;
-  const std::vector<const char*> d_queryParams;
+  const MMDBQueryParams d_queryParams;
 };
 #endif // HAVE_MMDB

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -237,6 +237,7 @@ private:
 
 #ifdef HAVE_MMDB
 
+#include <boost/variant.hpp>
 #include "mmdb.hh"
 
 class MMDBKVStore : public KeyValueStore

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -241,7 +241,6 @@ class MMDBKVStore : public KeyValueStore
 public:
   MMDBKVStore(const std::string& fname, const std::string& modeStr, const std::string& field) :
     d_mmdb(std::make_unique<MMDB>(fname, modeStr)), d_field(field) {}
-  ~MMDBKVStore();
 
   bool keyExists(const std::string& key) override;
   bool getValue(const std::string& key, std::string& value) override;

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -259,6 +259,6 @@ private:
 
   std::shared_ptr<MMDB> d_mmdb;
   const LuaTypeOrArrayOf<std::string> d_originalParams;
-  const boost::variant<const char*, std::vector<const char*>> d_queryParams;
+  const std::vector<const char*> d_queryParams;
 };
 #endif // HAVE_MMDB

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -242,7 +242,7 @@ private:
 class MMDBKVStore : public KeyValueStore
 {
 public:
-  MMDBKVStore(const std::shared_ptr<MMDB> mmdb, const LuaTypeOrArrayOf<std::string>& queryParams) :
+  MMDBKVStore(const std::shared_ptr<MMDB>& mmdb, const LuaTypeOrArrayOf<std::string>& queryParams) :
     d_mmdb(mmdb), d_originalParams(queryParams), d_queryParams(MMDB::convertParams(d_originalParams)) {};
 
   bool keyExists(const std::string& key) override;
@@ -253,11 +253,11 @@ public:
   }
 
 private:
-  std::shared_ptr<const Logr::Logger> getLogger() const;
+  [[nodiscard]] std::shared_ptr<const Logr::Logger> getLogger() const;
+  json11::Json parseAny(const LuaAny& any);
+
   std::shared_ptr<MMDB> d_mmdb;
   const LuaTypeOrArrayOf<std::string> d_originalParams;
   const boost::variant<const char*, std::vector<const char*>> d_queryParams;
-
-  json11::Json parseAny(const LuaAny& any);
 };
 #endif // HAVE_MMDB

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -231,3 +231,25 @@ private:
 };
 
 #endif /* HAVE_LMDB */
+
+#ifdef HAVE_MMDB
+
+#include "mmdb.hh"
+
+class MMDBKVStore : public KeyValueStore
+{
+public:
+  MMDBKVStore(const std::string& fname, const std::string& modeStr, const std::string& field) :
+    d_mmdb(std::make_unique<MMDB>(fname, modeStr)), d_field(field) {}
+  ~MMDBKVStore();
+
+  bool keyExists(const std::string& key) override;
+  bool getValue(const std::string& key, std::string& value) override;
+  bool reload() override;
+
+private:
+  std::unique_ptr<MMDB> d_mmdb{nullptr};
+  std::string d_field;
+};
+
+#endif // HAVE_MMDB

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -24,6 +24,9 @@
 #include <memory>
 #include "dnsdist.hh"
 #include "logr.hh"
+#include "dnsdist-lua-types.hh"
+#include "ext/json11/json11.hpp"
+#include "iputils.hh"
 
 class KeyValueLookupKey
 {
@@ -239,16 +242,22 @@ private:
 class MMDBKVStore : public KeyValueStore
 {
 public:
-  MMDBKVStore(const std::string& fname, const std::string& modeStr, const std::string& field) :
-    d_mmdb(std::make_unique<MMDB>(fname, modeStr)), d_field(field) {}
+  MMDBKVStore(const std::shared_ptr<MMDB> mmdb, const LuaTypeOrArrayOf<std::string>& queryParams) :
+    d_mmdb(mmdb), d_originalParams(queryParams), d_queryParams(MMDB::convertParams(d_originalParams)) {};
 
   bool keyExists(const std::string& key) override;
   bool getValue(const std::string& key, std::string& value) override;
-  bool reload() override;
+  bool reload() override
+  {
+    return true;
+  }
 
 private:
-  std::unique_ptr<MMDB> d_mmdb{nullptr};
-  std::string d_field;
-};
+  std::shared_ptr<const Logr::Logger> getLogger() const;
+  std::shared_ptr<MMDB> d_mmdb;
+  const LuaTypeOrArrayOf<std::string> d_originalParams;
+  const boost::variant<const char*, std::vector<const char*>> d_queryParams;
 
+  json11::Json parseAny(const LuaAny& any);
+};
 #endif // HAVE_MMDB

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-kvs.cc
@@ -44,13 +44,13 @@ void setupLuaBindingsKVS([[maybe_unused]] LuaContext& luaCtx, [[maybe_unused]] b
 #endif /* HAVE_CDB */
 
 #ifdef HAVE_MMDB
-  luaCtx.writeFunction("newMMDBKVStore", [client](const std::string& fname, const std::string& field, std::optional<bool> mmap) {
+  luaCtx.writeFunction("newMMDBKVStore", [client](const std::shared_ptr<MMDB>& mmdb, const LuaTypeOrArrayOf<std::string>& queryParams) {
     if (client) {
       return std::shared_ptr<KeyValueStore>(nullptr);
     }
-    return std::shared_ptr<KeyValueStore>(new MMDBKVStore(fname, mmap ? "mmap" : "", field));
+    return std::shared_ptr<KeyValueStore>(new MMDBKVStore(mmdb, queryParams));
   });
-#endif /* HAVE_MMDB */
+#endif // HAVE_MMDB
 
 #if defined(HAVE_LMDB) || defined(HAVE_CDB) || defined(HAVE_MMDB)
   /* Key Value Store objects */

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-kvs.cc
@@ -43,7 +43,16 @@ void setupLuaBindingsKVS([[maybe_unused]] LuaContext& luaCtx, [[maybe_unused]] b
   });
 #endif /* HAVE_CDB */
 
-#if defined(HAVE_LMDB) || defined(HAVE_CDB)
+#ifdef HAVE_MMDB
+  luaCtx.writeFunction("newMMDBKVStore", [client](const std::string& fname, const std::string& field, std::optional<bool> mmap) {
+    if (client) {
+      return std::shared_ptr<KeyValueStore>(nullptr);
+    }
+    return std::shared_ptr<KeyValueStore>(new MMDBKVStore(fname, mmap ? "mmap" : "", field));
+  });
+#endif /* HAVE_MMDB */
+
+#if defined(HAVE_LMDB) || defined(HAVE_CDB) || defined(HAVE_MMDB)
   /* Key Value Store objects */
   luaCtx.writeFunction("KeyValueLookupKeySourceIP", [](std::optional<uint8_t> v4Mask, std::optional<uint8_t> v6Mask, std::optional<bool> includePort) {
     return std::shared_ptr<KeyValueLookupKey>(new KeyValueLookupKeySourceIP(v4Mask ? *v4Mask : 32, v6Mask ? *v6Mask : 128, includePort ? *includePort : false));

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
@@ -19,6 +19,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#include "dnsdist-lua-types.hh"
 #include "dnsdist-lua.hh"
 #include "iputils.hh"
 #include <memory>
@@ -33,109 +34,33 @@ void setupLuaBindingsMMDB([[maybe_unused]] LuaContext& luaCtx)
     bool mmap{false};
     getOptionalValue<bool>(vars, "mmap", mmap);
 
-    auto mmdb = std::shared_ptr<MMDB>(new MMDB(name, mmap ? "mmap" : ""));
+    auto mmdb = std::make_shared<MMDB>(name, mmap ? "mmap" : "");
 
     return mmdb;
   });
 
-  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryCountry", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
-    std::optional<std::string> result{std::nullopt};
+  luaCtx.registerFunction<std::optional<LuaAny> (std::shared_ptr<MMDB>::*)(const LuaTypeOrArrayOf<std::string>&, const ComboAddress&)>("query", [](std::shared_ptr<MMDB>& mmdb, const LuaTypeOrArrayOf<std::string>& queryParams, const ComboAddress& ip) {
+    std::optional<LuaAny> result{std::nullopt};
     if (!mmdb) {
       return result;
     }
 
-    std::string value;
-    if (mmdb->queryCountry(value, ip)) {
+    LuaAny value{false};
+
+    if (mmdb->query(value, MMDB::convertParams(queryParams), ip)) {
       result = value;
     }
 
     return result;
   });
 
-  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryContinent", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
-    std::optional<std::string> result{std::nullopt};
+  luaCtx.registerFunction<bool (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("exists", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
+    bool result = false;
     if (!mmdb) {
       return result;
     }
 
-    std::string value;
-    if (mmdb->queryContinent(value, ip)) {
-      result = value;
-    }
-
-    return result;
-  });
-
-  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryAS", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
-    std::optional<std::string> result{std::nullopt};
-    if (!mmdb) {
-      return result;
-    }
-
-    std::string value;
-    if (mmdb->queryAS(value, ip)) {
-      result = value;
-    }
-
-    return result;
-  });
-
-  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryASN", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
-    std::optional<std::string> result{std::nullopt};
-    if (!mmdb) {
-      return result;
-    }
-
-    std::string value;
-    if (mmdb->queryASN(value, ip)) {
-      result = value;
-    }
-
-    return result;
-  });
-
-  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryRegion", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
-    std::optional<std::string> result{std::nullopt};
-    if (!mmdb) {
-      return result;
-    }
-
-    std::string value;
-    if (mmdb->queryRegion(value, ip)) {
-      result = value;
-    }
-
-    return result;
-  });
-
-  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&, const std::string&)>("queryCity", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip, const std::string& language) {
-    std::optional<std::string> result{std::nullopt};
-    if (!mmdb) {
-      return result;
-    }
-
-    std::string value;
-    if (mmdb->queryCity(value, ip, language)) {
-      result = value;
-    }
-
-    return result;
-  });
-
-  luaCtx.registerFunction<std::optional<std::tuple<double, double, int>> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryLocation", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
-    std::optional<std::tuple<double, double, int>> result{std::nullopt};
-    if (!mmdb) {
-      return result;
-    }
-
-    double lat;
-    double lon;
-    int prec;
-    if (mmdb->queryLocation(lat, lon, prec, ip)) {
-      result = {lat, lon, prec};
-    }
-
-    return result;
+    return mmdb->exists(ip);
   });
 #endif
 }

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
@@ -56,7 +56,7 @@ void setupLuaBindingsMMDB([[maybe_unused]] LuaContext& luaCtx)
       return result;
     }
 
-    if (mmdb->query(value, MMDB::convertParams(queryParams), queryIp)) {
+    if (mmdb->query(value, MMDBQueryParams(queryParams), queryIp)) {
       result = value;
     }
 

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
@@ -39,7 +39,7 @@ void setupLuaBindingsMMDB([[maybe_unused]] LuaContext& luaCtx)
     return mmdb;
   });
 
-  luaCtx.registerFunction<std::optional<LuaAny> (std::shared_ptr<MMDB>::*)(const LuaTypeOrArrayOf<std::string>&, const ComboAddress&)>("query", [](std::shared_ptr<MMDB>& mmdb, const LuaTypeOrArrayOf<std::string>& queryParams, const ComboAddress& ip) {
+  luaCtx.registerFunction<std::optional<LuaAny> (std::shared_ptr<MMDB>::*)(const LuaTypeOrArrayOf<std::string>&, const boost::variant<ComboAddress, std::string>)>("query", [](std::shared_ptr<MMDB>& mmdb, const LuaTypeOrArrayOf<std::string>& queryParams, const boost::variant<ComboAddress, std::string>& ip) {
     std::optional<LuaAny> result{std::nullopt};
     if (!mmdb) {
       return result;
@@ -47,20 +47,37 @@ void setupLuaBindingsMMDB([[maybe_unused]] LuaContext& luaCtx)
 
     LuaAny value{false};
 
-    if (mmdb->query(value, MMDB::convertParams(queryParams), ip)) {
+    ComboAddress queryIp;
+    if (const auto str = boost::get<std::string>(&ip)) {
+      queryIp = ComboAddress(*str);
+    }
+    else if (const auto addr = boost::get<ComboAddress>(&ip)) {
+      queryIp = *addr;
+    }
+    else {
+      return result;
+    }
+
+    if (mmdb->query(value, MMDB::convertParams(queryParams), queryIp)) {
       result = value;
     }
 
     return result;
   });
 
-  luaCtx.registerFunction<bool (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("exists", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
+  luaCtx.registerFunction<bool (std::shared_ptr<MMDB>::*)(const boost::variant<ComboAddress, std::string>)>("exists", [](std::shared_ptr<MMDB>& mmdb, const boost::variant<ComboAddress, std::string>& ip) {
     bool result = false;
     if (!mmdb) {
       return result;
     }
 
-    return mmdb->exists(ip);
+    if (const auto str = boost::get<std::string>(&ip)) {
+      return mmdb->exists(ComboAddress(*str));
+    }
+    else if (const auto addr = boost::get<ComboAddress>(&ip)) {
+      return mmdb->exists(*addr);
+    }
+    return false;
   });
 #endif
 }

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
@@ -23,9 +23,7 @@
 #include "dnsdist-lua.hh"
 #include "iputils.hh"
 #include <memory>
-#ifdef HAVE_MMDB
 #include "mmdb.hh"
-#endif
 
 void setupLuaBindingsMMDB([[maybe_unused]] LuaContext& luaCtx)
 {

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-mmdb.cc
@@ -1,0 +1,141 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "dnsdist-lua.hh"
+#include "iputils.hh"
+#include <memory>
+#ifdef HAVE_MMDB
+#include "mmdb.hh"
+#endif
+
+void setupLuaBindingsMMDB([[maybe_unused]] LuaContext& luaCtx)
+{
+#ifdef HAVE_MMDB
+  luaCtx.writeFunction("openMMDB", [](const std::string& name, std::optional<LuaAssociativeTable<boost::variant<bool>>> vars) {
+    bool mmap{false};
+    getOptionalValue<bool>(vars, "mmap", mmap);
+
+    auto mmdb = std::shared_ptr<MMDB>(new MMDB(name, mmap ? "mmap" : ""));
+
+    return mmdb;
+  });
+
+  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryCountry", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
+    std::optional<std::string> result{std::nullopt};
+    if (!mmdb) {
+      return result;
+    }
+
+    std::string value;
+    if (mmdb->queryCountry(value, ip)) {
+      result = value;
+    }
+
+    return result;
+  });
+
+  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryContinent", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
+    std::optional<std::string> result{std::nullopt};
+    if (!mmdb) {
+      return result;
+    }
+
+    std::string value;
+    if (mmdb->queryContinent(value, ip)) {
+      result = value;
+    }
+
+    return result;
+  });
+
+  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryAS", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
+    std::optional<std::string> result{std::nullopt};
+    if (!mmdb) {
+      return result;
+    }
+
+    std::string value;
+    if (mmdb->queryAS(value, ip)) {
+      result = value;
+    }
+
+    return result;
+  });
+
+  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryASN", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
+    std::optional<std::string> result{std::nullopt};
+    if (!mmdb) {
+      return result;
+    }
+
+    std::string value;
+    if (mmdb->queryASN(value, ip)) {
+      result = value;
+    }
+
+    return result;
+  });
+
+  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryRegion", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
+    std::optional<std::string> result{std::nullopt};
+    if (!mmdb) {
+      return result;
+    }
+
+    std::string value;
+    if (mmdb->queryRegion(value, ip)) {
+      result = value;
+    }
+
+    return result;
+  });
+
+  luaCtx.registerFunction<std::optional<std::string> (std::shared_ptr<MMDB>::*)(const ComboAddress&, const std::string&)>("queryCity", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip, const std::string& language) {
+    std::optional<std::string> result{std::nullopt};
+    if (!mmdb) {
+      return result;
+    }
+
+    std::string value;
+    if (mmdb->queryCity(value, ip, language)) {
+      result = value;
+    }
+
+    return result;
+  });
+
+  luaCtx.registerFunction<std::optional<std::tuple<double, double, int>> (std::shared_ptr<MMDB>::*)(const ComboAddress&)>("queryLocation", [](std::shared_ptr<MMDB>& mmdb, const ComboAddress& ip) {
+    std::optional<std::tuple<double, double, int>> result{std::nullopt};
+    if (!mmdb) {
+      return result;
+    }
+
+    double lat;
+    double lon;
+    int prec;
+    if (mmdb->queryLocation(lat, lon, prec, ip)) {
+      result = {lat, lon, prec};
+    }
+
+    return result;
+  });
+#endif
+}

--- a/pdns/dnsdistdist/dnsdist-lua-types.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-types.hh
@@ -1,0 +1,39 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <boost/any.hpp>
+#include <boost/variant/recursive_variant.hpp>
+#include <boost/variant/recursive_wrapper.hpp>
+#include <boost/variant/variant.hpp>
+#include <boost/variant/variant_fwd.hpp>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+template <class T>
+using LuaArray = std::vector<std::pair<int, T>>;
+template <class T>
+using LuaAssociativeTable = std::unordered_map<std::string, T>;
+template <class T>
+using LuaTypeOrArrayOf = boost::variant<T, LuaArray<T>>;
+using LuaAny = boost::make_recursive_variant<std::string, int64_t, uint64_t, double, bool, LuaArray<boost::recursive_variant_>, LuaAssociativeTable<boost::recursive_variant_>>::type;

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3380,6 +3380,7 @@ void setupLuaBindingsOnly(LuaContext& luaCtx, bool client, bool configCheck)
   setupLuaBindingsKVS(luaCtx, client);
   setupLuaBindingsLogging(luaCtx);
   setupLuaBindingsNetwork(luaCtx, client, configCheck);
+  setupLuaBindingsMMDB(luaCtx);
   setupLuaBindingsPacketCache(luaCtx, client);
   setupLuaBindingsProtoBuf(luaCtx, client, configCheck);
   setupLuaBindingsRings(luaCtx, client);

--- a/pdns/dnsdistdist/dnsdist-lua.hh
+++ b/pdns/dnsdistdist/dnsdist-lua.hh
@@ -23,18 +23,12 @@
 
 #include "dolog.hh"
 #include "dnsdist.hh"
+#include "dnsdist-lua-types.hh"
 
 #include "ext/luawrapper/include/LuaContext.hpp"
 
 extern RecursiveLockGuarded<LuaContext> g_lua;
 extern std::string g_outputBuffer; // locking for this is ok, as locked by g_luamutex
-
-template <class T>
-using LuaArray = std::vector<std::pair<int, T>>;
-template <class T>
-using LuaAssociativeTable = std::unordered_map<std::string, T>;
-template <class T>
-using LuaTypeOrArrayOf = boost::variant<T, LuaArray<T>>;
 
 using luaruleparams_t = LuaAssociativeTable<std::string>;
 

--- a/pdns/dnsdistdist/dnsdist-lua.hh
+++ b/pdns/dnsdistdist/dnsdist-lua.hh
@@ -50,6 +50,7 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck);
 void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client);
 void setupLuaBindingsDNSParser(LuaContext& luaCtx);
 void setupLuaBindingsDNSQuestion(LuaContext& luaCtx);
+void setupLuaBindingsMMDB(LuaContext& luaCtx);
 void setupLuaBindingsKVS(LuaContext& luaCtx, bool client);
 void setupLuaBindingsLogging(LuaContext& luaCtx);
 void setupLuaBindingsNetwork(LuaContext& luaCtx, bool client, bool configCheck);

--- a/pdns/dnsdistdist/dnsdist-rust-bridge.hh
+++ b/pdns/dnsdistdist/dnsdist-rust-bridge.hh
@@ -33,12 +33,14 @@ struct DNSResponseActionWrapper
 struct ProtobufLoggerConfiguration;
 struct DnstapLoggerConfiguration;
 struct KeyValueStoresConfiguration;
+struct MmdbConfiguration;
 struct NetmaskGroupConfiguration;
 struct TimedIpSetConfiguration;
 
 void registerProtobufLogger(const ProtobufLoggerConfiguration& config);
 void registerDnstapLogger(const DnstapLoggerConfiguration& config);
 void registerKVSObjects(const KeyValueStoresConfiguration& config);
+void registerMMDBObjects(const ::rust::Vec<MmdbConfiguration>& config);
 void registerNMGObjects(const ::rust::Vec<NetmaskGroupConfiguration>& nmgs);
 void registerTimedIPSetObjects(const ::rust::Vec<TimedIpSetConfiguration>& sets);
 

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
@@ -15,6 +15,7 @@
         fn registerProtobufLogger(config: &ProtobufLoggerConfiguration);
         fn registerDnstapLogger(config: &DnstapLoggerConfiguration);
         fn registerKVSObjects(config: &KeyValueStoresConfiguration);
+        fn registerMMDBObjects(config: &Vec<MmdbConfiguration>);
         fn registerNMGObjects(nmgs: &Vec<NetmaskGroupConfiguration>);
         fn registerTimedIPSetObjects(sets: &Vec<TimedIpSetConfiguration>);
     }

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-post-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-post-in.rs
@@ -70,6 +70,7 @@ fn get_global_configuration_from_serde(
         ebpf: serde.ebpf,
         edns_client_subnet: serde.edns_client_subnet,
         general: serde.general,
+        mmdbs: serde.mmdbs,
         key_value_stores: serde.key_value_stores,
         load_balancing_policies: serde.load_balancing_policies,
         logging: serde.logging,
@@ -91,6 +92,8 @@ fn get_global_configuration_from_serde(
     };
     // this needs to be done before the rules so that they can refer to the loggers
     register_remote_loggers(&config.remote_logging);
+    // this needs to be done before the KVS so they can refer to the DBs
+    dnsdistsettings::registerMMDBObjects(&config.mmdbs);
     // this needs to be done before the rules so that they can refer to the KVS objects
     dnsdistsettings::registerKVSObjects(&config.key_value_stores);
     // this needs to be done before the rules so that they can refer to the NMG objects

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -73,6 +73,10 @@ global:
       type: "MetricsConfiguration"
       default: true
       description: "Metrics-related settings"
+    - name: "mmdbs"
+      type: "Vec<MmdbConfiguration>"
+      default: true
+      description: "List of MMDB databases"
     - name: "netmask_groups"
       type: "Vec<NetmaskGroupConfiguration>"
       default: true
@@ -310,6 +314,38 @@ cdb_kv_store:
       type: "u32"
       description: "The delay in seconds between two checks of the database modification time. 0 means disabled"
 
+mmdb_kv_store:
+  description: "MMDB-based key-value store"
+  parameters:
+    - name: "name"
+      type: "String"
+      description: "The name of this object"
+    - name: "mmdb"
+      type: "String"
+      description: "Name of an existing MMDB database"
+    - name: "query_param"
+      type: "String"
+      default: ""
+      description: "Key to look up in the MMDB database associated with an IP - top level only."
+    - name: "query_params"
+      type: "Vec<String>"
+      default: true
+      description: "List of nested keys to look up in the MMDB database associated with an IP"
+
+mmdb:
+  description: "MMDB database"
+  parameters:
+    - name: "name"
+      type: "String"
+      description: "The name of this object"
+    - name: "file_name"
+      type: "String"
+      description: "The path to the MMDB file"
+    - name: "mmap"
+      type: "bool"
+      default: "false"
+      description: "Whether to open the MMDB in mmap mode"
+
 kvs_lookup_key_source_ip:
   description: "Lookup key that can be used with :ref:`yaml-settings-KeyValueStoreLookupAction` or :ref:`yaml-settings-KeyValueStoreLookupSelector`, will return the source IP of the client in network byte-order"
   parameters:
@@ -404,6 +440,10 @@ key_value_stores:
       type: "Vec<CdbKvStoreConfiguration>"
       default: true
       description: "List of CDB-based key-value stores"
+    - name: "mmdb"
+      type: "Vec<MmdbKvStoreConfiguration>"
+      default: true
+      description: "List of MMDB-based key-value stores"
     - name: "lookup_keys"
       type: "KvsLookupKeysConfiguration"
       default: true

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -27,7 +27,6 @@
 #include <thread>
 #include <variant>
 
-#include "dnsdist-lua-types.hh"
 #include "ext/json11/json11.hpp"
 #include <yahttp/yahttp.hpp>
 
@@ -41,6 +40,7 @@
 #include "dnsdist-frontend.hh"
 #include "dnsdist-healthchecks.hh"
 #include "dnsdist-lua.hh"
+#include "dnsdist-lua-types.hh"
 #include "dnsdist-metrics.hh"
 #include "dnsdist-prometheus.hh"
 #include "dnsdist-rings.hh"

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -27,6 +27,7 @@
 #include <thread>
 #include <variant>
 
+#include "dnsdist-lua-types.hh"
 #include "ext/json11/json11.hpp"
 #include <yahttp/yahttp.hpp>
 

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -2240,6 +2240,9 @@ static void reportFeatures()
 #ifdef HAVE_LMDB
   cout << "lmdb ";
 #endif
+#ifdef HAVE_MMDB
+  cout << "mmdb ";
+#endif
 #ifndef DISABLE_PROTOBUF
   cout << "protobuf ";
 #endif

--- a/pdns/dnsdistdist/docs/guides/geoip.rst
+++ b/pdns/dnsdistdist/docs/guides/geoip.rst
@@ -1,0 +1,64 @@
+GeoIP (MMDB)
+============
+
+:program:`dnsdist`, when compiled with MMDB support, can access MMDB databases to match queries based on origin IP.
+
+Here's a configuration example to make :program:`dnsdist` match queries based on the country of origin.
+
+.. md-tab-set::
+
+   .. md-tab-item:: YAML
+
+      The :ref:`mmdbs <yaml-settings-MmdbConfiguration>` key is used to create a :class:`MMDB` object for MMDB access and :ref:`key_value_stores.mmdb <yaml-settings-KeyValueStoresConfiguration>` is used to create a :class:`KeyValueStore` based on it. The :ref:`query_rules <yaml-settings-QueryRuleConfiguration>` key can then be used to add rules that look up country based on source IP and change response based on country of origin.
+
+      .. code-block:: yaml
+
+        mmdbs:
+          - name: test-mmdb
+            file_name: /tmp/test-mmdb-db.mmdb
+            mmap: true
+
+        key_value_stores:
+          mmdb:
+            - name: MMDBCountryKV
+              mmdb: test-mmdb
+              query_params:
+                - country
+                - iso_code
+          lookup_keys:
+            source_ip_keys:
+              - name: source_ip
+
+        query_rules:
+          - name: MMDB Country rule
+            selector:
+              type: All
+            action:
+              type: KeyValueStoreLookup
+              kvs_name: MMDBCountryKV
+              lookup_key_name: source_ip
+              destination_tag: kvs-source-ip-result
+
+          - name: Spoof US rule
+            selector:
+              type: Tag
+              tag: kvs-source-ip-result
+              value: US
+            action:
+              type: Spoof
+              ips:
+                - 5.6.7.8
+
+   .. md-tab-item:: Lua
+
+      The :func:`openMMDB` directive can be used to create a :class:`MMDB` object for MMDB access and :func:`newMMDBKVStore` directive can be used to create a :class:`KeyValueStore` based on it. The :func:`addAction` directive, combined with :func:`KeyValueStoreLookupAction` and :func:`KeyValueLookupKeySourceIP` can then be used to use these in requests.
+
+      .. code-block:: lua
+
+         mmdb = openMMDB('/tmp/test-mmdb-db.mmdb')
+         -- creates a KV store based on MMDB, that looks up country.iso_code in MMDB
+         kvs = newMMDBKVStore(mmdb, { "country", "iso_code" })
+         -- does a lookup in the MMDB database using the source IP as key, and store the result into the 'kvs-source-ip-result' tag
+         addAction(AllRule(), KeyValueStoreLookupAction(kvs, KeyValueLookupKeySourceIP(), 'kvs-source-ip-result'))
+         -- if the value of the 'kvs-source-ip-result' is set to 'US', spoof a response
+         addAction(TagRule('kvs-sourceip-result', 'US'), SpoofAction('5.6.7.8'))

--- a/pdns/dnsdistdist/docs/guides/index.rst
+++ b/pdns/dnsdistdist/docs/guides/index.rst
@@ -20,5 +20,4 @@ These chapters contain several guides and nuggets of information regarding dnsdi
    dns-over-tls
    dnscrypt
    dynblocks
-
-
+   geoip

--- a/pdns/dnsdistdist/docs/reference/actions.rst
+++ b/pdns/dnsdistdist/docs/reference/actions.rst
@@ -139,7 +139,7 @@ The following actions exist.
 
   Does a lookup into the key value store referenced by 'kvs' using the key returned by 'lookupKey',
   and storing the result if any into the tag named 'destinationTag'.
-  The store can be a CDB (:func:`newCDBKVStore`) or a LMDB database (:func:`newLMDBKVStore`).
+  The store can be a CDB (:func:`newCDBKVStore`), a LMDB database (:func:`newLMDBKVStore`), or a MMDB database (:func: `newMMDBKVStore`).
   The key can be based on the qname (:func:`KeyValueLookupKeyQName` and :func:`KeyValueLookupKeySuffix`),
   source IP (:func:`KeyValueLookupKeySourceIP`) or the value of an existing tag (:func:`KeyValueLookupKeyTag`).
   Subsequent rules are processed after this action.

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -2539,6 +2539,40 @@ LuaRingEntry
 
 .. _timespec:
 
+MMDB
+~~~~
+
+.. class:: MMDB
+
+  .. versionadded:: 2.2.0
+
+  .. method:: query(queryParams, ip)
+
+     Queries the database for the specific IP, taking a specific key from the object based on the provided query params.
+
+     :param str-or-list queryParams: Key or list of keys to fetch from the retrieved object from the MMDB database. Use empty list to retrieve the whole object.
+     :param ComboAddress ip: IP to look for in the DB.
+
+  .. method:: exists(ip)
+
+     Checks if the specified IP exists in the database.
+
+     :param ComboAddress ip: IP to look for in the DB.
+
+.. function:: openMMDB(name [, options])
+
+  .. versionadded:: 2.2.0
+
+   Opens a MMDB database with the provided path.
+
+   :param string name: Path to the MMDB database file.
+   :param table options: A table with key: value pairs with options.
+   :returns:  The :class:`MMDB` object
+
+   Options:
+
+   * ``mmap``: bool - If set to true, opens the database in memory-map mode.
+
 timespec
 ~~~~~~~~
 

--- a/pdns/dnsdistdist/docs/reference/kvs.rst
+++ b/pdns/dnsdistdist/docs/reference/kvs.rst
@@ -11,6 +11,7 @@ The first step is to get a :class:`KeyValueStore` object via one of the followin
 
  * :func:`newCDBKVStore` for a CDB database ;
  * :func:`newLMDBKVStore` for a LMDB one.
+ * :func:`newMMDBKVStore` for a MMDB one.
 
 Then the key used for the lookup can be selected via one of the following functions:
 
@@ -126,3 +127,12 @@ If the value found in the LMDB database for the key '\\8powerdns\\3com\\0' was '
   :param string filename: The path to an existing LMDB database created with ``MDB_NOSUBDIR``
   :param string dbName: The name of the database to use
   :param bool noLock: Whether to open the database with the ``MDB_NOLOCK`` flag. Default is false
+
+.. function:: newMMDBKVStore(mmdb, queryParams) -> KeyValueStore
+
+  .. versionadded:: 2.2.0
+
+  Return a new KeyValueStore object associated to the corresponding MMDB database. The database can be created using :func:`openMMDB`.
+
+  :param MMDB mmdb: The reference to an existing MMDB database created with :func:`openMMDB`.
+  :param str-or-list queryParams: Key or list of keys to fetch from the retrieved object from the MMDB database. Use empty list to retrieve the whole object.

--- a/pdns/dnsdistdist/docs/reference/selectors.rst
+++ b/pdns/dnsdistdist/docs/reference/selectors.rst
@@ -81,7 +81,7 @@ Selectors can be combined via :func:`AndRule`, :func:`OrRule` and :func:`NotRule
 .. function:: KeyValueStoreLookupRule(kvs, lookupKey)
 
   Return true if the key returned by 'lookupKey' exists in the key value store referenced by 'kvs'.
-  The store can be a CDB (:func:`newCDBKVStore`) or a LMDB database (:func:`newLMDBKVStore`).
+  The store can be a CDB (:func:`newCDBKVStore`), a LMDB database (:func:`newLMDBKVStore`), or a MMDB database (:func: `newMMDBKVStore`).
   The key can be based on the qname (:func:`KeyValueLookupKeyQName` and :func:`KeyValueLookupKeySuffix`),
   source IP (:func:`KeyValueLookupKeySourceIP`) or the value of an existing tag (:func:`KeyValueLookupKeyTag`).
 

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -85,6 +85,7 @@ subdir('meson' / 'doq')                     # DNS over QUIC
 subdir('meson' / 'doh3')                    # DNS over HTTP/3
 subdir('meson' / 'yaml-configuration')      # YAML configuration
 subdir('meson' / 'catch2')                  # Microbenchmark
+subdir('meson' / 'mmdb')                    # MMDB (MaxmindDB)
 
 common_sources = []
 
@@ -246,6 +247,12 @@ conditional_sources = {
       src_dir / 'doq-common.cc',
     ],
     'condition': dep_libquiche.found(),
+  },
+  'mmdb': {
+    'sources': [
+      src_dir / 'mmdb.cc',
+    ],
+    'condition': get_option('mmdb').allowed() and dep_mmdb.found(),
    },
 }
 
@@ -398,6 +405,7 @@ deps = [
   dep_lmdb,
   dep_lmdb_safe,
   dep_lua,
+  dep_mmdb,
   dep_protozero,
   dep_yahttp,
   dep_libre2,

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -155,6 +155,7 @@ common_sources += files(
   src_dir / 'dnsdist-lua-bindings-dnsparser.cc',
   src_dir / 'dnsdist-lua-bindings-dnsquestion.cc',
   src_dir / 'dnsdist-lua-bindings-kvs.cc',
+  src_dir / 'dnsdist-lua-bindings-mmdb.cc',
   src_dir / 'dnsdist-lua-bindings-network.cc',
   src_dir / 'dnsdist-lua-bindings-opentelemetry.cc',
   src_dir / 'dnsdist-lua-bindings-packetcache.cc',

--- a/pdns/dnsdistdist/meson/mmdb/meson.build
+++ b/pdns/dnsdistdist/meson/mmdb/meson.build
@@ -1,0 +1,18 @@
+opt_mmdb = get_option('mmdb')
+dep_mmdb = dependency('libmaxminddb', required: opt_mmdb)
+
+if opt_mmdb.allowed()
+  if not dep_mmdb.found()
+    if cxx.has_header('maxminddb.h', required: false)
+      if cxx.has_function('MMDB_open', args: ['-lmaxminddb'])
+        dep_mmdb = declare_dependency(link_args: ['-lmaxminddb'])
+      endif
+    endif
+  endif
+endif
+
+conf.set('HAVE_MMDB', dep_mmdb.found(), description: 'Whether we have MMDB')
+summary('MMDB', dep_mmdb.found(), bool_yn: true, section: 'Key-Value')
+if dep_mmdb.found()
+  summary('MMDB version', dep_mmdb.version(), bool_yn: true, section: 'Key-Value')
+endif

--- a/pdns/dnsdistdist/meson_options.txt
+++ b/pdns/dnsdistdist/meson_options.txt
@@ -41,3 +41,4 @@ option('yaml', type: 'feature', value: 'disabled', description: 'Enable YAML con
 option('man-pages', type: 'boolean', value: true, description: 'Generate man pages')
 option('clang-coverage-format', type: 'boolean', value: false, description: 'Whether to generate coverage data in clang format')
 option('benchmark', type: 'boolean', value: false, description: 'Whether to run microbenchmarks')
+option('mmdb', type: 'feature', value: 'disabled', description: 'MMDB key-value store support')

--- a/pdns/dnsdistdist/mmdb.cc
+++ b/pdns/dnsdistdist/mmdb.cc
@@ -1,0 +1,26 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "maxminddb.h"

--- a/pdns/dnsdistdist/mmdb.cc
+++ b/pdns/dnsdistdist/mmdb.cc
@@ -69,7 +69,7 @@ bool MMDB::query(LuaAny& ret, const boost::variant<const char*, std::vector<cons
   }
 
   if (const auto* param = boost::get<const char*>(&queryParams); param != nullptr) {
-    if (MMDB_get_value(&res.entry, &data, param, NULL) != MMDB_SUCCESS || !data.has_data) {
+    if (MMDB_get_value(&res.entry, &data, *param, NULL) != MMDB_SUCCESS || !data.has_data) {
       return false;
     }
   }

--- a/pdns/dnsdistdist/mmdb.cc
+++ b/pdns/dnsdistdist/mmdb.cc
@@ -19,8 +19,144 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
+#include <string>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
-#include "maxminddb.h"
+#include "dolog.hh"
+#include "iputils.hh"
+#include "mmdb.hh"
+#include <maxminddb.h>
+
+MMDB::MMDB(const std::string& fname, const std::string& modeStr)
+{
+  int ec;
+  int flags = 0;
+  if (modeStr == "")
+    /* for the benefit of ifdef */
+    ;
+#ifdef HAVE_MMAP
+  else if (modeStr == "mmap")
+    flags |= MMDB_MODE_MMAP;
+#endif
+  else
+    throw std::runtime_error(std::string("Unsupported mode ") + modeStr + ("for mmdb"));
+  memset(&d_db, 0, sizeof(d_db));
+  if ((ec = MMDB_open(fname.c_str(), flags, &d_db)) < 0)
+    throw std::runtime_error(std::string("Cannot open ") + fname + std::string(": ") + std::string(MMDB_strerror(ec)));
+  VERBOSESLOG(infolog("Opened MMDB database %s (type: %s version: %d.%d)", fname, d_db.metadata.database_type, d_db.metadata.binary_format_major_version, d_db.metadata.binary_format_minor_version),
+              dnsdist::logging::getTopLogger("mmdb")->info(Logr::Info, "Opened MMDB database", "path", Logging::Loggable(fname), "type", Logging::Loggable(d_db.metadata.database_type), "version", Logging::Loggable(std::to_string(d_db.metadata.binary_format_major_version) + "." + std::to_string(d_db.metadata.binary_format_minor_version))));
+}
+
+bool MMDB::queryCountry(string& ret, const ComboAddress& ip)
+{
+  MMDB_entry_data_s data;
+  MMDB_lookup_result_s res;
+  if (!mmdbLookup(ip, res))
+    return false;
+  if (MMDB_get_value(&res.entry, &data, "country", "iso_code", NULL) != MMDB_SUCCESS || !data.has_data)
+    return false;
+  ret = string(data.utf8_string, data.data_size);
+  return true;
+}
+
+bool MMDB::queryContinent(string& ret, const ComboAddress& ip)
+{
+  MMDB_entry_data_s data;
+  MMDB_lookup_result_s res;
+  if (!mmdbLookup(ip, res))
+    return false;
+  if (MMDB_get_value(&res.entry, &data, "continent", "code", NULL) != MMDB_SUCCESS || !data.has_data)
+    return false;
+  ret = string(data.utf8_string, data.data_size);
+  return true;
+}
+
+bool MMDB::queryAS(string& ret, const ComboAddress& ip)
+{
+  MMDB_entry_data_s data;
+  MMDB_lookup_result_s res;
+  if (!mmdbLookup(ip, res))
+    return false;
+  if (MMDB_get_value(&res.entry, &data, "autonomous_system_organization", NULL) != MMDB_SUCCESS || !data.has_data)
+    return false;
+  ret = string(data.utf8_string, data.data_size);
+  return true;
+}
+
+bool MMDB::queryASN(string& ret, const ComboAddress& ip)
+{
+  MMDB_entry_data_s data;
+  MMDB_lookup_result_s res;
+  if (!mmdbLookup(ip, res))
+    return false;
+  if (MMDB_get_value(&res.entry, &data, "autonomous_system_number", NULL) != MMDB_SUCCESS || !data.has_data)
+    return false;
+  ret = std::to_string(data.uint32);
+  return true;
+}
+
+bool MMDB::queryRegion(string& ret, const ComboAddress& ip)
+{
+  MMDB_entry_data_s data;
+  MMDB_lookup_result_s res;
+  if (!mmdbLookup(ip, res))
+    return false;
+  if (MMDB_get_value(&res.entry, &data, "subdivisions", "0", "iso_code", NULL) != MMDB_SUCCESS || !data.has_data)
+    return false;
+  ret = string(data.utf8_string, data.data_size);
+  return true;
+}
+
+bool MMDB::queryCity(string& ret, const ComboAddress& ip, const string& language)
+{
+  MMDB_entry_data_s data;
+  MMDB_lookup_result_s res;
+  if (!mmdbLookup(ip, res))
+    return false;
+  if ((MMDB_get_value(&res.entry, &data, "cities", "0", NULL) != MMDB_SUCCESS || !data.has_data) && (MMDB_get_value(&res.entry, &data, "city", "names", language.c_str(), NULL) != MMDB_SUCCESS || !data.has_data))
+    return false;
+  ret = string(data.utf8_string, data.data_size);
+  return true;
+}
+
+bool MMDB::queryLocation(const ComboAddress& ip,
+                         double& latitude, double& longitude,
+                         int& prec)
+{
+  MMDB_entry_data_s data;
+  MMDB_lookup_result_s res;
+  if (!mmdbLookup(ip, res))
+    return false;
+  if (MMDB_get_value(&res.entry, &data, "location", "latitude", NULL) != MMDB_SUCCESS || !data.has_data)
+    return false;
+  latitude = data.double_value;
+  if (MMDB_get_value(&res.entry, &data, "location", "longitude", NULL) != MMDB_SUCCESS || !data.has_data)
+    return false;
+  longitude = data.double_value;
+  if (MMDB_get_value(&res.entry, &data, "location", "accuracy_radius", NULL) != MMDB_SUCCESS || !data.has_data)
+    return false;
+  prec = data.uint16;
+  return true;
+}
+
+bool MMDB::mmdbLookup(const ComboAddress& ip, MMDB_lookup_result_s& res)
+{
+  int mmdb_ec = 0;
+  res = MMDB_lookup_sockaddr(&d_db, reinterpret_cast<const struct sockaddr*>(&ip), &mmdb_ec);
+
+  if (mmdb_ec != MMDB_SUCCESS) {
+    VERBOSESLOG(infolog("mmdbLookup(%s) failed: %s", ip.toString(), MMDB_strerror(mmdb_ec)), dnsdist::logging::getTopLogger("mmdb")->error(Logr::Info, MMDB_strerror(mmdb_ec), "mmdbLookup failed", "ip", Logging::Loggable(ip)));
+  }
+  else if (res.found_entry) {
+    // gl.netmask = res.netmask;
+    // /* If it's a IPv6 database, IPv4 netmasks are reduced from 128, so we need to deduct
+    //    96 to get from [96,128] => [0,32] range */
+    // if (!v6 && gl.netmask > 32)
+    //   gl.netmask -= 96;
+    return true;
+  }
+  return false;
+}

--- a/pdns/dnsdistdist/mmdb.cc
+++ b/pdns/dnsdistdist/mmdb.cc
@@ -20,6 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "dnsdist-lua-types.hh"
+#include <boost/variant/get.hpp>
+#include <memory>
 #include <string>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -30,19 +33,22 @@
 #include "mmdb.hh"
 #include <maxminddb.h>
 
-MMDB::MMDB(const std::string& fname, const std::string& modeStr)
+MMDB::MMDB(const std::string& fname, const std::string& modeStr) :
+  d_fname(fname)
 {
   int ec;
   int flags = 0;
-  if (modeStr == "")
+  if (modeStr == "") {
     /* for the benefit of ifdef */
-    ;
+  }
 #ifdef HAVE_MMAP
-  else if (modeStr == "mmap")
+  else if (modeStr == "mmap") {
     flags |= MMDB_MODE_MMAP;
+  }
 #endif
-  else
+  else {
     throw std::runtime_error(std::string("Unsupported mode ") + modeStr + ("for mmdb"));
+  }
   memset(&d_db, 0, sizeof(d_db));
   if ((ec = MMDB_open(fname.c_str(), flags, &d_db)) < 0)
     throw std::runtime_error(std::string("Cannot open ") + fname + std::string(": ") + std::string(MMDB_strerror(ec)));
@@ -50,113 +56,201 @@ MMDB::MMDB(const std::string& fname, const std::string& modeStr)
               dnsdist::logging::getTopLogger("mmdb")->info(Logr::Info, "Opened MMDB database", "path", Logging::Loggable(fname), "type", Logging::Loggable(d_db.metadata.database_type), "version", Logging::Loggable(std::to_string(d_db.metadata.binary_format_major_version) + "." + std::to_string(d_db.metadata.binary_format_minor_version))));
 }
 
-bool MMDB::queryCountry(string& ret, const ComboAddress& ip)
+bool MMDB::query(LuaAny& ret, const boost::variant<const char*, std::vector<const char*>>& queryParams, const ComboAddress& ip) const
 {
   MMDB_entry_data_s data;
   MMDB_lookup_result_s res;
-  if (!mmdbLookup(ip, res))
+  if (!mmdbLookup(ip, res)) {
     return false;
-  if (MMDB_get_value(&res.entry, &data, "country", "iso_code", NULL) != MMDB_SUCCESS || !data.has_data)
+  }
+
+  if (auto q = boost::get<const char*>(&queryParams)) {
+    if (MMDB_get_value(&res.entry, &data, q, NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+  }
+  else if (auto params = boost::get<std::vector<const char*>>(&queryParams)) {
+    if (MMDB_aget_value(&res.entry, &data, &params->at(0)) != MMDB_SUCCESS || !data.has_data)
+      return false;
+  }
+
+  if (mmdbDecode(&data, ret)) {
+    return true;
+  }
+
+  MMDB_entry_s data_entry{&d_db, data.offset};
+  auto elistopt = getEntryList(&data_entry);
+  if (!elistopt) {
     return false;
-  ret = string(data.utf8_string, data.data_size);
-  return true;
+  }
+  auto elist = std::move(*elistopt);
+  auto first = elist.getFirst();
+  return mmdbDecodeEntryList(&first, ret);
 }
 
-bool MMDB::queryContinent(string& ret, const ComboAddress& ip)
+const boost::variant<const char*, std::vector<const char*>> MMDB::convertParams(const LuaTypeOrArrayOf<std::string>& queryParams)
 {
-  MMDB_entry_data_s data;
-  MMDB_lookup_result_s res;
-  if (!mmdbLookup(ip, res))
-    return false;
-  if (MMDB_get_value(&res.entry, &data, "continent", "code", NULL) != MMDB_SUCCESS || !data.has_data)
-    return false;
-  ret = string(data.utf8_string, data.data_size);
-  return true;
+  if (auto param = boost::get<std::string>(&queryParams)) {
+    return param->c_str();
+  }
+  else if (auto params = boost::get<std::vector<std::pair<int, std::string>>>(&queryParams)) {
+    auto paramsArray = std::vector<const char*>(params->size() + 1);
+    for (size_t i = 0; i < params->size(); ++i) {
+      paramsArray.at(i) = params->at(i).second.c_str();
+    }
+    paramsArray.at(params->size()) = NULL;
+    return paramsArray;
+  }
+  else {
+    return "";
+  }
 }
 
-bool MMDB::queryAS(string& ret, const ComboAddress& ip)
+std::shared_ptr<const Logr::Logger> MMDB::getLogger() const
 {
-  MMDB_entry_data_s data;
-  MMDB_lookup_result_s res;
-  if (!mmdbLookup(ip, res))
-    return false;
-  if (MMDB_get_value(&res.entry, &data, "autonomous_system_organization", NULL) != MMDB_SUCCESS || !data.has_data)
-    return false;
-  ret = string(data.utf8_string, data.data_size);
-  return true;
+  return dnsdist::logging::getTopLogger("mmdb")->withValues("path", Logging::Loggable(d_fname));
 }
 
-bool MMDB::queryASN(string& ret, const ComboAddress& ip)
+bool MMDB::mmdbDecode(MMDB_entry_data_s* data, LuaAny& ret) const
 {
-  MMDB_entry_data_s data;
-  MMDB_lookup_result_s res;
-  if (!mmdbLookup(ip, res))
+  switch (data->type) {
+  case MMDB_DATA_TYPE_BOOLEAN:
+    ret = data->boolean;
+    break;
+  case MMDB_DATA_TYPE_UTF8_STRING:
+    ret = string(data->utf8_string, data->data_size);
+    break;
+  case MMDB_DATA_TYPE_DOUBLE:
+    ret = data->double_value;
+    break;
+  case MMDB_DATA_TYPE_FLOAT:
+    ret = data->float_value;
+    break;
+  case MMDB_DATA_TYPE_INT32:
+    ret = static_cast<int64_t>(data->int32);
+    break;
+  case MMDB_DATA_TYPE_UINT16:
+    ret = static_cast<uint64_t>(data->uint16);
+    break;
+  case MMDB_DATA_TYPE_UINT32:
+    ret = static_cast<uint64_t>(data->uint32);
+    break;
+  case MMDB_DATA_TYPE_UINT64:
+    ret = static_cast<uint64_t>(data->uint64);
+    break;
+  default:
     return false;
-  if (MMDB_get_value(&res.entry, &data, "autonomous_system_number", NULL) != MMDB_SUCCESS || !data.has_data)
-    return false;
-  ret = std::to_string(data.uint32);
+  }
   return true;
 }
 
-bool MMDB::queryRegion(string& ret, const ComboAddress& ip)
+bool MMDB::mmdbDecodeEntryList(MMDB_entry_data_list_s** data, LuaAny& ret) const
 {
-  MMDB_entry_data_s data;
-  MMDB_lookup_result_s res;
-  if (!mmdbLookup(ip, res))
+  switch ((*data)->entry_data.type) {
+  case MMDB_DATA_TYPE_BOOLEAN:
+  case MMDB_DATA_TYPE_UTF8_STRING:
+  case MMDB_DATA_TYPE_DOUBLE:
+  case MMDB_DATA_TYPE_FLOAT:
+  case MMDB_DATA_TYPE_INT32:
+  case MMDB_DATA_TYPE_UINT16:
+  case MMDB_DATA_TYPE_UINT32:
+  case MMDB_DATA_TYPE_UINT64:
+    return mmdbDecode(&((*data)->entry_data), ret);
+  case MMDB_DATA_TYPE_ARRAY:
+    return mmdbDecodeArray(data, ret);
+    break;
+  case MMDB_DATA_TYPE_MAP:
+    return mmdbDecodeMap(data, ret);
+    break;
+  default:
     return false;
-  if (MMDB_get_value(&res.entry, &data, "subdivisions", "0", "iso_code", NULL) != MMDB_SUCCESS || !data.has_data)
-    return false;
-  ret = string(data.utf8_string, data.data_size);
-  return true;
+  }
 }
 
-bool MMDB::queryCity(string& ret, const ComboAddress& ip, const string& language)
+bool MMDB::mmdbDecodeMap(MMDB_entry_data_list_s** data, LuaAny& ret) const
 {
-  MMDB_entry_data_s data;
-  MMDB_lookup_result_s res;
-  if (!mmdbLookup(ip, res))
-    return false;
-  if ((MMDB_get_value(&res.entry, &data, "cities", "0", NULL) != MMDB_SUCCESS || !data.has_data) && (MMDB_get_value(&res.entry, &data, "city", "names", language.c_str(), NULL) != MMDB_SUCCESS || !data.has_data))
-    return false;
-  ret = string(data.utf8_string, data.data_size);
+  LuaAssociativeTable<LuaAny> result;
+
+  MMDB_entry_data_list_s* this_data = *data;
+
+  for (auto size = this_data->entry_data.data_size; size > 0; --size) {
+    *data = (*data)->next;
+
+    if (!*data) {
+      break;
+    }
+
+    if ((*data)->entry_data.type != MMDB_DATA_TYPE_UTF8_STRING) {
+      // Invalid key, stop decoding
+      return false;
+    }
+
+    std::string key{(*data)->entry_data.utf8_string, (*data)->entry_data.data_size};
+
+    *data = (*data)->next;
+    if (!*data) {
+      break;
+    }
+
+    LuaAny value;
+    if (!mmdbDecodeEntryList(data, value)) {
+      // Failed value decoding, stop decoding
+      return false;
+    }
+
+    result.emplace(std::move(key), std::move(value));
+  }
+
+  ret = result;
   return true;
 }
 
-bool MMDB::queryLocation(double& latitude, double& longitude,
-                         int& prec,
-                         const ComboAddress& ip)
+bool MMDB::mmdbDecodeArray(MMDB_entry_data_list_s** data, LuaAny& ret) const
 {
-  MMDB_entry_data_s data;
-  MMDB_lookup_result_s res;
-  if (!mmdbLookup(ip, res))
-    return false;
-  if (MMDB_get_value(&res.entry, &data, "location", "latitude", NULL) != MMDB_SUCCESS || !data.has_data)
-    return false;
-  latitude = data.double_value;
-  if (MMDB_get_value(&res.entry, &data, "location", "longitude", NULL) != MMDB_SUCCESS || !data.has_data)
-    return false;
-  longitude = data.double_value;
-  if (MMDB_get_value(&res.entry, &data, "location", "accuracy_radius", NULL) != MMDB_SUCCESS || !data.has_data)
-    return false;
-  prec = data.uint16;
+  LuaArray<LuaAny> result;
+
+  MMDB_entry_data_list_s* this_data = *data;
+
+  for (uint32_t i = 0; i < this_data->entry_data.data_size; ++i) {
+    *data = (*data)->next;
+
+    if (!*data) {
+      break;
+    }
+
+    LuaAny value;
+    if (!mmdbDecodeEntryList(data, value)) {
+      // Failed value decoding, stop decoding
+      return false;
+    }
+
+    result.emplace_back(i + 1, std::move(value));
+  }
+
+  ret = result;
   return true;
 }
 
-bool MMDB::mmdbLookup(const ComboAddress& ip, MMDB_lookup_result_s& res)
+bool MMDB::mmdbLookup(const ComboAddress& ip, MMDB_lookup_result_s& res) const
 {
   int mmdb_ec = 0;
   res = MMDB_lookup_sockaddr(&d_db, reinterpret_cast<const struct sockaddr*>(&ip), &mmdb_ec);
 
   if (mmdb_ec != MMDB_SUCCESS) {
-    VERBOSESLOG(infolog("mmdbLookup(%s) failed: %s", ip.toString(), MMDB_strerror(mmdb_ec)), dnsdist::logging::getTopLogger("mmdb")->error(Logr::Info, MMDB_strerror(mmdb_ec), "mmdbLookup failed", "ip", Logging::Loggable(ip)));
+    VERBOSESLOG(infolog("mmdbLookup(%s) failed: %s", ip.toString(), MMDB_strerror(mmdb_ec)), getLogger()->error(Logr::Info, MMDB_strerror(mmdb_ec), "mmdbLookup failed", "ip", Logging::Loggable(ip)));
   }
   else if (res.found_entry) {
-    // gl.netmask = res.netmask;
-    // /* If it's a IPv6 database, IPv4 netmasks are reduced from 128, so we need to deduct
-    //    96 to get from [96,128] => [0,32] range */
-    // if (!v6 && gl.netmask > 32)
-    //   gl.netmask -= 96;
     return true;
   }
   return false;
+}
+
+std::optional<MMDBEntryList> MMDB::getEntryList(MMDB_entry_s* entry) const
+{
+  MMDB_entry_data_list_s* entry_data_list;
+  int status = MMDB_get_entry_data_list(entry, &entry_data_list);
+
+  if (status != MMDB_SUCCESS) {
+    return std::nullopt;
+  }
+  return {entry_data_list};
 }

--- a/pdns/dnsdistdist/mmdb.cc
+++ b/pdns/dnsdistdist/mmdb.cc
@@ -122,9 +122,9 @@ bool MMDB::queryCity(string& ret, const ComboAddress& ip, const string& language
   return true;
 }
 
-bool MMDB::queryLocation(const ComboAddress& ip,
-                         double& latitude, double& longitude,
-                         int& prec)
+bool MMDB::queryLocation(double& latitude, double& longitude,
+                         int& prec,
+                         const ComboAddress& ip)
 {
   MMDB_entry_data_s data;
   MMDB_lookup_result_s res;

--- a/pdns/dnsdistdist/mmdb.cc
+++ b/pdns/dnsdistdist/mmdb.cc
@@ -39,9 +39,8 @@
 MMDB::MMDB(const std::string& fname, const std::string& modeStr) :
   d_fname(fname)
 {
-  int ec;
   int flags = 0;
-  if (modeStr == "") {
+  if (modeStr.empty()) {
     /* for the benefit of ifdef */
   }
 #ifdef HAVE_MMAP
@@ -50,30 +49,34 @@ MMDB::MMDB(const std::string& fname, const std::string& modeStr) :
   }
 #endif
   else {
-    throw std::runtime_error(std::string("Unsupported mode ") + modeStr + ("for mmdb"));
+    throw std::runtime_error(std::string("Unsupported mode ") + modeStr + "for mmdb");
   }
   memset(&d_db, 0, sizeof(d_db));
-  if ((ec = MMDB_open(fname.c_str(), flags, &d_db)) < 0)
-    throw std::runtime_error(std::string("Cannot open ") + fname + std::string(": ") + std::string(MMDB_strerror(ec)));
+  if (int errorCode = MMDB_open(fname.c_str(), flags, &d_db); errorCode != MMDB_SUCCESS) {
+    throw std::runtime_error(std::string("Cannot open ") + fname + std::string(": ") + std::string(MMDB_strerror(errorCode)));
+  }
+
   VERBOSESLOG(infolog("Opened MMDB database %s (type: %s version: %d.%d)", fname, d_db.metadata.database_type, d_db.metadata.binary_format_major_version, d_db.metadata.binary_format_minor_version),
               dnsdist::logging::getTopLogger("mmdb")->info(Logr::Info, "Opened MMDB database", "path", Logging::Loggable(fname), "type", Logging::Loggable(d_db.metadata.database_type), "version", Logging::Loggable(std::to_string(d_db.metadata.binary_format_major_version) + "." + std::to_string(d_db.metadata.binary_format_minor_version))));
 }
 
-bool MMDB::query(LuaAny& ret, const boost::variant<const char*, std::vector<const char*>>& queryParams, const ComboAddress& ip) const
+bool MMDB::query(LuaAny& ret, const boost::variant<const char*, std::vector<const char*>>& queryParams, const ComboAddress& address) const
 {
   MMDB_entry_data_s data;
   MMDB_lookup_result_s res;
-  if (!mmdbLookup(ip, res)) {
+  if (!mmdbLookup(address, res)) {
     return false;
   }
 
-  if (auto q = boost::get<const char*>(&queryParams)) {
-    if (MMDB_get_value(&res.entry, &data, q, NULL) != MMDB_SUCCESS || !data.has_data)
+  if (const auto* param = boost::get<const char*>(&queryParams); param != nullptr) {
+    if (MMDB_get_value(&res.entry, &data, param, NULL) != MMDB_SUCCESS || !data.has_data) {
       return false;
+    }
   }
-  else if (auto params = boost::get<std::vector<const char*>>(&queryParams)) {
-    if (MMDB_aget_value(&res.entry, &data, &params->at(0)) != MMDB_SUCCESS || !data.has_data)
+  else if (const auto* params = boost::get<std::vector<const char*>>(&queryParams); params != nullptr) {
+    if (MMDB_aget_value(&res.entry, &data, &params->at(0)) != MMDB_SUCCESS || !data.has_data) {
       return false;
+    }
   }
 
   if (mmdbDecode(&data, ret)) {
@@ -86,26 +89,24 @@ bool MMDB::query(LuaAny& ret, const boost::variant<const char*, std::vector<cons
     return false;
   }
   auto elist = std::move(*elistopt);
-  auto first = elist.getFirst();
+  auto* first = elist.getFirst();
   return mmdbDecodeEntryList(&first, ret);
 }
 
-const boost::variant<const char*, std::vector<const char*>> MMDB::convertParams(const LuaTypeOrArrayOf<std::string>& queryParams)
+boost::variant<const char*, std::vector<const char*>> MMDB::convertParams(const LuaTypeOrArrayOf<std::string>& queryParams)
 {
-  if (auto param = boost::get<std::string>(&queryParams)) {
+  if (const auto* param = boost::get<std::string>(&queryParams)) {
     return param->c_str();
   }
-  else if (auto params = boost::get<std::vector<std::pair<int, std::string>>>(&queryParams)) {
+  if (const auto* params = boost::get<std::vector<std::pair<int, std::string>>>(&queryParams)) {
     auto paramsArray = std::vector<const char*>(params->size() + 1);
     for (size_t i = 0; i < params->size(); ++i) {
       paramsArray.at(i) = params->at(i).second.c_str();
     }
-    paramsArray.at(params->size()) = NULL;
+    paramsArray.at(params->size()) = nullptr;
     return paramsArray;
   }
-  else {
-    return "";
-  }
+  return "";
 }
 
 std::shared_ptr<const Logr::Logger> MMDB::getLogger() const
@@ -113,7 +114,7 @@ std::shared_ptr<const Logr::Logger> MMDB::getLogger() const
   return dnsdist::logging::getTopLogger("mmdb")->withValues("path", Logging::Loggable(d_fname));
 }
 
-bool MMDB::mmdbDecode(MMDB_entry_data_s* data, LuaAny& ret) const
+bool MMDB::mmdbDecode(MMDB_entry_data_s* data, LuaAny& ret)
 {
   switch (data->type) {
   case MMDB_DATA_TYPE_BOOLEAN:
@@ -138,7 +139,7 @@ bool MMDB::mmdbDecode(MMDB_entry_data_s* data, LuaAny& ret) const
     ret = static_cast<uint64_t>(data->uint32);
     break;
   case MMDB_DATA_TYPE_UINT64:
-    ret = static_cast<uint64_t>(data->uint64);
+    ret = data->uint64;
     break;
   default:
     return false;
@@ -178,7 +179,7 @@ bool MMDB::mmdbDecodeMap(MMDB_entry_data_list_s** data, LuaAny& ret) const
   for (auto size = this_data->entry_data.data_size; size > 0; --size) {
     *data = (*data)->next;
 
-    if (!*data) {
+    if (*data == nullptr) {
       break;
     }
 
@@ -190,7 +191,7 @@ bool MMDB::mmdbDecodeMap(MMDB_entry_data_list_s** data, LuaAny& ret) const
     std::string key{(*data)->entry_data.utf8_string, (*data)->entry_data.data_size};
 
     *data = (*data)->next;
-    if (!*data) {
+    if (*data == nullptr) {
       break;
     }
 
@@ -216,7 +217,7 @@ bool MMDB::mmdbDecodeArray(MMDB_entry_data_list_s** data, LuaAny& ret) const
   for (uint32_t i = 0; i < this_data->entry_data.data_size; ++i) {
     *data = (*data)->next;
 
-    if (!*data) {
+    if (*data == nullptr) {
       break;
     }
 
@@ -233,13 +234,15 @@ bool MMDB::mmdbDecodeArray(MMDB_entry_data_list_s** data, LuaAny& ret) const
   return true;
 }
 
-bool MMDB::mmdbLookup(const ComboAddress& ip, MMDB_lookup_result_s& res) const
+bool MMDB::mmdbLookup(const ComboAddress& address, MMDB_lookup_result_s& res) const
 {
   int mmdb_ec = 0;
-  res = MMDB_lookup_sockaddr(&d_db, reinterpret_cast<const struct sockaddr*>(&ip), &mmdb_ec);
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  res = MMDB_lookup_sockaddr(&d_db, reinterpret_cast<const struct sockaddr*>(&address), &mmdb_ec);
 
   if (mmdb_ec != MMDB_SUCCESS) {
-    VERBOSESLOG(infolog("mmdbLookup(%s) failed: %s", ip.toString(), MMDB_strerror(mmdb_ec)), getLogger()->error(Logr::Info, MMDB_strerror(mmdb_ec), "mmdbLookup failed", "ip", Logging::Loggable(ip)));
+    VERBOSESLOG(infolog("mmdbLookup(%s) failed: %s", address.toString(), MMDB_strerror(mmdb_ec)),
+                getLogger()->error(Logr::Info, MMDB_strerror(mmdb_ec), "mmdbLookup failed", "ip", Logging::Loggable(address)));
   }
   else if (res.found_entry) {
     return true;
@@ -247,9 +250,9 @@ bool MMDB::mmdbLookup(const ComboAddress& ip, MMDB_lookup_result_s& res) const
   return false;
 }
 
-std::optional<MMDBEntryList> MMDB::getEntryList(MMDB_entry_s* entry) const
+std::optional<MMDBEntryList> MMDB::getEntryList(MMDB_entry_s* entry)
 {
-  MMDB_entry_data_list_s* entry_data_list;
+  MMDB_entry_data_list_s* entry_data_list{};
   int status = MMDB_get_entry_data_list(entry, &entry_data_list);
 
   if (status != MMDB_SUCCESS) {

--- a/pdns/dnsdistdist/mmdb.cc
+++ b/pdns/dnsdistdist/mmdb.cc
@@ -20,13 +20,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef HAVE_MMDB
+#include "dnsdist-logging.hh"
 #include "dnsdist-lua-types.hh"
 #include <boost/variant/get.hpp>
 #include <memory>
 #include <string>
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
 
 #include "dolog.hh"
 #include "iputils.hh"
@@ -254,3 +257,4 @@ std::optional<MMDBEntryList> MMDB::getEntryList(MMDB_entry_s* entry) const
   }
   return {entry_data_list};
 }
+#endif

--- a/pdns/dnsdistdist/mmdb.cc
+++ b/pdns/dnsdistdist/mmdb.cc
@@ -60,7 +60,7 @@ MMDB::MMDB(const std::string& fname, const std::string& modeStr) :
               dnsdist::logging::getTopLogger("mmdb")->info(Logr::Info, "Opened MMDB database", "path", Logging::Loggable(fname), "type", Logging::Loggable(d_db.metadata.database_type), "version", Logging::Loggable(std::to_string(d_db.metadata.binary_format_major_version) + "." + std::to_string(d_db.metadata.binary_format_minor_version))));
 }
 
-bool MMDB::query(LuaAny& ret, const std::vector<const char*>& queryParams, const ComboAddress& address) const
+bool MMDB::query(LuaAny& ret, const MMDBQueryParams& queryParams, const ComboAddress& address) const
 {
   MMDB_entry_data_s data;
   MMDB_lookup_result_s res;
@@ -68,7 +68,7 @@ bool MMDB::query(LuaAny& ret, const std::vector<const char*>& queryParams, const
     return false;
   }
 
-  if (MMDB_aget_value(&res.entry, &data, &queryParams.at(0)) != MMDB_SUCCESS || !data.has_data) {
+  if (MMDB_aget_value(&res.entry, &data, queryParams.get()) != MMDB_SUCCESS || !data.has_data) {
     return false;
   }
 
@@ -84,22 +84,6 @@ bool MMDB::query(LuaAny& ret, const std::vector<const char*>& queryParams, const
   auto elist = std::move(*elistopt);
   auto* first = elist.getFirst();
   return mmdbDecodeEntryList(&first, ret);
-}
-
-std::vector<const char*> MMDB::convertParams(const LuaTypeOrArrayOf<std::string>& queryParams)
-{
-  if (const auto* param = boost::get<std::string>(&queryParams)) {
-    return {param->c_str(), nullptr};
-  }
-  if (const auto* params = boost::get<std::vector<std::pair<int, std::string>>>(&queryParams)) {
-    auto paramsArray = std::vector<const char*>(params->size() + 1);
-    for (size_t i = 0; i < params->size(); ++i) {
-      paramsArray.at(i) = params->at(i).second.c_str();
-    }
-    paramsArray.at(params->size()) = nullptr;
-    return paramsArray;
-  }
-  return {nullptr};
 }
 
 std::shared_ptr<const Logr::Logger> MMDB::getLogger() const
@@ -252,5 +236,31 @@ std::optional<MMDBEntryList> MMDB::getEntryList(MMDB_entry_s* entry)
     return std::nullopt;
   }
   return {entry_data_list};
+}
+
+static std::vector<const char*> convertParams(const LuaTypeOrArrayOf<std::string>& queryParams)
+{
+  if (const auto* param = boost::get<std::string>(&queryParams)) {
+    return {param->c_str(), nullptr};
+  }
+  if (const auto* params = boost::get<std::vector<std::pair<int, std::string>>>(&queryParams)) {
+    auto paramsArray = std::vector<const char*>(params->size() + 1);
+    for (size_t i = 0; i < params->size(); ++i) {
+      paramsArray.at(i) = params->at(i).second.c_str();
+    }
+    paramsArray.at(params->size()) = nullptr;
+    return paramsArray;
+  }
+  return {nullptr};
+}
+
+MMDBQueryParams::MMDBQueryParams(const LuaTypeOrArrayOf<std::string>& queryParams) :
+  d_params(convertParams(queryParams))
+{
+}
+
+const char* const* MMDBQueryParams::get() const
+{
+  return &d_params.at(0);
 }
 #endif

--- a/pdns/dnsdistdist/mmdb.cc
+++ b/pdns/dnsdistdist/mmdb.cc
@@ -60,7 +60,7 @@ MMDB::MMDB(const std::string& fname, const std::string& modeStr) :
               dnsdist::logging::getTopLogger("mmdb")->info(Logr::Info, "Opened MMDB database", "path", Logging::Loggable(fname), "type", Logging::Loggable(d_db.metadata.database_type), "version", Logging::Loggable(std::to_string(d_db.metadata.binary_format_major_version) + "." + std::to_string(d_db.metadata.binary_format_minor_version))));
 }
 
-bool MMDB::query(LuaAny& ret, const boost::variant<const char*, std::vector<const char*>>& queryParams, const ComboAddress& address) const
+bool MMDB::query(LuaAny& ret, const std::vector<const char*>& queryParams, const ComboAddress& address) const
 {
   MMDB_entry_data_s data;
   MMDB_lookup_result_s res;
@@ -68,15 +68,8 @@ bool MMDB::query(LuaAny& ret, const boost::variant<const char*, std::vector<cons
     return false;
   }
 
-  if (const auto* param = boost::get<const char*>(&queryParams); param != nullptr) {
-    if (MMDB_get_value(&res.entry, &data, *param, NULL) != MMDB_SUCCESS || !data.has_data) {
-      return false;
-    }
-  }
-  else if (const auto* params = boost::get<std::vector<const char*>>(&queryParams); params != nullptr) {
-    if (MMDB_aget_value(&res.entry, &data, &params->at(0)) != MMDB_SUCCESS || !data.has_data) {
-      return false;
-    }
+  if (MMDB_aget_value(&res.entry, &data, &queryParams.at(0)) != MMDB_SUCCESS || !data.has_data) {
+    return false;
   }
 
   if (mmdbDecode(&data, ret)) {
@@ -93,10 +86,10 @@ bool MMDB::query(LuaAny& ret, const boost::variant<const char*, std::vector<cons
   return mmdbDecodeEntryList(&first, ret);
 }
 
-boost::variant<const char*, std::vector<const char*>> MMDB::convertParams(const LuaTypeOrArrayOf<std::string>& queryParams)
+std::vector<const char*> MMDB::convertParams(const LuaTypeOrArrayOf<std::string>& queryParams)
 {
   if (const auto* param = boost::get<std::string>(&queryParams)) {
-    return param->c_str();
+    return {param->c_str(), nullptr};
   }
   if (const auto* params = boost::get<std::vector<std::pair<int, std::string>>>(&queryParams)) {
     auto paramsArray = std::vector<const char*>(params->size() + 1);
@@ -106,7 +99,7 @@ boost::variant<const char*, std::vector<const char*>> MMDB::convertParams(const 
     paramsArray.at(params->size()) = nullptr;
     return paramsArray;
   }
-  return "";
+  return {nullptr};
 }
 
 std::shared_ptr<const Logr::Logger> MMDB::getLogger() const

--- a/pdns/dnsdistdist/mmdb.hh
+++ b/pdns/dnsdistdist/mmdb.hh
@@ -1,0 +1,22 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once

--- a/pdns/dnsdistdist/mmdb.hh
+++ b/pdns/dnsdistdist/mmdb.hh
@@ -21,32 +21,59 @@
  */
 #pragma once
 
+#include "dnsdist-lua-types.hh"
 #include "iputils.hh"
 #include <maxminddb.h>
+#include <memory>
 #include <string>
+
+class MMDBEntryList;
 
 class MMDB
 {
 public:
   MMDB(const std::string& fname, const std::string& modeStr);
 
-  bool queryCountry(std::string& ret, const ComboAddress& ip);
-  bool queryContinent(std::string& ret, const ComboAddress& ip);
-  bool queryAS(std::string& ret, const ComboAddress& ip);
-  bool queryASN(std::string& ret, const ComboAddress& ip);
-  bool queryRegion(std::string& ret, const ComboAddress& ip);
-  bool queryCity(std::string& ret, const ComboAddress& ip, const std::string& language);
-  bool queryLocation(double& latitude, double& longitude, int& prec, const ComboAddress& ip);
-  bool exists(const ComboAddress& ip)
+  static const boost::variant<const char*, std::vector<const char*>> convertParams(const LuaTypeOrArrayOf<std::string>& queryParams);
+  bool query(LuaAny& ret, const boost::variant<const char*, std::vector<const char*>>& queryParams, const ComboAddress& ip) const;
+  bool exists(const ComboAddress& ip) const
   {
     MMDB_lookup_result_s res;
     return mmdbLookup(ip, res);
+  }
+  const std::string& file_name() const
+  {
+    return d_fname;
   }
 
   ~MMDB() { MMDB_close(&d_db); };
 
 private:
+  std::string d_fname;
   MMDB_s d_db;
 
-  bool mmdbLookup(const ComboAddress& ip, MMDB_lookup_result_s& res);
+  std::shared_ptr<const Logr::Logger> getLogger() const;
+  // Decodes one of the basic types (no arrays and maps)
+  bool mmdbDecode(MMDB_entry_data_s* data, LuaAny& ret) const;
+  // Decodes whole entry data list (supports arrays and maps too)
+  bool mmdbDecodeEntryList(MMDB_entry_data_list_s** data, LuaAny& ret) const;
+  bool mmdbDecodeMap(MMDB_entry_data_list_s** data, LuaAny& ret) const;
+  bool mmdbDecodeArray(MMDB_entry_data_list_s** data, LuaAny& ret) const;
+  bool mmdbLookup(const ComboAddress& ip, MMDB_lookup_result_s& res) const;
+  std::optional<MMDBEntryList> getEntryList(MMDB_entry_s* entry) const;
+};
+
+class MMDBEntryList
+{
+public:
+  MMDBEntryList(MMDB_entry_data_list_s* first) :
+    d_entry_list_first(first, MMDB_free_entry_data_list) {}
+
+  MMDB_entry_data_list_s* getFirst() const
+  {
+    return d_entry_list_first.get();
+  }
+
+private:
+  std::unique_ptr<MMDB_entry_data_list_s, decltype(&MMDB_free_entry_data_list)> d_entry_list_first;
 };

--- a/pdns/dnsdistdist/mmdb.hh
+++ b/pdns/dnsdistdist/mmdb.hh
@@ -36,7 +36,7 @@ public:
   bool queryASN(std::string& ret, const ComboAddress& ip);
   bool queryRegion(std::string& ret, const ComboAddress& ip);
   bool queryCity(std::string& ret, const ComboAddress& ip, const std::string& language);
-  bool queryLocation(const ComboAddress& ip, double& latitude, double& longitude, int& prec);
+  bool queryLocation(double& latitude, double& longitude, int& prec, const ComboAddress& ip);
   bool exists(const ComboAddress& ip)
   {
     MMDB_lookup_result_s res;

--- a/pdns/dnsdistdist/mmdb.hh
+++ b/pdns/dnsdistdist/mmdb.hh
@@ -21,155 +21,32 @@
  */
 #pragma once
 
-#include "dolog.hh"
+#include "iputils.hh"
 #include <maxminddb.h>
 #include <string>
 
 class MMDB
 {
 public:
-  MMDB(const std::string& fname, const std::string& modeStr)
-  {
-    int ec;
-    int flags = 0;
-    if (modeStr == "")
-      /* for the benefit of ifdef */
-      ;
-#ifdef HAVE_MMAP
-    else if (modeStr == "mmap")
-      flags |= MMDB_MODE_MMAP;
-#endif
-    else
-      throw std::runtime_error(std::string("Unsupported mode ") + modeStr + ("for mmdb"));
-    memset(&d_s, 0, sizeof(d_s));
-    if ((ec = MMDB_open(fname.c_str(), flags, &d_s)) < 0)
-      throw std::runtime_error(std::string("Cannot open ") + fname + std::string(": ") + std::string(MMDB_strerror(ec)));
-    VERBOSESLOG(infolog("Opened MMDB database %s (type: %s version: %d.%d)", fname, d_db.metadata.database_type, d_db.metadata.binary_format_major_version, d_db.metadata.binary_format_minor_version),
-                dnsdist::logging::getTopLogger("mmdb")->info(Logr::Info, "Opened MMDB database", "path", Logging::Loggable(fname), "type", Logging::Loggable(d_db.metadata.database_type), "version", Logging::Loggable(std::to_string(d_db.metadata.binary_format_major_version) + "." + std::to_string(d_db.metadata.binary_format_minor_version))));
-  }
+  MMDB(const std::string& fname, const std::string& modeStr);
 
-  bool queryCountry(string& ret, const string& ip)
-  {
-    MMDB_entry_data_s data;
-    MMDB_lookup_result_s res;
-    if (!mmdbLookup(ip, res))
-      return false;
-    if (MMDB_get_value(&res.entry, &data, "country", "iso_code", NULL) != MMDB_SUCCESS || !data.has_data)
-      return false;
-    ret = string(data.utf8_string, data.data_size);
-    return true;
-  }
-
-  bool queryContinent(string& ret, const string& ip)
-  {
-    MMDB_entry_data_s data;
-    MMDB_lookup_result_s res;
-    if (!mmdbLookup(ip, res))
-      return false;
-    if (MMDB_get_value(&res.entry, &data, "continent", "code", NULL) != MMDB_SUCCESS || !data.has_data)
-      return false;
-    ret = string(data.utf8_string, data.data_size);
-    return true;
-  }
-
-  bool queryAS(string& ret, const string& ip)
-  {
-    MMDB_entry_data_s data;
-    MMDB_lookup_result_s res;
-    if (!mmdbLookup(ip, res))
-      return false;
-    if (MMDB_get_value(&res.entry, &data, "autonomous_system_organization", NULL) != MMDB_SUCCESS || !data.has_data)
-      return false;
-    ret = string(data.utf8_string, data.data_size);
-    return true;
-  }
-
-  bool queryASN(string& ret, const string& ip)
-  {
-    MMDB_entry_data_s data;
-    MMDB_lookup_result_s res;
-    if (!mmdbLookup(ip, res))
-      return false;
-    if (MMDB_get_value(&res.entry, &data, "autonomous_system_number", NULL) != MMDB_SUCCESS || !data.has_data)
-      return false;
-    ret = std::to_string(data.uint32);
-    return true;
-  }
-
-  bool queryRegion(string& ret, const string& ip)
-  {
-    MMDB_entry_data_s data;
-    MMDB_lookup_result_s res;
-    if (!mmdbLookup(ip, res))
-      return false;
-    if (MMDB_get_value(&res.entry, &data, "subdivisions", "0", "iso_code", NULL) != MMDB_SUCCESS || !data.has_data)
-      return false;
-    ret = string(data.utf8_string, data.data_size);
-    return true;
-  }
-
-  bool queryCity(string& ret, const string& ip, const string& language)
-  {
-    MMDB_entry_data_s data;
-    MMDB_lookup_result_s res;
-    if (!mmdbLookup(ip, res))
-      return false;
-    if ((MMDB_get_value(&res.entry, &data, "cities", "0", NULL) != MMDB_SUCCESS || !data.has_data) && (MMDB_get_value(&res.entry, &data, "city", "names", language.c_str(), NULL) != MMDB_SUCCESS || !data.has_data))
-      return false;
-    ret = string(data.utf8_string, data.data_size);
-    return true;
-  }
-
-  bool queryLocation(const string& ip,
-                     double& latitude, double& longitude,
-                     int& prec)
-  {
-    MMDB_entry_data_s data;
-    MMDB_lookup_result_s res;
-    if (!mmdbLookup(ip, res))
-      return false;
-    if (MMDB_get_value(&res.entry, &data, "location", "latitude", NULL) != MMDB_SUCCESS || !data.has_data)
-      return false;
-    latitude = data.double_value;
-    if (MMDB_get_value(&res.entry, &data, "location", "longitude", NULL) != MMDB_SUCCESS || !data.has_data)
-      return false;
-    longitude = data.double_value;
-    if (MMDB_get_value(&res.entry, &data, "location", "accuracy_radius", NULL) != MMDB_SUCCESS || !data.has_data)
-      return false;
-    prec = data.uint16;
-    return true;
-  }
-
-  bool exists(const string& ip)
+  bool queryCountry(std::string& ret, const ComboAddress& ip);
+  bool queryContinent(std::string& ret, const ComboAddress& ip);
+  bool queryAS(std::string& ret, const ComboAddress& ip);
+  bool queryASN(std::string& ret, const ComboAddress& ip);
+  bool queryRegion(std::string& ret, const ComboAddress& ip);
+  bool queryCity(std::string& ret, const ComboAddress& ip, const std::string& language);
+  bool queryLocation(const ComboAddress& ip, double& latitude, double& longitude, int& prec);
+  bool exists(const ComboAddress& ip)
   {
     MMDB_lookup_result_s res;
     return mmdbLookup(ip, res);
   }
 
-  ~MMDB() { MMDB_close(&d_s); };
+  ~MMDB() { MMDB_close(&d_db); };
 
 private:
-  MMDB_s d_s;
+  MMDB_s d_db;
 
-  bool mmdbLookup(const string& ip, MMDB_lookup_result_s& res)
-  {
-    int gai_ec = 0, mmdb_ec = 0;
-    res = MMDB_lookup_string(&d_s, ip.c_str(), &gai_ec, &mmdb_ec);
-
-    if (gai_ec != 0) {
-      VERBOSESLOG(infolog("mmdbLookup(%s) failed: %s", ip.toString(), MMDB_strerror(mmdb_ec)), dnsdist::logging::getTopLogger("mmdb")->error(Logr::Info, gai_strerror(mmdb_ec), "mmdbLookup failed", "ip", Logging::Loggable(ip)));
-    }
-    else if (mmdb_ec != MMDB_SUCCESS) {
-      VERBOSESLOG(infolog("mmdbLookup(%s) failed: %s", ip.toString(), MMDB_strerror(mmdb_ec)), dnsdist::logging::getTopLogger("mmdb")->error(Logr::Info, MMDB_strerror(mmdb_ec), "mmdbLookup failed", "ip", Logging::Loggable(ip)));
-    }
-    else if (res.found_entry) {
-      // gl.netmask = res.netmask;
-      // /* If it's a IPv6 database, IPv4 netmasks are reduced from 128, so we need to deduct
-      //    96 to get from [96,128] => [0,32] range */
-      // if (!v6 && gl.netmask > 32)
-      //   gl.netmask -= 96;
-      return true;
-    }
-    return false;
-  }
+  bool mmdbLookup(const ComboAddress& ip, MMDB_lookup_result_s& res);
 };

--- a/pdns/dnsdistdist/mmdb.hh
+++ b/pdns/dnsdistdist/mmdb.hh
@@ -40,8 +40,8 @@ public:
   MMDB& operator=(const MMDB&) = delete;
   MMDB& operator=(MMDB&&) = delete;
 
-  static boost::variant<const char*, std::vector<const char*>> convertParams(const LuaTypeOrArrayOf<std::string>& queryParams);
-  bool query(LuaAny& ret, const boost::variant<const char*, std::vector<const char*>>& queryParams, const ComboAddress& address) const;
+  static std::vector<const char*> convertParams(const LuaTypeOrArrayOf<std::string>& queryParams);
+  bool query(LuaAny& ret, const std::vector<const char*>& queryParams, const ComboAddress& address) const;
   [[nodiscard]] bool exists(const ComboAddress& address) const
   {
     MMDB_lookup_result_s res{};

--- a/pdns/dnsdistdist/mmdb.hh
+++ b/pdns/dnsdistdist/mmdb.hh
@@ -20,3 +20,156 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
+
+#include "dolog.hh"
+#include <maxminddb.h>
+#include <string>
+
+class MMDB
+{
+public:
+  MMDB(const std::string& fname, const std::string& modeStr)
+  {
+    int ec;
+    int flags = 0;
+    if (modeStr == "")
+      /* for the benefit of ifdef */
+      ;
+#ifdef HAVE_MMAP
+    else if (modeStr == "mmap")
+      flags |= MMDB_MODE_MMAP;
+#endif
+    else
+      throw std::runtime_error(std::string("Unsupported mode ") + modeStr + ("for mmdb"));
+    memset(&d_s, 0, sizeof(d_s));
+    if ((ec = MMDB_open(fname.c_str(), flags, &d_s)) < 0)
+      throw std::runtime_error(std::string("Cannot open ") + fname + std::string(": ") + std::string(MMDB_strerror(ec)));
+    VERBOSESLOG(infolog("Opened MMDB database %s (type: %s version: %d.%d)", fname, d_db.metadata.database_type, d_db.metadata.binary_format_major_version, d_db.metadata.binary_format_minor_version),
+                dnsdist::logging::getTopLogger("mmdb")->info(Logr::Info, "Opened MMDB database", "path", Logging::Loggable(fname), "type", Logging::Loggable(d_db.metadata.database_type), "version", Logging::Loggable(std::to_string(d_db.metadata.binary_format_major_version) + "." + std::to_string(d_db.metadata.binary_format_minor_version))));
+  }
+
+  bool queryCountry(string& ret, const string& ip)
+  {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "country", "iso_code", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    ret = string(data.utf8_string, data.data_size);
+    return true;
+  }
+
+  bool queryContinent(string& ret, const string& ip)
+  {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "continent", "code", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    ret = string(data.utf8_string, data.data_size);
+    return true;
+  }
+
+  bool queryAS(string& ret, const string& ip)
+  {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "autonomous_system_organization", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    ret = string(data.utf8_string, data.data_size);
+    return true;
+  }
+
+  bool queryASN(string& ret, const string& ip)
+  {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "autonomous_system_number", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    ret = std::to_string(data.uint32);
+    return true;
+  }
+
+  bool queryRegion(string& ret, const string& ip)
+  {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "subdivisions", "0", "iso_code", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    ret = string(data.utf8_string, data.data_size);
+    return true;
+  }
+
+  bool queryCity(string& ret, const string& ip, const string& language)
+  {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, res))
+      return false;
+    if ((MMDB_get_value(&res.entry, &data, "cities", "0", NULL) != MMDB_SUCCESS || !data.has_data) && (MMDB_get_value(&res.entry, &data, "city", "names", language.c_str(), NULL) != MMDB_SUCCESS || !data.has_data))
+      return false;
+    ret = string(data.utf8_string, data.data_size);
+    return true;
+  }
+
+  bool queryLocation(const string& ip,
+                     double& latitude, double& longitude,
+                     int& prec)
+  {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "location", "latitude", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    latitude = data.double_value;
+    if (MMDB_get_value(&res.entry, &data, "location", "longitude", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    longitude = data.double_value;
+    if (MMDB_get_value(&res.entry, &data, "location", "accuracy_radius", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    prec = data.uint16;
+    return true;
+  }
+
+  bool exists(const string& ip)
+  {
+    MMDB_lookup_result_s res;
+    return mmdbLookup(ip, res);
+  }
+
+  ~MMDB() { MMDB_close(&d_s); };
+
+private:
+  MMDB_s d_s;
+
+  bool mmdbLookup(const string& ip, MMDB_lookup_result_s& res)
+  {
+    int gai_ec = 0, mmdb_ec = 0;
+    res = MMDB_lookup_string(&d_s, ip.c_str(), &gai_ec, &mmdb_ec);
+
+    if (gai_ec != 0) {
+      VERBOSESLOG(infolog("mmdbLookup(%s) failed: %s", ip.toString(), MMDB_strerror(mmdb_ec)), dnsdist::logging::getTopLogger("mmdb")->error(Logr::Info, gai_strerror(mmdb_ec), "mmdbLookup failed", "ip", Logging::Loggable(ip)));
+    }
+    else if (mmdb_ec != MMDB_SUCCESS) {
+      VERBOSESLOG(infolog("mmdbLookup(%s) failed: %s", ip.toString(), MMDB_strerror(mmdb_ec)), dnsdist::logging::getTopLogger("mmdb")->error(Logr::Info, MMDB_strerror(mmdb_ec), "mmdbLookup failed", "ip", Logging::Loggable(ip)));
+    }
+    else if (res.found_entry) {
+      // gl.netmask = res.netmask;
+      // /* If it's a IPv6 database, IPv4 netmasks are reduced from 128, so we need to deduct
+      //    96 to get from [96,128] => [0,32] range */
+      // if (!v6 && gl.netmask > 32)
+      //   gl.netmask -= 96;
+      return true;
+    }
+    return false;
+  }
+};

--- a/pdns/dnsdistdist/mmdb.hh
+++ b/pdns/dnsdistdist/mmdb.hh
@@ -30,6 +30,7 @@
 #include <string>
 
 class MMDBEntryList;
+class MMDBQueryParams;
 
 class MMDB
 {
@@ -40,8 +41,7 @@ public:
   MMDB& operator=(const MMDB&) = delete;
   MMDB& operator=(MMDB&&) = delete;
 
-  static std::vector<const char*> convertParams(const LuaTypeOrArrayOf<std::string>& queryParams);
-  bool query(LuaAny& ret, const std::vector<const char*>& queryParams, const ComboAddress& address) const;
+  bool query(LuaAny& ret, const MMDBQueryParams& queryParams, const ComboAddress& address) const;
   [[nodiscard]] bool exists(const ComboAddress& address) const
   {
     MMDB_lookup_result_s res{};
@@ -68,6 +68,21 @@ private:
   bool mmdbDecodeMap(MMDB_entry_data_list_s** data, LuaAny& ret) const;
   bool mmdbDecodeArray(MMDB_entry_data_list_s** data, LuaAny& ret) const;
   bool mmdbLookup(const ComboAddress& address, MMDB_lookup_result_s& res) const;
+};
+
+class MMDBQueryParams
+{
+public:
+  MMDBQueryParams(const LuaTypeOrArrayOf<std::string>& queryParams);
+
+  // libmaxmind takes params (path) as a pointer to a const char*,
+  // representing a const char* array, which should end with nullptr
+  // This returns a pointer to the first element of the vector,
+  // which still works because vector has contiguous storage
+  [[nodiscard]] const char* const* get() const;
+
+private:
+  std::vector<const char*> d_params;
 };
 
 class MMDBEntryList

--- a/pdns/dnsdistdist/mmdb.hh
+++ b/pdns/dnsdistdist/mmdb.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#ifdef HAVE_MMDB
 #include "dnsdist-lua-types.hh"
 #include "iputils.hh"
 #include <maxminddb.h>
@@ -77,3 +78,8 @@ public:
 private:
   std::unique_ptr<MMDB_entry_data_list_s, decltype(&MMDB_free_entry_data_list)> d_entry_list_first;
 };
+#else
+class MMDB
+{
+};
+#endif

--- a/pdns/dnsdistdist/mmdb.hh
+++ b/pdns/dnsdistdist/mmdb.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include "config.h"
 #ifdef HAVE_MMDB
 #include "dnsdist-lua-types.hh"
 #include "iputils.hh"
@@ -34,15 +35,19 @@ class MMDB
 {
 public:
   MMDB(const std::string& fname, const std::string& modeStr);
+  MMDB(const MMDB&) = delete;
+  MMDB(MMDB&&) = delete;
+  MMDB& operator=(const MMDB&) = delete;
+  MMDB& operator=(MMDB&&) = delete;
 
-  static const boost::variant<const char*, std::vector<const char*>> convertParams(const LuaTypeOrArrayOf<std::string>& queryParams);
-  bool query(LuaAny& ret, const boost::variant<const char*, std::vector<const char*>>& queryParams, const ComboAddress& ip) const;
-  bool exists(const ComboAddress& ip) const
+  static boost::variant<const char*, std::vector<const char*>> convertParams(const LuaTypeOrArrayOf<std::string>& queryParams);
+  bool query(LuaAny& ret, const boost::variant<const char*, std::vector<const char*>>& queryParams, const ComboAddress& address) const;
+  [[nodiscard]] bool exists(const ComboAddress& address) const
   {
-    MMDB_lookup_result_s res;
-    return mmdbLookup(ip, res);
+    MMDB_lookup_result_s res{};
+    return mmdbLookup(address, res);
   }
-  const std::string& file_name() const
+  [[nodiscard]] const std::string& file_name() const
   {
     return d_fname;
   }
@@ -51,17 +56,18 @@ public:
 
 private:
   std::string d_fname;
-  MMDB_s d_db;
+  MMDB_s d_db{};
 
-  std::shared_ptr<const Logr::Logger> getLogger() const;
   // Decodes one of the basic types (no arrays and maps)
-  bool mmdbDecode(MMDB_entry_data_s* data, LuaAny& ret) const;
+  static bool mmdbDecode(MMDB_entry_data_s* data, LuaAny& ret);
+  static std::optional<MMDBEntryList> getEntryList(MMDB_entry_s* entry);
+
+  [[nodiscard]] std::shared_ptr<const Logr::Logger> getLogger() const;
   // Decodes whole entry data list (supports arrays and maps too)
   bool mmdbDecodeEntryList(MMDB_entry_data_list_s** data, LuaAny& ret) const;
   bool mmdbDecodeMap(MMDB_entry_data_list_s** data, LuaAny& ret) const;
   bool mmdbDecodeArray(MMDB_entry_data_list_s** data, LuaAny& ret) const;
-  bool mmdbLookup(const ComboAddress& ip, MMDB_lookup_result_s& res) const;
-  std::optional<MMDBEntryList> getEntryList(MMDB_entry_s* entry) const;
+  bool mmdbLookup(const ComboAddress& address, MMDB_lookup_result_s& res) const;
 };
 
 class MMDBEntryList
@@ -70,7 +76,7 @@ public:
   MMDBEntryList(MMDB_entry_data_list_s* first) :
     d_entry_list_first(first, MMDB_free_entry_data_list) {}
 
-  MMDB_entry_data_list_s* getFirst() const
+  [[nodiscard]] MMDB_entry_data_list_s* getFirst() const
   {
     return d_entry_list_first.get();
   }

--- a/regression-tests.dnsdist/requirements.in
+++ b/regression-tests.dnsdist/requirements.in
@@ -20,3 +20,4 @@ aioquic
 async_timeout
 opentelemetry-proto>=1.7,<2
 setuptools<82
+mmdb_writer>=0.2.6

--- a/regression-tests.dnsdist/requirements.txt
+++ b/regression-tests.dnsdist/requirements.txt
@@ -386,6 +386,14 @@ lmdb==2.2.1 \
 opentelemetry-proto==1.42.1 \
     --hash=sha256:c6a51e6b4f05ae63565f3a113217f3d2bfaec68f78c02d7a6c85f9010d1cfca6 \
     --hash=sha256:dedb74cba2886c59c7789b227a7a670613025a07489040050aedff6e5c0fb43c
+mmdb-writer==0.2.6 \
+    --hash=sha256:6e77abcb1e2fa1dc4ac82117d4b7532d7238d518fcd0d904f21bb503dd5209cd \
+    --hash=sha256:76085bed6fdc692403824ec96dbf4b4c5a141b1bc7b73d4a440cbc369b882161
+    # via -r requirements.in
+netaddr==1.3.0 \
+    --hash=sha256:5c3c3d9895b551b763779ba7db7a03487dc1f8e3b385af819af341ae9ef6e48a \
+    --hash=sha256:c2c6a8ebe5554ce33b7d5b3a306b71bbb373e000bbbf2350dd5213cc56e3dbbe
+    # via mmdb-writer
     # via -r requirements.in
 packaging==26.2 \
     --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \

--- a/regression-tests.dnsdist/test_MMDB.py
+++ b/regression-tests.dnsdist/test_MMDB.py
@@ -16,7 +16,7 @@ def writeMMDB(fname, empty=False):
     if not empty:
         writer.insert_network(
             IPSet(IPNetwork("127.0.0.0/24")),
-            {"country": {"iso_code": "US"}, "result_ip": "6.7.8.9", "array": [1, 2, 3]},
+            {"country": {"iso_code": "US"}, "result_ip": "6.7.8.9", "array": [1, -2, 3]},
         )
     writer.to_db_file(fname)
 
@@ -53,7 +53,7 @@ class MMDBTest(DNSDistTest):
     addAction(TagRule('kvs-sourceip-result', 'US'), SpoofAction('5.6.7.8'))
 
     -- if the value of the 'kvs-full-sourceip-result' is set to the set object, spoof a response
-    addAction(TagRule('kvs-full-sourceip-result', '{"array": [1, 2, 3], "country": {"iso_code": "US"}, "result_ip": "6.7.8.9"}'), SpoofAction('7.8.9.10'))
+    addAction(TagRule('kvs-full-sourceip-result', '{"array": [1, -2, 3], "country": {"iso_code": "US"}, "result_ip": "6.7.8.9"}'), SpoofAction('7.8.9.10'))
 
     -- if the value of the 'kvs-top-sourceip-result' is set to '6.7.8.9', spoof a response
     addAction(TagRule('kvs-top-sourceip-result', '6.7.8.9'), SpoofAction('6.7.8.9'))

--- a/regression-tests.dnsdist/test_MMDB.py
+++ b/regression-tests.dnsdist/test_MMDB.py
@@ -30,6 +30,7 @@ class MMDBTest(DNSDistTest):
     mmdb = openMMDB('%s')
     kvs = newMMDBKVStore(mmdb, { "country", "iso_code" })
     full_object_kvs = newMMDBKVStore(mmdb, {})
+    top_level_kvs = newMMDBKVStore(mmdb, "result_ip")
 
     function lua_mmdb_query(dq)
         -- Additional exists check is not needed, but it is added here to test it
@@ -46,12 +47,16 @@ class MMDBTest(DNSDistTest):
     -- does a lookup in the MMDB database using the source IP as key, and store the result into the 'kvs-sourceip-result' tag
     addAction(RegexRule('regular.*'), KeyValueStoreLookupAction(kvs, KeyValueLookupKeySourceIP(), 'kvs-sourceip-result'))
     addAction(RegexRule('full.*'), KeyValueStoreLookupAction(full_object_kvs, KeyValueLookupKeySourceIP(), 'kvs-full-sourceip-result'))
+    addAction(RegexRule('top.*'), KeyValueStoreLookupAction(top_level_kvs, KeyValueLookupKeySourceIP(), 'kvs-top-sourceip-result'))
 
     -- if the value of the 'kvs-sourceip-result' is set to 'US', spoof a response
     addAction(TagRule('kvs-sourceip-result', 'US'), SpoofAction('5.6.7.8'))
 
     -- if the value of the 'kvs-full-sourceip-result' is set to the set object, spoof a response
     addAction(TagRule('kvs-full-sourceip-result', '{"array": [1, 2, 3], "country": {"iso_code": "US"}, "result_ip": "6.7.8.9"}'), SpoofAction('7.8.9.10'))
+
+    -- if the value of the 'kvs-top-sourceip-result' is set to '6.7.8.9', spoof a response
+    addAction(TagRule('kvs-top-sourceip-result', '6.7.8.9'), SpoofAction('6.7.8.9'))
 
     -- does a lookup and directly spoofs if found, using data from MMDB
     addAction(RegexRule('lua.*'), LuaAction(lua_mmdb_query))
@@ -60,6 +65,7 @@ class MMDBTest(DNSDistTest):
     addAction(RegexRule('regular.*'), SpoofAction('9.9.9.9'))
     addAction(RegexRule('lua.*'), SpoofAction('9.9.9.10'))
     addAction(RegexRule('full.*'), SpoofAction('9.9.9.11'))
+    addAction(RegexRule('top.*'), SpoofAction('9.9.9.12'))
     """
     _config_params = ["_testServerPort", "_mmdbFileName"]
 
@@ -100,7 +106,7 @@ class TestMMDBSimple(MMDBTest):
 
     def testMMDBComplexObject(self):
         """
-        MMDB: Match on source address, returning a comple object
+        MMDB: Match on source address, returning a complex object
         """
         name = "full.source-ip.mmdb.tests.powerdns.com."
         query = dns.message.make_query(name, "A", "IN")
@@ -108,6 +114,25 @@ class TestMMDBSimple(MMDBTest):
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "7.8.9.10")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+    def testMMDBStringLookup(self):
+        """
+        MMDB: Match on source address, returning a top level object
+        """
+        name = "top.source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "6.7.8.9")
         expectedResponse.answer.append(rrset)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):

--- a/regression-tests.dnsdist/test_MMDB.py
+++ b/regression-tests.dnsdist/test_MMDB.py
@@ -16,7 +16,7 @@ def writeMMDB(fname, empty=False):
     if not empty:
         writer.insert_network(
             IPSet(IPNetwork("127.0.0.0/24")),
-            {"country": {"iso_code": "US"}, "result_ip": "6.7.8.9"},
+            {"country": {"iso_code": "US"}, "result_ip": "6.7.8.9", "array": [1, 2, 3]},
         )
     writer.to_db_file(fname)
 
@@ -29,8 +29,13 @@ class MMDBTest(DNSDistTest):
 
     mmdb = openMMDB('%s')
     kvs = newMMDBKVStore(mmdb, { "country", "iso_code" })
+    full_object_kvs = newMMDBKVStore(mmdb, {})
 
     function lua_mmdb_query(dq)
+        -- Additional exists check is not needed, but it is added here to test it
+        if not mmdb:exists(dq.remoteaddr) then
+            return DNSAction.None
+        end
     	local mmdbData = mmdb:query({"result_ip"}, dq.remoteaddr)
         if mmdbData == nil then
             return DNSAction.None
@@ -40,9 +45,13 @@ class MMDBTest(DNSDistTest):
 
     -- does a lookup in the MMDB database using the source IP as key, and store the result into the 'kvs-sourceip-result' tag
     addAction(RegexRule('regular.*'), KeyValueStoreLookupAction(kvs, KeyValueLookupKeySourceIP(), 'kvs-sourceip-result'))
+    addAction(RegexRule('full.*'), KeyValueStoreLookupAction(full_object_kvs, KeyValueLookupKeySourceIP(), 'kvs-full-sourceip-result'))
 
     -- if the value of the 'kvs-sourceip-result' is set to 'US', spoof a response
     addAction(TagRule('kvs-sourceip-result', 'US'), SpoofAction('5.6.7.8'))
+
+    -- if the value of the 'kvs-full-sourceip-result' is set to the set object, spoof a response
+    addAction(TagRule('kvs-full-sourceip-result', '{"array": [1, 2, 3], "country": {"iso_code": "US"}, "result_ip": "6.7.8.9"}'), SpoofAction('7.8.9.10'))
 
     -- does a lookup and directly spoofs if found, using data from MMDB
     addAction(RegexRule('lua.*'), LuaAction(lua_mmdb_query))
@@ -50,6 +59,7 @@ class MMDBTest(DNSDistTest):
     -- otherwise, spoof a different response
     addAction(RegexRule('regular.*'), SpoofAction('9.9.9.9'))
     addAction(RegexRule('lua.*'), SpoofAction('9.9.9.10'))
+    addAction(RegexRule('full.*'), SpoofAction('9.9.9.11'))
     """
     _config_params = ["_testServerPort", "_mmdbFileName"]
 
@@ -79,6 +89,25 @@ class TestMMDBSimple(MMDBTest):
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "5.6.7.8")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+    def testMMDBComplexObject(self):
+        """
+        MMDB: Match on source address, returning a comple object
+        """
+        name = "full.source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "7.8.9.10")
         expectedResponse.answer.append(rrset)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):

--- a/regression-tests.dnsdist/test_MMDB.py
+++ b/regression-tests.dnsdist/test_MMDB.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+import os
+import socket
+import time
+import unittest
+
+import dns
+from mmdb_writer import MMDBWriter
+from netaddr import IPNetwork, IPSet
+
+from dnsdisttests import DNSDistTest
+
+
+def writeMMDB(fname, empty=False):
+    writer = MMDBWriter()
+    if not empty:
+        writer.insert_network(
+            IPSet(IPNetwork("127.0.0.0/24")),
+            {"country": {"iso_code": "US"}},
+        )
+    writer.to_db_file(fname)
+
+
+@unittest.skipIf("SKIP_MMDB_TESTS" in os.environ, "MMDB tests are disabled")
+class MMDBTest(DNSDistTest):
+    _mmdbFileName = "/tmp/test-mmdb-db"
+    _config_template = """
+    newServer{address="127.0.0.1:%d"}
+
+    mmdb = openMMDB('%s')
+    kvs = newMMDBKVStore(mmdb, { "country", "iso_code" })
+
+    -- does a lookup in the MMDB database using the source IP as key, and store the result into the 'kvs-sourceip-result' tag
+    addAction(AllRule(), KeyValueStoreLookupAction(kvs, KeyValueLookupKeySourceIP(), 'kvs-sourceip-result'))
+
+    -- if the value of the 'kvs-sourceip-result' is set to 'US', spoof a response
+    addAction(TagRule('kvs-sourceip-result', 'US'), SpoofAction('5.6.7.8'))
+
+    -- otherwise, spoof a different response
+    addAction(AllRule(), SpoofAction('9.9.9.9'))
+    """
+    _config_params = ["_testServerPort", "_mmdbFileName"]
+
+
+class TestMMDBSimple(MMDBTest):
+    @classmethod
+    def setUpMMDB(cls):
+        writeMMDB(cls._mmdbFileName)
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.setUpMMDB()
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+
+        print("Launching tests..")
+
+    def testMMDBSource(self):
+        """
+        MMDB: Match on source address
+        """
+        name = "source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "5.6.7.8")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+
+class TestMMDBMissing(MMDBTest):
+    @classmethod
+    def setUpMMDB(cls):
+        writeMMDB(cls._mmdbFileName, empty=True)
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.setUpMMDB()
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+
+        print("Launching tests..")
+
+    def testMMDBSource(self):
+        """
+        MMDB: Match on source address
+        """
+        name = "source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "9.9.9.9")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)

--- a/regression-tests.dnsdist/test_MMDB.py
+++ b/regression-tests.dnsdist/test_MMDB.py
@@ -16,7 +16,7 @@ def writeMMDB(fname, empty=False):
     if not empty:
         writer.insert_network(
             IPSet(IPNetwork("127.0.0.0/24")),
-            {"country": {"iso_code": "US"}},
+            {"country": {"iso_code": "US"}, "result_ip": "6.7.8.9"},
         )
     writer.to_db_file(fname)
 
@@ -30,14 +30,26 @@ class MMDBTest(DNSDistTest):
     mmdb = openMMDB('%s')
     kvs = newMMDBKVStore(mmdb, { "country", "iso_code" })
 
+    function lua_mmdb_query(dq)
+    	local mmdbData = mmdb:query({"result_ip"}, dq.remoteaddr)
+        if mmdbData == nil then
+            return DNSAction.None
+        end
+        return DNSAction.Spoof, mmdbData
+    end
+
     -- does a lookup in the MMDB database using the source IP as key, and store the result into the 'kvs-sourceip-result' tag
-    addAction(AllRule(), KeyValueStoreLookupAction(kvs, KeyValueLookupKeySourceIP(), 'kvs-sourceip-result'))
+    addAction(RegexRule('regular.*'), KeyValueStoreLookupAction(kvs, KeyValueLookupKeySourceIP(), 'kvs-sourceip-result'))
 
     -- if the value of the 'kvs-sourceip-result' is set to 'US', spoof a response
     addAction(TagRule('kvs-sourceip-result', 'US'), SpoofAction('5.6.7.8'))
 
+    -- does a lookup and directly spoofs if found, using data from MMDB
+    addAction(RegexRule('lua.*'), LuaAction(lua_mmdb_query))
+
     -- otherwise, spoof a different response
-    addAction(AllRule(), SpoofAction('9.9.9.9'))
+    addAction(RegexRule('regular.*'), SpoofAction('9.9.9.9'))
+    addAction(RegexRule('lua.*'), SpoofAction('9.9.9.10'))
     """
     _config_params = ["_testServerPort", "_mmdbFileName"]
 
@@ -61,12 +73,31 @@ class TestMMDBSimple(MMDBTest):
         """
         MMDB: Match on source address
         """
-        name = "source-ip.mmdb.tests.powerdns.com."
+        name = "regular.source-ip.mmdb.tests.powerdns.com."
         query = dns.message.make_query(name, "A", "IN")
         # dnsdist set RA = RD for spoofed responses
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "5.6.7.8")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+    def testMMDBLua(self):
+        """
+        MMDB: Using MMDB in Lua
+        """
+        name = "lua.source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "6.7.8.9")
         expectedResponse.answer.append(rrset)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -96,12 +127,224 @@ class TestMMDBMissing(MMDBTest):
         """
         MMDB: Match on source address
         """
-        name = "source-ip.mmdb.tests.powerdns.com."
+        name = "regular.source-ip.mmdb.tests.powerdns.com."
         query = dns.message.make_query(name, "A", "IN")
         # dnsdist set RA = RD for spoofed responses
         query.flags &= ~dns.flags.RD
         expectedResponse = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "9.9.9.9")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+    def testMMDBLua(self):
+        """
+        MMDB: Using MMDB in Lua
+        """
+        name = "lua.source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "9.9.9.10")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+
+@unittest.skipIf("SKIP_MMDB_TESTS" in os.environ, "MMDB tests are disabled")
+class MMDBYamlTest(DNSDistTest):
+    _mmdbFileName = "/tmp/test-mmdb-db"
+    _yaml_config_template = """---
+binds:
+  - listen_address: "127.0.0.1:%d"
+    reuseport: true
+    protocol: Do53
+    threads: 2
+
+mmdbs:
+  - name: test-mmdb
+    file_name: %s
+    mmap: true
+
+key_value_stores:
+  mmdb:
+    - name: MMDBCountryKV
+      mmdb: test-mmdb
+      query_params:
+        - country
+        - iso_code
+  lookup_keys:
+    source_ip_keys:
+      - name: source_ip
+
+query_rules:
+  - name: MMDB Country rule
+    selector:
+      type: Regex
+      expression: regular.*
+    action:
+      type: KeyValueStoreLookup
+      kvs_name: MMDBCountryKV
+      lookup_key_name: source_ip
+      destination_tag: kvs-source-ip-result
+
+  - name: Spoof US rule
+    selector:
+      type: Tag
+      tag: kvs-source-ip-result
+      value: US
+    action:
+      type: Spoof
+      ips:
+        - 5.6.7.8
+
+  - name: MMDB Lua lookup rule
+    selector:
+      type: Regex
+      expression: lua.*
+    action:
+      type: Lua
+      function_code: |
+        function lua_mmdb_query(dq)
+            local mmdb = getObjectFromYAMLConfiguration("test-mmdb")
+            local mmdbData = mmdb:query({"result_ip"}, dq.remoteaddr)
+            if mmdbData == nil then
+                return DNSAction.None
+            end
+            return DNSAction.Spoof, mmdbData
+        end
+        return lua_mmdb_query
+
+  - name: Spoof regular missed rule
+    selector:
+      type: Regex
+      expression: regular.*
+    action:
+      type: Spoof
+      ips:
+        - 9.9.9.9
+
+  - name: Spoof Lua missed rule
+    selector:
+      type: Regex
+      expression: lua.*
+    action:
+      type: Spoof
+      ips:
+        - 9.9.9.10
+"""
+    _yaml_config_params = ["_testServerPort", "_mmdbFileName"]
+
+
+class TestMMDBYamlSimple(MMDBYamlTest):
+    @classmethod
+    def setUpMMDB(cls):
+        writeMMDB(cls._mmdbFileName)
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.setUpMMDB()
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+
+        print("Launching tests..")
+
+    def testMMDBSource(self):
+        """
+        MMDB: Match on source address
+        """
+        name = "regular.source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "5.6.7.8")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+    def testMMDBLua(self):
+        """
+        MMDB: Using MMDB in Lua
+        """
+        name = "lua.source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "6.7.8.9")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+
+class TestMMDBYamlMissing(MMDBYamlTest):
+    @classmethod
+    def setUpMMDB(cls):
+        writeMMDB(cls._mmdbFileName, empty=True)
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.setUpMMDB()
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+
+        print("Launching tests..")
+
+    def testMMDBSource(self):
+        """
+        MMDB: Match on source address
+        """
+        name = "regular.source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "9.9.9.9")
+        expectedResponse.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertFalse(receivedQuery)
+            self.assertTrue(receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
+
+    def testMMDBLua(self):
+        """
+        MMDB: Using MMDB in Lua
+        """
+        name = "lua.source-ip.mmdb.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "9.9.9.10")
         expectedResponse.answer.append(rrset)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):

--- a/tasks.py
+++ b/tasks.py
@@ -89,6 +89,7 @@ dnsdist_build_deps = [
     "libfstrm-dev",
     "libgnutls28-dev",
     "liblmdb-dev",
+    "libmaxminddb-dev",
     "libnghttp2-dev",
     "libre2-dev",
     "libsnmp-dev",
@@ -377,6 +378,7 @@ def install_dnsdist_test_deps(c, skipXDP=False):  # FIXME: rename this, we do wa
             libfstrm0 \
             libgnutls30 \
             liblmdb0 \
+            libmaxminddb0 \
             libnghttp2-14 \
             "libre2-[1-9]+" \
             libssl-dev \
@@ -1000,6 +1002,7 @@ DNSDIST_CONFIGURE_MESON_FEATURE_SET_FULL = " ".join(
         "-D libedit=enabled",
         "-D libsodium=enabled",
         "-D lmdb=enabled",
+        "-D mmdb=enabled",
         "-D nghttp2=enabled",
         "-D re2=enabled",
         "-D systemd-service=enabled",


### PR DESCRIPTION
### Short description
Adds support for opening and reading MMDB, as well as a `MMDBKVStore` implementation, supporting generic query.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

---
>Sponsored by [Quad9](https://quad9.net/)