### PR TITLE
auth: better RFC3597 conformance

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -35,33 +35,115 @@ std::atomic<bool> DNSRecordContent::d_locked{false};
 
 UnknownRecordContent::UnknownRecordContent(const string& zone)
 {
-  // parse the input
-  vector<string> parts;
-  stringtok(parts, zone);
-  // we need exactly 3 parts, except if the length field is set to 0 then we only need 2
-  if (parts.size() != 3 && !(parts.size() == 2 && boost::equals(parts.at(1), "0"))) {
-    throw MOADNSException("Unknown record was stored incorrectly, need 3 fields, got " + std::to_string(parts.size()) + ": " + zone);
+  // The expected format is '\#', followed by the length in decimal, and as
+  // many pairs of hex digits as the length, which may be separated by
+  // whitespace.
+  // Because of this, using stringtok() might be horribly suboptimal for large
+  // data with every byte separated by spaces.
+
+  // The following is equivalent to strintok(parts, zone), but stops after
+  // filling two parts, and stores the beginning of the actual payload for
+  // further consumption.
+  constexpr const char *delimiters = " \t\n";
+  std::vector<std::string> parts;
+  parts.reserve(2);
+  std::string::size_type pos{0};
+  {
+    const auto len = zone.length();
+
+    while (pos<len) {
+      // eat leading whitespace
+      pos = zone.find_first_not_of (delimiters, pos);
+      if (pos == string::npos) {
+        break;   // nothing left but white space
+      }
+
+      // find the end of the token
+      std::string::size_type epos = zone.find_first_of (delimiters, pos);
+
+      // push token
+      if (epos == std::string::npos) {
+        parts.push_back (zone.substr(pos));
+        pos = epos;
+        break;
+      }
+      parts.push_back (zone.substr(pos, epos-pos));
+      // set up for next loop
+      pos = epos + 1;
+      if (parts.size() == 2) {
+        break;
+      }
+    }
   }
 
-  if (parts.at(0) != "\\#") {
-    throw MOADNSException("Unknown record was stored incorrectly, first part should be '\\#', got '" + parts.at(0) + "'");
+  if (parts.empty() || parts.at(0) != "\\#") {
+    throw MOADNSException("Unknown record was stored incorrectly, should start with '\\#'");
   }
 
-  const string& relevant = (parts.size() > 2) ? parts.at(2) : "";
-  auto total = pdns::checked_stoi<unsigned int>(parts.at(1));
-  if (relevant.size() % 2 || (relevant.size() / 2) != total) {
-    throw MOADNSException((boost::format("invalid unknown record length: size not equal to length field (%d != 2 * %d)") % relevant.size() % total).str());
+  if (parts.size() < 2) {
+    throw MOADNSException("Unknown record was stored incorrectly, missing size field");
+  }
+  auto total = pdns::checked_stoi<unsigned long>(parts.at(1));
+  if (total == 0) {
+    if (pos != std::string::npos) {
+      throw MOADNSException("Unknown record was stored incorrectly, spurious data after zero size field");
+    }
+    return;
   }
 
-  string out;
+  if (total > std::numeric_limits<uint16_t>::max()) {
+    throw MOADNSException((boost::format("invalid unknown record length size (%d)") % total).str());
+  }
+
+  std::string out;
   out.reserve(total + 1);
 
-  for (unsigned int n = 0; n < total; ++n) {
-    int c;
-    if (sscanf(&relevant.at(2*n), "%02x", &c) != 1) {
-      throw MOADNSException("unable to read data at position " + std::to_string(2 * n) + " from unknown record of size " + std::to_string(relevant.size()));
+  // This loops mimics stringtok() again
+  unsigned int byte = 0;
+  while (byte < total) {
+    // eat leading whitespace
+    pos = zone.find_first_not_of (delimiters, pos);
+    if (pos == std::string::npos) { // nothing left but white space
+      throw MOADNSException("Unknown record was stored incorrectly, truncated after byte " + std::to_string(byte) + " of " + std::to_string(total));
     }
-    out.append(1, (char)c);
+
+    // find the end of the token
+    std::string::size_type epos = zone.find_first_of (delimiters, pos);
+
+    // extract token
+    std::string_view chunk{};
+    if (epos == std::string::npos) {
+      // TODO: replace with zone.subview(pos) once we can use C++26
+      chunk = std::string_view(&zone.at(pos));
+      pos = epos;
+    } else {
+      // TODO: replace with zone.subview(pos, epos-pos) once we can use C++26
+      chunk = std::string_view(&zone.at(pos), epos-pos);
+    }
+
+    // process token
+    if ((chunk.size() % 2) != 0) {
+      throw MOADNSException("Unknown record was stored incorrectly, sequence of digits for byte " + std::to_string(byte) + " of " + std::to_string(total) + " onward at offset " + std::to_string(pos) + " has uneven length");
+    }
+    if ((chunk.size() / 2) > total - byte) {
+      throw MOADNSException("Unknown record was stored incorrectly, sequence of digits for byte " + std::to_string(byte) + " of " + std::to_string(total) + " onward at offset " + std::to_string(pos) + " is too long");
+    }
+    for (std::string_view::size_type subpos = 0; subpos < chunk.size(); subpos += 2) {
+      int chr{0};
+      if (sscanf(&chunk.at(subpos), "%02x", &chr) != 1) {
+        throw MOADNSException("unable to read data for byte " + std::to_string(byte) + " of " + std::to_string(total) + " at offset " + std::to_string(pos + subpos) + " from unknown record");
+      }
+      out.append(1, static_cast<char>(chr));
+      ++byte;
+    }
+
+    // set up for next loop
+    if (epos == std::string::npos) {
+      pos = epos;
+    }
+    else {
+      pos = epos + 1;
+    }
   }
 
   d_record.insert(d_record.end(), out.begin(), out.end());

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -96,7 +96,7 @@ UnknownRecordContent::UnknownRecordContent(const string& zone)
   }
 
   std::string out;
-  out.reserve(total + 1);
+  out.reserve(total);
 
   // This loops mimics stringtok() again
   unsigned int byte = 0;

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -296,7 +296,10 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
      (CASE_S(QType::CAA, "0 issue \"aaaaaaa.aaa\"", "\x00\x05\x69\x73\x73\x75\x65\x61\x61\x61\x61\x61\x61\x61\x2e\x61\x61\x61"))
      (CASE_S(QType::RESINFO, "\"qnamemin exterr=15-17\"", "\x15qnamemin exterr=15-17"))
      (CASE_S(QType::DLV, "20642 8 2 04443abe7e94c3985196beae5d548c727b044dda5151e60d7cd76a9fd931d00e", "\x50\xa2\x08\x02\x04\x44\x3a\xbe\x7e\x94\xc3\x98\x51\x96\xbe\xae\x5d\x54\x8c\x72\x7b\x04\x4d\xda\x51\x51\xe6\x0d\x7c\xd7\x6a\x9f\xd9\x31\xd0\x0e"))
+     (CASE_S((QType::typeenum)65226,"\\# 0",""))
      (CASE_S((QType::typeenum)65226,"\\# 3 414243","\x41\x42\x43"))
+     (CASE_L((QType::typeenum)65226,"\\# 3   41 42    43","\\# 3 414243","\x41\x42\x43"))
+     (CASE_L((QType::typeenum)65226,"\\# 3   4142    43  ","\\# 3 414243","\x41\x42\x43"))
 
 ;
 
@@ -401,6 +404,10 @@ BOOST_AUTO_TEST_CASE(test_record_types_bad_values) {
      (ZONE_CASE(QType::TXT, "\\384excessive")) // incorrect escape
      (ZONE_CASE(QType::HTTPS, "1 . port=443 port=8080")) // repeated SvcParamKey
      (ZONE_CASE(QType::SVCB, "1 foo.powerdns.org. alpn=h2 alpn=h3")) // repeated SvcParamKey
+     (ZONE_CASE((QType::typeenum)65226,"\\# 3 4142")) // truncated record
+     (ZONE_CASE((QType::typeenum)65226,"\\# 3 4142  ")) // truncated record with extra whitespace
+     (ZONE_CASE((QType::typeenum)65226,"\\# 3 4142 4344")) // too much data
+     (ZONE_CASE((QType::typeenum)65226,"\\# 3 414 243")) // payload not split on even boundaries
 ;
 
   int n=0;


### PR DESCRIPTION
### Short description
This rewrites the parsing of unknown records (`TYPEnnn \# n xxxxxx`) to allow for the binary data to contain whitespace between pairs of digits (i.e. allow `xx xx xx` or `xxxx xxxx` or `xx xxxxxx xx` but not `x x`).

I also tried to make the error messages, in case of ill-formed data, more useful.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
