### PR TITLE
dnsdist: Fix the packet cache micro-benchmarks

### DIFF
--- a/pdns/dnsdistdist/bench-dnsdist-cache.cc
+++ b/pdns/dnsdistdist/bench-dnsdist-cache.cc
@@ -88,8 +88,9 @@ TEST_CASE("Cache/Lookup")
 
     BENCHMARK(std::to_string(threadsCount))
     {
+      threads.clear();
       for (size_t idx = 0U; idx < threadsCount; idx++) {
-        threads.emplace_back(std::thread(testCode, iterations / threadsCount));
+        threads.emplace_back(testCode, iterations / threadsCount);
       }
       for (auto& thread : threads) {
         thread.join();
@@ -133,8 +134,9 @@ TEST_CASE("Cache/Insertion")
 
     BENCHMARK(std::to_string(threadsCount))
     {
+      threads.clear();
       for (size_t idx = 0U; idx < threadsCount; idx++) {
-        threads.emplace_back(std::thread(testCode, iterations / threadsCount));
+        threads.emplace_back(testCode, iterations / threadsCount);
       }
       for (auto& thread : threads) {
         thread.join();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The existing code was trying to join threads from the previous iteration, triggering an exception.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
