### PR TITLE
auth lua: stricter checks in createreverse*

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -96,7 +96,7 @@ DNSName::DNSName(const std::string_view sw)
         d_storage.append(begiter,iter);
         if(iter != pend)
           ++iter;
-        if(labellen > 63)
+        if(labellen > s_maxDNSLabelLength)
           throwSafeRangeError("label too long to append: ", p, length);
 
         if(iter-pbegin > static_cast<ptrdiff_t>(s_maxDNSNameLength - 1)) // reserve two bytes, one for length and one for the root label
@@ -134,7 +134,7 @@ static void checkLabelLength(uint8_t length)
   if (length == 0) {
     throw std::range_error("no such thing as an empty label to append");
   }
-  if (length > 63) {
+  if (length > DNSName::s_maxDNSLabelLength) {
     throw std::range_error("label too long to append");
   }
 }
@@ -361,7 +361,7 @@ bool DNSName::isPartOf(const DNSName& parent) const
       }
       return true;
     }
-    if (static_cast<uint8_t>(*us) > 63) {
+    if (static_cast<uint8_t>(*us) > s_maxDNSLabelLength) {
       throw std::out_of_range("illegal label length in DNSName");
     }
   }

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -96,8 +96,9 @@ DNSName::DNSName(const std::string_view sw)
         d_storage.append(begiter,iter);
         if(iter != pend)
           ++iter;
-        if(labellen > s_maxDNSLabelLength)
+        if(labellen > s_maxDNSLabelLength) {
           throwSafeRangeError("label too long to append: ", p, length);
+        }
 
         if(iter-pbegin > static_cast<ptrdiff_t>(s_maxDNSNameLength - 1)) // reserve two bytes, one for length and one for the root label
           throwSafeRangeError("name too long to append: ", p, length);
@@ -924,7 +925,7 @@ std::string_view::size_type ZoneName::findVariantSeparator(std::string_view name
         ++slashes;
       }
       if ((slashes % 2) == 0) {
-	break;
+        break;
       }
     }
   }

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -88,7 +88,8 @@ class ZoneName;
 class DNSName
 {
 public:
-  static const size_t s_maxDNSNameLength = 255;
+  static constexpr size_t s_maxDNSNameLength = 255;
+  static constexpr size_t s_maxDNSLabelLength = 63;
 
   DNSName() = default; //!< Constructs an *empty* DNSName, NOT the root!
   // Work around assertion in some boost versions that do not like self-assignment of boost::container::string

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1052,6 +1052,27 @@ static string lua_createReverse(const string &format, boost::optional<opts_t> ex
       return {"unknown"};
     }
 
+    // Try to parse the first four labels as an IPv4 address, for we'll need
+    // these values both to search for an exception and to build the result
+    // otherwise.
+    std::array<unsigned long, 4> ip4part{};
+    for (int i = 3; i >= 0; --i) {
+      char *eptr;
+      auto number = strtoul(labels[i].c_str(), &eptr, 10);
+      if (*eptr != '\0') {
+        throw std::invalid_argument("invalid number in label '" + labels[i] + "'");
+      }
+      if (number > 255) {
+        throw std::out_of_range("invalid number in label '" + labels[i] + "'");
+      }
+      ip4part[i] = number;
+    }
+
+    // Note that the above checks have the side-effect of rejecting labels
+    // with non-digit bytes, so we do not need to check for possibly
+    // escaped dots or other bytes which may cause misinterpretation when
+    // labels are processed in ASCII form.
+
     // so, query comes in for 4.3.2.1.in-addr.arpa, zone is called 2.1.in-addr.arpa
     // exceptions["1.2.3.4"]="bert.powerdns.com" then provides an exception
     if (exceptions) {
@@ -1063,17 +1084,16 @@ static string lua_createReverse(const string &format, boost::optional<opts_t> ex
         }
       }
     }
+
     boost::format fmt(format);
     fmt.exceptions(boost::io::all_error_bits ^ (boost::io::too_many_args_bit | boost::io::too_few_args_bit));
     fmt % labels[3] % labels[2] % labels[1] % labels[0];
