### PR TITLE
dnsdist: Prevent an exception when accessing an empty StatNode

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection-ffi.cc
@@ -66,7 +66,7 @@ unsigned int dnsdist_ffi_stat_node_get_labels_count(const dnsdist_ffi_stat_node_
 
 void dnsdist_ffi_stat_node_get_full_name_raw(const dnsdist_ffi_stat_node_t* node, const char** name, size_t* nameSize)
 {
-  if (node->fullname.empty()) {
+  if (node->fullname.empty() && !node->node.fullname.empty()) {
     node->fullname = node->node.fullname.toString();
   }
   *name = node->fullname.c_str();

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -589,6 +589,7 @@ if get_option('unit-tests')
           # FFI files are directly added to the binary, because otherwise the visibility
           # is ignored and the functions that are not used in the binary are not exported
           src_dir / 'dnsdist-lua-ffi.cc',
+          src_dir / 'dnsdist-lua-inspection-ffi.cc',
         ],
         'deps-extra': [
           libdnsdist_test,

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -1233,6 +1233,7 @@ BOOST_AUTO_TEST_CASE(query_response_pointer_mismatch)
   BOOST_CHECK_EQUAL(bufferSize, 0U);
 }
 
+#ifndef DISABLE_DYNBLOCKS
 BOOST_AUTO_TEST_CASE(stat_node)
 {
   StatNode node{};
@@ -1277,5 +1278,6 @@ BOOST_AUTO_TEST_CASE(stat_node)
   BOOST_REQUIRE(blockParameters.d_action.has_value());
   BOOST_CHECK(*blockParameters.d_action == DNSAction::Action::NoRecurse);
 }
+#endif /* DISABLE_DYNBLOCKS */
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/test-dnsdist-lua-ffi.cc
@@ -31,6 +31,7 @@
 #include "base64.hh"
 #include "dnsdist-cache.hh"
 #include "dnsdist-configuration.hh"
+#include "dnsdist-dynblocks.hh"
 #include "dnsdist-rings.hh"
 #include "dnsdist-web.hh"
 #include "dnsparser.hh"
@@ -1230,6 +1231,51 @@ BOOST_AUTO_TEST_CASE(query_response_pointer_mismatch)
   dnsdist_ffi_dnsquestion_get_masked_remoteaddr(reinterpret_cast<dnsdist_ffi_dnsquestion_t*>(&lightDR), reinterpret_cast<const void**>(&buffer), &bufferSize, 16);
   BOOST_CHECK(buffer == nullptr);
   BOOST_CHECK_EQUAL(bufferSize, 0U);
+}
+
+BOOST_AUTO_TEST_CASE(stat_node)
+{
+  StatNode node{};
+  StatNode::Stat nodeStats{};
+  nodeStats.queries = 42U;
+  StatNode::Stat childrenStats{};
+  childrenStats.queries = 84U;
+  SMTBlockParameters blockParameters{};
+  dnsdist_ffi_stat_node_t ffi_node(node, nodeStats, childrenStats, blockParameters);
+
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_queries_count(&ffi_node), nodeStats.queries);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_noerrors_count(&ffi_node), nodeStats.noerrors);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_nxdomains_count(&ffi_node), nodeStats.nxdomains);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_servfails_count(&ffi_node), nodeStats.servfails);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_drops_count(&ffi_node), nodeStats.drops);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_bytes(&ffi_node), nodeStats.bytes);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_hits(&ffi_node), nodeStats.hits);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_labels_count(&ffi_node), node.fullname.countLabels());
+  {
+    const char* name = nullptr;
+    size_t nameSize{0};
+    dnsdist_ffi_stat_node_get_full_name_raw(&ffi_node, &name, &nameSize);
+    BOOST_CHECK_EQUAL(nameSize, 0U);
+  }
+
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_children_count(&ffi_node), node.getNumberOfChildren());
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_children_queries_count(&ffi_node), childrenStats.queries);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_children_noerrors_count(&ffi_node), childrenStats.noerrors);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_children_nxdomains_count(&ffi_node), childrenStats.nxdomains);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_children_servfails_count(&ffi_node), childrenStats.servfails);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_children_drops_count(&ffi_node), childrenStats.drops);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_children_bytes_count(&ffi_node), childrenStats.bytes);
+  BOOST_CHECK_EQUAL(dnsdist_ffi_stat_node_get_children_hits(&ffi_node), childrenStats.hits);
+
+  const std::string customReason{"myCustomReason"};
+  BOOST_CHECK(!blockParameters.d_reason.has_value());
+  dnsdist_ffi_state_node_set_reason(&ffi_node, customReason.c_str(), customReason.size());
+  BOOST_REQUIRE(blockParameters.d_reason.has_value());
+  BOOST_CHECK_EQUAL(*blockParameters.d_reason, customReason);
+  BOOST_CHECK(!blockParameters.d_action.has_value());
+  dnsdist_ffi_state_node_set_action(&ffi_node, static_cast<int>(DNSAction::Action::NoRecurse));
+  BOOST_REQUIRE(blockParameters.d_action.has_value());
+  BOOST_CHECK(*blockParameters.d_action == DNSAction::Action::NoRecurse);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We fixed it for the regular interface in bd21d60 but overlooked the FFI one.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
