### PR TITLE
Emit EDE 33 (Negative Trust Anchor) on NTA-covered responses

### DIFF
--- a/pdns/ednsextendederror.hh
+++ b/pdns/ednsextendederror.hh
@@ -58,6 +58,7 @@ struct EDNSExtendedError
     UnsupportedNSEC3IterationsValue = 27,
     UnableToConformToPolicy = 28,
     Synthesized = 29,
+    NegativeTrustAnchor = 33,
   };
   uint16_t infoCode;
   std::string extraText;

--- a/pdns/recursordist/docs/dnssec.rst
+++ b/pdns/recursordist/docs/dnssec.rst
@@ -173,6 +173,17 @@ The NTA entries require the name of the zone and an optional reason:
       - name: example.com
         reason: an example
 
+Extended DNS Error for Negative Trust Anchors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While a negative trust anchor is in effect, the recursor by default adds an EDNS Extended Error (:rfc:`8914`) with info-code 33, "Negative Trust Anchor", to an insecure response whose queried name, or a chased CNAME target, is covered by a configured NTA.
+This lets clients and downstream operators tell that an NTA is in effect for the name.
+The signal indicates that an NTA covers the name. However it does not assert that the NTA is why the answer is insecure, and it may appear on a name that would have been insecure regardless (for example an already-unsigned delegation).
+The EDE is diagnostic only and does not change validation, the AD bit, or any other protocol behaviour.
+Emission is controlled by :ref:`setting-yaml-dnssec.nta_extended_error`, which is enabled by default.
+
+Because responses are stored in the packet cache, adding or removing an NTA does not retroactively change responses that are already cached: the Extended Error starts or stops appearing only once the affected cache entries expire or are flushed with ``rec_control wipe-cache``.
+
 Runtime Configuration of Negative Trust Anchors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pdns/recursordist/docs/dnssec.rst
+++ b/pdns/recursordist/docs/dnssec.rst
@@ -176,12 +176,12 @@ The NTA entries require the name of the zone and an optional reason:
 Extended DNS Error for Negative Trust Anchors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While a negative trust anchor is in effect, the recursor by default adds an EDNS Extended Error (:rfc:`8914`) with info-code 33, "Negative Trust Anchor", to an insecure response whose queried name, or a chased CNAME target, is covered by a configured NTA.
+While a negative trust anchor is in effect, the recursor can add an EDNS Extended Error (:rfc:`8914`) with info-code 33 ("Negative Trust Anchor") to an insecure response whose queried name or a chased CNAME target is covered by a configured NTA.
 This lets clients and downstream operators tell that an NTA is in effect for the name.
 The Extended Error is only added when the query was subject to DNSSEC validation, which depends on :ref:`setting-yaml-dnssec.validation` and, in ``process`` mode, on the client setting the AD or DO bit.
 The signal indicates that an NTA covers the name. However it does not assert that the NTA is why the answer is insecure, and it may appear on a name that would have been insecure regardless (for example an already-unsigned delegation).
 The EDE is diagnostic only and does not change validation, the AD bit, or any other protocol behaviour.
-Emission is controlled by :ref:`setting-yaml-dnssec.nta_extended_error`, which is enabled by default.
+Emission is controlled by :ref:`setting-yaml-dnssec.nta_extended_error`, which is disabled by default.
 
 Because responses are stored in the packet cache, adding or removing an NTA does not retroactively change responses that are already cached: the Extended Error starts or stops appearing only once the affected cache entries expire or are flushed with ``rec_control wipe-cache``.
 

--- a/pdns/recursordist/docs/dnssec.rst
+++ b/pdns/recursordist/docs/dnssec.rst
@@ -178,6 +178,7 @@ Extended DNS Error for Negative Trust Anchors
 
 While a negative trust anchor is in effect, the recursor by default adds an EDNS Extended Error (:rfc:`8914`) with info-code 33, "Negative Trust Anchor", to an insecure response whose queried name, or a chased CNAME target, is covered by a configured NTA.
 This lets clients and downstream operators tell that an NTA is in effect for the name.
+The Extended Error is only added when the query was subject to DNSSEC validation, which depends on :ref:`setting-yaml-dnssec.validation` and, in ``process`` mode, on the client setting the AD or DO bit.
 The signal indicates that an NTA covers the name. However it does not assert that the NTA is why the answer is insecure, and it may appear on a name that would have been insecure regardless (for example an already-unsigned delegation).
 The EDE is diagnostic only and does not change validation, the AD bit, or any other protocol behaviour.
 Emission is controlled by :ref:`setting-yaml-dnssec.nta_extended_error`, which is enabled by default.

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -20,12 +20,8 @@ The :ref:`outgoing-tls-configuration` YAML struct has been extended to be able t
 
 New Settings
 ^^^^^^^^^^^^
