### PR TITLE
auth tests: preserve brain cells

### DIFF
--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -174,3 +174,13 @@ echo -n " ("
 res=$((echo scale=2; echo 100*$passed/\($passed+$failed\)) | bc )
 echo -n "$res%) "
 echo tests passed, $skipped were skipped
+# Display the oracle search order in case of failures
+if [ $failed -gt 0 ]; then
+        echo -n "Oracle files searched in order:"
+        for extracontext in $extracontexts
+        do
+                echo -n " expected_result.$extracontext"
+        done
+        [ -n "$context" ] && echo -n " expected_result.$context"
+        echo ""
+fi


### PR DESCRIPTION
### Short description
Many tests in `regression-tests/` have different outcomes, depending on whether DNSSEC is used, and in that case, depending on the NSEC settings (e.g. narrow mode).

In order to cope with this, these tests have multiple oracle files (expected test results), and the `runtests` logic tries to pick the narrowest (har, har) oracle.

When adding a test or doing a behaviour change impacting many tests, mere mortals can spend quite some time figuring out which oracles to change and/or add.

This PR changes the `runtest` script so that, when errors occurs, it reminds you of the different oracle files it had been checked, in order. This will hopefully help people (including me, who have had local changes similar to this many times in the past) work on the oracles without having to lose too many brain cells and having to sacrifice too many household pets.

Signed-off-by: the housecat who does not want to be sacrificed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s) (sort of)
- [ ] added or modified unit test(s)
