### PR TITLE
dnsdist: Properly handle bogus DATA frame for DoH3 GET streams

### DIFF
--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -862,14 +862,13 @@ static void processH3DataEvent(ClientState& clientState, DOH3Frontend& frontend,
     }
     auto& headers = headersIt->second;
     {
-      auto methodIt = headers.find(":method");
-      if (methodIt == headers.end() || methodIt->second != "POST") {
+      if (auto methodIt = headers.find(":method"); methodIt == headers.end() || methodIt->second != "POST") {
         handleImmediateError("DATA frame for non-POST method");
         return;
       }
     }
-    auto contentTypeHeaderIt = headers.find("content-type");
-    if (contentTypeHeaderIt == headers.end() || contentTypeHeaderIt->second != "application/dns-message") {
+
+    if (auto contentTypeHeaderIt = headers.find("content-type"); contentTypeHeaderIt == headers.end() || contentTypeHeaderIt->second != "application/dns-message") {
       handleImmediateError("Unsupported content-type");
       return;
     }

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -868,7 +868,8 @@ static void processH3DataEvent(ClientState& clientState, DOH3Frontend& frontend,
         return;
       }
     }
-    if (headers.count("content-type") == 0 || headers.at("content-type") != "application/dns-message") {
+    auto contentTypeHeaderIt = headers.find("content-type");
+    if (contentTypeHeaderIt == headers.end() || contentTypeHeaderIt->second != "application/dns-message") {
       handleImmediateError("Unsupported content-type");
       return;
     }

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -772,7 +772,7 @@ static void processH3HeaderEvent(ClientState& clientState, DOH3Frontend& fronten
   };
 
   try {
-    auto& headers = conn.d_headersBuffers.at(streamID);
+    auto& headers = conn.d_headersBuffers[streamID];
     // Callback result. Any value other than 0 will interrupt further header processing.
     int cbresult = quiche_h3_event_for_each_header(
       event,
@@ -855,13 +855,19 @@ static void processH3DataEvent(ClientState& clientState, DOH3Frontend& frontend,
   };
 
   try {
-    auto& headers = conn.d_headersBuffers.at(streamID);
-
-    if (headers.at(":method") != "POST") {
-      handleImmediateError("DATA frame for non-POST method");
+    auto headersIt = conn.d_headersBuffers.find(streamID);
+    if (headersIt == conn.d_headersBuffers.end()) {
+      handleImmediateError("DATA frame for stream without headers");
       return;
     }
-
+    auto& headers = headersIt->second;
+    {
+      auto methodIt = headers.find(":method");
+      if (methodIt == headers.end() || methodIt->second != "POST") {
+        handleImmediateError("DATA frame for non-POST method");
+        return;
+      }
+    }
     if (headers.count("content-type") == 0 || headers.at("content-type") != "application/dns-message") {
       handleImmediateError("Unsupported content-type");
       return;
@@ -924,26 +930,32 @@ static void processH3Events(ClientState& clientState, DOH3Frontend& frontend, H3
     if (streamID < 0) {
       break;
     }
-    std::unique_ptr<quiche_h3_event, decltype(&quiche_h3_event_free)> eventPtr(event, quiche_h3_event_free);
-    event = nullptr;
-    conn.d_headersBuffers.try_emplace(streamID, dnsdist::doh3::h3_headers_t{});
 
-    switch (quiche_h3_event_type(eventPtr.get())) {
-    case QUICHE_H3_EVENT_HEADERS: {
-      processH3HeaderEvent(clientState, frontend, conn, client, serverConnID, streamID, eventPtr.get());
-      break;
+    try {
+      std::unique_ptr<quiche_h3_event, decltype(&quiche_h3_event_free)> eventPtr(event, quiche_h3_event_free);
+      event = nullptr;
+
+      switch (quiche_h3_event_type(eventPtr.get())) {
+      case QUICHE_H3_EVENT_HEADERS: {
+        processH3HeaderEvent(clientState, frontend, conn, client, serverConnID, streamID, eventPtr.get());
+        break;
+      }
+      case QUICHE_H3_EVENT_DATA: {
+        processH3DataEvent(clientState, frontend, conn, client, serverConnID, streamID, buffer);
+        break;
+      }
+      case QUICHE_H3_EVENT_FINISHED:
+      case QUICHE_H3_EVENT_RESET:
+        conn.removeTemporaryQueryContent(streamID);
+        break;
+      case QUICHE_H3_EVENT_PRIORITY_UPDATE:
+      case QUICHE_H3_EVENT_GOAWAY:
+        break;
+      }
     }
-    case QUICHE_H3_EVENT_DATA: {
-      processH3DataEvent(clientState, frontend, conn, client, serverConnID, streamID, buffer);
-      break;
-    }
-    case QUICHE_H3_EVENT_FINISHED:
-    case QUICHE_H3_EVENT_RESET:
-      conn.removeTemporaryQueryContent(streamID);
-      break;
-    case QUICHE_H3_EVENT_GOAWAY:
-    case QUICHE_H3_EVENT_PRIORITY_UPDATE:
-      break;
+    catch (const std::exception& exp) {
+      VERBOSESLOG(infolog("Error processing DoH3 event for stream %d: %s", streamID, exp.what()),
+                  frontend.d_logger->error(Logr::Info, exp.what(), "Error processing DoH3 event", "http.stream_id", Logging::Loggable(streamID)));
     }
   }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We would like to thank ylwango613 for bringing this issue to our attention.

CVE-2026-40208

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
