### PR TITLE
rec: do not attempt to refresh NS records in refresh-almost-expired.

### DIFF
--- a/pdns/recursordist/recpacketcache.cc
+++ b/pdns/recursordist/recpacketcache.cc
@@ -146,7 +146,9 @@ bool RecursorPacketCache::checkResponseMatches(MapCombo::LockedContent& shard, s
       *age = static_cast<uint32_t>(now - iter->d_creation);
       // we know ttl is > 0
       auto ttl = static_cast<uint32_t>(iter->d_ttd - now);
-      if (s_refresh_ttlperc > 0 && !iter->d_submitted && taskQTypeIsSupported(qtype)) {
+      // Be wary of refreshing NS records, it could lead to ghosts if the record cache entry expires between
+      // sending out the request and the reply coming back in, as then the TTL capping does not work.
+      if (s_refresh_ttlperc > 0 && !iter->d_submitted && taskQTypeIsSupported(qtype) && qtype != QType::NS) {
         const dnsheader_aligned header(iter->d_packet.data());
         const auto* headerPtr = header.get();
         if (headerPtr->rcode == RCode::NoError) {

--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -425,7 +425,10 @@ time_t MemRecursorCache::fakeTTD(MemRecursorCache::OrderedTagIterator_t& entry, 
       if (refresh) {
         return -1;
       }
-      if (!entry->d_submitted) {
+      // We do not want to refresh auth NS entries, as it could lead to ghost domains if an entry
+      // expires between submit and response coming in, as the TTL capping then does not work for
+      // lack of current TTL info.
+      if (!entry->d_submitted && (qtype != QType::NS || !entry->d_auth)) {
         pushRefreshTask(qname, qtype, entry->d_ttd, entry->d_netmask);
         entry->d_submitted = true;
       }


### PR DESCRIPTION
If the auth responds *very* slowly and the records expire in between, the capping of TTLs is not enforced for lack of data.

This does not happen on regular resolve as then then the child records are used immediately if not expired and thus valid, or the records *are* expired, and in that case not used.  So this case can only happen if almost expired records are used to refresh the authoritative NS records.

This was assigned CVE-2026-52684. Severity is Low and does not warrant a security release.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
