### PR TITLE
auth: set version in meson.build in autoconf make dist path

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.authoritative
+++ b/builder-support/dockerfiles/Dockerfile.authoritative
@@ -10,6 +10,7 @@ ADD configure.ac Makefile.am COPYING INSTALL NOTICE README /pdns-authoritative/
 @EXEC sdist_paths=(build-aux m4 pdns ext docs modules codedocs contrib regression-tests meson meson.build meson_options.txt)
 @EXEC for d in ${sdist_paths[@]} ; do echo "COPY $d /pdns-authoritative/$d" ; done
 ADD builder/helpers/set-configure-ac-version.sh /pdns-authoritative/builder/helpers/
+ADD builder/helpers/set-meson-build-version.sh /pdns-authoritative/builder/helpers/
 ADD builder-support/gen-version /pdns-authoritative/builder-support/gen-version
 WORKDIR /pdns-authoritative/
 
@@ -18,6 +19,7 @@ RUN mkdir /sdist
 ARG BUILDER_VERSION
 RUN rm -rf /pdns-authoritative/docs/.venv
 RUN /pdns-authoritative/builder/helpers/set-configure-ac-version.sh && \
+    /pdns-authoritative/builder/helpers/set-meson-build-version.sh && \
      autoreconf -v -i --force && \
     ./configure --disable-lua-records --disable-ixfrdist --without-modules --without-dynmodules --disable-dependency-tracking && \
     make dist


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Set version in meson.build in builder sdist path.

Stopgap until auth switches to meson dist.


❗ ❗ ❗ ❗ This needs https://github.com/PowerDNS/pdns-builder/pull/85 to land first and then the subproject commit needs to be fixed up. ❗ ❗ ❗ ❗ 


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
