### PR TITLE
ednsoptions.hh: #include <string>

### DIFF
--- a/pdns/ednsoptions.hh
+++ b/pdns/ednsoptions.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 #include <map>
+#include <string>
 #include <vector>
 
 #include "noinitvector.hh"


### PR DESCRIPTION
### Short description

gcc-17 (or its libstdc++) is stricter about includes and needs this

closes #17524

(I checked "I compiled this code" but I did not compile it on gcc-17)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
