### PR TITLE
dnsdist: Fix the dropping of responses for DoQ and DoH3 queries

### DIFF
--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -1022,7 +1022,7 @@ ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_
 */
 bool processResponse(PacketBuffer& response, DNSResponse& dnsResponse, bool muted);
 /* Apply the decision (result) of a single rule to this query. If the decision implies to drop the query
-   `query` will be set to `true`. The return value indicates whether subsequent rules should be evaluated (true)
+   `drop` will be set to `true`. The return value indicates whether subsequent rules should be evaluated (true)
    or not (false).
 */
 bool processRulesResult(const DNSAction::Action& action, DNSQuestion& dnsQuestion, std::string& ruleresult, bool& drop);

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -1017,8 +1017,18 @@ enum class ProcessQueryResult : uint8_t
 
 ProcessQueryResult processQuery(DNSQuestion& dnsQuestion, std::shared_ptr<DownstreamState>& selectedBackend);
 ProcessQueryResult processQueryAfterRules(DNSQuestion& dnsQuestion, std::shared_ptr<DownstreamState>& outgoingBackend);
+/* Process a response received from a backend. The return value indicates whether
+   the response processing should continue (true) or if it should be dropped right away (false).
+*/
 bool processResponse(PacketBuffer& response, DNSResponse& dnsResponse, bool muted);
+/* Apply the decision (result) of a single rule to this query. If the decision implies to drop the query
+   `query` will be set to `true`. The return value indicates whether subsequent rules should be evaluated (true)
+   or not (false).
+*/
 bool processRulesResult(const DNSAction::Action& action, DNSQuestion& dnsQuestion, std::string& ruleresult, bool& drop);
+/* Handle the processing of a response once the rules have been applied. The return value indicates whether
+   the response processing should continue (true) or if it should be dropped right away (false).
+*/
 bool processResponseAfterRules(PacketBuffer& response, DNSResponse& dnsResponse, bool muted);
 bool processResponderPacket(std::shared_ptr<DownstreamState>& dss, PacketBuffer& response, InternalQueryState&& ids);
 bool applyRulesToResponse(const std::vector<dnsdist::rules::ResponseRuleAction>& respRuleActions, DNSResponse& dnsResponse);

--- a/pdns/dnsdistdist/doh3.cc
+++ b/pdns/dnsdistdist/doh3.cc
@@ -142,7 +142,8 @@ public:
 
       if (!processResponse(dnsResponse.ids.doh3u->response, dnsResponse, false)) {
         if (dnsResponse.ids.doh3u) {
-
+          /* this will signal an error */
+          dnsResponse.ids.doh3u->response.clear();
           sendBackDOH3Unit(std::move(dnsResponse.ids.doh3u), "Response dropped by rules");
         }
         return;

--- a/pdns/dnsdistdist/doq.cc
+++ b/pdns/dnsdistdist/doq.cc
@@ -118,7 +118,8 @@ public:
 
       if (!processResponse(dnsResponse.ids.doqu->response, dnsResponse, false)) {
         if (dnsResponse.ids.doqu) {
-
+          /* this will signal an error */
+          dnsResponse.ids.doqu->response.clear();
           sendBackDOQUnit(std::move(dnsResponse.ids.doqu), "Response dropped by rules");
         }
         return;

--- a/regression-tests.dnsdist/quictests.py
+++ b/regression-tests.dnsdist/quictests.py
@@ -63,6 +63,20 @@ class QUICTests(object):
         except StreamResetError as e:
             self.assertEqual(e.error, 5)
 
+    def testDroppedResponse(self):
+        """
+        QUIC: Dropped query response
+        """
+        name = "drop-response.doq.tests.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        backendResponse = dns.message.make_response(query)
+        backendResponse.set_rcode(dns.rcode.REFUSED)
+        try:
+            (_, _) = self.sendQUICQuery(query, response=backendResponse, passExceptions=True)
+            self.fail()
+        except StreamResetError as e:
+            self.assertEqual(e.error, 5)
+
     def testRefused(self):
         """
         QUIC: Refused

--- a/regression-tests.dnsdist/test_DOH3.py
+++ b/regression-tests.dnsdist/test_DOH3.py
@@ -44,6 +44,7 @@ class TestDOH3(DOH3Common, QUICTests, DNSDistTest):
     addAction("http-status-action.doh3.tests.powerdns.com.", HTTPStatusAction(200, "Plaintext answer", "text/plain"))
     addAction("http-status-action-redirect.doh3.tests.powerdns.com.", HTTPStatusAction(307, "https://doh.powerdns.org"))
     addAction("no-backend.doq.tests.powerdns.com.", PoolAction('this-pool-has-no-backend'))
+    addResponseAction("drop-response.doq.tests.powerdns.com.", DropResponseAction())
 
     function dohHandler(dq)
       if dq:getHTTPScheme() == 'https' and dq:getHTTPHost() == '%s:%d' and dq:getHTTPPath() == '/' and dq:getHTTPQueryString() == '' then
@@ -322,6 +323,13 @@ query_rules:
     action:
       type: "Pool"
       pool_name: "this-pool-has-no-backend"
+response_rules:
+  - name: "Drop"
+    selector:
+      type: "QName"
+      qname: "drop-response.doq.tests.powerdns.com."
+    action:
+      type: "Drop"
     """
     _yaml_config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
 

--- a/regression-tests.dnsdist/test_DOQ.py
+++ b/regression-tests.dnsdist/test_DOQ.py
@@ -78,6 +78,7 @@ class TestDOQ(DOQCommon, QUICTests, DNSDistTest):
     addAction("refused.doq.tests.powerdns.com.", RCodeAction(DNSRCode.REFUSED))
     addAction("spoof.doq.tests.powerdns.com.", SpoofAction("1.2.3.4"))
     addAction("no-backend.doq.tests.powerdns.com.", PoolAction('this-pool-has-no-backend'))
+    addResponseAction("drop-response.doq.tests.powerdns.com.", DropResponseAction())
 
     addDOQLocal("127.0.0.1:%d", "%s", "%s")
     """
@@ -133,6 +134,13 @@ query_rules:
     action:
       type: "Pool"
       pool_name: "this-pool-has-no-backend"
+response_rules:
+  - name: "Drop"
+    selector:
+      type: "QName"
+      qname: "drop-response.doq.tests.powerdns.com."
+    action:
+      type: "Drop"
     """
     _yaml_config_params = ["_testServerPort", "_doqServerPort", "_serverCert", "_serverKey"]
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Calling `DropResponseAction` (or `drop` in `YAML`) for queries received over DoQ or DoH3 was silently ignored.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
