### PR TITLE
Recursor: Add more, empty Special Use domains

### DIFF
--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -30,6 +30,8 @@ The .onion domain is no longer forwarded to any authoritative server but respond
 
 Any domains under .test and .invalid are no longer forwarded to authoritatives on the internet, but can be individually forwarded or overwritten.
 
+The Special Use Domains :rfc:`home.arpa <8375>`, :rfc:`resolver.arpa <9462>`, and :rfc:`service.arpa <9665>` are no longer forwarded to the internet, but can be individually overwritten or forwarded.
+
 5.1.10, 5.2.8 and 5.3.5
 -----------------------
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -12,6 +12,11 @@ Building
 ^^^^^^^^
 Building using autotools is no longer possible, use meson. See :doc:`appendices/compiling`.
 
+New Settings
+^^^^^^^^^^^^
+
+- The :ref:`setting-yaml-recursor.serve_rfc6761` setting has been introduced to NXDomain .test and .invalid by default, unless any subdomains are forwarded.
+
 Changed Settings
 ^^^^^^^^^^^^^^^^
 The :ref:`incoming-ws-config` YAML struct has been extended to be able to specify an encrypted PKCS12 file to configure TLS key and certificate chain for the embedded web server.
@@ -22,6 +27,8 @@ Special-Use Domain Names
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 The .onion domain is no longer forwarded to any authoritative server but responded to with an NXDomain, as prescribed by :rfc:`7686`.
+
+Any domains under .test and .invalid are no longer forwarded to authoritatives on the internet, but can be individually forwarded or overwritten.
 
 5.1.10, 5.2.8 and 5.3.5
 -----------------------

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -18,6 +18,11 @@ The :ref:`incoming-ws-config` YAML struct has been extended to be able to specif
 
 The :ref:`outgoing-tls-configuration` YAML struct has been extended to be able to specify an TLS client certificate to be used for outgoing DoT connections.
 
+Special-Use Domain Names
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The .onion domain is no longer forwarded to any authoritative server but responded to with an NXDomain, as prescribed by :rfc:`7686`.
+
 5.1.10, 5.2.8 and 5.3.5
 -----------------------
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -37,6 +37,8 @@ The .onion domain is no longer forwarded to any authoritative server but respond
 
 Any domains under .test and .invalid are no longer forwarded to authoritatives on the internet, but can be individually forwarded or overwritten.
 
+The Special Use Domains :rfc:`home.arpa <8375>`, :rfc:`resolver.arpa <9462>`, and :rfc:`service.arpa <9665>` are no longer forwarded to the internet, but can be individually overwritten or forwarded.
+
 5.1.10, 5.2.8, 5.3.5 and 5.5.0
 ------------------------------
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -28,11 +28,14 @@ New Settings
   It does not change validation or the AD bit.
   Because responses are packet-cached, adding or removing an NTA only affects the presence of this   Extended Error once the relevant cache entries expire or are flushed.
   See :ref:`ntas`.
+- The :ref:`setting-yaml-recursor.serve_rfc6761` setting has been introduced to NXDomain .test and .invalid by default, unless any subdomains are forwarded.
 
 Special-Use Domain Names
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 The .onion domain is no longer forwarded to any authoritative server but responded to with an NXDomain, as prescribed by :rfc:`7686`.
+
+Any domains under .test and .invalid are no longer forwarded to authoritatives on the internet, but can be individually forwarded or overwritten.
 
 5.1.10, 5.2.8, 5.3.5 and 5.5.0
 ------------------------------

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -29,6 +29,11 @@ New Settings
   Because responses are packet-cached, adding or removing an NTA only affects the presence of this   Extended Error once the relevant cache entries expire or are flushed.
   See :ref:`ntas`.
 
+Special-Use Domain Names
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The .onion domain is no longer forwarded to any authoritative server but responded to with an NXDomain, as prescribed by :rfc:`7686`.
+
 5.1.10, 5.2.8, 5.3.5 and 5.5.0
 ------------------------------
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -33,11 +33,16 @@ New Settings
 Special-Use Domain Names
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The .onion domain is no longer forwarded to any authoritative server but responded to with an NXDomain, as prescribed by :rfc:`7686`.
+Several special use domains have been added. These domains (and names under them) should not be sent to authoritatives on the Internet, and will be responded to with an NXDOMAIN response.
+However, these domains and names under them can still be forwarded or served locally by :program:`PowerDNS Recursor`.
+This is the case for the following domains:
 
-Any domains under .test and .invalid are no longer forwarded to authoritatives on the internet, but can be individually forwarded or overwritten.
-
-The Special Use Domains :rfc:`home.arpa <8375>`, :rfc:`resolver.arpa <9462>`, and :rfc:`service.arpa <9665>` are no longer forwarded to the internet, but can be individually overwritten or forwarded.
+* .onion, specified in :rfc:`7686`.
+* .test, specified in :rfc:`6761`
+* .invalid, specified in :rfc:`6761`
+* home.arpa, specified in :rfc:`8375`
+* resolver.arpa, specified in :rfc:`9462`
+* service.arpa, specified in :rfc:`9665`
 
 5.1.10, 5.2.8, 5.3.5 and 5.5.0
 ------------------------------

