### PR TITLE
ci: Fix clang-tidy workflow for dnsdist and recursor

### DIFF
--- a/.github/scripts/git-filter.py
+++ b/.github/scripts/git-filter.py
@@ -29,7 +29,7 @@ def create_argument_parser():
         "--database",
         type=str,
         required=False,
-        default='',
+        default="",
         help="Path to the directory where the compile_commands.json database can be found",
     )
     return parser.parse_args()

--- a/.github/scripts/git-filter.py
+++ b/.github/scripts/git-filter.py
@@ -25,6 +25,13 @@ def create_argument_parser():
         required=True,
         help="Product (auth, dnsdist or rec)",
     )
+    parser.add_argument(
+        "--database",
+        type=str,
+        required=False,
+        default='',
+        help="Path to the directory where the compile_commands.json database can be found",
+    )
     return parser.parse_args()
 
 
@@ -32,8 +39,8 @@ def main():
     """Start the script."""
     args = create_argument_parser()
     product = args.product
-
-    compdb = helpers.load_compdb("compile_commands.json")
+    compdb_path = os.path.join(args.database, "compile_commands.json")
+    compdb = helpers.load_compdb(compdb_path)
     compdb = helpers.index_compdb(compdb)
 
     cwd = Path(os.getcwd())

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -188,7 +188,7 @@ jobs:
     - name: Run clang-tidy for dnsdist
       if: matrix.product == 'dnsdist'
       working-directory: ./pdns/dnsdistdist/
-      run: git diff --no-prefix -U0 HEAD^..HEAD | /usr/bin/python3 ../../.github/scripts/git-filter.py --product dnsdist | /usr/bin/python3 ../../.github/scripts/clang-tidy-diff.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p0 -export-fixes clang-tidy-dnsdist.yml
+      run: git diff --no-prefix -U0 HEAD^..HEAD | /usr/bin/python3 ../../.github/scripts/git-filter.py --product dnsdist --database build | /usr/bin/python3 ../../.github/scripts/clang-tidy-diff.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p0 -export-fixes clang-tidy-dnsdist.yml
     - name: Print clang-tidy fixes YAML for dnsdist
       if: matrix.product == 'dnsdist'
       working-directory: ./pdns/dnsdistdist/
@@ -238,7 +238,7 @@ jobs:
     - name: Run clang-tidy for rec
       if: matrix.product == 'rec'
       working-directory: ./pdns/recursordist/
-      run: git diff --no-prefix -U0 HEAD^..HEAD | /usr/bin/python3 ../../.github/scripts/git-filter.py --product rec | /usr/bin/python3 ../../.github/scripts/clang-tidy-diff.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p0 -export-fixes clang-tidy-rec.yml
+      run: git diff --no-prefix -U0 HEAD^..HEAD | /usr/bin/python3 ../../.github/scripts/git-filter.py --product rec --database build | /usr/bin/python3 ../../.github/scripts/clang-tidy-diff.py -clang-tidy-binary /usr/bin/clang-tidy-${CLANG_VERSION} -extra-arg=-ferror-limit=0 -p0 -export-fixes clang-tidy-rec.yml
     - name: Print clang-tidy fixes YAML for rec
       if: matrix.product == 'rec'
       working-directory: ./pdns/recursordist/


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`git-filter` was no longer looking into the correct compilation database, likely since we removed autotools support.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
