### PR TITLE
auth: minor Lua2 backend improvements

### DIFF
--- a/docs/backends/lua2.rst
+++ b/docs/backends/lua2.rst
@@ -13,13 +13,15 @@ Lua2 Backend
 * Comments: No
 * Search: Yes\*
 * Views: No
-* API: Read-Write
+* API: Read-only\**
 * :ref:`Multiple instances <setting-launch>`: Yes
 * Zone caching: Yes\*
 * Module name: lua2
 * Launch name: ``lua2``
 
 \* If the responder (your script) implements ``dns_get_all_domains``, see below.
+
+\** Except for the notification timestamp, if the responder (your script) implements ``dns_set_notified``, see below.
 
 This is a rewrite of existing Lua backend.
 This backend is stub between your Lua script and PowerDNS authoritative server.

--- a/modules/lua2backend/lua2api2.cc
+++ b/modules/lua2backend/lua2api2.cc
@@ -156,7 +156,9 @@ void Lua2BackendAPIv2::parseLookup(const lookup_result_t& result)
         }
       }
       catch (const std::exception& e) {
-        throw PDNSException("Unable to parse " + item.first + " value in lookup or list result: " + e.what());
+        std::stringstream value;
+        value << item.second;
+        throw PDNSException("Unable to parse " + item.first + " value (" + value.str() + ") of variant type " + std::to_string(item.second.which()) + " in lookup or list result: " + e.what());
       }
     }
     if (d_debug_log) {
@@ -304,7 +306,9 @@ void Lua2BackendAPIv2::parseDomainInfo(const domaininfo_result_t& row, DomainInf
       }
     }
     catch (const std::exception& e) {
-      throw PDNSException("Unable to parse " + item.first + " value in domaininfo result: " + e.what());
+      // We can't get a printable version of the contents, because of the
+      // vector<string> case, which is not OutputStreamable.
+      throw PDNSException("Unable to parse " + item.first + " value of variant type " + std::to_string(item.second.which()) + " in domaininfo result: " + e.what());
     }
   }
   info.backend = this;
