### PR TITLE
dnsdist-2.0: Backport 17396 - snmp-agent: Fix a memory leak

### DIFF
--- a/pdns/snmp-agent.cc
+++ b/pdns/snmp-agent.cc
@@ -92,6 +92,7 @@ void SNMPAgent::handleSNMPQueryEvent(int fd)
   NETSNMP_LARGE_FD_ZERO(&fdset);
   NETSNMP_LARGE_FD_SET(fd, &fdset);
   snmp_read2(&fdset);
+  netsnmp_large_fd_set_cleanup(&fdset);
 }
 
 void SNMPAgent::handleTrapsCB(int /* fd */, FDMultiplexer::funcparam_t& var)
@@ -173,6 +174,7 @@ void SNMPAgent::worker()
         }
       }
     }
+    netsnmp_large_fd_set_cleanup(&fdset);
   }
 #endif /* HAVE_NET_SNMP */
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17396 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
