### PR TITLE
auth: perform validation of metadata name before querying the backend.

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1269,7 +1269,11 @@ static void apiZoneMetadataKindGET(HttpRequest* req, HttpResponse* resp)
 {
   ZoneData zoneData{req};
 
-  string kind = req->parameters["kind"];
+  const string& kind = req->parameters["kind"];
+
+  if (!isValidMetadataKind(kind, true)) {
+    throw ApiException("Unsupported metadata kind '" + kind + "'");
+  }
 
   vector<string> metadata;
   Json::object document;
@@ -1277,9 +1281,6 @@ static void apiZoneMetadataKindGET(HttpRequest* req, HttpResponse* resp)
 
   if (!zoneData.backend.getDomainMetadata(zoneData.zoneName, kind, metadata)) {
     throw HttpNotFoundException();
-  }
-  if (!isValidMetadataKind(kind, true)) {
-    throw ApiException("Unsupported metadata kind '" + kind + "'");
   }
 
   document["type"] = "Metadata";
@@ -1297,15 +1298,14 @@ static void apiZoneMetadataKindPUT(HttpRequest* req, HttpResponse* resp)
 {
   ZoneData zoneData{req};
 
-  string kind = req->parameters["kind"];
-
-  const auto& document = req->json();
+  const string& kind = req->parameters["kind"];
 
   if (!isValidMetadataKind(kind, false)) {
     throw ApiException("Unsupported metadata kind '" + kind + "'");
   }
 
   vector<string> vecMetadata;
+  const auto& document = req->json();
   const auto& metadata = document["metadata"];
   if (!metadata.is_array()) {
     throw ApiException("metadata is not specified or not an array");


### PR DESCRIPTION
### Short description
For no good reason, one of the API entry points regarding zone metadata would check for a proper metadata name after having queried the backend, instead of before.
This PR moves the validation to the right place.

(reported by "Oxamino" in YWH-PGM6095-285)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
