### PR TITLE
auth lmdb: make the database page size user-configurable

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -197,6 +197,19 @@ on out-of-date data and may send unnecessary notifications, as well as
 perform unnecessary freshness checks. This however allows this feature to work
 without requiring a database schema upgrade.
 
+.. _settings-lmdb-page-size:
+
+``lmdb-page-size``
+^^^^^^^^^^^^^^^^^^
+
+  .. versionadded:: 5.2.0
+
+Size, in bytes, of the database page size. Must be a power of two, ranging from 256 to 65536, included. Defaults to 4096.
+
+On hardware where the MMU page size is larger than the commonly encountered value of 4096 bytes, setting this value to the hardware page size can yield a small performance improvement.
+
+This setting is only available with LMDB 1.0 and up, and will be silently ignored if the authoritative server is built against an older LMDB library.
+
 ``lmdb-lightning-stream``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -204,7 +204,7 @@ without requiring a database schema upgrade.
 
   .. versionadded:: 5.2.0
 
-Size, in bytes, of the database page size. Must be a power of two, ranging from 256 to 65536, included. Defaults to 4096.
+Size, in bytes, of the database page size. Must be a power of two, ranging from 256 to 65536, included, or zero (default), which uses the default value of the LMDB library, which is currently (as of LMDB 1.0) 4096 bytes.
 
 On hardware where the MMU page size is larger than the commonly encountered value of 4096 bytes, setting this value to the hardware page size can yield a small performance improvement.
 

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -108,14 +108,19 @@ int MDBDbi::mdb_dbi_open(MDB_txn* txn, const char* name, unsigned int flags, MDB
   return ::mdb_dbi_open(txn, name, flags, dbi);
 }
 
-MDBEnv::MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB)
+MDBEnv::MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, [[maybe_unused]] int pagesize)
 {
   mdb_env_create(&d_env);
-  if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576))
-    throw std::runtime_error("setting map size");
-    /*
-Various other options may also need to be set before opening the handle, e.g. mdb_env_set_mapsize(), mdb_env_set_maxreaders(), mdb_env_set_maxdbs(),
-    */
+
+#if MDB_VERSION_MAJOR >= 1 // Not available prior to lmdb 1.0
+  if (pagesize > 0 && mdb_env_set_pagesize(d_env, pagesize)) {
+    throw std::runtime_error("setting lmdb page size to " + std::to_string(pagesize));
+  }
+#endif
+
+  if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576)) {
+    throw std::runtime_error("setting lmdb map size to " + std::to_string(mapsizeMB));
+  }
 
   mdb_env_set_maxdbs(d_env, 128);
 
@@ -175,7 +180,7 @@ int MDBEnv::getRWTX()
 }
 
 
-std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB)
+std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, int pagesize)
 {
   struct Value
   {
@@ -198,7 +203,7 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64
       if (errno != ENOENT) {
         throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
       }
-      auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
+      auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB, pagesize);
       if (stat(fname, &statbuf) != 0) {
         throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
       }
@@ -223,7 +228,7 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64
     s_envs.erase(iter); // useful if make_shared fails
   }
 
-  auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
+  auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB, pagesize);
   s_envs.emplace(key, Value{fresh, flags});
 
   return fresh;

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -118,7 +118,7 @@ MDBEnv::MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, [[may
   }
 #endif
 
-  if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576)) {
+  if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576) != 0) {
     throw std::runtime_error("setting lmdb map size to " + std::to_string(mapsizeMB));
   }
 

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -131,7 +131,7 @@ MDBEnv::MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, [[may
   }
 #endif
 
-  if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576)) {
+  if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576) != 0) {
     throw std::runtime_error("setting lmdb map size to " + std::to_string(mapsizeMB));
   }
 

--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -121,14 +121,19 @@ int MDBDbi::mdb_dbi_open(MDB_txn* txn, const char* name, unsigned int flags, MDB
   return ::mdb_dbi_open(txn, name, flags, dbi);
 }
 
-MDBEnv::MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB)
+MDBEnv::MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, [[maybe_unused]] int pagesize)
 {
   mdb_env_create(&d_env);
-  if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576))
-    throw std::runtime_error("setting map size");
-    /*
-Various other options may also need to be set before opening the handle, e.g. mdb_env_set_mapsize(), mdb_env_set_maxreaders(), mdb_env_set_maxdbs(),
-    */
+
+#if MDB_VERSION_MAJOR >= 1 // Not available prior to lmdb 1.0
+  if (pagesize > 0 && mdb_env_set_pagesize(d_env, pagesize)) {
+    throw std::runtime_error("setting lmdb page size to " + std::to_string(pagesize));
+  }
+#endif
+
+  if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576)) {
+    throw std::runtime_error("setting lmdb map size to " + std::to_string(mapsizeMB));
+  }
 
   mdb_env_set_maxdbs(d_env, 128);
 
