### PR TITLE
dnsdist: add qlogdir support for DoH3 and DOQ

### DIFF
--- a/builder-support/helpers/install_quiche.sh
+++ b/builder-support/helpers/install_quiche.sh
@@ -48,7 +48,7 @@ cd "quiche-${QUICHE_VERSION}"
 # Disable SONAME in the quiche shared library, we do not intend this library to be used by anyone else and it makes things more complicated since we rename it to libdnsdist-quiche
 sed -i.bak 's/ffi = \["dep:cdylib-link-lines"\]/ffi = \[\]/' quiche/Cargo.toml
 sed -i.bak 's,cdylib_link_lines::metabuild();,//cdylib_link_lines::metabuild();,' quiche/src/build.rs
-RUST_BACKTRACE=1 cargo build --release --no-default-features --features ffi,boringssl-boring-crate --package quiche
+RUST_BACKTRACE=1 cargo build --release --no-default-features --features ffi,boringssl-boring-crate,qlog --package quiche
 
 # While we tried to get rid of the SONAME in libquiche.so, on debian trixie's
 # packaged rustc puts it in anyway.

--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -344,6 +344,7 @@ static bool handleTLSConfiguration(const Context& context, const dnsdist::rust::
     frontend->d_quicheParams.d_maxInFlight = bind.doq.max_concurrent_queries_per_connection;
     frontend->d_quicheParams.d_idleTimeout = bind.quic.idle_timeout;
     frontend->d_quicheParams.d_keyLogFile = std::string(bind.tls.key_log_file);
+    frontend->d_quicheParams.d_qLogDir = std::string(bind.quic.qlog_dir);
     frontend->d_quicheParams.d_ccAlgo = std::string(bind.quic.congestion_control_algorithm);
     frontend->d_internalPipeBufferSize = bind.quic.internal_pipe_buffer_size;
     state.doqFrontend = std::move(frontend);
@@ -356,6 +357,7 @@ static bool handleTLSConfiguration(const Context& context, const dnsdist::rust::
     frontend->d_quicheParams.d_tlsConfig = std::move(tlsConfig);
     frontend->d_quicheParams.d_idleTimeout = bind.quic.idle_timeout;
     frontend->d_quicheParams.d_keyLogFile = std::string(bind.tls.key_log_file);
+    frontend->d_quicheParams.d_qLogDir = std::string(bind.quic.qlog_dir);
     frontend->d_quicheParams.d_ccAlgo = std::string(bind.quic.congestion_control_algorithm);
     frontend->d_internalPipeBufferSize = bind.quic.internal_pipe_buffer_size;
 

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -2475,6 +2475,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       getOptionalValue<int>(vars, "internalPipeBufferSize", frontend->d_internalPipeBufferSize);
       getOptionalValue<int>(vars, "idleTimeout", frontend->d_quicheParams.d_idleTimeout);
       getOptionalValue<std::string>(vars, "keyLogFile", frontend->d_quicheParams.d_keyLogFile);
+      getOptionalValue<std::string>(vars, "qLogDir", frontend->d_quicheParams.d_qLogDir);
       getOptionalValue<bool>(vars, "padResponses", padResponses);
       {
         std::string valueStr;
@@ -2551,6 +2552,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       getOptionalValue<int>(vars, "internalPipeBufferSize", frontend->d_internalPipeBufferSize);
       getOptionalValue<int>(vars, "idleTimeout", frontend->d_quicheParams.d_idleTimeout);
       getOptionalValue<std::string>(vars, "keyLogFile", frontend->d_quicheParams.d_keyLogFile);
+      getOptionalValue<std::string>(vars, "qLogDir", frontend->d_quicheParams.d_qLogDir);
       getOptionalValue<bool>(vars, "padResponses", padResponses);
       {
         std::string valueStr;

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1123,6 +1123,11 @@ incoming_quic:
       type: "u32"
       default: 1048576
       description: "Set the size in bytes of the internal buffer of the pipes used internally to pass queries and responses between threads. Requires support for ``F_SETPIPE_SZ`` which is present in Linux since 2.6.35. The actual size might be rounded up to a multiple of a page size. 0 means that the OS default size is used"
+    - name: "qlog_dir"
+      type: "String"
+      default: ""
+      description: "Write QUIC connection logs in QLOG format, as described in https://quicwg.org/qlog/draft-ietf-quic-qlog-main-schema.html"
+
 
 incoming_dnscrypt_certificate_key_pair:
   description: "Certificate and associated key for DNSCrypt frontends"

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1127,7 +1127,7 @@ incoming_quic:
       type: "String"
       default: ""
       description: "Write QUIC connection logs in QLOG format, as described in https://quicwg.org/qlog/draft-ietf-quic-qlog-main-schema.html"
-
+      version_added: "2.2.0"
 
 incoming_dnscrypt_certificate_key_pair:
   description: "Certificate and associated key for DNSCrypt frontends"

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -176,6 +176,7 @@ Listen Sockets
 
   .. versionchanged:: 2.2.0
      ``padResponses`` option added.
+     ``qLogDir`` option added.
 
   Listen on the specified address and UDP port for incoming DNS over HTTP3 connections, presenting the specified X.509 certificate. See :doc:`../advanced/tls-certificates-management` for details about the handling of TLS certificates and keys.
   More information is available in :doc:`../guides/dns-over-http3`.
@@ -197,6 +198,7 @@ Listen Sockets
   * ``congestionControlAlgo="cubic"``: str - The congestion control algorithm to be chosen between ``reno``, ``cubic`` and ``bbr``.
   * ``keyLogFile``: str - Write the TLS keys in the specified file so that an external program can decrypt TLS exchanges, in the format described in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format.
   * ``padResponses``: bool - Whether to pad DNS responses as specified in RFC 7830. Default is ``false``, meaning responses are not padded.
+  * ``qLogDir``: str - Path to directory to store QLOG (QUIC logs) files in. By default QLOG is disabled.
 
 .. function:: addDOQLocal(address, certFile(s), keyFile(s) [, options])
 
@@ -207,6 +209,7 @@ Listen Sockets
 
   .. versionchanged:: 2.2.0
      ``padResponses`` option added.
+     ``qLogDir`` option added.
 
   Listen on the specified address and UDP port for incoming DNS over QUIC connections, presenting the specified X.509 certificate.
   See :doc:`../advanced/tls-certificates-management` for details about the handling of TLS certificates and keys.
@@ -229,6 +232,7 @@ Listen Sockets
   * ``congestionControlAlgo="cubic"``: str - The congestion control algorithm to be chosen between ``reno``, ``cubic`` and ``bbr``.
   * ``keyLogFile``: str - Write the TLS keys in the specified file so that an external program can decrypt TLS exchanges, in the format described in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format.
   * ``padResponses``: bool - Whether to pad DNS responses as specified in RFC 7830. Default is ``false``, meaning responses are not padded.
+  * ``qLogDir``: str - Path to directory to store QLOG (QUIC logs) files in. By default QLOG is disabled.
 
 .. function:: addTLSLocal(address, certFile(s), keyFile(s) [, options])
 

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -449,6 +449,18 @@ static std::optional<std::reference_wrapper<H3Connection>> createConnection(DOH3
     quiche_conn_set_keylog_path(quicheConn.get(), config.df->d_quicheParams.d_keyLogFile.c_str());
   }
 
+#ifdef HAVE_QUICHE_CONN_SET_QLOG_PATH
+  if (config.df && !config.df->d_quicheParams.d_qLogDir.empty()) {
+    const unsigned char* trace_id = nullptr;
+    size_t trace_id_len = 0;
+    quiche_conn_trace_id(quicheConn.get(), &trace_id, &trace_id_len);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): std::string's API
+    auto path = (config.df->d_quicheParams.d_qLogDir + "/" + std::string(reinterpret_cast<const char*>(trace_id), trace_id_len)) + ".qlog";
+    auto description = "peer_ip=" + peer.toString();
+    quiche_conn_set_qlog_path(quicheConn.get(), path.c_str(), "", description.c_str());
+  }
+#endif
+
   auto conn = H3Connection(peer, localAddr, std::move(quicheConfig), std::move(quicheConn), *config.clientState);
   gettimeofday(&conn.d_connectionStartTime, nullptr);
   auto pair = config.d_connections.emplace(serverSideID, std::move(conn));

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -451,13 +451,7 @@ static std::optional<std::reference_wrapper<H3Connection>> createConnection(DOH3
 
 #ifdef HAVE_QUICHE_CONN_SET_QLOG_PATH
   if (config.df && !config.df->d_quicheParams.d_qLogDir.empty()) {
-    const unsigned char* trace_id = nullptr;
-    size_t trace_id_len = 0;
-    quiche_conn_trace_id(quicheConn.get(), &trace_id, &trace_id_len);
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): std::string's API
-    auto path = (config.df->d_quicheParams.d_qLogDir + "/" + std::string(reinterpret_cast<const char*>(trace_id), trace_id_len)) + ".qlog";
-    auto description = "peer_ip=" + peer.toString();
-    quiche_conn_set_qlog_path(quicheConn.get(), path.c_str(), "", description.c_str());
+    configureQLog(quicheConn, config.df->d_quicheParams.d_qLogDir, peer);
   }
 #endif
 

--- a/pdns/dnsdistdist/doq-common.cc
+++ b/pdns/dnsdistdist/doq-common.cc
@@ -352,6 +352,20 @@ std::string getSNIFromQuicheConnection([[maybe_unused]] const QuicheConnection& 
   return {};
 }
 
+void configureQLog(const QuicheConnection& conn, const std::string& qLogDir, const ComboAddress& peer)
+{
+  const unsigned char* trace_id = nullptr;
+  size_t trace_id_len = 0;
+  quiche_conn_trace_id(conn.get(), &trace_id, &trace_id_len);
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): std::string's API
+  auto path = (qLogDir + "/" + std::string(reinterpret_cast<const char*>(trace_id), trace_id_len)) + ".qlog";
+  auto description = "peer_ip=" + peer.toString();
+  if (!quiche_conn_set_qlog_path(conn.get(), path.c_str(), "", description.c_str())) {
+    VERBOSESLOG(infolog("QLOG creation failed for connection from $s", peer.toStringWithPort()),
+                dnsdist::logging::getTopLogger("quic-qlog")->info(Logr::Info, "QLOG creation failed", "client.address", Logging::Loggable(peer)));
+  }
+}
+
 QUICConnection::QUICConnection(ClientState& frontend, const ComboAddress& peer, const ComboAddress& localAddr, QuicheConfig config, QuicheConnection&& conn) :
   d_frontend(frontend), d_peer(peer), d_localAddr(localAddr), d_conn(std::move(conn)), d_config(std::move(config))
 {

--- a/pdns/dnsdistdist/doq-common.hh
+++ b/pdns/dnsdistdist/doq-common.hh
@@ -48,6 +48,7 @@ struct QuicheParams
 {
   TLSConfig d_tlsConfig;
   std::string d_keyLogFile;
+  std::string d_qLogDir;
   uint64_t d_idleTimeout{5};
   uint64_t d_maxInFlight{65535};
   std::string d_ccAlgo{"cubic"};

--- a/pdns/dnsdistdist/doq-common.hh
+++ b/pdns/dnsdistdist/doq-common.hh
@@ -119,6 +119,7 @@ void flushEgress(Socket& sock, QuicheConnection& conn, const ComboAddress& peer,
 void configureQuiche(QuicheConfig& config, const QuicheParams& params, bool isHTTP);
 bool recvAsync(Socket& socket, PacketBuffer& buffer, ComboAddress& clientAddr, ComboAddress& localAddr);
 std::string getSNIFromQuicheConnection(const QuicheConnection& conn);
+void configureQLog(const QuicheConnection& conn, const std::string& qLogDir, const ComboAddress& peer);
 };
 
 #endif

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -340,6 +340,14 @@ static std::optional<std::reference_wrapper<Connection>> createConnection(DOQSer
     quiche_conn_set_keylog_path(quicheConn.get(), config.df->d_quicheParams.d_keyLogFile.c_str());
   }
 
+#ifdef HAVE_QUICHE_CONN_SET_QLOG_PATH
+  if (config.df && !config.df->d_quicheParams.d_qLogDir.empty()) {
+    auto description = "peer_ip=" + peer.toString();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): std::string's API
+    quiche_conn_set_qlog_path(quicheConn.get(), (config.df->d_quicheParams.d_qLogDir + "/" + std::string(reinterpret_cast<const char*>(originalDestinationID.data()), originalDestinationID.size()) + ".qlog").c_str(), "", description.c_str());
+  }
+#endif
+
   auto conn = Connection(*config.clientState, peer, localAddr, std::move(quicheConfig), std::move(quicheConn));
   gettimeofday(&conn.d_connectionStartTime, nullptr);
   auto pair = config.d_connections.emplace(serverSideID, std::move(conn));

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -342,9 +342,7 @@ static std::optional<std::reference_wrapper<Connection>> createConnection(DOQSer
 
 #ifdef HAVE_QUICHE_CONN_SET_QLOG_PATH
   if (config.df && !config.df->d_quicheParams.d_qLogDir.empty()) {
-    auto description = "peer_ip=" + peer.toString();
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): std::string's API
-    quiche_conn_set_qlog_path(quicheConn.get(), (config.df->d_quicheParams.d_qLogDir + "/" + std::string(reinterpret_cast<const char*>(originalDestinationID.data()), originalDestinationID.size()) + ".qlog").c_str(), "", description.c_str());
+    configureQLog(quicheConn, config.df->d_quicheParams.d_qLogDir, peer);
   }
 #endif
 

--- a/pdns/dnsdistdist/meson/quiche/meson.build
+++ b/pdns/dnsdistdist/meson/quiche/meson.build
@@ -19,6 +19,7 @@ if (opt_quic.allowed() or opt_doh3.allowed()) and opt_libquiche.allowed()
   if dep_libquiche.found()
     funcs = [
       'quiche_conn_server_name',
+      'quiche_conn_set_qlog_path'
     ]
 
     foreach func: funcs


### PR DESCRIPTION
### Short description
Adds support for qlog output for DoH3 and DOQ frontents. This changes the way quiche lib is built to enable qlog feature flag.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

---
>Sponsored by [Quad9](https://quad9.net/)