### PR TITLE
pdnsutil: tidy zone check code

### DIFF
--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: "0.0.19"
+  version: "0.0.20"
   title: PowerDNS Authoritative HTTP API
   license:
     name: MIT
@@ -683,6 +683,8 @@ paths:
       responses:
         "204":
           description: "Returns 204 No Content on success."
+        "422":
+          description: "Returned when the requested changes are in error. Contains an error message"
         default:
           $ref: "#/components/responses/Error"
 
@@ -702,6 +704,8 @@ paths:
       responses:
         "204":
           description: "Returns 204 No Content on success."
+        "422":
+          description: "Returned when the requested changes are in error. Contains an error message"
         default:
           $ref: "#/components/responses/Error"
 

--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: "0.0.21"
+  version: "0.0.22"
   title: PowerDNS Authoritative HTTP API
   license:
     name: MIT
@@ -654,6 +654,8 @@ paths:
       responses:
         "204":
           description: "Returns 204 No Content on success."
+        "422":
+          description: "Returned when the requested changes are in error. Contains an error message"
         default:
           $ref: "#/components/responses/Error"
 
@@ -673,6 +675,8 @@ paths:
       responses:
         "204":
           description: "Returns 204 No Content on success."
+        "422":
+          description: "Returned when the requested changes are in error. Contains an error message"
         default:
           $ref: "#/components/responses/Error"
 

--- a/pdns/check-zone.cc
+++ b/pdns/check-zone.cc
@@ -53,7 +53,7 @@ bool validateViewName(std::string_view name, std::string& error)
   return true;
 }
 
-void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecord>& allrrs, const ZoneName& zone, RRSetFlags flags, vector<pair<DNSResourceRecord, string>>& errors)
+void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecord>& allrrs, const ZoneName& zone, RRSetFlags flags, vector<std::tuple<Logr::Priority, DNSResourceRecord, string>>& diagnostics)
 {
   // QTypes that MUST NOT have multiple records of the same type in a given RRset.
   static const std::set<uint16_t> onlyOneEntryTypes = {QType::CNAME, QType::DNAME, QType::SOA};
@@ -85,10 +85,10 @@ void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecor
     if (previous.qname == rec.qname) {
       if (previous.qtype == rec.qtype) {
         if (onlyOneEntryTypes.count(rec.qtype.getCode()) != 0) {
-          errors.emplace_back(std::make_pair(rec, "only one such record allowed"));
+          diagnostics.emplace_back(std::make_tuple(Logr::Error, rec, "only one such record allowed"));
         }
         if (previous.content == contentstr) {
-          errors.emplace_back(std::make_pair(rec, std::string{"duplicate record with content \""} + rec.content + "\""));
+          diagnostics.emplace_back(std::make_tuple(Logr::Error, rec, std::string{"duplicate record with content \""} + rec.content + "\""));
         }
         // Enforce identical TTLs for all records with the same name and type,
         // if required. This is optional because some callers are able to
@@ -99,7 +99,7 @@ void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecor
             // This error message may be misleading if a TTL discrepancy already
             // exists in the RRset, as it might blame an existing record rather
             // than those being added. ¯\_(ツ)_/¯
-            errors.emplace_back(std::make_pair(rec, std::string{"uses a different TTL value than the remainder of the RRset"}));
+            diagnostics.emplace_back(std::make_tuple(Logr::Error, rec, std::string{"uses a different TTL value than the remainder of the RRset"}));
           }
         }
       }
@@ -113,10 +113,10 @@ void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecor
           // order to decide which record to blame in order to make the error
           // message as less confusing as possible.
           if (std::find(oldrrs.begin(), oldrrs.end(), rec) != oldrrs.end()) {
-            errors.emplace_back(std::make_pair(previous, std::string{"conflicts with existing "} + rec.qtype.toString() + " RRset of the same name"));
+            diagnostics.emplace_back(std::make_tuple(Logr::Error, previous, std::string{"conflicts with existing "} + rec.qtype.toString() + " RRset of the same name"));
           }
           else {
-            errors.emplace_back(std::make_pair(rec, std::string{"conflicts with existing "} + previous.qtype.toString() + " RRset of the same name"));
+            diagnostics.emplace_back(std::make_tuple(Logr::Error, rec, std::string{"conflicts with existing "} + previous.qtype.toString() + " RRset of the same name"));
           }
         }
       }
@@ -124,11 +124,11 @@ void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecor
 
     if (rec.qname == zone.operator const DNSName&()) {
       if (nonApexTypes.count(rec.qtype.getCode()) != 0) {
-        errors.emplace_back(std::make_pair(rec, "is not allowed at apex"));
+        diagnostics.emplace_back(std::make_tuple(Logr::Warning, rec, "is not allowed at apex"));
       }
     }
     else if (atApexTypes.count(rec.qtype.getCode()) != 0) {
-      errors.emplace_back(std::make_pair(rec, "is only allowed at apex"));
+      diagnostics.emplace_back(std::make_tuple(rec.qtype == QType::SOA ? Logr::Error : Logr::Warning, rec, "is only allowed at apex"));
     }
 
     // Check if the DNSNames that should be hostnames, are hostnames
@@ -137,7 +137,7 @@ void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecor
       checkHostnameCorrectness(rec, allowUnderscores);
     }
     catch (const std::exception& e) {
-      errors.emplace_back(std::make_pair(rec, e.what()));
+      diagnostics.emplace_back(std::make_tuple(Logr::Warning, rec, e.what()));
     }
 
     previous = rec;

