### PR TITLE
auth api: get the number of rrsets of a zone

### DIFF
--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -60,6 +60,68 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  "/servers/{server_id}/autoprimaries":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+    get:
+      summary: "Get a list of autoprimaries"
+      operationId: getAutoprimaries
+      tags:
+        - autoprimary
+      responses:
+        "200":
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Autoprimary"
+        default:
+          $ref: "#/components/responses/Error"
+    post:
+      summary: "Add an autoprimary"
+      description: "This methods add a new autoprimary server."
+      operationId: createAutoprimary
+      tags:
+        - autoprimary
+      requestBody:
+        required: true
+        description: autoprimary entry to add
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Autoprimary"
+      responses:
+        "201":
+          description: Created
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/autoprimaries/{ip}/{nameserver}":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - name: ip
+        in: path
+        required: true
+        description: "IP address of autoprimary"
+        schema:
+          type: string
+      - name: nameserver
+        in: path
+        required: true
+        description: "DNS name of the autoprimary"
+        schema:
+          type: string
+    delete:
+      summary: "Delete the autoprimary entry"
+      operationId: deleteAutoprimary
+      tags:
+        - autoprimary
+      responses:
+        "204":
+          description: "OK, key was deleted"
+        default:
+          $ref: "#/components/responses/Error"
+
   "/servers/{server_id}/cache/flush":
     parameters:
       - $ref: "#/components/parameters/server_id"
