### PR TITLE
dnsdist-2.1: Backport 17469 - Consistently handle slow protobuf messages in our tests

### DIFF
--- a/regression-tests.dnsdist/test_OpenTelemetryTracing.py
+++ b/regression-tests.dnsdist/test_OpenTelemetryTracing.py
@@ -14,6 +14,7 @@ import dns.rrset
 import google.protobuf.json_format
 import opentelemetry.proto.trace.v1.trace_pb2
 
+from dnsdisttests import pickAvailablePort
 import test_Protobuf
 
 
@@ -757,6 +758,11 @@ def servfailOnTraceParent(request: dns.message.Message):
 class TestOpenTelemetryTracingStripIncomingTraceParent(
     DNSDistOpenTelemetryProtobufTest
 ):
+    # this test suite uses a different responder port
+    # because it uses a different responder logic so we
+    # need to make sure we are not hitting the backend
+    # from a different test
+    _testServerPort = pickAvailablePort()
     _yaml_config_params = [
         "_testServerPort",
     ]
@@ -865,6 +871,11 @@ def verifyTraceparentInQuery(request: dns.message.Message):
 class TestOpenTelemetryTracingSendTraceparentDownstream(
     DNSDistOpenTelemetryProtobufTest
 ):
+    # this test suite uses a different responder port
+    # because it uses a different responder logic so we
+    # need to make sure we are not hitting the backend
+    # from a different test
+    _testServerPort = pickAvailablePort()
     _yaml_config_params = [
         "_testServerPort",
     ]

--- a/regression-tests.dnsdist/test_OpenTelemetryTracing.py
+++ b/regression-tests.dnsdist/test_OpenTelemetryTracing.py
@@ -72,12 +72,8 @@ class DNSDistOpenTelemetryProtobufTest(test_Protobuf.DNSDistProtobufTest):
             self.assertTrue(receivedResponse)
             self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP query
