### PR TITLE
dnsdist-2.1.x: Backport 17543 - Catch exceptions when parsing CNAME via the Lua FFI API

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -1936,8 +1936,8 @@ size_t dnsdist_ffi_dnspacket_get_name_at_offset_raw(const char* packet, size_t p
     return storage.size();
   }
   catch (const std::exception& e) {
-    VERBOSESLOG(infolog("Error parsing DNSName via dnsdist_ffi_dnspacket_get_name_at_offset_raw: %s", e.what()),
-                getLogger(__func__)->error(Logr::Info, e.what(), "Error parsing DNS name", "packet_size", Logging::Loggable(packetSize), "offset", Logging::Loggable(offset)));
+    VERBOSESLOG(infolog("Error parsing DNSName from packet (%s) via dnsdist_ffi_dnspacket_get_name_at_offset_raw: %s", makeHexDump(std::string(packet, packetSize)), e.what()),
+                getLogger(__func__)->error(Logr::Info, e.what(), "Error parsing DNS name", "packet_size", Logging::Loggable(packetSize), "offset", Logging::Loggable(offset), "packet_bytes", Logging::Loggable(makeHexDump(std::string(packet, packetSize)))));
   }
   return 0;
 }

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -2015,12 +2015,19 @@ bool dnsdist_ffi_dnspacket_parse_cname_record(const char* raw, const dnsdist_ffi
     return false;
   }
 
-  DNSName parsed(raw, record.d_contentOffset + record.d_contentLength, record.d_contentOffset, true);
-  const auto& storage = parsed.getStorage();
-  memcpy(name, storage.data(), storage.size());
-  *nameSize = storage.size();
+  try {
+    DNSName parsed(raw, record.d_contentOffset + record.d_contentLength, record.d_contentOffset, true);
+    const auto& storage = parsed.getStorage();
+    memcpy(name, storage.data(), storage.size());
+    *nameSize = storage.size();
 
-  return true;
+    return true;
+  }
+  catch (const std::exception& e) {
+    VERBOSESLOG(infolog("Error parsing CNAME record: %s", e.what()),
+                getLogger(__func__)->error(Logr::Info, e.what(), "Error parsing CNAME record"));
+    return false;
+  }
 }
 
 void dnsdist_ffi_dnspacket_free(dnsdist_ffi_dnspacket_t* packet)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17543 to rel/dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
