### PR TITLE
auth lmdb: correctly update timestamps in non-split domain table mode

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1354,6 +1354,13 @@ void LMDBBackend::consolidateDomainInfo(DomainInfo& info) const
   }
 }
 
+void LMDBBackend::writeDomainInfo(const DomainInfo& info)
+{
+  auto txn = d_tdomains->getRWTransaction();
+  txn.put(info, info.id);
+  txn.commit();
+}
+
 void LMDBBackend::writeTransientDomainInfo(const DomainInfo& info)
 {
   // If the DomainInfo table is split, write the TransientDomainInfo part
@@ -1384,9 +1391,7 @@ void LMDBBackend::updateDomainInfo(const DomainInfo& info)
     return;
   }
 
-  auto txn = d_tdomains->getRWTransaction();
-  txn.put(info, info.id);
-  txn.commit();
+  writeDomainInfo(info);
   writeTransientDomainInfo(info);
 }
 
@@ -2437,9 +2442,7 @@ bool LMDBBackend::genChangeTransientDomain(domainid_t id, const std::function<vo
       writeTransientDomainInfo(info);
     }
     else {
-      auto txn = d_tdomains->getRWTransaction();
-      txn.put(info, info.id);
-      txn.commit();
+      writeDomainInfo(info);
     }
   }
   return true;
@@ -3752,9 +3755,7 @@ void LMDBBackend::flush()
           writeTransientDomainInfo(info);
         }
         else {
-          auto txn = d_tdomains->getRWTransaction();
-          txn.put(info, info.id);
-          txn.commit();
+          writeDomainInfo(info);
         }
       }
       else {

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2432,8 +2432,15 @@ bool LMDBBackend::genChangeTransientDomain(domainid_t id, const std::function<vo
     writeDomainInfo(info);
   }
   else {
-    // No need to write the complete DomainInfo in this case
-    writeTransientDomainInfo(info);
+    // If the DomainInfo table is split, only update the extra table.
+    if (d_split_domains_table) {
+      writeTransientDomainInfo(info);
+    }
+    else {
+      auto txn = d_tdomains->getRWTransaction();
+      txn.put(info, info.id);
+      txn.commit();
+    }
   }
   return true;
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1368,7 +1368,7 @@ void LMDBBackend::writeTransientDomainInfo(const DomainInfo& info)
   }
 }
 
-void LMDBBackend::writeDomainInfo(const DomainInfo& info)
+void LMDBBackend::updateDomainInfo(const DomainInfo& info)
 {
   // Update the in-memory cache if we don't keep the database up to date.
   if (!d_write_notification_update) {
@@ -2400,7 +2400,7 @@ bool LMDBBackend::genChangeDomain(const ZoneName& domain, const std::function<vo
   }
   consolidateDomainInfo(info);
   func(info);
-  writeDomainInfo(info);
+  updateDomainInfo(info);
   return true;
 }
 
@@ -2413,7 +2413,7 @@ bool LMDBBackend::genChangeDomain(domainid_t id, const std::function<void(Domain
   }
   consolidateDomainInfo(info);
   func(info);
-  writeDomainInfo(info);
+  updateDomainInfo(info);
   return true;
 }
 
@@ -2429,7 +2429,7 @@ bool LMDBBackend::genChangeTransientDomain(domainid_t id, const std::function<vo
   func(info);
   if (!d_write_notification_update) {
     // This won't write anything but update the in-memory cache
-    writeDomainInfo(info);
+    updateDomainInfo(info);
   }
   else {
     // If the DomainInfo table is split, only update the extra table.

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -359,6 +359,7 @@ private:
   bool findDomain(domainid_t domainid, DomainInfo& info) const;
   void consolidateDomainInfo(DomainInfo& info) const;
   void updateDomainInfo(const DomainInfo& info);
+  void writeDomainInfo(const DomainInfo& info);
   void writeTransientDomainInfo(const DomainInfo& info);
 
   void setLastCheckTime(domainid_t domain_id, time_t last_check);

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -358,7 +358,7 @@ private:
   bool findDomain(const ZoneName& domain, DomainInfo& info) const;
   bool findDomain(domainid_t domainid, DomainInfo& info) const;
   void consolidateDomainInfo(DomainInfo& info) const;
-  void writeDomainInfo(const DomainInfo& info);
+  void updateDomainInfo(const DomainInfo& info);
   void writeTransientDomainInfo(const DomainInfo& info);
 
   void setLastCheckTime(domainid_t domain_id, time_t last_check);


### PR DESCRIPTION
### Short description
This is an embarassing bug which is tarnishing the 5.1 release. As noticed by @mind04, an lmdb database configured with the defaults (write notification update timestamps immediately, and domain table not split) will fail to actually write these timestamps.

Possible workaround are to enable split domain table (but will not be interoperable with older versions lacking the feature), or disable writes and perform regular flushes with pdns_control.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
