### PR TITLE
rec: If EDNS is mandatory, do it always in the first iteration (#YWH-PGM6095-290)

### DIFF
--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -1468,12 +1468,15 @@ LWResult::Result SyncRes::asyncresolveWrapper(const OptLog& log, const ComboAddr
 
   for (int tries = 0; tries < 2; ++tries) {
 
-    if (mode == EDNSStatus::NOEDNS) {
+    // We might have recorded (due to transient or spoofing issues) the target as not supporting
+    // EDNS. But if we plan to do DNSSEC validation, actually force EDNS for the first try so DNSSEC
+    // has a chance.
+    if ((tries == 0 && ednsMANDATORY) || mode != EDNSStatus::NOEDNS) {
+      EDNSLevel = 1;
+    }
+    else {
       t_Counters.at(rec::Counter::noEdnsOutQueries)++;
       EDNSLevel = 0; // level != mode
-    }
-    else if (ednsMANDATORY || mode != EDNSStatus::NOEDNS) {
-      EDNSLevel = 1;
     }
 
     DNSName sendQname(domain);


### PR DESCRIPTION
CVE-2026-52690
YWH-PGM6095-290

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
