### PR TITLE
do not use str{n,}casecmp for DNS names

### DIFF
--- a/.github/actions/spell-check/allow.txt
+++ b/.github/actions/spell-check/allow.txt
@@ -3476,7 +3476,6 @@ stringstream
 stringtok
 stringvalue
 STRLIT
-strncasecmp
 strncmp
 strncpy
 strptime

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -475,7 +475,7 @@ struct SuffixMatchTree
   }
   bool operator<(const SuffixMatchTree& rhs) const
   {
-    return strcasecmp(d_name.c_str(), rhs.d_name.c_str()) < 0;
+    return pdns_ilexicographical_compare(d_name, rhs.d_name);
   }
 
   std::string d_name;
@@ -492,7 +492,9 @@ struct SuffixMatchTree
     bool operator<(const SuffixMatchTree& smt) const
     {
       auto compareUpTo = std::min(this->d_name.size(), smt.d_name.size());
-      auto ret = strncasecmp(this->d_name.data(), smt.d_name.data(), compareUpTo);
+      auto this_name = std::string_view(this->d_name.data(), compareUpTo);
+      auto smt_name = std::string_view(smt.d_name.data(), compareUpTo);
+      auto ret = pdns_ilexicographical_compare_three_way(this_name, smt_name);
       if (ret != 0) {
         return ret < 0;
       }
@@ -506,7 +508,9 @@ struct SuffixMatchTree
   bool operator<(const LightKey& lk) const
   {
     auto compareUpTo = std::min(this->d_name.size(), lk.d_name.size());
-    auto ret = strncasecmp(this->d_name.data(), lk.d_name.data(), compareUpTo);
+    auto this_name = std::string_view(this->d_name.data(), compareUpTo);
+    auto lk_name = std::string_view(lk.d_name.data(), compareUpTo);
+    auto ret = pdns_ilexicographical_compare_three_way(this_name, lk_name);
     if (ret != 0) {
       return ret < 0;
     }

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -491,6 +491,10 @@ struct SuffixMatchTree
     std::string_view d_name;
     bool operator<(const SuffixMatchTree& smt) const
     {
+      // This whole logic unfortunately can't be rewritten as
+      // pdns_ilexicographical_compare_three_way(this->d_name, smt.d_name)
+      // for, when the strings differ in length, the last return statement
+      // in the code below returns the opposite value.
       auto compareUpTo = std::min(this->d_name.size(), smt.d_name.size());
       auto this_name = std::string_view(this->d_name.data(), compareUpTo);
       auto smt_name = std::string_view(smt.d_name.data(), compareUpTo);
@@ -499,7 +503,7 @@ struct SuffixMatchTree
         return ret < 0;
       }
       if (this->d_name.size() == smt.d_name.size()) {
-        return ret < 0;
+        return 0;
       }
       return this->d_name.size() < smt.d_name.size();
     }
@@ -507,6 +511,10 @@ struct SuffixMatchTree
 
   bool operator<(const LightKey& lk) const
   {
+    // This whole logic unfortunately can't be rewritten as
+    // pdns_ilexicographical_compare_three_way(this->d_name, lk.d_name)
+    // for, when the strings differ in length, the last return statement
+    // in the code below returns the opposite value.
     auto compareUpTo = std::min(this->d_name.size(), lk.d_name.size());
     auto this_name = std::string_view(this->d_name.data(), compareUpTo);
     auto lk_name = std::string_view(lk.d_name.data(), compareUpTo);
@@ -515,7 +523,7 @@ struct SuffixMatchTree
       return ret < 0;
     }
     if (this->d_name.size() == lk.d_name.size()) {
-      return ret < 0;
+      return 0;
     }
     return this->d_name.size() < lk.d_name.size();
   }

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -60,7 +60,7 @@ inline unsigned char dns_tolower(unsigned char chr)
 }
 
 inline int pdns_ilexicographical_compare_three_way(std::string_view a, std::string_view b)  __attribute__((pure));
