### PR TITLE
docs(dnsdist): remove quoted lists

### DIFF
--- a/pdns/dnsdistdist/docs/advanced/ebpf.rst
+++ b/pdns/dnsdistdist/docs/advanced/ebpf.rst
@@ -128,8 +128,8 @@ For example, to instruct dnsdist to create under the ``/sys/fs/bpf`` mount point
 
 The last parameter to :func:`newBPFFilter` is set to ``true`` to indicate to dnsdist not to load its internal eBPF socket filter program, which is not needed since packets will be intercepted by an external program and would at best duplicate the work done by the other program. It also tell dnsdist to use a slightly different format for the eBPF maps:
 
- * IPv4 and IPv6 maps still use the address as key, but the value contains an action field in addition to the 'matched' counter, to allow for more actions than just dropping the packet
- * the qname map now uses the qname and qtype as key, instead of using only the qname, and the value contains the action and counter fields described above instead of having a counter and the qtype
+* IPv4 and IPv6 maps still use the address as key, but the value contains an action field in addition to the 'matched' counter, to allow for more actions than just dropping the packet
+* the qname map now uses the qname and qtype as key, instead of using only the qname, and the value contains the action and counter fields described above instead of having a counter and the qtype
 
 The first, legacy format is still used because of the limitations of eBPF socket filter programs on older kernels, and the number of instructions in particular, that prevented us from using the qname and qtype as key. We will likely switch to the newer format by default once Linux distributions stop shipping these older kernels. XDP programs require newer kernel versions anyway and have thus fewer limitations.
 

--- a/pdns/dnsdistdist/docs/advanced/multiple-instance.rst
+++ b/pdns/dnsdistdist/docs/advanced/multiple-instance.rst
@@ -4,8 +4,8 @@ Running multiple instances
 Sometimes, it can be advantageous to run multiple instances of :program:`dnsdist`.
 Usecases can be:
 
- * Multiple inbound IP addresses with different rulesets
- * Taking advantage of more processes, using SO_REUSEPORT
+* Multiple inbound IP addresses with different rulesets
+* Taking advantage of more processes, using SO_REUSEPORT
 
 :program:`dnsdist` supports loading a different configuration file with the ``--config`` command line switch.
 

