### PR TITLE
dnsdist: Check the owner name when parsing an OPT record

### DIFF
--- a/pdns/dnsdistdist/dnsdist-ecs.cc
+++ b/pdns/dnsdistdist/dnsdist-ecs.cc
@@ -107,7 +107,7 @@ int rewriteResponseWithoutEDNS(const PacketBuffer& initialPacket, PacketBuffer& 
     rrname = packetReader.getName();
     packetReader.getDnsrecordheader(recordHeader);
 
-    if (recordHeader.d_type != QType::OPT) {
+    if (!rrname.isRoot() || recordHeader.d_type != QType::OPT) {
       packetWriter.startRecord(rrname, recordHeader.d_type, recordHeader.d_ttl, recordHeader.d_class, DNSResourceRecord::ADDITIONAL, true);
       packetReader.xfrBlob(blob);
       packetWriter.xfrBlob(blob);
@@ -230,7 +230,7 @@ bool slowRewriteEDNSOptionInQueryWithRecords(const PacketBuffer& initialPacket, 
     rrname = packetReader.getName();
     packetReader.getDnsrecordheader(recordHeader);
 
-    if (recordHeader.d_type != QType::OPT) {
+    if (!rrname.isRoot() || recordHeader.d_type != QType::OPT) {
       packetWriter.startRecord(rrname, recordHeader.d_type, recordHeader.d_ttl, recordHeader.d_class, DNSResourceRecord::ADDITIONAL, true);
       packetReader.xfrBlob(blob);
       packetWriter.xfrBlob(blob);
@@ -313,7 +313,7 @@ int locateEDNSOptRR(const PacketBuffer& packet, uint16_t* optStart, size_t* optL
     rrname = packetReader.getName();
     packetReader.getDnsrecordheader(recordHeader);
 
-    if (rrname == g_rootdnsname && recordHeader.d_type == QType::OPT) {
+    if (rrname.isRoot() && recordHeader.d_type == QType::OPT) {
       *optStart = start;
       *optLen = (packetReader.getPosition() - start) + recordHeader.d_clen;
 
@@ -800,7 +800,7 @@ int rewriteResponseWithoutEDNSOption(const PacketBuffer& initialPacket, const ui
     rrname = packetReader.getName();
     packetReader.getDnsrecordheader(recordHeader);
 
-    if (recordHeader.d_type != QType::OPT) {
+    if (!rrname.isRoot() || recordHeader.d_type != QType::OPT) {
       packetWriter.startRecord(rrname, recordHeader.d_type, recordHeader.d_ttl, recordHeader.d_class, DNSResourceRecord::ADDITIONAL, true);
       packetReader.xfrBlob(blob);
       packetWriter.xfrBlob(blob);

--- a/pdns/dnsdistdist/test-dnsdist_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdist_cc.cc
@@ -177,7 +177,7 @@ static void validateECS(const PacketBuffer& packet, const ComboAddress& expected
   BOOST_CHECK_EQUAL(expectedOption.substr(EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE), std::string(ecsOption->second.values.at(0).content, ecsOption->second.values.at(0).size));
 }
 
-static void validateResponse(const PacketBuffer& packet, bool hasEdns, uint8_t additionalCount = 0)
+static void validateResponse(const PacketBuffer& packet, bool hasEdns, uint8_t additionalCount = 0, uint8_t answerCount = 1U)
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   MOADNSParser mdp(false, reinterpret_cast<const char*>(packet.data()), packet.size());
@@ -186,9 +186,30 @@ static void validateResponse(const PacketBuffer& packet, bool hasEdns, uint8_t a
 
   BOOST_CHECK_EQUAL(mdp.d_header.qr, 1U);
   BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
-  BOOST_CHECK_EQUAL(mdp.d_header.ancount, 1U);
+  BOOST_CHECK_EQUAL(mdp.d_header.ancount, answerCount);
   BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
   BOOST_CHECK_EQUAL(mdp.d_header.arcount, (hasEdns ? 1U : 0U) + additionalCount);
+}
+
+static void addOptWithWrongOwnerName(GenericDNSPacketWriter<PacketBuffer>& packetWriter, const GenericDNSPacketWriter<PacketBuffer>::optvect_t& opts)
+{
+  // same as packetWriter.addOpt(512, 0, 0, opts) except with the wrong owner name
+  const DNSName notRoot{"dnsdist.org."};
+  uint32_t ttl{0};
+  EDNS0Record stuff{};
+  stuff.version = 0U;
+  stuff.extFlags = htons(0U);
+  stuff.extRCode = 0U;
+  memcpy(&ttl, &stuff, sizeof(stuff));
+  ttl = ntohl(ttl); // will be reversed later on
+  packetWriter.startRecord(notRoot, QType::OPT, ttl, 512U, DNSResourceRecord::ADDITIONAL, false);
+  for (const auto& option : opts) {
+    packetWriter.xfr16BitInt(option.first);
+    packetWriter.xfr16BitInt(option.second.length());
+    packetWriter.xfrBlob(option.second);
+  }
+
+  packetWriter.commit();
 }
 
 BOOST_AUTO_TEST_CASE(addECSWithoutEDNS)
@@ -1122,6 +1143,24 @@ BOOST_AUTO_TEST_CASE(removeEDNSWhenLast)
   validateResponse(newResponse, false, 1);
 }
 
+BOOST_AUTO_TEST_CASE(removeEDNSWrongOwnerName)
+{
+  DNSName name("www.powerdns.com.");
+
+  PacketBuffer response;
+  GenericDNSPacketWriter<PacketBuffer> packetWriter(response, name, QType::A, QClass::IN, 0);
+  packetWriter.getHeader()->qr = 1;
+  addOptWithWrongOwnerName(packetWriter, {});
+
+  PacketBuffer newResponse;
+  int res = rewriteResponseWithoutEDNS(response, newResponse);
+
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(newResponse.size(), response.size());
+
+  validateResponse(newResponse, true, 0U, 0U);
+}
+
 BOOST_AUTO_TEST_CASE(removeECSWhenOnlyOption)
 {
   DNSName name("www.powerdns.com.");
@@ -1499,6 +1538,32 @@ BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenLastOption)
   BOOST_CHECK(qtype == QType::A);
 
   validateResponse(newResponse, true, 1);
+}
+
+BOOST_AUTO_TEST_CASE(rewritingOPTWrongOwnerName)
+{
+  DNSName name("www.powerdns.com.");
+  ComboAddress origRemote("127.0.0.1");
+
+  PacketBuffer response;
+  GenericDNSPacketWriter<PacketBuffer> packetWriter(response, name, QType::A, QClass::IN, 0);
+  packetWriter.getHeader()->qr = 1;
+
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.setSource(Netmask(origRemote, ECSSourcePrefixV4));
+  string origECSOptionStr = ecsOpts.makeOptString();
+  GenericDNSPacketWriter<PacketBuffer>::optvect_t opts;
+  opts.emplace_back(EDNSOptionCode::ECS, origECSOptionStr);
+
+  // same as packetWriter.addOpt(512, 0, 0, opts) except with the wrong owner name
+  addOptWithWrongOwnerName(packetWriter, opts);
+
+  PacketBuffer newResponse;
+  int res = rewriteResponseWithoutEDNSOption(response, EDNSOptionCode::ECS, newResponse);
+  BOOST_CHECK_EQUAL(res, 0);
+  // we should not have modified the payload
+  BOOST_CHECK_EQUAL(newResponse.size(), response.size());
+  validateResponse(newResponse, true, 0U, 0U);
 }
 
 static DNSQuestion turnIntoResponse(InternalQueryState& ids, PacketBuffer& query, bool resizeBuffer = true)
@@ -2512,6 +2577,39 @@ BOOST_AUTO_TEST_CASE(test_DNSQuestion_Tags)
   dnsQuestion.unsetTag(tagName);
   got = dnsQuestion.getTag(tagName);
   BOOST_CHECK(!got);
+}
+
+BOOST_AUTO_TEST_CASE(slowRewriteEDNSOptionInQueryWithRecordsWrongOwnerName)
+{
+  DNSName name("www.powerdns.com.");
+
+  PacketBuffer response;
+  GenericDNSPacketWriter<PacketBuffer> packetWriter(response, name, QType::A, QClass::IN, 0);
+  packetWriter.getHeader()->qr = 1;
+  addOptWithWrongOwnerName(packetWriter, {});
+
+  uint16_t optStart = 0;
+  size_t optLen = 0;
+  bool last = false;
+
+  auto located = locateEDNSOptRR(response, &optStart, &optLen, &last);
+  BOOST_CHECK_EQUAL(located, ENOENT);
+
+  PacketBuffer newResponse;
+  bool ednsAdded = false;
+  bool optionAdded = false;
+  std::string newEmptyContent;
+  newEmptyContent.resize(EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE + 1);
+  auto got = slowRewriteEDNSOptionInQueryWithRecords(response, newResponse, ednsAdded, EDNSOptionCode::ECS, optionAdded, true, false, newEmptyContent);
+  BOOST_CHECK_EQUAL(got, true);
+  BOOST_CHECK_EQUAL(ednsAdded, true);
+  BOOST_CHECK_EQUAL(optionAdded, true);
+  BOOST_CHECK_GT(newResponse.size(), response.size());
+
+  validateResponse(newResponse, true, 1U, 0U);
+
+  located = locateEDNSOptRR(newResponse, &optStart, &optLen, &last);
+  BOOST_CHECK_EQUAL(located, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We would like to thank Vitaly Simonovich for bringing this issue to our attention.

CVE-2026-42004

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
