### PR TITLE
auth: minor zone parsing tweaks

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2226,7 +2226,7 @@ static std::vector<DNSRecord>fillTempZoneFile(int& tmpfd, const char* tmpnam, Do
 static bool parseZoneFile(const char* tmpnam, int& errorline, std::vector<DNSRecord>& records)
 {
   records.clear();
-  ZoneParserTNG zpt(tmpnam, g_rootzonename);
+  ZoneParserTNG zpt(tmpnam, g_rootzonename, "", ::arg().mustDo("upgrade-unknown-types"));
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
   zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
   DNSResourceRecord zrr;
@@ -2675,7 +2675,7 @@ static int loadZone(const ZoneName& zone, const string& fname) {
     }
   }
   DNSBackend* db = di.backend;
-  ZoneParserTNG zpt(fname, zone);
+  ZoneParserTNG zpt(fname, zone, "", ::arg().mustDo("upgrade-unknown-types"));
   zpt.setDefaultTTL(::arg().asNum("default-ttl"));
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
 

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -572,7 +572,13 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
   }
   boost::trim_if(rr.content, boost::is_any_of(" \r\n\t\x1a"));
 
-  if (d_upgradeContent && DNSRecordContent::isUnknownType(qtypeString)) {
+  if (DNSRecordContent::isUnknownType(qtypeString)) {
+    if (!d_upgradeContent) {
+      // If the record has been read as TYPE##, then rr.content should be of
+      // the form \# len hex bytes, and it doesn't make any sense to perform
+      // further changes to it.
+      return true;
+    }
     rr.content = DNSRecordContent::upgradeContent(rr.qname, rr.qtype, rr.content);
   }
 
@@ -672,7 +678,8 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
         rr.content+=recparts[n];
     }
     break;
-  default:;
+  default:
+    break;
   }
   return true;
 }


### PR DESCRIPTION
### Short description
This PR:
- skips record contents checks when provided as raw binary, in the zone parser
- makes pdnsutil honour the `upgrade-unknown-types` setting in the `zone load` and `zone edit` operations.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] lightly tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