-The :ref:`setting-yaml-dnssec.nta_extended_error` setting has been introduced, enabled by default.
-
-Changed Behaviour
-^^^^^^^^^^^^^^^^^
-When a Negative Trust Anchor is in effect, the recursor now adds an EDNS Extended Error (:rfc:`8914`) with info-code 33, "Negative Trust Anchor", to insecure responses covered by the NTA, as a diagnostic signal.
-This is enabled by default and can be turned off with :ref:`setting-yaml-dnssec.nta_extended_error`.
+The :ref:`setting-yaml-dnssec.nta_extended_error` setting has been introduced, disabled by default.
+When enabled and a Negative Trust Anchor is in effect, the recursor adds an EDNS Extended Error (:rfc:`8914`) with info-code 33 ("Negative Trust Anchor") to insecure responses covered by the NTA as a diagnostic signal.
 It does not change validation or the AD bit.
 Because responses are packet-cached, adding or removing an NTA only affects the presence of this Extended Error once the relevant cache entries expire or are flushed.
 See :ref:`ntas`.

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -18,6 +18,18 @@ The :ref:`incoming-ws-config` YAML struct has been extended to be able to specif
 
 The :ref:`outgoing-tls-configuration` YAML struct has been extended to be able to specify an TLS client certificate to be used for outgoing DoT connections.
 
+New Settings
+^^^^^^^^^^^^
+The :ref:`setting-yaml-dnssec.nta_extended_error` setting has been introduced, enabled by default.
+
+Changed Behaviour
+^^^^^^^^^^^^^^^^^
+When a Negative Trust Anchor is in effect, the recursor now adds an EDNS Extended Error (:rfc:`8914`) with info-code 33, "Negative Trust Anchor", to insecure responses covered by the NTA, as a diagnostic signal.
+This is enabled by default and can be turned off with :ref:`setting-yaml-dnssec.nta_extended_error`.
+It does not change validation or the AD bit.
+Because responses are packet-cached, adding or removing an NTA only affects the presence of this Extended Error once the relevant cache entries expire or are flushed.
+See :ref:`ntas`.
+
 5.1.10, 5.2.8 and 5.3.5
 -----------------------
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2286,6 +2286,7 @@ static int serviceMain(Logr::log_t log)
   s_statisticsInterval = ::arg().asNum("statistics-interval");
 
   SyncRes::s_addExtendedResolutionDNSErrors = ::arg().mustDo("extended-resolution-errors");