--- a/pdns/check-zone.cc
+++ b/pdns/check-zone.cc
@@ -70,12 +70,24 @@ void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecor
 
   DNSResourceRecord previous;
   for (const auto& rec : allrrs) {
+    bool lowercase{false};
+    switch (rec.qtype) {
+    case QType::MX:
+    case QType::PTR:
+    case QType::SRV:
+      lowercase = true;
+      break;
+    }
+    std::string contentstr{rec.content};
+    if (lowercase) {
+      toLowerInPlace(contentstr);
+    }
     if (previous.qname == rec.qname) {
       if (previous.qtype == rec.qtype) {
         if (onlyOneEntryTypes.count(rec.qtype.getCode()) != 0) {
           errors.emplace_back(std::make_pair(rec, "only one such record allowed"));
         }
-        if (previous.content == rec.content) {
+        if (previous.content == contentstr) {
           errors.emplace_back(std::make_pair(rec, std::string{"duplicate record with content \""} + rec.content + "\""));
         }
         // Enforce identical TTLs for all records with the same name and type,
@@ -129,6 +141,9 @@ void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecor
     }
 
     previous = rec;
+    if (lowercase) {
+      previous.content = contentstr;
+    }
   }
 }
 

--- a/pdns/check-zone.hh
+++ b/pdns/check-zone.hh
@@ -48,6 +48,7 @@ enum RRSetFlags : unsigned int
 //   *) no exact duplicates
 //   *) no duplicates for QTypes that can only be present once per RRset
 //   *) hostnames are hostnames
-void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecord>& allrrs, const ZoneName& zone, RRSetFlags flags, vector<pair<DNSResourceRecord, string>>& errors);
+//   *) no mismatching TTL (if asked in flags)
+void checkRRSet(const vector<DNSResourceRecord>& oldrrs, vector<DNSResourceRecord>& allrrs, const ZoneName& zone, RRSetFlags flags, vector<std::tuple<Logr::Priority, DNSResourceRecord, string>>& diagnostics);
 
 } // namespace Check

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -958,8 +958,8 @@ static bool areUnderscoresAllowed(const ZoneName& zonename, DomainInfo& info)
 static int checkZoneTLSA(const set<DNSName>& tlsas, const set<DNSName>& cnames, const set<DNSName>& noncnames)
 {
   int numwarnings{0};
-  for(const auto &i: tlsas) {
-    DNSName name = DNSName(i);
+  for(const auto& origname: tlsas) {
+    auto name = origname;
     name.trimToLabels(name.countLabels()-2);
     if (cnames.find(name) == cnames.end() && noncnames.find(name) == noncnames.end()) {
       // No specific record for the name in the TLSA record exists, this
@@ -969,9 +969,9 @@ static int checkZoneTLSA(const set<DNSName>& tlsas, const set<DNSName>& cnames, 
       wcname.chopOff();
       wcname.prependRawLabel("*");
       if (cnames.find(wcname) != cnames.end() || noncnames.find(wcname) != noncnames.end()) {
-        cout<<"A wildcard record exist for '"<<wcname<<"' and a TLSA record for '"<<i<<"'.";
+        cout<<"A wildcard record exist for '"<<wcname<<"' and a TLSA record for '"<<origname<<"'.";
       } else {
-        cout<<"No record for '"<<name<<"' exists, but a TLSA record for '"<<i<<"' does.";
+        cout<<"No record for '"<<name<<"' exists, but a TLSA record for '"<<origname<<"' does.";
       }
       numwarnings++;
       cout<<" A query for '"<<name<<"' will yield an empty response. This is most likely a mistake, please create records for '"<<name<<"'."<<endl;
@@ -1066,7 +1066,7 @@ static bool checkRecordContents(int& numwarnings, int& numerrors, DNSResourceRec
         }
       }
     } else {
-      struct in6_addr tmpbuf;
+      struct in6_addr tmpbuf{};
       if (inet_pton(AF_INET6, drr.content.c_str(), &tmpbuf) != 1) {
         cout<<"[Warning] Following record is not a valid IPv6 address: "<<drr.qname<<" IN " <<drr.qtype.toString()<< " '" << drr.content<<"'"<<endl;
         numwarnings++;
@@ -1274,48 +1274,49 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   }
   recordCount = records.size();
 
-  for(auto &rr : records) { // We modify SOA and TXT record contents
-    if(rr.qtype.getCode() == QType::TLSA)
-      tlsas.insert(rr.qname);
-    if(rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) {
-      addresses.insert(rr.qname);
+  for(auto &drr : records) { // We modify SOA and TXT record contents
+    if(drr.qtype.getCode() == QType::TLSA) {
+      tlsas.insert(drr.qname);
+    }
+    if(drr.qtype.getCode() == QType::A || drr.qtype.getCode() == QType::AAAA) {
+      addresses.insert(drr.qname);
     }
 #ifdef HAVE_LUA_RECORDS
-    if(rr.qtype.getCode() == QType::LUA) {
-      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(rr.qtype.getCode(), QClass::IN, rr.content));
+    if(drr.qtype.getCode() == QType::LUA) {
+      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(drr.qtype.getCode(), QClass::IN, drr.content));
       auto luarec = std::dynamic_pointer_cast<LUARecordContent>(drc);
       QType qtype = luarec->d_type;
       if(qtype == QType::A || qtype == QType::AAAA) {
-        addresses.insert(rr.qname);
+        addresses.insert(drr.qname);
       }
     }
 #endif
-    if(rr.qtype.getCode() == QType::A) {
-      arecords.insert(rr.qname);
+    if(drr.qtype.getCode() == QType::A) {
+      arecords.insert(drr.qname);
     }
-    if(rr.qtype.getCode() == QType::AAAA) {
-      aaaarecords.insert(rr.qname);
+    if(drr.qtype.getCode() == QType::AAAA) {
+      aaaarecords.insert(drr.qname);
     }
-    if(rr.qtype.getCode() == QType::SOA) {
-      numwarnings += normalizeSOARecord(rr);
+    if(drr.qtype.getCode() == QType::SOA) {
+      numwarnings += normalizeSOARecord(drr);
     }
 
-    if (!checkRecordContents(numwarnings, numerrors, rr)) {
+    if (!checkRecordContents(numwarnings, numerrors, drr)) {
       continue;
     }
 
-    if(!rr.qname.isPartOf(zone)) {
-      cout<<"[Error] Record '"<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"' in zone '"<<zone<<"' is out-of-zone."<<endl;
+    if(!drr.qname.isPartOf(zone)) {
+      cout<<"[Error] Record '"<<drr.qname<<" IN "<<drr.qtype.toString()<<" "<<drr.content<<"' in zone '"<<zone<<"' is out-of-zone."<<endl;
       numerrors++;
       continue;
     }
 
-    if (rr.qtype.getCode() == QType::SVCB || rr.qtype.getCode() == QType::HTTPS) {
-      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(rr.qtype.getCode(), QClass::IN, rr.content));
+    if (drr.qtype.getCode() == QType::SVCB || drr.qtype.getCode() == QType::HTTPS) {
+      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(drr.qtype.getCode(), QClass::IN, drr.content));
       // I, too, like to live dangerously
       auto svcbrc = std::dynamic_pointer_cast<SVCBBaseRecordContent>(drc);
       if (svcbrc->getPriority() == 0 && svcbrc->hasParams()) {
-        cout<<"[Warning] Aliasform "<<rr.qtype.toString()<<" record "<<rr.qname<<" has service parameters."<<endl;
+        cout<<"[Warning] Aliasform "<<drr.qtype.toString()<<" record "<<drr.qname<<" has service parameters."<<endl;
         numwarnings++;
       }
 
@@ -1327,106 +1328,107 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
            *  also be specified in order for the RR to be "self-consistent
            *  (Section 2.4.3).
            */
-          cout<<"[Warning] "<<rr.qname<<"|"<<rr.qtype.toString()<<" is not self-consistent: 'no-default-alpn' parameter without 'alpn' parameter"<<endl;
+          cout<<"[Warning] "<<drr.qname<<"|"<<drr.qtype.toString()<<" is not self-consistent: 'no-default-alpn' parameter without 'alpn' parameter"<<endl;
           numwarnings++;
         }
         if (svcbrc->hasParam(SvcParam::mandatory)) {
           auto keys = svcbrc->getParam(SvcParam::mandatory).getMandatory();
           for (auto const &k: keys) {
             if (!svcbrc->hasParam(k)) {
-              cout<<"[Warning] "<<rr.qname<<"|"<<rr.qtype.toString()<<" is not self-consistent: 'mandatory' parameter lists '"+ SvcParam::keyToString(k) +"', but that parameter does not exist"<<endl;
+              cout<<"[Warning] "<<drr.qname<<"|"<<drr.qtype.toString()<<" is not self-consistent: 'mandatory' parameter lists '"+ SvcParam::keyToString(k) +"', but that parameter does not exist"<<endl;
               numwarnings++;
             }
           }
         }
       }
 
-      bool isSvcb = rr.qtype.getCode() == QType::SVCB;
+      bool isSvcb = drr.qtype.getCode() == QType::SVCB;
       set<DNSName>& aliases = isSvcb ? svcbAliases : httpsAliases;
       svcbset_t& targets = isSvcb ? svcbTargets : httpsTargets;
       set<DNSName>& ourrecords = isSvcb ? svcbRecords : httpsRecords;
 
       if (svcbrc->getPriority() == 0) {
-        if (aliases.find(rr.qname) != aliases.end()) {
-          cout << "[Warning] More than one Alias form " << rr.qtype.toString()<< " " << rr.qname << " exists." << endl;
+        if (aliases.find(drr.qname) != aliases.end()) {
+          cout << "[Warning] More than one Alias form " << drr.qtype.toString()<< " " << drr.qname << " exists." << endl;
           numwarnings++;
         }
-        aliases.insert(rr.qname);
+        aliases.insert(drr.qname);
       }
-      targets.emplace(rr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
-      ourrecords.insert(rr.qname);
+      targets.emplace(drr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
+      ourrecords.insert(drr.qname);
     }
 
-    if (isSecure && isOptOut && (rr.qname.hasLabels() && rr.qname.getRawLabel(0) == "*")) {
-      cout<<"[Warning] wildcard record '"<<rr.qname<<" IN " <<rr.qtype.toString()<<" "<<rr.content<<"' is insecure"<<endl;
+    if (isSecure && isOptOut && (drr.qname.hasLabels() && drr.qname.getRawLabel(0) == "*")) {
+      cout<<"[Warning] wildcard record '"<<drr.qname<<" IN " <<drr.qtype.toString()<<" "<<drr.content<<"' is insecure"<<endl;
       cout<<"[Info] Wildcard records in opt-out zones are insecure. Disable the opt-out flag for this zone to avoid this warning. Command: 'pdnsutil zone set-nsec3 "<<zone<<"'"<<endl;
       numwarnings++;
     }
 
-    if(rr.qname==zone.operator const DNSName&()) {
+    if(drr.qname==zone.operator const DNSName&()) {
       // apex checks
-      if (rr.qtype.getCode() == QType::NS) {
+      if (drr.qtype.getCode() == QType::NS) {
         hasNsAtApex=true;
       }
     } else {
       // non-apex checks
-      if (rr.qtype.getCode() == QType::NS) {
-        if (DNSName(rr.content).isPartOf(rr.qname)) {
-          checkglue.insert(DNSName(toLower(rr.content)));
+      if (drr.qtype.getCode() == QType::NS) {
+        if (DNSName(drr.content).isPartOf(drr.qname)) {
+          checkglue.insert(DNSName(toLower(drr.content)));
         }
-        checkOcclusion.insert({rr.qname, rr.qtype});
-      } else if (rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) {
-        glue.insert(rr.qname);
+        checkOcclusion.insert({drr.qname, drr.qtype});
+      } else if (drr.qtype.getCode() == QType::A || drr.qtype.getCode() == QType::AAAA) {
+        glue.insert(drr.qname);
       }
     }
 
     // DNAMEs can occur both at the apex and below it
-    if (rr.qtype == QType::DNAME) {
-      checkOcclusion.insert({rr.qname, rr.qtype});
+    if (drr.qtype == QType::DNAME) {
+      checkOcclusion.insert({drr.qname, drr.qtype});
     }
 
-    if((rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) && !rr.qname.isWildcard() && !rr.qname.isHostname())
-      cout<<"[Info] "<<rr.qname.toString()<<" record for '"<<rr.qtype.toString()<<"' is not a valid hostname."<<endl;
+    if((drr.qtype.getCode() == QType::A || drr.qtype.getCode() == QType::AAAA) && !drr.qname.isWildcard() && !drr.qname.isHostname()) {
+      cout<<"[Info] "<<drr.qname.toString()<<" record for '"<<drr.qtype.toString()<<"' is not a valid hostname."<<endl;
+    }
 
-    if (rr.qtype.getCode() == QType::CNAME) {
-      if (cnames.count(rr.qname) == 0) {
-        cnames.insert(rr.qname);
+    if (drr.qtype.getCode() == QType::CNAME) {
+      if (cnames.count(drr.qname) == 0) {
+        cnames.insert(drr.qname);
       }
     } else {
-      if (rr.qtype.getCode() == QType::RRSIG) {
+      if (drr.qtype.getCode() == QType::RRSIG) {
         if(!presigned) {
-          cout<<"[Error] RRSIG found at '"<<rr.qname<<"' in non-presigned zone. These do not belong in the database."<<endl;
+          cout<<"[Error] RRSIG found at '"<<drr.qname<<"' in non-presigned zone. These do not belong in the database."<<endl;
           numerrors++;
           continue;
         }
       } else
-        noncnames.insert(rr.qname);
+        noncnames.insert(drr.qname);
     }
 
-    if (rr.qtype == QType::MX || rr.qtype == QType::NS || rr.qtype == QType::SRV) {
-      checkCNAME.push_back(rr);
+    if (drr.qtype == QType::MX || drr.qtype == QType::NS || drr.qtype == QType::SRV) {
+      checkCNAME.push_back(drr);
     }
 
-    if(rr.qtype.getCode() == QType::NSEC || rr.qtype.getCode() == QType::NSEC3)
+    if(drr.qtype.getCode() == QType::NSEC || drr.qtype.getCode() == QType::NSEC3)
     {
-      cout<<"[Error] NSEC or NSEC3 found at '"<<rr.qname<<"'. These do not belong in the database."<<endl;
+      cout<<"[Error] NSEC or NSEC3 found at '"<<drr.qname<<"'. These do not belong in the database."<<endl;
       numerrors++;
       continue;
     }
 
-    if(!presigned && rr.qtype.getCode() == QType::DNSKEY)
+    if(!presigned && drr.qtype.getCode() == QType::DNSKEY)
     {
       if(::arg().mustDo("direct-dnskey"))
       {
-        if(rr.ttl != sd.minimum)
+        if(drr.ttl != sd.minimum)
         {
-          cout<<"[Warning] DNSKEY TTL of "<<rr.ttl<<" at '"<<rr.qname<<"' differs from SOA minimum of "<<sd.minimum<<endl;
+          cout<<"[Warning] DNSKEY TTL of "<<drr.ttl<<" at '"<<drr.qname<<"' differs from SOA minimum of "<<sd.minimum<<endl;
           numwarnings++;
         }
       }
       else
       {
-        cout<<"[Warning] DNSKEY at '"<<rr.qname<<"' in non-presigned zone will mostly be ignored and can cause problems."<<endl;
+        cout<<"[Warning] DNSKEY at '"<<drr.qname<<"' in non-presigned zone will mostly be ignored and can cause problems."<<endl;
         numwarnings++;
       }
     }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -955,6 +955,104 @@ static bool areUnderscoresAllowed(const ZoneName& zonename, DomainInfo& info)
   return underscores == "0";
 }
 
+static int checkZoneTLSA(const set<DNSName>& tlsas, const set<DNSName>& cnames, const set<DNSName>& noncnames)
+{
+  int numwarnings{0};
+  for(const auto &i: tlsas) {
+    DNSName name = DNSName(i);
+    name.trimToLabels(name.countLabels()-2);
+    if (cnames.find(name) == cnames.end() && noncnames.find(name) == noncnames.end()) {
+      // No specific record for the name in the TLSA record exists, this
+      // is already worth emitting a warning. Let's see if a wildcard exist.
+      cout<<"[Warning] ";
+      DNSName wcname(name);
+      wcname.chopOff();
+      wcname.prependRawLabel("*");
+      if (cnames.find(wcname) != cnames.end() || noncnames.find(wcname) != noncnames.end()) {
+        cout<<"A wildcard record exist for '"<<wcname<<"' and a TLSA record for '"<<i<<"'.";
+      } else {
+        cout<<"No record for '"<<name<<"' exists, but a TLSA record for '"<<i<<"' does.";
+      }
+      numwarnings++;
+      cout<<" A query for '"<<name<<"' will yield an empty response. This is most likely a mistake, please create records for '"<<name<<"'."<<endl;
+    }
+  }
+  return numwarnings;
+}
+
+// Record name, prio, target name, ipv4hint=auto, ipv6hint=auto
+using svcbset_t = set<std::tuple<DNSName, uint16_t, DNSName, bool, bool>>;
+
+static void checkZoneSVCB(int& numwarnings, int& numerrors, const ZoneName& zone, const svcbset_t& svcbTargets, const set<DNSName>& svcbAliases, const set<DNSName>& svcbRecords, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
+{
+  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : svcbTargets) {
+    if (name == target) {
+      cout<<"[Error] SVCB record "<<name<<" has itself as target."<<endl;
+      numerrors++;
+    }
+
+    if (prio == 0) {
+      if (target.isPartOf(zone)) {
+        if (svcbAliases.find(target) != svcbAliases.end()) {
+          cout << "[Warning] SVCB record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
+          numwarnings++;
+        }
+        if (addresses.find(target) == addresses.end() && svcbRecords.find(target) == svcbRecords.end()) {
+          cout<<"[Error] SVCB record "<<name<<" has a target "<<target<<" that has neither address nor SVCB records."<<endl;
+          numerrors++;
+        }
+      }
+    }
+
+    const auto& trueTarget = target.isRoot() ? name : target;
+    if (prio > 0) {
+      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
+        cout << "[warning] SVCB record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
+        numwarnings++;
+      }
+      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
+        cout << "[warning] SVCB record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
+        numwarnings++;
+      }
+    }
+  }
+}
+
+static void checkZoneHTTPS(int& numwarnings, int& numerrors, const ZoneName& zone, const svcbset_t& httpsTargets, const set<DNSName>& httpsAliases, const set<DNSName>& httpsRecords, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
+{
+  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : httpsTargets) {
+    if (name == target) {
+      cout<<"[Error] HTTPS record "<<name<<" has itself as target."<<endl;
+      numerrors++;
+    }
+
+    if (prio == 0) {
+      if (target.isPartOf(zone)) {
+        if (httpsAliases.find(target) != httpsAliases.end()) {
+          cout << "[Warning] HTTPS record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
+          numwarnings++;
+        }
+        if (addresses.find(target) == addresses.end() && httpsRecords.find(target) == httpsRecords.end()) {
+          cout<<"[Error] HTTPS record "<<name<<" has a target "<<target<<" that has neither address nor HTTPS records."<<endl;
+          numerrors++;
+        }
+      }
+    }
+
+    const auto& trueTarget = target.isRoot() ? name : target;
+    if (prio > 0) {
+      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
+        cout << "[warning] HTTPS record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
+        numwarnings++;
+      }
+      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
+        cout << "[warning] HTTPS record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
+        numwarnings++;
+      }
+    }
+  }
+}
+
 static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
 {
   int numerrors=0;
@@ -1081,11 +1179,22 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   // only be performed on complete zone contents and are only done here.
 
   bool hasNsAtApex = false;
-  set<DNSName> tlsas, cnames, noncnames, glue, checkglue, addresses, svcbAliases, httpsAliases, svcbRecords, httpsRecords, arecords, aaaarecords;
+  set<DNSName> tlsas;
+  set<DNSName> cnames;
+  set<DNSName> noncnames;
+  set<DNSName> glue;
+  set<DNSName> checkglue;
+  set<DNSName> addresses;
+  set<DNSName> svcbAliases;
+  set<DNSName> httpsAliases;
+  set<DNSName> svcbRecords;
+  set<DNSName> httpsRecords;
+  set<DNSName> arecords;
+  set<DNSName> aaaarecords;
   vector<DNSResourceRecord> checkCNAME;
-  set<pair<DNSName, QType> > checkOcclusion;
-  // Record name, prio, target name, ipv4hint=auto, ipv6hint=auto
-  set<std::tuple<DNSName, uint16_t, DNSName, bool, bool> > svcbTargets, httpsTargets;
+  set<pair<DNSName, QType>> checkOcclusion;
+  svcbset_t svcbTargets;
+  svcbset_t httpsTargets;
 
   ostringstream content;
   pair<map<string, unsigned int>::iterator,bool> ret;
@@ -1371,89 +1480,21 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
     }
   }
 
-  for(const auto &i: tlsas) {
-    DNSName name = DNSName(i);
-    name.trimToLabels(name.countLabels()-2);
-    if (cnames.find(name) == cnames.end() && noncnames.find(name) == noncnames.end()) {
-      // No specific record for the name in the TLSA record exists, this
-      // is already worth emitting a warning. Let's see if a wildcard exist.
-      cout<<"[Warning] ";
-      DNSName wcname(name);
-      wcname.chopOff();
-      wcname.prependRawLabel("*");
-      if (cnames.find(wcname) != cnames.end() || noncnames.find(wcname) != noncnames.end()) {
-        cout<<"A wildcard record exist for '"<<wcname<<"' and a TLSA record for '"<<i<<"'.";
-      } else {
-        cout<<"No record for '"<<name<<"' exists, but a TLSA record for '"<<i<<"' does.";
-      }
-      numwarnings++;
-      cout<<" A query for '"<<name<<"' will yield an empty response. This is most likely a mistake, please create records for '"<<name<<"'."<<endl;
-    }
-  }
+  numwarnings += checkZoneTLSA(tlsas, cnames, noncnames);
+  tlsas.clear();
 
-  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : svcbTargets) {
-    if (name == target) {
-      cout<<"[Error] SVCB record "<<name<<" has itself as target."<<endl;
-      numerrors++;
-    }
+  checkZoneSVCB(numwarnings, numerrors, zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
+  svcbTargets.clear();
+  svcbAliases.clear();
+  svcbRecords.clear();
+  checkZoneHTTPS(numwarnings, numerrors, zone, httpsTargets, httpsAliases, httpsRecords, arecords, aaaarecords, addresses);
+  httpsTargets.clear();
+  httpsAliases.clear();
+  httpsRecords.clear();
 
-    if (prio == 0) {
-      if (target.isPartOf(zone)) {
-        if (svcbAliases.find(target) != svcbAliases.end()) {
-          cout << "[Warning] SVCB record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
-          numwarnings++;
-        }
-        if (addresses.find(target) == addresses.end() && svcbRecords.find(target) == svcbRecords.end()) {
-          cout<<"[Error] SVCB record "<<name<<" has a target "<<target<<" that has neither address nor SVCB records."<<endl;
-          numerrors++;
-        }
-      }
-    }
-
-    const auto& trueTarget = target.isRoot() ? name : target;
-    if (prio > 0) {
-      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
-        cout << "[warning] SVCB record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
-        cout << "[warning] SVCB record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-    }
-  }
-
-  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : httpsTargets) {
-    if (name == target) {
-      cout<<"[Error] HTTPS record "<<name<<" has itself as target."<<endl;
-      numerrors++;
-    }
-
-    if (prio == 0) {
-      if (target.isPartOf(zone)) {
-        if (httpsAliases.find(target) != httpsAliases.end()) {
-          cout << "[Warning] HTTPS record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
-          numwarnings++;
-        }
-        if (addresses.find(target) == addresses.end() && httpsRecords.find(target) == httpsRecords.end()) {
-          cout<<"[Error] HTTPS record "<<name<<" has a target "<<target<<" that has neither address nor HTTPS records."<<endl;
-          numerrors++;
-        }
-      }
-    }
-
-    const auto& trueTarget = target.isRoot() ? name : target;
-    if (prio > 0) {
-      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
-        cout << "[warning] HTTPS record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
-        cout << "[warning] HTTPS record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-    }
-  }
+  arecords.clear();
+  aaaarecords.clear();
+  addresses.clear();
 
   if(!hasNsAtApex) {
     cout<<"[Error] No NS record at zone apex in zone '"<<zone<<"'"<<endl;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1018,6 +1018,71 @@ static void checkZoneSVCB(int& numwarnings, int& numerrors, const std::string& t
   }
 }
 
+static int normalizeSOARecord(DNSResourceRecord& drr)
+{
+  int numwarnings{0};
+  vector<string> parts;
+  stringtok(parts, drr.content);
+
+  if(parts.size() < 7) {
+    cout << "[Info] SOA autocomplete is deprecated, missing field(s) in SOA content: " << drr.qname << " IN " << drr.qtype.toString() << " '" << drr.content << "'" << endl;
+  }
+
+  if(parts.size() >= 2) {
+    if(parts[1].find('@') != string::npos) {
+      cout<<"[Warning] Found @-sign in SOA RNAME, should probably be a dot (.): "<<drr.qname<<" IN " <<drr.qtype.toString()<< " '" << drr.content<<"'"<<endl;
+      numwarnings++;
+    }
+  }
+
+  ostringstream ostr;
+  ostr<<drr.content;
+  for(auto pleft=parts.size(); pleft < 7; ++pleft) {
+    ostr<<" 0";
+  }
+  drr.content=ostr.str();
+  return numwarnings;
+}
+
+static bool checkRecordContents(int& numwarnings, int& numerrors, DNSResourceRecord& drr)
+{
+  // Make sure TXT record contents are quoted
+  if(drr.qtype.getCode() == QType::TXT && !drr.content.empty() && drr.content[0]!='"') {
+    drr.content = "\""+drr.content+"\"";
+  }
+
+  try {
+    shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(drr.qtype.getCode(), QClass::IN, drr.content));
+    string tmp=drc->serialize(drr.qname);
+    tmp = drc->getZoneRepresentation(true);
+    if (drr.qtype.getCode() != QType::AAAA) {
+      if (!pdns_iequals(tmp, drr.content)) {
+        if(drr.qtype.getCode() == QType::SOA) {
+          tmp = drc->getZoneRepresentation(false);
+        }
+        if(!pdns_iequals(tmp, drr.content)) {
+          cout<<"[Warning] Parsed and original record content are not equal: "<<drr.qname<<" IN " <<drr.qtype.toString()<< " '" << drr.content<<"' (Content parsed as '"<<tmp<<"')"<<endl;
+          numwarnings++;
+        }
+      }
+    } else {
+      struct in6_addr tmpbuf;
+      if (inet_pton(AF_INET6, drr.content.c_str(), &tmpbuf) != 1) {
+        cout<<"[Warning] Following record is not a valid IPv6 address: "<<drr.qname<<" IN " <<drr.qtype.toString()<< " '" << drr.content<<"'"<<endl;
+        numwarnings++;
+      }
+    }
+    return true;
+  }
+  catch(std::exception& e)
+  {
+    cout<<"[Error] Following record had a problem: \""<<drr.qname<<" IN "<<drr.qtype.toString()<<" "<<drr.content<<"\""<<endl;
+    cout<<"[Error] Error was: "<<e.what()<<endl;
+    numerrors++;
+    return false;
+  }
+}
+
 static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
 {
   int numerrors=0;
@@ -1227,58 +1292,10 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       aaaarecords.insert(rr.qname);
     }
     if(rr.qtype.getCode() == QType::SOA) {
-      vector<string>parts;
-      stringtok(parts, rr.content);
-
-      if(parts.size() < 7) {
-        cout << "[Info] SOA autocomplete is deprecated, missing field(s) in SOA content: " << rr.qname << " IN " << rr.qtype.toString() << " '" << rr.content << "'" << endl;
-      }
-
-      if(parts.size() >= 2) {
-        if(parts[1].find('@') != string::npos) {
-          cout<<"[Warning] Found @-sign in SOA RNAME, should probably be a dot (.): "<<rr.qname<<" IN " <<rr.qtype.toString()<< " '" << rr.content<<"'"<<endl;
-          numwarnings++;
-        }
-      }
-
-      ostringstream o;
-      o<<rr.content;
-      for(auto pleft=parts.size(); pleft < 7; ++pleft) {
-        o<<" 0";
-      }
-      rr.content=o.str();
+      numwarnings += normalizeSOARecord(rr);
     }
 
-    if(rr.qtype.getCode() == QType::TXT && !rr.content.empty() && rr.content[0]!='"')
-      rr.content = "\""+rr.content+"\"";
-
-    try {
-      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(rr.qtype.getCode(), QClass::IN, rr.content));
-      string tmp=drc->serialize(rr.qname);
-      tmp = drc->getZoneRepresentation(true);
-      if (rr.qtype.getCode() != QType::AAAA) {
-        if (!pdns_iequals(tmp, rr.content)) {
-          if(rr.qtype.getCode() == QType::SOA) {
-            tmp = drc->getZoneRepresentation(false);
-          }
-          if(!pdns_iequals(tmp, rr.content)) {
-            cout<<"[Warning] Parsed and original record content are not equal: "<<rr.qname<<" IN " <<rr.qtype.toString()<< " '" << rr.content<<"' (Content parsed as '"<<tmp<<"')"<<endl;
-            numwarnings++;
-          }
-        }
-      } else {
-        struct in6_addr tmpbuf;
-        if (inet_pton(AF_INET6, rr.content.c_str(), &tmpbuf) != 1) {
-          cout<<"[Warning] Following record is not a valid IPv6 address: "<<rr.qname<<" IN " <<rr.qtype.toString()<< " '" << rr.content<<"'"<<endl;
-          numwarnings++;
-        }
-      }
-    }
-    catch(std::exception& e)
-    {
-      cout<<"[Error] Following record had a problem: \""<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"\""<<endl;
-      cout<<"[Error] Error was: "<<e.what()<<endl;
-      numerrors++;
+    if (!checkRecordContents(numwarnings, numerrors, rr)) {
       continue;
     }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1420,24 +1420,6 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
     }
   }
 
-  Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
-  if (allowUnderscores) {
-    flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
-  }
-  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
-  Check::checkRRSet({}, records, zone, flags, errors);
-  for (const auto& error : errors) {
-    const auto [prio, rec, why] = error;
-    cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
-    if (prio == Logr::Error) {
-      numerrors++;
-    }
-    else {
-      numwarnings++;
-    }
-  }
-  errors.clear();
-
   for(const auto &name: cnames) {
     if (noncnames.find(name) != noncnames.end()) {
       cout<<"[Error] CNAME "<<name<<" found, but other records with same label exist."<<endl;
@@ -1460,6 +1442,24 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   arecords.clear();
   aaaarecords.clear();
   addresses.clear();
+
+  Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
+  if (allowUnderscores) {
+    flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
+  }
+  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
+  Check::checkRRSet({}, records, zone, flags, errors);
+  for (const auto& error : errors) {
+    const auto [prio, rec, why] = error;
+    cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
+    if (prio == Logr::Error) {
+      numerrors++;
+    }
+    else {
+      numwarnings++;
+    }
+  }
+  errors.clear();
 
   if(!hasNsAtApex) {
     cout<<"[Error] No NS record at zone apex in zone '"<<zone<<"'"<<endl;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -983,22 +983,22 @@ static int checkZoneTLSA(const set<DNSName>& tlsas, const set<DNSName>& cnames, 
 // Record name, prio, target name, ipv4hint=auto, ipv6hint=auto
 using svcbset_t = set<std::tuple<DNSName, uint16_t, DNSName, bool, bool>>;
 
-static void checkZoneSVCB(int& numwarnings, int& numerrors, const ZoneName& zone, const svcbset_t& svcbTargets, const set<DNSName>& svcbAliases, const set<DNSName>& svcbRecords, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
+static void checkZoneSVCB(int& numwarnings, int& numerrors, const std::string& type, const ZoneName& zone, const svcbset_t& targets, const set<DNSName>& aliases, const set<DNSName>& records, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
 {
-  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : svcbTargets) {
+  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : targets) {
     if (name == target) {
-      cout<<"[Error] SVCB record "<<name<<" has itself as target."<<endl;
+      cout<<"[Error] " << type << " record "<<name<<" has itself as target."<<endl;
       numerrors++;
     }
 
     if (prio == 0) {
       if (target.isPartOf(zone)) {
-        if (svcbAliases.find(target) != svcbAliases.end()) {
-          cout << "[Warning] SVCB record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
+        if (aliases.find(target) != aliases.end()) {
+          cout << "[Warning] " << type << " record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
           numwarnings++;
         }
-        if (addresses.find(target) == addresses.end() && svcbRecords.find(target) == svcbRecords.end()) {
-          cout<<"[Error] SVCB record "<<name<<" has a target "<<target<<" that has neither address nor SVCB records."<<endl;
+        if (addresses.find(target) == addresses.end() && records.find(target) == records.end()) {
+          cout<<"[Error] " << type << " record "<<name<<" has a target "<<target<<" that has neither address nor " << type << " records."<<endl;
           numerrors++;
         }
       }
@@ -1007,46 +1007,11 @@ static void checkZoneSVCB(int& numwarnings, int& numerrors, const ZoneName& zone
     const auto& trueTarget = target.isRoot() ? name : target;
     if (prio > 0) {
       if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
-        cout << "[warning] SVCB record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
+        cout << "[warning] " << type << " record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
         numwarnings++;
       }
       if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
-        cout << "[warning] SVCB record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-    }
-  }
-}
-
-static void checkZoneHTTPS(int& numwarnings, int& numerrors, const ZoneName& zone, const svcbset_t& httpsTargets, const set<DNSName>& httpsAliases, const set<DNSName>& httpsRecords, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
-{
-  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : httpsTargets) {
-    if (name == target) {
-      cout<<"[Error] HTTPS record "<<name<<" has itself as target."<<endl;
-      numerrors++;
-    }
-
-    if (prio == 0) {
-      if (target.isPartOf(zone)) {
-        if (httpsAliases.find(target) != httpsAliases.end()) {
-          cout << "[Warning] HTTPS record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
-          numwarnings++;
-        }
-        if (addresses.find(target) == addresses.end() && httpsRecords.find(target) == httpsRecords.end()) {
-          cout<<"[Error] HTTPS record "<<name<<" has a target "<<target<<" that has neither address nor HTTPS records."<<endl;
-          numerrors++;
-        }
-      }
-    }
-
-    const auto& trueTarget = target.isRoot() ? name : target;
-    if (prio > 0) {
-      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
-        cout << "[warning] HTTPS record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
-        cout << "[warning] HTTPS record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
+        cout << "[warning] " << type << " record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
         numwarnings++;
       }
     }
@@ -1483,11 +1448,11 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   numwarnings += checkZoneTLSA(tlsas, cnames, noncnames);
   tlsas.clear();
 
-  checkZoneSVCB(numwarnings, numerrors, zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
+  checkZoneSVCB(numwarnings, numerrors, "SVCB", zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
   svcbTargets.clear();
   svcbAliases.clear();
   svcbRecords.clear();
-  checkZoneHTTPS(numwarnings, numerrors, zone, httpsTargets, httpsAliases, httpsRecords, arecords, aaaarecords, addresses);
+  checkZoneSVCB(numwarnings, numerrors, "HTTPS", zone, httpsTargets, httpsAliases, httpsRecords, arecords, aaaarecords, addresses);
   httpsTargets.clear();
   httpsAliases.clear();
   httpsRecords.clear();

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1336,30 +1336,20 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
         }
       }
 
-      switch (rr.qtype.getCode()) {
-      case QType::SVCB:
-        if (svcbrc->getPriority() == 0) {
-          if (svcbAliases.find(rr.qname) != svcbAliases.end()) {
-            cout << "[Warning] More than one Alias form SVCB record for " << rr.qname << " exists." << endl;
-            numwarnings++;
-          }
-          svcbAliases.insert(rr.qname);
+      bool isSvcb = rr.qtype.getCode() == QType::SVCB;
+      set<DNSName>& aliases = isSvcb ? svcbAliases : httpsAliases;
+      svcbset_t& targets = isSvcb ? svcbTargets : httpsTargets;
+      set<DNSName>& ourrecords = isSvcb ? svcbRecords : httpsRecords;
+
+      if (svcbrc->getPriority() == 0) {
+        if (aliases.find(rr.qname) != aliases.end()) {
+          cout << "[Warning] More than one Alias form " << rr.qtype.toString()<< " " << rr.qname << " exists." << endl;
+          numwarnings++;
         }
-        svcbTargets.emplace(rr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
-        svcbRecords.insert(rr.qname);
-        break;
-      case QType::HTTPS:
-        if (svcbrc->getPriority() == 0) {
-          if (httpsAliases.find(rr.qname) != httpsAliases.end()) {
-            cout << "[Warning] More than one Alias form HTTPS record for " << rr.qname << " exists." << endl;
-            numwarnings++;
-          }
-          httpsAliases.insert(rr.qname);
-        }
-        httpsTargets.emplace(rr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
-        httpsRecords.insert(rr.qname);
-        break;
+        aliases.insert(rr.qname);
       }
+      targets.emplace(rr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
+      ourrecords.insert(rr.qname);
     }
 
     if (isSecure && isOptOut && (rr.qname.hasLabels() && rr.qname.getRawLabel(0) == "*")) {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1425,7 +1425,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
         numwarnings++;
       }
     }
-  }
+  } // end of complete records loop
 
   for(const auto &name: cnames) {
     if (noncnames.find(name) != noncnames.end()) {
@@ -1436,6 +1436,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
 
   numwarnings += checkZoneTLSA(tlsas, cnames, noncnames);
   tlsas.clear();
+  noncnames.clear();
 
   checkZoneSVCB(numwarnings, numerrors, "SVCB", zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
   svcbTargets.clear();
@@ -1479,6 +1480,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numwarnings++;
     }
   }
+  glue.clear();
+  checkglue.clear();
 
   for (const auto& qname : checkOcclusion) {
     for (const auto& drr : records) {
@@ -1546,7 +1549,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
         target = std::dynamic_pointer_cast<NSRecordContent>(drc)->getNS();
         break;
       default:
-        // programmer error, but let's not abort() :)
+        // can't happen due to the way checkCNAME is filled
         break;
     }
     if (target.isPartOf(zone) && cnames.count(target) != 0) {
@@ -1554,6 +1557,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numwarnings++;
     }
   }
+  checkCNAME.clear();
+  cnames.clear();
 
   bool ok, ds_ns, done;
   for( const auto &rr : records ) {
@@ -1590,6 +1595,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numerrors++;
     }
   }
+  checkOcclusion.clear();
 
   std::map<std::string, std::vector<std::string>> metadatas;
   if (B.getAllDomainMetadata(zone, metadatas)) {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1208,28 +1208,34 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   // We defer some of them to Check::checkRRSet(), but some of the checks can
   // only be performed on complete zone contents and are only done here.
 
+  bool allowUnderscores = areUnderscoresAllowed(zone, di);
   bool hasNsAtApex = false;
-  set<DNSName> tlsas;
+  size_t recordCount{0};
+  {
+  vector<DNSResourceRecord> records;
+  set<pair<DNSName, QType>> checkOcclusion;
+  {
+  vector<DNSResourceRecord> checkCNAME;
   set<DNSName> cnames;
-  set<DNSName> noncnames;
+  {
   set<DNSName> glue;
   set<DNSName> checkglue;
-  set<DNSName> addresses;
-  set<DNSName> svcbAliases;
-  set<DNSName> httpsAliases;
-  set<DNSName> svcbRecords;
-  set<DNSName> httpsRecords;
+  {
   set<DNSName> arecords;
   set<DNSName> aaaarecords;
-  vector<DNSResourceRecord> checkCNAME;
-  set<pair<DNSName, QType>> checkOcclusion;
-  svcbset_t svcbTargets;
+  set<DNSName> addresses;
+  {
+  set<DNSName> httpsAliases;
+  set<DNSName> httpsRecords;
   svcbset_t httpsTargets;
+  {
+  set<DNSName> svcbAliases;
+  set<DNSName> svcbRecords;
+  svcbset_t svcbTargets;
+  {
+  set<DNSName> tlsas;
+  set<DNSName> noncnames;
 
-  ostringstream content;
-  pair<map<string, unsigned int>::iterator,bool> ret;
-
-  vector<DNSResourceRecord> records;
   if(suppliedrecords == nullptr) {
     std::vector<std::pair<std::string, std::string>> invalid;
     DNSResourceRecord drr;
@@ -1266,8 +1272,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   else {
     records = *suppliedrecords;
   }
-
-  bool allowUnderscores = areUnderscoresAllowed(zone, di);
+  recordCount = records.size();
 
   for(auto &rr : records) { // We modify SOA and TXT record contents
     if(rr.qtype.getCode() == QType::TLSA)
@@ -1435,39 +1440,33 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   }
 
   numwarnings += checkZoneTLSA(tlsas, cnames, noncnames);
-  tlsas.clear();
-  noncnames.clear();
+  } // end of scope for tlsas and noncnames
 
   checkZoneSVCB(numwarnings, numerrors, "SVCB", zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
-  svcbTargets.clear();
-  svcbAliases.clear();
-  svcbRecords.clear();
+  } // end of scope for svcbTargets, svcbAliases and svcbRecords
   checkZoneSVCB(numwarnings, numerrors, "HTTPS", zone, httpsTargets, httpsAliases, httpsRecords, arecords, aaaarecords, addresses);
-  httpsTargets.clear();
-  httpsAliases.clear();
-  httpsRecords.clear();
+  } // end of scope for httpsTargets, httpsAliases and httpsRecords
 
-  arecords.clear();
-  aaaarecords.clear();
-  addresses.clear();
+  } // end of scope for arecords, aaaarecords and addresses
 
-  Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
-  if (allowUnderscores) {
-    flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
-  }
-  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
-  Check::checkRRSet({}, records, zone, flags, errors);
-  for (const auto& error : errors) {
-    const auto [prio, rec, why] = error;
-    cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
-    if (prio == Logr::Error) {
-      numerrors++;
+  {
+    Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
+    if (allowUnderscores) {
+      flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
     }
-    else {
-      numwarnings++;
+    std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
+    Check::checkRRSet({}, records, zone, flags, errors);
+    for (const auto& error : errors) {
+      const auto [prio, rec, why] = error;
+      cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
+      if (prio == Logr::Error) {
+        numerrors++;
+      }
+      else {
+        numwarnings++;
+      }
     }
   }
-  errors.clear();
 
   if(!hasNsAtApex) {
     cout<<"[Error] No NS record at zone apex in zone '"<<zone<<"'"<<endl;
@@ -1480,8 +1479,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numwarnings++;
     }
   }
-  glue.clear();
-  checkglue.clear();
+
+  } // end of scope for glue and checkglue
 
   for (const auto& qname : checkOcclusion) {
     for (const auto& drr : records) {
@@ -1557,8 +1556,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numwarnings++;
     }
   }
-  checkCNAME.clear();
-  cnames.clear();
+
+  } // end of scope for checkCNAME and cnames
 
   bool ok, ds_ns, done;
   for( const auto &rr : records ) {
@@ -1595,7 +1594,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numerrors++;
     }
   }
-  checkOcclusion.clear();
+
+  } // end of scope for records and checkOcclusion
 
   std::map<std::string, std::vector<std::string>> metadatas;
   if (B.getAllDomainMetadata(zone, metadatas)) {
@@ -1616,7 +1616,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
     }
   }
 
-  cout<<"Checked "<<records.size()<<" records of '"<<zone<<"', "<<numerrors<<" errors, "<<numwarnings<<" warnings."<<endl;
+  cout<<"Checked "<<recordCount<<" records of '"<<zone<<"', "<<numerrors<<" errors, "<<numwarnings<<" warnings."<<endl;
   return numerrors;
 }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -955,7 +955,7 @@ static bool areUnderscoresAllowed(const ZoneName& zonename, DomainInfo& info)
   return underscores == "0";
 }
 
-static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
+static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
 {
   int numerrors=0;
   int numwarnings=0;
@@ -978,6 +978,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
     return 1;
   }
 
+  // SOA record checks
   SOAData sd;
   try {
     if (!B.getSOAUncached(zone, sd)) {
@@ -1002,6 +1003,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
     }
   }
 
+  // NSEC3 parameters checks
   NSEC3PARAMRecordContent ns3pr;
   bool narrow = false;
   bool haveNSEC3 = dk.getNSEC3PARAM(zone, &ns3pr, &narrow);
@@ -1074,13 +1076,14 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
     }
   }
 
+  // Record checks.
+  // We defer some of them to Check::checkRRSet(), but some of the checks can
+  // only be performed on complete zone contents and are only done here.
 
   bool hasNsAtApex = false;
   set<DNSName> tlsas, cnames, noncnames, glue, checkglue, addresses, svcbAliases, httpsAliases, svcbRecords, httpsRecords, arecords, aaaarecords;
   vector<DNSResourceRecord> checkCNAME;
   set<pair<DNSName, QType> > checkOcclusion;
-  set<string> recordcontents;
-  map<string, unsigned int> ttl;
   // Record name, prio, target name, ipv4hint=auto, ipv6hint=auto
   set<std::tuple<DNSName, uint16_t, DNSName, bool, bool> > svcbTargets, httpsTargets;
 
@@ -1121,12 +1124,13 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       numwarnings++;
     }
   }
-  else
-    records=*suppliedrecords;
+  else {
+    records = *suppliedrecords;
+  }
 
   bool allowUnderscores = areUnderscoresAllowed(zone, di);
 
-  for(auto &rr : records) { // we modify this
+  for(auto &rr : records) { // We modify SOA and TXT record contents
     if(rr.qtype.getCode() == QType::TLSA)
       tlsas.insert(rr.qname);
     if(rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) {
@@ -1267,32 +1271,6 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       }
     }
 
-    content.str("");
-    content<<rr.qname<<" "<<rr.qtype.toString()<<" "<<rr.content;
-    string contentstr = content.str();
-    if (rr.qtype.getCode() != QType::TXT) {
-      contentstr=toLower(contentstr);
-    }
-    if (recordcontents.count(contentstr) != 0) {
-      cout<<"[Error] Duplicate record found in rrset: '"<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"'"<<endl;
-      numerrors++;
-      continue;
-    }
-    recordcontents.insert(std::move(contentstr));
-
-    content.str("");
-    content<<rr.qname<<" "<<rr.qtype.toString();
-    if (rr.qtype.getCode() == QType::RRSIG) {
-      RRSIGRecordContent rrc(rr.content);
-      content<<" ("<<DNSRecordContent::NumberToType(rrc.d_type)<<")";
-    }
-    ret = ttl.insert(pair<string, unsigned int>(toLower(content.str()), rr.ttl));
-    if (!ret.second && ret.first->second != rr.ttl) {
-      cout<<"[Error] TTL mismatch in rrset: '"<<rr.qname<<" IN " <<rr.qtype.toString()<<" "<<rr.content<<"' ("<<ret.first->second<<" != "<<rr.ttl<<")"<<endl;
-      numerrors++;
-      continue;
-    }
-
     if (isSecure && isOptOut && (rr.qname.hasLabels() && rr.qname.getRawLabel(0) == "*")) {
       cout<<"[Warning] wildcard record '"<<rr.qname<<" IN " <<rr.qtype.toString()<<" "<<rr.content<<"' is insecure"<<endl;
       cout<<"[Info] Wildcard records in opt-out zones are insecure. Disable the opt-out flag for this zone to avoid this warning. Command: 'pdnsutil zone set-nsec3 "<<zone<<"'"<<endl;
@@ -1303,21 +1281,10 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       // apex checks
       if (rr.qtype.getCode() == QType::NS) {
         hasNsAtApex=true;
-      } else if (rr.qtype.getCode() == QType::DS) {
-        cout<<"[Warning] DS at apex in zone '"<<zone<<"', should not be here."<<endl;
-        numwarnings++;
       }
     } else {
       // non-apex checks
-      if (rr.qtype.getCode() == QType::SOA) {
-        cout<<"[Error] SOA record not at apex '"<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"' in zone '"<<zone<<"'"<<endl;
-        numerrors++;
-        continue;
-      }
-      if (rr.qtype.getCode() == QType::DNSKEY) {
-        cout<<"[Warning] DNSKEY record not at apex '"<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"' in zone '"<<zone<<"', should not be here."<<endl;
-        numwarnings++;
-      } else if (rr.qtype.getCode() == QType::NS) {
+      if (rr.qtype.getCode() == QType::NS) {
         if (DNSName(rr.content).isPartOf(rr.qname)) {
           checkglue.insert(DNSName(toLower(rr.content)));
         }
@@ -1335,22 +1302,9 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
     if((rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) && !rr.qname.isWildcard() && !rr.qname.isHostname())
       cout<<"[Info] "<<rr.qname.toString()<<" record for '"<<rr.qtype.toString()<<"' is not a valid hostname."<<endl;
 
-    // Check if the DNSNames that should be hostnames, are hostnames
-    try {
-      checkHostnameCorrectness(rr, allowUnderscores);
-    } catch (const std::exception& e) {
-      cout << "[Warning] " << rr.qtype.toString() << " record in zone '" << zone << ": " << e.what() << endl;
-      numwarnings++;
-    }
-
     if (rr.qtype.getCode() == QType::CNAME) {
       if (cnames.count(rr.qname) == 0) {
         cnames.insert(rr.qname);
-      }
-      else {
-        cout<<"[Error] Duplicate CNAME found at '"<<rr.qname<<"'"<<endl;
-        numerrors++;
-        continue;
       }
     } else {
       if (rr.qtype.getCode() == QType::RRSIG) {
@@ -1391,6 +1345,24 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       }
     }
   }
+
+  Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
+  if (allowUnderscores) {
+    flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
+  }
+  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
+  Check::checkRRSet({}, records, zone, flags, errors);
+  for (const auto& error : errors) {
+    const auto [prio, rec, why] = error;
+    cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
+    if (prio == Logr::Error) {
+      numerrors++;
+    }
+    else {
+      numwarnings++;
+    }
+  }
+  errors.clear();
 
   for(const auto &name: cnames) {
     if (noncnames.find(name) != noncnames.end()) {
@@ -1646,7 +1618,7 @@ static int checkAllZones(DNSSECKeeper &dk, bool exitOnError)
   B.getAllDomains(&domainInfo, true, true);
   int errors=0;
   for (auto& di : domainInfo) {
-    if (checkZone(dk, B, di.zone) > 0) {
+    if (checkZoneRecords(dk, B, di.zone) > 0) {
       errors++;
     }
 
@@ -2423,7 +2395,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
           drr.domain_id = info.id;
           checkrr.push_back(std::move(drr));
         }
-        if(checkZone(dsk, B, zone, &checkrr) != 0) {
+        if(checkZoneRecords(dsk, B, zone, &checkrr) != 0) {
           state = INVALIDZONE;
           break;
         }
@@ -4034,7 +4006,7 @@ static int checkZone(vector<string>& cmds, const std::string_view synopsis)
   }
   DNSSECKeeper dk(nullptr /* no structured logging */); //NOLINT(readability-identifier-length)
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
-  return checkZone(dk, B, ZoneName(cmds.at(0)));
+  return checkZoneRecords(dk, B, ZoneName(cmds.at(0)));
 }
 
 static int benchDb(vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <string>
 #include <termios.h>            //termios, TCSANOW, ECHO, ICANON
+#include <tuple>
 #include <utility>
 #include <sys/stat.h>
 #include <sys/wait.h>
@@ -2904,17 +2905,17 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds)
     newrrs.insert(newrrs.end(), oldrrs.begin(), oldrrs.end());
   }
 
-  std::vector<std::pair<DNSResourceRecord, string>> errors;
+  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, string>> diagnostics;
   Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
   if (allowUnderscores) {
     flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
   }
-  Check::checkRRSet(oldrrs, newrrs, zone, flags, errors);
+  Check::checkRRSet(oldrrs, newrrs, zone, flags, diagnostics);
   oldrrs.clear(); // no longer needed
-  if (!errors.empty()) {
-    for (const auto& error : errors) {
-      const auto [rec, why] = error;
-      cerr << "RRset " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
+  if (!diagnostics.empty()) {
+    for (const auto& error : diagnostics) {
+      const auto [prio, rec, why] = error;
+      cerr << Logr::Logger::toString(prio) << ": RRset " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
     }
     return EXIT_FAILURE;
   }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1212,28 +1212,34 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   // We defer some of them to Check::checkRRSet(), but some of the checks can
   // only be performed on complete zone contents and are only done here.
 
+  bool allowUnderscores = areUnderscoresAllowed(zone, di);
   bool hasNsAtApex = false;
-  set<DNSName> tlsas;
+  size_t recordCount{0};
+  {
+  vector<DNSResourceRecord> records;
+  set<pair<DNSName, QType>> checkOcclusion;
+  {
+  vector<DNSResourceRecord> checkCNAME;
   set<DNSName> cnames;
-  set<DNSName> noncnames;
+  {
   set<DNSName> glue;
   set<DNSName> checkglue;
-  set<DNSName> addresses;
-  set<DNSName> svcbAliases;
-  set<DNSName> httpsAliases;
-  set<DNSName> svcbRecords;
-  set<DNSName> httpsRecords;
+  {
   set<DNSName> arecords;
   set<DNSName> aaaarecords;
-  vector<DNSResourceRecord> checkCNAME;
-  set<pair<DNSName, QType>> checkOcclusion;
-  svcbset_t svcbTargets;
+  set<DNSName> addresses;
+  {
+  set<DNSName> httpsAliases;
+  set<DNSName> httpsRecords;
   svcbset_t httpsTargets;
+  {
+  set<DNSName> svcbAliases;
+  set<DNSName> svcbRecords;
+  svcbset_t svcbTargets;
+  {
+  set<DNSName> tlsas;
+  set<DNSName> noncnames;
 
-  ostringstream content;
-  pair<map<string, unsigned int>::iterator,bool> ret;
-
-  vector<DNSResourceRecord> records;
   if(suppliedrecords == nullptr) {
     std::vector<std::pair<std::string, std::string>> invalid;
     DNSResourceRecord drr;
@@ -1270,8 +1276,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   else {
     records = *suppliedrecords;
   }
-
-  bool allowUnderscores = areUnderscoresAllowed(zone, di);
+  recordCount = records.size();
 
   for(auto &rr : records) { // We modify SOA and TXT record contents
     if(rr.qtype.getCode() == QType::TLSA)
@@ -1439,39 +1444,33 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   }
 
   numwarnings += checkZoneTLSA(tlsas, cnames, noncnames);
-  tlsas.clear();
-  noncnames.clear();
+  } // end of scope for tlsas and noncnames
 
   checkZoneSVCB(numwarnings, numerrors, "SVCB", zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
-  svcbTargets.clear();
-  svcbAliases.clear();
-  svcbRecords.clear();
+  } // end of scope for svcbTargets, svcbAliases and svcbRecords
   checkZoneSVCB(numwarnings, numerrors, "HTTPS", zone, httpsTargets, httpsAliases, httpsRecords, arecords, aaaarecords, addresses);
-  httpsTargets.clear();
-  httpsAliases.clear();
-  httpsRecords.clear();
+  } // end of scope for httpsTargets, httpsAliases and httpsRecords
 
-  arecords.clear();
-  aaaarecords.clear();
-  addresses.clear();
+  } // end of scope for arecords, aaaarecords and addresses
 
-  Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
-  if (allowUnderscores) {
-    flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
-  }
-  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
-  Check::checkRRSet({}, records, zone, flags, errors);
-  for (const auto& error : errors) {
-    const auto [prio, rec, why] = error;
-    cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
-    if (prio == Logr::Error) {
-      numerrors++;
+  {
+    Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
+    if (allowUnderscores) {
+      flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
     }
-    else {
-      numwarnings++;
+    std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
+    Check::checkRRSet({}, records, zone, flags, errors);
+    for (const auto& error : errors) {
+      const auto [prio, rec, why] = error;
+      cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
+      if (prio == Logr::Error) {
+        numerrors++;
+      }
+      else {
+        numwarnings++;
+      }
     }
   }
-  errors.clear();
 
   if(!hasNsAtApex) {
     cout<<"[Error] No NS record at zone apex in zone '"<<zone<<"'"<<endl;
@@ -1484,8 +1483,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numwarnings++;
     }
   }
-  glue.clear();
-  checkglue.clear();
+
+  } // end of scope for glue and checkglue
 
   for (const auto& qname : checkOcclusion) {
     for (const auto& drr : records) {
@@ -1561,8 +1560,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numwarnings++;
     }
   }
-  checkCNAME.clear();
-  cnames.clear();
+
+  } // end of scope for checkCNAME and cnames
 
   bool ok, ds_ns, done;
   for( const auto &rr : records ) {
@@ -1599,7 +1598,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numerrors++;
     }
   }
-  checkOcclusion.clear();
+
+  } // end of scope for records and checkOcclusion
 
   std::map<std::string, std::vector<std::string>> metadatas;
   if (B.getAllDomainMetadata(zone, metadatas)) {
@@ -1620,7 +1620,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
     }
   }
 
-  cout<<"Checked "<<records.size()<<" records of '"<<zone<<"', "<<numerrors<<" errors, "<<numwarnings<<" warnings."<<endl;
+  cout<<"Checked "<<recordCount<<" records of '"<<zone<<"', "<<numerrors<<" errors, "<<numwarnings<<" warnings."<<endl;
   return numerrors;
 }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -959,6 +959,104 @@ static bool areUnderscoresAllowed(const ZoneName& zonename, DomainInfo& info)
   return underscores == "0";
 }
 
+static int checkZoneTLSA(const set<DNSName>& tlsas, const set<DNSName>& cnames, const set<DNSName>& noncnames)
+{
+  int numwarnings{0};
+  for(const auto &i: tlsas) {
+    DNSName name = DNSName(i);
+    name.trimToLabels(name.countLabels()-2);
+    if (cnames.find(name) == cnames.end() && noncnames.find(name) == noncnames.end()) {
+      // No specific record for the name in the TLSA record exists, this
+      // is already worth emitting a warning. Let's see if a wildcard exist.
+      cout<<"[Warning] ";
+      DNSName wcname(name);
+      wcname.chopOff();
+      wcname.prependRawLabel("*");
+      if (cnames.find(wcname) != cnames.end() || noncnames.find(wcname) != noncnames.end()) {
+        cout<<"A wildcard record exist for '"<<wcname<<"' and a TLSA record for '"<<i<<"'.";
+      } else {
+        cout<<"No record for '"<<name<<"' exists, but a TLSA record for '"<<i<<"' does.";
+      }
+      numwarnings++;
+      cout<<" A query for '"<<name<<"' will yield an empty response. This is most likely a mistake, please create records for '"<<name<<"'."<<endl;
+    }
+  }
+  return numwarnings;
+}
+
+// Record name, prio, target name, ipv4hint=auto, ipv6hint=auto
+using svcbset_t = set<std::tuple<DNSName, uint16_t, DNSName, bool, bool>>;
+
+static void checkZoneSVCB(int& numwarnings, int& numerrors, const ZoneName& zone, const svcbset_t& svcbTargets, const set<DNSName>& svcbAliases, const set<DNSName>& svcbRecords, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
+{
+  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : svcbTargets) {
+    if (name == target) {
+      cout<<"[Error] SVCB record "<<name<<" has itself as target."<<endl;
+      numerrors++;
+    }
+
+    if (prio == 0) {
+      if (target.isPartOf(zone)) {
+        if (svcbAliases.find(target) != svcbAliases.end()) {
+          cout << "[Warning] SVCB record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
+          numwarnings++;
+        }
+        if (addresses.find(target) == addresses.end() && svcbRecords.find(target) == svcbRecords.end()) {
+          cout<<"[Error] SVCB record "<<name<<" has a target "<<target<<" that has neither address nor SVCB records."<<endl;
+          numerrors++;
+        }
+      }
+    }
+
+    const auto& trueTarget = target.isRoot() ? name : target;
+    if (prio > 0) {
+      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
+        cout << "[warning] SVCB record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
+        numwarnings++;
+      }
+      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
+        cout << "[warning] SVCB record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
+        numwarnings++;
+      }
+    }
+  }
+}
+
+static void checkZoneHTTPS(int& numwarnings, int& numerrors, const ZoneName& zone, const svcbset_t& httpsTargets, const set<DNSName>& httpsAliases, const set<DNSName>& httpsRecords, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
+{
+  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : httpsTargets) {
+    if (name == target) {
+      cout<<"[Error] HTTPS record "<<name<<" has itself as target."<<endl;
+      numerrors++;
+    }
+
+    if (prio == 0) {
+      if (target.isPartOf(zone)) {
+        if (httpsAliases.find(target) != httpsAliases.end()) {
+          cout << "[Warning] HTTPS record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
+          numwarnings++;
+        }
+        if (addresses.find(target) == addresses.end() && httpsRecords.find(target) == httpsRecords.end()) {
+          cout<<"[Error] HTTPS record "<<name<<" has a target "<<target<<" that has neither address nor HTTPS records."<<endl;
+          numerrors++;
+        }
+      }
+    }
+
+    const auto& trueTarget = target.isRoot() ? name : target;
+    if (prio > 0) {
+      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
+        cout << "[warning] HTTPS record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
+        numwarnings++;
+      }
+      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
+        cout << "[warning] HTTPS record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
+        numwarnings++;
+      }
+    }
+  }
+}
+
 static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
 {
   int numerrors=0;
@@ -1085,11 +1183,22 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   // only be performed on complete zone contents and are only done here.
 
   bool hasNsAtApex = false;
-  set<DNSName> tlsas, cnames, noncnames, glue, checkglue, addresses, svcbAliases, httpsAliases, svcbRecords, httpsRecords, arecords, aaaarecords;
+  set<DNSName> tlsas;
+  set<DNSName> cnames;
+  set<DNSName> noncnames;
+  set<DNSName> glue;
+  set<DNSName> checkglue;
+  set<DNSName> addresses;
+  set<DNSName> svcbAliases;
+  set<DNSName> httpsAliases;
+  set<DNSName> svcbRecords;
+  set<DNSName> httpsRecords;
+  set<DNSName> arecords;
+  set<DNSName> aaaarecords;
   vector<DNSResourceRecord> checkCNAME;
-  set<pair<DNSName, QType> > checkOcclusion;
-  // Record name, prio, target name, ipv4hint=auto, ipv6hint=auto
-  set<std::tuple<DNSName, uint16_t, DNSName, bool, bool> > svcbTargets, httpsTargets;
+  set<pair<DNSName, QType>> checkOcclusion;
+  svcbset_t svcbTargets;
+  svcbset_t httpsTargets;
 
   ostringstream content;
   pair<map<string, unsigned int>::iterator,bool> ret;
@@ -1375,89 +1484,21 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
     }
   }
 
-  for(const auto &i: tlsas) {
-    DNSName name = DNSName(i);
-    name.trimToLabels(name.countLabels()-2);
-    if (cnames.find(name) == cnames.end() && noncnames.find(name) == noncnames.end()) {
-      // No specific record for the name in the TLSA record exists, this
-      // is already worth emitting a warning. Let's see if a wildcard exist.
-      cout<<"[Warning] ";
-      DNSName wcname(name);
-      wcname.chopOff();
-      wcname.prependRawLabel("*");
-      if (cnames.find(wcname) != cnames.end() || noncnames.find(wcname) != noncnames.end()) {
-        cout<<"A wildcard record exist for '"<<wcname<<"' and a TLSA record for '"<<i<<"'.";
-      } else {
-        cout<<"No record for '"<<name<<"' exists, but a TLSA record for '"<<i<<"' does.";
-      }
-      numwarnings++;
-      cout<<" A query for '"<<name<<"' will yield an empty response. This is most likely a mistake, please create records for '"<<name<<"'."<<endl;
-    }
-  }
+  numwarnings += checkZoneTLSA(tlsas, cnames, noncnames);
+  tlsas.clear();
 
-  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : svcbTargets) {
-    if (name == target) {
-      cout<<"[Error] SVCB record "<<name<<" has itself as target."<<endl;
-      numerrors++;
-    }
+  checkZoneSVCB(numwarnings, numerrors, zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
+  svcbTargets.clear();
+  svcbAliases.clear();
+  svcbRecords.clear();
+  checkZoneHTTPS(numwarnings, numerrors, zone, httpsTargets, httpsAliases, httpsRecords, arecords, aaaarecords, addresses);
+  httpsTargets.clear();
+  httpsAliases.clear();
+  httpsRecords.clear();
 
-    if (prio == 0) {
-      if (target.isPartOf(zone)) {
-        if (svcbAliases.find(target) != svcbAliases.end()) {
-          cout << "[Warning] SVCB record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
-          numwarnings++;
-        }
-        if (addresses.find(target) == addresses.end() && svcbRecords.find(target) == svcbRecords.end()) {
-          cout<<"[Error] SVCB record "<<name<<" has a target "<<target<<" that has neither address nor SVCB records."<<endl;
-          numerrors++;
-        }
-      }
-    }
-
-    const auto& trueTarget = target.isRoot() ? name : target;
-    if (prio > 0) {
-      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
-        cout << "[warning] SVCB record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
-        cout << "[warning] SVCB record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-    }
-  }
-
-  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : httpsTargets) {
-    if (name == target) {
-      cout<<"[Error] HTTPS record "<<name<<" has itself as target."<<endl;
-      numerrors++;
-    }
-
-    if (prio == 0) {
-      if (target.isPartOf(zone)) {
-        if (httpsAliases.find(target) != httpsAliases.end()) {
-          cout << "[Warning] HTTPS record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
-          numwarnings++;
-        }
-        if (addresses.find(target) == addresses.end() && httpsRecords.find(target) == httpsRecords.end()) {
-          cout<<"[Error] HTTPS record "<<name<<" has a target "<<target<<" that has neither address nor HTTPS records."<<endl;
-          numerrors++;
-        }
-      }
-    }
-
-    const auto& trueTarget = target.isRoot() ? name : target;
-    if (prio > 0) {
-      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
-        cout << "[warning] HTTPS record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
-        cout << "[warning] HTTPS record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-    }
-  }
+  arecords.clear();
+  aaaarecords.clear();
+  addresses.clear();
 
   if(!hasNsAtApex) {
     cout<<"[Error] No NS record at zone apex in zone '"<<zone<<"'"<<endl;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1424,24 +1424,6 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
     }
   }
 
-  Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
-  if (allowUnderscores) {
-    flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
-  }
-  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
-  Check::checkRRSet({}, records, zone, flags, errors);
-  for (const auto& error : errors) {
-    const auto [prio, rec, why] = error;
-    cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
-    if (prio == Logr::Error) {
-      numerrors++;
-    }
-    else {
-      numwarnings++;
-    }
-  }
-  errors.clear();
-
   for(const auto &name: cnames) {
     if (noncnames.find(name) != noncnames.end()) {
       cout<<"[Error] CNAME "<<name<<" found, but other records with same label exist."<<endl;
@@ -1464,6 +1446,24 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   arecords.clear();
   aaaarecords.clear();
   addresses.clear();
+
+  Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
+  if (allowUnderscores) {
+    flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
+  }
+  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
+  Check::checkRRSet({}, records, zone, flags, errors);
+  for (const auto& error : errors) {
+    const auto [prio, rec, why] = error;
+    cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
+    if (prio == Logr::Error) {
+      numerrors++;
+    }
+    else {
+      numwarnings++;
+    }
+  }
+  errors.clear();
 
   if(!hasNsAtApex) {
     cout<<"[Error] No NS record at zone apex in zone '"<<zone<<"'"<<endl;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -962,8 +962,8 @@ static bool areUnderscoresAllowed(const ZoneName& zonename, DomainInfo& info)
 static int checkZoneTLSA(const set<DNSName>& tlsas, const set<DNSName>& cnames, const set<DNSName>& noncnames)
 {
   int numwarnings{0};
-  for(const auto &i: tlsas) {
-    DNSName name = DNSName(i);
+  for(const auto& origname: tlsas) {
+    auto name = origname;
     name.trimToLabels(name.countLabels()-2);
     if (cnames.find(name) == cnames.end() && noncnames.find(name) == noncnames.end()) {
       // No specific record for the name in the TLSA record exists, this
@@ -973,9 +973,9 @@ static int checkZoneTLSA(const set<DNSName>& tlsas, const set<DNSName>& cnames, 
       wcname.chopOff();
       wcname.prependRawLabel("*");
       if (cnames.find(wcname) != cnames.end() || noncnames.find(wcname) != noncnames.end()) {
-        cout<<"A wildcard record exist for '"<<wcname<<"' and a TLSA record for '"<<i<<"'.";
+        cout<<"A wildcard record exist for '"<<wcname<<"' and a TLSA record for '"<<origname<<"'.";
       } else {
-        cout<<"No record for '"<<name<<"' exists, but a TLSA record for '"<<i<<"' does.";
+        cout<<"No record for '"<<name<<"' exists, but a TLSA record for '"<<origname<<"' does.";
       }
       numwarnings++;
       cout<<" A query for '"<<name<<"' will yield an empty response. This is most likely a mistake, please create records for '"<<name<<"'."<<endl;
@@ -1070,7 +1070,7 @@ static bool checkRecordContents(int& numwarnings, int& numerrors, DNSResourceRec
         }
       }
     } else {
-      struct in6_addr tmpbuf;
+      struct in6_addr tmpbuf{};
       if (inet_pton(AF_INET6, drr.content.c_str(), &tmpbuf) != 1) {
         cout<<"[Warning] Following record is not a valid IPv6 address: "<<drr.qname<<" IN " <<drr.qtype.toString()<< " '" << drr.content<<"'"<<endl;
         numwarnings++;
@@ -1278,48 +1278,49 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   }
   recordCount = records.size();
 
-  for(auto &rr : records) { // We modify SOA and TXT record contents
-    if(rr.qtype.getCode() == QType::TLSA)
-      tlsas.insert(rr.qname);
-    if(rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) {
-      addresses.insert(rr.qname);
+  for(auto &drr : records) { // We modify SOA and TXT record contents
+    if(drr.qtype.getCode() == QType::TLSA) {
+      tlsas.insert(drr.qname);
+    }
+    if(drr.qtype.getCode() == QType::A || drr.qtype.getCode() == QType::AAAA) {
+      addresses.insert(drr.qname);
     }
 #ifdef HAVE_LUA_RECORDS
-    if(rr.qtype.getCode() == QType::LUA) {
-      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(rr.qtype.getCode(), QClass::IN, rr.content));
+    if(drr.qtype.getCode() == QType::LUA) {
+      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(drr.qtype.getCode(), QClass::IN, drr.content));
       auto luarec = std::dynamic_pointer_cast<LUARecordContent>(drc);
       QType qtype = luarec->d_type;
       if(qtype == QType::A || qtype == QType::AAAA) {
-        addresses.insert(rr.qname);
+        addresses.insert(drr.qname);
       }
     }
 #endif
-    if(rr.qtype.getCode() == QType::A) {
-      arecords.insert(rr.qname);
+    if(drr.qtype.getCode() == QType::A) {
+      arecords.insert(drr.qname);
     }
-    if(rr.qtype.getCode() == QType::AAAA) {
-      aaaarecords.insert(rr.qname);
+    if(drr.qtype.getCode() == QType::AAAA) {
+      aaaarecords.insert(drr.qname);
     }
-    if(rr.qtype.getCode() == QType::SOA) {
-      numwarnings += normalizeSOARecord(rr);
+    if(drr.qtype.getCode() == QType::SOA) {
+      numwarnings += normalizeSOARecord(drr);
     }
 
-    if (!checkRecordContents(numwarnings, numerrors, rr)) {
+    if (!checkRecordContents(numwarnings, numerrors, drr)) {
       continue;
     }
 
-    if(!rr.qname.isPartOf(zone)) {
-      cout<<"[Error] Record '"<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"' in zone '"<<zone<<"' is out-of-zone."<<endl;
+    if(!drr.qname.isPartOf(zone)) {
+      cout<<"[Error] Record '"<<drr.qname<<" IN "<<drr.qtype.toString()<<" "<<drr.content<<"' in zone '"<<zone<<"' is out-of-zone."<<endl;
       numerrors++;
       continue;
     }
 
-    if (rr.qtype.getCode() == QType::SVCB || rr.qtype.getCode() == QType::HTTPS) {
-      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(rr.qtype.getCode(), QClass::IN, rr.content));
+    if (drr.qtype.getCode() == QType::SVCB || drr.qtype.getCode() == QType::HTTPS) {
+      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(drr.qtype.getCode(), QClass::IN, drr.content));
       // I, too, like to live dangerously
       auto svcbrc = std::dynamic_pointer_cast<SVCBBaseRecordContent>(drc);
       if (svcbrc->getPriority() == 0 && svcbrc->hasParams()) {
-        cout<<"[Warning] Aliasform "<<rr.qtype.toString()<<" record "<<rr.qname<<" has service parameters."<<endl;
+        cout<<"[Warning] Aliasform "<<drr.qtype.toString()<<" record "<<drr.qname<<" has service parameters."<<endl;
         numwarnings++;
       }
 
@@ -1331,106 +1332,107 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
            *  also be specified in order for the RR to be "self-consistent
            *  (Section 2.4.3).
            */
-          cout<<"[Warning] "<<rr.qname<<"|"<<rr.qtype.toString()<<" is not self-consistent: 'no-default-alpn' parameter without 'alpn' parameter"<<endl;
+          cout<<"[Warning] "<<drr.qname<<"|"<<drr.qtype.toString()<<" is not self-consistent: 'no-default-alpn' parameter without 'alpn' parameter"<<endl;
           numwarnings++;
         }
         if (svcbrc->hasParam(SvcParam::mandatory)) {
           auto keys = svcbrc->getParam(SvcParam::mandatory).getMandatory();
           for (auto const &k: keys) {
             if (!svcbrc->hasParam(k)) {
-              cout<<"[Warning] "<<rr.qname<<"|"<<rr.qtype.toString()<<" is not self-consistent: 'mandatory' parameter lists '"+ SvcParam::keyToString(k) +"', but that parameter does not exist"<<endl;
+              cout<<"[Warning] "<<drr.qname<<"|"<<drr.qtype.toString()<<" is not self-consistent: 'mandatory' parameter lists '"+ SvcParam::keyToString(k) +"', but that parameter does not exist"<<endl;
               numwarnings++;
             }
           }
         }
       }
 
-      bool isSvcb = rr.qtype.getCode() == QType::SVCB;
+      bool isSvcb = drr.qtype.getCode() == QType::SVCB;
       set<DNSName>& aliases = isSvcb ? svcbAliases : httpsAliases;
       svcbset_t& targets = isSvcb ? svcbTargets : httpsTargets;
       set<DNSName>& ourrecords = isSvcb ? svcbRecords : httpsRecords;
 
       if (svcbrc->getPriority() == 0) {
-        if (aliases.find(rr.qname) != aliases.end()) {
-          cout << "[Warning] More than one Alias form " << rr.qtype.toString()<< " " << rr.qname << " exists." << endl;
+        if (aliases.find(drr.qname) != aliases.end()) {
+          cout << "[Warning] More than one Alias form " << drr.qtype.toString()<< " " << drr.qname << " exists." << endl;
           numwarnings++;
         }
-        aliases.insert(rr.qname);
+        aliases.insert(drr.qname);
       }
-      targets.emplace(rr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
-      ourrecords.insert(rr.qname);
+      targets.emplace(drr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
+      ourrecords.insert(drr.qname);
     }
 
-    if (isSecure && isOptOut && (rr.qname.hasLabels() && rr.qname.getRawLabel(0) == "*")) {
-      cout<<"[Warning] wildcard record '"<<rr.qname<<" IN " <<rr.qtype.toString()<<" "<<rr.content<<"' is insecure"<<endl;
+    if (isSecure && isOptOut && (drr.qname.hasLabels() && drr.qname.getRawLabel(0) == "*")) {
+      cout<<"[Warning] wildcard record '"<<drr.qname<<" IN " <<drr.qtype.toString()<<" "<<drr.content<<"' is insecure"<<endl;
       cout<<"[Info] Wildcard records in opt-out zones are insecure. Disable the opt-out flag for this zone to avoid this warning. Command: 'pdnsutil zone set-nsec3 "<<zone<<"'"<<endl;
       numwarnings++;
     }
 
-    if(rr.qname==zone.operator const DNSName&()) {
+    if(drr.qname==zone.operator const DNSName&()) {
       // apex checks
-      if (rr.qtype.getCode() == QType::NS) {
+      if (drr.qtype.getCode() == QType::NS) {
         hasNsAtApex=true;
       }
     } else {
       // non-apex checks
-      if (rr.qtype.getCode() == QType::NS) {
-        if (DNSName(rr.content).isPartOf(rr.qname)) {
-          checkglue.insert(DNSName(toLower(rr.content)));
+      if (drr.qtype.getCode() == QType::NS) {
+        if (DNSName(drr.content).isPartOf(drr.qname)) {
+          checkglue.insert(DNSName(toLower(drr.content)));
         }
-        checkOcclusion.insert({rr.qname, rr.qtype});
-      } else if (rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) {
-        glue.insert(rr.qname);
+        checkOcclusion.insert({drr.qname, drr.qtype});
+      } else if (drr.qtype.getCode() == QType::A || drr.qtype.getCode() == QType::AAAA) {
+        glue.insert(drr.qname);
       }
     }
 
     // DNAMEs can occur both at the apex and below it
-    if (rr.qtype == QType::DNAME) {
-      checkOcclusion.insert({rr.qname, rr.qtype});
+    if (drr.qtype == QType::DNAME) {
+      checkOcclusion.insert({drr.qname, drr.qtype});
     }
 
-    if((rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) && !rr.qname.isWildcard() && !rr.qname.isHostname())
-      cout<<"[Info] "<<rr.qname.toString()<<" record for '"<<rr.qtype.toString()<<"' is not a valid hostname."<<endl;
+    if((drr.qtype.getCode() == QType::A || drr.qtype.getCode() == QType::AAAA) && !drr.qname.isWildcard() && !drr.qname.isHostname()) {
+      cout<<"[Info] "<<drr.qname.toString()<<" record for '"<<drr.qtype.toString()<<"' is not a valid hostname."<<endl;
+    }
 
-    if (rr.qtype.getCode() == QType::CNAME) {
-      if (cnames.count(rr.qname) == 0) {
-        cnames.insert(rr.qname);
+    if (drr.qtype.getCode() == QType::CNAME) {
+      if (cnames.count(drr.qname) == 0) {
+        cnames.insert(drr.qname);
       }
     } else {
-      if (rr.qtype.getCode() == QType::RRSIG) {
+      if (drr.qtype.getCode() == QType::RRSIG) {
         if(!presigned) {
-          cout<<"[Error] RRSIG found at '"<<rr.qname<<"' in non-presigned zone. These do not belong in the database."<<endl;
+          cout<<"[Error] RRSIG found at '"<<drr.qname<<"' in non-presigned zone. These do not belong in the database."<<endl;
           numerrors++;
           continue;
         }
       } else
-        noncnames.insert(rr.qname);
+        noncnames.insert(drr.qname);
     }
 
-    if (rr.qtype == QType::MX || rr.qtype == QType::NS || rr.qtype == QType::SRV) {
-      checkCNAME.push_back(rr);
+    if (drr.qtype == QType::MX || drr.qtype == QType::NS || drr.qtype == QType::SRV) {
+      checkCNAME.push_back(drr);
     }
 
-    if(rr.qtype.getCode() == QType::NSEC || rr.qtype.getCode() == QType::NSEC3)
+    if(drr.qtype.getCode() == QType::NSEC || drr.qtype.getCode() == QType::NSEC3)
     {
-      cout<<"[Error] NSEC or NSEC3 found at '"<<rr.qname<<"'. These do not belong in the database."<<endl;
+      cout<<"[Error] NSEC or NSEC3 found at '"<<drr.qname<<"'. These do not belong in the database."<<endl;
       numerrors++;
       continue;
     }
 
-    if(!presigned && rr.qtype.getCode() == QType::DNSKEY)
+    if(!presigned && drr.qtype.getCode() == QType::DNSKEY)
     {
       if(::arg().mustDo("direct-dnskey"))
       {
-        if(rr.ttl != sd.minimum)
+        if(drr.ttl != sd.minimum)
         {
-          cout<<"[Warning] DNSKEY TTL of "<<rr.ttl<<" at '"<<rr.qname<<"' differs from SOA minimum of "<<sd.minimum<<endl;
+          cout<<"[Warning] DNSKEY TTL of "<<drr.ttl<<" at '"<<drr.qname<<"' differs from SOA minimum of "<<sd.minimum<<endl;
           numwarnings++;
         }
       }
       else
       {
-        cout<<"[Warning] DNSKEY at '"<<rr.qname<<"' in non-presigned zone will mostly be ignored and can cause problems."<<endl;
+        cout<<"[Warning] DNSKEY at '"<<drr.qname<<"' in non-presigned zone will mostly be ignored and can cause problems."<<endl;
         numwarnings++;
       }
     }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1022,6 +1022,71 @@ static void checkZoneSVCB(int& numwarnings, int& numerrors, const std::string& t
   }
 }
 
+static int normalizeSOARecord(DNSResourceRecord& drr)
+{
+  int numwarnings{0};
+  vector<string> parts;
+  stringtok(parts, drr.content);
+
+  if(parts.size() < 7) {
+    cout << "[Info] SOA autocomplete is deprecated, missing field(s) in SOA content: " << drr.qname << " IN " << drr.qtype.toString() << " '" << drr.content << "'" << endl;
+  }
+
+  if(parts.size() >= 2) {
+    if(parts[1].find('@') != string::npos) {
+      cout<<"[Warning] Found @-sign in SOA RNAME, should probably be a dot (.): "<<drr.qname<<" IN " <<drr.qtype.toString()<< " '" << drr.content<<"'"<<endl;
+      numwarnings++;
+    }
+  }
+
+  ostringstream ostr;
+  ostr<<drr.content;
+  for(auto pleft=parts.size(); pleft < 7; ++pleft) {
+    ostr<<" 0";
+  }
+  drr.content=ostr.str();
+  return numwarnings;
+}
+
+static bool checkRecordContents(int& numwarnings, int& numerrors, DNSResourceRecord& drr)
+{
+  // Make sure TXT record contents are quoted
+  if(drr.qtype.getCode() == QType::TXT && !drr.content.empty() && drr.content[0]!='"') {
+    drr.content = "\""+drr.content+"\"";
+  }
+
+  try {
+    shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(drr.qtype.getCode(), QClass::IN, drr.content));
+    string tmp=drc->serialize(drr.qname);
+    tmp = drc->getZoneRepresentation(true);
+    if (drr.qtype.getCode() != QType::AAAA) {
+      if (!pdns_iequals(tmp, drr.content)) {
+        if(drr.qtype.getCode() == QType::SOA) {
+          tmp = drc->getZoneRepresentation(false);
+        }
+        if(!pdns_iequals(tmp, drr.content)) {
+          cout<<"[Warning] Parsed and original record content are not equal: "<<drr.qname<<" IN " <<drr.qtype.toString()<< " '" << drr.content<<"' (Content parsed as '"<<tmp<<"')"<<endl;
+          numwarnings++;
+        }
+      }
+    } else {
+      struct in6_addr tmpbuf;
+      if (inet_pton(AF_INET6, drr.content.c_str(), &tmpbuf) != 1) {
+        cout<<"[Warning] Following record is not a valid IPv6 address: "<<drr.qname<<" IN " <<drr.qtype.toString()<< " '" << drr.content<<"'"<<endl;
+        numwarnings++;
+      }
+    }
+    return true;
+  }
+  catch(std::exception& e)
+  {
+    cout<<"[Error] Following record had a problem: \""<<drr.qname<<" IN "<<drr.qtype.toString()<<" "<<drr.content<<"\""<<endl;
+    cout<<"[Error] Error was: "<<e.what()<<endl;
+    numerrors++;
+    return false;
+  }
+}
+
 static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
 {
   int numerrors=0;
@@ -1231,58 +1296,10 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       aaaarecords.insert(rr.qname);
     }
     if(rr.qtype.getCode() == QType::SOA) {
-      vector<string>parts;
-      stringtok(parts, rr.content);
-
-      if(parts.size() < 7) {
-        cout << "[Info] SOA autocomplete is deprecated, missing field(s) in SOA content: " << rr.qname << " IN " << rr.qtype.toString() << " '" << rr.content << "'" << endl;
-      }
-
-      if(parts.size() >= 2) {
-        if(parts[1].find('@') != string::npos) {
-          cout<<"[Warning] Found @-sign in SOA RNAME, should probably be a dot (.): "<<rr.qname<<" IN " <<rr.qtype.toString()<< " '" << rr.content<<"'"<<endl;
-          numwarnings++;
-        }
-      }
-
-      ostringstream o;
-      o<<rr.content;
-      for(auto pleft=parts.size(); pleft < 7; ++pleft) {
-        o<<" 0";
-      }
-      rr.content=o.str();
+      numwarnings += normalizeSOARecord(rr);
     }
 
-    if(rr.qtype.getCode() == QType::TXT && !rr.content.empty() && rr.content[0]!='"')
-      rr.content = "\""+rr.content+"\"";
-
-    try {
-      shared_ptr<DNSRecordContent> drc(DNSRecordContent::make(rr.qtype.getCode(), QClass::IN, rr.content));
-      string tmp=drc->serialize(rr.qname);
-      tmp = drc->getZoneRepresentation(true);
-      if (rr.qtype.getCode() != QType::AAAA) {
-        if (!pdns_iequals(tmp, rr.content)) {
-          if(rr.qtype.getCode() == QType::SOA) {
-            tmp = drc->getZoneRepresentation(false);
-          }
-          if(!pdns_iequals(tmp, rr.content)) {
-            cout<<"[Warning] Parsed and original record content are not equal: "<<rr.qname<<" IN " <<rr.qtype.toString()<< " '" << rr.content<<"' (Content parsed as '"<<tmp<<"')"<<endl;
-            numwarnings++;
-          }
-        }
-      } else {
-        struct in6_addr tmpbuf;
-        if (inet_pton(AF_INET6, rr.content.c_str(), &tmpbuf) != 1) {
-          cout<<"[Warning] Following record is not a valid IPv6 address: "<<rr.qname<<" IN " <<rr.qtype.toString()<< " '" << rr.content<<"'"<<endl;
-          numwarnings++;
-        }
-      }
-    }
-    catch(std::exception& e)
-    {
-      cout<<"[Error] Following record had a problem: \""<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"\""<<endl;
-      cout<<"[Error] Error was: "<<e.what()<<endl;
-      numerrors++;
+    if (!checkRecordContents(numwarnings, numerrors, rr)) {
       continue;
     }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <string>
 #include <termios.h>            //termios, TCSANOW, ECHO, ICANON
+#include <tuple>
 #include <utility>
 #include <sys/stat.h>
 #include <sys/wait.h>
@@ -2930,17 +2931,17 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds)
     newrrs.insert(newrrs.end(), oldrrs.begin(), oldrrs.end());
   }
 
-  std::vector<std::pair<DNSResourceRecord, string>> errors;
+  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, string>> diagnostics;
   Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
   if (allowUnderscores) {
     flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
   }
-  Check::checkRRSet(oldrrs, newrrs, zone, flags, errors);
+  Check::checkRRSet(oldrrs, newrrs, zone, flags, diagnostics);
   oldrrs.clear(); // no longer needed
-  if (!errors.empty()) {
-    for (const auto& error : errors) {
-      const auto [rec, why] = error;
-      cerr << "RRset " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
+  if (!diagnostics.empty()) {
+    for (const auto& error : diagnostics) {
+      const auto [prio, rec, why] = error;
+      cerr << Logr::Logger::toString(prio) << ": RRset " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
     }
     return EXIT_FAILURE;
   }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -959,7 +959,7 @@ static bool areUnderscoresAllowed(const ZoneName& zonename, DomainInfo& info)
   return underscores == "0";
 }
 
-static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
+static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, const vector<DNSResourceRecord>* suppliedrecords=nullptr) // NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
 {
   int numerrors=0;
   int numwarnings=0;
@@ -982,6 +982,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
     return 1;
   }
 
+  // SOA record checks
   SOAData sd;
   try {
     if (!B.getSOAUncached(zone, sd)) {
@@ -1006,6 +1007,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
     }
   }
 
+  // NSEC3 parameters checks
   NSEC3PARAMRecordContent ns3pr;
   bool narrow = false;
   bool haveNSEC3 = dk.getNSEC3PARAM(zone, &ns3pr, &narrow);
@@ -1078,13 +1080,14 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
     }
   }
 
+  // Record checks.
+  // We defer some of them to Check::checkRRSet(), but some of the checks can
+  // only be performed on complete zone contents and are only done here.
 
   bool hasNsAtApex = false;
   set<DNSName> tlsas, cnames, noncnames, glue, checkglue, addresses, svcbAliases, httpsAliases, svcbRecords, httpsRecords, arecords, aaaarecords;
   vector<DNSResourceRecord> checkCNAME;
   set<pair<DNSName, QType> > checkOcclusion;
-  set<string> recordcontents;
-  map<string, unsigned int> ttl;
   // Record name, prio, target name, ipv4hint=auto, ipv6hint=auto
   set<std::tuple<DNSName, uint16_t, DNSName, bool, bool> > svcbTargets, httpsTargets;
 
@@ -1125,12 +1128,13 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       numwarnings++;
     }
   }
-  else
-    records=*suppliedrecords;
+  else {
+    records = *suppliedrecords;
+  }
 
   bool allowUnderscores = areUnderscoresAllowed(zone, di);
 
-  for(auto &rr : records) { // we modify this
+  for(auto &rr : records) { // We modify SOA and TXT record contents
     if(rr.qtype.getCode() == QType::TLSA)
       tlsas.insert(rr.qname);
     if(rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) {
@@ -1271,32 +1275,6 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       }
     }
 
-    content.str("");
-    content<<rr.qname<<" "<<rr.qtype.toString()<<" "<<rr.content;
-    string contentstr = content.str();
-    if (rr.qtype.getCode() != QType::TXT) {
-      contentstr=toLower(contentstr);
-    }
-    if (recordcontents.count(contentstr) != 0) {
-      cout<<"[Error] Duplicate record found in rrset: '"<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"'"<<endl;
-      numerrors++;
-      continue;
-    }
-    recordcontents.insert(std::move(contentstr));
-
-    content.str("");
-    content<<rr.qname<<" "<<rr.qtype.toString();
-    if (rr.qtype.getCode() == QType::RRSIG) {
-      RRSIGRecordContent rrc(rr.content);
-      content<<" ("<<DNSRecordContent::NumberToType(rrc.d_type)<<")";
-    }
-    ret = ttl.insert(pair<string, unsigned int>(toLower(content.str()), rr.ttl));
-    if (!ret.second && ret.first->second != rr.ttl) {
-      cout<<"[Error] TTL mismatch in rrset: '"<<rr.qname<<" IN " <<rr.qtype.toString()<<" "<<rr.content<<"' ("<<ret.first->second<<" != "<<rr.ttl<<")"<<endl;
-      numerrors++;
-      continue;
-    }
-
     if (isSecure && isOptOut && (rr.qname.hasLabels() && rr.qname.getRawLabel(0) == "*")) {
       cout<<"[Warning] wildcard record '"<<rr.qname<<" IN " <<rr.qtype.toString()<<" "<<rr.content<<"' is insecure"<<endl;
       cout<<"[Info] Wildcard records in opt-out zones are insecure. Disable the opt-out flag for this zone to avoid this warning. Command: 'pdnsutil zone set-nsec3 "<<zone<<"'"<<endl;
@@ -1307,21 +1285,10 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       // apex checks
       if (rr.qtype.getCode() == QType::NS) {
         hasNsAtApex=true;
-      } else if (rr.qtype.getCode() == QType::DS) {
-        cout<<"[Warning] DS at apex in zone '"<<zone<<"', should not be here."<<endl;
-        numwarnings++;
       }
     } else {
       // non-apex checks
-      if (rr.qtype.getCode() == QType::SOA) {
-        cout<<"[Error] SOA record not at apex '"<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"' in zone '"<<zone<<"'"<<endl;
-        numerrors++;
-        continue;
-      }
-      if (rr.qtype.getCode() == QType::DNSKEY) {
-        cout<<"[Warning] DNSKEY record not at apex '"<<rr.qname<<" IN "<<rr.qtype.toString()<<" "<<rr.content<<"' in zone '"<<zone<<"', should not be here."<<endl;
-        numwarnings++;
-      } else if (rr.qtype.getCode() == QType::NS) {
+      if (rr.qtype.getCode() == QType::NS) {
         if (DNSName(rr.content).isPartOf(rr.qname)) {
           checkglue.insert(DNSName(toLower(rr.content)));
         }
@@ -1339,22 +1306,9 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
     if((rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) && !rr.qname.isWildcard() && !rr.qname.isHostname())
       cout<<"[Info] "<<rr.qname.toString()<<" record for '"<<rr.qtype.toString()<<"' is not a valid hostname."<<endl;
 
-    // Check if the DNSNames that should be hostnames, are hostnames
-    try {
-      checkHostnameCorrectness(rr, allowUnderscores);
-    } catch (const std::exception& e) {
-      cout << "[Warning] " << rr.qtype.toString() << " record in zone '" << zone << ": " << e.what() << endl;
-      numwarnings++;
-    }
-
     if (rr.qtype.getCode() == QType::CNAME) {
       if (cnames.count(rr.qname) == 0) {
         cnames.insert(rr.qname);
-      }
-      else {
-        cout<<"[Error] Duplicate CNAME found at '"<<rr.qname<<"'"<<endl;
-        numerrors++;
-        continue;
       }
     } else {
       if (rr.qtype.getCode() == QType::RRSIG) {
@@ -1395,6 +1349,24 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
       }
     }
   }
+
+  Check::RRSetFlags flags{Check::RRSET_CHECK_TTL};
+  if (allowUnderscores) {
+    flags = static_cast<Check::RRSetFlags>(flags | Check::RRSET_ALLOW_UNDERSCORES);
+  }
+  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, std::string>> errors;
+  Check::checkRRSet({}, records, zone, flags, errors);
+  for (const auto& error : errors) {
+    const auto [prio, rec, why] = error;
+    cerr << "[" << Logr::Logger::toString(prio) << "] " << rec.qname.toString() << " IN " << rec.qtype.toString() << ": " << why << endl;
+    if (prio == Logr::Error) {
+      numerrors++;
+    }
+    else {
+      numwarnings++;
+    }
+  }
+  errors.clear();
 
   for(const auto &name: cnames) {
     if (noncnames.find(name) != noncnames.end()) {
@@ -1650,7 +1622,7 @@ static int checkAllZones(DNSSECKeeper &dk, bool exitOnError)
   B.getAllDomains(&domainInfo, true, true);
   int errors=0;
   for (auto& di : domainInfo) {
-    if (checkZone(dk, B, di.zone) > 0) {
+    if (checkZoneRecords(dk, B, di.zone) > 0) {
       errors++;
     }
 
@@ -2434,7 +2406,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
           drr.domain_id = info.id;
           checkrr.push_back(std::move(drr));
         }
-        if(checkZone(dsk, B, zone, &checkrr) != 0) {
+        if(checkZoneRecords(dsk, B, zone, &checkrr) != 0) {
           state = INVALIDZONE;
           break;
         }
@@ -4059,7 +4031,7 @@ static int checkZone(vector<string>& cmds, const std::string_view synopsis)
   }
   DNSSECKeeper dk(nullptr /* no structured logging */); //NOLINT(readability-identifier-length)
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
-  return checkZone(dk, B, ZoneName(cmds.at(0)));
+  return checkZoneRecords(dk, B, ZoneName(cmds.at(0)));
 }
 
 static int benchDb(vector<string>& cmds, [[maybe_unused]] const std::string_view synopsis)

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -987,22 +987,22 @@ static int checkZoneTLSA(const set<DNSName>& tlsas, const set<DNSName>& cnames, 
 // Record name, prio, target name, ipv4hint=auto, ipv6hint=auto
 using svcbset_t = set<std::tuple<DNSName, uint16_t, DNSName, bool, bool>>;
 
-static void checkZoneSVCB(int& numwarnings, int& numerrors, const ZoneName& zone, const svcbset_t& svcbTargets, const set<DNSName>& svcbAliases, const set<DNSName>& svcbRecords, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
+static void checkZoneSVCB(int& numwarnings, int& numerrors, const std::string& type, const ZoneName& zone, const svcbset_t& targets, const set<DNSName>& aliases, const set<DNSName>& records, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
 {
-  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : svcbTargets) {
+  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : targets) {
     if (name == target) {
-      cout<<"[Error] SVCB record "<<name<<" has itself as target."<<endl;
+      cout<<"[Error] " << type << " record "<<name<<" has itself as target."<<endl;
       numerrors++;
     }
 
     if (prio == 0) {
       if (target.isPartOf(zone)) {
-        if (svcbAliases.find(target) != svcbAliases.end()) {
-          cout << "[Warning] SVCB record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
+        if (aliases.find(target) != aliases.end()) {
+          cout << "[Warning] " << type << " record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
           numwarnings++;
         }
-        if (addresses.find(target) == addresses.end() && svcbRecords.find(target) == svcbRecords.end()) {
-          cout<<"[Error] SVCB record "<<name<<" has a target "<<target<<" that has neither address nor SVCB records."<<endl;
+        if (addresses.find(target) == addresses.end() && records.find(target) == records.end()) {
+          cout<<"[Error] " << type << " record "<<name<<" has a target "<<target<<" that has neither address nor " << type << " records."<<endl;
           numerrors++;
         }
       }
@@ -1011,46 +1011,11 @@ static void checkZoneSVCB(int& numwarnings, int& numerrors, const ZoneName& zone
     const auto& trueTarget = target.isRoot() ? name : target;
     if (prio > 0) {
       if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
-        cout << "[warning] SVCB record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
+        cout << "[warning] " << type << " record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
         numwarnings++;
       }
       if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
-        cout << "[warning] SVCB record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-    }
-  }
-}
-
-static void checkZoneHTTPS(int& numwarnings, int& numerrors, const ZoneName& zone, const svcbset_t& httpsTargets, const set<DNSName>& httpsAliases, const set<DNSName>& httpsRecords, const set<DNSName>& arecords, const set<DNSName>& aaaarecords, const set<DNSName>& addresses)
-{
-  for (const auto& [name, prio, target, v4hintsAuto, v6hintsAuto] : httpsTargets) {
-    if (name == target) {
-      cout<<"[Error] HTTPS record "<<name<<" has itself as target."<<endl;
-      numerrors++;
-    }
-
-    if (prio == 0) {
-      if (target.isPartOf(zone)) {
-        if (httpsAliases.find(target) != httpsAliases.end()) {
-          cout << "[Warning] HTTPS record for " << name << " has an aliasform target (" << target << ") that is in aliasform itself." << endl;
-          numwarnings++;
-        }
-        if (addresses.find(target) == addresses.end() && httpsRecords.find(target) == httpsRecords.end()) {
-          cout<<"[Error] HTTPS record "<<name<<" has a target "<<target<<" that has neither address nor HTTPS records."<<endl;
-          numerrors++;
-        }
-      }
-    }
-
-    const auto& trueTarget = target.isRoot() ? name : target;
-    if (prio > 0) {
-      if(v4hintsAuto && arecords.find(trueTarget) == arecords.end()) {
-        cout << "[warning] HTTPS record for "<< name << " has automatic IPv4 hints, but no A-record for the target at "<< trueTarget <<" exists."<<endl;
-        numwarnings++;
-      }
-      if(v6hintsAuto && aaaarecords.find(trueTarget) == aaaarecords.end()) {
-        cout << "[warning] HTTPS record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
+        cout << "[warning] " << type << " record for "<< name << " has automatic IPv6 hints, but no AAAA-record for the target at "<< trueTarget <<" exists."<<endl;
         numwarnings++;
       }
     }
@@ -1487,11 +1452,11 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
   numwarnings += checkZoneTLSA(tlsas, cnames, noncnames);
   tlsas.clear();
 
-  checkZoneSVCB(numwarnings, numerrors, zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
+  checkZoneSVCB(numwarnings, numerrors, "SVCB", zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
   svcbTargets.clear();
   svcbAliases.clear();
   svcbRecords.clear();
-  checkZoneHTTPS(numwarnings, numerrors, zone, httpsTargets, httpsAliases, httpsRecords, arecords, aaaarecords, addresses);
+  checkZoneSVCB(numwarnings, numerrors, "HTTPS", zone, httpsTargets, httpsAliases, httpsRecords, arecords, aaaarecords, addresses);
   httpsTargets.clear();
   httpsAliases.clear();
   httpsRecords.clear();

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1340,30 +1340,20 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
         }
       }
 
-      switch (rr.qtype.getCode()) {
-      case QType::SVCB:
-        if (svcbrc->getPriority() == 0) {
-          if (svcbAliases.find(rr.qname) != svcbAliases.end()) {
-            cout << "[Warning] More than one Alias form SVCB record for " << rr.qname << " exists." << endl;
-            numwarnings++;
-          }
-          svcbAliases.insert(rr.qname);
+      bool isSvcb = rr.qtype.getCode() == QType::SVCB;
+      set<DNSName>& aliases = isSvcb ? svcbAliases : httpsAliases;
+      svcbset_t& targets = isSvcb ? svcbTargets : httpsTargets;
+      set<DNSName>& ourrecords = isSvcb ? svcbRecords : httpsRecords;
+
+      if (svcbrc->getPriority() == 0) {
+        if (aliases.find(rr.qname) != aliases.end()) {
+          cout << "[Warning] More than one Alias form " << rr.qtype.toString()<< " " << rr.qname << " exists." << endl;
+          numwarnings++;
         }
-        svcbTargets.emplace(rr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
-        svcbRecords.insert(rr.qname);
-        break;
-      case QType::HTTPS:
-        if (svcbrc->getPriority() == 0) {
-          if (httpsAliases.find(rr.qname) != httpsAliases.end()) {
-            cout << "[Warning] More than one Alias form HTTPS record for " << rr.qname << " exists." << endl;
-            numwarnings++;
-          }
-          httpsAliases.insert(rr.qname);
-        }
-        httpsTargets.emplace(rr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
-        httpsRecords.insert(rr.qname);
-        break;
+        aliases.insert(rr.qname);
       }
+      targets.emplace(rr.qname, svcbrc->getPriority(), svcbrc->getTarget(), svcbrc->autoHint(SvcParam::ipv4hint), svcbrc->autoHint(SvcParam::ipv6hint));
+      ourrecords.insert(rr.qname);
     }
 
     if (isSecure && isOptOut && (rr.qname.hasLabels() && rr.qname.getRawLabel(0) == "*")) {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1429,7 +1429,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
         numwarnings++;
       }
     }
-  }
+  } // end of complete records loop
 
   for(const auto &name: cnames) {
     if (noncnames.find(name) != noncnames.end()) {
@@ -1440,6 +1440,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
 
   numwarnings += checkZoneTLSA(tlsas, cnames, noncnames);
   tlsas.clear();
+  noncnames.clear();
 
   checkZoneSVCB(numwarnings, numerrors, "SVCB", zone, svcbTargets, svcbAliases, svcbRecords, arecords, aaaarecords, addresses);
   svcbTargets.clear();
@@ -1483,6 +1484,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numwarnings++;
     }
   }
+  glue.clear();
+  checkglue.clear();
 
   for (const auto& qname : checkOcclusion) {
     for (const auto& drr : records) {
@@ -1550,7 +1553,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
         target = std::dynamic_pointer_cast<NSRecordContent>(drc)->getNS();
         break;
       default:
-        // programmer error, but let's not abort() :)
+        // can't happen due to the way checkCNAME is filled
         break;
     }
     if (target.isPartOf(zone) && cnames.count(target) != 0) {
@@ -1558,6 +1561,8 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numwarnings++;
     }
   }
+  checkCNAME.clear();
+  cnames.clear();
 
   bool ok, ds_ns, done;
   for( const auto &rr : records ) {
@@ -1594,6 +1599,7 @@ static int checkZoneRecords(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& z
       numerrors++;
     }
   }
+  checkOcclusion.clear();
 
   std::map<std::string, std::vector<std::string>> metadatas;
   if (B.getAllDomainMetadata(zone, metadatas)) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1768,25 +1768,25 @@ static bool areUnderscoresAllowed(const ZoneName& zonename, DNSBackend& backend)
 // not, in which case the response body and status have been filled up.
 static bool checkNewRecords(HttpResponse* resp, vector<DNSResourceRecord>& records, const ZoneName& zone, Check::RRSetFlags flags)
 {
-  std::vector<std::pair<DNSResourceRecord, string>> errors;
+  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, string>> diagnostics;
 
   // Do not perform Lua records updates if not allowed to.
   if (!::arg().mustDo("enable-lua-record-updates")) {
     for (const auto& rec : records) {
       if (rec.qtype == QType::LUA) {
-        errors.emplace_back(std::make_pair(rec, std::string("update of Lua records is not allowed")));
+        diagnostics.emplace_back(std::make_tuple(Logr::Error, rec, std::string("update of Lua records is not allowed")));
       }
     }
   }
 
-  Check::checkRRSet({}, records, zone, flags, errors);
-  if (errors.empty()) {
+  Check::checkRRSet({}, records, zone, flags, diagnostics);
+  if (diagnostics.empty()) {
     return true;
   }
 
   Json::array errs;
-  for (const auto& error : errors) {
-    const auto& [rec, why] = error;
+  for (const auto& error : diagnostics) {
+    const auto& [_, rec, why] = error; // we report everything as errors
     errs.emplace_back(std::string{"RRset "} + rec.qname.toString() + " IN " + rec.qtype.toString() + ": " + why);
   }
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1868,25 +1868,25 @@ static bool areUnderscoresAllowed(const ZoneName& zonename, DNSBackend& backend)
 // not, in which case the response body and status have been filled up.
 static bool checkNewRecords(HttpResponse* resp, vector<DNSResourceRecord>& records, const ZoneName& zone, Check::RRSetFlags flags)
 {
-  std::vector<std::pair<DNSResourceRecord, string>> errors;
+  std::vector<std::tuple<Logr::Priority, DNSResourceRecord, string>> diagnostics;
 
   // Do not perform Lua records updates if not allowed to.
   if (!::arg().mustDo("enable-lua-record-updates")) {
     for (const auto& rec : records) {
       if (rec.qtype == QType::LUA) {
-        errors.emplace_back(std::make_pair(rec, std::string("update of Lua records is not allowed")));
+        diagnostics.emplace_back(std::make_tuple(Logr::Error, rec, std::string("update of Lua records is not allowed")));
       }
     }
   }
 
-  Check::checkRRSet({}, records, zone, flags, errors);
-  if (errors.empty()) {
+  Check::checkRRSet({}, records, zone, flags, diagnostics);
+  if (diagnostics.empty()) {
     return true;
   }
 
   Json::array errs;
-  for (const auto& error : errors) {
-    const auto& [rec, why] = error;
+  for (const auto& error : diagnostics) {
+    const auto& [_, rec, why] = error; // we report everything as errors
     errs.emplace_back(std::string{"RRset "} + rec.qname.toString() + " IN " + rec.qtype.toString() + ": " + why);
   }
 

--- a/regression-tests/tests/pdnsutil-zone-handling/expected_result
+++ b/regression-tests/tests/pdnsutil-zone-handling/expected_result
@@ -5,8 +5,8 @@ host.bug.less. 3600 IN A 127.0.0.1
 Ignoring duplicate record content "127.0.0.2"
 New rrset:
 host2.bug.less. 3600 IN A 127.0.0.2
-RRset cname.bug.less. IN A: conflicts with existing CNAME RRset of the same name
-RRset host.bug.less. IN CNAME: conflicts with existing A RRset of the same name
+Error: RRset cname.bug.less. IN A: conflicts with existing CNAME RRset of the same name
+Error: RRset host.bug.less. IN CNAME: conflicts with existing A RRset of the same name
 New rrset:
 host2.bug.less. 3600 IN A 127.0.0.2
 host2.bug.less. 3600 IN A 127.0.0.3

--- a/regression-tests/tests/pdnsutil-zone-handling/expected_result.lmdb
+++ b/regression-tests/tests/pdnsutil-zone-handling/expected_result.lmdb
@@ -5,8 +5,8 @@ host.bug.less. 3600 IN A 127.0.0.1
 Ignoring duplicate record content "127.0.0.2"
 New rrset:
 host2.bug.less. 3600 IN A 127.0.0.2
-RRset cname.bug.less. IN A: conflicts with existing CNAME RRset of the same name
-RRset host.bug.less. IN CNAME: conflicts with existing A RRset of the same name
+Error: RRset cname.bug.less. IN A: conflicts with existing CNAME RRset of the same name
+Error: RRset host.bug.less. IN CNAME: conflicts with existing A RRset of the same name
 New rrset:
 host2.bug.less. 3600 IN A 127.0.0.2
 host2.bug.less. 3600 IN A 127.0.0.3


### PR DESCRIPTION
### Short description
This is one more step of many towards sharing more zone contents check code between `pdnsutil` and the API.

The API uses `checkRRSet` those days to validate a bunch of records. There are, however, some checks which can only be performed when you've got all the zone records, and `checkRRSet` does not know if its input is the complete zone or not.

This PR makes `pdnsutil zone check` (or `pdnsutil check-zone`, for you with pre-5.0 muscle memory) invoke `checkRRSet` in addition to its own work; and because of this, the checks which would be redundant (`SOA` only found at apex, no non-`CNAME` record with the same name as a `CNAME`, TTL mismatches...) are removed from `pdnsutil`.

Because `pdnsutil zone check` reports its diagnostics as errors and warnings, a priority field has been added to the output of `checkRRSet`. When used from the API, this field is ignored, and warnings are reported as errors; there is no change of behaviour here.

With that done, I have started to clean the `pdnsutil` code a bit, with some large chunks of code moved to their own subroutines, the usual thing.

Probably best reviewed in a per-commit basis, Fibonacci style (take one aspirin before reading the first commit, two before the second, three before the third, five before the fourth, eight before the fifth, etc) 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
