### PR TITLE
rec: nsspeed fixes

### DIFF
--- a/pdns/recursordist/rec-nsspeeds.cc
+++ b/pdns/recursordist/rec-nsspeeds.cc
@@ -65,8 +65,8 @@ void nsspeeds_t::getPBEntry(T& message, U& entry)
   for (const auto& [address, collection] : entry.d_collection) {
     protozero::pbf_builder<PBNSSpeedMap> map(message, PBNSSpeedEntry::repeated_message_map);
     encodeComboAddress(map, PBNSSpeedMap::required_bytes_address, address);
-    map.add_float(PBNSSpeedMap::required_float_val, collection.d_val);
-    map.add_int32(PBNSSpeedMap::required_int32_last, collection.d_last);
+    map.add_float(PBNSSpeedMap::required_float_val, collection.d_decayed_value);
+    map.add_int32(PBNSSpeedMap::required_int32_last, collection.d_last_value);
   }
 }
 

--- a/pdns/recursordist/rec-nsspeeds.cc
+++ b/pdns/recursordist/rec-nsspeeds.cc
@@ -52,6 +52,7 @@ enum class PBNSSpeedMap : protozero::pbf_tag_type
   required_bytes_address = 1,
   required_float_val = 2,
   required_int32_last = 3,
+  optional_uint64_last_ts = 4,
 };
 
 template <typename T, typename U>
@@ -67,6 +68,7 @@ void nsspeeds_t::getPBEntry(T& message, U& entry)
     encodeComboAddress(map, PBNSSpeedMap::required_bytes_address, address);
     map.add_float(PBNSSpeedMap::required_float_val, collection.d_decayed_value);
     map.add_int32(PBNSSpeedMap::required_int32_last, collection.d_last_value);
+    map.add_uint64(PBNSSpeedMap::optional_uint64_last_ts, collection.d_last_timestamp);
   }
 }
 
@@ -122,6 +124,7 @@ bool nsspeeds_t::putPBEntry(time_t cutoff, T& message)
       ComboAddress address;
       float val{};
       int last{};
+      uint64_t last_ts{0};
       while (map.next()) {
         switch (map.tag()) {
         case PBNSSpeedMap::required_bytes_address:
@@ -133,12 +136,14 @@ bool nsspeeds_t::putPBEntry(time_t cutoff, T& message)
         case PBNSSpeedMap::required_int32_last:
           last = map.get_int32();
           break;
+        case PBNSSpeedMap::optional_uint64_last_ts:
+          last_ts = map.get_uint64();
+          break;
         default:
           map.skip();
-          break;
         }
       }
-      entry.insert(address, val, last);
+      entry.insert(address, val, last, last_ts);
       break;
     }
     default:

--- a/pdns/recursordist/rec-nsspeeds.cc
+++ b/pdns/recursordist/rec-nsspeeds.cc
@@ -222,13 +222,13 @@ size_t nsspeeds_t::putPB(time_t cutoff, const std::string& pbuf)
     return inserted;
   }
   catch (const std::runtime_error& e) {
-    log->error(Logr::Error, e.what(), "Runtime exception processing cache dump");
+    log->error(Logr::Error, e.what(), "Runtime exception processing nsspeed dump");
   }
   catch (const std::exception& e) {
-    log->error(Logr::Error, e.what(), "Exception processing cache dump");
+    log->error(Logr::Error, e.what(), "Exception processing nsspeed dump");
   }
   catch (...) {
-    log->info(Logr::Error, "Other exception processing cache dump");
+    log->info(Logr::Error, "Other exception processing nsspeed dump");
   }
   return 0;
 }

--- a/pdns/recursordist/rec-nsspeeds.hh
+++ b/pdns/recursordist/rec-nsspeeds.hh
@@ -44,18 +44,22 @@ private:
   struct DecayingEwma
   {
   public:
-    void submit(int arg, const struct timeval& last, const struct timeval& now)
+    void submit(int arg, const struct timeval& now)
     {
-      d_last_value = arg;
       auto val = static_cast<float>(arg);
+      auto usecTS = uSec(now);
       if (d_decayed_value == 0) {
         d_decayed_value = val;
       }
       else {
-        auto diff = makeFloat(last - now);
-        auto factor = expf(diff) / 2.0F; // might be '0.5', or 0.0001
-        d_decayed_value = (1.0F - factor) * val + factor * d_decayed_value;
+        auto int_diff = static_cast<int64_t>(d_last_timestamp - usecTS); // usecs
+        auto diff = static_cast<float>(int_diff) / 1000000.0F; // seconds
+        auto factor = expf(diff / DecayingEwmaCollection::s_memory) / 2.0F; // might be '0.5', or 0.0001
+        auto original_value = static_cast<float>(d_last_value);
+        d_decayed_value = (1.0F - factor) * val + factor * original_value;
       }
+      d_last_value = arg;
+      d_last_timestamp = usecTS;
     }
 
     float get(float factor)
@@ -73,11 +77,14 @@ private:
       return d_last_value;
     }
 
+    uint64_t d_last_timestamp{0};
     float d_decayed_value{0};
     int d_last_value{0};
   };
 
 public:
