### PR TITLE
coverity: Add missing argument to `ninja`

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1561,7 +1561,7 @@ def coverity_make(c):
 
 @task
 def coverity_ninja(c):
-    c.run("/usr/local/bin/cov-build --dir cov-int ninja -C build -k")
+    c.run("/usr/local/bin/cov-build --dir cov-int ninja -C build -k 0")
 
 
 @task


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If the third time is the charm, what's the fourth?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
