### PR TITLE
lmdbbackend: bounds-check compoundOrdername key decoders

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2192,11 +2192,11 @@ bool LMDBBackend::getInternal(DNSName& basename, std::string_view& key)
 
     key = d_lookupstate.key.getNoStripHeader<string_view>();
     // remove hash from the key so compoundOrdername::get* works
-    key = key.substr(0, key.size() - 256 / 8);
-    if (key.size() == 0) {
-      // removing the hash-sized suffix left us with nothing
+    if (key.size() <= 256 / 8) {
+      // there is nothing left once the hash-sized suffix is removed
       throw DBException("got invalid serialized comment: key too short");
     }
+    key = key.substr(0, key.size() - 256 / 8);
 
     basename = compoundOrdername::getQName(key);
 

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -217,6 +217,9 @@ private:
     static domainid_t getDomainID(const string_view& key)
     {
       uint32_t ret;
+      if (key.size() < sizeof(ret)) {
+        throw std::out_of_range("LMDB key is too short to hold a domain id");
+      }
       memcpy(&ret, &key[0], sizeof(ret));
       return static_cast<domainid_t>(ntohl(ret));
     }
@@ -226,6 +229,9 @@ private:
       /* www.ds9a.nl -> nl0ds9a0www0
          root -> 0   <- we need this to keep lmdb happy
          nl -> nl0 */
+      if (key.size() < 4 + sizeof(uint16_t)) {
+        throw std::out_of_range("LMDB key is too short to hold a name");
+      }
       DNSName ret;
       auto iter = key.cbegin() + 4;
       auto end = key.cend() - 2;
@@ -249,6 +255,9 @@ private:
     static QType getQType(const string_view& key)
     {
       uint16_t ret;
+      if (key.size() < sizeof(ret)) {
+        throw std::out_of_range("LMDB key is too short to hold a qtype");
+      }
       memcpy(&ret, &key[key.size() - 2], sizeof(ret));
       return QType(ntohs(ret));
     }


### PR DESCRIPTION
### Short description

The `compoundOrdername` key decoders in `lmdbbackend.hh` read a record key straight out of LMDB with no length check. `getDomainID` copies four bytes off the front and `getQType` reads at `key.size() - 2`, so a key shorter than the fixed 4-byte id / 2-byte qtype fields reads past the buffer, and the `getQType` offset wraps to a huge value on a one-byte key. `getInternal` feeds a truncated comment key in: stripping the 32-byte hash suffix with `key.size() - 256 / 8` underflows when the stored key is shorter than the hash, and the later `key.size() == 0` guard never catches it.

Length-check the key inside each decoder before the read, and reject the too-short key in `getInternal` before the subtraction instead of after. Keeping the checks in the decoders covers every caller that walks these keys off a cursor, not just the comment path. `deserializeRRFromBuffer` in the same backend already validates length before touching stored bytes, so this brings the key decoders in line with it.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

