### PR TITLE
auth: smarter(?) splitting of large Lua record contents

### DIFF
--- a/pdns/dnslabeltext.rl
+++ b/pdns/dnslabeltext.rl
@@ -85,6 +85,97 @@ vector<string> segmentDNSText(const string& input )
         return ret;
 };
 
+#ifdef HAVE_LUA_RECORDS
+namespace {
+void appendSplitLua(vector<string>& ret, string& segment, unsigned char c, size_t& splitpos)
+{
+  if(segment.size()>254) {
+    // Try to split at the last "good" split position, if any.
+    if (splitpos != 0) {
+      ret.push_back(segment.substr(0, splitpos));
+      segment.erase(0, splitpos);
+    }
+    else {
+      ret.push_back(segment);
+      segment.clear();
+    }
+    splitpos = 0;
+  }
+  if (::isspace(static_cast<int>(c)) != 0) {
+    splitpos = segment.size();
+  }
+  segment.append(1, c);
+}
+
+}
+
+vector<string> segmentLuaText(const string& input)
+{
+%%{
+        machine luatext;
+        write data;
+        alphtype unsigned char;
+}%%
+        (void)luatext_error;  // silence warnings
+        (void)luatext_en_main;
+        const char *p = input.c_str(), *pe = input.c_str() + input.length();
+        const char* eof = pe;
+        int cs;
+        char val = 0;
+        size_t splitpos{0};
+
+        string segment;
+        vector<string> ret;
+
+        %%{
+                action segmentEnd { 
+                        ret.push_back(segment);
+                        segment.clear();
+                        splitpos = 0;
+                }
+                action segmentBegin { 
+                        segment.clear();
+                        splitpos = 0;
+                }
+
+                action reportEscaped {
+                  char c = *fpc;
+                  appendSplitLua(ret, segment, c, splitpos);
+                }
+                action reportEscapedNumber {
+                  char c = *fpc;
+                  val *= 10;
+                  val += c-'0';
+                  
+                }
+                action doneEscapedNumber {
+                  appendSplitLua(ret, segment, val, splitpos);
+                  val=0;
+                }
+                
+                action reportPlain {
+                  appendSplitLua(ret, segment, *(fpc), splitpos);
+                }
+
+                escaped = '\\' (([^0-9]@reportEscaped) | ([0-9]{3}$reportEscapedNumber%doneEscapedNumber));
+                plain = ((extend-'\\'-'"')|'\n'|'\t') $ reportPlain;
+                txtElement = escaped | plain;
+            
+                main := (('"' txtElement* '"' space?) >segmentBegin %segmentEnd)+;
+
+                # Initialize and execute.
+                write init;
+                write exec;
+        }%%
+
+        if ( cs < luatext_first_final ) {
+                throw runtime_error("Unable to parse DNS LUA '"+input+"'");
+        }
+
+        return ret;
+};
+#endif
+
 
 DNSName::string_t segmentDNSNameRaw(const char* realinput, size_t inputlen)
 {

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -146,6 +146,13 @@ public:
     text=getText(multi, lenField);
   }
 
+#ifdef HAVE_LUA_RECORDS
+  void xfrLua(string &text)
+  {
+    xfrText(text, true);
+  }
+#endif
+
   void xfrUnquotedText(string &text, bool lenField){
     text=getUnquotedText(lenField);
   }

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -159,7 +159,7 @@ boilerplate_conv(MR, conv.xfrName(d_alias, true));
 boilerplate_conv(MINFO, conv.xfrName(d_rmailbx, true); conv.xfrName(d_emailbx, true));
 boilerplate_conv(TXT, conv.xfrText(d_text, true));
 #ifdef HAVE_LUA_RECORDS
