### PR TITLE
dnsdist: Use a longer timeout for DoT connections in the proxy tests

### DIFF
--- a/regression-tests.dnsdist/test_ProxyProtocol.py
+++ b/regression-tests.dnsdist/test_ProxyProtocol.py
@@ -1125,7 +1125,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
         receivedResponse = None
         conn = self.openTLSConnection(reverseProxyPort, self._serverName, self._caCert, timeout=2.0)
         self.sendTCPQueryOverConnection(conn, query, response=response)
-        receivedResponse = self.recvTCPResponseOverConnection(conn)
+        # longer timeout, this often fails on CI
+        receivedResponse = self.recvTCPResponseOverConnection(conn, timeout=4.0)
         (receivedProxyPayload, receivedDNSData) = fromProxyQueue.get(True, 2.0)
         self.assertTrue(receivedProxyPayload)
         self.assertTrue(receivedDNSData)
@@ -1215,7 +1216,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
         conn = self.openTLSConnection(reverseProxyPort, self._serverName, self._caCert, timeout=2.0)
 
         self.sendTCPQueryOverConnection(conn, query, response=response)
-        receivedResponse = self.recvTCPResponseOverConnection(conn)
+        # longer timeout, this often fails on CI
+        receivedResponse = self.recvTCPResponseOverConnection(conn, timeout=4.0)
         (receivedProxyPayload, receivedDNSData) = fromProxyQueue.get(True, 2.0)
         self.assertTrue(receivedProxyPayload)
         self.assertTrue(receivedDNSData)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
These tests regularly fail when the CI is overloaded, probably because establishing the TLS connection is taking a long time.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
