### PR TITLE
dnsdist-2.1: Backport 17380 - Fix OPT rdlen computation when adding ECS

### DIFF
--- a/pdns/dnsdistdist/dnsdist-ecs.cc
+++ b/pdns/dnsdistdist/dnsdist-ecs.cc
@@ -513,7 +513,11 @@ static bool addECSToExistingOPT(PacketBuffer& packet, size_t maximumSize, const 
     return false;
   }
 
-  uint16_t newRDLen = oldRDLen + newECSOption.size();
+  const uint32_t computedRDLen = static_cast<uint32_t>(oldRDLen) + newECSOption.size();
+  if (computedRDLen > std::numeric_limits<uint16_t>::max()) {
+    return false;
+  }
+  const auto newRDLen = static_cast<uint16_t>(computedRDLen);
   packet.at(optRDLenPosition) = newRDLen / 256;
   packet.at(optRDLenPosition + 1) = newRDLen % 256;
 
@@ -603,6 +607,11 @@ bool handleEDNSClientSubnet(PacketBuffer& packet, const size_t maximumSize, cons
     }
 
     return replaceEDNSClientSubnetOption(packet, maximumSize, optRDPosition + ecsOptionStartPosition, ecsOptionSize, optRDPosition, newECSOption);
+  }
+
+  if (res != ENOENT) {
+    /* something is wrong */
+    return false;
   }
 
   /* we have an EDNS OPT RR but no existing ECS option */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17380 to dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
