### PR TITLE
dnsdist-2.0: Backport 17379 - Compute a less inaccurate number of DNS records to pass to `reserve()`

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dnsparser.cc
+++ b/pdns/dnsdistdist/dnsdist-dnsparser.cc
@@ -31,22 +31,28 @@ DNSPacketOverlay::DNSPacketOverlay(const std::string_view& packet)
   }
 
   memcpy(&d_header, packet.data(), sizeof(dnsheader));
-  uint64_t numRecords = ntohs(d_header.ancount) + ntohs(d_header.nscount) + ntohs(d_header.arcount);
-  d_records.reserve(numRecords);
+  uint64_t supposedRecordCount = ntohs(d_header.ancount) + ntohs(d_header.nscount) + ntohs(d_header.arcount);
+  // No need to reserve more memory for more records than the request can
+  // contain. We could try to be smarter and actually count the records
+  // by doing getDnsrecordheader and skip the payload in a loop, but all
+  // we really want here is to avoid reserving too much memory in case of
+  // maliciously high record counts.
+  auto reserveRecordCount = std::min(1 + ((packet.size() - sizeof(dnsheader)) / sizeof(dnsrecordheader)), static_cast<size_t>(supposedRecordCount));
+  d_records.reserve(reserveRecordCount);
 
   try {
     PacketReader reader(std::string_view(reinterpret_cast<const char*>(packet.data()), packet.size()));
 
-    for (uint16_t n = 0; n < ntohs(d_header.qdcount); ++n) {
+    for (uint16_t idx = 0; idx < ntohs(d_header.qdcount); ++idx) {
       reader.xfrName(d_qname);
       reader.xfrType(d_qtype);
       reader.xfrType(d_qclass);
     }
 
-    for (uint64_t n = 0; n < numRecords; ++n) {
+    for (uint64_t idx = 0; idx < supposedRecordCount; ++idx) {
       Record rec;
       reader.xfrName(rec.d_name);
-      rec.d_place = n < ntohs(d_header.ancount) ? DNSResourceRecord::ANSWER : (n < (ntohs(d_header.ancount) + ntohs(d_header.nscount)) ? DNSResourceRecord::AUTHORITY : DNSResourceRecord::ADDITIONAL);
+      rec.d_place = idx < ntohs(d_header.ancount) ? DNSResourceRecord::ANSWER : (idx < (ntohs(d_header.ancount) + ntohs(d_header.nscount)) ? DNSResourceRecord::AUTHORITY : DNSResourceRecord::ADDITIONAL);
       reader.xfrType(rec.d_type);
       reader.xfrType(rec.d_class);
       reader.xfr32BitInt(rec.d_ttl);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17379 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
