### PR TITLE
dnsdist-2.0: Backport 17378 - Fix the dynamic block top suffixes counters computation

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dynblocks.cc
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.cc
@@ -721,10 +721,10 @@ void DynBlockMaintenance::generateMetrics()
         auto& stat = reasonStat[entry.first];
         if (entry.second < stat.lastSeenValue) {
           /* it wrapped, or we did not have a last value */
-          stat.sum = entry.second;
+          stat.sum += entry.second;
         }
         else {
-          stat.sum = entry.second - stat.lastSeenValue;
+          stat.sum += entry.second - stat.lastSeenValue;
         }
         stat.lastSeenValue = entry.second;
       }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17378 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
