### PR TITLE
CI: Update DCO action and its config

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: KineticCafe/actions-dco@6e1652ef3027ce128e65e6edd215ae053350bd16 # 2.1.1
+      - uses: KineticCafe/actions-dco@1da04282bbf757dab7d92a5c8535dbfb8113da5c # 3.1.0
         with:
           exempt-authors: |
             @powerdns.com

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,15 +3,19 @@ name: Test Developer Certificate of Origin
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check:
+    permissions:
+      contents: read
+      pull-requests: write # Track DCO results in a comment on the pull request
     runs-on: ubuntu-latest
     steps:
       - uses: KineticCafe/actions-dco@1da04282bbf757dab7d92a5c8535dbfb8113da5c # 3.1.0
         with:
-          exempt-authors: |
-            @powerdns.com
-            @open-xchange.com
+          config: |
+            comment = true
+            exempt-authors = ["@powerdns.com", "@open-xchange.com"]
+            bot.policy = "well-known"
+            bot.categories = ["dependency-updaters"]


### PR DESCRIPTION
### Short description

This updates the DCO signoff action to the latest version and updates the config to the new format (TOML) while adding 2 features:

* Force bots to also sign-off
* Enable Pull-Request comment

Closes: #17402

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
