### PR TITLE
dnsdist: Better handling of invalid SOA in IXFR queries

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -216,6 +216,10 @@ static bool getSerialFromIXFRQuery(TCPQuery& query)
     DEBUGLOG("Exception when parsing IXFR TCP Query to DNS: " << e.what());
     /* ponder what to do here, shall we close the connection? */
   }
+  catch (const std::exception& exp) {
+    DEBUGLOG("Exception when parsing IXFR TCP Query to DNS: " << exp.what());
+    /* ponder what to do here, shall we close the connection? */
+  }
 
   return false;
 }
@@ -575,13 +579,13 @@ void TCPConnectionToBackend::queueQuery(std::shared_ptr<TCPQuerySender>& sender,
   // start sending the query
   if (d_state == State::idle || d_state == State::waitingForResponseFromBackend) {
     DEBUGLOG("Sending new query to backend right away, with ID " << d_highestStreamID);
-    d_state = State::sendingQueryToBackend;
     d_currentPos = 0;
 
     uint16_t id = d_highestStreamID;
 
     d_currentQuery = PendingRequest({sender, std::move(query)});
     prepareQueryForSending(d_currentQuery.d_query, id, needProxyProtocolPayload() ? ConnectionState::needProxy : ConnectionState::proxySent);
+    d_state = State::sendingQueryToBackend;
 
     struct timeval now;
     gettimeofday(&now, 0);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This fixes an issue if the incoming `XIFR` query has an invalid `SOA`, and the exception raised by the parser could cause the outgoing connection to the backend to not being released immediately, instead waiting until a timeout occurs. This can be used to cause a denial of service if there is a limit to the number of concurrent connections to this backend, or if we run out of file descriptors quickly.

We would like to thank Qifan Zhang (Palo Alto Networks) for bringing this issue to our attention.

CVE-2026-40209

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