@@ -82,6 +144,405 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CacheFlushResult"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/config":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+    get:
+      summary: "Returns all ConfigSettings for a single server"
+      operationId: getConfig
+      tags:
+        - config
+      responses:
+        "200":
+          description: List of config values
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ConfigSetting"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/config/{config_setting_name}":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - name: config_setting_name
+        in: path
+        required: true
+        description: The name of the setting to retrieve
+        schema:
+          type: string
+    get:
+      summary: "Returns a specific ConfigSetting for a single server"
+      description: "NOT IMPLEMENTED"
+      operationId: getConfigSetting
+      tags:
+        - config
+      responses:
+        "200":
+          description: List of config values
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConfigSetting"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/networks":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+    get:
+      summary: List all registered networks and views in a server
+      operationId: listNetworks
+      tags:
+        - networks
+      responses:
+        "200":
+          description: An array of networks
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Networks"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/networks/{ip}/{prefixlen}":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - name: ip
+        schema:
+          type: string
+        in: path
+        required: true
+        description: The base address of the network
+      - name: prefixlen
+        schema:
+          type: string
+        in: path
+        required: true
+        description: The length of the network prefix
+    get:
+      summary: Return the view associated to the given network
+      operationId: getNetwork
+      tags:
+        - networks
+      responses:
+        "200":
+          description: A network
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Network"
+        default:
+          $ref: "#/components/responses/Error"
+
+    put:
+      summary: Sets the view associated to the given network
+      operationId: setNetwork
+      tags:
+        - networks
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                view:
+                  type: string
+                  description: The name of the view to use for this network
+
+      responses:
+        "204":
+          description: "Returns 204 No Content on success."
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/search-data":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+    get:
+      summary: "Search the data inside PowerDNS"
+      description: "Search the data inside PowerDNS for search_term and return at most max_results. This includes zones, records and comments. The * character can be used in search_term as a wildcard character and the ? character can be used as a wildcard for a single character."
+      operationId: searchData
+      tags:
+        - search
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: "The string to search for"
+          schema:
+            type: string
+        - name: max
+          in: query
+          required: true
+          description: "Maximum number of entries to return"
+          schema:
+            type: integer
+        - name: object_type
+          in: query
+          required: false
+          description: "Type of data to search for, one of “all”, “zone”, “record”, “comment”"
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Returns a JSON array with results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResults"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/statistics":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+    get:
+      summary: "Query statistics."
+      description: "Query PowerDNS internal statistics."
+      operationId: getStats
+      tags:
+        - stats
+      parameters:
+        - name: statistic
+          in: query
+          required: false
+          schema:
+            type: string
+          description: |
+            When set to the name of a specific statistic, only this value is returned.
+            If no statistic with that name exists, the response has a 422 status and an error message.
+        - name: includerings
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: true
+          description: "“true” (default) or “false”, whether to include the Ring items, which can contain thousands of log messages or queried domains. Setting this to ”false” may make the response a lot smaller."
+      responses:
+        "200":
+          description: List of Statistic Items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  discriminator:
+                    propertyName: object_type
+                    mapping:
+                      StatisticItem: "#/components/schemas/StatisticItem"
+                      MapStatisticItem: "#/components/schemas/MapStatisticItem"
+                      RingStatisticItem: "#/components/schemas/RingStatisticItem"
+                  oneOf:
+                    - $ref: "#/components/schemas/StatisticItem"
+                    - $ref: "#/components/schemas/MapStatisticItem"
+                    - $ref: "#/components/schemas/RingStatisticItem"
+        "422":
+          description: "Returned when a non-existing statistic name has been requested. Contains an error message"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/tsigkeys":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+    get:
+      summary: "Get all TSIGKeys on the server, except the actual key"
+      operationId: listTSIGKeys
+      tags:
+        - tsigkey
+      responses:
+        "200":
+          description: List of TSIGKey objects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TSIGKey"
+        default:
+          $ref: "#/components/responses/Error"
+    post:
+      summary: "Add a TSIG key"
+      description: "This methods add a new TSIGKey. The actual key can be generated by the server or be provided by the client"
+      operationId: createTSIGKey
+      tags:
+        - tsigkey
+      requestBody:
+        required: true
+        description: The TSIGKey to add
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TSIGKey"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TSIGKey"
+        "409":
+          description: An item with this name already exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/tsigkeys/{tsigkey_id}":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - name: tsigkey_id
+        in: path
+        required: true
+        description: 'The id of the TSIGkey. Should match the "id" field in the TSIGKey object'
+        schema:
+          type: string
+    get:
+      summary: "Get a specific TSIGKeys on the server, including the actual key"
+      operationId: getTSIGKey
+      tags:
+        - tsigkey
+      responses:
+        "200":
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TSIGKey"
+        default:
+          $ref: "#/components/responses/Error"
+    put:
+      description: |
+        The TSIGKey at tsigkey_id can be changed in multiple ways:
+         * Changing the Name, this will remove the key with tsigkey_id after adding.
+         * Changing the Algorithm
+         * Changing the Key
+
+        Only the relevant fields have to be provided in the request body.
+      operationId: putTSIGKey
+      tags:
+        - tsigkey
+      requestBody:
+        required: true
+        description: A (possibly stripped down) TSIGKey object with the new values
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TSIGKey"
+      responses:
+        "200":
+          description: OK. TSIGKey is changed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TSIGKey"
+        "409":
+          description: An item with this name already exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          $ref: "#/components/responses/Error"
+    delete:
+      summary: "Delete the TSIGKey with tsigkey_id"
+      operationId: deleteTSIGKey
+      tags:
+        - tsigkey
+      responses:
+        "204":
+          description: "OK, key was deleted"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/views":
+    get:
+      summary: List all views in a server
+      operationId: listViews
+      tags:
+        - views
+      parameters:
+        - $ref: "#/components/parameters/server_id"
+      responses:
+        "200":
+          description: An array of view names
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Views"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/views/{view}":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - $ref: "#/components/parameters/view"
+
+    get:
+      summary: List the contents of a given view
+      operationId: listView
+      tags:
+        - views
+      responses:
+        "200":
+          description: An array of zone names
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/View"
+        default:
+          $ref: "#/components/responses/Error"
+
+    post:
+      summary: Adds a zone to a given view, creating it if needed
+      operationId: addToView
+      tags:
+        - views
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                name:
+                  type: string
+                  description: The zone to add to the view
+      responses:
+        "204":
+          description: "Returns 204 No Content on success."
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/views/{view}/{id}":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - $ref: "#/components/parameters/view"
+      - name: id
+        description: The zone to remove from the view
+        required: true
+        in: path
+        schema:
+          type: string
+    delete:
+      summary: Removes the given zone from the given view
+      operationId: deleteFromView
+      tags:
+        - views
+      responses:
+        "204":
+          description: "Returns 204 No Content on success."
         default:
           $ref: "#/components/responses/Error"
 
