### PR TITLE
auth 5.0: backport "ednscookies: fix timestamp validity check"

### DIFF
--- a/pdns/ednscookies.cc
+++ b/pdns/ednscookies.cc
@@ -85,8 +85,8 @@ static bool cookieTSIsValid(uint32_t timestamp, uint32_t now)
   //    The DNS server
   //    SHOULD allow cookies within a 1-hour period in the past and a
   //    5-minute period into the future
-  // valid: now - 300 < timestamp < now + 3600
-  return rfc1982LessThan(now - 300, timestamp) && rfc1982LessThan(timestamp, now + 3600);
+  // valid: now - 3600 < timestamp < now + 300
+  return rfc1982LessThan(now - 3600, timestamp) && rfc1982LessThan(timestamp, now + 300);
 }
 
 bool EDNSCookiesOpt::isValid([[maybe_unused]] const string& secret, [[maybe_unused]] const ComboAddress& source) const

--- a/pdns/ednscookies.cc
+++ b/pdns/ednscookies.cc
@@ -79,6 +79,16 @@ void EDNSCookiesOpt::getEDNSCookiesOptFromString(const char* option, unsigned in
   }
 }
 
+static bool cookieTSIsValid(uint32_t timestamp, uint32_t now)
+{
+  // RFC 9018 section 4.3:
+  //    The DNS server
+  //    SHOULD allow cookies within a 1-hour period in the past and a
+  //    5-minute period into the future
+  // valid: now - 300 < timestamp < now + 3600
+  return rfc1982LessThan(now - 300, timestamp) && rfc1982LessThan(timestamp, now + 3600);
+}
+
 bool EDNSCookiesOpt::isValid([[maybe_unused]] const string& secret, [[maybe_unused]] const ComboAddress& source) const
 {
 #ifdef HAVE_CRYPTO_SHORTHASH
@@ -94,11 +104,7 @@ bool EDNSCookiesOpt::isValid([[maybe_unused]] const string& secret, [[maybe_unus
   timestamp = ntohl(timestamp);
   // coverity[store_truncates_time_t]
   auto now = static_cast<uint32_t>(time(nullptr));
-  // RFC 9018 section 4.3:
-  //    The DNS server
-  //    SHOULD allow cookies within a 1-hour period in the past and a
-  //    5-minute period into the future
-  if (rfc1982LessThan(now + 300, timestamp) && rfc1982LessThan(timestamp + 3600, now)) {
+  if (!cookieTSIsValid(timestamp, now)) {
     return false;
   }
   if (secret.length() != crypto_shorthash_KEYBYTES) {
@@ -131,12 +137,8 @@ bool EDNSCookiesOpt::shouldRefresh() const
   timestamp = ntohl(timestamp);
   // coverity[store_truncates_time_t]
   auto now = static_cast<uint32_t>(time(nullptr));
-  // RFC 9018 section 4.3:
-  //    The DNS server
-  //    SHOULD allow cookies within a 1-hour period in the past and a
-  //    5-minute period into the future
-  // If this is not the case, we need to refresh
-  if (rfc1982LessThan(now + 300, timestamp) && rfc1982LessThan(timestamp + 3600, now)) {
+  // If the cookie is not within acceptable time bounds, we need to refresh
+  if (!cookieTSIsValid(timestamp, now)) {
     return true;
   }
 


### PR DESCRIPTION
### Short description
Backport of 1b6bc8f1db4c31fc694b5ceaadbc64515e7eef31 and #17384.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
