### PR TITLE
dnsdist: Implement missing connection metrics for QUIC frontends

### DIFF
--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -48,37 +48,18 @@
 
 using namespace dnsdist::doq;
 
-class H3Connection
+class H3Connection : public QUICConnection
 {
 public:
-  H3Connection(const ComboAddress& peer, const ComboAddress& localAddr, QuicheConfig config, QuicheConnection&& conn) :
-    d_peer(peer), d_localAddr(localAddr), d_conn(std::move(conn)), d_config(std::move(config))
+  H3Connection(const ComboAddress& peer, const ComboAddress& localAddr, QuicheConfig config, QuicheConnection&& conn, ClientState& frontend) :
+    QUICConnection(frontend, peer, localAddr, std::move(config), std::move(conn))
   {
   }
   H3Connection(const H3Connection&) = delete;
   H3Connection(H3Connection&&) = default;
   H3Connection& operator=(const H3Connection&) = delete;
-  H3Connection& operator=(H3Connection&&) = default;
-  ~H3Connection()
-  {
-    try {
-      /* do not account if we have been moved! */
-      if (d_conn) {
-        dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(d_peer);
-      }
-    }
-    catch (...) {
-      /* in theory it might raise an exception, and we cannot allow it to be uncaught in a dtor */
-    }
-  }
-
-  std::shared_ptr<const std::string> getSNI()
-  {
-    if (!d_sni) {
-      d_sni = std::make_shared<const std::string>(getSNIFromQuicheConnection(d_conn));
-    }
-    return d_sni;
-  }
+  H3Connection& operator=(H3Connection&&) = delete;
+  ~H3Connection() = default;
 
   void removeTemporaryQueryContent(uint64_t streamID)
   {
@@ -86,16 +67,9 @@ public:
     d_streamBuffers.erase(streamID);
   }
 
-  ComboAddress d_peer;
-  ComboAddress d_localAddr;
-  QuicheConnection d_conn;
-  QuicheConfig d_config;
   QuicheHTTP3Connection d_http3{nullptr, quiche_h3_conn_free};
   // buffer request headers by streamID
   std::unordered_map<uint64_t, dnsdist::doh3::h3_headers_t> d_headersBuffers;
-  std::unordered_map<uint64_t, PacketBuffer> d_streamBuffers;
-  std::unordered_map<uint64_t, PacketBuffer> d_streamOutBuffers;
-  std::shared_ptr<const std::string> d_sni{nullptr};
 };
 
 static void sendBackDOH3Unit(DOH3UnitUniquePtr&& unit, const char* description);
@@ -475,7 +449,8 @@ static std::optional<std::reference_wrapper<H3Connection>> createConnection(DOH3
     quiche_conn_set_keylog_path(quicheConn.get(), config.df->d_quicheParams.d_keyLogFile.c_str());
   }
 
-  auto conn = H3Connection(peer, localAddr, std::move(quicheConfig), std::move(quicheConn));
+  auto conn = H3Connection(peer, localAddr, std::move(quicheConfig), std::move(quicheConn), *config.clientState);
+  gettimeofday(&conn.d_connectionStartTime, nullptr);
   auto pair = config.d_connections.emplace(serverSideID, std::move(conn));
   return pair.first->second;
 }
@@ -819,6 +794,7 @@ static void processH3HeaderEvent(ClientState& clientState, DOH3Frontend& fronten
         return;
       }
       DEBUGLOG("Dispatching GET query");
+      ++conn.d_queriesCount;
       doh3_dispatch_query(*(frontend.d_server_config), std::move(*payload), conn.d_localAddr, client, serverConnID, streamID, conn.getSNI(), std::move(headers));
       conn.removeTemporaryQueryContent(streamID);
       return;
@@ -908,6 +884,7 @@ static void processH3DataEvent(ClientState& clientState, DOH3Frontend& frontend,
     }
 
     DEBUGLOG("Dispatching POST query");
+    ++conn.d_queriesCount;
     doh3_dispatch_query(*(frontend.d_server_config), std::move(streamBuffer), conn.d_localAddr, client, serverConnID, streamID, conn.getSNI(), std::move(headers));
     conn.removeTemporaryQueryContent(streamID);
   }
