### PR TITLE
auth: enable structured logging in some tests

### DIFF
--- a/regression-tests.auth-py/test_ALIAS.py
+++ b/regression-tests.auth-py/test_ALIAS.py
@@ -21,6 +21,7 @@ resolver=%s.1:5301
 any-to-tcp=no
 launch={backend}
 edns-subnet-processing=yes
+logging-structured
 """
 
     _config_params = ["_PREFIX"]

--- a/regression-tests.auth-py/test_AuthSignal.py
+++ b/regression-tests.auth-py/test_AuthSignal.py
@@ -26,6 +26,7 @@ launch=gsqlite3
 gsqlite3-database=configs/auth/powerdns.sqlite
 gsqlite3-pragma-foreign-keys=yes
 gsqlite3-dnssec=yes
+logging-structured
 """
 
     @classmethod

--- a/regression-tests.auth-py/test_Cookies.py
+++ b/regression-tests.auth-py/test_Cookies.py
@@ -10,6 +10,7 @@ class TestEdnsCookies(AuthTest):
     _config_template = """
 launch={backend}
 edns-cookie-secret=aabbccddeeff11223344556677889900
+logging-structured
 """
 
     _zones = {
@@ -105,4 +106,5 @@ class TestEdnsRandomCookies(TestEdnsCookies):
     _config_template = """
 launch={backend}
 edns-cookie-secret=random
+logging-structured
 """

--- a/regression-tests.auth-py/test_GSSTSIG.py
+++ b/regression-tests.auth-py/test_GSSTSIG.py
@@ -29,6 +29,7 @@ enable-gss-tsig=yes
 allow-dnsupdate-from=0.0.0.0/0
 dnsupdate=yes
 dnsupdate-require-tsig=no
+logging-structured
 """
     _auth_env = {"KRB5_CONFIG": "./kerberos-client/krb5.conf", "KRB5_KTNAME": "./kerberos-client/kt.keytab"}
 
@@ -106,6 +107,7 @@ gsqlite3-dnssec=yes
 enable-gss-tsig=yes
 allow-dnsupdate-from=0.0.0.0/0
 dnsupdate=yes
+logging-structured
 """
 
     def testAllowedUpdate(self):
@@ -140,6 +142,7 @@ enable-gss-tsig=yes
 allow-dnsupdate-from=0.0.0.0/0
 dnsupdate=yes
 lua-dnsupdate-policy-script=kerberos-client/update-policy.lua
+logging-structured
 """
 
     def testDisallowedByLuaUpdate(self):
@@ -172,6 +175,7 @@ gsqlite3-dnssec=yes
 enable-gss-tsig=no
 allow-dnsupdate-from=0.0.0.0/0
 dnsupdate=yes
+logging-structured
 """
 
     def testNoAcceptor(self):
@@ -190,6 +194,7 @@ enable-gss-tsig=no
 allow-dnsupdate-from=0.0.0.0/0
 dnsupdate=yes
 dnsupdate-require-tsig=yes
+logging-structured
 """
 
     def testNoAcceptor(self):
@@ -207,6 +212,7 @@ enable-gss-tsig=yes
 allow-dnsupdate-from=0.0.0.0/0
 dnsupdate=yes
 dnsupdate-require-tsig=yes
+logging-structured
 """
 
     def testAllowedUpdate(self):

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -58,6 +58,7 @@ any-to-tcp=no
 enable-lua-records
 lua-records-insert-whitespace=yes
 lua-health-checks-interval=1
+logging-structured
 """
 
     _zones = {
@@ -1370,6 +1371,7 @@ any-to-tcp=no
 enable-lua-records=shared
 lua-records-insert-whitespace=yes
 lua-health-checks-interval=1
+logging-structured
 """
 
     def testCounter(self):
@@ -1393,6 +1395,7 @@ any-to-tcp=no
 enable-lua-records
 lua-records-insert-whitespace=no
 lua-health-checks-interval=1
+logging-structured
 """
 
     def testWhitespace(self):
@@ -1410,6 +1413,7 @@ any-to-tcp=no
 enable-lua-records
 lua-records-insert-whitespace=yes
 lua-health-checks-interval=5
+logging-structured
 """
 
     def testIfurlupMinimumFailures(self):
@@ -1552,6 +1556,7 @@ any-to-tcp=no
 enable-lua-records
 lua-records-insert-whitespace=yes
 lua-records-exec-limit=1
+logging-structured
 """
 
     def testA(self):

--- a/regression-tests.auth-py/test_Protobuf.py
+++ b/regression-tests.auth-py/test_Protobuf.py
@@ -74,6 +74,7 @@ class TestAuthProtobuf(AuthTest):
 expand-alias=yes
 launch={backend}
 protobuf-servers=127.0.0.1:%s
+logging-structured
 """ % (protobufServersParameters[0].port,)
 
     _zones = {

--- a/regression-tests.auth-py/test_ResolveAcrossZones.py
+++ b/regression-tests.auth-py/test_ResolveAcrossZones.py
@@ -12,6 +12,7 @@ class CrossZoneResolveBase(AuthTest):
 any-to-tcp=no
 launch={backend}
 edns-subnet-processing=yes
+logging-structured
 """
     target_otherzone_ip = "192.0.2.2"
     target_subzone_ip = "192.0.2.3"

--- a/regression-tests.auth-py/test_SoaEdit.py
+++ b/regression-tests.auth-py/test_SoaEdit.py
@@ -111,6 +111,7 @@ launch={backend}
 default-soa-edit=INCEPTION-INCREMENT
 soa-edit-spread=10
 rrsig-expiry-extend=20
+logging-structured
     """
 
     expected = {2025121801, 2025122501}
@@ -122,6 +123,7 @@ class TestSoaEditSpreadIncrementWeeks(TestSoaEditSpreadBase):
 launch={backend}
 default-soa-edit=INCREMENT-WEEKS
 soa-edit-spread=10
+logging-structured
     """
 
     expected = {2921, 2922}
@@ -133,6 +135,7 @@ class TestSoaEditSpreadInceptionEpoch(TestSoaEditSpreadBase):
 launch={backend}
 default-soa-edit=INCEPTION-EPOCH
 soa-edit-spread=10
+logging-structured
     """
 
     expected = {2920 * 604800, 2921 * 604800}

--- a/regression-tests/backends/bind-master
+++ b/regression-tests/backends/bind-master
@@ -6,6 +6,7 @@ module-dir=$PDNS_MODULE_PATH
 launch=bind
 bind-config=./named.conf
 bind-ignore-broken-records=yes
+logging-structured
 __EOF__
 
         $RUNWRAPPER $PDNS --loglevel=7 --daemon=no --local-address=$address --local-port=$port --config-dir=. \
@@ -24,6 +25,7 @@ module-dir=$PDNS_MODULE_PATH
 launch=bind
 bind-config=./named.conf
 bind-ignore-broken-records=yes
+logging-structured
 __EOF__
         if [ $context = bind-hybrid-nsec3 ]
         then

--- a/regression-tests/backends/geoip-master
+++ b/regression-tests/backends/geoip-master
@@ -122,6 +122,7 @@ module-dir=$PDNS_MODULE_PATH
 launch=geoip
 geoip-zones-file=$testsdir/geo.yaml
 geoip-database-files=$geoipdatabase
+logging-structured
 EOF
 
 		if [ "$geoipdosec" = "yes" ]

--- a/regression-tests/backends/gmysql-master
+++ b/regression-tests/backends/gmysql-master
@@ -26,6 +26,7 @@ gmysql-password=$GMYSQLPASSWD
 
 any-to-tcp=no
 zone-cache-refresh-interval=0
+logging-structured
 __EOF__
 
 		# setup catalog zone

--- a/regression-tests/backends/godbc_mssql-master
+++ b/regression-tests/backends/godbc_mssql-master
@@ -23,6 +23,7 @@ godbc-datasource=$GODBC_MSSQL_DSN
 godbc-username=$GODBC_MSSQL_USERNAME
 godbc-password=$GODBC_MSSQL_PASSWORD
 godbc-dnssec=yes
+logging-structured
 __EOF__
 
 		gsql_master godbc_mssql nodyndns

--- a/regression-tests/backends/godbc_sqlite3-master
+++ b/regression-tests/backends/godbc_sqlite3-master
@@ -11,6 +11,7 @@ module-dir=$PDNS_MODULE_PATH
 launch=godbc
 godbc-datasource=$GODBC_SQLITE3_DSN
 
+logging-structured
 __EOF__
 		${PDNSSERVER:-../pdns/pdns_server} --launch=gsqlite3 --config | grep query= | perl -pe 's/^# gsqlite3/godbc/; s/:\w+/?/g' >> pdns-godbc_sqlite3.conf
 

--- a/regression-tests/backends/gpgsql-master
+++ b/regression-tests/backends/gpgsql-master
@@ -18,6 +18,7 @@ gpgsql-dbname=$GPGSQLDB
 gpgsql-user=$GPGSQLUSER
 
 zone-cache-refresh-interval=120
+logging-structured
 __EOF__
 
 		gsql_master gpgsql nodyndns

--- a/regression-tests/backends/gsqlite3-master
+++ b/regression-tests/backends/gsqlite3-master
@@ -14,6 +14,7 @@ gsqlite3-database=pdns.sqlite3
 consistent-backends
 zone-cache-refresh-interval=5
 direct-dnskey
+logging-structured
 __EOF__
 
 		gsql_master gsqlite3 nodyndns

--- a/regression-tests/backends/ldap-master
+++ b/regression-tests/backends/ldap-master
@@ -25,6 +25,7 @@ ldap-binddn=$LDAPUSER
 ldap-secret=$LDAPPASSWD
 ldap-method=$layout
 ldap-host=$LDAPHOST
+logging-structured
 __EOF__
 
 		$RUNWRAPPER $PDNS --loglevel=7 --daemon=no --local-address=$address --local-port=$port --config-dir=. \

--- a/regression-tests/backends/lmdb-master
+++ b/regression-tests/backends/lmdb-master
@@ -20,6 +20,7 @@ edns-subnet-processing
 views=yes
 any-to-tcp=no
 dnsupdate=yes
+logging-structured
 __EOF__
 
         rm -f pdns.lmdb*

--- a/regression-tests/backends/lua2-master
+++ b/regression-tests/backends/lua2-master
@@ -29,6 +29,7 @@ launch=lua2
 lua2-filename=$testsdir/$luascript
 lua2-api=2
 allow-axfr-ips=0.0.0.0/0,::/0
+logging-structured
 EOF
 
 		$RUNWRAPPER $PDNS --loglevel=7 --daemon=no --local-address=$address --local-port=$port --socket-dir=./ \

--- a/regression-tests/backends/remote-master
+++ b/regression-tests/backends/remote-master
@@ -93,6 +93,7 @@ case $context in
 module-dir=$PDNS_MODULE_PATH
 launch=remote
 remote-connection-string=$connstr,timeout=10000
+logging-structured
 EOF
 
 		if [ "$remotedosec" = "yes" ]

--- a/regression-tests/backends/tinydns-master
+++ b/regression-tests/backends/tinydns-master
@@ -4,6 +4,7 @@ case $context in
 			--no-shuffle --launch=tinydns \
 		 --cache-ttl=$cachettl --dname-processing --no-config \
 			--dnsupdate=yes \
+			--logging-structured=yes \
 			--tinydns-dbfile=../modules/tinydnsbackend/data.cdb --module-dir="$PDNS_MODULE_PATH" &
 		skipreasons="nodnssec noent nodyndns nometa noaxfr noalias"
 		;;


### PR DESCRIPTION
### Short description
To make sure the structured logging code path gets exercized properly, this enables in various test configurations:
- all primary servers in `regression-tests`
- 50% of the servers (every other test file) in `regression-tests.auth-py`

(note that structured logging will become enabled by default some time in the future, but likely not until 5.3 or 5.4)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
