### PR TITLE
rec: add handling of new protobuf logging parameter: stalledWriteTimeout

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -1015,7 +1015,7 @@ static void mainthread()
     stringtok(addrs, ::arg()["protobuf-servers"], ", ;");
 
     for (const string& addr : addrs) {
-      g_remote_loggers.emplace_back(make_unique<RemoteLogger>(ComboAddress(addr)));
+      g_remote_loggers.emplace_back(make_unique<RemoteLogger>(ComboAddress(addr), 2, 100000, 1, false, RemoteLogger::FrameSize::Two, 5));
     }
   }
 

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -135,7 +135,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
       return std::shared_ptr<RemoteLoggerInterface>(new RemoteLoggerPool(std::move(loggers)));
     }
 
-    return std::shared_ptr<RemoteLoggerInterface>(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client, RemoteLogger::FrameSize::Two));
+    return std::shared_ptr<RemoteLoggerInterface>(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client, RemoteLogger::FrameSize::Two, 5));
   });
 
   luaCtx.writeFunction("newFrameStreamUnixLogger", [client, configCheck]([[maybe_unused]] const std::string& address, [[maybe_unused]] std::optional<LuaAssociativeTable<unsigned int>> params) {

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -135,7 +135,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
       return std::shared_ptr<RemoteLoggerInterface>(new RemoteLoggerPool(std::move(loggers)));
     }
 
-    return std::shared_ptr<RemoteLoggerInterface>(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client, RemoteLogger::FrameSize::Two, 5));
+    return std::shared_ptr<RemoteLoggerInterface>(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? (*maxQueuedEntries * 100) : 10000, reconnectWaitTime ? *reconnectWaitTime : 1, client, RemoteLogger::FrameSize::Two, stalledWriteTimeout ? *stalledWriteTimeout : 5));
   });
 
   luaCtx.writeFunction("newFrameStreamUnixLogger", [client, configCheck]([[maybe_unused]] const std::string& address, [[maybe_unused]] std::optional<LuaAssociativeTable<unsigned int>> params) {

--- a/pdns/recursordist/docs/lua-config/protobuf.rst
+++ b/pdns/recursordist/docs/lua-config/protobuf.rst
@@ -59,6 +59,9 @@ Protobuf export to a server is enabled using the ``protobufServer()`` directive:
     - ``'FirstAvailable'`` send to first server that has room in its queue.
     - ``'Hashed'`` send to a single server, indexed by a hash of the qname and client address.
 
+
+  * ``stalledWriteTimeout=5``: int - If we have been unable to write or buffer data on our side of the TCP socket for that long, in seconds, consider that the remote endpoint has died and reconnect
+
 .. function:: setProtobufMasks(maskv4, maskV6)
 
   .. versionadded:: 4.2.0
@@ -100,6 +103,20 @@ While :func:`protobufServer` only exports the queries sent to the recursor from 
   .. versionchanged:: 5.1.0
 
      Added support for the HTTPS, SVCB and NAPTR records types.
+
+  .. versionadded:: 5.5.0
+
+  * ``frame4=false``: bool - Whether to use 4 byte ints as framing value. Default is to use 2 bytes, which limits the message size to 64k.
+  * ``strategy='All'``: string - The strategy to use, possible values are:
+
+    - ``'All'`` send to all servers.
+    - ``'RoundRobin'`` alternate between servers in a cyclic way.
+    - ``'FirstAvailable'`` send to first server that has room in its queue.
+    - ``'Hashed'`` send to a single server, indexed by a hash of the qname and client address.
+
+
+  * ``stalledWriteTimeout=5``: int - If we have been unable to write or buffer data on our side of the TCP socket for that long, in seconds, consider that the remote endpoint has died and reconnect
+
 
 Protocol Buffers Definition
 ---------------------------

--- a/pdns/recursordist/docs/lua-config/protobuf.rst
+++ b/pdns/recursordist/docs/lua-config/protobuf.rst
@@ -60,7 +60,7 @@ Protobuf export to a server is enabled using the ``protobufServer()`` directive:
     - ``'Hashed'`` send to a single server, indexed by a hash of the qname and client address.
 
 
-  * ``stalledWriteTimeout=5``: int - If we have been unable to write or buffer data on our side of the TCP socket for that long, in seconds, consider that the remote endpoint has died and reconnect
+  * ``stalledWriteTimeout=5``: int - If we have been unable to write or buffer data on our side of the TCP socket for that long, in seconds, consider that the remote endpoint has died and reconnect.
 
 .. function:: setProtobufMasks(maskv4, maskV6)
 
@@ -115,7 +115,7 @@ While :func:`protobufServer` only exports the queries sent to the recursor from 
     - ``'Hashed'`` send to a single server, indexed by a hash of the qname and client address.
 
 
-  * ``stalledWriteTimeout=5``: int - If we have been unable to write or buffer data on our side of the TCP socket for that long, in seconds, consider that the remote endpoint has died and reconnect
+  * ``stalledWriteTimeout=5``: int - If we have been unable to write or buffer data on our side of the TCP socket for that long, in seconds, consider that the remote endpoint has died and reconnect.
 
 
 Protocol Buffers Definition

--- a/pdns/recursordist/rec-lua-conf.cc
+++ b/pdns/recursordist/rec-lua-conf.cc
@@ -68,6 +68,7 @@ bool operator==(const ProtobufExportConfig& configA, const ProtobufExportConfig&
   return configA.exportTypes          == configB.exportTypes       &&
          configA.servers              == configB.servers           &&
          configA.maxQueuedEntries     == configB.maxQueuedEntries  &&
+         configA.stalledWriteTimeout  == configB.stalledWriteTimeout &&
          configA.timeout              == configB.timeout           &&
          configA.reconnectWaitTime    == configB.reconnectWaitTime &&
          configA.asyncConnect         == configB.asyncConnect      &&
@@ -249,6 +250,10 @@ static void parseProtobufOptions(const std::optional<protobufOptions_t>& vars, P
   if (have.count("strategy") != 0) {
     const auto& strategy = boost::get<string>(have.at("strategy"));
     config.strategy = ProtobufExportConfig::strategyFromString(strategy);
+  }
+
+  if (have.count("stalledWriteTimeout") != 0) {
+    config.stalledWriteTimeout = boost::get<uint64_t>(have.at("stalledWriteTimeout"));
   }
 
   if (have.count("exportTypes") != 0) {

--- a/pdns/recursordist/rec-lua-conf.hh
+++ b/pdns/recursordist/rec-lua-conf.hh
@@ -47,6 +47,7 @@ struct ProtobufExportConfig
   std::set<uint16_t> exportTypes = {QType::A, QType::AAAA, QType::CNAME};
   std::vector<ComboAddress> servers;
   uint64_t maxQueuedEntries{100};
+  uint64_t stalledWriteTimeout{5};
   uint16_t timeout{2};
   uint16_t reconnectWaitTime{1};
   Strategy strategy{Strategy::All};

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -416,7 +416,7 @@ static std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>> startProtobuf
 
   for (const auto& server : config.servers) {
     try {
-      auto logger = make_unique<RemoteLogger>(server, config.timeout, 100 * config.maxQueuedEntries, config.reconnectWaitTime, config.asyncConnect, config.frame4 ? RemoteLogger::FrameSize::Four : RemoteLogger::FrameSize::Two);
+      auto logger = make_unique<RemoteLogger>(server, config.timeout, 100 * config.maxQueuedEntries, config.reconnectWaitTime, config.asyncConnect, config.frame4 ? RemoteLogger::FrameSize::Four : RemoteLogger::FrameSize::Two, config.stalledWriteTimeout);
       logger->setLogQueries(config.logQueries);
       logger->setLogResponses(config.logResponses);
       result->emplace_back(std::move(logger));

--- a/pdns/recursordist/rec-rust-lib/cxxsupport.cc
+++ b/pdns/recursordist/rec-rust-lib/cxxsupport.cc
@@ -782,6 +782,7 @@ void fromLuaToRust(const ProtobufExportConfig& pbConfig, pdns::rust::settings::r
   pbServer.timeout = pbConfig.timeout;
   pbServer.maxQueuedEntries = pbConfig.maxQueuedEntries;
   pbServer.reconnectWaitTime = pbConfig.reconnectWaitTime;
+  pbServer.stalledWriteTimeout = pbConfig.stalledWriteTimeout;
   pbServer.taggedOnly = pbConfig.taggedOnly;
   pbServer.asyncConnect = pbConfig.asyncConnect;
   pbServer.logQueries = pbConfig.logQueries;
@@ -1142,6 +1143,7 @@ void fromRustToLuaConfig(const pdns::rust::settings::rec::ProtobufServer& pbServ
   exp.maxQueuedEntries = pbServer.maxQueuedEntries;
   exp.timeout = pbServer.timeout;
   exp.reconnectWaitTime = pbServer.reconnectWaitTime;
+  exp.stalledWriteTimeout = pbServer.stalledWriteTimeout;
   exp.asyncConnect = pbServer.asyncConnect;
   exp.logQueries = pbServer.logQueries;
   exp.logResponses = pbServer.logResponses;

--- a/pdns/recursordist/rec-rust-lib/docs-new-preamble-in.rst
+++ b/pdns/recursordist/rec-rust-lib/docs-new-preamble-in.rst
@@ -275,8 +275,11 @@ As of version 5.1.0, a protobuf server is defined as
     logMappedFrom: false
     frame4: false # since 5.5.0
     strategy: All # since 5.5.0
+    stalledWriteTimeout: 5 # since 5.5.0
 
 .. versionchanged:: 5.3.0 The aliases ``max_queued_entries``, ``reconnect_wait_time``, ``tagged_only``, ``async_connect``, ``log_queries``, ``log_responses``, ``export_types``, ``log_mapped_from`` have been introduced.
+
+.. versionchanged:: 5.5.0 The alias ``stalled_write_timeout`` has been introduced.
 
 An example of a ``protobuf_servers`` entry, which is a sequence of `ProtobufServer`_:
 

--- a/pdns/recursordist/rec-rust-lib/rust-bridge-in.rs
+++ b/pdns/recursordist/rec-rust-lib/rust-bridge-in.rs
@@ -76,6 +76,8 @@ pub struct ProtobufServer {
     frame4: bool,
     #[serde(default = "crate::def_pb_strategy", skip_serializing_if = "crate::def_value_equals_pb_strategy")]
     strategy: String,
+    #[serde(default = "crate::U64::<5>::value", skip_serializing_if = "crate::U64::<5>::is_equal", alias = "stalled_write_timeout")]
+    stalledWriteTimeout: u64,
 }
 
 // A dnstap logging server

--- a/pdns/recursordist/rec-rust-lib/rust/src/bridge.rs
+++ b/pdns/recursordist/rec-rust-lib/rust/src/bridge.rs
@@ -428,6 +428,7 @@ impl ProtobufServer {
         insertu(&mut map, "timeout", self.timeout);
         insertu(&mut map, "maxQueuedEntries", self.maxQueuedEntries);
         insertu(&mut map, "reconnectWaitTime", self.reconnectWaitTime);
+        insertu(&mut map, "stalledWriteTimeout", self.stalledWriteTimeout);
         insertb(&mut map, "taggedOnly", self.taggedOnly);
         insertb(&mut map, "asyncConnect", self.asyncConnect);
         insertb(&mut map, "logQueries", self.logQueries);

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -137,12 +137,12 @@ public:
   RemoteLogger& operator=(const RemoteLogger&) = delete;
   RemoteLogger& operator=(RemoteLogger&&) = delete;
   RemoteLogger(const ComboAddress& remote,
-               uint16_t timeout = 2,
-               uint64_t maxQueuedBytes = 100000,
-               uint8_t reconnectWaitTime = 1,
-               bool asyncConnect = false,
-               FrameSize frame = FrameSize::Two,
-               time_t stalledWriteTimeoutSeconds = 5);
+               uint16_t timeout, // typically 2
+               uint64_t maxQueuedBytes, // typically 100 * maxQueuedEntries
+               uint8_t reconnectWaitTime, // typically 1
+               bool asyncConnect, // typically false
+               FrameSize frame, // typically FrameSize::Two
+               time_t stalledWriteTimeoutSeconds); // typically 5
   ~RemoteLogger() override;
 
   std::string address() const override

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -78,7 +78,7 @@ for param in protobufServersParameters:
 
 class TestRecursorProtobuf(RecursorTest):
     _lua_config_file = """
-    protobufServer({"127.0.0.1:%d", "127.0.0.1:%d"})
+    protobufServer({"127.0.0.1:%d", "127.0.0.1:%d"}, { stalledWriteTimeout = 10 })
     """ % (protobufServersParameters[0].port, protobufServersParameters[1].port)
 
     def getFirstProtobufMessage(self, retries=100, waitTime=0.01):
@@ -381,6 +381,7 @@ recursor:
 logging:
   protobuf_servers:
     - servers: [127.0.0.1:%s, 127.0.0.1:%s]
+      stalledWriteTimeout: 10
   opentelemetry_trace_conditions:
     - acls: ['0.0.0.0/0']
 """ % (_confdir, protobufServersParameters[0].port, protobufServersParameters[1].port)


### PR DESCRIPTION
While there, remove default parameters of RemoteLogger ct, as it is called with all args (exceptions in dnsdist and auth fixed)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