@@ -237,22 +698,6 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
-  "/servers/{server_id}/zones/{zone_id}/notify":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - $ref: "#/components/parameters/zone_id"
-    put:
-      summary: Send a DNS NOTIFY to all slaves.
-      description: "Fails when zone kind is not Master or Slave, or master and slave are disabled in the configuration. Only works for Slave if renotify is on. Clients MUST NOT send a body."
-      operationId: notifyZone
-      tags:
-        - zones
-      responses:
-        "200":
-          description: OK
-        default:
-          $ref: "#/components/responses/Error"
-
   "/servers/{server_id}/zones/{zone_id}/axfr-retrieve":
     parameters:
       - $ref: "#/components/parameters/server_id"
@@ -265,267 +710,6 @@ paths:
         - zones
       responses:
         "200":
-          description: OK
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/zones/{zone_id}/export":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - $ref: "#/components/parameters/zone_id"
-    get:
-      summary: "Returns the zone in AXFR format."
-      operationId: axfrExportZone
-      tags:
-        - zones
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: string
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/zones/{zone_id}/rectify":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - $ref: "#/components/parameters/zone_id"
-    put:
-      summary: "Rectify the zone data."
-      description: "This does not take into account the API-RECTIFY metadata. Fails on slave zones and zones that do not have DNSSEC."
-      operationId: rectifyZone
-      tags:
-        - zones
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: string
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/config":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-    get:
-      summary: "Returns all ConfigSettings for a single server"
-      operationId: getConfig
-      tags:
-        - config
-      responses:
-        "200":
-          description: List of config values
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ConfigSetting"
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/config/{config_setting_name}":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - name: config_setting_name
-        in: path
-        required: true
-        description: The name of the setting to retrieve
-        schema:
-          type: string
-    get:
-      summary: "Returns a specific ConfigSetting for a single server"
-      description: "NOT IMPLEMENTED"
-      operationId: getConfigSetting
-      tags:
-        - config
-      responses:
-        "200":
-          description: List of config values
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ConfigSetting"
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/statistics":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-    get:
-      summary: "Query statistics."
-      description: "Query PowerDNS internal statistics."
-      operationId: getStats
-      tags:
-        - stats
-      parameters:
-        - name: statistic
-          in: query
-          required: false
-          schema:
-            type: string
-          description: |
-            When set to the name of a specific statistic, only this value is returned.
-            If no statistic with that name exists, the response has a 422 status and an error message.
-        - name: includerings
-          in: query
-          required: false
-          schema:
-            type: boolean
-            default: true
-          description: "“true” (default) or “false”, whether to include the Ring items, which can contain thousands of log messages or queried domains. Setting this to ”false” may make the response a lot smaller."
-      responses:
-        "200":
-          description: List of Statistic Items
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  discriminator:
-                    propertyName: object_type
-                    mapping:
-                      StatisticItem: "#/components/schemas/StatisticItem"
-                      MapStatisticItem: "#/components/schemas/MapStatisticItem"
-                      RingStatisticItem: "#/components/schemas/RingStatisticItem"
-                  oneOf:
-                    - $ref: "#/components/schemas/StatisticItem"
-                    - $ref: "#/components/schemas/MapStatisticItem"
-                    - $ref: "#/components/schemas/RingStatisticItem"
-        "422":
-          description: "Returned when a non-existing statistic name has been requested. Contains an error message"
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/search-data":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-    get:
-      summary: "Search the data inside PowerDNS"
-      description: "Search the data inside PowerDNS for search_term and return at most max_results. This includes zones, records and comments. The * character can be used in search_term as a wildcard character and the ? character can be used as a wildcard for a single character."
-      operationId: searchData
-      tags:
-        - search
-      parameters:
-        - name: q
-          in: query
-          required: true
-          description: "The string to search for"
-          schema:
-            type: string
-        - name: max
-          in: query
-          required: true
-          description: "Maximum number of entries to return"
-          schema:
-            type: integer
-        - name: object_type
-          in: query
-          required: false
-          description: "Type of data to search for, one of “all”, “zone”, “record”, “comment”"
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Returns a JSON array with results
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SearchResults"
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/zones/{zone_id}/metadata":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - $ref: "#/components/parameters/zone_id"
-    get:
-      summary: "Get all the Metadata associated with the zone."
-      operationId: listMetadata
-      tags:
-        - zonemetadata
-      responses:
-        "200":
-          description: List of Metadata objects
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Metadata"
-        default:
-          $ref: "#/components/responses/Error"
-    post:
-      summary: "Creates a set of metadata entries"
-      description: "Creates a set of metadata entries of given kind for the zone. Existing metadata entries for the zone with the same kind are not overwritten."
-      operationId: createMetadata
-      tags:
-        - zonemetadata
-
-      requestBody:
-        required: true
-        description: Metadata object with list of values to create
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Metadata"
-      responses:
-        "204":
-          description: OK
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/zones/{zone_id}/metadata/{metadata_kind}":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - $ref: "#/components/parameters/zone_id"
-      - name: metadata_kind
-        schema:
-          type: string
-        in: path
-        required: true
-        description: The kind of metadata
-    get:
-      summary: "Get the content of a single kind of domain metadata as a Metadata object."
-      operationId: getMetadata
-      tags:
-        - zonemetadata
-      responses:
-        "200":
-          description: Metadata object with list of values
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Metadata"
-        default:
-          $ref: "#/components/responses/Error"
-    put:
-      summary: "Replace the content of a single kind of domain metadata."
-      description: "Creates a set of metadata entries of given kind for the zone. Existing metadata entries for the zone with the same kind are removed."
-      operationId: modifyMetadata
-      tags:
-        - zonemetadata
-      responses:
-        "200":
-          description: Metadata object with list of values
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Metadata"
-        default:
-          $ref: "#/components/responses/Error"
-    delete:
-      summary: "Delete all items of a single kind of domain metadata."
-      operationId: deleteMetadata
-      tags:
-        - zonemetadata
-      responses:
-        "204":
           description: OK
         default:
           $ref: "#/components/responses/Error"
