### PR TITLE
dnsdist: add generic object cache

### DIFF
--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -33,23 +33,14 @@
 #include "qtype.hh"
 
 DNSDistPacketCache::DNSDistPacketCache(CacheSettings settings) :
+  d_cache({.d_ttlEnabled = false,
+           .d_ttl = 0,
+           .d_lruEnabled = false,
+           .d_shardCount = settings.d_shardCount == 0 ? 1 : settings.d_shardCount,
+           .d_maxEntries = settings.d_maxEntries,
+           .d_deferrableInsertLock = settings.d_deferrableInsertLock}),
   d_settings(std::move(settings))
 {
-  if (d_settings.d_maxEntries == 0) {
-    throw std::runtime_error("Trying to create a 0-sized packet-cache");
-  }
-
-  if (d_settings.d_shardCount == 0) {
-    d_settings.d_shardCount = 1;
-  }
-
-  d_shards.resize(d_settings.d_shardCount);
-
-  /* we reserve maxEntries + 1 to avoid rehashing from occurring
-     when we get to maxEntries, as it means a load factor of 1 */
-  for (auto& shard : d_shards) {
-    shard.setSize((d_settings.d_maxEntries / d_settings.d_shardCount) + 1);
-  }
 }
 
 bool DNSDistPacketCache::getClientSubnet(const PacketBuffer& packet, size_t qnameWireLength, std::optional<Netmask>& subnet)
@@ -91,40 +82,6 @@ bool DNSDistPacketCache::cachedValueMatches(const CacheValue& cachedValue, uint1
   }
 
   return true;
-}
-
-bool DNSDistPacketCache::insertLocked(std::unordered_map<uint32_t, CacheValue>& map, uint32_t key, CacheValue& newValue)
-{
-  /* check again now that we hold the lock to prevent a race */
-  if (map.size() >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
-    return false;
-  }
-
-  std::unordered_map<uint32_t, CacheValue>::iterator mapIt;
-  bool result{false};
-  std::tie(mapIt, result) = map.insert({key, newValue});
-
-  if (result) {
-    return true;
-  }
-
-  /* in case of collision, don't override the existing entry
-     except if it has expired */
-  CacheValue& value = mapIt->second;
-  bool wasExpired = value.validity <= newValue.added;
-
-  if (!wasExpired && !cachedValueMatches(value, newValue.queryFlags, newValue.qname, newValue.qtype, newValue.qclass, newValue.receivedOverUDP, newValue.dnssecOK, newValue.subnet)) {
-    ++d_insertCollisions;
-    return false;
-  }
-
-  /* if the existing entry had a longer TTD, keep it */
-  if (newValue.validity <= value.validity) {
-    return false;
-  }
-
-  value = newValue;
-  return false;
 }
 
 void DNSDistPacketCache::insert(uint32_t key, const std::optional<Netmask>& subnet, uint16_t queryFlags, bool dnssecOK, const DNSName& qname, uint16_t qtype, uint16_t qclass, const PacketBuffer& response, bool receivedOverUDP, uint8_t rcode, std::optional<uint32_t> tempFailureTTL)
@@ -177,9 +134,7 @@ void DNSDistPacketCache::insert(uint32_t key, const std::optional<Netmask>& subn
     }
   }
 
-  uint32_t shardIndex = getShardIndex(key);
-
-  if (d_shards.at(shardIndex).d_entriesCount >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
+  if (!d_cache.hasCapacityFor(key)) {
     return;
   }
 
@@ -198,26 +153,20 @@ void DNSDistPacketCache::insert(uint32_t key, const std::optional<Netmask>& subn
   newValue.value = std::string(response.begin(), response.end());
   newValue.subnet = subnet;
 
-  auto& shard = d_shards.at(shardIndex);
+  d_cache.insert(key, newValue, [this, &newValue](const CacheValue& previousValue) {
+    bool wasExpired = previousValue.validity <= newValue.added;
 
-  bool inserted = false;
-  if (d_settings.d_deferrableInsertLock) {
-    auto lock = shard.d_map.try_write_lock();
-
-    if (!lock.owns_lock()) {
-      ++d_deferredInserts;
-      return;
+    if (!wasExpired && !cachedValueMatches(previousValue, newValue.queryFlags, newValue.qname, newValue.qtype, newValue.qclass, newValue.receivedOverUDP, newValue.dnssecOK, newValue.subnet)) {
+      ++d_insertCollisions;
+      return false;
     }
-    inserted = insertLocked(*lock, key, newValue);
-  }
-  else {
-    auto lock = shard.d_map.write_lock();
 
-    inserted = insertLocked(*lock, key, newValue);
-  }
-  if (inserted) {
-    ++shard.d_entriesCount;
-  }
+    /* if the existing entry had a longer TTD, keep it */
+    if (newValue.validity <= previousValue.validity) {
+      return false;
+    }
+    return true;
+  });
 }
 
 bool DNSDistPacketCache::get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_t* keyOut, std::optional<Netmask>& subnet, bool dnssecOK, bool receivedOverUDP, uint32_t allowExpired, bool skipAging, bool truncatedOK, bool recordMiss)
@@ -238,82 +187,70 @@ bool DNSDistPacketCache::get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_
     getClientSubnet(dnsQuestion.getData(), dnsQuestion.ids.qname.wirelength(), subnet);
   }
 
-  uint32_t shardIndex = getShardIndex(key);
   time_t now = time(nullptr);
   time_t age{0};
   bool stale = false;
   auto& response = dnsQuestion.getMutableData();