@@ -188,7 +193,7 @@ int MDBEnv::getRWTX()
 }
 
 
-std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB)
+std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, int pagesize)
 {
   struct Value
   {
@@ -211,7 +216,7 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64
       if (errno != ENOENT) {
         throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
       }
-      auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
+      auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB, pagesize);
       if (stat(fname, &statbuf) != 0) {
         throw std::runtime_error("Unable to stat prospective mdb database: " + MDBError(errno));
       }
@@ -236,7 +241,7 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64
     s_envs.erase(iter); // useful if make_shared fails
   }
 
-  auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB);
+  auto fresh = std::make_shared<MDBEnv>(fname, flags, mode, mapsizeMB, pagesize);
   s_envs.emplace(key, Value{fresh, flags});
 
   return fresh;

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -105,7 +105,7 @@ public:
   {
     return d_env;
   }
-  MDB_env* d_env;
+  MDB_env* d_env{nullptr};
 
   int getRWTX();
   void incRWTX();

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -86,7 +86,7 @@ using MDBRWTransaction = std::unique_ptr<MDBRWTransactionImpl>;
 class MDBEnv
 {
 public:
-  MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB);
+  MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, int pagesize);
 
   ~MDBEnv()
   {
@@ -116,7 +116,7 @@ private:
   std::unordered_map<std::thread::id, std::atomic<int>> d_RWtransactionsOut;
 };
 
-std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB);
+std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, int pagesize);
 
 #ifndef DNSDIST
 

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -88,7 +88,7 @@ using MDBRWTransaction = std::unique_ptr<MDBRWTransactionImpl>;
 class MDBEnv
 {
 public:
-  MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB);
+  MDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, int pagesize);
 
   ~MDBEnv()
   {
@@ -118,7 +118,7 @@ private:
   std::unordered_map<std::thread::id, std::atomic<int>> d_RWtransactionsOut;
 };
 
-std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB);
+std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode, uint64_t mapsizeMB, int pagesize);
 
 #ifndef DNSDIST
 

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -107,7 +107,7 @@ public:
   {
     return d_env;
   }
-  MDB_env* d_env;
+  MDB_env* d_env{nullptr};
 
   int getRWTX();
   void incRWTX();

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -749,6 +749,13 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     // Old configuration with only one settings for main and shards.
     d_mapsize_shards = d_mapsize_main;
   }
+  d_pagesize = 0;
+  try {
+    d_pagesize = std::stoi(getArg("page-size"));
+  }
+  catch (const std::exception& e) {
+    throw std::runtime_error(std::string("Unable to parse the 'page-size' LMDB value: ") + e.what());
+  }
 
   d_write_notification_update = mustDo("write-notification-update");
   d_split_domains_table = mustDo("split-domains-table");
@@ -757,6 +764,7 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     d_random_ids = true;
     d_handle_dups = true;
     LMDBLS::s_flag_deleted = true;
+    // TODO: should we force a large value for d_pagesize here by default?
 
     if (atoi(getArg("shards").c_str()) != 1) {
       throw std::runtime_error(std::string("running with Lightning Stream support requires shards=1"));
@@ -893,7 +901,7 @@ LMDBBackend::~LMDBBackend()
 void LMDBBackend::openAllTheDatabases()
 {
   const auto& filename = getArg("filename");
-  d_tdomains = std::make_shared<tdomains_t>(getMDBEnv(filename.c_str(), MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_main), "domains_v5");
+  d_tdomains = std::make_shared<tdomains_t>(getMDBEnv(filename.c_str(), MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_main, d_pagesize), "domains_v5");
   d_tmeta = std::make_shared<tmeta_t>(d_tdomains->getEnv(), "metadata_v5");
   d_tkdb = std::make_shared<tkdb_t>(d_tdomains->getEnv(), "keydata_v5");
   d_ttsig = std::make_shared<ttsig_t>(d_tdomains->getEnv(), "tsig_v5");
@@ -1924,7 +1932,7 @@ std::shared_ptr<LMDBBackend::RecordsRWTransaction> LMDBBackend::getRecordsRWTran
   auto& shard = d_trecords[id % s_shards];
   if (!shard.env) {
     shard.env = getMDBEnv((getArg("filename") + "-" + std::to_string(id % s_shards)).c_str(),
-                          MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards);
+                          MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards, d_pagesize);
     shard.rdbi = shard.env->openDB("records_v5", MDB_CREATE);
     shard.cdbi = shard.env->openDB("comments_v7", MDB_CREATE);
   }
@@ -1943,7 +1951,7 @@ std::shared_ptr<LMDBBackend::RecordsROTransaction> LMDBBackend::getRecordsROTran
       throw DBException("attempting to start nested transaction without open parent env");
     }
     shard.env = getMDBEnv((getArg("filename") + "-" + std::to_string(id % s_shards)).c_str(),
-                          MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards);
+                          MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards, d_pagesize);
     shard.rdbi = shard.env->openDB("records_v5", MDB_CREATE);
     shard.cdbi = shard.env->openDB("comments_v7", MDB_CREATE);
   }
