### PR TITLE
Better reporting of filesystem errors

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1691,6 +1691,8 @@ fuzz_target_packetcache_SOURCES = \
 	dnsname.cc dnsname.hh \
 	ednsoptions.cc ednsoptions.hh \
 	fuzz_packetcache.cc \
+	logger.cc logger.hh \
+	logging.cc logging.hh \
 	misc.cc misc.hh \
 	packetcache.hh \
 	qtype.cc qtype.hh \

--- a/pdns/arguments.cc
+++ b/pdns/arguments.cc
@@ -564,36 +564,7 @@ void ArgvMap::gatherIncludes(const std::string& directory, const std::string& su
     return; // nothing to do
   }
 
-  std::vector<std::string> vec;
-  auto directoryError = pdns::visit_directory(directory, [this, &directory, &suffix, &vec]([[maybe_unused]] ino_t inodeNumber, const std::string_view& name) {
-    (void)this;
-    if (boost::starts_with(name, ".")) {
-      return true; // skip any dots
-    }
-    if (boost::ends_with(name, suffix)) {
-      // build name
-      string fullName = directory + "/" + std::string(name);
-      // ensure it's readable file
-      struct stat statInfo{};
-      if (stat(fullName.c_str(), &statInfo) != 0 || !S_ISREG(statInfo.st_mode)) {
-        string msg = fullName + " is not a regular file";
-        SLOG(g_log << Logger::Error << msg << std::endl,
-             d_log->info(Logr::Error, "Unable to open non-regular file", "name", Logging::Loggable(fullName)));
-        throw ArgException(std::move(msg));
-      }
-      vec.emplace_back(fullName);
-    }
-    return true;
-  });
-
-  if (directoryError) {
-    int err = errno;
-    string msg = directory + " is not accessible: " + stringerror(err);
-    SLOG(g_log << Logger::Error << msg << std::endl,
-         d_log->error(Logr::Error, err, "Directory is not accessible", "name", Logging::Loggable(directory)));
-    throw ArgException(std::move(msg));
-  }
-
+  std::vector<std::string> vec = pdns::list_directory(directory, suffix, d_log);
   std::sort(vec.begin(), vec.end(), CIStringComparePOSIX());
   extraConfigs.insert(extraConfigs.end(), vec.begin(), vec.end());
 }

--- a/pdns/dnsdemog.cc
+++ b/pdns/dnsdemog.cc
@@ -34,6 +34,8 @@
 
 #include "namespaces.hh"
 
+bool g_slogStructured{false};
+
 StatBag S;
 
 struct Entry

--- a/pdns/dnsdistdist/logger.hh
+++ b/pdns/dnsdistdist/logger.hh
@@ -1,0 +1,1 @@
+../logger.hh

--- a/pdns/kvresp.cc
+++ b/pdns/kvresp.cc
@@ -30,6 +30,8 @@
    What it does is provide answers to queries from the Lua generic UDP Question/Answer
    stuff in kv-example-script.lua */
 
