### PR TITLE
auth lmdb: do not serialize records over 64K in length

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1085,6 +1085,10 @@ constexpr size_t serialize_offset_ordername = serialize_offset_disabled + sizeof
 template <>
 void serializeToBuffer(std::string& buffer, const LMDBBackend::LMDBResourceRecord& value)
 {
+  if (value.content.length() > std::numeric_limits<uint16_t>::max()) {
+    throw PDNSException("DNS record is too large (" + std::to_string(value.content.length()) + "), unable to serialize in LMDB");
+  }
+
   // Data size of the resource record.
   uint16_t len = value.content.length();
 


### PR DESCRIPTION
### Short description
The in-database record format we use with LMDB stores the record length as a 16-bit integer.
In the unlikely event that we get fed a record so large that this field would overflow, reject the operation, rather than writing an incorrect size and not being able to fetch the contents back correctly afterwards.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