-        return self.getFirstProtobufMessage()
+        return self.getFirstProtobufMessage(timeout=1)
 
     def checkOTData(
         self,

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -72,13 +72,21 @@ class DNSDistProtobufTest(DNSDistTest):
         cls._protobufListener.daemon = True
         cls._protobufListener.start()
 
-    def getFirstProtobufMessage(self):
+    def getFirstProtobufMessage(self, timeout=None):
+        if timeout is not None:
+            self.waitUntilPBQueueIsNoLongerEmpty(timeout)
         self.assertFalse(self._protobufQueue.empty())
         data = self._protobufQueue.get(False)
         self.assertTrue(data)
         msg = dnsmessage_pb2.PBDNSMessage()
         msg.ParseFromString(data)
         return msg
+
+    def waitUntilPBQueueIsNoLongerEmpty(self, timeout=1):
+        remaining = timeout * 1000  # milliseconds
+        while self._protobufQueue.empty() and remaining > 0:
+            time.sleep(0.01)
+            remaining -= 10
 
     def checkProtobufBase(self, msg, protocol, query, initiator, normalQueryResponse=True, v6=False, flags=None):
         self.assertTrue(msg)
@@ -301,18 +309,14 @@ class TestProtobuf(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
 
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.UDP, query, dns.rdataclass.IN, dns.rdatatype.A, name)
         self.checkProtobufTags(msg.response.tags, [u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Query,123"])
 
         # check the protobuf message corresponding to the UDP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Response,456"])
         self.assertEqual(len(msg.response.rrs), 2)
@@ -330,18 +334,14 @@ class TestProtobuf(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the TCP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
 
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.TCP, query, dns.rdataclass.IN, dns.rdatatype.A, name)
         self.checkProtobufTags(msg.response.tags, [u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Query,123"])
 
         # check the protobuf message corresponding to the TCP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, response)
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Response,456"])
         self.assertEqual(len(msg.response.rrs), 2)
@@ -376,18 +376,14 @@ class TestProtobuf(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         flags = int.from_bytes(query.to_wire()[2:4], byteorder=sys.byteorder)
         self.checkProtobufQueryConvertedToResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response, '127.0.0.0', flags=flags)
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Query,123"])
 
         # check the protobuf message corresponding to the UDP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response, '127.0.0.0')
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Response,456"])
         self.assertEqual(len(msg.response.rrs), 1)
@@ -402,18 +398,14 @@ class TestProtobuf(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the TCP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         flags = int.from_bytes(query.to_wire()[2:4], byteorder=sys.byteorder)
         self.checkProtobufQueryConvertedToResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, response, '127.0.0.0', flags=flags)
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Query,123"])
 
         # check the protobuf message corresponding to the TCP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, response, '127.0.0.0')
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Response,456"])
         self.assertEqual(len(msg.response.rrs), 1)
@@ -491,12 +483,8 @@ class TestProtobufMetaTags(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
 
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.UDP, query, dns.rdataclass.IN, dns.rdatatype.A, name)
         # regular tags
@@ -529,7 +517,7 @@ class TestProtobufMetaTags(DNSDistProtobufTest):
         self.assertEqual(tags['my-tag-export-name'], ['my-tag-value'])
 
         # check the protobuf message corresponding to the UDP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
         # regular tags
         self.assertEqual(len(msg.response.tags), 2)
@@ -601,12 +589,8 @@ class TestProtobufExtendedDNSErrorTags(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
 
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.UDP, query, dns.rdataclass.IN, dns.rdatatype.A, name)
 
@@ -614,7 +598,7 @@ class TestProtobufExtendedDNSErrorTags(DNSDistProtobufTest):
         self.assertEqual(len(msg.meta), 0)
 
         # check the protobuf message corresponding to the UDP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
 
         # meta tags
@@ -660,12 +644,8 @@ class TestProtobufCacheHit(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
         self.assertTrue(msg.HasField('packetCacheHit'))
         self.assertFalse(msg.packetCacheHit)
@@ -677,12 +657,8 @@ class TestProtobufCacheHit(DNSDistProtobufTest):
         self.assertTrue(receivedResponse)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
         self.assertTrue(msg.HasField('packetCacheHit'))
         self.assertTrue(msg.packetCacheHit)
@@ -736,12 +712,8 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
             self.assertEqual(query, receivedQuery)
             self.assertEqual(response, receivedResponse)
 
-            if self._protobufQueue.empty():
-                # let the protobuf messages the time to get there
-                time.sleep(1)
-
             # check the protobuf message corresponding to the query
-            msg = self.getFirstProtobufMessage()
+            msg = self.getFirstProtobufMessage(timeout=1)
 
             if method == "sendUDPQuery":
                 pbMessageType = dnsmessage_pb2.PBDNSMessage.UDP
@@ -774,7 +746,7 @@ class TestProtobufMetaDOH(DNSDistProtobufTest):
                 self.assertEqual(msg.httpVersion, dnsmessage_pb2.PBDNSMessage.HTTPVersion.HTTP2)
 
             # check the protobuf message corresponding to the response
-            msg = self.getFirstProtobufMessage()
+            msg = self.getFirstProtobufMessage(timeout=1)
             self.checkProtobufResponse(msg, pbMessageType, response)
             self.assertEqual(len(msg.meta), 5)
             tags = {}
@@ -837,12 +809,8 @@ class TestProtobufMetaProxy(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
 
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.UDP, query, dns.rdataclass.IN, dns.rdatatype.A, name, initiator='2001:db8::8', v6=True)
         self.assertEqual(len(msg.meta), 2)
@@ -899,18 +867,14 @@ class TestProtobufIPCipher(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
 
         # 108.41.239.98 is 127.0.0.1 pseudonymized with ipcipher and the current key
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.UDP, query, dns.rdataclass.IN, dns.rdatatype.A, name, '108.41.239.98')
 
         # check the protobuf message corresponding to the UDP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response, '108.41.239.98')
 
         self.assertEqual(len(msg.response.rrs), 2)
@@ -928,17 +892,13 @@ class TestProtobufIPCipher(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the TCP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         # 108.41.239.98 is 127.0.0.1 pseudonymized with ipcipher and the current key
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.TCP, query, dns.rdataclass.IN, dns.rdatatype.A, name, '108.41.239.98')
 
         # check the protobuf message corresponding to the TCP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, response, '108.41.239.98')
         self.assertEqual(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
@@ -990,18 +950,14 @@ class TestProtobufIPCrypt2PFX(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
 
         # 108.41.239.98 is 127.0.0.1 pseudonymized with ipcrypt2-pfx and the current key
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.UDP, query, dns.rdataclass.IN, dns.rdatatype.A, name, '109.33.15.148')
 
         # check the protobuf message corresponding to the UDP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response, '109.33.15.148')
 
         self.assertEqual(len(msg.response.rrs), 2)
@@ -1019,17 +975,13 @@ class TestProtobufIPCrypt2PFX(DNSDistProtobufTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
-
         # check the protobuf message corresponding to the TCP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         # 108.41.239.98 is 127.0.0.1 pseudonymized with ipcrypt2-pfx and the current key
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.TCP, query, dns.rdataclass.IN, dns.rdatatype.A, name, '109.33.15.148')
 
         # check the protobuf message corresponding to the TCP response
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, response, '109.33.15.148')
         self.assertEqual(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
@@ -1084,12 +1036,8 @@ class TestProtobufQUIC(DNSDistProtobufTest):
             self.assertEqual(query, receivedQuery)
             self.assertEqual(response, receivedResponse)
 
-            if self._protobufQueue.empty():
-                # let the protobuf messages the time to get there
-                time.sleep(1)
-
             # check the protobuf message corresponding to the query
-            msg = self.getFirstProtobufMessage()
+            msg = self.getFirstProtobufMessage(timeout=1)
 
             if method == "sendDOQQueryWrapper":
                 pbMessageType = dnsmessage_pb2.PBDNSMessage.DOQ
@@ -1213,7 +1161,7 @@ class TestProtobufAXFR(DNSDistProtobufTest):
         # check the protobuf messages corresponding to the responses
         count = 0
         while not self._protobufQueue.empty():
-            msg = self.getFirstProtobufMessage()
+            msg = self.getFirstProtobufMessage(timeout=None)
             count = count + 1
             self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, responses[count-1])
 
@@ -1287,19 +1235,12 @@ query_rules:
             self.assertEqual(receivedQuery, query)
             self.assertEqual(receivedResponse, response)
 
-
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
         # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.UDP, query, dns.rdataclass.IN, dns.rdatatype.A, name)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
         # TCP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufQuery(msg, dnsmessage_pb2.PBDNSMessage.TCP, query, dns.rdataclass.IN, dns.rdatatype.A, name)
 
 
@@ -1364,18 +1305,12 @@ response_rules:
             self.assertEqual(receivedResponse, response)
             receivedResponses.append(receivedResponse)
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
         # check the protobuf message corresponding to the UDP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, receivedResponses[0])
 
-        if self._protobufQueue.empty():
-            # let the protobuf messages the time to get there
-            time.sleep(1)
         # TCP query
-        msg = self.getFirstProtobufMessage()
+        msg = self.getFirstProtobufMessage(timeout=1)
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, receivedResponses[1])
 
 
@@ -1450,7 +1385,7 @@ timeout_response_rules:
                     continue
 
             # check the protobuf message
-            msg = self.getFirstProtobufMessage()
+            msg = self.getFirstProtobufMessage(timeout=None)
             if msg.socketProtocol == dnsmessage_pb2.PBDNSMessage.UDP:
                 gotUDP = True
                 protocol = dnsmessage_pb2.PBDNSMessage.UDP


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17469

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
