### PR TITLE
auth: remove dead test

### DIFF
--- a/regression-tests/tests/big-axfr/command
+++ b/regression-tests/tests/big-axfr/command
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-#cleandig example.com AXFR @$nameserver

--- a/regression-tests/tests/big-axfr/description
+++ b/regression-tests/tests/big-axfr/description
@@ -1,1 +1,0 @@
-This tries to transfer a 20.000 record zone over AXFR. Takes a long time.


### PR DESCRIPTION
### Short description
The `big-axfr` test has been disabled in february 2005. I think we can afford to remove it now.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
