### PR TITLE
auth: stricter proxy protocol size limit enforcement

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -275,14 +275,18 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
       for (;;) {
         used = isProxyHeaderComplete(proxyData);
         if (used < 0) {
-          ssize_t origsize = proxyData.size();
-          proxyData.resize(origsize + -used);
+          size_t origsize = proxyData.size();
+          auto extra = static_cast<size_t>(-used);
+          if (origsize + extra > g_proxyProtocolMaximumSize) {
+            throw NetworkError("Error reading PROXYv2 header from TCP client "+remote.toString()+": PROXYv2 header too big");
+          }
+          proxyData.resize(origsize + extra);
           if (maxConnectionDurationReached(d_maxConnectionDuration, start, remainingTime)) {
             throw NetworkError("Error reading PROXYv2 header from TCP client "+remote.toString()+": maximum TCP connection duration exceeded");
           }
 
           try {
-            readnWithTimeout(fd, &proxyData[origsize], -used, d_idleTimeout, true, remainingTime);
+            readnWithTimeout(fd, &proxyData[origsize], extra, d_idleTimeout, true, remainingTime);
           }
           catch(NetworkError& ae) {
             throw NetworkError("Error reading PROXYv2 header from TCP client "+remote.toString()+": "+ae.what());


### PR DESCRIPTION
### Short description
This moves the check for the size limit of proxied messages a bit earlier.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
