### PR TITLE
pdnsutil b2b-migrate: also copy zone options and catalog membership

### DIFF
--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -190,13 +190,15 @@ zone check-all [exit-on-error]
 zone clear *ZONE*
 
     Clear the records in zone *ZONE*, but leave actual zone and
-    settings unchanged
+    settings unchanged.
 
 zone copy *ZONE* *NEW-ZONE*
 
     Copies the contents of *ZONE* (records, comments, metadata, keys) to a
     new zone *NEW-ZONE*. The new zone must not exist and gets created as
     part of the copy, in the same backend as *ZONE*.
+    Note that the *ZONE* options and catalog memberships, if any, are
+    not copied.
 
 zone create *ZONE*
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1103,7 +1103,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       // The invalid part might be the record name itself, only output it if
       // non-empty.
       if (!drr.qname.empty()) {
-	cout << "'" << drr.qname << "' ";
+        cout << "'" << drr.qname << "' ";
       }
       cout << "record in backend storage: ";
       bool first = true;
@@ -5668,6 +5668,23 @@ static int B2BMigrate(vector<string>& cmds, const std::string_view synopsis)
     cout<<"Processing '"<<di.zone<<"'"<<endl;
 
     copyZoneContents(di, di.zone, tgt.get());
+
+    // Copy zone options and catalog memberships, which are not handled by
+    // copyZoneContents() above. Note that getAllDomains above does not
+    // necessarily fill the options and catalog fields of the DomainInfo
+    // struct, so we need to query it again.
+    DomainInfo info;
+    if (src->getDomainInfo(di.zone, info, false)) {
+      if (!info.options.empty() && !tgt->setOptions(di.zone, info.options)) {
+        cout << "WARNING: could not copy zone options" << endl;
+      }
+      if (!info.catalog.empty() && !tgt->setCatalog(di.zone, info.catalog)) {
+        cout << "WARNING: could not copy zone catalog" << endl;
+      }
+    }
+    else {
+      cout << "WARNING: could not get zone options and catalog" << endl;
+    }
   }
 
   int ntk=0;


### PR DESCRIPTION
### Short description
As mentioned in #12879, these two parts of domain information were left out during migration.
This PR fixes it (and it was not as easy as it seemed to be).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
