### PR TITLE
bump alpine version for sdist stage to 3.23

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.authoritative
+++ b/builder-support/dockerfiles/Dockerfile.authoritative
@@ -1,4 +1,4 @@
-FROM alpine:3.21 AS pdns-authoritative
+FROM alpine:3.23 AS pdns-authoritative
 ARG BUILDER_CACHE_BUSTER=
 
 RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \

--- a/builder-support/dockerfiles/Dockerfile.dnsdist
+++ b/builder-support/dockerfiles/Dockerfile.dnsdist
@@ -1,4 +1,4 @@
-FROM alpine:3.21 AS dnsdist
+FROM alpine:3.23 AS dnsdist
 ARG BUILDER_CACHE_BUSTER=
 
 RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \

--- a/builder-support/dockerfiles/Dockerfile.recursor
+++ b/builder-support/dockerfiles/Dockerfile.recursor
@@ -1,4 +1,4 @@
-FROM alpine:3.21 AS pdns-recursor
+FROM alpine:3.23 AS pdns-recursor
 ARG BUILDER_CACHE_BUSTER=
 
 RUN apk add --no-cache gcc g++ make tar autoconf automake protobuf-dev lua-dev \

--- a/builder-support/dockerfiles/Dockerfile.target.sdist
+++ b/builder-support/dockerfiles/Dockerfile.target.sdist
@@ -10,7 +10,7 @@
 @INCLUDE Dockerfile.dnsdist
 @ENDIF
 
-FROM alpine:3.21 AS sdist
+FROM alpine:3.23 AS sdist
 ARG BUILDER_CACHE_BUSTER=
 
 @IF [ -z "$M_authoritative$M_recursor$M_dnsdist$M_all" ]


### PR DESCRIPTION
### Short description
alpine 3.21 is out of support. Bumping alpine also gives us newer autotools (although we care about that less and less).

~~Not yet tested.~~ this successfully builds auth/rec/dnsdist for debian-trixie.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
