### PR TITLE
Allow NAPTR additional processing to be disabled

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1401,6 +1401,18 @@ Catalog group used to signal that a member zone is a catalog.
 Directory for modules. Default depends on ``PKGLIBDIR`` during
 compile-time.
 
+.. _setting-naptr-additional-processing:
+
+``naptr-additional-processing``
+-------------------------------
+
+-  Boolean
+-  Default: yes
+
+.. versionadded:: 5.2.0
+
+Add NAPTR `a` and `s` records to the additional answer section.
+
 .. _setting-negquery-cache-ttl:
 
 ``negquery-cache-ttl``

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -8,7 +8,15 @@ Please upgrade to the PowerDNS Authoritative Server 4.0.0 from 3.4.2+.
 See the `3.X <https://doc.powerdns.com/3/authoritative/upgrading/>`__
 upgrade notes if your version is older than 3.4.2.
 
-5.0.0 to 5.1.0
+5.1.x to master
+---------------
+
+NAPTR additional answers
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since version 5.0, the information of the `a` and `s` NAPTR records are added to the additional answers section. This behaviour can be disabled by setting :ref:`setting-naptr-additional-processing` to `no`.
+
+5.0.x to 5.1.x
 --------------
 
 Cross origin requests

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -345,6 +345,7 @@ static void declareArguments()
   ::arg().set("max-include-depth", "Maximum number of nested $INCLUDE directives while processing a zone file") = "20";
   ::arg().setSwitch("upgrade-unknown-types", "Transparently upgrade known TYPExxx records. Recommended to keep off, except for PowerDNS upgrades until data sources are cleaned up") = "no";
   ::arg().setSwitch("svc-autohints", "Transparently fill ipv6hint=auto ipv4hint=auto SVC params with AAAA/A records for the target name of the record (if within the same zone)") = "no";
+  ::arg().setSwitch("naptr-additional-processing", "Add NAPTR a and s records to the additional section") = "yes";
 
   ::arg().setSwitch("consistent-backends", "Assume individual zones are not divided over backends. Send only ANY lookup operations to the backend to reduce the number of lookups") = "yes";
 
@@ -848,6 +849,7 @@ static void mainthread()
   DNSPacket::s_udpTruncationThreshold = std::max(512, ::arg().asNum("udp-truncation-threshold"));
   DNSPacket::s_doEDNSSubnetProcessing = ::arg().mustDo("edns-subnet-processing");
   PacketHandler::s_SVCAutohints = ::arg().mustDo("svc-autohints");
+  PacketHandler::s_NAPTRprocessing = ::arg().mustDo("naptr-additional-processing");
 
   g_proxyProtocolACL.toMasks(::arg()["proxy-protocol-from"]);
   g_proxyProtocolMaximumSize = ::arg().asNum("proxy-protocol-maximum-size");

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -526,11 +526,9 @@ DNSName PacketHandler::doAdditionalServiceProcessing(const DNSName &firstTarget,
 }
 
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void PacketHandler::doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPacket>& r)
 {
   DNSName content;
-  DNSZoneRecord dzr;
   std::unordered_set<DNSName> lookup;
   vector<DNSZoneRecord> extraRecords;
   const auto& rrs = r->getRRS();
@@ -561,32 +559,9 @@ void PacketHandler::doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPack
           }
           break;
         }
-        case QType::NAPTR: {
-          auto naptrContent = getRR<NAPTRRecordContent>(rr.dr);
-          auto flags = naptrContent->getFlags();
-          toLowerInPlace(flags);
-          if (flags.find('a') != string::npos) {
-            content = naptrContent->getReplacement();
-            DLOG(SLOG(g_log<<Logger::Debug<<"adding NAPTR replacement 'a'="<<content<<endl,
-                      d_slog->info(Logr::Debug, "adding NAPTR replacement", "a", Logging::Loggable(content))));
-          }
-          else if (flags.find('s') != string::npos) {
-            content = naptrContent->getReplacement();
-            DLOG(SLOG(g_log<<Logger::Debug<<"adding NAPTR replacement 's'="<<content<<endl,
-                      d_slog->info(Logr::Debug, "adding NAPTR replacement", "s", Logging::Loggable(content))));
-            B.lookup(QType(QType::SRV), content, d_sd.domain_id, &p);
-            while(B.get(dzr)) {
-              content=getRR<SRVRecordContent>(dzr.dr)->d_target;
-              if(content.isPartOf(d_sd.qname())) {
-                lookup.emplace(content);
-              }
-              dzr.dr.d_place=DNSResourceRecord::ADDITIONAL;
-              extraRecords.emplace_back(std::move(dzr));
-            }
-            content.clear();
-          }
-          break;
-        }
+        case QType::NAPTR:
+          doAdditionalNAPTRProcessing(p, rr, lookup, extraRecords);
+          continue;
         default:
           continue;
       }
