### PR TITLE
dnsdist-2.1.x: Backport 17639 - Set Rust LTO mode automatically, and allow setting RUSTFLAGS

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
@@ -25,6 +25,7 @@ case "${CARGO_LTO_MODE:-unspecified}" in
         ;;
 esac
 
+# echo "RUSTFLAGS = ${RUSTFLAGS}"
 # echo "CARGO_PROFILE = ${CARGO_PROFILE}"
 # echo "CARGO_LTO_MODE = ${CARGO_LTO_MODE}"
 # echo "CARGO_CONFIG = ${CARGO_CONFIG}"

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/build_dnsdist_rust_library
@@ -11,15 +11,25 @@ export CARGO="${CARGO:-$_defaultCARGO}"
 mytarget=${CARGO_TARGET_DIR-target}
 #echo "mytarget=${mytarget}"
 
-CARGO_PROFILE="--release"
+CARGO_PROFILE="release"
 if [ -n "${CARGO_USE_DEV}" ]; then
-    CARGO_PROFILE=""
+    CARGO_PROFILE="dev"
     if [ -n "${CARGO_USE_CLIPPY}" ]; then
         $CARGO clippy --manifest-path $srcdir/Cargo.toml
     fi
 fi
 
-$CARGO build ${CARGO_PROFILE} $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml --locked
+case "${CARGO_LTO_MODE:-unspecified}" in
+    "fat" | "thin")
+        CARGO_CONFIG="--config profile.${CARGO_PROFILE}.lto=\"${CARGO_LTO_MODE}\""
+        ;;
+esac
+
+# echo "CARGO_PROFILE = ${CARGO_PROFILE}"
+# echo "CARGO_LTO_MODE = ${CARGO_LTO_MODE}"
+# echo "CARGO_CONFIG = ${CARGO_CONFIG}"
+
+$CARGO build --profile ${CARGO_PROFILE} ${CARGO_CONFIG} $RUST_TARGET --target-dir=$builddir/target --manifest-path $srcdir/Cargo.toml --locked
 
 if [ -n "${CARGO_USE_DEV}" ]; then
     cp -p target/$RUSTC_TARGET_ARCH/debug/libdnsdist_rust.a $builddir/dnsdist-rust-lib/rust/libdnsdist_rust.a

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
@@ -13,6 +13,18 @@ env.set('srcdir', meson.current_source_dir())
 env.append('RUST_TARGET', '', separator: '')
 env.append('RUSTC_TARGET_ARCH', '', separator: '')
 
+if get_option('rust-lto') and get_option('b_lto') and get_option('b_lto_mode') == 'default'
+  env.set('CARGO_LTO_MODE', 'fat')
+  summary('LTO', true, bool_yn: true, section: 'Rust')
+  summary('LTO mode', 'fat', section: 'Rust')
+elif get_option('rust-lto') and get_option('b_lto') and get_option('b_lto_mode') == 'thin'
+  env.set('CARGO_LTO_MODE', 'thin')
+  summary('LTO', true, bool_yn: true, section: 'Rust')
+  summary('LTO mode', 'thin', section: 'Rust')
+else
+  summary('LTO', false, bool_yn: true, section: 'Rust')
+endif
+
 lib_dnsdist_rust = custom_target('libdnsdist_rust.a',
   output: [outfile, 'cxx.h'],
   input: infile,

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust/meson.build
@@ -13,6 +13,11 @@ env.set('srcdir', meson.current_source_dir())
 env.append('RUST_TARGET', '', separator: '')
 env.append('RUSTC_TARGET_ARCH', '', separator: '')
 
+opt_rust_args = get_option('rust-args')
+if opt_rust_args != ''
+  env.set('RUSTFLAGS', opt_rust_args)
+endif
+
 if get_option('rust-lto') and get_option('b_lto') and get_option('b_lto_mode') == 'default'
   env.set('CARGO_LTO_MODE', 'fat')
   summary('LTO', true, bool_yn: true, section: 'Rust')

--- a/pdns/dnsdistdist/meson_options.txt
+++ b/pdns/dnsdistdist/meson_options.txt
@@ -41,3 +41,4 @@ option('yaml', type: 'feature', value: 'disabled', description: 'Enable YAML con
 option('man-pages', type: 'boolean', value: true, description: 'Generate man pages')
 option('clang-coverage-format', type: 'boolean', value: false, description: 'Whether to generate coverage data in clang format')
 option('benchmark', type: 'boolean', value: false, description: 'Whether to run microbenchmarks')
+option('rust-lto', type: 'boolean', value: true, description: 'Enable LTO for Rust according to b_lto, b_lto_mode settings')

--- a/pdns/dnsdistdist/meson_options.txt
+++ b/pdns/dnsdistdist/meson_options.txt
@@ -41,4 +41,5 @@ option('yaml', type: 'feature', value: 'disabled', description: 'Enable YAML con
 option('man-pages', type: 'boolean', value: true, description: 'Generate man pages')
 option('clang-coverage-format', type: 'boolean', value: false, description: 'Whether to generate coverage data in clang format')
 option('benchmark', type: 'boolean', value: false, description: 'Whether to run microbenchmarks')
+option('rust-args', type: 'string', description: 'Rust compile arguments to use')
 option('rust-lto', type: 'boolean', value: true, description: 'Enable LTO for Rust according to b_lto, b_lto_mode settings')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17639 to dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
