### PR TITLE
dnsdist-2.1.x: Backport 17575 - fix build error on 32 bits systems (armhf, ...)

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1052,7 +1052,7 @@ static void handlePacketCacheConfiguration(const ::rust::Vec<dnsdist::rust::sett
 {
   for (const auto& cache : caches) {
     DNSDistPacketCache::CacheSettings settings{
-      .d_maxEntries = cache.size,
+      .d_maxEntries = static_cast<size_t>(cache.size),
       .d_maxTTL = cache.max_ttl,
       .d_minTTL = cache.min_ttl,
       .d_tempFailureTTL = cache.temporary_failure_ttl,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17575 to dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
