### PR TITLE
fix(dnsdist): remove dangling symlink

### DIFF
--- a/pdns/dnsdistdist/meson/kiss-rng
+++ b/pdns/dnsdistdist/meson/kiss-rng
@@ -1,1 +1,0 @@
-../../../meson/kiss-rng


### PR DESCRIPTION
### Short description

KISS is not used.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
