### PR TITLE
dnsdist: Do not check the counters in eBPF's regression test

### DIFF
--- a/regression-tests.dnsdist/test_EBPF.py
+++ b/regression-tests.dnsdist/test_EBPF.py
@@ -146,7 +146,8 @@ class TestSimpleEBPF(DNSDistTest):
         # block 127.0.0.1
         self.sendConsoleCommand('bpf:block(newCA("127.0.0.1"))')
         stats = self.sendConsoleCommand("bpf:getStats()")
-        self.assertIn("127.0.0.1: 0", stats)
+        # careful with the counters, we might have already been blocked during TestDynBlockEBPFQPS
+        self.assertIn("127.0.0.1: ", stats)
 
         name = "ip-blocked.ebpf.tests.powerdns.com."
         query = dns.message.make_query(name, "A", "IN", use_edns=False)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We might have already been blocked by the dynamic block regression tests, if we are unlucky.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
