### PR TITLE
soa-edit-spread test: start measuring earlier

### DIFF
--- a/regression-tests.auth-py/test_SoaEdit.py
+++ b/regression-tests.auth-py/test_SoaEdit.py
@@ -42,7 +42,7 @@ PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
         """,
     }
 
-    _auth_env = {"LD_PRELOAD": os.environ.get("LIBFAKETIME"), "FAKETIME": "@2025-12-25 00:00:00", "TZ": "UTC"}
+    _auth_env = {"LD_PRELOAD": os.environ.get("LIBFAKETIME"), "FAKETIME": "@2025-12-24 23:59:55", "TZ": "UTC"}
 
     def testSOAQuery(self):
         """Test to verify SOA serials are served correctly"""
@@ -50,7 +50,7 @@ PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
         serials = collections.defaultdict(list)
         done = False
 
-        for i in range(15):
+        for i in range(20):
             for j in [1, 2]:
                 query = dns.message.make_query(f"{j}.example.org", "SOA", use_edns=True, want_dnssec=True)
                 res = self.sendUDPQuery(query)
@@ -64,9 +64,10 @@ PrivateKey: Lt0v0Gol3pRUFM7fDdcy0IWN0O/MnEmVPA+VylL8Y4U=
                 serials[j].append(soa[0].serial)
                 self.assertListEqual(serials[j], sorted(serials[j]))
                 print(rrsig[0].expiration)
-                self.assertEqual(
-                    rrsig[0].expiration, 1767830400 + self.extend
-                )  # 2026-01-08 00:00:00 UTC + self.extend, or two weeks plus self.extend seconds after our FAKETIME
+                self.assertIn(
+                    rrsig[0].expiration, (1767830400 + self.extend, 1767830400 + self.extend - 604800)
+                )  # 2026-01-08 00:00:00 UTC + self.extend, that is two weeks plus self.extend seconds after our FAKETIME
+                # or one week earlier since we start running a bit before midnight
 
             if set(serials[1]) == self.expected and set(serials[2]) == self.expected:
                 done = True


### PR DESCRIPTION
### Short description
Because Miod spotted

```
AssertionError: False is not true : defaultdict(<class 'list'>, {1: [2025121801, 2025121801, 2025121801, 2025121801, 2025121801, 2025121801, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501], 2: [2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501, 2025122501]})
```

in a test run, and the 2-series starting with ..2501 means we completely missed the window to see the old serial. This PR extends that window from 2 to 7 seconds.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
