### PR TITLE
ci(recursor): Fix flaky test and a Zone to Cache bug

### DIFF
--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -155,7 +155,7 @@ pdns::ZoneMD::Result ZoneData::getByAXFR(const RecZoneToCache::Config& config, p
   // coverity[store_truncates_time_t]
   while (axfr.getChunk(nop, &chunk, (axfrStart + axfrTimeout - axfrNow)) != 0) {
     for (auto& dnsRecord : chunk) {
-      if (config.d_zonemd != pdns::ZoneMD::Config::Ignore) {
+      if (config.d_zonemd != pdns::ZoneMD::Config::Ignore || config.d_dnssec != pdns::ZoneMD::Config::Ignore) {
         zonemd.readRecord(dnsRecord);
       }
       parseDRForCache(dnsRecord);

--- a/regression-tests.recursor-dnssec/test_RecDnstap.py
+++ b/regression-tests.recursor-dnssec/test_RecDnstap.py
@@ -280,7 +280,7 @@ cname 3600 IN CNAME a.example.
 
     def getFirstDnstap(self):
         try:
-            data = DNSTapServerParameters.queue.get(True, timeout=2.0)
+            data = DNSTapServerParameters.queue.get(True, timeout=5.0)
         except Exception:
             data = False
         self.assertTrue(data)

--- a/regression-tests.recursor-dnssec/test_ZTC.py
+++ b/regression-tests.recursor-dnssec/test_ZTC.py
@@ -40,3 +40,27 @@ recordcache:
             break
         print(ret)
         self.assertNotEqual(ret, b"")
+
+
+class ZTCIgnoreZoneMDTest(ZTCTest):
+    _confdir = "ZTCIgnoreZoneMD"
+    _config_template = """
+dnssec:
+    validation: validate
+    trustanchors:
+        - name: .
+          dsrecords:
+              - %s
+recordcache:
+    zonetocaches:
+    - zone: .
+      method: axfr
+      zonemd: ignore
+      sources:
+          - %s.8
+"""
+    _config_params = ["_root_DS", "_PREFIX"]
+
+    @classmethod
+    def generateRecursorConfig(cls, confdir):
+        super(ZTCTest, cls).generateRecursorYamlConfig(confdir, False)

--- a/regression-tests.recursor-dnssec/test_ZTC.py
+++ b/regression-tests.recursor-dnssec/test_ZTC.py
@@ -1,4 +1,5 @@
 import time
+import os
 import subprocess
 
 from recursortests import RecursorTest
@@ -9,13 +10,18 @@ class ZTCTest(RecursorTest):
     _config_template = """
 dnssec:
     validation: validate
+    trustanchors:
+        - name: .
+          dsrecords:
+              - %s
 recordcache:
     zonetocaches:
     - zone: .
       method: axfr
       sources:
-      - 193.0.14.129
+          - %s.8
 """
+    _config_params = ["_root_DS", "_PREFIX"]
 
     @classmethod
     def generateRecursorConfig(cls, confdir):


### PR DESCRIPTION
### Short description

This PR "fixes" the ASAN and TSAN tests by not requiring an AXFR from k-root, but using the local fake root server in the Zone to Cache test.

It also fixes an issue that was found when `zonemd: ignore` is set, but DNSSEC is enabled for a Zone to Cache.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