@@ -619,332 +803,148 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
-  "/servers/{server_id}/tsigkeys":
+  "/servers/{server_id}/zones/{zone_id}/export":
     parameters:
       - $ref: "#/components/parameters/server_id"
+      - $ref: "#/components/parameters/zone_id"
     get:
-      summary: "Get all TSIGKeys on the server, except the actual key"
-      operationId: listTSIGKeys
+      summary: "Returns the zone in AXFR format."
+      operationId: axfrExportZone
       tags:
-        - tsigkey
+        - zones
       responses:
         "200":
-          description: List of TSIGKey objects
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/zones/{zone_id}/metadata":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - $ref: "#/components/parameters/zone_id"
+    get:
+      summary: "Get all the Metadata associated with the zone."
+      operationId: listMetadata
+      tags:
+        - zonemetadata
+      responses:
+        "200":
+          description: List of Metadata objects
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/TSIGKey"
+                  $ref: "#/components/schemas/Metadata"
         default:
           $ref: "#/components/responses/Error"
     post:
-      summary: "Add a TSIG key"
-      description: "This methods add a new TSIGKey. The actual key can be generated by the server or be provided by the client"
-      operationId: createTSIGKey
+      summary: "Creates a set of metadata entries"
+      description: "Creates a set of metadata entries of given kind for the zone. Existing metadata entries for the zone with the same kind are not overwritten."
+      operationId: createMetadata
       tags:
-        - tsigkey
+        - zonemetadata
+
       requestBody:
         required: true
-        description: The TSIGKey to add
+        description: Metadata object with list of values to create
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TSIGKey"
+              $ref: "#/components/schemas/Metadata"
       responses:
-        "201":
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TSIGKey"
-        "409":
-          description: An item with this name already exists
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+        "204":
+          description: OK
         default:
           $ref: "#/components/responses/Error"
 
-  "/servers/{server_id}/tsigkeys/{tsigkey_id}":
+  "/servers/{server_id}/zones/{zone_id}/metadata/{metadata_kind}":
     parameters:
       - $ref: "#/components/parameters/server_id"
-      - name: tsigkey_id
-        in: path
-        required: true
-        description: 'The id of the TSIGkey. Should match the "id" field in the TSIGKey object'
+      - $ref: "#/components/parameters/zone_id"
+      - name: metadata_kind
         schema:
           type: string
+        in: path
+        required: true
+        description: The kind of metadata
     get:
-      summary: "Get a specific TSIGKeys on the server, including the actual key"
-      operationId: getTSIGKey
+      summary: "Get the content of a single kind of domain metadata as a Metadata object."
+      operationId: getMetadata
       tags:
-        - tsigkey
+        - zonemetadata
       responses:
         "200":
-          description: OK.
+          description: Metadata object with list of values
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TSIGKey"
+                $ref: "#/components/schemas/Metadata"
         default:
           $ref: "#/components/responses/Error"
     put:
-      description: |
-        The TSIGKey at tsigkey_id can be changed in multiple ways:
-         * Changing the Name, this will remove the key with tsigkey_id after adding.
-         * Changing the Algorithm
-         * Changing the Key
-
-        Only the relevant fields have to be provided in the request body.
-      operationId: putTSIGKey
+      summary: "Replace the content of a single kind of domain metadata."
+      description: "Creates a set of metadata entries of given kind for the zone. Existing metadata entries for the zone with the same kind are removed."
+      operationId: modifyMetadata
       tags:
-        - tsigkey
-      requestBody:
-        required: true
-        description: A (possibly stripped down) TSIGKey object with the new values
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TSIGKey"
+        - zonemetadata
       responses:
         "200":
-          description: OK. TSIGKey is changed.
+          description: Metadata object with list of values
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TSIGKey"
-        "409":
-          description: An item with this name already exists
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/Metadata"
         default:
           $ref: "#/components/responses/Error"
     delete:
-      summary: "Delete the TSIGKey with tsigkey_id"
-      operationId: deleteTSIGKey
+      summary: "Delete all items of a single kind of domain metadata."
+      operationId: deleteMetadata
       tags:
-        - tsigkey
+        - zonemetadata
       responses:
         "204":
-          description: "OK, key was deleted"
+          description: OK
         default:
           $ref: "#/components/responses/Error"
 
-  "/servers/{server_id}/autoprimaries":
+  "/servers/{server_id}/zones/{zone_id}/notify":
     parameters:
       - $ref: "#/components/parameters/server_id"
-    get:
-      summary: "Get a list of autoprimaries"
-      operationId: getAutoprimaries
-      tags:
-        - autoprimary
-      responses:
-        "200":
-          description: OK.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Autoprimary"
-        default:
-          $ref: "#/components/responses/Error"
-    post:
-      summary: "Add an autoprimary"
-      description: "This methods add a new autoprimary server."
-      operationId: createAutoprimary
-      tags:
-        - autoprimary
-      requestBody:
-        required: true
-        description: autoprimary entry to add
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Autoprimary"
-      responses:
-        "201":
-          description: Created
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/autoprimaries/{ip}/{nameserver}":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - name: ip
-        in: path
-        required: true
-        description: "IP address of autoprimary"
-        schema:
-          type: string
-      - name: nameserver
-        in: path
-        required: true
-        description: "DNS name of the autoprimary"
-        schema:
-          type: string
-    delete:
-      summary: "Delete the autoprimary entry"
-      operationId: deleteAutoprimary
-      tags:
-        - autoprimary
-      responses:
-        "204":
-          description: "OK, key was deleted"
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/views":
-    get:
-      summary: List all views in a server
-      operationId: listViews
-      tags:
-        - views
-      parameters:
-        - $ref: "#/components/parameters/server_id"
-      responses:
-        "200":
-          description: An array of view names
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Views"
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/views/{view}":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - $ref: "#/components/parameters/view"
-
-    get:
-      summary: List the contents of a given view
-      operationId: listView
-      tags:
-        - views
-      responses:
-        "200":
-          description: An array of zone names
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/View"
-        default:
-          $ref: "#/components/responses/Error"
-
-    post:
-      summary: Adds a zone to a given view, creating it if needed
-      operationId: addToView
-      tags:
-        - views
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: false
-              properties:
-                name:
-                  type: string
-                  description: The zone to add to the view
-      responses:
-        "204":
-          description: "Returns 204 No Content on success."
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/views/{view}/{id}":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - $ref: "#/components/parameters/view"
-      - name: id
-        description: The zone to remove from the view
-        required: true
-        in: path
-        schema:
-          type: string
-    delete:
-      summary: Removes the given zone from the given view
-      operationId: deleteFromView
-      tags:
-        - views
-      responses:
-        "204":
-          description: "Returns 204 No Content on success."
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/networks":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-    get:
-      summary: List all registered networks and views in a server
-      operationId: listNetworks
-      tags:
-        - networks
-      responses:
-        "200":
-          description: An array of networks
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Networks"
-        default:
-          $ref: "#/components/responses/Error"
-
-  "/servers/{server_id}/networks/{ip}/{prefixlen}":
-    parameters:
-      - $ref: "#/components/parameters/server_id"
-      - name: ip
-        schema:
-          type: string
-        in: path
-        required: true
-        description: The base address of the network
-      - name: prefixlen
-        schema:
-          type: string
-        in: path
-        required: true
-        description: The length of the network prefix
-    get:
-      summary: Return the view associated to the given network
-      operationId: getNetwork
-      tags:
-        - networks
-      responses:
-        "200":
-          description: A network
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Network"
-        default:
-          $ref: "#/components/responses/Error"
-
+      - $ref: "#/components/parameters/zone_id"
     put:
