### PR TITLE
dnsdist: fix compilation on platforms lacking quiche_conn_set_qlog_path()

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-dnscrypt.cc
@@ -31,7 +31,7 @@
 namespace dnsdist::dnscrypt
 {
 
-bool handleDNSCryptQuery(PacketBuffer& packet, DNSCryptQuery& query, bool tcp, time_t now, PacketBuffer& response)
+bool handleDNSCryptQuery([[maybe_unused]] PacketBuffer& packet, [[maybe_unused]] DNSCryptQuery& query, [[maybe_unused]] bool tcp, [[maybe_unused]] time_t now, [[maybe_unused]] PacketBuffer& response)
 {
 #ifdef HAVE_DNSCRYPT
   query.parsePacket(packet, tcp, now);
@@ -59,7 +59,7 @@ bool handleDNSCryptQuery(PacketBuffer& packet, DNSCryptQuery& query, bool tcp, t
 #endif
 }
 
-bool encryptResponse(PacketBuffer& response, size_t maximumSize, bool tcp, std::unique_ptr<DNSCryptQuery>& dnsCryptQuery)
+bool encryptResponse([[maybe_unused]] PacketBuffer& response, [[maybe_unused]] size_t maximumSize, [[maybe_unused]] bool tcp, [[maybe_unused]] std::unique_ptr<DNSCryptQuery>& dnsCryptQuery)
 {
 #ifdef HAVE_DNSCRYPT
   if (dnsCryptQuery) {

--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1865,11 +1865,9 @@ static void checkFileDescriptorsLimits(size_t udpBindsCount, size_t tcpBindsCoun
   }
 }
 
-static void setupLocalSocket(ClientState& clientState, const ComboAddress& addr, int& socket, bool tcp, bool warn, const std::shared_ptr<const Logr::Logger>& logger)
+static void setupLocalSocket(ClientState& clientState, const ComboAddress& addr, int& socket, bool tcp, [[maybe_unused]] bool warn, const std::shared_ptr<const Logr::Logger>& logger)
 {
-  const auto& immutableConfig = dnsdist::configuration::getImmutableConfiguration();
   static bool s_warned_ipv6_recvpktinfo = false;
-  (void)warn;
   socket = SSocket(addr.sin4.sin_family, !tcp ? SOCK_DGRAM : SOCK_STREAM, 0);
 
   if (tcp) {
@@ -1881,6 +1879,7 @@ static void setupLocalSocket(ClientState& clientState, const ComboAddress& addr,
 #ifdef TCP_FASTOPEN
       SSetsockopt(socket, IPPROTO_TCP, TCP_FASTOPEN, clientState.fastOpenQueueSize);
 #ifdef TCP_FASTOPEN_KEY
+      const auto& immutableConfig = dnsdist::configuration::getImmutableConfiguration();
       if (!immutableConfig.d_tcpFastOpenKey.empty()) {
         auto res = setsockopt(socket, IPPROTO_IP, TCP_FASTOPEN_KEY, immutableConfig.d_tcpFastOpenKey.data(), immutableConfig.d_tcpFastOpenKey.size() * sizeof(immutableConfig.d_tcpFastOpenKey[0]));
         if (res == -1) {

--- a/pdns/dnsdistdist/doq-common.cc
+++ b/pdns/dnsdistdist/doq-common.cc
@@ -351,8 +351,9 @@ std::string getSNIFromQuicheConnection([[maybe_unused]] const QuicheConnection& 
   return {};
 }
 
-void configureQLog(const QuicheConnection& conn, const std::string& qLogDir, const ComboAddress& peer)
+void configureQLog([[maybe_unused]] const QuicheConnection& conn, [[maybe_unused]] const std::string& qLogDir, [[maybe_unused]] const ComboAddress& peer)
 {
+#ifdef HAVE_QUICHE_CONN_SET_QLOG_PATH
   const unsigned char* trace_id = nullptr;
   size_t trace_id_len = 0;
   quiche_conn_trace_id(conn.get(), &trace_id, &trace_id_len);
@@ -363,6 +364,7 @@ void configureQLog(const QuicheConnection& conn, const std::string& qLogDir, con
     VERBOSESLOG(infolog("QLOG creation failed for connection from $s", peer.toStringWithPort()),
                 dnsdist::logging::getTopLogger("quic-qlog")->info(Logr::Info, "QLOG creation failed", "client.address", Logging::Loggable(peer)));
   }
+#endif
 }
 
 QUICConnection::QUICConnection(ClientState& frontend, const ComboAddress& peer, const ComboAddress& localAddr, QuicheConfig config, QuicheConnection&& conn) :


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

And, as a bonus fix a few compile warnings about unused args & vars

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
