### PR TITLE
dnsdist: Add a TSAN suppression for DownstreamState::setUpStatus

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tsan.supp
+++ b/pdns/dnsdistdist/dnsdist-tsan.supp
@@ -6,11 +6,12 @@ race:handleStats
 race:ClientState::updateTCPMetrics
 race:DownstreamState::updateTCPMetrics
 race:DownstreamState::updateTCPLatency
-# There is a race when we update the status of a backend,
+# There is a race when we update the latency of a backend,
 # but eventual consistency is fine there
 race:DownstreamState::setDown
 race:DownstreamState::setUp
 race:DownstreamState::setAuto
+race:DownstreamState::setUpStatus
 # Same thing for whether a backend has been stopped,
 # eventual consistency is fine
 race:DownstreamState::stop


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Prevents:
```
WARNING: ThreadSanitizer: data race (pid=11817)
  Write of size 8 at 0x728400000f58 by thread T25:
    #0 __tsan_memset <null> (dnsdist+0x503c41) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #1 DownstreamState::setUpStatus(bool) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist.hh:824:22 (dnsdist+0x657aba) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #2 DownstreamState::submitHealthCheckResult(bool, bool) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist-backend.cc:914:5 (dnsdist+0x657aba)
    #3 healthCheckUDPCallback(int, boost::any&) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist-healthchecks.cc:285:19 (dnsdist+0x82b696) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #4 void std::__invoke_impl<void, void (*&)(int, boost::any&), int, boost::any&>(std::__invoke_other, void (*&)(int, boost::any&), int&&, boost::any&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:61:14 (dnsdist+0x839ce7) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #5 std::enable_if<is_invocable_r_v<void, void (*&)(int, boost::any&), int, boost::any&>, void>::type std::__invoke_r<void, void (*&)(int, boost::any&), int, boost::any&>(void (*&)(int, boost::any&), int&&, boost::any&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:111:2 (dnsdist+0x839ce7)
    #6 std::_Function_handler<void (int, boost::any&), void (*)(int, boost::any&)>::_M_invoke(std::_Any_data const&, int&&, boost::any&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_function.h:290:9 (dnsdist+0x839ce7)
    #7 std::function<void (int, boost::any&)>::operator()(int, boost::any&) const /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_function.h:591:9 (dnsdist+0x62b2e1) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #8 EpollFDMultiplexer::run(timeval*, int) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/epollmplexer.cc:188:9 (dnsdist+0x62b2e1)
    #9 handleQueuedHealthChecks(FDMultiplexer&, bool) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist-healthchecks.cc:560:23 (dnsdist+0x82d873) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #10 healthChecksThread() /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist.cc:2627:9 (dnsdist+0x5ace08) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #11 void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:61:14 (dnsdist+0x5f839d) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #12 std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:96:14 (dnsdist+0x5f839d)
    #13 void std::thread::_Invoker<std::tuple<void (*)()>>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:301:13 (dnsdist+0x5f839d)
    #14 std::thread::_Invoker<std::tuple<void (*)()>>::operator()() /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:308:11 (dnsdist+0x5f839d)
    #15 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()>>>::_M_run() /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:253:13 (dnsdist+0x5f839d)
    #16 <null> <null> (libstdc++.so.6+0xe1223) (BuildId: 133b71e0013695cc7832680a74edb51008c4fc4c)
2026-05-21T12:42:22.4242125Z
  Previous write of size 8 at 0x728400000f58 by thread T15:
    #0 processResponderPacket(std::shared_ptr<DownstreamState>&, std::vector<unsigned char, noinit_adaptor<std::allocator<unsigned char>>>&, InternalQueryState&&) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist.cc:767:20 (dnsdist+0x59159e) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #1 responderThread(std::shared_ptr<DownstreamState>) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist.cc:849:15 (dnsdist+0x5930f8) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #2 void std::__invoke_impl<void, void (*)(std::shared_ptr<DownstreamState>), std::shared_ptr<DownstreamState>>(std::__invoke_other, void (*&&)(std::shared_ptr<DownstreamState>), std::shared_ptr<DownstreamState>&&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:61:14 (dnsdist+0x66ba55) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #3 std::__invoke_result<void (*)(std::shared_ptr<DownstreamState>), std::shared_ptr<DownstreamState>>::type std::__invoke<void (*)(std::shared_ptr<DownstreamState>), std::shared_ptr<DownstreamState>>(void (*&&)(std::shared_ptr<DownstreamState>), std::shared_ptr<DownstreamState>&&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:96:14 (dnsdist+0x66ba55)
    #4 void std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<DownstreamState>), std::shared_ptr<DownstreamState>>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:301:13 (dnsdist+0x66ba55)
    #5 std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<DownstreamState>), std::shared_ptr<DownstreamState>>>::operator()() /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:308:11 (dnsdist+0x66ba55)
    #6 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<DownstreamState>), std::shared_ptr<DownstreamState>>>>::_M_run() /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:253:13 (dnsdist+0x66ba55)
    #7 <null> <null> (libstdc++.so.6+0xe1223) (BuildId: 133b71e0013695cc7832680a74edb51008c4fc4c)
2026-05-21T12:42:22.4257091Z
  As if synchronized via sleep:
    #0 usleep <null> (dnsdist+0x504f82) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #1 healthChecksThread() /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist.cc:2595:9 (dnsdist+0x5ac98f) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #2 void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:61:14 (dnsdist+0x5f839d) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #3 std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:96:14 (dnsdist+0x5f839d)
    #4 void std::thread::_Invoker<std::tuple<void (*)()>>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:301:13 (dnsdist+0x5f839d)
    #5 std::thread::_Invoker<std::tuple<void (*)()>>::operator()() /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:308:11 (dnsdist+0x5f839d)
    #6 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()>>>::_M_run() /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:253:13 (dnsdist+0x5f839d)
    #7 <null> <null> (libstdc++.so.6+0xe1223) (BuildId: 133b71e0013695cc7832680a74edb51008c4fc4c)
2026-05-21T12:42:22.4265086Z
  Location is heap block of size 4160 at 0x728400000000 allocated by main thread:
    #0 operator new(unsigned long, std::align_val_t) <null> (dnsdist+0x58cb9a) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #1 std::__new_allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>>::allocate(unsigned long, void const*) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/new_allocator.h:147:31 (dnsdist+0x6ff574) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #2 std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>>>::allocate(std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>>&, unsigned long) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/alloc_traits.h:515:20 (dnsdist+0x6ff574)
    #3 std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>>> std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>>>(std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>>&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/allocated_ptr.h:98:21 (dnsdist+0x6ff574)
    #4 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<DownstreamState, std::allocator<void>, DownstreamState::Config, std::shared_ptr<TLSCtx>, bool>(DownstreamState*&, std::_Sp_alloc_shared_tag<std::allocator<void>>, DownstreamState::Config&&, std::shared_ptr<TLSCtx>&&, bool&&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/shared_ptr_base.h:967:19 (dnsdist+0x6ff574)
    #5 std::__shared_ptr<DownstreamState, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, DownstreamState::Config, std::shared_ptr<TLSCtx>, bool>(std::_Sp_alloc_shared_tag<std::allocator<void>>, DownstreamState::Config&&, std::shared_ptr<TLSCtx>&&, bool&&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/shared_ptr_base.h:1713:14 (dnsdist+0x6ff574)
    #6 std::shared_ptr<DownstreamState>::shared_ptr<std::allocator<void>, DownstreamState::Config, std::shared_ptr<TLSCtx>, bool>(std::_Sp_alloc_shared_tag<std::allocator<void>>, DownstreamState::Config&&, std::shared_ptr<TLSCtx>&&, bool&&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/shared_ptr.h:463:4 (dnsdist+0xac6d46) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #7 std::shared_ptr<std::enable_if<!is_array<DownstreamState>::value, DownstreamState>::type> std::make_shared<DownstreamState, DownstreamState::Config, std::shared_ptr<TLSCtx>, bool>(DownstreamState::Config&&, std::shared_ptr<TLSCtx>&&, bool&&) /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/shared_ptr.h:1007:14 (dnsdist+0xac6d46)
    #8 setupLuaConfig(LuaContext&, bool, bool)::$_36::operator()(boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>>, std::optional<int>) const /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist-lua.cc:644:37 (dnsdist+0xac6d46)
    #9 decltype((*this).function((*this).param, std::forward<std::optional<int> const&>(fp))) LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_36&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>> const&>::operator()<std::optional<int> const&>(std::optional<int> const&) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:1889:20 (dnsdist+0xac0fd8) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #10 decltype((*this).function((*this).param)) LuaContext::Binder<LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_36&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>> const&>&, std::optional<int> const&>::operator()<>() /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:1889:20 (dnsdist+0xac0fd8)
    #11 std::shared_ptr<DownstreamState> LuaContext::readIntoFunction<std::shared_ptr<DownstreamState>, LuaContext::Binder<LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_36&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>> const&>&, std::optional<int> const&>&>(lua_State*, LuaContext::tag<std::shared_ptr<DownstreamState>>, LuaContext::Binder<LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_36&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>> const&>&, std::optional<int> const&>&, int) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:1808:16 (dnsdist+0xac0fd8)
    #12 std::enable_if<IsOptional<std::optional<int>>::value, std::shared_ptr<DownstreamState>>::type LuaContext::readIntoFunction<std::shared_ptr<DownstreamState>, LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_36&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>> const&>&, std::optional<int>>(lua_State*, LuaContext::tag<std::shared_ptr<DownstreamState>>, LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_36&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>> const&>&, int, LuaContext::tag<std::optional<int>>) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:1817:20 (dnsdist+0xac0fd8)
    #13 std::enable_if<!IsOptional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>>>::value, std::shared_ptr<DownstreamState>>::type LuaContext::readIntoFunction<std::shared_ptr<DownstreamState>, setupLuaConfig(LuaContext&, bool, bool)::$_36&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>>, std::optional<int>>(lua_State*, LuaContext::tag<std::shared_ptr<DownstreamState>>, setupLuaConfig(LuaContext&, bool, bool)::$_36&, int, LuaContext::tag<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>>>, LuaContext::tag<std::optional<int>>) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:1839:16 (dnsdist+0xac0fd8)
    #14 std::enable_if<!std::integral_constant<bool, false>::value && !std::is_void<setupLuaConfig(LuaContext&, bool, bool)::$_36&>::value, LuaContext::PushedObject>::type LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>>, std::optional<int>), void>::callback2<setupLuaConfig(LuaContext&, bool, bool)::$_36&>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_36&, int) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:2478:31 (dnsdist+0xac0fd8)
    #15 LuaContext::PushedObject LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>>, std::optional<int>), void>::callback<setupLuaConfig(LuaContext&, bool, bool)::$_36>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_36*, int) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:2447:20 (dnsdist+0xac0fd8)
    #16 std::enable_if<boost::has_trivial_destructor<setupLuaConfig(LuaContext&, bool, bool)::$_36>::value, LuaContext::PushedObject>::type LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>>, std::optional<int>), void>::push<setupLuaConfig(LuaContext&, bool, bool)::$_36>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_36)::'lambda'(lua_State*)::operator()(lua_State*) const /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:2375:20 (dnsdist+0xac0fd8)
    #17 std::enable_if<boost::has_trivial_destructor<setupLuaConfig(LuaContext&, bool, bool)::$_36>::value, LuaContext::PushedObject>::type LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::pair<int, std::shared_ptr<XskSocket>>, std::allocator<std::pair<int, std::shared_ptr<XskSocket>>>>, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)>>>>>>, std::optional<int>), void>::push<setupLuaConfig(LuaContext&, bool, bool)::$_36>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_36)::'lambda'(lua_State*)::__invoke(lua_State*) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:2371:31 (dnsdist+0xac0fd8)
    #18 <null> <null> (libluajit-5.1.so.2+0xaaf5) (BuildId: e1deeeb04de4ac076ef5cc53b583f2c4db375dbe)
    #19 std::tuple<> LuaContext::call<std::tuple<>>(lua_State*, LuaContext::PushedObject) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:1441:29 (dnsdist+0x61f3bd) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #20 LuaContext::executeCode(std::istream&) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/ext/luawrapper/include/LuaContext.hpp:295:9 (dnsdist+0xb61a34) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #21 dnsdist::configuration::lua::loadLuaConfigurationFile(LuaContext&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist-lua.cc:3363:10 (dnsdist+0xac0d1c) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #22 loadConfigurationFromFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool, bool, std::shared_ptr<Logr::Logger const> const&) /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist.cc:3593:5 (dnsdist+0x5ab330) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #23 main /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist.cc:3722:10 (dnsdist+0x5a2399) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
2026-05-21T12:42:22.4779568Z
  Thread T25 'dnsdist/healthC' (tid=11843, running) created by main thread at:
    #0 pthread_create <null> (dnsdist+0x507f55) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) <null> (libstdc++.so.6+0xe12f8) (BuildId: 133b71e0013695cc7832680a74edb51008c4fc4c)
    #2 <null> <null> (libc.so.6+0x29ca7) (BuildId: c495b62edadd6c356265942ec1282d98058a7b41)
2026-05-21T12:42:22.4782711Z
  Thread T15 'dnsdist/respond' (tid=11833, running) created by main thread at:
    #0 pthread_create <null> (dnsdist+0x507f55) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) <null> (libstdc++.so.6+0xe12f8) (BuildId: 133b71e0013695cc7832680a74edb51008c4fc4c)
    #2 main /__w/pdns-private/pdns-private/pdns/dnsdistdist/dnsdist-0.0.0-git1/../../../../../../tmp/dnsdist-meson-dist-build/meson-dist/dnsdist-0.0.0-git1/dnsdist.cc:3862:18 (dnsdist+0x5a6880) (BuildId: 22ed65c8a459bfe2a40f94878815ce579cb879a9)
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
