### PR TITLE
Do not pass signed char to ctype functions in text parsers

### DIFF
--- a/pdns/qtype.cc
+++ b/pdns/qtype.cc
@@ -160,7 +160,7 @@ uint16_t QType::chartocode(const char *p)
    // not all callers are ready to handle exceptions arising here.
    char *end{nullptr};
    unsigned long typeno = strtoul(digits, &end, 10);
-   if (typeno <= std::numeric_limits<uint16_t>::max() && end != digits && (*end == '\0' || isspace(static_cast<int>(*end)) != 0)) {
+   if (typeno <= std::numeric_limits<uint16_t>::max() && end != digits && (*end == '\0' || isspace(static_cast<unsigned char>(*end)) != 0)) {
      return typeno;
    }
   }

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -58,7 +58,7 @@ void RecordTextReader::xfrNodeOrLocatorID(NodeOrLocatorID& val) {
   skipSpaces();
   size_t len;
   for(len=0;
-      d_pos+len < d_string.length() && (isxdigit(d_string.at(d_pos+len)) || d_string.at(d_pos+len) == ':');
+      d_pos+len < d_string.length() && (isxdigit(static_cast<unsigned char>(d_string.at(d_pos+len))) || d_string.at(d_pos+len) == ':');
       len++) ;   // find length of ID
 
   // Parse as v6, and then strip the final 64 zero bytes
@@ -77,7 +77,7 @@ void RecordTextReader::xfr64BitInt(uint64_t &val)
 {
   skipSpaces();
 
-  if(!isdigit(d_string.at(d_pos)))
+  if(!isdigit(static_cast<unsigned char>(d_string.at(d_pos))))
     throw RecordTextException("expected digits at position "+std::to_string(d_pos)+" in '"+d_string+"'");
 
   size_t pos;
@@ -91,7 +91,7 @@ void RecordTextReader::xfr32BitInt(uint32_t &val)
 {
   skipSpaces();
 
-  if(!isdigit(d_string.at(d_pos)))
+  if(!isdigit(static_cast<unsigned char>(d_string.at(d_pos))))
     throw RecordTextException("expected digits at position "+std::to_string(d_pos)+" in '"+d_string+"'");
 
   size_t pos;
@@ -141,7 +141,7 @@ void RecordTextReader::xfrIP(uint32_t &val)
 {
   skipSpaces();
 
-  if(!isdigit(d_string.at(d_pos)))
+  if(!isdigit(static_cast<unsigned char>(d_string.at(d_pos))))
     throw RecordTextException("while parsing IP address, expected digits at position "+std::to_string(d_pos)+" in '"+d_string+"'");
 
   uint32_t octet=0;
@@ -161,7 +161,7 @@ void RecordTextReader::xfrIP(uint32_t &val)
       if(count > 3)
         throw RecordTextException(string("unable to parse IP address, too many dots"));
     }
-    else if(isdigit(d_string.at(d_pos))) {
+    else if(isdigit(static_cast<unsigned char>(d_string.at(d_pos)))) {
       last_was_digit = true;
       octet*=10;
       octet+=d_string.at(d_pos) - '0';
@@ -196,7 +196,7 @@ void RecordTextReader::xfrIP6(std::string &val)
   size_t len;
   // lookup end of value - think of ::ffff encoding too, has dots in it!
   for(len=0;
-      d_pos+len < d_string.length() && (isxdigit(d_string.at(d_pos+len)) || d_string.at(d_pos+len) == ':' || d_string.at(d_pos+len)=='.');
+      d_pos+len < d_string.length() && (isxdigit(static_cast<unsigned char>(d_string.at(d_pos+len))) || d_string.at(d_pos+len) == ':' || d_string.at(d_pos+len)=='.');
     len++);
 
   if(!len)
@@ -633,7 +633,7 @@ static void HEXDecode(std::string_view chunk, string& out)
   bool lowdigit{false};
   uint8_t val{0};
   for (auto chr : chunk) {
-    if(isalnum(chr) == 0) {
+    if(isalnum(static_cast<unsigned char>(chr)) == 0) {
       continue;
     }
     if (!lowdigit) {

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -58,7 +58,7 @@ void RecordTextReader::xfrNodeOrLocatorID(NodeOrLocatorID& val) {
   skipSpaces();
   size_t len;
   for(len=0;
-      d_pos+len < d_string.length() && (isxdigit(static_cast<unsigned char>(d_string.at(d_pos+len))) || d_string.at(d_pos+len) == ':');
+      d_pos+len < d_string.length() && (isxdigit(static_cast<unsigned char>(d_string.at(d_pos+len))) != 0 || d_string.at(d_pos+len) == ':');
       len++) ;   // find length of ID
 
   // Parse as v6, and then strip the final 64 zero bytes
@@ -77,9 +77,9 @@ void RecordTextReader::xfr64BitInt(uint64_t &val)
 {
   skipSpaces();
 
-  if(!isdigit(static_cast<unsigned char>(d_string.at(d_pos))))
+  if (isdigit(static_cast<unsigned char>(d_string.at(d_pos))) == 0) {
     throw RecordTextException("expected digits at position "+std::to_string(d_pos)+" in '"+d_string+"'");
-
+  }
   size_t pos;
   val=std::stoull(d_string.substr(d_pos), &pos);
 
@@ -91,9 +91,9 @@ void RecordTextReader::xfr32BitInt(uint32_t &val)
 {
   skipSpaces();
 
-  if(!isdigit(static_cast<unsigned char>(d_string.at(d_pos))))
+  if (isdigit(static_cast<unsigned char>(d_string.at(d_pos))) == 0) {
     throw RecordTextException("expected digits at position "+std::to_string(d_pos)+" in '"+d_string+"'");
-
+  }
   size_t pos;
   val = pdns::checked_stoi<uint32_t>(d_string.c_str() + d_pos, &pos);
 
@@ -141,9 +141,9 @@ void RecordTextReader::xfrIP(uint32_t &val)
 {
   skipSpaces();
 
-  if(!isdigit(static_cast<unsigned char>(d_string.at(d_pos))))
+  if (isdigit(static_cast<unsigned char>(d_string.at(d_pos))) == 0) {
     throw RecordTextException("while parsing IP address, expected digits at position "+std::to_string(d_pos)+" in '"+d_string+"'");
-
+  }
   uint32_t octet=0;
   val=0;
   char count=0;
@@ -161,7 +161,7 @@ void RecordTextReader::xfrIP(uint32_t &val)
       if(count > 3)
         throw RecordTextException(string("unable to parse IP address, too many dots"));
     }
-    else if(isdigit(static_cast<unsigned char>(d_string.at(d_pos)))) {
+    else if (isdigit(static_cast<unsigned char>(d_string.at(d_pos))) != 0) {
       last_was_digit = true;
       octet*=10;
       octet+=d_string.at(d_pos) - '0';
@@ -196,7 +196,7 @@ void RecordTextReader::xfrIP6(std::string &val)
   size_t len;
   // lookup end of value - think of ::ffff encoding too, has dots in it!
   for(len=0;
-      d_pos+len < d_string.length() && (isxdigit(static_cast<unsigned char>(d_string.at(d_pos+len))) || d_string.at(d_pos+len) == ':' || d_string.at(d_pos+len)=='.');
+      d_pos+len < d_string.length() && (isxdigit(static_cast<unsigned char>(d_string.at(d_pos+len))) != 0 || d_string.at(d_pos+len) == ':' || d_string.at(d_pos+len)=='.');
     len++);
 
   if(!len)

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -25,7 +25,7 @@ enum coordtype { LATITUDE, LONGITUDE };
 static void
 skipspace(const std::string& content, std::string::size_type& pos)
 {
-  while (pos < content.length() && std::isspace(content.at(pos)) != 0) {
+  while (pos < content.length() && std::isspace(static_cast<unsigned char>(content.at(pos))) != 0) {
     ++pos;
   }
 }
@@ -54,7 +54,7 @@ parsenum(const std::string& content, std::string::size_type& pos, unsigned int& 
   bool parsed{false};
 
   number = 0;
-  while (pos < content.length() && std::isdigit(content.at(pos)) != 0) {
+  while (pos < content.length() && std::isdigit(static_cast<unsigned char>(content.at(pos))) != 0) {
     parsed = true;
     number = number * 10 + (content.at(pos) - '0');
     ++pos;
@@ -75,14 +75,14 @@ parsefrac(const std::string& content, std::string::size_type& pos, unsigned int 
     ++pos;
     while (digits-- != 0) {
       number *= 10;
-      if (pos < content.length() && std::isdigit(content.at(pos)) != 0) {
+      if (pos < content.length() && std::isdigit(static_cast<unsigned char>(content.at(pos))) != 0) {
         parsed = true; // intentionally rejects '.' alone
         number += (content.at(pos) - '0');
         ++pos;
       }
     }
     // skip any further digits
-    while (pos < content.length() && std::isdigit(content.at(pos)) != 0) {
+    while (pos < content.length() && std::isdigit(static_cast<unsigned char>(content.at(pos))) != 0) {
       ++pos;
     }
   }

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -143,7 +143,7 @@ unsigned int ZoneParserTNG::makeTTLFromZone(const string& str)
   }
 
   char lc=dns_tolower(str[str.length()-1]);
-  if(!isdigit(static_cast<unsigned char>(lc)))
+  if (isdigit(static_cast<unsigned char>(lc)) == 0) {
     switch(lc) {
     case 's':
       break;
@@ -166,6 +166,7 @@ unsigned int ZoneParserTNG::makeTTLFromZone(const string& str)
     default:
       throw PDNSException("Unable to parse time specification '"+str+"' "+getLineOfFile());
     }
+  }
   return val;
 }
 

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -143,7 +143,7 @@ unsigned int ZoneParserTNG::makeTTLFromZone(const string& str)
   }
 
   char lc=dns_tolower(str[str.length()-1]);
-  if(!isdigit(lc))
+  if(!isdigit(static_cast<unsigned char>(lc)))
     switch(lc) {
     case 's':
       break;


### PR DESCRIPTION
### Short description

The record text parsers walk RDATA and zone text one character at a time with `content.at(pos)` or `d_string.at(pos)`, then hand the resulting `char` to `isspace`/`isdigit`/`isxdigit`/`isalnum`. `char` is signed on the usual platforms, so a byte of 0x80 or higher in a record's text form (an API-supplied record, a zone file, or backend content feeding a LOC, IP, hex, TTL, or numeric field) reaches the ctype function as a negative `int`. That is undefined behavior and indexes before the ctype classification table on libcs that do not pad for negative values.

Cast each argument to `unsigned char` before the call so the value stays in the 0..255 range these functions accept. `dnsname.cc` and `ws-auth.cc` already guard their ctype calls this way, and this follows the same reasoning as the recent "do not assume char is unsigned when parsing SVCB records" change. Valid ASCII input is unaffected.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
