### PR TITLE
Auth: add SOA Edit Spread docs

### DIFF
--- a/docs/changelog/5.1.rst
+++ b/docs/changelog/5.1.rst
@@ -13,7 +13,7 @@ Changelogs for 5.1.x
     :tags: New Features
     :pullreq: 17582
 
-    implement SOA-EDIT spreading + RRSIG expiry extension
+    Implement ref:`SOA-EDIT spreading <setting-soa-edit-spread>` + ref:`RRSIG expiry extension <setting-rrsig-expiry-extend>` setting.
 
   .. change::
     :tags: Bug Fixes

--- a/docs/dnssec/modes-of-operation.rst
+++ b/docs/dnssec/modes-of-operation.rst
@@ -132,6 +132,9 @@ PowerDNS also serves the DNSKEY records in live-signing mode. Their TTL
 is derived from the SOA records *minimum* field. When using NSEC3, the
 TTL of the NSEC3PARAM record is also derived from that field.
 
+The :ref:`rrsig-expiry-extend <setting-rrsig-expiry-extend>` setting can be used to extend the expiry time to up to a year.
+This can be useful when secondaries are slow to update their zones, or when using :ref:`SOA Edit spreading <soa-edit-spread-info>`.
+
 .. _dnssec_presigned_records:
 
 Pre-signed records

--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -274,6 +274,22 @@ Ignore :ref:`setting-default-soa-edit` and/or
 :ref:`setting-default-soa-edit-signed`
 settings.
 
+.. _soa-edit-spread-info:
+
+Spreading SOA serial updates over time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.1.3
+
+The SOA-edit updates happen at the same time the RRSIG rolls (:ref:`Thursday midnight UTC <dnssec-signatures>`).
+When serving a large number of zones on the primary, it can happen that the primary becomes overloaded when all secondaries start transferring all these zones at the same time.
+This usually happens the SOA REFRESH field is set to a low value.
+
+To prevent overloading the primary by secondaries, the :ref:`soa-edit-spread <setting-soa-edit-spread>` can be used to apply the serial increases over time (starting on Thursday midnight UTC).
+These increases happen within the amount of seconds for that setting based on the hash of the zone name.
+
+To prevent RRSIGs expiring on the secondaries when :ref:`soa-edit-spread <setting-soa-edit-spread>` is set to high value, the :ref:`rrsig-expiry-extend <setting-rrsig-expiry-extend>` setting ensures that the RRSIG expiry time is extended by the same amount by default.
+
 Security
 --------
 

--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -283,12 +283,12 @@ Spreading SOA serial updates over time
 
 The SOA-edit updates happen at the same time the RRSIG rolls (:ref:`Thursday midnight UTC <dnssec-signatures>`).
 When serving a large number of zones on the primary, it can happen that the primary becomes overloaded when all secondaries start transferring all these zones at the same time.
-This usually happens the SOA REFRESH field is set to a low value.
+This usually happens if the SOA REFRESH field is set to a low value.
 
 To prevent overloading the primary by secondaries, the :ref:`soa-edit-spread <setting-soa-edit-spread>` can be used to apply the serial increases over time (starting on Thursday midnight UTC).
 These increases happen within the amount of seconds for that setting based on the hash of the zone name.
 
-To prevent RRSIGs expiring on the secondaries when :ref:`soa-edit-spread <setting-soa-edit-spread>` is set to high value, the :ref:`rrsig-expiry-extend <setting-rrsig-expiry-extend>` setting ensures that the RRSIG expiry time is extended by the same amount by default.
+To prevent RRSIGs expiring on the secondaries when :ref:`soa-edit-spread <setting-soa-edit-spread>` is set to a high value, the :ref:`rrsig-expiry-extend <setting-rrsig-expiry-extend>` setting ensures that the RRSIG expiry time is extended by the same amount by default.
 
 Security
 --------

--- a/docs/security-advisories/powerdns-advisory-2026-06.rst
+++ b/docs/security-advisories/powerdns-advisory-2026-06.rst
@@ -104,8 +104,7 @@ Insufficient Validation of Member Zone Data May Cause Catalog Zone Transfer to F
 - Not affected: PowerDNS Authoritative Server 4.9.15, 5.0.5
 - Severity: Medium
 - Impact: Denial of service
-- Exploit: AXFR of catalog zone with a member whose producer group option
-contains a double-quote character
+- Exploit: AXFR of catalog zone with a member whose producer group option contains a double-quote character
 - Risk of system compromise: None
 - Solution: Upgrade to patched version, or remove all double-quote characters from producer group names.
 - CWE: CWE-94


### PR DESCRIPTION
### Short description

This PR adds some more words, info, and links on the new SOA Edit spread functionality.

It also fixes a tiny formatting issue in a recent security advisory.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
