### PR TITLE
dnsdist-2.1: Backport 17381 - Fix DownstreamState::setHealthCheckParams

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings.cc
@@ -299,7 +299,7 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
     if (getOptionalValue<size_t>(vars, "rise", value) > 0 && value > 0) {
       state->d_config.minRiseSuccesses.store(value);
     }
-    if (getOptionalValue<size_t>(vars, "checkTimeout", value) && value > 0) {
+    if (getOptionalValue<size_t>(vars, "checkTimeout", value) > 0 && value > 0) {
       state->d_config.checkTimeout.store(value);
     }
     if (getOptionalValue<size_t>(vars, "checkInterval", value) > 0 && value > 0) {

--- a/pdns/dnsdistdist/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings.cc
@@ -293,20 +293,16 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
       return;
     }
     size_t value = 0;
-    getOptionalValue<size_t>(vars, "maxCheckFailures", value);
-    if (value > 0) {
+    if (getOptionalValue<size_t>(vars, "maxCheckFailures", value) > 0 && value > 0) {
       state->d_config.maxCheckFailures.store(value);
     }
-    getOptionalValue<size_t>(vars, "rise", value);
-    if (value > 0) {
+    if (getOptionalValue<size_t>(vars, "rise", value) > 0 && value > 0) {
       state->d_config.minRiseSuccesses.store(value);
     }
-    getOptionalValue<size_t>(vars, "checkTimeout", value);
-    if (value > 0) {
+    if (getOptionalValue<size_t>(vars, "checkTimeout", value) && value > 0) {
       state->d_config.checkTimeout.store(value);
     }
-    getOptionalValue<size_t>(vars, "checkInterval", value);
-    if (value > 0) {
+    if (getOptionalValue<size_t>(vars, "checkInterval", value) > 0 && value > 0) {
       state->d_config.checkInterval.store(value);
     }
   });

--- a/regression-tests.dnsdist/test_HealthChecks.py
+++ b/regression-tests.dnsdist/test_HealthChecks.py
@@ -669,6 +669,13 @@ class TestHealthCheckLatency(HealthCheckUpdateParams):
         # introduce 500 ms of latency
         self.setDelay(0.5)
 
+        # consume any value received in the meantime (it does happen on GH actions runners)
+        try:
+            while self.wait1(False):
+                pass
+        except queue.Empty:
+            pass
+
         self.wait1(True)
 
         # should have no failures, still up


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17381 to dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
