### PR TITLE
auth: scrub axfr code

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -689,7 +689,7 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket)  // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket) // NOLINT(readability-function-cognitive-complexity)
 {
   const ZoneName& targetZone = q->qdomainzone;
   const DNSName& target = targetZone.operator const DNSName&();
@@ -856,242 +856,16 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
     zrrs.push_back(zrr);
   }
 
-  const bool rectify = !(presignedZone || ::arg().mustDo("disable-axfr-rectify"));
-  set<DNSName> qnames, nsset, terms;
-
-  // Catalog zone start
-  if (di.kind == DomainInfo::Producer) {
-    // Ignore all records except NS at apex
-    sd.db->lookup(QType::NS, target, di.id);
-    while (sd.db->get(zrr)) {
-      zrrs.emplace_back(zrr);
-    }
-    if (zrrs.empty()) {
-      zrr.dr.d_name = target;
-      zrr.dr.d_ttl = 0;
-      zrr.dr.d_type = QType::NS;
-      zrr.dr.setContent(std::make_shared<NSRecordContent>("invalid."));
-      zrrs.emplace_back(zrr);
-    }
-
-    zrrs.emplace_back(CatalogInfo::getCatalogVersionRecord(targetZone));
-
-    vector<CatalogInfo> members;
-    if (!sd.db->getCatalogMembers(targetZone, members, CatalogInfo::CatalogType::Producer)) {
-      SLOG(g_log << Logger::Error << logPrefix << "getting catalog members failed, aborting AXFR" << endl,
-           slog->info(Logr::Error, "AXFR aborted: getting catalog members failed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::ServFail);
-      sendPacket(outpacket, outsock);
+  if (di.kind == DomainInfo::Producer) { // Catalog zone
+    if (!axfrProducerZone(q, outsock, slog, logPrefix, outpacket, zrrs, di, sd)) {
       return 0;
     }
-    for (const auto& ci : members) {
-      ci.toDNSZoneRecords(targetZone, zrrs);
-    }
-    if (members.empty()) {
-      SLOG(g_log << Logger::Warning << logPrefix << "catalog zone '" << targetZone << "' has no members" << endl,
-           slog->info(Logr::Warning, "AXFR: Catalog zone has no members", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    }
-    goto send;
   }
-  // Catalog zone end
-
-  // now start list zone
-  if (!sd.db->list(targetZone, sd.domain_id, isCatalogZone)) {
-    SLOG(g_log<<Logger::Error<<logPrefix<<"backend signals error condition, aborting AXFR"<<endl,
-         slog->info(Logr::Error, "AXFR aborted: backend signals error condition", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    outpacket->setRcode(RCode::ServFail);
-    sendPacket(outpacket,outsock);
-    return 0;
-  }
-
-  while(sd.db->get(zrr)) {
-    if (!presignedZone) {
-      if (zrr.dr.d_type == QType::RRSIG) {
-        continue;
-      }
-      if (zrr.dr.d_type == QType::DNSKEY || zrr.dr.d_type == QType::CDNSKEY || zrr.dr.d_type == QType::CDS) {
-        if(!::arg().mustDo("direct-dnskey")) {
-          continue;
-        } else {
-          zrr.dr.d_ttl = sd.minimum;
-        }
-      }
-    }
-    zrr.dr.d_name.makeUsLowerCase();
-    if(zrr.dr.d_name.isPartOf(target)) {
-      if (zrr.dr.d_type == QType::ALIAS && (::arg().mustDo("outgoing-axfr-expand-alias") || ::arg()["outgoing-axfr-expand-alias"] == "ignore-errors")) {
-        vector<DNSZoneRecord> ips;
-        int ret1 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
-        int ret2 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
-        if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
-          if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
-            if (ret1 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            }
-            if (ret2 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            }
-          }
-          else {
-            SLOG(g_log << Logger::Warning << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
-                 slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            outpacket->setRcode(RCode::ServFail);
-            sendPacket(outpacket, outsock);
-            return 0;
-          }
-        }
-        for (auto& ip: ips) {
-          zrr.dr.d_type = ip.dr.d_type;
-          zrr.dr.setContent(ip.dr.getContent());
-          zrrs.push_back(zrr);
-        }
-        continue;
-      }
-
-      if (rectify) {
-        if (zrr.dr.d_type) {
-          qnames.insert(zrr.dr.d_name);
-          if(zrr.dr.d_type == QType::NS && zrr.dr.d_name!=target)
-            nsset.insert(zrr.dr.d_name);
-        } else {
-          // remove existing ents
-          continue;
-        }
-      }
-      zrrs.push_back(zrr);
-    } else {
-      if (zrr.dr.d_type != QType::ENT)
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
-             slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
+  else {
+    if (!axfrRegularZone(q, outsock, slog, logPrefix, outpacket, zrrs, sd, presignedZone, securedZone, NSEC3Zone, isCatalogZone, ns3pr)) {
+      return 0;
     }
   }
-
-  for (auto& loopRR : zrrs) {
-    if ((loopRR.dr.d_type == QType::SVCB || loopRR.dr.d_type == QType::HTTPS)) {
-      // Process auto hints
-      // TODO this is an almost copy of the code in the packethandler
-      auto rrc = getRR<SVCBBaseRecordContent>(loopRR.dr);
-      if (rrc == nullptr) {
-        continue;
-      }
-      auto newRRC = rrc->clone();
-      if (!newRRC) {
-        continue;
-      }
-      DNSName svcTarget = newRRC->getTarget().isRoot() ? loopRR.dr.d_name : newRRC->getTarget();
-      if (newRRC->autoHint(SvcParam::ipv4hint)) {
-        sd.db->lookup(QType::A, svcTarget, sd.domain_id);
-        vector<ComboAddress> hints;
-        DNSZoneRecord rr;
-        while (sd.db->get(rr)) {
-          auto arrc = getRR<ARecordContent>(rr.dr);
-          hints.push_back(arrc->getCA());
-        }
-        if (hints.size() == 0) {
-          newRRC->removeParam(SvcParam::ipv4hint);
-        } else {
-          newRRC->setHints(SvcParam::ipv4hint, hints);
-        }
-      }
-
-      if (newRRC->autoHint(SvcParam::ipv6hint)) {
-        sd.db->lookup(QType::AAAA, svcTarget, sd.domain_id);
-        vector<ComboAddress> hints;
-        DNSZoneRecord rr;
-        while (sd.db->get(rr)) {
-          auto arrc = getRR<AAAARecordContent>(rr.dr);
-          hints.push_back(arrc->getCA());
-        }
-        if (hints.size() == 0) {
-          newRRC->removeParam(SvcParam::ipv6hint);
-        } else {
-          newRRC->setHints(SvcParam::ipv6hint, hints);
-        }
-      }
-
-      loopRR.dr.setContent(std::move(newRRC));
-    }
-  }
-
-  // Group records by name and type, signpipe stumbles over interrupted rrsets
-  if(securedZone && !presignedZone) {
-    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
-      return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
-    });
-  }
-
-  if(rectify) {
-    // set auth
-    for(DNSZoneRecord &loopZRR :  zrrs) {
-      loopZRR.auth=true;
-      if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
-        DNSName shorter(loopZRR.dr.d_name);
-        do {
-          if (shorter==target) // apex is always auth
-            break;
-          if(nsset.count(shorter) && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
-            loopZRR.auth=false;
-            break;
-          }
-        } while(shorter.chopOff());
-      }
-    }
-
-    if(NSEC3Zone) {
-      // ents are only required for NSEC3 zones
-      uint32_t maxent = ::arg().asNum("max-ent-entries");
-      set<DNSName> nsec3set, nonterm;
-      for (auto &loopZRR: zrrs) {
-        bool skip=false;
-        DNSName shorter = loopZRR.dr.d_name;
-        if (shorter != target && shorter.chopOff() && shorter != target) {
-          do {
-            if(nsset.count(shorter)) {
-              skip=true;
-              break;
-            }
-          } while(shorter.chopOff() && shorter != target);
-        }
-        shorter = loopZRR.dr.d_name;
-        if(!skip && (loopZRR.dr.d_type != QType::NS || !ns3pr.d_flags)) {
-          do {
-            if(!nsec3set.count(shorter)) {
-              nsec3set.insert(shorter);
-            }
-          } while(shorter != target && shorter.chopOff());
-        }
-      }
-
-      for(DNSZoneRecord &loopZRR :  zrrs) {
-        DNSName shorter(loopZRR.dr.d_name);
-        while(shorter != target && shorter.chopOff()) {
-          if(!qnames.count(shorter) && !nonterm.count(shorter) && nsec3set.count(shorter)) {
-            if(!(maxent)) {
-              SLOG(g_log<<Logger::Warning<<logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
-                   slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-              outpacket->setRcode(RCode::ServFail);
-              sendPacket(outpacket,outsock);
-              return 0;
-            }
-            nonterm.insert(shorter);
-            --maxent;
-          }
-        }
-      }
-
-      for(const auto& nt :  nonterm) {
-        DNSZoneRecord tempRR;
-        tempRR.dr.d_name=nt;
-        tempRR.dr.d_type=QType::ENT;
-        tempRR.auth=true;
-        zrrs.push_back(tempRR);
-      }
-    }
-  }
-
-send:
 
   /* now write all other records */
 
@@ -1264,6 +1038,256 @@ send:
        slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
 
   return 1;
+}
+
+bool TCPNameserver::axfrProducerZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const DomainInfo& di, const SOAData& sd)
+{
+  const ZoneName& targetZone = q->qdomainzone;
+  const DNSName& target = targetZone.operator const DNSName&();
+
+  DNSZoneRecord zrr;
+
+  // Ignore all records except NS at apex
+  sd.db->lookup(QType::NS, target, di.id);
+  while (sd.db->get(zrr)) {
+    zrrs.emplace_back(zrr);
+  }
+  if (zrrs.empty()) {
+    zrr.dr.d_name = target;
+    zrr.dr.d_ttl = 0;
+    zrr.dr.d_type = QType::NS;
+    zrr.dr.setContent(std::make_shared<NSRecordContent>("invalid."));
+    zrrs.emplace_back(zrr);
+  }
+
+  zrrs.emplace_back(CatalogInfo::getCatalogVersionRecord(targetZone));
+
+  vector<CatalogInfo> members;
+  if (!sd.db->getCatalogMembers(targetZone, members, CatalogInfo::CatalogType::Producer)) {
+    SLOG(g_log << Logger::Error << logPrefix << "getting catalog members failed, aborting AXFR" << endl,
+         slog->info(Logr::Error, "AXFR aborted: getting catalog members failed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+    outpacket->setRcode(RCode::ServFail);
+    sendPacket(outpacket, outsock);
+    return false;
+  }
+  for (const auto& ci : members) {
+    ci.toDNSZoneRecords(targetZone, zrrs);
+  }
+  if (members.empty()) {
+    SLOG(g_log << Logger::Warning << logPrefix << "catalog zone '" << targetZone << "' has no members" << endl,
+         slog->info(Logr::Warning, "AXFR: Catalog zone has no members", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+  }
+
+  return true;
+}
+
+bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const SOAData& sd, bool presignedZone, bool securedZone, bool NSEC3Zone, bool isCatalogZone, const NSEC3PARAMRecordContent& ns3pr) // NOLINT(readability-function-cognitive-complexity)
+{
+  const ZoneName& targetZone = q->qdomainzone;
+  const DNSName& target = targetZone.operator const DNSName&();
+
+  // now start list zone
+  if (!sd.db->list(targetZone, sd.domain_id, isCatalogZone)) {
+    SLOG(g_log<<Logger::Error<<logPrefix<<"backend signals error condition, aborting AXFR"<<endl,
+         slog->info(Logr::Error, "AXFR aborted: backend signals error condition", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+    outpacket->setRcode(RCode::ServFail);
+    sendPacket(outpacket,outsock);
+    return false;
+  }
+
+  const bool rectify = !(presignedZone || ::arg().mustDo("disable-axfr-rectify"));
+  set<DNSName> qnames, nsset;
+
+  DNSZoneRecord zrr;
+
+  while(sd.db->get(zrr)) {
+    if (!presignedZone) {
+      if (zrr.dr.d_type == QType::RRSIG) {
+        continue;
+      }
+      if (zrr.dr.d_type == QType::DNSKEY || zrr.dr.d_type == QType::CDNSKEY || zrr.dr.d_type == QType::CDS) {
+        if(!::arg().mustDo("direct-dnskey")) {
+          continue;
+        } else {
+          zrr.dr.d_ttl = sd.minimum;
+        }
+      }
+    }
+    zrr.dr.d_name.makeUsLowerCase();
+    if(zrr.dr.d_name.isPartOf(target)) {
+      if (zrr.dr.d_type == QType::ALIAS && (::arg().mustDo("outgoing-axfr-expand-alias") || ::arg()["outgoing-axfr-expand-alias"] == "ignore-errors")) {
+        vector<DNSZoneRecord> ips;
+        int ret1 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
+        int ret2 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
+        if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
+          if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
+            if (ret1 != RCode::NoError) {
+              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+                   slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+            }
+            if (ret2 != RCode::NoError) {
+              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+                   slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+            }
+          }
+          else {
+            SLOG(g_log << Logger::Warning << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
+                 slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+            outpacket->setRcode(RCode::ServFail);
+            sendPacket(outpacket, outsock);
+            return false;
+          }
+        }
+        for (auto& ip: ips) {
+          zrr.dr.d_type = ip.dr.d_type;
+          zrr.dr.setContent(ip.dr.getContent());
+          zrrs.push_back(zrr);
+        }
+        continue;
+      }
+
+      if (rectify) {
+        if (zrr.dr.d_type) {
+          qnames.insert(zrr.dr.d_name);
+          if(zrr.dr.d_type == QType::NS && zrr.dr.d_name!=target)
+            nsset.insert(zrr.dr.d_name);
+        } else {
+          // remove existing ents
+          continue;
+        }
+      }
+      zrrs.push_back(zrr);
+    } else {
+      if (zrr.dr.d_type != QType::ENT)
+        SLOG(g_log<<Logger::Warning<<logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
+             slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
+    }
+  }
+
+  for (auto& loopRR : zrrs) {
+    if ((loopRR.dr.d_type == QType::SVCB || loopRR.dr.d_type == QType::HTTPS)) {
+      // Process auto hints
+      // TODO this is an almost copy of the code in the packethandler
+      auto rrc = getRR<SVCBBaseRecordContent>(loopRR.dr);
+      if (rrc == nullptr) {
+        continue;
+      }
+      auto newRRC = rrc->clone();
+      if (!newRRC) {
+        continue;
+      }
+      DNSName svcTarget = newRRC->getTarget().isRoot() ? loopRR.dr.d_name : newRRC->getTarget();
+      if (newRRC->autoHint(SvcParam::ipv4hint)) {
+        sd.db->lookup(QType::A, svcTarget, sd.domain_id);
+        vector<ComboAddress> hints;
+        DNSZoneRecord rr;
+        while (sd.db->get(rr)) {
+          auto arrc = getRR<ARecordContent>(rr.dr);
+          hints.push_back(arrc->getCA());
+        }
+        if (hints.size() == 0) {
+          newRRC->removeParam(SvcParam::ipv4hint);
+        } else {
+          newRRC->setHints(SvcParam::ipv4hint, hints);
+        }
+      }
+
+      if (newRRC->autoHint(SvcParam::ipv6hint)) {
+        sd.db->lookup(QType::AAAA, svcTarget, sd.domain_id);
+        vector<ComboAddress> hints;
+        DNSZoneRecord rr;
+        while (sd.db->get(rr)) {
+          auto arrc = getRR<AAAARecordContent>(rr.dr);
+          hints.push_back(arrc->getCA());
+        }
+        if (hints.size() == 0) {
+          newRRC->removeParam(SvcParam::ipv6hint);
+        } else {
+          newRRC->setHints(SvcParam::ipv6hint, hints);
+        }
+      }
+
+      loopRR.dr.setContent(std::move(newRRC));
+    }
+  }
+
+  // Group records by name and type, signpipe stumbles over interrupted rrsets
+  if(securedZone && !presignedZone) {
+    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
+      return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
+    });
+  }
+
+  if(rectify) {
+    // set auth
+    for(DNSZoneRecord &loopZRR :  zrrs) {
+      loopZRR.auth=true;
+      if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
+        DNSName shorter(loopZRR.dr.d_name);
+        do {
+          if (shorter==target) // apex is always auth
+            break;
+          if(nsset.count(shorter) && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
+            loopZRR.auth=false;
+            break;
+          }
+        } while(shorter.chopOff());
+      }
+    }
+
+    if(NSEC3Zone) {
+      // ents are only required for NSEC3 zones
+      uint32_t maxent = ::arg().asNum("max-ent-entries");
+      set<DNSName> nsec3set, nonterm;
+      for (auto &loopZRR: zrrs) {
+        bool skip=false;
+        DNSName shorter = loopZRR.dr.d_name;
+        if (shorter != target && shorter.chopOff() && shorter != target) {
+          do {
+            if(nsset.count(shorter)) {
+              skip=true;
+              break;
+            }
+          } while(shorter.chopOff() && shorter != target);
+        }
+        shorter = loopZRR.dr.d_name;
+        if(!skip && (loopZRR.dr.d_type != QType::NS || !ns3pr.d_flags)) {
+          do {
+            if(!nsec3set.count(shorter)) {
+              nsec3set.insert(shorter);
+            }
+          } while(shorter != target && shorter.chopOff());
+        }
+      }
+
+      for(DNSZoneRecord &loopZRR :  zrrs) {
+        DNSName shorter(loopZRR.dr.d_name);
+        while(shorter != target && shorter.chopOff()) {
+          if(!qnames.count(shorter) && !nonterm.count(shorter) && nsec3set.count(shorter)) {
+            if(!(maxent)) {
+              SLOG(g_log<<Logger::Warning<<logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
+                   slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+              outpacket->setRcode(RCode::ServFail);
+              sendPacket(outpacket,outsock);
+              return false;
+            }
+            nonterm.insert(shorter);
+            --maxent;
+          }
+        }
+      }
+
+      for(const auto& nt :  nonterm) {
+        DNSZoneRecord tempRR;
+        tempRR.dr.d_name=nt;
+        tempRR.dr.d_type=QType::ENT;
+        tempRR.auth=true;
+        zrrs.push_back(tempRR);
+      }
+    }
+  }
+
+  return true;
 }
 
 int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -637,12 +637,10 @@ namespace {
 }
 
 
-/** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
 // NOLINTNEXTLINE(readability-identifier-length)
-int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)  // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
 {
   const ZoneName& targetZone = q->qdomainzone;
-  const DNSName& target = targetZone.operator const DNSName&();
   string logPrefix;
 
   if (!g_slogStructured) {
@@ -660,7 +658,6 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   // determine if zone exists and AXFR is allowed using existing backend before spawning a new backend.
   DLOG(SLOG(g_log<<logPrefix<<"looking for SOA"<<endl,
             slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-  SOAData sd;
   {
     auto packetHandler = s_P.lock();
     if(!*packetHandler) {
@@ -678,6 +675,7 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       return 0;
     }
 
+    SOAData sd;
     if (!(*packetHandler)->getBackend()->getSOAUncached(targetZone, sd)) {
       SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative"<<endl,
            slog->info(Logr::Warning, "AXFR failed: not authoritative", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
@@ -687,8 +685,18 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     }
   }
 
+  return doAXFRinternal(q, outsock, slog, logPrefix, outpacket);
+}
+
+/** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket)  // NOLINT(readability-function-cognitive-complexity)
+{
+  const ZoneName& targetZone = q->qdomainzone;
+  const DNSName& target = targetZone.operator const DNSName&();
+
   // find domain_id via SOA and list complete domain. No SOA, no AXFR
   UeberBackend db;
+  SOAData sd;
   if(!db.getSOAUncached(targetZone, sd)) {
     SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative in second instance"<<endl,
          slog->info(Logr::Warning, "AXFR failed: not authoritative in second instance", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
@@ -1413,7 +1421,11 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 
   SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR fallback to AXFR"<<endl,
        slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-  return doAXFR(q, outsock, slog);
+  // Update log prefix as well
+  if (!g_slogStructured) {
+    logPrefix.at(0) = 'A';
+  }
+  return doAXFRinternal(q, outsock, slog, logPrefix, outpacket);
 }
 
 TCPNameserver::~TCPNameserver() = default;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -514,6 +514,7 @@ public:
   XFRContext& operator=(const XFRContext&) = delete;
 
   void setupOutputPacket();
+  void sendIntermediatePacket(TSIGRecordContent &trc);
 
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
   const ZoneName& targetZone; // domain being XFR'ed
@@ -563,6 +564,19 @@ void TCPNameserver::XFRContext::setupOutputPacket()
   outpacket->setCompress(false);
   outpacket->d_dnssecOk=false; // RFC 5936, 2.2.5
   outpacket->d_tcp = true;
+}
+
+void TCPNameserver::XFRContext::sendIntermediatePacket(TSIGRecordContent &trc)
+{
+  try {
+    sendPacket(outpacket, outsock, false);
+  }
+  catch (PDNSException& pe) {
+    throw PDNSException("during " + xfrType + "-out of " + targetZone.toLogString() + ", this happened: "+pe.reason);
+  }
+  trc.d_mac = outpacket->d_trc.d_mac;
+
+  setupOutputPacket();
 }
 
 bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler) // NOLINT(readability-identifier-length)
@@ -799,10 +813,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
   }
 
-  sendPacket(ctx.outpacket, ctx.outsock, false);
-
-  trc.d_mac = ctx.outpacket->d_trc.d_mac;
-  ctx.setupOutputPacket();
+  ctx.sendIntermediatePacket(trc);
 
   DNSZoneRecord zrr;
   vector<DNSZoneRecord> zrrs;
@@ -926,9 +937,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
           if(haveTSIGDetails && !tsigkeyname.empty()) {
             ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
           }
-          sendPacket(ctx.outpacket, ctx.outsock, false);
-          trc.d_mac=ctx.outpacket->d_trc.d_mac;
-          ctx.setupOutputPacket();
+          ctx.sendIntermediatePacket(trc);
         }
         else {
           break;
@@ -977,9 +986,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
                 if(haveTSIGDetails && !tsigkeyname.empty()) {
                   ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
                 }
-                sendPacket(ctx.outpacket, ctx.outsock, false);
-                trc.d_mac=ctx.outpacket->d_trc.d_mac;
-                ctx.setupOutputPacket();
+                ctx.sendIntermediatePacket(trc);
               }
               else {
                 break;
@@ -1016,9 +1023,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
               if(haveTSIGDetails && !tsigkeyname.empty()) {
                 ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
               }
-              sendPacket(ctx.outpacket, ctx.outsock, false);
-              trc.d_mac=ctx.outpacket->d_trc.d_mac;
-              ctx.setupOutputPacket();
+              ctx.sendIntermediatePacket(trc);
             }
             else {
               break;
@@ -1034,14 +1039,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
       if(haveTSIGDetails && !tsigkeyname.empty()) {
         ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
       }
-      try {
-        sendPacket(ctx.outpacket, ctx.outsock, false);
-      }
-      catch (PDNSException& pe) {
-        throw PDNSException("during axfr-out of "+target.toString()+", this happened: "+pe.reason);
-      }
-      trc.d_mac=ctx.outpacket->d_trc.d_mac;
-      ctx.setupOutputPacket();
+      ctx.sendIntermediatePacket(trc);
     }
     else {
       break;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -63,8 +63,6 @@
 #include "noinitvector.hh"
 #include "gss_context.hh"
 #include "pdnsexception.hh"
-extern AuthPacketCache PC;
-extern StatBag S;
 
 /**
 \file tcpreceiver.cc
@@ -400,8 +398,8 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
       if(g_logDNSQueries)  {
         if (g_slogStructured) {
           slogger = slog->withValues("remote", Logging::Loggable(packet->getRemoteString()), "query", Logging::Loggable(packet->qdomain), "type", Logging::Loggable(packet->qtype), "dnssecok", Logging::Loggable(packet->d_dnssecOk), "bufsize", Logging::Loggable(packet->getMaxReplyLen()));
-	}
-	else {
+        }
+        else {
           g_log << Logger::Notice<<"TCP Remote "<< packet->getRemoteString() <<" wants '" << packet->qdomain<<"|"<<packet->qtype.toString() <<
                "', do = " <<packet->d_dnssecOk <<", bufsize = "<< packet->getMaxReplyLen();
         }
@@ -496,33 +494,25 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
     SLOG(g_log << Logger::Error << "Error closing TCP socket for client " << remote << ": " << e.reason << endl,
          slog->error(Logr::Error, e.reason, "Error closing TCP socket", "remote", Logging::Loggable(remote)));
   }
-  decrementClientCount(remote);
+ decrementClientCount(remote);
 }
 
 namespace {
   struct NSECXEntry
   {
     NSECBitmap d_set;
-    unsigned int d_ttl;
-    bool d_auth;
+    unsigned int d_ttl{0};
+    bool d_auth{false};
   };
-
-  static std::unique_ptr<DNSPacket> getFreshAXFRPacket(std::unique_ptr<DNSPacket>& q)
-  {
-    std::unique_ptr<DNSPacket> ret = std::unique_ptr<DNSPacket>(q->replyPacket());
-    ret->setCompress(false);
-    ret->d_dnssecOk=false; // RFC 5936, 2.2.5
-    ret->d_tcp = true;
-    return ret;
-  }
 }
 
-class XFRContext : public boost::noncopyable
+class TCPNameserver::XFRContext : public boost::noncopyable
 {
 public:
-  XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log, bool isIXFR);
+  XFRContext(std::unique_ptr<DNSPacket>& qry, int sock, Logr::log_t log, bool isAXFR);
   void setupOutputPacket();
 
+  // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
   const ZoneName& targetZone; // domain being XFR'ed
   DomainInfo info;
   SOAData soa;
@@ -542,13 +532,14 @@ public:
   std::string client;
   std::string logPrefix;
   Logr::log_t slog;
+  // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
 
 private:
   std::unique_ptr<DNSPacket>& query;
 };
 
-XFRContext::XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log, bool isAXFR) :
-  targetZone(q->qdomainzone), outsock(sock), slog(log), query(q)
+TCPNameserver::XFRContext::XFRContext(std::unique_ptr<DNSPacket>& qry, int sock, Logr::log_t log, bool isAXFR) :
+  targetZone(qry->qdomainzone), outsock(sock), slog(log), query(qry)
 {
   setupOutputPacket();
   if (query->d_dnssecOk) {
@@ -562,15 +553,19 @@ XFRContext::XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log,
   }
 }
 
-void XFRContext::setupOutputPacket()
+void TCPNameserver::XFRContext::setupOutputPacket()
 {
-  outpacket = getFreshAXFRPacket(query);
+  outpacket = std::unique_ptr<DNSPacket>(query->replyPacket());
+  outpacket->setCompress(false);
+  outpacket->d_dnssecOk=false; // RFC 5936, 2.2.5
+  outpacket->d_tcp = true;
 }
 
-bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler)
+bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler) // NOLINT(readability-identifier-length)
 {
-  if(::arg().mustDo("disable-axfr"))
+  if(::arg().mustDo("disable-axfr")) {
     return false;
+  }
 
   if(q->d_havetsig) { // if you have one, it must be good
     TSIGRecordContent tsigContent;
@@ -590,7 +585,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
     }
 #endif
 
-    DNSSECKeeper dk(ctx.slog, packetHandler->getBackend());
+    DNSSECKeeper dk(ctx.slog, packetHandler->getBackend()); // NOLINT(readability-identifier-length)
 #ifdef ENABLE_GSS_TSIG
     if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
       vector<string> princs;
@@ -612,11 +607,9 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
            ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
       return false;
     }
-    else {
-      SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
-           ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
-      return true;
-    }
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
+         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+    return true;
   }
 
   if(!(::arg()["allow-axfr-ips"].empty()) && d_ng.match( q->getInnerRemote() )) {
@@ -630,17 +623,17 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
   if(packetHandler->getBackend()->getSOAUncached(ctx.targetZone,ctx.soa)) {
     vector<string> acl;
     packetHandler->getBackend()->getDomainMetadata(ctx.targetZone, "ALLOW-AXFR-FROM", acl);
-    for (const auto & i : acl) {
-      if(pdns_iequals(i, "AUTO-NS")) {
-        DNSResourceRecord rr;
+    for (const auto & entry : acl) {
+      if(pdns_iequals(entry, "AUTO-NS")) {
+        DNSResourceRecord rr; // NOLINT(readability-identifier-length)
         set<DNSName> nsset;
 
         ctx.soa.db->lookup(QType(QType::NS), q->qdomain, ctx.soa.domain_id);
         while (ctx.soa.db->get(rr)) {
           nsset.insert(DNSName(rr.content));
         }
-        for(const auto & j: nsset) {
-          vector<string> nsips=fns.lookup(j, packetHandler->getBackend());
+        for(const auto & nameserver: nsset) {
+          vector<string> nsips=fns.lookup(nameserver, packetHandler->getBackend());
           for(const auto & nsip : nsips) {
             if(nsip == q->getInnerRemote().toString())
             {
@@ -653,7 +646,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
       }
       else
       {
-        Netmask nm = Netmask(i);
+        auto nm = Netmask(entry); // NOLINT(readability-identifier-length)
         if(nm.match( q->getInnerRemote() ))
         {
           SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in per-zone ACL"<<endl,
@@ -663,8 +656,6 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
       }
     }
   }
-
-  extern CommunicatorClass Communicator;
 
   if(Communicator.justNotified(ctx.targetZone, q->getInnerRemote().toString())) { // we just notified this ip
     SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is from recently notified secondary"<<endl,
@@ -719,12 +710,12 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx) // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
   // find domain_id via SOA and list complete domain. No SOA, no AXFR
-  UeberBackend db;
+  UeberBackend db; // NOLINT(readability-identifier-length)
   if(!db.getSOAUncached(ctx.targetZone, ctx.soa)) {
     SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative in second instance"<<endl,
          ctx.slog->info(Logr::Warning, "AXFR failed: not authoritative in second instance", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
@@ -741,7 +732,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
 
   ctx.isCatalogZone = ctx.soa.db->getDomainInfo(ctx.targetZone, ctx.info, false) && ctx.info.isCatalogType();
 
-  DNSSECKeeper dk(ctx.slog, &db);
+  DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
   DNSSECKeeper::clearCaches(ctx.targetZone);
   if (!ctx.isCatalogZone) {
     ctx.securedZone = dk.isSecuredZone(ctx.targetZone);
@@ -801,14 +792,14 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
   }
 
-  if(haveTSIGDetails && !tsigkeyname.empty())
+  if(haveTSIGDetails && !tsigkeyname.empty()) {
     ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+  }
 
   sendPacket(ctx.outpacket, ctx.outsock, false);
 
   trc.d_mac = ctx.outpacket->d_trc.d_mac;
   ctx.setupOutputPacket();
-
 
   DNSZoneRecord zrr;
   vector<DNSZoneRecord> zrrs;
@@ -817,8 +808,10 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
   zrr.dr.d_ttl = ctx.soa.minimum;
 
   if(ctx.securedZone && !ctx.presignedZone) { // this is where the DNSKEYs, CDNSKEYs and CDSs go in
-    bool doCDNSKEY = true, doCDS = true;
-    string publishCDNSKEY, publishCDS;
+    bool doCDNSKEY{true};
+    bool doCDS{true};
+    string publishCDNSKEY;
+    string publishCDS;
     dk.getPublishCDNSKEY(q->qdomainzone, publishCDNSKEY);
     dk.getPublishCDS(q->qdomainzone, publishCDS);
 
@@ -890,56 +883,59 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
 
   /* now write all other records */
 
-  typedef map<DNSName, NSECXEntry, CanonDNSNameCompare> nsecxrepo_t;
+  using nsecxrepo_t = map<DNSName, NSECXEntry, CanonDNSNameCompare>;
   nsecxrepo_t nsecxrepo;
 
   ChunkedSigningPipe csp(ctx.slog, ctx.targetZone, (ctx.securedZone && !ctx.presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
 
   DNSName keyname;
-  unsigned int udiff;
-  DTime dt;
+  DTime dt; // NOLINT(readability-identifier-length)
   dt.set();
   for(DNSZoneRecord &loopZRR :  zrrs) {
     if(ctx.securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
-      if (ctx.NSEC3Zone || loopZRR.dr.d_type) {
+      if (ctx.NSEC3Zone || loopZRR.dr.d_type != QType::ENT) {
         if (ctx.presignedZone && ctx.NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
           keyname = loopZRR.dr.d_name.makeRelative(ctx.soa.qname());
         } else {
           keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
         }
-        NSECXEntry& ne = nsecxrepo[keyname];
+        NSECXEntry& ne = nsecxrepo[keyname]; // NOLINT(readability-identifier-length)
         ne.d_ttl = ctx.soa.getNegativeTTL();
-        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (!ctx.ns3pr.d_flags)));
-        if (loopZRR.dr.d_type && loopZRR.dr.d_type != QType::RRSIG) {
+        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (ctx.ns3pr.d_flags == 0)));
+        if (loopZRR.dr.d_type != QType::ENT && loopZRR.dr.d_type != QType::RRSIG) {
           ne.d_set.set(loopZRR.dr.d_type);
         }
       }
     }
 
-    if (!loopZRR.dr.d_type)
+    if (loopZRR.dr.d_type == QType::ENT) {
       continue; // skip empty non-terminals
+    }
 
-    if(loopZRR.dr.d_type == QType::SOA)
+    if(loopZRR.dr.d_type == QType::SOA) {
       continue; // skip SOA - would indicate end of AXFR
+    }
 
     if(csp.submit(loopZRR)) {
       for(;;) {
         ctx.outpacket->getRRS() = csp.getChunk();
         if(!ctx.outpacket->getRRS().empty()) {
-          if(haveTSIGDetails && !tsigkeyname.empty())
+          if(haveTSIGDetails && !tsigkeyname.empty()) {
             ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+          }
           sendPacket(ctx.outpacket, ctx.outsock, false);
           trc.d_mac=ctx.outpacket->d_trc.d_mac;
           ctx.setupOutputPacket();
         }
-        else
+        else {
           break;
+        }
       }
     }
   }
   if(ctx.securedZone) {
     if(ctx.NSEC3Zone) {
-      for(nsecxrepo_t::const_iterator iter = nsecxrepo.begin(); iter != nsecxrepo.end(); ++iter) {
+      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
         if(iter->second.d_auth) {
           NSEC3RecordContent n3rc;
           n3rc.set(iter->second.d_set);
@@ -951,15 +947,17 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
           n3rc.d_flags = ctx.ns3pr.d_flags;
           n3rc.d_iterations = ctx.ns3pr.d_iterations;
           n3rc.d_algorithm = DNSSECKeeper::DIGEST_SHA1; // SHA1, fixed in PowerDNS for now
-          nsecxrepo_t::const_iterator inext = iter;
+          auto inext = iter;
           ++inext;
-          if(inext == nsecxrepo.end())
-            inext = nsecxrepo.begin();
+          if(inext == nsecxrepo.cend()) {
+            inext = nsecxrepo.cbegin();
+          }
           while(!inext->second.d_auth && inext != iter)
           {
             ++inext;
-            if(inext == nsecxrepo.end())
-              inext = nsecxrepo.begin();
+            if(inext == nsecxrepo.cend()) {
+              inext = nsecxrepo.cbegin();
+            }
           }
           n3rc.d_nexthash = fromBase32Hex(inext->first.toStringNoDot());
           zrr.dr.d_name = iter->first+ctx.soa.qname();
@@ -973,48 +971,56 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
             for(;;) {
               ctx.outpacket->getRRS() = csp.getChunk();
               if(!ctx.outpacket->getRRS().empty()) {
-                if(haveTSIGDetails && !tsigkeyname.empty())
+                if(haveTSIGDetails && !tsigkeyname.empty()) {
                   ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+                }
                 sendPacket(ctx.outpacket, ctx.outsock, false);
                 trc.d_mac=ctx.outpacket->d_trc.d_mac;
                 ctx.setupOutputPacket();
               }
-              else
+              else {
                 break;
+              }
             }
           }
         }
       }
     }
-    else for(nsecxrepo_t::const_iterator iter = nsecxrepo.begin(); iter != nsecxrepo.end(); ++iter) {
-      NSECRecordContent nrc;
-      nrc.set(iter->second.d_set);
-      nrc.set(QType::RRSIG);
-      nrc.set(QType::NSEC);
+    else {
+      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
+        NSECRecordContent nrc;
+        nrc.set(iter->second.d_set);
+        nrc.set(QType::RRSIG);
+        nrc.set(QType::NSEC);
 
-      if(boost::next(iter) != nsecxrepo.end())
-        nrc.d_next = boost::next(iter)->first;
-      else
-        nrc.d_next=nsecxrepo.begin()->first;
-      zrr.dr.d_name = iter->first;
+        if(boost::next(iter) != nsecxrepo.cend()) {
+          nrc.d_next = boost::next(iter)->first;
+        }
+        else {
+          nrc.d_next=nsecxrepo.cbegin()->first;
+        }
+        zrr.dr.d_name = iter->first;
 
-      zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
-      zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
-      zrr.dr.d_type = QType::NSEC;
-      zrr.dr.d_place = DNSResourceRecord::ANSWER;
-      zrr.auth=true;
-      if(csp.submit(zrr)) {
-        for(;;) {
-          ctx.outpacket->getRRS() = csp.getChunk();
-          if(!ctx.outpacket->getRRS().empty()) {
-            if(haveTSIGDetails && !tsigkeyname.empty())
-              ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-            sendPacket(ctx.outpacket, ctx.outsock, false);
-            trc.d_mac=ctx.outpacket->d_trc.d_mac;
-            ctx.setupOutputPacket();
+        zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
+        zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
+        zrr.dr.d_type = QType::NSEC;
+        zrr.dr.d_place = DNSResourceRecord::ANSWER;
+        zrr.auth=true;
+        if(csp.submit(zrr)) {
+          for(;;) {
+            ctx.outpacket->getRRS() = csp.getChunk();
+            if(!ctx.outpacket->getRRS().empty()) {
+              if(haveTSIGDetails && !tsigkeyname.empty()) {
+                ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+              }
+              sendPacket(ctx.outpacket, ctx.outsock, false);
+              trc.d_mac=ctx.outpacket->d_trc.d_mac;
+              ctx.setupOutputPacket();
+            }
+            else {
+              break;
+            }
           }
-          else
-            break;
         }
       }
     }
@@ -1022,8 +1028,9 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
   for(;;) {
     ctx.outpacket->getRRS() = csp.getChunk(true); // flush the pipe
     if(!ctx.outpacket->getRRS().empty()) {
-      if(haveTSIGDetails && !tsigkeyname.empty())
+      if(haveTSIGDetails && !tsigkeyname.empty()) {
         ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
+      }
       try {
         sendPacket(ctx.outpacket, ctx.outsock, false);
       }
@@ -1033,11 +1040,12 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
       trc.d_mac=ctx.outpacket->d_trc.d_mac;
       ctx.setupOutputPacket();
     }
-    else
+    else {
       break;
+    }
   }
 
-  udiff=dt.udiffNoReset();
+  unsigned int udiff=dt.udiffNoReset();
   if(ctx.securedZone) {
     SLOG(g_log<<Logger::Debug<<ctx.logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
          ctx.slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
@@ -1048,8 +1056,9 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
   /* and terminate with yet again the SOA record */
   ctx.setupOutputPacket();
   ctx.outpacket->addRecord(std::move(soa));
-  if(haveTSIGDetails && !tsigkeyname.empty())
+  if(haveTSIGDetails && !tsigkeyname.empty()) {
     ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+  }
 
   sendPacket(ctx.outpacket, ctx.outsock);
 
@@ -1090,8 +1099,8 @@ bool TCPNameserver::axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrr
     sendPacket(ctx.outpacket, ctx.outsock);
     return false;
   }
-  for (const auto& ci : members) {
-    ci.toDNSZoneRecords(ctx.targetZone, zrrs);
+  for (const auto& catalog : members) {
+    catalog.toDNSZoneRecords(ctx.targetZone, zrrs);
   }
   if (members.empty()) {
     SLOG(g_log << Logger::Warning << ctx.logPrefix << "catalog zone '" << ctx.targetZone << "' has no members" << endl,
@@ -1115,7 +1124,8 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
   }
 
   const bool rectify = !(ctx.presignedZone || ::arg().mustDo("disable-axfr-rectify"));
-  set<DNSName> qnames, nsset;
+  set<DNSName> qnames;
+  set<DNSName> nsset;
 
   DNSZoneRecord zrr;
 
@@ -1127,9 +1137,8 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       if (zrr.dr.d_type == QType::DNSKEY || zrr.dr.d_type == QType::CDNSKEY || zrr.dr.d_type == QType::CDS) {
         if(!::arg().mustDo("direct-dnskey")) {
           continue;
-        } else {
-          zrr.dr.d_ttl = ctx.soa.minimum;
         }
+        zrr.dr.d_ttl = ctx.soa.minimum;
       }
     }
     zrr.dr.d_name.makeUsLowerCase();
@@ -1157,19 +1166,20 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
             return false;
           }
         }
-        for (auto& ip: ips) {
-          zrr.dr.d_type = ip.dr.d_type;
-          zrr.dr.setContent(ip.dr.getContent());
+        for (auto& dzr: ips) {
+          zrr.dr.d_type = dzr.dr.d_type;
+          zrr.dr.setContent(dzr.dr.getContent());
           zrrs.push_back(zrr);
         }
         continue;
       }
 
       if (rectify) {
-        if (zrr.dr.d_type) {
+        if (zrr.dr.d_type != QType::ENT) {
           qnames.insert(zrr.dr.d_name);
-          if(zrr.dr.d_type == QType::NS && zrr.dr.d_name!=target)
+          if(zrr.dr.d_type == QType::NS && zrr.dr.d_name!=target) {
             nsset.insert(zrr.dr.d_name);
+          }
         } else {
           // remove existing ents
           continue;
@@ -1177,9 +1187,10 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       }
       zrrs.push_back(zrr);
     } else {
-      if (zrr.dr.d_type != QType::ENT)
+      if (zrr.dr.d_type != QType::ENT) {
         SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
              ctx.slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
+      }
     }
   }
 
@@ -1199,12 +1210,12 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       if (newRRC->autoHint(SvcParam::ipv4hint)) {
         ctx.soa.db->lookup(QType::A, svcTarget, ctx.soa.domain_id);
         vector<ComboAddress> hints;
-        DNSZoneRecord rr;
+        DNSZoneRecord rr; // NOLINT(readability-identifier-length)
         while (ctx.soa.db->get(rr)) {
           auto arrc = getRR<ARecordContent>(rr.dr);
           hints.push_back(arrc->getCA());
         }
-        if (hints.size() == 0) {
+        if (hints.empty()) {
           newRRC->removeParam(SvcParam::ipv4hint);
         } else {
           newRRC->setHints(SvcParam::ipv4hint, hints);
@@ -1214,12 +1225,12 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       if (newRRC->autoHint(SvcParam::ipv6hint)) {
         ctx.soa.db->lookup(QType::AAAA, svcTarget, ctx.soa.domain_id);
         vector<ComboAddress> hints;
-        DNSZoneRecord rr;
+        DNSZoneRecord rr; // NOLINT(readability-identifier-length)
         while (ctx.soa.db->get(rr)) {
           auto arrc = getRR<AAAARecordContent>(rr.dr);
           hints.push_back(arrc->getCA());
         }
-        if (hints.size() == 0) {
+        if (hints.empty()) {
           newRRC->removeParam(SvcParam::ipv6hint);
         } else {
           newRRC->setHints(SvcParam::ipv6hint, hints);
@@ -1232,7 +1243,7 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
 
   // Group records by name and type, signpipe stumbles over interrupted rrsets
   if(ctx.securedZone && !ctx.presignedZone) {
-    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
+    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) { // NOLINT(readability-identifier-length)
       return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
     });
   }
@@ -1244,9 +1255,10 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
         DNSName shorter(loopZRR.dr.d_name);
         do {
-          if (shorter==target) // apex is always auth
+          if (shorter==target) { // apex is always auth
             break;
-          if(nsset.count(shorter) && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
+          }
+          if(nsset.count(shorter) != 0 && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
             loopZRR.auth=false;
             break;
           }
@@ -1257,22 +1269,23 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
     if(ctx.NSEC3Zone) {
       // ents are only required for NSEC3 zones
       uint32_t maxent = ::arg().asNum("max-ent-entries");
-      set<DNSName> nsec3set, nonterm;
+      set<DNSName> nsec3set;
+      set<DNSName> nonterm;
       for (auto &loopZRR: zrrs) {
         bool skip=false;
         DNSName shorter = loopZRR.dr.d_name;
         if (shorter != target && shorter.chopOff() && shorter != target) {
           do {
-            if(nsset.count(shorter)) {
+            if(nsset.count(shorter) != 0) {
               skip=true;
               break;
             }
           } while(shorter.chopOff() && shorter != target);
         }
         shorter = loopZRR.dr.d_name;
-        if(!skip && (loopZRR.dr.d_type != QType::NS || !ctx.ns3pr.d_flags)) {
+        if(!skip && (loopZRR.dr.d_type != QType::NS || ctx.ns3pr.d_flags == 0)) {
           do {
-            if(!nsec3set.count(shorter)) {
+            if(nsec3set.count(shorter) == 0) {
               nsec3set.insert(shorter);
             }
           } while(shorter != target && shorter.chopOff());
@@ -1282,8 +1295,8 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       for(DNSZoneRecord &loopZRR :  zrrs) {
         DNSName shorter(loopZRR.dr.d_name);
         while(shorter != target && shorter.chopOff()) {
-          if(!qnames.count(shorter) && !nonterm.count(shorter) && nsec3set.count(shorter)) {
-            if(!(maxent)) {
+          if(qnames.count(shorter) == 0 && nonterm.count(shorter) == 0 && nsec3set.count(shorter) != 0) {
+            if(maxent == 0) {
               SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
                    ctx.slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
               ctx.outpacket->setRcode(RCode::ServFail);
@@ -1296,7 +1309,7 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
         }
       }
 
-      for(const auto& nt :  nonterm) {
+      for(const auto& nt : nonterm) { // NOLINT(readability-identifier-length)
         DNSZoneRecord tempRR;
         tempRR.dr.d_name=nt;
         tempRR.dr.d_type=QType::ENT;
@@ -1309,7 +1322,7 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
   return true;
 }
 
-int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
+int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog) // NOLINT(readability-identifier-length)
 {
   XFRContext ctx(q, outsock, slog, false);
 
@@ -1353,7 +1366,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   // determine if zone exists, XFR is allowed, and if IXFR can proceed using existing backend before spawning a new backend.
   DLOG(SLOG(g_log<<ctx.logPrefix<<"Looking for SOA"<<endl,
             ctx.slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
-  bool serialPermitsIXFR;
+  bool serialPermitsIXFR{false};
   {
     auto packetHandler = s_P.lock();
     if(!*packetHandler) {
@@ -1380,7 +1393,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       return 0;
     }
 
-    DNSSECKeeper dk(ctx.slog, (*packetHandler)->getBackend());
+    DNSSECKeeper dk(ctx.slog, (*packetHandler)->getBackend()); // NOLINT(readability-identifier-length)
     DNSSECKeeper::clearCaches(ctx.targetZone);
     bool narrow = false;
     ctx.securedZone = dk.isSecuredZone(ctx.targetZone);
@@ -1402,8 +1415,8 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     DNSName tsigkeyname;
     string tsigsecret;
 
-    UeberBackend db;
-    DNSSECKeeper dk(ctx.slog, &db);
+    UeberBackend db; // NOLINT(readability-identifier-length)
+    DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
 
     bool haveTSIGDetails = q->getTSIGDetails(&trc, &tsigkeyname);
 
@@ -1440,8 +1453,9 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
     }
 
-    if(haveTSIGDetails && !tsigkeyname.empty())
+    if(haveTSIGDetails && !tsigkeyname.empty()) {
       ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+    }
 
     sendPacket(ctx.outpacket, ctx.outsock);
 

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -383,7 +383,7 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
       if(packet->qtype.getCode()==QType::AXFR) {
         packet->d_xfr=true;
         g_zoneCache.setZoneVariant(*packet);
-        doAXFR(packet->qdomainzone, packet, fd, slog);
+        doAXFR(packet, fd, slog);
         continue;
       }
 
@@ -639,8 +639,9 @@ namespace {
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
 // NOLINTNEXTLINE(readability-identifier-length)
-int TCPNameserver::doAXFR(const ZoneName &targetZone, std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)  // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)  // NOLINT(readability-function-cognitive-complexity)
 {
+  const ZoneName& targetZone = q->qdomainzone;
   const DNSName& target = targetZone.operator const DNSName&();
   string logPrefix;
 
@@ -1403,7 +1404,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 
   SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR fallback to AXFR"<<endl,
        slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-  return doAXFR(q->qdomainzone, q, outsock, slog);
+  return doAXFR(q, outsock, slog);
 }
 
 TCPNameserver::~TCPNameserver() = default;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -499,125 +499,6 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
   decrementClientCount(remote);
 }
 
-
-bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, bool isAXFR, std::unique_ptr<PacketHandler>& packetHandler, Logr::log_t slog)
-{
-  if(::arg().mustDo("disable-axfr"))
-    return false;
-
-  string xfrType = isAXFR ? "AXFR" : "IXFR";
-  string logPrefix;
-
-  if (!g_slogStructured) {
-    logPrefix = xfrType +"-out zone '"+q->qdomainzone.toLogString()+"', client '"+q->getInnerRemote().toStringWithPort()+"', ";
-  }
-
-  if(q->d_havetsig) { // if you have one, it must be good
-    TSIGRecordContent tsigContent;
-    DNSName tsigkeyname;
-    string secret;
-    if (!packetHandler->checkForCorrectTSIG(*q, &tsigkeyname, &secret, &tsigContent)) {
-      return false;
-    }
-    getTSIGHashEnum(tsigContent.d_algoName, q->d_tsig_algo);
-#ifdef ENABLE_GSS_TSIG
-    if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
-      GssContext gssctx(tsigkeyname);
-      if (!gssctx.getPeerPrincipal(q->d_peer_principal)) {
-        SLOG(g_log<<Logger::Warning<<"Failed to extract peer principal from GSS context with keyname '"<<tsigkeyname<<"'"<<endl,
-             slog->info(Logr::Warning, "Failed to extract peer principal from GSS context", "keyname", Logging::Loggable(tsigkeyname)));
-      }
-    }
-#endif
-
-    DNSSECKeeper dk(slog, packetHandler->getBackend());
-#ifdef ENABLE_GSS_TSIG
-    if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
-      vector<string> princs;
-      packetHandler->getBackend()->getDomainMetadata(q->qdomainzone, "GSS-ALLOW-AXFR-PRINCIPAL", princs);
-      for(const std::string& princ :  princs) {
-        if (q->d_peer_principal == princ) {
-          SLOG(g_log<<Logger::Warning<<xfrType<<" of domain '"<<q->qdomainzone<<"' allowed: TSIG signed request with authorized principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig'"<<endl,
-               slog->info(Logr::Warning, xfrType + " allowed: TSIG signed request with authorized principal", "zone", Logging::Loggable(q->qdomainzone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
-          return true;
-        }
-      }
-      SLOG(g_log<<Logger::Warning<<xfrType<<" of domain '"<<q->qdomainzone<<"' denied: TSIG signed request with principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig' is not permitted"<<endl,
-           slog->info(Logr::Warning, xfrType + " denied: TSIG signed request with unauthorized principal", "zone", Logging::Loggable(q->qdomainzone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
-      return false;
-    }
-#endif
-    if(!dk.TSIGGrantsAccess(q->qdomainzone, tsigkeyname)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"denied: key with name '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"' does not grant access"<<endl,
-           slog->info(Logr::Warning, xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
-      return false;
-    }
-    else {
-      SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
-           slog->info(Logr::Notice, xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
-      return true;
-    }
-  }
-
-  if(!(::arg()["allow-axfr-ips"].empty()) && d_ng.match( q->getInnerRemote() )) {
-    SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: client IP is in allow-axfr-ips"<<endl,
-         slog->info(Logr::Notice, xfrType + " allowed: client IP is in allow-axfr-ips", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-    return true;
-  }
-
-  FindNS fns;
-
-  SOAData sd;
-  if(packetHandler->getBackend()->getSOAUncached(q->qdomainzone,sd)) {
-    vector<string> acl;
-    packetHandler->getBackend()->getDomainMetadata(q->qdomainzone, "ALLOW-AXFR-FROM", acl);
-    for (const auto & i : acl) {
-      if(pdns_iequals(i, "AUTO-NS")) {
-        DNSResourceRecord rr;
-        set<DNSName> nsset;
-
-        sd.db->lookup(QType(QType::NS), q->qdomain, sd.domain_id);
-        while (sd.db->get(rr)) {
-          nsset.insert(DNSName(rr.content));
-        }
-        for(const auto & j: nsset) {
-          vector<string> nsips=fns.lookup(j, packetHandler->getBackend());
-          for(const auto & nsip : nsips) {
-            if(nsip == q->getInnerRemote().toString())
-            {
-              SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: client IP is in NSset"<<endl,
-                   slog->info(Logr::Notice, xfrType + " allowed: client IP is in NSset", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-              return true;
-            }
-          }
-        }
-      }
-      else
-      {
-        Netmask nm = Netmask(i);
-        if(nm.match( q->getInnerRemote() ))
-        {
-          SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: client IP is in per-zone ACL"<<endl,
-               slog->info(Logr::Notice, xfrType + " allowed: client IP is in per-zone ACL", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-          return true;
-        }
-      }
-    }
-  }
-
-  extern CommunicatorClass Communicator;
-
-  if(Communicator.justNotified(q->qdomainzone, q->getInnerRemote().toString())) { // we just notified this ip
-    SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: client IP is from recently notified secondary"<<endl,
-         slog->info(Logr::Notice, xfrType + " allowed: client IP is from recently notified secondary", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-    return true;
-  }
-
-  SLOG(g_log<<Logger::Warning<<logPrefix<<"denied: client IP has no permission"<<endl,
-       slog->info(Logr::Warning, xfrType + " denied: client IP has no permission", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-  return false;
-}
-
 namespace {
   struct NSECXEntry
   {
@@ -636,99 +517,244 @@ namespace {
   }
 }
 
+class XFRContext : public boost::noncopyable
+{
+public:
+  XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log, bool isIXFR);
+  void setupOutputPacket();
+
+  const ZoneName& targetZone; // domain being XFR'ed
+  DomainInfo info;
+  SOAData soa;
+
+  bool presignedZone{false};
+  bool securedZone{false};
+  bool NSEC3Zone{false};
+  bool isCatalogZone{false};
+  NSEC3PARAMRecordContent ns3pr;
+
+  // Network-related fields
+  int outsock;
+  std::unique_ptr<DNSPacket> outpacket;
+
+  // Logging-related fields
+  std::string xfrType;
+  std::string client;
+  std::string logPrefix;
+  Logr::log_t slog;
+
+private:
+  std::unique_ptr<DNSPacket>& query;
+};
+
+XFRContext::XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log, bool isAXFR) :
+  targetZone(q->qdomainzone), outsock(sock), slog(log), query(q)
+{
+  setupOutputPacket();
+  if (query->d_dnssecOk) {
+    outpacket->d_dnssecOk = true; // RFC 5936, 2.2.5 'SHOULD'
+  }
+
+  xfrType = isAXFR ? "AXFR" : "IXFR";
+  client = query->getRemoteStringWithPort();
+  if (!g_slogStructured) {
+    logPrefix = xfrType + "-out zone '" + targetZone.toLogString() + "', client '" + client + "', ";
+  }
+}
+
+void XFRContext::setupOutputPacket()
+{
+  outpacket = getFreshAXFRPacket(query);
+}
+
+bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler)
+{
+  if(::arg().mustDo("disable-axfr"))
+    return false;
+
+  if(q->d_havetsig) { // if you have one, it must be good
+    TSIGRecordContent tsigContent;
+    DNSName tsigkeyname;
+    string secret;
+    if (!packetHandler->checkForCorrectTSIG(*q, &tsigkeyname, &secret, &tsigContent)) {
+      return false;
+    }
+    getTSIGHashEnum(tsigContent.d_algoName, q->d_tsig_algo);
+#ifdef ENABLE_GSS_TSIG
+    if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
+      GssContext gssctx(tsigkeyname);
+      if (!gssctx.getPeerPrincipal(q->d_peer_principal)) {
+        SLOG(g_log<<Logger::Warning<<"Failed to extract peer principal from GSS context with keyname '"<<tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Warning, "Failed to extract peer principal from GSS context", "keyname", Logging::Loggable(tsigkeyname)));
+      }
+    }
+#endif
+
+    DNSSECKeeper dk(ctx.slog, packetHandler->getBackend());
+#ifdef ENABLE_GSS_TSIG
+    if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
+      vector<string> princs;
+      packetHandler->getBackend()->getDomainMetadata(ctx.targetZone, "GSS-ALLOW-AXFR-PRINCIPAL", princs);
+      for(const std::string& princ :  princs) {
+        if (q->d_peer_principal == princ) {
+          SLOG(g_log<<Logger::Warning<<ctx.xfrType<<" of domain '"<<ctx.targetZone<<"' allowed: TSIG signed request with authorized principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig'"<<endl,
+               ctx.slog->info(Logr::Warning, ctx.xfrType + " allowed: TSIG signed request with authorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
+          return true;
+        }
+      }
+      SLOG(g_log<<Logger::Warning<<ctx.xfrType<<" of domain '"<<ctx.targetZone<<"' denied: TSIG signed request with principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig' is not permitted"<<endl,
+           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: TSIG signed request with unauthorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
+      return false;
+    }
+#endif
+    if(!dk.TSIGGrantsAccess(ctx.targetZone, tsigkeyname)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"denied: key with name '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"' does not grant access"<<endl,
+           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+      return false;
+    }
+    else {
+      SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
+           ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+      return true;
+    }
+  }
+
+  if(!(::arg()["allow-axfr-ips"].empty()) && d_ng.match( q->getInnerRemote() )) {
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in allow-axfr-ips"<<endl,
+         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in allow-axfr-ips", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    return true;
+  }
+
+  FindNS fns;
+
+  if(packetHandler->getBackend()->getSOAUncached(ctx.targetZone,ctx.soa)) {
+    vector<string> acl;
+    packetHandler->getBackend()->getDomainMetadata(ctx.targetZone, "ALLOW-AXFR-FROM", acl);
+    for (const auto & i : acl) {
+      if(pdns_iequals(i, "AUTO-NS")) {
+        DNSResourceRecord rr;
+        set<DNSName> nsset;
+
+        ctx.soa.db->lookup(QType(QType::NS), q->qdomain, ctx.soa.domain_id);
+        while (ctx.soa.db->get(rr)) {
+          nsset.insert(DNSName(rr.content));
+        }
+        for(const auto & j: nsset) {
+          vector<string> nsips=fns.lookup(j, packetHandler->getBackend());
+          for(const auto & nsip : nsips) {
+            if(nsip == q->getInnerRemote().toString())
+            {
+              SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in NSset"<<endl,
+                   ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in NSset", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+              return true;
+            }
+          }
+        }
+      }
+      else
+      {
+        Netmask nm = Netmask(i);
+        if(nm.match( q->getInnerRemote() ))
+        {
+          SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in per-zone ACL"<<endl,
+               ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in per-zone ACL", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+          return true;
+        }
+      }
+    }
+  }
+
+  extern CommunicatorClass Communicator;
+
+  if(Communicator.justNotified(ctx.targetZone, q->getInnerRemote().toString())) { // we just notified this ip
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is from recently notified secondary"<<endl,
+         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is from recently notified secondary", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    return true;
+  }
+
+  SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"denied: client IP has no permission"<<endl,
+       ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: client IP has no permission", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+  return false;
+}
 
 // NOLINTNEXTLINE(readability-identifier-length)
 int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  string logPrefix;
+  XFRContext ctx(q, outsock, slog, true);
 
-  if (!g_slogStructured) {
-    logPrefix="AXFR-out zone '"+targetZone.toLogString()+"', client '"+q->getRemoteStringWithPort()+"', ";
-  }
-
-  std::unique_ptr<DNSPacket> outpacket= getFreshAXFRPacket(q);
-  if(q->d_dnssecOk) {
-    outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
-  }
-
-  SLOG(g_log<<Logger::Warning<<logPrefix<<"transfer initiated"<<endl,
-       slog->info(Logr::Warning, "AXFR transfer initiated", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+  SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"transfer initiated"<<endl,
+       ctx.slog->info(Logr::Warning, "AXFR transfer initiated", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
 
   // determine if zone exists and AXFR is allowed using existing backend before spawning a new backend.
-  DLOG(SLOG(g_log<<logPrefix<<"looking for SOA"<<endl,
-            slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"looking for SOA"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
   {
     auto packetHandler = s_P.lock();
     if(!*packetHandler) {
       SLOG(g_log<<Logger::Warning<<"TCP server is without backend connections in doAXFR, launching"<<endl,
-           slog->info(Logr::Warning, "TCP server is without backend connections in doAXFR, launching", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      *packetHandler = make_unique<PacketHandler>(slog);
+           ctx.slog->info(Logr::Warning, "TCP server is without backend connections in doAXFR, launching", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      *packetHandler = make_unique<PacketHandler>(ctx.slog);
     }
 
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
-    if (!canDoAXFR(q, true, *packetHandler, slog)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: client may not request AXFR"<<endl,
-           slog->info(Logr::Warning, "AXFR failed: client may not request AXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::NotAuth);
-      sendPacket(outpacket,outsock);
+    if (!canDoAXFR(q, ctx, *packetHandler)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: client may not request AXFR"<<endl,
+           ctx.slog->info(Logr::Warning, "AXFR failed: client may not request AXFR", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::NotAuth);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
 
-    SOAData sd;
-    if (!(*packetHandler)->getBackend()->getSOAUncached(targetZone, sd)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative"<<endl,
-           slog->info(Logr::Warning, "AXFR failed: not authoritative", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::NotAuth);
-      sendPacket(outpacket,outsock);
+    // ctx.soa has been computed by canDoAXFR above
+    if (!(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative"<<endl,
+           ctx.slog->info(Logr::Warning, "AXFR failed: not authoritative", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::NotAuth);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
   }
 
-  return doAXFRinternal(q, outsock, slog, logPrefix, outpacket);
+  return doAXFRinternal(q, ctx);
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket) // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx) // NOLINT(readability-function-cognitive-complexity)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  const DNSName& target = targetZone.operator const DNSName&();
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
 
   // find domain_id via SOA and list complete domain. No SOA, no AXFR
   UeberBackend db;
-  SOAData sd;
-  if(!db.getSOAUncached(targetZone, sd)) {
-    SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative in second instance"<<endl,
-         slog->info(Logr::Warning, "AXFR failed: not authoritative in second instance", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    outpacket->setRcode(RCode::NotAuth);
-    sendPacket(outpacket,outsock);
+  if(!db.getSOAUncached(ctx.targetZone, ctx.soa)) {
+    SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative in second instance"<<endl,
+         ctx.slog->info(Logr::Warning, "AXFR failed: not authoritative in second instance", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    ctx.outpacket->setRcode(RCode::NotAuth);
+    sendPacket(ctx.outpacket,ctx.outsock);
     return 0;
   }
 
-  bool securedZone = false;
-  bool presignedZone = false;
-  bool NSEC3Zone = false;
+  // Reset these - if we come from doIXFR, they may have been used already.
+  ctx.presignedZone = false;
+  ctx.securedZone = false;
+  ctx.NSEC3Zone = false;
   bool narrow = false;
 
-  DomainInfo di;
-  bool isCatalogZone = sd.db->getDomainInfo(targetZone, di, false) && di.isCatalogType();
+  ctx.isCatalogZone = ctx.soa.db->getDomainInfo(ctx.targetZone, ctx.info, false) && ctx.info.isCatalogType();
 
-  NSEC3PARAMRecordContent ns3pr;
-
-  DNSSECKeeper dk(slog, &db);
-  DNSSECKeeper::clearCaches(targetZone);
-  if (!isCatalogZone) {
-    securedZone = dk.isSecuredZone(targetZone);
-    presignedZone = dk.isPresigned(targetZone);
+  DNSSECKeeper dk(ctx.slog, &db);
+  DNSSECKeeper::clearCaches(ctx.targetZone);
+  if (!ctx.isCatalogZone) {
+    ctx.securedZone = dk.isSecuredZone(ctx.targetZone);
+    ctx.presignedZone = dk.isPresigned(ctx.targetZone);
   }
 
-  if(securedZone && dk.getNSEC3PARAM(targetZone, &ns3pr, &narrow)) {
-    NSEC3Zone=true;
+  if(ctx.securedZone && dk.getNSEC3PARAM(ctx.targetZone, &ctx.ns3pr, &narrow)) {
+    ctx.NSEC3Zone=true;
     if(narrow) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not doing AXFR of an NSEC3 narrow zone"<<endl,
-           slog->info(Logr::Warning, "AXFR failed: not doing AXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::Refused);
-      sendPacket(outpacket,outsock);
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not doing AXFR of an NSEC3 narrow zone"<<endl,
+           ctx.slog->info(Logr::Warning, "AXFR failed: not doing AXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::Refused);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
   }
@@ -747,17 +773,17 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
     }
     if (algorithm != g_gsstsigdnsname) {
       if(!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"TSIG key not found"<<endl,
-             slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        outpacket->setRcode(RCode::NotAuth);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"TSIG key not found"<<endl,
+             ctx.slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::NotAuth);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
       if (B64Decode(tsig64, tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        outpacket->setRcode(RCode::ServFail);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::ServFail);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     }
@@ -765,51 +791,51 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
 
 
   // SOA *must* go out first, our signing pipe might reorder
-  DLOG(SLOG(g_log<<logPrefix<<"sending out SOA"<<endl,
-            slog->info(Logr::Debug, /*"I send an SOA to the world"*/"AXFR: sending out SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-  DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, sd, DNSResourceRecord::ANSWER, slog);
-  outpacket->addRecord(DNSZoneRecord(soa));
-  if(securedZone && !presignedZone) {
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"sending out SOA"<<endl,
+            ctx.slog->info(Logr::Debug, /*"I send an SOA to the world"*/"AXFR: sending out SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+  DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, ctx.soa, DNSResourceRecord::ANSWER, ctx.slog);
+  ctx.outpacket->addRecord(DNSZoneRecord(soa));
+  if(ctx.securedZone && !ctx.presignedZone) {
     set<ZoneName> authSet;
-    authSet.insert(targetZone);
-    addRRSigs(dk, db, authSet, outpacket->getRRS());
+    authSet.insert(ctx.targetZone);
+    addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
   }
 
   if(haveTSIGDetails && !tsigkeyname.empty())
-    outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+    ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
 
-  sendPacket(outpacket, outsock, false);
+  sendPacket(ctx.outpacket, ctx.outsock, false);
 
-  trc.d_mac = outpacket->d_trc.d_mac;
-  outpacket = getFreshAXFRPacket(q);
+  trc.d_mac = ctx.outpacket->d_trc.d_mac;
+  ctx.setupOutputPacket();
 
 
   DNSZoneRecord zrr;
   vector<DNSZoneRecord> zrrs;
 
   zrr.dr.d_name = target;
-  zrr.dr.d_ttl = sd.minimum;
+  zrr.dr.d_ttl = ctx.soa.minimum;
 
-  if(securedZone && !presignedZone) { // this is where the DNSKEYs, CDNSKEYs and CDSs go in
+  if(ctx.securedZone && !ctx.presignedZone) { // this is where the DNSKEYs, CDNSKEYs and CDSs go in
     bool doCDNSKEY = true, doCDS = true;
     string publishCDNSKEY, publishCDS;
     dk.getPublishCDNSKEY(q->qdomainzone, publishCDNSKEY);
     dk.getPublishCDS(q->qdomainzone, publishCDS);
 
     set<uint32_t> entryPointIds;
-    DNSSECKeeper::keyset_t entryPoints = dk.getEntryPoints(targetZone);
+    DNSSECKeeper::keyset_t entryPoints = dk.getEntryPoints(ctx.targetZone);
     for (auto const& value : entryPoints) {
       entryPointIds.insert(value.second.id);
     }
 
-    DNSSECKeeper::keyset_t keys = dk.getKeys(targetZone);
+    DNSSECKeeper::keyset_t keys = dk.getKeys(ctx.targetZone);
     for(const DNSSECKeeper::keyset_t::value_type& value :  keys) {
       if (!value.second.published) {
         continue;
       }
       zrr.dr.d_type = QType::DNSKEY;
       zrr.dr.setContent(std::make_shared<DNSKEYRecordContent>(value.first.getDNSKEY()));
-      DNSName keyname = NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, zrr.dr.d_name))) : zrr.dr.d_name;
+      DNSName keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, zrr.dr.d_name))) : zrr.dr.d_name;
       zrrs.push_back(zrr);
 
       // generate CDS and CDNSKEY records
@@ -836,7 +862,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
             zrrs.push_back(zrr);
           } else {
             for(auto const &digestAlgo : digestAlgos) {
-              zrr.dr.setContent(std::make_shared<DSRecordContent>(makeDSFromDNSKey(slog, target, value.first.getDNSKEY(), pdns::checked_stoi<uint8_t>(digestAlgo))));
+              zrr.dr.setContent(std::make_shared<DSRecordContent>(makeDSFromDNSKey(ctx.slog, target, value.first.getDNSKEY(), pdns::checked_stoi<uint8_t>(digestAlgo))));
               zrrs.push_back(zrr);
             }
           }
@@ -846,25 +872,20 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
 
   }
 
-  if(NSEC3Zone) { // now stuff in the NSEC3PARAM
-    uint8_t flags = ns3pr.d_flags;
+  if(ctx.NSEC3Zone) { // now stuff in the NSEC3PARAM
+    uint8_t flags = ctx.ns3pr.d_flags;
     zrr.dr.d_type = QType::NSEC3PARAM;
-    ns3pr.d_flags = 0;
-    zrr.dr.setContent(std::make_shared<NSEC3PARAMRecordContent>(ns3pr));
-    ns3pr.d_flags = flags;
-    DNSName keyname = DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, zrr.dr.d_name)));
+    ctx.ns3pr.d_flags = 0;
+    zrr.dr.setContent(std::make_shared<NSEC3PARAMRecordContent>(ctx.ns3pr));
+    ctx.ns3pr.d_flags = flags;
+    DNSName keyname = DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, zrr.dr.d_name)));
     zrrs.push_back(zrr);
   }
 
-  if (di.kind == DomainInfo::Producer) { // Catalog zone
-    if (!axfrProducerZone(q, outsock, slog, logPrefix, outpacket, zrrs, di, sd)) {
-      return 0;
-    }
-  }
-  else {
-    if (!axfrRegularZone(q, outsock, slog, logPrefix, outpacket, zrrs, sd, presignedZone, securedZone, NSEC3Zone, isCatalogZone, ns3pr)) {
-      return 0;
-    }
+  // Catalog zones need a specific processing at this point.
+  auto zoneKindSpecificOp = ctx.info.kind == DomainInfo::Producer ? axfrProducerZone : axfrRegularZone;
+  if (!zoneKindSpecificOp(ctx, zrrs)) {
+    return 0;
   }
 
   /* now write all other records */
@@ -872,23 +893,23 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
   typedef map<DNSName, NSECXEntry, CanonDNSNameCompare> nsecxrepo_t;
   nsecxrepo_t nsecxrepo;
 
-  ChunkedSigningPipe csp(slog, targetZone, (securedZone && !presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
+  ChunkedSigningPipe csp(ctx.slog, ctx.targetZone, (ctx.securedZone && !ctx.presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
 
   DNSName keyname;
   unsigned int udiff;
   DTime dt;
   dt.set();
   for(DNSZoneRecord &loopZRR :  zrrs) {
-    if(securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
-      if (NSEC3Zone || loopZRR.dr.d_type) {
-        if (presignedZone && NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
-          keyname = loopZRR.dr.d_name.makeRelative(sd.qname());
+    if(ctx.securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
+      if (ctx.NSEC3Zone || loopZRR.dr.d_type) {
+        if (ctx.presignedZone && ctx.NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
+          keyname = loopZRR.dr.d_name.makeRelative(ctx.soa.qname());
         } else {
-          keyname = NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
+          keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
         }
         NSECXEntry& ne = nsecxrepo[keyname];
-        ne.d_ttl = sd.getNegativeTTL();
-        ne.d_auth = (ne.d_auth || loopZRR.auth || (NSEC3Zone && (!ns3pr.d_flags)));
+        ne.d_ttl = ctx.soa.getNegativeTTL();
+        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (!ctx.ns3pr.d_flags)));
         if (loopZRR.dr.d_type && loopZRR.dr.d_type != QType::RRSIG) {
           ne.d_set.set(loopZRR.dr.d_type);
         }
@@ -903,21 +924,21 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
 
     if(csp.submit(loopZRR)) {
       for(;;) {
-        outpacket->getRRS() = csp.getChunk();
-        if(!outpacket->getRRS().empty()) {
+        ctx.outpacket->getRRS() = csp.getChunk();
+        if(!ctx.outpacket->getRRS().empty()) {
           if(haveTSIGDetails && !tsigkeyname.empty())
-            outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-          sendPacket(outpacket, outsock, false);
-          trc.d_mac=outpacket->d_trc.d_mac;
-          outpacket=getFreshAXFRPacket(q);
+            ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+          sendPacket(ctx.outpacket, ctx.outsock, false);
+          trc.d_mac=ctx.outpacket->d_trc.d_mac;
+          ctx.setupOutputPacket();
         }
         else
           break;
       }
     }
   }
-  if(securedZone) {
-    if(NSEC3Zone) {
+  if(ctx.securedZone) {
+    if(ctx.NSEC3Zone) {
       for(nsecxrepo_t::const_iterator iter = nsecxrepo.begin(); iter != nsecxrepo.end(); ++iter) {
         if(iter->second.d_auth) {
           NSEC3RecordContent n3rc;
@@ -926,9 +947,9 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
           if (numberOfTypesSet != 0 && (numberOfTypesSet != 1 || !n3rc.isSet(QType::NS))) {
             n3rc.set(QType::RRSIG);
           }
-          n3rc.d_salt = ns3pr.d_salt;
-          n3rc.d_flags = ns3pr.d_flags;
-          n3rc.d_iterations = ns3pr.d_iterations;
+          n3rc.d_salt = ctx.ns3pr.d_salt;
+          n3rc.d_flags = ctx.ns3pr.d_flags;
+          n3rc.d_iterations = ctx.ns3pr.d_iterations;
           n3rc.d_algorithm = DNSSECKeeper::DIGEST_SHA1; // SHA1, fixed in PowerDNS for now
           nsecxrepo_t::const_iterator inext = iter;
           ++inext;
@@ -941,22 +962,22 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
               inext = nsecxrepo.begin();
           }
           n3rc.d_nexthash = fromBase32Hex(inext->first.toStringNoDot());
-          zrr.dr.d_name = iter->first+sd.qname();
+          zrr.dr.d_name = iter->first+ctx.soa.qname();
 
-          zrr.dr.d_ttl = sd.getNegativeTTL();
+          zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
           zrr.dr.setContent(std::make_shared<NSEC3RecordContent>(std::move(n3rc)));
           zrr.dr.d_type = QType::NSEC3;
           zrr.dr.d_place = DNSResourceRecord::ANSWER;
           zrr.auth=true;
           if(csp.submit(zrr)) {
             for(;;) {
-              outpacket->getRRS() = csp.getChunk();
-              if(!outpacket->getRRS().empty()) {
+              ctx.outpacket->getRRS() = csp.getChunk();
+              if(!ctx.outpacket->getRRS().empty()) {
                 if(haveTSIGDetails && !tsigkeyname.empty())
-                  outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-                sendPacket(outpacket, outsock, false);
-                trc.d_mac=outpacket->d_trc.d_mac;
-                outpacket=getFreshAXFRPacket(q);
+                  ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+                sendPacket(ctx.outpacket, ctx.outsock, false);
+                trc.d_mac=ctx.outpacket->d_trc.d_mac;
+                ctx.setupOutputPacket();
               }
               else
                 break;
@@ -977,20 +998,20 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
         nrc.d_next=nsecxrepo.begin()->first;
       zrr.dr.d_name = iter->first;
 
-      zrr.dr.d_ttl = sd.getNegativeTTL();
+      zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
       zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
       zrr.dr.d_type = QType::NSEC;
       zrr.dr.d_place = DNSResourceRecord::ANSWER;
       zrr.auth=true;
       if(csp.submit(zrr)) {
         for(;;) {
-          outpacket->getRRS() = csp.getChunk();
-          if(!outpacket->getRRS().empty()) {
+          ctx.outpacket->getRRS() = csp.getChunk();
+          if(!ctx.outpacket->getRRS().empty()) {
             if(haveTSIGDetails && !tsigkeyname.empty())
-              outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-            sendPacket(outpacket, outsock, false);
-            trc.d_mac=outpacket->d_trc.d_mac;
-            outpacket=getFreshAXFRPacket(q);
+              ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+            sendPacket(ctx.outpacket, ctx.outsock, false);
+            trc.d_mac=ctx.outpacket->d_trc.d_mac;
+            ctx.setupOutputPacket();
           }
           else
             break;
@@ -999,57 +1020,56 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
     }
   }
   for(;;) {
-    outpacket->getRRS() = csp.getChunk(true); // flush the pipe
-    if(!outpacket->getRRS().empty()) {
+    ctx.outpacket->getRRS() = csp.getChunk(true); // flush the pipe
+    if(!ctx.outpacket->getRRS().empty()) {
       if(haveTSIGDetails && !tsigkeyname.empty())
-        outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
+        ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
       try {
-        sendPacket(outpacket, outsock, false);
+        sendPacket(ctx.outpacket, ctx.outsock, false);
       }
       catch (PDNSException& pe) {
         throw PDNSException("during axfr-out of "+target.toString()+", this happened: "+pe.reason);
       }
-      trc.d_mac=outpacket->d_trc.d_mac;
-      outpacket=getFreshAXFRPacket(q);
+      trc.d_mac=ctx.outpacket->d_trc.d_mac;
+      ctx.setupOutputPacket();
     }
     else
       break;
   }
 
   udiff=dt.udiffNoReset();
-  if(securedZone) {
-    SLOG(g_log<<Logger::Debug<<logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
-         slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
+  if(ctx.securedZone) {
+    SLOG(g_log<<Logger::Debug<<ctx.logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
+         ctx.slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
   }
 
-  DLOG(SLOG(g_log<<logPrefix<<"done writing out records"<<endl,
-            slog->info(Logr::Debug, "AXFR: done writing out records", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"done writing out records"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: done writing out records", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
   /* and terminate with yet again the SOA record */
-  outpacket=getFreshAXFRPacket(q);
-  outpacket->addRecord(std::move(soa));
+  ctx.setupOutputPacket();
+  ctx.outpacket->addRecord(std::move(soa));
   if(haveTSIGDetails && !tsigkeyname.empty())
-    outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+    ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
 
-  sendPacket(outpacket, outsock);
+  sendPacket(ctx.outpacket, ctx.outsock);
 
-  DLOG(SLOG(g_log<<logPrefix<<"last packet - close"<<endl,
-            slog->info(Logr::Debug, "AXFR: last packet sent", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-  SLOG(g_log<<Logger::Notice<<logPrefix<<"AXFR finished"<<endl,
-       slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"last packet - close"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: last packet sent", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+  SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"AXFR finished"<<endl,
+       ctx.slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
 
   return 1;
 }
 
-bool TCPNameserver::axfrProducerZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const DomainInfo& di, const SOAData& sd)
+bool TCPNameserver::axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  const DNSName& target = targetZone.operator const DNSName&();
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
 
   DNSZoneRecord zrr;
 
   // Ignore all records except NS at apex
-  sd.db->lookup(QType::NS, target, di.id);
-  while (sd.db->get(zrr)) {
+  ctx.soa.db->lookup(QType::NS, target, ctx.info.id);
+  while (ctx.soa.db->get(zrr)) {
     zrrs.emplace_back(zrr);
   }
   if (zrrs.empty()) {
@@ -1060,48 +1080,47 @@ bool TCPNameserver::axfrProducerZone(std::unique_ptr<DNSPacket>& q, int outsock,
     zrrs.emplace_back(zrr);
   }
 
-  zrrs.emplace_back(CatalogInfo::getCatalogVersionRecord(targetZone));
+  zrrs.emplace_back(CatalogInfo::getCatalogVersionRecord(ctx.targetZone));
 
   vector<CatalogInfo> members;
-  if (!sd.db->getCatalogMembers(targetZone, members, CatalogInfo::CatalogType::Producer)) {
-    SLOG(g_log << Logger::Error << logPrefix << "getting catalog members failed, aborting AXFR" << endl,
-         slog->info(Logr::Error, "AXFR aborted: getting catalog members failed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    outpacket->setRcode(RCode::ServFail);
-    sendPacket(outpacket, outsock);
+  if (!ctx.soa.db->getCatalogMembers(ctx.targetZone, members, CatalogInfo::CatalogType::Producer)) {
+    SLOG(g_log << Logger::Error << ctx.logPrefix << "getting catalog members failed, aborting AXFR" << endl,
+         ctx.slog->info(Logr::Error, "AXFR aborted: getting catalog members failed", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    ctx.outpacket->setRcode(RCode::ServFail);
+    sendPacket(ctx.outpacket, ctx.outsock);
     return false;
   }
   for (const auto& ci : members) {
-    ci.toDNSZoneRecords(targetZone, zrrs);
+    ci.toDNSZoneRecords(ctx.targetZone, zrrs);
   }
   if (members.empty()) {
-    SLOG(g_log << Logger::Warning << logPrefix << "catalog zone '" << targetZone << "' has no members" << endl,
-         slog->info(Logr::Warning, "AXFR: Catalog zone has no members", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+    SLOG(g_log << Logger::Warning << ctx.logPrefix << "catalog zone '" << ctx.targetZone << "' has no members" << endl,
+         ctx.slog->info(Logr::Warning, "AXFR: Catalog zone has no members", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
   }
 
   return true;
 }
 
-bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const SOAData& sd, bool presignedZone, bool securedZone, bool NSEC3Zone, bool isCatalogZone, const NSEC3PARAMRecordContent& ns3pr) // NOLINT(readability-function-cognitive-complexity)
+bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs) // NOLINT(readability-function-cognitive-complexity)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  const DNSName& target = targetZone.operator const DNSName&();
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
 
   // now start list zone
-  if (!sd.db->list(targetZone, sd.domain_id, isCatalogZone)) {
-    SLOG(g_log<<Logger::Error<<logPrefix<<"backend signals error condition, aborting AXFR"<<endl,
-         slog->info(Logr::Error, "AXFR aborted: backend signals error condition", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    outpacket->setRcode(RCode::ServFail);
-    sendPacket(outpacket,outsock);
+  if (!ctx.soa.db->list(ctx.targetZone, ctx.soa.domain_id, ctx.isCatalogZone)) {
+    SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"backend signals error condition, aborting AXFR"<<endl,
+         ctx.slog->info(Logr::Error, "AXFR aborted: backend signals error condition", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    ctx.outpacket->setRcode(RCode::ServFail);
+    sendPacket(ctx.outpacket,ctx.outsock);
     return false;
   }
 
-  const bool rectify = !(presignedZone || ::arg().mustDo("disable-axfr-rectify"));
+  const bool rectify = !(ctx.presignedZone || ::arg().mustDo("disable-axfr-rectify"));
   set<DNSName> qnames, nsset;
 
   DNSZoneRecord zrr;
 
-  while(sd.db->get(zrr)) {
-    if (!presignedZone) {
+  while(ctx.soa.db->get(zrr)) {
+    if (!ctx.presignedZone) {
       if (zrr.dr.d_type == QType::RRSIG) {
         continue;
       }
@@ -1109,7 +1128,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
         if(!::arg().mustDo("direct-dnskey")) {
           continue;
         } else {
-          zrr.dr.d_ttl = sd.minimum;
+          zrr.dr.d_ttl = ctx.soa.minimum;
         }
       }
     }
@@ -1117,24 +1136,24 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
     if(zrr.dr.d_name.isPartOf(target)) {
       if (zrr.dr.d_type == QType::ALIAS && (::arg().mustDo("outgoing-axfr-expand-alias") || ::arg()["outgoing-axfr-expand-alias"] == "ignore-errors")) {
         vector<DNSZoneRecord> ips;
-        int ret1 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
-        int ret2 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
+        int ret1 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
+        int ret2 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
         if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
           if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
             if (ret1 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+              SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+                   ctx.slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
             }
             if (ret2 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+              SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+                   ctx.slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
             }
           }
           else {
-            SLOG(g_log << Logger::Warning << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
-                 slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            outpacket->setRcode(RCode::ServFail);
-            sendPacket(outpacket, outsock);
+            SLOG(g_log << Logger::Warning << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
+                 ctx.slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+            ctx.outpacket->setRcode(RCode::ServFail);
+            sendPacket(ctx.outpacket, ctx.outsock);
             return false;
           }
         }
@@ -1159,8 +1178,8 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
       zrrs.push_back(zrr);
     } else {
       if (zrr.dr.d_type != QType::ENT)
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
-             slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
+        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
+             ctx.slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
     }
   }
 
@@ -1178,10 +1197,10 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
       }
       DNSName svcTarget = newRRC->getTarget().isRoot() ? loopRR.dr.d_name : newRRC->getTarget();
       if (newRRC->autoHint(SvcParam::ipv4hint)) {
-        sd.db->lookup(QType::A, svcTarget, sd.domain_id);
+        ctx.soa.db->lookup(QType::A, svcTarget, ctx.soa.domain_id);
         vector<ComboAddress> hints;
         DNSZoneRecord rr;
-        while (sd.db->get(rr)) {
+        while (ctx.soa.db->get(rr)) {
           auto arrc = getRR<ARecordContent>(rr.dr);
           hints.push_back(arrc->getCA());
         }
@@ -1193,10 +1212,10 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
       }
 
       if (newRRC->autoHint(SvcParam::ipv6hint)) {
-        sd.db->lookup(QType::AAAA, svcTarget, sd.domain_id);
+        ctx.soa.db->lookup(QType::AAAA, svcTarget, ctx.soa.domain_id);
         vector<ComboAddress> hints;
         DNSZoneRecord rr;
-        while (sd.db->get(rr)) {
+        while (ctx.soa.db->get(rr)) {
           auto arrc = getRR<AAAARecordContent>(rr.dr);
           hints.push_back(arrc->getCA());
         }
@@ -1212,7 +1231,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
   }
 
   // Group records by name and type, signpipe stumbles over interrupted rrsets
-  if(securedZone && !presignedZone) {
+  if(ctx.securedZone && !ctx.presignedZone) {
     sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
       return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
     });
@@ -1235,7 +1254,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
       }
     }
 
-    if(NSEC3Zone) {
+    if(ctx.NSEC3Zone) {
       // ents are only required for NSEC3 zones
       uint32_t maxent = ::arg().asNum("max-ent-entries");
       set<DNSName> nsec3set, nonterm;
@@ -1251,7 +1270,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
           } while(shorter.chopOff() && shorter != target);
         }
         shorter = loopZRR.dr.d_name;
-        if(!skip && (loopZRR.dr.d_type != QType::NS || !ns3pr.d_flags)) {
+        if(!skip && (loopZRR.dr.d_type != QType::NS || !ctx.ns3pr.d_flags)) {
           do {
             if(!nsec3set.count(shorter)) {
               nsec3set.insert(shorter);
@@ -1265,10 +1284,10 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
         while(shorter != target && shorter.chopOff()) {
           if(!qnames.count(shorter) && !nonterm.count(shorter) && nsec3set.count(shorter)) {
             if(!(maxent)) {
-              SLOG(g_log<<Logger::Warning<<logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
-                   slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-              outpacket->setRcode(RCode::ServFail);
-              sendPacket(outpacket,outsock);
+              SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
+                   ctx.slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+              ctx.outpacket->setRcode(RCode::ServFail);
+              sendPacket(ctx.outpacket,ctx.outsock);
               return false;
             }
             nonterm.insert(shorter);
@@ -1292,17 +1311,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
 
 int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  string logPrefix;
-
-  if (!g_slogStructured) {
-    logPrefix="IXFR-out zone '"+targetZone.toLogString()+"', client '"+q->getRemoteStringWithPort()+"', ";
-  }
-
-  std::unique_ptr<DNSPacket> outpacket=getFreshAXFRPacket(q);
-  if(q->d_dnssecOk) {
-    outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
-  }
+  XFRContext ctx(q, outsock, slog, false);
 
   uint32_t serial = 0;
   MOADNSParser mdp(false, q->getString());
@@ -1316,77 +1325,76 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
           pdns::checked_stoi_into(serial, parts[2]);
         }
         catch(const std::logic_error& exc) {
-          SLOG(g_log<<Logger::Warning<<logPrefix<<"invalid serial in IXFR query"<<endl,
-               slog->error(Logr::Warning, exc.what(), "IXFR: invalid serial in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-          outpacket->setRcode(RCode::FormErr);
-          sendPacket(outpacket,outsock);
+          SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"invalid serial in IXFR query"<<endl,
+               ctx.slog->error(Logr::Warning, exc.what(), "IXFR: invalid serial in query", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+          ctx.outpacket->setRcode(RCode::FormErr);
+          sendPacket(ctx.outpacket,ctx.outsock);
           return 0;
         }
       } else {
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"no serial in IXFR query"<<endl,
-             slog->info(Logr::Warning, "IXFR: no serial in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-        outpacket->setRcode(RCode::FormErr);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"no serial in IXFR query"<<endl,
+             ctx.slog->info(Logr::Warning, "IXFR: no serial in query", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+        ctx.outpacket->setRcode(RCode::FormErr);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     } else if (dnsRecord->d_type != QType::TSIG && dnsRecord->d_type != QType::OPT) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"additional records in IXFR query, type: "<<QType(dnsRecord->d_type).toString()<<endl,
-             slog->info(Logr::Warning, "IXFR: additional record in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "type", Logging::Loggable(dnsRecord->d_type)));
-      outpacket->setRcode(RCode::FormErr);
-      sendPacket(outpacket,outsock);
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"additional records in IXFR query, type: "<<QType(dnsRecord->d_type).toString()<<endl,
+             ctx.slog->info(Logr::Warning, "IXFR: additional record in query", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "type", Logging::Loggable(dnsRecord->d_type)));
+      ctx.outpacket->setRcode(RCode::FormErr);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
   }
 
-  SLOG(g_log<<Logger::Warning<<logPrefix<<"transfer initiated with serial "<<serial<<endl,
-       slog->info(Logr::Warning, "IXFR: transfer initiated", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "serial", Logging::Loggable(serial)));
+  SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"transfer initiated with serial "<<serial<<endl,
+       ctx.slog->info(Logr::Warning, "IXFR: transfer initiated", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "serial", Logging::Loggable(serial)));
 
   // determine if zone exists, XFR is allowed, and if IXFR can proceed using existing backend before spawning a new backend.
-  DLOG(SLOG(g_log<<logPrefix<<"Looking for SOA"<<endl,
-            slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-  SOAData sd;
-  bool securedZone;
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"Looking for SOA"<<endl,
+            ctx.slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
   bool serialPermitsIXFR;
   {
     auto packetHandler = s_P.lock();
     if(!*packetHandler) {
       SLOG(g_log<<Logger::Warning<<"TCP server is without backend connections in doIXFR, launching"<<endl,
-           slog->info(Logr::Warning, "IXFR: TCP server is without backend connections in doIXFR, launching", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      *packetHandler = make_unique<PacketHandler>(slog);
+           ctx.slog->info(Logr::Warning, "IXFR: TCP server is without backend connections in doIXFR, launching", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      *packetHandler = make_unique<PacketHandler>(ctx.slog);
     }
 
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
-    if(!canDoAXFR(q, false, *packetHandler, slog)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: client may not request IXFR"<<endl,
-           slog->info(Logr::Warning, "IXFR failed: client may not request IXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::NotAuth);
-      sendPacket(outpacket,outsock);
+    if(!canDoAXFR(q, ctx, *packetHandler)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: client may not request IXFR"<<endl,
+           ctx.slog->info(Logr::Warning, "IXFR failed: client may not request IXFR", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::NotAuth);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
 
-    if(!(*packetHandler)->getBackend()->getSOAUncached(targetZone, sd)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative"<<endl,
-           slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::NotAuth);
-      sendPacket(outpacket,outsock);
+    // ctx.soa has been computed by canDoAXFR above
+    if(!(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative"<<endl,
+           ctx.slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::NotAuth);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
 
-    DNSSECKeeper dk(slog, (*packetHandler)->getBackend());
-    DNSSECKeeper::clearCaches(targetZone);
+    DNSSECKeeper dk(ctx.slog, (*packetHandler)->getBackend());
+    DNSSECKeeper::clearCaches(ctx.targetZone);
     bool narrow = false;
-    securedZone = dk.isSecuredZone(targetZone);
-    if(dk.getNSEC3PARAM(targetZone, nullptr, &narrow)) {
+    ctx.securedZone = dk.isSecuredZone(ctx.targetZone);
+    if(dk.getNSEC3PARAM(ctx.targetZone, nullptr, &narrow)) {
       if(narrow) {
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"not doing IXFR of an NSEC3 narrow zone"<<endl,
-           slog->info(Logr::Warning, "IXFR refused: not doing IXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-        outpacket->setRcode(RCode::Refused);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"not doing IXFR of an NSEC3 narrow zone"<<endl,
+           ctx.slog->info(Logr::Warning, "IXFR refused: not doing IXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+        ctx.outpacket->setRcode(RCode::Refused);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     }
 
-    serialPermitsIXFR = !rfc1982LessThan(serial, calculateEditSOA(sd.serial, dk, sd.zonename, slog));
+    serialPermitsIXFR = !rfc1982LessThan(serial, calculateEditSOA(ctx.soa.serial, dk, ctx.soa.zonename, ctx.slog));
   }
 
   if (serialPermitsIXFR) {
@@ -1395,7 +1403,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     string tsigsecret;
 
     UeberBackend db;
-    DNSSECKeeper dk(slog, &db);
+    DNSSECKeeper dk(ctx.slog, &db);
 
     bool haveTSIGDetails = q->getTSIGDetails(&trc, &tsigkeyname);
 
@@ -1406,50 +1414,50 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
         algorithm = g_hmacmd5dnsname;
       }
       if (!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << targetZone << "' not found" << endl,
-           slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        outpacket->setRcode(RCode::NotAuth);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
+           ctx.slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::NotAuth);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
       if (B64Decode(tsig64, tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        outpacket->setRcode(RCode::ServFail);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::ServFail);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     }
 
     // SOA *must* go out first, our signing pipe might reorder
-    DLOG(SLOG(g_log<<logPrefix<<"sending out SOA"<<endl,
-              slog->info(Logr::Debug, /*"I send an SOA to the world"*/"IXFR: sending out SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-    DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, sd, DNSResourceRecord::ANSWER, slog);
-    outpacket->addRecord(std::move(soa));
-    if(securedZone && outpacket->d_dnssecOk) {
+    DLOG(SLOG(g_log<<ctx.logPrefix<<"sending out SOA"<<endl,
+              ctx.slog->info(Logr::Debug, /*"I send an SOA to the world"*/"IXFR: sending out SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+    DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, ctx.soa, DNSResourceRecord::ANSWER, ctx.slog);
+    ctx.outpacket->addRecord(std::move(soa));
+    if(ctx.securedZone && ctx.outpacket->d_dnssecOk) {
       set<ZoneName> authSet;
-      authSet.insert(targetZone);
-      addRRSigs(dk, db, authSet, outpacket->getRRS());
+      authSet.insert(ctx.targetZone);
+      addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
     }
 
     if(haveTSIGDetails && !tsigkeyname.empty())
-      outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+      ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
 
-    sendPacket(outpacket, outsock);
+    sendPacket(ctx.outpacket, ctx.outsock);
 
-    SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR finished"<<endl,
-         slog->info(Logr::Notice, "IXFR finished", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"IXFR finished"<<endl,
+         ctx.slog->info(Logr::Notice, "IXFR finished", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
 
     return 1;
   }
 
-  SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR fallback to AXFR"<<endl,
-       slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+  SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"IXFR fallback to AXFR"<<endl,
+       ctx.slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
   // Update log prefix as well
   if (!g_slogStructured) {
-    logPrefix.at(0) = 'A';
+    ctx.logPrefix.at(0) = 'A';
   }
-  return doAXFRinternal(q, outsock, slog, logPrefix, outpacket);
+  return doAXFRinternal(q, ctx);
 }
 
 TCPNameserver::~TCPNameserver() = default;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -517,7 +517,7 @@ public:
   ~XFRContext() = default;
 
   void setupOutputPacket();
-  void sendIntermediatePacket(TSIGRecordContent &trc);
+  void sendIntermediatePacket();
 
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
   const ZoneName& targetZone; // domain being XFR'ed
@@ -530,6 +530,11 @@ public:
   bool NSEC3Zone{false};
   bool isCatalogZone{false};
   NSEC3PARAMRecordContent ns3pr;
+
+  bool haveTSIGDetails{false};
+  TSIGRecordContent trc;
+  DNSName tsigkeyname;
+  string tsigsecret;
 
   // Network-related fields
   int outsock;
@@ -569,7 +574,7 @@ void TCPNameserver::XFRContext::setupOutputPacket()
   outpacket->d_tcp = true;
 }
 
-void TCPNameserver::XFRContext::sendIntermediatePacket(TSIGRecordContent &trc)
+void TCPNameserver::XFRContext::sendIntermediatePacket()
 {
   try {
     sendPacket(outpacket, outsock, false);
@@ -589,19 +594,16 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
   }
 
   if(q->d_havetsig) { // if you have one, it must be good
-    TSIGRecordContent tsigContent;
-    DNSName tsigkeyname;
-    string secret;
-    if (!packetHandler->checkForCorrectTSIG(*q, &tsigkeyname, &secret, &tsigContent)) {
+    if (!packetHandler->checkForCorrectTSIG(*q, &ctx.tsigkeyname, &ctx.tsigsecret, &ctx.trc)) {
       return false;
     }
-    getTSIGHashEnum(tsigContent.d_algoName, q->d_tsig_algo);
+    getTSIGHashEnum(ctx.trc.d_algoName, q->d_tsig_algo);
 #ifdef ENABLE_GSS_TSIG
     if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
-      GssContext gssctx(tsigkeyname);
+      GssContext gssctx(ctx.tsigkeyname);
       if (!gssctx.getPeerPrincipal(q->d_peer_principal)) {
-        SLOG(g_log<<Logger::Warning<<"Failed to extract peer principal from GSS context with keyname '"<<tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Warning, "Failed to extract peer principal from GSS context", "keyname", Logging::Loggable(tsigkeyname)));
+        SLOG(g_log<<Logger::Warning<<"Failed to extract peer principal from GSS context with keyname '"<<ctx.tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Warning, "Failed to extract peer principal from GSS context", "keyname", Logging::Loggable(ctx.tsigkeyname)));
       }
     }
 #endif
@@ -614,22 +616,22 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
       for(const std::string& princ :  princs) {
         if (q->d_peer_principal == princ) {
           SLOG(g_log<<Logger::Warning<<ctx.xfrType<<" of domain '"<<ctx.targetZone<<"' allowed: TSIG signed request with authorized principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig'"<<endl,
-               ctx.slog->info(Logr::Warning, ctx.xfrType + " allowed: TSIG signed request with authorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
+               ctx.slog->info(Logr::Warning, ctx.xfrType + " allowed: TSIG signed request with authorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
           return true;
         }
       }
       SLOG(g_log<<Logger::Warning<<ctx.xfrType<<" of domain '"<<ctx.targetZone<<"' denied: TSIG signed request with principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig' is not permitted"<<endl,
-           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: TSIG signed request with unauthorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
+           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: TSIG signed request with unauthorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
       return false;
     }
 #endif
-    if(!dk.TSIGGrantsAccess(ctx.targetZone, tsigkeyname)) {
-      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"denied: key with name '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"' does not grant access"<<endl,
-           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+    if(!dk.TSIGGrantsAccess(ctx.targetZone, ctx.tsigkeyname)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"denied: key with name '"<<ctx.tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"' does not grant access"<<endl,
+           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
       return false;
     }
-    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
-         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<ctx.tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
+         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
     return true;
   }
 
@@ -730,7 +732,7 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
@@ -770,36 +772,31 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     }
   }
 
-  TSIGRecordContent trc;
-  DNSName tsigkeyname;
-  string tsigsecret;
+  ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
 
-  bool haveTSIGDetails = q->getTSIGDetails(&trc, &tsigkeyname);
-
-  if(haveTSIGDetails && !tsigkeyname.empty()) {
+  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
     string tsig64;
-    DNSName algorithm=trc.d_algoName;
+    DNSName algorithm=ctx.trc.d_algoName;
     if (algorithm == g_hmacmd5dnsname_long) {
       algorithm = g_hmacmd5dnsname;
     }
     if (algorithm != g_gsstsigdnsname) {
-      if(!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
+      if(!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
         SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"TSIG key not found"<<endl,
-             ctx.slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+             ctx.slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         ctx.outpacket->setRcode(RCode::NotAuth);
         sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
-      if (B64Decode(tsig64, tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         ctx.outpacket->setRcode(RCode::ServFail);
         sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     }
   }
-
 
   // SOA *must* go out first, our signing pipe might reorder
   DLOG(SLOG(g_log<<ctx.logPrefix<<"sending out SOA"<<endl,
@@ -812,15 +809,88 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
   }
 
-  if(haveTSIGDetails && !tsigkeyname.empty()) {
-    ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+    ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac); // first answer is 'normal'
   }
 
-  ctx.sendIntermediatePacket(trc);
+  ctx.sendIntermediatePacket();
 
   DNSZoneRecord zrr;
   vector<DNSZoneRecord> zrrs;
 
+  zrr.dr.d_name = target;
+  zrr.dr.d_ttl = ctx.soa.minimum;
+
+  axfrKeys(ctx, zrrs, dk);
+
+  // now stuff in the NSEC3PARAM
+  if(ctx.NSEC3Zone) {
+    uint8_t flags = ctx.ns3pr.d_flags;
+    zrr.dr.d_type = QType::NSEC3PARAM;
+    ctx.ns3pr.d_flags = 0;
+    zrr.dr.setContent(std::make_shared<NSEC3PARAMRecordContent>(ctx.ns3pr));
+    ctx.ns3pr.d_flags = flags;
+    DNSName keyname = DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, zrr.dr.d_name)));
+    zrrs.push_back(zrr);
+  }
+
+  // Catalog zones need a specific processing at this point.
+  auto zoneKindSpecificOp = ctx.info.kind == DomainInfo::Producer ? axfrProducerZone : axfrRegularZone;
+  if (!zoneKindSpecificOp(ctx, zrrs)) {
+    return 0;
+  }
+
+  /* now write all other records */
+
+  ChunkedSigningPipe csp(ctx.slog, ctx.targetZone, (ctx.securedZone && !ctx.presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
+
+  DTime dt; // NOLINT(readability-identifier-length)
+  dt.set();
+
+  axfrSubmitRecords(ctx, zrrs, csp);
+  for(;;) {
+    ctx.outpacket->getRRS() = csp.getChunk(true); // flush the pipe
+    if(!ctx.outpacket->getRRS().empty()) {
+      if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+        ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true); // first answer is 'normal'
+      }
+      ctx.sendIntermediatePacket();
+    }
+    else {
+      break;
+    }
+  }
+
+  unsigned int udiff=dt.udiffNoReset();
+  if(ctx.securedZone) {
+    SLOG(g_log<<Logger::Debug<<ctx.logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
+         ctx.slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
+  }
+
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"done writing out records"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: done writing out records", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+  /* and terminate with yet again the SOA record */
+  ctx.setupOutputPacket();
+  ctx.outpacket->addRecord(std::move(soa));
+  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+    ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true);
+  }
+
+  sendPacket(ctx.outpacket, ctx.outsock);
+
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"last packet - close"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: last packet sent", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+  SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"AXFR finished"<<endl,
+       ctx.slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+
+  return 1;
+}
+
+void TCPNameserver::axfrKeys(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, DNSSECKeeper& dk)
+{
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
+
+  DNSZoneRecord zrr;
   zrr.dr.d_name = target;
   zrr.dr.d_ttl = ctx.soa.minimum;
 
@@ -829,8 +899,8 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     bool doCDS{true};
     string publishCDNSKEY;
     string publishCDS;
-    dk.getPublishCDNSKEY(q->qdomainzone, publishCDNSKEY);
-    dk.getPublishCDS(q->qdomainzone, publishCDS);
+    dk.getPublishCDNSKEY(ctx.targetZone, publishCDNSKEY);
+    dk.getPublishCDS(ctx.targetZone, publishCDS);
 
     set<uint32_t> entryPointIds;
     DNSSECKeeper::keyset_t entryPoints = dk.getEntryPoints(ctx.targetZone);
@@ -881,197 +951,6 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     }
 
   }
-
-  if(ctx.NSEC3Zone) { // now stuff in the NSEC3PARAM
-    uint8_t flags = ctx.ns3pr.d_flags;
-    zrr.dr.d_type = QType::NSEC3PARAM;
-    ctx.ns3pr.d_flags = 0;
-    zrr.dr.setContent(std::make_shared<NSEC3PARAMRecordContent>(ctx.ns3pr));
-    ctx.ns3pr.d_flags = flags;
-    DNSName keyname = DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, zrr.dr.d_name)));
-    zrrs.push_back(zrr);
-  }
-
-  // Catalog zones need a specific processing at this point.
-  auto zoneKindSpecificOp = ctx.info.kind == DomainInfo::Producer ? axfrProducerZone : axfrRegularZone;
-  if (!zoneKindSpecificOp(ctx, zrrs)) {
-    return 0;
-  }
-
-  /* now write all other records */
-
-  using nsecxrepo_t = map<DNSName, NSECXEntry, CanonDNSNameCompare>;
-  nsecxrepo_t nsecxrepo;
-
-  ChunkedSigningPipe csp(ctx.slog, ctx.targetZone, (ctx.securedZone && !ctx.presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
-
-  DNSName keyname;
-  DTime dt; // NOLINT(readability-identifier-length)
-  dt.set();
-  for(DNSZoneRecord &loopZRR :  zrrs) {
-    if(ctx.securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
-      if (ctx.NSEC3Zone || loopZRR.dr.d_type != QType::ENT) {
-        if (ctx.presignedZone && ctx.NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
-          keyname = loopZRR.dr.d_name.makeRelative(ctx.soa.qname());
-        } else {
-          keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
-        }
-        NSECXEntry& ne = nsecxrepo[keyname]; // NOLINT(readability-identifier-length)
-        ne.d_ttl = ctx.soa.getNegativeTTL();
-        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (ctx.ns3pr.d_flags == 0)));
-        if (loopZRR.dr.d_type != QType::ENT && loopZRR.dr.d_type != QType::RRSIG) {
-          ne.d_set.set(loopZRR.dr.d_type);
-        }
-      }
-    }
-
-    if (loopZRR.dr.d_type == QType::ENT) {
-      continue; // skip empty non-terminals
-    }
-
-    if(loopZRR.dr.d_type == QType::SOA) {
-      continue; // skip SOA - would indicate end of AXFR
-    }
-
-    if(csp.submit(loopZRR)) {
-      for(;;) {
-        ctx.outpacket->getRRS() = csp.getChunk();
-        if(!ctx.outpacket->getRRS().empty()) {
-          if(haveTSIGDetails && !tsigkeyname.empty()) {
-            ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-          }
-          ctx.sendIntermediatePacket(trc);
-        }
-        else {
-          break;
-        }
-      }
-    }
-  }
-  if(ctx.securedZone) {
-    if(ctx.NSEC3Zone) {
-      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
-        if(iter->second.d_auth) {
-          NSEC3RecordContent n3rc;
-          n3rc.set(iter->second.d_set);
-          const auto numberOfTypesSet = n3rc.numberOfTypesSet();
-          if (numberOfTypesSet != 0 && (numberOfTypesSet != 1 || !n3rc.isSet(QType::NS))) {
-            n3rc.set(QType::RRSIG);
-          }
-          n3rc.d_salt = ctx.ns3pr.d_salt;
-          n3rc.d_flags = ctx.ns3pr.d_flags;
-          n3rc.d_iterations = ctx.ns3pr.d_iterations;
-          n3rc.d_algorithm = DNSSECKeeper::DIGEST_SHA1; // SHA1, fixed in PowerDNS for now
-          auto inext = iter;
-          ++inext;
-          if(inext == nsecxrepo.cend()) {
-            inext = nsecxrepo.cbegin();
-          }
-          while(!inext->second.d_auth && inext != iter)
-          {
-            ++inext;
-            if(inext == nsecxrepo.cend()) {
-              inext = nsecxrepo.cbegin();
-            }
-          }
-          n3rc.d_nexthash = fromBase32Hex(inext->first.toStringNoDot());
-          zrr.dr.d_name = iter->first+ctx.soa.qname();
-
-          zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
-          zrr.dr.setContent(std::make_shared<NSEC3RecordContent>(std::move(n3rc)));
-          zrr.dr.d_type = QType::NSEC3;
-          zrr.dr.d_place = DNSResourceRecord::ANSWER;
-          zrr.auth=true;
-          if(csp.submit(zrr)) {
-            for(;;) {
-              ctx.outpacket->getRRS() = csp.getChunk();
-              if(!ctx.outpacket->getRRS().empty()) {
-                if(haveTSIGDetails && !tsigkeyname.empty()) {
-                  ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-                }
-                ctx.sendIntermediatePacket(trc);
-              }
-              else {
-                break;
-              }
-            }
-          }
-        }
-      }
-    }
-    else {
-      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
-        NSECRecordContent nrc;
-        nrc.set(iter->second.d_set);
-        nrc.set(QType::RRSIG);
-        nrc.set(QType::NSEC);
-
-        if(boost::next(iter) != nsecxrepo.cend()) {
-          nrc.d_next = boost::next(iter)->first;
-        }
-        else {
-          nrc.d_next=nsecxrepo.cbegin()->first;
-        }
-        zrr.dr.d_name = iter->first;
-
-        zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
-        zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
-        zrr.dr.d_type = QType::NSEC;
-        zrr.dr.d_place = DNSResourceRecord::ANSWER;
-        zrr.auth=true;
-        if(csp.submit(zrr)) {
-          for(;;) {
-            ctx.outpacket->getRRS() = csp.getChunk();
-            if(!ctx.outpacket->getRRS().empty()) {
-              if(haveTSIGDetails && !tsigkeyname.empty()) {
-                ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-              }
-              ctx.sendIntermediatePacket(trc);
-            }
-            else {
-              break;
-            }
-          }
-        }
-      }
-    }
-  }
-  for(;;) {
-    ctx.outpacket->getRRS() = csp.getChunk(true); // flush the pipe
-    if(!ctx.outpacket->getRRS().empty()) {
-      if(haveTSIGDetails && !tsigkeyname.empty()) {
-        ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
-      }
-      ctx.sendIntermediatePacket(trc);
-    }
-    else {
-      break;
-    }
-  }
-
-  unsigned int udiff=dt.udiffNoReset();
-  if(ctx.securedZone) {
-    SLOG(g_log<<Logger::Debug<<ctx.logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
-         ctx.slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
-  }
-
-  DLOG(SLOG(g_log<<ctx.logPrefix<<"done writing out records"<<endl,
-            ctx.slog->info(Logr::Debug, "AXFR: done writing out records", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
-  /* and terminate with yet again the SOA record */
-  ctx.setupOutputPacket();
-  ctx.outpacket->addRecord(std::move(soa));
-  if(haveTSIGDetails && !tsigkeyname.empty()) {
-    ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-  }
-
-  sendPacket(ctx.outpacket, ctx.outsock);
-
-  DLOG(SLOG(g_log<<ctx.logPrefix<<"last packet - close"<<endl,
-            ctx.slog->info(Logr::Debug, "AXFR: last packet sent", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
-  SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"AXFR finished"<<endl,
-       ctx.slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
-
-  return 1;
 }
 
 bool TCPNameserver::axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs)
@@ -1114,7 +993,7 @@ bool TCPNameserver::axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrr
   return true;
 }
 
-bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs) // NOLINT(readability-function-cognitive-complexity)
+bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
@@ -1148,32 +1027,8 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
     zrr.dr.d_name.makeUsLowerCase();
     if(zrr.dr.d_name.isPartOf(target)) {
       if (zrr.dr.d_type == QType::ALIAS && (::arg().mustDo("outgoing-axfr-expand-alias") || ::arg()["outgoing-axfr-expand-alias"] == "ignore-errors")) {
-        vector<DNSZoneRecord> ips;
-        int ret1 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
-        int ret2 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
-        if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
-          if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
-            if (ret1 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   ctx.slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            }
-            if (ret2 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   ctx.slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            }
-          }
-          else {
-            SLOG(g_log << Logger::Warning << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
-                 ctx.slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            ctx.outpacket->setRcode(RCode::ServFail);
-            sendPacket(ctx.outpacket, ctx.outsock);
-            return false;
-          }
-        }
-        for (auto& dzr: ips) {
-          zrr.dr.d_type = dzr.dr.d_type;
-          zrr.dr.setContent(dzr.dr.getContent());
-          zrrs.push_back(zrr);
+        if (!axfrAlias(ctx, zrrs, zrr)) {
+          return false;
         }
         continue;
       }
@@ -1198,8 +1053,61 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
     }
   }
 
+  // Process SVCB and HTTP hints
+  axfrHints(ctx, zrrs);
+
+  // Group records by name and type, signpipe stumbles over interrupted rrsets
+  if(ctx.securedZone && !ctx.presignedZone) {
+    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) { // NOLINT(readability-identifier-length)
+      return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
+    });
+  }
+
+  // Add ENT records if necessary
+  if (rectify) {
+    return axfrRectify(ctx, zrrs, qnames, nsset);
+  }
+
+  return true;
+}
+
+bool TCPNameserver::axfrAlias(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, DNSZoneRecord& zrr)
+{
+  vector<DNSZoneRecord> ips;
+
+  int ret1 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
+  int ret2 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
+  if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
+    if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
+      if (ret1 != RCode::NoError) {
+        SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+             ctx.slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+      }
+      if (ret2 != RCode::NoError) {
+        SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+             ctx.slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+      }
+    }
+    else {
+      SLOG(g_log << Logger::Warning << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
+           ctx.slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+      ctx.outpacket->setRcode(RCode::ServFail);
+      sendPacket(ctx.outpacket, ctx.outsock);
+      return false;
+    }
+  }
+  for (auto& dzr: ips) {
+    zrr.dr.d_type = dzr.dr.d_type;
+    zrr.dr.setContent(dzr.dr.getContent());
+    zrrs.push_back(zrr);
+  }
+  return true;
+}
+
+void TCPNameserver::axfrHints(XFRContext& ctx, vector<DNSZoneRecord>& zrrs)
+{
   for (auto& loopRR : zrrs) {
-    if ((loopRR.dr.d_type == QType::SVCB || loopRR.dr.d_type == QType::HTTPS)) {
+    if (loopRR.dr.d_type == QType::SVCB || loopRR.dr.d_type == QType::HTTPS) {
       // Process auto hints
       // TODO this is an almost copy of the code in the packethandler
       auto rrc = getRR<SVCBBaseRecordContent>(loopRR.dr);
@@ -1244,88 +1152,223 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       loopRR.dr.setContent(std::move(newRRC));
     }
   }
+}
 
-  // Group records by name and type, signpipe stumbles over interrupted rrsets
-  if(ctx.securedZone && !ctx.presignedZone) {
-    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) { // NOLINT(readability-identifier-length)
-      return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
-    });
+bool TCPNameserver::axfrRectify(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, const set<DNSName>& qnames, const set<DNSName>& nsset)
+{
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
+
+  DNSZoneRecord zrr;
+
+  // set auth
+  for(auto &loopZRR : zrrs) {
+    loopZRR.auth=true;
+    if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
+      DNSName shorter(loopZRR.dr.d_name);
+      do {
+        if (shorter==target) { // apex is always auth
+          break;
+        }
+        if(nsset.count(shorter) != 0 && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
+          loopZRR.auth=false;
+          break;
+        }
+      } while(shorter.chopOff());
+    }
   }
 
-  if(rectify) {
-    // set auth
-    for(DNSZoneRecord &loopZRR :  zrrs) {
-      loopZRR.auth=true;
-      if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
-        DNSName shorter(loopZRR.dr.d_name);
+  if(ctx.NSEC3Zone) {
+    // ents are only required for NSEC3 zones
+    uint32_t maxent = ::arg().asNum("max-ent-entries");
+    set<DNSName> nsec3set;
+    set<DNSName> nonterm;
+    for (auto &loopZRR: zrrs) {
+      bool skip=false;
+      DNSName shorter = loopZRR.dr.d_name;
+      if (shorter != target && shorter.chopOff() && shorter != target) {
         do {
-          if (shorter==target) { // apex is always auth
+          if(nsset.count(shorter) != 0) {
+            skip=true;
             break;
           }
-          if(nsset.count(shorter) != 0 && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
-            loopZRR.auth=false;
-            break;
+        } while(shorter.chopOff() && shorter != target);
+      }
+      shorter = loopZRR.dr.d_name;
+      if(!skip && (loopZRR.dr.d_type != QType::NS || ctx.ns3pr.d_flags == 0)) {
+        do {
+          if(nsec3set.count(shorter) == 0) {
+            nsec3set.insert(shorter);
           }
-        } while(shorter.chopOff());
+        } while(shorter != target && shorter.chopOff());
       }
     }
 
-    if(ctx.NSEC3Zone) {
-      // ents are only required for NSEC3 zones
-      uint32_t maxent = ::arg().asNum("max-ent-entries");
-      set<DNSName> nsec3set;
-      set<DNSName> nonterm;
-      for (auto &loopZRR: zrrs) {
-        bool skip=false;
-        DNSName shorter = loopZRR.dr.d_name;
-        if (shorter != target && shorter.chopOff() && shorter != target) {
-          do {
-            if(nsset.count(shorter) != 0) {
-              skip=true;
-              break;
-            }
-          } while(shorter.chopOff() && shorter != target);
-        }
-        shorter = loopZRR.dr.d_name;
-        if(!skip && (loopZRR.dr.d_type != QType::NS || ctx.ns3pr.d_flags == 0)) {
-          do {
-            if(nsec3set.count(shorter) == 0) {
-              nsec3set.insert(shorter);
-            }
-          } while(shorter != target && shorter.chopOff());
-        }
-      }
-
-      for(DNSZoneRecord &loopZRR :  zrrs) {
-        DNSName shorter(loopZRR.dr.d_name);
-        while(shorter != target && shorter.chopOff()) {
-          if(qnames.count(shorter) == 0 && nonterm.count(shorter) == 0 && nsec3set.count(shorter) != 0) {
-            if(maxent == 0) {
-              SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
-                   ctx.slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
-              ctx.outpacket->setRcode(RCode::ServFail);
-              sendPacket(ctx.outpacket,ctx.outsock);
-              return false;
-            }
-            nonterm.insert(shorter);
-            --maxent;
+    for(auto &loopZRR : zrrs) {
+      DNSName shorter(loopZRR.dr.d_name);
+      while(shorter != target && shorter.chopOff()) {
+        if(qnames.count(shorter) == 0 && nonterm.count(shorter) == 0 && nsec3set.count(shorter) != 0) {
+          if(maxent == 0) {
+            SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
+                 ctx.slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+            ctx.outpacket->setRcode(RCode::ServFail);
+            sendPacket(ctx.outpacket,ctx.outsock);
+            return false;
           }
+          nonterm.insert(shorter);
+          --maxent;
         }
       }
+    }
 
-      for(const auto& nt : nonterm) { // NOLINT(readability-identifier-length)
-        DNSZoneRecord tempRR;
-        tempRR.dr.d_name=nt;
-        tempRR.dr.d_type=QType::ENT;
-        tempRR.auth=true;
-        zrrs.push_back(tempRR);
-      }
+    for(const auto& nt : nonterm) { // NOLINT(readability-identifier-length)
+      DNSZoneRecord tempRR;
+      tempRR.dr.d_name=nt;
+      tempRR.dr.d_type=QType::ENT;
+      tempRR.auth=true;
+      zrrs.push_back(tempRR);
     }
   }
 
   return true;
 }
 
+void TCPNameserver::axfrSubmitRecords(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, ChunkedSigningPipe& csp) // NOLINT(readability-function-cognitive-complexity)
+{
+  DNSZoneRecord zrr;
+
+  using nsecxrepo_t = map<DNSName, NSECXEntry, CanonDNSNameCompare>;
+  nsecxrepo_t nsecxrepo;
+
+  for(DNSZoneRecord &loopZRR :  zrrs) {
+    if(ctx.securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
+      if (ctx.NSEC3Zone || loopZRR.dr.d_type != QType::ENT) {
+        DNSName keyname;
+        if (ctx.presignedZone && ctx.NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
+          keyname = loopZRR.dr.d_name.makeRelative(ctx.soa.qname());
+        } else {
+          keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
+        }
+        NSECXEntry& ne = nsecxrepo[keyname]; // NOLINT(readability-identifier-length)
+        ne.d_ttl = ctx.soa.getNegativeTTL();
+        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (ctx.ns3pr.d_flags == 0)));
+        if (loopZRR.dr.d_type != QType::ENT && loopZRR.dr.d_type != QType::RRSIG) {
+          ne.d_set.set(loopZRR.dr.d_type);
+        }
+      }
+    }
+
+    if (loopZRR.dr.d_type == QType::ENT) {
+      continue; // skip empty non-terminals
+    }
+
+    if(loopZRR.dr.d_type == QType::SOA) {
+      continue; // skip SOA - would indicate end of AXFR
+    }
+
+    if(csp.submit(loopZRR)) {
+      for(;;) {
+        ctx.outpacket->getRRS() = csp.getChunk();
+        if(!ctx.outpacket->getRRS().empty()) {
+          if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+            ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true);
+          }
+          ctx.sendIntermediatePacket();
+        }
+        else {
+          break;
+        }
+      }
+    }
+  }
+  if(ctx.securedZone) {
+    if(ctx.NSEC3Zone) {
+      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
+        if(iter->second.d_auth) {
+          NSEC3RecordContent n3rc;
+          n3rc.set(iter->second.d_set);
+          const auto numberOfTypesSet = n3rc.numberOfTypesSet();
+          if (numberOfTypesSet != 0 && (numberOfTypesSet != 1 || !n3rc.isSet(QType::NS))) {
+            n3rc.set(QType::RRSIG);
+          }
+          n3rc.d_salt = ctx.ns3pr.d_salt;
+          n3rc.d_flags = ctx.ns3pr.d_flags;
+          n3rc.d_iterations = ctx.ns3pr.d_iterations;
+          n3rc.d_algorithm = DNSSECKeeper::DIGEST_SHA1; // SHA1, fixed in PowerDNS for now
+          auto inext = iter;
+          ++inext;
+          if(inext == nsecxrepo.cend()) {
+            inext = nsecxrepo.cbegin();
+          }
+          while(!inext->second.d_auth && inext != iter)
+          {
+            ++inext;
+            if(inext == nsecxrepo.cend()) {
+              inext = nsecxrepo.cbegin();
+            }
+          }
+          n3rc.d_nexthash = fromBase32Hex(inext->first.toStringNoDot());
+
+          zrr.dr.d_name = iter->first+ctx.soa.qname();
+          zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
+          zrr.dr.setContent(std::make_shared<NSEC3RecordContent>(std::move(n3rc)));
+          zrr.dr.d_type = QType::NSEC3;
+          zrr.dr.d_place = DNSResourceRecord::ANSWER;
+          zrr.auth=true;
+          if(csp.submit(zrr)) {
+            for(;;) {
+              ctx.outpacket->getRRS() = csp.getChunk();
+              if(!ctx.outpacket->getRRS().empty()) {
+                if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+                  ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true);
+                }
+                ctx.sendIntermediatePacket();
+              }
+              else {
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+    else {
+      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
+        NSECRecordContent nrc;
+        nrc.set(iter->second.d_set);
+        nrc.set(QType::RRSIG);
+        nrc.set(QType::NSEC);
+
+        if(boost::next(iter) != nsecxrepo.cend()) {
+          nrc.d_next = boost::next(iter)->first;
+        }
+        else {
+          nrc.d_next=nsecxrepo.cbegin()->first;
+        }
+        zrr.dr.d_name = iter->first;
+
+        zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
+        zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
+        zrr.dr.d_type = QType::NSEC;
+        zrr.dr.d_place = DNSResourceRecord::ANSWER;
+        zrr.auth=true;
+        if(csp.submit(zrr)) {
+          for(;;) {
+            ctx.outpacket->getRRS() = csp.getChunk();
+            if(!ctx.outpacket->getRRS().empty()) {
+              if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+                ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true);
+              }
+              ctx.sendIntermediatePacket();
+            }
+            else {
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+}
 int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog) // NOLINT(readability-identifier-length)
 {
   XFRContext ctx(q, outsock, slog, false);
@@ -1415,31 +1458,27 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   }
 
   if (serialPermitsIXFR) {
-    TSIGRecordContent trc;
-    DNSName tsigkeyname;
-    string tsigsecret;
-
     UeberBackend db; // NOLINT(readability-identifier-length)
     DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
 
-    bool haveTSIGDetails = q->getTSIGDetails(&trc, &tsigkeyname);
+    ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
 
-    if(haveTSIGDetails && !tsigkeyname.empty()) {
+    if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
       string tsig64;
-      DNSName algorithm=trc.d_algoName; // FIXME400: was toLowerCanonic, compare output
+      DNSName algorithm=ctx.trc.d_algoName; // FIXME400: was toLowerCanonic, compare output
       if (algorithm == g_hmacmd5dnsname_long) {
         algorithm = g_hmacmd5dnsname;
       }
-      if (!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
-           ctx.slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+      if (!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
+        SLOG(g_log << Logger::Error << "TSIG key '" << ctx.tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
+           ctx.slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         ctx.outpacket->setRcode(RCode::NotAuth);
         sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
-      if (B64Decode(tsig64, tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         ctx.outpacket->setRcode(RCode::ServFail);
         sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
@@ -1457,8 +1496,8 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
     }
 
-    if(haveTSIGDetails && !tsigkeyname.empty()) {
-      ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+    if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+      ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac); // first answer is 'normal'
     }
 
     sendPacket(ctx.outpacket, ctx.outsock);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -731,6 +731,37 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   return doAXFRinternal(q, ctx);
 }
 
+bool TCPNameserver::axfrCheckTSIG(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, UeberBackend& db, bool alwaysCheck)
+{
+  ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
+
+  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+    string tsig64;
+    DNSName algorithm=ctx.trc.d_algoName;
+    if (algorithm == g_hmacmd5dnsname_long) {
+      algorithm = g_hmacmd5dnsname;
+    }
+    if (algorithm != g_gsstsigdnsname || alwaysCheck) {
+      if(!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
+        SLOG(g_log << Logger::Error << "TSIG key '" << ctx.tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
+             ctx.slog->info(Logr::Error, ctx.xfrType + " refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::NotAuth);
+        sendPacket(ctx.outpacket,ctx.outsock);
+        return false;
+      }
+      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::ServFail);
+        sendPacket(ctx.outpacket,ctx.outsock);
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
 int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx)
 {
@@ -772,30 +803,8 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     }
   }
 
-  ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
-
-  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
-    string tsig64;
-    DNSName algorithm=ctx.trc.d_algoName;
-    if (algorithm == g_hmacmd5dnsname_long) {
-      algorithm = g_hmacmd5dnsname;
-    }
-    if (algorithm != g_gsstsigdnsname) {
-      if(!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"TSIG key not found"<<endl,
-             ctx.slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        ctx.outpacket->setRcode(RCode::NotAuth);
-        sendPacket(ctx.outpacket,ctx.outsock);
-        return 0;
-      }
-      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        ctx.outpacket->setRcode(RCode::ServFail);
-        sendPacket(ctx.outpacket,ctx.outsock);
-        return 0;
-      }
-    }
+  if (!axfrCheckTSIG(q, ctx, db, false)) {
+    return 0;
   }
 
   // SOA *must* go out first, our signing pipe might reorder
@@ -1461,28 +1470,8 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     UeberBackend db; // NOLINT(readability-identifier-length)
     DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
 
-    ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
-
-    if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
-      string tsig64;
-      DNSName algorithm=ctx.trc.d_algoName; // FIXME400: was toLowerCanonic, compare output
-      if (algorithm == g_hmacmd5dnsname_long) {
-        algorithm = g_hmacmd5dnsname;
-      }
-      if (!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log << Logger::Error << "TSIG key '" << ctx.tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
-           ctx.slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        ctx.outpacket->setRcode(RCode::NotAuth);
-        sendPacket(ctx.outpacket,ctx.outsock);
-        return 0;
-      }
-      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        ctx.outpacket->setRcode(RCode::ServFail);
-        sendPacket(ctx.outpacket,ctx.outsock);
-        return 0;
-      }
+    if (!axfrCheckTSIG(q, ctx, db, true)) {
+      return 0;
     }
 
     // SOA *must* go out first, our signing pipe might reorder

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1031,6 +1031,7 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
         if(!::arg().mustDo("direct-dnskey")) {
           continue;
         }
+	// Override TTL
         zrr.dr.d_ttl = ctx.soa.minimum;
       }
     }
@@ -1108,6 +1109,7 @@ bool TCPNameserver::axfrAlias(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, DNSZ
   }
   for (auto& dzr: ips) {
     zrr.dr.d_type = dzr.dr.d_type;
+    zrr.dr.d_ttl = dzr.dr.d_ttl;
     zrr.dr.setContent(dzr.dr.getContent());
     zrrs.push_back(zrr);
   }

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -506,16 +506,20 @@ namespace {
   };
 }
 
-class TCPNameserver::XFRContext : public boost::noncopyable
+class TCPNameserver::XFRContext
 {
 public:
   XFRContext(std::unique_ptr<DNSPacket>& qry, int sock, Logr::log_t log, bool isAXFR);
+  XFRContext(const XFRContext&) = delete;
+  XFRContext& operator=(const XFRContext&) = delete;
+
   void setupOutputPacket();
 
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
   const ZoneName& targetZone; // domain being XFR'ed
   DomainInfo info;
   SOAData soa;
+  bool soaValid{false};
 
   bool presignedZone{false};
   bool securedZone{false};
@@ -621,6 +625,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
   FindNS fns;
 
   if(packetHandler->getBackend()->getSOAUncached(ctx.targetZone,ctx.soa)) {
+    ctx.soaValid = true;
     vector<string> acl;
     packetHandler->getBackend()->getDomainMetadata(ctx.targetZone, "ALLOW-AXFR-FROM", acl);
     for (const auto & entry : acl) {
@@ -635,8 +640,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
         for(const auto & nameserver: nsset) {
           vector<string> nsips=fns.lookup(nameserver, packetHandler->getBackend());
           for(const auto & nsip : nsips) {
-            if(nsip == q->getInnerRemote().toString())
-            {
+            if(nsip == q->getInnerRemote().toString()) {
               SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in NSset"<<endl,
                    ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in NSset", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
               return true;
@@ -647,8 +651,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
       else
       {
         auto nm = Netmask(entry); // NOLINT(readability-identifier-length)
-        if(nm.match( q->getInnerRemote() ))
-        {
+        if(nm.match( q->getInnerRemote() )) {
           SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in per-zone ACL"<<endl,
                ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in per-zone ACL", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
           return true;
@@ -696,8 +699,8 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       return 0;
     }
 
-    // ctx.soa has been computed by canDoAXFR above
-    if (!(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
+    // ctx.soaValid has been computed by canDoAXFR above
+    if (!ctx.soaValid && !(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
       SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative"<<endl,
            ctx.slog->info(Logr::Warning, "AXFR failed: not authoritative", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
       ctx.outpacket->setRcode(RCode::NotAuth);
@@ -1384,8 +1387,8 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       return 0;
     }
 
-    // ctx.soa has been computed by canDoAXFR above
-    if(!(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
+    // ctx.soaValid has been computed by canDoAXFR above
+    if(!ctx.soaValid && !(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
       SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative"<<endl,
            ctx.slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
       ctx.outpacket->setRcode(RCode::NotAuth);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -597,6 +597,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
     if (!packetHandler->checkForCorrectTSIG(*q, &ctx.tsigkeyname, &ctx.tsigsecret, &ctx.trc)) {
       return false;
     }
+    ctx.haveTSIGDetails = true;
     getTSIGHashEnum(ctx.trc.d_algoName, q->d_tsig_algo);
 #ifdef ENABLE_GSS_TSIG
     if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
@@ -728,13 +729,13 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     }
   }
 
-  return doAXFRinternal(q, ctx);
+  return doAXFRinternal(ctx);
 }
 
-bool TCPNameserver::axfrCheckTSIG(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, UeberBackend& db, bool alwaysCheck)
+bool TCPNameserver::axfrCheckTSIG(XFRContext& ctx, UeberBackend& db, bool alwaysCheck) // NOLINT(readability-identifier-length)
 {
-  ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
-
+  // TSIG-related fields in ctx have been computed as part of the
+  // checkForCorrectTSIG() call in canDoAXFR
   if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
     string tsig64;
     DNSName algorithm=ctx.trc.d_algoName;
@@ -763,7 +764,7 @@ bool TCPNameserver::axfrCheckTSIG(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx)
+int TCPNameserver::doAXFRinternal(XFRContext& ctx)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
@@ -803,7 +804,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     }
   }
 
-  if (!axfrCheckTSIG(q, ctx, db, false)) {
+  if (!axfrCheckTSIG(ctx, db, false)) {
     return 0;
   }
 
@@ -895,7 +896,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
   return 1;
 }
 
-void TCPNameserver::axfrKeys(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, DNSSECKeeper& dk)
+void TCPNameserver::axfrKeys(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, DNSSECKeeper& dk) // NOLINT(readability-identifier-length)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
@@ -1470,7 +1471,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     UeberBackend db; // NOLINT(readability-identifier-length)
     DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
 
-    if (!axfrCheckTSIG(q, ctx, db, true)) {
+    if (!axfrCheckTSIG(ctx, db, true)) {
       return 0;
     }
 
@@ -1503,7 +1504,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   if (!g_slogStructured) {
     ctx.logPrefix.at(0) = 'A';
   }
-  return doAXFRinternal(q, ctx);
+  return doAXFRinternal(ctx);
 }
 
 TCPNameserver::~TCPNameserver() = default;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -658,11 +658,11 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
        slog->info(Logr::Warning, "AXFR transfer initiated", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
 
   // determine if zone exists and AXFR is allowed using existing backend before spawning a new backend.
+  DLOG(SLOG(g_log<<logPrefix<<"looking for SOA"<<endl,
+            slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
   SOAData sd;
   {
     auto packetHandler = s_P.lock();
-    DLOG(SLOG(g_log<<logPrefix<<"looking for SOA"<<endl,
-              slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));    // find domain_id via SOA and list complete domain. No SOA, no AXFR
     if(!*packetHandler) {
       SLOG(g_log<<Logger::Warning<<"TCP server is without backend connections in doAXFR, launching"<<endl,
            slog->info(Logr::Warning, "TCP server is without backend connections in doAXFR, launching", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
@@ -687,6 +687,7 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     }
   }
 
+  // find domain_id via SOA and list complete domain. No SOA, no AXFR
   UeberBackend db;
   if(!db.getSOAUncached(targetZone, sd)) {
     SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative in second instance"<<endl,
@@ -1259,15 +1260,17 @@ send:
 
 int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
 {
+  const ZoneName& targetZone = q->qdomainzone;
   string logPrefix;
 
   if (!g_slogStructured) {
-    logPrefix="IXFR-out zone '"+q->qdomainzone.toLogString()+"', client '"+q->getRemoteStringWithPort()+"', ";
+    logPrefix="IXFR-out zone '"+targetZone.toLogString()+"', client '"+q->getRemoteStringWithPort()+"', ";
   }
 
   std::unique_ptr<DNSPacket> outpacket=getFreshAXFRPacket(q);
-  if(q->d_dnssecOk)
+  if(q->d_dnssecOk) {
     outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
+  }
 
   uint32_t serial = 0;
   MOADNSParser mdp(false, q->getString());
@@ -1282,21 +1285,21 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
         }
         catch(const std::logic_error& exc) {
           SLOG(g_log<<Logger::Warning<<logPrefix<<"invalid serial in IXFR query"<<endl,
-               slog->error(Logr::Warning, exc.what(), "IXFR: invalid serial in query", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+               slog->error(Logr::Warning, exc.what(), "IXFR: invalid serial in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
           outpacket->setRcode(RCode::FormErr);
           sendPacket(outpacket,outsock);
           return 0;
         }
       } else {
         SLOG(g_log<<Logger::Warning<<logPrefix<<"no serial in IXFR query"<<endl,
-             slog->info(Logr::Warning, "IXFR: no serial in query", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+             slog->info(Logr::Warning, "IXFR: no serial in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
         outpacket->setRcode(RCode::FormErr);
         sendPacket(outpacket,outsock);
         return 0;
       }
     } else if (dnsRecord->d_type != QType::TSIG && dnsRecord->d_type != QType::OPT) {
       SLOG(g_log<<Logger::Warning<<logPrefix<<"additional records in IXFR query, type: "<<QType(dnsRecord->d_type).toString()<<endl,
-             slog->info(Logr::Warning, "IXFR: additional record in query", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "type", Logging::Loggable(dnsRecord->d_type)));
+             slog->info(Logr::Warning, "IXFR: additional record in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "type", Logging::Loggable(dnsRecord->d_type)));
       outpacket->setRcode(RCode::FormErr);
       sendPacket(outpacket,outsock);
       return 0;
@@ -1304,40 +1307,47 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   }
 
   SLOG(g_log<<Logger::Warning<<logPrefix<<"transfer initiated with serial "<<serial<<endl,
-       slog->info(Logr::Warning, "IXFR: transfer initiated", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "serial", Logging::Loggable(serial)));
+       slog->info(Logr::Warning, "IXFR: transfer initiated", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "serial", Logging::Loggable(serial)));
 
   // determine if zone exists, XFR is allowed, and if IXFR can proceed using existing backend before spawning a new backend.
+  DLOG(SLOG(g_log<<logPrefix<<"Looking for SOA"<<endl,
+            slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
   SOAData sd;
   bool securedZone;
   bool serialPermitsIXFR;
   {
     auto packetHandler = s_P.lock();
-    // find domain_id via SOA and list complete domain. No SOA, no IXFR
-    DLOG(SLOG(g_log<<logPrefix<<"Looking for SOA"<<endl,
-              slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
     if(!*packetHandler) {
       SLOG(g_log<<Logger::Warning<<"TCP server is without backend connections in doIXFR, launching"<<endl,
-           slog->info(Logr::Warning, "IXFR: TCP server is without backend connections in doIXFR, launching", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+           slog->info(Logr::Warning, "IXFR: TCP server is without backend connections in doIXFR, launching", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
       *packetHandler = make_unique<PacketHandler>(slog);
     }
 
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
-    if(!canDoAXFR(q, false, *packetHandler, slog) || !(*packetHandler)->getBackend()->getSOAUncached(q->qdomainzone, sd)) {
+    if(!canDoAXFR(q, false, *packetHandler, slog)) {
+      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: client may not request IXFR"<<endl,
+           slog->info(Logr::Warning, "IXFR failed: client may not request IXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+      outpacket->setRcode(RCode::NotAuth);
+      sendPacket(outpacket,outsock);
+      return 0;
+    }
+
+    if(!(*packetHandler)->getBackend()->getSOAUncached(targetZone, sd)) {
       SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative"<<endl,
-           slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+           slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
       outpacket->setRcode(RCode::NotAuth);
       sendPacket(outpacket,outsock);
       return 0;
     }
 
     DNSSECKeeper dk(slog, (*packetHandler)->getBackend());
-    DNSSECKeeper::clearCaches(q->qdomainzone);
+    DNSSECKeeper::clearCaches(targetZone);
     bool narrow = false;
-    securedZone = dk.isSecuredZone(q->qdomainzone);
-    if(dk.getNSEC3PARAM(q->qdomainzone, nullptr, &narrow)) {
+    securedZone = dk.isSecuredZone(targetZone);
+    if(dk.getNSEC3PARAM(targetZone, nullptr, &narrow)) {
       if(narrow) {
         SLOG(g_log<<Logger::Warning<<logPrefix<<"not doing IXFR of an NSEC3 narrow zone"<<endl,
-           slog->info(Logr::Warning, "IXFR refused: not doing IXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+           slog->info(Logr::Warning, "IXFR refused: not doing IXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
         outpacket->setRcode(RCode::Refused);
         sendPacket(outpacket,outsock);
         return 0;
@@ -1348,7 +1358,6 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   }
 
   if (serialPermitsIXFR) {
-    const ZoneName& target = q->qdomainzone;
     TSIGRecordContent trc;
     DNSName tsigkeyname;
     string tsigsecret;
@@ -1365,15 +1374,15 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
         algorithm = g_hmacmd5dnsname;
       }
       if (!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << target << "' not found" << endl,
-           slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(target), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << targetZone << "' not found" << endl,
+           slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         outpacket->setRcode(RCode::NotAuth);
         sendPacket(outpacket,outsock);
         return 0;
       }
       if (B64Decode(tsig64, tsigsecret) == -1) {
         SLOG(g_log<<Logger::Error<<logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(target), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+             slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         outpacket->setRcode(RCode::ServFail);
         sendPacket(outpacket,outsock);
         return 0;
@@ -1382,12 +1391,12 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 
     // SOA *must* go out first, our signing pipe might reorder
     DLOG(SLOG(g_log<<logPrefix<<"sending out SOA"<<endl,
-              slog->info(Logr::Debug, /*"I send an SOA to the world"*/"IXFR: sending out SOA", "zone", Logging::Loggable(target), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
+              slog->info(Logr::Debug, /*"I send an SOA to the world"*/"IXFR: sending out SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
     DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, sd, DNSResourceRecord::ANSWER, slog);
     outpacket->addRecord(std::move(soa));
     if(securedZone && outpacket->d_dnssecOk) {
       set<ZoneName> authSet;
-      authSet.insert(target);
+      authSet.insert(targetZone);
       addRRSigs(dk, db, authSet, outpacket->getRRS());
     }
 
@@ -1397,13 +1406,13 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     sendPacket(outpacket, outsock);
 
     SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR finished"<<endl,
-         slog->info(Logr::Notice, "IXFR finished", "zone", Logging::Loggable(target), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+         slog->info(Logr::Notice, "IXFR finished", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
 
     return 1;
   }
 
   SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR fallback to AXFR"<<endl,
-       slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+       slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
   return doAXFR(q, outsock, slog);
 }
 

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -512,6 +512,9 @@ public:
   XFRContext(std::unique_ptr<DNSPacket>& qry, int sock, Logr::log_t log, bool isAXFR);
   XFRContext(const XFRContext&) = delete;
   XFRContext& operator=(const XFRContext&) = delete;
+  XFRContext(XFRContext&&) = delete;
+  XFRContext& operator=(XFRContext&&) = delete;
+  ~XFRContext() = default;
 
   void setupOutputPacket();
   void sendIntermediatePacket(TSIGRecordContent &trc);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -382,7 +382,7 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
       if(packet->qtype.getCode()==QType::AXFR) {
         packet->d_xfr=true;
         g_zoneCache.setZoneVariant(*packet);
-        doAXFR(packet->qdomainzone, packet, fd, slog);
+        doAXFR(packet, fd, slog);
         continue;
       }
 
@@ -638,8 +638,9 @@ namespace {
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
 // NOLINTNEXTLINE(readability-identifier-length)
-int TCPNameserver::doAXFR(const ZoneName &targetZone, std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)  // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)  // NOLINT(readability-function-cognitive-complexity)
 {
+  const ZoneName& targetZone = q->qdomainzone;
   const DNSName& target = targetZone.operator const DNSName&();
   string logPrefix;
 
@@ -1402,7 +1403,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 
   SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR fallback to AXFR"<<endl,
        slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-  return doAXFR(q->qdomainzone, q, outsock, slog);
+  return doAXFR(q, outsock, slog);
 }
 
 TCPNameserver::~TCPNameserver() = default;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -688,7 +688,7 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket)  // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket) // NOLINT(readability-function-cognitive-complexity)
 {
   const ZoneName& targetZone = q->qdomainzone;
   const DNSName& target = targetZone.operator const DNSName&();
@@ -855,242 +855,16 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
     zrrs.push_back(zrr);
   }
 
-  const bool rectify = !(presignedZone || ::arg().mustDo("disable-axfr-rectify"));
-  set<DNSName> qnames, nsset, terms;
-
-  // Catalog zone start
-  if (di.kind == DomainInfo::Producer) {
-    // Ignore all records except NS at apex
-    sd.db->lookup(QType::NS, target, di.id);
-    while (sd.db->get(zrr)) {
-      zrrs.emplace_back(zrr);
-    }
-    if (zrrs.empty()) {
-      zrr.dr.d_name = target;
-      zrr.dr.d_ttl = 0;
-      zrr.dr.d_type = QType::NS;
-      zrr.dr.setContent(std::make_shared<NSRecordContent>("invalid."));
-      zrrs.emplace_back(zrr);
-    }
-
-    zrrs.emplace_back(CatalogInfo::getCatalogVersionRecord(targetZone));
-
-    vector<CatalogInfo> members;
-    if (!sd.db->getCatalogMembers(targetZone, members, CatalogInfo::CatalogType::Producer)) {
-      SLOG(g_log << Logger::Error << logPrefix << "getting catalog members failed, aborting AXFR" << endl,
-           slog->info(Logr::Error, "AXFR aborted: getting catalog members failed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::ServFail);
-      sendPacket(outpacket, outsock);
+  if (di.kind == DomainInfo::Producer) { // Catalog zone
+    if (!axfrProducerZone(q, outsock, slog, logPrefix, outpacket, zrrs, di, sd)) {
       return 0;
     }
-    for (const auto& ci : members) {
-      ci.toDNSZoneRecords(targetZone, zrrs);
-    }
-    if (members.empty()) {
-      SLOG(g_log << Logger::Warning << logPrefix << "catalog zone '" << targetZone << "' has no members" << endl,
-           slog->info(Logr::Warning, "AXFR: Catalog zone has no members", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    }
-    goto send;
   }
-  // Catalog zone end
-
-  // now start list zone
-  if (!sd.db->list(targetZone, sd.domain_id, isCatalogZone)) {
-    SLOG(g_log<<Logger::Error<<logPrefix<<"backend signals error condition, aborting AXFR"<<endl,
-         slog->info(Logr::Error, "AXFR aborted: backend signals error condition", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    outpacket->setRcode(RCode::ServFail);
-    sendPacket(outpacket,outsock);
-    return 0;
-  }
-
-  while(sd.db->get(zrr)) {
-    if (!presignedZone) {
-      if (zrr.dr.d_type == QType::RRSIG) {
-        continue;
-      }
-      if (zrr.dr.d_type == QType::DNSKEY || zrr.dr.d_type == QType::CDNSKEY || zrr.dr.d_type == QType::CDS) {
-        if(!::arg().mustDo("direct-dnskey")) {
-          continue;
-        } else {
-          zrr.dr.d_ttl = sd.minimum;
-        }
-      }
-    }
-    zrr.dr.d_name.makeUsLowerCase();
-    if(zrr.dr.d_name.isPartOf(target)) {
-      if (zrr.dr.d_type == QType::ALIAS && (::arg().mustDo("outgoing-axfr-expand-alias") || ::arg()["outgoing-axfr-expand-alias"] == "ignore-errors")) {
-        vector<DNSZoneRecord> ips;
-        int ret1 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
-        int ret2 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
-        if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
-          if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
-            if (ret1 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            }
-            if (ret2 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            }
-          }
-          else {
-            SLOG(g_log << Logger::Warning << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
-                 slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            outpacket->setRcode(RCode::ServFail);
-            sendPacket(outpacket, outsock);
-            return 0;
-          }
-        }
-        for (auto& ip: ips) {
-          zrr.dr.d_type = ip.dr.d_type;
-          zrr.dr.setContent(ip.dr.getContent());
-          zrrs.push_back(zrr);
-        }
-        continue;
-      }
-
-      if (rectify) {
-        if (zrr.dr.d_type) {
-          qnames.insert(zrr.dr.d_name);
-          if(zrr.dr.d_type == QType::NS && zrr.dr.d_name!=target)
-            nsset.insert(zrr.dr.d_name);
-        } else {
-          // remove existing ents
-          continue;
-        }
-      }
-      zrrs.push_back(zrr);
-    } else {
-      if (zrr.dr.d_type != QType::ENT)
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
-             slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
+  else {
+    if (!axfrRegularZone(q, outsock, slog, logPrefix, outpacket, zrrs, sd, presignedZone, securedZone, NSEC3Zone, isCatalogZone, ns3pr)) {
+      return 0;
     }
   }
-
-  for (auto& loopRR : zrrs) {
-    if ((loopRR.dr.d_type == QType::SVCB || loopRR.dr.d_type == QType::HTTPS)) {
-      // Process auto hints
-      // TODO this is an almost copy of the code in the packethandler
-      auto rrc = getRR<SVCBBaseRecordContent>(loopRR.dr);
-      if (rrc == nullptr) {
-        continue;
-      }
-      auto newRRC = rrc->clone();
-      if (!newRRC) {
-        continue;
-      }
-      DNSName svcTarget = newRRC->getTarget().isRoot() ? loopRR.dr.d_name : newRRC->getTarget();
-      if (newRRC->autoHint(SvcParam::ipv4hint)) {
-        sd.db->lookup(QType::A, svcTarget, sd.domain_id);
-        vector<ComboAddress> hints;
-        DNSZoneRecord rr;
-        while (sd.db->get(rr)) {
-          auto arrc = getRR<ARecordContent>(rr.dr);
-          hints.push_back(arrc->getCA());
-        }
-        if (hints.size() == 0) {
-          newRRC->removeParam(SvcParam::ipv4hint);
-        } else {
-          newRRC->setHints(SvcParam::ipv4hint, hints);
-        }
-      }
-
-      if (newRRC->autoHint(SvcParam::ipv6hint)) {
-        sd.db->lookup(QType::AAAA, svcTarget, sd.domain_id);
-        vector<ComboAddress> hints;
-        DNSZoneRecord rr;
-        while (sd.db->get(rr)) {
-          auto arrc = getRR<AAAARecordContent>(rr.dr);
-          hints.push_back(arrc->getCA());
-        }
-        if (hints.size() == 0) {
-          newRRC->removeParam(SvcParam::ipv6hint);
-        } else {
-          newRRC->setHints(SvcParam::ipv6hint, hints);
-        }
-      }
-
-      loopRR.dr.setContent(std::move(newRRC));
-    }
-  }
-
-  // Group records by name and type, signpipe stumbles over interrupted rrsets
-  if(securedZone && !presignedZone) {
-    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
-      return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
-    });
-  }
-
-  if(rectify) {
-    // set auth
-    for(DNSZoneRecord &loopZRR :  zrrs) {
-      loopZRR.auth=true;
-      if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
-        DNSName shorter(loopZRR.dr.d_name);
-        do {
-          if (shorter==target) // apex is always auth
-            break;
-          if(nsset.count(shorter) && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
-            loopZRR.auth=false;
-            break;
-          }
-        } while(shorter.chopOff());
-      }
-    }
-
-    if(NSEC3Zone) {
-      // ents are only required for NSEC3 zones
-      auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
-      set<DNSName> nsec3set, nonterm;
-      for (auto &loopZRR: zrrs) {
-        bool skip=false;
-        DNSName shorter = loopZRR.dr.d_name;
-        if (shorter != target && shorter.chopOff() && shorter != target) {
-          do {
-            if(nsset.count(shorter)) {
-              skip=true;
-              break;
-            }
-          } while(shorter.chopOff() && shorter != target);
-        }
-        shorter = loopZRR.dr.d_name;
-        if(!skip && (loopZRR.dr.d_type != QType::NS || !ns3pr.d_flags)) {
-          do {
-            if(!nsec3set.count(shorter)) {
-              nsec3set.insert(shorter);
-            }
-          } while(shorter != target && shorter.chopOff());
-        }
-      }
-
-      for(DNSZoneRecord &loopZRR :  zrrs) {
-        DNSName shorter(loopZRR.dr.d_name);
-        while(shorter != target && shorter.chopOff()) {
-          if(!qnames.count(shorter) && !nonterm.count(shorter) && nsec3set.count(shorter)) {
-            if(!(maxent)) {
-              SLOG(g_log<<Logger::Warning<<logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
-                   slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-              outpacket->setRcode(RCode::ServFail);
-              sendPacket(outpacket,outsock);
-              return 0;
-            }
-            nonterm.insert(shorter);
-            --maxent;
-          }
-        }
-      }
-
-      for(const auto& nt :  nonterm) {
-        DNSZoneRecord tempRR;
-        tempRR.dr.d_name=nt;
-        tempRR.dr.d_type=QType::ENT;
-        tempRR.auth=true;
-        zrrs.push_back(tempRR);
-      }
-    }
-  }
-
-send:
 
   /* now write all other records */
 
@@ -1263,6 +1037,256 @@ send:
        slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
 
   return 1;
+}
+
+bool TCPNameserver::axfrProducerZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const DomainInfo& di, const SOAData& sd)
+{
+  const ZoneName& targetZone = q->qdomainzone;
+  const DNSName& target = targetZone.operator const DNSName&();
+
+  DNSZoneRecord zrr;
+
+  // Ignore all records except NS at apex
+  sd.db->lookup(QType::NS, target, di.id);
+  while (sd.db->get(zrr)) {
+    zrrs.emplace_back(zrr);
+  }
+  if (zrrs.empty()) {
+    zrr.dr.d_name = target;
+    zrr.dr.d_ttl = 0;
+    zrr.dr.d_type = QType::NS;
+    zrr.dr.setContent(std::make_shared<NSRecordContent>("invalid."));
+    zrrs.emplace_back(zrr);
+  }
+
+  zrrs.emplace_back(CatalogInfo::getCatalogVersionRecord(targetZone));
+
+  vector<CatalogInfo> members;
+  if (!sd.db->getCatalogMembers(targetZone, members, CatalogInfo::CatalogType::Producer)) {
+    SLOG(g_log << Logger::Error << logPrefix << "getting catalog members failed, aborting AXFR" << endl,
+         slog->info(Logr::Error, "AXFR aborted: getting catalog members failed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+    outpacket->setRcode(RCode::ServFail);
+    sendPacket(outpacket, outsock);
+    return false;
+  }
+  for (const auto& ci : members) {
+    ci.toDNSZoneRecords(targetZone, zrrs);
+  }
+  if (members.empty()) {
+    SLOG(g_log << Logger::Warning << logPrefix << "catalog zone '" << targetZone << "' has no members" << endl,
+         slog->info(Logr::Warning, "AXFR: Catalog zone has no members", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+  }
+
+  return true;
+}
+
+bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const SOAData& sd, bool presignedZone, bool securedZone, bool NSEC3Zone, bool isCatalogZone, const NSEC3PARAMRecordContent& ns3pr) // NOLINT(readability-function-cognitive-complexity)
+{
+  const ZoneName& targetZone = q->qdomainzone;
+  const DNSName& target = targetZone.operator const DNSName&();
+
+  // now start list zone
+  if (!sd.db->list(targetZone, sd.domain_id, isCatalogZone)) {
+    SLOG(g_log<<Logger::Error<<logPrefix<<"backend signals error condition, aborting AXFR"<<endl,
+         slog->info(Logr::Error, "AXFR aborted: backend signals error condition", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+    outpacket->setRcode(RCode::ServFail);
+    sendPacket(outpacket,outsock);
+    return false;
+  }
+
+  const bool rectify = !(presignedZone || ::arg().mustDo("disable-axfr-rectify"));
+  set<DNSName> qnames, nsset;
+
+  DNSZoneRecord zrr;
+
+  while(sd.db->get(zrr)) {
+    if (!presignedZone) {
+      if (zrr.dr.d_type == QType::RRSIG) {
+        continue;
+      }
+      if (zrr.dr.d_type == QType::DNSKEY || zrr.dr.d_type == QType::CDNSKEY || zrr.dr.d_type == QType::CDS) {
+        if(!::arg().mustDo("direct-dnskey")) {
+          continue;
+        } else {
+          zrr.dr.d_ttl = sd.minimum;
+        }
+      }
+    }
+    zrr.dr.d_name.makeUsLowerCase();
+    if(zrr.dr.d_name.isPartOf(target)) {
+      if (zrr.dr.d_type == QType::ALIAS && (::arg().mustDo("outgoing-axfr-expand-alias") || ::arg()["outgoing-axfr-expand-alias"] == "ignore-errors")) {
+        vector<DNSZoneRecord> ips;
+        int ret1 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
+        int ret2 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
+        if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
+          if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
+            if (ret1 != RCode::NoError) {
+              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+                   slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+            }
+            if (ret2 != RCode::NoError) {
+              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+                   slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+            }
+          }
+          else {
+            SLOG(g_log << Logger::Warning << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
+                 slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+            outpacket->setRcode(RCode::ServFail);
+            sendPacket(outpacket, outsock);
+            return false;
+          }
+        }
+        for (auto& ip: ips) {
+          zrr.dr.d_type = ip.dr.d_type;
+          zrr.dr.setContent(ip.dr.getContent());
+          zrrs.push_back(zrr);
+        }
+        continue;
+      }
+
+      if (rectify) {
+        if (zrr.dr.d_type) {
+          qnames.insert(zrr.dr.d_name);
+          if(zrr.dr.d_type == QType::NS && zrr.dr.d_name!=target)
+            nsset.insert(zrr.dr.d_name);
+        } else {
+          // remove existing ents
+          continue;
+        }
+      }
+      zrrs.push_back(zrr);
+    } else {
+      if (zrr.dr.d_type != QType::ENT)
+        SLOG(g_log<<Logger::Warning<<logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
+             slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
+    }
+  }
+
+  for (auto& loopRR : zrrs) {
+    if ((loopRR.dr.d_type == QType::SVCB || loopRR.dr.d_type == QType::HTTPS)) {
+      // Process auto hints
+      // TODO this is an almost copy of the code in the packethandler
+      auto rrc = getRR<SVCBBaseRecordContent>(loopRR.dr);
+      if (rrc == nullptr) {
+        continue;
+      }
+      auto newRRC = rrc->clone();
+      if (!newRRC) {
+        continue;
+      }
+      DNSName svcTarget = newRRC->getTarget().isRoot() ? loopRR.dr.d_name : newRRC->getTarget();
+      if (newRRC->autoHint(SvcParam::ipv4hint)) {
+        sd.db->lookup(QType::A, svcTarget, sd.domain_id);
+        vector<ComboAddress> hints;
+        DNSZoneRecord rr;
+        while (sd.db->get(rr)) {
+          auto arrc = getRR<ARecordContent>(rr.dr);
+          hints.push_back(arrc->getCA());
+        }
+        if (hints.size() == 0) {
+          newRRC->removeParam(SvcParam::ipv4hint);
+        } else {
+          newRRC->setHints(SvcParam::ipv4hint, hints);
+        }
+      }
+
+      if (newRRC->autoHint(SvcParam::ipv6hint)) {
+        sd.db->lookup(QType::AAAA, svcTarget, sd.domain_id);
+        vector<ComboAddress> hints;
+        DNSZoneRecord rr;
+        while (sd.db->get(rr)) {
+          auto arrc = getRR<AAAARecordContent>(rr.dr);
+          hints.push_back(arrc->getCA());
+        }
+        if (hints.size() == 0) {
+          newRRC->removeParam(SvcParam::ipv6hint);
+        } else {
+          newRRC->setHints(SvcParam::ipv6hint, hints);
+        }
+      }
+
+      loopRR.dr.setContent(std::move(newRRC));
+    }
+  }
+
+  // Group records by name and type, signpipe stumbles over interrupted rrsets
+  if(securedZone && !presignedZone) {
+    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
+      return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
+    });
+  }
+
+  if(rectify) {
+    // set auth
+    for(DNSZoneRecord &loopZRR :  zrrs) {
+      loopZRR.auth=true;
+      if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
+        DNSName shorter(loopZRR.dr.d_name);
+        do {
+          if (shorter==target) // apex is always auth
+            break;
+          if(nsset.count(shorter) && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
+            loopZRR.auth=false;
+            break;
+          }
+        } while(shorter.chopOff());
+      }
+    }
+
+    if(NSEC3Zone) {
+      // ents are only required for NSEC3 zones
+      auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
+      set<DNSName> nsec3set, nonterm;
+      for (auto &loopZRR: zrrs) {
+        bool skip=false;
+        DNSName shorter = loopZRR.dr.d_name;
+        if (shorter != target && shorter.chopOff() && shorter != target) {
+          do {
+            if(nsset.count(shorter)) {
+              skip=true;
+              break;
+            }
+          } while(shorter.chopOff() && shorter != target);
+        }
+        shorter = loopZRR.dr.d_name;
+        if(!skip && (loopZRR.dr.d_type != QType::NS || !ns3pr.d_flags)) {
+          do {
+            if(!nsec3set.count(shorter)) {
+              nsec3set.insert(shorter);
+            }
+          } while(shorter != target && shorter.chopOff());
+        }
+      }
+
+      for(DNSZoneRecord &loopZRR :  zrrs) {
+        DNSName shorter(loopZRR.dr.d_name);
+        while(shorter != target && shorter.chopOff()) {
+          if(!qnames.count(shorter) && !nonterm.count(shorter) && nsec3set.count(shorter)) {
+            if(!(maxent)) {
+              SLOG(g_log<<Logger::Warning<<logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
+                   slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+              outpacket->setRcode(RCode::ServFail);
+              sendPacket(outpacket,outsock);
+              return false;
+            }
+            nonterm.insert(shorter);
+            --maxent;
+          }
+        }
+      }
+
+      for(const auto& nt :  nonterm) {
+        DNSZoneRecord tempRR;
+        tempRR.dr.d_name=nt;
+        tempRR.dr.d_type=QType::ENT;
+        tempRR.auth=true;
+        zrrs.push_back(tempRR);
+      }
+    }
+  }
+
+  return true;
 }
 
 int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -498,125 +498,6 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
   decrementClientCount(remote);
 }
 
-
-bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, bool isAXFR, std::unique_ptr<PacketHandler>& packetHandler, Logr::log_t slog)
-{
-  if(::arg().mustDo("disable-axfr"))
-    return false;
-
-  string xfrType = isAXFR ? "AXFR" : "IXFR";
-  string logPrefix;
-
-  if (!g_slogStructured) {
-    logPrefix = xfrType +"-out zone '"+q->qdomainzone.toLogString()+"', client '"+q->getInnerRemote().toStringWithPort()+"', ";
-  }
-
-  if(q->d_havetsig) { // if you have one, it must be good
-    TSIGRecordContent tsigContent;
-    DNSName tsigkeyname;
-    string secret;
-    if (!packetHandler->checkForCorrectTSIG(*q, &tsigkeyname, &secret, &tsigContent)) {
-      return false;
-    }
-    getTSIGHashEnum(tsigContent.d_algoName, q->d_tsig_algo);
-#ifdef ENABLE_GSS_TSIG
-    if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
-      GssContext gssctx(tsigkeyname);
-      if (!gssctx.getPeerPrincipal(q->d_peer_principal)) {
-        SLOG(g_log<<Logger::Warning<<"Failed to extract peer principal from GSS context with keyname '"<<tsigkeyname<<"'"<<endl,
-             slog->info(Logr::Warning, "Failed to extract peer principal from GSS context", "keyname", Logging::Loggable(tsigkeyname)));
-      }
-    }
-#endif
-
-    DNSSECKeeper dk(slog, packetHandler->getBackend());
-#ifdef ENABLE_GSS_TSIG
-    if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
-      vector<string> princs;
-      packetHandler->getBackend()->getDomainMetadata(q->qdomainzone, "GSS-ALLOW-AXFR-PRINCIPAL", princs);
-      for(const std::string& princ :  princs) {
-        if (q->d_peer_principal == princ) {
-          SLOG(g_log<<Logger::Warning<<xfrType<<" of domain '"<<q->qdomainzone<<"' allowed: TSIG signed request with authorized principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig'"<<endl,
-               slog->info(Logr::Warning, xfrType + " allowed: TSIG signed request with authorized principal", "zone", Logging::Loggable(q->qdomainzone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
-          return true;
-        }
-      }
-      SLOG(g_log<<Logger::Warning<<xfrType<<" of domain '"<<q->qdomainzone<<"' denied: TSIG signed request with principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig' is not permitted"<<endl,
-           slog->info(Logr::Warning, xfrType + " denied: TSIG signed request with unauthorized principal", "zone", Logging::Loggable(q->qdomainzone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
-      return false;
-    }
-#endif
-    if(!dk.TSIGGrantsAccess(q->qdomainzone, tsigkeyname)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"denied: key with name '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"' does not grant access"<<endl,
-           slog->info(Logr::Warning, xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
-      return false;
-    }
-    else {
-      SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
-           slog->info(Logr::Notice, xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
-      return true;
-    }
-  }
-
-  if(!(::arg()["allow-axfr-ips"].empty()) && d_ng.match( q->getInnerRemote() )) {
-    SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: client IP is in allow-axfr-ips"<<endl,
-         slog->info(Logr::Notice, xfrType + " allowed: client IP is in allow-axfr-ips", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-    return true;
-  }
-
-  FindNS fns;
-
-  SOAData sd;
-  if(packetHandler->getBackend()->getSOAUncached(q->qdomainzone,sd)) {
-    vector<string> acl;
-    packetHandler->getBackend()->getDomainMetadata(q->qdomainzone, "ALLOW-AXFR-FROM", acl);
-    for (const auto & i : acl) {
-      if(pdns_iequals(i, "AUTO-NS")) {
-        DNSResourceRecord rr;
-        set<DNSName> nsset;
-
-        sd.db->lookup(QType(QType::NS), q->qdomain, sd.domain_id);
-        while (sd.db->get(rr)) {
-          nsset.insert(DNSName(rr.content));
-        }
-        for(const auto & j: nsset) {
-          vector<string> nsips=fns.lookup(j, packetHandler->getBackend());
-          for(const auto & nsip : nsips) {
-            if(nsip == q->getInnerRemote().toString())
-            {
-              SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: client IP is in NSset"<<endl,
-                   slog->info(Logr::Notice, xfrType + " allowed: client IP is in NSset", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-              return true;
-            }
-          }
-        }
-      }
-      else
-      {
-        Netmask nm = Netmask(i);
-        if(nm.match( q->getInnerRemote() ))
-        {
-          SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: client IP is in per-zone ACL"<<endl,
-               slog->info(Logr::Notice, xfrType + " allowed: client IP is in per-zone ACL", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-          return true;
-        }
-      }
-    }
-  }
-
-  extern CommunicatorClass Communicator;
-
-  if(Communicator.justNotified(q->qdomainzone, q->getInnerRemote().toString())) { // we just notified this ip
-    SLOG(g_log<<Logger::Notice<<logPrefix<<"allowed: client IP is from recently notified secondary"<<endl,
-         slog->info(Logr::Notice, xfrType + " allowed: client IP is from recently notified secondary", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-    return true;
-  }
-
-  SLOG(g_log<<Logger::Warning<<logPrefix<<"denied: client IP has no permission"<<endl,
-       slog->info(Logr::Warning, xfrType + " denied: client IP has no permission", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getInnerRemote().toStringWithPort())));
-  return false;
-}
-
 namespace {
   struct NSECXEntry
   {
@@ -635,99 +516,244 @@ namespace {
   }
 }
 
+class XFRContext : public boost::noncopyable
+{
+public:
+  XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log, bool isIXFR);
+  void setupOutputPacket();
+
+  const ZoneName& targetZone; // domain being XFR'ed
+  DomainInfo info;
+  SOAData soa;
+
+  bool presignedZone{false};
+  bool securedZone{false};
+  bool NSEC3Zone{false};
+  bool isCatalogZone{false};
+  NSEC3PARAMRecordContent ns3pr;
+
+  // Network-related fields
+  int outsock;
+  std::unique_ptr<DNSPacket> outpacket;
+
+  // Logging-related fields
+  std::string xfrType;
+  std::string client;
+  std::string logPrefix;
+  Logr::log_t slog;
+
+private:
+  std::unique_ptr<DNSPacket>& query;
+};
+
+XFRContext::XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log, bool isAXFR) :
+  targetZone(q->qdomainzone), outsock(sock), slog(log), query(q)
+{
+  setupOutputPacket();
+  if (query->d_dnssecOk) {
+    outpacket->d_dnssecOk = true; // RFC 5936, 2.2.5 'SHOULD'
+  }
+
+  xfrType = isAXFR ? "AXFR" : "IXFR";
+  client = query->getRemoteStringWithPort();
+  if (!g_slogStructured) {
+    logPrefix = xfrType + "-out zone '" + targetZone.toLogString() + "', client '" + client + "', ";
+  }
+}
+
+void XFRContext::setupOutputPacket()
+{
+  outpacket = getFreshAXFRPacket(query);
+}
+
+bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler)
+{
+  if(::arg().mustDo("disable-axfr"))
+    return false;
+
+  if(q->d_havetsig) { // if you have one, it must be good
+    TSIGRecordContent tsigContent;
+    DNSName tsigkeyname;
+    string secret;
+    if (!packetHandler->checkForCorrectTSIG(*q, &tsigkeyname, &secret, &tsigContent)) {
+      return false;
+    }
+    getTSIGHashEnum(tsigContent.d_algoName, q->d_tsig_algo);
+#ifdef ENABLE_GSS_TSIG
+    if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
+      GssContext gssctx(tsigkeyname);
+      if (!gssctx.getPeerPrincipal(q->d_peer_principal)) {
+        SLOG(g_log<<Logger::Warning<<"Failed to extract peer principal from GSS context with keyname '"<<tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Warning, "Failed to extract peer principal from GSS context", "keyname", Logging::Loggable(tsigkeyname)));
+      }
+    }
+#endif
+
+    DNSSECKeeper dk(ctx.slog, packetHandler->getBackend());
+#ifdef ENABLE_GSS_TSIG
+    if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
+      vector<string> princs;
+      packetHandler->getBackend()->getDomainMetadata(ctx.targetZone, "GSS-ALLOW-AXFR-PRINCIPAL", princs);
+      for(const std::string& princ :  princs) {
+        if (q->d_peer_principal == princ) {
+          SLOG(g_log<<Logger::Warning<<ctx.xfrType<<" of domain '"<<ctx.targetZone<<"' allowed: TSIG signed request with authorized principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig'"<<endl,
+               ctx.slog->info(Logr::Warning, ctx.xfrType + " allowed: TSIG signed request with authorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
+          return true;
+        }
+      }
+      SLOG(g_log<<Logger::Warning<<ctx.xfrType<<" of domain '"<<ctx.targetZone<<"' denied: TSIG signed request with principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig' is not permitted"<<endl,
+           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: TSIG signed request with unauthorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
+      return false;
+    }
+#endif
+    if(!dk.TSIGGrantsAccess(ctx.targetZone, tsigkeyname)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"denied: key with name '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"' does not grant access"<<endl,
+           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+      return false;
+    }
+    else {
+      SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
+           ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+      return true;
+    }
+  }
+
+  if(!(::arg()["allow-axfr-ips"].empty()) && d_ng.match( q->getInnerRemote() )) {
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in allow-axfr-ips"<<endl,
+         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in allow-axfr-ips", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    return true;
+  }
+
+  FindNS fns;
+
+  if(packetHandler->getBackend()->getSOAUncached(ctx.targetZone,ctx.soa)) {
+    vector<string> acl;
+    packetHandler->getBackend()->getDomainMetadata(ctx.targetZone, "ALLOW-AXFR-FROM", acl);
+    for (const auto & i : acl) {
+      if(pdns_iequals(i, "AUTO-NS")) {
+        DNSResourceRecord rr;
+        set<DNSName> nsset;
+
+        ctx.soa.db->lookup(QType(QType::NS), q->qdomain, ctx.soa.domain_id);
+        while (ctx.soa.db->get(rr)) {
+          nsset.insert(DNSName(rr.content));
+        }
+        for(const auto & j: nsset) {
+          vector<string> nsips=fns.lookup(j, packetHandler->getBackend());
+          for(const auto & nsip : nsips) {
+            if(nsip == q->getInnerRemote().toString())
+            {
+              SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in NSset"<<endl,
+                   ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in NSset", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+              return true;
+            }
+          }
+        }
+      }
+      else
+      {
+        Netmask nm = Netmask(i);
+        if(nm.match( q->getInnerRemote() ))
+        {
+          SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in per-zone ACL"<<endl,
+               ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in per-zone ACL", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+          return true;
+        }
+      }
+    }
+  }
+
+  extern CommunicatorClass Communicator;
+
+  if(Communicator.justNotified(ctx.targetZone, q->getInnerRemote().toString())) { // we just notified this ip
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is from recently notified secondary"<<endl,
+         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is from recently notified secondary", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    return true;
+  }
+
+  SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"denied: client IP has no permission"<<endl,
+       ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: client IP has no permission", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+  return false;
+}
 
 // NOLINTNEXTLINE(readability-identifier-length)
 int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  string logPrefix;
+  XFRContext ctx(q, outsock, slog, true);
 
-  if (!g_slogStructured) {
-    logPrefix="AXFR-out zone '"+targetZone.toLogString()+"', client '"+q->getRemoteStringWithPort()+"', ";
-  }
-
-  std::unique_ptr<DNSPacket> outpacket= getFreshAXFRPacket(q);
-  if(q->d_dnssecOk) {
-    outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
-  }
-
-  SLOG(g_log<<Logger::Warning<<logPrefix<<"transfer initiated"<<endl,
-       slog->info(Logr::Warning, "AXFR transfer initiated", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+  SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"transfer initiated"<<endl,
+       ctx.slog->info(Logr::Warning, "AXFR transfer initiated", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
 
   // determine if zone exists and AXFR is allowed using existing backend before spawning a new backend.
-  DLOG(SLOG(g_log<<logPrefix<<"looking for SOA"<<endl,
-            slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"looking for SOA"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
   {
     auto packetHandler = s_P.lock();
     if(!*packetHandler) {
       SLOG(g_log<<Logger::Warning<<"TCP server is without backend connections in doAXFR, launching"<<endl,
-           slog->info(Logr::Warning, "TCP server is without backend connections in doAXFR, launching", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      *packetHandler = make_unique<PacketHandler>(slog);
+           ctx.slog->info(Logr::Warning, "TCP server is without backend connections in doAXFR, launching", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      *packetHandler = make_unique<PacketHandler>(ctx.slog);
     }
 
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
-    if (!canDoAXFR(q, true, *packetHandler, slog)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: client may not request AXFR"<<endl,
-           slog->info(Logr::Warning, "AXFR failed: client may not request AXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::NotAuth);
-      sendPacket(outpacket,outsock);
+    if (!canDoAXFR(q, ctx, *packetHandler)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: client may not request AXFR"<<endl,
+           ctx.slog->info(Logr::Warning, "AXFR failed: client may not request AXFR", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::NotAuth);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
 
-    SOAData sd;
-    if (!(*packetHandler)->getBackend()->getSOAUncached(targetZone, sd)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative"<<endl,
-           slog->info(Logr::Warning, "AXFR failed: not authoritative", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::NotAuth);
-      sendPacket(outpacket,outsock);
+    // ctx.soa has been computed by canDoAXFR above
+    if (!(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative"<<endl,
+           ctx.slog->info(Logr::Warning, "AXFR failed: not authoritative", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::NotAuth);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
   }
 
-  return doAXFRinternal(q, outsock, slog, logPrefix, outpacket);
+  return doAXFRinternal(q, ctx);
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket) // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx) // NOLINT(readability-function-cognitive-complexity)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  const DNSName& target = targetZone.operator const DNSName&();
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
 
   // find domain_id via SOA and list complete domain. No SOA, no AXFR
   UeberBackend db;
-  SOAData sd;
-  if(!db.getSOAUncached(targetZone, sd)) {
-    SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative in second instance"<<endl,
-         slog->info(Logr::Warning, "AXFR failed: not authoritative in second instance", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    outpacket->setRcode(RCode::NotAuth);
-    sendPacket(outpacket,outsock);
+  if(!db.getSOAUncached(ctx.targetZone, ctx.soa)) {
+    SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative in second instance"<<endl,
+         ctx.slog->info(Logr::Warning, "AXFR failed: not authoritative in second instance", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    ctx.outpacket->setRcode(RCode::NotAuth);
+    sendPacket(ctx.outpacket,ctx.outsock);
     return 0;
   }
 
-  bool securedZone = false;
-  bool presignedZone = false;
-  bool NSEC3Zone = false;
+  // Reset these - if we come from doIXFR, they may have been used already.
+  ctx.presignedZone = false;
+  ctx.securedZone = false;
+  ctx.NSEC3Zone = false;
   bool narrow = false;
 
-  DomainInfo di;
-  bool isCatalogZone = sd.db->getDomainInfo(targetZone, di, false) && di.isCatalogType();
+  ctx.isCatalogZone = ctx.soa.db->getDomainInfo(ctx.targetZone, ctx.info, false) && ctx.info.isCatalogType();
 
-  NSEC3PARAMRecordContent ns3pr;
-
-  DNSSECKeeper dk(slog, &db);
-  DNSSECKeeper::clearCaches(targetZone);
-  if (!isCatalogZone) {
-    securedZone = dk.isSecuredZone(targetZone);
-    presignedZone = dk.isPresigned(targetZone);
+  DNSSECKeeper dk(ctx.slog, &db);
+  DNSSECKeeper::clearCaches(ctx.targetZone);
+  if (!ctx.isCatalogZone) {
+    ctx.securedZone = dk.isSecuredZone(ctx.targetZone);
+    ctx.presignedZone = dk.isPresigned(ctx.targetZone);
   }
 
-  if(securedZone && dk.getNSEC3PARAM(targetZone, &ns3pr, &narrow)) {
-    NSEC3Zone=true;
+  if(ctx.securedZone && dk.getNSEC3PARAM(ctx.targetZone, &ctx.ns3pr, &narrow)) {
+    ctx.NSEC3Zone=true;
     if(narrow) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not doing AXFR of an NSEC3 narrow zone"<<endl,
-           slog->info(Logr::Warning, "AXFR failed: not doing AXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::Refused);
-      sendPacket(outpacket,outsock);
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not doing AXFR of an NSEC3 narrow zone"<<endl,
+           ctx.slog->info(Logr::Warning, "AXFR failed: not doing AXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::Refused);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
   }
@@ -746,17 +772,17 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
     }
     if (algorithm != g_gsstsigdnsname) {
       if(!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"TSIG key not found"<<endl,
-             slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        outpacket->setRcode(RCode::NotAuth);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"TSIG key not found"<<endl,
+             ctx.slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::NotAuth);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
       if (B64Decode(tsig64, tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        outpacket->setRcode(RCode::ServFail);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::ServFail);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     }
@@ -764,51 +790,51 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
 
 
   // SOA *must* go out first, our signing pipe might reorder
-  DLOG(SLOG(g_log<<logPrefix<<"sending out SOA"<<endl,
-            slog->info(Logr::Debug, /*"I send an SOA to the world"*/"AXFR: sending out SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-  DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, sd, DNSResourceRecord::ANSWER, slog);
-  outpacket->addRecord(DNSZoneRecord(soa));
-  if(securedZone && !presignedZone) {
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"sending out SOA"<<endl,
+            ctx.slog->info(Logr::Debug, /*"I send an SOA to the world"*/"AXFR: sending out SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+  DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, ctx.soa, DNSResourceRecord::ANSWER, ctx.slog);
+  ctx.outpacket->addRecord(DNSZoneRecord(soa));
+  if(ctx.securedZone && !ctx.presignedZone) {
     set<ZoneName> authSet;
-    authSet.insert(targetZone);
-    addRRSigs(dk, db, authSet, outpacket->getRRS());
+    authSet.insert(ctx.targetZone);
+    addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
   }
 
   if(haveTSIGDetails && !tsigkeyname.empty())
-    outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+    ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
 
-  sendPacket(outpacket, outsock, false);
+  sendPacket(ctx.outpacket, ctx.outsock, false);
 
-  trc.d_mac = outpacket->d_trc.d_mac;
-  outpacket = getFreshAXFRPacket(q);
+  trc.d_mac = ctx.outpacket->d_trc.d_mac;
+  ctx.setupOutputPacket();
 
 
   DNSZoneRecord zrr;
   vector<DNSZoneRecord> zrrs;
 
   zrr.dr.d_name = target;
-  zrr.dr.d_ttl = sd.minimum;
+  zrr.dr.d_ttl = ctx.soa.minimum;
 
-  if(securedZone && !presignedZone) { // this is where the DNSKEYs, CDNSKEYs and CDSs go in
+  if(ctx.securedZone && !ctx.presignedZone) { // this is where the DNSKEYs, CDNSKEYs and CDSs go in
     bool doCDNSKEY = true, doCDS = true;
     string publishCDNSKEY, publishCDS;
     dk.getPublishCDNSKEY(q->qdomainzone, publishCDNSKEY);
     dk.getPublishCDS(q->qdomainzone, publishCDS);
 
     set<uint32_t> entryPointIds;
-    DNSSECKeeper::keyset_t entryPoints = dk.getEntryPoints(targetZone);
+    DNSSECKeeper::keyset_t entryPoints = dk.getEntryPoints(ctx.targetZone);
     for (auto const& value : entryPoints) {
       entryPointIds.insert(value.second.id);
     }
 
-    DNSSECKeeper::keyset_t keys = dk.getKeys(targetZone);
+    DNSSECKeeper::keyset_t keys = dk.getKeys(ctx.targetZone);
     for(const DNSSECKeeper::keyset_t::value_type& value :  keys) {
       if (!value.second.published) {
         continue;
       }
       zrr.dr.d_type = QType::DNSKEY;
       zrr.dr.setContent(std::make_shared<DNSKEYRecordContent>(value.first.getDNSKEY()));
-      DNSName keyname = NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, zrr.dr.d_name))) : zrr.dr.d_name;
+      DNSName keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, zrr.dr.d_name))) : zrr.dr.d_name;
       zrrs.push_back(zrr);
 
       // generate CDS and CDNSKEY records
@@ -835,7 +861,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
             zrrs.push_back(zrr);
           } else {
             for(auto const &digestAlgo : digestAlgos) {
-              zrr.dr.setContent(std::make_shared<DSRecordContent>(makeDSFromDNSKey(slog, target, value.first.getDNSKEY(), pdns::checked_stoi<uint8_t>(digestAlgo))));
+              zrr.dr.setContent(std::make_shared<DSRecordContent>(makeDSFromDNSKey(ctx.slog, target, value.first.getDNSKEY(), pdns::checked_stoi<uint8_t>(digestAlgo))));
               zrrs.push_back(zrr);
             }
           }
@@ -845,25 +871,20 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
 
   }
 
-  if(NSEC3Zone) { // now stuff in the NSEC3PARAM
-    uint8_t flags = ns3pr.d_flags;
+  if(ctx.NSEC3Zone) { // now stuff in the NSEC3PARAM
+    uint8_t flags = ctx.ns3pr.d_flags;
     zrr.dr.d_type = QType::NSEC3PARAM;
-    ns3pr.d_flags = 0;
-    zrr.dr.setContent(std::make_shared<NSEC3PARAMRecordContent>(ns3pr));
-    ns3pr.d_flags = flags;
-    DNSName keyname = DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, zrr.dr.d_name)));
+    ctx.ns3pr.d_flags = 0;
+    zrr.dr.setContent(std::make_shared<NSEC3PARAMRecordContent>(ctx.ns3pr));
+    ctx.ns3pr.d_flags = flags;
+    DNSName keyname = DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, zrr.dr.d_name)));
     zrrs.push_back(zrr);
   }
 
-  if (di.kind == DomainInfo::Producer) { // Catalog zone
-    if (!axfrProducerZone(q, outsock, slog, logPrefix, outpacket, zrrs, di, sd)) {
-      return 0;
-    }
-  }
-  else {
-    if (!axfrRegularZone(q, outsock, slog, logPrefix, outpacket, zrrs, sd, presignedZone, securedZone, NSEC3Zone, isCatalogZone, ns3pr)) {
-      return 0;
-    }
+  // Catalog zones need a specific processing at this point.
+  auto zoneKindSpecificOp = ctx.info.kind == DomainInfo::Producer ? axfrProducerZone : axfrRegularZone;
+  if (!zoneKindSpecificOp(ctx, zrrs)) {
+    return 0;
   }
 
   /* now write all other records */
@@ -871,23 +892,23 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
   typedef map<DNSName, NSECXEntry, CanonDNSNameCompare> nsecxrepo_t;
   nsecxrepo_t nsecxrepo;
 
-  ChunkedSigningPipe csp(slog, targetZone, (securedZone && !presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
+  ChunkedSigningPipe csp(ctx.slog, ctx.targetZone, (ctx.securedZone && !ctx.presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
 
   DNSName keyname;
   unsigned int udiff;
   DTime dt;
   dt.set();
   for(DNSZoneRecord &loopZRR :  zrrs) {
-    if(securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
-      if (NSEC3Zone || loopZRR.dr.d_type) {
-        if (presignedZone && NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
-          keyname = loopZRR.dr.d_name.makeRelative(sd.qname());
+    if(ctx.securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
+      if (ctx.NSEC3Zone || loopZRR.dr.d_type) {
+        if (ctx.presignedZone && ctx.NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
+          keyname = loopZRR.dr.d_name.makeRelative(ctx.soa.qname());
         } else {
-          keyname = NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
+          keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
         }
         NSECXEntry& ne = nsecxrepo[keyname];
-        ne.d_ttl = sd.getNegativeTTL();
-        ne.d_auth = (ne.d_auth || loopZRR.auth || (NSEC3Zone && (!ns3pr.d_flags)));
+        ne.d_ttl = ctx.soa.getNegativeTTL();
+        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (!ctx.ns3pr.d_flags)));
         if (loopZRR.dr.d_type && loopZRR.dr.d_type != QType::RRSIG) {
           ne.d_set.set(loopZRR.dr.d_type);
         }
@@ -902,21 +923,21 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
 
     if(csp.submit(loopZRR)) {
       for(;;) {
-        outpacket->getRRS() = csp.getChunk();
-        if(!outpacket->getRRS().empty()) {
+        ctx.outpacket->getRRS() = csp.getChunk();
+        if(!ctx.outpacket->getRRS().empty()) {
           if(haveTSIGDetails && !tsigkeyname.empty())
-            outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-          sendPacket(outpacket, outsock, false);
-          trc.d_mac=outpacket->d_trc.d_mac;
-          outpacket=getFreshAXFRPacket(q);
+            ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+          sendPacket(ctx.outpacket, ctx.outsock, false);
+          trc.d_mac=ctx.outpacket->d_trc.d_mac;
+          ctx.setupOutputPacket();
         }
         else
           break;
       }
     }
   }
-  if(securedZone) {
-    if(NSEC3Zone) {
+  if(ctx.securedZone) {
+    if(ctx.NSEC3Zone) {
       for(nsecxrepo_t::const_iterator iter = nsecxrepo.begin(); iter != nsecxrepo.end(); ++iter) {
         if(iter->second.d_auth) {
           NSEC3RecordContent n3rc;
@@ -925,9 +946,9 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
           if (numberOfTypesSet != 0 && (numberOfTypesSet != 1 || !n3rc.isSet(QType::NS))) {
             n3rc.set(QType::RRSIG);
           }
-          n3rc.d_salt = ns3pr.d_salt;
-          n3rc.d_flags = ns3pr.d_flags;
-          n3rc.d_iterations = ns3pr.d_iterations;
+          n3rc.d_salt = ctx.ns3pr.d_salt;
+          n3rc.d_flags = ctx.ns3pr.d_flags;
+          n3rc.d_iterations = ctx.ns3pr.d_iterations;
           n3rc.d_algorithm = DNSSECKeeper::DIGEST_SHA1; // SHA1, fixed in PowerDNS for now
           nsecxrepo_t::const_iterator inext = iter;
           ++inext;
@@ -940,22 +961,22 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
               inext = nsecxrepo.begin();
           }
           n3rc.d_nexthash = fromBase32Hex(inext->first.toStringNoDot());
-          zrr.dr.d_name = iter->first+sd.qname();
+          zrr.dr.d_name = iter->first+ctx.soa.qname();
 
-          zrr.dr.d_ttl = sd.getNegativeTTL();
+          zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
           zrr.dr.setContent(std::make_shared<NSEC3RecordContent>(std::move(n3rc)));
           zrr.dr.d_type = QType::NSEC3;
           zrr.dr.d_place = DNSResourceRecord::ANSWER;
           zrr.auth=true;
           if(csp.submit(zrr)) {
             for(;;) {
-              outpacket->getRRS() = csp.getChunk();
-              if(!outpacket->getRRS().empty()) {
+              ctx.outpacket->getRRS() = csp.getChunk();
+              if(!ctx.outpacket->getRRS().empty()) {
                 if(haveTSIGDetails && !tsigkeyname.empty())
-                  outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-                sendPacket(outpacket, outsock, false);
-                trc.d_mac=outpacket->d_trc.d_mac;
-                outpacket=getFreshAXFRPacket(q);
+                  ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+                sendPacket(ctx.outpacket, ctx.outsock, false);
+                trc.d_mac=ctx.outpacket->d_trc.d_mac;
+                ctx.setupOutputPacket();
               }
               else
                 break;
@@ -976,20 +997,20 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
         nrc.d_next=nsecxrepo.begin()->first;
       zrr.dr.d_name = iter->first;
 
-      zrr.dr.d_ttl = sd.getNegativeTTL();
+      zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
       zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
       zrr.dr.d_type = QType::NSEC;
       zrr.dr.d_place = DNSResourceRecord::ANSWER;
       zrr.auth=true;
       if(csp.submit(zrr)) {
         for(;;) {
-          outpacket->getRRS() = csp.getChunk();
-          if(!outpacket->getRRS().empty()) {
+          ctx.outpacket->getRRS() = csp.getChunk();
+          if(!ctx.outpacket->getRRS().empty()) {
             if(haveTSIGDetails && !tsigkeyname.empty())
-              outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-            sendPacket(outpacket, outsock, false);
-            trc.d_mac=outpacket->d_trc.d_mac;
-            outpacket=getFreshAXFRPacket(q);
+              ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+            sendPacket(ctx.outpacket, ctx.outsock, false);
+            trc.d_mac=ctx.outpacket->d_trc.d_mac;
+            ctx.setupOutputPacket();
           }
           else
             break;
@@ -998,57 +1019,56 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Lo
     }
   }
   for(;;) {
-    outpacket->getRRS() = csp.getChunk(true); // flush the pipe
-    if(!outpacket->getRRS().empty()) {
+    ctx.outpacket->getRRS() = csp.getChunk(true); // flush the pipe
+    if(!ctx.outpacket->getRRS().empty()) {
       if(haveTSIGDetails && !tsigkeyname.empty())
-        outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
+        ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
       try {
-        sendPacket(outpacket, outsock, false);
+        sendPacket(ctx.outpacket, ctx.outsock, false);
       }
       catch (PDNSException& pe) {
         throw PDNSException("during axfr-out of "+target.toString()+", this happened: "+pe.reason);
       }
-      trc.d_mac=outpacket->d_trc.d_mac;
-      outpacket=getFreshAXFRPacket(q);
+      trc.d_mac=ctx.outpacket->d_trc.d_mac;
+      ctx.setupOutputPacket();
     }
     else
       break;
   }
 
   udiff=dt.udiffNoReset();
-  if(securedZone) {
-    SLOG(g_log<<Logger::Debug<<logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
-         slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
+  if(ctx.securedZone) {
+    SLOG(g_log<<Logger::Debug<<ctx.logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
+         ctx.slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
   }
 
-  DLOG(SLOG(g_log<<logPrefix<<"done writing out records"<<endl,
-            slog->info(Logr::Debug, "AXFR: done writing out records", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"done writing out records"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: done writing out records", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
   /* and terminate with yet again the SOA record */
-  outpacket=getFreshAXFRPacket(q);
-  outpacket->addRecord(std::move(soa));
+  ctx.setupOutputPacket();
+  ctx.outpacket->addRecord(std::move(soa));
   if(haveTSIGDetails && !tsigkeyname.empty())
-    outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+    ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
 
-  sendPacket(outpacket, outsock);
+  sendPacket(ctx.outpacket, ctx.outsock);
 
-  DLOG(SLOG(g_log<<logPrefix<<"last packet - close"<<endl,
-            slog->info(Logr::Debug, "AXFR: last packet sent", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-  SLOG(g_log<<Logger::Notice<<logPrefix<<"AXFR finished"<<endl,
-       slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"last packet - close"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: last packet sent", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+  SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"AXFR finished"<<endl,
+       ctx.slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
 
   return 1;
 }
 
-bool TCPNameserver::axfrProducerZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const DomainInfo& di, const SOAData& sd)
+bool TCPNameserver::axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  const DNSName& target = targetZone.operator const DNSName&();
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
 
   DNSZoneRecord zrr;
 
   // Ignore all records except NS at apex
-  sd.db->lookup(QType::NS, target, di.id);
-  while (sd.db->get(zrr)) {
+  ctx.soa.db->lookup(QType::NS, target, ctx.info.id);
+  while (ctx.soa.db->get(zrr)) {
     zrrs.emplace_back(zrr);
   }
   if (zrrs.empty()) {
@@ -1059,48 +1079,47 @@ bool TCPNameserver::axfrProducerZone(std::unique_ptr<DNSPacket>& q, int outsock,
     zrrs.emplace_back(zrr);
   }
 
-  zrrs.emplace_back(CatalogInfo::getCatalogVersionRecord(targetZone));
+  zrrs.emplace_back(CatalogInfo::getCatalogVersionRecord(ctx.targetZone));
 
   vector<CatalogInfo> members;
-  if (!sd.db->getCatalogMembers(targetZone, members, CatalogInfo::CatalogType::Producer)) {
-    SLOG(g_log << Logger::Error << logPrefix << "getting catalog members failed, aborting AXFR" << endl,
-         slog->info(Logr::Error, "AXFR aborted: getting catalog members failed", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    outpacket->setRcode(RCode::ServFail);
-    sendPacket(outpacket, outsock);
+  if (!ctx.soa.db->getCatalogMembers(ctx.targetZone, members, CatalogInfo::CatalogType::Producer)) {
+    SLOG(g_log << Logger::Error << ctx.logPrefix << "getting catalog members failed, aborting AXFR" << endl,
+         ctx.slog->info(Logr::Error, "AXFR aborted: getting catalog members failed", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    ctx.outpacket->setRcode(RCode::ServFail);
+    sendPacket(ctx.outpacket, ctx.outsock);
     return false;
   }
   for (const auto& ci : members) {
-    ci.toDNSZoneRecords(targetZone, zrrs);
+    ci.toDNSZoneRecords(ctx.targetZone, zrrs);
   }
   if (members.empty()) {
-    SLOG(g_log << Logger::Warning << logPrefix << "catalog zone '" << targetZone << "' has no members" << endl,
-         slog->info(Logr::Warning, "AXFR: Catalog zone has no members", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+    SLOG(g_log << Logger::Warning << ctx.logPrefix << "catalog zone '" << ctx.targetZone << "' has no members" << endl,
+         ctx.slog->info(Logr::Warning, "AXFR: Catalog zone has no members", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
   }
 
   return true;
 }
 
-bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const SOAData& sd, bool presignedZone, bool securedZone, bool NSEC3Zone, bool isCatalogZone, const NSEC3PARAMRecordContent& ns3pr) // NOLINT(readability-function-cognitive-complexity)
+bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs) // NOLINT(readability-function-cognitive-complexity)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  const DNSName& target = targetZone.operator const DNSName&();
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
 
   // now start list zone
-  if (!sd.db->list(targetZone, sd.domain_id, isCatalogZone)) {
-    SLOG(g_log<<Logger::Error<<logPrefix<<"backend signals error condition, aborting AXFR"<<endl,
-         slog->info(Logr::Error, "AXFR aborted: backend signals error condition", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-    outpacket->setRcode(RCode::ServFail);
-    sendPacket(outpacket,outsock);
+  if (!ctx.soa.db->list(ctx.targetZone, ctx.soa.domain_id, ctx.isCatalogZone)) {
+    SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"backend signals error condition, aborting AXFR"<<endl,
+         ctx.slog->info(Logr::Error, "AXFR aborted: backend signals error condition", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+    ctx.outpacket->setRcode(RCode::ServFail);
+    sendPacket(ctx.outpacket,ctx.outsock);
     return false;
   }
 
-  const bool rectify = !(presignedZone || ::arg().mustDo("disable-axfr-rectify"));
+  const bool rectify = !(ctx.presignedZone || ::arg().mustDo("disable-axfr-rectify"));
   set<DNSName> qnames, nsset;
 
   DNSZoneRecord zrr;
 
-  while(sd.db->get(zrr)) {
-    if (!presignedZone) {
+  while(ctx.soa.db->get(zrr)) {
+    if (!ctx.presignedZone) {
       if (zrr.dr.d_type == QType::RRSIG) {
         continue;
       }
@@ -1108,7 +1127,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
         if(!::arg().mustDo("direct-dnskey")) {
           continue;
         } else {
-          zrr.dr.d_ttl = sd.minimum;
+          zrr.dr.d_ttl = ctx.soa.minimum;
         }
       }
     }
@@ -1116,24 +1135,24 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
     if(zrr.dr.d_name.isPartOf(target)) {
       if (zrr.dr.d_type == QType::ALIAS && (::arg().mustDo("outgoing-axfr-expand-alias") || ::arg()["outgoing-axfr-expand-alias"] == "ignore-errors")) {
         vector<DNSZoneRecord> ips;
-        int ret1 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
-        int ret2 = stubDoResolve(slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
+        int ret1 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
+        int ret2 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
         if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
           if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
             if (ret1 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+              SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+                   ctx.slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
             }
             if (ret2 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+              SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+                   ctx.slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
             }
           }
           else {
-            SLOG(g_log << Logger::Warning << logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
-                 slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            outpacket->setRcode(RCode::ServFail);
-            sendPacket(outpacket, outsock);
+            SLOG(g_log << Logger::Warning << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
+                 ctx.slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+            ctx.outpacket->setRcode(RCode::ServFail);
+            sendPacket(ctx.outpacket, ctx.outsock);
             return false;
           }
         }
@@ -1158,8 +1177,8 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
       zrrs.push_back(zrr);
     } else {
       if (zrr.dr.d_type != QType::ENT)
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
-             slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
+        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
+             ctx.slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
     }
   }
 
@@ -1177,10 +1196,10 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
       }
       DNSName svcTarget = newRRC->getTarget().isRoot() ? loopRR.dr.d_name : newRRC->getTarget();
       if (newRRC->autoHint(SvcParam::ipv4hint)) {
-        sd.db->lookup(QType::A, svcTarget, sd.domain_id);
+        ctx.soa.db->lookup(QType::A, svcTarget, ctx.soa.domain_id);
         vector<ComboAddress> hints;
         DNSZoneRecord rr;
-        while (sd.db->get(rr)) {
+        while (ctx.soa.db->get(rr)) {
           auto arrc = getRR<ARecordContent>(rr.dr);
           hints.push_back(arrc->getCA());
         }
@@ -1192,10 +1211,10 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
       }
 
       if (newRRC->autoHint(SvcParam::ipv6hint)) {
-        sd.db->lookup(QType::AAAA, svcTarget, sd.domain_id);
+        ctx.soa.db->lookup(QType::AAAA, svcTarget, ctx.soa.domain_id);
         vector<ComboAddress> hints;
         DNSZoneRecord rr;
-        while (sd.db->get(rr)) {
+        while (ctx.soa.db->get(rr)) {
           auto arrc = getRR<AAAARecordContent>(rr.dr);
           hints.push_back(arrc->getCA());
         }
@@ -1211,7 +1230,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
   }
 
   // Group records by name and type, signpipe stumbles over interrupted rrsets
-  if(securedZone && !presignedZone) {
+  if(ctx.securedZone && !ctx.presignedZone) {
     sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
       return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
     });
@@ -1234,7 +1253,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
       }
     }
 
-    if(NSEC3Zone) {
+    if(ctx.NSEC3Zone) {
       // ents are only required for NSEC3 zones
       auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
       set<DNSName> nsec3set, nonterm;
@@ -1250,7 +1269,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
           } while(shorter.chopOff() && shorter != target);
         }
         shorter = loopZRR.dr.d_name;
-        if(!skip && (loopZRR.dr.d_type != QType::NS || !ns3pr.d_flags)) {
+        if(!skip && (loopZRR.dr.d_type != QType::NS || !ctx.ns3pr.d_flags)) {
           do {
             if(!nsec3set.count(shorter)) {
               nsec3set.insert(shorter);
@@ -1264,10 +1283,10 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
         while(shorter != target && shorter.chopOff()) {
           if(!qnames.count(shorter) && !nonterm.count(shorter) && nsec3set.count(shorter)) {
             if(!(maxent)) {
-              SLOG(g_log<<Logger::Warning<<logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
-                   slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-              outpacket->setRcode(RCode::ServFail);
-              sendPacket(outpacket,outsock);
+              SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
+                   ctx.slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+              ctx.outpacket->setRcode(RCode::ServFail);
+              sendPacket(ctx.outpacket,ctx.outsock);
               return false;
             }
             nonterm.insert(shorter);
@@ -1291,17 +1310,7 @@ bool TCPNameserver::axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, 
 
 int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
 {
-  const ZoneName& targetZone = q->qdomainzone;
-  string logPrefix;
-
-  if (!g_slogStructured) {
-    logPrefix="IXFR-out zone '"+targetZone.toLogString()+"', client '"+q->getRemoteStringWithPort()+"', ";
-  }
-
-  std::unique_ptr<DNSPacket> outpacket=getFreshAXFRPacket(q);
-  if(q->d_dnssecOk) {
-    outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
-  }
+  XFRContext ctx(q, outsock, slog, false);
 
   uint32_t serial = 0;
   MOADNSParser mdp(false, q->getString());
@@ -1315,77 +1324,76 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
           pdns::checked_stoi_into(serial, parts[2]);
         }
         catch(const std::logic_error& exc) {
-          SLOG(g_log<<Logger::Warning<<logPrefix<<"invalid serial in IXFR query"<<endl,
-               slog->error(Logr::Warning, exc.what(), "IXFR: invalid serial in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-          outpacket->setRcode(RCode::FormErr);
-          sendPacket(outpacket,outsock);
+          SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"invalid serial in IXFR query"<<endl,
+               ctx.slog->error(Logr::Warning, exc.what(), "IXFR: invalid serial in query", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+          ctx.outpacket->setRcode(RCode::FormErr);
+          sendPacket(ctx.outpacket,ctx.outsock);
           return 0;
         }
       } else {
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"no serial in IXFR query"<<endl,
-             slog->info(Logr::Warning, "IXFR: no serial in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-        outpacket->setRcode(RCode::FormErr);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"no serial in IXFR query"<<endl,
+             ctx.slog->info(Logr::Warning, "IXFR: no serial in query", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+        ctx.outpacket->setRcode(RCode::FormErr);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     } else if (dnsRecord->d_type != QType::TSIG && dnsRecord->d_type != QType::OPT) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"additional records in IXFR query, type: "<<QType(dnsRecord->d_type).toString()<<endl,
-             slog->info(Logr::Warning, "IXFR: additional record in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "type", Logging::Loggable(dnsRecord->d_type)));
-      outpacket->setRcode(RCode::FormErr);
-      sendPacket(outpacket,outsock);
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"additional records in IXFR query, type: "<<QType(dnsRecord->d_type).toString()<<endl,
+             ctx.slog->info(Logr::Warning, "IXFR: additional record in query", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "type", Logging::Loggable(dnsRecord->d_type)));
+      ctx.outpacket->setRcode(RCode::FormErr);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
   }
 
-  SLOG(g_log<<Logger::Warning<<logPrefix<<"transfer initiated with serial "<<serial<<endl,
-       slog->info(Logr::Warning, "IXFR: transfer initiated", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "serial", Logging::Loggable(serial)));
+  SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"transfer initiated with serial "<<serial<<endl,
+       ctx.slog->info(Logr::Warning, "IXFR: transfer initiated", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "serial", Logging::Loggable(serial)));
 
   // determine if zone exists, XFR is allowed, and if IXFR can proceed using existing backend before spawning a new backend.
-  DLOG(SLOG(g_log<<logPrefix<<"Looking for SOA"<<endl,
-            slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-  SOAData sd;
-  bool securedZone;
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"Looking for SOA"<<endl,
+            ctx.slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
   bool serialPermitsIXFR;
   {
     auto packetHandler = s_P.lock();
     if(!*packetHandler) {
       SLOG(g_log<<Logger::Warning<<"TCP server is without backend connections in doIXFR, launching"<<endl,
-           slog->info(Logr::Warning, "IXFR: TCP server is without backend connections in doIXFR, launching", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      *packetHandler = make_unique<PacketHandler>(slog);
+           ctx.slog->info(Logr::Warning, "IXFR: TCP server is without backend connections in doIXFR, launching", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      *packetHandler = make_unique<PacketHandler>(ctx.slog);
     }
 
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
-    if(!canDoAXFR(q, false, *packetHandler, slog)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: client may not request IXFR"<<endl,
-           slog->info(Logr::Warning, "IXFR failed: client may not request IXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::NotAuth);
-      sendPacket(outpacket,outsock);
+    if(!canDoAXFR(q, ctx, *packetHandler)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: client may not request IXFR"<<endl,
+           ctx.slog->info(Logr::Warning, "IXFR failed: client may not request IXFR", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::NotAuth);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
 
-    if(!(*packetHandler)->getBackend()->getSOAUncached(targetZone, sd)) {
-      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative"<<endl,
-           slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-      outpacket->setRcode(RCode::NotAuth);
-      sendPacket(outpacket,outsock);
+    // ctx.soa has been computed by canDoAXFR above
+    if(!(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative"<<endl,
+           ctx.slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+      ctx.outpacket->setRcode(RCode::NotAuth);
+      sendPacket(ctx.outpacket,ctx.outsock);
       return 0;
     }
 
-    DNSSECKeeper dk(slog, (*packetHandler)->getBackend());
-    DNSSECKeeper::clearCaches(targetZone);
+    DNSSECKeeper dk(ctx.slog, (*packetHandler)->getBackend());
+    DNSSECKeeper::clearCaches(ctx.targetZone);
     bool narrow = false;
-    securedZone = dk.isSecuredZone(targetZone);
-    if(dk.getNSEC3PARAM(targetZone, nullptr, &narrow)) {
+    ctx.securedZone = dk.isSecuredZone(ctx.targetZone);
+    if(dk.getNSEC3PARAM(ctx.targetZone, nullptr, &narrow)) {
       if(narrow) {
-        SLOG(g_log<<Logger::Warning<<logPrefix<<"not doing IXFR of an NSEC3 narrow zone"<<endl,
-           slog->info(Logr::Warning, "IXFR refused: not doing IXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-        outpacket->setRcode(RCode::Refused);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"not doing IXFR of an NSEC3 narrow zone"<<endl,
+           ctx.slog->info(Logr::Warning, "IXFR refused: not doing IXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+        ctx.outpacket->setRcode(RCode::Refused);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     }
 
-    serialPermitsIXFR = !rfc1982LessThan(serial, calculateEditSOA(sd.serial, dk, sd.zonename, slog));
+    serialPermitsIXFR = !rfc1982LessThan(serial, calculateEditSOA(ctx.soa.serial, dk, ctx.soa.zonename, ctx.slog));
   }
 
   if (serialPermitsIXFR) {
@@ -1394,7 +1402,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     string tsigsecret;
 
     UeberBackend db;
-    DNSSECKeeper dk(slog, &db);
+    DNSSECKeeper dk(ctx.slog, &db);
 
     bool haveTSIGDetails = q->getTSIGDetails(&trc, &tsigkeyname);
 
@@ -1405,50 +1413,50 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
         algorithm = g_hmacmd5dnsname;
       }
       if (!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << targetZone << "' not found" << endl,
-           slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        outpacket->setRcode(RCode::NotAuth);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
+           ctx.slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::NotAuth);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
       if (B64Decode(tsig64, tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        outpacket->setRcode(RCode::ServFail);
-        sendPacket(outpacket,outsock);
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::ServFail);
+        sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     }
 
     // SOA *must* go out first, our signing pipe might reorder
-    DLOG(SLOG(g_log<<logPrefix<<"sending out SOA"<<endl,
-              slog->info(Logr::Debug, /*"I send an SOA to the world"*/"IXFR: sending out SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-    DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, sd, DNSResourceRecord::ANSWER, slog);
-    outpacket->addRecord(std::move(soa));
-    if(securedZone && outpacket->d_dnssecOk) {
+    DLOG(SLOG(g_log<<ctx.logPrefix<<"sending out SOA"<<endl,
+              ctx.slog->info(Logr::Debug, /*"I send an SOA to the world"*/"IXFR: sending out SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+    DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, ctx.soa, DNSResourceRecord::ANSWER, ctx.slog);
+    ctx.outpacket->addRecord(std::move(soa));
+    if(ctx.securedZone && ctx.outpacket->d_dnssecOk) {
       set<ZoneName> authSet;
-      authSet.insert(targetZone);
-      addRRSigs(dk, db, authSet, outpacket->getRRS());
+      authSet.insert(ctx.targetZone);
+      addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
     }
 
     if(haveTSIGDetails && !tsigkeyname.empty())
-      outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+      ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
 
-    sendPacket(outpacket, outsock);
+    sendPacket(ctx.outpacket, ctx.outsock);
 
-    SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR finished"<<endl,
-         slog->info(Logr::Notice, "IXFR finished", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"IXFR finished"<<endl,
+         ctx.slog->info(Logr::Notice, "IXFR finished", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
 
     return 1;
   }
 
-  SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR fallback to AXFR"<<endl,
-       slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+  SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"IXFR fallback to AXFR"<<endl,
+       ctx.slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
   // Update log prefix as well
   if (!g_slogStructured) {
-    logPrefix.at(0) = 'A';
+    ctx.logPrefix.at(0) = 'A';
   }
-  return doAXFRinternal(q, outsock, slog, logPrefix, outpacket);
+  return doAXFRinternal(q, ctx);
 }
 
 TCPNameserver::~TCPNameserver() = default;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -516,7 +516,7 @@ public:
   ~XFRContext() = default;
 
   void setupOutputPacket();
-  void sendIntermediatePacket(TSIGRecordContent &trc);
+  void sendIntermediatePacket();
 
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
   const ZoneName& targetZone; // domain being XFR'ed
@@ -529,6 +529,11 @@ public:
   bool NSEC3Zone{false};
   bool isCatalogZone{false};
   NSEC3PARAMRecordContent ns3pr;
+
+  bool haveTSIGDetails{false};
+  TSIGRecordContent trc;
+  DNSName tsigkeyname;
+  string tsigsecret;
 
   // Network-related fields
   int outsock;
@@ -568,7 +573,7 @@ void TCPNameserver::XFRContext::setupOutputPacket()
   outpacket->d_tcp = true;
 }
 
-void TCPNameserver::XFRContext::sendIntermediatePacket(TSIGRecordContent &trc)
+void TCPNameserver::XFRContext::sendIntermediatePacket()
 {
   try {
     sendPacket(outpacket, outsock, false);
@@ -588,19 +593,16 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
   }
 
   if(q->d_havetsig) { // if you have one, it must be good
-    TSIGRecordContent tsigContent;
-    DNSName tsigkeyname;
-    string secret;
-    if (!packetHandler->checkForCorrectTSIG(*q, &tsigkeyname, &secret, &tsigContent)) {
+    if (!packetHandler->checkForCorrectTSIG(*q, &ctx.tsigkeyname, &ctx.tsigsecret, &ctx.trc)) {
       return false;
     }
-    getTSIGHashEnum(tsigContent.d_algoName, q->d_tsig_algo);
+    getTSIGHashEnum(ctx.trc.d_algoName, q->d_tsig_algo);
 #ifdef ENABLE_GSS_TSIG
     if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
-      GssContext gssctx(tsigkeyname);
+      GssContext gssctx(ctx.tsigkeyname);
       if (!gssctx.getPeerPrincipal(q->d_peer_principal)) {
-        SLOG(g_log<<Logger::Warning<<"Failed to extract peer principal from GSS context with keyname '"<<tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Warning, "Failed to extract peer principal from GSS context", "keyname", Logging::Loggable(tsigkeyname)));
+        SLOG(g_log<<Logger::Warning<<"Failed to extract peer principal from GSS context with keyname '"<<ctx.tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Warning, "Failed to extract peer principal from GSS context", "keyname", Logging::Loggable(ctx.tsigkeyname)));
       }
     }
 #endif
@@ -613,22 +615,22 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
       for(const std::string& princ :  princs) {
         if (q->d_peer_principal == princ) {
           SLOG(g_log<<Logger::Warning<<ctx.xfrType<<" of domain '"<<ctx.targetZone<<"' allowed: TSIG signed request with authorized principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig'"<<endl,
-               ctx.slog->info(Logr::Warning, ctx.xfrType + " allowed: TSIG signed request with authorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
+               ctx.slog->info(Logr::Warning, ctx.xfrType + " allowed: TSIG signed request with authorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
           return true;
         }
       }
       SLOG(g_log<<Logger::Warning<<ctx.xfrType<<" of domain '"<<ctx.targetZone<<"' denied: TSIG signed request with principal '"<<q->d_peer_principal<<"' and algorithm 'gss-tsig' is not permitted"<<endl,
-           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: TSIG signed request with unauthorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
+           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: TSIG signed request with unauthorized principal", "zone", Logging::Loggable(ctx.targetZone), "principal", Logging::Loggable(q->d_peer_principal), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable("gss-tsig")));
       return false;
     }
 #endif
-    if(!dk.TSIGGrantsAccess(ctx.targetZone, tsigkeyname)) {
-      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"denied: key with name '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"' does not grant access"<<endl,
-           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+    if(!dk.TSIGGrantsAccess(ctx.targetZone, ctx.tsigkeyname)) {
+      SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"denied: key with name '"<<ctx.tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"' does not grant access"<<endl,
+           ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
       return false;
     }
-    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
-         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<ctx.tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
+         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
     return true;
   }
 
@@ -729,7 +731,7 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
@@ -769,36 +771,31 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     }
   }
 
-  TSIGRecordContent trc;
-  DNSName tsigkeyname;
-  string tsigsecret;
+  ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
 
-  bool haveTSIGDetails = q->getTSIGDetails(&trc, &tsigkeyname);
-
-  if(haveTSIGDetails && !tsigkeyname.empty()) {
+  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
     string tsig64;
-    DNSName algorithm=trc.d_algoName;
+    DNSName algorithm=ctx.trc.d_algoName;
     if (algorithm == g_hmacmd5dnsname_long) {
       algorithm = g_hmacmd5dnsname;
     }
     if (algorithm != g_gsstsigdnsname) {
-      if(!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
+      if(!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
         SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"TSIG key not found"<<endl,
-             ctx.slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+             ctx.slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         ctx.outpacket->setRcode(RCode::NotAuth);
         sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
-      if (B64Decode(tsig64, tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         ctx.outpacket->setRcode(RCode::ServFail);
         sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
     }
   }
-
 
   // SOA *must* go out first, our signing pipe might reorder
   DLOG(SLOG(g_log<<ctx.logPrefix<<"sending out SOA"<<endl,
@@ -811,15 +808,88 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
   }
 
-  if(haveTSIGDetails && !tsigkeyname.empty()) {
-    ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+    ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac); // first answer is 'normal'
   }
 
-  ctx.sendIntermediatePacket(trc);
+  ctx.sendIntermediatePacket();
 
   DNSZoneRecord zrr;
   vector<DNSZoneRecord> zrrs;
 
+  zrr.dr.d_name = target;
+  zrr.dr.d_ttl = ctx.soa.minimum;
+
+  axfrKeys(ctx, zrrs, dk);
+
+  // now stuff in the NSEC3PARAM
+  if(ctx.NSEC3Zone) {
+    uint8_t flags = ctx.ns3pr.d_flags;
+    zrr.dr.d_type = QType::NSEC3PARAM;
+    ctx.ns3pr.d_flags = 0;
+    zrr.dr.setContent(std::make_shared<NSEC3PARAMRecordContent>(ctx.ns3pr));
+    ctx.ns3pr.d_flags = flags;
+    DNSName keyname = DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, zrr.dr.d_name)));
+    zrrs.push_back(zrr);
+  }
+
+  // Catalog zones need a specific processing at this point.
+  auto zoneKindSpecificOp = ctx.info.kind == DomainInfo::Producer ? axfrProducerZone : axfrRegularZone;
+  if (!zoneKindSpecificOp(ctx, zrrs)) {
+    return 0;
+  }
+
+  /* now write all other records */
+
+  ChunkedSigningPipe csp(ctx.slog, ctx.targetZone, (ctx.securedZone && !ctx.presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
+
+  DTime dt; // NOLINT(readability-identifier-length)
+  dt.set();
+
+  axfrSubmitRecords(ctx, zrrs, csp);
+  for(;;) {
+    ctx.outpacket->getRRS() = csp.getChunk(true); // flush the pipe
+    if(!ctx.outpacket->getRRS().empty()) {
+      if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+        ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true); // first answer is 'normal'
+      }
+      ctx.sendIntermediatePacket();
+    }
+    else {
+      break;
+    }
+  }
+
+  unsigned int udiff=dt.udiffNoReset();
+  if(ctx.securedZone) {
+    SLOG(g_log<<Logger::Debug<<ctx.logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
+         ctx.slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
+  }
+
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"done writing out records"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: done writing out records", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+  /* and terminate with yet again the SOA record */
+  ctx.setupOutputPacket();
+  ctx.outpacket->addRecord(std::move(soa));
+  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+    ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true);
+  }
+
+  sendPacket(ctx.outpacket, ctx.outsock);
+
+  DLOG(SLOG(g_log<<ctx.logPrefix<<"last packet - close"<<endl,
+            ctx.slog->info(Logr::Debug, "AXFR: last packet sent", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
+  SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"AXFR finished"<<endl,
+       ctx.slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+
+  return 1;
+}
+
+void TCPNameserver::axfrKeys(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, DNSSECKeeper& dk)
+{
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
+
+  DNSZoneRecord zrr;
   zrr.dr.d_name = target;
   zrr.dr.d_ttl = ctx.soa.minimum;
 
@@ -828,8 +898,8 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     bool doCDS{true};
     string publishCDNSKEY;
     string publishCDS;
-    dk.getPublishCDNSKEY(q->qdomainzone, publishCDNSKEY);
-    dk.getPublishCDS(q->qdomainzone, publishCDS);
+    dk.getPublishCDNSKEY(ctx.targetZone, publishCDNSKEY);
+    dk.getPublishCDS(ctx.targetZone, publishCDS);
 
     set<uint32_t> entryPointIds;
     DNSSECKeeper::keyset_t entryPoints = dk.getEntryPoints(ctx.targetZone);
@@ -880,197 +950,6 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     }
 
   }
-
-  if(ctx.NSEC3Zone) { // now stuff in the NSEC3PARAM
-    uint8_t flags = ctx.ns3pr.d_flags;
-    zrr.dr.d_type = QType::NSEC3PARAM;
-    ctx.ns3pr.d_flags = 0;
-    zrr.dr.setContent(std::make_shared<NSEC3PARAMRecordContent>(ctx.ns3pr));
-    ctx.ns3pr.d_flags = flags;
-    DNSName keyname = DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, zrr.dr.d_name)));
-    zrrs.push_back(zrr);
-  }
-
-  // Catalog zones need a specific processing at this point.
-  auto zoneKindSpecificOp = ctx.info.kind == DomainInfo::Producer ? axfrProducerZone : axfrRegularZone;
-  if (!zoneKindSpecificOp(ctx, zrrs)) {
-    return 0;
-  }
-
-  /* now write all other records */
-
-  using nsecxrepo_t = map<DNSName, NSECXEntry, CanonDNSNameCompare>;
-  nsecxrepo_t nsecxrepo;
-
-  ChunkedSigningPipe csp(ctx.slog, ctx.targetZone, (ctx.securedZone && !ctx.presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
-
-  DNSName keyname;
-  DTime dt; // NOLINT(readability-identifier-length)
-  dt.set();
-  for(DNSZoneRecord &loopZRR :  zrrs) {
-    if(ctx.securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
-      if (ctx.NSEC3Zone || loopZRR.dr.d_type != QType::ENT) {
-        if (ctx.presignedZone && ctx.NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
-          keyname = loopZRR.dr.d_name.makeRelative(ctx.soa.qname());
-        } else {
-          keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
-        }
-        NSECXEntry& ne = nsecxrepo[keyname]; // NOLINT(readability-identifier-length)
-        ne.d_ttl = ctx.soa.getNegativeTTL();
-        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (ctx.ns3pr.d_flags == 0)));
-        if (loopZRR.dr.d_type != QType::ENT && loopZRR.dr.d_type != QType::RRSIG) {
-          ne.d_set.set(loopZRR.dr.d_type);
-        }
-      }
-    }
-
-    if (loopZRR.dr.d_type == QType::ENT) {
-      continue; // skip empty non-terminals
-    }
-
-    if(loopZRR.dr.d_type == QType::SOA) {
-      continue; // skip SOA - would indicate end of AXFR
-    }
-
-    if(csp.submit(loopZRR)) {
-      for(;;) {
-        ctx.outpacket->getRRS() = csp.getChunk();
-        if(!ctx.outpacket->getRRS().empty()) {
-          if(haveTSIGDetails && !tsigkeyname.empty()) {
-            ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-          }
-          ctx.sendIntermediatePacket(trc);
-        }
-        else {
-          break;
-        }
-      }
-    }
-  }
-  if(ctx.securedZone) {
-    if(ctx.NSEC3Zone) {
-      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
-        if(iter->second.d_auth) {
-          NSEC3RecordContent n3rc;
-          n3rc.set(iter->second.d_set);
-          const auto numberOfTypesSet = n3rc.numberOfTypesSet();
-          if (numberOfTypesSet != 0 && (numberOfTypesSet != 1 || !n3rc.isSet(QType::NS))) {
-            n3rc.set(QType::RRSIG);
-          }
-          n3rc.d_salt = ctx.ns3pr.d_salt;
-          n3rc.d_flags = ctx.ns3pr.d_flags;
-          n3rc.d_iterations = ctx.ns3pr.d_iterations;
-          n3rc.d_algorithm = DNSSECKeeper::DIGEST_SHA1; // SHA1, fixed in PowerDNS for now
-          auto inext = iter;
-          ++inext;
-          if(inext == nsecxrepo.cend()) {
-            inext = nsecxrepo.cbegin();
-          }
-          while(!inext->second.d_auth && inext != iter)
-          {
-            ++inext;
-            if(inext == nsecxrepo.cend()) {
-              inext = nsecxrepo.cbegin();
-            }
-          }
-          n3rc.d_nexthash = fromBase32Hex(inext->first.toStringNoDot());
-          zrr.dr.d_name = iter->first+ctx.soa.qname();
-
-          zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
-          zrr.dr.setContent(std::make_shared<NSEC3RecordContent>(std::move(n3rc)));
-          zrr.dr.d_type = QType::NSEC3;
-          zrr.dr.d_place = DNSResourceRecord::ANSWER;
-          zrr.auth=true;
-          if(csp.submit(zrr)) {
-            for(;;) {
-              ctx.outpacket->getRRS() = csp.getChunk();
-              if(!ctx.outpacket->getRRS().empty()) {
-                if(haveTSIGDetails && !tsigkeyname.empty()) {
-                  ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-                }
-                ctx.sendIntermediatePacket(trc);
-              }
-              else {
-                break;
-              }
-            }
-          }
-        }
-      }
-    }
-    else {
-      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
-        NSECRecordContent nrc;
-        nrc.set(iter->second.d_set);
-        nrc.set(QType::RRSIG);
-        nrc.set(QType::NSEC);
-
-        if(boost::next(iter) != nsecxrepo.cend()) {
-          nrc.d_next = boost::next(iter)->first;
-        }
-        else {
-          nrc.d_next=nsecxrepo.cbegin()->first;
-        }
-        zrr.dr.d_name = iter->first;
-
-        zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
-        zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
-        zrr.dr.d_type = QType::NSEC;
-        zrr.dr.d_place = DNSResourceRecord::ANSWER;
-        zrr.auth=true;
-        if(csp.submit(zrr)) {
-          for(;;) {
-            ctx.outpacket->getRRS() = csp.getChunk();
-            if(!ctx.outpacket->getRRS().empty()) {
-              if(haveTSIGDetails && !tsigkeyname.empty()) {
-                ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-              }
-              ctx.sendIntermediatePacket(trc);
-            }
-            else {
-              break;
-            }
-          }
-        }
-      }
-    }
-  }
-  for(;;) {
-    ctx.outpacket->getRRS() = csp.getChunk(true); // flush the pipe
-    if(!ctx.outpacket->getRRS().empty()) {
-      if(haveTSIGDetails && !tsigkeyname.empty()) {
-        ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
-      }
-      ctx.sendIntermediatePacket(trc);
-    }
-    else {
-      break;
-    }
-  }
-
-  unsigned int udiff=dt.udiffNoReset();
-  if(ctx.securedZone) {
-    SLOG(g_log<<Logger::Debug<<ctx.logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
-         ctx.slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
-  }
-
-  DLOG(SLOG(g_log<<ctx.logPrefix<<"done writing out records"<<endl,
-            ctx.slog->info(Logr::Debug, "AXFR: done writing out records", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
-  /* and terminate with yet again the SOA record */
-  ctx.setupOutputPacket();
-  ctx.outpacket->addRecord(std::move(soa));
-  if(haveTSIGDetails && !tsigkeyname.empty()) {
-    ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-  }
-
-  sendPacket(ctx.outpacket, ctx.outsock);
-
-  DLOG(SLOG(g_log<<ctx.logPrefix<<"last packet - close"<<endl,
-            ctx.slog->info(Logr::Debug, "AXFR: last packet sent", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
-  SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"AXFR finished"<<endl,
-       ctx.slog->info(Logr::Notice, "AXFR completed", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
-
-  return 1;
 }
 
 bool TCPNameserver::axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs)
@@ -1113,7 +992,7 @@ bool TCPNameserver::axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrr
   return true;
 }
 
-bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs) // NOLINT(readability-function-cognitive-complexity)
+bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
@@ -1147,32 +1026,8 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
     zrr.dr.d_name.makeUsLowerCase();
     if(zrr.dr.d_name.isPartOf(target)) {
       if (zrr.dr.d_type == QType::ALIAS && (::arg().mustDo("outgoing-axfr-expand-alias") || ::arg()["outgoing-axfr-expand-alias"] == "ignore-errors")) {
-        vector<DNSZoneRecord> ips;
-        int ret1 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
-        int ret2 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
-        if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
-          if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
-            if (ret1 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   ctx.slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            }
-            if (ret2 != RCode::NoError) {
-              SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
-                   ctx.slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            }
-          }
-          else {
-            SLOG(g_log << Logger::Warning << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
-                 ctx.slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
-            ctx.outpacket->setRcode(RCode::ServFail);
-            sendPacket(ctx.outpacket, ctx.outsock);
-            return false;
-          }
-        }
-        for (auto& dzr: ips) {
-          zrr.dr.d_type = dzr.dr.d_type;
-          zrr.dr.setContent(dzr.dr.getContent());
-          zrrs.push_back(zrr);
+        if (!axfrAlias(ctx, zrrs, zrr)) {
+          return false;
         }
         continue;
       }
@@ -1197,8 +1052,61 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
     }
   }
 
+  // Process SVCB and HTTP hints
+  axfrHints(ctx, zrrs);
+
+  // Group records by name and type, signpipe stumbles over interrupted rrsets
+  if(ctx.securedZone && !ctx.presignedZone) {
+    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) { // NOLINT(readability-identifier-length)
+      return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
+    });
+  }
+
+  // Add ENT records if necessary
+  if (rectify) {
+    return axfrRectify(ctx, zrrs, qnames, nsset);
+  }
+
+  return true;
+}
+
+bool TCPNameserver::axfrAlias(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, DNSZoneRecord& zrr)
+{
+  vector<DNSZoneRecord> ips;
+
+  int ret1 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::A, ips);
+  int ret2 = stubDoResolve(ctx.slog, getRR<ALIASRecordContent>(zrr.dr)->getContent(), QType::AAAA, ips);
+  if (ret1 != RCode::NoError || ret2 != RCode::NoError) {
+    if (::arg()["outgoing-axfr-expand-alias"] == "ignore-errors") {
+      if (ret1 != RCode::NoError) {
+        SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving A record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+             ctx.slog->info(Logr::Error, "AXFR: Error resolving A record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+      }
+      if (ret2 != RCode::NoError) {
+        SLOG(g_log << Logger::Error << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving AAAA record for ALIAS target " << zrr.dr.getContent()->getZoneRepresentation() << ", continuing AXFR" << endl,
+             ctx.slog->info(Logr::Error, "AXFR: Error resolving AAAA record for ALIAS target, continuing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+      }
+    }
+    else {
+      SLOG(g_log << Logger::Warning << ctx.logPrefix << zrr.dr.d_name.toLogString() << ": error resolving for ALIAS " << zrr.dr.getContent()->getZoneRepresentation() << ", aborting AXFR" << endl,
+           ctx.slog->info(Logr::Error, "AXFR aborted: error resolving for ALIAS target", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "content", Logging::Loggable(zrr.dr.getContent()->getZoneRepresentation())));
+      ctx.outpacket->setRcode(RCode::ServFail);
+      sendPacket(ctx.outpacket, ctx.outsock);
+      return false;
+    }
+  }
+  for (auto& dzr: ips) {
+    zrr.dr.d_type = dzr.dr.d_type;
+    zrr.dr.setContent(dzr.dr.getContent());
+    zrrs.push_back(zrr);
+  }
+  return true;
+}
+
+void TCPNameserver::axfrHints(XFRContext& ctx, vector<DNSZoneRecord>& zrrs)
+{
   for (auto& loopRR : zrrs) {
-    if ((loopRR.dr.d_type == QType::SVCB || loopRR.dr.d_type == QType::HTTPS)) {
+    if (loopRR.dr.d_type == QType::SVCB || loopRR.dr.d_type == QType::HTTPS) {
       // Process auto hints
       // TODO this is an almost copy of the code in the packethandler
       auto rrc = getRR<SVCBBaseRecordContent>(loopRR.dr);
@@ -1243,88 +1151,223 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       loopRR.dr.setContent(std::move(newRRC));
     }
   }
+}
 
-  // Group records by name and type, signpipe stumbles over interrupted rrsets
-  if(ctx.securedZone && !ctx.presignedZone) {
-    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) { // NOLINT(readability-identifier-length)
-      return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
-    });
+bool TCPNameserver::axfrRectify(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, const set<DNSName>& qnames, const set<DNSName>& nsset)
+{
+  const DNSName& target = ctx.targetZone.operator const DNSName&();
+
+  DNSZoneRecord zrr;
+
+  // set auth
+  for(auto &loopZRR : zrrs) {
+    loopZRR.auth=true;
+    if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
+      DNSName shorter(loopZRR.dr.d_name);
+      do {
+        if (shorter==target) { // apex is always auth
+          break;
+        }
+        if(nsset.count(shorter) != 0 && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
+          loopZRR.auth=false;
+          break;
+        }
+      } while(shorter.chopOff());
+    }
   }
 
-  if(rectify) {
-    // set auth
-    for(DNSZoneRecord &loopZRR :  zrrs) {
-      loopZRR.auth=true;
-      if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
-        DNSName shorter(loopZRR.dr.d_name);
+  if(ctx.NSEC3Zone) {
+    // ents are only required for NSEC3 zones
+    auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
+    set<DNSName> nsec3set;
+    set<DNSName> nonterm;
+    for (auto &loopZRR: zrrs) {
+      bool skip=false;
+      DNSName shorter = loopZRR.dr.d_name;
+      if (shorter != target && shorter.chopOff() && shorter != target) {
         do {
-          if (shorter==target) { // apex is always auth
+          if(nsset.count(shorter) != 0) {
+            skip=true;
             break;
           }
-          if(nsset.count(shorter) != 0 && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
-            loopZRR.auth=false;
-            break;
+        } while(shorter.chopOff() && shorter != target);
+      }
+      shorter = loopZRR.dr.d_name;
+      if(!skip && (loopZRR.dr.d_type != QType::NS || ctx.ns3pr.d_flags == 0)) {
+        do {
+          if(nsec3set.count(shorter) == 0) {
+            nsec3set.insert(shorter);
           }
-        } while(shorter.chopOff());
+        } while(shorter != target && shorter.chopOff());
       }
     }
 
-    if(ctx.NSEC3Zone) {
-      // ents are only required for NSEC3 zones
-      auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
-      set<DNSName> nsec3set;
-      set<DNSName> nonterm;
-      for (auto &loopZRR: zrrs) {
-        bool skip=false;
-        DNSName shorter = loopZRR.dr.d_name;
-        if (shorter != target && shorter.chopOff() && shorter != target) {
-          do {
-            if(nsset.count(shorter) != 0) {
-              skip=true;
-              break;
-            }
-          } while(shorter.chopOff() && shorter != target);
-        }
-        shorter = loopZRR.dr.d_name;
-        if(!skip && (loopZRR.dr.d_type != QType::NS || ctx.ns3pr.d_flags == 0)) {
-          do {
-            if(nsec3set.count(shorter) == 0) {
-              nsec3set.insert(shorter);
-            }
-          } while(shorter != target && shorter.chopOff());
-        }
-      }
-
-      for(DNSZoneRecord &loopZRR :  zrrs) {
-        DNSName shorter(loopZRR.dr.d_name);
-        while(shorter != target && shorter.chopOff()) {
-          if(qnames.count(shorter) == 0 && nonterm.count(shorter) == 0 && nsec3set.count(shorter) != 0) {
-            if(maxent == 0) {
-              SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
-                   ctx.slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
-              ctx.outpacket->setRcode(RCode::ServFail);
-              sendPacket(ctx.outpacket,ctx.outsock);
-              return false;
-            }
-            nonterm.insert(shorter);
-            --maxent;
+    for(auto &loopZRR : zrrs) {
+      DNSName shorter(loopZRR.dr.d_name);
+      while(shorter != target && shorter.chopOff()) {
+        if(qnames.count(shorter) == 0 && nonterm.count(shorter) == 0 && nsec3set.count(shorter) != 0) {
+          if(maxent == 0) {
+            SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
+                 ctx.slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
+            ctx.outpacket->setRcode(RCode::ServFail);
+            sendPacket(ctx.outpacket,ctx.outsock);
+            return false;
           }
+          nonterm.insert(shorter);
+          --maxent;
         }
       }
+    }
 
-      for(const auto& nt : nonterm) { // NOLINT(readability-identifier-length)
-        DNSZoneRecord tempRR;
-        tempRR.dr.d_name=nt;
-        tempRR.dr.d_type=QType::ENT;
-        tempRR.auth=true;
-        zrrs.push_back(tempRR);
-      }
+    for(const auto& nt : nonterm) { // NOLINT(readability-identifier-length)
+      DNSZoneRecord tempRR;
+      tempRR.dr.d_name=nt;
+      tempRR.dr.d_type=QType::ENT;
+      tempRR.auth=true;
+      zrrs.push_back(tempRR);
     }
   }
 
   return true;
 }
 
+void TCPNameserver::axfrSubmitRecords(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, ChunkedSigningPipe& csp) // NOLINT(readability-function-cognitive-complexity)
+{
+  DNSZoneRecord zrr;
+
+  using nsecxrepo_t = map<DNSName, NSECXEntry, CanonDNSNameCompare>;
+  nsecxrepo_t nsecxrepo;
+
+  for(DNSZoneRecord &loopZRR :  zrrs) {
+    if(ctx.securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
+      if (ctx.NSEC3Zone || loopZRR.dr.d_type != QType::ENT) {
+        DNSName keyname;
+        if (ctx.presignedZone && ctx.NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
+          keyname = loopZRR.dr.d_name.makeRelative(ctx.soa.qname());
+        } else {
+          keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
+        }
+        NSECXEntry& ne = nsecxrepo[keyname]; // NOLINT(readability-identifier-length)
+        ne.d_ttl = ctx.soa.getNegativeTTL();
+        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (ctx.ns3pr.d_flags == 0)));
+        if (loopZRR.dr.d_type != QType::ENT && loopZRR.dr.d_type != QType::RRSIG) {
+          ne.d_set.set(loopZRR.dr.d_type);
+        }
+      }
+    }
+
+    if (loopZRR.dr.d_type == QType::ENT) {
+      continue; // skip empty non-terminals
+    }
+
+    if(loopZRR.dr.d_type == QType::SOA) {
+      continue; // skip SOA - would indicate end of AXFR
+    }
+
+    if(csp.submit(loopZRR)) {
+      for(;;) {
+        ctx.outpacket->getRRS() = csp.getChunk();
+        if(!ctx.outpacket->getRRS().empty()) {
+          if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+            ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true);
+          }
+          ctx.sendIntermediatePacket();
+        }
+        else {
+          break;
+        }
+      }
+    }
+  }
+  if(ctx.securedZone) {
+    if(ctx.NSEC3Zone) {
+      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
+        if(iter->second.d_auth) {
+          NSEC3RecordContent n3rc;
+          n3rc.set(iter->second.d_set);
+          const auto numberOfTypesSet = n3rc.numberOfTypesSet();
+          if (numberOfTypesSet != 0 && (numberOfTypesSet != 1 || !n3rc.isSet(QType::NS))) {
+            n3rc.set(QType::RRSIG);
+          }
+          n3rc.d_salt = ctx.ns3pr.d_salt;
+          n3rc.d_flags = ctx.ns3pr.d_flags;
+          n3rc.d_iterations = ctx.ns3pr.d_iterations;
+          n3rc.d_algorithm = DNSSECKeeper::DIGEST_SHA1; // SHA1, fixed in PowerDNS for now
+          auto inext = iter;
+          ++inext;
+          if(inext == nsecxrepo.cend()) {
+            inext = nsecxrepo.cbegin();
+          }
+          while(!inext->second.d_auth && inext != iter)
+          {
+            ++inext;
+            if(inext == nsecxrepo.cend()) {
+              inext = nsecxrepo.cbegin();
+            }
+          }
+          n3rc.d_nexthash = fromBase32Hex(inext->first.toStringNoDot());
+
+          zrr.dr.d_name = iter->first+ctx.soa.qname();
+          zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
+          zrr.dr.setContent(std::make_shared<NSEC3RecordContent>(std::move(n3rc)));
+          zrr.dr.d_type = QType::NSEC3;
+          zrr.dr.d_place = DNSResourceRecord::ANSWER;
+          zrr.auth=true;
+          if(csp.submit(zrr)) {
+            for(;;) {
+              ctx.outpacket->getRRS() = csp.getChunk();
+              if(!ctx.outpacket->getRRS().empty()) {
+                if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+                  ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true);
+                }
+                ctx.sendIntermediatePacket();
+              }
+              else {
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+    else {
+      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
+        NSECRecordContent nrc;
+        nrc.set(iter->second.d_set);
+        nrc.set(QType::RRSIG);
+        nrc.set(QType::NSEC);
+
+        if(boost::next(iter) != nsecxrepo.cend()) {
+          nrc.d_next = boost::next(iter)->first;
+        }
+        else {
+          nrc.d_next=nsecxrepo.cbegin()->first;
+        }
+        zrr.dr.d_name = iter->first;
+
+        zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
+        zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
+        zrr.dr.d_type = QType::NSEC;
+        zrr.dr.d_place = DNSResourceRecord::ANSWER;
+        zrr.auth=true;
+        if(csp.submit(zrr)) {
+          for(;;) {
+            ctx.outpacket->getRRS() = csp.getChunk();
+            if(!ctx.outpacket->getRRS().empty()) {
+              if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+                ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac, true);
+              }
+              ctx.sendIntermediatePacket();
+            }
+            else {
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+}
 int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog) // NOLINT(readability-identifier-length)
 {
   XFRContext ctx(q, outsock, slog, false);
@@ -1414,31 +1457,27 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   }
 
   if (serialPermitsIXFR) {
-    TSIGRecordContent trc;
-    DNSName tsigkeyname;
-    string tsigsecret;
-
     UeberBackend db; // NOLINT(readability-identifier-length)
     DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
 
-    bool haveTSIGDetails = q->getTSIGDetails(&trc, &tsigkeyname);
+    ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
 
-    if(haveTSIGDetails && !tsigkeyname.empty()) {
+    if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
       string tsig64;
-      DNSName algorithm=trc.d_algoName; // FIXME400: was toLowerCanonic, compare output
+      DNSName algorithm=ctx.trc.d_algoName; // FIXME400: was toLowerCanonic, compare output
       if (algorithm == g_hmacmd5dnsname_long) {
         algorithm = g_hmacmd5dnsname;
       }
-      if (!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
-           ctx.slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+      if (!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
+        SLOG(g_log << Logger::Error << "TSIG key '" << ctx.tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
+           ctx.slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         ctx.outpacket->setRcode(RCode::NotAuth);
         sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
       }
-      if (B64Decode(tsig64, tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         ctx.outpacket->setRcode(RCode::ServFail);
         sendPacket(ctx.outpacket,ctx.outsock);
         return 0;
@@ -1456,8 +1495,8 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
     }
 
-    if(haveTSIGDetails && !tsigkeyname.empty()) {
-      ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+    if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+      ctx.outpacket->setTSIGDetails(ctx.trc, ctx.tsigkeyname, ctx.tsigsecret, ctx.trc.d_mac); // first answer is 'normal'
     }
 
     sendPacket(ctx.outpacket, ctx.outsock);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -730,6 +730,37 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   return doAXFRinternal(q, ctx);
 }
 
+bool TCPNameserver::axfrCheckTSIG(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, UeberBackend& db, bool alwaysCheck)
+{
+  ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
+
+  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
+    string tsig64;
+    DNSName algorithm=ctx.trc.d_algoName;
+    if (algorithm == g_hmacmd5dnsname_long) {
+      algorithm = g_hmacmd5dnsname;
+    }
+    if (algorithm != g_gsstsigdnsname || alwaysCheck) {
+      if(!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
+        SLOG(g_log << Logger::Error << "TSIG key '" << ctx.tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
+             ctx.slog->info(Logr::Error, ctx.xfrType + " refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::NotAuth);
+        sendPacket(ctx.outpacket,ctx.outsock);
+        return false;
+      }
+      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
+        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
+             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        ctx.outpacket->setRcode(RCode::ServFail);
+        sendPacket(ctx.outpacket,ctx.outsock);
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
 int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx)
 {
@@ -771,30 +802,8 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     }
   }
 
-  ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
-
-  if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
-    string tsig64;
-    DNSName algorithm=ctx.trc.d_algoName;
-    if (algorithm == g_hmacmd5dnsname_long) {
-      algorithm = g_hmacmd5dnsname;
-    }
-    if (algorithm != g_gsstsigdnsname) {
-      if(!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"TSIG key not found"<<endl,
-             ctx.slog->info(Logr::Warning, "AXFR: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        ctx.outpacket->setRcode(RCode::NotAuth);
-        sendPacket(ctx.outpacket,ctx.outsock);
-        return 0;
-      }
-      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Error, "AXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        ctx.outpacket->setRcode(RCode::ServFail);
-        sendPacket(ctx.outpacket,ctx.outsock);
-        return 0;
-      }
-    }
+  if (!axfrCheckTSIG(q, ctx, db, false)) {
+    return 0;
   }
 
   // SOA *must* go out first, our signing pipe might reorder
@@ -1460,28 +1469,8 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     UeberBackend db; // NOLINT(readability-identifier-length)
     DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
 
-    ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
-
-    if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
-      string tsig64;
-      DNSName algorithm=ctx.trc.d_algoName; // FIXME400: was toLowerCanonic, compare output
-      if (algorithm == g_hmacmd5dnsname_long) {
-        algorithm = g_hmacmd5dnsname;
-      }
-      if (!db.getTSIGKey(ctx.tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log << Logger::Error << "TSIG key '" << ctx.tsigkeyname << "' for domain '" << ctx.targetZone << "' not found" << endl,
-           ctx.slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        ctx.outpacket->setRcode(RCode::NotAuth);
-        sendPacket(ctx.outpacket,ctx.outsock);
-        return 0;
-      }
-      if (B64Decode(tsig64, ctx.tsigsecret) == -1) {
-        SLOG(g_log<<Logger::Error<<ctx.logPrefix<<"unable to Base-64 decode TSIG key '"<<ctx.tsigkeyname<<"'"<<endl,
-             ctx.slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(ctx.tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
-        ctx.outpacket->setRcode(RCode::ServFail);
-        sendPacket(ctx.outpacket,ctx.outsock);
-        return 0;
-      }
+    if (!axfrCheckTSIG(q, ctx, db, true)) {
+      return 0;
     }
 
     // SOA *must* go out first, our signing pipe might reorder

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -596,6 +596,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
     if (!packetHandler->checkForCorrectTSIG(*q, &ctx.tsigkeyname, &ctx.tsigsecret, &ctx.trc)) {
       return false;
     }
+    ctx.haveTSIGDetails = true;
     getTSIGHashEnum(ctx.trc.d_algoName, q->d_tsig_algo);
 #ifdef ENABLE_GSS_TSIG
     if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
@@ -727,13 +728,13 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     }
   }
 
-  return doAXFRinternal(q, ctx);
+  return doAXFRinternal(ctx);
 }
 
-bool TCPNameserver::axfrCheckTSIG(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, UeberBackend& db, bool alwaysCheck)
+bool TCPNameserver::axfrCheckTSIG(XFRContext& ctx, UeberBackend& db, bool alwaysCheck) // NOLINT(readability-identifier-length)
 {
-  ctx.haveTSIGDetails = q->getTSIGDetails(&ctx.trc, &ctx.tsigkeyname);
-
+  // TSIG-related fields in ctx have been computed as part of the
+  // checkForCorrectTSIG() call in canDoAXFR
   if(ctx.haveTSIGDetails && !ctx.tsigkeyname.empty()) {
     string tsig64;
     DNSName algorithm=ctx.trc.d_algoName;
@@ -762,7 +763,7 @@ bool TCPNameserver::axfrCheckTSIG(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx)
+int TCPNameserver::doAXFRinternal(XFRContext& ctx)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
@@ -802,7 +803,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     }
   }
 
-  if (!axfrCheckTSIG(q, ctx, db, false)) {
+  if (!axfrCheckTSIG(ctx, db, false)) {
     return 0;
   }
 
@@ -894,7 +895,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
   return 1;
 }
 
-void TCPNameserver::axfrKeys(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, DNSSECKeeper& dk)
+void TCPNameserver::axfrKeys(XFRContext& ctx, vector<DNSZoneRecord> &zrrs, DNSSECKeeper& dk) // NOLINT(readability-identifier-length)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
@@ -1469,7 +1470,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     UeberBackend db; // NOLINT(readability-identifier-length)
     DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
 
-    if (!axfrCheckTSIG(q, ctx, db, true)) {
+    if (!axfrCheckTSIG(ctx, db, true)) {
       return 0;
     }
 
@@ -1502,7 +1503,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   if (!g_slogStructured) {
     ctx.logPrefix.at(0) = 'A';
   }
-  return doAXFRinternal(q, ctx);
+  return doAXFRinternal(ctx);
 }
 
 TCPNameserver::~TCPNameserver() = default;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -511,6 +511,9 @@ public:
   XFRContext(std::unique_ptr<DNSPacket>& qry, int sock, Logr::log_t log, bool isAXFR);
   XFRContext(const XFRContext&) = delete;
   XFRContext& operator=(const XFRContext&) = delete;
+  XFRContext(XFRContext&&) = delete;
+  XFRContext& operator=(XFRContext&&) = delete;
+  ~XFRContext() = default;
 
   void setupOutputPacket();
   void sendIntermediatePacket(TSIGRecordContent &trc);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -63,8 +63,6 @@
 #include "noinitvector.hh"
 #include "gss_context.hh"
 #include "pdnsexception.hh"
-extern AuthPacketCache PC;
-extern StatBag S;
 
 /**
 \file tcpreceiver.cc
@@ -399,8 +397,8 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
       if(g_logDNSQueries)  {
         if (g_slogStructured) {
           slogger = slog->withValues("remote", Logging::Loggable(packet->getRemoteString()), "query", Logging::Loggable(packet->qdomain), "type", Logging::Loggable(packet->qtype), "dnssecok", Logging::Loggable(packet->d_dnssecOk), "bufsize", Logging::Loggable(packet->getMaxReplyLen()));
-	}
-	else {
+        }
+        else {
           g_log << Logger::Notice<<"TCP Remote "<< packet->getRemoteString() <<" wants '" << packet->qdomain<<"|"<<packet->qtype.toString() <<
                "', do = " <<packet->d_dnssecOk <<", bufsize = "<< packet->getMaxReplyLen();
         }
@@ -495,33 +493,25 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
     SLOG(g_log << Logger::Error << "Error closing TCP socket for client " << remote << ": " << e.reason << endl,
          slog->error(Logr::Error, e.reason, "Error closing TCP socket", "remote", Logging::Loggable(remote)));
   }
-  decrementClientCount(remote);
+ decrementClientCount(remote);
 }
 
 namespace {
   struct NSECXEntry
   {
     NSECBitmap d_set;
-    unsigned int d_ttl;
-    bool d_auth;
+    unsigned int d_ttl{0};
+    bool d_auth{false};
   };
-
-  static std::unique_ptr<DNSPacket> getFreshAXFRPacket(std::unique_ptr<DNSPacket>& q)
-  {
-    std::unique_ptr<DNSPacket> ret = std::unique_ptr<DNSPacket>(q->replyPacket());
-    ret->setCompress(false);
-    ret->d_dnssecOk=false; // RFC 5936, 2.2.5
-    ret->d_tcp = true;
-    return ret;
-  }
 }
 
-class XFRContext : public boost::noncopyable
+class TCPNameserver::XFRContext : public boost::noncopyable
 {
 public:
-  XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log, bool isIXFR);
+  XFRContext(std::unique_ptr<DNSPacket>& qry, int sock, Logr::log_t log, bool isAXFR);
   void setupOutputPacket();
 
+  // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
   const ZoneName& targetZone; // domain being XFR'ed
   DomainInfo info;
   SOAData soa;
@@ -541,13 +531,14 @@ public:
   std::string client;
   std::string logPrefix;
   Logr::log_t slog;
+  // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
 
 private:
   std::unique_ptr<DNSPacket>& query;
 };
 
-XFRContext::XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log, bool isAXFR) :
-  targetZone(q->qdomainzone), outsock(sock), slog(log), query(q)
+TCPNameserver::XFRContext::XFRContext(std::unique_ptr<DNSPacket>& qry, int sock, Logr::log_t log, bool isAXFR) :
+  targetZone(qry->qdomainzone), outsock(sock), slog(log), query(qry)
 {
   setupOutputPacket();
   if (query->d_dnssecOk) {
@@ -561,15 +552,19 @@ XFRContext::XFRContext(std::unique_ptr<DNSPacket>& q, int sock, Logr::log_t log,
   }
 }
 
-void XFRContext::setupOutputPacket()
+void TCPNameserver::XFRContext::setupOutputPacket()
 {
-  outpacket = getFreshAXFRPacket(query);
+  outpacket = std::unique_ptr<DNSPacket>(query->replyPacket());
+  outpacket->setCompress(false);
+  outpacket->d_dnssecOk=false; // RFC 5936, 2.2.5
+  outpacket->d_tcp = true;
 }
 
-bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler)
+bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler) // NOLINT(readability-identifier-length)
 {
-  if(::arg().mustDo("disable-axfr"))
+  if(::arg().mustDo("disable-axfr")) {
     return false;
+  }
 
   if(q->d_havetsig) { // if you have one, it must be good
     TSIGRecordContent tsigContent;
@@ -589,7 +584,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
     }
 #endif
 
-    DNSSECKeeper dk(ctx.slog, packetHandler->getBackend());
+    DNSSECKeeper dk(ctx.slog, packetHandler->getBackend()); // NOLINT(readability-identifier-length)
 #ifdef ENABLE_GSS_TSIG
     if (g_doGssTSIG && q->d_tsig_algo == TSIG_GSS) {
       vector<string> princs;
@@ -611,11 +606,9 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
            ctx.slog->info(Logr::Warning, ctx.xfrType + " denied: key and algorithm do not grant access", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
       return false;
     }
-    else {
-      SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
-           ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
-      return true;
-    }
+    SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: TSIG signed request with authorized key '"<<tsigkeyname<<"' and algorithm '"<<getTSIGAlgoName(q->d_tsig_algo)<<"'"<<endl,
+         ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: TSIG signed request", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(getTSIGAlgoName(q->d_tsig_algo))));
+    return true;
   }
 
   if(!(::arg()["allow-axfr-ips"].empty()) && d_ng.match( q->getInnerRemote() )) {
@@ -629,17 +622,17 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
   if(packetHandler->getBackend()->getSOAUncached(ctx.targetZone,ctx.soa)) {
     vector<string> acl;
     packetHandler->getBackend()->getDomainMetadata(ctx.targetZone, "ALLOW-AXFR-FROM", acl);
-    for (const auto & i : acl) {
-      if(pdns_iequals(i, "AUTO-NS")) {
-        DNSResourceRecord rr;
+    for (const auto & entry : acl) {
+      if(pdns_iequals(entry, "AUTO-NS")) {
+        DNSResourceRecord rr; // NOLINT(readability-identifier-length)
         set<DNSName> nsset;
 
         ctx.soa.db->lookup(QType(QType::NS), q->qdomain, ctx.soa.domain_id);
         while (ctx.soa.db->get(rr)) {
           nsset.insert(DNSName(rr.content));
         }
-        for(const auto & j: nsset) {
-          vector<string> nsips=fns.lookup(j, packetHandler->getBackend());
+        for(const auto & nameserver: nsset) {
+          vector<string> nsips=fns.lookup(nameserver, packetHandler->getBackend());
           for(const auto & nsip : nsips) {
             if(nsip == q->getInnerRemote().toString())
             {
@@ -652,7 +645,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
       }
       else
       {
-        Netmask nm = Netmask(i);
+        auto nm = Netmask(entry); // NOLINT(readability-identifier-length)
         if(nm.match( q->getInnerRemote() ))
         {
           SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in per-zone ACL"<<endl,
@@ -662,8 +655,6 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
       }
     }
   }
-
-  extern CommunicatorClass Communicator;
 
   if(Communicator.justNotified(ctx.targetZone, q->getInnerRemote().toString())) { // we just notified this ip
     SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is from recently notified secondary"<<endl,
@@ -718,12 +709,12 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 }
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx) // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
 {
   const DNSName& target = ctx.targetZone.operator const DNSName&();
 
   // find domain_id via SOA and list complete domain. No SOA, no AXFR
-  UeberBackend db;
+  UeberBackend db; // NOLINT(readability-identifier-length)
   if(!db.getSOAUncached(ctx.targetZone, ctx.soa)) {
     SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative in second instance"<<endl,
          ctx.slog->info(Logr::Warning, "AXFR failed: not authoritative in second instance", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
@@ -740,7 +731,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
 
   ctx.isCatalogZone = ctx.soa.db->getDomainInfo(ctx.targetZone, ctx.info, false) && ctx.info.isCatalogType();
 
-  DNSSECKeeper dk(ctx.slog, &db);
+  DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
   DNSSECKeeper::clearCaches(ctx.targetZone);
   if (!ctx.isCatalogZone) {
     ctx.securedZone = dk.isSecuredZone(ctx.targetZone);
@@ -800,14 +791,14 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
   }
 
-  if(haveTSIGDetails && !tsigkeyname.empty())
+  if(haveTSIGDetails && !tsigkeyname.empty()) {
     ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+  }
 
   sendPacket(ctx.outpacket, ctx.outsock, false);
 
   trc.d_mac = ctx.outpacket->d_trc.d_mac;
   ctx.setupOutputPacket();
-
 
   DNSZoneRecord zrr;
   vector<DNSZoneRecord> zrrs;
@@ -816,8 +807,10 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
   zrr.dr.d_ttl = ctx.soa.minimum;
 
   if(ctx.securedZone && !ctx.presignedZone) { // this is where the DNSKEYs, CDNSKEYs and CDSs go in
-    bool doCDNSKEY = true, doCDS = true;
-    string publishCDNSKEY, publishCDS;
+    bool doCDNSKEY{true};
+    bool doCDS{true};
+    string publishCDNSKEY;
+    string publishCDS;
     dk.getPublishCDNSKEY(q->qdomainzone, publishCDNSKEY);
     dk.getPublishCDS(q->qdomainzone, publishCDS);
 
@@ -889,56 +882,59 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
 
   /* now write all other records */
 
-  typedef map<DNSName, NSECXEntry, CanonDNSNameCompare> nsecxrepo_t;
+  using nsecxrepo_t = map<DNSName, NSECXEntry, CanonDNSNameCompare>;
   nsecxrepo_t nsecxrepo;
 
   ChunkedSigningPipe csp(ctx.slog, ctx.targetZone, (ctx.securedZone && !ctx.presignedZone), ::arg().asNum("signing-threads", 1), ::arg().mustDo("workaround-11804") ? 1 : 100);
 
   DNSName keyname;
-  unsigned int udiff;
-  DTime dt;
+  DTime dt; // NOLINT(readability-identifier-length)
   dt.set();
   for(DNSZoneRecord &loopZRR :  zrrs) {
     if(ctx.securedZone && (loopZRR.auth || loopZRR.dr.d_type == QType::NS)) {
-      if (ctx.NSEC3Zone || loopZRR.dr.d_type) {
+      if (ctx.NSEC3Zone || loopZRR.dr.d_type != QType::ENT) {
         if (ctx.presignedZone && ctx.NSEC3Zone && loopZRR.dr.d_type == QType::RRSIG && getRR<RRSIGRecordContent>(loopZRR.dr)->d_type == QType::NSEC3) {
           keyname = loopZRR.dr.d_name.makeRelative(ctx.soa.qname());
         } else {
           keyname = ctx.NSEC3Zone ? DNSName(toBase32Hex(hashQNameWithSalt(ctx.ns3pr, loopZRR.dr.d_name))) : loopZRR.dr.d_name;
         }
-        NSECXEntry& ne = nsecxrepo[keyname];
+        NSECXEntry& ne = nsecxrepo[keyname]; // NOLINT(readability-identifier-length)
         ne.d_ttl = ctx.soa.getNegativeTTL();
-        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (!ctx.ns3pr.d_flags)));
-        if (loopZRR.dr.d_type && loopZRR.dr.d_type != QType::RRSIG) {
+        ne.d_auth = (ne.d_auth || loopZRR.auth || (ctx.NSEC3Zone && (ctx.ns3pr.d_flags == 0)));
+        if (loopZRR.dr.d_type != QType::ENT && loopZRR.dr.d_type != QType::RRSIG) {
           ne.d_set.set(loopZRR.dr.d_type);
         }
       }
     }
 
-    if (!loopZRR.dr.d_type)
+    if (loopZRR.dr.d_type == QType::ENT) {
       continue; // skip empty non-terminals
+    }
 
-    if(loopZRR.dr.d_type == QType::SOA)
+    if(loopZRR.dr.d_type == QType::SOA) {
       continue; // skip SOA - would indicate end of AXFR
+    }
 
     if(csp.submit(loopZRR)) {
       for(;;) {
         ctx.outpacket->getRRS() = csp.getChunk();
         if(!ctx.outpacket->getRRS().empty()) {
-          if(haveTSIGDetails && !tsigkeyname.empty())
+          if(haveTSIGDetails && !tsigkeyname.empty()) {
             ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+          }
           sendPacket(ctx.outpacket, ctx.outsock, false);
           trc.d_mac=ctx.outpacket->d_trc.d_mac;
           ctx.setupOutputPacket();
         }
-        else
+        else {
           break;
+        }
       }
     }
   }
   if(ctx.securedZone) {
     if(ctx.NSEC3Zone) {
-      for(nsecxrepo_t::const_iterator iter = nsecxrepo.begin(); iter != nsecxrepo.end(); ++iter) {
+      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
         if(iter->second.d_auth) {
           NSEC3RecordContent n3rc;
           n3rc.set(iter->second.d_set);
@@ -950,15 +946,17 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
           n3rc.d_flags = ctx.ns3pr.d_flags;
           n3rc.d_iterations = ctx.ns3pr.d_iterations;
           n3rc.d_algorithm = DNSSECKeeper::DIGEST_SHA1; // SHA1, fixed in PowerDNS for now
-          nsecxrepo_t::const_iterator inext = iter;
+          auto inext = iter;
           ++inext;
-          if(inext == nsecxrepo.end())
-            inext = nsecxrepo.begin();
+          if(inext == nsecxrepo.cend()) {
+            inext = nsecxrepo.cbegin();
+          }
           while(!inext->second.d_auth && inext != iter)
           {
             ++inext;
-            if(inext == nsecxrepo.end())
-              inext = nsecxrepo.begin();
+            if(inext == nsecxrepo.cend()) {
+              inext = nsecxrepo.cbegin();
+            }
           }
           n3rc.d_nexthash = fromBase32Hex(inext->first.toStringNoDot());
           zrr.dr.d_name = iter->first+ctx.soa.qname();
@@ -972,48 +970,56 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
             for(;;) {
               ctx.outpacket->getRRS() = csp.getChunk();
               if(!ctx.outpacket->getRRS().empty()) {
-                if(haveTSIGDetails && !tsigkeyname.empty())
+                if(haveTSIGDetails && !tsigkeyname.empty()) {
                   ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+                }
                 sendPacket(ctx.outpacket, ctx.outsock, false);
                 trc.d_mac=ctx.outpacket->d_trc.d_mac;
                 ctx.setupOutputPacket();
               }
-              else
+              else {
                 break;
+              }
             }
           }
         }
       }
     }
-    else for(nsecxrepo_t::const_iterator iter = nsecxrepo.begin(); iter != nsecxrepo.end(); ++iter) {
-      NSECRecordContent nrc;
-      nrc.set(iter->second.d_set);
-      nrc.set(QType::RRSIG);
-      nrc.set(QType::NSEC);
+    else {
+      for(auto iter = nsecxrepo.cbegin(); iter != nsecxrepo.cend(); ++iter) {
+        NSECRecordContent nrc;
+        nrc.set(iter->second.d_set);
+        nrc.set(QType::RRSIG);
+        nrc.set(QType::NSEC);
 
-      if(boost::next(iter) != nsecxrepo.end())
-        nrc.d_next = boost::next(iter)->first;
-      else
-        nrc.d_next=nsecxrepo.begin()->first;
-      zrr.dr.d_name = iter->first;
+        if(boost::next(iter) != nsecxrepo.cend()) {
+          nrc.d_next = boost::next(iter)->first;
+        }
+        else {
+          nrc.d_next=nsecxrepo.cbegin()->first;
+        }
+        zrr.dr.d_name = iter->first;
 
-      zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
-      zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
-      zrr.dr.d_type = QType::NSEC;
-      zrr.dr.d_place = DNSResourceRecord::ANSWER;
-      zrr.auth=true;
-      if(csp.submit(zrr)) {
-        for(;;) {
-          ctx.outpacket->getRRS() = csp.getChunk();
-          if(!ctx.outpacket->getRRS().empty()) {
-            if(haveTSIGDetails && !tsigkeyname.empty())
-              ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-            sendPacket(ctx.outpacket, ctx.outsock, false);
-            trc.d_mac=ctx.outpacket->d_trc.d_mac;
-            ctx.setupOutputPacket();
+        zrr.dr.d_ttl = ctx.soa.getNegativeTTL();
+        zrr.dr.setContent(std::make_shared<NSECRecordContent>(std::move(nrc)));
+        zrr.dr.d_type = QType::NSEC;
+        zrr.dr.d_place = DNSResourceRecord::ANSWER;
+        zrr.auth=true;
+        if(csp.submit(zrr)) {
+          for(;;) {
+            ctx.outpacket->getRRS() = csp.getChunk();
+            if(!ctx.outpacket->getRRS().empty()) {
+              if(haveTSIGDetails && !tsigkeyname.empty()) {
+                ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+              }
+              sendPacket(ctx.outpacket, ctx.outsock, false);
+              trc.d_mac=ctx.outpacket->d_trc.d_mac;
+              ctx.setupOutputPacket();
+            }
+            else {
+              break;
+            }
           }
-          else
-            break;
         }
       }
     }
@@ -1021,8 +1027,9 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
   for(;;) {
     ctx.outpacket->getRRS() = csp.getChunk(true); // flush the pipe
     if(!ctx.outpacket->getRRS().empty()) {
-      if(haveTSIGDetails && !tsigkeyname.empty())
+      if(haveTSIGDetails && !tsigkeyname.empty()) {
         ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
+      }
       try {
         sendPacket(ctx.outpacket, ctx.outsock, false);
       }
@@ -1032,11 +1039,12 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
       trc.d_mac=ctx.outpacket->d_trc.d_mac;
       ctx.setupOutputPacket();
     }
-    else
+    else {
       break;
+    }
   }
 
-  udiff=dt.udiffNoReset();
+  unsigned int udiff=dt.udiffNoReset();
   if(ctx.securedZone) {
     SLOG(g_log<<Logger::Debug<<ctx.logPrefix<<"done signing: "<<csp.d_signed/(udiff/1000000.0)<<" sigs/s, "<<endl,
          ctx.slog->info(Logr::Debug, "AXFR: done signing", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "duration (microseconds)", Logging::Loggable(udiff), "signatures per second", Logging::Loggable(csp.d_signed/(udiff/1000000.0))));
@@ -1047,8 +1055,9 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
   /* and terminate with yet again the SOA record */
   ctx.setupOutputPacket();
   ctx.outpacket->addRecord(std::move(soa));
-  if(haveTSIGDetails && !tsigkeyname.empty())
+  if(haveTSIGDetails && !tsigkeyname.empty()) {
     ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
+  }
 
   sendPacket(ctx.outpacket, ctx.outsock);
 
@@ -1089,8 +1098,8 @@ bool TCPNameserver::axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrr
     sendPacket(ctx.outpacket, ctx.outsock);
     return false;
   }
-  for (const auto& ci : members) {
-    ci.toDNSZoneRecords(ctx.targetZone, zrrs);
+  for (const auto& catalog : members) {
+    catalog.toDNSZoneRecords(ctx.targetZone, zrrs);
   }
   if (members.empty()) {
     SLOG(g_log << Logger::Warning << ctx.logPrefix << "catalog zone '" << ctx.targetZone << "' has no members" << endl,
@@ -1114,7 +1123,8 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
   }
 
   const bool rectify = !(ctx.presignedZone || ::arg().mustDo("disable-axfr-rectify"));
-  set<DNSName> qnames, nsset;
+  set<DNSName> qnames;
+  set<DNSName> nsset;
 
   DNSZoneRecord zrr;
 
@@ -1126,9 +1136,8 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       if (zrr.dr.d_type == QType::DNSKEY || zrr.dr.d_type == QType::CDNSKEY || zrr.dr.d_type == QType::CDS) {
         if(!::arg().mustDo("direct-dnskey")) {
           continue;
-        } else {
-          zrr.dr.d_ttl = ctx.soa.minimum;
         }
+        zrr.dr.d_ttl = ctx.soa.minimum;
       }
     }
     zrr.dr.d_name.makeUsLowerCase();
@@ -1156,19 +1165,20 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
             return false;
           }
         }
-        for (auto& ip: ips) {
-          zrr.dr.d_type = ip.dr.d_type;
-          zrr.dr.setContent(ip.dr.getContent());
+        for (auto& dzr: ips) {
+          zrr.dr.d_type = dzr.dr.d_type;
+          zrr.dr.setContent(dzr.dr.getContent());
           zrrs.push_back(zrr);
         }
         continue;
       }
 
       if (rectify) {
-        if (zrr.dr.d_type) {
+        if (zrr.dr.d_type != QType::ENT) {
           qnames.insert(zrr.dr.d_name);
-          if(zrr.dr.d_type == QType::NS && zrr.dr.d_name!=target)
+          if(zrr.dr.d_type == QType::NS && zrr.dr.d_name!=target) {
             nsset.insert(zrr.dr.d_name);
+          }
         } else {
           // remove existing ents
           continue;
@@ -1176,9 +1186,10 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       }
       zrrs.push_back(zrr);
     } else {
-      if (zrr.dr.d_type != QType::ENT)
+      if (zrr.dr.d_type != QType::ENT) {
         SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone contains out-of-zone data '"<<zrr.dr.d_name<<"|"<<DNSRecordContent::NumberToType(zrr.dr.d_type)<<"', ignoring"<<endl,
              ctx.slog->info(Logr::Warning, "AXFR: ignoring out-of-zone data", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client), "record", Logging::Loggable(zrr.dr.d_name), "type", Logging::Loggable(zrr.dr.d_type)));
+      }
     }
   }
 
@@ -1198,12 +1209,12 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       if (newRRC->autoHint(SvcParam::ipv4hint)) {
         ctx.soa.db->lookup(QType::A, svcTarget, ctx.soa.domain_id);
         vector<ComboAddress> hints;
-        DNSZoneRecord rr;
+        DNSZoneRecord rr; // NOLINT(readability-identifier-length)
         while (ctx.soa.db->get(rr)) {
           auto arrc = getRR<ARecordContent>(rr.dr);
           hints.push_back(arrc->getCA());
         }
-        if (hints.size() == 0) {
+        if (hints.empty()) {
           newRRC->removeParam(SvcParam::ipv4hint);
         } else {
           newRRC->setHints(SvcParam::ipv4hint, hints);
@@ -1213,12 +1224,12 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       if (newRRC->autoHint(SvcParam::ipv6hint)) {
         ctx.soa.db->lookup(QType::AAAA, svcTarget, ctx.soa.domain_id);
         vector<ComboAddress> hints;
-        DNSZoneRecord rr;
+        DNSZoneRecord rr; // NOLINT(readability-identifier-length)
         while (ctx.soa.db->get(rr)) {
           auto arrc = getRR<AAAARecordContent>(rr.dr);
           hints.push_back(arrc->getCA());
         }
-        if (hints.size() == 0) {
+        if (hints.empty()) {
           newRRC->removeParam(SvcParam::ipv6hint);
         } else {
           newRRC->setHints(SvcParam::ipv6hint, hints);
@@ -1231,7 +1242,7 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
 
   // Group records by name and type, signpipe stumbles over interrupted rrsets
   if(ctx.securedZone && !ctx.presignedZone) {
-    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
+    sort(zrrs.begin(), zrrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) { // NOLINT(readability-identifier-length)
       return std::tie(a.dr.d_name, a.dr.d_type) < std::tie(b.dr.d_name, b.dr.d_type);
     });
   }
@@ -1243,9 +1254,10 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       if (loopZRR.dr.d_type != QType::NS || loopZRR.dr.d_name!=target) {
         DNSName shorter(loopZRR.dr.d_name);
         do {
-          if (shorter==target) // apex is always auth
+          if (shorter==target) { // apex is always auth
             break;
-          if(nsset.count(shorter) && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
+          }
+          if(nsset.count(shorter) != 0 && !(loopZRR.dr.d_name==shorter && loopZRR.dr.d_type == QType::DS)) {
             loopZRR.auth=false;
             break;
           }
@@ -1256,22 +1268,23 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
     if(ctx.NSEC3Zone) {
       // ents are only required for NSEC3 zones
       auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
-      set<DNSName> nsec3set, nonterm;
+      set<DNSName> nsec3set;
+      set<DNSName> nonterm;
       for (auto &loopZRR: zrrs) {
         bool skip=false;
         DNSName shorter = loopZRR.dr.d_name;
         if (shorter != target && shorter.chopOff() && shorter != target) {
           do {
-            if(nsset.count(shorter)) {
+            if(nsset.count(shorter) != 0) {
               skip=true;
               break;
             }
           } while(shorter.chopOff() && shorter != target);
         }
         shorter = loopZRR.dr.d_name;
-        if(!skip && (loopZRR.dr.d_type != QType::NS || !ctx.ns3pr.d_flags)) {
+        if(!skip && (loopZRR.dr.d_type != QType::NS || ctx.ns3pr.d_flags == 0)) {
           do {
-            if(!nsec3set.count(shorter)) {
+            if(nsec3set.count(shorter) == 0) {
               nsec3set.insert(shorter);
             }
           } while(shorter != target && shorter.chopOff());
@@ -1281,8 +1294,8 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
       for(DNSZoneRecord &loopZRR :  zrrs) {
         DNSName shorter(loopZRR.dr.d_name);
         while(shorter != target && shorter.chopOff()) {
-          if(!qnames.count(shorter) && !nonterm.count(shorter) && nsec3set.count(shorter)) {
-            if(!(maxent)) {
+          if(qnames.count(shorter) == 0 && nonterm.count(shorter) == 0 && nsec3set.count(shorter) != 0) {
+            if(maxent == 0) {
               SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"zone has too many empty non terminals, aborting AXFR"<<endl,
                    ctx.slog->info(Logr::Warning, "AXFR aborted, too many empty non-terminals in zone", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
               ctx.outpacket->setRcode(RCode::ServFail);
@@ -1295,7 +1308,7 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
         }
       }
 
-      for(const auto& nt :  nonterm) {
+      for(const auto& nt : nonterm) { // NOLINT(readability-identifier-length)
         DNSZoneRecord tempRR;
         tempRR.dr.d_name=nt;
         tempRR.dr.d_type=QType::ENT;
@@ -1308,7 +1321,7 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
   return true;
 }
 
-int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
+int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog) // NOLINT(readability-identifier-length)
 {
   XFRContext ctx(q, outsock, slog, false);
 
@@ -1352,7 +1365,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   // determine if zone exists, XFR is allowed, and if IXFR can proceed using existing backend before spawning a new backend.
   DLOG(SLOG(g_log<<ctx.logPrefix<<"Looking for SOA"<<endl,
             ctx.slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client))));
-  bool serialPermitsIXFR;
+  bool serialPermitsIXFR{false};
   {
     auto packetHandler = s_P.lock();
     if(!*packetHandler) {
@@ -1379,7 +1392,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       return 0;
     }
 
-    DNSSECKeeper dk(ctx.slog, (*packetHandler)->getBackend());
+    DNSSECKeeper dk(ctx.slog, (*packetHandler)->getBackend()); // NOLINT(readability-identifier-length)
     DNSSECKeeper::clearCaches(ctx.targetZone);
     bool narrow = false;
     ctx.securedZone = dk.isSecuredZone(ctx.targetZone);
@@ -1401,8 +1414,8 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     DNSName tsigkeyname;
     string tsigsecret;
 
-    UeberBackend db;
-    DNSSECKeeper dk(ctx.slog, &db);
+    UeberBackend db; // NOLINT(readability-identifier-length)
+    DNSSECKeeper dk(ctx.slog, &db); // NOLINT(readability-identifier-length)
 
     bool haveTSIGDetails = q->getTSIGDetails(&trc, &tsigkeyname);
 
@@ -1439,8 +1452,9 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       addRRSigs(dk, db, authSet, ctx.outpacket->getRRS());
     }
 
-    if(haveTSIGDetails && !tsigkeyname.empty())
+    if(haveTSIGDetails && !tsigkeyname.empty()) {
       ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
+    }
 
     sendPacket(ctx.outpacket, ctx.outsock);
 

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -657,11 +657,11 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
        slog->info(Logr::Warning, "AXFR transfer initiated", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
 
   // determine if zone exists and AXFR is allowed using existing backend before spawning a new backend.
+  DLOG(SLOG(g_log<<logPrefix<<"looking for SOA"<<endl,
+            slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
   SOAData sd;
   {
     auto packetHandler = s_P.lock();
-    DLOG(SLOG(g_log<<logPrefix<<"looking for SOA"<<endl,
-              slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));    // find domain_id via SOA and list complete domain. No SOA, no AXFR
     if(!*packetHandler) {
       SLOG(g_log<<Logger::Warning<<"TCP server is without backend connections in doAXFR, launching"<<endl,
            slog->info(Logr::Warning, "TCP server is without backend connections in doAXFR, launching", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
@@ -686,6 +686,7 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     }
   }
 
+  // find domain_id via SOA and list complete domain. No SOA, no AXFR
   UeberBackend db;
   if(!db.getSOAUncached(targetZone, sd)) {
     SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative in second instance"<<endl,
@@ -1258,15 +1259,17 @@ send:
 
 int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
 {
+  const ZoneName& targetZone = q->qdomainzone;
   string logPrefix;
 
   if (!g_slogStructured) {
-    logPrefix="IXFR-out zone '"+q->qdomainzone.toLogString()+"', client '"+q->getRemoteStringWithPort()+"', ";
+    logPrefix="IXFR-out zone '"+targetZone.toLogString()+"', client '"+q->getRemoteStringWithPort()+"', ";
   }
 
   std::unique_ptr<DNSPacket> outpacket=getFreshAXFRPacket(q);
-  if(q->d_dnssecOk)
+  if(q->d_dnssecOk) {
     outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
+  }
 
   uint32_t serial = 0;
   MOADNSParser mdp(false, q->getString());
@@ -1281,21 +1284,21 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
         }
         catch(const std::logic_error& exc) {
           SLOG(g_log<<Logger::Warning<<logPrefix<<"invalid serial in IXFR query"<<endl,
-               slog->error(Logr::Warning, exc.what(), "IXFR: invalid serial in query", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+               slog->error(Logr::Warning, exc.what(), "IXFR: invalid serial in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
           outpacket->setRcode(RCode::FormErr);
           sendPacket(outpacket,outsock);
           return 0;
         }
       } else {
         SLOG(g_log<<Logger::Warning<<logPrefix<<"no serial in IXFR query"<<endl,
-             slog->info(Logr::Warning, "IXFR: no serial in query", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+             slog->info(Logr::Warning, "IXFR: no serial in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
         outpacket->setRcode(RCode::FormErr);
         sendPacket(outpacket,outsock);
         return 0;
       }
     } else if (dnsRecord->d_type != QType::TSIG && dnsRecord->d_type != QType::OPT) {
       SLOG(g_log<<Logger::Warning<<logPrefix<<"additional records in IXFR query, type: "<<QType(dnsRecord->d_type).toString()<<endl,
-             slog->info(Logr::Warning, "IXFR: additional record in query", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "type", Logging::Loggable(dnsRecord->d_type)));
+             slog->info(Logr::Warning, "IXFR: additional record in query", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "type", Logging::Loggable(dnsRecord->d_type)));
       outpacket->setRcode(RCode::FormErr);
       sendPacket(outpacket,outsock);
       return 0;
@@ -1303,40 +1306,47 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   }
 
   SLOG(g_log<<Logger::Warning<<logPrefix<<"transfer initiated with serial "<<serial<<endl,
-       slog->info(Logr::Warning, "IXFR: transfer initiated", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "serial", Logging::Loggable(serial)));
+       slog->info(Logr::Warning, "IXFR: transfer initiated", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "serial", Logging::Loggable(serial)));
 
   // determine if zone exists, XFR is allowed, and if IXFR can proceed using existing backend before spawning a new backend.
+  DLOG(SLOG(g_log<<logPrefix<<"Looking for SOA"<<endl,
+            slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
   SOAData sd;
   bool securedZone;
   bool serialPermitsIXFR;
   {
     auto packetHandler = s_P.lock();
-    // find domain_id via SOA and list complete domain. No SOA, no IXFR
-    DLOG(SLOG(g_log<<logPrefix<<"Looking for SOA"<<endl,
-              slog->info(Logr::Warning, "IXFR: looking for SOA", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
     if(!*packetHandler) {
       SLOG(g_log<<Logger::Warning<<"TCP server is without backend connections in doIXFR, launching"<<endl,
-           slog->info(Logr::Warning, "IXFR: TCP server is without backend connections in doIXFR, launching", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+           slog->info(Logr::Warning, "IXFR: TCP server is without backend connections in doIXFR, launching", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
       *packetHandler = make_unique<PacketHandler>(slog);
     }
 
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
-    if(!canDoAXFR(q, false, *packetHandler, slog) || !(*packetHandler)->getBackend()->getSOAUncached(q->qdomainzone, sd)) {
+    if(!canDoAXFR(q, false, *packetHandler, slog)) {
+      SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: client may not request IXFR"<<endl,
+           slog->info(Logr::Warning, "IXFR failed: client may not request IXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+      outpacket->setRcode(RCode::NotAuth);
+      sendPacket(outpacket,outsock);
+      return 0;
+    }
+
+    if(!(*packetHandler)->getBackend()->getSOAUncached(targetZone, sd)) {
       SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative"<<endl,
-           slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+           slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
       outpacket->setRcode(RCode::NotAuth);
       sendPacket(outpacket,outsock);
       return 0;
     }
 
     DNSSECKeeper dk(slog, (*packetHandler)->getBackend());
-    DNSSECKeeper::clearCaches(q->qdomainzone);
+    DNSSECKeeper::clearCaches(targetZone);
     bool narrow = false;
-    securedZone = dk.isSecuredZone(q->qdomainzone);
-    if(dk.getNSEC3PARAM(q->qdomainzone, nullptr, &narrow)) {
+    securedZone = dk.isSecuredZone(targetZone);
+    if(dk.getNSEC3PARAM(targetZone, nullptr, &narrow)) {
       if(narrow) {
         SLOG(g_log<<Logger::Warning<<logPrefix<<"not doing IXFR of an NSEC3 narrow zone"<<endl,
-           slog->info(Logr::Warning, "IXFR refused: not doing IXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+           slog->info(Logr::Warning, "IXFR refused: not doing IXFR of an NSEC3 narrow zone", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
         outpacket->setRcode(RCode::Refused);
         sendPacket(outpacket,outsock);
         return 0;
@@ -1347,7 +1357,6 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   }
 
   if (serialPermitsIXFR) {
-    const ZoneName& target = q->qdomainzone;
     TSIGRecordContent trc;
     DNSName tsigkeyname;
     string tsigsecret;
@@ -1364,15 +1373,15 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
         algorithm = g_hmacmd5dnsname;
       }
       if (!db.getTSIGKey(tsigkeyname, algorithm, tsig64)) {
-        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << target << "' not found" << endl,
-           slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(target), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+        SLOG(g_log << Logger::Error << "TSIG key '" << tsigkeyname << "' for domain '" << targetZone << "' not found" << endl,
+           slog->info(Logr::Error, "IXFR refused: TSIG key not found", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         outpacket->setRcode(RCode::NotAuth);
         sendPacket(outpacket,outsock);
         return 0;
       }
       if (B64Decode(tsig64, tsigsecret) == -1) {
         SLOG(g_log<<Logger::Error<<logPrefix<<"unable to Base-64 decode TSIG key '"<<tsigkeyname<<"'"<<endl,
-             slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(target), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
+             slog->info(Logr::Error, "IXFR: Unable to Base-64 decode TSIG key", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()), "key", Logging::Loggable(tsigkeyname), "algorithm", Logging::Loggable(algorithm)));
         outpacket->setRcode(RCode::ServFail);
         sendPacket(outpacket,outsock);
         return 0;
@@ -1381,12 +1390,12 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 
     // SOA *must* go out first, our signing pipe might reorder
     DLOG(SLOG(g_log<<logPrefix<<"sending out SOA"<<endl,
-              slog->info(Logr::Debug, /*"I send an SOA to the world"*/"IXFR: sending out SOA", "zone", Logging::Loggable(target), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
+              slog->info(Logr::Debug, /*"I send an SOA to the world"*/"IXFR: sending out SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
     DNSZoneRecord soa = makeEditedDNSZRFromSOAData(dk, sd, DNSResourceRecord::ANSWER, slog);
     outpacket->addRecord(std::move(soa));
     if(securedZone && outpacket->d_dnssecOk) {
       set<ZoneName> authSet;
-      authSet.insert(target);
+      authSet.insert(targetZone);
       addRRSigs(dk, db, authSet, outpacket->getRRS());
     }
 
@@ -1396,13 +1405,13 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     sendPacket(outpacket, outsock);
 
     SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR finished"<<endl,
-         slog->info(Logr::Notice, "IXFR finished", "zone", Logging::Loggable(target), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+         slog->info(Logr::Notice, "IXFR finished", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
 
     return 1;
   }
 
   SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR fallback to AXFR"<<endl,
-       slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(q->qdomainzone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
+       slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
   return doAXFR(q, outsock, slog);
 }
 

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1030,6 +1030,7 @@ bool TCPNameserver::axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs
         if(!::arg().mustDo("direct-dnskey")) {
           continue;
         }
+	// Override TTL
         zrr.dr.d_ttl = ctx.soa.minimum;
       }
     }
@@ -1107,6 +1108,7 @@ bool TCPNameserver::axfrAlias(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, DNSZ
   }
   for (auto& dzr: ips) {
     zrr.dr.d_type = dzr.dr.d_type;
+    zrr.dr.d_ttl = dzr.dr.d_ttl;
     zrr.dr.setContent(dzr.dr.getContent());
     zrrs.push_back(zrr);
   }

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -505,16 +505,20 @@ namespace {
   };
 }
 
-class TCPNameserver::XFRContext : public boost::noncopyable
+class TCPNameserver::XFRContext
 {
 public:
   XFRContext(std::unique_ptr<DNSPacket>& qry, int sock, Logr::log_t log, bool isAXFR);
+  XFRContext(const XFRContext&) = delete;
+  XFRContext& operator=(const XFRContext&) = delete;
+
   void setupOutputPacket();
 
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
   const ZoneName& targetZone; // domain being XFR'ed
   DomainInfo info;
   SOAData soa;
+  bool soaValid{false};
 
   bool presignedZone{false};
   bool securedZone{false};
@@ -620,6 +624,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
   FindNS fns;
 
   if(packetHandler->getBackend()->getSOAUncached(ctx.targetZone,ctx.soa)) {
+    ctx.soaValid = true;
     vector<string> acl;
     packetHandler->getBackend()->getDomainMetadata(ctx.targetZone, "ALLOW-AXFR-FROM", acl);
     for (const auto & entry : acl) {
@@ -634,8 +639,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
         for(const auto & nameserver: nsset) {
           vector<string> nsips=fns.lookup(nameserver, packetHandler->getBackend());
           for(const auto & nsip : nsips) {
-            if(nsip == q->getInnerRemote().toString())
-            {
+            if(nsip == q->getInnerRemote().toString()) {
               SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in NSset"<<endl,
                    ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in NSset", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
               return true;
@@ -646,8 +650,7 @@ bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, st
       else
       {
         auto nm = Netmask(entry); // NOLINT(readability-identifier-length)
-        if(nm.match( q->getInnerRemote() ))
-        {
+        if(nm.match( q->getInnerRemote() )) {
           SLOG(g_log<<Logger::Notice<<ctx.logPrefix<<"allowed: client IP is in per-zone ACL"<<endl,
                ctx.slog->info(Logr::Notice, ctx.xfrType + " allowed: client IP is in per-zone ACL", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
           return true;
@@ -695,8 +698,8 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       return 0;
     }
 
-    // ctx.soa has been computed by canDoAXFR above
-    if (!(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
+    // ctx.soaValid has been computed by canDoAXFR above
+    if (!ctx.soaValid && !(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
       SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative"<<endl,
            ctx.slog->info(Logr::Warning, "AXFR failed: not authoritative", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
       ctx.outpacket->setRcode(RCode::NotAuth);
@@ -1383,8 +1386,8 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       return 0;
     }
 
-    // ctx.soa has been computed by canDoAXFR above
-    if(!(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
+    // ctx.soaValid has been computed by canDoAXFR above
+    if(!ctx.soaValid && !(*packetHandler)->getBackend()->getSOAUncached(ctx.targetZone, ctx.soa)) {
       SLOG(g_log<<Logger::Warning<<ctx.logPrefix<<"failed: not authoritative"<<endl,
            ctx.slog->info(Logr::Warning, "IXFR failed: not authoritative", "zone", Logging::Loggable(ctx.targetZone), "client", Logging::Loggable(ctx.client)));
       ctx.outpacket->setRcode(RCode::NotAuth);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -513,6 +513,7 @@ public:
   XFRContext& operator=(const XFRContext&) = delete;
 
   void setupOutputPacket();
+  void sendIntermediatePacket(TSIGRecordContent &trc);
 
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
   const ZoneName& targetZone; // domain being XFR'ed
@@ -562,6 +563,19 @@ void TCPNameserver::XFRContext::setupOutputPacket()
   outpacket->setCompress(false);
   outpacket->d_dnssecOk=false; // RFC 5936, 2.2.5
   outpacket->d_tcp = true;
+}
+
+void TCPNameserver::XFRContext::sendIntermediatePacket(TSIGRecordContent &trc)
+{
+  try {
+    sendPacket(outpacket, outsock, false);
+  }
+  catch (PDNSException& pe) {
+    throw PDNSException("during " + xfrType + "-out of " + targetZone.toLogString() + ", this happened: "+pe.reason);
+  }
+  trc.d_mac = outpacket->d_trc.d_mac;
+
+  setupOutputPacket();
 }
 
 bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler) // NOLINT(readability-identifier-length)
@@ -798,10 +812,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
     ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
   }
 
-  sendPacket(ctx.outpacket, ctx.outsock, false);
-
-  trc.d_mac = ctx.outpacket->d_trc.d_mac;
-  ctx.setupOutputPacket();
+  ctx.sendIntermediatePacket(trc);
 
   DNSZoneRecord zrr;
   vector<DNSZoneRecord> zrrs;
@@ -925,9 +936,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
           if(haveTSIGDetails && !tsigkeyname.empty()) {
             ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
           }
-          sendPacket(ctx.outpacket, ctx.outsock, false);
-          trc.d_mac=ctx.outpacket->d_trc.d_mac;
-          ctx.setupOutputPacket();
+          ctx.sendIntermediatePacket(trc);
         }
         else {
           break;
@@ -976,9 +985,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
                 if(haveTSIGDetails && !tsigkeyname.empty()) {
                   ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
                 }
-                sendPacket(ctx.outpacket, ctx.outsock, false);
-                trc.d_mac=ctx.outpacket->d_trc.d_mac;
-                ctx.setupOutputPacket();
+                ctx.sendIntermediatePacket(trc);
               }
               else {
                 break;
@@ -1015,9 +1022,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
               if(haveTSIGDetails && !tsigkeyname.empty()) {
                 ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
               }
-              sendPacket(ctx.outpacket, ctx.outsock, false);
-              trc.d_mac=ctx.outpacket->d_trc.d_mac;
-              ctx.setupOutputPacket();
+              ctx.sendIntermediatePacket(trc);
             }
             else {
               break;
@@ -1033,14 +1038,7 @@ int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, XFRContext& ctx
       if(haveTSIGDetails && !tsigkeyname.empty()) {
         ctx.outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
       }
-      try {
-        sendPacket(ctx.outpacket, ctx.outsock, false);
-      }
-      catch (PDNSException& pe) {
-        throw PDNSException("during axfr-out of "+target.toString()+", this happened: "+pe.reason);
-      }
-      trc.d_mac=ctx.outpacket->d_trc.d_mac;
-      ctx.setupOutputPacket();
+      ctx.sendIntermediatePacket(trc);
     }
     else {
       break;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -636,12 +636,10 @@ namespace {
 }
 
 
-/** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
 // NOLINTNEXTLINE(readability-identifier-length)
-int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)  // NOLINT(readability-function-cognitive-complexity)
+int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog)
 {
   const ZoneName& targetZone = q->qdomainzone;
-  const DNSName& target = targetZone.operator const DNSName&();
   string logPrefix;
 
   if (!g_slogStructured) {
@@ -659,7 +657,6 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
   // determine if zone exists and AXFR is allowed using existing backend before spawning a new backend.
   DLOG(SLOG(g_log<<logPrefix<<"looking for SOA"<<endl,
             slog->info(Logr::Debug, "AXFR: looking for SOA", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort()))));
-  SOAData sd;
   {
     auto packetHandler = s_P.lock();
     if(!*packetHandler) {
@@ -677,6 +674,7 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
       return 0;
     }
 
+    SOAData sd;
     if (!(*packetHandler)->getBackend()->getSOAUncached(targetZone, sd)) {
       SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative"<<endl,
            slog->info(Logr::Warning, "AXFR failed: not authoritative", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
@@ -686,8 +684,18 @@ int TCPNameserver::doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
     }
   }
 
+  return doAXFRinternal(q, outsock, slog, logPrefix, outpacket);
+}
+
+/** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
+int TCPNameserver::doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket)  // NOLINT(readability-function-cognitive-complexity)
+{
+  const ZoneName& targetZone = q->qdomainzone;
+  const DNSName& target = targetZone.operator const DNSName&();
+
   // find domain_id via SOA and list complete domain. No SOA, no AXFR
   UeberBackend db;
+  SOAData sd;
   if(!db.getSOAUncached(targetZone, sd)) {
     SLOG(g_log<<Logger::Warning<<logPrefix<<"failed: not authoritative in second instance"<<endl,
          slog->info(Logr::Warning, "AXFR failed: not authoritative in second instance", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
@@ -1412,7 +1420,11 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_
 
   SLOG(g_log<<Logger::Notice<<logPrefix<<"IXFR fallback to AXFR"<<endl,
        slog->info(Logr::Notice, "IXFR fallback to AXFR", "zone", Logging::Loggable(targetZone), "client", Logging::Loggable(q->getRemoteStringWithPort())));
-  return doAXFR(q, outsock, slog);
+  // Update log prefix as well
+  if (!g_slogStructured) {
+    logPrefix.at(0) = 'A';
+  }
+  return doAXFRinternal(q, outsock, slog, logPrefix, outpacket);
 }
 
 TCPNameserver::~TCPNameserver() = default;

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -54,6 +54,8 @@ private:
   static int doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket);
   static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
   static bool canDoAXFR(std::unique_ptr<DNSPacket>& q, bool isAXFR, std::unique_ptr<PacketHandler>& packetHandler, Logr::log_t slog);
+  static bool axfrProducerZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const DomainInfo& di, const SOAData& sd);
+  static bool axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const SOAData& sd, bool presignedZone, bool securedZone, bool NSEC3Zone, bool isCatalogZone, const NSEC3PARAMRecordContent& ns3pr);
   static void doConnection(int fd, Logr::log_t slog);
   static void decrementClientCount(const ComboAddress& remote);
   void thread();

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -58,6 +58,7 @@ private:
   static int doAXFRinternal(std::unique_ptr<DNSPacket>&q, XFRContext& ctx);
   static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
   static bool canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler);
+  static bool axfrCheckTSIG(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, UeberBackend& db, bool alwaysCheck);
   static bool axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord>& zrrs);
   static bool axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord>& zrrs);
   static bool axfrAlias(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, DNSZoneRecord& zrr);

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -39,6 +39,8 @@
 #include "lock.hh"
 #include "namespaces.hh"
 
+class ChunkedSigningPipe;
+
 class TCPNameserver
 {
 public:
@@ -51,13 +53,18 @@ private:
   class XFRContext;
 
   static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last=true);
-  static void getQuestion(int fd, char *mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);
+  static void getQuestion(int fd, char* mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);
   static int doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
   static int doAXFRinternal(std::unique_ptr<DNSPacket>&q, XFRContext& ctx);
   static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
   static bool canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler);
-  static bool axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs);
-  static bool axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs);
+  static bool axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord>& zrrs);
+  static bool axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord>& zrrs);
+  static bool axfrAlias(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, DNSZoneRecord& zrr);
+  static void axfrHints(XFRContext& ctx, vector<DNSZoneRecord>& zrrs);
+  static void axfrKeys(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, DNSSECKeeper& dk);
+  static bool axfrRectify(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, const set<DNSName>& qnames, const set<DNSName>& nsset);
+  static void axfrSubmitRecords(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, ChunkedSigningPipe& csp);
   static void doConnection(int fd, Logr::log_t slog);
   static void decrementClientCount(const ComboAddress& remote);
   void thread();

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -51,6 +51,7 @@ private:
   static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last=true);
   static void getQuestion(int fd, char *mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);
   static int doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
+  static int doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket);
   static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
   static bool canDoAXFR(std::unique_ptr<DNSPacket>& q, bool isAXFR, std::unique_ptr<PacketHandler>& packetHandler, Logr::log_t slog);
   static void doConnection(int fd, Logr::log_t slog);

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -39,8 +39,6 @@
 #include "lock.hh"
 #include "namespaces.hh"
 
-class XFRContext;
-
 class TCPNameserver
 {
 public:
@@ -49,6 +47,8 @@ public:
   void go();
   unsigned int numTCPConnections();
 private:
+
+  class XFRContext;
 
   static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last=true);
   static void getQuestion(int fd, char *mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -50,12 +50,13 @@ private:
 
   static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last=true);
   static void getQuestion(int fd, char *mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);
-  static int doAXFR(const ZoneName &target, std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
+  static int doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
   static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
   static bool canDoAXFR(std::unique_ptr<DNSPacket>& q, bool isAXFR, std::unique_ptr<PacketHandler>& packetHandler, Logr::log_t slog);
   static void doConnection(int fd, Logr::log_t slog);
   static void decrementClientCount(const ComboAddress& remote);
   void thread();
+
   static LockGuarded<std::map<ComboAddress,size_t,ComboAddress::addressOnlyLessThan>> s_clientsCount;
   static LockGuarded<std::unique_ptr<PacketHandler>> s_P;
   static std::unique_ptr<Semaphore> d_connectionroom_sem;

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -39,6 +39,8 @@
 #include "lock.hh"
 #include "namespaces.hh"
 
+class XFRContext;
+
 class TCPNameserver
 {
 public:
@@ -51,11 +53,11 @@ private:
   static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last=true);
   static void getQuestion(int fd, char *mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);
   static int doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
-  static int doAXFRinternal(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket);
+  static int doAXFRinternal(std::unique_ptr<DNSPacket>&q, XFRContext& ctx);
   static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
-  static bool canDoAXFR(std::unique_ptr<DNSPacket>& q, bool isAXFR, std::unique_ptr<PacketHandler>& packetHandler, Logr::log_t slog);
-  static bool axfrProducerZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const DomainInfo& di, const SOAData& sd);
-  static bool axfrRegularZone(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog, const std::string& logPrefix, std::unique_ptr<DNSPacket>& outpacket, vector<DNSZoneRecord> &zrrs, const SOAData& sd, bool presignedZone, bool securedZone, bool NSEC3Zone, bool isCatalogZone, const NSEC3PARAMRecordContent& ns3pr);
+  static bool canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler);
+  static bool axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs);
+  static bool axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord> &zrrs);
   static void doConnection(int fd, Logr::log_t slog);
   static void decrementClientCount(const ComboAddress& remote);
   void thread();

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -55,10 +55,10 @@ private:
   static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last=true);
   static void getQuestion(int fd, char* mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);
   static int doAXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
-  static int doAXFRinternal(std::unique_ptr<DNSPacket>&q, XFRContext& ctx);
+  static int doAXFRinternal(XFRContext& ctx);
   static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock, Logr::log_t slog);
   static bool canDoAXFR(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, std::unique_ptr<PacketHandler>& packetHandler);
-  static bool axfrCheckTSIG(std::unique_ptr<DNSPacket>& q, XFRContext& ctx, UeberBackend& db, bool alwaysCheck);
+  static bool axfrCheckTSIG(XFRContext& ctx, UeberBackend& db, bool alwaysCheck);
   static bool axfrProducerZone(XFRContext& ctx, vector<DNSZoneRecord>& zrrs);
   static bool axfrRegularZone(XFRContext& ctx, vector<DNSZoneRecord>& zrrs);
   static bool axfrAlias(XFRContext& ctx, vector<DNSZoneRecord>& zrrs, DNSZoneRecord& zrr);


### PR DESCRIPTION
### Short description
This PR attempts to slowly clean and unmessify the AXFR/IXFR code in `tcpreceiver.cc`.
Summary of the changes:
- `doAXFR` split into multiple functions (this needs to be carried further).
- thanks to the above, removal of `goto`.
- thanks to the above, when `doIXFR` falls back to performing an AXFR, do not perform redundant computations (is AXFR allowed? are we authoritative? etc).
- introduce a "working context" struct to carry relevant data around, rather than pass everything as function arguments (really needed with `doAXFR` being split).
- make use of said context to make `canDoAXFR` log in the same way `doAXFR` would, and to avoid querying the SOA record of a zone twice.
- random cleanups required by clang-tidy, including identifier name changes.

Probably best reviewed in a per-commit basis, Fibonacci style (take one aspirin before reading the first commit, two before the second, three before the third, five before the fourth, eight before the fifth, etc)

Currently marked as draft as more cleanup commits may land without notice.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] (lightly) tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code (could do better)
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] realized this PR is in violation of the "no-evil-PRs-on-fridays' act