-
     fmt % (labels[3]+"-"+labels[2]+"-"+labels[1]+"-"+labels[0]);
 
     boost::format fmt2("%02x%02x%02x%02x");
     for (int i = 3; i >= 0; --i) {
-      fmt2 % atoi(labels[i].c_str());
+      fmt2 % ip4part[i];
     }
-
     fmt % (fmt2.str());
 
     return fmt.str();

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1237,9 +1237,6 @@ static string lua_createReverse6(const string &format, boost::optional<opts_t> e
       return {"unknown"};
     }
 
-    boost::format fmt(format);
-    fmt.exceptions(boost::io::all_error_bits ^ (boost::io::too_many_args_bit | boost::io::too_few_args_bit));
-
     string together;
     vector<string> quads;
     for (int chunk = 0; chunk < 8; ++chunk) {
@@ -1248,8 +1245,18 @@ static string lua_createReverse6(const string &format, boost::optional<opts_t> e
       }
       string lquad;
       for (int quartet = 0; quartet < 4; ++quartet) {
-        lquad.append(1, labels[31 - chunk * 4 - quartet][0]);
-        together += labels[31 - chunk * 4 - quartet][0];
+        const std::string& label = labels[31 - chunk * 4 - quartet];
+        if (label.length() != 1) {
+          throw std::invalid_argument("invalid hex digit in label '" + label + "'");
+        }
+        auto digit = label[0];
+        if ((digit >= '0' && digit <= '9') || (digit >= 'a' && digit <= 'f') || (digit >= 'A' && digit <= 'F')) {
+          lquad.push_back(digit);
+          together.push_back(digit);
+        }
+        else {
+          throw std::out_of_range("invalid hex digit in label '" + label + "'");
+        }
       }
       quads.push_back(std::move(lquad));
     }
@@ -1277,6 +1284,9 @@ static string lua_createReverse6(const string &format, boost::optional<opts_t> e
       // "-a--a" -> "0-a--a"               "aa--a" -> "0aa--a"
       dashed.insert(0, "0");
     }
+
+    boost::format fmt(format);
+    fmt.exceptions(boost::io::all_error_bits ^ (boost::io::too_many_args_bit | boost::io::too_few_args_bit));
 
     for (int byte = 31; byte >= 0; --byte) {
       fmt % labels[byte];

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1057,7 +1057,7 @@ static string lua_createReverse(const string &format, boost::optional<opts_t> ex
     // otherwise.
     std::array<unsigned long, 4> ip4part{};
     for (int i = 3; i >= 0; --i) {
-      char *eptr;
+      char *eptr{nullptr};
       auto number = strtoul(labels[i].c_str(), &eptr, 10);
       if (*eptr != '\0') {
         throw std::invalid_argument("invalid number in label '" + labels[i] + "'");
@@ -1065,7 +1065,7 @@ static string lua_createReverse(const string &format, boost::optional<opts_t> ex
       if (number > 255) {
         throw std::out_of_range("invalid number in label '" + labels[i] + "'");
       }
-      ip4part[i] = number;
+      ip4part.at(i) = number;
     }
 
     // Note that the above checks have the side-effect of rejecting labels
@@ -1092,7 +1092,7 @@ static string lua_createReverse(const string &format, boost::optional<opts_t> ex
 
     boost::format fmt2("%02x%02x%02x%02x");
     for (int i = 3; i >= 0; --i) {
-      fmt2 % ip4part[i];
+      fmt2 % ip4part.at(i);
     }
     fmt % (fmt2.str());
 

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -1193,6 +1193,8 @@ class TestLuaRecords(BaseLuaTest):
                     "10.10.10.10": "quad10.example.com.",  # exception
                     # error: values not in the 0..255 range
                     "256.384.512.640": "error.",
+                    # error: trailing data after numbers
+                    "12a.34b.56c.78d": "error.",
                 },
             ),
             ".createforward6.example.org.": (


### PR DESCRIPTION
### Short description
It has been reported to us that the use of the DNS labels in ascii form in the bowels of the Lua `createreverse{,6}` functions can lead to unexpected results, should these labels contain dots.

This PR makes sure that the labels which will be considered by these routines are in the expected format (a number between 0 and 255 for `createReverse`, or an hexadecimal digit for `createReverse6`), and rejects mismatching labels early.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
