### PR TITLE
dnsdist: Log TraceID in structured logs (when available)

### DIFF
--- a/pdns/dnsdistdist/dnsdist-idstate.cc
+++ b/pdns/dnsdistdist/dnsdist-idstate.cc
@@ -163,5 +163,10 @@ std::shared_ptr<const Logr::Logger> InternalQueryState::getLogger(std::shared_pt
     parent = dnsdist::logging::getTopLogger("query-processing");
   }
   auto logger = parent->withValues("dns.question.name", Logging::Loggable(this->qname), "dns.question.type", Logging::Loggable(this->qtype), "dns.question.class", Logging::Loggable(this->qclass), "source.address", Logging::Loggable(this->origRemote), "destination.address", Logging::Loggable(this->origDest), "proto", Logging::Loggable(this->protocol), "dns.question.id", Logging::Loggable(ntohs(this->origID)), "dns.question.flags", Logging::Loggable(this->origFlags));
+#ifndef DISABLE_PROTOBUF
+  if (d_OTTracer != nullptr) {
+    logger = logger->withValues("traceID", Logging::Loggable{d_OTTracer->getTraceID().toLogString()});
+  }
+#endif
   return logger;
 }

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1550,6 +1550,7 @@ static void maintThread()
   size_t counter = 0;
   size_t otCounter = 0;
   int32_t secondsToWaitLog = 0;
+  auto sLogger = dnsdist::logging::getTopLogger("maintenance");
 
   for (;;) {
     std::this_thread::sleep_for(std::chrono::seconds(interval));
@@ -1563,7 +1564,7 @@ static void maintThread()
     auto maint_closer = pdns::trace::dnsdist::getCloserForInternalSpan(tracer, "maintenanceThread");
     auto lua = g_lua.lock();
 
-    pdns::trace::dnsdist::runWithLuaTracing(*lua, tracer, [&lua, &tracer, &secondsToWaitLog]() {
+    pdns::trace::dnsdist::runWithLuaTracing(*lua, tracer, [&lua, &tracer, &secondsToWaitLog, &sLogger]() {
       try {
         auto maintenanceCallback = lua->readVariable<std::optional<std::function<void()>>>("maintenance");
         if (maintenanceCallback) {
@@ -1584,8 +1585,14 @@ static void maintThread()
       }
       catch (const std::exception& e) {
         if (secondsToWaitLog <= 0) {
+          auto logger = sLogger;
+#ifndef DISABLE_PROTOBUF
+          if (tracer != nullptr) {
+            logger = logger->withValues("traceID", Logging::Loggable{tracer->getTraceID().toLogString()});
+          }
+#endif
           SLOG(warnlog("Error during execution of maintenance function(s): %s", e.what()),
-               dnsdist::logging::getTopLogger("maintenance")->error(Logr::Warning, e.what(), "Error during execution of maintenance function(s)"));
+               logger->error(Logr::Warning, e.what(), "Error during execution of maintenance function(s)"));
           secondsToWaitLog = 61;
         }
         secondsToWaitLog -= interval;


### PR DESCRIPTION
### Short description

- **feat(dnsdist): Log TraceID in structured logs**
- **feat(dnsdist): Log TraceID in maintenance logs**


### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
