### PR TITLE
auth: minor SVCB record parsing fixes

### DIFF
--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -494,8 +494,8 @@ void RecordTextReader::xfrSvcParamKeyVals(set<SvcParam>& val) // NOLINT(readabil
         }
         std::set<SvcParam::SvcParamKey> keys;
         for (size_t i=0; i < v.length(); i += 2) {
-          uint16_t mand = (v.at(i) << 8);
-          mand += v.at(i+1);
+          uint16_t mand = (static_cast<uint8_t>(v.at(i)) << 8);
+          mand += static_cast<uint8_t>(v.at(i+1));
           keys.insert(SvcParam::SvcParamKey(mand));
         }
         val.insert(SvcParam(key, std::move(keys)));
@@ -521,8 +521,8 @@ void RecordTextReader::xfrSvcParamKeyVals(set<SvcParam>& val) // NOLINT(readabil
         if (v.length() != 2) {
           throw RecordTextException("port in generic format has the wrong length, expected 2, got " + std::to_string(v.length()));
         }
-        port = (v.at(0) << 8);
-        port += v.at(1);
+        port = static_cast<uint8_t>(v.at(0)) << 8;
+        port += static_cast<uint8_t>(v.at(1));
       } else {
         string portstring;
         xfrRFC1035CharString(portstring);

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -224,6 +224,7 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. alpn=h3,h2", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x01\x00\x06\x02h3\x02h2"))
      (BROKEN_CASE_S(QType::SVCB, "1 foo.powerdns.org. alpn=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x01\x00\x06\x02h3\x02h2"))
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. port=53", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x03\x00\x02\x00\x35"))
+     (CASE_S(QType::SVCB, "1 foo.powerdns.org. port=253", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x03\x00\x02\x00\xfd"))
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. ipv4hint=192.0.2.53,192.0.2.2", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x04\x00\x08\xc0\x00\x02\x35\xc0\x00\x02\x02"))
      (CASE_S(QType::SVCB, "1 foo.powerdns.org. ech=\"aGVsbG8=\"", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x05\x00\x05hello"))
      (CASE_L(QType::SVCB, "1 foo.powerdns.org. ech=aGVsbG8=", "1 foo.powerdns.org. ech=\"aGVsbG8=\"", "\0\x01\3foo\x08powerdns\x03org\x00\x00\x05\x00\x05hello"))


### PR DESCRIPTION
### Short description
The SVCB record wire parser will build port numbers from two bytes picked out of a `string` object, but there is no guarantee that these bytes are unsigned.
This PR adds the appropriate casts to prevent unwanted effects of sign-extension.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
