### PR TITLE
auth: better scalability of Lua health checks

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <condition_variable>
+#include <forward_list>
 #include <future>
 #include <random>
 #include <stdexcept>
@@ -246,7 +247,7 @@ private:
     {
       std::chrono::system_clock::time_point checkStart = std::chrono::system_clock::now();
       std::vector<std::future<void>> results;
-      std::vector<CheckDesc> toDelete;
+      std::forward_list<CheckDesc> toDelete;
       {
         // make sure there's no insertion
         auto statuses = d_statuses.read_lock();
@@ -285,7 +286,7 @@ private:
           // This is unlikely to be a problem in practice due to the default value of the expire delay being one hour.
           if (not state->first &&
               lastAccess < (checkStart - std::chrono::seconds(g_luaHealthChecksExpireDelay))) {
-            toDelete.push_back(desc);
+            toDelete.push_front(desc);
           }
         }
       }

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -246,7 +246,7 @@ private:
     while (true)
     {
       std::chrono::system_clock::time_point checkStart = std::chrono::system_clock::now();
-      std::vector<std::future<void>> results;
+      std::forward_list<std::future<void>> results;
       std::forward_list<CheckDesc> toDelete;
       {
         // make sure there's no insertion
@@ -277,9 +277,9 @@ private:
           }
 
           if (desc.url.empty()) { // TCP
-            results.push_back(std::async(std::launch::async, &IsUpOracle::checkTCP, this, desc, state->status.load(), state->first.load()));
+            results.push_front(std::async(std::launch::async, &IsUpOracle::checkTCP, this, desc, state->status.load(), state->first.load()));
           } else { // URL
-            results.push_back(std::async(std::launch::async, &IsUpOracle::checkURL, this, desc, state->status.load(), state->first.load()));
+            results.push_front(std::async(std::launch::async, &IsUpOracle::checkURL, this, desc, state->status.load(), state->first.load()));
           }
           // Give it a chance to run at least once.
           // If minimumFailures * interval > lua-health-checks-expire-delay, then a down status will never get reported.
@@ -294,6 +294,8 @@ private:
       for (auto& future: results) {
         future.wait();
       }
+      // No need to keep these objects around any further
+      results.clear();
       if (!toDelete.empty()) {
         {
           auto statuses = d_statuses.write_lock();

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -299,8 +299,8 @@ private:
       if (!toDelete.empty()) {
         {
           auto statuses = d_statuses.write_lock();
-          for (auto& it: toDelete) {
-            statuses->erase(it);
+          for (auto& iter: toDelete) {
+            statuses->erase(iter);
           }
         }
         // No need to keep these objects around while we'll be waiting below.

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -294,10 +294,14 @@ private:
         future.wait();
       }
       if (!toDelete.empty()) {
-        auto statuses = d_statuses.write_lock();
-        for (auto& it: toDelete) {
-          statuses->erase(it);
+        {
+          auto statuses = d_statuses.write_lock();
+          for (auto& it: toDelete) {
+            statuses->erase(it);
+          }
         }
+        // No need to keep these objects around while we'll be waiting below.
+        toDelete.clear();
       }
 
       // set thread name again, in case std::async surprised us by doing work in this thread
@@ -347,7 +351,8 @@ private:
   }
 
   //NOLINTNEXTLINE(readability-identifier-length)
-  void setWeight(const CheckDesc& cd, int weight){
+  void setWeight(const CheckDesc& cd, int weight)
+  {
     auto statuses = d_statuses.write_lock();
     auto& state = (*statuses)[cd];
     state->weight = weight;


### PR DESCRIPTION
### Short description
This PR tries to improve the scalability of Lua health checks, by using better containers to store intermediate data, and release memory used by these containers earlier.

Probably easier to review on a per-commit basis.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
