### PR TITLE
auth: stricter lmdb AXFR checks

### DIFF
--- a/regression-tests/backends/gmysql-slave
+++ b/regression-tests/backends/gmysql-slave
@@ -102,6 +102,6 @@ __EOF__
 	done
 	if [ $present -ne $zones ]
 	then
-		echo "AXFR FAILED" >> failed_tests
+		echo "AXFR FAILED" | tee -a failed_tests
 		exit
 	fi

--- a/regression-tests/backends/godbc_mssql-slave
+++ b/regression-tests/backends/godbc_mssql-slave
@@ -53,7 +53,7 @@ __EOF__
 	done
 	if [ $todo -ne 0 ]
 	then
-		echo "AXFR FAILED" >> failed_tests
+		echo "AXFR FAILED" | tee -a failed_tests
 		exit
 	fi
 	set -e

--- a/regression-tests/backends/gpgsql-slave
+++ b/regression-tests/backends/gpgsql-slave
@@ -60,6 +60,6 @@ __EOF__
 	done
 	if [ $todo -ne 0 ]
 	then
-		echo "AXFR FAILED" >> failed_tests
+		echo "AXFR FAILED" | tee -a failed_tests
 		exit
 	fi

--- a/regression-tests/backends/gsqlite3-slave
+++ b/regression-tests/backends/gsqlite3-slave
@@ -57,7 +57,7 @@ __EOF__
 	done
 	if [ $todo -ne 0 ]
 	then
-		echo "AXFR FAILED" >> failed_tests
+		echo "AXFR FAILED" | tee -a failed_tests
 		exit
 	fi
 	set -e

--- a/regression-tests/backends/lmdb-slave
+++ b/regression-tests/backends/lmdb-slave
@@ -55,15 +55,15 @@ __EOF__
                 $PDNSUTIL --config-dir=. --config-name=lmdb2 set-catalog remove.invalid catalog.invalid
         fi
 
-        # search for a zone which has never been AXFR'd yet
-        axfrzone=
+        # make sure none of the zones has been AXFR'd yet
         for zone in $(grep 'zone ' named.conf  | cut -f2 -d\" | grep -v '^nztest.com$')
         do
                 notificationtime=$($PDNSUTIL --config-dir=. --config-name=lmdb2 zone show $zone | grep ^Last | cut -d: -f2-)
-                if [ "$notificationtime" = " Never" ]
+                # Will be empty if the zone does not exist yet
+                if [ -n "$notificationtime" -a  "$notificationtime" != " Never" ]
                 then
-                        axfrzone=$zone
-                        break
+                        echo "ZONE $zone EXISTS AND HAS BEEN AXFR'D IN SECONDARY ALREADY" | tee -a failed_tests
+                        exit
                 fi
         done
 
@@ -94,14 +94,13 @@ __EOF__
                 exit
         fi
 
-        # If we had a zone which had never had its contents AXFR'd before,
-        # check the notification timestamp has been updated.
-        if [ -n "$axfrzone" ]
-        then
+        # make sure all of the zones have been AXFR'd now
+        for zone in $(grep 'zone ' named.conf  | cut -f2 -d\" | grep -v '^nztest.com$')
+        do
                 notificationtime=$($PDNSUTIL --config-dir=. --config-name=lmdb2 zone show $zone | grep ^Last | cut -d: -f2-)
                 if [ "$notificationtime" = " Never" ]
                 then
-                        echo "AXFR FAILED TO UPDATE NOTIFICATION TIMESTAMP" | tee -a failed_tests
+                        echo "AXFR FAILED TO UPDATE NOTIFICATION TIMESTAMP FOR ZONE $zone" | tee -a failed_tests
                         exit
                 fi
-        fi
+        done

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -116,7 +116,7 @@ bindwait ()
 
         if [ $done != $domcount ]
         then
-                echo "Domain parsing failed" >> failed_tests
+                echo "Domain parsing failed" | tee -a failed_tests
         fi
 }
 

--- a/regression-tests/tests/bind-add-zone/stress/run.sh
+++ b/regression-tests/tests/bind-add-zone/stress/run.sh
@@ -42,7 +42,7 @@ bindwait ()
 	done
 
 	if [ $done != $domcount ]; then
-		echo "Domain parsing failed" >> failed_tests
+		echo "Domain parsing failed" | tee -a failed_tests
 	fi
 }
 


### PR DESCRIPTION
### Short description
The test added in #17523 was a bit cheap. This PR replaces it with a thorough check, which verifies that an actual AXFR operation occurs on the secondary, for all zones, as reported by the `pdnsutil zone show` output showing a timestamp for freshness check.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
