### PR TITLE
dnsdist: Do not send UDP responses when the frontend is muted

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1990,7 +1990,9 @@ static void processUDPQuery(ClientState& clientState, const struct msghdr* msgh,
 
     auto dnsCryptResponse = checkDNSCryptQuery(clientState, query, ids.dnsCryptQuery, ids.queryRealTime.d_start.tv_sec, false);
     if (dnsCryptResponse) {
-      sendUDPResponse(clientState.udpFD, query, 0, dest, remote);
+      if (!clientState.muted) {
+        sendUDPResponse(clientState.udpFD, query, 0, dest, remote);
+      }
       return;
     }
 
@@ -2010,7 +2012,9 @@ static void processUDPQuery(ClientState& clientState, const struct msghdr* msgh,
           return true;
         });
 
-        sendUDPResponse(clientState.udpFD, query, 0, dest, remote);
+        if (!clientState.muted) {
+          sendUDPResponse(clientState.udpFD, query, 0, dest, remote);
+        }
         return;
       }
     }
@@ -2063,7 +2067,9 @@ static void processUDPQuery(ClientState& clientState, const struct msghdr* msgh,
 #endif /* defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE) */
 #endif /* DISABLE_RECVMMSG */
       /* we use dest, always, because we don't want to use the listening address to send a response since it could be 0.0.0.0 */
-      sendUDPResponse(clientState.udpFD, query, dnsQuestion.ids.delayMsec, dest, remote);
+      if (!clientState.muted) {
+        sendUDPResponse(clientState.udpFD, query, dnsQuestion.ids.delayMsec, dest, remote);
+      }
 
       handleResponseSent(std::move(dnsQuestion.ids.qname), dnsQuestion.ids.qtype, 0., remote, ComboAddress(), query.size(), *dnsHeader, dnsdist::Protocol::DoUDP, dnsdist::Protocol::DoUDP, false);
       return;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We were not checking in various places (cache hits, self-answered responses).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
