### PR TITLE
rec: Allow failure for some tests if running on GH, which has flaky net often (especially UDP)

### DIFF
--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -6,6 +6,7 @@ import pytest
 from recursortests import RecursorTest
 
 
+@pytest.mark.xfail(os.environ.get("GITHUB_ACTIONS") == "true", reason="GH actions have flaky net")
 class ExtendedErrorsTest(RecursorTest):
     _confdir = "ExtendedErrors"
     _config_template = """
@@ -197,6 +198,7 @@ extended-resolution-errors=yes
         self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(10, b"Extra text from Lua!"))
 
 
+@pytest.mark.xfail(os.environ.get("GITHUB_ACTIONS") == "true", reason="GH actions have flaky net")
 class NoExtendedErrorsTest(RecursorTest):
     _confdir = "NoExtendedErrors"
     _config_template = """

--- a/regression-tests.recursor-dnssec/test_WellKnown.py
+++ b/regression-tests.recursor-dnssec/test_WellKnown.py
@@ -1,9 +1,11 @@
 import pytest
 import dns
+import os
 from recursortests import RecursorTest
 
 
 @pytest.mark.external
+@pytest.mark.xfail(os.environ.get("GITHUB_ACTIONS") == "true", reason="GH actions have flaky net")
 class WellKnownTest(RecursorTest):
     _auths_zones = None
     _confdir = "WellKnown"


### PR DESCRIPTION
When run locally, these test are _not_ allowed to fail.

I did not change the TCP (TLS) bases tests that use external networking as they do not tend to fail.

We should spend effort to rewrite these tests to not be dependent on external networking.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
