### PR TITLE
auth REST API: escaping issue with generic record syntax

### DIFF
--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -459,6 +459,22 @@ class AuthZones(ZonesApiTestCase, AuthZonesHelperMixin):
             ],
         )
 
+    def test_create_zone_with_generic_records(self):
+        name = unique_zone_name()
+        rrset = {
+            "name": name,
+            "type": "TYPE1234",
+            "ttl": 3600,
+            "records": [{
+                "content": "\\# 2 4142",
+                "disabled": False,
+            }],
+        }
+        name, payload, data = self.create_zone(name=name, rrsets=[rrset])
+        # check our record has appeared
+        self.assertEqual(get_rrset(data, name, 'TYPE1234')['records'], rrset['records'])
+
+
     def test_create_zone_with_wildcard_records(self):
         name = unique_zone_name()
         rrset = {


### PR DESCRIPTION
### Short description
Reported by a user on IRC. This PR right now only contains a failing test. A quick bisect with this test shows, unsurprisingly:

```
f9d59a1afef30814b95aff4635ca84e49bb733d0 is the first bad commit
commit f9d59a1afef30814b95aff4635ca84e49bb733d0
Author: Miod Vallat <miod.vallat@powerdns.com>
Date:   Wed Aug 20 10:48:44 2025 +0200

    Perform normalization of record data received in the REST API.
```

so I guess we missed a case.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
