### PR TITLE
feat(auth): Add PKCS#11 configuration switch

### DIFF
--- a/docs/dnssec/pkcs11.rst
+++ b/docs/dnssec/pkcs11.rst
@@ -4,8 +4,10 @@ PKCS#11 support
 .. note::
   This is an experimental feature, use at your own risk!
 
-To enable it, compile PowerDNS Authoritative Server using ``--enable-experimental-pkcs11`` flag on configure.
+To enable it, compile PowerDNS Authoritative Server using ``--enable-experimental-pkcs11`` flag on configure or ``-Dexperimental-pkcs11=enabled`` when using Meson.
 This requires you to have the p11-kit libraries and headers.
+
+Since version 5.2.0, the :ref:`pkcs11 <setting-pkcs11>` setting should be set to ``yes`` to enable PKCS#11 at runtime.
 
 You can also log on to the tokens after starting the server, in this case you need to edit your PKCS#11 cryptokey record and remove PIN or set it empty.
 Do this after assigning/creating a key, as the PIN is required for assigning keys to zone.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1554,6 +1554,19 @@ itself in primary mode. In very complicated situations we could guess
 wrong and not notify a server that should be notified. In that case, set
 prevent-self-notification to "no".
 
+.. _setting-pkcs11:
+
+``pkcs11``
+----------
+
+.. versionadded:: 5.2.0
+
+- Boolean
+- Default: no
+
+When the PowerDNS Authoritative server is built with support for :doc:`PKCS#11 <dnssec/pkcs11>`,
+this switch enables the PKCS#11 engine.
+
 .. _setting-primary:
 
 ``primary``

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -16,6 +16,11 @@ NAPTR additional answers
 
 Since version 5.0, the information of the `a` and `s` NAPTR records are added to the additional answers section. This behaviour can be disabled by setting :ref:`setting-naptr-additional-processing` to `no`.
 
+PKCS#11 now requires setting an option
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When PowerDNS is built with :doc:`PKCS#11 support <dnssec/pkcs11>`, the PKCS#11 engine is disabled by the :ref:`setting-pkcs11` configuration setting by default. To use the PKCS#11 engine, this setting must be set to ``yes``.
+
 5.0.x to 5.1.x
 --------------
 

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -688,6 +688,7 @@ stubquery_LDADD = $(LIBCRYPTO_LIBS)
 stubquery_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
 
 saxfr_SOURCES = \
+	arguments.cc arguments.hh \
 	base32.cc \
 	base64.cc base64.hh \
 	dns_random.hh \
@@ -887,6 +888,7 @@ dnstcpbench_LDADD = \
 	$(BOOST_PROGRAM_OPTIONS_LIBS)
 
 nsec3dig_SOURCES = \
+	arguments.cc arguments.hh \
 	base32.cc \
 	base64.cc base64.hh \
 	dnslabeltext.cc \

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -359,6 +359,10 @@ static void declareArguments()
   ::arg().set("gss-max-contexts", "The maximum number of simultaneous GSS contexts allowed") = "1000";
 #endif
 
+#ifdef HAVE_P11KIT1
+  ::arg().set("pkcs11", "Enable the use of PKCS#11 providers") = "no";
+#endif
+
   ::arg().setSwitch("views", "Enable views (variants) of zones, for backends which support them") = "no";
 
   // explicitly declared outside of HAVE_LUA_RECORDS guard to prevent writes

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -44,6 +44,8 @@
 #include <boost/assign/list_inserter.hpp>
 #include "base64.hh"
 #include "namespaces.hh"
+#include "arguments.hh"
+#include "pdnsexception.hh"
 #ifdef HAVE_P11KIT1
 #include "pkcs11signers.hh"
 #endif
@@ -157,6 +159,9 @@ std::unique_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCString(Logr::
 
   if (stormap.count("engine")) {
 #ifdef HAVE_P11KIT1
+    if (!::arg().mustDo("pkcs11")) {
+      throw PDNSException("PKCS#11 key requested, but pkcs11 is not enabled in the configuration");
+    }
     if (stormap.count("slot") == 0) {
       throw PDNSException("Cannot load PKCS#11 key, no Slot specified");
     }

--- a/pdns/nsec3dig.cc
+++ b/pdns/nsec3dig.cc
@@ -22,6 +22,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "arguments.hh"
 #include "dnsparser.hh"
 #include "sstuff.hh"
 #include "misc.hh"
@@ -32,6 +33,12 @@
 #include "dnssecinfra.hh"
 
 bool g_slogStructured{false};
+
+ArgvMap &arg()
+{
+  static ArgvMap theArg;
+  return theArg;
+}
 
 StatBag S;
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -755,6 +755,10 @@ static void loadMainConfig(const std::string& configdir)
   ::arg().set("consistent-backends", "Assume individual zones are not divided over backends. Send only ANY lookup operations to the backend to reduce the number of lookups") = "yes";
   ::arg().set("soa-edit-spread", "Seconds to spread SOA-EDIT bumps over") = "0";
 
+#ifdef HAVE_P11KIT1
+  ::arg().set("pkcs11", "Enable the use of PKCS#11 providers") = "no";
+#endif
+
   // Keep this line below all ::arg().set() statements
   if (! ::arg().laxFile(configname)) {
     cerr<<"Warning: unable to read configuration file '"<<configname<<"': "<<stringerror()<<endl;

--- a/pdns/saxfr.cc
+++ b/pdns/saxfr.cc
@@ -1,6 +1,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "arguments.hh"
 #include "base64.hh"
 #include "dnsparser.hh"
 #include "sstuff.hh"
@@ -15,6 +16,12 @@
 #include "gss_context.hh"
 
 bool g_slogStructured{false};
+
+ArgvMap &arg()
+{
+  static ArgvMap theArg;
+  return theArg;
+}
 
 StatBag S;
 

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -21,6 +21,11 @@
 #endif
 
 bool g_slogStructured{false};
+ArgvMap &arg()
+{
+  static ArgvMap theArg;
+  return theArg;
+}
 
 #ifndef RECURSOR
 #include "statbag.hh"

--- a/regression-tests/backends/bind-master
+++ b/regression-tests/backends/bind-master
@@ -26,6 +26,7 @@ launch=bind
 bind-config=./named.conf
 bind-ignore-broken-records=yes
 logging-structured
+pkcs11=yes
 __EOF__
         if [ $context = bind-hybrid-nsec3 ]
         then


### PR DESCRIPTION
### Short description

As discussed in #17534, it would be safer in PKCS#11-enabled builds to
still have it disabled unless the operator explicitly enables the
feature.

Closes: #17534

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
