### PR TITLE
auth: ignore the closing SOA record in IXFR-turned-AXFR

### DIFF
--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -887,7 +887,8 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
           if (!g_slogStructured) {
             ctx.logPrefix[0] = 'A'; // IXFR -> AXFR
           }
-          bool firstNSEC3 = true;
+          bool firstNSEC3{true};
+          bool soa_received{false};
           rrs.reserve(axfr.size());
           for (const auto& dr : axfr) { // NOLINT(readability-identifier-length)
             auto rr = DNSResourceRecord::fromWire(dr); // NOLINT(readability-identifier-length)
@@ -898,8 +899,12 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
               continue;
             }
             if (dr.d_type == QType::SOA) {
+              if (soa_received) {
+                continue; // skip the last SOA
+              }
               auto sd = getRR<SOARecordContent>(dr); // NOLINT(readability-identifier-length)
               ctx.soa_serial = sd->d_st.serial;
+              soa_received = true;
             }
             rrs.emplace_back(std::move(rr));
           }


### PR DESCRIPTION
### Short description
As described in #12984, when an IXFR turns out to be handled as an AXFR, the logic was missing the guard to ignore the closing SOA record and would cause duplicate SOA records to be inserted.

This PR simply adds the missing logic. Some of this code is crying for factorization, but there are enough little differences for this to be a can of worms I'm not really wanting to open at the moment.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
