### PR TITLE
dnsdist: Fix warnings about the use of `offsetof` on non-POD types

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-ffi.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.hh
@@ -61,6 +61,8 @@ struct dnsdist_ffi_dnsquestion_t
   {
   }
 
+  // these two fields (pointer to DNSQuestion, then objectType) should remain at the same offset
+  // here and in dnsdist_ffi_dnsresponse_t
   DNSQuestion* dq{nullptr};
   const dnsdist::lua::ffi::ObjectType objectType{dnsdist::lua::ffi::ObjectType::Question};
   ComboAddress maskedRemote;
@@ -103,6 +105,8 @@ struct dnsdist_ffi_dnsresponse_t
   {
   }
 
+  // these two fields (pointer to DNSResponse, then objectType) should remain at the same offset
+  // here and in dnsdist_ffi_dnsquestion_t
   DNSResponse* dr{nullptr};
   const dnsdist::lua::ffi::ObjectType objectType{dnsdist::lua::ffi::ObjectType::Response};
   std::optional<std::string> result{std::nullopt};
@@ -112,9 +116,6 @@ struct dnsdist_ffi_dnsresponse_t
   protozero::pbf_writer pbfMetaValueWriter{};
 #endif /* DISABLE_PROTOBUF */
 };
-
-static_assert(offsetof(dnsdist_ffi_dnsresponse_t, dr) == offsetof(dnsdist_ffi_dnsquestion_t, dq), "The DNSQuestion object in dnsdist_ffi_dnsquestion_t and DNSResponse object in dnsdist_ffi_dnsresponse_t must be located at the same offset");
-static_assert(offsetof(dnsdist_ffi_dnsresponse_t, objectType) == offsetof(dnsdist_ffi_dnsquestion_t, objectType), "The object type in dnsdist_ffi_dnsquestion_t and dnsdist_ffi_dnsresponse_t must be located at the same offset");
 
 // dnsdist_ffi_server_t is a lightuserdata
 template <>


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`clang++` is a lot less permissive than `g++` and the warnings are annoying.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
