### PR TITLE
Add `auth-51` to repo test script.

### DIFF
--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -47,6 +47,7 @@ def init_argparser():
             "auth-48",
             "auth-49",
             "auth-50",
+            "auth-51",
             "auth-master",
             # Recursor
             "rec-48",
@@ -142,6 +143,7 @@ def write_release_files(release):
         "auth-48",
         "auth-49",
         "auth-50",
+        "auth-51",
         "auth-master",
         "rec-48",
         "rec-49",
@@ -161,15 +163,17 @@ def write_release_files(release):
         write_pkg_pin_file(release)
         write_dockerfile("el", "8", release)
         write_dockerfile("el", "9", release)
-        write_dockerfile("debian", "bullseye", release)
-        write_list_file("debian", "bullseye", release)
-        if not release in ["auth-50", "rec-54", "rec-53", "dnsdist-20", "dnsdist-21"]:
+        if not release in ["auth-51"]:
+            write_dockerfile("debian", "bullseye", release)
+            write_list_file("debian", "bullseye", release)
+        if not release in ["auth-51", "auth-50", "rec-54", "rec-53", "dnsdist-20", "dnsdist-21"]:
             write_dockerfile("ubuntu", "focal", release)
             write_list_file("ubuntu", "focal", release)
         write_dockerfile("ubuntu", "jammy", release)
         write_list_file("ubuntu", "jammy", release)
 
     if release in [
+        "auth-51",
         "auth-50",
         "auth-master",
         "rec-53",
@@ -185,6 +189,7 @@ def write_release_files(release):
         "auth-48",
         "auth-49",
         "auth-50",
+        "auth-51",
         "auth-master",
         "rec-48",
         "rec-49",
@@ -205,6 +210,7 @@ def write_release_files(release):
     if release in [
         "auth-49",
         "auth-50",
+        "auth-51",
         "auth-master",
         "rec-53",
         "rec-54",
@@ -219,6 +225,7 @@ def write_release_files(release):
     if release in [
         "auth-49",
         "auth-50",
+        "auth-51",
         "auth-master",
         "rec-50",
         "rec-51",
@@ -234,10 +241,7 @@ def write_release_files(release):
         write_dockerfile("ubuntu", "noble", release)
         write_list_file("ubuntu", "noble", release)
 
-    if release in [
-        "dnsdist-21",
-        "dnsdist-master",
-    ]:
+    if release in ["auth-51", "auth-master", "dnsdist-21", "dnsdist-master"]:
         write_dockerfile("ubuntu", "resolute", release)
         write_list_file("ubuntu", "resolute", release)
 
@@ -340,6 +344,7 @@ def test_release(release, arch="x86_64"):
     print("=== testing {} ({}) ===".format(release, arch))
     for df in dockerfiles:
         if arch == "aarch64" and not release in [
+            "auth-51",
             "auth-50",
             "auth-49",
             "rec-49",


### PR DESCRIPTION
### Short description

This PR adds testing of the `auth-51` repositories to the script.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)