### PR TITLE
auth-5.1: implement SOA-EDIT spreading + RRSIG expiry extension

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1869,6 +1869,20 @@ signing-secondary.
 
 See :ref:`metadata-slave-renotify` to set this per-zone.
 
+.. _setting-soa-edit-spread:
+
+``soa-edit-spread``
+-------------------
+
+.. versionadded:: 5.1.3
+
+-  Integer (seconds)
+-  Default: 0
+-  Valid range: 0..604800
+
+If set to a non-zero value, SOA-EDIT will apply serial increases to different zones at different times.
+Over the configured spread time, a time will be chosen for each zone based on a hash over the zone name (including variant).
+
 .. _setting-soa-expire-default:
 
 ``soa-expire-default``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1739,6 +1739,21 @@ Specify which random number generator to use. Permissible choices are:
 .. note::
   Not all choices are available on all systems.
 
+.. _setting-rrsig-expiry-extend:
+
+``rrsig-expiry-extend``
+-----------------------
+
+.. versionadded:: 5.1.3
+
+- Integer (seconds)
+- Default: ``soa-edit-spread``
+- Valid range: 0..31536000 (zero seconds to one year), or special value ``soa-edit-spread``
+
+Seconds to extend RRSIG expiry by.
+This is added to the default 3 week span described in :ref:`dnssec-signatures`.
+If set to ``soa-edit-spread`` (the default), this copies the value of :ref:`setting-soa-edit-spread`, extending all RRSIG expiries by that full number.
+
 .. _setting-secondary:
 
 ``secondary``

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -276,6 +276,7 @@ static void declareArguments()
   ::arg().set("default-soa-edit-signed", "Default SOA-EDIT value for signed zones") = "";
   ::arg().set("default-soa-edit-api", "Default SOA-EDIT-API value for new zones") = "DEFAULT";
   ::arg().set("soa-edit-spread", "Seconds to spread SOA-EDIT bumps over") = "0";
