### PR TITLE
dnsdist: Fix out-of-bounds read in SetMacAddrAction

### DIFF
--- a/pdns/dnsdistdist/dnsdist-actions-factory.cc
+++ b/pdns/dnsdistdist/dnsdist-actions-factory.cc
@@ -986,9 +986,10 @@ public:
       return Action::None;
     }
 
-    std::string optRData;
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    generateEDNSOption(d_code, reinterpret_cast<const char*>(mac.data()), optRData);
+    std::string macStr(reinterpret_cast<const char*>(mac.data()), mac.size());
+    std::string optRData;
+    generateEDNSOption(d_code, macStr, optRData);
 
     if (dnsquestion->getHeader()->arcount > 0) {
       bool ednsAdded = false;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We would like to thank Qifan Zhang (Palo Alto Networks) for bringing this issue to our attention.

CVE-2026-40210

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
