### PR TITLE
auth: Fix deprecated "meson.build_root" warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1177,7 +1177,7 @@ if get_option('unit-tests-backends')
       test(
         'pdns-auth-backend-' + module,
         start_test_stop,
-        env: {'PDNS_BUILD_PATH': meson.build_root()},
+        env: {'PDNS_BUILD_PATH': meson.project_build_root()},
         args: ['5300', module],
         workdir: product_source_dir / 'regression-tests',
         depends: [pdns_server, pdnsutil, sdig, saxfr, pdns_notify, nsec3dig],


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Meson complains that:
```
../meson.build:1181: WARNING: Project targets '>= 1.2.1' but uses feature deprecated since '0.56.0': meson.build_root. use meson.project_build_root() or meson.global_build_root() instead.
```
Looking at the docs I believe `meson.project_build_root()` is the logic replacement, and it works for me locally, but let's see if our CI agrees.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