@@ -645,12 +620,45 @@ void PacketHandler::doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPack
   }
 
   for(const auto& name : lookup) {
+    DNSZoneRecord dzr;
     B.lookup(QType(QType::ANY), name, d_sd.domain_id, &p);
     while(B.get(dzr)) {
       if(dzr.dr.d_type == QType::A || dzr.dr.d_type == QType::AAAA) {
         dzr.dr.d_place=DNSResourceRecord::ADDITIONAL;
         r->addRecord(std::move(dzr));
       }
+    }
+  }
+}
+
+void PacketHandler::doAdditionalNAPTRProcessing(DNSPacket&p, const DNSZoneRecord& rr, std::unordered_set<DNSName>& lookup, vector<DNSZoneRecord>& extraRecords) // NOLINT(readability-identifier-length)
+{
+  DNSName content;
+  auto naptrContent = getRR<NAPTRRecordContent>(rr.dr);
+  auto flags = naptrContent->getFlags();
+  toLowerInPlace(flags);
+
+  if (flags.find('a') != string::npos) {
+    content = naptrContent->getReplacement();
+    DLOG(SLOG(g_log<<Logger::Debug<<"adding NAPTR replacement 'a'="<<content<<endl,
+              d_slog->info(Logr::Debug, "adding NAPTR replacement", "a", Logging::Loggable(content))));
+    if(content.isPartOf(d_sd.qname())) {
+      lookup.emplace(content);
+    }
+  }
+  else if (flags.find('s') != string::npos) {
+    content = naptrContent->getReplacement();
+    DLOG(SLOG(g_log<<Logger::Debug<<"adding NAPTR replacement 's'="<<content<<endl,
+              d_slog->info(Logr::Debug, "adding NAPTR replacement", "s", Logging::Loggable(content))));
+    DNSZoneRecord dzr;
+    B.lookup(QType(QType::SRV), content, d_sd.domain_id, &p);
+    while(B.get(dzr)) {
+      content=getRR<SRVRecordContent>(dzr.dr)->d_target;
+      if(content.isPartOf(d_sd.qname())) {
+        lookup.emplace(content);
+      }
+      dzr.dr.d_place=DNSResourceRecord::ADDITIONAL;
+      extraRecords.emplace_back(std::move(dzr));
     }
   }
 }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -60,6 +60,7 @@ AtomicCounter PacketHandler::s_count;
 NetmaskGroup PacketHandler::s_allowNotifyFrom;
 set<string> PacketHandler::s_forwardNotify;
 bool PacketHandler::s_SVCAutohints{false};
+bool PacketHandler::s_NAPTRprocessing{false};
 
 extern string g_programname;
 
@@ -560,7 +561,9 @@ void PacketHandler::doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPack
           break;
         }
         case QType::NAPTR:
-          doAdditionalNAPTRProcessing(p, rr, lookup, extraRecords);
+          if (s_NAPTRprocessing) {
+            doAdditionalNAPTRProcessing(p, rr, lookup, extraRecords);
+          }
           continue;
         default:
           continue;

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -83,6 +83,7 @@ private:
   bool addCDS(DNSPacket& p, std::unique_ptr<DNSPacket>& r);
   bool addNSEC3PARAM(const DNSPacket& p, std::unique_ptr<DNSPacket>& r);
   void doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPacket>& r);
+  void doAdditionalNAPTRProcessing(DNSPacket& p, const DNSZoneRecord& rr, std::unordered_set<DNSName>& lookup, vector<DNSZoneRecord>& extraRecords);
   DNSName doAdditionalServiceProcessing(const DNSName &firstTarget, const uint16_t &qtype, std::unique_ptr<DNSPacket>& r, vector<DNSZoneRecord>& extraRecords);
 
   //! Get all IPv4 or IPv6 addresses (based on |qtype|) for |target|.

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -67,6 +67,7 @@ public:
   static NetmaskGroup s_allowNotifyFrom;
   static set<string> s_forwardNotify;
   static bool s_SVCAutohints;
+  static bool s_NAPTRprocessing;
   static const std::shared_ptr<CDNSKEYRecordContent> s_deleteCDNSKEYContent;
   static const std::shared_ptr<CDSRecordContent> s_deleteCDSContent;
 


### PR DESCRIPTION
### Short description
As requested in #17362, this adds a global setting deciding whether `NAPTR` records will be processed to yield additional answers. The default is the 5.x behaviour (do this processing), setting it to `no` reverts to the pre-5.x behaviour (no such processing).

Fixes: #17362 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
