### PR TITLE
auth: missing html escaping in webserver

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -256,7 +256,7 @@ static void printargs(ostringstream& ret)
 
   vector<string> entries = arg().list();
   for (const auto& entry : entries) {
-    ret << "<tr><td>" << entry << "</td><td>" << arg()[entry] << "</td><td>" << arg().getHelp(entry) << "</td>" << endl;
+    ret << "<tr><td>" << entry << "</td><td>" << htmlescape(arg()[entry]) << "</td><td>" << arg().getHelp(entry) << "</td>" << endl;
   }
 }
 


### PR DESCRIPTION
### Short description
The webserver entry point listing the currently running server's configuration did not properly html-escape their values.

(reported by "invincible001" in YWH-PGM6095-298)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