+  ::arg().set("rrsig-expiry-extend", "Seconds to extend RRSIG expiry by, or follow soa-edit-spread") = "soa-edit-spread";
   ::arg().set("dnssec-key-cache-ttl", "Seconds to cache DNSSEC keys from the database") = "30";
   ::arg().set("domain-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "";
   ::arg().set("zone-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "60";
@@ -807,6 +808,21 @@ static void mainthread()
 
     exit(1); // NOLINT(concurrency-mt-unsafe) we're single threaded at this point
   }
+
+  if (::arg()["rrsig-expiry-extend"] == "soa-edit-spread") {
+    g_rrsig_expiry_extend = g_soa_edit_spread;
+  }
+  else {
+    g_rrsig_expiry_extend = ::arg().asNum("rrsig-expiry-extend");
+
+    if (g_rrsig_expiry_extend > 31536000) {
+      SLOG(g_log << Logger::Error << "Value " << ::arg()["rrsig-expiry-extend"] << " for rrsig-expiry-extend too large" << endl,
+           slog->error(Logr::Error, "Out of range", "Invalid value", "rrsig-expiry-extend", Logging::Loggable(::arg()["rrsig-expiry-extend"])));
+
+      exit(1); // NOLINT(concurrency-mt-unsafe) we're single threaded at this point
+    }
+  }
+
 #ifdef HAVE_LUA_RECORDS
   g_doLuaRecord = ::arg().mustDo("enable-lua-records");
   g_LuaRecordSharedState = (::arg()["enable-lua-records"] == "shared");

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -275,6 +275,7 @@ static void declareArguments()
   ::arg().set("default-soa-edit", "Default SOA-EDIT value") = "";
   ::arg().set("default-soa-edit-signed", "Default SOA-EDIT value for signed zones") = "";
   ::arg().set("default-soa-edit-api", "Default SOA-EDIT-API value for new zones") = "DEFAULT";
+  ::arg().set("soa-edit-spread", "Seconds to spread SOA-EDIT bumps over") = "0";
   ::arg().set("dnssec-key-cache-ttl", "Seconds to cache DNSSEC keys from the database") = "30";
   ::arg().set("domain-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "";
   ::arg().set("zone-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "60";
@@ -799,6 +800,13 @@ static void mainthread()
   g_anyToTcp = ::arg().mustDo("any-to-tcp");
   g_8bitDNS = ::arg().mustDo("8bit-dns");
   g_logDNSQueries = ::arg().mustDo("log-dns-queries");
+  g_soa_edit_spread = ::arg().asNum("soa-edit-spread");
+  if (g_soa_edit_spread > 604800) {
+    SLOG(g_log << Logger::Error << "Value " << ::arg()["soa-edit-spread"] << " for soa-edit-spread too large" << endl,
+         slog->error(Logr::Error, "Out of range", "Invalid value", "soa-edit-spread", Logging::Loggable(::arg()["soa-edit-spread"])));
+
+    exit(1); // NOLINT(concurrency-mt-unsafe) we're single threaded at this point
+  }
 #ifdef HAVE_LUA_RECORDS
   g_doLuaRecord = ::arg().mustDo("enable-lua-records");
   g_LuaRecordSharedState = (::arg()["enable-lua-records"] == "shared");

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -52,6 +52,7 @@
 
 using namespace boost::assign;
 
+uint32_t g_rrsig_expiry_extend{0};
 uint32_t g_soa_edit_spread{0};
 
 std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCFile(Logr::log_t slog, DNSKEYRecordContent& drc, const char* fname)

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -19,6 +19,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#include <cstdint>
+#include <limits>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -49,6 +51,8 @@
 #include "misc.hh"
 
 using namespace boost::assign;
+
+uint32_t g_soa_edit_spread{0};
 
 std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCFile(Logr::log_t slog, DNSKEYRecordContent& drc, const char* fname)
 {
@@ -647,12 +651,36 @@ static DNSKEYRecordContent makeDNSKEYFromDNSCryptoKeyEngine(const std::shared_pt
   return drc;
 }
 
-uint32_t getStartOfWeek()
+// returns [startOfWeek, secondsSince]
+// startOfWeek is always 0:00 UTC on a Thursday
+// secondsSince is the number of seconds since that 0:00 UTC
+std::pair<uint32_t, uint32_t> getStartOfWeek()
 {
   // coverity[store_truncates_time_t]
   uint32_t now = time(nullptr);
-  now -= (now % (7*86400));
-  return now;
+  uint32_t secondsSince = (now % (7*86400));
+  return std::make_pair(now-secondsSince, secondsSince);
+}
+
+// if spreading is disabled: returns 0 (this means calling code behaves as before we introduced spreading)
+// if spreading is enabled: return the number of seconds since the 'week epoch' (thursday 0:00 UTC) that this zone should be soa-edit bumped at
+uint32_t weekSpreadDelay(const ZoneName& zone)
+{
+  if (g_soa_edit_spread == 0) {
+    return 0;
+  }
+
+  // uint32_t because our underlying burtleCI returns 32 bits
+  // don't change this to auto, it'll zero-extend the result which ends badly
+  uint32_t zonehash = zone.hash();
+
+  static_assert(sizeof(zonehash) == 4, "our burtleCI is 32 bits so this also needs to be 32 bits");
+
+  // this stacked division does two things:
+  // (1) take the zonehash value as an ordering, independent of the configured spread
+  // (2) stretch/compress (depending on how you look at it) this ordered list to the given number of spread seconds
+  auto spreaddelay = zonehash / (std::numeric_limits<decltype(zonehash)>::max() / g_soa_edit_spread);
+  return spreaddelay;
 }
 
 string hashQNameWithSalt(const NSEC3PARAMRecordContent& ns3prc, const DNSName& qname)

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -23,6 +23,7 @@
 #include "dnsrecords.hh"
 #include "dnspacket.hh"
 
+#include <cstddef>
 #include <string>
 #include <vector>
 #include <optional>
@@ -285,7 +286,8 @@ DSRecordContent makeDSFromDNSKey(Logr::log_t slog, const DNSName& qname, const D
 
 class DNSSECKeeper;
 
-uint32_t getStartOfWeek();
+std::pair<uint32_t, uint32_t> getStartOfWeek();
+uint32_t weekSpreadDelay(const ZoneName& zone);
 
 string hashQNameWithSalt(const NSEC3PARAMRecordContent& ns3prc, const DNSName& qname);
 string hashQNameWithSalt(const std::string& salt, unsigned int iterations, const DNSName& qname);
@@ -299,3 +301,5 @@ void addTSIG(Logr::log_t slog, DNSPacketWriter& pw, TSIGRecordContent& trc, cons
 bool validateTSIG(Logr::log_t slog, const std::string& packet, size_t sigPos, const TSIGTriplet& tt, const TSIGRecordContent& trc, const std::string& previousMAC, const std::string& theirMAC, bool timersOnly, unsigned int dnsHeaderOffset=0);
 
 uint64_t signatureCacheSize(const std::string& str);
+
+extern uint32_t g_soa_edit_spread;

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -302,4 +302,5 @@ bool validateTSIG(Logr::log_t slog, const std::string& packet, size_t sigPos, co
 
 uint64_t signatureCacheSize(const std::string& str);
 
+extern uint32_t g_rrsig_expiry_extend;
 extern uint32_t g_soa_edit_spread;

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -115,7 +115,7 @@ static int getRRSIGsForRRSET(DNSSECKeeper& dsk, const ZoneName& signer, const DN
 {
   if(toSign.empty())
     return -1;
-  uint32_t startOfWeek = getStartOfWeek();
+  auto [startOfWeek, _] = getStartOfWeek();
   RRSIGRecordContent rrc;
   rrc.d_type=signQType;
 

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -122,7 +122,7 @@ static int getRRSIGsForRRSET(DNSSECKeeper& dsk, const ZoneName& signer, const DN
   rrc.d_labels=signQName.countLabels()-signQName.isWildcard();
   rrc.d_originalttl=signTTL;
   rrc.d_siginception=startOfWeek - 7*86400; // XXX should come from zone metadata
-  rrc.d_sigexpire=startOfWeek + 14*86400;
+  rrc.d_sigexpire=startOfWeek + 14*86400 + g_rrsig_expiry_extend;
   rrc.d_signer = signer.operator const DNSName&();
   rrc.d_tag = 0;
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -753,6 +753,7 @@ static void loadMainConfig(const std::string& configdir)
   ::arg().set("domain-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "0";
   ::arg().set("zone-metadata-cache-ttl", "Seconds to cache zone metadata from the database") = "60";
   ::arg().set("consistent-backends", "Assume individual zones are not divided over backends. Send only ANY lookup operations to the backend to reduce the number of lookups") = "yes";
+  ::arg().set("soa-edit-spread", "Seconds to spread SOA-EDIT bumps over") = "0";
 
   // Keep this line below all ::arg().set() statements
   if (! ::arg().laxFile(configname)) {
@@ -3343,6 +3344,16 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
       // for scripts to know that something is odd here
       return false;
     }
+  }
+
+  g_soa_edit_spread = ::arg().asNum("soa-edit-spread");
+  if (g_verbose && g_soa_edit_spread > 0) {
+    auto [inception, _] = getStartOfWeek();
+    auto delay = weekSpreadDelay(zone);
+    time_t bumpTt = inception + delay;
+    std::tm bumpTm{};
+    localtime_r(&bumpTt, &bumpTm);
+    cout << "soa-edit spread delay: " << delay << " (change time " << std::put_time(&bumpTm, "%c %Z") << ")" << endl;
   }
 
   NSEC3PARAMRecordContent ns3pr;

--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -41,7 +41,8 @@ uint32_t localtime_format_YYYYMMDDSS(time_t t, uint32_t seq)
 uint32_t calculateEditSOA(uint32_t old_serial, const string& kind, const ZoneName& zonename, Logr::log_t slog)
 {
   if(pdns_iequals(kind,"INCEPTION-INCREMENT")) {
-    time_t inception = getStartOfWeek();
+    auto [inception, secondsSince] = getStartOfWeek();
+    if (weekSpreadDelay(zonename) > secondsSince) { inception -= 7*86400; }
     uint32_t inception_serial = localtime_format_YYYYMMDDSS(inception, 1);
     uint32_t dont_increment_after = localtime_format_YYYYMMDDSS(inception + 2*86400, 99);
 
@@ -55,7 +56,8 @@ uint32_t calculateEditSOA(uint32_t old_serial, const string& kind, const ZoneNam
     }
   }
   else if(pdns_iequals(kind,"INCREMENT-WEEKS")) {
-    time_t inception = getStartOfWeek();
+    auto [inception, secondsSince] = getStartOfWeek();
+    if (weekSpreadDelay(zonename) > secondsSince) { inception -= 7*86400; }
     return (old_serial + (inception / (7*86400)));
   }
   else if(pdns_iequals(kind,"EPOCH")) {
@@ -63,7 +65,8 @@ uint32_t calculateEditSOA(uint32_t old_serial, const string& kind, const ZoneNam
     return time(nullptr);
   }
   else if(pdns_iequals(kind,"INCEPTION-EPOCH")) {
-    uint32_t inception = getStartOfWeek();
+    auto [inception, secondsSince] = getStartOfWeek();
+    if (weekSpreadDelay(zonename) > secondsSince) { inception -= 7*86400; }
     if (old_serial < inception)
       return inception;
   }

--- a/regression-tests.auth-py/runtests
+++ b/regression-tests.auth-py/runtests
@@ -24,6 +24,18 @@ export PDNSUTIL=${PDNSUTIL:-$PDNS_BUILD_PATH/pdnsutil}
 export PDNSCONTROL=${PDNSCONTROL:-$PDNS_BUILD_PATH/pdns_control}
 export PDNS_MODULE_DIR=${PDNS_MODULE_DIR:-$PDNS_BUILD_PATH/modules}
 
+LIBFAKETIME_DEFAULT=/usr/local/lib/faketime/libfaketimeMT.so.1 # location after building and installing from https://github.com/wolfcw/libfaketime
+if [ $(uname -s) = "Darwin" ]; then
+  # macOS is not /really/ supported here; it works for some tests, and then you might need sudo.
+  LIBFAKETIME_DEFAULT=/usr/local/lib/faketime/libfaketime.1.dylib
+fi
+if [ $(uname -s) = "OpenBSD" ]; then
+  # OpenBSD is not /really/ supported here; it works for some tests, and then you might need doas.
+  LIBFAKETIME_DEFAULT=""
+fi
+
+export LIBFAKETIME=${LIBFAKETIME:-$LIBFAKETIME_DEFAULT}
+
 export PREFIX=127.0.0
 
 for bin in "$PDNS" "$PDNSUTIL"; do

--- a/regression-tests.auth-py/test_SoaEdit.py
+++ b/regression-tests.auth-py/test_SoaEdit.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+import collections
+import dns
+import os
+import socket
+import subprocess
+import time
+from authtests import AuthTest
+
+
+class TestSoaEditSpreadBase(AuthTest):
+    # 1.example.org hashes to 0.860233, or '8 seconds' under a 10 seconds spread
+    # 2.example.org hashes to 0.121543, or '1 second' under a 10 second spread
+    _zones = {
+        "1.example.org": """
+1.example.org.                 3600 IN SOA     {soa}
+1.example.org.                 3600 IN NS      ns1.1.example.org.
+1.example.org.                 3600 IN NS      ns2.1.example.org.
+ns1.1.example.org.             3600 IN A       192.0.2.1
+ns2.1.example.org.             3600 IN A       192.0.2.2
+        """,
+        "2.example.org": """
+2.example.org.                 3600 IN SOA     {soa}
+2.example.org.                 3600 IN NS      ns1.2.example.org.
+2.example.org.                 3600 IN NS      ns2.2.example.org.
+ns1.2.example.org.             3600 IN A       192.0.2.1
+ns2.2.example.org.             3600 IN A       192.0.2.2
+        """,
+    }
+
+    _zone_keys = {
+        "1.example.org": """
+Private-key-format: v1.2
+Algorithm: 13 (ECDSAP256SHA256)
+PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
+        """,
+        "2.example.org": """
+Private-key-format: v1.2
+Algorithm: 13 (ECDSAP256SHA256)
+PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
+        """,
+    }
+
+    _auth_env = {"LD_PRELOAD": os.environ.get("LIBFAKETIME"), "FAKETIME": "@2025-12-25 00:00:00", "TZ": "UTC"}
+
+    def testSOAQuery(self):
+        """Test to verify SOA serials are served correctly"""
+
+        serials = collections.defaultdict(list)
+        done = False
+
+        for i in range(15):
+            for j in [1, 2]:
+                query = dns.message.make_query(f"{j}.example.org", "SOA", use_edns=True)
+                res = self.sendUDPQuery(query)
+
+                # Ensure no error in response
+                self.assertRcodeEqual(res, dns.rcode.NOERROR)
+
+                # Validate SOA record
+                soa_found = any(rrset.rdtype == dns.rdatatype.SOA for rrset in res.answer)
+                self.assertTrue(soa_found, "SOA record not found in the answer section")
+
+                serials[j].append(res.answer[0][0].serial)
+                self.assertListEqual(serials[j], sorted(serials[j]))
+
+            if set(serials[1]) == self.expected and set(serials[2]) == self.expected:
+                done = True
+                break
+
+            time.sleep(1)
+
+        print(serials)
+
+        self.assertTrue(done, serials)
+
+    def testPdnsutilDelay(self):
+        """Test to verify that the calculated delay is correct"""
+
+        for i, delay in [(1, 8), (2, 1)]:
+            pdnsutilCmd = [
+                os.environ["PDNSUTIL"],
+                "--config-dir=%s" % os.path.join("configs", self._confdir),
+                "zone",
+                "show",
+                "-v",
+                f"{i}.example.org",
+            ]
+
+            print(" ".join(pdnsutilCmd))
+            try:
+                output = subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as e:
+                raise AssertionError("%s failed (%d): %s" % (pdnsutilCmd, e.returncode, e.output))
+
+            print(output)
+
+            spreadline = list(filter(lambda x: x.startswith(b"soa-edit spread delay: "), output.split(b"\n")))[0]
+            sdelay = int(spreadline.split()[3])
+            self.assertEqual(sdelay, delay)
+
+
+class TestSoaEditSpreadInceptionIncrement(TestSoaEditSpreadBase):
+    _config_template = """
+launch={backend}
+default-soa-edit=INCEPTION-INCREMENT
+soa-edit-spread=10
+    """
+
+    expected = {2025121801, 2025122501}
+
+
+class TestSoaEditSpreadIncrementWeeks(TestSoaEditSpreadBase):
+    _config_template = """
+launch={backend}
+default-soa-edit=INCREMENT-WEEKS
+soa-edit-spread=10
+    """
+
+    expected = {2921, 2922}
+
+
+class TestSoaEditSpreadInceptionEpoch(TestSoaEditSpreadBase):
+    _config_template = """
+launch={backend}
+default-soa-edit=INCEPTION-EPOCH
+soa-edit-spread=10
+    """
+
+    expected = {2920*604800, 2921*604800}
+
+
+# with thanks to https://adamj.eu/tech/2025/05/30/python-unittest-common-tests/
+del TestSoaEditSpreadBase  # Hide base class from test discovery

--- a/regression-tests.auth-py/test_SoaEdit.py
+++ b/regression-tests.auth-py/test_SoaEdit.py
@@ -42,7 +42,7 @@ PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
         """,
     }
 
-    _auth_env = {"LD_PRELOAD": os.environ.get("LIBFAKETIME"), "FAKETIME": "@2025-12-25 00:00:00", "TZ": "UTC"}
+    _auth_env = {"LD_PRELOAD": os.environ.get("LIBFAKETIME"), "FAKETIME": "@2025-12-24 23:59:55", "TZ": "UTC"}
 
     def testSOAQuery(self):
         """Test to verify SOA serials are served correctly"""
@@ -50,7 +50,7 @@ PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
         serials = collections.defaultdict(list)
         done = False
 
-        for i in range(15):
+        for i in range(20):
             for j in [1, 2]:
                 query = dns.message.make_query(f"{j}.example.org", "SOA", use_edns=True, want_dnssec=True)
                 res = self.sendUDPQuery(query)
@@ -64,9 +64,10 @@ PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
                 serials[j].append(soa[0].serial)
                 self.assertListEqual(serials[j], sorted(serials[j]))
                 print(rrsig[0].expiration)
-                self.assertEqual(
-                    rrsig[0].expiration, 1767830400 + self.extend
-                )  # 2026-01-08 00:00:00 UTC + self.extend, or two weeks plus self.extend seconds after our FAKETIME
+                self.assertIn(
+                    rrsig[0].expiration, (1767830400 + self.extend, 1767830400 + self.extend - 604800)
+                )  # 2026-01-08 00:00:00 UTC + self.extend, that is two weeks plus self.extend seconds after our FAKETIME
+                # or one week earlier since we start running a bit before midnight
 
             if set(serials[1]) == self.expected and set(serials[2]) == self.expected:
                 done = True

--- a/regression-tests.auth-py/test_SoaEdit.py
+++ b/regression-tests.auth-py/test_SoaEdit.py
@@ -52,18 +52,21 @@ PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
 
         for i in range(15):
             for j in [1, 2]:
-                query = dns.message.make_query(f"{j}.example.org", "SOA", use_edns=True)
+                query = dns.message.make_query(f"{j}.example.org", "SOA", use_edns=True, want_dnssec=True)
                 res = self.sendUDPQuery(query)
 
                 # Ensure no error in response
                 self.assertRcodeEqual(res, dns.rcode.NOERROR)
 
-                # Validate SOA record
-                soa_found = any(rrset.rdtype == dns.rdatatype.SOA for rrset in res.answer)
-                self.assertTrue(soa_found, "SOA record not found in the answer section")
+                soa = list(filter(lambda rrset: rrset.rdtype == dns.rdatatype.SOA, res.answer))[0]
+                rrsig = list(filter(lambda rrset: rrset.rdtype == dns.rdatatype.RRSIG, res.answer))[0]
 
-                serials[j].append(res.answer[0][0].serial)
+                serials[j].append(soa[0].serial)
                 self.assertListEqual(serials[j], sorted(serials[j]))
+                print(rrsig[0].expiration)
+                self.assertEqual(
+                    rrsig[0].expiration, 1767830400 + self.extend
+                )  # 2026-01-08 00:00:00 UTC + self.extend, or two weeks plus self.extend seconds after our FAKETIME
 
             if set(serials[1]) == self.expected and set(serials[2]) == self.expected:
                 done = True
@@ -106,9 +109,11 @@ class TestSoaEditSpreadInceptionIncrement(TestSoaEditSpreadBase):
 launch={backend}
 default-soa-edit=INCEPTION-INCREMENT
 soa-edit-spread=10
+rrsig-expiry-extend=20
     """
 
     expected = {2025121801, 2025122501}
+    extend = 20
 
 
 class TestSoaEditSpreadIncrementWeeks(TestSoaEditSpreadBase):
@@ -119,6 +124,7 @@ soa-edit-spread=10
     """
 
     expected = {2921, 2922}
+    extend = 10
 
 
 class TestSoaEditSpreadInceptionEpoch(TestSoaEditSpreadBase):
@@ -128,7 +134,8 @@ default-soa-edit=INCEPTION-EPOCH
 soa-edit-spread=10
     """
 
-    expected = {2920*604800, 2921*604800}
+    expected = {2920 * 604800, 2921 * 604800}
+    extend = 10
 
 
 # with thanks to https://adamj.eu/tech/2025/05/30/python-unittest-common-tests/

--- a/regression-tests.recursor-dnssec/runtests
+++ b/regression-tests.recursor-dnssec/runtests
@@ -43,7 +43,7 @@ if [ $(uname -s) = "Darwin" ]; then
   LIBAUTHBIND_DEFAULT=""
 fi
 if [ $(uname -s) = "OpenBSD" ]; then
-  # OpenBSD is not /really/ supported here; it works for some tests, and then you might need sudo.
+  # OpenBSD is not /really/ supported here; it works for some tests, and then you might need doas.
   LIBFAKETIME_DEFAULT=""
   LIBAUTHBIND_DEFAULT=""
 fi


### PR DESCRIPTION
### Short description
backport of #17281. Docs in that PR note the feature as available from version 5.1.3

now also contains #17583 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