--- a/pdns/recursordist/rec-rust-lib/cxxsupport.cc
+++ b/pdns/recursordist/rec-rust-lib/cxxsupport.cc
@@ -436,6 +436,7 @@ void pdns::settings::rec::setArgsForZoneRelatedSettings(Recursorsettings& settin
   ::arg().set("allow-notify-for-file") = to_arg(settings.incoming.allow_notify_for_file);
   ::arg().set("export-etc-hosts") = to_arg(settings.recursor.export_etc_hosts);
   ::arg().set("serve-rfc1918") = to_arg(settings.recursor.serve_rfc1918);
+  ::arg().set("serve-rfc6303") = to_arg(settings.recursor.serve_rfc6303);
 }
 
 void pdns::settings::rec::setArgsForACLRelatedSettings(Recursorsettings& settings)

--- a/pdns/recursordist/rec-rust-lib/cxxsupport.cc
+++ b/pdns/recursordist/rec-rust-lib/cxxsupport.cc
@@ -437,6 +437,7 @@ void pdns::settings::rec::setArgsForZoneRelatedSettings(Recursorsettings& settin
   ::arg().set("export-etc-hosts") = to_arg(settings.recursor.export_etc_hosts);
   ::arg().set("serve-rfc1918") = to_arg(settings.recursor.serve_rfc1918);
   ::arg().set("serve-rfc6303") = to_arg(settings.recursor.serve_rfc6303);
+  ::arg().set("serve-rfc6761") = to_arg(settings.recursor.serve_rfc6761);
 }
 
 void pdns::settings::rec::setArgsForACLRelatedSettings(Recursorsettings& settings)

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -2537,6 +2537,24 @@ Individual parts of these zones can still be loaded or forwarded.
         "runtime": ["reload-zones"],
     },
     {
+        "name": "serve_rfc6761",
+        "section": "recursor",
+        "type": LType.Bool,
+        "default": "true",
+        "help": "If we should be authoritative for some of the RFC 6761 Special-Use domains",
+        "doc": """
+This makes the server authoritatively aware of some of the zones in :rfc:`6761`.
+These are:
+
+* .test
+* .invalid
+
+Individual parts of these zones can still be loaded or forwarded.
+""",
+        "versionadded": ["5.4.0"],
+        "runtime": ["reload-zones"],
+    },
+    {
         "name": "serve_stale_extensions",
         "section": "recordcache",
         "type": LType.Uint64,

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -2535,6 +2535,24 @@ Individual parts of these zones can still be loaded or forwarded.
         "runtime": ["reload-zones"],
     },
     {
+        "name": "serve_rfc6761",
+        "section": "recursor",
+        "type": LType.Bool,
+        "default": "true",
+        "help": "If we should be authoritative for some of the RFC 6761 Special-Use domains",
+        "doc": """
+This makes the server authoritatively aware of some of the zones in :rfc:`6761`.
+These are:
+
+* .test
+* .invalid
+
+Individual parts of these zones can still be loaded or forwarded.
+""",
+        "versionadded": ["5.5.0"],
+        "runtime": ["reload-zones"],
+    },
+    {
         "name": "serve_stale_extensions",
         "section": "recordcache",
         "type": LType.Uint64,

--- a/pdns/recursordist/reczones-helpers.cc
+++ b/pdns/recursordist/reczones-helpers.cc
@@ -321,3 +321,12 @@ bool parseEtcHostsLine(std::vector<std::string>& parts, std::string& line)
   stringtok(parts, line, "\t\r\n ");
   return parts.size() >= 2;
 }
+
+void makeEmptyZone(SyncRes::domainmap_t& newMap, const std::string zoneName, Logr::log_t log)
+{
+  DNSRecord dnsRecord;
+  dnsRecord.d_name = DNSName(zoneName);
+  SyncRes::AuthDomain authDomain = makeSOAAndNSNodes(dnsRecord, DNSName("localhost."));
+
+  addToDomainMap(newMap, std::move(authDomain), dnsRecord.d_name, log, true, false);
+}

--- a/pdns/recursordist/reczones-helpers.hh
+++ b/pdns/recursordist/reczones-helpers.hh
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "logr.hh"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/pdns/recursordist/reczones-helpers.hh
+++ b/pdns/recursordist/reczones-helpers.hh
@@ -53,3 +53,7 @@ void addForwardAndReverseLookupEntries(SyncRes::domainmap_t& newMap,
                                        const std::string& searchSuffix,
                                        const std::vector<std::string>& parts,
                                        Logr::log_t log);
+
+void makeEmptyZone(SyncRes::domainmap_t& newMap,
+                   const std::string zoneName,
+                   Logr::log_t log);

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -566,5 +566,14 @@ std::tuple<std::shared_ptr<SyncRes::domainmap_t>, std::shared_ptr<notifyset_t>> 
   // RFC 7686 tells us to NXDomain .onion unless the resolver is hooked up to resolve it
   makeEmptyZone(*newMap, "onion.", log);
 
