### PR TITLE
Correct the EDNS option length bound in queryMatches

### DIFF
--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -217,7 +217,10 @@ public:
     uint16_t optionLen;
 
     while (pos < querySize && rdataRead < rdLen && getNextEDNSOption(&query.at(pos), rdLen - rdataRead, optionCode, optionLen)) {
-      if (optionLen > (rdLen - rdataRead)) {
+      /* getNextEDNSOption() only returns true if at least 4 bytes (the option
+         code and length) are left, so rdLen - rdataRead >= 4 here and the
+         subtraction below cannot underflow */
+      if (optionLen > (rdLen - rdataRead - 4)) {
         return cachedQuery.compare(pos, cachedQuerySize - pos, query, pos, querySize - pos) == 0;
       }
 

--- a/pdns/test-packetcache_hh.cc
+++ b/pdns/test-packetcache_hh.cc
@@ -387,4 +387,55 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_PacketCacheEDNSOptionLengthBound) {
+  /* queryMatches() has to use the same EDNS option-length bound as
+     hashAfterQname(): the room left for an option value is
+     (rdLen - rdataRead - 4), since the option code (2) and length (2)
+     precede the value. A query whose OPT option declares a length within
+     four bytes of the remaining RDATA is malformed and must be treated the
+     same way by both, otherwise the hash and the match disagree. */
+  const DNSName qname("www.powerdns.com.");
+  const uint16_t qtype = QType::AAAA;
+  static const std::unordered_set<uint16_t> skipECS{ EDNSOptionCode::ECS };
+
+  EDNSSubnetOpts opt;
+  DNSPacketWriter::optvect_t ednsOptions;
+
+  auto makeQuery = [&](const std::string& ecsSource) -> std::string {
+    vector<uint8_t> packet;
+    DNSPacketWriter pw(packet, qname, qtype);
+    pw.getHeader()->rd = true;
+    pw.getHeader()->qr = false;
+    pw.getHeader()->id = 0x42;
+    opt.setSource(Netmask(ecsSource));
+    const std::string ecs = opt.makeOptString();
+    ednsOptions.clear();
+    ednsOptions.emplace_back(EDNSOptionCode::ECS, ecs);
+    pw.addOpt(512, 0, 0, ednsOptions);
+    pw.commit();
+
+    std::string spacket(reinterpret_cast<const char*>(packet.data()), packet.size());
+    /* the ECS option is the last thing in the packet; its length field sits two
+       bytes before its value. Bump it by 3 so the option claims to run past the
+       actual RDATA end, landing in the (rdLen - 3 .. rdLen) window. */
+    auto* optLen = reinterpret_cast<unsigned char*>(&spacket.at(spacket.size() - ecs.size() - 2));
+    const uint16_t bumped = static_cast<uint16_t>((optLen[0] * 256 + optLen[1]) + 3);
+    optLen[0] = static_cast<unsigned char>(bumped >> 8);
+    optLen[1] = static_cast<unsigned char>(bumped & 0xff);
+    return spacket;
+  };
+
+  /* two queries differing only in the (skipped) ECS option value */
+  const std::string queryA = makeQuery("192.0.2.0/24");
+  const std::string queryB = makeQuery("203.0.113.0/24");
+
+  /* hashAfterQname() sees the malformed option and hashes the raw remainder, so
+     the differing ECS bytes give different hashes */
+  BOOST_CHECK(PacketCache::canHashPacket(queryA, skipECS) != PacketCache::canHashPacket(queryB, skipECS));
+
+  /* queryMatches() confirms a hash hit, so it must refuse to match two queries
+     that hash differently */
+  BOOST_CHECK(!PacketCache::queryMatches(queryA, queryB, qname, skipECS));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-packetcache_hh.cc
+++ b/pdns/test-packetcache_hh.cc
@@ -34,7 +34,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw1.getHeader()->rd = true;
     pw1.getHeader()->qr = false;
     pw1.getHeader()->id = 0x42;
-    string spacket1((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket1(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash1 = PacketCache::canHashPacket(spacket1, optionsToSkip);
 
     packet.clear();
@@ -42,7 +43,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw2.getHeader()->rd = true;
     pw2.getHeader()->qr = false;
     pw2.getHeader()->id = 0x84;
-    string spacket2((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket2(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash2 = PacketCache::canHashPacket(spacket2, optionsToSkip);
 
     BOOST_CHECK_EQUAL(hash1, hash2);
@@ -62,7 +64,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw1.addOpt(512, 0, 0, ednsOptions);
     pw1.commit();
 
-    string spacket1((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket1(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash1 = PacketCache::canHashPacket(spacket1, optionsToSkip);
 
     packet.clear();
@@ -76,7 +79,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw2.addOpt(512, 0, 0, ednsOptions);
     pw2.commit();
 
-    string spacket2((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket2(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash2 = PacketCache::canHashPacket(spacket2, optionsToSkip);
 
     BOOST_CHECK_EQUAL(hash1, hash2);
@@ -134,7 +138,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw1.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);
     pw1.commit();
 
-    string spacket1((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket1(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash1 = PacketCache::canHashPacket(spacket1, optionsToSkip);
 
     packet.clear();
@@ -149,7 +154,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw2.addOpt(512, 0, 0, ednsOptions);
     pw2.commit();
 
-    string spacket2((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket2(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash2 = PacketCache::canHashPacket(spacket2, optionsToSkip);
 
     BOOST_CHECK_EQUAL(hash1, hash2);
@@ -172,7 +178,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw1.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);
     pw1.commit();
 
-    string spacket1((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket1(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash1 = PacketCache::canHashPacket(spacket1, optionsToSkip);
 
     packet.clear();
@@ -188,7 +195,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheAuthCollision) {
     pw2.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);
     pw2.commit();
 
-    string spacket2((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket2(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash2 = PacketCache::canHashPacket(spacket2, optionsToSkip);
 
     BOOST_CHECK_EQUAL(hash1, hash2);
@@ -266,10 +274,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecSimple) {
     pw1.addOpt(512, 0, 0);
     pw1.commit();
 
-    string spacket1((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket1(reinterpret_cast<const char*>(packet.data()), packet.size());
     /* set the RD length to a large value */
-    unsigned char* ptr = reinterpret_cast<unsigned char*>(&spacket1.at(sizeof(dnsheader) + qname.wirelength() + /* qtype and qclass */ 4 + /* OPT root label (1), type (2), class (2) and ttl (4) */ 9));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto* ptr = reinterpret_cast<unsigned char*>(&spacket1.at(sizeof(dnsheader) + qname.wirelength() + /* qtype and qclass */ 4 + /* OPT root label (1), type (2), class (2) and ttl (4) */ 9));
     *ptr = 255;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     *(ptr + 1) = 255;
     /* truncate the end of the OPT header to try to trigger an out of bounds read */
     spacket1.resize(spacket1.size() - 6);
@@ -293,7 +304,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     pw1.getHeader()->rd = true;
     pw1.getHeader()->qr = false;
     pw1.getHeader()->id = 0x42;
-    string spacket1((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket1(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash1 = PacketCache::canHashPacket(spacket1, optionsToSkip);
 
     packet.clear();
@@ -301,7 +313,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     pw2.getHeader()->rd = true;
     pw2.getHeader()->qr = false;
     pw2.getHeader()->id = 0x84;
-    string spacket2((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket2(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash2 = PacketCache::canHashPacket(spacket2, optionsToSkip);
 
     BOOST_CHECK_EQUAL(hash1, hash2);
@@ -321,7 +334,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     pw1.addOpt(512, 0, 0, ednsOptions);
     pw1.commit();
 
-    string spacket1((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket1(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash1 = PacketCache::canHashPacket(spacket1, optionsToSkip);
 
     packet.clear();
@@ -335,7 +349,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     pw2.addOpt(512, 0, 0, ednsOptions);
     pw2.commit();
 
-    string spacket2((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket2(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash2 = PacketCache::canHashPacket(spacket2, optionsToSkip);
 
     BOOST_CHECK_EQUAL(hash1, hash2);
@@ -353,12 +368,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     opt.setSource(Netmask("192.0.2.1/32"));
     ednsOptions.clear();
     ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
-    EDNSCookiesOpt cookiesOpt(string("deadbeefdead\x11\xee\x00\x00").c_str(), 16);
+    EDNSCookiesOpt cookiesOpt("deadbeefdead\x11\xee\x00\x00", 16);
     ednsOptions.emplace_back(EDNSOptionCode::COOKIE, cookiesOpt.makeOptString());
     pw1.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);
     pw1.commit();
 
-    string spacket1((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket1(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash1 = PacketCache::canHashPacket(spacket1, optionsToSkip);
 
     packet.clear();
@@ -369,12 +385,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheRecCollision) {
     opt.setSource(Netmask("192.0.2.1/32"));
     ednsOptions.clear();
     ednsOptions.emplace_back(EDNSOptionCode::ECS, opt.makeOptString());
-    cookiesOpt.makeFromString(string("deadbeefdead\x67\x44\x00\x00").c_str(), 16);
+    cookiesOpt.makeFromString("deadbeefdead\x67\x44\x00\x00", 16);
     ednsOptions.emplace_back(EDNSOptionCode::COOKIE, cookiesOpt.makeOptString());
     pw2.addOpt(512, 0, EDNSOpts::DNSSECOK, ednsOptions);
     pw2.commit();
 
-    string spacket2((const char*)&packet[0], packet.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    string spacket2(reinterpret_cast<const char*>(packet.data()), packet.size());
     auto hash2 = PacketCache::canHashPacket(spacket2, optionsToSkip);
 
     BOOST_CHECK_EQUAL(hash1, hash2);
@@ -403,24 +420,29 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheEDNSOptionLengthBound) {
 
   auto makeQuery = [&](const std::string& ecsSource) -> std::string {
     vector<uint8_t> packet;
-    DNSPacketWriter pw(packet, qname, qtype);
-    pw.getHeader()->rd = true;
-    pw.getHeader()->qr = false;
-    pw.getHeader()->id = 0x42;
+    DNSPacketWriter packetWriter(packet, qname, qtype);
+    packetWriter.getHeader()->rd = true;
+    packetWriter.getHeader()->qr = false;
+    packetWriter.getHeader()->id = 0x42;
     opt.setSource(Netmask(ecsSource));
     const std::string ecs = opt.makeOptString();
     ednsOptions.clear();
     ednsOptions.emplace_back(EDNSOptionCode::ECS, ecs);
-    pw.addOpt(512, 0, 0, ednsOptions);
-    pw.commit();
+    packetWriter.addOpt(512, 0, 0, ednsOptions);
+    packetWriter.commit();
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     std::string spacket(reinterpret_cast<const char*>(packet.data()), packet.size());
     /* the ECS option is the last thing in the packet; its length field sits two
        bytes before its value. Bump it by 3 so the option claims to run past the
        actual RDATA end, landing in the (rdLen - 3 .. rdLen) window. */
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto* optLen = reinterpret_cast<unsigned char*>(&spacket.at(spacket.size() - ecs.size() - 2));
-    const uint16_t bumped = static_cast<uint16_t>((optLen[0] * 256 + optLen[1]) + 3);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const auto bumped = static_cast<uint16_t>(((optLen[0] * 256) + optLen[1]) + 3);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     optLen[0] = static_cast<unsigned char>(bumped >> 8);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     optLen[1] = static_cast<unsigned char>(bumped & 0xff);
     return spacket;
   };


### PR DESCRIPTION
### Short description

`queryMatches` in `packetcache.hh` walks the EDNS options of an incoming query and checks each option's declared length against the RDATA left, but it does not subtract the 4-byte option header (code + length) that `getNextEDNSOption` has already consumed. `hashAfterQname`, which computes the cache key over the same bytes, does subtract it (`rdLen - rdataRead - 4`). So an OPT option that declares a value length within four bytes of the remaining RDATA is treated as malformed by the hash but kept by the match, and the two walk the same client-controlled bytes differently.

Subtracting the header in `queryMatches` makes both bail on the same input. Keeping the match consistent with the hash is what makes a packet-cache hit trustworthy, so the bound belongs next to the option walk rather than in the callers. The added test builds two queries that differ only in a skipped option's value, placed past the tampered length, and shows they now hash apart and no longer match.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
