### PR TITLE
rec: Make sure the queue is empty before starting the dnstap test

### DIFF
--- a/regression-tests.recursor-dnssec/test_RecDnstap.py
+++ b/regression-tests.recursor-dnssec/test_RecDnstap.py
@@ -338,6 +338,9 @@ dnstapFrameStreamServer({"%s"}, {logQueries=false})
     """ % (DNSTapServerParameters.path)
 
     def testA(self):
+        # Empty whatever may be in the queue
+        while not DNSTapServerParameters.queue.empty():
+            DNSTapServerParameters.queue.get(False)
         name = "www.example.org."
         query = dns.message.make_query(name, "A", want_dnssec=True)
         query.flags |= dns.flags.RD


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
