### PR TITLE
auth: webserver documentation tweaks

### DIFF
--- a/docs/http-api/index.rst
+++ b/docs/http-api/index.rst
@@ -26,8 +26,9 @@ The following webserver related configuration items are available:
 
 .. warning::
 
-   To achieve defense-in-depth, expose the webserver only to client addresses that have a real need for access.
+   To achieve defense-in-depth, expose the webserver only to client addresses that have a real need for access, and configure a webserver password.
    Network access is configured by setting :ref:`setting-webserver-address` and :ref:`setting-webserver-allow-from`.
+   Password protection is configured by setting :ref:`setting-webserver-password`.
 
 
 Metrics Endpoint

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -2138,6 +2138,28 @@ IP Address for webserver/API to listen on.
 Webserver/API access is only allowed from these subnets.
 Ignored if ``webserver-address`` is set to a UNIX domain socket.
 
+.. _setting-webserver-connection-timeout:
+
+``webserver-connection-timeout``
+--------------------------------
+.. versionadded:: 4.8.5
+
+-  Integer
+-  Default: 5
+
+Request/response timeout in seconds.
+
+.. _setting-webserver-cross-origin-request-header:
+
+``webserver-cross-origin-request-header``
+-----------------------------------------
+.. versionadded:: 5.1.0
+
+-  String
+-  Default: empty
+
+The value if the access-control-allow-origin HTTP header to include. This header is not included if the value is empty.
+
 .. _setting-webserver-hash-plaintext-credentials:
 
 ``webserver-hash-plaintext-credentials``
@@ -2212,17 +2234,6 @@ Maximum request/response body size in megabytes.
 
 Maximum number of allowed concurrent connections to the web server.
 
-.. _setting-webserver-connection-timeout:
-
-``webserver-connection-timeout``
---------------------------------
-.. versionadded:: 4.8.5
-
--  Integer
--  Default: 5
-
-Request/response timeout in seconds.
-
 .. _setting-webserver-password:
 
 ``webserver-password``
@@ -2254,17 +2265,6 @@ Ignored if ``webserver-address`` is set to a UNIX domain socket.
 -  Default: no
 
 If the webserver should print arguments.
-
-.. _setting-webserver-cross-origin-request-header:
-
-``webserver-cross-origin-request-header``
------------------------------------------
-.. versionadded:: 5.1.0
-
--  String
--  Default: empty
-
-The value if the access-control-allow-origin HTTP header to include. This header is not included if the value is empty.
 
 .. _setting-write-pid:
 


### PR DESCRIPTION
### Short description
This stresses that setting `webserver-password` is recommended a bit more, and fixes ordering of webserver-related configuration parameters.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
