### PR TITLE
dnsdist-2.0: Backport 17382 - Fix a data race on concurrent CDB KVS lookups

### DIFF
--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -192,7 +192,7 @@ bool CDBKVStore::reload(const struct stat& st)
 {
   auto newCDB = std::make_unique<CDB>(d_fname);
   {
-    *(d_cdb.write_lock()) = std::move(newCDB);
+    *(d_cdb.lock()) = std::move(newCDB);
   }
   d_mtime = st.st_mtime;
   return true;
@@ -246,7 +246,7 @@ bool CDBKVStore::getValue(const std::string& key, std::string& value)
     }
 
     {
-      auto cdb = d_cdb.read_lock();
+      auto cdb = d_cdb.lock();
       if (*cdb && (*cdb)->findOne(key, value)) {
         return true;
       }
@@ -268,7 +268,7 @@ bool CDBKVStore::keyExists(const std::string& key)
     }
 
     {
-      auto cdb = d_cdb.read_lock();
+      auto cdb = d_cdb.lock();
       if (!*cdb) {
         return false;
       }

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -212,7 +212,7 @@ private:
   void refreshDBIfNeeded(time_t now);
   bool reload(const struct stat& st);
 
-  SharedLockGuarded<std::unique_ptr<CDB>> d_cdb{nullptr};
+  LockGuarded<std::unique_ptr<CDB>> d_cdb{nullptr};
   std::string d_fname;
   time_t d_mtime{0};
   time_t d_nextCheck{0};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17382 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
