### PR TITLE
build-scripts: Add "git log --merges --oneline" to "list of PR numbers" tool

### DIFF
--- a/build-scripts/git-log-merges-oneline-to-list-of-pr-numbers.py
+++ b/build-scripts/git-log-merges-oneline-to-list-of-pr-numbers.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import fileinput
+import re
+
+
+def main():
+    pr_number_regex = re.compile(r"#(\d+)")
+    prs = []
+
+    for line in fileinput.input():
+        line = line.rstrip()
+        numbers = re.findall(pr_number_regex, line)
+        for number in numbers:
+            prs.append(number)
+
+    for pr in prs:
+        print(pr, end=" ")
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This script is useful to me when I'm generating a new ChangeLog entry: I do `git log --merges --oneline <previous tag>..<head of branch> | python git-log-merges-oneline-to-list-of-pr-numbers.py` to get a list of PR numbers that I can then feed to `changelog-from-pr.py`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