@@ -3768,6 +3776,7 @@ public:
     declare(suffix, "random-ids", "Numeric IDs inside the database are generated randomly instead of sequentially", "no");
     declare(suffix, "map-size", "main LMDB map size in megabytes", (sizeof(void*) == 4) ? "100" : "16000");
     declare(suffix, "shards-map-size", "shard LMDB map size in megabytes, zero to use the same size as main", "0");
+    declare(suffix, "page-size", "LMDB page size in kilobytes", "4096");
     declare(suffix, "flag-deleted", "Flag entries on deletion instead of deleting them", "no");
     declare(suffix, "write-notification-update", "Update domain table upon notification", "yes");
     declare(suffix, "split-domains-table", "Use a split domain table to reduce I/O load after XFR notifications", "no");

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -750,6 +750,13 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     // Old configuration with only one settings for main and shards.
     d_mapsize_shards = d_mapsize_main;
   }
+  d_pagesize = 0;
+  try {
+    d_pagesize = std::stoi(getArg("page-size"));
+  }
+  catch (const std::exception& e) {
+    throw std::runtime_error(std::string("Unable to parse the 'page-size' LMDB value: ") + e.what());
+  }
 
   d_write_notification_update = mustDo("write-notification-update");
   d_split_domains_table = mustDo("split-domains-table");
@@ -894,7 +901,7 @@ LMDBBackend::~LMDBBackend()
 void LMDBBackend::openAllTheDatabases()
 {
   const auto& filename = getArg("filename");
-  d_tdomains = std::make_shared<tdomains_t>(getMDBEnv(filename.c_str(), MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_main), "domains_v5");
+  d_tdomains = std::make_shared<tdomains_t>(getMDBEnv(filename.c_str(), MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_main, d_pagesize), "domains_v5");
   d_tmeta = std::make_shared<tmeta_t>(d_tdomains->getEnv(), "metadata_v5");
   d_tkdb = std::make_shared<tkdb_t>(d_tdomains->getEnv(), "keydata_v5");
   d_ttsig = std::make_shared<ttsig_t>(d_tdomains->getEnv(), "tsig_v5");
@@ -1925,7 +1932,7 @@ std::shared_ptr<LMDBBackend::RecordsRWTransaction> LMDBBackend::getRecordsRWTran
   auto& shard = d_trecords[id % s_shards];
   if (!shard.env) {
     shard.env = getMDBEnv((getArg("filename") + "-" + std::to_string(id % s_shards)).c_str(),
-                          MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards);
+                          MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards, d_pagesize);
     shard.rdbi = shard.env->openDB("records_v5", MDB_CREATE);
     shard.cdbi = shard.env->openDB("comments_v7", MDB_CREATE);
   }
@@ -1944,7 +1951,7 @@ std::shared_ptr<LMDBBackend::RecordsROTransaction> LMDBBackend::getRecordsROTran
       throw DBException("attempting to start nested transaction without open parent env");
     }
     shard.env = getMDBEnv((getArg("filename") + "-" + std::to_string(id % s_shards)).c_str(),
-                          MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards);
+                          MDB_NOSUBDIR | MDB_NORDAHEAD | d_asyncFlag, 0600, d_mapsize_shards, d_pagesize);
     shard.rdbi = shard.env->openDB("records_v5", MDB_CREATE);
     shard.cdbi = shard.env->openDB("comments_v7", MDB_CREATE);
   }
