### PR TITLE
auth: stop being an optimist

### DIFF
--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -226,7 +226,6 @@ UDPNameserver::UDPNameserver(Logr::log_t slog, bool additional_socket)
 void UDPNameserver::send(DNSPacket& p)
 {
   const string& buffer=p.getString();
-  g_rs.submitResponse(p, true);
 
   struct msghdr msgh;
   struct iovec iov;
@@ -249,6 +248,8 @@ void UDPNameserver::send(DNSPacket& p)
     SLOG(g_log<<Logger::Error<<"Error sending reply with sendmsg (socket="<<p.getSocket()<<", dest="<<p.d_remote.toStringWithPort()<<"): "<<stringerror(err)<<endl,
          d_slog->error(Logr::Error, errno, "Error sending reply with sendmsg", "socket", Logging::Loggable(p.getSocket()), "remote", Logging::Loggable(p.d_remote.toStringWithPort())));
   }
+
+  g_rs.submitResponse(p, true);
 }
 
 bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -249,7 +249,7 @@ void UDPNameserver::send(DNSPacket& p)
          d_slog->error(Logr::Error, errno, "Error sending reply with sendmsg", "socket", Logging::Loggable(p.getSocket()), "remote", Logging::Loggable(p.d_remote.toStringWithPort())));
   }
 
-  g_rs.submitResponse(p, true);
+  g_rs.submitResponse(p, buffer.length(), true);
 }
 
 bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)

--- a/pdns/responsestats-auth.cc
+++ b/pdns/responsestats-auth.cc
@@ -7,8 +7,7 @@ extern StatBag S;
  *  Function that creates all the stats
  *  when udpOrTCP is true, it is udp
  */
-void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP, bool last) const {
-  const string& buf=p.getString();
+void ResponseStats::submitResponse(const DNSPacket &p, size_t length, bool udpOrTCP, bool last) const { // NOLINT(readability-identifier-length)
   static AtomicCounter &udpnumanswered=*S.getPointer("udp-answers");
   static AtomicCounter &udpnumanswered4=*S.getPointer("udp4-answers");
   static AtomicCounter &udpnumanswered6=*S.getPointer("udp6-answers");
@@ -38,20 +37,20 @@ void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP, bool last) const
 
   if (udpOrTCP) { // udp
     udpnumanswered++;
-    udpbytesanswered+=buf.length();
+    udpbytesanswered+=length;
     if(accountremote.sin4.sin_family==AF_INET) {
       udpnumanswered4++;
-      udpbytesanswered4+=buf.length();
+      udpbytesanswered4+=length;
     } else {
       udpnumanswered6++;
-      udpbytesanswered6+=buf.length();
+      udpbytesanswered6+=length;
     }
   } else { //tcp
-    tcpbytesanswered+=buf.length();
+    tcpbytesanswered+=length;
     if(accountremote.sin4.sin_family==AF_INET) {
-      tcpbytesanswered4+=buf.length();
+      tcpbytesanswered4+=length;
     } else {
-      tcpbytesanswered6+=buf.length();
+      tcpbytesanswered6+=length;
     }
     if(last) {
      tcpnumanswered++;
@@ -63,5 +62,5 @@ void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP, bool last) const
     }
   }
 
-  submitResponse(p.qtype.getCode(), buf.length(), p.d.rcode, udpOrTCP);
+  submitResponse(p.qtype.getCode(), length, p.d.rcode, udpOrTCP);
 }

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -32,7 +32,7 @@ class ResponseStats
 public:
   ResponseStats();
 
-  void submitResponse(DNSPacket& p, bool udpOrTCP, bool last = true) const;
+  void submitResponse(const DNSPacket& p, size_t length, bool udpOrTCP, bool last = true) const;
   void submitResponse(uint16_t qtype, uint16_t respsize, bool udpOrTCP) const;
   void submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rcode, bool udpOrTCP) const;
   map<uint16_t, uint64_t> getQTypeResponseCounts() const;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -180,12 +180,11 @@ void TCPNameserver::sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool 
 {
   uint16_t len=htons(p->getString(true).length());
 
-  // this also calls p->getString; call it after our explicit call so throwsOnTruncation=true is honoured
-  g_rs.submitResponse(*p, false, last);
-
   string buffer((const char*)&len, 2);
   buffer.append(p->getString());
   writenWithTimeout(outsock, buffer.c_str(), buffer.length(), d_idleTimeout);
+
+  g_rs.submitResponse(*p, false, last);
 }
 
 

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -184,7 +184,7 @@ void TCPNameserver::sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool 
   buffer.append(p->getString());
   writenWithTimeout(outsock, buffer.c_str(), buffer.length(), d_idleTimeout);
 
-  g_rs.submitResponse(*p, false, last);
+  g_rs.submitResponse(*p, buffer.length() - 2, false, last);
 }
 
 


### PR DESCRIPTION
### Short description
We used to update the network-related counters before attempting to send the actual data.

Move this update after the operation, so that they will not get updated if an error occurs.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