-boilerplate_conv(LUA, conv.xfrType(d_type); conv.xfrText(d_code, true));
+boilerplate_conv(LUA, conv.xfrType(d_type); conv.xfrLua(d_code));
 #endif
 #if defined(PDNS_AUTH) // [
 /* Move the position to the end of the current DNS record,

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -210,7 +210,19 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfrText(co
 #ifdef HAVE_LUA_RECORDS
 template <typename Container> void GenericDNSPacketWriter<Container>::xfrLua(const string& text)
 {
-  xfrText(text, true);
+  // This is similar in spirit to xfrText(text, true), but while xfrText uses
+  // segmentDNSText which attemps to produce the largest possible segments,
+  // we will try to split segmentts on whitespace boundaries.
+  if(text.empty()) {
+    d_content.push_back(0);
+    return;
+  }
+  vector<string> segments = segmentLuaText(text);
+  for(const string& str : segments) {
+    d_content.push_back(str.length());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    d_content.insert(d_content.end(), str.c_str(), str.c_str() + str.length());
+  }
 }
 #endif
 

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -207,6 +207,13 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfrText(co
   }
 }
 
+#ifdef HAVE_LUA_RECORDS
+template <typename Container> void GenericDNSPacketWriter<Container>::xfrLua(const string& text)
+{
+  xfrText(text, true);
+}
+#endif
+
 template <typename Container> void GenericDNSPacketWriter<Container>::xfrUnquotedText(const string& text, bool lenField)
 {
   if(text.empty()) {

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -191,3 +191,6 @@ private:
 using DNSPacketWriter = GenericDNSPacketWriter<std::vector<uint8_t>>;
 
 std::vector<string> segmentDNSText(const string& text); // from dnslabeltext.rl
+#ifdef HAVE_LUA_RECORDS
+std::vector<string> segmentLuaText(const string& text); // from dnslabeltext.rl
+#endif

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -129,6 +129,9 @@ public:
 
   void xfrName(const DNSName& name, bool compress=false);
   void xfrText(const string& text, bool multi=false, bool lenField=true);
+#ifdef HAVE_LUA_RECORDS
+  void xfrLua(const string& text);
+#endif
   void xfrUnquotedText(const string& text, bool lenField);
   void xfrBlob(const string& blob, int len=-1);
   void xfrBlob(const vector<uint8_t>& blob);

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -751,6 +751,13 @@ void RecordTextReader::xfrText(string& val, bool multi, bool /* lenField */)
   }
 }
 
+#ifdef HAVE_LUA_RECORDS
+void RecordTextReader::xfrLua(string& val)
+{
+  xfrText(val, true);
+}
+#endif
+
 void RecordTextReader::xfrUnquotedText(string& val, bool /* lenField */)
 {
   val.clear();
@@ -1095,6 +1102,13 @@ void RecordTextWriter::xfrText(const string& val, bool /* multi */, bool /* lenF
     d_string.append(val);
   }
 }
+
+#ifdef HAVE_LUA_RECORDS
+void RecordTextWriter::xfrLua(const string& val)
+{
+  xfrText(val, true);
+}
+#endif
 
 void RecordTextWriter::xfrUnquotedText(const string& val, bool /* lenField */)
 {

--- a/pdns/rcpgenerator.hh
+++ b/pdns/rcpgenerator.hh
@@ -57,6 +57,9 @@ public:
 
   void xfrName(DNSName& val, bool compress=false);
   void xfrText(string& val, bool multi=false, bool lenField=true);
+#ifdef HAVE_LUA_RECORDS
+  void xfrLua(string& val);
+#endif
   void xfrUnquotedText(string& val, bool lenField=true);
   void xfrHexBlob(string& val, bool keepReading=false);
   void xfrBase32HexBlob(string& val);
@@ -110,6 +113,9 @@ public:
   void xfrType(const uint16_t& val);
   void xfrName(const DNSName& val, bool compress=false);
   void xfrText(const string& val, bool multi=false, bool lenField=true);
+#ifdef HAVE_LUA_RECORDS
+  void xfrLua(const string& val);
+#endif
   void xfrUnquotedText(const string& val, bool lenField=true);
   void xfrBlobNoSpaces(const string& val, int len=-1);
   void xfrBlob(const string& val, int len=-1);

--- a/pdns/test-dnswriter_cc.cc
+++ b/pdns/test-dnswriter_cc.cc
@@ -407,4 +407,34 @@ BOOST_AUTO_TEST_CASE(test_NodeOrLocatorID) {
     0, 0, 0, 1}));
 }
 
