### PR TITLE
dnsdist-2.0: Backport 17399 - More minor fixes

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-configuration-items.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-configuration-items.cc
@@ -157,11 +157,10 @@ static const std::map<std::string, UnsignedIntegerImmutableConfigurationItems> s
   {"setMaxTCPReadIOsPerQuery", {[](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_maxTCPReadIOsPerQuery = newValue; }, std::numeric_limits<uint32_t>::max()}},
   {"setBanDurationForExceedingMaxReadIOsPerQuery", {[](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpBanDurationForExceedingMaxReadIOsPerQuery = newValue; }, std::numeric_limits<uint32_t>::max()}},
   {"setBanDurationForExceedingTCPTLSRate", {[](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpBanDurationForExceedingTCPTLSRate = newValue; }, std::numeric_limits<uint32_t>::max()}},
-  {"setTCPConnectionsOverloadThreshold", {[](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpConnectionsOverloadThreshold = newValue; }, std::numeric_limits<uint8_t>::max()}},
   {"setTCPConnectionsMaskV4", {[](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpConnectionsMaskV4 = newValue; }, std::numeric_limits<uint8_t>::max()}},
   {"setTCPConnectionsMaskV6", {[](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpConnectionsMaskV6 = newValue; }, std::numeric_limits<uint8_t>::max()}},
   {"setTCPConnectionsMaskV4Port", {[](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpConnectionsMaskV4Port = newValue; }, std::numeric_limits<uint8_t>::max()}},
-  {"setTCPConnectionsOverloadThreshold", {[](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpConnectionsOverloadThreshold = newValue; }, 100}},
+  {"setTCPConnectionsOverloadThreshold", {[](dnsdist::configuration::ImmutableConfiguration& config, uint64_t newValue) { config.d_tcpConnectionsOverloadThreshold = newValue; }, 100U}},
 };
 
 static const std::map<std::string, DoubleImmutableConfigurationItems> s_doubleImmutableConfigItems{

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -691,7 +691,7 @@ void setupLuaInspection(LuaContext& luaCtx)
             iter->second++;
           }
           else {
-            histo.rbegin()++;
+            histo.rbegin()->second++;
           }
           totlat += entry.usec;
         }

--- a/pdns/dnsdistdist/dnsdist-lua-network.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-network.cc
@@ -158,12 +158,9 @@ void NetworkListener::runOnce(timeval& now, uint32_t timeout)
   runOnce(*d_data, now, timeout);
 }
 
-void NetworkListener::mainThread(std::shared_ptr<ListenerData>& dataArg)
+// NOLINTNEXTLINE(performance-unnecessary-value-param): take our own copy of the shared_ptr so it's still alive if the NetworkListener object gets destroyed while we are still running
+void NetworkListener::mainThread(std::shared_ptr<ListenerData> data)
 {
-  /* take our own copy of the shared_ptr so it's still alive if the NetworkListener object
-     gets destroyed while we are still running */
-  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization): we really need a copy here, or we end up with use-after-free as explained above
-  auto data = dataArg;
   setThreadName("dnsdist/lua-net");
   timeval now{};
 
