### PR TITLE
auth 5.1 lmdb: correctly update timestamps in non-split domain table mode

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1354,6 +1354,13 @@ void LMDBBackend::consolidateDomainInfo(DomainInfo& info) const
   }
 }
 
+void LMDBBackend::writeDomainInfo(const DomainInfo& info)
+{
+  auto txn = d_tdomains->getRWTransaction();
+  txn.put(info, info.id);
+  txn.commit();
+}
+
 void LMDBBackend::writeTransientDomainInfo(const DomainInfo& info)
 {
   // If the DomainInfo table is split, write the TransientDomainInfo part
@@ -1384,9 +1391,7 @@ void LMDBBackend::updateDomainInfo(const DomainInfo& info)
     return;
   }
 
-  auto txn = d_tdomains->getRWTransaction();
-  txn.put(info, info.id);
-  txn.commit();
+  writeDomainInfo(info);
   writeTransientDomainInfo(info);
 }
 
@@ -2437,9 +2442,7 @@ bool LMDBBackend::genChangeTransientDomain(domainid_t id, const std::function<vo
       writeTransientDomainInfo(info);
     }
     else {
-      auto txn = d_tdomains->getRWTransaction();
-      txn.put(info, info.id);
-      txn.commit();
+      writeDomainInfo(info);
     }
   }
   return true;
@@ -3752,9 +3755,7 @@ void LMDBBackend::flush()
           writeTransientDomainInfo(info);
         }
         else {
-          auto txn = d_tdomains->getRWTransaction();
-          txn.put(info, info.id);
-          txn.commit();
+          writeDomainInfo(info);
         }
       }
       else {

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2432,8 +2432,15 @@ bool LMDBBackend::genChangeTransientDomain(domainid_t id, const std::function<vo
     writeDomainInfo(info);
   }
   else {
-    // No need to write the complete DomainInfo in this case
-    writeTransientDomainInfo(info);
+    // If the DomainInfo table is split, only update the extra table.
+    if (d_split_domains_table) {
+      writeTransientDomainInfo(info);
+    }
+    else {
+      auto txn = d_tdomains->getRWTransaction();
+      txn.put(info, info.id);
+      txn.commit();
+    }
   }
   return true;
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1368,7 +1368,7 @@ void LMDBBackend::writeTransientDomainInfo(const DomainInfo& info)
   }
 }
 
-void LMDBBackend::writeDomainInfo(const DomainInfo& info)
+void LMDBBackend::updateDomainInfo(const DomainInfo& info)
 {
   // Update the in-memory cache if we don't keep the database up to date.
   if (!d_write_notification_update) {
@@ -2400,7 +2400,7 @@ bool LMDBBackend::genChangeDomain(const ZoneName& domain, const std::function<vo
   }
   consolidateDomainInfo(info);
   func(info);
-  writeDomainInfo(info);
+  updateDomainInfo(info);
   return true;
 }
 
@@ -2413,7 +2413,7 @@ bool LMDBBackend::genChangeDomain(domainid_t id, const std::function<void(Domain
   }
   consolidateDomainInfo(info);
   func(info);
-  writeDomainInfo(info);
+  updateDomainInfo(info);
   return true;
 }
 
@@ -2429,7 +2429,7 @@ bool LMDBBackend::genChangeTransientDomain(domainid_t id, const std::function<vo
   func(info);
   if (!d_write_notification_update) {
     // This won't write anything but update the in-memory cache
-    writeDomainInfo(info);
+    updateDomainInfo(info);
   }
   else {
     // If the DomainInfo table is split, only update the extra table.

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -359,6 +359,7 @@ private:
   bool findDomain(domainid_t domainid, DomainInfo& info) const;
   void consolidateDomainInfo(DomainInfo& info) const;
   void updateDomainInfo(const DomainInfo& info);
+  void writeDomainInfo(const DomainInfo& info);
   void writeTransientDomainInfo(const DomainInfo& info);
 
   void setLastCheckTime(domainid_t domain_id, time_t last_check);

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -358,7 +358,7 @@ private:
   bool findDomain(const ZoneName& domain, DomainInfo& info) const;
   bool findDomain(domainid_t domainid, DomainInfo& info) const;
   void consolidateDomainInfo(DomainInfo& info) const;
-  void writeDomainInfo(const DomainInfo& info);
+  void updateDomainInfo(const DomainInfo& info);
   void writeTransientDomainInfo(const DomainInfo& info);
 
   void setLastCheckTime(domainid_t domain_id, time_t last_check);

--- a/regression-tests/backends/lmdb-slave
+++ b/regression-tests/backends/lmdb-slave
@@ -55,6 +55,18 @@ __EOF__
                 $PDNSUTIL --config-dir=. --config-name=lmdb2 set-catalog remove.invalid catalog.invalid
         fi
 
+        # search for a zone which has never been AXFR'd yet
+        axfrzone=
+        for zone in $(grep 'zone ' named.conf  | cut -f2 -d\" | grep -v '^nztest.com$')
+        do
+                notificationtime=$($PDNSUTIL --config-dir=. --config-name=lmdb2 zone show $zone | grep ^Last | cut -d: -f2-)
+                if [ "$notificationtime" = " Never" ]
+                then
+                        axfrzone=$zone
+                        break
+                fi
+        done
+
         port=$((port+100))
 
         $RUNWRAPPER $PDNS2 --daemon=no --local-port=$port --config-dir=. \
@@ -78,6 +90,18 @@ __EOF__
         done
         if [ $zones -ne $present ]
         then
-                echo "AXFR FAILED" >> failed_tests
+                echo "AXFR FAILED" | tee -a failed_tests
                 exit
+        fi
+
+        # If we had a zone which had never had its contents AXFR'd before,
+        # check the notification timestamp has been updated.
+        if [ -n "$axfrzone" ]
+        then
+                notificationtime=$($PDNSUTIL --config-dir=. --config-name=lmdb2 zone show $zone | grep ^Last | cut -d: -f2-)
+                if [ "$notificationtime" = " Never" ]
+                then
+                        echo "AXFR FAILED TO UPDATE NOTIFICATION TIMESTAMP" | tee -a failed_tests
+                        exit
+                fi
         fi


### PR DESCRIPTION
### Short description
5.1 backport for #17523

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
