### PR TITLE
dnsdist: Fix build readme - link, meson, mac brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See [README.md](pdns/recursordist/README.md) in `pdns/recursordist/`.
 
 Compiling dnsdist
 -----------------
-See [README-dnsdist.md](pdns/README-dnsdist.md) in `pdns/`.
+See [README.md](pdns/dnsdistdist/README.md) in `pdns/dnsdistdist`.
 
 Building the HTML documentation
 -------------------------------

--- a/pdns/dnsdistdist/README.md
+++ b/pdns/dnsdistdist/README.md
@@ -11,19 +11,35 @@ All `dnsdist` features are documented at [dnsdist.org](https://dnsdist.org).
 
 ## Compiling from git
 
-Make sure to `autoreconf -vi` before running `configure`.
+We are now using [Meson](https://mesonbuild.com/) to build dnsdist.
+
+Run `meson setup build`, then `meson compile -C build`.
+
+You can list meson options by running `meson configure`, then set them like this
+(for example for `yaml` option)
+
+`meson setup --reconfigure build -Dyaml=enabled`
+
+The default options for the various builds are in
+[builder-support/debian/dnsdist/](builder-support/debian/dnsdist) - for example
+[here for Debian bookworm](builder-support/debian/dnsdist/debian-bookworm/rules).
 
 ## macOS Notes
 
-Install dependencies from Homebrew:
+Install dependencies from Homebrew for the base build:
 
 ```sh
-brew install autoconf automake boost libedit libsodium libtool lua pkg-config protobuf
+brew install meson luajit pkg-config boost cmake libsodium ragel gnutls libnghttp2 cloudflare-quiche re2
 ```
 
-Let configure know where to find libedit, and openssl or libressl:
+You also need to install pyyaml globally (make sure you are using brew pip3, not the default system one)
 
 ```sh
-./configure 'PKG_CONFIG_PATH=/usr/local/opt/libedit/lib/pkgconfig:/usr/local/opt/libressl/lib/pkgconfig'
-make
+pip3 install pyyaml --break-system-packages
+```
+
+For yaml support (`-Dyaml=enabled`), you also need to install rust
+
+```sh
+brew install rust
 ```


### PR DESCRIPTION
### Short description
I fixed the readme for building dnsdist.

I didn't want to write Debian Linux instructions from scratch as I am not sure what all is needed there

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)