### PR TITLE
auth REST API: escaping issue with generic record syntax

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -70,11 +70,14 @@ UnknownRecordContent::UnknownRecordContent(const string& zone)
 string UnknownRecordContent::getZoneRepresentation(bool /* noDot */) const
 {
   ostringstream str;
-  str<<"\\# "<<(unsigned int)d_record.size()<<" ";
-  char hex[4];
-  for (unsigned char n : d_record) {
-    snprintf(hex, sizeof(hex), "%02x", n);
-    str << hex;
+  str<<"\\# "<<(unsigned int)d_record.size();
+  if (!d_record.empty()) {
+    char hex[4];
+    str<<" ";
+    for (unsigned char n : d_record) {
+      snprintf(hex, sizeof(hex), "%02x", n);
+      str << hex;
+    }
   }
   return str.str();
 }

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -72,11 +72,11 @@ string UnknownRecordContent::getZoneRepresentation(bool /* noDot */) const
   ostringstream str;
   str<<"\\# "<<(unsigned int)d_record.size();
   if (!d_record.empty()) {
-    char hex[4];
-    str<<" ";
-    for (unsigned char n : d_record) {
-      snprintf(hex, sizeof(hex), "%02x", n);
-      str << hex;
+    std::array<char,4> hex{};
+    str << " ";
+    for (auto byte : d_record) {
+      snprintf(hex.data(), hex.size(), "%02x", byte);
+      str << hex.data();
     }
   }
   return str.str();

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -714,12 +714,14 @@ static void gatherRecords(const Json& container, const DNSName& qname, const QTy
   const auto& items = container["records"].array_items();
   for (const auto& record : items) {
     string content = stringFromJson(record, "content");
-    switch (resourceRecord.qtype.getCode()) {
+    switch (qtype.getCode()) {
     case QType::LUA:
       // Keep LUA record contents unmodified
       break;
     default:
-      content = normalizeJsonString(content);
+      if (!DNSRecordContent::isUnknownType(DNSRecordContent::NumberToType(qtype.getCode()))) {
+        content = normalizeJsonString(content);
+      }
       break;
     }
     if (record.object_items().count("priority") > 0) {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -461,7 +461,7 @@ class AuthZones(ZonesApiTestCase, AuthZonesHelperMixin):
 
     def test_create_zone_with_generic_records(self):
         name = unique_zone_name()
-        rrset = {
+        rrset1 = {
             "name": name,
             "type": "TYPE65420",
             "ttl": 3600,
@@ -472,9 +472,21 @@ class AuthZones(ZonesApiTestCase, AuthZonesHelperMixin):
                 }
             ],
         }
-        name, payload, data = self.create_zone(name=name, rrsets=[rrset])
+        rrset2 = {
+            "name": name,
+            "type": "TYPE65421",
+            "ttl": 3600,
+            "records": [
+                {
+                    "content": "\\# 0",
+                    "disabled": False,
+                }
+            ],
+        }
+        name, payload, data = self.create_zone(name=name, rrsets=[rrset1, rrset2])
         # check our record has appeared
-        self.assertEqual(get_rrset(data, name, "TYPE65420")["records"], rrset["records"])
+        self.assertEqual(get_rrset(data, name, "TYPE65420")["records"], rrset1["records"])
+        self.assertEqual(get_rrset(data, name, "TYPE65421")["records"][0]["content"], "\\# 0")
 
     def test_create_zone_with_wildcard_records(self):
         name = unique_zone_name()

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -459,6 +459,23 @@ class AuthZones(ZonesApiTestCase, AuthZonesHelperMixin):
             ],
         )
 
+    def test_create_zone_with_generic_records(self):
+        name = unique_zone_name()
+        rrset = {
+            "name": name,
+            "type": "TYPE65420",
+            "ttl": 3600,
+            "records": [
+                {
+                    "content": "\\# 2 4142",
+                    "disabled": False,
+                }
+            ],
+        }
+        name, payload, data = self.create_zone(name=name, rrsets=[rrset])
+        # check our record has appeared
+        self.assertEqual(get_rrset(data, name, "TYPE65420")["records"], rrset["records"])
+
     def test_create_zone_with_wildcard_records(self):
         name = unique_zone_name()
         rrset = {


### PR DESCRIPTION
### Short description
The introduction of record content normalization in the API turned out to break unknown record contents by incorrectly turning the `\#` header into a single `#`. This is fixed in this PR.

Supersedes #17585 (I couldn't push to @Habbie's branch).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
