### PR TITLE
dnsdist-2.0: Backport 17393 - Ignore invalid backend weight coming from YAML

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -438,11 +438,11 @@ static std::shared_ptr<DownstreamState> createBackendFromConfiguration(const dns
   backendConfig.d_numberOfSockets = config.sockets;
   backendConfig.d_qpsLimit = config.queries_per_second;
   backendConfig.order = config.order;
-  if (config.weight < 1) {
+  if (config.weight < 1 || config.weight > std::numeric_limits<decltype(backendConfig.d_weight)>::max()) {
     warnlog("Ignoring invalid weight on backend %s", std::string(config.address));
   }
   else {
-    backendConfig.d_weight = config.weight;
+    backendConfig.d_weight = static_cast<int>(config.weight);
   }
 
   backendConfig.d_maxInFlightQueriesPerConn = config.max_in_flight;

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -438,7 +438,13 @@ static std::shared_ptr<DownstreamState> createBackendFromConfiguration(const dns
   backendConfig.d_numberOfSockets = config.sockets;
   backendConfig.d_qpsLimit = config.queries_per_second;
   backendConfig.order = config.order;
-  backendConfig.d_weight = config.weight;
+  if (config.weight < 1) {
+    warnlog("Ignoring invalid weight on backend %s", std::string(config.address));
+  }
+  else {
+    backendConfig.d_weight = config.weight;
+  }
+
   backendConfig.d_maxInFlightQueriesPerConn = config.max_in_flight;
   backendConfig.d_tcpConcurrentConnectionsLimit = config.max_concurrent_tcp_connections;
   backendConfig.name = std::string(config.name);

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -442,7 +442,7 @@ static std::shared_ptr<DownstreamState> createBackendFromConfiguration(const dns
     warnlog("Ignoring invalid weight on backend %s", std::string(config.address));
   }
   else {
-    backendConfig.d_weight = static_cast<int>(config.weight);
+    backendConfig.d_weight = static_cast<decltype(backendConfig.d_weight)>(config.weight);
   }
 
   backendConfig.d_maxInFlightQueriesPerConn = config.max_in_flight;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17393 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
