### PR TITLE
pdnsutil: more checks in set-catalog

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3064,7 +3064,6 @@ static int listAllZones(const std::string_view synopsis, const string &type="") 
 
 static int listMemberZones(const string& catalog)
 {
-
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
 
   ZoneName catz(catalog);
@@ -3274,13 +3273,28 @@ static int setZoneOption(const ZoneName& zone, const string& type, const string&
 static int setZoneCatalog(const ZoneName& zone, const ZoneName& catalog)
 {
   UtilBackend B("default"); //NOLINT(readability-identifier-length)
-  DomainInfo di;
+  DomainInfo info;
 
-  if (!B.getDomainInfo(zone, di)) {
+  if (!B.getDomainInfo(zone, info)) {
     cerr << "No such zone " << zone << " in the database" << endl;
     return EXIT_FAILURE;
   }
-  if (!di.backend->setCatalog(zone, catalog)) {
+  // Check that the catalog exists and is indeed a catalog zone.
+  // If the zone does not exist, assume the user knows what they are doing
+  // and only output a warning.
+  if (!catalog.empty()) {
+    DomainInfo info2;
+    if (B.getDomainInfo(catalog, info2)) {
+      if (!info2.isCatalogType()) {
+        cerr << "Zone '" << catalog << "' is not a catalog zone" << endl;
+        return EXIT_FAILURE;
+      }
+    }
+    else {
+      cout << "Warning: catalog zone '" << catalog << "' not found" << endl;
+    }
+  }
+  if (!info.backend->setCatalog(zone, catalog)) {
     cerr << "Could not find backend willing to accept new zone configuration" << endl;
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
### Short description
This adds some checks to `pdnsutil catalog set`. It will now warn if the catalog zone is not found (but will proceed anyway, for it may be created or, in the case of a secondary server, axfr'ed, later), and it will fail if the zone is found but is not of the catalog type.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
