### PR TITLE
auth: meson: install module_resources into /usr/share/doc/pdns

### DIFF
--- a/modules/meson.build
+++ b/modules/meson.build
@@ -56,7 +56,7 @@ foreach module_name: all_modules
 
   foreach resource: module_resources
     install_data(resource,
-      install_dir: get_option('datadir') / 'pdns'
+      install_dir: get_option('datadir') / 'doc' / 'pdns'
     )
   endforeach
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

autoconf installs the SQL files into dist_doc_..., landing them in `/usr/share/doc/pdns` (at least on Debian).

meson so far put them into `/usr/share/pdns` (note the missing `doc`).

This mirrors what the autoconf build does.

AFAICT meson does not expose /usr/share/doc in any xxxdir. https://mesonbuild.com/Builtin-options.html#directories

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
