### PR TITLE
dnsdist: Use the correct timestamp, not now, for ISO-8601 format

### DIFF
--- a/pdns/dnsdistdist/dnsdist-logging.cc
+++ b/pdns/dnsdistdist/dnsdist-logging.cc
@@ -40,10 +40,8 @@ static const char* convertTime(const timeval& tval, std::array<char, 64>& buffer
 {
   auto format = dnsdist::configuration::getImmutableConfiguration().d_structuredLoggingTimeFormat;
   if (format == dnsdist::configuration::TimeFormat::ISO8601) {
-    time_t now{};
-    time(&now);
     struct tm localNow{};
-    localtime_r(&now, &localNow);
+    localtime_r(&tval.tv_sec, &localNow);
 
     {
       // strftime is not thread safe, it can access locale information


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
