### PR TITLE
dnsdist-2.0: Backport 17385 - Keep concurrent connection entries for live connections

### DIFF
--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -163,6 +163,11 @@ void IncomingConcurrentTCPConnectionsManager::cleanup(time_t now)
     auto clients = shard.lock();
     auto& index = clients->get<TimeTag>();
     for (auto entry = index.begin(); entry != index.end();) {
+      if (entry->d_concurrentConnections > 0) {
+        /* we need to keep this around as we still have open connections */
+        ++entry;
+        continue;
+      }
       if (entry->d_lastSeen >= cutOff) {
         /* this index is ordered on timestamps,
            so the first valid entry we see means we are done */

--- a/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/dnsdist-concurrent-connections.cc
@@ -185,6 +185,7 @@ void IncomingConcurrentTCPConnectionsManager::clear()
     auto clients = shard.lock();
     clients->clear();
   }
+  s_nextCleanup.store(0);
 }
 
 size_t IncomingConcurrentTCPConnectionsManager::getNumberOfEntries()

--- a/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
@@ -412,7 +412,6 @@ BOOST_FIXTURE_TEST_CASE(test_Live_Connections_Cleanup, TestFixture)
   auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
   BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
 
-
   BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 1U);
 
   /* now we should be after interval * 60s, entries should NOT be removed because it is active */

--- a/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
@@ -398,4 +398,34 @@ BOOST_FIXTURE_TEST_CASE(test_TLS_Resumed_Without_TCP_Rate_Limiting, TestFixture)
   BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Denied);
 }
 
+BOOST_FIXTURE_TEST_CASE(test_Live_Connections_Cleanup, TestFixture)
+{
+  const uint64_t maxTCPConnectionsRatePerClient = 10U;
+  const uint64_t tcpConnectionsRatePerClientInterval = 5U;
+  const uint64_t maxTCPConnectionsPerClient = 1U;
+  const uint32_t banDuration = 10U;
+  initConfiguration(maxTCPConnectionsRatePerClient, tcpConnectionsRatePerClientInterval, maxTCPConnectionsPerClient, banDuration);
+  time_t now = time(nullptr);
+
+  const ComboAddress client{"192.0.2.1"};
+  /* open one connection */
+  auto result = dnsdist::IncomingConcurrentTCPConnectionsManager::accountNewTCPConnection(client, false, false, now);
+  BOOST_REQUIRE(result == dnsdist::IncomingConcurrentTCPConnectionsManager::NewConnectionResult::Allowed);
+
+
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 1U);
+
+  /* now we should be after interval * 60s, entries should NOT be removed because it is active */
+  now += 300U;
+  dnsdist::IncomingConcurrentTCPConnectionsManager::cleanup(now);
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 1U);
+
+  /* close it */
+  dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+  /* now it should be removed (we need more than 60s between two cleanups) */
+  now += 120U;
+  dnsdist::IncomingConcurrentTCPConnectionsManager::cleanup(now);
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 0U);
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
+++ b/pdns/dnsdistdist/test-dnsdist-concurrent-connections.cc
@@ -421,6 +421,8 @@ BOOST_FIXTURE_TEST_CASE(test_Live_Connections_Cleanup, TestFixture)
 
   /* close it */
   dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(client);
+  BOOST_REQUIRE_EQUAL(dnsdist::IncomingConcurrentTCPConnectionsManager::getNumberOfEntries(), 1U);
+
   /* now it should be removed (we need more than 60s between two cleanups) */
   now += 120U;
   dnsdist::IncomingConcurrentTCPConnectionsManager::cleanup(now);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17385 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [w] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
