### PR TITLE
auth: stricter string-to-int conversions

### DIFF
--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -384,7 +384,7 @@ bool Bind2Backend::addDomainKey(const ZoneName& name, const KeyData& key, int64_
     SSqlStatement::row_t row;
     d_GetLastInsertedKeyIdQuery_stmt->nextRow(row);
     ASSERT_ROW_COLUMNS("get-last-inserted-key-id-query", row, 1);
-    keyId = std::stoi(row[0]);
+    pdns::checked_stoi_into(keyId, row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
     if (keyId == 0) {
       // No insert took place, report as error.

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -320,7 +320,7 @@ bool PipeBackend::get(DNSResourceRecord& r)
         }
 
         if (d_abiVersion >= 3) {
-          r.scopeMask = std::stoi(parts[1]);
+          pdns::checked_stoi_into(r.scopeMask, parts[1]);
           r.auth = (parts[2] == "1");
           parts.erase(parts.begin() + 1, parts.begin() + 3);
         }

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1066,7 +1066,7 @@ bool GSQLBackend::addDomainKey(const ZoneName& name, const KeyData& key, int64_t
     if (d_AddDomainKeyQuery_stmt->hasNextRow()) {
       SSqlStatement::row_t row;
       d_AddDomainKeyQuery_stmt->nextRow(row);
-      keyId = std::stoi(row[0]);
+      pdns::checked_stoi_into(keyId, row[0]);
       d_AddDomainKeyQuery_stmt->reset();
       return true;
     } else {
@@ -1088,7 +1088,7 @@ bool GSQLBackend::addDomainKey(const ZoneName& name, const KeyData& key, int64_t
     SSqlStatement::row_t row;
     d_GetLastInsertedKeyIdQuery_stmt->nextRow(row);
     ASSERT_ROW_COLUMNS("get-last-inserted-key-id-query", row, 1);
-    keyId = std::stoi(row[0]);
+    pdns::checked_stoi_into(keyId, row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
     if (keyId == 0) {
       // No insert took place, report as error.

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -343,7 +343,7 @@ static map<string, string> ISCStringtoMap(const string& argStr)
       continue;
     }
     if (pdns_iequals(key,"slot")) {
-      int slot = std::stoi(value);
+      auto slot = pdns::checked_stoi<int>(value);
       stormap["slot"]=std::to_string(slot);
       continue;
     }

--- a/pdns/json.cc
+++ b/pdns/json.cc
@@ -37,7 +37,7 @@ static inline int intFromJsonInternal(const Json& container, const std::string& 
 
   if (val.is_string()) {
     try {
-      return std::stoi(val.string_value());
+      return pdns::checked_stoi<int>(val.string_value());
     } catch (std::logic_error&) {
       throw JsonException("Key '" + string(key) + "' is not a valid number");
     }

--- a/pdns/minicurl.cc
+++ b/pdns/minicurl.cc
@@ -136,10 +136,8 @@ void MiniCurl::setupURL(const std::string& str, const ComboAddress* rem, const C
     std::size_t found = host4.find(':');
     vector<uint16_t> ports{80, 443};
     if (found != std::string::npos) {
-      int port = std::stoi(host4.substr(found + 1));
-      if (port <= 0 || port > 65535)
-        throw std::overflow_error("Invalid port number");
-      ports = {(uint16_t)port};
+      auto port = pdns::checked_stoi<uint16_t>(host4.substr(found + 1));
+      ports = {port};
       host4 = host4.substr(0, found);
     }
 

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -723,7 +723,7 @@ CK_RV Pkcs11Slot::HuntSlot(Logr::log_t slog, const string& tokenId, CK_SLOT_ID &
 
   // see if we can find it with slotId
   try {
-    slotId = std::stoi(tokenId);
+    pdns::checked_stoi_into(slotId, tokenId);
     if ((err = functions->C_GetSlotInfo(slotId, info))) {
       SLOG(g_log<<Logger::Warning<<"C_GetSlotInfo("<<slotId<<", info) = " << err << std::endl,
            slog->info(Logr::Warning, "C_GetSlotInfo failed", "slotId", Logging::Loggable(slotId), "errorcode", Logging::Loggable(err)));

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1352,7 +1352,7 @@ static inline int getInquireKeyId(HttpRequest* req, const ZoneName& zonename, DN
 {
   int inquireKeyId = -1;
   if (req->parameters.count("key_id") == 1) {
-    inquireKeyId = std::stoi(req->parameters["key_id"]);
+    pdns::checked_stoi_into(inquireKeyId, req->parameters["key_id"]);
     apiZoneCryptoKeysCheckKeyExists(zonename, inquireKeyId, dnsseckeeper);
   }
   return inquireKeyId;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2906,7 +2906,12 @@ static void apiServerSearchData(HttpRequest* req, HttpResponse* resp)
     throw ApiException("Query q can't be blank");
   }
   if (!sMaxVar.empty()) {
-    maxEnts = std::stoi(sMaxVar);
+    try {
+      pdns::checked_stoi_into(maxEnts, sMaxVar);
+    }
+    catch (std::logic_error&) {
+      throw ApiException("Invalid value for maximum entries");
+    }
   }
   if (maxEnts < 1) {
     throw ApiException("Maximum entries must be larger than 0");


### PR DESCRIPTION
### Short description
This fixes a few laxist string-to-int conversions by making sure the result of the conversion fits in the expected type.

Prompted by a YesWeHack report (YWH-PGM6095-297).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
