### PR TITLE
auth: add a test for #2625

### DIFF
--- a/regression-tests/tests/cname-to-apex-2/command
+++ b/regression-tests/tests/cname-to-apex-2/command
@@ -1,0 +1,3 @@
+#!/bin/sh
+cleandig www.test.com AAAA
+cleandig www.cryptokeys.org AAAA

--- a/regression-tests/tests/cname-to-apex-2/description
+++ b/regression-tests/tests/cname-to-apex-2/description
@@ -1,0 +1,4 @@
+Tries to resolve the AAAA for a name which is a CNAME to the apex, lacking
+an AAAA record.
+This used to trigger a scary warning with the TinyDNS backend, see
+https://github.com/PowerDNS/pdns/issues/2625

--- a/regression-tests/tests/cname-to-apex-2/expected_result
+++ b/regression-tests/tests/cname-to-apex-2/expected_result
@@ -1,0 +1,8 @@
+0	www.test.com.	3600	IN	CNAME	server1.test.com.
+1	test.com.	3600	IN	SOA	ns1.test.com. ahu.example.com. 2005092501 28800 7200 604800 86400
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='www.test.com.', qtype=AAAA
+0	www.cryptokeys.org.	3600	IN	CNAME	cryptokeys.org.
+1	cryptokeys.org.	3600	IN	SOA	cryptokeys.ds9a.nl. ahu.ds9a.nl. 2009071301 14400 3600 604800 3600
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='www.cryptokeys.org.', qtype=AAAA


### PR DESCRIPTION
### Short description
This adds a test querying a name for `AAAA`, with the name being a `CNAME` to the zone apex.
This used to trigger a scary warning with the TinyDNS backend (said warning has been disabled in 561434a6d4cdfbf6fc18c6c7e4a4f23c6944c8c3).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
