### PR TITLE
auth api: make cryptokeys endpoint more versatile

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1659,10 +1659,6 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
       }
 
       algorithm = dkrc.d_algorithm;
-      // TODO remove in 4.2.0
-      if (algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1) {
-        algorithm = DNSSECKeeper::RSASHA1;
-      }
       dpk.setKey(dke, flags, algorithm);
     }
     catch (std::runtime_error& error) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1588,31 +1588,38 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
 
   int64_t insertedId = -1;
 
-  if (privatekey.is_null()) {
-    int bits = keyOrZone ? ::arg().asNum("default-ksk-size") : ::arg().asNum("default-zsk-size");
-    auto docbits = document["bits"];
-    if (!docbits.is_null()) {
-      if (!docbits.is_number() || (fmod(docbits.number_value(), 1.0) != 0) || docbits.int_value() < 0) {
-        throw ApiException("'bits' must be a positive integer value");
-      }
-
+  int bits = -1;
+  const auto& docbits = document["bits"];
+  if (!docbits.is_null()) {
+    if (docbits.is_number() && fmod(docbits.number_value(), 1.0) == 0.0) {
       bits = docbits.int_value();
     }
-    int algorithm = DNSSECKeeper::shorthand2algorithm(keyOrZone ? ::arg()["default-ksk-algorithm"] : ::arg()["default-zsk-algorithm"]);
-    const auto& providedAlgo = document["algorithm"];
+    if (bits < 0) {
+      throw ApiException("'bits' must be a positive integer value");
+    }
+  }
+  int algorithm = -1;
+  const auto& providedAlgo = document["algorithm"];
+  if (!providedAlgo.is_null()) {
     if (providedAlgo.is_string()) {
       algorithm = DNSSECKeeper::shorthand2algorithm(providedAlgo.string_value());
-      if (algorithm == -1) {
-        throw ApiException("Unknown algorithm: " + providedAlgo.string_value());
-      }
     }
     else if (providedAlgo.is_number()) {
       algorithm = providedAlgo.int_value();
     }
-    else if (!providedAlgo.is_null()) {
+    if (algorithm < 0 || algorithm > std::numeric_limits<uint8_t>::max()) {
       throw ApiException("Unknown algorithm: " + providedAlgo.string_value());
     }
+  }
 
+  if (privatekey.is_null()) {
+    // Use defaults for bits and algorithm if they have not been specified
+    if (bits < 0) {
+      bits = keyOrZone ? ::arg().asNum("default-ksk-size") : ::arg().asNum("default-zsk-size");
+    }
+    if (algorithm < 0) {
+      algorithm = DNSSECKeeper::shorthand2algorithm(keyOrZone ? ::arg()["default-ksk-algorithm"] : ::arg()["default-zsk-algorithm"]);
+    }
     try {
       if (!zoneData.dnssecKeeper.addKey(zoneData.zoneName, keyOrZone, algorithm, insertedId, bits, active, published)) {
         throw ApiException("Adding key failed, perhaps DNSSEC not enabled in configuration?");
@@ -1625,12 +1632,24 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
       throw ApiException("Adding key failed, perhaps DNSSEC not enabled in configuration?");
     }
   }
-  else if (document["bits"].is_null() && document["algorithm"].is_null()) {
+  else {
     const auto& keyData = stringFromJson(document, privatekey_fieldname);
     DNSKEYRecordContent dkrc;
     DNSSECPrivateKey dpk;
     try {
       shared_ptr<DNSCryptoKeyEngine> dke(DNSCryptoKeyEngine::makeFromISCString(resp->d_slog, dkrc, keyData));
+      // If we have been passed bits and/or algorithm, make sure they match
+      // the private key.
+      if (!docbits.is_null()) {
+        if (dke->getBits() != bits) {
+          throw ApiException("Private key size (" + std::to_string(dke->getBits()) + " bits) is inconsistent with the 'bits' field");
+        }
+      }
+      if (!providedAlgo.is_null()) {
+        if (dke->getAlgorithm() != static_cast<unsigned int>(algorithm)) {
+          throw ApiException("Private key algorithm (" + DNSSECKeeper::algorithm2name(dke->getBits()) + ") is inconsistent with the 'algorithm' field");
+        }
+      }
       uint16_t flags = 0;
       if (keyOrZone) {
         flags = 257;
@@ -1639,7 +1658,7 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
         flags = 256;
       }
 
-      uint8_t algorithm = dkrc.d_algorithm;
+      algorithm = dkrc.d_algorithm;
       // TODO remove in 4.2.0
       if (algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1) {
         algorithm = DNSSECKeeper::RSASHA1;
@@ -1660,9 +1679,6 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
     if (insertedId < 0) {
       throw ApiException("Adding key failed, perhaps DNSSEC not enabled in configuration?");
     }
-  }
-  else {
-    throw ApiException("Either you submit just the 'privatekey' field or you leave 'privatekey' empty and submit the other fields.");
   }
   apiZoneCryptokeysPostProcessing(zoneData, resp->d_slog);
   apiZoneCryptokeysExport(zoneData.zoneName, insertedId, resp, &zoneData.dnssecKeeper);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1668,31 +1668,38 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
 
   int64_t insertedId = -1;
 
-  if (privatekey.is_null()) {
-    int bits = keyOrZone ? ::arg().asNum("default-ksk-size") : ::arg().asNum("default-zsk-size");
-    auto docbits = document["bits"];
-    if (!docbits.is_null()) {
-      if (!docbits.is_number() || (fmod(docbits.number_value(), 1.0) != 0) || docbits.int_value() < 0) {
-        throw ApiException("'bits' must be a positive integer value");
-      }
-
+  int bits = -1;
+  const auto& docbits = document["bits"];
+  if (!docbits.is_null()) {
+    if (docbits.is_number() && fmod(docbits.number_value(), 1.0) == 0.0) {
       bits = docbits.int_value();
     }
-    int algorithm = DNSSECKeeper::shorthand2algorithm(keyOrZone ? ::arg()["default-ksk-algorithm"] : ::arg()["default-zsk-algorithm"]);
-    const auto& providedAlgo = document["algorithm"];
+    if (bits < 0) {
+      throw ApiException("'bits' must be a positive integer value");
+    }
+  }
+  int algorithm = -1;
+  const auto& providedAlgo = document["algorithm"];
+  if (!providedAlgo.is_null()) {
     if (providedAlgo.is_string()) {
       algorithm = DNSSECKeeper::shorthand2algorithm(providedAlgo.string_value());
-      if (algorithm == -1) {
-        throw ApiException("Unknown algorithm: " + providedAlgo.string_value());
-      }
     }
     else if (providedAlgo.is_number()) {
       algorithm = providedAlgo.int_value();
     }
-    else if (!providedAlgo.is_null()) {
+    if (algorithm < 0 || algorithm > std::numeric_limits<uint8_t>::max()) {
       throw ApiException("Unknown algorithm: " + providedAlgo.string_value());
     }
+  }
 
+  if (privatekey.is_null()) {
+    // Use defaults for bits and algorithm if they have not been specified
+    if (bits < 0) {
+      bits = keyOrZone ? ::arg().asNum("default-ksk-size") : ::arg().asNum("default-zsk-size");
+    }
+    if (algorithm < 0) {
+      algorithm = DNSSECKeeper::shorthand2algorithm(keyOrZone ? ::arg()["default-ksk-algorithm"] : ::arg()["default-zsk-algorithm"]);
+    }
     try {
       if (!zoneData.dnssecKeeper.addKey(zoneData.zoneName, keyOrZone, algorithm, insertedId, bits, active, published)) {
         throw ApiException("Adding key failed, perhaps DNSSEC not enabled in configuration?");
@@ -1705,12 +1712,24 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
       throw ApiException("Adding key failed, perhaps DNSSEC not enabled in configuration?");
     }
   }
-  else if (document["bits"].is_null() && document["algorithm"].is_null()) {
+  else {
     const auto& keyData = stringFromJson(document, privatekey_fieldname);
     DNSKEYRecordContent dkrc;
     DNSSECPrivateKey dpk;
     try {
       shared_ptr<DNSCryptoKeyEngine> dke(DNSCryptoKeyEngine::makeFromISCString(resp->d_slog, dkrc, keyData));
+      // If we have been passed bits and/or algorithm, make sure they match
+      // the private key.
+      if (!docbits.is_null()) {
+        if (dke->getBits() != bits) {
+          throw ApiException("Private key size (" + std::to_string(dke->getBits()) + " bits) is inconsistent with the 'bits' field");
+        }
+      }
+      if (!providedAlgo.is_null()) {
+        if (dke->getAlgorithm() != static_cast<unsigned int>(algorithm)) {
+          throw ApiException("Private key algorithm (" + DNSSECKeeper::algorithm2name(dke->getBits()) + ") is inconsistent with the 'algorithm' field");
+        }
+      }
       uint16_t flags = 0;
       if (keyOrZone) {
         flags = 257;
@@ -1719,7 +1738,7 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
         flags = 256;
       }
 
-      uint8_t algorithm = dkrc.d_algorithm;
+      algorithm = dkrc.d_algorithm;
       // TODO remove in 4.2.0
       if (algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1) {
         algorithm = DNSSECKeeper::RSASHA1;
@@ -1740,9 +1759,6 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
     if (insertedId < 0) {
       throw ApiException("Adding key failed, perhaps DNSSEC not enabled in configuration?");
     }
-  }
-  else {
-    throw ApiException("Either you submit just the 'privatekey' field or you leave 'privatekey' empty and submit the other fields.");
   }
   apiZoneCryptokeysPostProcessing(zoneData, resp->d_slog);
   apiZoneCryptokeysExport(zoneData.zoneName, insertedId, resp, &zoneData.dnssecKeeper);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1739,10 +1739,6 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
       }
 
       algorithm = dkrc.d_algorithm;
-      // TODO remove in 4.2.0
-      if (algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1) {
-        algorithm = DNSSECKeeper::RSASHA1;
-      }
       dpk.setKey(dke, flags, algorithm);
     }
     catch (std::runtime_error& error) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1742,7 +1742,7 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
       dpk.setKey(dke, flags, algorithm);
     }
     catch (std::runtime_error& error) {
-      throw ApiException("Key could not be parsed. Make sure your key format is correct.");
+      throw ApiException(std::string("Key could not be parsed. Make sure your key format is correct. ") + error.what());
     }
     try {
       if (!zoneData.dnssecKeeper.addKey(zoneData.zoneName, dpk, insertedId, active, published)) {

--- a/regression-tests.api/test_cryptokeys.py
+++ b/regression-tests.api/test_cryptokeys.py
@@ -346,3 +346,23 @@ class Cryptokeys(ApiTestCase):
         # check if key is activated
         out = pdnsutil("show-zone", self.zone_nodot)
         self.assertIn("Unpublished", out)
+
+    # Test adding a key from the exact json data obtained from a key query
+    def test_post_get_delete_post(self):
+        # 1. create a key
+        self.keyid = self.add_zone_key()
+        # 2. query it
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + self.zone + "/cryptokeys/" + self.keyid))
+        self.assertEqual(r.status_code, 200)
+        payload = r.json()
+        # 3. delete it
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/" + self.zone + "/cryptokeys/" + self.keyid))
+        self.assertEqual(r.status_code, 204)
+        # 4. put it back
+        r = self.session.post(
+            self.url("/api/v1/servers/localhost/zones/" + self.zone + "/cryptokeys"),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+        self.assert_success_json(r)
+        self.assertEqual(r.status_code, 201)

--- a/regression-tests.api/test_cryptokeys.py
+++ b/regression-tests.api/test_cryptokeys.py
@@ -346,3 +346,36 @@ class Cryptokeys(ApiTestCase):
         # check if key is activated
         out = pdnsutil("show-zone", self.zone_nodot)
         self.assertIn("Unpublished", out)
+
+    # Test adding a key from the exact json data obtained from a key query
+    def test_post_get_delete_post(self):
+        # 1. create a key
+        self.keyid = self.add_zone_key()
+        # 2. query it
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + self.zone + "/cryptokeys/" + self.keyid))
+        self.assertEqual(r.status_code, 200)
+        payload = r.json()
+        # 3. delete it
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/" + self.zone + "/cryptokeys/" + self.keyid))
+        self.assertEqual(r.status_code, 204)
+        # 4. put it back
+        r = self.session.post(
+            self.url("/api/v1/servers/localhost/zones/" + self.zone + "/cryptokeys"),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+        self.assert_success_json(r)
+        self.assertEqual(r.status_code, 201)
+        # 5. try to put it back, but with inconsistent parameters
+        if payload["bits"] == 1024:
+            payload["bits"] = 2048
+        else:
+            payload["bits"] = 1024
+        r = self.session.post(
+            self.url("/api/v1/servers/localhost/zones/" + self.zone + "/cryptokeys"),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+        self.assert_error_json(r)
+        self.assertEqual(r.status_code, 422)
+        self.assertIn("inconsistent with the 'bits' field", r.json()["error"])


### PR DESCRIPTION
### Short description
As mentioned in #16403, the current behaviour of the `cryptokeys` api endpoint prevents the output of a query for a given key to be directly usable as input to the same endpoint.

This PR relaxes the logic by allowing the `bits` and `algorithm` fields to be present, as long as their values match those of the `privatekey`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
