### PR TITLE
auth: give even more slack to the IfurlupMinimumFailures test

### DIFF
--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -1456,16 +1456,25 @@ lua-health-checks-interval=5
         time.sleep(8)
 
         # Unfortunately, the above delay appears to be too tight for CI to
-        # pass reliably, so apply the good old workaround of putting our heads
-        # in the sand and sleep a bit longer, hoping that the failure rate will
-        # go down to acceptable "once in a blue moon" levels.
-        if os.environ.get("GITHUB_ACTIONS") == "true":
-            time.sleep(1 + 1)
-
-        res = self.sendUDPQuery(query)
-        self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertAnyRRsetInAnswer(res, reachable_rrs)
-        self.assertNoneRRsetInAnswer(res, unreachable_rrs)
+        # pass reliably, so we try a few times...
+        for attempt in range(0, 5):
+            res = self.sendUDPQuery(query)
+            self.assertRcodeEqual(res, dns.rcode.NOERROR)
+            foundReachable = True
+            try:
+                self.assertAnyRRsetInAnswer(res, reachable_rrs)
+            except AssertionError:
+                foundReachable = False
+            foundUnreachable = True
+            try:
+                self.assertNoneRRsetInAnswer(res, unreachable_rrs)
+            except AssertionError:
+                foundUnreachable = False
+            if foundReachable and foundUnreachable:
+                break
+            time.sleep(3)
+        if attempt > 5:
+            self.fail()
 
     def testIfurlupInterval(self):
         """


### PR DESCRIPTION
### Short description
Because not enough human sacrifices had been made, this test keeps failing randomly in CI due to scheduling troubles. This allows for more time for the test to pass, as long as it ends up returning the expected outcome.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] cursed this code
- [X] considered quiting and going to the mountains to herd goats
- [X] remembered I am too lazy for such a task
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
