### PR TITLE
auth 5.0: backport "Use the proper size after processing a proxy protocol payload"

### DIFF
--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -284,7 +284,9 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
   if(sock==-1)
     throw PDNSException("poll betrayed us! (should not happen)");
   
-  DLOG(g_log<<"Received a packet " << len <<" bytes long from "<< remote.toString()<<endl);
+  buffer.resize(len);
+
+  DLOG(g_log<<"Received a packet " << buffer.size() <<" bytes long from "<< remote.toString()<<endl);
 
   BOOST_STATIC_ASSERT(offsetof(sockaddr_in, sin_port) == offsetof(sockaddr_in6, sin6_port));
 
@@ -312,9 +314,8 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
     bool proxyProto, tcp;
     std::vector<ProxyProtocolValue> ppvalues;
 
-    buffer.resize(len);
     ssize_t used = parseProxyHeader(buffer, proxyProto, psource, pdestination, tcp, ppvalues);
-    if (used <= 0 || (size_t) used > g_proxyProtocolMaximumSize || (len - used) > DNSPacket::s_udpTruncationThreshold) {
+    if (used <= 0 || (size_t) used > g_proxyProtocolMaximumSize || (buffer.size() - used) > DNSPacket::s_udpTruncationThreshold) {
       S.inc("corrupt-packets");
       S.ringAccount("remotes-corrupt", packet.d_remote);
       return false;
@@ -327,7 +328,7 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
     packet.d_inner_remote.reset();
   }
 
-  if(packet.parse(&buffer.at(0), (size_t) len)<0) {
+  if (packet.parse(buffer.data(), buffer.size()) < 0) {
     S.inc("corrupt-packets");
     S.ringAccount("remotes-corrupt", packet.getInnerRemote());
 


### PR DESCRIPTION
### Short description
Backport of #16965 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
