### PR TITLE
dnsdist: Remove autotool remants from Docker image build

### DIFF
--- a/Dockerfile-dnsdist
+++ b/Dockerfile-dnsdist
@@ -25,7 +25,6 @@ COPY pdns /source/pdns
 COPY build-aux /source/build-aux
 COPY m4 /source/m4
 COPY ext /source/ext
-COPY builder/helpers/set-configure-ac-version.sh /usr/local/bin
 COPY .git /source/.git
 
 # build and install (TODO: before we hit this line, rearrange /source structure if we are coming from a tarball)
@@ -38,11 +37,6 @@ ARG DOCKER_FAKE_RELEASE=NO
 ENV DOCKER_FAKE_RELEASE=${DOCKER_FAKE_RELEASE}
 
 RUN touch dnsdist.1 # avoid having to install pandoc and venv
-
-RUN if [ "${DOCKER_FAKE_RELEASE}" = "YES" ]; then \
-      BUILDER_VERSION="$(IS_RELEASE=YES BUILDER_MODULES=dnsdist ./builder-support/gen-version | sed 's/\([0-9]\+\.[0-9]\+\.[0-9]\+\(\(alpha|beta|rc\)\d\+\)\)?.*/\1/')" set-configure-ac-version.sh;\
-    fi && \
-    BUILDER_MODULES=dnsdist autoreconf -vfi
 
 RUN mkdir /quiche && cd /quiche && \
     apt-get install -y cmake curl jq libclang-dev && \


### PR DESCRIPTION
### Short description

The image builds broke after #17010 was merged.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