+  static constexpr float s_memory = 60; // higher value means we remember past performance longer
+
   DecayingEwmaCollection(DNSName name, const struct timeval val = {0, 0}) :
     d_name(std::move(name)), d_lastget(val)
   {
@@ -85,13 +92,13 @@ public:
 
   void submit(const ComboAddress& remote, int usecs, const struct timeval& now) const
   {
-    d_collection[remote].submit(usecs, d_lastget, now);
+    d_collection[remote].submit(usecs, now);
   }
 
   float getFactor(const struct timeval& now) const
   {
     float diff = makeFloat(d_lastget - now);
-    return expf(diff / 60.0F); // is 1.0 or less
+    return expf(diff / s_memory); // is 1.0 or less
   }
 
   bool stale(time_t limit) const
@@ -111,9 +118,9 @@ public:
     }
   }
 
-  void insert(const ComboAddress& address, float val, int last)
+  void insert(const ComboAddress& address, float val, int last, uint64_t last_ts)
   {
-    d_collection.insert(std::make_pair(address, DecayingEwma{val, last}));
+    d_collection.insert(std::make_pair(address, DecayingEwma{.d_last_timestamp = last_ts, .d_decayed_value = val, .d_last_value = last}));
   }
 
   // d_collection is the modifyable part of the record, we index on DNSName and timeval, and DNSName never changes

--- a/pdns/recursordist/rec-nsspeeds.hh
+++ b/pdns/recursordist/rec-nsspeeds.hh
@@ -46,35 +46,35 @@ private:
   public:
     void submit(int arg, const struct timeval& last, const struct timeval& now)
     {
-      d_last = arg;
+      d_last_value = arg;
       auto val = static_cast<float>(arg);
-      if (d_val == 0) {
-        d_val = val;
+      if (d_decayed_value == 0) {
+        d_decayed_value = val;
       }
       else {
         auto diff = makeFloat(last - now);
         auto factor = expf(diff) / 2.0F; // might be '0.5', or 0.0001
-        d_val = (1.0F - factor) * val + factor * d_val;
+        d_decayed_value = (1.0F - factor) * val + factor * d_decayed_value;
       }
     }
 
     float get(float factor)
     {
-      return d_val *= factor;
+      return d_decayed_value *= factor;
     }
 
     [[nodiscard]] float peek() const
     {
-      return d_val;
+      return d_decayed_value;
     }
 
     [[nodiscard]] int last() const
     {
-      return d_last;
+      return d_last_value;
     }
 
-    float d_val{0};
-    int d_last{0};
+    float d_decayed_value{0};
+    int d_last_value{0};
   };
 
 public:

--- a/pdns/recursordist/rec-nsspeeds.hh
+++ b/pdns/recursordist/rec-nsspeeds.hh
@@ -52,11 +52,18 @@ private:
         d_decayed_value = val;
       }
       else {
-        auto int_diff = static_cast<int64_t>(d_last_timestamp - usecTS); // usecs
-        auto diff = static_cast<float>(int_diff) / 1000000.0F; // seconds
-        auto factor = expf(diff / DecayingEwmaCollection::s_memory) / 2.0F; // might be '0.5', or 0.0001
-        auto original_value = static_cast<float>(d_last_value);
-        d_decayed_value = (1.0F - factor) * val + factor * original_value;
+        // We compute the new moving average based on the latest measurement and the *undecayed*
+        // previous value.  As we modify the decayed value on get(), we recompute the original value
+        // by using the inverse of the decaying function.  The new weighted average is then
+        // computed, with old values not weighting in much because factor will be small
+        auto int_diff = static_cast<int64_t>(d_last_timestamp - usecTS); // usecs, is negative
+        auto diff = static_cast<float>(int_diff) / 1000000.0F; // seconds, is negative
+        auto factor = expf(diff / DecayingEwmaCollection::s_memory); // range [0, 1]; close to 1 for small diff, 0 for very negative (large) diff
+        // if decayed = undecayed * exp(diff/60) what is undecayed?
+        // answer: undecayed = exp(-diff/60) * decayed (with help form alpha)
+        float undecayed = expf(-diff / DecayingEwmaCollection::s_memory) * d_decayed_value;
+        // small diff means the new value has a small weight
+        d_decayed_value = ((1.0F - factor) * val) + (factor * undecayed);
       }
       d_last_value = arg;
       d_last_timestamp = usecTS;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This should fix most of #17492.

1. When averaging in the new measured roundtrip time in, use the timestamp of the latest update (and not of the `get`!) and compute the decay factor in the same way `get` does. That factor then determines how much weight to assign to the new value and old value. The current code took the decayed value, which is smaller by nature, so the newly computed average is too small plus the factor computed was based on the timestamp of the latest `get`, assigning too much weight on the old (small) value.

2.  Be more careful computed differences of float values. Converting timevals to float and then subtracting looses a lot of precision, as the absolute values are big but the difference is small. So compute the diff using uint64_t values and *then* convert to float.

3. We might ponder making the "memory" factor tunable.

This need tests on operability between recursors having the new timestamp and ones not having them, as the ns speed dump and undump code is touched since a field was added.

Tip: review per commit, as the first one is just a renaming exercise.

<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
