### PR TITLE
fix: EL-8 package builds

### DIFF
--- a/builder-support/helpers/install_meson.sh
+++ b/builder-support/helpers/install_meson.sh
@@ -5,8 +5,8 @@ set -e
 [ -e /tmp/.pdns_meson_installed ] && exit 0  # we already have meson, let's assume we put it there earlier
 
 readonly MESON_VERSION=$(jq -r .version < meson.json)
-readonly MESON_TARBALL="${MESON_VERSION}.tar.gz"
-readonly MESON_TARBALL_URL="https://github.com/mesonbuild/meson/archive/${MESON_TARBALL}"
+readonly MESON_TARBALL="meson-${MESON_VERSION}.tar.gz"
+readonly MESON_TARBALL_URL="https://github.com/mesonbuild/meson/releases/download/${MESON_VERSION}/${MESON_TARBALL}"
 readonly MESON_TARBALL_HASH=$(jq -r .SHA256SUM < meson.json)
 
 cd /tmp

--- a/builder-support/helpers/meson.json
+++ b/builder-support/helpers/meson.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.11.1",
+  "version": "1.9.2",
   "license": "Apache-2.0",
   "publisher": "https://github.com/mesonbuild/meson",
-  "SHA256SUM": "1a2219422be4a66ad0e8daed125c2a3d5c963458e289203eae22edf3224f5d3e"
+  "SHA256SUM": "3499b59bb23982496e01e57b4103ac2f826f9c3a3f59e507a0a832487fe55e3d"
 }


### PR DESCRIPTION
### Short description

Meson >= 1.10.0 updated their `%meson_build` RPM macro to use the `%[`
syntax. This feature was added to rpm 4.16.0, but EL-8 has 4.14.3. As
we're not using any modern meson functions, 1.9.2 can be used to build
packages.

* https://github.com/mesonbuild/meson/commit/12b1e3c6a72b715bf20e4c304da065e16c510830
* https://rpm.org/wiki/Releases/4.16.0

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
