### PR TITLE
auth: preserve brain cells

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -649,7 +649,14 @@ void DNSSECKeeper::getPreRRSIGs(UeberBackend& db, vector<DNSZoneRecord>& rrs, ui
     return;
   }
 
-  const auto rr = *rrs.rbegin();
+  // This is an intentional copy of the last item in rrs.
+  // It looks like we could afford using a const auto& reference to that item,
+  // but if we do, as soon as the emplace_back call in the loop below causes
+  // a vector reallocation, that reference would be dangling.
+  // Despite callers performing a generous reserve() call to reduce the
+  // odds of reallocation occurring, this can (and will!) nevertheless happen.
+  // NOLINTNEXTLINE(readability-identifier-length)
+  const auto rr = *rrs.rbegin(); // coverity[auto_causes_copy] dear Coverity, you made me try and "fix" this twice, and I lost brain cells I will never recover trying to understand why this apparently innocent fix would burst in flames, please stop
 
   DNSZoneRecord dzr;
 


### PR DESCRIPTION
### Short description
Dear Prudenc^WCoverity, you've convinced me to do that change twice in the last 18 months, and each time it caused the CI to burst in flames and figuring out that supposedly innocent change was the cause took me hours and fresh brain cells I'll never recover.

So, as a gift to my future self who is about to fall again in the same trap in a few months from now while browsing Coverity reports, explain why this is a bad idea.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
