### PR TITLE
rec: RRSIGs with too few labels can lead to bypass of DNSSEC wildcard validation

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -535,6 +535,12 @@ string getMessageForRRSET(const DNSName& qname, const RRSIGRecordContent& rrc, c
     unsigned int fqdn_labels = qname.countLabels();
 
     if (rrsig_labels < fqdn_labels) {
+      const auto signer_labels = rrc.d_signer.countLabels();
+      if (rrsig_labels < signer_labels) {
+        // the RRSIG labels field is a lie (the wildcard would be
+        // out of the signer's zone) and thus the RRSIG can never be valid
+        return {};
+      }
       DNSName choppedQname(qname);
       for (auto nlabels = fqdn_labels; nlabels > rrsig_labels; --nlabels) {
         choppedQname.chopOff();

--- a/pdns/recursordist/test-syncres_cc3.cc
+++ b/pdns/recursordist/test-syncres_cc3.cc
@@ -1284,13 +1284,13 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_cname_wildcard_expanded
   /* unsigned */
   const DNSName target("test.");
   /* signed */
-  const DNSName cnameTarget("cname.");
+  const DNSName cnameTarget("cname.zone.");
   testkeysset_t keys;
 
   auto luaconfsCopy = g_luaconfs.getCopy();
   luaconfsCopy.dsAnchors.clear();
   generateKeyMaterial(g_rootdnsname, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
-  generateKeyMaterial(cnameTarget, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
+  generateKeyMaterial(DNSName("zone."), DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
   g_luaconfs.setState(luaconfsCopy);
 
   const ComboAddress forwardedNS("192.0.2.42:53");
@@ -1320,10 +1320,10 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_cname_wildcard_expanded
       addRecordToLW(res, target, QType::CNAME, cnameTarget.toString());
       addRecordToLW(res, cnameTarget, QType::A, "192.0.2.1");
       /* the RRSIG proves that the cnameTarget was expanded from a wildcard */
-      addRRSIG(keys, res->d_records, cnameTarget, 300, false, std::nullopt, DNSName("*"));
+      addRRSIG(keys, res->d_records, DNSName("zone."), 300, false, std::nullopt, DNSName("*.zone"));
       /* we need to add the proof that this name does not exist, so the wildcard may apply */
-      addNSECRecordToLW(DNSName("cnamd."), DNSName("cnamf."), {QType::A, QType::NSEC, QType::RRSIG}, 60, res->d_records);
-      addRRSIG(keys, res->d_records, cnameTarget, 300);
+      addNSECRecordToLW(DNSName("cnamd.zone."), DNSName("cnamf.zone."), {QType::A, QType::NSEC, QType::RRSIG}, 60, res->d_records);
+      addRRSIG(keys, res->d_records, DNSName("zone."), 300);
 
       return LWResult::Result::Success;
     }

--- a/pdns/recursordist/test-syncres_cc5.cc
+++ b/pdns/recursordist/test-syncres_cc5.cc
@@ -5,6 +5,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "test-syncres_cc.hh"
+#include "aggressive_nsec.hh"
 
 BOOST_AUTO_TEST_SUITE(syncres_cc5)
 
@@ -2431,6 +2432,118 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_wildcard_like_expanded_from_wildcard
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   /* A + RRSIG, NSEC + RRSIG */
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+}
+
+BOOST_AUTO_TEST_CASE(test_dnssec_validation_out_of_zone_wildcard)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target("www.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("com."), DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([&](const ComboAddress& address, const DNSName& domain, int type, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, std::optional<Netmask>& /* srcmask */, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (type == QType::DS && domain == target) {
+        setLWResult(res, RCode::NoError, true, false, true);
+        addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        addNSECRecordToLW(DNSName("www.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+        return LWResult::Result::Success;
+      }
+      return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+    }
+    {
+      if (isRootServer(address)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      if (address == ComboAddress("192.0.2.1:53")) {
+        if (domain == DNSName("com.")) {
+          setLWResult(res, 0, true, false, true);
+          addRecordToLW(res, domain, QType::NS, "a.gtld-servers.com.");
+          addRRSIG(keys, res->d_records, domain, 300);
+          addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+          addRRSIG(keys, res->d_records, domain, 300);
+        }
+        else {
+          setLWResult(res, 0, false, false, true);
+          addRecordToLW(res, "powerdns.com.", QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 3600);
+          addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+          addRRSIG(keys, res->d_records, DNSName("com."), 300);
+          addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
+        }
+        return LWResult::Result::Success;
+      }
+      if (address == ComboAddress("192.0.2.2:53")) {
+        setLWResult(res, 0, true, false, true);
+        if (type == QType::NS) {
+          if (domain == DNSName("powerdns.com.")) {
+            addRecordToLW(res, domain, QType::NS, "ns1.powerdns.com.");
+            addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+            addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
+            addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+          }
+          else {
+            addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+            addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+            addNSECRecordToLW(DNSName("www.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
+            addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+          }
+        }
+        else {
+          addRecordToLW(res, domain, QType::A, "192.0.2.42", DNSResourceRecord::ANSWER, 600);
+          /* this pretends that the wildcard lives out of the powerdns.com zone, even though it will be signed by the powerdns.com key */
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, std::nullopt, DNSName("*.com"));
+          /* we need to add the proof that this name does not exist, so the wildcard may apply */
+          addNSECRecordToLW(DNSName("wwa.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 60, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+        }
+        return LWResult::Result::Success;
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  g_recCache->doWipeCache(DNSName("wwa.powerdns.com."), false);
+  /* we enable the aggressive NSEC cache to check if the computed wildcard is then inserted
+     into the record cache */
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(10000);
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusNoValidRRSIG);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+
+  /* make sure that the bogus wildcard entry has not been cached! */
+  const time_t now = sr->getNow().tv_sec;
+  const ComboAddress who;
+  vector<DNSRecord> cached;
+  BOOST_CHECK_EQUAL(g_recCache->get(now, DNSName("*.com."), QType(QType::A), MemRecursorCache::RequireAuth, &cached, who), -1);
+  g_aggressiveNSECCache.reset();
 }
 
 // Tests PR 8648

--- a/pdns/recursordist/test-syncres_cc5.cc
+++ b/pdns/recursordist/test-syncres_cc5.cc
@@ -2535,7 +2535,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_out_of_zone_wildcard)
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusNoValidRRSIG);
-  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_REQUIRE_EQUAL(ret.size(), 2U);
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 
   /* make sure that the bogus wildcard entry has not been cached! */

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -1092,7 +1092,7 @@ vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t
       continue;
     }
     if (!isRRSIGLabelCountValid(*signature)) {
-      VLOG(log, name << ": Discarding invalid RRSIG whose label count is " << signature->d_labels << " while the signer has only " << signature->d_signer.countLabels() << endl);
+      VLOG(log, name << ": Discarding invalid RRSIG whose label count is " << signature->d_labels << ", not enough to match the signer which has " << signature->d_signer.countLabels() << endl);
       continue;
     }
     allDiscarded = false;

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -234,6 +234,12 @@ bool denialProvesNoDelegation(const DNSName& zone, const std::vector<DNSRecord>&
   return false;
 }
 
+static bool isRRSIGLabelCountValid(const RRSIGRecordContent& sign)
+{
+  const auto signerLabelCount = sign.d_signer.countLabels();
+  return sign.d_labels >= signerLabelCount;
+}
+
 /* RFC 4035 section-5.3.4:
    "If the number of labels in an RRset's owner name is greater than the
    Labels field of the covering RRSIG RR, then the RRset and its
@@ -241,7 +247,7 @@ bool denialProvesNoDelegation(const DNSName& zone, const std::vector<DNSRecord>&
 */
 bool isWildcardExpanded(unsigned int labelCount, const RRSIGRecordContent& sign)
 {
-  return sign.d_labels < labelCount;
+  return sign.d_labels < labelCount && isRRSIGLabelCountValid(sign);
 }
 
 static bool isWildcardExpanded(const DNSName& owner, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures)
@@ -258,7 +264,7 @@ static bool isWildcardExpanded(const DNSName& owner, const std::vector<std::shar
 bool isWildcardExpandedOntoItself(const DNSName& owner, unsigned int labelCount, const RRSIGRecordContent& sign)
 {
   /* this is a wildcard alright, but it has not been expanded */
-  return owner.isWildcard() && (labelCount - 1) == sign.d_labels;
+  return owner.isWildcard() && (labelCount - 1) == sign.d_labels && isRRSIGLabelCountValid(sign);
 }
 
 static bool isWildcardExpandedOntoItself(const DNSName& owner, const std::vector<std::shared_ptr<const RRSIGRecordContent>>& signatures)
@@ -284,7 +290,7 @@ DNSName getNSECOwnerName(const DNSName& initialOwner, const std::vector<std::sha
 
   const auto& sign = signatures.at(0);
   unsigned int labelsCount = initialOwner.countLabels();
-  if (sign && sign->d_labels < labelsCount) {
+  if (sign && sign->d_labels < labelsCount && isRRSIGLabelCountValid(*sign)) {
     do {
       result.chopOff();
       labelsCount--;
@@ -1085,9 +1091,8 @@ vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t
       VLOG(log, name << ": Discarding invalid RRSIG whose label count is " << signature->d_labels << " while the RRset owner name has only " << labelCount << endl);
       continue;
     }
-    const auto signerLabelsCount = signature->d_signer.countLabels();
-    if (signature->d_labels < signerLabelsCount) {
-      VLOG(log, name << ": Discarding invalid RRSIG whose label count is " << signature->d_labels << " while the signer has only " << signerLabelsCount << endl);
+    if (!isRRSIGLabelCountValid(*signature)) {
+      VLOG(log, name << ": Discarding invalid RRSIG whose label count is " << signature->d_labels << " while the signer has only " << signature->d_signer.countLabels() << endl);
       continue;
     }
     allDiscarded = false;

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -1078,10 +1078,15 @@ namespace
 
 vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t& toSign, const vector<shared_ptr<const RRSIGRecordContent>>& signatures, const skeyset_t& keys, const OptLog& log, pdns::validation::ValidationContext& context, bool validateAllSigs)
 {
+  // whether we could not find the corresponding key in keys for at least one signature
   bool missingKey = false;
+  // whether we were able to validate at least one signature
   bool isValid = false;
+  // whether all signatures were expired (will be set to false if at least one signature is not expired)
   bool allExpired = true;
+  // whether we discarded all signatures (will be set to false if we accept, but not necessarily validate, at least one signature)
   bool allDiscarded = true;
+  // whether all signatures were not yet incepted (will be set to false if at least one signature is found to be incepted)
   bool noneIncepted = true;
   uint16_t signaturesConsidered = 0;
 
@@ -1095,6 +1100,8 @@ vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t
       VLOG(log, name << ": Discarding invalid RRSIG whose label count is " << signature->d_labels << ", not enough to match the signer which has " << signature->d_signer.countLabels() << endl);
       continue;
     }
+    // we don't have the information in this function at the moment, but it would be nice to validate that the signer is coherent with the zone we are validating
+
     allDiscarded = false;
 
     vState ede = vState::Indeterminate;

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -1075,6 +1075,7 @@ vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t
   bool missingKey = false;
   bool isValid = false;
   bool allExpired = true;
+  bool allDiscarded = true;
   bool noneIncepted = true;
   uint16_t signaturesConsidered = 0;
 
@@ -1084,6 +1085,12 @@ vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t
       VLOG(log, name << ": Discarding invalid RRSIG whose label count is " << signature->d_labels << " while the RRset owner name has only " << labelCount << endl);
       continue;
     }
+    const auto signerLabelsCount = signature->d_signer.countLabels();
+    if (signature->d_labels < signerLabelsCount) {
+      VLOG(log, name << ": Discarding invalid RRSIG whose label count is " << signature->d_labels << " while the signer has only " << signerLabelsCount << endl);
+      continue;
+    }
+    allDiscarded = false;
 
     vState ede = vState::Indeterminate;
     if (!DNSCryptoKeyEngine::isAlgorithmSupported(signature->d_algorithm)) {
@@ -1156,6 +1163,9 @@ vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t
     return vState::Secure;
   }
   if (missingKey) {
+    return vState::BogusNoValidRRSIG;
+  }
+  if (allDiscarded) {
     return vState::BogusNoValidRRSIG;
   }
   if (noneIncepted) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Assigned CVE-2026-52688

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
