### PR TITLE
rec: allow explicitly named interface for source address

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1,4 +1,4 @@
-JSON11_LIBS = $(top_builddir)/ext/json11/libjson11.la
+sJSON11_LIBS = $(top_builddir)/ext/json11/libjson11.la
 ARC4RANDOM_LIBS = $(top_builddir)/ext/arc4random/libarc4random.la
 
 AM_CPPFLAGS += \
@@ -237,6 +237,7 @@ pdns_server_SOURCES = \
 	ednscookies.cc ednscookies.hh \
 	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
+	expected.hh \
 	gettime.cc gettime.hh \
 	gss_context.cc gss_context.hh \
 	histogram.hh \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1,4 +1,4 @@
-sJSON11_LIBS = $(top_builddir)/ext/json11/libjson11.la
+JSON11_LIBS = $(top_builddir)/ext/json11/libjson11.la
 ARC4RANDOM_LIBS = $(top_builddir)/ext/arc4random/libarc4random.la
 
 AM_CPPFLAGS += \

--- a/pdns/auth-primarycommunicator.cc
+++ b/pdns/auth-primarycommunicator.cc
@@ -389,13 +389,13 @@ bool CommunicatorClass::justNotified(const ZoneName& domain, const string& ipAdd
 void CommunicatorClass::makeNotifySockets()
 {
   if (pdns::isQueryLocalAddressFamilyEnabled(AF_INET)) {
-    d_nsock4 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET, 0), true, ::arg().mustDo("non-local-bind"));
+    d_nsock4 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET, 0).d_address, true, ::arg().mustDo("non-local-bind"));
   }
   else {
     d_nsock4 = -1;
   }
   if (pdns::isQueryLocalAddressFamilyEnabled(AF_INET6)) {
-    d_nsock6 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET6, 0), true, ::arg().mustDo("non-local-bind"));
+    d_nsock6 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET6, 0).d_address, true, ::arg().mustDo("non-local-bind"));
   }
   else {
     d_nsock6 = -1;

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -851,7 +851,7 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
              ctx.slog->info(Logr::Warning, "XFR: unable to xfr, address family is not enabled for outgoing traffic (query-local-address)", "address family", Logging::Loggable(isV6 ? "IPv6" : "IPv4")));
         return;
       }
-      laddr = pdns::getQueryLocalAddress(remote.sin4.sin_family, 0);
+      laddr = pdns::getQueryLocalAddress(remote.sin4.sin_family, 0).d_address;
     }
 
     bool hadDnssecZone = false;

--- a/pdns/axfr-retriever.cc
+++ b/pdns/axfr-retriever.cc
@@ -45,7 +45,7 @@ AXFRRetriever::AXFRRetriever(Logr::log_t slog,
     if (!pdns::isQueryLocalAddressFamilyEnabled(remote.sin4.sin_family)) {
       throw ResolverException("Unable to determine source address for AXFR request to " + remote.toStringWithPort() + " for " + domain.toLogString() + ". Address family is not configured for outgoing queries");
     }
-    local = pdns::getQueryLocalAddress(remote.sin4.sin_family, 0);
+    local = pdns::getQueryLocalAddress(remote.sin4.sin_family, 0).d_address;
   }
   d_sock = -1;
   try {

--- a/pdns/dnsdistdist/dnsdist-udp.cc
+++ b/pdns/dnsdistdist/dnsdist-udp.cc
@@ -118,12 +118,10 @@ void sendfromto(int sock, const PacketBuffer& buffer, const ComboAddress& from, 
     return;
   }
 
-  try {
-    sendMsgWithOptions(sock, buffer.data(), buffer.size(), &dest, &from, 0, 0);
-  }
-  catch (const std::exception& exp) {
-    VERBOSESLOG(infolog("Error sending UDP response from %s to %s: %s", from.toStringWithPort(), dest.toStringWithPort(), exp.what()),
-                dnsdist::logging::getTopLogger("sendfromto")->error(Logr::Info, exp.what(), "Error sending UDP response", "source.address", Logging::Loggable(from), "client.address", Logging::Loggable(dest)));
+  auto ret = sendMsgWithOptions(sock, buffer.data(), buffer.size(), &dest, &from, 0, 0);
+  if (!ret.has_value()) {
+    VERBOSESLOG(infolog("Error sending UDP response from %s to %s: %s", from.toStringWithPort(), dest.toStringWithPort(), stringerror(ret.error())),
+                dnsdist::logging::getTopLogger("sendfromto")->error(Logr::Info, ret.error(), "Error sending UDP response", "source.address", Logging::Loggable(from), "client.address", Logging::Loggable(dest)));
   }
 }
 

--- a/pdns/dnsdistdist/doq-common.cc
+++ b/pdns/dnsdistdist/doq-common.cc
@@ -154,12 +154,11 @@ static void sendFromTo(Socket& sock, const ComboAddress& peer, const ComboAddres
     return;
   }
 
-  try {
-    sendMsgWithOptions(sock.getHandle(), buffer.data(), buffer.size(), &peer, &local, 0, 0);
-  }
-  catch (const std::exception& exp) {
-    VERBOSESLOG(infolog("Error while sending QUIC datagram of size %d from %s to %s: %s", buffer.size(), local.toStringWithPort(), peer.toStringWithPort(), exp.what()),
-                dnsdist::logging::getTopLogger("quic-send-from-to")->error(Logr::Info, exp.what(), "Error while sending QUIC datagram", "datagram_size", Logging::Loggable(buffer.size()), "source.address", Logging::Loggable(local), "client.address", Logging::Loggable(peer)));
+  auto ret = sendMsgWithOptions(sock.getHandle(), buffer.data(), buffer.size(), &peer, &local, 0, 0);
+
+  if (!ret.has_value()) {
+    VERBOSESLOG(infolog("Error while sending QUIC datagram of size %d from %s to %s: %s", buffer.size(), local.toStringWithPort(), peer.toStringWithPort(), stringerror(ret.error())),
+                dnsdist::logging::getTopLogger("quic-send-from-to")->error(Logr::Info, ret.error(), "Error while sending QUIC datagram", "datagram_size", Logging::Loggable(buffer.size()), "source.address", Logging::Loggable(local), "client.address", Logging::Loggable(peer)));
   }
 }
 

--- a/pdns/dnsdistdist/expected.hh
+++ b/pdns/dnsdistdist/expected.hh
@@ -1,0 +1,1 @@
+../expected.hh

--- a/pdns/expected.hh
+++ b/pdns/expected.hh
@@ -30,7 +30,7 @@ template <class E>
 class unexpected
 {
 public:
-  unexpected(const E& arg) :
+  explicit unexpected(const E& arg) :
     err(arg) {}
   const E& error() const
   {
@@ -47,6 +47,8 @@ class expected : private std::variant<T, E>
 public:
   expected(const T& arg) :
     std::variant<T, E>(arg) {}
+  expected(T&& arg) :
+    std::variant<T, E>(std::forward<T>(arg)) {}
 
   expected(const unexpected<E>& arg) :
     std::variant<T, E>(arg.error()) {}

--- a/pdns/expected.hh
+++ b/pdns/expected.hh
@@ -1,0 +1,68 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ */
+#pragma once
+
+#include <variant>
+
+// A poor man's std::expected, which only becomes available for real with C++23
+
+namespace pdns
+{
+template <class E>
+class unexpected
+{
+public:
+  unexpected(const E& arg) :
+    err(arg) {}
+  const E& error() const
+  {
+    return err;
+  }
+
+private:
+  E err;
+};
+
+template <class T, class E>
+class expected : private std::variant<T, E>
+{
+public:
+  expected(const T& arg) :
+    std::variant<T, E>(arg) {}
+
+  expected(const unexpected<E>& arg) :
+    std::variant<T, E>(arg.error()) {}
+
+  [[nodiscard]] bool has_value() const
+  {
+    return std::holds_alternative<T>(*this);
+  }
+
+  const T& value() const
+  {
+    return std::get<T>(*this);
+  }
+  const E& error() const
+  {
+    return std::get<E>(*this);
+  }
+};
+}

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -392,7 +392,7 @@ void ComboAddress::truncate(unsigned int bits) noexcept
   *place &= (~((1 << bitsleft) - 1));
 }
 
-size_t sendMsgWithOptions(int socketDesc, const void* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags)
+pdns::expected<size_t, int> sendMsgWithOptions(int socketDesc, const void* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags)
 {
   msghdr msgh{};
   iovec iov{};
@@ -457,7 +457,7 @@ size_t sendMsgWithOptions(int socketDesc, const void* buffer, size_t len, const 
       iov.iov_base = reinterpret_cast<void*>(reinterpret_cast<char*>(iov.iov_base) + written);
     }
     else if (res == 0) {
-      return res;
+      return static_cast<size_t>(0);
     }
     else if (res == -1) {
       int err = errno;
@@ -469,7 +469,7 @@ size_t sendMsgWithOptions(int socketDesc, const void* buffer, size_t len, const 
            especially with TCP Fast Open */
         return sent;
       }
-      unixDie("failed in sendMsgWithOptions");
+      return pdns::unexpected{err};
     }
   } while (true);
 

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -32,6 +32,7 @@
 #include <netdb.h>
 #include <sstream>
 #include <sys/un.h>
+#include <variant>
 
 #include "namespaces.hh"
 
@@ -2077,7 +2078,52 @@ bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destinat
 bool HarvestTimestamp(struct msghdr* msgh, struct timeval* timeval);
 void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, cmsgbuf_aligned* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr);
 int sendOnNBSocket(int fileDesc, const struct msghdr* msgh);
-size_t sendMsgWithOptions(int socketDesc, const void* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags);
+
+// A poor man's std::expected, which only becomes available for real with C++23
+namespace pdns
+{
+template <class E>
+class unexpected
+{
+public:
+  unexpected(const E& arg) :
+    err(arg) {}
+  const E& error() const
+  {
+    return err;
+  }
+
+private:
+  E err;
+};
+
+template <class T, class E>
+class expected : private std::variant<T, E>
+{
+public:
+  expected(const T& arg) :
+    std::variant<T, E>(arg) {}
+
+  expected(const unexpected<E>& arg) :
+    std::variant<T, E>(arg.error()) {}
+
+  [[nodiscard]] bool has_value() const
+  {
+    return std::holds_alternative<T>(*this);
+  }
+
+  const T& value() const
+  {
+    return std::get<T>(*this);
+  }
+  const E& error() const
+  {
+    return std::get<E>(*this);
+  }
+};
+}
+
+[[nodiscard]] pdns::expected<size_t, int> sendMsgWithOptions(int socketDesc, const void* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags);
 
 /* requires a non-blocking, connected TCP socket */
 bool isTCPSocketUsable(int sock);

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -32,7 +32,7 @@
 #include <netdb.h>
 #include <sstream>
 #include <sys/un.h>
-#include <variant>
+#include "expected.hh"
 
 #include "namespaces.hh"
 
@@ -2078,51 +2078,6 @@ bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destinat
 bool HarvestTimestamp(struct msghdr* msgh, struct timeval* timeval);
 void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, cmsgbuf_aligned* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr);
 int sendOnNBSocket(int fileDesc, const struct msghdr* msgh);
