### PR TITLE
dnsdist: Set Rust LTO mode automatically, and allow setting RUSTFLAGS

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
@@ -25,6 +25,7 @@ case "${CARGO_LTO_MODE:-unspecified}" in
         ;;
 esac
 
+# echo "RUSTFLAGS = ${RUSTFLAGS}"
 # echo "CARGO_PROFILE = ${CARGO_PROFILE}"
 # echo "CARGO_LTO_MODE = ${CARGO_LTO_MODE}"
 # echo "CARGO_CONFIG = ${CARGO_CONFIG}"

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
@@ -11,15 +11,25 @@ export CARGO="${CARGO:-$_defaultCARGO}"
 mytarget=${CARGO_TARGET_DIR-target}
 #echo "mytarget=${mytarget}"
 
-CARGO_PROFILE="--release"
+CARGO_PROFILE="release"
 if [ -n "${CARGO_USE_DEV}" ]; then
-    CARGO_PROFILE=""
+    CARGO_PROFILE="dev"
     if [ -n "${CARGO_USE_CLIPPY}" ]; then
         $CARGO clippy --manifest-path $srcdir/Cargo.toml
     fi
 fi
 
-$CARGO build ${CARGO_PROFILE} $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml --locked
+case "${CARGO_LTO_MODE:-unspecified}" in
+    "fat" | "thin")
+        CARGO_CONFIG="--config profile.${CARGO_PROFILE}.lto=\"${CARGO_LTO_MODE}\""
+        ;;
+esac
+
+# echo "CARGO_PROFILE = ${CARGO_PROFILE}"
+# echo "CARGO_LTO_MODE = ${CARGO_LTO_MODE}"
+# echo "CARGO_CONFIG = ${CARGO_CONFIG}"
+
+$CARGO build --profile ${CARGO_PROFILE} ${CARGO_CONFIG} $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml --locked
 
 if [ -n "${CARGO_USE_DEV}" ]; then
     cp -p target/$RUSTC_TARGET_ARCH/debug/libdnsdist_rust.a $builddir/dnsdist-rust-lib/rust/libdnsdist_rust.a

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
@@ -13,6 +13,18 @@ env.set('srcdir', meson.current_source_dir())
 env.append('RUST_TARGET', '', separator: '')
 env.append('RUSTC_TARGET_ARCH', '', separator: '')
 
+if get_option('rust-lto') and get_option('b_lto') and get_option('b_lto_mode') == 'default'
+  env.set('CARGO_LTO_MODE', 'fat')
+  summary('LTO', true, bool_yn: true, section: 'Rust')
+  summary('LTO mode', 'fat', section: 'Rust')
+elif get_option('rust-lto') and get_option('b_lto') and get_option('b_lto_mode') == 'thin'
+  env.set('CARGO_LTO_MODE', 'thin')
+  summary('LTO', true, bool_yn: true, section: 'Rust')
+  summary('LTO mode', 'thin', section: 'Rust')
+else
+  summary('LTO', false, bool_yn: true, section: 'Rust')
+endif
+
 lib_dnsdist_rust = custom_target('libdnsdist_rust.a',
   output: [outfile, 'cxx.h'],
   input: infile,

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
@@ -13,6 +13,11 @@ env.set('srcdir', meson.current_source_dir())
 env.append('RUST_TARGET', '', separator: '')
 env.append('RUSTC_TARGET_ARCH', '', separator: '')
 
+opt_rust_args = get_option('rust-args')
+if opt_rust_args != ''
+  env.set('RUSTFLAGS', opt_rust_args)
+endif
+
 if get_option('rust-lto') and get_option('b_lto') and get_option('b_lto_mode') == 'default'
   env.set('CARGO_LTO_MODE', 'fat')
   summary('LTO', true, bool_yn: true, section: 'Rust')

--- a/pdns/dnsdistdist/meson_options.txt
+++ b/pdns/dnsdistdist/meson_options.txt
@@ -42,3 +42,4 @@ option('man-pages', type: 'boolean', value: true, description: 'Generate man pag
 option('clang-coverage-format', type: 'boolean', value: false, description: 'Whether to generate coverage data in clang format')
 option('benchmark', type: 'boolean', value: false, description: 'Whether to run microbenchmarks')
 option('mmdb', type: 'feature', value: 'disabled', description: 'MMDB key-value store support')
+option('rust-lto', type: 'boolean', value: true, description: 'Enable LTO for Rust according to b_lto, b_lto_mode settings')

--- a/pdns/dnsdistdist/meson_options.txt
+++ b/pdns/dnsdistdist/meson_options.txt
@@ -42,4 +42,5 @@ option('man-pages', type: 'boolean', value: true, description: 'Generate man pag
 option('clang-coverage-format', type: 'boolean', value: false, description: 'Whether to generate coverage data in clang format')
 option('benchmark', type: 'boolean', value: false, description: 'Whether to run microbenchmarks')
 option('mmdb', type: 'feature', value: 'disabled', description: 'MMDB key-value store support')
+option('rust-args', type: 'string', description: 'Rust compile arguments to use')
 option('rust-lto', type: 'boolean', value: true, description: 'Enable LTO for Rust according to b_lto, b_lto_mode settings')


### PR DESCRIPTION
### Short description

This PR updates dnsdist's meson build system to automatically plumb in the existing meson built-in options `b_lto` and `b_lto_mode` into the Cargo Rust build. This behavior can be disabled by setting `-Drust-lto=false`.

It also adds a `rust-args` option that passes user-supplied arguments to the Rust compiler via the `RUSTFLAGS` environment variable. This is similar to the `c_args` and `cpp_args` built-in options for the C/C++ compilers. For instance, it might be nice to specify Rust compiler parameters like `-C target-cpu=x86-64-v3` or `-C codegen-units=1` or `-C linker-plugin-lto` if one is interested in building a highly optimized binary.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
