### PR TITLE
docs: replace mit keyserver with ubuntu

### DIFF
--- a/docs/common/tarball-pgp-keys.rst
+++ b/docs/common/tarball-pgp-keys.rst
@@ -1,13 +1,13 @@
-* `FBAE 0323 821C 7706 A5CA 151B DCF5 13FA 7EED 19F3 <https://pgp.mit.edu/pks/lookup?op=get&search=0xDCF513FA7EED19F3>`_
-* `D630 0CAB CBF4 69BB E392 E503 A208 ED4F 8AF5 8446 <https://pgp.mit.edu/pks/lookup?op=get&search=0xA208ED4F8AF58446>`_
-* `16E1 2866 B773 8C73 976A 5743 6FFC 3343 9B0D 04DF <https://pgp.mit.edu/pks/lookup?op=get&search=0x6FFC33439B0D04DF>`_
-* `990C 3D0E AC7C 275D C6B1 8436 EACA B90B 1963 EC2B <https://pgp.mit.edu/pks/lookup?op=get&search=0xEACAB90B1963EC2B>`_
+* `FBAE 0323 821C 7706 A5CA 151B DCF5 13FA 7EED 19F3 <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=DCF513FA7EED19F3>`_
+* `D630 0CAB CBF4 69BB E392 E503 A208 ED4F 8AF5 8446 <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=A208ED4F8AF58446>`_
+* `16E1 2866 B773 8C73 976A 5743 6FFC 3343 9B0D 04DF <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=6FFC33439B0D04DF>`_
+* `990C 3D0E AC7C 275D C6B1 8436 EACA B90B 1963 EC2B <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=EACAB90B1963EC2B>`_
 
 There is a PGP keyblock with these keys available on `https://doc.powerdns.com/powerdns-keyblock.asc <https://doc.powerdns.com/powerdns-keyblock.asc>`_.
 
 Older releases (4.3.x and earlier) can also be signed with one of the following keys:
 
-* `1628 90D0 689D D12D D33E 4696 1C5E E990 D2E7 1575 <https://pgp.mit.edu/pks/lookup?op=get&search=0x1C5EE990D2E71575>`_
-* `B76C D467 1C09 68BA A87D E61C 5E50 715B F2FF E1A7 <https://pgp.mit.edu/pks/lookup?op=get&search=0x5E50715BF2FFE1A7>`_
+* `1628 90D0 689D D12D D33E 4696 1C5E E990 D2E7 1575 <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=1C5EE990D2E71575>`_
+* `B76C D467 1C09 68BA A87D E61C 5E50 715B F2FF E1A7 <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=5E50715BF2FFE1A7>`_
 
 

--- a/pdns/dnsdistdist/docs/install.rst
+++ b/pdns/dnsdistdist/docs/install.rst
@@ -79,17 +79,17 @@ Release tarballs are available `from the downloads site <https://downloads.power
 
 The release tarballs have detached PGP signatures, signed by one of these PGP keys:
 
-* `FBAE 0323 821C 7706 A5CA 151B DCF5 13FA 7EED 19F3 <https://pgp.mit.edu/pks/lookup?op=get&search=0xDCF513FA7EED19F3>`_
-* `D630 0CAB CBF4 69BB E392 E503 A208 ED4F 8AF5 8446 <https://pgp.mit.edu/pks/lookup?op=get&search=0xA208ED4F8AF58446>`_
-* `16E1 2866 B773 8C73 976A 5743 6FFC 3343 9B0D 04DF <https://pgp.mit.edu/pks/lookup?op=get&search=0x6FFC33439B0D04DF>`_
-* `990C 3D0E AC7C 275D C6B1 8436 EACA B90B 1963 EC2B <https://pgp.mit.edu/pks/lookup?op=get&search=0xEACAB90B1963EC2B>`_
+* `FBAE 0323 821C 7706 A5CA 151B DCF5 13FA 7EED 19F3 <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=DCF513FA7EED19F3>`_
+* `D630 0CAB CBF4 69BB E392 E503 A208 ED4F 8AF5 8446 <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=A208ED4F8AF58446>`_
+* `16E1 2866 B773 8C73 976A 5743 6FFC 3343 9B0D 04DF <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=6FFC33439B0D04DF>`_
+* `990C 3D0E AC7C 275D C6B1 8436 EACA B90B 1963 EC2B <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=EACAB90B1963EC2B>`_
 
 There is a PGP keyblock with these keys available on `https://dnsdist.org/_static/dnsdist-keyblock.asc <https://dnsdist.org/_static/dnsdist-keyblock.asc>`__.
 
 Older (1.0.x) releases can also be signed with one of the following keys:
 
-* `1628 90D0 689D D12D D33E 4696 1C5E E990 D2E7 1575 <https://pgp.mit.edu/pks/lookup?op=get&search=0x1C5EE990D2E71575>`_
-* `B76C D467 1C09 68BA A87D E61C 5E50 715B F2FF E1A7 <https://pgp.mit.edu/pks/lookup?op=get&search=0x5E50715BF2FFE1A7>`_
+* `1628 90D0 689D D12D D33E 4696 1C5E E990 D2E7 1575 <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=1C5EE990D2E71575>`_
+* `B76C D467 1C09 68BA A87D E61C 5E50 715B F2FF E1A7 <https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=5E50715BF2FFE1A7>`_
 
 To compile from tarball using make (until version 2.2.0):
 


### PR DESCRIPTION
### Short description
The MIT keyserver interface fails much more often than the ubuntu one (I'm not saying the ubuntu one is great)

- https://pgp.mit.edu/pks/lookup?op=get&search=0xDCF513FA7EED19F3
   (eventually loaded, but took considerably longer, and at least some of my previous attempts failed with an error)
- https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=DCF513FA7EED19F3
   pub [(4)rsa4096/fbae0323821c7706a5ca151bdcf513fa7eed19f3](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xfbae0323821c7706a5ca151bdcf513fa7eed19f3) 2011-09-01T06:30:41Z

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
