### PR TITLE
StatNode: Adjust the number of children based on the sampling rate

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
@@ -75,7 +75,7 @@ void dnsdist_ffi_stat_node_get_full_name_raw(const dnsdist_ffi_stat_node_t* node
 
 unsigned int dnsdist_ffi_stat_node_get_children_count(const dnsdist_ffi_stat_node_t* node)
 {
-  return node->node.size();
+  return node->node.getNumberOfChildren(g_rings.getSamplingRate());
 }
 
 uint64_t dnsdist_ffi_stat_node_get_children_queries_count(const dnsdist_ffi_stat_node_t* node)

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -900,7 +900,7 @@ void setupLuaInspection(LuaContext& luaCtx)
   /* StatNode */
   luaCtx.registerFunction<unsigned int (StatNode::*)() const>("numChildren",
                                                               [](const StatNode& node) -> unsigned int {
-                                                                return node.size();
+                                                                return node.getNumberOfChildren(g_rings.getSamplingRate());
                                                               });
   luaCtx.registerMember<std::string(StatNode::*)>(std::string("fullname"), [](const StatNode& node) -> std::string {
     /* we are not using toLogString() because we want:

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -116,11 +116,11 @@ static void visitor(const StatNode* node, const StatNode::Stat& /* selfstat */, 
 {
   // 20% servfails, >100 children, on average less than 2 copies of a query
   // >100 different subqueries
-  double dups=1.0*childstat.queries/node->size();
+  double dups=1.0*childstat.queries/node->getNumberOfChildren();
   if(dups > 2.0)
     return;
-  if(1.0*childstat.servfails / childstat.queries > 0.2 && node->size()>100) {
-    cout<<node->fullname<<", servfails: "<<childstat.servfails<<", nxdomains: "<<childstat.nxdomains<<", remotes: "<<childstat.remotes.size()<<", children: "<<node->size()<<", childstat.queries: "<<childstat.queries;
+  if(1.0*childstat.servfails / childstat.queries > 0.2 && node->getNumberOfChildren()>100) {
+    cout<<node->fullname<<", servfails: "<<childstat.servfails<<", nxdomains: "<<childstat.nxdomains<<", remotes: "<<childstat.remotes.size()<<", children: "<<node->getNumberOfChildren()<<", childstat.queries: "<<childstat.queries;
     cout<<", dups2: "<<dups<<endl;
     for(const StatNode::Stat::remotes_t::value_type& rem :  childstat.remotes) {
       cout<<"source: "<<node->fullname<<"\t"<<rem.first.toString()<<"\t"<<rem.second<<endl;

--- a/pdns/statnode.cc
+++ b/pdns/statnode.cc
@@ -132,3 +132,12 @@ void StatNode::submit(std::vector<string>::const_iterator end, std::vector<strin
     children[*end].submit(end, begin, fullname, rcode, bytes, remote, count+1, hit, samplingRate);
   }
 }
+
+size_t StatNode::getNumberOfChildren(size_t samplingRate) const
+{
+  // this might seem surprising, but all consumers are using this value
+  // to get some context for the other counters (number of queries,
+  // number of responses with specific response codes) that have all
+  // been adjusted for sampling
+  return adjustForSampling(children.size(), samplingRate);
+}

--- a/pdns/statnode.hh
+++ b/pdns/statnode.hh
@@ -67,14 +67,11 @@ public:
   void submit(const DNSName& domain, int rcode, uint32_t bytes, bool hit, const std::optional<ComboAddress>& remote, size_t samplingRate);
   Stat print(unsigned int depth=0, Stat newstat=Stat(), bool silent=false) const;
   void visit(const visitor_t& visitor, Stat& newstat, unsigned int depth = 0) const;
-  bool empty() const
+  [[nodiscard]] bool empty() const
   {
     return children.empty() && s.remotes.empty();
   }
-  size_t size() const
-  {
-    return children.size();
-  }
+  [[nodiscard]] size_t getNumberOfChildren(size_t samplingRate = 0U) const;
 
 private:
   void submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const DNSName& domain, int rcode, uint32_t bytes, const std::optional<ComboAddress>& remote, unsigned int count, bool hit, size_t samplingRate);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This might seem surprising, but all consumers are using this values to get some context for the other counters (number of queries, number of responses with specific response codes) that have all been adjusted for sampling.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
