### PR TITLE
dnsdist: fix build error on 32 bits systems (armhf, ...)

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1102,7 +1102,7 @@ static void handlePacketCacheConfiguration(const ::rust::Vec<dnsdist::rust::sett
 {
   for (const auto& cache : caches) {
     DNSDistPacketCache::CacheSettings settings{
-      .d_maxEntries = cache.size,
+      .d_maxEntries = static_cast<size_t>(cache.size),
       .d_maxTTL = cache.max_ttl,
       .d_minTTL = cache.min_ttl,
       .d_tempFailureTTL = cache.temporary_failure_ttl,


### PR DESCRIPTION
The YAML configuration field cache.size is a uint64_t, while DNSDistPacketCache::CacheSettings::d_maxEntries is a size_t. On 32-bit architectures (e.g. armhf) size_t is 32-bit, so the designated-initializer assignment is a narrowing conversion, which clang rejects with -Wc++11-narrowing. Cast explicitly to size_t.