+  // RFC 8375
+  makeEmptyZone(*newMap, "home.arpa.", log);
+
+  // RFC 9462 says "idem", but for resolver.arpa
+  makeEmptyZone(*newMap, "resolver.arpa.", log);
+
+  // RFC 9665 say "idem", for service.arpa
+  makeEmptyZone(*newMap, "service.arpa.", log);
+
   return {newMap, newSet};
 }

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -135,6 +135,7 @@ string reloadZoneConfiguration(bool yaml)
       ::arg().preParseFile(configname, "export-etc-hosts", "off");
       ::arg().preParseFile(configname, "serve-rfc1918");
       ::arg().preParseFile(configname, "serve-rfc6303");
+      ::arg().preParseFile(configname, "serve-rfc6761");
       ::arg().preParseFile(configname, "include-dir");
       ::arg().preParse(g_argc, g_argv, "include-dir");
 
@@ -154,6 +155,7 @@ string reloadZoneConfiguration(bool yaml)
         ::arg().preParseFile(filename, "export-etc-hosts", ::arg()["export-etc-hosts"]);
         ::arg().preParseFile(filename, "serve-rfc1918", ::arg()["serve-rfc1918"]);
         ::arg().preParseFile(filename, "serve-rfc6303", ::arg()["serve-rfc6303"]);
+        ::arg().preParseFile(filename, "serve-rfc6761", ::arg()["serve-rfc6761"]);
       }
     }
     // Process command line args potentially overriding what we read from config files
@@ -166,6 +168,7 @@ string reloadZoneConfiguration(bool yaml)
     ::arg().preParse(g_argc, g_argv, "export-etc-hosts");
     ::arg().preParse(g_argc, g_argv, "serve-rfc1918");
     ::arg().preParse(g_argc, g_argv, "serve-rfc6303");
+    ::arg().preParse(g_argc, g_argv, "serve-rfc6761");
 
     auto [newDomainMap, newNotifySet] = parseZoneConfiguration(yaml);
 
@@ -484,6 +487,17 @@ static void processServeRFC6303(std::shared_ptr<SyncRes::domainmap_t>& newMap, L
   makePartialIP6Zone(*newMap, "8.b.d.0.1.0.0.2.ip6.arpa", log);
 }
 
+static void processServeRFC6761(std::shared_ptr<SyncRes::domainmap_t>& newMap, Logr::log_t log)
+{
+  if (!::arg().mustDo("serve-rfc6761")) {
+    return;
+  }
+  log->info(Logr::Notice, "Inserting rfc 6761 private space zones");
+
+  makeEmptyZone(*newMap, "test.", log);
+  makeEmptyZone(*newMap, "invalid.", log);
+}
+
 static void processAllowNotifyFor(shared_ptr<notifyset_t>& newSet)
 {
   vector<string> parts;
@@ -545,6 +559,7 @@ std::tuple<std::shared_ptr<SyncRes::domainmap_t>, std::shared_ptr<notifyset_t>> 
   processExportEtcHosts(newMap, log);
   processServeRFC1918(newMap, log);
   processServeRFC6303(newMap, log);
+  processServeRFC6761(newMap, log);
   processAllowNotifyFor(newSet);
   processAllowNotifyForFile(newSet, log);
 

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -548,5 +548,8 @@ std::tuple<std::shared_ptr<SyncRes::domainmap_t>, std::shared_ptr<notifyset_t>> 
   processAllowNotifyFor(newSet);
   processAllowNotifyForFile(newSet, log);
 
+  // RFC 7686 tells us to NXDomain .onion unless the resolver is hooked up to resolve it
+  makeEmptyZone(*newMap, "onion.", log);
+
   return {newMap, newSet};
 }

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -563,17 +563,17 @@ std::tuple<std::shared_ptr<SyncRes::domainmap_t>, std::shared_ptr<notifyset_t>> 
   processAllowNotifyFor(newSet);
   processAllowNotifyForFile(newSet, log);
 
-  // RFC 7686 tells us to NXDomain .onion unless the resolver is hooked up to resolve it
-  makeEmptyZone(*newMap, "onion.", log);
-
-  // RFC 8375
-  makeEmptyZone(*newMap, "home.arpa.", log);
-
-  // RFC 9462 says "idem", but for resolver.arpa
-  makeEmptyZone(*newMap, "resolver.arpa.", log);
-
-  // RFC 9665 say "idem", for service.arpa
-  makeEmptyZone(*newMap, "service.arpa.", log);
+  // Add Special Use domains, unless already forwarded
+  for (const auto& domain : {
+         "onion.", // RFC 7686
+         "home.arpa.", // RFC 8375
+         "resolver.arpa", // RFC 9462
+         "service.arpa", // RFC 9665
+       }) {
+    if (newMap->count(DNSName(domain)) == 0) {
+      makeEmptyZone(*newMap, domain, log);
+    }
+  }
 
   return {newMap, newSet};
 }


### PR DESCRIPTION
### Short description

This PR adds ".onion", ".test", ".invalid", "home.arpa", "resolver.arpa", and "service.arpa" as empty auth zones that can be overwritten by the operator.

There are no tests yet, I'll write those later but I could use feedback.

Closes: #17726

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