-      summary: Sets the view associated to the given network
-      operationId: setNetwork
+      summary: Send a DNS NOTIFY to all slaves.
+      description: "Fails when zone kind is not Master or Slave, or master and slave are disabled in the configuration. Only works for Slave if renotify is on. Clients MUST NOT send a body."
+      operationId: notifyZone
       tags:
-        - networks
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: false
-              properties:
-                view:
-                  type: string
-                  description: The name of the view to use for this network
-
+        - zones
       responses:
-        "204":
-          description: "Returns 204 No Content on success."
+        "200":
+          description: OK
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/zones/{zone_id}/rectify":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - $ref: "#/components/parameters/zone_id"
+    put:
+      summary: "Rectify the zone data."
+      description: "This does not take into account the API-RECTIFY metadata. Fails on slave zones and zones that do not have DNSSEC."
+      operationId: rectifyZone
+      tags:
+        - zones
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
         default:
           $ref: "#/components/responses/Error"
 

--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: "0.0.18"
+  version: "0.0.19"
   title: PowerDNS Authoritative HTTP API
   license:
     name: MIT
@@ -627,14 +627,20 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: record_count
+          in: query
+          description: "“true” or “false” (default), whether to include a count of the records returned in “rrsets” in the response Zone object."
+          schema:
+            type: boolean
+            default: false
         - name: rrset_name
           in: query
-          description: Limit output to RRsets for this name.
+          description: Limit output and/or count to RRsets for this name.
           schema:
             type: string
         - name: rrset_type
           in: query
-          description: Limit output to the RRset of this type. Can only be used together with rrset_name.
+          description: Limit output and/or count to the RRset of this type. Can only be used together with rrset_name.
           schema:
             type: string
         - name: include_disabled
@@ -642,6 +648,7 @@ paths:
           description: "“true” (default) or “false”, whether to include disabled RRsets in the response."
           schema:
             type: boolean
+            default: true
       responses:
         "200":
           description: A Zone
@@ -1047,6 +1054,9 @@ components:
             - "Producer"
             - "Consumer"
           description: "Zone kind, one of “Native”, “Master”, “Slave”, “Producer”, “Consumer”"
+        record_count:
+          type: integer
+          description: "The number of records in this zone (for zones/{zone_id} endpoint only; omitted during GET on the .../zones list endpoint)"
         rrsets:
           type: array
           items:

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -406,9 +406,12 @@ static Json::object getZoneInfo(const DomainInfo& domainInfo, DNSSECKeeper* dnss
   return obj;
 }
 
