### PR TITLE
auth: declare enable-lua-record-updates unconditionally

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -324,7 +324,6 @@ static void declareArguments()
   ::arg().setSwitch("8bit-dns", "Allow 8bit dns queries") = "no";
 #ifdef HAVE_LUA_RECORDS
   ::arg().setSwitch("enable-lua-records", "Process Lua records for all zones (metadata overrides this)") = "no";
-  ::arg().setSwitch("enable-lua-record-updates", "Allow updates to Lua records") = "no";
   ::arg().setSwitch("lua-records-insert-whitespace", "Insert whitespace when combining Lua chunks") = "no";
   ::arg().set("lua-records-exec-limit", "Lua records scripts execution limit (instructions count). Values <= 0 mean no limit") = "1000";
   ::arg().set("lua-health-checks-expire-delay", "Stops doing health checks after the record hasn't been used for that delay (in seconds)") = "3600";
@@ -358,6 +357,9 @@ static void declareArguments()
 #endif
 
   ::arg().setSwitch("views", "Enable views (variants) of zones, for backends which support them") = "no";
+
+  // Needed by Lua backend
+  ::arg().setSwitch("enable-lua-record-updates", "Allow updates to Lua records") = "no";
 
   // FIXME520: remove when branching 5.2
   ::arg().set("entropy-source", "") = "";

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -358,7 +358,8 @@ static void declareArguments()
 
   ::arg().setSwitch("views", "Enable views (variants) of zones, for backends which support them") = "no";
 
-  // Needed by Lua backend
+  // explicitly declared outside of HAVE_LUA_RECORDS guard to prevent writes
+  // even when LUA is not currently used
   ::arg().setSwitch("enable-lua-record-updates", "Allow updates to Lua records") = "no";
 
   // FIXME520: remove when branching 5.2


### PR DESCRIPTION
### Short description

The Lua record update restrictions added in #17131 rely on the enable-lua-record-updates setting. When built without Lua record support, this setting is not defined, causing errors like:

Undefined but needed argument: 'enable-lua-record-updates'

Add the setting unconditionally.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
