### PR TITLE
Yet more xfr* hardening

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -610,6 +610,10 @@ void PacketReader::xfrBlob(string& blob, int length)
     if (length < 0) {
       throw std::out_of_range("xfrBlob out of range (negative length)");
     }
+    auto available = (d_startrecordpos + d_recordlen) - d_pos;
+    if (available < length) {
+      throw std::out_of_range("xfrBlob out of range (excessive length)");
+    }
 
     blob.assign(&d_content.at(d_pos), &d_content.at(d_pos + length - 1 ) + 1 );
 

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -327,7 +327,7 @@ void RecordTextReader::xfrBlobNoSpaces(string& val, int len)
     throw RecordTextException("Record length "+std::to_string(val.size()) + " does not match expected length '"+std::to_string(len));
 }
 
-void RecordTextReader::xfrBlob(string& val, int)
+void RecordTextReader::xfrBlob(string& val, int len)
 {
   skipSpaces();
   auto pos = d_pos;
@@ -342,6 +342,10 @@ void RecordTextReader::xfrBlob(string& val, int)
   boost::erase_all(tmp," ");
   val.clear();
   B64Decode(tmp, val);
+
+  if (len>-1 && val.size() != static_cast<size_t>(len)) {
+    throw RecordTextException("Record length "+std::to_string(val.size()) + " does not match expected length '"+std::to_string(len));
+  }
 }
 
 void RecordTextReader::xfrRFC1035CharString(string &val) {


### PR DESCRIPTION
### Short description
This make sure the two-argument form of `xfrBlob` (and `xfrBlobNoSpaces`) will not access data out of the packet buffer, when reading from a packet.

Reported by Naija_Overflow in YWH-PGM6095-292, many thanks!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
