### PR TITLE
auth: yet another round of coverity-induced improvements

### DIFF
--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -522,7 +522,7 @@ bool Bind2Backend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
       key.name = DNSName(row[0]);
       key.algorithm = DNSName(row[1]);
       key.key = row[2];
-      keys.push_back(key);
+      keys.push_back(std::move(key));
     }
 
     d_getTSIGKeysQuery_stmt->reset();

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -883,7 +883,7 @@ LMDBBackend::~LMDBBackend()
 
 void LMDBBackend::openAllTheDatabases()
 {
-  auto filename = getArg("filename");
+  const auto& filename = getArg("filename");
   d_tdomains = std::make_shared<tdomains_t>(getMDBEnv(filename.c_str(), MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_main), "domains_v5");
   d_tmeta = std::make_shared<tmeta_t>(d_tdomains->getEnv(), "metadata_v5");
   d_tkdb = std::make_shared<tkdb_t>(d_tdomains->getEnv(), "keydata_v5");

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -191,7 +191,7 @@ public:
         SLOG(g_log << Logger::Debug << "[" << getPrefix() << "] Got result " << "'" << rec.qname << " IN " << rec.qtype.toString() << " " << rec.ttl << " " << rec.getZoneRepresentation() << "'" << endl,
              d_slog->info(Logr::Debug, "Got result", "name", Logging::Loggable(rec.qname), "type", Logging::Loggable(rec.qtype), "ttl", Logging::Loggable(rec.ttl), "data", Logging::Loggable(rec.getZoneRepresentation())));
       }
-      d_result.push_back(rec);
+      d_result.push_back(std::move(rec));
     }
     if (d_result.empty() && d_debug_log) {
       SLOG(g_log << Logger::Debug << "[" << getPrefix() << "] Got empty result" << endl,
@@ -384,7 +384,7 @@ public:
              d_slog->info(Logr::Debug, "Got result", "domain", Logging::Loggable(di.zone)));
       }
       parseDomainInfo(row.second, di);
-      domains->push_back(di);
+      domains->push_back(std::move(di));
     }
   }
 
@@ -525,13 +525,13 @@ public:
         value = DNSName(boost::get<DNSName>(item.second));
       }
       if (item.first == "unhashed") {
-        unhashed = value;
+        unhashed = std::move(value);
       }
       else if (item.first == "before") {
-        before = value;
+        before = std::move(value);
       }
       else if (item.first == "after") {
-        after = value;
+        after = std::move(value);
       }
       else {
         SLOG(g_log << Logger::Error << "Invalid result from dns_get_before_and_after_names_absolute, unexpected key " << item.first << endl,

--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -196,7 +196,7 @@ void TinyDNSBackend::getAllDomains_locked(vector<DomainInfo>* domains, bool getS
       }
 
       di.notified_serial = di.serial;
-      domains->push_back(di);
+      domains->push_back(std::move(di));
     }
   }
 }

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -1809,7 +1809,7 @@ int main(int argc, char** argv)
   }
 
   try {
-    auto defaultCatalog = ::arg()["default-catalog-zone"];
+    const auto& defaultCatalog = ::arg()["default-catalog-zone"];
     if (!defaultCatalog.empty()) {
       auto defCatalog = DNSName(defaultCatalog);
     }

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -1266,7 +1266,7 @@ void CommunicatorClass::addSecondaryCheckRequest(const DomainInfo& di, const Com
     }
   }
   data->d_tocheck.erase(di);
-  data->d_tocheck.insert(ours);
+  data->d_tocheck.insert(std::move(ours));
   d_any_sem.post(); // kick the loop!
 }
 

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1306,7 +1306,7 @@ bool GSQLBackend::getTSIGKeys(std::vector< struct TSIGKey > &keys)
         continue;
       }
       key.key = row[2];
-      keys.push_back(key);
+      keys.push_back(std::move(key));
     }
 
     d_getTSIGKeysQuery_stmt->reset();
@@ -2396,7 +2396,7 @@ bool GSQLBackend::searchComments(const string &pattern, size_t maxResults, vecto
       ASSERT_ROW_COLUMNS("search-comments-query", row, 6);
       Comment comment;
       extractComment(row, comment);
-      result.push_back(comment);
+      result.push_back(std::move(comment));
     }
 
     d_SearchCommentsQuery_stmt->reset();

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -128,7 +128,7 @@ bool AuthLua4::axfrfilter(const ComboAddress& remote, const DNSName& zone, const
       }
       rec.setContent(boost::get<std::string>(map.at("content")));
 
-      out.push_back(rec);
+      out.push_back(std::move(rec));
     }
   }
   catch (const std::exception& e) {

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -754,7 +754,7 @@ static vector<vector<ComboAddress>> convMultiComboAddressList(const boost::varia
 
   if(auto simple = boost::get<iplist_t>(&items)) {
     vector<ComboAddress> unit = convComboAddressList(*simple, port);
-    candidates.push_back(unit);
+    candidates.push_back(std::move(unit));
   } else {
     auto units = boost::get<ipunitlist_t>(items);
     for(const auto& u : units) {
@@ -1147,7 +1147,7 @@ static string lua_createForward()
         // 1-2-3-4 with any prefix (e.g. ip-foo-bar-1-2-3-4)
         string ret;
         for (size_t index=4; index > 0; index--) {
-          const auto octet = ip_parts.at(ip_parts.size() - index);
+          const auto& octet = ip_parts.at(ip_parts.size() - index);
           size_t octetLength{0};
           auto octetVal = pdns::checked_stoi<uint8_t>(octet, &octetLength); // may throw
 

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -73,7 +73,7 @@ bool doSecPoll(Logr::log_t slog, bool first)
 
 
   S.set("security-status", security_status);
-  g_security_message = security_message;
+  g_security_message = std::move(security_message);
 
   if(security_status == 1 && first) {
     SLOG(g_log<<Logger::Warning << "Polled security status of version "<<PACKAGEVERSION<<" at startup, no known issues reported: " <<g_security_message<<endl,

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -600,7 +600,7 @@ void WebServer::serveConnection(const std::shared_ptr<Socket>& client) const
 }
 
 WebServer::WebServer(std::shared_ptr<ConcurrentConnectionManager> ccm, string listenaddress, int port) :
-  d_ccm(ccm),
+  d_ccm(std::move(ccm)),
   d_listenaddress(std::move(listenaddress)),
   d_port(port),
   d_server(nullptr),


### PR DESCRIPTION
### Short description
Bunch of one-liners to avoid causing object copies, either by taking const references to them instead of copies, or by using `std::move()` when possible.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
