### PR TITLE
dnsdist-2.1.x: Backport 17484 - Add OpenSSL >= 4.0.0 compatibility

### DIFF
--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -1029,7 +1029,9 @@ static std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)> getNewServerContext(con
   }
 
 #ifdef SSL_CTX_set_ecdh_auto
+#if !defined(OPENSSL_VERSION_MAJOR) || OPENSSL_VERSION_MAJOR < 4
   SSL_CTX_set_ecdh_auto(ctx.get(), 1);
+#endif /* OPENSSL_VERSION_MAJOR < 4 */
 #endif
 
   if (config.d_maxStoredSessions == 0) {

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -214,7 +214,12 @@ public:
     else {
 #if (OPENSSL_VERSION_NUMBER >= 0x1010000fL) && defined(HAVE_SSL_SET_HOSTFLAGS) // grrr libressl
       SSL_set_hostflags(d_conn.get(), X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
-      if (SSL_set1_host(d_conn.get(), d_hostname.c_str()) != 1) {
+#if !defined(OPENSSL_VERSION_MAJOR) || OPENSSL_VERSION_MAJOR < 4
+      auto ret = SSL_set1_host(d_conn.get(), d_hostname.c_str());
+#else
+      auto ret = SSL_set1_dnsname(d_conn.get(), d_hostname.c_str());
+#endif
+      if (ret != 1) {
         throw std::runtime_error("Error setting TLS hostname for certificate validation");
       }
 #elif (OPENSSL_VERSION_NUMBER >= 0x10002000L)
@@ -806,7 +811,9 @@ public:
 
     SSL_CTX_set_options(d_tlsCtx.get(), sslOptions);
 #if defined(SSL_CTX_set_ecdh_auto)
+#if !defined(OPENSSL_VERSION_MAJOR) || OPENSSL_VERSION_MAJOR < 4
     SSL_CTX_set_ecdh_auto(d_tlsCtx.get(), 1);
+#endif /* OPENSSL_VERSION_MAJOR < 4 */
 #endif
 
     if (!params.d_ciphers.empty()) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17484 to dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
