### PR TITLE
dnsdist-1.9.x: Upgrade to h2o 2.2.6-pdns4 in our packages (CVE-2026-49975)

### DIFF
--- a/builder-support/helpers/h2o.json
+++ b/builder-support/helpers/h2o.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.2.6-pdns3",
+  "version": "2.2.6-pdns4",
   "license": "MIT",
   "publisher": "https://github.com/h2o/h2o",
-  "SHA256SUM": "c37b2184169f41a2d10bacb8a2b0e90df238b7a172478ddc77e7077754e0ab17"
+  "SHA256SUM": "67f278bf8b230f4678104f72c2f32e44bb00d0942801a07075f18ca80a99263e"
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR upgrades h2o to v2.2.6-pdns4 in our packages, fixing CVE-2026-49975 when the h2o DNS over HTTPS provider is used.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
