### PR TITLE
remote logger: Reconnect if writes have been stalled for too long

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1943,12 +1943,12 @@ void registerProtobufLogger(const ProtobufLoggerConfiguration& config)
     std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
     loggers.reserve(config.connection_count);
     for (uint64_t i = 0; i < config.connection_count; i++) {
-      loggers.push_back(std::make_shared<RemoteLogger>(ComboAddress(std::string(config.address)), config.timeout, config.max_queued_entries * 100, config.reconnect_wait_time, dnsdist::configuration::yaml::s_inClientMode, RemoteLogger::FrameSize::Two));
+      loggers.push_back(std::make_shared<RemoteLogger>(ComboAddress(std::string(config.address)), config.timeout, config.max_queued_entries * 100, config.reconnect_wait_time, dnsdist::configuration::yaml::s_inClientMode, RemoteLogger::FrameSize::Two, config.stalled_write_timeout));
     }
     object = std::shared_ptr<RemoteLoggerInterface>(std::make_shared<RemoteLoggerPool>(std::move(loggers)));
   }
   else {
-    object = std::shared_ptr<RemoteLoggerInterface>(std::make_shared<RemoteLogger>(ComboAddress(std::string(config.address)), config.timeout, config.max_queued_entries * 100, config.reconnect_wait_time, dnsdist::configuration::yaml::s_inClientMode, RemoteLogger::FrameSize::Two));
+    object = std::shared_ptr<RemoteLoggerInterface>(std::make_shared<RemoteLogger>(ComboAddress(std::string(config.address)), config.timeout, config.max_queued_entries * 100, config.reconnect_wait_time, dnsdist::configuration::yaml::s_inClientMode, RemoteLogger::FrameSize::Two, config.stalled_write_timeout));
   }
   dnsdist::configuration::yaml::registerType<RemoteLoggerInterface>(object, config.name);
 #endif

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -121,7 +121,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
   /* RemoteLogger */