-  auto& shard = d_shards.at(shardIndex);
-  {
-    auto map = shard.d_map.try_read_lock();
-    if (!map.owns_lock()) {
-      ++d_deferredLookups;
-      return false;
-    }
 
-    auto mapIt = map->find(key);
-    if (mapIt == map->end()) {
+  CacheValue value;
+  bool found = d_cache.getValue(key, value, recordMiss, allowExpired);
+  if (!found) {
+    return false;
+  }
+
+  if (value.validity <= now) {
+    if ((now - value.validity) >= static_cast<time_t>(allowExpired)) {
       if (recordMiss) {
         ++d_misses;
       }
       return false;
     }
+    stale = true;
+  }
 
-    const CacheValue& value = mapIt->second;
-    if (value.validity <= now) {
-      if ((now - value.validity) >= static_cast<time_t>(allowExpired)) {
-        if (recordMiss) {
-          ++d_misses;
-        }
-        return false;
-      }
-      stale = true;
-    }
+  if (value.len < sizeof(dnsheader)) {
+    return false;
+  }
 
-    if (value.len < sizeof(dnsheader)) {
+  /* check for collision */
+  if (!cachedValueMatches(value, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnsQuestion.ids.qname, dnsQuestion.ids.qtype, dnsQuestion.ids.qclass, receivedOverUDP, dnssecOK, subnet)) {
+    ++d_lookupCollisions;
+    return false;
+  }
+
+  if (!truncatedOK) {
+    dnsheader_aligned dh_aligned(value.value.data());
+    if (dh_aligned->tc != 0) {
       return false;
     }
+  }
 
-    /* check for collision */
-    if (!cachedValueMatches(value, *(getFlagsFromDNSHeader(dnsQuestion.getHeader().get())), dnsQuestion.ids.qname, dnsQuestion.ids.qtype, dnsQuestion.ids.qclass, receivedOverUDP, dnssecOK, subnet)) {
-      ++d_lookupCollisions;
-      return false;
-    }
+  response.resize(value.len);
+  memcpy(&response.at(0), &queryId, sizeof(queryId));
+  memcpy(&response.at(sizeof(queryId)), &value.value.at(sizeof(queryId)), sizeof(dnsheader) - sizeof(queryId));
 
-    if (!truncatedOK) {
-      dnsheader_aligned dh_aligned(value.value.data());
-      if (dh_aligned->tc != 0) {
-        return false;
-      }
-    }
+  if (value.len == sizeof(dnsheader)) {
+    /* DNS header only, our work here is done */
+    ++d_hits;
+    return true;
+  }
 
-    response.resize(value.len);
-    memcpy(&response.at(0), &queryId, sizeof(queryId));
-    memcpy(&response.at(sizeof(queryId)), &value.value.at(sizeof(queryId)), sizeof(dnsheader) - sizeof(queryId));
+  const size_t dnsQNameLen = dnsQName.length();
+  if (value.len < (sizeof(dnsheader) + dnsQNameLen)) {
+    return false;
+  }
 
-    if (value.len == sizeof(dnsheader)) {
-      /* DNS header only, our work here is done */
-      ++d_hits;
-      return true;
-    }
+  memcpy(&response.at(sizeof(dnsheader)), dnsQName.c_str(), dnsQNameLen);
+  if (value.len > (sizeof(dnsheader) + dnsQNameLen)) {
+    memcpy(&response.at(sizeof(dnsheader) + dnsQNameLen), &value.value.at(sizeof(dnsheader) + dnsQNameLen), value.len - (sizeof(dnsheader) + dnsQNameLen));
+  }
 
-    const size_t dnsQNameLen = dnsQName.length();
-    if (value.len < (sizeof(dnsheader) + dnsQNameLen)) {
-      return false;
-    }
-
-    memcpy(&response.at(sizeof(dnsheader)), dnsQName.c_str(), dnsQNameLen);
-    if (value.len > (sizeof(dnsheader) + dnsQNameLen)) {
-      memcpy(&response.at(sizeof(dnsheader) + dnsQNameLen), &value.value.at(sizeof(dnsheader) + dnsQNameLen), value.len - (sizeof(dnsheader) + dnsQNameLen));
-    }
-
-    if (!stale) {
-      age = now - value.added;
-    }
-    else {
-      age = (value.validity - value.added) - d_settings.d_staleTTL;
-      dnsQuestion.ids.staleCacheHit = true;
-    }
+  if (!stale) {
+    age = now - value.added;
+  }
+  else {
+    age = (value.validity - value.added) - d_settings.d_staleTTL;
+    dnsQuestion.ids.staleCacheHit = true;
   }
 
   if (!d_settings.d_dontAge && !skipAging) {
@@ -347,35 +284,8 @@ bool DNSDistPacketCache::get(DNSQuestion& dnsQuestion, uint16_t queryId, uint32_
 */
 size_t DNSDistPacketCache::purgeExpired(size_t upTo, const time_t now)
 {
-  const size_t maxPerShard = upTo / d_settings.d_shardCount;
-
-  size_t removed = 0;
-
   ++d_cleanupCount;
-  for (auto& shard : d_shards) {
-    auto map = shard.d_map.write_lock();
-    if (map->size() <= maxPerShard) {
-      continue;
-    }
-
-    size_t toRemove = map->size() - maxPerShard;
-
-    for (auto it = map->begin(); toRemove > 0 && it != map->end();) {
-      const CacheValue& value = it->second;
-
-      if (value.validity <= now) {
-        it = map->erase(it);
-        --toRemove;
-        --shard.d_entriesCount;
-        ++removed;
-      }
-      else {
-        ++it;
-      }
-    }
-  }
-
-  return removed;
+  return d_cache.purgeExpired(upTo, now);
 }
 
 /* Remove all entries, keeping only upTo
@@ -385,89 +295,26 @@ size_t DNSDistPacketCache::purgeExpired(size_t upTo, const time_t now)
 */
 size_t DNSDistPacketCache::expunge(size_t upTo)
 {
-  const size_t maxPerShard = upTo / d_settings.d_shardCount;
-
-  size_t removed = 0;
-
-  for (auto& shard : d_shards) {
-    auto map = shard.d_map.write_lock();
-
-    if (map->size() <= maxPerShard) {
-      continue;
-    }
-
-    size_t toRemove = map->size() - maxPerShard;
-
-    auto beginIt = map->begin();
-    auto endIt = beginIt;
-
-    if (map->size() >= toRemove) {
-      std::advance(endIt, toRemove);
-      map->erase(beginIt, endIt);
-      shard.d_entriesCount -= toRemove;
-      removed += toRemove;
-    }
-    else {
-      removed += map->size();
-      map->clear();
-      shard.d_entriesCount = 0;
-    }
-  }
-
-  return removed;
+  return d_cache.expunge(upTo);
 }
 
 size_t DNSDistPacketCache::expungeByName(const DNSName& name, uint16_t qtype, bool suffixMatch)
 {
-  size_t removed = 0;
-
-  for (auto& shard : d_shards) {
-    auto map = shard.d_map.write_lock();
-
-    for (auto it = map->begin(); it != map->end();) {
-      const CacheValue& value = it->second;
-
-      if ((value.qname == name || (suffixMatch && value.qname.isPartOf(name))) && (qtype == QType::ANY || qtype == value.qtype)) {
-        it = map->erase(it);
-        --shard.d_entriesCount;
-        ++removed;
-      }
-      else {
-        ++it;
-      }
-    }
-  }
-
-  return removed;
+  return d_cache.expungeByCondition([&name, &qtype, &suffixMatch](const CacheValue& value) {
+    return ((value.qname == name || (suffixMatch && value.qname.isPartOf(name))) && (qtype == QType::ANY || qtype == value.qtype));
+  });
 }
 
 size_t DNSDistPacketCache::expungeByName(const std::vector<DNSName>& names, uint16_t qtype, bool suffixMatch)
 {
-  size_t removed = 0;
-
-  for (auto& shard : d_shards) {
-    auto map = shard.d_map.write_lock();
-
-    for (auto it = map->begin(); it != map->end();) {
-      const CacheValue& value = it->second;
-
-      if (std::find_if(names.cbegin(), names.cend(),
-                       [&value, &qtype, &suffixMatch](const DNSName& name) {
-                         return (
-                           (value.qname == name || (suffixMatch && value.qname.isPartOf(name))) && (qtype == QType::ANY || value.qtype == qtype));
-                       })
-          != names.cend()) {
-        it = map->erase(it);
-        --shard.d_entriesCount;
-        ++removed;
-      }
-      else {
-        ++it;
-      }
-    }
-  }
-
-  return removed;
+  return d_cache.expungeByCondition([&names, &qtype, &suffixMatch](const CacheValue& value) {
+    return (std::find_if(names.cbegin(), names.cend(),
+                         [&value, &qtype, &suffixMatch](const DNSName& name) {
+                           return (
+                             (value.qname == name || (suffixMatch && value.qname.isPartOf(name))) && (qtype == QType::ANY || value.qtype == qtype));
+                         })
+            != names.cend());
+  });
 }
 
 bool DNSDistPacketCache::isFull()
@@ -477,13 +324,7 @@ bool DNSDistPacketCache::isFull()
 
 uint64_t DNSDistPacketCache::getSize()
 {
-  uint64_t count = 0;
-
-  for (auto& shard : d_shards) {
-    count += shard.d_entriesCount;
-  }
-
-  return count;
+  return d_cache.getSize();
 }
 
 uint32_t DNSDistPacketCache::getMinTTL(const char* packet, uint16_t length, bool* seenNoDataSOA)
@@ -550,32 +391,27 @@ uint64_t DNSDistPacketCache::dump(int fileDesc, bool rawResponse)
 
   uint64_t count = 0;
   time_t now = time(nullptr);
-  for (auto& shard : d_shards) {
-    auto map = shard.d_map.read_lock();
-
-    for (const auto& entry : *map) {
-      const CacheValue& value = entry.second;
-      count++;
-
-      try {
-        uint8_t rcode = 0;
-        if (value.len >= sizeof(dnsheader)) {
-          dnsheader dnsHeader{};
-          memcpy(&dnsHeader, value.value.data(), sizeof(dnsheader));
-          rcode = dnsHeader.rcode;
-        }
-
-        fprintf(filePtr.get(), "%s %" PRId64 " %s %s ; ecs %s, rcode %" PRIu8 ", key %" PRIu32 ", length %" PRIu16 ", received over UDP %d, added %" PRId64 ", dnssecOK %d, raw query flags %" PRIu16, value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QClass(value.qclass).toString().c_str(), QType(value.qtype).toString().c_str(), value.subnet ? value.subnet.value().toString().c_str() : "empty", rcode, entry.first, value.len, value.receivedOverUDP ? 1 : 0, static_cast<int64_t>(value.added), value.dnssecOK ? 1 : 0, value.queryFlags);
-
-        if (rawResponse) {
-          std::string rawDataResponse = Base64Encode(value.value);
-          fprintf(filePtr.get(), ", base64response %s", rawDataResponse.c_str());
-        }
-        fprintf(filePtr.get(), "\n");
+  for (auto it = d_cache.begin(); it != d_cache.end(); ++it) {
+    const CacheValue& value = (*it).value;
+    count++;
+    try {
+      uint8_t rcode = 0;
+      if (value.len >= sizeof(dnsheader)) {
+        dnsheader dnsHeader{};
+        memcpy(&dnsHeader, value.value.data(), sizeof(dnsheader));
+        rcode = dnsHeader.rcode;
       }
-      catch (...) {
-        fprintf(filePtr.get(), "; error printing '%s'\n", value.qname.empty() ? "EMPTY" : value.qname.toString().c_str());
+
+      fprintf(filePtr.get(), "%s %" PRId64 " %s %s ; ecs %s, rcode %" PRIu8 ", key %" PRIu32 ", length %" PRIu16 ", received over UDP %d, added %" PRId64 ", dnssecOK %d, raw query flags %" PRIu16, value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QClass(value.qclass).toString().c_str(), QType(value.qtype).toString().c_str(), value.subnet ? value.subnet.value().toString().c_str() : "empty", rcode, (*it).key, value.len, value.receivedOverUDP ? 1 : 0, static_cast<int64_t>(value.added), value.dnssecOK ? 1 : 0, value.queryFlags);
+
+      if (rawResponse) {
+        std::string rawDataResponse = Base64Encode(value.value);
+        fprintf(filePtr.get(), ", base64response %s", rawDataResponse.c_str());
       }
+      fprintf(filePtr.get(), "\n");
+    }
+    catch (...) {
+      fprintf(filePtr.get(), "; error printing '%s'\n", value.qname.empty() ? "EMPTY" : value.qname.toString().c_str());
     }
   }
 
@@ -586,53 +422,49 @@ std::set<DNSName> DNSDistPacketCache::getDomainsContainingRecords(const ComboAdd
 {
   std::set<DNSName> domains;
 
-  for (auto& shard : d_shards) {
-    auto map = shard.d_map.read_lock();
+  for (auto it = d_cache.begin(); it != d_cache.end(); ++it) {
+    const CacheValue& value = (*it).value;
 
-    for (const auto& entry : *map) {
-      const CacheValue& value = entry.second;
-
-      try {
-        if (value.len < sizeof(dnsheader)) {
-          continue;
-        }
-
-        dnsheader_aligned dnsHeader(value.value.data());
-        if (dnsHeader->rcode != RCode::NoError || (dnsHeader->ancount == 0 && dnsHeader->nscount == 0 && dnsHeader->arcount == 0)) {
-          continue;
-        }
-
-        bool found = false;
-        bool valid = visitDNSPacket(value.value, [addr, &found](uint8_t /* section */, uint16_t qclass, uint16_t qtype, uint32_t /* ttl */, uint16_t rdatalength, const char* rdata) {
-          if (qtype == QType::A && qclass == QClass::IN && addr.isIPv4() && rdatalength == 4 && rdata != nullptr) {
-            ComboAddress parsed;
-            parsed.sin4.sin_family = AF_INET;
-            memcpy(&parsed.sin4.sin_addr.s_addr, rdata, rdatalength);
-            if (parsed == addr) {
-              found = true;
-              return true;
-            }
-          }
-          else if (qtype == QType::AAAA && qclass == QClass::IN && addr.isIPv6() && rdatalength == 16 && rdata != nullptr) {
-            ComboAddress parsed;
-            parsed.sin6.sin6_family = AF_INET6;
-            memcpy(&parsed.sin6.sin6_addr.s6_addr, rdata, rdatalength);
-            if (parsed == addr) {
-              found = true;
-              return true;
-            }
-          }
-
-          return false;
-        });
-
-        if (valid && found) {
-          domains.insert(value.qname);
-        }
-      }
-      catch (...) {
+    try {
+      if (value.len < sizeof(dnsheader)) {
         continue;
       }
+
+      dnsheader_aligned dnsHeader(value.value.data());
+      if (dnsHeader->rcode != RCode::NoError || (dnsHeader->ancount == 0 && dnsHeader->nscount == 0 && dnsHeader->arcount == 0)) {
+        continue;
+      }
+
+      bool found = false;
+      bool valid = visitDNSPacket(value.value, [addr, &found](uint8_t /* section */, uint16_t qclass, uint16_t qtype, uint32_t /* ttl */, uint16_t rdatalength, const char* rdata) {
+        if (qtype == QType::A && qclass == QClass::IN && addr.isIPv4() && rdatalength == 4 && rdata != nullptr) {
+          ComboAddress parsed;
+          parsed.sin4.sin_family = AF_INET;
+          memcpy(&parsed.sin4.sin_addr.s_addr, rdata, rdatalength);
+          if (parsed == addr) {
+            found = true;
+            return true;
+          }
+        }
+        else if (qtype == QType::AAAA && qclass == QClass::IN && addr.isIPv6() && rdatalength == 16 && rdata != nullptr) {
+          ComboAddress parsed;
+          parsed.sin6.sin6_family = AF_INET6;
+          memcpy(&parsed.sin6.sin6_addr.s6_addr, rdata, rdatalength);
+          if (parsed == addr) {
+            found = true;
+            return true;
+          }
+        }
+
+        return false;
+      });
+
+      if (valid && found) {
+        domains.insert(value.qname);
+      }
+    }
+    catch (...) {
+      continue;
     }
   }
 
@@ -643,46 +475,42 @@ std::set<ComboAddress> DNSDistPacketCache::getRecordsForDomain(const DNSName& do
 {
   std::set<ComboAddress> addresses;
 
-  for (auto& shard : d_shards) {
-    auto map = shard.d_map.read_lock();
+  for (auto it = d_cache.begin(); it != d_cache.end(); ++it) {
+    const CacheValue& value = (*it).value;
 
-    for (const auto& entry : *map) {
-      const CacheValue& value = entry.second;
-
-      try {
-        if (value.qname != domain) {
-          continue;
-        }
-
-        if (value.len < sizeof(dnsheader)) {
-          continue;
-        }
-
-        dnsheader_aligned dnsHeader(value.value.data());
-        if (dnsHeader->rcode != RCode::NoError || (dnsHeader->ancount == 0 && dnsHeader->nscount == 0 && dnsHeader->arcount == 0)) {
-          continue;
-        }
-
-        visitDNSPacket(value.value, [&addresses](uint8_t /* section */, uint16_t qclass, uint16_t qtype, uint32_t /* ttl */, uint16_t rdatalength, const char* rdata) {
-          if (qtype == QType::A && qclass == QClass::IN && rdatalength == 4 && rdata != nullptr) {
-            ComboAddress parsed;
-            parsed.sin4.sin_family = AF_INET;
-            memcpy(&parsed.sin4.sin_addr.s_addr, rdata, rdatalength);
-            addresses.insert(parsed);
-          }
-          else if (qtype == QType::AAAA && qclass == QClass::IN && rdatalength == 16 && rdata != nullptr) {
-            ComboAddress parsed;
-            parsed.sin6.sin6_family = AF_INET6;
-            memcpy(&parsed.sin6.sin6_addr.s6_addr, rdata, rdatalength);
-            addresses.insert(parsed);
-          }
-
-          return false;
-        });
-      }
-      catch (...) {
+    try {
+      if (value.qname != domain) {
         continue;
       }
+
+      if (value.len < sizeof(dnsheader)) {
+        continue;
+      }
+
+      dnsheader_aligned dnsHeader(value.value.data());
+      if (dnsHeader->rcode != RCode::NoError || (dnsHeader->ancount == 0 && dnsHeader->nscount == 0 && dnsHeader->arcount == 0)) {
+        continue;
+      }
+
+      visitDNSPacket(value.value, [&addresses](uint8_t /* section */, uint16_t qclass, uint16_t qtype, uint32_t /* ttl */, uint16_t rdatalength, const char* rdata) {
+        if (qtype == QType::A && qclass == QClass::IN && rdatalength == 4 && rdata != nullptr) {
+          ComboAddress parsed;
+          parsed.sin4.sin_family = AF_INET;
+          memcpy(&parsed.sin4.sin_addr.s_addr, rdata, rdatalength);
+          addresses.insert(parsed);
+        }
+        else if (qtype == QType::AAAA && qclass == QClass::IN && rdatalength == 16 && rdata != nullptr) {
+          ComboAddress parsed;
+          parsed.sin6.sin6_family = AF_INET6;
+          memcpy(&parsed.sin6.sin6_addr.s6_addr, rdata, rdatalength);
+          addresses.insert(parsed);
+        }
+
+        return false;
+      });
+    }
+    catch (...) {
+      continue;
     }
   }
 

--- a/pdns/dnsdistdist/dnsdist-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-cache.hh
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <unordered_map>
 
+#include "generic-cache.hh"
 #include "iputils.hh"
 #include "lock.hh"
 #include "noinitvector.hh"
@@ -67,9 +68,9 @@ public:
   [[nodiscard]] string toString();
   [[nodiscard]] uint64_t getSize();
   [[nodiscard]] uint64_t getHits() const { return d_hits.load(); }
-  [[nodiscard]] uint64_t getMisses() const { return d_misses.load(); }
-  [[nodiscard]] uint64_t getDeferredLookups() const { return d_deferredLookups.load(); }
-  [[nodiscard]] uint64_t getDeferredInserts() const { return d_deferredInserts.load(); }
+  [[nodiscard]] uint64_t getMisses() const { return d_cache.getStats().d_misses.load() + d_misses.load(); }
+  [[nodiscard]] uint64_t getDeferredLookups() const { return d_cache.getStats().d_deferredLookups.load(); }
+  [[nodiscard]] uint64_t getDeferredInserts() const { return d_cache.getStats().d_deferredInserts.load(); }
   [[nodiscard]] uint64_t getLookupCollisions() const { return d_lookupCollisions.load(); }
   [[nodiscard]] uint64_t getInsertCollisions() const { return d_insertCollisions.load(); }
   [[nodiscard]] uint64_t getMaxEntries() const { return d_settings.d_maxEntries; }
@@ -114,43 +115,10 @@ private:
     bool dnssecOK{false};
   };
 
-  class CacheShard
-  {
-  public:
-    CacheShard() = default;
-    CacheShard(CacheShard&& /* old */) noexcept
-    {
-    }
-    CacheShard(const CacheShard& /* old */)
-    {
-    }
-    CacheShard& operator=(CacheShard&& /* old */) noexcept
-    {
-      return *this;
-    }
-    CacheShard& operator=(const CacheShard& /* old */)
-    {
-      return *this;
-    }
-    ~CacheShard() = default;
-
-    void setSize(size_t maxSize)
-    {
-      d_map.write_lock()->reserve(maxSize);
-    }
-
-    SharedLockGuarded<std::unordered_map<uint32_t, CacheValue>> d_map{};
-    std::atomic<uint64_t> d_entriesCount{0};
-  };
-
   [[nodiscard]] bool cachedValueMatches(const CacheValue& cachedValue, uint16_t queryFlags, const DNSName& qname, uint16_t qtype, uint16_t qclass, bool receivedOverUDP, bool dnssecOK, const std::optional<Netmask>& subnet) const;
   [[nodiscard]] uint32_t getShardIndex(uint32_t key) const;
-  bool insertLocked(std::unordered_map<uint32_t, CacheValue>& map, uint32_t key, CacheValue& newValue);
 
-  std::vector<CacheShard> d_shards{};
-
-  pdns::stat_t d_deferredLookups{0};
-  pdns::stat_t d_deferredInserts{0};
+  GenericCache<uint32_t, CacheValue, std::hash<uint32_t>, &CacheValue::validity> d_cache;
   pdns::stat_t d_hits{0};
   pdns::stat_t d_misses{0};
   pdns::stat_t d_insertCollisions{0};

--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -19,6 +19,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#include "dnsdist-lua-types.hh"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -225,6 +226,35 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint, const Logr::Logg
       }
     }
 
+    for (const auto& entry : dnsdist::configuration::getCurrentRuntimeConfiguration().d_caches) {
+      string cacheName = entry.first;
+      std::replace(cacheName.begin(), cacheName.end(), '.', '_');
+      if (cacheName.empty()) {
+        cacheName = "_default_";
+      }
+      string base = namespace_name;
+      base += ".";
+      base += hostname;
+      base += ".";
+      base += instance_name;
+      base += ".caches.";
+      base += cacheName;
+      base += ".";
+      const std::shared_ptr<GenericCacheInterface<std::string, std::optional<LuaAny>>> cache = entry.second;
+      const auto& stats = cache->getStats();
+      str << base << "memory-used"
+          << " " << stats.d_memoryUsed << " " << now << "\r\n";
+      str << base << "entries"
+          << " " << stats.d_entriesCount << " " << now << "\r\n";
+      str << base << "cache-hits"
+          << " " << stats.d_cacheHits << " " << now << "\r\n";
+      str << base << "cache-misses"
+          << " " << stats.d_cacheMisses << " " << now << "\r\n";
+      str << base << "expired"
+          << " " << stats.d_expiredItems << " " << now << "\r\n";
+      str << base << "kicked"
+          << " " << stats.d_kickedItems << " " << now << "\r\n";
+    }
 #ifdef HAVE_DNS_OVER_HTTPS
     {
       std::map<std::string, uint64_t> dohFrontendDuplicates;

--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -247,13 +247,17 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint, const Logr::Logg
       str << base << "entries"
           << " " << stats.d_entriesCount << " " << now << "\r\n";
       str << base << "cache-hits"
-          << " " << stats.d_cacheHits << " " << now << "\r\n";
+          << " " << stats.d_hits << " " << now << "\r\n";
       str << base << "cache-misses"
-          << " " << stats.d_cacheMisses << " " << now << "\r\n";
+          << " " << stats.d_misses << " " << now << "\r\n";
       str << base << "expired"
           << " " << stats.d_expiredItems << " " << now << "\r\n";
       str << base << "kicked"
           << " " << stats.d_kickedItems << " " << now << "\r\n";
+      str << base << "deferred-lookups"
+          << " " << stats.d_deferredLookups << " " << now << "\r\n";
+      str << base << "deferred-inserts"
+          << " " << stats.d_deferredInserts << " " << now << "\r\n";
     }
 #ifdef HAVE_DNS_OVER_HTTPS
     {

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -29,6 +29,8 @@
 #include "logging.hh"
 #include "logr.hh"
 #include "mmdb.hh"
+#include "generic-cache-interface.hh"
+#include "generic-cache.hh"
 
 #if defined(HAVE_YAML_CONFIGURATION)
 #include "base64.hh"
@@ -74,7 +76,7 @@ struct Context
 
 using XSKMap = std::vector<std::shared_ptr<XskSocket>>;
 
-using RegisteredTypes = std::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<dnsdist::rust::settings::DNSSelector>, std::shared_ptr<dnsdist::rust::settings::DNSActionWrapper>, std::shared_ptr<dnsdist::rust::settings::DNSResponseActionWrapper>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>, std::shared_ptr<MMDB>>;
+using RegisteredTypes = std::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<dnsdist::rust::settings::DNSSelector>, std::shared_ptr<dnsdist::rust::settings::DNSActionWrapper>, std::shared_ptr<dnsdist::rust::settings::DNSResponseActionWrapper>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>, std::shared_ptr<MMDB>, std::shared_ptr<GenericCacheInterface<std::string, std::optional<LuaAny>>>>;
 static LockGuarded<std::unordered_map<std::string, RegisteredTypes>> s_registeredTypesMap;
 static std::atomic<bool> s_inConfigCheckMode;
 static std::atomic<bool> s_inClientMode;
@@ -1407,7 +1409,7 @@ bool loadConfigurationFromFile(const std::string& fileName, [[maybe_unused]] boo
 void addLuaBindingsForYAMLObjects([[maybe_unused]] LuaContext& luaCtx)
 {
 #if defined(HAVE_YAML_CONFIGURATION)
-  using ReturnValue = std::optional<boost::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction>, std::shared_ptr<DNSResponseAction>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>, std::shared_ptr<MMDB>>>;
+  using ReturnValue = std::optional<boost::variant<std::shared_ptr<DNSDistPacketCache>, std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction>, std::shared_ptr<DNSResponseAction>, std::shared_ptr<NetmaskGroup>, std::shared_ptr<KeyValueStore>, std::shared_ptr<KeyValueLookupKey>, std::shared_ptr<RemoteLoggerInterface>, std::shared_ptr<ServerPolicy>, std::shared_ptr<TimedIPSetRule>, std::shared_ptr<XSKMap>, std::shared_ptr<MMDB>, std::shared_ptr<GenericCacheInterface<std::string, std::optional<LuaAny>>>>>;
 
   luaCtx.writeFunction("getObjectFromYAMLConfiguration", [](const std::string& name) -> ReturnValue {
     auto map = s_registeredTypesMap.lock();
@@ -1453,6 +1455,9 @@ void addLuaBindingsForYAMLObjects([[maybe_unused]] LuaContext& luaCtx)
       return ReturnValue(*ptr);
     }
 #endif
+    if (auto* ptr = std::get_if<std::shared_ptr<GenericCacheInterface<std::string, std::optional<LuaAny>>>>(&item->second)) {
+      return ReturnValue(*ptr);
+    }
 
     return std::nullopt;
   });
@@ -2034,6 +2039,24 @@ void registerOtlpLogger([[maybe_unused]] const OtlpLoggerConfiguration& config)
 #else
   throw std::runtime_error("Unable to create OTLP logger: OTLP support is disabled");
 #endif /* !defined(DISABLE_PROTOBUF) && defined(HAVE_LIBCURL) */
+}
+
+void registerGenericCacheObjects([[maybe_unused]] const GenericCachesConfiguration& config)
+{
+  bool createObjects = !dnsdist::configuration::yaml::s_inClientMode && !dnsdist::configuration::yaml::s_inConfigCheckMode;
+  for (const auto& objectCache : config.object) {
+    auto cache = createObjects ? std::shared_ptr<GenericCacheInterface<std::string, std::optional<LuaAny>>>(new GenericCache<std::string, std::optional<LuaAny>>({.d_ttlEnabled = objectCache.ttl_enabled, .d_ttl = objectCache.ttl, .d_lruEnabled = objectCache.lru_enabled, .d_shardCount = objectCache.shard_count, .d_maxEntries = objectCache.max_entries, .d_lruDeleteUpTo = objectCache.lru_delete_up_to})) : std::shared_ptr<GenericCacheInterface<std::string, std::optional<LuaAny>>>();
+    dnsdist::configuration::yaml::registerType<GenericCacheInterface<std::string, std::optional<LuaAny>>>(cache, objectCache.name);
+    if (createObjects) {
+      auto name = std::string(objectCache.name);
+      dnsdist::configuration::updateRuntimeConfiguration([name, &cache](dnsdist::configuration::RuntimeConfiguration& runtimeConfig) {
+        if (runtimeConfig.d_caches.count(name) > 0) {
+          throw std::runtime_error("Duplicate cache name: " + name);
+        }
+        runtimeConfig.d_caches.emplace(name, cache);
+      });
+    }
+  }
 }
 
 void registerKVSObjects([[maybe_unused]] const KeyValueStoresConfiguration& config)

--- a/pdns/dnsdistdist/dnsdist-configuration.hh
+++ b/pdns/dnsdistdist/dnsdist-configuration.hh
@@ -36,6 +36,7 @@
 #include "dnsdist-query-count.hh"
 #include "dnsdist-rule-chains.hh"
 #include "dnsdist-server-pool.hh"
+#include "generic-cache-interface.hh"
 #include "iputils.hh"
 #include "remote_logger.hh"
 
@@ -134,6 +135,7 @@ struct RuntimeConfiguration
   std::vector<dnsdist::Carbon::Endpoint> d_carbonEndpoints;
 #endif /* DISABLE_CARBON */
   std::unordered_map<std::string, ServerPool> d_pools;
+  std::unordered_map<std::string, std::shared_ptr<GenericCacheInterface<std::string, std::optional<LuaAny>>>> d_caches;
   std::shared_ptr<const CredentialsHolder> d_webPassword;
   std::shared_ptr<const CredentialsHolder> d_webAPIKey;
   std::optional<std::unordered_map<std::string, std::string>> d_webCustomHeaders;

--- a/pdns/dnsdistdist/dnsdist-console-completion.cc
+++ b/pdns/dnsdistdist/dnsdist-console-completion.cc
@@ -190,6 +190,7 @@ static std::vector<dnsdist::console::completion::ConsoleKeyword> s_consoleKeywor
   {"newMMDBKVStore", true, "mmdb, queryParams", "Return a new KeyValueStore object associated to the corresponding MMDB database"},
 #endif
   {"newNMG", true, "", "Returns a NetmaskGroup"},
+  {"newObjectCache", true, "name[, options]", "Returns a new object cache"},
   {"newPacketCache", true, "maxEntries[, maxTTL=86400, minTTL=0, temporaryFailureTTL=60, staleTTL=60, dontAge=false, shuffle=false, numberOfShards=1, deferrableInsertLock=true, options={}]", "return a new Packet Cache"},
   {"newQPSLimiter", true, "rate, burst", "configure a QPS limiter with that rate and that burst capacity"},
   {"newRemoteLogger", true, "address:port [, timeout=2, maxQueuedEntries=100, reconnectWaitTime=1]", "create a Remote Logger object, to use with `RemoteLogAction()` and `RemoteLogResponseAction()`"},

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-cache.cc
@@ -1,0 +1,119 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "dnsdist-lua.hh"
+#include "generic-cache.hh"
+#include <memory>
+#include <stdexcept>
+
+using cache_t = GenericCacheInterface<std::string, std::optional<LuaAny>>;
+
+void setupLuaBindingsCache(LuaContext& luaCtx)
+{
+  luaCtx.writeFunction("newObjectCache", [](const std::string& name, std::optional<LuaAssociativeTable<boost::variant<bool, std::string>>> vars) {
+    unsigned int shardCount{1};
+    unsigned int ttl{100};
+    unsigned int maxEntries{100};
+    unsigned int lruDeleteUpTo{0};
+    bool ttlEnabled{false};
+    bool lruEnabled{false};
+    getOptionalValue<bool>(vars, "ttlEnabled", ttlEnabled);
+    getOptionalValue<bool>(vars, "lruEnabled", lruEnabled);
+    getOptionalIntegerValue<unsigned int>("newObjectCache", vars, "shardCount", shardCount);
+    getOptionalIntegerValue<unsigned int>("newObjectCache", vars, "maxEntries", maxEntries);
+    getOptionalIntegerValue<unsigned int>("newObjectCache", vars, "lruDeleteUpTo", lruDeleteUpTo);
+    getOptionalIntegerValue<unsigned int>("newObjectCache", vars, "ttl", ttl);
+
+    auto cache = std::shared_ptr<cache_t>(new GenericCache<std::string, std::optional<LuaAny>>({.d_ttlEnabled = ttlEnabled, .d_ttl = ttl, .d_lruEnabled = lruEnabled, .d_shardCount = shardCount, .d_maxEntries = maxEntries, .d_lruDeleteUpTo = lruDeleteUpTo}));
+
+    dnsdist::configuration::updateRuntimeConfiguration([name, &cache](dnsdist::configuration::RuntimeConfiguration& config) {
+      if (config.d_caches.count(name) > 0) {
+        throw std::runtime_error("Duplicate cache name: " + name);
+      }
+      config.d_caches.emplace(name, cache);
+    });
+    return cache;
+  });
+
+  luaCtx.registerFunction<std::optional<LuaAny> (std::shared_ptr<cache_t>::*)(const std::string&)>("get", [](std::shared_ptr<cache_t>& cache, const std::string& key) {
+    std::optional<LuaAny> result{std::nullopt};
+    if (!cache) {
+      return result;
+    }
+
+    cache->getValue(key, result);
+    return result;
+  });
+
+  luaCtx.registerFunction<bool (std::shared_ptr<cache_t>::*)(const std::string&)>("remove", [](std::shared_ptr<cache_t>& cache, const std::string& key) {
+    if (!cache) {
+      return false;
+    }
+
+    return cache->remove(key);
+  });
+
+  luaCtx.registerFunction<bool (std::shared_ptr<cache_t>::*)(const std::string&)>("contains", [](std::shared_ptr<cache_t>& cache, const std::string& key) {
+    if (!cache) {
+      return false;
+    }
+
+    return cache->contains(key);
+  });
+
+  luaCtx.registerFunction<void (std::shared_ptr<cache_t>::*)(const std::string&, std::optional<LuaAny>)>("insert", [](std::shared_ptr<cache_t>& cache, const std::string& key, std::optional<LuaAny> value) {
+    if (!cache) {
+      return;
+    }
+
+    cache->insert(key, std::move(value));
+  });
+
+  luaCtx.registerFunction<void (std::shared_ptr<cache_t>::*)(const std::string&)>("insertKey", [](std::shared_ptr<cache_t>& cache, const std::string& key) {
+    if (!cache) {
+      return;
+    }
+
+    cache->insertKey(key);
+  });
+
+  luaCtx.registerFunction<void (std::shared_ptr<cache_t>::*)(const int&)>("purgeExpired", [](std::shared_ptr<cache_t>& cache, const int& upTo) {
+    if (!cache) {
+      return;
+    }
+
+    auto time = time_t(nullptr);
+    cache->purgeExpired(upTo, time);
+  });
+
+  luaCtx.registerFunction<void (std::shared_ptr<cache_t>::*)(std::optional<int>)>("expunge", [](std::shared_ptr<cache_t>& cache, std::optional<int> upTo) {
+    if (!cache) {
+      return;
+    }
+
+    if (upTo) {
+      cache->expunge(upTo.value());
+    }
+    else {
+      cache->expunge();
+    }
+  });
+}

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3377,6 +3377,7 @@ void setupLuaBindingsOnly(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
   setupLuaBindings(luaCtx, client, configCheck);
+  setupLuaBindingsCache(luaCtx);
   setupLuaBindingsDNSCrypt(luaCtx, client);
   setupLuaBindingsDNSParser(luaCtx);
   setupLuaBindingsDNSQuestion(luaCtx);

--- a/pdns/dnsdistdist/dnsdist-lua.hh
+++ b/pdns/dnsdistdist/dnsdist-lua.hh
@@ -41,6 +41,7 @@ void checkParameterBound(const std::string& parameter, uint64_t value, uint64_t 
 void setupLua(LuaContext& luaCtx, bool client, bool configCheck, const std::string& config);
 void setupLuaActions(LuaContext& luaCtx);
 void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck);
+void setupLuaBindingsCache(LuaContext& luaCtx);
 void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client);
 void setupLuaBindingsDNSParser(LuaContext& luaCtx);
 void setupLuaBindingsDNSQuestion(LuaContext& luaCtx);

--- a/pdns/dnsdistdist/dnsdist-rust-bridge.hh
+++ b/pdns/dnsdistdist/dnsdist-rust-bridge.hh
@@ -59,6 +59,7 @@ struct DNSResponseActionWrapper
 struct ProtobufLoggerConfiguration;
 struct DnstapLoggerConfiguration;
 struct OtlpLoggerConfiguration;
+struct GenericCachesConfiguration;
 struct KeyValueStoresConfiguration;
 struct MmdbConfiguration;
 struct NetmaskGroupConfiguration;
@@ -67,6 +68,7 @@ struct TimedIpSetConfiguration;
 void registerProtobufLogger(const ProtobufLoggerConfiguration& config);
 void registerDnstapLogger(const DnstapLoggerConfiguration& config);
 void registerOtlpLogger(const OtlpLoggerConfiguration& config);
+void registerGenericCacheObjects(const GenericCachesConfiguration& config);
 void registerKVSObjects(const KeyValueStoresConfiguration& config);
 void registerMMDBObjects(const ::rust::Vec<MmdbConfiguration>& config);
 void registerNMGObjects(const ::rust::Vec<NetmaskGroupConfiguration>& nmgs);

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
@@ -15,6 +15,7 @@
         fn registerProtobufLogger(config: &ProtobufLoggerConfiguration) -> Result<()>;
         fn registerDnstapLogger(config: &DnstapLoggerConfiguration) -> Result<()>;
         fn registerOtlpLogger(config: &OtlpLoggerConfiguration) -> Result<()>;
+        fn registerGenericCacheObjects(config: &GenericCachesConfiguration) -> Result<()>;
         fn registerKVSObjects(config: &KeyValueStoresConfiguration) -> Result<()>;
         fn registerMMDBObjects(config: &Vec<MmdbConfiguration>) -> Result<()>;
         fn registerNMGObjects(nmgs: &Vec<NetmaskGroupConfiguration>) -> Result<()>;

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-post-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-post-in.rs
@@ -73,6 +73,7 @@ fn get_global_configuration_from_serde(
         dynamic_rules_settings: serde.dynamic_rules_settings,
         ebpf: serde.ebpf,
         edns_client_subnet: serde.edns_client_subnet,
+        generic_caches: serde.generic_caches,
         general: serde.general,
         mmdbs: serde.mmdbs,
         key_value_stores: serde.key_value_stores,
@@ -98,6 +99,7 @@ fn get_global_configuration_from_serde(
     register_remote_loggers(&config.remote_logging)?;
     // this needs to be done before the KVS so they can refer to the DBs
     dnsdistsettings::registerMMDBObjects(&config.mmdbs)?;
+    dnsdistsettings::registerGenericCacheObjects(&config.generic_caches)?;
     // this needs to be done before the rules so that they can refer to the KVS objects
     dnsdistsettings::registerKVSObjects(&config.key_value_stores)?;
     // this needs to be done before the rules so that they can refer to the NMG objects

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -57,6 +57,10 @@ global:
       type: "GeneralConfiguration"
       default: true
       description: "General settings"
+    - name: "generic_caches"
+      type: "GenericCachesConfiguration"
+      default: true
+      description: "Generic object caches"
     - name: "key_value_stores"
       type: "KeyValueStoresConfiguration"
       default: true
@@ -2148,6 +2152,44 @@ general:
           Keeping ``CAP_SYS_ADMIN`` on kernel 5.8+ for example allows loading eBPF programs and altering eBPF maps at runtime even if the ``kernel.unprivileged_bpf_disabled`` sysctl is set.
           Note that this does not grant the capabilities to the process, doing so might be done by running it as root which we don't advise, or by adding capabilities via the systemd unit file, for example.
           Please also be aware that switching to a different user via ``--uid`` will still drop all capabilities."
+
+generic_caches:
+  description: "Generic caches"
+  parameters:
+    - name: "object"
+      type: "Vec<GenericObjectCacheConfiguration>"
+      default: true
+      description: "List of generic object caches"
+
+generic_object_cache:
+  description: "Generic object cache"
+  parameters:
+    - name: "name"
+      type: "String"
+      description: "The name of this cache"
+    - name: "ttl_enabled"
+      type: "bool"
+      default: "false"
+      description: "Whether this cache should use TTL based eviction"
+    - name: "lru_enabled"
+      type: "bool"
+      default: "false"
+      description: "Whether this cache should use LRU based eviction"
+    - name: "shard_count"
+      type: "u32"
+      description: "Number of shards this cache should be split up in"
+      default: "1"
+    - name: "max_entries"
+      type: "u32"
+      description: "Total maximum number of entries this cache can hold"
+    - name: "lru_delete_up_to"
+      type: "u32"
+      description: "If defined, number of items that should be left in the cache after LRU cleanup is triggered, when cache is full"
+      default: "0"
+    - name: "ttl"
+      type: "u32"
+      description: "The TTL value to assign to new objects in the cache"
+      default: "0"
 
 netmask_group:
   description: "Group of netmasks"

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -1000,10 +1000,12 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp,
 
     output << genericcachebase << "memory_used" << label << " " << stats.d_memoryUsed << "\n";
     output << genericcachebase << "entries" << label << " " << stats.d_entriesCount << "\n";
-    output << genericcachebase << "cache_hits" << label << " " << stats.d_cacheHits << "\n";
-    output << genericcachebase << "cache_misses" << label << " " << stats.d_cacheMisses << "\n";
+    output << genericcachebase << "cache_hits" << label << " " << stats.d_hits << "\n";
+    output << genericcachebase << "cache_misses" << label << " " << stats.d_misses << "\n";
     output << genericcachebase << "expired" << label << " " << stats.d_expiredItems << "\n";
     output << genericcachebase << "kicked" << label << " " << stats.d_kickedItems << "\n";
+    output << genericcachebase << "deferred_lookups" << label << " " <<  stats.d_deferredLookups << "\n";
+    output << genericcachebase << "deferred_inserts" << label << " " <<  stats.d_deferredInserts << "\n";
   }
 
   output << "# HELP dnsdist_rule_hits " << "Number of hits of that rule" << "\n";

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -27,6 +27,7 @@
 #include <thread>
 #include <variant>
 
+#include "dnsdist-lua-types.hh"
 #include "ext/json11/json11.hpp"
 #include <yahttp/yahttp.hpp>
 
@@ -969,6 +970,40 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp,
       output << cachebase << "cache_ttl_too_shorts"    <<label << " " << cache->getTTLTooShorts()     << "\n";
       output << cachebase << "cache_cleanup_count_total"     <<label << " " << cache->getCleanupCount()     << "\n";
     }
+  }
+
+  const string genericcachebase = "dnsdist_genericcache_";
+  output << "# HELP dnsdist_genericcache_memory_used " << "Memory used by cache in bytes" << "\n";
+  output << "# TYPE dnsdist_genericcache_memory_used " << "gauge" << "\n";
+  output << "# HELP dnsdist_genericcache_entries " << "Number of cached items" << "\n";
+  output << "# TYPE dnsdist_genericcache_entries " << "gauge" << "\n";
+  output << "# HELP dnsdist_genericcache_cache_hits " << "Number of cache hits" << "\n";
+  output << "# TYPE dnsdist_genericcache_cache_hits " << "counter" << "\n";
+  output << "# HELP dnsdist_genericcache_cache_misses " << "Number of cache misses" << "\n";
+  output << "# TYPE dnsdist_genericcache_cache_misses " << "counter" << "\n";
+  output << "# HELP dnsdist_genericcache_expired " << "Number of expired items" << "\n";
+  output << "# TYPE dnsdist_genericcache_expired " << "counter" << "\n";
+  output << "# HELP dnsdist_genericcache_kicked " << "Number of kicked items" << "\n";
+  output << "# TYPE dnsdist_genericcache_kicked " << "counter" << "\n";
+
+  for (const auto& entry : dnsdist::configuration::getCurrentRuntimeConfiguration().d_caches) {
+    string cacheName = entry.first;
+
+    if (cacheName.empty()) {
+      cacheName = "_default_";
+    }
+    const std::shared_ptr<GenericCacheInterface<std::string, std::optional<LuaAny>>> cache = entry.second;
+
+    const auto& stats = cache->getStats();
+
+    const string label = "{cache=\"" + cacheName + "\"," + stats.d_labels + "}";
+
+    output << genericcachebase << "memory_used" << label << " " << stats.d_memoryUsed << "\n";
+    output << genericcachebase << "entries" << label << " " << stats.d_entriesCount << "\n";
+    output << genericcachebase << "cache_hits" << label << " " << stats.d_cacheHits << "\n";
+    output << genericcachebase << "cache_misses" << label << " " << stats.d_cacheMisses << "\n";
+    output << genericcachebase << "expired" << label << " " << stats.d_expiredItems << "\n";
+    output << genericcachebase << "kicked" << label << " " << stats.d_kickedItems << "\n";
   }
 
   output << "# HELP dnsdist_rule_hits " << "Number of hits of that rule" << "\n";

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -2499,6 +2499,79 @@ DOQFrontend
 
      Reload the current TLS certificate and key pairs.
 
+GenericCache
+~~~~~~~~~~~
+
+.. class:: GenericCache
+
+  Represents a generic object cache which can be used from Lua to store and retrieve any values.
+
+  .. versionadded:: 2.2.0
+
+  .. method:: get(key)
+
+    Returns the value of a key stored in the cache.
+
+    :param str key: Key to look up.
+    :returns: The value of the key.
+
+  .. method:: remove(key)
+
+    Removes a key from the cache.
+
+    :param str key: Key to remove.
+    :returns: true if the key was removed.
+
+  .. method:: contains(key)
+
+    Checks whether a key is contained in the cache.
+
+    :param str key: Key to look up.
+    :returns: true if the key is present.
+
+  .. method:: insert(key, value)
+
+    Inserts a value into the cache.
+
+    :param str key: Key to store value at.
+    :param any value: Value to store.
+
+  .. method:: insertKey(key)
+
+    Inserts a key into the cache. The value assigned to the key will be null. Useful to use the cache as a set of keys.
+
+    :param str key: Key to store.
+
+  .. method:: purgeExpired(upTo)
+
+    Deletes expired items from the cache (if TTL is used). Keeps upTo items stored in the cache.
+
+    :param int upTo: Minimum number of items to leave in the cache.
+
+  .. method:: expunge([upTo])
+
+    Deletes items from the cache. Keeps upTo items stored in the cache. If LRU is used, it will be honored while deleting.
+
+    :param int upTo: Minimum number of items to leave in the cache.
+
+.. function:: newObjectCache(name[, options])
+
+  Creates a new generic object cache.
+
+  :param str name: Unique name for the cache instance.
+  :param table options: A table with key: value pairs with options.
+  :returns: The :class:`GenericCache` object.
+
+  Options:
+
+  * ``ttlEnabled``: bool - If set to true, items will have a time-to-live assigned to them and will be removed after that time (if :meth:`GenericCache.purgeExpired` is called periodically) or when the cache is at full capacity.
+  * ``ttl``: int - Number of seconds to assign as time-to-live to each inserted item.
+  * ``lruEnabled``: bool - If set to true, least recently items will be removed when :meth:`GenericCache.expunge` is called and when the cache is at full capacity.
+  * ``lruDeleteUpTo``: int - Number of items to leave in the cache after LRU purge, which occurs when the cache is at capacity and space needs to be freed for a new entry. If set to 0, a single entry will be removed each time.
+  * ``shardCount``: int - Number of shards to divide the cache in. This is useful if the cache is used from multiple threads.
+  * ``maxEntries``: int - Maximum number of entries to hold in the cache. If this number is reached and no items can be removed, insertion will fail.
+
+
 LuaRingEntry
 ~~~~~~~~~~~~
 

--- a/pdns/dnsdistdist/generic-cache-interface.hh
+++ b/pdns/dnsdistdist/generic-cache-interface.hh
@@ -1,0 +1,82 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "stat_t.hh"
+#include <cstddef>
+#include <ctime>
+#include <string>
+
+class GenericExpiringCacheInterface
+{
+public:
+  virtual ~GenericExpiringCacheInterface() {};
+  virtual size_t purgeExpired(size_t upTo, time_t now) = 0;
+  virtual size_t expunge(size_t upTo = 0) = 0;
+};
+
+template <typename K>
+class GenericFilterInterface : public GenericExpiringCacheInterface
+{
+public:
+  virtual ~GenericFilterInterface() {};
+  virtual void insertKey(const K& key) = 0;
+  virtual bool contains(const K& key) = 0;
+  virtual bool remove(const K& key) = 0;
+};
+
+template <typename K, typename V>
+class GenericCacheInterface : public GenericFilterInterface<K>
+{
+protected:
+  struct Stats
+  {
+    Stats() {}
+    explicit Stats(std::string labels) :
+      d_labels(labels) {}
+
+    pdns::stat_t d_memoryUsed{0};
+    pdns::stat_t d_cacheHits{0};
+    pdns::stat_t d_cacheMisses{0};
+    pdns::stat_t d_entriesCount{0};
+    pdns::stat_t d_kickedItems{0};
+    pdns::stat_t d_expiredItems{0};
+    std::string d_labels{};
+
+    Stats& operator+=(const Stats& rhs)
+    {
+      d_memoryUsed += rhs.d_memoryUsed;
+      d_cacheHits += d_cacheHits;
+      d_cacheMisses += d_cacheMisses;
+      d_entriesCount += d_entriesCount;
+      d_kickedItems += d_kickedItems;
+      d_expiredItems += d_expiredItems;
+      return *this;
+    }
+  };
+
+public:
+  virtual ~GenericCacheInterface() {};
+  virtual void insert(const K& key, V value) = 0;
+  virtual bool getValue(const K& key, V& value) = 0;
+  [[nodiscard]] virtual const Stats& getStats() const = 0;
+};

--- a/pdns/dnsdistdist/generic-cache-interface.hh
+++ b/pdns/dnsdistdist/generic-cache-interface.hh
@@ -24,24 +24,39 @@
 #include "stat_t.hh"
 #include <cstddef>
 #include <ctime>
+#include <functional>
 #include <string>
+#include <utility>
 
 class GenericExpiringCacheInterface
 {
 public:
-  virtual ~GenericExpiringCacheInterface() {};
+  GenericExpiringCacheInterface() = default;
+  virtual ~GenericExpiringCacheInterface() = default;
   virtual size_t purgeExpired(size_t upTo, time_t now) = 0;
   virtual size_t expunge(size_t upTo = 0) = 0;
+  [[nodiscard]] virtual uint64_t getSize() const = 0;
+
+  GenericExpiringCacheInterface(const GenericExpiringCacheInterface&) = default;
+  GenericExpiringCacheInterface(GenericExpiringCacheInterface&&) = delete;
+  GenericExpiringCacheInterface& operator=(const GenericExpiringCacheInterface&) = default;
+  GenericExpiringCacheInterface& operator=(GenericExpiringCacheInterface&&) = delete;
 };
 
 template <typename K>
 class GenericFilterInterface : public GenericExpiringCacheInterface
 {
 public:
-  virtual ~GenericFilterInterface() {};
+  GenericFilterInterface() = default;
+  ~GenericFilterInterface() override = default;
   virtual void insertKey(const K& key) = 0;
-  virtual bool contains(const K& key) = 0;
+  virtual bool contains(const K& key, bool recordMiss = true) = 0;
   virtual bool remove(const K& key) = 0;
+
+  GenericFilterInterface(const GenericFilterInterface&) = delete;
+  GenericFilterInterface(GenericFilterInterface&&) = delete;
+  GenericFilterInterface& operator=(const GenericFilterInterface&) = delete;
+  GenericFilterInterface& operator=(GenericFilterInterface&&) = delete;
 };
 
 template <typename K, typename V>
@@ -50,33 +65,47 @@ class GenericCacheInterface : public GenericFilterInterface<K>
 protected:
   struct Stats
   {
-    Stats() {}
+    Stats() = default;
     explicit Stats(std::string labels) :
-      d_labels(labels) {}
+      d_labels(std::move(labels)) {}
 
     pdns::stat_t d_memoryUsed{0};
-    pdns::stat_t d_cacheHits{0};
-    pdns::stat_t d_cacheMisses{0};
+    pdns::stat_t d_hits{0};
+    pdns::stat_t d_misses{0};
     pdns::stat_t d_entriesCount{0};
     pdns::stat_t d_kickedItems{0};
     pdns::stat_t d_expiredItems{0};
-    std::string d_labels{};
+    pdns::stat_t d_deferredLookups{0};
+    pdns::stat_t d_deferredInserts{0};
+    std::string d_labels;
 
     Stats& operator+=(const Stats& rhs)
     {
       d_memoryUsed += rhs.d_memoryUsed;
-      d_cacheHits += d_cacheHits;
-      d_cacheMisses += d_cacheMisses;
-      d_entriesCount += d_entriesCount;
-      d_kickedItems += d_kickedItems;
-      d_expiredItems += d_expiredItems;
+      d_hits += rhs.d_hits;
+      d_misses += rhs.d_misses;
+      d_entriesCount += rhs.d_entriesCount;
+      d_kickedItems += rhs.d_kickedItems;
+      d_expiredItems += rhs.d_expiredItems;
+      d_deferredLookups += rhs.d_deferredLookups;
+      d_deferredInserts += rhs.d_deferredInserts;
       return *this;
     }
   };
 
 public:
-  virtual ~GenericCacheInterface() {};
-  virtual void insert(const K& key, V value) = 0;
-  virtual bool getValue(const K& key, V& value) = 0;
+  GenericCacheInterface() = default;
+  virtual ~GenericCacheInterface() = default;
+  virtual void insert(
+    const K& key, V value, const std::function<bool(const V&)>& replaceCondition = []([[maybe_unused]] const V& value) { return true; })
+    = 0;
+  virtual bool getValue(const K& key, V& value, bool recordMiss = true, uint32_t allowExpired = 0) = 0;
+  virtual bool hasCapacityFor(const K& key) = 0;
   [[nodiscard]] virtual const Stats& getStats() const = 0;
+  virtual size_t expungeByCondition(const std::function<bool(const V&)>& condition, size_t upTo = 0) = 0;
+
+  GenericCacheInterface(const GenericCacheInterface&) = delete;
+  GenericCacheInterface(GenericCacheInterface&&) = delete;
+  GenericCacheInterface& operator=(const GenericCacheInterface&) = delete;
+  GenericCacheInterface& operator=(GenericCacheInterface&&) = delete;
 };

--- a/pdns/dnsdistdist/generic-cache.hh
+++ b/pdns/dnsdistdist/generic-cache.hh
@@ -1,0 +1,394 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <atomic>
+#include <boost/dynamic_bitset.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <cassert>
+#include <cstring>
+#include <iterator>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#include "cachecleaner.hh"
+#include "generic-cache-interface.hh"
+#include "gettime.hh"
+#include "lock.hh"
+
+using namespace ::boost::multi_index;
+
+template <typename K, typename V, typename Hash = std::hash<K>>
+class GenericCache : public GenericCacheInterface<K, V>, boost::noncopyable
+{
+private:
+  struct CacheValue
+  {
+    K key;
+    V value;
+    time_t validity;
+  };
+
+public:
+  struct CacheSettings
+  {
+    bool d_ttlEnabled;
+    unsigned int d_ttl;
+    bool d_lruEnabled;
+    uint32_t d_shardCount{1};
+    uint32_t d_maxEntries{0};
+    uint32_t d_lruDeleteUpTo{0};
+  };
+
+  GenericCache(CacheSettings settings) :
+    d_settings(settings), d_shards(settings.d_shardCount)
+  {
+    d_stats.d_memoryUsed = sizeof(*this) + d_shards.size() * sizeof(CacheShard);
+  }
+  virtual ~GenericCache() = default;
+
+  void insert(const K& key, V value) override
+  {
+    size_t hash = Hash{}(key);
+    size_t shardIndex = hash % d_settings.d_shardCount;
+
+    if (d_settings.d_maxEntries > 0 && d_shards.at(shardIndex).d_entriesCount >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
+      if (d_settings.d_ttlEnabled) {
+        timespec now;
+        gettime(&now);
+        purgeExpired(0, now.tv_sec);
+      }
+      if (d_settings.d_lruEnabled) {
+        expunge(d_settings.d_lruDeleteUpTo == 0 ? d_settings.d_maxEntries - 1 : d_settings.d_lruDeleteUpTo);
+      }
+
+      if (d_shards.at(shardIndex).d_entriesCount >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
+        return;
+      }
+    }
+
+    time_t validity;
+    if (d_settings.d_ttlEnabled) {
+      timespec now;
+      gettime(&now);
+      validity = now.tv_sec + d_settings.d_ttl;
+    }
+    else {
+      validity = time_t();
+    }
+    CacheValue cacheValue{
+      .key = key,
+      .value = value,
+      .validity = validity};
+
+    auto& shard = d_shards.at(shardIndex);
+
+    auto map = shard.d_map.write_lock();
+
+    // check again now that we hold the lock to prevent a race
+    if (d_settings.d_maxEntries > 0 && map->size() >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
+      return;
+    }
+
+    auto result = map->insert(cacheValue);
+
+    if (!result.second) {
+      // This key already exists - replace it
+      if (map->replace(result.first, cacheValue)) {
+        d_stats.d_memoryUsed += sizeof(cacheValue) - sizeof(result.first);
+      }
+    }
+    else {
+      ++d_stats.d_entriesCount;
+      ++shard.d_entriesCount;
+      d_stats.d_memoryUsed += sizeof(cacheValue);
+    }
+  }
+
+  void insertKey(const K& key) override
+  {
+    if constexpr (std::is_default_constructible<V>()) {
+      insert(key, V());
+    }
+    else {
+      throw new std::runtime_error("Unsupported insertKey operation.");
+    }
+  }
+
+  bool getValue(const K& key, V& value) override
+  {
+    size_t hash = Hash{}(key);
+    size_t shardIndex = hash % d_settings.d_shardCount;
+    auto result = false;
+    auto& shard = d_shards.at(shardIndex);
+    {
+      auto map = shard.d_map.read_lock();
+
+      auto mapIt = map->find(key);
+      if (mapIt == map->end()) {
+        d_stats.d_cacheMisses += 1;
+        return false;
+      }
+
+      if (d_settings.d_ttlEnabled) {
+        timespec now;
+        gettime(&now);
+        if (mapIt->validity > now.tv_sec) {
+          value = mapIt->value;
+          result = true;
+        }
+      }
+      else {
+        value = mapIt->value;
+        result = true;
+      }
+    }
+
+    if (result) {
+      d_stats.d_cacheHits += 1;
+    }
+    else {
+      d_stats.d_cacheMisses += 1;
+    }
+
+    if (d_settings.d_lruEnabled || (!result && d_settings.d_ttlEnabled)) {
+      auto map = shard.d_map.write_lock();
+      auto mapIt = map->find(key);
+      if (mapIt == map->end()) {
+        return result;
+      }
+      if (d_settings.d_lruEnabled) {
+        moveCacheItemToBack<SequencedTag>(*map, mapIt);
+      }
+      if (!result && d_settings.d_ttlEnabled) {
+        shard.d_entriesCount -= 1;
+        d_stats.d_entriesCount -= 1;
+        d_stats.d_expiredItems += 1;
+        d_stats.d_memoryUsed -= sizeof(*mapIt);
+        map->erase(mapIt);
+      }
+    }
+
+    return result;
+  }
+
+  bool contains(const K& key) override
+  {
+    size_t hash = Hash{}(key);
+    size_t shardIndex = hash % d_settings.d_shardCount;
+    auto result = false;
+    auto& shard = d_shards.at(shardIndex);
+    {
+      auto map = shard.d_map.read_lock();
+
+      auto mapIt = map->find(key);
+
+      if (mapIt == map->end()) {
+        d_stats.d_cacheMisses += 1;
+        return false;
+      }
+
+      if (d_settings.d_ttlEnabled) {
+        timespec now;
+        gettime(&now);
+        if (mapIt->validity > now.tv_sec) {
+          result = true;
+        }
+      }
+      else {
+        result = true;
+      }
+    }
+
+    if (result) {
+      d_stats.d_cacheHits += 1;
+    }
+    else {
+      d_stats.d_cacheMisses += 1;
+    }
+
+    if (d_settings.d_lruEnabled || (!result && d_settings.d_ttlEnabled)) {
+      auto map = shard.d_map.write_lock();
+      auto mapIt = map->find(key);
+      if (mapIt == map->end()) {
+        return result;
+      }
+      if (d_settings.d_lruEnabled) {
+        moveCacheItemToBack<SequencedTag>(*map, mapIt);
+      }
+      if (!result && d_settings.d_ttlEnabled) {
+        shard.d_entriesCount -= 1;
+        d_stats.d_entriesCount -= 1;
+        d_stats.d_expiredItems += 1;
+        d_stats.d_memoryUsed -= sizeof(*mapIt);
+        map->erase(mapIt);
+      }
+    }
+
+    return result;
+  }
+
+  bool remove(const K& key) override
+  {
+    size_t hash = Hash{}(key);
+    size_t shardIndex = hash % d_settings.d_shardCount;
+    auto& shard = d_shards.at(shardIndex);
+    auto map = shard.d_map.write_lock();
+
+    auto mapIt = map->find(key);
+    if (mapIt == map->end()) {
+      return false;
+    }
+
+    shard.d_entriesCount -= 1;
+    d_stats.d_entriesCount -= 1;
+    d_stats.d_memoryUsed -= sizeof(*mapIt);
+    map->erase(mapIt);
+    return true;
+  }
+
+  size_t purgeExpired(size_t upTo, const time_t now) override
+  {
+    if (d_settings.d_ttlEnabled) {
+      const size_t maxPerShard = upTo / d_settings.d_shardCount;
+
+      size_t removed = 0;
+      for (auto& shard : d_shards) {
+        auto map = shard.d_map.write_lock();
+        if (map->size() <= maxPerShard) {
+          continue;
+        }
+
+        size_t toRemove = map->size() - maxPerShard;
+
+        for (auto it = map->begin(); toRemove > 0 && it != map->end();) {
+          if (it->validity <= now) {
+            d_stats.d_memoryUsed -= sizeof(*it);
+            it = map->erase(it);
+            --toRemove;
+            --shard.d_entriesCount;
+            ++removed;
+          }
+          else {
+            ++it;
+          }
+        }
+      }
+
+      d_stats.d_entriesCount -= removed;
+      d_stats.d_expiredItems += removed;
+
+      return removed;
+    }
+    else {
+      return expunge(upTo);
+    }
+  }
+
+  size_t expunge(size_t upTo = 0) override
+  {
+    const size_t maxPerShard = upTo / d_settings.d_shardCount;
+
+    size_t removed = 0;
+
+    for (auto& shard : d_shards) {
+      auto map = shard.d_map.write_lock();
+
+      if (map->size() <= maxPerShard) {
+        continue;
+      }
+
+      size_t toRemove = map->size() - maxPerShard;
+
+      if (map->size() >= toRemove) {
+        auto& sequence = map->template get<SequencedTag>();
+        auto beginIt = sequence.begin();
+        auto endIt = beginIt;
+
+        std::advance(endIt, toRemove);
+        sequence.erase(beginIt, endIt);
+        shard.d_entriesCount -= toRemove;
+        for (auto it = beginIt; it != endIt; ++it) {
+          d_stats.d_memoryUsed -= sizeof(*it);
+        }
+        removed += toRemove;
+      }
+      else {
+        removed += map->size();
+        map->clear();
+        shard.d_entriesCount = 0;
+      }
+    }
+
+    d_stats.d_entriesCount -= removed;
+    d_stats.d_kickedItems += removed;
+
+    return removed;
+  }
+
+  [[nodiscard]] virtual const typename GenericCacheInterface<K, V>::Stats& getStats() const override
+  {
+    return d_stats;
+  }
+
+private:
+  struct HashedTag
+  {
+  };
+  struct SequencedTag
+  {
+  };
+
+  class CacheShard
+  {
+  public:
+    CacheShard()
+    {
+    }
+    CacheShard(const CacheShard& /* old */)
+    {
+    }
+
+    void setSize(size_t maxSize)
+    {
+      d_map.write_lock()->reserve(maxSize);
+    }
+
+    using cache_t = multi_index_container<
+      CacheValue,
+      indexed_by<
+        hashed_unique<tag<HashedTag>, member<CacheValue, K, &CacheValue::key>, Hash>,
+        sequenced<tag<SequencedTag>>>>;
+
+    SharedLockGuarded<cache_t> d_map;
+    std::atomic<uint64_t> d_entriesCount{0};
+  };
+
+  CacheSettings d_settings;
+  std::vector<CacheShard> d_shards;
+  typename GenericCacheInterface<K, V>::Stats d_stats{"filter=\"none\""};
+};

--- a/pdns/dnsdistdist/generic-cache.hh
+++ b/pdns/dnsdistdist/generic-cache.hh
@@ -30,6 +30,7 @@
 #include <boost/multi_index/key_extractors.hpp>
 #include <cassert>
 #include <cstring>
+#include <functional>
 #include <iterator>
 #include <stdexcept>
 #include <type_traits>
@@ -37,65 +38,154 @@
 
 #include "cachecleaner.hh"
 #include "generic-cache-interface.hh"
-#include "gettime.hh"
 #include "lock.hh"
 
 using namespace ::boost::multi_index;
 
-template <typename K, typename V, typename Hash = std::hash<K>>
+template <typename K, typename V, typename Hash = std::hash<K>, time_t V::* Ttl = nullptr>
 class GenericCache : public GenericCacheInterface<K, V>, boost::noncopyable
 {
 private:
+  class CacheShard;
+  struct HashedTag;
+  struct SequencedTag;
+
+public:
   struct CacheValue
   {
     K key;
     V value;
     time_t validity;
   };
-
-public:
   struct CacheSettings
   {
-    bool d_ttlEnabled;
-    unsigned int d_ttl;
-    bool d_lruEnabled;
+    bool d_ttlEnabled{false};
+    unsigned int d_ttl{0};
+    bool d_lruEnabled{false};
     uint32_t d_shardCount{1};
-    uint32_t d_maxEntries{0};
+    size_t d_maxEntries{0};
     uint32_t d_lruDeleteUpTo{0};
+    bool d_deferrableInsertLock{false};
   };
 
-  GenericCache(CacheSettings settings) :
-    d_settings(settings), d_shards(settings.d_shardCount)
+  struct Iterator
   {
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = CacheValue;
+    using pointer = const CacheValue*;
+    using reference = const CacheValue&;
+
+    Iterator(std::vector<CacheShard>& shards, bool end = false) :
+      d_shard_it(end ? shards.end() : shards.begin()), d_shard_it_end(shards.end()), d_map_lock((end || shards.empty()) ? std::unique_ptr<SharedLockGuardedNonExclusiveHolder<typename CacheShard::cache_t>>() : std::make_unique<SharedLockGuardedNonExclusiveHolder<typename CacheShard::cache_t>>(d_shard_it->d_map.read_lock())), d_map_it((end || shards.empty()) ? std::unique_ptr<typename CacheShard::cache_t::iterator>() : std::make_unique<typename CacheShard::cache_t::iterator>((**d_map_lock).begin())), d_map_it_end((end || shards.empty()) ? std::unique_ptr<typename CacheShard::cache_t::iterator>() : std::make_unique<typename CacheShard::cache_t::iterator>((**d_map_lock).end()))
+    {
+    }
+
+    reference operator*() const { return **d_map_it; }
+    pointer operator->() { return **d_map_it; }
+
+    Iterator& operator++()
+    {
+      ++*d_map_it;
+      if (*d_map_it == *d_map_it_end) {
+        ++d_shard_it;
+        if (d_shard_it != d_shard_it_end) {
+          d_map_lock = std::make_unique<SharedLockGuardedNonExclusiveHolder<typename CacheShard::cache_t>>(d_shard_it->d_map.read_lock());
+          d_map_it = std::make_unique<typename CacheShard::cache_t::iterator>((**d_map_lock).begin());
+          d_map_it_end = std::make_unique<typename CacheShard::cache_t::iterator>((**d_map_lock).end());
+        }
+        else {
+          d_map_it.reset();
+          d_map_it_end.reset();
+          d_map_lock.reset();
+        }
+      }
+      return *this;
+    }
+
+    Iterator operator++(int)
+    {
+      Iterator tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+
+    friend bool operator==(const Iterator& left, const Iterator& right)
+    {
+      return left.d_shard_it == right.d_shard_it && left.d_map_it == right.d_map_it;
+    };
+    friend bool operator!=(const Iterator& left, const Iterator& right)
+    {
+      return left.d_shard_it != right.d_shard_it || left.d_map_it != right.d_map_it;
+    };
+
+  private:
+    typename std::vector<CacheShard>::iterator d_shard_it;
+    typename std::vector<CacheShard>::iterator d_shard_it_end;
+    std::unique_ptr<SharedLockGuardedNonExclusiveHolder<typename CacheShard::cache_t>> d_map_lock;
+    std::unique_ptr<typename CacheShard::cache_t::iterator> d_map_it;
+    std::unique_ptr<typename CacheShard::cache_t::iterator> d_map_it_end;
+  };
+
+  GenericCache(const GenericCache&) = delete;
+  GenericCache(GenericCache&&) = delete;
+  GenericCache& operator=(const GenericCache&) = delete;
+  GenericCache& operator=(GenericCache&&) = delete;
+
+  GenericCache(CacheSettings settings) :
+    d_settings(std::move(settings))
+  {
+    if (d_settings.d_maxEntries == 0) {
+      throw std::runtime_error("Trying to create a 0-sized cache");
+    }
+    if (d_settings.d_ttlEnabled && Ttl != nullptr) {
+      throw std::runtime_error("TTL can't be enabled because validity is provided externally");
+    }
+
+    if (d_settings.d_shardCount == 0) {
+      d_settings.d_shardCount = 1;
+    }
+
+    d_shards.resize(d_settings.d_shardCount);
+
+    /* we reserve maxEntries + 1 to avoid rehashing from occurring
+     when we get to maxEntries, as it means a load factor of 1 */
+    for (auto& shard : d_shards) {
+      shard.setSize((d_settings.d_maxEntries / d_settings.d_shardCount) + 1);
+    }
     d_stats.d_memoryUsed = sizeof(*this) + d_shards.size() * sizeof(CacheShard);
   }
   virtual ~GenericCache() = default;
 
-  void insert(const K& key, V value) override
+  void insert(
+    const K& key, V value, const std::function<bool(const V&)>& replaceCondition = []([[maybe_unused]] const V& value) { return true; }) override
   {
     size_t hash = Hash{}(key);
     size_t shardIndex = hash % d_settings.d_shardCount;
 
-    if (d_settings.d_maxEntries > 0 && d_shards.at(shardIndex).d_entriesCount >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
-      if (d_settings.d_ttlEnabled) {
-        timespec now;
-        gettime(&now);
-        purgeExpired(0, now.tv_sec);
+    if (d_shards.at(shardIndex).d_entriesCount >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
+      if (d_settings.d_ttlEnabled || Ttl != nullptr) {
+        time_t now = time(nullptr);
+        purgeExpired(0, now);
       }
       if (d_settings.d_lruEnabled) {
         expunge(d_settings.d_lruDeleteUpTo == 0 ? d_settings.d_maxEntries - 1 : d_settings.d_lruDeleteUpTo);
       }
 
+      if (!d_settings.d_ttlEnabled && Ttl == nullptr && !d_settings.d_lruEnabled) {
+        return;
+      }
+
+      // We didn't manage to free up space
       if (d_shards.at(shardIndex).d_entriesCount >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
         return;
       }
     }
 
-    time_t validity;
+    time_t validity = 0;
     if (d_settings.d_ttlEnabled) {
-      timespec now;
-      gettime(&now);
-      validity = now.tv_sec + d_settings.d_ttl;
+      time_t now = time(nullptr);
+      validity = now + d_settings.d_ttl;
     }
     else {
       validity = time_t();
@@ -107,25 +197,19 @@ public:
 
     auto& shard = d_shards.at(shardIndex);
 
-    auto map = shard.d_map.write_lock();
+    if (d_settings.d_deferrableInsertLock) {
+      auto lock = shard.d_map.try_write_lock();
 
-    // check again now that we hold the lock to prevent a race
-    if (d_settings.d_maxEntries > 0 && map->size() >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
-      return;
-    }
-
-    auto result = map->insert(cacheValue);
-
-    if (!result.second) {
-      // This key already exists - replace it
-      if (map->replace(result.first, cacheValue)) {
-        d_stats.d_memoryUsed += sizeof(cacheValue) - sizeof(result.first);
+      if (!lock.owns_lock()) {
+        ++d_stats.d_deferredInserts;
+        return;
       }
+      insertLocked(shard, *lock, cacheValue, replaceCondition);
     }
     else {
-      ++d_stats.d_entriesCount;
-      ++shard.d_entriesCount;
-      d_stats.d_memoryUsed += sizeof(cacheValue);
+      auto lock = shard.d_map.write_lock();
+
+      insertLocked(shard, *lock, cacheValue, replaceCondition);
     }
   }
 
@@ -139,27 +223,65 @@ public:
     }
   }
 
-  bool getValue(const K& key, V& value) override
+  void insertLocked(
+    CacheShard& shard, typename CacheShard::cache_t& map, const CacheValue& cacheValue, const std::function<bool(const V&)>& replaceCondition)
+  {
+    // check again now that we hold the lock to prevent a race
+    if (map.size() >= (d_settings.d_maxEntries / d_settings.d_shardCount)) {
+      return;
+    }
+
+    auto result = map.insert(cacheValue);
+
+    if (!result.second) {
+      if (replaceCondition(result.first->value)) {
+        // This key already exists - replace it
+        if (map.replace(result.first, cacheValue)) {
+          d_stats.d_memoryUsed += sizeof(cacheValue) - sizeof(result.first);
+        }
+      }
+    }
+    else {
+      ++d_stats.d_entriesCount;
+      ++shard.d_entriesCount;
+      d_stats.d_memoryUsed += sizeof(cacheValue);
+    }
+  }
+
+  bool getValue(const K& key, V& value, bool recordMiss = false, uint32_t allowExpired = 0) override
   {
     size_t hash = Hash{}(key);
     size_t shardIndex = hash % d_settings.d_shardCount;
     auto result = false;
     auto& shard = d_shards.at(shardIndex);
     {
-      auto map = shard.d_map.read_lock();
-
-      auto mapIt = map->find(key);
-      if (mapIt == map->end()) {
-        d_stats.d_cacheMisses += 1;
+      auto map = shard.d_map.try_read_lock();
+      if (!map.owns_lock()) {
+        ++d_stats.d_deferredLookups;
         return false;
       }
 
-      if (d_settings.d_ttlEnabled) {
-        timespec now;
-        gettime(&now);
-        if (mapIt->validity > now.tv_sec) {
-          value = mapIt->value;
-          result = true;
+      auto mapIt = map->find(key);
+      if (mapIt == map->end()) {
+        if (recordMiss) {
+          d_stats.d_misses += 1;
+        }
+        return false;
+      }
+
+      if (d_settings.d_ttlEnabled || Ttl != nullptr) {
+        time_t now = time(nullptr);
+        if constexpr (Ttl == nullptr) {
+          if (mapIt->validity + static_cast<time_t>(allowExpired) > now) {
+            value = mapIt->value;
+            result = true;
+          }
+        }
+        else {
+          if (mapIt->value.*Ttl + static_cast<time_t>(allowExpired) > now) {
+            value = mapIt->value;
+            result = true;
+          }
         }
       }
       else {
@@ -169,13 +291,15 @@ public:
     }
 
     if (result) {
-      d_stats.d_cacheHits += 1;
+      d_stats.d_hits += 1;
     }
     else {
-      d_stats.d_cacheMisses += 1;
+      if (recordMiss) {
+        d_stats.d_misses += 1;
+      }
     }
 
-    if (d_settings.d_lruEnabled || (!result && d_settings.d_ttlEnabled)) {
+    if (d_settings.d_lruEnabled || (!result && (d_settings.d_ttlEnabled || Ttl != nullptr))) {
       auto map = shard.d_map.write_lock();
       auto mapIt = map->find(key);
       if (mapIt == map->end()) {
@@ -184,7 +308,7 @@ public:
       if (d_settings.d_lruEnabled) {
         moveCacheItemToBack<SequencedTag>(*map, mapIt);
       }
-      if (!result && d_settings.d_ttlEnabled) {
+      if (!result && (d_settings.d_ttlEnabled || Ttl != nullptr)) {
         shard.d_entriesCount -= 1;
         d_stats.d_entriesCount -= 1;
         d_stats.d_expiredItems += 1;
@@ -196,27 +320,47 @@ public:
     return result;
   }
 
-  bool contains(const K& key) override
+  bool hasCapacityFor(const K& key) override
+  {
+    size_t hash = Hash{}(key);
+    size_t shardIndex = hash % d_settings.d_shardCount;
+
+    return static_cast<bool>(d_shards.at(shardIndex).d_entriesCount < (d_settings.d_maxEntries / d_settings.d_shardCount));
+  }
+
+  bool contains(const K& key, bool recordMiss = false) override
   {
     size_t hash = Hash{}(key);
     size_t shardIndex = hash % d_settings.d_shardCount;
     auto result = false;
     auto& shard = d_shards.at(shardIndex);
     {
-      auto map = shard.d_map.read_lock();
+      auto map = shard.d_map.try_read_lock();
+      if (!map.owns_lock()) {
+        ++d_stats.d_deferredLookups;
+        return false;
+      }
 
       auto mapIt = map->find(key);
 
       if (mapIt == map->end()) {
-        d_stats.d_cacheMisses += 1;
+        if (recordMiss) {
+          d_stats.d_misses += 1;
+        }
         return false;
       }
 
-      if (d_settings.d_ttlEnabled) {
-        timespec now;
-        gettime(&now);
-        if (mapIt->validity > now.tv_sec) {
-          result = true;
+      if (d_settings.d_ttlEnabled || Ttl != nullptr) {
+        time_t now = time(nullptr);
+        if constexpr (Ttl == nullptr) {
+          if (mapIt->validity > now) {
+            result = true;
+          }
+        }
+        else {
+          if (mapIt->value.*Ttl > now) {
+            result = true;
+          }
         }
       }
       else {
@@ -225,13 +369,15 @@ public:
     }
 
     if (result) {
-      d_stats.d_cacheHits += 1;
+      d_stats.d_hits += 1;
     }
     else {
-      d_stats.d_cacheMisses += 1;
+      if (recordMiss) {
+        d_stats.d_misses += 1;
+      }
     }
 
-    if (d_settings.d_lruEnabled || (!result && d_settings.d_ttlEnabled)) {
+    if (d_settings.d_lruEnabled || (!result && (d_settings.d_ttlEnabled || Ttl != nullptr))) {
       auto map = shard.d_map.write_lock();
       auto mapIt = map->find(key);
       if (mapIt == map->end()) {
@@ -240,7 +386,7 @@ public:
       if (d_settings.d_lruEnabled) {
         moveCacheItemToBack<SequencedTag>(*map, mapIt);
       }
-      if (!result && d_settings.d_ttlEnabled) {
+      if (!result && (d_settings.d_ttlEnabled || Ttl != nullptr)) {
         shard.d_entriesCount -= 1;
         d_stats.d_entriesCount -= 1;
         d_stats.d_expiredItems += 1;
@@ -273,7 +419,7 @@ public:
 
   size_t purgeExpired(size_t upTo, const time_t now) override
   {
-    if (d_settings.d_ttlEnabled) {
+    if (d_settings.d_ttlEnabled || Ttl != nullptr) {
       const size_t maxPerShard = upTo / d_settings.d_shardCount;
 
       size_t removed = 0;
@@ -286,7 +432,11 @@ public:
         size_t toRemove = map->size() - maxPerShard;
 
         for (auto it = map->begin(); toRemove > 0 && it != map->end();) {
-          if (it->validity <= now) {
+          auto validity = it->validity;
+          if constexpr (Ttl != nullptr) {
+            validity = it->value.*Ttl;
+          }
+          if (validity <= now) {
             d_stats.d_memoryUsed -= sizeof(*it);
             it = map->erase(it);
             --toRemove;
@@ -304,9 +454,8 @@ public:
 
       return removed;
     }
-    else {
-      return expunge(upTo);
-    }
+
+    return expunge(upTo);
   }
 
   size_t expunge(size_t upTo = 0) override
@@ -330,11 +479,11 @@ public:
         auto endIt = beginIt;
 
         std::advance(endIt, toRemove);
-        sequence.erase(beginIt, endIt);
-        shard.d_entriesCount -= toRemove;
-        for (auto it = beginIt; it != endIt; ++it) {
+        for (auto it = beginIt; it != endIt;) {
           d_stats.d_memoryUsed -= sizeof(*it);
+          sequence.erase(it++);
         }
+        shard.d_entriesCount -= toRemove;
         removed += toRemove;
       }
       else {
@@ -350,7 +499,69 @@ public:
     return removed;
   }
 
-  [[nodiscard]] virtual const typename GenericCacheInterface<K, V>::Stats& getStats() const override
+  size_t expungeByCondition(const std::function<bool(const V&)>& condition, size_t upTo = 0) override
+  {
+    const size_t maxPerShard = upTo / d_settings.d_shardCount;
+
+    size_t removed = 0;
+
+    for (auto& shard : d_shards) {
+      auto map = shard.d_map.write_lock();
+
+      if (map->size() <= maxPerShard) {
+        continue;
+      }
+
+      size_t toRemove = map->size() - maxPerShard;
+
+      for (auto it = map->begin(); it != map->end();) {
+        if (toRemove == 0) {
+          break;
+        }
+
+        const V& value = it->value;
+
+        if (condition(value)) {
+          it = map->erase(it);
+          --shard.d_entriesCount;
+          ++removed;
+          --toRemove;
+          d_stats.d_memoryUsed -= sizeof(*it);
+        }
+        else {
+          ++it;
+        }
+      }
+    }
+
+    d_stats.d_entriesCount -= removed;
+    d_stats.d_kickedItems += removed;
+
+    return removed;
+  }
+
+  [[nodiscard]] uint64_t getSize() const override
+  {
+    uint64_t count = 0;
+
+    for (auto& shard : d_shards) {
+      count += shard.d_entriesCount;
+    }
+
+    return count;
+  }
+
+  Iterator begin()
+  {
+    return Iterator(d_shards);
+  }
+
+  Iterator end()
+  {
+    return Iterator(d_shards, true);
+  }
+
+  [[nodiscard]] const typename GenericCacheInterface<K, V>::Stats& getStats() const override
   {
     return d_stats;
   }
@@ -366,23 +577,33 @@ private:
   class CacheShard
   {
   public:
-    CacheShard()
-    {
-    }
-    CacheShard(const CacheShard& /* old */)
-    {
-    }
-
-    void setSize(size_t maxSize)
-    {
-      d_map.write_lock()->reserve(maxSize);
-    }
-
     using cache_t = multi_index_container<
       CacheValue,
       indexed_by<
         hashed_unique<tag<HashedTag>, member<CacheValue, K, &CacheValue::key>, Hash>,
         sequenced<tag<SequencedTag>>>>;
+
+    CacheShard() = default;
+    CacheShard(CacheShard&& /* old */) noexcept
+    {
+    }
+    CacheShard(const CacheShard& /* old */)
+    {
+    }
+    CacheShard& operator=(CacheShard&& /* old */) noexcept
+    {
+      return *this;
+    }
+    CacheShard& operator=(const CacheShard& /* old */)
+    {
+      return *this;
+    }
+    ~CacheShard() = default;
+
+    void setSize(size_t maxSize)
+    {
+      d_map.write_lock()->reserve(maxSize);
+    }
 
     SharedLockGuarded<cache_t> d_map;
     std::atomic<uint64_t> d_entriesCount{0};

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -569,6 +569,7 @@ test_sources += files(
   src_dir / 'test-dnsdist-ipcrypt2_cc.cc',
   src_dir / 'test-dnsdistdynblocks_hh.cc',
   src_dir / 'test-dnsdistedns.cc',
+  src_dir / 'test-dnsdistgenericcache_hh.cc',
   src_dir / 'test-dnsdistkvs_cc.cc',
   src_dir / 'test-dnsdistlbpolicies_cc.cc',
   src_dir / 'test-dnsdist-lua-ffi.cc',

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -155,6 +155,7 @@ common_sources += files(
   src_dir / 'dnsdist-lua-bindings-dnscrypt.cc',
   src_dir / 'dnsdist-lua-bindings-dnsparser.cc',
   src_dir / 'dnsdist-lua-bindings-dnsquestion.cc',
+  src_dir / 'dnsdist-lua-bindings-cache.cc',
   src_dir / 'dnsdist-lua-bindings-kvs.cc',
   src_dir / 'dnsdist-lua-bindings-mmdb.cc',
   src_dir / 'dnsdist-lua-bindings-network.cc',

--- a/pdns/dnsdistdist/test-dnsdistgenericcache_hh.cc
+++ b/pdns/dnsdistdist/test-dnsdistgenericcache_hh.cc
@@ -1,0 +1,358 @@
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include <thread>
+#include "iputils.hh"
+#include "generic-cache.hh"
+
+BOOST_AUTO_TEST_SUITE(test_dnsdistgenericcache_hh)
+
+struct TestStruct
+{
+  std::string value;
+  time_t validity;
+};
+
+static void test_genericcache_insertion_removal(GenericCache<std::string, std::string>& cache)
+{
+  size_t counter = 0;
+  for (counter = 0; counter < 100000; ++counter) {
+    std::string key = std::to_string(counter);
+    std::string value = "Value for key: " + std::to_string(counter);
+    bool found = cache.contains(key);
+    BOOST_CHECK_EQUAL(found, false);
+
+    cache.insert(key, value);
+
+    std::string readValue;
+    found = cache.getValue(key, readValue);
+    BOOST_CHECK_EQUAL(found, true);
+    BOOST_CHECK_EQUAL(value, readValue);
+  }
+
+  BOOST_CHECK_EQUAL(cache.getSize(), counter);
+
+  size_t deleted = 0;
+  size_t delcounter = 0;
+  for (delcounter = 0; delcounter < counter / 1000; ++delcounter) {
+    std::string value = "Value for key: " + std::to_string(delcounter);
+    auto removed = cache.expungeByCondition([&value](const std::string& storedValue) {
+      return storedValue == value;
+    });
+    BOOST_CHECK_EQUAL(removed, 1U);
+    deleted += removed;
+  }
+  BOOST_CHECK_EQUAL(cache.getSize(), counter - deleted);
+
+  for (; delcounter < counter / 500; ++delcounter) {
+    std::string key = std::to_string(delcounter);
+    auto removed = cache.remove(key);
+    BOOST_CHECK_EQUAL(removed, true);
+    deleted++;
+  }
+  BOOST_CHECK_EQUAL(cache.getSize(), counter - deleted);
+
+  size_t matches = 0;
+  size_t expected = counter - deleted;
+  for (; delcounter < counter; ++delcounter) {
+    std::string key = std::to_string(delcounter);
+    if (cache.contains(key)) {
+      matches++;
+    }
+  }
+
+  BOOST_CHECK_EQUAL(matches, expected);
+
+  auto remaining = cache.getSize();
+  auto removed = cache.expunge();
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+  BOOST_CHECK_EQUAL(removed, remaining);
+
+  /* nothing to remove */
+  BOOST_CHECK_EQUAL(cache.expunge(), 0U);
+}
+
+static void test_genericcachefilter_insertion_removal(GenericFilterInterface<std::string>& cache)
+{
+  size_t counter = 0;
+  for (counter = 0; counter < 100000; ++counter) {
+    std::string key = std::to_string(counter);
+    bool found = cache.contains(key);
+    BOOST_CHECK_EQUAL(found, false);
+
+    cache.insertKey(key);
+
+    found = cache.contains(key);
+    BOOST_CHECK_EQUAL(found, true);
+  }
+
+  BOOST_CHECK_EQUAL(cache.getSize(), counter);
+
+  size_t deleted = 0;
+  size_t delcounter = 0;
+  for (delcounter = 0; delcounter < counter / 1000; ++delcounter) {
+    std::string key = std::to_string(delcounter);
+    auto removed = cache.remove(key);
+    BOOST_CHECK_EQUAL(removed, true);
+    deleted++;
+  }
+  BOOST_CHECK_EQUAL(cache.getSize(), counter - deleted);
+
+  size_t matches = 0;
+  size_t expected = counter - deleted;
+  for (; delcounter < counter; ++delcounter) {
+    std::string key = std::to_string(delcounter);
+    if (cache.contains(key)) {
+      matches++;
+    }
+  }
+
+  BOOST_CHECK_EQUAL(matches, expected);
+
+  auto remaining = cache.getSize();
+  auto removed = cache.expunge();
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+  BOOST_CHECK_EQUAL(removed, remaining);
+
+  /* nothing to remove */
+  BOOST_CHECK_EQUAL(cache.expunge(), 0U);
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheSimple)
+{
+  const GenericCache<std::string, std::string>::CacheSettings settings{
+    .d_maxEntries = 150000};
+  GenericCache<std::string, std::string> cache(settings);
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+
+  test_genericcache_insertion_removal(cache);
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheSharded)
+{
+  const GenericCache<std::string, std::string>::CacheSettings settings{
+    .d_shardCount = 10,
+    .d_maxEntries = 150000};
+  GenericCache<std::string, std::string> cache(settings);
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+
+  test_genericcache_insertion_removal(cache);
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheAsFilterSimple)
+{
+  const GenericCache<std::string, std::string>::CacheSettings settings{
+    .d_maxEntries = 150000};
+  GenericCache<std::string, std::string> cache(settings);
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+
+  test_genericcachefilter_insertion_removal(cache);
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheAsFilterSharded)
+{
+  const GenericCache<std::string, std::string>::CacheSettings settings{
+    .d_shardCount = 10,
+    .d_maxEntries = 150000};
+  GenericCache<std::string, std::string> cache(settings);
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+
+  test_genericcachefilter_insertion_removal(cache);
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheSimpleLru)
+{
+  const GenericCache<std::string, std::string>::CacheSettings settings{
+    .d_lruEnabled = true,
+    .d_maxEntries = 100000};
+  GenericCache<std::string, std::string> cache(settings);
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+
+  size_t counter = 0;
+  for (counter = 0; counter < 150000; ++counter) {
+    std::string key = std::to_string(counter);
+    std::string value = "Value for key: " + std::to_string(counter);
+    bool found = cache.contains(key);
+    BOOST_CHECK_EQUAL(found, false);
+
+    cache.insert(key, value);
+
+    std::string readValue;
+    found = cache.getValue(key, readValue);
+    BOOST_CHECK_EQUAL(found, true);
+    BOOST_CHECK_EQUAL(value, readValue);
+  }
+
+  BOOST_CHECK_EQUAL(cache.getSize(), settings.d_maxEntries);
+
+  for (counter = 0; counter < 150000; ++counter) {
+    std::string key = std::to_string(counter);
+    bool found = cache.contains(key);
+    if (counter < 50000) {
+      BOOST_CHECK_EQUAL(found, false);
+    }
+    else {
+      BOOST_CHECK_EQUAL(found, true);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheSimpleTtl)
+{
+  const GenericCache<std::string, std::string>::CacheSettings settings{
+    .d_ttlEnabled = true,
+    .d_ttl = 100,
+    .d_maxEntries = 100000};
+  GenericCache<std::string, std::string> cache(settings);
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+
+  size_t counter = 0;
+  for (counter = 0; counter < 100000; ++counter) {
+    std::string key = std::to_string(counter);
+    std::string value = "Value for key: " + std::to_string(counter);
+    bool found = cache.contains(key);
+    BOOST_CHECK_EQUAL(found, false);
+
+    cache.insert(key, value);
+
+    std::string readValue;
+    found = cache.getValue(key, readValue);
+    BOOST_CHECK_EQUAL(found, true);
+    BOOST_CHECK_EQUAL(value, readValue);
+  }
+
+  BOOST_CHECK_EQUAL(cache.getSize(), settings.d_maxEntries);
+
+  time_t now = time(nullptr);
+  size_t removed = cache.purgeExpired(0, now);
+  BOOST_CHECK_EQUAL(removed, 0);
+
+  now += settings.d_ttl + 1;
+
+  removed = cache.purgeExpired(0, now);
+  BOOST_CHECK_EQUAL(removed, settings.d_maxEntries);
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheCustomValidity)
+{
+  const GenericCache<std::string, TestStruct, std::hash<std::string>, &TestStruct::validity>::CacheSettings settings{
+    .d_maxEntries = 100000};
+  GenericCache<std::string, TestStruct, std::hash<std::string>, &TestStruct::validity> cache(settings);
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+
+  size_t counter = 0;
+  for (counter = 0; counter < 100000; ++counter) {
+    std::string key = std::to_string(counter);
+    std::string value = "Value for key: " + std::to_string(counter);
+    bool found = cache.contains(key);
+    BOOST_CHECK_EQUAL(found, false);
+
+    cache.insert(key, {value, 0});
+
+    TestStruct readValue;
+    found = cache.getValue(key, readValue);
+    BOOST_CHECK_EQUAL(found, false);
+  }
+
+  BOOST_CHECK_EQUAL(cache.getSize(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheCapacityCheck)
+{
+  const GenericCache<std::string, std::string>::CacheSettings settings{
+    .d_maxEntries = 100000};
+  GenericCache<std::string, std::string> cache(settings);
+  BOOST_CHECK_EQUAL(cache.getSize(), 0U);
+
+  for (size_t counter = 0; counter < 100000; ++counter) {
+    std::string key = std::to_string(counter);
+    std::string value = "Value for key: " + std::to_string(counter);
+    bool found = cache.contains(key);
+    BOOST_CHECK_EQUAL(found, false);
+    bool hasCapacity = cache.hasCapacityFor(key);
+    BOOST_CHECK_EQUAL(hasCapacity, true);
+
+    cache.insert(key, value);
+
+    std::string readValue;
+    found = cache.getValue(key, readValue);
+    BOOST_CHECK_EQUAL(found, true);
+    BOOST_CHECK_EQUAL(value, readValue);
+  }
+
+  BOOST_CHECK_EQUAL(cache.getSize(), 100000);
+  BOOST_CHECK_EQUAL(cache.hasCapacityFor("100000"), false);
+  cache.remove("99999");
+  BOOST_CHECK_EQUAL(cache.hasCapacityFor("100000"), true);
+}
+
+const GenericCache<std::string, std::string>::CacheSettings s_localCacheSettings{
+  .d_maxEntries = 500000,
+  .d_deferrableInsertLock = true};
+static GenericCache<std::string, std::string> s_localCache(s_localCacheSettings);
+
+static void threadMangler(unsigned int offset)
+{
+  for (unsigned int counter = 0; counter < 100000; ++counter) {
+    std::string key = std::to_string(counter + offset);
+    std::string value = "Value for key: " + std::to_string(counter + offset);
+    s_localCache.insert(key, value);
+  }
+}
+
+static std::atomic<uint64_t> s_missing{0};
+
+static void threadReader(unsigned int offset)
+{
+  ComboAddress remote;
+  for (unsigned int counter = 0; counter < 100000; ++counter) {
+    std::string key = std::to_string(counter + offset);
+    bool found = s_localCache.contains(key);
+    if (!found) {
+      s_missing++;
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheThreaded)
+{
+  std::vector<std::thread> threads;
+  threads.reserve(4);
+  for (int i = 0; i < 4; ++i) {
+    threads.emplace_back(threadMangler, i * 1000000UL);
+  }
+
+  for (auto& thr : threads) {
+    thr.join();
+  }
+
+  threads.clear();
+
+  BOOST_CHECK_EQUAL(s_localCache.getSize() + s_localCache.getStats().d_deferredInserts, 400000U);
+
+  for (int i = 0; i < 4; ++i) {
+    threads.emplace_back(threadReader, i * 1000000UL);
+  }
+
+  for (auto& thr : threads) {
+    thr.join();
+  }
+
+  BOOST_CHECK((s_localCache.getStats().d_deferredInserts + s_localCache.getStats().d_deferredLookups) >= s_missing.load());
+}
+
+BOOST_AUTO_TEST_CASE(test_GenericCacheExceptions)
+{
+  using cache_t = GenericCache<std::string, std::string>;
+  BOOST_CHECK_THROW(cache_t({.d_maxEntries = 0}), std::runtime_error);
+  BOOST_REQUIRE_NO_THROW(cache_t({.d_ttlEnabled = true, .d_maxEntries = 1}));
+  using custom_ttl_cache_t = GenericCache<std::string, TestStruct, std::hash<std::string>, &TestStruct::validity>;
+  BOOST_CHECK_THROW(custom_ttl_cache_t({.d_ttlEnabled = true, .d_maxEntries = 1}), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/regression-tests.dnsdist/test_GenericCache.py
+++ b/regression-tests.dnsdist/test_GenericCache.py
@@ -7,25 +7,7 @@ import cookiesoption
 from dnsdisttests import DNSDistTest, pickAvailablePort
 
 
-class TestGenericCache(DNSDistTest):
-    _config_template = """
-    cache = newObjectCache("test", { maxEntries = 1000 })
-    function store(dq)
-        cache:insert(dq.remoteaddr:toString(), "some value")
-        return DNSAction.None, ""
-    end
-    function dropWhenExists(dq)
-        if cache:contains(dq.remoteaddr:toString()) then
-            cache:remove(dq.remoteaddr:toString())
-            return DNSAction.Refused
-        end
-        return DNSAction.None, ""
-    end
-    addAction("store.cache.tests.powerdns.com.", LuaAction(store))
-    addAction("read.cache.tests.powerdns.com.", LuaAction(dropWhenExists))
-    newServer{address="127.0.0.1:%d"}
-    """
-
+class CacheTests(object):
     def testExistsCheck(self):
         """
         Cache: Refused when value is cached
@@ -108,3 +90,69 @@ class TestGenericCache(DNSDistTest):
         (_, receivedResponse) = self.sendUDPQuery(query, response)
         self.assertTrue(receivedResponse)
         self.assertEqual(receivedResponse, response)
+
+
+class TestGenericCache(DNSDistTest, CacheTests):
+    _config_template = """
+    cache = newObjectCache("test", { maxEntries = 1000 })
+    function store(dq)
+        cache:insert(dq.remoteaddr:toString(), "some value")
+        return DNSAction.None, ""
+    end
+    function dropWhenExists(dq)
+        if cache:contains(dq.remoteaddr:toString()) then
+            cache:remove(dq.remoteaddr:toString())
+            return DNSAction.Refused
+        end
+        return DNSAction.None, ""
+    end
+    addAction("store.cache.tests.powerdns.com.", LuaAction(store))
+    addAction("read.cache.tests.powerdns.com.", LuaAction(dropWhenExists))
+    newServer{address="127.0.0.1:%d"}
+    """
+
+
+class TestGenericCacheYaml(DNSDistTest, CacheTests):
+    _yaml_config_template = """---
+backends:
+  - address: "127.0.0.1:%d"
+    protocol: Do53
+
+generic_caches:
+  object:
+    - name: "test-cache"
+      max_entries: 1000
+
+query_rules:
+  - name: Lua store to cache rule
+    selector:
+      type: Regex
+      expression: store.*
+    action:
+      type: Lua
+      function_code: |
+        function store(dq)
+            local cache = getObjectFromYAMLConfiguration("test-cache")
+            cache:insert(dq.remoteaddr:toString(), "some value")
+            return DNSAction.None, ""
+        end
+        return store
+
+  - name: Lua read from cache rule
+    selector:
+      type: Regex
+      expression: read.*
+    action:
+      type: Lua
+      function_code: |
+        function dropWhenExists(dq)
+            local cache = getObjectFromYAMLConfiguration("test-cache")
+            if cache:contains(dq.remoteaddr:toString()) then
+                cache:remove(dq.remoteaddr:toString())
+                return DNSAction.Refused
+            end
+            return DNSAction.None, ""
+        end
+        return dropWhenExists
+    """
+    _yaml_config_params = ["_testServerPort"]

--- a/regression-tests.dnsdist/test_GenericCache.py
+++ b/regression-tests.dnsdist/test_GenericCache.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+import dns
+import requests
+
+import clientsubnetoption
+import cookiesoption
+from dnsdisttests import DNSDistTest, pickAvailablePort
+
+
+class TestGenericCache(DNSDistTest):
+    _config_template = """
+    cache = newObjectCache("test", { maxEntries = 1000 })
+    function store(dq)
+        cache:insert(dq.remoteaddr:toString(), "some value")
+        return DNSAction.None, ""
+    end
+    function dropWhenExists(dq)
+        if cache:contains(dq.remoteaddr:toString()) then
+            cache:remove(dq.remoteaddr:toString())
+            return DNSAction.Refused
+        end
+        return DNSAction.None, ""
+    end
+    addAction("store.cache.tests.powerdns.com.", LuaAction(store))
+    addAction("read.cache.tests.powerdns.com.", LuaAction(dropWhenExists))
+    newServer{address="127.0.0.1:%d"}
+    """
+
+    def testExistsCheck(self):
+        """
+        Cache: Refused when value is cached
+        """
+        read_name = "read.cache.tests.powerdns.com."
+        store_name = "store.cache.tests.powerdns.com."
+
+        # First read, to show no Refused
+        query = dns.message.make_query(read_name, "A", "IN")
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(read_name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
+
+        # then store
+        query = dns.message.make_query(store_name, "A", "IN")
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(store_name, 3600, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
+
+        # Then read again, should get Refused
+        query = dns.message.make_query(read_name, "A", "IN")
+        response = dns.message.make_response(query)
+        response.set_rcode(dns.rcode.Rcode.REFUSED)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertIsNone(receivedQuery)
+        self.assertTrue(receivedResponse)
+        self.assertEqual(receivedResponse, response)
+
+    def testRemove(self):
+        """
+        Cache: Refused when value is cached, but it gets removed too
+        """
+        read_name = "read.cache.tests.powerdns.com."
+        store_name = "store.cache.tests.powerdns.com."
+
+        # store
+        query = dns.message.make_query(store_name, "AAAA", "IN")
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(store_name, 3600, dns.rdataclass.IN, dns.rdatatype.AAAA, "::1")
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
+
+        # read, should get Refused
+        query = dns.message.make_query(read_name, "AAAA", "IN")
+        response = dns.message.make_response(query)
+        response.set_rcode(dns.rcode.Rcode.REFUSED)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response, useQueue=False)
+        self.assertIsNone(receivedQuery)
+        self.assertTrue(receivedResponse)
+        self.assertEqual(receivedResponse, response)
+
+        # read again, should get response
+        query = dns.message.make_query(read_name, "AAAA", "IN")
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(read_name, 3600, dns.rdataclass.IN, dns.rdatatype.AAAA, "::1")
+        response.answer.append(rrset)
+
+        (_, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedResponse)
+        self.assertEqual(receivedResponse, response)


### PR DESCRIPTION
### Short description
This adds a new object usable from Lua - `GenericCache` - which can be used to store any values under string keys and retrieve them later on.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)


---
>Sponsored by [Quad9](https://quad9.net/)
