### PR TITLE
auth: initial meson dist script

### DIFF
--- a/meson-dist-script.sh
+++ b/meson-dist-script.sh
@@ -1,0 +1,41 @@
+#!/bin/sh -e
+
+echo Running meson-dist-script
+echo PWD=$(pwd)
+echo MESON_SOURCE_ROOT=$MESON_SOURCE_ROOT
+echo MESON_PROJECT_DIST_ROOT=$MESON_PROJECT_DIST_ROOT
+
+if [ -z "${MESON_PROJECT_DIST_ROOT}" ]; then
+    echo "MESON_PROJECT_DIST_ROOT is not set" >&2
+    exit 1
+fi
+
+cd "$MESON_PROJECT_DIST_ROOT"
+
+rm AI_POLICY.md BUILDING-PACKAGES.md CODE_COVERAGE.md
+rm Brewfile
+rm -r builder
+rm -r builder-support
+rm -r build-scripts
+rm -r contrib
+rm docker-compose.yml
+rm -r dockerdata
+rm Dockerfile*
+rm .dockerignore
+rm -r ext/ipcrypt2
+rm -r ext/libbpf
+rm -r ext/probds
+rm -r fuzzing
+rm invoke.yaml
+rm lgtm.yml
+rm Makefile.docker
+rm -r pdns/dnsdistdist
+rm -r pdns/recursordist
+rm -r regression-tests.dnsdist
+rm -r regression-tests.recursor
+rm -r regression-tests.recursor-dnssec
+rm tasks.py
+rm -r website
+
+# TODO: Generate man pages
+# TODO: openapi

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ project(
     'cpp_std=c++17',
   ],
 )
+meson.add_dist_script('meson-dist-script.sh')
 
 add_project_arguments('-DPDNS_AUTH', language: 'cpp')
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Initial step towards `meson dist` for auth.

Known things that need doing:
- add set-version meson dist script, like in rec/dnsdist
- decide on regression-tests* (autoconf does not include them)
- decide on docs (autoconf does not include them)
- run manpage build
- run openapi build

I'd propose landing an initial step (this PR) and the list can be tackled in separate PRs.

#13987

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