+bool g_slogStructured{false};
+
 StatBag S;
 
 int main(int argc, char** argv)

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -36,41 +36,9 @@ void BaseLua4::loadString(const std::string &script) {
 };
 
 void BaseLua4::includePath(const std::string& directory) {
-  std::vector<std::string> vec;
   const std::string& suffix = "lua";
-  auto directoryError = pdns::visit_directory(directory, [this, &directory, &suffix, &vec]([[maybe_unused]] ino_t inodeNumber, const std::string_view& name) {
-    (void)this;
-    if (boost::starts_with(name, ".")) {
-      return true; // skip any dots
-    }
-    if (boost::ends_with(name, suffix)) {
-      // build name
-      string fullName = directory + "/" + std::string(name);
-      // ensure it's readable file
-      struct stat statInfo
-      {
-      };
-      if (stat(fullName.c_str(), &statInfo) != 0 || !S_ISREG(statInfo.st_mode)) {
-        string msg = fullName + " is not a regular file";
-        SLOG(g_log << Logger::Error << msg << std::endl,
-             g_slog->withName("lua")->info(Logr::Error, "include file is not a regular file", "file", Logging::Loggable(fullName)));
-        throw PDNSException(std::move(msg));
-      }
-      vec.emplace_back(fullName);
-    }
-    return true;
-  });
-
-  if (directoryError) {
-    int err = errno;
-    string msg = directory + " is not accessible: " + stringerror(err);
-    SLOG(g_log << Logger::Error << msg << std::endl,
-         g_slog->withName("lua")->error(Logr::Error, err, "Error trying to walk directory", "directory", Logging::Loggable(directory)));
-    throw PDNSException(std::move(msg));
-  }
-
+  std::vector<std::string> vec = pdns::list_directory(directory, suffix, g_slog->withName("lua"));
   std::sort(vec.begin(), vec.end(), CIStringComparePOSIX());
-
   for(const auto& file: vec) {
     loadFile(file, false);
   }

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1807,10 +1807,17 @@ std::vector<std::string> list_directory(const std::string& directory, const std:
       string fullName = directory + "/" + std::string(name);
       // ensure it's a readable file
       struct stat statInfo{};
-      if (stat(fullName.c_str(), &statInfo) != 0 || !S_ISREG(statInfo.st_mode)) {
-        string msg = fullName + " is not a regular file";
+      if (stat(fullName.c_str(), &statInfo) != 0) {
+        int err = errno;
+        string msg = "Unable to stat file '" + fullName + "': " + stringerror(err);
         SLOG(g_log << Logger::Error << msg << std::endl,
-             d_log->info(Logr::Error, "Unable to open non-regular file", "name", Logging::Loggable(fullName)));
+             d_log->error(Logr::Error, err, "Unable to stat file", "name", Logging::Loggable(fullName)));
+        throw PDNSException(std::move(msg));
+      }
+      if (!S_ISREG(statInfo.st_mode)) {
+        string msg = "File '" + fullName + "' is not a regular file";
+        SLOG(g_log << Logger::Error << msg << std::endl,
+             d_log->info(Logr::Error, "File is not a regular file", "name", Logging::Loggable(fullName)));
         throw PDNSException(std::move(msg));
       }
       results.emplace_back(fullName);

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -26,6 +26,7 @@
 
 #include <sys/param.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #include <netdb.h>
 #include <sys/time.h>
@@ -57,6 +58,8 @@
 #include "iputils.hh"
 #include "dnsparser.hh"
 #include "dns_random.hh"
+#include "logger.hh"
+#include "logging.hh"
 #include <pwd.h>
 #include <grp.h>
 #include <climits>
@@ -1787,6 +1790,43 @@ std::optional<std::string> visit_directory(const std::string& directory, const s
   }
 
   return std::nullopt;
+}
+
+std::vector<std::string> list_directory(const std::string& directory, const std::string& suffix, Logr::log_t d_log)
+{
+  std::vector<std::string> results;
+
+  auto directoryError = pdns::visit_directory(directory,
+    [&directory, &suffix, &results, d_log]
+    ([[maybe_unused]] ino_t inodeNumber, const std::string_view& name) {
+    if (boost::starts_with(name, ".")) {
+      return true; // skip any dots
+    }
+    if (boost::ends_with(name, suffix)) {
+      // build name
+      string fullName = directory + "/" + std::string(name);
+      // ensure it's a readable file
+      struct stat statInfo{};
+      if (stat(fullName.c_str(), &statInfo) != 0 || !S_ISREG(statInfo.st_mode)) {
+        string msg = fullName + " is not a regular file";
+        SLOG(g_log << Logger::Error << msg << std::endl,
+             d_log->info(Logr::Error, "Unable to open non-regular file", "name", Logging::Loggable(fullName)));
+        throw PDNSException(std::move(msg));
+      }
+      results.emplace_back(fullName);
+    }
+    return true;
+  });
+
+  if (directoryError) {
+    int err = errno;
+    string msg = directory + " is not accessible: " + stringerror(err);
+    SLOG(g_log << Logger::Error << msg << std::endl,
+         d_log->error(Logr::Error, err, "Directory is not accessible", "name", Logging::Loggable(directory)));
+    throw PDNSException(std::move(msg));
+  }
+
+  return results;
 }
 
 UniqueFilePtr openFileForWriting(const std::string& filePath, mode_t permissions, bool mustNotExist, bool appendIfExists)

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1792,6 +1792,7 @@ std::optional<std::string> visit_directory(const std::string& directory, const s
   return std::nullopt;
 }
 
+#ifndef DNSDIST
 std::vector<std::string> list_directory(const std::string& directory, const std::string& suffix, Logr::log_t d_log)
 {
   std::vector<std::string> results;
@@ -1835,6 +1836,7 @@ std::vector<std::string> list_directory(const std::string& directory, const std:
 
   return results;
 }
+#endif
 
 UniqueFilePtr openFileForWriting(const std::string& filePath, mode_t permissions, bool mustNotExist, bool appendIfExists)
 {

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -977,7 +977,9 @@ namespace pdns
 {
 [[nodiscard]] std::optional<std::string> visit_directory(const std::string& directory, const std::function<bool(ino_t inodeNumber, const std::string_view& name)>& visitor);
 
+#ifndef DNSDIST
 std::vector<std::string> list_directory(const std::string& directory, const std::string& suffix, Logr::log_t d_log);
+#endif
 
 struct FilePtrDeleter
 {

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -45,6 +45,7 @@
 #include <vector>
 
 #include "namespaces.hh"
+#include "logr.hh"
 
 class DNSName;
 #if defined(PDNS_AUTH)
@@ -975,6 +976,8 @@ private:
 namespace pdns
 {
 [[nodiscard]] std::optional<std::string> visit_directory(const std::string& directory, const std::function<bool(ino_t inodeNumber, const std::string_view& name)>& visitor);
+
+std::vector<std::string> list_directory(const std::string& directory, const std::string& suffix, Logr::log_t d_log);
 
 struct FilePtrDeleter
 {


### PR DESCRIPTION
### Short description
This PR is supposed to address #9090. It first factors common directory walking code (we can, now that structured logging is available everywhere), and then improves the report of some errors in order to be less puzzling, in the 2nd commit.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
