### PR TITLE
auth api: allow forced update for EXTEND and DELETE zone patch operations

### DIFF
--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1157,6 +1157,9 @@ components:
           description: "List of Comment. Must be empty when changetype is set to DELETE, EXTEND or PRUNE. An empty list results in deletion of all comments. modified_at is optional and defaults to the current server time."
           items:
             $ref: "#/components/schemas/Comment"
+        write_unchanged:
+          type: boolean
+          description: "In the case of a PRUNE or EXTEND operation, specifies whether a database update should be performed even if the operation does not change the RRSet, causing the modification timestamp to be updated if the backend supports it."
 
     Record:
       title: Record

--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1146,15 +1146,15 @@ components:
           description: "DNS TTL of the records, in seconds. MUST NOT be included when changetype is set to “DELETE”."
         changetype:
           type: string
-          description: "MUST be added when updating the RRSet. Must be REPLACE or DELETE. With DELETE, all existing RRs matching name and type will be deleted, including all comments. With REPLACE: when records is present, all existing RRs matching name and type will be deleted, and then new records given in records will be created. If no records are left, any existing comments will be deleted as well. When comments is present, all existing comments for the RRs matching name and type will be deleted, and then new comments given in comments will be created."
+          description: "MUST be added when updating the RRSet. Must be one of DELETE, EXTEND, PRUNE or REPLACE. With DELETE, all existing RRs matching name and type will be deleted, including all comments. With EXTEND, only a single record shall be present, and it will be added to the RRSet if not already present. With PRUNE, only a single record shall be present, and it will be deleted from the RRSet if present. With REPLACE, when records is present, all existing RRs matching name and type will be deleted, and then new records given in records will be created. If no records are left, any existing comments will be deleted as well. When comments is present, all existing comments for the RRs matching name and type will be deleted, and then new comments given in comments will be created."
         records:
           type: array
-          description: "All records in this RRSet. When updating Records, this is the list of new records (replacing the old ones). Must be empty when changetype is set to DELETE. An empty list results in deletion of all records (and comments)."
+          description: "All records in this RRSet. When updating Records, this is the list of new records (replacing the old ones). Must be empty when changetype is set to DELETE, and must contain only one element when changetype is set to EXTEND or PRUNE. An empty list results in deletion of all records (and comments)."
           items:
             $ref: "#/components/schemas/Record"
         comments:
           type: array
-          description: "List of Comment. Must be empty when changetype is set to DELETE. An empty list results in deletion of all comments. modified_at is optional and defaults to the current server time."
+          description: "List of Comment. Must be empty when changetype is set to DELETE, EXTEND or PRUNE. An empty list results in deletion of all comments. modified_at is optional and defaults to the current server time."
           items:
             $ref: "#/components/schemas/Comment"
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2706,7 +2706,12 @@ static applyResult applyPruneOrExtend(const DomainInfo& domainInfo, const ZoneNa
     if (operationType == EXTEND && !seenRecord) {
       rrset.emplace_back(new_record);
     }
-    bool submitChanges = (operationType == EXTEND && !seenRecord) || (operationType == PRUNE && seenRecord);
+    // clang-format off
+    bool submitChanges =
+      boolFromJson(container, "write_unchanged", false) ||
+      (operationType == EXTEND && !seenRecord) ||
+      (operationType == PRUNE && seenRecord);
+    // clang-format on
     if (!submitChanges) {
       return NOP;
     }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1949,6 +1949,62 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         self.assertIn(a2, records)
         self.assertIn(a4, records)
 
+    @unittest.skipIf(not is_auth_lmdb(), "No rrset timestamps except with LMDB")
+    def test_zone_rr_update_with_forced_extend(self):
+        name, payload, zone = self.create_zone()
+        # add a record
+        rec = {"content": "1.2.3.4", "disabled": False}
+        rrset = {"changetype": "extend", "name": "a." + name, "type": "A", "ttl": 3600, "records": [rec]}
+        payload = {"rrsets": [rrset]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+        self.assert_success(r)
+        data = self.get_zone(name)
+        self.assertEqual(get_rrset(data, "a." + name, "A")["records"], rrset["records"])
+        # reload the zone because get_rrset above has removed the timestamps
+        data = self.get_zone(name)
+        # force update of the record with a different timestamp
+        time.sleep(1)
+        rrset = {
+            "changetype": "extend",
+            "name": "a." + name,
+            "type": "A",
+            "ttl": 3600,
+            "records": [rec],
+            "write_unchanged": True,
+        }
+        payload = {"rrsets": [rrset]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+        self.assert_success(r)
+        # verify the zone contents
+        data1 = self.get_zone(name)
+        # not using get_rrset() here so as NOT to remove timestamps
+        before = None
+        for rrset in data["rrsets"]:
+            if rrset["name"] == "a." + name:
+                before = rrset["records"]
+                break
+        after = None
+        for rrset in data1["rrsets"]:
+            if rrset["name"] == "a." + name:
+                after = rrset["records"]
+                break
+        self.assertEqual(len(before), 1)
+        self.assertEqual(len(after), 1)
+        before = before[0]
+        after = after[0]
+        self.assertNotEqual(before["modified_at"], after["modified_at"])
+        del before["modified_at"]
+        del after["modified_at"]
+        self.assertEqual(before, after)
+
     def test_zone_disable_reenable(self):
         # This also tests that SOA-EDIT-API works.
         name, payload, zone = self.create_zone(soa_edit_api="EPOCH")


### PR DESCRIPTION
### Short description
Look at my API, and despair!

The main user of the `EXTEND` changetype for rrset updates has noticed that, if the operation would turn out to be a no-op, because the same exact record already exists, we do not perform any backend operation and the `modified_at` rrset timestamp is left unmodified. That user would like the timestamp to change even when the rrset contents don't.

~~This PR introduces a variant of `EXTEND` named `ALWAYSEXTEND` which will always perform an rrset update (thus causing the timestamp to change) even if the contents are identical.~~
This PR introduces an optional `force` argument to the patch operation which, if set to `true`, will cause the server to always perform an rrset update (thus causing the timestamp to change) even if the contents are identical.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
