### PR TITLE
protozero: extend test to determine endianess

### DIFF
--- a/ext/protozero/include/protozero/config.hpp
+++ b/ext/protozero/include/protozero/config.hpp
@@ -37,6 +37,13 @@ documentation.
 # if (__BYTE_ORDER == __BIG_ENDIAN)
 #  define PROTOZERO_BYTE_ORDER PROTOZERO_BIG_ENDIAN
 # endif
+#elif defined(__BYTE_ORDER__)
+# if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#  define PROTOZERO_BYTE_ORDER PROTOZERO_LITTLE_ENDIAN
+# endif
+# if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#  define PROTOZERO_BYTE_ORDER PROTOZERO_BIG_ENDIAN
+# endif
 #else
 // This probably isn't a very good default, but might do until we figure
 // out something better.


### PR DESCRIPTION
By using symbols defined by modern compilers

This should make OpenBSD/sparc64 determine the correct endianness.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
