### PR TITLE
docs: fix RST syntax in changelog/5.1.rst

### DIFF
--- a/docs/changelog/5.1.rst
+++ b/docs/changelog/5.1.rst
@@ -13,7 +13,7 @@ Changelogs for 5.1.x
     :tags: New Features
     :pullreq: 17582
 
-    Implement ref:`SOA-EDIT spreading <setting-soa-edit-spread>` + ref:`RRSIG expiry extension <setting-rrsig-expiry-extend>` setting.
+    Implement :ref:`SOA-EDIT spreading <setting-soa-edit-spread>` + :ref:`RRSIG expiry extension <setting-rrsig-expiry-extend>` setting.
 
   .. change::
     :tags: Bug Fixes


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

RST syntax is [rendered](https://doc.powerdns.com/authoritative/changelog/5.1.html#change-5.1.3) verbatim in the document due to roles missing first colon.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
