### PR TITLE
rec: only set ACCESS_CONTROL_ALLOW_ORIGIN if auth succeeded (#YWH-PGM-6095-250)

### DIFF
--- a/pdns/recursordist/rec-rust-lib/rust/src/web.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/web.rs
@@ -175,15 +175,6 @@ fn api_wrapper(
     headers: &mut header::HeaderMap,
     allow_password: bool,
 ) {
-    // security headers
-    if !ctx.cross_origin_request_header.is_empty()  {
-        if let Ok(value) = header::HeaderValue::from_str(&ctx.cross_origin_request_header) {
-            headers.insert(
-                header::ACCESS_CONTROL_ALLOW_ORIGIN,
-                value,
-            );
-        }
-    }
 
     // XXX AUDIT!
 
@@ -241,6 +232,16 @@ fn api_wrapper(
         return;
     }
     response.status = StatusCode::OK.as_u16(); // 200;
+
+    // security headers
+    if !ctx.cross_origin_request_header.is_empty()  {
+        if let Ok(value) = header::HeaderValue::from_str(&ctx.cross_origin_request_header) {
+            headers.insert(
+                header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                value,
+            );
+        }
+    }
 
     headers.insert(
         header::X_CONTENT_TYPE_OPTIONS,


### PR DESCRIPTION

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