+  SyncRes::s_ntaExtendedError = ::arg().mustDo("nta-extended-error");
 
   if (::arg().asNum("aggressive-nsec-cache-size") > 0) {
     if (g_dnssecmode == DNSSECMode::ValidateAll || g_dnssecmode == DNSSECMode::ValidateForLog || g_dnssecmode == DNSSECMode::Process) {

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -3452,11 +3452,11 @@ Sequence of negative trust anchors.
         "name": "nta_extended_error",
         "section": "dnssec",
         "type": LType.Bool,
-        "default": "true",
+        "default": "false",
         "help": "Add an EDNS Extended Error (code 33, Negative Trust Anchor) to insecure answers covered by an NTA",
         "doc": """
-When enabled, the recursor adds an EDNS Extended Error (:rfc:`8914`) with info-code 33, "Negative Trust Anchor", to an insecure response when the queried name, or a CNAME target it chased, is covered by a configured Negative Trust Anchor (see :ref:`ntas`).
-The Extended Error is only added when the query was subject to DNSSEC validation, which depends on :ref:`setting-yaml-dnssec.validation` and, in ``process`` mode, on the client setting the AD or DO bit.
+When enabled the recursor adds an EDNS Extended Error (:rfc:`8914`) with info-code 33 ("Negative Trust Anchor") to an insecure response when the queried name or a CNAME target it chased is covered by a configured Negative Trust Anchor (see :ref:`ntas`).
+The Extended Error is only added when the query was subject to DNSSEC validation, which depends on :ref:`setting-yaml-dnssec.validation` and when in ``process`` mode on the client setting the AD or DO bit.
 The signal means an NTA is in effect for the name. However it does not assert that the NTA is why the answer is insecure, and it may appear on a name that would be insecure regardless.
 This is diagnostic only: it does not change validation, the AD bit, or any other protocol behaviour.
  """,

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -3449,6 +3449,19 @@ Sequence of negative trust anchors.
         "runtime": ["add-nta", "clear-nta", "reload-lua-config", "reload-yaml"],
     },
     {
+        "name": "nta_extended_error",
+        "section": "dnssec",
+        "type": LType.Bool,
+        "default": "true",
+        "help": "Add an EDNS Extended Error (code 33, Negative Trust Anchor) to insecure answers covered by an NTA",
+        "doc": """
+When enabled, the recursor adds an EDNS Extended Error (:rfc:`8914`) with info-code 33, "Negative Trust Anchor", to an insecure response when the queried name, or a CNAME target it chased, is covered by a configured Negative Trust Anchor (see :ref:`ntas`).
+The signal means an NTA is in effect for the name. However it does not assert that the NTA is why the answer is insecure, and it may appear on a name that would be insecure regardless.
+This is diagnostic only: it does not change validation, the AD bit, or any other protocol behaviour.
+ """,
+        "versionadded": "5.5.0",
+    },
+    {
         "name": "trustanchorfile",
         "section": "dnssec",
         "type": LType.String,

--- a/pdns/recursordist/rec-rust-lib/table.py
+++ b/pdns/recursordist/rec-rust-lib/table.py
@@ -3456,6 +3456,7 @@ Sequence of negative trust anchors.
         "help": "Add an EDNS Extended Error (code 33, Negative Trust Anchor) to insecure answers covered by an NTA",
         "doc": """
 When enabled, the recursor adds an EDNS Extended Error (:rfc:`8914`) with info-code 33, "Negative Trust Anchor", to an insecure response when the queried name, or a CNAME target it chased, is covered by a configured Negative Trust Anchor (see :ref:`ntas`).
+The Extended Error is only added when the query was subject to DNSSEC validation, which depends on :ref:`setting-yaml-dnssec.validation` and, in ``process`` mode, on the client setting the AD or DO bit.
 The signal means an NTA is in effect for the name. However it does not assert that the NTA is why the answer is insecure, and it may appear on a name that would be insecure regardless.
 This is diagnostic only: it does not change validation, the AD bit, or any other protocol behaviour.
  """,

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -398,6 +398,7 @@ bool SyncRes::s_save_parent_ns_set;
 unsigned int SyncRes::s_max_busy_dot_probes;
 unsigned int SyncRes::s_max_CNAMES_followed;
 bool SyncRes::s_addExtendedResolutionDNSErrors;
+bool SyncRes::s_ntaExtendedError;
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define LOG(x)                       \
@@ -649,6 +650,20 @@ bool SyncRes::addAdditionals(QType qtype, vector<DNSRecord>& ret, unsigned int d
   return additionalsNotInCache;
 }
 
+/* An NTA covers its whole subtree, but haveNegativeTrustAnchor() only matches a zone
+   exactly, so we walk the name up to the root to decide coverage. */
+static bool isCoveredByNTA(const std::map<DNSName, std::string>& negAnchors, const DNSName& name)
+{
+  std::string reason;
+  DNSName node(name);
+  do {
+    if (haveNegativeTrustAnchor(negAnchors, node, reason)) {
+      return true;
+    }
+  } while (node.chopOff());
+  return false;
+}
+
 /** everything begins here - this is the entry point just after receiving a packet */
 int SyncRes::beginResolve(const DNSName& qname, const QType qtype, QClass qclass, vector<DNSRecord>& ret, unsigned int depth)
 {
@@ -688,6 +703,24 @@ int SyncRes::beginResolve(const DNSName& qname, const QType qtype, QClass qclass
   int res = doResolve(qname, qtype, ret, depth, beenthere, context);
   d_queryValidationState = context.state;
   d_extendedError = context.extendedError;
+
+  /* EDE 33 signals that an NTA is in effect for this name (coverage, not causation).
+     Consult negAnchors directly rather than via getTA(), so cache hits are covered too;
+     the answer-owner check catches a CNAME chased into an NTA. */
+  if (s_ntaExtendedError && !d_extendedError && d_queryValidationState == vState::Insecure) {
+    auto luaLocal = g_luaconfs.getLocal();
+    if (!luaLocal->negAnchors.empty()) {
+      bool covered = isCoveredByNTA(luaLocal->negAnchors, qname);
+      for (auto iter = ret.cbegin(); !covered && iter != ret.cend(); ++iter) {
+        if (iter->d_place == DNSResourceRecord::ANSWER) {
+          covered = isCoveredByNTA(luaLocal->negAnchors, iter->d_name);
+        }
+      }
+      if (covered) {
+        d_extendedError = EDNSExtendedError{static_cast<uint16_t>(EDNSExtendedError::code::NegativeTrustAnchor), ""};
+      }
+    }
+  }
 
   if (shouldValidate()) {
     if (d_queryValidationState != vState::Indeterminate) {

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -706,8 +706,9 @@ int SyncRes::beginResolve(const DNSName& qname, const QType qtype, QClass qclass
 
   /* EDE 33 signals that an NTA is in effect for this name (coverage, not causation).
      Consult negAnchors directly rather than via getTA(), so cache hits are covered too;
-     the answer-owner check catches a CNAME chased into an NTA. */
-  if (s_ntaExtendedError && !d_extendedError && d_queryValidationState == vState::Insecure) {
+     the answer-owner check catches a CNAME chased into an NTA. shouldValidate() keeps
+     the EDE off for queries not subject to validation, even on a cache hit. */
+  if (s_ntaExtendedError && shouldValidate() && !d_extendedError && d_queryValidationState == vState::Insecure) {
     auto luaLocal = g_luaconfs.getLocal();
     if (!luaLocal->negAnchors.empty()) {
       bool covered = isCoveredByNTA(luaLocal->negAnchors, qname);

--- a/pdns/recursordist/syncres.hh
+++ b/pdns/recursordist/syncres.hh
@@ -484,6 +484,11 @@ public:
     return d_queryValidationState;
   }
 
+  const std::optional<EDNSExtendedError>& getExtendedError() const
+  {
+    return d_extendedError;
+  }
+
   [[nodiscard]] bool getDNSSECLimitHit() const
   {
     return d_validationContext.d_limitHit;
@@ -579,6 +584,7 @@ public:
   static int s_event_trace_enabled;
   static bool s_save_parent_ns_set;
   static bool s_addExtendedResolutionDNSErrors;
+  static bool s_ntaExtendedError;
 
   static bool eventTraceEnabled(int flag)
   {

--- a/pdns/recursordist/test-settings.cc
+++ b/pdns/recursordist/test-settings.cc
@@ -426,6 +426,7 @@ BOOST_AUTO_TEST_CASE(test_yaml_defaults_ta)
   BOOST_CHECK_EQUAL(settings.dnssec.negative_trustanchors.size(), 0U);
   BOOST_CHECK_EQUAL(std::string(settings.dnssec.trustanchorfile), "");
   BOOST_CHECK_EQUAL(settings.dnssec.trustanchorfile_interval, 24U);
+  BOOST_CHECK_EQUAL(settings.dnssec.nta_extended_error, true);
 
   const std::string yaml2 = R"EOT(dnssec:
   trustanchors:
@@ -438,6 +439,7 @@ BOOST_AUTO_TEST_CASE(test_yaml_defaults_ta)
       reason: d
   trustanchorfile: e
   trustanchorfile_interval: 99
+  nta_extended_error: false
 )EOT";
   settings = pdns::rust::settings::rec::parse_yaml_string(yaml2);
   settings.validate();
@@ -449,6 +451,7 @@ BOOST_AUTO_TEST_CASE(test_yaml_defaults_ta)
   BOOST_CHECK_EQUAL(std::string(settings.dnssec.negative_trustanchors[0].reason), "d");
   BOOST_CHECK_EQUAL(std::string(settings.dnssec.trustanchorfile), "e");
   BOOST_CHECK_EQUAL(settings.dnssec.trustanchorfile_interval, 99U);
+  BOOST_CHECK_EQUAL(settings.dnssec.nta_extended_error, false);
 }
 
 BOOST_AUTO_TEST_CASE(test_yaml_ta_merge)

--- a/pdns/recursordist/test-settings.cc
+++ b/pdns/recursordist/test-settings.cc
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(test_yaml_defaults_ta)
   BOOST_CHECK_EQUAL(settings.dnssec.negative_trustanchors.size(), 0U);
   BOOST_CHECK_EQUAL(std::string(settings.dnssec.trustanchorfile), "");
   BOOST_CHECK_EQUAL(settings.dnssec.trustanchorfile_interval, 24U);
-  BOOST_CHECK_EQUAL(settings.dnssec.nta_extended_error, true);
+  BOOST_CHECK_EQUAL(settings.dnssec.nta_extended_error, false);
 
   const std::string yaml2 = R"EOT(dnssec:
   trustanchors:

--- a/pdns/recursordist/test-syncres_cc7.cc
+++ b/pdns/recursordist/test-syncres_cc7.cc
@@ -1532,6 +1532,79 @@ BOOST_AUTO_TEST_CASE(test_dnssec_nta_extended_error_disabled)
   BOOST_CHECK_EQUAL(queriesCount, 1U);
 }
 
+BOOST_AUTO_TEST_CASE(test_dnssec_nta_extended_error_no_validation)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  const bool savedNtaEde = SyncRes::s_ntaExtendedError;
+  auto restoreNtaEde = pdns::defer([savedNtaEde] { SyncRes::s_ntaExtendedError = savedNtaEde; });
+  SyncRes::s_ntaExtendedError = true;
+
+  primeHints();
+  const DNSName target(".");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  luaconfsCopy.negAnchors[g_rootdnsname] = "NTA for Root";
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([&](const ComboAddress& /* ip */, const DNSName& domain, int type, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, std::optional<Netmask>& /* srcmask */, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
+    queriesCount++;
+
+    if (domain == target && type == QType::NS) {
+
+      setLWResult(res, 0, true, false, true);
+      char addr[] = "a.root-servers.net.";
+      for (char idx = 'a'; idx <= 'm'; idx++) {
+        addr[0] = idx;
+        addRecordToLW(res, domain, QType::NS, std::string(addr), DNSResourceRecord::ANSWER, 3600);
+      }
+
+      addRRSIG(keys, res->d_records, domain, 300);
+
+      addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
+      addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
+
+      return LWResult::Result::Success;
+    }
+    if (domain == target && type == QType::DNSKEY) {
+
+      setLWResult(res, 0, true, false, true);
+
+      /* No DNSKEY */
+
+      return LWResult::Result::Success;
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  /* a validating query primes the record cache with the Insecure state and gets the EDE */
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
+  BOOST_REQUIRE(sr->getExtendedError().has_value());
+  BOOST_CHECK_EQUAL(sr->getExtendedError()->infoCode, static_cast<uint16_t>(EDNSExtendedError::code::NegativeTrustAnchor));
+  BOOST_CHECK_EQUAL(queriesCount, 1U);
+
+  /* a non-validating query hits the record cache, inherits the cached Insecure state,
+     but must not get the EDE */
+  sr->setDNSSECValidationRequested(false);
+  ret.clear();
+  res = sr->beginResolve(target, QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
+  BOOST_CHECK(!sr->getExtendedError().has_value());
+  BOOST_CHECK_EQUAL(queriesCount, 1U);
+}
+
 BOOST_AUTO_TEST_CASE(test_dnssec_no_ta)
 {
   std::unique_ptr<SyncRes> sr;

--- a/pdns/recursordist/test-syncres_cc7.cc
+++ b/pdns/recursordist/test-syncres_cc7.cc
@@ -1296,6 +1296,242 @@ BOOST_AUTO_TEST_CASE(test_dnssec_nta)
   BOOST_CHECK_EQUAL(queriesCount, 1U);
 }
 
+BOOST_AUTO_TEST_CASE(test_dnssec_nta_extended_error)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  const bool savedNtaEde = SyncRes::s_ntaExtendedError;
+  auto restoreNtaEde = pdns::defer([savedNtaEde] { SyncRes::s_ntaExtendedError = savedNtaEde; });
+  SyncRes::s_ntaExtendedError = true;
+
+  primeHints();
+  const DNSName target(".");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  /* Add a NTA for "." */
+  luaconfsCopy.negAnchors[g_rootdnsname] = "NTA for Root";
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([&](const ComboAddress& /* ip */, const DNSName& domain, int type, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, std::optional<Netmask>& /* srcmask */, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
+    queriesCount++;
+
+    if (domain == target && type == QType::NS) {
+
+      setLWResult(res, 0, true, false, true);
+      char addr[] = "a.root-servers.net.";
+      for (char idx = 'a'; idx <= 'm'; idx++) {
+        addr[0] = idx;
+        addRecordToLW(res, domain, QType::NS, std::string(addr), DNSResourceRecord::ANSWER, 3600);
+      }
+
+      addRRSIG(keys, res->d_records, domain, 300);
+
+      addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
+      addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
+
+      return LWResult::Result::Success;
+    }
+    if (domain == target && type == QType::DNSKEY) {
+
+      setLWResult(res, 0, true, false, true);
+
+      /* No DNSKEY */
+
+      return LWResult::Result::Success;
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
+  BOOST_REQUIRE(sr->getExtendedError().has_value());
+  BOOST_CHECK_EQUAL(sr->getExtendedError()->infoCode, static_cast<uint16_t>(EDNSExtendedError::code::NegativeTrustAnchor));
+  BOOST_CHECK_EQUAL(queriesCount, 1U);
+
+  /* again, to test that a cache hit still carries the EDE */
+  ret.clear();
+  res = sr->beginResolve(target, QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
+  BOOST_REQUIRE(sr->getExtendedError().has_value());
+  BOOST_CHECK_EQUAL(sr->getExtendedError()->infoCode, static_cast<uint16_t>(EDNSExtendedError::code::NegativeTrustAnchor));
+  BOOST_CHECK_EQUAL(queriesCount, 1U);
+}
+
+BOOST_AUTO_TEST_CASE(test_dnssec_insecure_no_nta_no_extended_error)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  const bool savedNtaEde = SyncRes::s_ntaExtendedError;
+  auto restoreNtaEde = pdns::defer([savedNtaEde] { SyncRes::s_ntaExtendedError = savedNtaEde; });
+  SyncRes::s_ntaExtendedError = true;
+
+  primeHints();
+  const DNSName target(".");
+
+  /* Remove the root DS: the answer is Insecure, but not because of an NTA,
+     so no EDE 33 should be attached. */
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([&](const ComboAddress& /* ip */, const DNSName& domain, int type, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, std::optional<Netmask>& /* srcmask */, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
+    queriesCount++;
+
+    if (domain == target && type == QType::NS) {
+
+      setLWResult(res, 0, true, false, true);
+      char addr[] = "a.root-servers.net.";
+      for (char idx = 'a'; idx <= 'm'; idx++) {
+        addr[0] = idx;
+        addRecordToLW(res, domain, QType::NS, std::string(addr), DNSResourceRecord::ANSWER, 3600);
+      }
+
+      addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
+      addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
+
+      return LWResult::Result::Success;
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
+  BOOST_CHECK(!sr->getExtendedError().has_value());
+  BOOST_CHECK_EQUAL(queriesCount, 1U);
+}
+
+BOOST_AUTO_TEST_CASE(test_dnssec_nta_extended_error_already_insecure)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  const bool savedNtaEde = SyncRes::s_ntaExtendedError;
+  auto restoreNtaEde = pdns::defer([savedNtaEde] { SyncRes::s_ntaExtendedError = savedNtaEde; });
+  SyncRes::s_ntaExtendedError = true;
+
+  primeHints();
+  const DNSName target(".");
+
+  /* Insecure because there is no root trust anchor, not because of the NTA. The name is
+     still covered by an NTA, so EDE 33 is expected (coverage, not causation). */
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  luaconfsCopy.negAnchors[g_rootdnsname] = "NTA for Root";
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([&](const ComboAddress& /* ip */, const DNSName& domain, int type, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, std::optional<Netmask>& /* srcmask */, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
+    queriesCount++;
+
+    if (domain == target && type == QType::NS) {
+
+      setLWResult(res, 0, true, false, true);
+      char addr[] = "a.root-servers.net.";
+      for (char idx = 'a'; idx <= 'm'; idx++) {
+        addr[0] = idx;
+        addRecordToLW(res, domain, QType::NS, std::string(addr), DNSResourceRecord::ANSWER, 3600);
+      }
+
+      addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
+      addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
+
+      return LWResult::Result::Success;
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
+  BOOST_REQUIRE(sr->getExtendedError().has_value());
+  BOOST_CHECK_EQUAL(sr->getExtendedError()->infoCode, static_cast<uint16_t>(EDNSExtendedError::code::NegativeTrustAnchor));
+  BOOST_CHECK_EQUAL(queriesCount, 1U);
+}
+
+BOOST_AUTO_TEST_CASE(test_dnssec_nta_extended_error_disabled)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  const bool savedNtaEde = SyncRes::s_ntaExtendedError;
+  auto restoreNtaEde = pdns::defer([savedNtaEde] { SyncRes::s_ntaExtendedError = savedNtaEde; });
+  SyncRes::s_ntaExtendedError = false;
+
+  primeHints();
+  const DNSName target(".");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  /* NTA is configured, but the feature is disabled: no EDE must be attached. */
+  luaconfsCopy.negAnchors[g_rootdnsname] = "NTA for Root";
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([&](const ComboAddress& /* ip */, const DNSName& domain, int type, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, std::optional<Netmask>& /* srcmask */, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
+    queriesCount++;
+
+    if (domain == target && type == QType::NS) {
+
+      setLWResult(res, 0, true, false, true);
+      char addr[] = "a.root-servers.net.";
+      for (char idx = 'a'; idx <= 'm'; idx++) {
+        addr[0] = idx;
+        addRecordToLW(res, domain, QType::NS, std::string(addr), DNSResourceRecord::ANSWER, 3600);
+      }
+
+      addRRSIG(keys, res->d_records, domain, 300);
+
+      addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
+      addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
+
+      return LWResult::Result::Success;
+    }
+    if (domain == target && type == QType::DNSKEY) {
+
+      setLWResult(res, 0, true, false, true);
+
+      /* No DNSKEY */
+
+      return LWResult::Result::Success;
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
+  BOOST_CHECK(!sr->getExtendedError().has_value());
+  BOOST_CHECK_EQUAL(queriesCount, 1U);
+}
+
 BOOST_AUTO_TEST_CASE(test_dnssec_no_ta)
 {
   std::unique_ptr<SyncRes> sr;

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -946,6 +946,14 @@ distributor-threads={threads}
         # This function is called before every tests
         super(RecursorTest, self).setUp()
 
+    @staticmethod
+    def getEDE(message):
+        """Return the first EDNS Extended Error (EDNS option 15) in message, or None."""
+        for option in message.options:
+            if option.otype == 15:
+                return option
+        return None
+
     ## Functions for comparisons
     def assertMessageHasFlags(self, msg, flags, ednsflags=[]):
         """Asserts that msg has all the flags from flags set

--- a/regression-tests.recursor-dnssec/test_NTAExtendedError.py
+++ b/regression-tests.recursor-dnssec/test_NTAExtendedError.py
@@ -65,13 +65,12 @@ class NTAExtendedErrorDisabledTest(RecursorTest):
     _confdir = "NTAExtendedErrorDisabled"
     _auth_zones = RecursorTest._default_auth_zones
 
-    _config_template = """dnssec=validate
-nta-extended-error=no"""
+    _config_template = """dnssec=validate"""
     _lua_config_file = """addNTA("bogus.example", "Negative Trust Anchor for testing")"""
 
     def testNTAWithFeatureDisabledHasNoEDE(self):
-        """With nta-extended-error=no the NTA still works (Insecure, no AD) but no EDE 33
-        is attached."""
+        """With nta-extended-error left at its default (off) the NTA still works (Insecure,
+        no AD) but no EDE 33 is attached."""
         msg = dns.message.make_query("ted.bogus.example.", dns.rdatatype.A)
         msg.flags = dns.flags.from_text("AD RD")
         msg.use_edns(edns=0, ednsflags=dns.flags.edns_from_text("DO"))

--- a/regression-tests.recursor-dnssec/test_NTAExtendedError.py
+++ b/regression-tests.recursor-dnssec/test_NTAExtendedError.py
@@ -1,0 +1,82 @@
+import dns
+import extendederrors
+from recursortests import RecursorTest
+
+
+class NTAExtendedErrorTest(RecursorTest):
+    _confdir = "NTAExtendedError"
+    _auth_zones = RecursorTest._default_auth_zones
+
+    _config_template = """dnssec=validate
+nta-extended-error=yes"""
+    _lua_config_file = """addNTA("bogus.example", "Negative Trust Anchor for testing")
+addNTA("insecure.example", "NTA on an already-insecure (unsigned) delegation")"""
+
+    def testDirectNTAHasEDE(self):
+        """A name under an NTA is Insecure (no AD) and carries EDE 33, on the fresh
+        answer and on the following cache hit."""
+        msg = dns.message.make_query("ted.bogus.example.", dns.rdatatype.A)
+        msg.flags = dns.flags.from_text("AD RD")
+        msg.use_edns(edns=0, ednsflags=dns.flags.edns_from_text("DO"))
+
+        for _ in range(2):
+            res = self.sendUDPQuery(msg)
+            self.assertMessageHasFlags(res, ["QR", "RA", "RD"], ["DO"])
+            self.assertRcodeEqual(res, dns.rcode.NOERROR)
+            self.assertEqual(self.getEDE(res), extendederrors.ExtendedErrorOption(33, b""))
+
+    def testCNAMEIntoNTAHasEDE(self):
+        """A secure CNAME whose chased target is under an NTA carries EDE 33."""
+        msg = dns.message.make_query("cname-to-bogus.secure.example.", dns.rdatatype.A)
+        msg.flags = dns.flags.from_text("AD RD")
+        msg.use_edns(edns=0, ednsflags=dns.flags.edns_from_text("DO"))
+
+        res = self.sendUDPQuery(msg)
+        self.assertMessageHasFlags(res, ["QR", "RA", "RD"], ["DO"])
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertEqual(self.getEDE(res), extendederrors.ExtendedErrorOption(33, b""))
+
+    def testSecureOutsideNTAHasNoEDE(self):
+        """A secure name outside any NTA validates (AD set) and carries no EDE 33."""
+        msg = dns.message.make_query("host1.secure.example.", dns.rdatatype.A)
+        msg.flags = dns.flags.from_text("AD RD")
+        msg.use_edns(edns=0, ednsflags=dns.flags.edns_from_text("DO"))
+
+        res = self.sendUDPQuery(msg)
+        self.assertMessageHasFlags(res, ["QR", "RA", "RD", "AD"], ["DO"])
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertIsNone(self.getEDE(res))
+
+    def testNTAOnAlreadyInsecureHasEDE(self):
+        """insecure.example is an unsigned delegation, so it is Insecure regardless of the
+        NTA. With an NTA configured for it the name is "covered", so EDE 33 is emitted even
+        though the NTA is not what made the answer insecure."""
+        msg = dns.message.make_query("node1.insecure.example.", dns.rdatatype.A)
+        msg.flags = dns.flags.from_text("AD RD")
+        msg.use_edns(edns=0, ednsflags=dns.flags.edns_from_text("DO"))
+
+        res = self.sendUDPQuery(msg)
+        self.assertMessageHasFlags(res, ["QR", "RA", "RD"], ["DO"])
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertEqual(self.getEDE(res), extendederrors.ExtendedErrorOption(33, b""))
+
+
+class NTAExtendedErrorDisabledTest(RecursorTest):
+    _confdir = "NTAExtendedErrorDisabled"
+    _auth_zones = RecursorTest._default_auth_zones
+
+    _config_template = """dnssec=validate
+nta-extended-error=no"""
+    _lua_config_file = """addNTA("bogus.example", "Negative Trust Anchor for testing")"""
+
+    def testNTAWithFeatureDisabledHasNoEDE(self):
+        """With nta-extended-error=no the NTA still works (Insecure, no AD) but no EDE 33
+        is attached."""
+        msg = dns.message.make_query("ted.bogus.example.", dns.rdatatype.A)
+        msg.flags = dns.flags.from_text("AD RD")
+        msg.use_edns(edns=0, ednsflags=dns.flags.edns_from_text("DO"))
+
+        res = self.sendUDPQuery(msg)
+        self.assertMessageHasFlags(res, ["QR", "RA", "RD"], ["DO"])
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertIsNone(self.getEDE(res))


### PR DESCRIPTION
When a Negative Trust Anchor is in effect, attach an EDNS Extended Error with info-code 33 to insecure answers whose queried name (or a chased CNAME target) is covered by the NTA, giving clients an in-band signal that an NTA applies to the name. The signal only indicates coverage, and does not imply that the NTA caused insecurity.

Controlled by the new `dnssec.nta-extended-error` setting, enabled by default. This is for diagnostic purposes only: the validation state and the AD bit are left intact.

Defined in draft-farrokhi-dnsop-ede-nta ("Disclosure of Negative Trust Anchors in DNS Responses"):
https://datatracker.ietf.org/doc/draft-farrokhi-dnsop-ede-nta/

### Short description

Adds an in-band diagnostic signal for Negative Trust Anchors. When an NTA is in
effect, the recursor attaches an EDNS Extended Error with info-code 33 ("Negative
Trust Anchor", per RFC 8914 ) to insecure answers that queried name, or a
chased CNAME target, is covered by the NTA. The signal only indicates coverage, and
does not change the validation process or the AD bit. It is set by the new
`dnssec.nta-extended-error` setting, enabled by default.

Includes unit tests (SyncRes emission for direct, cache-hit, CNAME-target,
already-insecure-under-NTA, and disabled cases), a settings default/override test,
a recursor-dnssec regression test, user documentation (NTA section and upgrade
note), and the generated setting reference docs.
Full disclosure that LLM tools were used to generate the unit tests, but I 
verified the output and take full responsibility of the generated code.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
