### PR TITLE
IPv4 sugar

### DIFF
--- a/m4/pdns_check_os.m4
+++ b/m4/pdns_check_os.m4
@@ -9,7 +9,6 @@ AC_DEFUN([PDNS_CHECK_OS],[
     ;;
   solaris2.8 | solaris2.9 )
     AC_DEFINE(NEED_POSIX_TYPEDEF,,[If POSIX typedefs need to be defined])
-    AC_DEFINE(NEED_INET_NTOP_PROTO,,[If your OS is so broken that it needs an additional prototype])
     LIBS="-lposix4 -lpthread $LIBS"
     CXXFLAGS="-D_REENTRANT $CXXFLAGS"
     have_solaris="yes"

--- a/meson/platform/meson.build
+++ b/meson/platform/meson.build
@@ -21,7 +21,6 @@ platforms = [
     'config-defines': [
       { 'name': 'HAVE_SOLARIS', 'description': 'On Solaris/SunOS' },
       { 'name': 'NEED_POSIX_TYPEDEF', 'description': 'POSIX typedefs need to be defined' },
-      { 'name': 'NEED_INET_NTOP_PROTO', 'description': 'OS is so broken that it needs an additional prototype' },
     ],
     'cmdline-defines': ['_REENTRANT'],
     'libraries': ['posix4'],

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -646,7 +646,7 @@ inline ComboAddress makeComboAddress(const string& str)
 {
   ComboAddress address;
   address.sin4.sin_family = AF_INET;
-  if (inet_pton(AF_INET, str.c_str(), &address.sin4.sin_addr) <= 0) {
+  if (makeIPv4sockaddr(str, &address.sin4) < 0) {
     address.sin4.sin_family = AF_INET6;
     if (makeIPv6sockaddr(str, &address.sin6) < 0) {
       throw NetmaskException("Unable to convert '" + str + "' to a netmask");

--- a/pdns/unix_utility.cc
+++ b/pdns/unix_utility.cc
@@ -36,13 +36,6 @@
 #include <sys/types.h>
 #include <sys/select.h>
 
-#ifdef NEED_INET_NTOP_PROTO
-extern "C" {
-const char *inet_ntop(int af, const void *src, char *dst, size_t cnt);
-}
-#endif
-
-
 #include "namespaces.hh"
 
 
@@ -115,11 +108,6 @@ void Utility::setBindAny([[maybe_unused]] int af, [[maybe_unused]] sock_t sock)
          g_slog->withName("runtime")->error(Logr::Warning, err, "Warning: SO_BINDANY setsockopt failed"));
   }
 #endif
-}
-
-const char *Utility::inet_ntop(int af, const char *src, char *dst, size_t size)
-{
-  return ::inet_ntop(af,src,dst,size);
 }
 
 unsigned int Utility::sleep(unsigned int sec)

--- a/pdns/utility.hh
+++ b/pdns/utility.hh
@@ -108,15 +108,6 @@ public:
   //! Gets the current time.
   static int gettimeofday( struct timeval *tv, void *tz = NULL );
 
-  //! Converts an address from dot and numbers format to binary data.
-  static int inet_aton( const char *cp, struct in_addr *inp );
-
-  //! Converts an address from presentation format to network format.
-  static int inet_pton( int af, const char *src, void *dst );
-
-  //! The inet_ntop() function converts an address from network format (usually a struct in_addr or some other binary form, in network byte order) to presentation format.
-  static const char *inet_ntop( int af, const char *src, char *dst, size_t size );
-
   //! Writes a vector.
   static int writev( Utility::sock_t socket, const iovec *vector, size_t count );
 

--- a/regression-tests.api/test_RecursorOTConditions.py
+++ b/regression-tests.api/test_RecursorOTConditions.py
@@ -33,14 +33,6 @@ class RecursorOT(ApiTestCase):
         self.assertEqual(r.status_code, 422)
         self.assert_in_json_error("Could not find otcondition", r.json())
 
-        # malformed netmask
-        r = self.session.get(
-            self.url("/api/v1/servers/localhost/ottraceconditions/1.2.3/32"),
-            headers={"content-type": "application/json"},
-        )
-        self.assertEqual(r.status_code, 422)
-        self.assert_in_json_error("Could not parse netmask", r.json())
-
         # deleting non-existent netmask
         r = self.session.delete(
             self.url("/api/v1/servers/localhost/ottraceconditions/1.2.3.4/32"),


### PR DESCRIPTION
### Short description
For $reasons, creation of a `ComboAddress` object (wrapping either an IPv4 address, or an IPv6 address, or a Unix domain socket), is strict when trying to parse its address specification as IPv4, and requires a four-digits-with-dots-in-between address, by using `inet_pton`.

However, many other parts of the code use `inet_aton` to parse IPv4 addresses, which allows for the shorter notations preferred by the greybeards.

This PR therefore changes this to use `inet_aton`, giving you enough rope to break your configurations. If you had a working configuration, it will keep working and you don't have to worry anyway.

As a bonus, you get an extra `inet_aton`-related cleanup commit, because why not.

Fixes #6149. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