-static bool boolFromHttpRequest(HttpRequest* req, const std::string& var)
+static bool boolFromHttpRequest(HttpRequest* req, const std::string& var, bool deflt)
 {
-  if (req->getvars.count(var) == 0 || req->getvars[var] == "true") {
+  if (req->getvars.count(var) == 0) {
+    return deflt;
+  }
+  if (req->getvars[var] == "true") {
     return true;
   }
   if (req->getvars[var] == "false") {
@@ -418,6 +421,7 @@ static bool boolFromHttpRequest(HttpRequest* req, const std::string& var)
   throw ApiException("'" + var + "' request parameter value '" + req->getvars[var] + "' is not supported");
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpResponse* resp, HttpRequest* req)
 {
   DomainInfo domainInfo;
@@ -477,9 +481,12 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
   }
   doc["slave_tsig_key_ids"] = tsig_secondary_keys;
 
-  if (boolFromHttpRequest(req, "rrsets")) {
+  bool returnRRSets = boolFromHttpRequest(req, "rrsets", true);
+  bool countRecords = boolFromHttpRequest(req, "record_count", false);
+  if (returnRRSets || countRecords) {
     vector<DNSResourceRecord> records;
     vector<Comment> comments;
+    size_t recordCount{0};
 
     QType qType = QType::ANY;
     DNSName qName;
@@ -495,31 +502,36 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
         if (req->getvars.count("rrset_type") != 0) {
           qType = req->getvars["rrset_type"];
         }
-        bool include_disabled = boolFromHttpRequest(req, "include_disabled");
+        bool include_disabled = boolFromHttpRequest(req, "include_disabled", true);
         domainInfo.backend->APILookup(qType, qName, static_cast<int>(domainInfo.id), include_disabled);
       }
       while (domainInfo.backend->get(resourceRecord)) {
         if (resourceRecord.qtype.getCode() == 0) {
           continue; // skip empty non-terminals
         }
-        records.push_back(resourceRecord);
-      }
-      sort(records.begin(), records.end(), [](const DNSResourceRecord& rrA, const DNSResourceRecord& rrB) {
-        /* if you ever want to update this comparison function,
-           please be aware that you will also need to update the conditions in the code merging
-           the records and comments below */
-        if (rrA.qname == rrB.qname) {
-          if (rrA.qtype == rrB.qtype) {
-            return rrB.content > rrA.content;
-          }
-          return rrB.qtype < rrA.qtype;
+        ++recordCount;
+        if (returnRRSets) {
+          records.push_back(resourceRecord);
         }
-        return rrB.qname < rrA.qname;
-      });
+      }
+      if (returnRRSets) {
+        sort(records.begin(), records.end(), [](const DNSResourceRecord& rrA, const DNSResourceRecord& rrB) {
+          /* if you ever want to update this comparison function,
+             please be aware that you will also need to update the conditions in the code merging
+             the records and comments below */
+          if (rrA.qname == rrB.qname) {
+            if (rrA.qtype == rrB.qtype) {
+              return rrB.content > rrA.content;
+            }
+            return rrB.qtype < rrA.qtype;
+          }
+          return rrB.qname < rrA.qname;
+        });
+      }
     }
 
     // load all comments + sort
-    {
+    if (returnRRSets) {
       Comment comment;
       domainInfo.backend->listComments(domainInfo.id);
       while (domainInfo.backend->getComment(comment)) {
@@ -539,74 +551,76 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
         }
         return rrB.qname < rrA.qname;
       });
+
+      Json::array rrsets;
+      Json::object rrset;
+      Json::array rrset_records;
+      Json::array rrset_comments;
+      DNSName current_qname;
+      QType current_qtype;
+      uint32_t ttl = 0;
+      auto rit = records.begin();
+      auto cit = comments.begin();
+
+      while (rit != records.end() || cit != comments.end()) {
+        // if you think this should be rit < cit instead of cit < rit, note the b < a instead of a < b in the sort comparison functions above
+        if (cit == comments.end() || (rit != records.end() && (rit->qname == cit->qname ? (cit->qtype < rit->qtype || cit->qtype == rit->qtype) : cit->qname < rit->qname))) {
+          current_qname = rit->qname;
+          current_qtype = rit->qtype;
+          ttl = rit->ttl;
+        }
+        else {
+          current_qname = cit->qname;
+          current_qtype = cit->qtype;
+          ttl = 0;
+        }
+
+        while (rit != records.end() && rit->qname == current_qname && rit->qtype == current_qtype) {
+          ttl = min(ttl, rit->ttl);
+          std::string content;
+          try {
+            content = makeApiRecordContent(rit->qtype, rit->content);
+          }
+          catch (std::exception& e) {
+            // makeApiRecordContent may throw an exception if the backend data
+            // is not well-formed (e.g. corrupted bind zone file).
+            // The exception gets caught here and rethrown as ApiException in
+            // order to return a 422 error code with a (hopefully) useful error
+            // message instead of a 500 error.
+            throw ApiException("Ill-formed record contents found for " + current_qname.toString() + ": " + e.what());
+          }
+          auto object = Json::object{
+            {"disabled", rit->disabled},
+            {"content", content}};
+          if (rit->last_modified != 0) {
+            object["modified_at"] = (double)rit->last_modified;
+          }
+          rrset_records.push_back(object);
+          rit++;
+        }
+        while (cit != comments.end() && cit->qname == current_qname && cit->qtype == current_qtype) {
+          rrset_comments.push_back(Json::object{
+            {"modified_at", (double)cit->modified_at},
+            {"account", cit->account},
+            {"content", cit->content}});
+          cit++;
+        }
+
+        rrset["name"] = current_qname.toString();
+        rrset["type"] = current_qtype.toString();
+        rrset["records"] = rrset_records;
+        rrset["comments"] = rrset_comments;
+        rrset["ttl"] = (double)ttl;
+        rrsets.emplace_back(rrset);
+        rrset.clear();
+        rrset_records.clear();
+        rrset_comments.clear();
+      }
+
+      doc["rrsets"] = rrsets;
     }
 
-    Json::array rrsets;
-    Json::object rrset;
-    Json::array rrset_records;
-    Json::array rrset_comments;
-    DNSName current_qname;
-    QType current_qtype;
-    uint32_t ttl = 0;
-    auto rit = records.begin();
-    auto cit = comments.begin();
-
-    while (rit != records.end() || cit != comments.end()) {
-      // if you think this should be rit < cit instead of cit < rit, note the b < a instead of a < b in the sort comparison functions above
-      if (cit == comments.end() || (rit != records.end() && (rit->qname == cit->qname ? (cit->qtype < rit->qtype || cit->qtype == rit->qtype) : cit->qname < rit->qname))) {
-        current_qname = rit->qname;
-        current_qtype = rit->qtype;
-        ttl = rit->ttl;
-      }
-      else {
-        current_qname = cit->qname;
-        current_qtype = cit->qtype;
-        ttl = 0;
-      }
-
-      while (rit != records.end() && rit->qname == current_qname && rit->qtype == current_qtype) {
-        ttl = min(ttl, rit->ttl);
-        std::string content;
-        try {
-          content = makeApiRecordContent(rit->qtype, rit->content);
-        }
-        catch (std::exception& e) {
-          // makeApiRecordContent may throw an exception if the backend data
-          // is not well-formed (e.g. corrupted bind zone file).
-          // The exception gets caught here and rethrown as ApiException in
-          // order to return a 422 error code with a (hopefully) useful error
-          // message instead of a 500 error.
-          throw ApiException("Ill-formed record contents found for " + current_qname.toString() + ": " + e.what());
-        }
-        auto object = Json::object{
-          {"disabled", rit->disabled},
-          {"content", content}};
-        if (rit->last_modified != 0) {
-          object["modified_at"] = (double)rit->last_modified;
-        }
-        rrset_records.push_back(object);
-        rit++;
-      }
-      while (cit != comments.end() && cit->qname == current_qname && cit->qtype == current_qtype) {
-        rrset_comments.push_back(Json::object{
-          {"modified_at", (double)cit->modified_at},
-          {"account", cit->account},
-          {"content", cit->content}});
-        cit++;
-      }
-
-      rrset["name"] = current_qname.toString();
-      rrset["type"] = current_qtype.toString();
-      rrset["records"] = rrset_records;
-      rrset["comments"] = rrset_comments;
-      rrset["ttl"] = (double)ttl;
-      rrsets.emplace_back(rrset);
-      rrset.clear();
-      rrset_records.clear();
-      rrset_comments.clear();
-    }
-
-    doc["rrsets"] = rrsets;
+    doc["record_count"] = static_cast<double>(recordCount);
   }
 
   resp->setJsonBody(doc);

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -3221,6 +3221,34 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         # check our record has appeared
         self.assertEqual(get_rrset(data, rrset["name"], "A")["records"], rrset["records"])
 
+    def test_record_count(self):
+        name, payload, zone = self.create_zone()
+        rrsets = []
+        count = 100
+        for record in range(count):
+            rrset = {
+                "changetype": "replace",
+                "name": "rec" + str(record) + "." + name,
+                "type": "A",
+                "ttl": 3600,
+                "records": [{"content": "192.168.0." + str(record), "disabled": False}],
+            }
+            rrsets.append(rrset)
+        payload = {"rrsets": rrsets}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+        self.assert_success(r)
+        # ask for a record count, without records
+        data = self.get_zone(name, rrsets="false", record_count="true")
+        self.assertEqual(data["record_count"], count + 3)  # SOA + 2 NS
+        self.assertEqual(data.get("rrsets"), None)
+        # ask for a filtered record count
+        data = self.get_zone(name, rrset_name="rec42." + name)
+        self.assertEqual(data["record_count"], 1)
+
 
 @unittest.skipIf(not is_auth(), "Not applicable")
 class AuthRootZone(ZonesApiTestCase, AuthZonesHelperMixin):


### PR DESCRIPTION
### Short description
This PR introduces a ~~`/size` endpoint for zones, which~~ way to return the number of records found in the zone (not counting the `ENT`).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