@@ -1078,6 +1055,7 @@ static void handleSocketReadable(DOH3Frontend& frontend, ClientState& clientStat
         DEBUGLOG("Successfully created HTTP/3 connection");
       }
 
+      ++conn->get().d_readIOsTotal;
       processH3Events(clientState, frontend, conn->get(), client, serverConnID, buffer);
 
       flushEgress(sock, conn->get().d_conn, client, localAddr, buffer, clientState.local.isUnspecified());

--- a/pdns/dnsdistdist/doq-common.cc
+++ b/pdns/dnsdistdist/doq-common.cc
@@ -26,6 +26,9 @@
 
 #ifdef HAVE_DNS_OVER_QUIC
 
+#include "dnsdist.hh"
+#include "dnsdist-concurrent-connections.hh"
+
 #if 0
 #define DEBUGLOG_ENABLED
 #define DEBUGLOG(x) std::cerr << x << std::endl;
@@ -348,6 +351,52 @@ std::string getSNIFromQuicheConnection([[maybe_unused]] const QuicheConnection& 
 #endif /* HAVE_QUICHE_CONN_SERVER_NAME */
   return {};
 }
+
+QUICConnection::QUICConnection(ClientState& frontend, const ComboAddress& peer, const ComboAddress& localAddr, QuicheConfig config, QuicheConnection&& conn) :
+  d_frontend(frontend), d_peer(peer), d_localAddr(localAddr), d_conn(std::move(conn)), d_config(std::move(config))
+{
+  auto concurrentConnections = ++d_frontend.tcpCurrentConnections;
+  if (concurrentConnections > d_frontend.tcpMaxConcurrentConnections.load()) {
+    d_frontend.tcpMaxConcurrentConnections.store(concurrentConnections);
+  }
 }
 
+QUICConnection::~QUICConnection()
+{
+  try {
+    /* do not account if we have been moved! */
+    if (d_conn) {
+      --d_frontend.tcpCurrentConnections;
+
+      dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(d_peer);
+
+      timeval now{};
+      gettimeofday(&now, nullptr);
+      auto diff = now - d_connectionStartTime;
+      d_frontend.updateTCPMetrics(d_queriesCount, (diff.tv_sec * 1000) + (diff.tv_usec / 1000), d_queriesCount > 0 ? d_readIOsTotal / d_queriesCount : d_readIOsTotal);
+
+      if (!quiche_conn_is_resumed(d_conn.get())) {
+        ++d_frontend.tlsNewSessions;
+        dnsdist::IncomingConcurrentTCPConnectionsManager::accountTLSNewSession(d_peer);
+      }
+      else {
+        ++d_frontend.tlsResumptions;
+        dnsdist::IncomingConcurrentTCPConnectionsManager::accountTLSResumedSession(d_peer);
+      }
+    }
+  }
+  catch (...) {
+    /* in theory it might raise an exception, and we cannot allow it to be uncaught in a dtor */
+  }
+}
+
+std::shared_ptr<const std::string> QUICConnection::getSNI()
+{
+  if (!d_sni) {
+    d_sni = std::make_shared<const std::string>(getSNIFromQuicheConnection(d_conn));
+  }
+  return d_sni;
+}
+
+}
 #endif

--- a/pdns/dnsdistdist/doq-common.hh
+++ b/pdns/dnsdistdist/doq-common.hh
@@ -54,6 +54,32 @@ struct QuicheParams
   std::string d_alpn;
 };
 
