### PR TITLE
dnsdist-2.1.x: Backport 17505 - Add a Lua accessor for the ring buffers sampling rate

### DIFF
--- a/pdns/dnsdistdist/dnsdist-console-completion.cc
+++ b/pdns/dnsdistdist/dnsdist-console-completion.cc
@@ -124,6 +124,7 @@ static std::vector<dnsdist::console::completion::ConsoleKeyword> s_consoleKeywor
   {"getQueryCounters", true, "[max=10]", "show current buffer of query counters, limited by 'max' if provided"},
   {"getResponseRing", true, "", "return the current content of the response ring"},
   {"getRespRing", true, "", "return the qname/rcode content of the response ring"},
+  {"getRingBuffersSamplingRate", true, "", "return current sampling rate of the in-memory ring buffers"},
   {"getServer", true, "id", "returns server with index 'n' or whose uuid matches if 'id' is an UUID string"},
   {"getServers", true, "", "returns a table with all defined servers"},
   {"getStatisticsCounters", true, "", "returns a map of statistic counters"},

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -897,6 +897,13 @@ void setupLuaInspection(LuaContext& luaCtx)
 
   luaCtx.writeFunction("getRespRing", getRespRing);
 
+  luaCtx.writeFunction("getRingBuffersSamplingRate", []() -> size_t {
+    if (dnsdist::configuration::isImmutableConfigurationDone()) {
+      return g_rings.getSamplingRate();
+    }
+    return dnsdist::configuration::getImmutableConfiguration().d_ringsSamplingRate;
+  });
+
   /* StatNode */
   luaCtx.registerFunction<unsigned int (StatNode::*)() const>("numChildren",
                                                               [](const StatNode& node) -> unsigned int {

--- a/pdns/dnsdistdist/dnsdist-rings.hh
+++ b/pdns/dnsdistdist/dnsdist-rings.hh
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include <time.h>
+#include <ctime>
 #include <unordered_map>
 
 #include <boost/variant.hpp>
@@ -64,7 +64,7 @@ struct Rings
     // outgoing protocol
     dnsdist::Protocol protocol;
 
-    bool isACacheHit() const;
+    [[nodiscard]] bool isACacheHit() const;
   };
 
   struct Shard
@@ -89,17 +89,17 @@ struct Rings
   /* This function should only be called at configuration time before any query or response has been inserted */
   void init(const RingsConfiguration& config);
 
-  size_t getNumberOfShards() const
+  [[nodiscard]] size_t getNumberOfShards() const
   {
     return d_numberOfShards;
   }
 
-  size_t getNumberOfQueryEntries() const
+  [[nodiscard]] size_t getNumberOfQueryEntries() const
   {
     return d_nbQueryEntries;
   }
 
-  size_t getNumberOfResponseEntries() const
+  [[nodiscard]] size_t getNumberOfResponseEntries() const
   {
     return d_nbResponseEntries;
   }
@@ -230,22 +230,22 @@ struct Rings
      only useful for debugging purposes */
   size_t loadFromFile(const std::string& filepath, const struct timespec& now);
 
-  bool shouldRecordQueries() const
+  [[nodiscard]] bool shouldRecordQueries() const
   {
     return d_recordQueries;
   }
 
-  bool shouldRecordResponses() const
+  [[nodiscard]] bool shouldRecordResponses() const
   {
     return d_recordResponses;
   }
 
-  size_t getSamplingRate() const
+  [[nodiscard]] size_t getSamplingRate() const
   {
     return d_samplingRate;
   }
 
-  uint32_t adjustForSamplingRate(uint32_t count) const
+  [[nodiscard]] uint32_t adjustForSamplingRate(uint32_t count) const
   {
     const auto samplingRate = getSamplingRate();
     if (samplingRate > 0) {
@@ -272,9 +272,9 @@ private:
   }
 
 #if defined(DNSDIST_RINGS_WITH_MACADDRESS)
-  bool insertQueryLocked(boost::circular_buffer<Query>& ring, const struct timespec& when, const ComboAddress& requestor, DNSName&& name, uint16_t qtype, uint16_t size, const struct dnsheader& dh, dnsdist::Protocol protocol, const dnsdist::MacAddress& macaddress, const bool hasmac)
+  static bool insertQueryLocked(boost::circular_buffer<Query>& ring, const struct timespec& when, const ComboAddress& requestor, DNSName&& name, uint16_t qtype, uint16_t size, const struct dnsheader& dh, dnsdist::Protocol protocol, const dnsdist::MacAddress& macaddress, const bool hasmac)
 #else
-  bool insertQueryLocked(boost::circular_buffer<Query>& ring, const struct timespec& when, const ComboAddress& requestor, DNSName&& name, uint16_t qtype, uint16_t size, const struct dnsheader& dh, dnsdist::Protocol protocol)
+  static bool insertQueryLocked(boost::circular_buffer<Query>& ring, const struct timespec& when, const ComboAddress& requestor, DNSName&& name, uint16_t qtype, uint16_t size, const struct dnsheader& dh, dnsdist::Protocol protocol)
 #endif
   {
     bool wasFull = ring.full();
@@ -290,14 +290,14 @@ private:
     return wasFull;
   }
 
-  bool insertResponseLocked(boost::circular_buffer<Response>& ring, const struct timespec& when, const ComboAddress& requestor, DNSName&& name, uint16_t qtype, unsigned int usec, uint16_t size, const struct dnsheader& dh, const ComboAddress& backend, dnsdist::Protocol protocol)
+  static bool insertResponseLocked(boost::circular_buffer<Response>& ring, const struct timespec& when, const ComboAddress& requestor, DNSName&& name, uint16_t qtype, unsigned int usec, uint16_t size, const struct dnsheader& dh, const ComboAddress& backend, dnsdist::Protocol protocol)
   {
     bool wasFull = ring.full();
     ring.push_back({requestor, backend, std::move(name), when, dh, usec, size, qtype, protocol});
     return wasFull;
   }
 
-  bool shouldSkipQueryDueToSampling()
+  [[nodiscard]] bool shouldSkipQueryDueToSampling() const
   {
     if (d_samplingRate == 0) {
       return false;
@@ -306,7 +306,7 @@ private:
     return (counter % d_samplingRate) != 0;
   }
 
-  bool shouldSkipResponseDueToSampling()
+  [[nodiscard]] bool shouldSkipResponseDueToSampling() const
   {
     if (d_samplingRate == 0) {
       return false;

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -619,6 +619,12 @@ EDNS Client Subnet
 Ringbuffers
 ~~~~~~~~~~~
 
+.. function:: getRingBuffersSampingRate() -> int
+
+  .. versionadded:: 2.1.0
+
+  Return the current sampling rate of the rings buffers, as configured via the ``samplingRate`` option to :func:`setRingBuffersOptions`
+
 .. function:: setRingBuffersLockRetries(num)
 
   .. deprecated:: 1.8.0

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -619,7 +619,7 @@ EDNS Client Subnet
 Ringbuffers
 ~~~~~~~~~~~
 
-.. function:: getRingBuffersSampingRate() -> int
+.. function:: getRingBuffersSamplingRate() -> int
 
   .. versionadded:: 2.1.0
 

--- a/regression-tests.dnsdist/test_Lua.py
+++ b/regression-tests.dnsdist/test_Lua.py
@@ -204,3 +204,31 @@ class TestLuaError(DNSDistTest):
         """
         res = self.sendConsoleCommand('error("expected" .. " " .. "error")')
         self.assertIn('expected error', res)
+
+
+class TestLuaRingBuffersSamplingRates(DNSDistTest):
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+
+    _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%d")
+    newServer{address="127.0.0.1:%d"}
+
+    local samplingRate = 10
+    setRingBuffersOptions({samplingRate=samplingRate})
+
+    local got = getRingBuffersSamplingRate()
+    if got ~= samplingRate then
+      print("Invalid sampling rate, got "..got..", expected "..samplingRate)
+      os.exit(1)
+    end
+    """
+
+    def testRingBuffersSamplingRate(self):
+        """
+        Lua: Test ring buffers sampling rate
+        """
+        res = self.sendConsoleCommand('getRingBuffersSamplingRate()').rstrip()
+        self.assertEqual(res, "10")

--- a/regression-tests.dnsdist/test_Lua.py
+++ b/regression-tests.dnsdist/test_Lua.py
@@ -230,5 +230,5 @@ class TestLuaRingBuffersSamplingRates(DNSDistTest):
         """
         Lua: Test ring buffers sampling rate
         """
-        res = self.sendConsoleCommand('getRingBuffersSamplingRate()').rstrip()
+        res = self.sendConsoleCommand("getRingBuffersSamplingRate()").rstrip()
         self.assertEqual(res, "10")


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17505 to dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
