### PR TITLE
dnsdist: Clarify that we will fall back to `dnsdist.conf`

### DIFF
--- a/pdns/dnsdistdist/docs/running.rst
+++ b/pdns/dnsdistdist/docs/running.rst
@@ -4,7 +4,7 @@ Running and Configuring dnsdist
 dnsdist is meant to run as a daemon.
 As such, distribution native packages know how to stop/start themselves using operating system services.
 
-It is configured with a configuration file called ``dnsdist.yml``
+It is configured with a configuration file called ``dnsdist.yml``. If that file does not exist, :program:`dnsdist` will attempt to fall back to a ``dnsdist.conf`` file, expecting a configuration in ``Lua`` instead of ``YAML``.
 The default path to this file is determined by the ``SYSCONFDIR`` variable during compilation.
 Most likely this path is ``/etc/dnsdist``,  ``/etc`` or ``/usr/local/etc/``, dnsdist will tell you on startup which file it reads.
 

--- a/pdns/dnsdistdist/docs/running.rst
+++ b/pdns/dnsdistdist/docs/running.rst
@@ -5,7 +5,7 @@ dnsdist is meant to run as a daemon.
 As such, distribution native packages know how to stop/start themselves using operating system services.
 
 It is configured with a configuration file called ``dnsdist.yml``. If that file does not exist, :program:`dnsdist` will attempt to fall back to a ``dnsdist.conf`` file, expecting a configuration in ``Lua`` instead of ``YAML``.
-The default path to this file is determined by the ``SYSCONFDIR`` variable during compilation.
+The default path to these files is determined by the ``SYSCONFDIR`` variable during compilation.
 Most likely this path is ``/etc/dnsdist``,  ``/etc`` or ``/usr/local/etc/``, dnsdist will tell you on startup which file it reads.
 
 dnsdist is designed to (re)start almost instantly.

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -41,7 +41,9 @@ support HTTP/2, but might be one in setups running dnsdist behind a reverse-prox
 
 Structured logging is now enabled by default, and can be disabled via :func:`setStructuredLogging` or the ``--structured-logging`` command-line switch.
 
-:program:`dnsdist` now looks by default for a configuration file named ``dnsdist.yml`` in the system configuration directory (determined by the ``SYSCONFDIR`` variable during compilation), instead of ``dnsdist.conf``. Please be aware that if a file named ``dnsdist.lua`` is present in the system configuration directory, it will also be loaded but without the ability to use configuration directives. Please see :doc:`the YAML settings reference <reference/yaml-settings>` for more information.
+:program:`dnsdist` now looks by default for a configuration file named ``dnsdist.yml`` in the system configuration directory (determined by the ``SYSCONFDIR`` variable during compilation), instead of ``dnsdist.conf``. If ``dnsdist.yml`` does not exist, it will automatically fall back to ``dnsdist.conf``. That means that if you are upgrading an existing setup using the ``Lua`` configuration format in a ``dnsdist.conf`` file, you should not have to edit your configuration as long as you don't have a ``dnsdist.yml`` file in the system configuration directory.
+
+Please be aware that after loading a ``dnsdist.yml`` file, :program:`dnsdist` which check whether a file named ``dnsdist.lua`` is present in the system configuration directory, and if so that file will also be loaded but without the ability to use configuration directives. Please see :doc:`the YAML settings reference <reference/yaml-settings>` for more information.
 
 The webserver no longer allows cross-origin HTTP requests by default, please have a look at ``webserver.allow_cross_origin_requests`` (:func:`setWebserverConfig`'s ``allowCrossOriginRequests`` for Lua-based configurations) if your setup requires them.
 

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -43,7 +43,7 @@ Structured logging is now enabled by default, and can be disabled via :func:`set
 
 :program:`dnsdist` now looks by default for a configuration file named ``dnsdist.yml`` in the system configuration directory (determined by the ``SYSCONFDIR`` variable during compilation), instead of ``dnsdist.conf``. If ``dnsdist.yml`` does not exist, it will automatically fall back to ``dnsdist.conf``. That means that if you are upgrading an existing setup using the ``Lua`` configuration format in a ``dnsdist.conf`` file, you should not have to edit your configuration as long as you don't have a ``dnsdist.yml`` file in the system configuration directory.
 
-Please be aware that after loading a ``dnsdist.yml`` file, :program:`dnsdist` which check whether a file named ``dnsdist.lua`` is present in the system configuration directory, and if so that file will also be loaded but without the ability to use configuration directives. Please see :doc:`the YAML settings reference <reference/yaml-settings>` for more information.
+Please be aware that after loading a ``dnsdist.yml`` file, :program:`dnsdist` will check whether a file named ``dnsdist.lua`` is present in the system configuration directory, and if so that file will also be loaded but without the ability to use configuration directives. Please see :doc:`the YAML settings reference <reference/yaml-settings>` for more information.
 
 The webserver no longer allows cross-origin HTTP requests by default, please have a look at ``webserver.allow_cross_origin_requests`` (:func:`setWebserverConfig`'s ``allowCrossOriginRequests`` for Lua-based configurations) if your setup requires them.
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If `dnsdist.yml` does not exist.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
