### PR TITLE
dnsdist: add missing ComboAddress functions to Lua bindings

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings.cc
@@ -482,6 +482,8 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.registerFunction<string (ComboAddress::*)() const>("tostringWithPort", [](const ComboAddress& addr) { return addr.toStringWithPort(); });
   luaCtx.registerFunction<string (ComboAddress::*)() const>("__tostring", [](const ComboAddress& addr) { return addr.toString(); });
   luaCtx.registerFunction<string (ComboAddress::*)() const>("toString", [](const ComboAddress& addr) { return addr.toString(); });
+  luaCtx.registerFunction<string (ComboAddress::*)() const>("toStringNoInterface", [](const ComboAddress& addr) { return addr.toStringNoInterface(); });
+  luaCtx.registerFunction<string (ComboAddress::*)() const>("toStringReversed", [](const ComboAddress& addr) { return addr.toStringReversed(); });
   luaCtx.registerFunction<string (ComboAddress::*)() const>("toStringWithPort", [](const ComboAddress& addr) { return addr.toStringWithPort(); });
   luaCtx.registerFunction<string (ComboAddress::*)() const>("getRaw", [](const ComboAddress& addr) { return addr.toByteString(); });
   luaCtx.registerFunction<uint16_t (ComboAddress::*)() const>("getPort", [](const ComboAddress& addr) { return ntohs(addr.sin4.sin_port); });

--- a/pdns/dnsdistdist/docs/reference/comboaddress.rst
+++ b/pdns/dnsdistdist/docs/reference/comboaddress.rst
@@ -60,7 +60,21 @@ ComboAddresses can be IPv4 or IPv6, and unless you want to know, you don't need 
   .. method:: tostring() -> string
               toString() -> string
 
-    Returns in human-friendly format
+    Returns the IP address in human-friendly format
+
+  .. method:: toStringReversed() -> string
+
+    .. versionadded:: 2.2.0
+
+    Returns the IP address in human-friendly format, but in reverse notation
+    as used for PTR records.
+
+  .. method:: toStringNoInterface() -> string
+
+    .. versionadded:: 2.2.0
+
+    Returns the IP address in human-friendly format, but with any interface
+    suffix stripped.
 
   .. method:: getRaw() -> string
 

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -158,6 +158,8 @@ void BaseLua4::prepareContext() {
   d_lw->registerFunction<void(ComboAddress::*)(unsigned int)>("truncate", [](ComboAddress& addr, unsigned int bits) { addr.truncate(bits); });
   d_lw->registerFunction<string(ComboAddress::*)()>("toString", [](const ComboAddress& addr) { return addr.toString(); });
   d_lw->registerToStringFunction<string(ComboAddress::*)()>([](const ComboAddress& addr) { return addr.toString(); });
+  d_lw->registerFunction<string (ComboAddress::*)() const>("toStringNoInterface", [](const ComboAddress& addr) { return addr.toStringNoInterface(); });
+  d_lw->registerFunction<string (ComboAddress::*)() const>("toStringReversed", [](const ComboAddress& addr) { return addr.toStringReversed(); });
   d_lw->registerFunction<string(ComboAddress::*)()>("toStringWithPort", [](const ComboAddress& addr) { return addr.toStringWithPort(); });
   d_lw->registerFunction<string(ComboAddress::*)()>("getRaw", [](const ComboAddress& addr) { return addr.toByteString(); });
 

--- a/pdns/recursordist/docs/lua-scripting/comboaddress.rst
+++ b/pdns/recursordist/docs/lua-scripting/comboaddress.rst
@@ -67,6 +67,20 @@ To get only the port number, use :meth:`:getPort() <ComboAddress:getPort>`.
 
       Returns the IP address without the port number as a string.
 
+  .. method:: toStringReversed() -> string
+
+      .. versionadded:: 5.5.0
+
+      Returns the IP address in human-friendly format, but in reverse notation
+      as used for PTR records.
+
+  .. method:: toStringNoInterface() -> string
+
+      .. versionadded:: 5.5.0
+
+      Returns the IP address in human-friendly format, but with any interface
+      suffix stripped.
+
   .. method:: toStringWithPort() -> str
 
       Returns the IP address with the port number as a string.


### PR DESCRIPTION
### Short description
While trying to generate PTR records for spoofed (but existing) hosts I was searching for a function to generate the reverse-dot form of a `ComboAddress`. Imagine my delight when I found `toStringReversed()` in `iputils.hh`, only to discover that it was not exposed via Lua. Now it is, together with the also-missing `toStringNoInterface()`:

 >\> ca4=newCA("192.168.100.200")
 >\> ca4:toStringReversed()
 200.100.168.192
 >\> ca6=newCA("fd39:8628:558:0:62b5:8dff:fe1e:d8a8")
 >\> ca6:toStringReversed()
 8.a.8.d.e.1.e.f.f.f.d.8.5.b.2.6.0.0.0.0.8.5.5.0.8.2.6.8.9.3.d.f
 >\> ca6if=newCA("fe80::1ff:fe23:4567:890a%eth0")
 >\> ca6if:toStringNoInterface()
 fe80::1ff:fe23:4567:890a

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