@@ -174,8 +171,8 @@ void NetworkListener::mainThread(std::shared_ptr<ListenerData>& dataArg)
 
 void NetworkListener::start()
 {
-  std::thread main = std::thread([this] {
-    mainThread(d_data);
+  std::thread main = std::thread([data = d_data]() mutable {
+    mainThread(std::move(data));
   });
   main.detach();
 }

--- a/pdns/dnsdistdist/dnsdist-lua-network.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-network.hh
@@ -58,7 +58,7 @@ private:
   };
 
   static void readCB(int desc, FDMultiplexer::funcparam_t& param);
-  static void mainThread(std::shared_ptr<ListenerData>& data);
+  static void mainThread(std::shared_ptr<ListenerData> data);
   static void runOnce(ListenerData& data, timeval& now, uint32_t timeout);
 
   struct CBData

--- a/pdns/dnsdistdist/dnsdist-mac-address.cc
+++ b/pdns/dnsdistdist/dnsdist-mac-address.cc
@@ -39,7 +39,7 @@ int MacAddressesCache::get(const ComboAddress& ca, unsigned char* dest, size_t d
   {
     auto cache = s_cache.read_lock();
     for (const auto& entry : *cache) {
-      if (entry.ttd >= now && compare(entry.ca, ca) == true) {
+      if (entry.ttd >= now && compare(entry.ca, ca)) {
         if (!entry.found) {
           // negative entry
           return ENOENT;
@@ -50,8 +50,12 @@ int MacAddressesCache::get(const ComboAddress& ca, unsigned char* dest, size_t d
     }
   }
 
+  // in theory we might encounter a MAC address smaller than 6 bytes,
+  // don't enter garbage data into our cache
+  memset(dest, 0, destLen);
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   auto res = getMACAddress(ca, reinterpret_cast<char*>(dest), destLen);
-  Entry entry;
+  Entry entry{};
   entry.ca = ca;
   if (res == 0) {
     memcpy(entry.mac.data(), dest, entry.mac.size());

--- a/pdns/dnsdistdist/xsk.cc
+++ b/pdns/dnsdistdist/xsk.cc
@@ -391,7 +391,7 @@ std::vector<XskPacket> XskSocket::recv(uint32_t recvSizeMax, uint32_t* failedCou
     try {
       const auto* desc = xsk_ring_cons__rx_desc(&rx, idx++);
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,performance-no-int-to-ptr)
-      XskPacket packet = XskPacket(reinterpret_cast<uint8_t*>(desc->addr + baseAddr), desc->len, frameSize);
+      auto packet = XskPacket(reinterpret_cast<uint8_t*>(desc->addr + baseAddr), desc->len, frameSize);
 #ifdef DEBUG_UMEM
       checkUmemIntegrity(__PRETTY_FUNCTION__, __LINE__, sharedEmptyFrameOffset, frameOffset(packet), {UmemEntryStatus::Status::FillQueue}, UmemEntryStatus::Status::Received);
 #endif /* DEBUG_UMEM */
@@ -407,12 +407,12 @@ std::vector<XskPacket> XskSocket::recv(uint32_t recvSizeMax, uint32_t* failedCou
     catch (const std::exception& exp) {
       ++failed;
       ++processed;
-      break;
+      continue;
     }
     catch (...) {
       ++failed;
       ++processed;
-      break;
+      continue;
     }
   }
 
@@ -796,7 +796,7 @@ bool XskPacket::isIPV6() const noexcept
   return v6;
 }
 
-XskPacket::XskPacket(uint8_t* frame_, size_t dataSize, size_t frameSize_) :
+XskPacket::XskPacket(uint8_t* frame_, size_t dataSize, size_t frameSize_) noexcept :
   frame(frame_), frameLength(dataSize), frameSize(frameSize_ - XDP_PACKET_HEADROOM)
 {
 }

--- a/pdns/dnsdistdist/xsk.hh
+++ b/pdns/dnsdistdist/xsk.hh
@@ -256,7 +256,7 @@ public:
   /* rewrite the headers, usually after setAddr() and setPayload() have been called */
   void rewrite() noexcept;
   void setHeader(PacketBuffer& buf);
-  XskPacket(uint8_t* frame, size_t dataSize, size_t frameSize);
+  XskPacket(uint8_t* frame, size_t dataSize, size_t frameSize) noexcept;
   void addDelay(int relativeMilliseconds) noexcept;
   /* if the payload have been updated, and the headers have not been rewritten, exchange the source
      and destination addresses (ethernet and IP) and rewrite the headers */

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -690,6 +690,10 @@ std::vector<Netmask> getListOfRangesOfNetworkInterface(const std::string& itf)
     if (ifa->ifa_addr == nullptr || (ifa->ifa_addr->sa_family != AF_INET && ifa->ifa_addr->sa_family != AF_INET6)) {
       continue;
     }
+    if (ifa->ifa_netmask == nullptr) {
+      continue;
+    }
+
     ComboAddress addr;
     try {
       addr.setSockaddr(ifa->ifa_addr, ifa->ifa_addr->sa_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17399 to dnsdist-2.0.x

Note that two commits from the original PR (setHealthCheckResponseValidator, OpenTelemetry) are not needed on 2.0.x and have been skipped.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
