### PR TITLE
clang-tidy: Properly process newly created files

### DIFF
--- a/.github/scripts/clang-tidy.py
+++ b/.github/scripts/clang-tidy.py
@@ -91,10 +91,11 @@ def main():
         print(f"{level}: {rel_filename}:{line}: {message} ({name})")
 
         if gh_step_summary:
-            print(
-                f"- **{rel_filename}:{line}** {message} (`{name}`)",
-                file=summary_fp,
-            )
+            with open(gh_step_summary, "a", encoding="utf-8") as summary_fp:
+                print(
+                    f"- **{rel_filename}:{line}** {message} (`{name}`)",
+                    file=summary_fp,
+                )
 
         have_warnings = True
 

--- a/.github/scripts/git-filter.py
+++ b/.github/scripts/git-filter.py
@@ -52,7 +52,12 @@ def main():
         # - files that live in pdns/ and are used by several products (but
         #   possibly not with the same compilation flags, so it is actually
         #   important that they are processed for all products: pdns/misc.cc
-        path = Path(patch.path)
+        if patch.path in (None, "/dev/null") and patch.target_file not in (None, "/dev/null"):
+            # if this is a rename, prefer the target filename
+            path = Path(patch.target_file)
+        else:
+            path = Path(patch.path)
+
         if product == "auth":
             path = Path(cwd).joinpath(path)
         else:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
I noticed on a recent PR that our clang-tidy check was not processing newly created files, which is really a shame. I tracked it to the use of `unidiff` in `git-filter.py`, that determines the file affected by a given change by looking at the source, which git reports as `/dev/null` for newly created files. This has been fixed in recent versions of `unidiff` [1], but the version we use in CI does not have the fix, so this PR adds a test and switches to the destination of the change instead when the source is `/dev/null`, similarly to what has been done in `unidiff`. 

A second commit fixes a `ValueError: I/O operation on closed file` error in `clang-tidy.py` that I spotted while testing the first change.

[1]: https://github.com/matiasb/python-unidiff/pull/79

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
