### PR TITLE
fix: dnsdist drops responses without HAVE_DNSCRYPT

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-dnscrypt.cc
@@ -73,7 +73,7 @@ bool encryptResponse(PacketBuffer& response, size_t maximumSize, bool tcp, std::
   }
   return true;
 #else
-  return false;
+  return true;
 #endif
 }
 


### PR DESCRIPTION
### Short description
There was a regression on https://github.com/PowerDNS/pdns/pull/16363 - dnsdist started dropping all responses without HAVE_DNSCRYPT.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