--- a/pdns/dnsdistdist/docs/advanced/passing-source-address.rst
+++ b/pdns/dnsdistdist/docs/advanced/passing-source-address.rst
@@ -16,9 +16,9 @@ When the backend supports it (ISC Bind, Knot, Knot Resolver, PowerDNS Authoritat
 Proxy Protocol
 --------------
 
-.. note:
+.. note::
   The Proxy Protocol has been designed by the HAProxy folks for HTTP over TCP, but is generic enough to be used in other places, and is a de-facto standard with implementations in ISC Bind, Knot, Knot Resolver, PowerDNS Authoritative, PowerDNS Recursor, Unbound, HAProxy, nginx, postfix and many others.
-  It works by pre-pending a small header at the very beginning of a UDP datagram or TCP connection, which holds the initial source and destination addresses and ports, and can also contain several custom values in a Type-Length-Value format. More information about the Proxy Protocol can be found at https://www.haproxy.org/download/2.2/doc/proxy-protocol.txt
+  It works by pre-pending a small header at the very beginning of a UDP datagram or TCP connection, which holds the initial source and destination addresses and ports, and can also contain several custom values in a Type-Length-Value format. More information about the Proxy Protocol can be found at https://www.haproxy.org/download/2.2/doc/proxy-protocol.txt.
 
 From dnsdist to its backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,9 +95,9 @@ Advanced usage
 
 In addition to the global settings, rules and Lua bindings can alter this behavior per query:
 
- * calling :func:`SetDisableECSAction` or setting ``dq.useECS`` to ``false`` prevents the sending of the ECS option.
- * calling :func:`SetECSOverrideAction` or setting ``dq.ecsOverride`` will override the global :func:`setECSOverride` value.
- * calling :func:`SetECSPrefixLengthAction(v4, v6)` or setting ``dq.ecsPrefixLength`` will override the global :func:`setECSSourcePrefixV4()` and :func:`setECSSourcePrefixV6()` values.
+* calling :func:`SetDisableECSAction` or setting ``dq.useECS`` to ``false`` prevents the sending of the ECS option.
+* calling :func:`SetECSOverrideAction` or setting ``dq.ecsOverride`` will override the global :func:`setECSOverride` value.
+* calling :func:`SetECSPrefixLengthAction(v4, v6)` or setting ``dq.ecsPrefixLength`` will override the global :func:`setECSSourcePrefixV4()` and :func:`setECSSourcePrefixV6()` values.
 
 In effect this means that for the EDNS Client Subnet option to be added to the request, ``useClientSubnet`` should be set to ``true`` for the backend used (default to ``false``) and ECS should not have been disabled by calling :func:`SetDisableECSAction` or setting ``dq.useECS`` to ``false`` (default to true).
 

--- a/pdns/dnsdistdist/docs/advanced/snmp.rst
+++ b/pdns/dnsdistdist/docs/advanced/snmp.rst
@@ -7,8 +7,8 @@ SNMP support is enabled via the :func:`snmpAgent` directive.
 By default, the only traps sent when Traps are enabled, are backend status change notifications.
 But custom traps can also be sent:
 
- * from Lua, with :func:`sendCustomTrap` and :meth:`DNSQuestion.sendTrap`
- * For selected queries and responses, using :func:`SNMPTrapAction` and :func:`SNMPTrapResponseAction`
+* from Lua, with :func:`sendCustomTrap` and :meth:`DNSQuestion.sendTrap`
+* For selected queries and responses, using :func:`SNMPTrapAction` and :func:`SNMPTrapResponseAction`
 
 ``Net SNMP snmpd`` doesn't accept subagent connections by default, so to use the SNMP features of :program:`dnsdist` the following line should be added to the ``snmpd.conf`` configuration file::
 

--- a/pdns/dnsdistdist/docs/advanced/tls-sessions-management.rst
+++ b/pdns/dnsdistdist/docs/advanced/tls-sessions-management.rst
@@ -92,6 +92,6 @@ Sessions management for outgoing connections
 Since 1.7, dnsdist supports securing the connection toward backends using DNS over TLS. For these connections, it keeps a cache of TLS tickets to be able to resume a TLS session quickly. By default that cache contains up to 20 TLS tickets per-backend, is cleaned up every 60s, and TLS tickets expire if they have not been used after 600 seconds.
 These values can be set at configuration time via:
 
- * :func:`setOutgoingTLSSessionsCacheMaxTicketsPerBackend`
- * :func:`setOutgoingTLSSessionsCacheCleanupDelay`
- * :func:`setOutgoingTLSSessionsCacheMaxTicketValidity`
+* :func:`setOutgoingTLSSessionsCacheMaxTicketsPerBackend`
+* :func:`setOutgoingTLSSessionsCacheCleanupDelay`
+* :func:`setOutgoingTLSSessionsCacheMaxTicketValidity`

--- a/pdns/dnsdistdist/docs/advanced/tuning.rst
+++ b/pdns/dnsdistdist/docs/advanced/tuning.rst
@@ -3,15 +3,15 @@ Performance Tuning
 
 First, a few words about :program:`dnsdist` architecture:
 
- * Each local bind has its own thread listening for incoming UDP queries
- * and its own thread listening for incoming TCP connections, dispatching them right away to a pool of TCP worker threads
- * Each backend has its own thread listening for UDP responses, including the ones triggered by DoH queries, if any
- * A maintenance thread calls the maintenance() Lua function every second if any, and is responsible for cleaning the cache
- * A health check thread checks the backends availability
- * A control thread handles console connections, plus one thread per connection
- * A carbon thread exports statistics to carbon servers if needed
- * One or more webserver threads handle queries to the internal webserver, plus one thread per HTTP connection
- * A SNMP thread handles SNMP operations, when enabled.
+* Each local bind has its own thread listening for incoming UDP queries
+* and its own thread listening for incoming TCP connections, dispatching them right away to a pool of TCP worker threads
+* Each backend has its own thread listening for UDP responses, including the ones triggered by DoH queries, if any
+* A maintenance thread calls the maintenance() Lua function every second if any, and is responsible for cleaning the cache
+* A health check thread checks the backends availability
+* A control thread handles console connections, plus one thread per connection
+* A carbon thread exports statistics to carbon servers if needed
+* One or more webserver threads handle queries to the internal webserver, plus one thread per HTTP connection
+* A SNMP thread handles SNMP operations, when enabled.
 
 UDP and incoming DNS over HTTPS
 -------------------------------
@@ -65,10 +65,10 @@ For DNS over HTTPS, every :func:`addDOHLocal`/:func:`addDOH3Local` directive add
 
 When dealing with a large traffic load, it might happen that the internal pipe used to pass queries between the threads handling the incoming connections and the one getting a response from the backend become full too quickly, degrading performance and causing timeouts. This can be prevented by increasing the size of the internal pipe buffer, via the `internalPipeBufferSize` option of :func:`addDOHLocal`. Setting a value of `1048576` is known to yield good results on Linux.
 
-`AF_XDP` / `XSK`
-----------------
+``AF_XDP`` / ``XSK``
+--------------------
 
-On recent versions of Linux (`>= 4.18`), DNSDist supports receiving UDP datagrams directly from the kernel, bypassing the usual network stack, via `AF_XDP`/`XSK`. This yields much better performance but comes with some limitations. Please see :doc:`xsk` for more information.
+On recent versions of Linux (``>= 4.18``), DNSDist supports receiving UDP datagrams directly from the kernel, bypassing the usual network stack, via ``AF_XDP``/``XSK``. This yields much better performance but comes with some limitations. Please see :doc:`xsk` for more information.
 
 UDP buffer sizes
 ----------------
@@ -118,8 +118,8 @@ Incoming DNS over TLS (since 1.8.0) and incoming DNS over HTTPS (since 1.9.0) mi
 
 Incoming and outgoing DNS over TLS, outgoing DNS over HTTPS, as well as incoming DNS over HTTPS with the ``nghttp2`` library (since 1.9.0), might benefit from experimental support kernel-accelerated TLS on Linux, when supported by the kernel and OpenSSL. See the `ktls` options on :func:`addTLSLocal`, :func:`addDOHLocal` and :func:`newServer` for more information. Kernel support for kTLS might be verified by looking at the counters in ``/proc/net/tls_stat``. Note that:
 
- * supported ciphers depend on the exact kernel version used. ``TLS_AES_128_GCM_SHA256`` might be a good option for testing purpose since it was supported pretty early
- * as of OpenSSL 3.0.7, kTLS can only be used for sending TLS 1.3 packets, not receiving them. Both sending and receiving packets should be working for TLS 1.2.
+* supported ciphers depend on the exact kernel version used. ``TLS_AES_128_GCM_SHA256`` might be a good option for testing purpose since it was supported pretty early
+* as of OpenSSL 3.0.7, kTLS can only be used for sending TLS 1.3 packets, not receiving them. Both sending and receiving packets should be working for TLS 1.2.
 
 TLS performance
 ---------------
@@ -140,8 +140,8 @@ Rules and Lua
 
 Most of the query processing is done in C++ for maximum performance, but some operations are executed in Lua for maximum flexibility:
 
- * Rules added by :func:`LuaAction`, :func:`LuaResponseAction`, :func:`LuaFFIAction` or :func:`LuaFFIResponseAction`
- * Server selection policies defined via :func:`setServerPolicyLua`, :func:`setServerPolicyLuaFFI`, :func:`setServerPolicyLuaFFIPerThread` or :func:`newServerPolicy`
+* Rules added by :func:`LuaAction`, :func:`LuaResponseAction`, :func:`LuaFFIAction` or :func:`LuaFFIResponseAction`
+* Server selection policies defined via :func:`setServerPolicyLua`, :func:`setServerPolicyLuaFFI`, :func:`setServerPolicyLuaFFIPerThread` or :func:`newServerPolicy`
 
 While Lua is fast, its use should be restricted to the strict necessary in order to achieve maximum performance, it might be worth considering using LuaJIT instead of Lua.
 When Lua inspection is needed, the best course of action is to restrict the queries sent to Lua inspection by using :func:`addLuaAction` with a selector.
@@ -181,12 +181,12 @@ Memory usage
 
 The main sources of memory usage in DNSDist are:
 
- * packet caches, when enabled
- * the number of outstanding UDP queries per backend, configured with :func:`setMaxUDPOutstanding` (see above)
- * the number of entries in the ring-buffers, configured with :func:`setRingBuffersSize`
- * the number of short-lived dynamic block entries
- * the number of user-defined rules and actions
- * the number of TCP, DoT and DoH connections
+* packet caches, when enabled
+* the number of outstanding UDP queries per backend, configured with :func:`setMaxUDPOutstanding` (see above)
+* the number of entries in the ring-buffers, configured with :func:`setRingBuffersSize`
+* the number of short-lived dynamic block entries
+* the number of user-defined rules and actions
+* the number of TCP, DoT and DoH connections
 
 Memory usage per connection for connected protocols:
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1364,11 +1364,11 @@ Status, Statistics and More
   * ``levelPrefix=prefix``: string - Set the prefix for the log level. Default is ``prio``. No longer supported as of 2.1.0.
   * ``setInstanceFromServerID=false``: bool - Add the "instance" field with the value of the server ID (set with :func:`setServerID`) to each log line. Added in 2.1.0.
 
- Available backends:
+  Available backends:
 
- * ``default``: use the traditional logging system to output structured logging information.
- * ``systemd-journal``: use ``systemd-journal``. When using this backend, provide ``-o verbose`` or simular output option to ``journalctl`` to view the full information.
- * ``json``: JSON objects are written to the standard error stream.
+  * ``default``: use the traditional logging system to output structured logging information.
+  * ``systemd-journal``: use ``systemd-journal``. When using this backend, provide ``-o verbose`` or simular output option to ``journalctl`` to view the full information.
+  * ``json``: JSON objects are written to the standard error stream.
 
 .. function:: setOpenTelemetryTracing(value)
 

--- a/pdns/dnsdistdist/docs/reference/constants.rst
+++ b/pdns/dnsdistdist/docs/reference/constants.rst
@@ -104,22 +104,22 @@ DNSAction
 
 These constants represent an Action that can be returned from :func:`LuaAction` functions.
 
- * ``DNSAction.Allow``: let the query pass, skipping other rules
- * ``DNSAction.Delay``: delay the response for the specified milliseconds (UDP-only), continue to the next rule
- * ``DNSAction.Drop``: drop the query
- * ``DNSAction.HeaderModify``: indicate that the query has been turned into a response
- * ``DNSAction.None``: continue to the next rule
- * ``DNSAction.NoOp``: continue to the next rule (used for Dynamic Block actions where None has a different meaning)
- * ``DNSAction.NoRecurse``: set rd=0 on the query
- * ``DNSAction.Nxdomain``: return a response with a NXDomain rcode
- * ``DNSAction.Pool``: use the specified pool to forward this query
- * ``DNSAction.Refused``: return a response with a Refused rcode
- * ``DNSAction.ServFail``: return a response with a ServFail rcode
- * ``DNSAction.SetTag``: set a tag, see :func:`SetTagAction` (only used for Dynamic Block actions, see :meth:`DNSQuestion.setTag` to set a tag from Lua)
- * ``DNSAction.Spoof``: spoof the response using the supplied IPv4 (A), IPv6 (AAAA) or string (CNAME) value. TTL will be 60 seconds.
- * ``DNSAction.SpoofPacket``: spoof the response using the supplied raw packet
- * ``DNSAction.SpoofRaw``: spoof the response using the supplied raw value as record data (see also :meth:`DNSQuestion.spoof` and :func:`dnsdist_ffi_dnsquestion_spoof_raw` to spoof multiple values)
- * ``DNSAction.Truncate``: truncate the response
+* ``DNSAction.Allow``: let the query pass, skipping other rules
+* ``DNSAction.Delay``: delay the response for the specified milliseconds (UDP-only), continue to the next rule
+* ``DNSAction.Drop``: drop the query
+* ``DNSAction.HeaderModify``: indicate that the query has been turned into a response
+* ``DNSAction.None``: continue to the next rule
+* ``DNSAction.NoOp``: continue to the next rule (used for Dynamic Block actions where None has a different meaning)
+* ``DNSAction.NoRecurse``: set rd=0 on the query
+* ``DNSAction.Nxdomain``: return a response with a NXDomain rcode
+* ``DNSAction.Pool``: use the specified pool to forward this query
+* ``DNSAction.Refused``: return a response with a Refused rcode
+* ``DNSAction.ServFail``: return a response with a ServFail rcode
+* ``DNSAction.SetTag``: set a tag, see :func:`SetTagAction` (only used for Dynamic Block actions, see :meth:`DNSQuestion.setTag` to set a tag from Lua)
+* ``DNSAction.Spoof``: spoof the response using the supplied IPv4 (A), IPv6 (AAAA) or string (CNAME) value. TTL will be 60 seconds.
+* ``DNSAction.SpoofPacket``: spoof the response using the supplied raw packet
+* ``DNSAction.SpoofRaw``: spoof the response using the supplied raw value as record data (see also :meth:`DNSQuestion.spoof` and :func:`dnsdist_ffi_dnsquestion_spoof_raw` to spoof multiple values)
+* ``DNSAction.Truncate``: truncate the response
 
 .. _DNSQType:
 
@@ -128,12 +128,12 @@ DNSQType
 
 All named `QTypes <https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4>`__ are available as constants, prefixed with ``DNSQType.``, e.g.:
 
- * ``DNSQType.AAAA``
- * ``DNSQType.AXFR``
- * ``DNSQType.A``
- * ``DNSQType.NS``
- * ``DNSQType.SOA``
- * etc.
+* ``DNSQType.AAAA``
+* ``DNSQType.AXFR``
+* ``DNSQType.A``
+* ``DNSQType.NS``
+* ``DNSQType.SOA``
+* etc.
 
 .. _DNSResponseAction:
 
@@ -145,10 +145,10 @@ DNSResponseAction
 
 These constants represent an Action that can be returned from :func:`LuaResponseAction` functions.
 
- * ``DNSResponseAction.Allow``: let the response pass, skipping other rules
- * ``DNSResponseAction.Delay``: delay the response for the specified milliseconds (UDP-only), continue to the next rule
- * ``DNSResponseAction.Drop``: drop the response
- * ``DNSResponseAction.HeaderModify``: indicate that the query has been turned into a response
- * ``DNSResponseAction.None``: continue to the next rule
- * ``DNSResponseAction.ServFail``: return a response with a ServFail rcode
- * ``DNSResponseAction.Truncate``: truncate the response, removing all records from the answer, authority and additional sections if any
+* ``DNSResponseAction.Allow``: let the response pass, skipping other rules
+* ``DNSResponseAction.Delay``: delay the response for the specified milliseconds (UDP-only), continue to the next rule
+* ``DNSResponseAction.Drop``: drop the response
+* ``DNSResponseAction.HeaderModify``: indicate that the query has been turned into a response
+* ``DNSResponseAction.None``: continue to the next rule
+* ``DNSResponseAction.ServFail``: return a response with a ServFail rcode
+* ``DNSResponseAction.Truncate``: truncate the response, removing all records from the answer, authority and additional sections if any

--- a/pdns/dnsdistdist/docs/reference/custommetrics.rst
+++ b/pdns/dnsdistdist/docs/reference/custommetrics.rst
@@ -7,15 +7,15 @@ The first step is to declare a new metric using :func:`declareMetric`. In 1.8.0 
 
 Then you can update those at runtime using the following functions, depending on the metric type:
 
- * manipulate counters using :func:`incMetric` and  :func:`decMetric`
- * update a gauge using :func:`setMetric`
+* manipulate counters using :func:`incMetric` and  :func:`decMetric`
+* update a gauge using :func:`setMetric`
 
 .. function:: declareMetric(name, type, description [, prometheusName|options]) -> bool
 
   .. versionchanged:: 2.0.0
     This function now takes options, with ``withLabels`` option added. ``prometheusName`` can now be provided in options.
 
- .. note::
+  .. note::
     Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Re-declaring an existing metric with the same name and type will not reset it.
@@ -39,7 +39,7 @@ Then you can update those at runtime using the following functions, depending on
   .. versionchanged:: 2.0.0
     This function now takes options, with ``labels`` option added. ``step`` can now be provided in options.
 
- .. note::
+  .. note::
     Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Increment counter by one (or more, see the ``step`` parameter), will issue an error if the metric is not declared or not a ``counter``.
@@ -60,7 +60,7 @@ Then you can update those at runtime using the following functions, depending on
   .. versionchanged:: 2.0.0
     This function now takes options, with ``labels`` option added. ``step`` can now be provided in options.
 
- .. note::
+  .. note::
     Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Decrement counter by one (or more, see the ``step`` parameter), will issue an error if the metric is not declared or not a ``counter``.
@@ -78,7 +78,7 @@ Then you can update those at runtime using the following functions, depending on
 
 .. function:: getMetric(name [, options]) -> double
 
- .. note::
+  .. note::
     Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Get metric value.
@@ -95,7 +95,7 @@ Then you can update those at runtime using the following functions, depending on
   .. versionchanged:: 2.0.0
     This function now takes options, with ``labels`` option added.
 
- .. note::
+  .. note::
     Labels are only available for prometheus. Metrics with labels are otherwise ignored.
 
   Set the new value, will issue an error if the metric is not declared or not a ``gauge``.

--- a/pdns/dnsdistdist/docs/reference/kvs.rst
+++ b/pdns/dnsdistdist/docs/reference/kvs.rst
@@ -9,16 +9,16 @@ queries for which the lookup should be done.
 
 The first step is to get a :class:`KeyValueStore` object via one of the following functions:
 
- * :func:`newCDBKVStore` for a CDB database ;
- * :func:`newLMDBKVStore` for a LMDB one.
- * :func:`newMMDBKVStore` for a MMDB one.
+* :func:`newCDBKVStore` for a CDB database ;
+* :func:`newLMDBKVStore` for a LMDB one.
+* :func:`newMMDBKVStore` for a MMDB one.
 
 Then the key used for the lookup can be selected via one of the following functions:
 
- * the exact qname with :func:`KeyValueLookupKeyQName` ;
- * a suffix match via :func:`KeyValueLookupKeySuffix`, meaning that several lookups will be done, removing one label from the qname at a time, until a match has been found or there is no label left ;
- * the source IP, in network byte order, with :func:`KeyValueLookupKeySourceIP` ;
- * the value of an existing tag with :func:`KeyValueLookupKeyTag`.
+* the exact qname with :func:`KeyValueLookupKeyQName` ;
+* a suffix match via :func:`KeyValueLookupKeySuffix`, meaning that several lookups will be done, removing one label from the qname at a time, until a match has been found or there is no label left ;
+* the source IP, in network byte order, with :func:`KeyValueLookupKeySourceIP` ;
+* the value of an existing tag with :func:`KeyValueLookupKeyTag`.
 
 For example, to do a suffix-based lookup into a LMDB KVS database, the following rule can be used:
 
@@ -30,9 +30,9 @@ For example, to do a suffix-based lookup into a LMDB KVS database, the following
 For a query whose qname is "sub.domain.powerdns.com.", and for which only the "\\8powerdns\\3com\\0" key exists in the database,
 this would result in the following lookups:
 
- * \\3sub\\6domain\\8powerdns\\3com\\0
- * \\6domain\\8powerdns\\3com\\0
- * \\8powerdns\\3com\\0
+* ``\\3sub\\6domain\\8powerdns\\3com\\0``
+* ``\\6domain\\8powerdns\\3com\\0``
+* ``\\8powerdns\\3com\\0``
 
 Then a match is found for the last key, and the corresponding value is stored into the 'kvs-suffix-result' tag. This tag can now be used in subsequent rules to take an action based on the result of the lookup.
 Note that the tag is also created when the key has not been found, but the content of the tag is empty.
@@ -90,17 +90,17 @@ If the value found in the LMDB database for the key '\\8powerdns\\3com\\0' was '
   Return a new KeyValueLookupKey object that, when passed to :func:`KeyValueStoreLookupAction` or :func:`KeyValueStoreLookupRule`, will return a vector of keys based on the labels of the qname in DNS wire format or plain text.
   For example if the qname is sub.domain.powerdns.com. the following keys will be returned:
 
-   * \\3sub\\6domain\\8powerdns\\3com\\0
-   * \\6domain\\8powerdns\\3com\\0
-   * \\8powerdns\\3com\\0
-   * \\3com\\0
-   * \\0
+  * ``\\3sub\\6domain\\8powerdns\\3com\\0``
+  * ``\\6domain\\8powerdns\\3com\\0``
+  * ``\\8powerdns\\3com\\0``
+  * ``\\3com\\0``
+  * ``\\0``
 
   If ``minLabels`` is set to a value larger than 0 the lookup will only be done as long as there is at least ``minLabels`` remaining. Taking back our previous example, it means only the following keys will be returned if ``minLabels`` is set to 2;
 
-   * \\3sub\\6domain\\8powerdns\\3com\\0
-   * \\6domain\\8powerdns\\3com\\0
-   * \\8powerdns\\3com\\0
+  * ``\\3sub\\6domain\\8powerdns\\3com\\0``
+  * ``\\6domain\\8powerdns\\3com\\0``
+  * ``\\8powerdns\\3com\\0``
 
   :param int minLabels: The minimum number of labels to do a lookup for. Default is 0 which means unlimited
   :param bool wireFormat: Whether to do the lookup in wire format (default) or in plain text

--- a/pdns/dnsdistdist/docs/running.rst
+++ b/pdns/dnsdistdist/docs/running.rst
@@ -40,9 +40,9 @@ Before 1.7.0, which introduced TCP fallback, that meant that there was a potenti
 
 In addition to TCP fallback for DoH, 1.7.0 introduced three new notions:
 
- * TCP-only backends, for which queries will always forwarded over a TCP connection (see the `tcpOnly` parameter of :func:`newServer`)
- * DNS over HTTPS backends, for which queries are forwarded over a DNS over HTTPS connection (see the `dohPath` parameter of :func:`newServer`)
- * and DNS over TLS backends, for which queries are forwarded over a DNS over TLS connection (see the `tls` parameter of :func:`newServer`)
+* TCP-only backends, for which queries will always forwarded over a TCP connection (see the `tcpOnly` parameter of :func:`newServer`)
+* DNS over HTTPS backends, for which queries are forwarded over a DNS over HTTPS connection (see the `dohPath` parameter of :func:`newServer`)
+* and DNS over TLS backends, for which queries are forwarded over a DNS over TLS connection (see the `tls` parameter of :func:`newServer`)
 
 To sum it up:
 

--- a/pdns/dnsdistdist/docs/statistics.rst
+++ b/pdns/dnsdistdist/docs/statistics.rst
@@ -286,10 +286,10 @@ security-status
 ---------------
 The security status of :program:`dnsdist`. This is regularly polled.
 
- * 0 = Unknown status or unreleased version
- * 1 = OK
- * 2 = Upgrade recommended
- * 3 = Upgrade required (most likely because there is a known security issue)
+* 0 = Unknown status or unreleased version
+* 1 = OK
+* 2 = Upgrade recommended
+* 3 = Upgrade required (most likely because there is a known security issue)
 
 self-answered
 -------------


### PR DESCRIPTION
### Short description

These lists were accidentally quoted because they had a space prefixed.
This commit also fixes a few other, related rendering issues.


### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
