### PR TITLE
Reject numerical record type values which do not fit in 16 bits

### DIFF
--- a/pdns/qtype.cc
+++ b/pdns/qtype.cc
@@ -147,14 +147,24 @@ uint16_t QType::chartocode(const char *p)
   if (num != names.cend()) {
     return num->second;
   }
+
+  const char *digits{nullptr};
   if (*p == '#') {
-    return static_cast<uint16_t>(atoi(p + 1));
+    digits = p + 1; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
-
-  if (boost::starts_with(P, "TYPE")) {
-    return static_cast<uint16_t>(atoi(p + 4));
+  else if (boost::starts_with(P, "TYPE")) {
+    digits = p + 4; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
-
+  if (digits != nullptr) {
+   // We would ideally return pdns::checked_stoi<uint16_t>(digits) here, but
+   // not all callers are ready to handle exceptions arising here.
+   char *end{nullptr};
+   unsigned long typeno = strtoul(digits, &end, 10);
+   if (typeno <= std::numeric_limits<uint16_t>::max() && end != digits && (*end == '\0' || isspace(static_cast<int>(*end)) != 0)) {
+     return typeno;
+   }
+  }
+  // Similarly, we would ideally throw std::invalid_argument here, but won't yet.
   return 0;
 }
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -93,6 +93,7 @@ double Ewma::getMax() const
   return d_max;
 }
 
+static void parseRecordNameAndType(const Json& rrset, DNSName& qname, QType& qtype);
 static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInfo& domainInfo, const vector<Json>& rrsets, HttpResponse* resp);
 
 AuthWebServer::AuthWebServer() :
@@ -2047,13 +2048,9 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   try {
     if (rrsets.is_array()) {
       for (const auto& rrset : rrsets.array_items()) {
-        DNSName qname = apiNameToDNSName(stringFromJson(rrset, "name"));
-        apiCheckQNameAllowedCharacters(qname.toString());
+        DNSName qname;
         QType qtype;
-        qtype = stringFromJson(rrset, "type");
-        if (qtype.getCode() == 0) {
-          throw ApiException("RRset " + qname.toString() + " IN " + stringFromJson(rrset, "type") + ": unknown type given");
-        }
+        parseRecordNameAndType(rrset, qname, qtype);
         if (rrset["records"].is_array()) {
           uint32_t ttl = uintFromJson(rrset, "ttl");
           gatherRecords(rrset, qname, qtype, ttl, new_records);
@@ -2276,13 +2273,9 @@ static void apiServerZoneDetailPUT(HttpRequest* req, HttpResponse* resp)
 
     try {
       for (const auto& rrset : rrsets.array_items()) {
-        DNSName qname = apiNameToDNSName(stringFromJson(rrset, "name"));
-        apiCheckQNameAllowedCharacters(qname.toString());
+        DNSName qname;
         QType qtype;
-        qtype = stringFromJson(rrset, "type");
-        if (qtype.getCode() == 0) {
-          throw ApiException("RRset " + qname.toString() + " IN " + stringFromJson(rrset, "type") + ": unknown type given");
-        }
+        parseRecordNameAndType(rrset, qname, qtype);
         if (rrset["records"].is_array()) {
           uint32_t ttl = uintFromJson(rrset, "ttl");
           gatherRecords(rrset, qname, qtype, ttl, new_records);


### PR DESCRIPTION
### Short description
We would accept e.g. TYPE131071 as an alias for TYPE65535 due to silent truncation of the parsed number.

This PR changes this behaviour and will raise an exception for invalid numbers.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
