### PR TITLE
dnsdist: Always log which configuration file has been loaded

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -2674,14 +2674,14 @@ static bool loadConfigurationFromFile(const std::string& configurationFile, bool
     dnsdist::lua::setupLuaBindingsOnly(*(g_lua.lock()), isClient, configCheck);
 
     if (auto tentativeLuaConfFile = lookForTentativeConfigurationFileWithExtension(configurationFile, "lua")) {
-      VERBOSESLOG(infolog("Loading configuration from auto-discovered Lua file %s", *tentativeLuaConfFile),
-                  logger->info(Logr::Info, "Loading configuration from auto-discovered Lua file", "path", Logging::Loggable(*tentativeLuaConfFile)));
+      SLOG(infolog("Loading configuration from auto-discovered Lua file %s", *tentativeLuaConfFile),
+           logger->info(Logr::Info, "Loading configuration from auto-discovered Lua file", "path", Logging::Loggable(*tentativeLuaConfFile)));
 
       dnsdist::configuration::lua::loadLuaConfigurationFile(*(g_lua.lock()), *tentativeLuaConfFile, configCheck);
     }
 
-    VERBOSESLOG(infolog("Loading configuration from YAML file %s", configurationFile),
-                logger->info(Logr::Info, "Loading configuration from YAML file", "path", Logging::Loggable(configurationFile)));
+    SLOG(infolog("Loading configuration from YAML file %s", configurationFile),
+         logger->info(Logr::Info, "Loading configuration from YAML file", "path", Logging::Loggable(configurationFile)));
 
     if (!dnsdist::configuration::yaml::loadConfigurationFromFile(configurationFile, isClient, configCheck)) {
       return false;
@@ -2694,19 +2694,19 @@ static bool loadConfigurationFromFile(const std::string& configurationFile, bool
 
   dnsdist::lua::setupLua(*(g_lua.lock()), isClient, configCheck);
   if (boost::ends_with(configurationFile, ".lua")) {
-    VERBOSESLOG(infolog("Loading configuration from Lua file %s", configurationFile),
-                logger->info(Logr::Info, "Loading configuration from Lua file", "path", Logging::Loggable(configurationFile)));
+    SLOG(infolog("Loading configuration from Lua file %s", configurationFile),
+         logger->info(Logr::Info, "Loading configuration from Lua file", "path", Logging::Loggable(configurationFile)));
 
     dnsdist::configuration::lua::loadLuaConfigurationFile(*(g_lua.lock()), configurationFile, configCheck);
     if (auto tentativeYamlConfFile = lookForTentativeConfigurationFileWithExtension(configurationFile, "yml")) {
-      VERBOSESLOG(infolog("Loading configuration from auto-discovered YAML file %s", *tentativeYamlConfFile),
-                  logger->info(Logr::Info, "Loading configuration from auto-discovered YAML file", "path", Logging::Loggable(*tentativeYamlConfFile)));
+      SLOG(infolog("Loading configuration from auto-discovered YAML file %s", *tentativeYamlConfFile),
+           logger->info(Logr::Info, "Loading configuration from auto-discovered YAML file", "path", Logging::Loggable(*tentativeYamlConfFile)));
       return dnsdist::configuration::yaml::loadConfigurationFromFile(*tentativeYamlConfFile, isClient, configCheck);
     }
   }
   else {
-    VERBOSESLOG(infolog("Loading configuration from Lua file %s", configurationFile),
-                logger->info(Logr::Info, "Loading configuration from Lua file", "path", Logging::Loggable(configurationFile)));
+    SLOG(infolog("Loading configuration from Lua file %s", configurationFile),
+         logger->info(Logr::Info, "Loading configuration from Lua file", "path", Logging::Loggable(configurationFile)));
 
     dnsdist::configuration::lua::loadLuaConfigurationFile(*(g_lua.lock()), configurationFile, configCheck);
   }

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -227,6 +227,12 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         except subprocess.CalledProcessError as exc:
             raise AssertionError("dnsdist --check-config failed (%d): %s" % (exc.returncode, exc.output))
 
+        output_without_loading_lines = b""
+        for line in output.splitlines():
+            if not line.startswith(b"Loading configuration from ") and not line.startswith(b"msg=\"Loading configuration from "):
+                output_without_loading_lines += line + b"\n"
+        output = output_without_loading_lines
+
         if cls._checkConfigExpectedOutputPrefix is not None:
             if not output.startswith(cls._checkConfigExpectedOutputPrefix):
                 raise AssertionError(

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -117,6 +117,16 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     _consolePort = pickAvailablePort()
     _testServerPort = pickAvailablePort()
 
+    @staticmethod
+    def filterLoadedConfigurationFromLines(output):
+        output_without_loading_lines = b""
+        for line in output.splitlines():
+            print("got line:")
+            print(line)
+            if not b"Loading configuration from " in line:
+                output_without_loading_lines += line + b"\n"
+        return output_without_loading_lines
+
     @classmethod
     def waitForTCPSocket(cls, ipaddress, port):
         for try_number in range(0, 20):
@@ -225,15 +235,10 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         try:
             output = subprocess.check_output(testcmd, stderr=subprocess.STDOUT, close_fds=True)
         except subprocess.CalledProcessError as exc:
-            raise AssertionError("dnsdist --check-config failed (%d): %s" % (exc.returncode, exc.output))
+            output = cls.filterLoadedConfigurationFromLines(exc.output)
+            raise AssertionError("dnsdist --check-config failed (%d): %s" % (exc.returncode, output))
 
-        output_without_loading_lines = b""
-        for line in output.splitlines():
-            if not line.startswith(b"Loading configuration from ") and not line.startswith(
-                b'msg=\"Loading configuration from '
-            ):
-                output_without_loading_lines += line + b"\n"
-        output = output_without_loading_lines
+        output = cls.filterLoadedConfigurationFromLines(output)
 
         if cls._checkConfigExpectedOutputPrefix is not None:
             if not output.startswith(cls._checkConfigExpectedOutputPrefix):

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -230,7 +230,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         output_without_loading_lines = b""
         for line in output.splitlines():
             if not line.startswith(b"Loading configuration from ") and not line.startswith(
-                    b'msg=\"Loading configuration from '
+                b'msg=\"Loading configuration from '
             ):
                 output_without_loading_lines += line + b"\n"
         output = output_without_loading_lines

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -229,7 +229,9 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
         output_without_loading_lines = b""
         for line in output.splitlines():
-            if not line.startswith(b"Loading configuration from ") and not line.startswith(b"msg=\"Loading configuration from "):
+            if not line.startswith(b"Loading configuration from ") and not line.startswith(
+                    b'msg=\"Loading configuration from '
+            ):
                 output_without_loading_lines += line + b"\n"
         output = output_without_loading_lines
 

--- a/regression-tests.dnsdist/test_Console.py
+++ b/regression-tests.dnsdist/test_Console.py
@@ -278,4 +278,5 @@ class TestConsoleViaBuiltInClient(DNSDistTest):
         if process.returncode != 0:
             raise AssertionError("%s failed (%d): %s" % (testcmd, process.returncode, output))
 
-        self.assertTrue(output[0].startswith(b"dnsdist "))
+        consoleOutput = self.filterLoadedConfigurationFromLines(output[0])
+        self.assertTrue(consoleOutput.startswith(b"dnsdist "))

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -924,7 +924,8 @@ class DOHTests(object):
         if process.returncode != 0:
             raise AssertionError("%s failed (%d): %s" % (testcmd, process.returncode, output))
 
-        self.assertTrue(output[0].startswith(b"dnsdist "))
+        consoleOutput = self.filterLoadedConfigurationFromLines(output[0])
+        self.assertTrue(consoleOutput.startswith(b"dnsdist "))
 
 
 class TestDoHNGHTTP2(DOHTests, DNSDistDOHTest):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It was previously only logged in verbose mode.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