@@ -473,7 +477,9 @@ bool Lua2BackendAPIv2::getDomainKeys(const ZoneName& name, std::vector<DNSBacken
         }
       }
       catch (const std::exception& e) {
-        throw PDNSException("Unable to parse " + item.first + " value in keydata result: " + e.what());
+        std::stringstream value;
+        value << item.second;
+        throw PDNSException("Unable to parse " + item.first + " value (" + value.str() + ") of variant type " + std::to_string(item.second.which()) + " in keydata result: " + e.what());
       }
     }
     if (d_debug_log) {

--- a/modules/lua2backend/lua2api2.cc
+++ b/modules/lua2backend/lua2api2.cc
@@ -128,7 +128,12 @@ void Lua2BackendAPIv2::parseLookup(const lookup_result_t& result)
           rec.domain_id = boost::get<int>(item.second);
         }
         else if (item.first == "auth") {
-          rec.auth = boost::get<bool>(item.second);
+          if (item.second.which() == 1) {
+            rec.auth = boost::get<int>(item.second) != 0;
+          }
+          else { // assuming item.second.which() == 0 here
+            rec.auth = boost::get<bool>(item.second);
+          }
         }
         else if (item.first == "last_modified") {
           rec.last_modified = static_cast<time_t>(boost::get<int>(item.second));
@@ -463,10 +468,20 @@ bool Lua2BackendAPIv2::getDomainKeys(const ZoneName& name, std::vector<DNSBacken
           key.flags = static_cast<unsigned int>(boost::get<int>(item.second));
         }
         else if (item.first == "active") {
-          key.active = boost::get<bool>(item.second);
+          if (item.second.which() == 1) {
+            key.active = boost::get<int>(item.second) != 0;
+          }
+          else { // assuming item.second.which() == 0 here
+            key.active = boost::get<bool>(item.second);
+          }
         }
         else if (item.first == "published") {
-          key.published = boost::get<bool>(item.second);
+          if (item.second.which() == 1) {
+            key.published = boost::get<int>(item.second) != 0;
+          }
+          else { // assuming item.second.which() == 0 here
+            key.published = boost::get<bool>(item.second);
+          }
         }
         else {
           SLOG(g_log << Logger::Warning << "[" << getPrefix() << "] Unsupported key '" << item.first << "' in keydata result" << endl,

--- a/modules/lua2backend/lua2api2.cc
+++ b/modules/lua2backend/lua2api2.cc
@@ -112,11 +112,8 @@ void Lua2BackendAPIv2::parseLookup(const lookup_result_t& result)
           else if (item.second.which() == 3) {
             rec.qtype = boost::get<string>(item.second);
           }
-          else if (item.second.which() == 4) {
+          else { // assuming item.second.which() == 4 here
             rec.qtype = boost::get<QType>(item.second);
-          }
-          else {
-            throw PDNSException("Unsupported value for type");
           }
         }
         else if (item.first == "name") {

--- a/modules/lua2backend/lua2api2.cc
+++ b/modules/lua2backend/lua2api2.cc
@@ -228,6 +228,11 @@ bool Lua2BackendAPIv2::get(DNSResourceRecord& drr)
   return true;
 }
 
+void Lua2BackendAPIv2::lookupEnd()
+{
+  d_result.clear();
+}
+
 string Lua2BackendAPIv2::directBackendCmd(const string& querystr)
 {
   string::size_type pos = querystr.find_first_of(" \t");

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -68,15 +68,18 @@ public:
   explicit Lua2BackendAPIv2(Logr::log_t slog, const string& suffix);
   ~Lua2BackendAPIv2() override;
 
+  // AuthLua4 overrides
   void postPrepareContext() override;
   void postLoad() override;
+
+  // DNSBackend overrides
   unsigned int getCapabilities() override;
   bool list(const ZoneName& target, domainid_t domain_id, bool /* include_disabled */ = false) override;
   void lookup(const QType& qtype, const DNSName& qname, domainid_t domain_id, DNSPacket* pkt = nullptr) override;
   bool get(DNSResourceRecord& drr) override;
+  void lookupEnd() override;
   string directBackendCmd(const string& querystr) override;
   void setNotified(domainid_t domain_id, uint32_t serial) override;
-  void parseDomainInfo(const domaininfo_result_t& row, DomainInfo& info);
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool /* getSerial */ = true) override;
   void getAllDomains(vector<DomainInfo>* domains, bool /* getSerial */, bool /* include_disabled */) override;
   bool getAllDomainMetadata(const ZoneName& name, std::map<std::string, std::vector<std::string>>& meta) override;
@@ -106,5 +109,6 @@ private:
 
   deinit_call_t f_deinit;
 
+  void parseDomainInfo(const domaininfo_result_t& row, DomainInfo& info);
   void parseLookup(const lookup_result_t& result);
 };

--- a/modules/lua2backend/regression-tests/lua2.lua
+++ b/modules/lua2backend/regression-tests/lua2.lua
@@ -71,12 +71,12 @@ function dns_lookup(qtype, qname, d_id, ctx)
      if qtype:getName() == "ANY" then
        for k, v in pairs(rr) do
          for idx,row in ipairs(v) do
-           table.insert(ret, { name = qname, type = newQType(k), content = row, ttl = 60, domain_id = d_id })
+           table.insert(ret, { name = qname, type = newQType(k), content = row, ttl = 60, domain_id = d_id, auth = 1 })
          end
        end
      elseif rr[qtype:getName()] ~= nil then
        for idx,row in ipairs(rr[qtype:getName()]) do
-         table.insert(ret, { name = qname, type = qtype, content = row, ttl = 60, domain_id = d_id })
+         table.insert(ret, { name = qname, type = qtype, content = row, ttl = 60, domain_id = d_id, auth = true })
        end
      end
   end


### PR DESCRIPTION
### Short description
There was a new ~~Lua~~ moon two days ago! Let's celebrate with a PR!

This is a followup to https://github.com/PowerDNS/pdns/pull/17731#discussion_r3573675886. It is sometimes possible to have a somewhat correct value of the unparseable data (although, if you put `false` in your script to get the `bool` case, the reported value will be `"0"`...), so add it to the exception text.

While there, fix a documentation error and add a faster `lookupEnd` implementation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
