### PR TITLE
Add Ubuntu Resolute to repo test script.

### DIFF
--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -234,6 +234,13 @@ def write_release_files(release):
         write_dockerfile("ubuntu", "noble", release)
         write_list_file("ubuntu", "noble", release)
 
+    if release in [
+        "dnsdist-21",
+        "dnsdist-master",
+    ]:
+        write_dockerfile("ubuntu", "resolute", release)
+        write_list_file("ubuntu", "resolute", release)
+
 
 # Test Release Functions
 


### PR DESCRIPTION
### Short description

This PR adds testing against Ubuntu Resolute (only for `dnsdist-21` for now).

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