-
-// A poor man's std::expected, which only becomes available for real with C++23
-namespace pdns
-{
-template <class E>
-class unexpected
-{
-public:
-  unexpected(const E& arg) :
-    err(arg) {}
-  const E& error() const
-  {
-    return err;
-  }
-
-private:
-  E err;
-};
-
-template <class T, class E>
-class expected : private std::variant<T, E>
-{
-public:
-  expected(const T& arg) :
-    std::variant<T, E>(arg) {}
-
-  expected(const unexpected<E>& arg) :
-    std::variant<T, E>(arg.error()) {}
-
-  [[nodiscard]] bool has_value() const
-  {
-    return std::holds_alternative<T>(*this);
-  }
-
-  const T& value() const
-  {
-    return std::get<T>(*this);
-  }
-  const E& error() const
-  {
-    return std::get<E>(*this);
-  }
-};
-}
-
 [[nodiscard]] pdns::expected<size_t, int> sendMsgWithOptions(int socketDesc, const void* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags);
 
 /* requires a non-blocking, connected TCP socket */

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -378,8 +378,8 @@ static void communicatorSendNotifications(const int sock4, const int sock6)
 static void communicatorThread()
 {
   setThreadName("ixfrdist/communicator");
-  auto sock4 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET, 0), true);
-  auto sock6 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET6, 0), true);
+  auto sock4 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET, 0).d_address, true);
+  auto sock6 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET6, 0).d_address, true);
 
   if (sock4 < 0) {
     throw std::runtime_error("Unable to create local query socket");

--- a/pdns/query-local-address.cc
+++ b/pdns/query-local-address.cc
@@ -23,55 +23,56 @@
 #include "iputils.hh"
 #include "dns_random.hh"
 
-namespace pdns {
+namespace pdns
+{
   static const ComboAddress local4("0.0.0.0");
   static const ComboAddress local6("::");
 
-  static vector<ComboAddress> g_localQueryAddresses4;
-  static vector<ComboAddress> g_localQueryAddresses6;
+  static vector<AddressAndInterface> g_localQueryAddresses4;
+  static vector<AddressAndInterface> g_localQueryAddresses6;
 
-  ComboAddress getQueryLocalAddress(const sa_family_t family, const in_port_t port) {
-    ComboAddress ret;
+  AddressAndInterface getQueryLocalAddress(const sa_family_t family, const in_port_t port) {
+    AddressAndInterface ret;
     if (family==AF_INET) {
       if (g_localQueryAddresses4.empty()) {
-        ret = local4;
+        ret.d_address = local4;
       } else if (g_localQueryAddresses4.size() == 1) {
         ret = g_localQueryAddresses4.at(0);
       } else {
         ret = g_localQueryAddresses4[dns_random(g_localQueryAddresses4.size())];
       }
-      ret.sin4.sin_port = htons(port);
+      ret.d_address.sin4.sin_port = htons(port);
     }
     else {
       if (g_localQueryAddresses6.empty()) {
-        ret = local6;
+        ret.d_address = local6;
       } else if (g_localQueryAddresses6.size() == 1) {
         ret = g_localQueryAddresses6.at(0);
       } else {
         ret = g_localQueryAddresses6[dns_random(g_localQueryAddresses6.size())];
       }
-      ret.sin6.sin6_port = htons(port);
+      ret.d_address.sin6.sin6_port = htons(port);
     }
     return ret;
   }
 
-  ComboAddress getNonAnyQueryLocalAddress(const sa_family_t family) {
+  AddressAndInterface getNonAnyQueryLocalAddress(const sa_family_t family) {
     if (family == AF_INET) {
       for (const auto& addr : pdns::g_localQueryAddresses4) {
-        if (!IsAnyAddress(addr)) {
+        if (!IsAnyAddress(addr.d_address)) {
           return addr;
         }
       }
     }
     if (family == AF_INET6) {
       for (const auto& addr : pdns::g_localQueryAddresses6) {
-        if (!IsAnyAddress(addr)) {
+        if (!IsAnyAddress(addr.d_address)) {
           return addr;
         }
       }
     }
-    ComboAddress ret("0.0.0.0");
-    ret.reset(); // Ensure all is zero, even the addr family
+    AddressAndInterface ret{ComboAddress{"0.0.0.0"}, std::nullopt};
+    ret.d_address.reset(); // Ensure all is zero, even the addr family
     return ret;
   }
 
@@ -79,12 +80,12 @@ namespace pdns {
     vector<string> addrs;
     stringtok(addrs, qla, ", ;");
     for(const string& addr : addrs) {
-      ComboAddress tmp(addr);
-      if (tmp.isIPv4()) {
-        g_localQueryAddresses4.push_back(tmp);
+      AddressAndInterface tmp{ComboAddress{addr}, std::nullopt};
+      if (tmp.d_address.isIPv4()) {
+        g_localQueryAddresses4.emplace_back(std::move(tmp));
         continue;
       }
-      g_localQueryAddresses6.push_back(tmp);
+      g_localQueryAddresses6.emplace_back(std::move(tmp));
     }
   }
 

--- a/pdns/query-local-address.cc
+++ b/pdns/query-local-address.cc
@@ -19,6 +19,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
+#include <net/if.h>
+
 #include "query-local-address.hh"
 #include "iputils.hh"
 #include "dns_random.hh"
@@ -79,8 +82,9 @@ namespace pdns
   void parseQueryLocalAddress(const std::string &qla) {
     vector<string> addrs;
     stringtok(addrs, qla, ", ;");
-    for(const string& addr : addrs) {
-      AddressAndInterface tmp{ComboAddress{addr}, std::nullopt};
+    for (const string& addr : addrs) {
+      cerr << "AAA" << addr << endl;
+      AddressAndInterface tmp{ComboAddress{addr}, Interface{ "en7", if_nametoindex("en7")} };
       if (tmp.d_address.isIPv4()) {
         g_localQueryAddresses4.emplace_back(std::move(tmp));
         continue;

--- a/pdns/query-local-address.cc
+++ b/pdns/query-local-address.cc
@@ -25,6 +25,8 @@
 #include "query-local-address.hh"
 #include "iputils.hh"
 #include "dns_random.hh"
+#include "logging.hh"
+#include "logger.hh"
 
 namespace pdns
 {
@@ -92,7 +94,12 @@ namespace pdns
       }
       addr = parts.at(0);
       if (parts.size() >= 2) {
-        itf = Interface{ parts.at(1), if_nametoindex(parts.at(1).data())};
+        auto idx = if_nametoindex(parts.at(1).data());
+        if (idx == 0) {
+          SLOG(g_log << Logger::Error << "Interface name " << parts.at(1) << " is unknown" << endl,
+               g_slog->withName("runtime")->info(Logr::Error, "interface unknown", "name", Logging::Loggable(parts.at(1))));
+        }
+        itf = Interface{ parts.at(1), idx };
       }
 
       AddressAndInterface tmp{ComboAddress{addr}, itf};

--- a/pdns/query-local-address.cc
+++ b/pdns/query-local-address.cc
@@ -80,11 +80,22 @@ namespace pdns
   }
 
   void parseQueryLocalAddress(const std::string &qla) {
-    vector<string> addrs;
+    std::vector<std::string> addrs;
     stringtok(addrs, qla, ", ;");
-    for (const string& addr : addrs) {
-      cerr << "AAA" << addr << endl;
-      AddressAndInterface tmp{ComboAddress{addr}, Interface{ "en7", if_nametoindex("en7")} };
+    for (const string& word : addrs) {
+      vector<std::string> parts;
+      std::string addr;
+      std::optional<Interface> itf;
+      stringtok(parts, word, "@");
+      if (parts.empty()) {
+        continue;
+      }
+      addr = parts.at(0);
+      if (parts.size() >= 2) {
+        itf = Interface{ parts.at(1), if_nametoindex(parts.at(1).data())};
+      }
+
+      AddressAndInterface tmp{ComboAddress{addr}, itf};
       if (tmp.d_address.isIPv4()) {
         g_localQueryAddresses4.emplace_back(std::move(tmp));
         continue;

--- a/pdns/query-local-address.hh
+++ b/pdns/query-local-address.hh
@@ -24,6 +24,22 @@
 #include "iputils.hh"
 
 namespace pdns {
+
+  struct Interface
+  {
+    std::string d_name;
+    int d_index{-1};
+  };
+  struct AddressAndInterface
+  {
+    ComboAddress d_address;
+    std::optional<Interface> d_interface;
+    bool operator<(const AddressAndInterface& arg) const
+    {
+      return d_address < arg.d_address; // XXX
+    };
+  };
+
   /*! pick a random query local address for family
    *
    * Will always return a ComboAddress.
@@ -31,13 +47,13 @@ namespace pdns {
    * @param family Address Family, only AF_INET and AF_INET6 are supported
    * @param port   Port to set in the returned ComboAddress
    */
-  ComboAddress getQueryLocalAddress(const sa_family_t family, const in_port_t port);
+  AddressAndInterface getQueryLocalAddress(sa_family_t family, in_port_t port);
 
   /*! Returns a non-Any address QLA, or an empty QLA when the QLA is any
    *
    * @param family  Address Family
    */
-  ComboAddress getNonAnyQueryLocalAddress(const sa_family_t family);
+  AddressAndInterface getNonAnyQueryLocalAddress(sa_family_t family);
 
   /*! Populate the query local address vectors
    *
@@ -55,5 +71,5 @@ namespace pdns {
    *
    * @param family  Address Family, only AF_INET and AF_INET6 are supported
    */
-  bool isQueryLocalAddressFamilyEnabled(const sa_family_t family);
+  bool isQueryLocalAddressFamilyEnabled(sa_family_t family);
 } // namespace pdns

--- a/pdns/query-local-address.hh
+++ b/pdns/query-local-address.hh
@@ -28,7 +28,7 @@ namespace pdns {
   struct Interface
   {
     std::string d_name;
-    int d_index{-1};
+    unsigned int d_index{0};
   };
   struct AddressAndInterface
   {

--- a/pdns/query-local-address.hh
+++ b/pdns/query-local-address.hh
@@ -38,6 +38,13 @@ namespace pdns {
     {
       return d_address < arg.d_address; // XXX
     };
+    std::string toString()
+    {
+      if (d_interface) {
+        return d_address.toString() + '@' + d_interface->d_name;
+      }
+      return d_address.toString();
+    }
   };
 
   /*! pick a random query local address for family

--- a/pdns/query-local-address.hh
+++ b/pdns/query-local-address.hh
@@ -36,7 +36,9 @@ namespace pdns {
     std::optional<Interface> d_interface;
     bool operator<(const AddressAndInterface& arg) const
     {
-      return d_address < arg.d_address; // XXX
+      // We only compare the address parts. Having two equal addresses on the same interface is not
+      // a case I want to think about at the moment.
+      return d_address < arg.d_address;
     };
     std::string toString()
     {

--- a/pdns/recursordist/expected.hh
+++ b/pdns/recursordist/expected.hh
@@ -1,0 +1,1 @@
+../expected.hh

--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -358,7 +358,7 @@ class BindError
 {
 };
 
-static bool tcpconnect(const OptLog& log, const ComboAddress& remote, const std::optional<ComboAddress> localBind, TCPOutConnectionManager::Connection& connection, bool& dnsOverTLS, const std::string& nsName, std::string& subjectName)
+static bool tcpconnect(const OptLog& log, const ComboAddress& remote, const std::optional<pdns::AddressAndInterface> localBind, TCPOutConnectionManager::Connection& connection, bool& dnsOverTLS, const std::string& nsName, std::string& subjectName)
 {
   dnsOverTLS = SyncRes::s_dot_to_port_853 && remote.getPort() == 853;
 
@@ -373,16 +373,16 @@ static bool tcpconnect(const OptLog& log, const ComboAddress& remote, const std:
   sock.setNonBlocking();
   setTCPNoDelay(sock.getHandle());
   // Bind to the same address the cookie is associated with (RFC 9018 section 3 last paragraph)
-  ComboAddress localip = localBind ? *localBind : pdns::getQueryLocalAddress(remote.sin4.sin_family, 0);
+  pdns::AddressAndInterface localip = localBind ? *localBind : pdns::getQueryLocalAddress(remote.sin4.sin_family, 0);
   if (localBind) {
-    VLOG(log, "Connecting TCP to " << remote.toStringWithPortExcept(53) << " with specific local address " << localip.toString() << endl);
+    VLOG(log, "Connecting TCP to " << remote.toStringWithPortExcept(53) << " with specific local address " << localip.d_address.toString() << endl);
   }
   else {
     VLOG(log, "Connecting TCP to " << remote.toStringWithPortExcept(53) << " with no specific local address" << endl);
   }
 
   try {
-    sock.bind(localip);
+    sock.bind(localip.d_address);
   }
   catch (const NetworkError& e) {
     if (localBind) {
@@ -498,7 +498,7 @@ static void addPadding(const DNSPacketWriter& pw, size_t bufsize, DNSPacketWrite
   }
 }
 
-static void outgoingCookie(const OptLog& log, const ComboAddress& address, const timeval& now, DNSPacketWriter::optvect_t& opts, std::optional<EDNSCookiesOpt>& cookieSentOut, std::optional<ComboAddress>& addressToBindTo)
+static void outgoingCookie(const OptLog& log, const ComboAddress& address, const timeval& now, DNSPacketWriter::optvect_t& opts, std::optional<EDNSCookiesOpt>& cookieSentOut, std::optional<pdns::AddressAndInterface>& addressToBindTo)
 {
   auto lock = s_cookiestore.lock();
   if (auto found = lock->find(address); found != lock->end()) {
@@ -528,7 +528,7 @@ static void outgoingCookie(const OptLog& log, const ComboAddress& address, const
   VLOG(log, "Sending new client cookie info to " << address.toString() << ": " << entry.d_cookie.toDisplayString() << endl);
 }
 
-static std::pair<bool, LWResult::Result> incomingCookie(const OptLog& log, const ComboAddress& address, const ComboAddress& localip, const timeval& now, const std::optional<EDNSCookiesOpt>& cookieSentOut, const EDNSOpts& edo, bool doTCP, LWResult& lwr, bool& cookieFoundInReply)
+static std::pair<bool, LWResult::Result> incomingCookie(const OptLog& log, const ComboAddress& address, const pdns::AddressAndInterface& localip, const timeval& now, const std::optional<EDNSCookiesOpt>& cookieSentOut, const EDNSOpts& edo, bool doTCP, LWResult& lwr, bool& cookieFoundInReply)
 {
   auto lock = s_cookiestore.lock();
   auto found = lock->find(address);
@@ -548,10 +548,10 @@ static std::pair<bool, LWResult::Result> incomingCookie(const OptLog& log, const
       cookieFoundInReply = true;
       VLOG(log, "Received cookie info back from " << address.toString() << ": " << received.toDisplayString() << endl);
       if (cookieSentOut && received.getClient() == cookieSentOut->getClient()) {
-        VLOG(log, "Client cookie from " << address.toString() << " matched! Storing with localAddress " << localip.toString() << endl);
+        VLOG(log, "Client cookie from " << address.toString() << " matched! Storing with localAddress " << localip.d_address.toString() << endl);
         ++t_Counters.at(rec::Counter::cookieMatched);
         found->d_localaddress = localip;
-        found->d_localaddress.setPort(0);
+        found->d_localaddress.d_address.setPort(0);
         found->d_cookie = std::move(received);
         if (found->getSupport() == CookieEntry::Support::Probing) {
           ++t_Counters.at(rec::Counter::cookieProbeSupported);
@@ -562,20 +562,20 @@ static std::pair<bool, LWResult::Result> incomingCookie(const OptLog& log, const
         if (ercode == ERCode::BADCOOKIE) {
           lwr.d_validpacket = true;
           ++t_Counters.at(rec::Counter::cookieRetry);
-          VLOG(log, "Server " << localip.toString() << " returned BADCOOKIE " << endl);
+          VLOG(log, "Server " << localip.d_address.toString() << " returned BADCOOKIE " << endl);
           return {true, LWResult::Result::BadCookie}; // We did update the entry, retry should succeed
         }
       }
       else {
         if (!doTCP) {
           // Server responded with a wrong client cookie, fall back to TCP, RFC 7873 5.3
-          VLOG(log, "Server " << localip.toString() << " responded with wrong client cookie, fall back to TCP" << endl);
+          VLOG(log, "Server " << localip.d_address.toString() << " responded with wrong client cookie, fall back to TCP" << endl);
           lwr.d_validpacket = true;
           ++t_Counters.at(rec::Counter::cookieMismatchedOverUDP);
           return {true, LWResult::Result::Spoofed};
         }
         // mismatched cookie when already doing TCP, ignore that
-        VLOG(log, "Server " << localip.toString() << " responded with wrong client cookie over TCP, ignoring that" << endl);
+        VLOG(log, "Server " << localip.d_address.toString() << " responded with wrong client cookie over TCP, ignoring that" << endl);
         ++t_Counters.at(rec::Counter::cookieMismatchedOverTCP);
       }
     }
@@ -627,7 +627,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
   pw.getHeader()->cd = (sendRDQuery && g_dnssecmode != DNSSECMode::Off);
 
   std::optional<EDNSSubnetOpts> subnetOpts = std::nullopt;
-  std::optional<ComboAddress> addressToBindTo;
+  std::optional<pdns::AddressAndInterface> addressToBindTo;
   std::optional<EDNSCookiesOpt> cookieSentOut;
 
   if (EDNS0Level > 0) {
@@ -745,7 +745,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
         // Cookie info already has been added to packet, so we must retry from a higher level
         auto lock = s_cookiestore.lock();
         lock->erase(address);
-        VLOG(log, "BindError remote: " << address.toString() << " localAddress: " << (addressToBindTo ? addressToBindTo->toString() : "none") << endl);
+        VLOG(log, "BindError remote: " << address.toString() << " localAddress: " << (addressToBindTo ? addressToBindTo->d_address.toString() : "none") << endl);
         return LWResult::Result::BindError;
       }
       catch (const NetworkError& nwe) {
@@ -874,7 +874,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
         }
       }
       if (g_cookies && cookieSentOut && !*chained) {
-        auto [done, result] = incomingCookie(log, address, localip, *now, cookieSentOut, edo, doTCP, *lwr, cookieFoundInReply);
+        auto [done, result] = incomingCookie(log, address, {localip, std::nullopt}, *now, cookieSentOut, edo, doTCP, *lwr, cookieFoundInReply);
         if (done) {
           return result;
         }

--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -21,6 +21,8 @@
  */
 #include "config.h"
 
+#include <net/if.h>
+
 #include "lwres.hh"
 #include "arguments.hh"
 #include "query-local-address.hh"
@@ -383,6 +385,14 @@ static bool tcpconnect(const OptLog& log, const ComboAddress& remote, const std:
 
   try {
     sock.bind(localip.d_address);
+    if (localip.d_interface) {
+      const auto& name = localip.d_interface->d_name;
+      int res = setsockopt(sock.getHandle(), SOL_SOCKET, SO_BINDTODEVICE, name.data(), name.length());
+      int err = errno;
+      if (res != 0) {
+        cerr << "SO_BINDTODEVICE " << res << stringerror(err) << endl;
+      }
+    }
   }
   catch (const NetworkError& e) {
     if (localBind) {
@@ -428,7 +438,7 @@ static bool tcpconnect(const OptLog& log, const ComboAddress& remote, const std:
 }
 
 static LWResult::Result tcpsendrecv(const ComboAddress& ip, TCPOutConnectionManager::Connection& connection,
-                                    ComboAddress& localip, const vector<uint8_t>& vpacket, size_t& len, PacketBuffer& buf,
+                                    pdns::AddressAndInterface& localip, const vector<uint8_t>& vpacket, size_t& len, PacketBuffer& buf,
                                     const std::string& nsName, const std::string& subjectName)
 {
   socklen_t slen = ip.getSocklen();
@@ -436,9 +446,17 @@ static LWResult::Result tcpsendrecv(const ComboAddress& ip, TCPOutConnectionMana
   const char* lenP = reinterpret_cast<const char*>(&tlen);
 
   len = 0; // in case of error
-  localip.sin4.sin_family = ip.sin4.sin_family;
-  if (getsockname(connection.d_handler->getDescriptor(), reinterpret_cast<sockaddr*>(&localip), &slen) != 0) {
+  localip.d_address.sin4.sin_family = ip.sin4.sin_family;
+  if (getsockname(connection.d_handler->getDescriptor(), reinterpret_cast<sockaddr*>(&localip.d_address), &slen) != 0) {
     return LWResult::Result::PermanentError;
+  }
+  std::array<char, IFNAMSIZ> name{};
+  socklen_t namelen = name.size();
+  if (getsockopt(connection.d_handler->getDescriptor(), SOL_SOCKET, SO_BINDTODEVICE, name.data(), &namelen) == 0) {
+    if (namelen > 0) {
+      unsigned int index = if_nametoindex(name.data());
+      localip.d_interface = pdns::Interface{std::string(name.data()), index};
+    }
   }
 
   PacketBuffer packet;
@@ -668,7 +686,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
   srcmask = std::nullopt; // this is also our return value, even if EDNS0Level == 0
 
   // We only store the localip if needed for fstrm logging or cookie support
-  ComboAddress localip;
+  pdns::AddressAndInterface localip;
   bool fstrmQEnabled = false;
   bool fstrmREnabled = false;
 
@@ -705,13 +723,13 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
 
     if (!*chained) {
       if (cookieSentOut || fstrmQEnabled || fstrmREnabled) {
-        localip.sin4.sin_family = address.sin4.sin_family;
+        localip.d_address.sin4.sin_family = address.sin4.sin_family;
         socklen_t slen = address.getSocklen();
-        (void)getsockname(queryfd, reinterpret_cast<sockaddr*>(&localip), &slen); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast))
+        (void)getsockname(queryfd, reinterpret_cast<sockaddr*>(&localip.d_address), &slen); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast))
       }
 #ifdef HAVE_FSTRM
       if (fstrmQEnabled) {
-        logFstreamQuery(fstrmLoggers, queryTime, localip, address, DnstapMessage::ProtocolType::DoUDP, context.d_auth, vpacket);
+        logFstreamQuery(fstrmLoggers, queryTime, localip.d_address, address, DnstapMessage::ProtocolType::DoUDP, context.d_auth, vpacket);
       }
 #endif
     }
@@ -733,7 +751,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
         ret = tcpsendrecv(address, connection, localip, vpacket, len, buf, nsName, subjectName);
 #ifdef HAVE_FSTRM
         if (fstrmQEnabled) {
-          logFstreamQuery(fstrmLoggers, queryTime, localip, address, !dnsOverTLS ? DnstapMessage::ProtocolType::DoTCP : DnstapMessage::ProtocolType::DoT, context.d_auth, vpacket);
+          logFstreamQuery(fstrmLoggers, queryTime, localip.d_address, address, !dnsOverTLS ? DnstapMessage::ProtocolType::DoTCP : DnstapMessage::ProtocolType::DoT, context.d_auth, vpacket);
         }
 #endif /* HAVE_FSTRM */
         if (ret == LWResult::Result::Success) {
@@ -789,7 +807,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
     if (dnsOverTLS) {
       protocol = DnstapMessage::ProtocolType::DoT;
     }
-    logFstreamResponse(fstrmLoggers, localip, address, protocol, context.d_auth, buf, queryTime, *now);
+    logFstreamResponse(fstrmLoggers, localip.d_address, address, protocol, context.d_auth, buf, queryTime, *now);
   }
 #endif /* HAVE_FSTRM */
 
@@ -874,7 +892,7 @@ static LWResult::Result asyncresolve(const OptLog& log, const ComboAddress& addr
         }
       }
       if (g_cookies && cookieSentOut && !*chained) {
-        auto [done, result] = incomingCookie(log, address, {localip, std::nullopt}, *now, cookieSentOut, edo, doTCP, *lwr, cookieFoundInReply);
+        auto [done, result] = incomingCookie(log, address, localip, *now, cookieSentOut, edo, doTCP, *lwr, cookieFoundInReply);
         if (done) {
           return result;
         }

--- a/pdns/recursordist/lwres.cc
+++ b/pdns/recursordist/lwres.cc
@@ -390,7 +390,7 @@ static bool tcpconnect(const OptLog& log, const ComboAddress& remote, const std:
       int res = setsockopt(sock.getHandle(), SOL_SOCKET, SO_BINDTODEVICE, name.data(), name.length());
       int err = errno;
       if (res != 0) {
-        cerr << "SO_BINDTODEVICE " << res << stringerror(err) << endl;
+        VLOG(log, "SO_BINDTODEVICE error while connecting TCP: " << stringerror(err));
       }
     }
   }

--- a/pdns/recursordist/lwres.hh
+++ b/pdns/recursordist/lwres.hh
@@ -28,6 +28,7 @@
 #include "pdnsexception.hh"
 #include "noinitvector.hh"
 #include "remote_logger.hh"
+#include "query-local-address.hh"
 
 class FrameStreamLogger;
 struct DNSRecord;
@@ -81,7 +82,7 @@ public:
 class EDNSSubnetOpts;
 
 LWResult::Result asendto(const void* data, size_t len, const ComboAddress& toAddress,
-                         std::optional<ComboAddress>& localAddress, uint16_t qid,
+                         std::optional<pdns::AddressAndInterface>& localAddress, uint16_t qid,
                          const DNSName& domain, uint16_t qtype, const std::optional<EDNSSubnetOpts>& ecs, int* fileDesc, timeval& now);
 LWResult::Result arecvfrom(PacketBuffer& packet, const ComboAddress& fromAddr, size_t& len, uint16_t qid,
                            const DNSName& domain, uint16_t qtype, int fileDesc, const std::optional<EDNSSubnetOpts>& ecs, const struct timeval& now);

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -100,7 +100,7 @@ GlobalStateHolder<NetmaskGroup> g_dontThrottleNetmasks;
 GlobalStateHolder<SuffixMatchNode> g_DoTToAuthNames;
 uint64_t g_latencyStatSize;
 
-LWResult::Result UDPClientSocks::getSocket(const ComboAddress& toaddr, const std::optional<ComboAddress>& localAddress, int* fileDesc)
+LWResult::Result UDPClientSocks::getSocket(const ComboAddress& toaddr, const std::optional<pdns::AddressAndInterface>& localAddress, int* fileDesc)
 {
   *fileDesc = makeClientSocket(toaddr.sin4.sin_family, localAddress);
   if (*fileDesc < 0) { // temporary error - receive exception otherwise
@@ -148,7 +148,7 @@ void UDPClientSocks::returnSocket(int fileDesc)
 }
 
 // returns -1 for errors which might go away, throws for ones that won't
-int UDPClientSocks::makeClientSocket(int family, const std::optional<ComboAddress>& localAddress)
+int UDPClientSocks::makeClientSocket(int family, const std::optional<pdns::AddressAndInterface>& localAddress)
 {
   int ret = socket(family, SOCK_DGRAM, 0); // turns out that setting CLO_EXEC and NONBLOCK from here is not a performance win on Linux (oddly enough)
 
@@ -183,11 +183,11 @@ int UDPClientSocks::makeClientSocket(int family, const std::optional<ComboAddres
     // localAddress is set if a cookie was involved, bind to the same address the cookie is
     // associated with (RFC 9018 section 3 last paragraph)
     if (localAddress) {
-      sin = *localAddress;
+      sin = localAddress->d_address;
       sin.setPort(port);
     }
     else {
-      sin = pdns::getQueryLocalAddress(family, port); // does htons for us
+      sin = pdns::getQueryLocalAddress(family, port).d_address; // does htons for us
     }
     if (::bind(ret, reinterpret_cast<struct sockaddr*>(&sin), sin.getSocklen()) >= 0) { // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
       break;
@@ -240,7 +240,7 @@ PacketBuffer GenUDPQueryResponse(const ComboAddress& dest, const string& query)
 {
   Socket socket(dest.sin4.sin_family, SOCK_DGRAM);
   socket.setNonBlocking();
-  ComboAddress local = pdns::getQueryLocalAddress(dest.sin4.sin_family, 0);
+  ComboAddress local = pdns::getQueryLocalAddress(dest.sin4.sin_family, 0).d_address;
 
   socket.bind(local);
   socket.connect(dest);
@@ -285,7 +285,7 @@ unsigned int authWaitTimeMSec(const std::unique_ptr<MT_t>& mtasker)
 
 /* these two functions are used by LWRes */
 LWResult::Result asendto(const void* data, size_t len,
-                         const ComboAddress& toAddress, std::optional<ComboAddress>& localAddress, uint16_t qid, const DNSName& domain, uint16_t qtype, const std::optional<EDNSSubnetOpts>& ecs, int* fileDesc, timeval& now)
+                         const ComboAddress& toAddress, std::optional<pdns::AddressAndInterface>& localAddress, uint16_t qid, const DNSName& domain, uint16_t qtype, const std::optional<EDNSSubnetOpts>& ecs, int* fileDesc, timeval& now)
 {
 
   auto pident = std::make_shared<PacketID>();

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -100,9 +100,9 @@ GlobalStateHolder<NetmaskGroup> g_dontThrottleNetmasks;
 GlobalStateHolder<SuffixMatchNode> g_DoTToAuthNames;
 uint64_t g_latencyStatSize;
 
-LWResult::Result UDPClientSocks::getSocket(const ComboAddress& toaddr, const std::optional<pdns::AddressAndInterface>& localAddress, int* fileDesc)
+LWResult::Result UDPClientSocks::getSocket(const ComboAddress& toaddr, const std::optional<pdns::AddressAndInterface>& localAddress, std::optional<pdns::Interface>& interface, int* fileDesc)
 {
-  *fileDesc = makeClientSocket(toaddr.sin4.sin_family, localAddress);
+  *fileDesc = makeClientSocket(toaddr.sin4.sin_family, localAddress, interface);
   if (*fileDesc < 0) { // temporary error - receive exception otherwise
     return LWResult::Result::OSLimitError;
   }
@@ -148,7 +148,7 @@ void UDPClientSocks::returnSocket(int fileDesc)
 }
 
 // returns -1 for errors which might go away, throws for ones that won't
-int UDPClientSocks::makeClientSocket(int family, const std::optional<pdns::AddressAndInterface>& localAddress)
+int UDPClientSocks::makeClientSocket(int family, const std::optional<pdns::AddressAndInterface>& localAddress, std::optional<pdns::Interface>& interface)
 {
   int ret = socket(family, SOCK_DGRAM, 0); // turns out that setting CLO_EXEC and NONBLOCK from here is not a performance win on Linux (oddly enough)
 
@@ -167,7 +167,7 @@ int UDPClientSocks::makeClientSocket(int family, const std::optional<pdns::Addre
 #else
   int tries = 2; // hit the reliable kernel random case for OpenBSD immediately (because it will match tries==1 below), using sysctl net.inet.udp.baddynamic to exclude ports
 #endif
-  ComboAddress sin;
+  pdns::AddressAndInterface sin;
   while (--tries != 0) {
     in_port_t port = 0;
 
@@ -183,13 +183,18 @@ int UDPClientSocks::makeClientSocket(int family, const std::optional<pdns::Addre
     // localAddress is set if a cookie was involved, bind to the same address the cookie is
     // associated with (RFC 9018 section 3 last paragraph)
     if (localAddress) {
-      sin = localAddress->d_address;
-      sin.setPort(port);
+      sin = *localAddress;
+      sin.d_address.setPort(port);
     }
     else {
-      sin = pdns::getQueryLocalAddress(family, port).d_address; // does htons for us
+      sin = pdns::getQueryLocalAddress(family, port); // does htons for us
+      cerr << "SIN " << !!sin.d_interface << endl;
     }
-    if (::bind(ret, reinterpret_cast<struct sockaddr*>(&sin), sin.getSocklen()) >= 0) { // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    if (::bind(ret, reinterpret_cast<struct sockaddr*>(&sin.d_address), sin.d_address.getSocklen()) >= 0) { // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast
+      if (sin.d_interface) {
+        // BIND XXX
+        interface = sin.d_interface;
+      }
       break;
     }
   }
@@ -198,7 +203,7 @@ int UDPClientSocks::makeClientSocket(int family, const std::optional<pdns::Addre
 
   if (tries == 0) {
     closesocket(ret);
-    throw PDNSException("Resolver binding to local query client socket on " + sin.toString() + ": " + stringerror(err));
+    throw PDNSException("Resolver binding to local query client socket on " + sin.d_address.toString() + ": " + stringerror(err));
   }
 
   try {
@@ -325,7 +330,10 @@ LWResult::Result asendto(const void* data, size_t len,
     }
   }
 
-  auto ret = t_udpclientsocks->getSocket(toAddress, localAddress, fileDesc);
+  cerr << "XXX1" << endl;;
+  std::optional<pdns::Interface> interface;
+  auto ret = t_udpclientsocks->getSocket(toAddress, localAddress, interface, fileDesc);
+  cerr << "XXX2 " << !!interface << endl;
   if (ret != LWResult::Result::Success) {
     return ret;
   }
@@ -334,7 +342,14 @@ LWResult::Result asendto(const void* data, size_t len,
   pident->id = qid;
 
   t_fdm->addReadFD(*fileDesc, handleUDPServerResponse, pident);
-  ssize_t sent = send(*fileDesc, data, len, 0);
+  ssize_t sent{};
+  if (!interface) {
+    sent = send(*fileDesc, data, len, 0);
+  }
+  else {
+    cerr << "XXX " << interface->d_index << endl;
+    sent = sendMsgWithOptions(*fileDesc, data, len, nullptr, &localAddress->d_address, interface->d_index, 0);
+  }
   if (sent < 0) {
     int tmp = errno;
     t_udpclientsocks->returnSocket(*fileDesc);

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -344,9 +344,14 @@ LWResult::Result asendto(const void* data, size_t len,
   pident->id = qid;
 
   t_fdm->addReadFD(*fileDesc, handleUDPServerResponse, pident);
-  ssize_t sent{};
   if (!interface) {
-    sent = send(*fileDesc, data, len, 0);
+    auto sent = send(*fileDesc, data, len, 0);
+    if (sent < 0) {
+      int tmp = errno;
+      t_udpclientsocks->returnSocket(*fileDesc);
+      errno = tmp; // this is for logging purposes only
+      return LWResult::Result::PermanentError;
+    }
   }
   else {
     ComboAddress local;
@@ -356,24 +361,13 @@ LWResult::Result asendto(const void* data, size_t len,
     else {
       local.sin4.sin_family = toAddress.sin4.sin_family;
     }
-    // sendMsgWithOptions returns size_t while send(2) returns ssize_t. sendMsgWithOption also
-    // fatals (with calling exit!) on some error conditions.  This all looks fragile, but there are
-    // existing callers, changing sendMsgWithOption() to return ssize_t to make it more send(2) like
-    // needs to be done with extra care.
 
     auto sendRet = sendMsgWithOptions(*fileDesc, data, len, nullptr, &local, interface->d_index, 0);
-    if (sendRet.has_value()) {
-      sent = static_cast<ssize_t>(sendRet.value());
+    if (!sendRet.has_value()) {
+      t_udpclientsocks->returnSocket(*fileDesc);
+      errno = sendRet.error(); // this is for logging purposes only
+      return LWResult::Result::PermanentError;
     }
-    else {
-      sent = sendRet.error();
-    }
-  }
-  if (sent < 0) {
-    int tmp = errno;
-    t_udpclientsocks->returnSocket(*fileDesc);
-    errno = tmp; // this is for logging purposes only
-    return LWResult::Result::PermanentError;
   }
 
   return LWResult::Result::Success;

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -360,7 +360,14 @@ LWResult::Result asendto(const void* data, size_t len,
     // fatals (with calling exit!) on some error conditions.  This all looks fragile, but there are
     // existing callers, changing sendMsgWithOption() to return ssize_t to mkae it more sned(2) like
     // needs to be done with extra care.
-    sent = sendMsgWithOptions(*fileDesc, data, len, nullptr, &local, interface->d_index, 0);
+
+    auto sendRet = sendMsgWithOptions(*fileDesc, data, len, nullptr, &local, interface->d_index, 0);
+    if (sendRet.has_value()) {
+      sent = static_cast<ssize_t>(sendRet.value());
+    }
+    else {
+      sent = sendRet.error();
+    }
   }
   if (sent < 0) {
     int tmp = errno;

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -356,7 +356,10 @@ LWResult::Result asendto(const void* data, size_t len,
     else {
       local.sin4.sin_family = toAddress.sin4.sin_family;
     }
-    // XXX signedness!
+    // sendMsgWithOptions returns size_t while send(2) returns ssize_t. sendMsgWithOption also
+    // fatals (with calling exit!) on some error conditions.  This all looks fragile, but there are
+    // existing callers, changing sendMsgWithOption() to return ssize_t to mkae it more sned(2) like
+    // needs to be done with extra care.
     sent = sendMsgWithOptions(*fileDesc, data, len, nullptr, &local, interface->d_index, 0);
   }
   if (sent < 0) {

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -358,7 +358,7 @@ LWResult::Result asendto(const void* data, size_t len,
     }
     // sendMsgWithOptions returns size_t while send(2) returns ssize_t. sendMsgWithOption also
     // fatals (with calling exit!) on some error conditions.  This all looks fragile, but there are
-    // existing callers, changing sendMsgWithOption() to return ssize_t to mkae it more sned(2) like
+    // existing callers, changing sendMsgWithOption() to return ssize_t to make it more send(2) like
     // needs to be done with extra care.
 
     auto sendRet = sendMsgWithOptions(*fileDesc, data, len, nullptr, &local, interface->d_index, 0);

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -188,11 +188,15 @@ int UDPClientSocks::makeClientSocket(int family, const std::optional<pdns::Addre
     }
     else {
       sin = pdns::getQueryLocalAddress(family, port); // does htons for us
-      cerr << "SIN " << !!sin.d_interface << endl;
     }
     if (::bind(ret, reinterpret_cast<struct sockaddr*>(&sin.d_address), sin.d_address.getSocklen()) >= 0) { // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast
       if (sin.d_interface) {
-        // BIND XXX
+        const auto& name = sin.d_interface->d_name;
+        int res = setsockopt(ret, SOL_SOCKET, SO_BINDTODEVICE, name.data(), name.length());
+        if (res != 0) {
+          int err = errno;
+          throw PDNSException("Resolver binding to interface " + name + ": " + stringerror(err));
+        }
         interface = sin.d_interface;
       }
       break;
@@ -330,10 +334,8 @@ LWResult::Result asendto(const void* data, size_t len,
     }
   }
 
-  cerr << "XXX1" << endl;;
   std::optional<pdns::Interface> interface;
   auto ret = t_udpclientsocks->getSocket(toAddress, localAddress, interface, fileDesc);
-  cerr << "XXX2 " << !!interface << endl;
   if (ret != LWResult::Result::Success) {
     return ret;
   }
@@ -347,8 +349,15 @@ LWResult::Result asendto(const void* data, size_t len,
     sent = send(*fileDesc, data, len, 0);
   }
   else {
-    cerr << "XXX " << interface->d_index << endl;
-    sent = sendMsgWithOptions(*fileDesc, data, len, nullptr, &localAddress->d_address, interface->d_index, 0);
+    ComboAddress local;
+    if (localAddress) {
+      local = localAddress->d_address;
+    }
+    else {
+      local.sin4.sin_family = toAddress.sin4.sin_family;
+    }
+    // XXX signedness!
+    sent = sendMsgWithOptions(*fileDesc, data, len, nullptr, &local, interface->d_index, 0);
   }
   if (sent < 0) {
     int tmp = errno;

--- a/pdns/recursordist/rec-cookiestore.cc
+++ b/pdns/recursordist/rec-cookiestore.cc
@@ -48,7 +48,7 @@ uint64_t CookieStore::dump(int fileDesc) const
     timebuf_t tmp;
     fprintf(filePtr.get(), "%s\t%s\t%s\t%s\t%s\n",
             entry.d_address.toStringWithPortExcept(53).c_str(),
-            entry.d_localaddress.isUnspecified() ? "-" : entry.d_localaddress.toString().c_str(),
+            entry.d_localaddress.d_address.isUnspecified() ? "-" : entry.d_localaddress.d_address.toString().c_str(),
             entry.d_support == CookieEntry::Support::Unsupported ? "-" : entry.d_cookie.toDisplayString().c_str(),
             CookieEntry::toString(entry.d_support).c_str(),
             entry.d_lastused == std::numeric_limits<time_t>::max() ? "Forever" : timestamp(entry.d_lastused, tmp));

--- a/pdns/recursordist/rec-cookiestore.hh
+++ b/pdns/recursordist/rec-cookiestore.hh
@@ -46,6 +46,7 @@
 
 #include "iputils.hh"
 #include "ednscookies.hh"
+#include "query-local-address.hh"
 
 using namespace ::boost::multi_index;
 
@@ -88,7 +89,7 @@ struct CookieEntry
   }
 
   ComboAddress d_address;
-  mutable ComboAddress d_localaddress; // The address we were bound to, see RFC 9018
+  mutable pdns::AddressAndInterface d_localaddress; // The address we were bound to, see RFC 9018
   mutable EDNSCookiesOpt d_cookie; // Contains both client and server cookie
   mutable time_t d_lastused{};
   mutable Support d_support{Support::Unsupported};

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1851,13 +1851,13 @@ static int initSyncRes(Logr::log_t log)
     Netmask netmask;
     bool done = false;
 
-    auto addr = pdns::getNonAnyQueryLocalAddress(AF_INET);
+    auto addr = pdns::getNonAnyQueryLocalAddress(AF_INET).d_address;
     if (addr.sin4.sin_family != 0) {
       netmask = Netmask(addr, 32);
       done = true;
     }
     if (!done) {
-      addr = pdns::getNonAnyQueryLocalAddress(AF_INET6);
+      addr = pdns::getNonAnyQueryLocalAddress(AF_INET6).d_address;
       if (addr.sin4.sin_family != 0) {
         netmask = Netmask(addr, 128);
         done = true;

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1654,6 +1654,7 @@ static int initNet(Logr::log_t log)
 {
   checkLinuxIPv6Limits(log);
   try {
+    cerr << "ZZZZ" << endl;
     pdns::parseQueryLocalAddress(::arg()["query-local-address"]);
   }
   catch (std::exception& e) {

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1654,7 +1654,6 @@ static int initNet(Logr::log_t log)
 {
   checkLinuxIPv6Limits(log);
   try {
-    cerr << "ZZZZ" << endl;
     pdns::parseQueryLocalAddress(::arg()["query-local-address"]);
   }
   catch (std::exception& e) {

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -153,7 +153,7 @@ extern DoneRunning g_doneRunning;
 class UDPClientSocks
 {
 public:
-  LWResult::Result getSocket(const ComboAddress& toaddr, const std::optional<pdns::AddressAndInterface>& localAddress, int* fileDesc);
+  LWResult::Result getSocket(const ComboAddress& toaddr, const std::optional<pdns::AddressAndInterface>& localAddress, std::optional<pdns::Interface>& interface, int* fileDesc);
 
   // return a socket to the pool, or simply erase it
   void returnSocket(int fileDesc);
@@ -161,7 +161,7 @@ public:
 private:
   unsigned int d_numsocks{0};
   // returns -1 for errors which might go away, throws for ones that won't
-  static int makeClientSocket(int family, const std::optional<pdns::AddressAndInterface>& localAddress);
+  static int makeClientSocket(int family, const std::optional<pdns::AddressAndInterface>& localAddress, std::optional<pdns::Interface>& interface);
 };
 
 enum class PaddingMode : uint8_t

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -153,7 +153,7 @@ extern DoneRunning g_doneRunning;
 class UDPClientSocks
 {
 public:
-  LWResult::Result getSocket(const ComboAddress& toaddr, const std::optional<ComboAddress>& localAddress, int* fileDesc);
+  LWResult::Result getSocket(const ComboAddress& toaddr, const std::optional<pdns::AddressAndInterface>& localAddress, int* fileDesc);
 
   // return a socket to the pool, or simply erase it
   void returnSocket(int fileDesc);
@@ -161,7 +161,7 @@ public:
 private:
   unsigned int d_numsocks{0};
   // returns -1 for errors which might go away, throws for ones that won't
-  static int makeClientSocket(int family, const std::optional<ComboAddress>& localAddress);
+  static int makeClientSocket(int family, const std::optional<pdns::AddressAndInterface>& localAddress);
 };
 
 enum class PaddingMode : uint8_t

--- a/pdns/recursordist/rec-rust-lib/generate.py
+++ b/pdns/recursordist/rec-rust-lib/generate.py
@@ -99,6 +99,7 @@ class LType(Enum):
     Bool = auto()
     Command = auto()
     Double = auto()
+    ListAddressAndInterfaces = auto()
     ListAllowedAdditionalQTypes = auto()
     ListAuthZones = auto()
     ListDNSTapFrameStreamServers = auto()
@@ -107,6 +108,8 @@ class LType(Enum):
     ListForwardingCatalogZones = auto()
     ListIncomingWSConfigs = auto()
     ListNegativeTrustAnchors = auto()
+    ListOpenTelemetryTraceConditions = auto()
+    ListOutgoingTLSConfigurations = auto()
     ListProtobufServers = auto()
     ListProxyMappings = auto()
     ListRPZs = auto()
@@ -116,13 +119,11 @@ class LType(Enum):
     ListSubnets = auto()
     ListTrustAnchors = auto()
     ListZoneToCaches = auto()
-    ListOutgoingTLSConfigurations = auto()
-    ListOpenTelemetryTraceConditions = auto()
     String = auto()
     Uint64 = auto()
 
 
-listOfStringTypes = (LType.ListSocketAddresses, LType.ListStrings, LType.ListSubnets)
+listOfStringTypes = (LType.ListSocketAddresses, LType.ListStrings, LType.ListSubnets, LType.ListAddressAndInterfaces)
 listOfStructuredTypes = (
     LType.ListAuthZones,
     LType.ListForwardZones,
@@ -163,6 +164,8 @@ def get_olddoc_typename(typ):
         return "Comma separated list of 'zonename=IP' pairs"
     if typ == LType.ListAuthZones:
         return "Comma separated list of 'zonename=filename' pairs"
+    if typ == LType.ListAddressAndInterfaces:
+        return "Comma separated list IP or IP@interface strings"
     return "Unknown1" + str(typ)
 
 
@@ -214,6 +217,8 @@ def get_newdoc_typename(typ):
         return "Sequence of `OutgoingTLSConfiguration`_"
     if typ == LType.ListOpenTelemetryTraceConditions:
         return "Sequence of `OpenTelemetryTraceCondition`_"
+    if typ == LType.ListAddressAndInterfaces:
+        return "Sequence of address or address@interface_"
     return "Unknown2" + str(typ)
 
 
@@ -277,6 +282,8 @@ def get_rust_type(typ):
     if typ == LType.ListSubnets:
         return "Vec<String>"
     if typ == LType.ListStrings:
+        return "Vec<String>"
+    if typ == LType.ListAddressAndInterfaces:
         return "Vec<String>"
     # These vectors map to Vec<Type>
     return "Vec<" + list_to_base_type(typ) + ">"

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -2369,7 +2369,7 @@ This value has precedence over :ref:`setting-qname-max-minimize-count`.
         "name": "source_address",
         "section": "outgoing",
         "oldname": "query-local-address",
-        "type": LType.ListSubnets,
+        "type": LType.ListAddressAndInterfaces,
         "default": "0.0.0.0",
         "help": "Source IP address for sending queries",
         "doc": """

--- a/pdns/recursordist/rec-tcpout.hh
+++ b/pdns/recursordist/rec-tcpout.hh
@@ -24,6 +24,7 @@
 
 #include "iputils.hh"
 #include "tcpiohandler.hh"
+#include "query-local-address.hh"
 
 namespace pdns::rust::settings::rec
 {
@@ -53,13 +54,13 @@ public:
     }
 
     std::shared_ptr<TCPIOHandler> d_handler;
-    std::optional<ComboAddress> d_local;
+    std::optional<pdns::AddressAndInterface> d_local;
     timeval d_last_used{0, 0};
     size_t d_numqueries{0};
     bool d_verboseLogging{false};
   };
 
-  using endpoints_t = std::pair<ComboAddress, std::optional<ComboAddress>>;
+  using endpoints_t = std::pair<ComboAddress, std::optional<pdns::AddressAndInterface>>;
 
   void store(const struct timeval& now, const endpoints_t& endpoints, Connection&& connection);
   Connection get(const endpoints_t& pair);

--- a/pdns/recursordist/rec-xfr.cc
+++ b/pdns/recursordist/rec-xfr.cc
@@ -180,7 +180,7 @@ static shared_ptr<const SOARecordContent> loadZoneFromServer(Logr::log_t plogger
 
   ComboAddress local(localAddress);
   if (local == ComboAddress()) {
-    local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0);
+    local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0).d_address;
   }
 
   AXFRRetriever axfr(logger, primary, zoneName, tsigTriplet, &local, maxReceivedBytes, axfrTimeout);
@@ -331,7 +331,7 @@ bool FWCatZoneXFR::zoneTrackerIteration(const DNSName& zoneName, std::shared_ptr
 
     ComboAddress local(d_params.localAddress);
     if (local == ComboAddress()) {
-      local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0);
+      local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0).d_address;
     }
 
     try {

--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -146,7 +146,7 @@ pdns::ZoneMD::Result ZoneData::getByAXFR(const RecZoneToCache::Config& config, p
   const TSIGTriplet tsigTriplet = config.d_tt;
   ComboAddress local = config.d_local;
   if (local == ComboAddress()) {
-    local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0);
+    local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0).d_address;
   }
 
   AXFRRetriever axfr(d_log, primary, d_zone, tsigTriplet, &local, maxReceivedBytes, axfrTimeout);

--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -253,7 +253,7 @@ static shared_ptr<const SOARecordContent> loadRPZFromServer(Logr::log_t plogger,
 
   ComboAddress local(localAddress);
   if (local == ComboAddress()) {
-    local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0);
+    local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0).d_address;
   }
 
   AXFRRetriever axfr(logger, primary, zoneName, tsigTriplet, &local, maxReceivedBytes, axfrTimeout);
@@ -568,7 +568,7 @@ static bool RPZTrackerIteration(RPZTrackerParams& params, const DNSName& zoneNam
 
     ComboAddress local(params.zoneXFRParams.localAddress);
     if (local == ComboAddress()) {
-      local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0);
+      local = pdns::getQueryLocalAddress(primary.sin4.sin_family, 0).d_address;
     }
 
     try {

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -103,10 +103,10 @@ Resolver::Resolver(Logr::log_t slog) : d_slog(slog)
   locals["default6"] = -1;
   try {
     if (pdns::isQueryLocalAddressFamilyEnabled(AF_INET)) {
-      locals["default4"] = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET, 0), true, ::arg().mustDo("non-local-bind"));
+      locals["default4"] = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET, 0).d_address, true, ::arg().mustDo("non-local-bind"));
     }
     if (pdns::isQueryLocalAddressFamilyEnabled(AF_INET6)) {
-      locals["default6"] = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET6, 0), true, ::arg().mustDo("non-local-bind"));
+      locals["default6"] = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET6, 0).d_address, true, ::arg().mustDo("non-local-bind"));
     }
   }
   catch(...) {

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -690,7 +690,7 @@ static int forwardPacket(UeberBackend& B, const updateContext& ctx, const DNSPac
     if (!pdns::isQueryLocalAddressFamilyEnabled(remote.sin4.sin_family)) {
       continue;
     }
-    auto local = pdns::getQueryLocalAddress(remote.sin4.sin_family, 0);
+    auto local = pdns::getQueryLocalAddress(remote.sin4.sin_family, 0).d_address;
     ctx.sock = makeQuerySocket(local, false); // create TCP socket. RFC2136 section 6.2 seems to be ok with this.
     if (ctx.sock < 0) {
       SLOG(g_log << Logger::Error << ctx.msgPrefix << "Error creating socket: " << stringerror() << endl,

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -439,10 +439,13 @@ public:
 #ifdef MSG_FASTOPEN
     if (d_fastOpen) {
       int socketFlags = MSG_FASTOPEN;
-      size_t sent = sendMsgWithOptions(d_socket, reinterpret_cast<const char *>(&buffer.at(pos)), toWrite - pos, &d_remote, nullptr, 0, socketFlags);
-      if (sent > 0) {
+      auto sendRet = sendMsgWithOptions(d_socket, reinterpret_cast<const char*>(&buffer.at(pos)), toWrite - pos, &d_remote, nullptr, 0, socketFlags);
+      if (!sendRet.has_value()) {
+        throw std::runtime_error("sendMsgWithOptions: " + stringerror(sendRet.error()));
+      }
+      if (sendRet.value() > 0) {
         d_fastOpen = false;
-        pos += sent;
+        pos += sendRet.value();
       }
 
       if (pos < toWrite) {
@@ -484,12 +487,15 @@ public:
 #ifdef MSG_FASTOPEN
     if (d_fastOpen) {
       int socketFlags = MSG_FASTOPEN;
-      size_t sent = sendMsgWithOptions(d_socket, reinterpret_cast<const char *>(buffer), bufferSize, &d_remote, nullptr, 0, socketFlags);
-      if (sent > 0) {
+      auto sendRet = sendMsgWithOptions(d_socket, reinterpret_cast<const char*>(buffer), bufferSize, &d_remote, nullptr, 0, socketFlags);
+      if (!sendRet.has_value()) {
+        throw std::runtime_error("sendMsgWithOptions: " + stringerror(sendRet.error()));
+      }
+      if (sendRet.value() > 0) {
         d_fastOpen = false;
       }
 
-      return sent;
+      return sendRet.value();
     }
 #endif /* MSG_FASTOPEN */
 

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -968,4 +968,22 @@ BOOST_AUTO_TEST_CASE(test_unspecified)
   }
 }
 
+// Check the tricky case: two somewhat compatibe types
+BOOST_AUTO_TEST_CASE(test_expected)
+{
+  pdns::expected<size_t, int> test(0);
+
+  test = static_cast<size_t>(1);
+  BOOST_ASSERT(test.has_value());
+  BOOST_CHECK_EQUAL(test.value(), 1U);
+
+  test = 2;
+  BOOST_ASSERT(test.has_value());
+  BOOST_CHECK_EQUAL(test.value(), 2U);
+
+  test = pdns::unexpected(3);
+  BOOST_ASSERT(!test.has_value());
+  BOOST_CHECK_EQUAL(test.error(), 3);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -968,7 +968,7 @@ BOOST_AUTO_TEST_CASE(test_unspecified)
   }
 }
 
-// Check the tricky case: two somewhat compatibe types
+// Check the tricky case: two somewhat compatible types
 BOOST_AUTO_TEST_CASE(test_expected)
 {
   pdns::expected<size_t, int> test(0);

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -984,6 +984,12 @@ BOOST_AUTO_TEST_CASE(test_expected)
   test = pdns::unexpected(3);
   BOOST_ASSERT(!test.has_value());
   BOOST_CHECK_EQUAL(test.error(), 3);
+
+  std::string str("foo");
+  pdns::expected<std::string, int> test1(str);
+  BOOST_ASSERT(!str.empty());
+
+  pdns::expected<std::string, int> test2("bar");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/regression-tests.recursor-dnssec/test_NamedInterface.py
+++ b/regression-tests.recursor-dnssec/test_NamedInterface.py
@@ -8,7 +8,7 @@ class NamedInterfaceTest(RecursorTest):
     """A simple use of a named interface.
 
     We do not test the case of the kernel derived interface != the named interface, as it requires a
-    funny network config. But at least the mechanism of naming an expliti interface is exercised.
+    funny network config. But at least the mechanism of naming an explicit interface is exercised.
     """
 
     _confdir = "NamedInterface"
@@ -38,11 +38,12 @@ outgoing:
         self.assertRRsetInAnswer(res, expected)
         self.assertMatchingRRSIGInAnswer(res, expected)
 
+
 class NamedInterfaceWithCookiesTest(RecursorTest):
     """A simple use of a named interface with cookies (and auth does not support them).
 
     As the source address (including interface) must be remembered and re-used with a specific
-    cookie, it makes sense to test a named intercace together with outgoing cookies.
+    cookie, it makes sense to test a named interface together with outgoing cookies.
     """
 
     _confdir = "NamedInterfaceWithCookies"
@@ -188,7 +189,7 @@ class NamedInterfaceWithCookiesAuthEnabledTest(NamedInterfaceWithCookiesTest):
     """A simple use of a named interface with cookies (auth does not support them).
 
     As the source address (including interface) must be remembered and re-used with a specific
-    cookie, it makes sense to test a named intercace together with outgoing cookies.
+    cookie, it makes sense to test a named interface together with outgoing cookies.
     """
 
     _confdir = "NamedInterfaceWithCookiesAuthEnabled"
@@ -219,4 +220,3 @@ class NamedInterfaceWithCookiesAuthEnabledTest(NamedInterfaceWithCookiesTest):
         # Be careful here, we don't want the overridden secureZone(), so call RecursorTest explicitly
         RecursorTest.generateAllAuthConfig(confdir)
         RecursorTest.startAllAuth(confdir)
-

--- a/regression-tests.recursor-dnssec/test_NamedInterface.py
+++ b/regression-tests.recursor-dnssec/test_NamedInterface.py
@@ -1,0 +1,222 @@
+import dns
+import os
+import shutil
+from recursortests import RecursorTest
+
+
+class NamedInterfaceTest(RecursorTest):
+    """A simple use of a named interface.
+
+    We do not test the case of the kernel derived interface != the named interface, as it requires a
+    funny network config. But at least the mechanism of naming an expliti interface is exercised.
+    """
+
+    _confdir = "NamedInterface"
+    _auth_zones = RecursorTest._default_auth_zones
+
+    _config_template = """
+dnssec:
+  validation: validate
+outgoing:
+    source_address: [ "127.0.0.1@lo" ]
+"""
+
+    @classmethod
+    def generateRecursorConfig(cls, confdir):
+        super(NamedInterfaceTest, cls).generateRecursorYamlConfig(confdir)
+
+    def testA(self):
+        expected = dns.rrset.from_text(
+            "ns.secure.example.", 0, dns.rdataclass.IN, "A", "{prefix}.9".format(prefix=self._PREFIX)
+        )
+        query = dns.message.make_query("ns.secure.example", "A", want_dnssec=True)
+        query.flags |= dns.flags.AD
+
+        res = self.sendUDPQuery(query)
+
+        self.assertMessageIsAuthenticated(res)
+        self.assertRRsetInAnswer(res, expected)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+
+class NamedInterfaceWithCookiesTest(RecursorTest):
+    """A simple use of a named interface with cookies (and auth does not support them).
+
+    As the source address (including interface) must be remembered and re-used with a specific
+    cookie, it makes sense to test a named intercace together with outgoing cookies.
+    """
+
+    _confdir = "NamedInterfaceWithCookies"
+    _auth_zones = RecursorTest._default_auth_zones
+
+    _config_template = (
+        """
+recursor:
+  auth_zones:
+  - zone: authzone.example
+    file: configs/%s/authzone.zone
+dnssec:
+  validation: validate
+outgoing:
+  source_address: [ "127.0.0.1@lo" ]
+  cookies: true"""
+        % _confdir
+    )
+
+    _expectedCookies = "Unsupported"
+
+    @classmethod
+    def generateRecursorConfig(cls, confdir):
+        authzonepath = os.path.join(confdir, "authzone.zone")
+        with open(authzonepath, "w") as authzone:
+            authzone.write(
+                """$ORIGIN authzone.example.
+@ 3600 IN SOA {soa}
+@ 3600 IN A 192.0.2.88
+""".format(soa=cls._SOA)
+            )
+        super(NamedInterfaceWithCookiesTest, cls).generateRecursorYamlConfig(confdir)
+
+    def checkCookies(self):
+        confdir = os.path.join("configs", self._confdir)
+        output = self.recControl(confdir, "dump-cookies", "-")
+        for line in output.splitlines():
+            tokens = line.split()
+            if tokens[0] == ";" or tokens[0] == "dump-cookies:":
+                continue
+            print(tokens)
+            self.assertEqual(len(tokens), 5)
+            self.assertEqual(tokens[3], self._expectedCookies)
+
+    def testSOAs(self):
+        for zone in [".", "example.", "secure.example."]:
+            expected = dns.rrset.from_text(zone, 0, dns.rdataclass.IN, "SOA", self._SOA)
+            query = dns.message.make_query(zone, "SOA", want_dnssec=True)
+            query.flags |= dns.flags.AD
+
+            res = self.sendUDPQuery(query)
+
+            self.assertMessageIsAuthenticated(res)
+            self.assertRRsetInAnswer(res, expected)
+            self.assertMatchingRRSIGInAnswer(res, expected)
+        self.checkCookies()
+
+    def testA(self):
+        expected = dns.rrset.from_text(
+            "ns.secure.example.", 0, dns.rdataclass.IN, "A", "{prefix}.9".format(prefix=self._PREFIX)
+        )
+        query = dns.message.make_query("ns.secure.example", "A", want_dnssec=True)
+        query.flags |= dns.flags.AD
+
+        res = self.sendUDPQuery(query)
+
+        self.assertMessageIsAuthenticated(res)
+        self.assertRRsetInAnswer(res, expected)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+        self.checkCookies()
+
+    def testDelegation(self):
+        query = dns.message.make_query("example", "NS", want_dnssec=True)
+        query.flags |= dns.flags.AD
+
+        expectedNS = dns.rrset.from_text("example.", 0, "IN", "NS", "ns1.example.", "ns2.example.")
+
+        res = self.sendUDPQuery(query)
+
+        self.assertMessageIsAuthenticated(res)
+        self.assertRRsetInAnswer(res, expectedNS)
+        self.checkCookies()
+
+    def testBogus(self):
+        query = dns.message.make_query("ted.bogus.example", "A", want_dnssec=True)
+
+        res = self.sendUDPQuery(query)
+
+        self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
+        self.checkCookies()
+
+    def testAuthZone(self):
+        query = dns.message.make_query("authzone.example", "A", want_dnssec=True)
+
+        expectedA = dns.rrset.from_text("authzone.example.", 0, "IN", "A", "192.0.2.88")
+
+        res = self.sendUDPQuery(query)
+
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertRRsetInAnswer(res, expectedA)
+        self.checkCookies()
+
+    def testLocalhost(self):
+        queryA = dns.message.make_query("localhost", "A", want_dnssec=True)
+        expectedA = dns.rrset.from_text("localhost.", 0, "IN", "A", "127.0.0.1")
+
+        queryPTR = dns.message.make_query("1.0.0.127.in-addr.arpa", "PTR", want_dnssec=True)
+        expectedPTR = dns.rrset.from_text("1.0.0.127.in-addr.arpa.", 0, "IN", "PTR", "localhost.")
+
+        resA = self.sendUDPQuery(queryA)
+        resPTR = self.sendUDPQuery(queryPTR)
+
+        self.assertRcodeEqual(resA, dns.rcode.NOERROR)
+        self.assertRRsetInAnswer(resA, expectedA)
+
+        self.assertRcodeEqual(resPTR, dns.rcode.NOERROR)
+        self.assertRRsetInAnswer(resPTR, expectedPTR)
+        self.checkCookies()
+
+    def testLocalhostSubdomain(self):
+        queryA = dns.message.make_query("foo.localhost", "A", want_dnssec=True)
+        expectedA = dns.rrset.from_text("foo.localhost.", 0, "IN", "A", "127.0.0.1")
+
+        resA = self.sendUDPQuery(queryA)
+
+        self.assertRcodeEqual(resA, dns.rcode.NOERROR)
+        self.assertRRsetInAnswer(resA, expectedA)
+        self.checkCookies()
+
+    def testIslandOfSecurity(self):
+        query = dns.message.make_query("cname-to-islandofsecurity.secure.example.", "A", want_dnssec=True)
+
+        expectedA = dns.rrset.from_text("node1.islandofsecurity.example.", 0, "IN", "A", "192.0.2.20")
+
+        res = self.sendUDPQuery(query)
+
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertRRsetInAnswer(res, expectedA)
+        self.checkCookies()
+
+
+class NamedInterfaceWithCookiesAuthEnabledTest(NamedInterfaceWithCookiesTest):
+    """A simple use of a named interface with cookies (auth does not support them).
+
+    As the source address (including interface) must be remembered and re-used with a specific
+    cookie, it makes sense to test a named intercace together with outgoing cookies.
+    """
+
+    _confdir = "NamedInterfaceWithCookiesAuthEnabled"
+    _auth_zones = NamedInterfaceWithCookiesTest._auth_zones
+    _expectedCookies = "Supported"
+
+    @classmethod
+    def generateAuthConfig(cls, confdir, threads):
+        super(NamedInterfaceWithCookiesAuthEnabledTest, cls).generateAuthConfig(
+            confdir, threads, "edns-cookie-secret=01234567890123456789012345678901"
+        )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setUpClassSpecialAuths()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        confdir = os.path.join("configs", "auths")
+        print("Specialized auth teardown " + confdir)
+        # tear down specialized auths, and then start standard ones
+        super().tearDownClass(True)
+        print("Starting default auths")
+        # confdir = 'configs/auths'
+        shutil.rmtree(confdir, True)
+        os.mkdir(confdir)
+        # Be careful here, we don't want the overridden secureZone(), so call RecursorTest explicitly
+        RecursorTest.generateAllAuthConfig(confdir)
+        RecursorTest.startAllAuth(confdir)
+


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

For outgoing DNS queries only atm, but can be extended for other outgoing traffic, e.g. protobuf logging.

Includes a small rewrite of `sendMsgWithOptions` to avoid exceptions and use new classes (`pdns::expected` and `pdbns::unexpected`) that are modeled after the c++23 ones. Alls callers are modified, that includes the ones in auth and dnsdist.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