@@ -3769,6 +3776,7 @@ public:
     declare(suffix, "random-ids", "Numeric IDs inside the database are generated randomly instead of sequentially", "no");
     declare(suffix, "map-size", "main LMDB map size in megabytes", (sizeof(void*) == 4) ? "100" : "16000");
     declare(suffix, "shards-map-size", "shard LMDB map size in megabytes, zero to use the same size as main", "0");
+    declare(suffix, "page-size", "LMDB page size in kilobytes", "4096");
     declare(suffix, "flag-deleted", "Flag entries on deletion instead of deleting them", "no");
     declare(suffix, "write-notification-update", "Update domain table upon notification", "yes");
     declare(suffix, "split-domains-table", "Use a split domain table to reduce I/O load after XFR notifications", "no");

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -3776,7 +3776,7 @@ public:
     declare(suffix, "random-ids", "Numeric IDs inside the database are generated randomly instead of sequentially", "no");
     declare(suffix, "map-size", "main LMDB map size in megabytes", (sizeof(void*) == 4) ? "100" : "16000");
     declare(suffix, "shards-map-size", "shard LMDB map size in megabytes, zero to use the same size as main", "0");
-    declare(suffix, "page-size", "LMDB page size in kilobytes", "4096");
+    declare(suffix, "page-size", "LMDB page size in kilobytes", "0");
     declare(suffix, "flag-deleted", "Flag entries on deletion instead of deleting them", "no");
     declare(suffix, "write-notification-update", "Update domain table upon notification", "yes");
     declare(suffix, "split-domains-table", "Use a split domain table to reduce I/O load after XFR notifications", "no");

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -455,4 +455,5 @@ private:
   DTime d_dtime; // used only for logging
   uint64_t d_mapsize_main;
   uint64_t d_mapsize_shards;
+  int d_pagesize;
 };

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -187,7 +187,7 @@ class LMDBKVStore : public KeyValueStore
 {
 public:
   LMDBKVStore(const std::string& fname, const std::string& dbName, bool noLock = false) :
-    d_env(getMDBEnv(fname.c_str(), noLock ? MDB_NOSUBDIR | MDB_RDONLY | MDB_NOLOCK : MDB_NOSUBDIR | MDB_RDONLY, 0600, 0)), d_dbi(d_env->openDB(dbName, 0)), d_fname(fname), d_dbName(dbName)
+    d_env(getMDBEnv(fname.c_str(), noLock ? MDB_NOSUBDIR | MDB_RDONLY | MDB_NOLOCK : MDB_NOSUBDIR | MDB_RDONLY, 0600, 0, 0)), d_dbi(d_env->openDB(dbName, 0)), d_fname(fname), d_dbName(dbName)
   {
   }
 

--- a/pdns/dnsdistdist/test-dnsdistkvs_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistkvs_cc.cc
@@ -330,7 +330,7 @@ BOOST_AUTO_TEST_CASE(test_LMDB)
 
   string dbPath("/tmp/test_lmdb.XXXXXX");
   {
-    MDBEnv env(dbPath.c_str(), MDB_NOSUBDIR, 0600, 50);
+    MDBEnv env(dbPath.c_str(), MDB_NOSUBDIR, 0600, 50, 0);
     auto transaction = env.getRWTransaction();
     auto dbi = transaction->openDB("db-name", MDB_CREATE);
     transaction->put(dbi, MDBInVal(std::string(reinterpret_cast<const char*>(&ids.origRemote.sin4.sin_addr.s_addr), sizeof(ids.origRemote.sin4.sin_addr.s_addr))), MDBInVal("this is the value for the remote addr"));
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(test_LMDB)
   }
 
   {
-    MDBEnv env(dbPath.c_str(), MDB_NOSUBDIR, 0600, 50);
+    MDBEnv env(dbPath.c_str(), MDB_NOSUBDIR, 0600, 50, 0);
     auto transaction = env.getRWTransaction();
     auto dbi = transaction->openDB("range-db-name", MDB_CREATE);
     /* range-based lookups */


### PR DESCRIPTION
### Short description
LMDB 1.0 allows users to select a "database page size", and the documentation hints that using a larger value than the default 4096 bytes can improve performance on hardware which MMU uses a larger page size than 4KB, or with some filesystems using large block sizes as well.

This PR adds a `lmdb-page-size` setting allowing users to play with this. Of course, the value matters at database creation; and this setting will be silently ignored if linking against an older LMDB library.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