+#ifdef HAVE_LUA_RECORDS
+BOOST_AUTO_TEST_CASE(test_luasplit) {
+  DNSName name("powerdns.com.");
+
+  vector<uint8_t> packet;
+  DNSPacketWriter pwR(packet, name, QType::LUA, QClass::IN, 0);
+  pwR.getHeader()->qr = 1;
+
+  pwR.startRecord(name, QType::LUA, 3600, QClass::IN, DNSResourceRecord::ANSWER);
+  // Example given in #12845
+  string chunk1{";local first_choice = ifurlup('http://a-really-really-long-string-to-test-lua-record-replication.domain.example.org:8081/metrics', {{'10.255.255.10', '10.255.255.11'}}, {backupSelector='all'}); local second_choice = ifportup(8081,{'10.255.255.12',"};
+  string chunk2{" '10.255.255.13'}, {backupSelector='all'}); if(#first_choice > 1) then return second_choice else return first_choice end"};
+  auto txt = std::string("\"") + chunk1 + chunk2 + std::string("\"");
+  pwR.xfrType(QType::A);
+  auto startpos = pwR.size();
+  pwR.xfrLua(txt);
+  pwR.commit();
+
+  string spacket(packet.begin(), packet.end());
+
+  // Check that it has been split in chunk1 and chunk2
+  BOOST_CHECK_EQUAL(static_cast<unsigned char>(spacket.at(startpos)), chunk1.size());
+  BOOST_CHECK_EQUAL(spacket.substr(startpos + 1, chunk1.size()), chunk1);
+  BOOST_CHECK_EQUAL(static_cast<unsigned char>(spacket.at(startpos + 1 + chunk1.size())), chunk2.size());
+  BOOST_CHECK_EQUAL(spacket.substr(startpos + 1 + chunk1.size() + 1, chunk2.size()), chunk2);
+
+  BOOST_CHECK_NO_THROW(MOADNSParser mdp(false, spacket));
+}
+#endif
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
Currently, `LUA` record contents are handled similarly to `TXT` records, being split in 254-byte chunks.

While this is fine for `TXT`, with `LUA` records this can cause unexpected trouble, depending on how the chunks are merged back. The `lua-records-insert-whitespace` setting tries to help.

This PR proposes a different split of the `LUA` record contents. Instead of splitting every 254 characters, it tries to split at whitespace boundaries, trying to produce the largest possible chunks (but <= 254 bytes). This way, constructing the original contents from the chunks should be safe, regardless of the `lua-records-insert-whitespace` setting.

### Details

Note that this logic will only apply to new Lua records being added to a zone. Existing large records have already been split in 254 byte chunks and won't be reprocessed.

Here is how it works with the example in #12845:
```
$ cat bug.less.zone
$ORIGIN .
bug.less.	1234	IN	NS	1.2.3.4.
bug.less.	1234	IN	SOA	ns.bug.less. hostmaster.bug.less. 5900 10800 3600 604800 3600
lua.bug.less.	1234	IN	LUA	A ";local first_choice = ifurlup('http://a-really-really-long-string-to-test-lua-record-replication.domain.example.org:8081/metrics', {{'10.255.255.10', '10.255.255.11'}}, {backupSelector='all'}); local second_choice = ifportup(8081,{'10.255.255.12', '10.255.255.13'}, {backupSelector='all'}); if(#first_choice > 1) then return second_choice else return first_choice end"
```
Without this PR:
```
$ pdnsutil zone load bug.less bug.less.zone
Zone 'bug.less' exists already, replacing contents
$ pdnsutil zone list bug.less
$ORIGIN .
bug.less.	1234	IN	NS	1.2.3.4.
bug.less.	1234	IN	SOA	ns.bug.less. hostmaster.bug.less. 5900 10800 3600 604800 3600
lua.bug.less.	1234	IN	LUA	A ";local first_choice = ifurlup('http://a-really-really-long-string-to-test-lua-record-replication.domain.example.org:8081/metrics', {{'10.255.255.10', '10.255.255.11'}}, {backupSelector='all'}); local second_choice = ifportup(8081,{'10.255.255.12', '10.255" ".255.13'}, {backupSelector='all'}); if(#first_choice > 1) then return second_choice else return first_choice end"
```
Note the `LUA` record is split in the middle of the `10.255.255.13` address, before `backupSelector` of the `second_choice`.
With this PR:
```
$ pdnsutil zone load bug.less bug.less.zone
Zone 'bug.less' exists already, replacing contents
$ pdnsutil zone list bug.less
$ORIGIN .
bug.less.	1234	IN	NS	1.2.3.4.
bug.less.	1234	IN	SOA	ns.bug.less. hostmaster.bug.less. 5900 10800 3600 604800 3600
lua.bug.less.	1234	IN	LUA	A ";local first_choice = ifurlup('http://a-really-really-long-string-to-test-lua-record-replication.domain.example.org:8081/metrics', {{'10.255.255.10', '10.255.255.11'}}, {backupSelector='all'}); local second_choice = ifportup(8081,{'10.255.255.12'," " '10.255.255.13'}, {backupSelector='all'}); if(#first_choice > 1) then return second_choice else return first_choice end"
```
Note the `LUA` record is now split at the whitespace between `10.255.255.12` and `10.255.255.13`, so that merging the two chunks creates working `Lua` code even if an extra whitespace is inserted.

Left to do: how to document this properly (it makes the "you should split your records by hand for AXFR" mention go away, but only if existing Lua records are edited or re-imported from an unsplit source).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
