### PR TITLE
dnsdist: Reduce the cost of disabled OpenTelemetry tracing

### DIFF
--- a/pdns/dnsdistdist/dnsdist-actions-factory.cc
+++ b/pdns/dnsdistdist/dnsdist-actions-factory.cc
@@ -1747,7 +1747,7 @@ public:
 
   DNSAction::Action operator()([[maybe_unused]] DNSQuestion* dnsquestion, [[maybe_unused]] std::string* ruleresult) const override
   {
-    auto tracer = dnsquestion->ids.getTracer();
+    auto& tracer = dnsquestion->ids.getTracer();
     if (tracer == nullptr) {
       VERBOSESLOG(infolog("SetTraceAction called, but OpenTelemetry tracing is globally disabled. Did you forget to call setOpenTelemetryTracing?"),
                   dnsquestion->getLogger()->info(Logr::Info, "SetTraceAction called, but OpenTelemetry tracing is globally disabled. Did you forget to call setOpenTelemetryTracing?"));

--- a/pdns/dnsdistdist/dnsdist-idstate.cc
+++ b/pdns/dnsdistdist/dnsdist-idstate.cc
@@ -117,7 +117,7 @@ std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getClose
   // getTracer returns a Tracer when tracing is globally enabled
   // tracingEnabled tells us whether or not tracing is enabled for this query
   // Should tracing be disabled, *but* we have not processed query rules, we will still return a closer if tracing is globally enabled
-  if (auto tracer = getTracer(); tracer != nullptr && (tracingEnabled || !rulesAppliedToQuery)) {
+  if (auto& tracer = getTracer(); tracer != nullptr && (tracingEnabled || !rulesAppliedToQuery)) {
     ret = d_OTTracer->openSpan(std::string(name), parentSpanID);
   }
 #endif
@@ -128,7 +128,7 @@ std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getClose
 {
   std::optional<pdns::trace::dnsdist::Tracer::Closer> ret{std::nullopt};
 #ifndef DISABLE_PROTOBUF
-  if (auto tracer = getTracer(); tracer != nullptr) {
+  if (auto& tracer = getTracer(); tracer != nullptr) {
     auto parentSpanID = d_OTTracer->getLastSpanIDForName(std::string(parentSpanName));
     ret = getCloser(name, parentSpanID);
   }
@@ -140,7 +140,7 @@ std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getClose
 {
   std::optional<pdns::trace::dnsdist::Tracer::Closer> ret{std::nullopt};
 #ifndef DISABLE_PROTOBUF
-  if (auto tracer = getTracer(); tracer != nullptr) {
+  if (auto& tracer = getTracer(); tracer != nullptr) {
     ret = getCloser(std::string(name), tracer->getLastSpanID());
   }
 #endif
@@ -155,7 +155,7 @@ std::optional<pdns::trace::dnsdist::Tracer::Closer> InternalQueryState::getRules
   // getTracer returns a Tracer when tracing is globally enabled
   // tracingEnabled tells us whether or not tracing is enabled for this query
   // Should tracing be disabled, *but* we have not processed query rules, we will still return a closer if tracing is globally enabled
-  if (auto tracer = getTracer(); tracer != nullptr && (tracingEnabled || !rulesAppliedToQuery)) {
+  if (auto& tracer = getTracer(); tracer != nullptr && (tracingEnabled || !rulesAppliedToQuery)) {
     auto parentSpanID = tracer->getLastSpanID();
     auto name = ruleType + prefix + std::string(ruleName);
     ret = tracer->openSpan(name, parentSpanID);

--- a/pdns/dnsdistdist/dnsdist-idstate.hh
+++ b/pdns/dnsdistdist/dnsdist-idstate.hh
@@ -133,15 +133,16 @@ struct InternalQueryState
 #ifdef DISABLE_PROTOBUF
     return d_OTTracer;
 #else
-    if (!d_OTTracingEnabled || d_OTTracer != nullptr) {
+    if ((d_OTTracingEnabledInConfiguration && !*d_OTTracingEnabledInConfiguration) || d_OTTracer != nullptr) {
       return d_OTTracer;
     }
     if (dnsdist::configuration::getCurrentRuntimeConfiguration().d_openTelemetryTracing) {
       // OpenTelemetry tracing is enabled, but we don't have a tracer yet
+      d_OTTracingEnabledInConfiguration = true;
       d_OTTracer = pdns::trace::dnsdist::Tracer::getTracer();
     }
     else {
-      d_OTTracingEnabled = false;
+      d_OTTracingEnabledInConfiguration = false;
     }
     return d_OTTracer;
 #endif
@@ -233,6 +234,9 @@ public:
   uint16_t udpPayloadSize{0}; // Max UDP payload size from the query // 2
   uint16_t sendTraceParentToDownstreamID{0}; // Whether or not to add a TRACEPARENT EDNS option to downstreams, set to non-0 for the EDNS Option ID
   std::optional<bool> dnssecOK;
+#ifndef DISABLE_PROTOBUF
+  std::optional<bool> d_OTTracingEnabledInConfiguration; // Whether OpenTelemetry tracing is enabled in the configuration. This prevents having to check the configuration several times for the same query
+#endif /* DISABLE_PROTOBUF */                                                         //
   dnsdist::Protocol protocol; // 1
   uint8_t restartCount{0}; // 1
   bool ednsAdded{false};
@@ -245,7 +249,6 @@ public:
   bool staleCacheHit{false};
   bool tracingEnabled{false}; // Whether or not Open Telemetry tracing is enabled for this query
   bool rulesAppliedToQuery{false}; // Whether applyRulesToQuery has been called for the query, used to determine if we need to trace
-  bool d_OTTracingEnabled{true}; // Whether OpenTelemetry tracing is enabled in the configuration. This prevents having to check the configuration several times for the same query
   struct rulesAppliedToQuerySetter
   {
     rulesAppliedToQuerySetter(bool& pastProcessRules) :

--- a/pdns/dnsdistdist/dnsdist-idstate.hh
+++ b/pdns/dnsdistdist/dnsdist-idstate.hh
@@ -128,20 +128,22 @@ struct InternalQueryState
    *
    * @return
    */
-  std::shared_ptr<pdns::trace::dnsdist::Tracer> getTracer()
+  std::shared_ptr<pdns::trace::dnsdist::Tracer>& getTracer()
   {
 #ifdef DISABLE_PROTOBUF
-    return nullptr;
+    return d_OTTracer;
 #else
-    if (dnsdist::configuration::getCurrentRuntimeConfiguration().d_openTelemetryTracing) {
-      if (d_OTTracer != nullptr) {
-        return d_OTTracer;
-      }
-      // OpenTelemetry tracing is enabled, but we don't have a tracer yet
-      d_OTTracer = pdns::trace::dnsdist::Tracer::getTracer();
+    if (d_OTTracingDisabled || d_OTTracer != nullptr) {
       return d_OTTracer;
     }
-    return nullptr;
+    if (dnsdist::configuration::getCurrentRuntimeConfiguration().d_openTelemetryTracing) {
+      // OpenTelemetry tracing is enabled, but we don't have a tracer yet
+      d_OTTracer = pdns::trace::dnsdist::Tracer::getTracer();
+    }
+    else {
+      d_OTTracingDisabled = true;
+    }
+    return d_OTTracer;
 #endif
   }
 
@@ -243,6 +245,7 @@ public:
   bool staleCacheHit{false};
   bool tracingEnabled{false}; // Whether or not Open Telemetry tracing is enabled for this query
   bool rulesAppliedToQuery{false}; // Whether applyRulesToQuery has been called for the query, used to determine if we need to trace
+  bool d_OTTracingDisabled{false}; // Whether OpenTelemetry tracing is disabled, prevent having to check the configuration several times for the same query
   struct rulesAppliedToQuerySetter
   {
     rulesAppliedToQuerySetter(bool& pastProcessRules) :

--- a/pdns/dnsdistdist/dnsdist-idstate.hh
+++ b/pdns/dnsdistdist/dnsdist-idstate.hh
@@ -236,7 +236,7 @@ public:
   std::optional<bool> dnssecOK;
 #ifndef DISABLE_PROTOBUF
   std::optional<bool> d_OTTracingEnabledInConfiguration; // Whether OpenTelemetry tracing is enabled in the configuration. This prevents having to check the configuration several times for the same query
-#endif /* DISABLE_PROTOBUF */                                                         //
+#endif /* DISABLE_PROTOBUF */
   dnsdist::Protocol protocol; // 1
   uint8_t restartCount{0}; // 1
   bool ednsAdded{false};

--- a/pdns/dnsdistdist/dnsdist-idstate.hh
+++ b/pdns/dnsdistdist/dnsdist-idstate.hh
@@ -133,7 +133,7 @@ struct InternalQueryState
 #ifdef DISABLE_PROTOBUF
     return d_OTTracer;
 #else
-    if (d_OTTracingDisabled || d_OTTracer != nullptr) {
+    if (!d_OTTracingEnabled || d_OTTracer != nullptr) {
       return d_OTTracer;
     }
     if (dnsdist::configuration::getCurrentRuntimeConfiguration().d_openTelemetryTracing) {
@@ -141,7 +141,7 @@ struct InternalQueryState
       d_OTTracer = pdns::trace::dnsdist::Tracer::getTracer();
     }
     else {
-      d_OTTracingDisabled = true;
+      d_OTTracingEnabled = false;
     }
     return d_OTTracer;
 #endif
@@ -245,7 +245,7 @@ public:
   bool staleCacheHit{false};
   bool tracingEnabled{false}; // Whether or not Open Telemetry tracing is enabled for this query
   bool rulesAppliedToQuery{false}; // Whether applyRulesToQuery has been called for the query, used to determine if we need to trace
-  bool d_OTTracingDisabled{false}; // Whether OpenTelemetry tracing is disabled, prevent having to check the configuration several times for the same query
+  bool d_OTTracingEnabled{true}; // Whether OpenTelemetry tracing is enabled in the configuration. This prevents having to check the configuration several times for the same query
   struct rulesAppliedToQuerySetter
   {
     rulesAppliedToQuerySetter(bool& pastProcessRules) :

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnsquestion.cc
@@ -374,7 +374,7 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
 #ifdef DISABLE_PROTOBUF
       return std::nullopt;
 #else
-      if (auto tracer = dnsQuestion.ids.getTracer(); tracer != nullptr && dnsQuestion.ids.tracingEnabled) {
+      if (auto& tracer = dnsQuestion.ids.getTracer(); tracer != nullptr && dnsQuestion.ids.tracingEnabled) {
         auto traceID = tracer->getTraceID();
         return std::string(traceID.begin(), traceID.end());
       }
@@ -388,7 +388,7 @@ void setupLuaBindingsDNSQuestion([[maybe_unused]] LuaContext& luaCtx)
 #ifdef DISABLE_PROTOBUF
       return std::nullopt;
 #else
-      if (auto tracer = dnsQuestion.ids.getTracer(); tracer != nullptr && dnsQuestion.ids.tracingEnabled) {
+      if (auto& tracer = dnsQuestion.ids.getTracer(); tracer != nullptr && dnsQuestion.ids.tracingEnabled) {
         auto spanID = tracer->getLastSpanID();
         return std::string(spanID.begin(), spanID.end());
       }

--- a/pdns/dnsdistdist/dnsdist-opentelemetry.cc
+++ b/pdns/dnsdistdist/dnsdist-opentelemetry.cc
@@ -324,7 +324,7 @@ void Tracer::Closer::setAttribute([[maybe_unused]] const std::string& key, [[may
 #endif
 }
 
-std::vector<uint8_t> makeEDNSTraceParentOption(std::shared_ptr<Tracer> tracer)
+std::vector<uint8_t> makeEDNSTraceParentOption([[maybe_unused]] std::shared_ptr<Tracer> tracer)
 {
   std::vector<uint8_t> ret;
 #ifndef DISABLE_PROTOBUF
@@ -343,7 +343,7 @@ std::vector<uint8_t> makeEDNSTraceParentOption(std::shared_ptr<Tracer> tracer)
   return ret;
 }
 
-bool addTraceparentEdnsOptionToPacketBuffer(PacketBuffer& origBuf, const std::shared_ptr<Tracer>& tracer, const size_t qnameWireLength, const size_t proxyProtocolPayloadSize, const uint16_t traceparentOptionCode, const bool isTCP)
+bool addTraceparentEdnsOptionToPacketBuffer([[maybe_unused]] PacketBuffer& origBuf, [[maybe_unused]] const std::shared_ptr<Tracer>& tracer, [[maybe_unused]] const size_t qnameWireLength, [[maybe_unused]] const size_t proxyProtocolPayloadSize, [[maybe_unused]] const uint16_t traceparentOptionCode, [[maybe_unused]] const bool isTCP)
 {
 #ifndef DISABLE_PROTOBUF
   if (tracer == nullptr) {

--- a/pdns/dnsdistdist/dnsdist-opentelemetry.cc
+++ b/pdns/dnsdistdist/dnsdist-opentelemetry.cc
@@ -219,7 +219,7 @@ SpanID Tracer::getRootSpanID()
     return data->d_oldAndNewRootSpanID.newID;
   }
 
-  if (auto& spans = data->d_spans; !spans.empty()) {
+  if (const auto& spans = data->d_spans; !spans.empty()) {
     auto iter = std::find_if(spans.cbegin(), spans.cend(), [](const auto& span) { return span.parent_span_id == pdns::trace::s_emptySpanID; });
     if (iter != spans.cend()) {
       return iter->span_id;
@@ -251,7 +251,7 @@ SpanID Tracer::getLastSpanIDForName([[maybe_unused]] const std::string& name)
   return 0;
 #else
   auto data = d_data.read_only_lock();
-  if (auto& spans = data->d_spans; !spans.empty()) {
+  if (const auto& spans = data->d_spans; !spans.empty()) {
     if (auto iter = std::find_if(spans.rbegin(),
                                  spans.rend(),
                                  [name](const miniSpan& span) { return span.name == name; });
@@ -320,11 +320,11 @@ void Tracer::Closer::setAttribute([[maybe_unused]] const std::string& key, [[may
 #ifdef DISABLE_PROTOBUF
   return;
 #else
-  return d_tracer->setSpanAttribute(d_spanID, key, value);
+  d_tracer->setSpanAttribute(d_spanID, key, value);
 #endif
 }
 
-std::vector<uint8_t> makeEDNSTraceParentOption([[maybe_unused]] std::shared_ptr<Tracer> tracer)
+std::vector<uint8_t> makeEDNSTraceParentOption([[maybe_unused]] const std::shared_ptr<Tracer>& tracer)
 {
   std::vector<uint8_t> ret;
 #ifndef DISABLE_PROTOBUF
@@ -352,19 +352,20 @@ bool addTraceparentEdnsOptionToPacketBuffer([[maybe_unused]] PacketBuffer& origB
   // buf contains the whole DNS query without PROXY protocol and TCP length header
   PacketBuffer buf{origBuf.begin() + proxyProtocolPayloadSize + (isTCP ? 2 : 0), origBuf.end()};
 
-  uint16_t optRDPosition;
-  size_t remaining;
+  uint16_t optRDPosition{};
+  size_t remaining{};
   bool queryHadEdns = ::dnsdist::getEDNSOptionsStart(buf, qnameWireLength, &optRDPosition, &remaining) == 0;
   if (queryHadEdns) {
     size_t optLen = buf.size() - optRDPosition - remaining;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     removeEDNSOptionFromOPT(reinterpret_cast<char*>(buf.data() + optRDPosition), &optLen, traceparentOptionCode);
   }
 
   auto opt = pdns::trace::dnsdist::makeEDNSTraceParentOption(tracer);
   bool ednsAdded{false};
   bool optionAdded{false};
-  uint16_t maxEdnsSize = queryHadEdns ? (uint16_t)(buf.at(optRDPosition - 6) << 8) + buf.at(optRDPosition - 5) : 512;
-  setEDNSOption(buf, traceparentOptionCode, std::string(opt.begin(), opt.end()), isTCP ? std::numeric_limits<uint16_t>().max() : maxEdnsSize, ednsAdded, optionAdded);
+  uint16_t maxEdnsSize = queryHadEdns ? static_cast<uint16_t>(buf.at(optRDPosition - 6) << 8) + buf.at(optRDPosition - 5) : 512;
+  setEDNSOption(buf, traceparentOptionCode, std::string(opt.begin(), opt.end()), isTCP ? std::numeric_limits<uint16_t>::max() : maxEdnsSize, ednsAdded, optionAdded);
 
   if (isTCP) {
     const std::array<uint8_t, 2> sizeBytes{static_cast<uint8_t>(buf.size() / 256), static_cast<uint8_t>(buf.size() % 256)};

--- a/pdns/dnsdistdist/dnsdist-opentelemetry.hh
+++ b/pdns/dnsdistdist/dnsdist-opentelemetry.hh
@@ -362,6 +362,6 @@ private:
 #endif
 };
 
-std::vector<uint8_t> makeEDNSTraceParentOption(std::shared_ptr<Tracer> tracer);
-bool addTraceparentEdnsOptionToPacketBuffer(PacketBuffer& origBuf, const std::shared_ptr<Tracer>& tracer, const size_t qnameWireLength, const size_t proxyProtocolPayloadSize, const uint16_t traceparentOptionCode = EDNSOptionCode::TRACEPARENT, const bool isTCP = false);
+std::vector<uint8_t> makeEDNSTraceParentOption(const std::shared_ptr<Tracer>& tracer);
+bool addTraceparentEdnsOptionToPacketBuffer(PacketBuffer& origBuf, const std::shared_ptr<Tracer>& tracer, size_t qnameWireLength, size_t proxyProtocolPayloadSize, uint16_t traceparentOptionCode = EDNSOptionCode::TRACEPARENT, bool isTCP = false);
 } // namespace pdns::trace::dnsdist

--- a/pdns/dnsdistdist/dnsdist-opentelemetry.hh
+++ b/pdns/dnsdistdist/dnsdist-opentelemetry.hh
@@ -217,7 +217,7 @@ public:
     }
     Closer(const Closer&) = delete;
     Closer& operator=(const Closer&) = delete;
-    Closer& operator=(Closer&& rhs) noexcept
+    Closer& operator=([[maybe_unused]] Closer&& rhs) noexcept
     {
 #ifndef DISABLE_PROTOBUF
       this->d_tracer = std::move(rhs.d_tracer);
@@ -228,7 +228,7 @@ public:
 #endif
       return *this;
     }
-    Closer(Closer&& rhs)
+    Closer([[maybe_unused]] Closer&& rhs) noexcept
     {
 #ifndef DISABLE_PROTOBUF
       this->d_tracer = std::move(rhs.d_tracer);

--- a/pdns/dnsdistdist/dnsdist-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-protobuf.cc
@@ -254,7 +254,7 @@ void DNSDistProtoBufMessage::serialize(std::string& data, bool withOpenTelemetry
     }
   }
 
-  if (auto tracer = d_dq.ids.getTracer(); tracer != nullptr && d_dq.ids.tracingEnabled) {
+  if (auto& tracer = d_dq.ids.getTracer(); tracer != nullptr && d_dq.ids.tracingEnabled) {
     msg.setOpenTelemetryTraceID(tracer->getTraceID());
     if (withOpenTelemetryTraceData) {
       msg.setOpenTelemetryData(tracer->getOTProtobuf());

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -289,7 +289,7 @@ IOState TCPConnectionToBackend::sendQuery(std::shared_ptr<TCPConnectionToBackend
   DEBUGLOG("sending query to backend " << conn->getDS()->getNameWithAddr() << " over FD " << conn->d_handler->getDescriptor());
 
 #ifndef DISABLE_PROTOBUF
-  if (auto tracer = conn->d_currentQuery.d_query.d_idstate.getTracer(); conn->d_currentQuery.d_query.d_idstate.sendTraceParentToDownstreamID != 0 && tracer != nullptr) {
+  if (auto& tracer = conn->d_currentQuery.d_query.d_idstate.getTracer(); conn->d_currentQuery.d_query.d_idstate.sendTraceParentToDownstreamID != 0 && tracer != nullptr) {
     auto ednsAdded = pdns::trace::dnsdist::addTraceparentEdnsOptionToPacketBuffer(
       conn->d_currentQuery.d_query.d_buffer,
       tracer,

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1899,7 +1899,7 @@ bool assignOutgoingUDPQueryToBackend(std::shared_ptr<DownstreamState>& downstrea
                 dnsQuestion.getLogger()->info(Logr::Info, "Relayed query to backend", "backend.name", Logging::Loggable(downstream->getName()), "backend.address", Logging::Loggable(downstream->d_config.remote), "dnsdist.xsk", Logging::Loggable(!actuallySend)));
 
 #ifndef DISABLE_PROTOBUF
-    if (auto tracer = dnsQuestion.ids.getTracer(); dnsQuestion.ids.sendTraceParentToDownstreamID != 0 && tracer != nullptr) {
+    if (auto& tracer = dnsQuestion.ids.getTracer(); dnsQuestion.ids.sendTraceParentToDownstreamID != 0 && tracer != nullptr) {
       auto ednsAdded = pdns::trace::dnsdist::addTraceparentEdnsOptionToPacketBuffer(
         dnsQuestion.getMutableData(),
         tracer,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR:
- prevents the copy of a shared pointer by passing a reference to the tracer instead, a copy (incrementing the reference count, then decrementing it later) can still be done when needed
- skips checking the runtime configuration to check if OT is enabled if we already have a tracer
- adds a boolean to the InternalQueryState to remember whether OT is disabled, preventing the need to check the runtime configuration every time we create a (most of the time empty) closer

The second commit fixes warnings about unused parameters when protobuf support is not enabled.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
