### PR TITLE
Docs: Link backend docs to launch setting

### DIFF
--- a/docs/backends/generic-mysql.rst
+++ b/docs/backends/generic-mysql.rst
@@ -14,7 +14,7 @@ Generic MySQL/MariaDB  backend
 * Search: Yes
 * Views: No
 * API: Read-Write
-* Multiple instances: yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: Yes
 * Module name: gmysql
 * Launch name: ``gmysql``

--- a/docs/backends/generic-odbc.rst
+++ b/docs/backends/generic-odbc.rst
@@ -14,7 +14,7 @@ Generic ODBC Backend
 * Search: Yes
 * Views: No
 * API: Read-Write
-* Multiple instances: yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: Yes
 * Module name: godbc
 * Launch name: ``godbc``

--- a/docs/backends/generic-postgresql.rst
+++ b/docs/backends/generic-postgresql.rst
@@ -14,7 +14,7 @@ Generic PostgreSQL backend
 * Search: Yes
 * Views: No
 * API: Read-Write
-* Multiple instances: yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: Yes
 * Module name: gpgsql
 * Launch name: ``gpgsql``

--- a/docs/backends/generic-sqlite3.rst
+++ b/docs/backends/generic-sqlite3.rst
@@ -14,7 +14,7 @@ Generic SQLite 3 backend
 * Search: Yes
 * Views: No
 * API: Read-Write
-* Multiple instances: yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: Yes
 * Module name: gsqlite3
 * Launch name: ``gsqlite3``

--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -14,7 +14,7 @@ GeoIP backend
 * Search: No
 * Views: No
 * API: Read-only
-* Multiple instances: Yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: Yes
 * Module name: geoip
 * Launch name: ``geoip``

--- a/docs/backends/ldap.rst
+++ b/docs/backends/ldap.rst
@@ -14,7 +14,7 @@ LDAP backend
 * Search: No
 * Views: No
 * API: Read-only
-* Multiple instances: Yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: No
 * Module name: ldap
 * Launch name: ``ldap``

--- a/docs/backends/lua2.rst
+++ b/docs/backends/lua2.rst
@@ -14,7 +14,7 @@ Lua2 Backend
 * Search: Yes\*
 * Views: No
 * API: Read-Write
-* Multiple instances: Yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: Yes\*
 * Module name: lua2
 * Launch name: ``lua2``

--- a/docs/backends/pipe.rst
+++ b/docs/backends/pipe.rst
@@ -14,7 +14,7 @@ Pipe Backend
 * Search: No
 * Views: No
 * API: Read-only
-* Multiple instances: Yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: No
 * Module name: pipe
 * Launch name: ``pipe``

--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -14,7 +14,7 @@ Remote Backend
 * Search: Yes\*
 * Views: No
 * API: Read-Write
-* Multiple instances: Yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: Yes\*
 * Module name: remote
 * Launch: ``remote``

--- a/docs/backends/tinydns.rst
+++ b/docs/backends/tinydns.rst
@@ -14,7 +14,7 @@ TinyDNS Backend
 * Search: since version 5.1.0
 * Views: No
 * API: Read-only
-* Multiple Instances: Yes
+* :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: Yes
 * Module name: tinydns
 * Launch: ``tinydns``


### PR DESCRIPTION
### Short description
For a user who has not read the documentation in detail, if they decide they want to run more multiple pipe backends, for example, then they will probably go to the pipe backend documentation to discover how to do this. The docs list the backend as having support for Multiple Instances, but no information on how to achieve this. Adding a link to the launch option immediately provides the information that is required.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)