-inline int pdns_ilexicographical_compare_three_way(std::string_view a, std::string_view b)
+inline int pdns_ilexicographical_compare_three_way(const std::string_view a, const std::string_view b)
 {
   const unsigned char *aPtr = (const unsigned char*)a.data(), *bPtr = (const unsigned char*)b.data();
   const unsigned char *aEptr = aPtr + a.length(), *bEptr = bPtr + b.length();

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -59,6 +59,58 @@ inline unsigned char dns_tolower(unsigned char chr)
   return dns_tolower_table[chr];
 }
 
+inline int pdns_ilexicographical_compare_three_way(std::string_view a, std::string_view b)  __attribute__((pure));
+inline int pdns_ilexicographical_compare_three_way(std::string_view a, std::string_view b)
+{
+  const unsigned char *aPtr = (const unsigned char*)a.data(), *bPtr = (const unsigned char*)b.data();
+  const unsigned char *aEptr = aPtr + a.length(), *bEptr = bPtr + b.length();
+  while(aPtr != aEptr && bPtr != bEptr) {
+    if (*aPtr != *bPtr) {
+      if (int rc = dns_tolower(*aPtr) - dns_tolower(*bPtr); rc != 0) {
+        return rc;
+      }
+    }
+    aPtr++;
+    bPtr++;
+  }
+  // At this point, one of the strings has been completely processed.
+  // Either both have the same length, and they are equal, or one of them
+  // is larger, and compares as higher.
+  if (aPtr == aEptr) {
+    if (bPtr != bEptr) {
+      return -1; // a < b
+    }
+  }
+  else {
+    return 1; // a > b
+  }
+  return 0; // a == b
+}
+
+inline bool pdns_ilexicographical_compare(const std::string& a, const std::string& b)  __attribute__((pure));
+inline bool pdns_ilexicographical_compare(const std::string& a, const std::string& b)
+{
+  return pdns_ilexicographical_compare_three_way(a, b) < 0;
+}
+
+inline bool pdns_iequals(const std::string& a, const std::string& b) __attribute__((pure));
+inline bool pdns_iequals(const std::string& a, const std::string& b)
+{
+  if (a.length() != b.length())
+    return false;
+
+  return pdns_ilexicographical_compare_three_way(a, b) == 0;
+}
+
+inline bool pdns_iequals_ch(const char a, const char b) __attribute__((pure));
+inline bool pdns_iequals_ch(const char a, const char b)
+{
+  if ((a != b) && (dns_tolower(a) != dns_tolower(b)))
+    return false;
+
+  return true;
+}
+
 #include "burtle.hh"
 #include "views.hh"
 

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -786,6 +786,7 @@ string simpleCompress(const string& elabel, const string& root)
   string ret;
   ret.reserve(label.size()+4);
   for(const auto & part : parts) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     auto label_part = std::string_view(label.c_str() + part.first, 1 + label.length() - part.first); // also match trailing 0, hence '1 +'
     if(!root.empty() && pdns_ilexicographical_compare_three_way(root, label_part) == 0) {
       const unsigned char rootptr[2]={0xc0,0x11};

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -786,7 +786,8 @@ string simpleCompress(const string& elabel, const string& root)
   string ret;
   ret.reserve(label.size()+4);
   for(const auto & part : parts) {
-    if(!root.empty() && !strncasecmp(root.c_str(), label.c_str() + part.first, 1 + label.length() - part.first)) { // also match trailing 0, hence '1 +'
+    auto label_part = std::string_view(label.c_str() + part.first, 1 + label.length() - part.first); // also match trailing 0, hence '1 +'
+    if(!root.empty() && pdns_ilexicographical_compare_three_way(root, label_part) == 0) {
       const unsigned char rootptr[2]={0xc0,0x11};
       ret.append((const char *) rootptr, 2);
       return ret;

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -225,7 +225,7 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfrUnquote
 
 static constexpr bool l_verbose=false;
 static constexpr uint16_t maxCompressionOffset=16384;
-template <typename Container> uint16_t GenericDNSPacketWriter<Container>::lookupName(const DNSName& name, uint16_t* matchLen)
+template <typename Container> uint16_t GenericDNSPacketWriter<Container>::lookupName(const DNSName& name, uint16_t* matchLen) // NOLINT(readability-function-cognitive-complexity)
 {
   // iterate over the written labels, see if we find a match
   const auto& raw = name.getStorage();
@@ -364,8 +364,8 @@ template <typename Container> uint16_t GenericDNSPacketWriter<Container>::lookup
         break;
       }
 
-      auto rawpart = std::string_view(raw.c_str() + *positionInNameIter + 1, nlen);
-      auto pktpart = std::string_view((const char*)&d_content[*positionInPacketIter] + 1, nlen);
+      auto rawpart = std::string_view(raw.c_str() + *positionInNameIter + 1, nlen); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      auto pktpart = std::string_view((const char*)&d_content[*positionInPacketIter] + 1, nlen); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       if (pdns_ilexicographical_compare_three_way(rawpart, pktpart) != 0) {
         if (l_verbose) {
           cout << "Mismatch: " << rawpart << " != " << pktpart << endl;

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -364,9 +364,11 @@ template <typename Container> uint16_t GenericDNSPacketWriter<Container>::lookup
         break;
       }
 
-      if (strncasecmp(raw.c_str() + *positionInNameIter + 1, (const char*)&d_content[*positionInPacketIter] + 1, nlen)) {
+      auto rawpart = std::string_view(raw.c_str() + *positionInNameIter + 1, nlen);
+      auto pktpart = std::string_view((const char*)&d_content[*positionInPacketIter] + 1, nlen);
+      if (pdns_ilexicographical_compare_three_way(rawpart, pktpart) != 0) {
         if (l_verbose) {
-          cout << "Mismatch: " << string(raw.c_str() + *positionInNameIter + 1, raw.c_str() + *positionInNameIter + nlen + 1) << " != " << string((const char*)&d_content[*positionInPacketIter] + 1, (const char*)&d_content[*positionInPacketIter] + nlen + 1) << endl;
+          cout << "Mismatch: " << rawpart << " != " << pktpart << endl;
         }
         break;
       }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -373,59 +373,6 @@ inline bool operator<(const struct timespec& lhs, const struct timespec& rhs)
 }
 
 
-inline int pdns_ilexicographical_compare_three_way(std::string_view a, std::string_view b)  __attribute__((pure));
-inline int pdns_ilexicographical_compare_three_way(std::string_view a, std::string_view b)
-{
-  const unsigned char *aPtr = (const unsigned char*)a.data(), *bPtr = (const unsigned char*)b.data();
-  const unsigned char *aEptr = aPtr + a.length(), *bEptr = bPtr + b.length();
-  while(aPtr != aEptr && bPtr != bEptr) {
-    if (*aPtr != *bPtr) {
-      if (int rc = dns_tolower(*aPtr) - dns_tolower(*bPtr); rc != 0) {
-        return rc;
-      }
-    }
-    aPtr++;
-    bPtr++;
-  }
-  // At this point, one of the strings has been completely processed.
-  // Either both have the same length, and they are equal, or one of them
-  // is larger, and compares as higher.
-  if (aPtr == aEptr) {
-    if (bPtr != bEptr) {
-      return -1; // a < b
-    }
-  }
-  else {
-    return 1; // a > b
-  }
-  return 0; // a == b
-}
-
-inline bool pdns_ilexicographical_compare(const std::string& a, const std::string& b)  __attribute__((pure));
-inline bool pdns_ilexicographical_compare(const std::string& a, const std::string& b)
-{
-  return pdns_ilexicographical_compare_three_way(a, b) < 0;
-}
-
-inline bool pdns_iequals(const std::string& a, const std::string& b) __attribute__((pure));
-inline bool pdns_iequals(const std::string& a, const std::string& b)
-{
-  if (a.length() != b.length())
-    return false;
-
-  return pdns_ilexicographical_compare_three_way(a, b) == 0;
-}
-
-inline bool pdns_iequals_ch(const char a, const char b) __attribute__((pure));
-inline bool pdns_iequals_ch(const char a, const char b)
-{
-  if ((a != b) && (dns_tolower(a) != dns_tolower(b)))
-    return false;
-
-  return true;
-}
-
-
 typedef unsigned long AtomicCounterInner;
 typedef std::atomic<AtomicCounterInner> AtomicCounter ;
 

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -1110,8 +1110,8 @@ BOOST_AUTO_TEST_CASE(test_variantnames) {
 #endif
 
 BOOST_AUTO_TEST_CASE(test_pdns_ilexicographical_compare) {
-  typedef boost::tuple<const std::string, const std::string, bool> case_t;
-  typedef std::list<case_t> cases_t;
+  using case_t = boost::tuple<const std::string, const std::string, bool>;
+  using cases_t = std::list<case_t>;
 
   cases_t cases = boost::assign::list_of
     (case_t(std::string(""), std::string(""), false))
@@ -1126,15 +1126,14 @@ BOOST_AUTO_TEST_CASE(test_pdns_ilexicographical_compare) {
   ;
 
   for(const case_t& val :  cases) {
-    bool res;
-    res = pdns_ilexicographical_compare(val.get<0>(), val.get<1>());
+    bool res = pdns_ilexicographical_compare(val.get<0>(), val.get<1>());
     BOOST_CHECK_EQUAL(res, val.get<2>());
   }
 }
 
 BOOST_AUTO_TEST_CASE(test_pdns_iequals) {
-  typedef boost::tuple<const std::string, const std::string, bool> case_t;
-  typedef std::list<case_t> cases_t;
+  using case_t = boost::tuple<const std::string, const std::string, bool>;
+  using cases_t = std::list<case_t>;
 
   cases_t cases = boost::assign::list_of
     (case_t(std::string(""), std::string(""), true))
@@ -1149,8 +1148,7 @@ BOOST_AUTO_TEST_CASE(test_pdns_iequals) {
   ;
 
   for(const case_t& val :  cases) {
-    bool res;
-    res = pdns_iequals(val.get<0>(), val.get<1>());
+    bool res = pdns_iequals(val.get<0>(), val.get<1>());
     BOOST_CHECK_EQUAL(res, val.get<2>());
   }
 }

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -5,6 +5,8 @@
 #define BOOST_TEST_NO_MAIN
 
 #include <boost/test/unit_test.hpp>
+#include <boost/assign/list_of.hpp>
+#include <boost/tuple/tuple.hpp>
 
 #include <cmath>
 #include <numeric>
@@ -1106,5 +1108,51 @@ BOOST_AUTO_TEST_CASE(test_variantnames) {
   BOOST_CHECK_THROW(ZoneName zone("variants.r.us..dot..dot...dot....dot.....dots"),std::out_of_range);
 }
 #endif
+
+BOOST_AUTO_TEST_CASE(test_pdns_ilexicographical_compare) {
+  typedef boost::tuple<const std::string, const std::string, bool> case_t;
+  typedef std::list<case_t> cases_t;
+
+  cases_t cases = boost::assign::list_of
+    (case_t(std::string(""), std::string(""), false))
+    (case_t(std::string(""), std::string("abc"), true))
+    (case_t(std::string("abc"), std::string(""), false))
+    (case_t(std::string("abc"), std::string("abcd"), true))
+    (case_t(std::string("abcd"), std::string("abc"), false))
+    (case_t(std::string("abd"), std::string("abc"), false))
+    (case_t(std::string("abc"), std::string("abd"), true))
+    (case_t(std::string("abc"), std::string("Abc"), false))
+    (case_t(std::string("Abc"), std::string("abc"), false))
+  ;
+
+  for(const case_t& val :  cases) {
+    bool res;
+    res = pdns_ilexicographical_compare(val.get<0>(), val.get<1>());
+    BOOST_CHECK_EQUAL(res, val.get<2>());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_pdns_iequals) {
+  typedef boost::tuple<const std::string, const std::string, bool> case_t;
+  typedef std::list<case_t> cases_t;
+
+  cases_t cases = boost::assign::list_of
+    (case_t(std::string(""), std::string(""), true))
+    (case_t(std::string(""), std::string("abc"), false))
+    (case_t(std::string("abc"), std::string(""), false))
+    (case_t(std::string("abc"), std::string("abcd"), false))
+    (case_t(std::string("abcd"), std::string("abc"), false))
+    (case_t(std::string("abd"), std::string("abc"), false))
+    (case_t(std::string("abc"), std::string("abd"), false))
+    (case_t(std::string("abc"), std::string("Abc"), true))
+    (case_t(std::string("Abc"), std::string("abc"), true))
+  ;
+
+  for(const case_t& val :  cases) {
+    bool res;
+    res = pdns_iequals(val.get<0>(), val.get<1>());
+    BOOST_CHECK_EQUAL(res, val.get<2>());
+  }
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -12,8 +12,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/assign/list_of.hpp>
 
-#include <boost/tuple/tuple.hpp>
-
 #include <arpa/inet.h>
 
 #include "dns.hh"
@@ -61,52 +59,6 @@ BOOST_AUTO_TEST_CASE(test_CIStringPairCompare) {
                 s<<"("<<i->first<<"|"<<i->second<<")";
         }
         BOOST_CHECK_EQUAL(s.str(), "(|1)(abc|1)(abc|2)(def|1)(ns.example.com|0)(ns.example.com|1)");
-}
-
-BOOST_AUTO_TEST_CASE(test_pdns_ilexicographical_compare) {
-  typedef boost::tuple<const std::string, const std::string, bool> case_t;
-  typedef std::list<case_t> cases_t;
-
-  cases_t cases = boost::assign::list_of
-    (case_t(std::string(""), std::string(""), false))
-    (case_t(std::string(""), std::string("abc"), true))
-    (case_t(std::string("abc"), std::string(""), false))
-    (case_t(std::string("abc"), std::string("abcd"), true))
-    (case_t(std::string("abcd"), std::string("abc"), false))
-    (case_t(std::string("abd"), std::string("abc"), false))
-    (case_t(std::string("abc"), std::string("abd"), true))
-    (case_t(std::string("abc"), std::string("Abc"), false))
-    (case_t(std::string("Abc"), std::string("abc"), false))
-  ;
-
-  for(const case_t& val :  cases) {
-    bool res;
-    res = pdns_ilexicographical_compare(val.get<0>(), val.get<1>());
-    BOOST_CHECK_EQUAL(res, val.get<2>());
-  }
-}
-
-BOOST_AUTO_TEST_CASE(test_pdns_iequals) {
-  typedef boost::tuple<const std::string, const std::string, bool> case_t;
-  typedef std::list<case_t> cases_t;
-
-  cases_t cases = boost::assign::list_of
-    (case_t(std::string(""), std::string(""), true))
-    (case_t(std::string(""), std::string("abc"), false))
-    (case_t(std::string("abc"), std::string(""), false))
-    (case_t(std::string("abc"), std::string("abcd"), false))
-    (case_t(std::string("abcd"), std::string("abc"), false))
-    (case_t(std::string("abd"), std::string("abc"), false))
-    (case_t(std::string("abc"), std::string("abd"), false))
-    (case_t(std::string("abc"), std::string("Abc"), true))
-    (case_t(std::string("Abc"), std::string("abc"), true))
-  ;
-
-  for(const case_t& val :  cases) {
-    bool res;
-    res = pdns_iequals(val.get<0>(), val.get<1>());
-    BOOST_CHECK_EQUAL(res, val.get<2>());
-  }
 }
 
 BOOST_AUTO_TEST_CASE(test_stripDot) {


### PR DESCRIPTION
### Short description
This PR replaces all uses of `strcasecmp` and `strncasecmp` in code dealing with DNS names, to use `pdns_ilexicographical_compare_three_way` instead.

This makes sure we get a well-defined behaviour, regardless of the locale settings of the system we are running on.

Due to circular dependencies, the first commit moves the `pdns_i*` routines from `misc.hh` to `dnsname.hh`. The other commits are (almost) trivial.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
