### PR TITLE
Prefer std::array to std::vector for const values

### DIFF
--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
     /* simple case */
     ZoneParserTNG zoneparser(pathbuf.str(), ZoneName("unit2.test"));
 
-    const vector<string> expected = {
+    const std::array expected = {
       "0.01.0003.000005.00000007.unit2.test.",
       "1.02.0004.000006.00000008.unit2.test.",
       "2.03.0005.000007.00000009.unit2.test.",
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
     /* GENERATE with a step of 2, and the template radix defaulting to 'd' */
     ZoneParserTNG zoneparser(std::vector<std::string>({"$GENERATE 0-4/2 $.${1,2,o}.${3,4}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), ZoneName("unit2.test"));
 
-    const vector<string> expected = {
+    const std::array expected = {
       "0.01.0003.000005.00000007.unit2.test.",
       "2.03.0005.000007.00000009.unit2.test.",
       "4.05.0007.000009.0000000b.unit2.test.",
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
     /* GENERATE with a larger initial counter and a large stop */
     ZoneParserTNG zoneparser(std::vector<std::string>({"$GENERATE 4294967294-4294967295/2 $	86400	IN	A 1.2.3.4"}), ZoneName("unit2.test"));
 
-    const vector<string> expected = {
+    const std::array expected = {
       "4294967294.unit2.test.",
     };
 

--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
     /* simple case */
     ZoneParserTNG zoneparser(pathbuf.str(), ZoneName("unit2.test"));
 
-    const std::array expected = {
+    constexpr std::array expected = {
       "0.01.0003.000005.00000007.unit2.test.",
       "1.02.0004.000006.00000008.unit2.test.",
       "2.03.0005.000007.00000009.unit2.test.",
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
     /* GENERATE with a step of 2, and the template radix defaulting to 'd' */
     ZoneParserTNG zoneparser(std::vector<std::string>({"$GENERATE 0-4/2 $.${1,2,o}.${3,4}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), ZoneName("unit2.test"));
 
-    const std::array expected = {
+    constexpr std::array expected = {
       "0.01.0003.000005.00000007.unit2.test.",
       "2.03.0005.000007.00000009.unit2.test.",
       "4.05.0007.000009.0000000b.unit2.test.",
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
     /* GENERATE with a larger initial counter and a large stop */
     ZoneParserTNG zoneparser(std::vector<std::string>({"$GENERATE 4294967294-4294967295/2 $	86400	IN	A 1.2.3.4"}), ZoneName("unit2.test"));
 
-    const std::array expected = {
+    constexpr std::array expected = {
       "4294967294.unit2.test.",
     };
 

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -1418,7 +1418,7 @@ std::ostream& operator<<(std::ostream& ostr, const vState dstate)
 
 std::ostream& operator<<(std::ostream& ostr, const dState dstate)
 {
-  static const std::array dStates = {"no denial", "inconclusive", "nxdomain", "nxqtype", "empty non-terminal", "insecure", "opt-out"};
+  constexpr std::array dStates = {"no denial", "inconclusive", "nxdomain", "nxqtype", "empty non-terminal", "insecure", "opt-out"};
   ostr << dStates.at(static_cast<size_t>(dstate));
   return ostr;
 }

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -1418,7 +1418,7 @@ std::ostream& operator<<(std::ostream& ostr, const vState dstate)
 
 std::ostream& operator<<(std::ostream& ostr, const dState dstate)
 {
-  static const std::vector<std::string> dStates = {"no denial", "inconclusive", "nxdomain", "nxqtype", "empty non-terminal", "insecure", "opt-out"};
+  static const std::array dStates = {"no denial", "inconclusive", "nxdomain", "nxqtype", "empty non-terminal", "insecure", "opt-out"};
   ostr << dStates.at(static_cast<size_t>(dstate));
   return ostr;
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -209,7 +209,7 @@ static void printtable(ostringstream& ret, const string& ringname, const std::st
   ret << "<input type=\"hidden\" name=\"resizering\" value=\"" << htmlescape(ringname) << "\" />";
   ret << "<input type=\"hidden\" name=\"unique\" value=\"" << htmlescape(unique) << "\" />";
   ret << "<select name=\"size\">";
-  static const std::array<uint64_t, 7> sizes{10, 100, 500, 1000, 10000, 500000, 0};
+  constexpr std::array<uint64_t, 7> sizes{10, 100, 500, 1000, 10000, 500000, 0};
   for (const auto size : sizes) {
     ret << "<option value=\"" << size << "\"";
     if (S.getRingSize(ringname) == size) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -209,7 +209,7 @@ static void printtable(ostringstream& ret, const string& ringname, const std::st
   ret << "<input type=\"hidden\" name=\"resizering\" value=\"" << htmlescape(ringname) << "\" />";
   ret << "<input type=\"hidden\" name=\"unique\" value=\"" << htmlescape(unique) << "\" />";
   ret << "<select name=\"size\">";
-  static const std::vector<uint64_t> sizes{10, 100, 500, 1000, 10000, 500000, 0};
+  static const std::array<uint64_t, 7> sizes{10, 100, 500, 1000, 10000, 500000, 0};
   for (const auto size : sizes) {
     ret << "<option value=\"" << size << "\"";
     if (S.getRingSize(ringname) == size) {


### PR DESCRIPTION
### Short description
Arr, matey!

This PR replaces some `const std::vector` with `const std::array`. Unfortunately we can't convert `std::vector<std::pair<...>>` yet using type deduction, until we switch to C++20 and can afford using `std::to_array` for them (I don't really want to use `std::array` with an explicit type _and number of items_ for these at this point).

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