+class QUICConnection
+{
+public:
+  QUICConnection(ClientState& frontend, const ComboAddress& peer, const ComboAddress& localAddr, QuicheConfig config, QuicheConnection&& conn);
+  QUICConnection(const QUICConnection&) = delete;
+  QUICConnection(QUICConnection&&) = default;
+  QUICConnection& operator=(const QUICConnection&) = delete;
+  QUICConnection& operator=(QUICConnection&&) = delete;
+  virtual ~QUICConnection();
+
+  std::shared_ptr<const std::string> getSNI();
+
+  ClientState& d_frontend;
+  ComboAddress d_peer;
+  ComboAddress d_localAddr;
+  QuicheConnection d_conn;
+  QuicheConfig d_config;
+
+  std::unordered_map<uint64_t, PacketBuffer> d_streamBuffers;
+  std::unordered_map<uint64_t, PacketBuffer> d_streamOutBuffers;
+  std::shared_ptr<const std::string> d_sni{nullptr};
+  timeval d_connectionStartTime{};
+  uint64_t d_readIOsTotal{0};
+  size_t d_queriesCount{0};
+};
+
 /* from rfc9250 section-4.3 */
 enum class DOQ_Error_Codes : uint64_t
 {

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -48,47 +48,7 @@ using namespace dnsdist::doq;
 #define DEBUGLOG(x)
 #endif
 
-class Connection
-{
-public:
-  Connection(const ComboAddress& peer, const ComboAddress& localAddr, QuicheConfig config, QuicheConnection conn) :
-    d_peer(peer), d_localAddr(localAddr), d_conn(std::move(conn)), d_config(std::move(config))
-  {
-  }
-  Connection(const Connection&) = delete;
-  Connection(Connection&&) = default;
-  Connection& operator=(const Connection&) = delete;
-  Connection& operator=(Connection&&) = default;
-  ~Connection()
-  {
-    try {
-      /* do not account if we have been moved! */
-      if (d_conn) {
-        dnsdist::IncomingConcurrentTCPConnectionsManager::accountClosedTCPConnection(d_peer);
-      }
-    }
-    catch (...) {
-      /* in theory it might raise an exception, and we cannot allow it to be uncaught in a dtor */
-    }
-  }
-
-  std::shared_ptr<const std::string> getSNI()
-  {
-    if (!d_sni) {
-      d_sni = std::make_shared<const std::string>(getSNIFromQuicheConnection(d_conn));
-    }
-    return d_sni;
-  }
-
-  ComboAddress d_peer;
-  ComboAddress d_localAddr;
-  QuicheConnection d_conn;
-  QuicheConfig d_config;
-
-  std::unordered_map<uint64_t, PacketBuffer> d_streamBuffers;
-  std::unordered_map<uint64_t, PacketBuffer> d_streamOutBuffers;
-  std::shared_ptr<const std::string> d_sni{nullptr};
-};
+using Connection = QUICConnection;
 
 static void sendBackDOQUnit(DOQUnitUniquePtr&& unit, const char* description);
 
@@ -380,7 +340,8 @@ static std::optional<std::reference_wrapper<Connection>> createConnection(DOQSer
     quiche_conn_set_keylog_path(quicheConn.get(), config.df->d_quicheParams.d_keyLogFile.c_str());
   }
 
-  auto conn = Connection(peer, localAddr, std::move(quicheConfig), std::move(quicheConn));
+  auto conn = Connection(*config.clientState, peer, localAddr, std::move(quicheConfig), std::move(quicheConn));
+  gettimeofday(&conn.d_connectionStartTime, nullptr);
   auto pair = config.d_connections.emplace(serverSideID, std::move(conn));
   return pair.first->second;
 }
@@ -675,6 +636,7 @@ static void handleReadableStream(DOQFrontend& frontend, ClientState& clientState
       return;
     }
 
+    ++conn.d_readIOsTotal;
     streamBuffer.resize(existingLength + received);
     if (fin) {
       break;
@@ -699,6 +661,7 @@ static void handleReadableStream(DOQFrontend& frontend, ClientState& clientState
     return;
   }
   DEBUGLOG("Dispatching query");
+  ++conn.d_queriesCount;
   doq_dispatch_query(*(frontend.d_server_config), std::move(streamBuffer), conn.d_localAddr, client, serverConnID, streamID, conn.getSNI());
   conn.d_streamBuffers.erase(streamID);
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This commit adds the following metrics for QUIC frontends:

- average queries per connection
- average duration per connection
- average IOs per connection
- concurrent connections
- max concurrent connections
- new TLS sessions
- resumed TLS sessions

These metrics are currently reported as TCP metrics, which is not right and will have to be refactored in the future.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
