### PR TITLE
iputils: Return early when the tree is empty

### DIFF
--- a/pdns/dnsdistdist/bench-iputils.cc
+++ b/pdns/dnsdistdist/bench-iputils.cc
@@ -1,0 +1,41 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#define CATCH_CONFIG_NO_MAIN
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include "iputils.hh"
+
+TEST_CASE("netmask_tree")
+{
+  const ComboAddress addr{"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"};
+  NetmaskTree<bool> tree{};
+
+  BENCHMARK("lookup_v6_empty_tree")
+  {
+    const auto* got = tree.lookup(addr);
+    if (got != nullptr) {
+      abort();
+    }
+    return got;
+  };
+}

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -606,6 +606,7 @@ benchmark_sources = files(
   src_dir / 'bench-dnsdist-opentelemetry_cc.cc',
   src_dir / 'bench-dnsdist-rings_cc.cc',
   src_dir / 'bench-misc_hh.cc',
+  src_dir / 'bench-iputils.cc',
 )
 
 if get_option('benchmark')

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1511,6 +1511,9 @@ public:
   //<! Returns "best match" for key_type, which might not be value
   [[nodiscard]] node_type* lookup(const key_type& value) const
   {
+    if (empty()) {
+      return nullptr;
+    }
     uint8_t max_bits = value.getBits();
     return lookupImpl(value, max_bits);
   }
@@ -1518,6 +1521,9 @@ public:
   //<! Perform best match lookup for value, using at most max_bits
   [[nodiscard]] node_type* lookup(const ComboAddress& value, int max_bits = 128) const
   {
+    if (empty()) {
+      return nullptr;
+    }
     uint8_t addr_bits = value.getBits();
     if (max_bits < 0 || max_bits > addr_bits) {
       max_bits = addr_bits;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This brings a small speed-up when the proxy protocol ACL is empty, for example.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
