### PR TITLE
auth: meson: avoid having boost_test_framework in all programs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -156,7 +156,6 @@ deps = [
   dep_geoip,
   dep_mmdb,
   dep_cxx_fs,
-  dep_boost_test,
 ]
 
 if dep_systemd_prog.found()
@@ -932,6 +931,7 @@ if get_option('unit-tests')
     'pdns-auth-testrunner': {
       'main': src_dir / 'testrunner.cc',
       'deps-extra': [
+        dep_boost_test,
         libpdns_test,
         libpdns_signers_openssl,
         libpdns_signers_sodium,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