-  luaCtx.writeFunction("newRemoteLogger", [client, configCheck](const std::string& remote, std::optional<uint16_t> timeout, std::optional<uint64_t> maxQueuedEntries, std::optional<uint8_t> reconnectWaitTime, std::optional<uint64_t> connectionCount) {
+  luaCtx.writeFunction("newRemoteLogger", [client, configCheck](const std::string& remote, std::optional<uint16_t> timeout, std::optional<uint64_t> maxQueuedEntries, std::optional<uint8_t> reconnectWaitTime, std::optional<uint64_t> connectionCount, std::optional<uint32_t> stalledWriteTimeout) {
     if (client || configCheck) {
       return std::shared_ptr<RemoteLoggerInterface>(nullptr);
     }
@@ -130,7 +130,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
       std::vector<std::shared_ptr<RemoteLoggerInterface>> loggers;
       loggers.reserve(count);
       for (uint64_t i = 0; i < count; i++) {
-        loggers.push_back(std::make_shared<RemoteLogger>(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client, RemoteLogger::FrameSize::Two));
+        loggers.push_back(std::make_shared<RemoteLogger>(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client, RemoteLogger::FrameSize::Two, stalledWriteTimeout ? *stalledWriteTimeout : 5));
       }
       return std::shared_ptr<RemoteLoggerInterface>(new RemoteLoggerPool(std::move(loggers)));
     }

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -225,6 +225,11 @@ protobuf_logger:
       type: "u64"
       default: 1
       description: "Number of connections to open to the endpoint"
+    - name: "stalled_write_timeout"
+      type: "u32"
+      default: 5
+      description: "If we have been unable to write or buffer data on our side of the TCP socket for that long, in seconds, consider that the remote endpoint has died and reconnect"
+      version_added: "2.2.0"
 
 dnstap_logger:
   description: "Endpoint to send queries and/or responses data to, using the dnstap format"

--- a/pdns/dnsdistdist/docs/reference/protobuf.rst
+++ b/pdns/dnsdistdist/docs/reference/protobuf.rst
@@ -1,10 +1,13 @@
 Protobuf Logging Reference
 ==========================
 
-.. function:: newRemoteLogger(address [, timeout=2[, maxQueuedEntries=100[, reconnectWaitTime=1[, connectionCount=1]]]])
+.. function:: newRemoteLogger(address [, timeout=2[, maxQueuedEntries=100[, reconnectWaitTime=1[, connectionCount=1, stalledWriteTimeout=5]]]])
 
   .. versionchanged:: 2.0.0
     Added the optional ``connectionCount`` parameter.
+
+  .. versionchanged:: 2.2.0
+    Added the optional ``stalledWriteTimeout`` parameter.
 
   Create a Remote Logger object, to use with :func:`RemoteLogAction` and :func:`RemoteLogResponseAction`.
 
@@ -13,6 +16,7 @@ Protobuf Logging Reference
   :param int maxQueuedEntries: Queue this many messages before dropping new ones (e.g. when the remote listener closes the connection)
   :param int reconnectWaitTime: Time in seconds between reconnection attempts
   :param int connectionCount: Number of connections to open to the socket
+  :param int stalledWriteTimeout: If we have been unable to write or buffer data on our side of the TCP socket for that long, in seconds, consider that the remote endpoint has died and reconnect
 
 .. class:: DNSDistProtoBufMessage
 

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -44,6 +44,16 @@ bool CircularWriteBuffer::tooBig(const std::string& str) const
   return str.size() > (d_framesize == 2 ? std::numeric_limits<uint16_t>::max() : std::numeric_limits<uint32_t>::max());
 }
 
+bool CircularWriteBuffer::isEmpty() const
+{
+  return d_buffer.empty();
+}
+
+void CircularWriteBuffer::clear()
+{
+  d_buffer.clear();
+}
+
 bool CircularWriteBuffer::write(const std::string& str)
 {
   if (tooBig(str) || !hasRoomFor(str)) {
@@ -192,8 +202,18 @@ RemoteLoggerInterface::Result RemoteLogger::queueData(const std::string& data)
       if (!runtime->d_writer.flush(runtime->d_socket->getHandle())) {
         /* but failed, let's just drop */
         ++runtime->d_stats.d_pipeFull;
+        if (connectionStalled()) {
+          /* we have not been able to write for far too long,
+             something is wrong. */
+          runtime->d_socket.reset();
+          /* we can't be sure we haven't sent a partial message,
+             and we don't want to send the remaining part after reconnecting */
+          runtime->d_writer.clear();
+          ++runtime->d_stats.d_otherError;
+        }
         return Result::PipeFull;
       }
+      d_tryingToWriteSince = 0;
 
       /* see if we freed enough data */
       if (!runtime->d_writer.hasRoomFor(data)) {
@@ -253,7 +273,20 @@ void RemoteLogger::maintenanceThread()
             /* if flush() returns false, it means that we couldn't flush anything yet
                either because there is nothing to flush, or because the outgoing TCP
                buffer is full. That's fine by us */
-            runtime->d_writer.flush(runtime->d_socket->getHandle());
+            auto flushed = runtime->d_writer.flush(runtime->d_socket->getHandle());
+            if (flushed) {
+              d_tryingToWriteSince = 0;
+            }
+            else if (!runtime->d_writer.isEmpty() && connectionStalled()) {
+              /* we have not been able to write for far too long,
+                 something is wrong. */
+              runtime->d_socket.reset();
+              /* we can't be sure we haven't sent a partial message,
+                 and we don't want to send the remaining part after reconnecting */
+              runtime->d_writer.clear();
+              connected = false;
+              ++runtime->d_stats.d_otherError;
+            }
           }
           else {
             connected = false;
@@ -297,4 +330,15 @@ RemoteLogger::~RemoteLogger()
   d_exiting = true;
 
   d_thread.join();
+}
+
+bool RemoteLogger::connectionStalled()
+{
+  auto now = time(nullptr);
+  if (d_tryingToWriteSince == 0) {
+    d_tryingToWriteSince = now;
+    return false;
+  }
+
+  return (d_tryingToWriteSince < now && (now - d_tryingToWriteSince) > s_stalledTimeoutSeconds);
 }

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -144,8 +144,8 @@ const std::string& RemoteLoggerInterface::toErrorString(Result result)
   return str.at(std::min(tmp, 4U));
 }
 
-RemoteLogger::RemoteLogger(const ComboAddress& remote, uint16_t timeout, uint64_t maxQueuedBytes, uint8_t reconnectWaitTime, bool asyncConnect, RemoteLogger::FrameSize frame) :
-  d_remote(remote), d_timeout(timeout), d_reconnectWaitTime(reconnectWaitTime), d_asyncConnect(asyncConnect), d_runtime({CircularWriteBuffer(maxQueuedBytes, frame == FrameSize::Two ? 2 : 4), nullptr}), d_framesize(frame)
+RemoteLogger::RemoteLogger(const ComboAddress& remote, uint16_t timeout, uint64_t maxQueuedBytes, uint8_t reconnectWaitTime, bool asyncConnect, RemoteLogger::FrameSize frame, time_t stalledWriteTimeoutSeconds) :
+  d_remote(remote), d_stalledWriteTimeoutSeconds(stalledWriteTimeoutSeconds), d_timeout(timeout), d_reconnectWaitTime(reconnectWaitTime), d_asyncConnect(asyncConnect), d_runtime({CircularWriteBuffer(maxQueuedBytes, frame == FrameSize::Two ? 2 : 4), nullptr}), d_framesize(frame)
 {
   if (!d_asyncConnect) {
     reconnect();
@@ -340,5 +340,5 @@ bool RemoteLogger::connectionStalled()
     return false;
   }
 
-  return (d_tryingToWriteSince < now && (now - d_tryingToWriteSince) > s_stalledTimeoutSeconds);
+  return (d_tryingToWriteSince < now && (now - d_tryingToWriteSince) > d_stalledWriteTimeoutSeconds);
 }

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -51,8 +51,10 @@ public:
 
   [[nodiscard]] bool hasRoomFor(const std::string& str) const;
   [[nodiscard]] bool tooBig(const std::string& str) const;
+  [[nodiscard]] bool isEmpty() const;
   bool write(const std::string& str);
   bool flush(int fileDesc);
+  void clear();
 
 private:
   boost::circular_buffer<char> d_buffer;
@@ -172,8 +174,13 @@ public:
   }
 
 private:
+  // if we have been trying to write for that long without any progress,
+  // the connection is dead
+  static constexpr time_t s_stalledTimeoutSeconds{5};
+
   bool reconnect();
   void maintenanceThread();
+  [[nodiscard]] bool connectionStalled();
 
   struct RuntimeData
   {
@@ -183,6 +190,7 @@ private:
   };
 
   ComboAddress d_remote;
+  time_t d_tryingToWriteSince{};
   uint16_t d_timeout;
   uint8_t d_reconnectWaitTime;
   std::atomic<bool> d_exiting{false};

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -136,11 +136,13 @@ public:
   RemoteLogger(RemoteLogger&&) = delete;
   RemoteLogger& operator=(const RemoteLogger&) = delete;
   RemoteLogger& operator=(RemoteLogger&&) = delete;
-  RemoteLogger(const ComboAddress& remote, uint16_t timeout = 2,
+  RemoteLogger(const ComboAddress& remote,
+               uint16_t timeout = 2,
                uint64_t maxQueuedBytes = 100000,
                uint8_t reconnectWaitTime = 1,
                bool asyncConnect = false,
-               FrameSize frame = FrameSize::Two);
+               FrameSize frame = FrameSize::Two,
+               time_t stalledWriteTimeoutSeconds = 5);
   ~RemoteLogger() override;
 
   std::string address() const override
@@ -174,10 +176,6 @@ public:
   }
 
 private:
-  // if we have been trying to write for that long without any progress,
-  // the connection is dead
-  static constexpr time_t s_stalledTimeoutSeconds{5};
-
   bool reconnect();
   void maintenanceThread();
   [[nodiscard]] bool connectionStalled();
@@ -190,13 +188,16 @@ private:
   };
 
   ComboAddress d_remote;
+  // if we have been trying to write for that long without any progress,
+  // the connection is dead
+  time_t d_stalledWriteTimeoutSeconds{};
   time_t d_tryingToWriteSince{};
-  uint16_t d_timeout;
-  uint8_t d_reconnectWaitTime;
+  uint16_t d_timeout{};
+  uint8_t d_reconnectWaitTime{};
   std::atomic<bool> d_exiting{false};
   bool d_asyncConnect{false};
 
   LockGuarded<RuntimeData> d_runtime;
   std::thread d_thread;
-  FrameSize d_framesize;
+  FrameSize d_framesize{};
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In very limited testing this solves the issue reported in https://github.com/PowerDNS/pdns/issues/17526

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
