### PR TITLE
auth: more RFC3597 conformance

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -154,6 +154,22 @@ std::shared_ptr<DNSRecordContent> DNSRecordContent::make(uint16_t qtype, uint16_
     return std::make_shared<UnknownRecordContent>(content);
   }
 
+  // If the record type is known, but is provided as raw data, we need to first
+  // parse it as an UnknownRecordContent, and then pretend the data is coming
+  // from the wire.
+  if (content.length() >= 3 && content.at(0) == '\\' && content.at(1) == '#' && isspace(content.at(2)) != 0) {
+    UnknownRecordContent urc(content);
+    const auto& rawdata = urc.getRawContent();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): rawdata.data() is uint8_t *
+    PacketReader reader(std::string_view(reinterpret_cast<const char *>(rawdata.data()), rawdata.size()), 0, false, true /* standalone */);
+    DNSRecord rec;
+    rec.d_class = qclass;
+    rec.d_type = qtype;
+    rec.d_ttl = 0;
+    rec.d_clen = rawdata.size();
+    return make(rec, reader);
+  }
+
   return i->second(content);
 }
 
@@ -473,10 +489,12 @@ DNSName PacketReader::getName()
 {
   unsigned int consumed;
   try {
-    DNSName dn((const char*) d_content.data(), d_content.size(), d_pos, true /* uncompress */, nullptr /* qtype */, nullptr /* qclass */, &consumed, sizeof(dnsheader));
+    uint16_t minOffset = d_standalone ? 0 : sizeof(dnsheader);
+    bool uncompress = !d_standalone;
+    DNSName name((const char*) d_content.data(), d_content.size(), d_pos, uncompress, nullptr /* qtype */, nullptr /* qclass */, &consumed, minOffset);
 
     d_pos+=consumed;
-    return dn;
+    return name;
   }
   catch(const std::range_error& re) {
     throw std::out_of_range(string("dnsname issue: ")+re.what());

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -68,14 +68,13 @@ class MOADNSParser;
 class PacketReader
 {
 public:
-  PacketReader(const std::string_view& content, uint16_t initialPos=sizeof(dnsheader), bool internalRepresentation = false)
-    : d_pos(initialPos), d_startrecordpos(initialPos), d_content(content), d_internal(internalRepresentation)
+  PacketReader(const std::string_view& content, uint16_t initialPos=sizeof(dnsheader), bool internalRepresentation = false, bool standalone = false)
+    : d_pos(initialPos), d_startrecordpos(initialPos), d_internal(internalRepresentation), d_standalone(standalone), d_content(content)
   {
     if(content.size() > std::numeric_limits<uint16_t>::max())
       throw std::out_of_range("packet too large");
 
     d_recordlen = (uint16_t) content.size();
-    not_used = 0;
   }
 
   uint32_t get32BitInt();
@@ -209,9 +208,9 @@ private:
   uint16_t d_pos;
   uint16_t d_startrecordpos; // needed for getBlob later on
   uint16_t d_recordlen;      // ditto
-  uint16_t not_used; // Aligns the whole class on 8-byte boundaries
-  const std::string_view d_content;
   bool d_internal;
+  bool d_standalone; // no dnsheader at the beginning of content
+  const std::string_view d_content;
 };
 
 struct DNSRecord;

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -55,6 +55,7 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
 
   const cases_t cases = boost::assign::list_of
      (CASE_S(QType::A, "127.0.0.1", "\x7F\x00\x00\x01"))
+     (CASE_L(QType::A, "\\# 4 7f000001", "127.0.0.1", "\x7F\x00\x00\x01"))
 // local nameserver
      (CASE_S(QType::NS, "ns.rec.test.", "\x02ns\xc0\x11"))
 // non-local nameserver
@@ -106,6 +107,7 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
      (CASE_S(QType::RP, "admin.example.com. admin-info.example.com.", "\x05""admin\x07""example\x03""com\x00\x0a""admin-info\x07""example\x03""com\x00"))
 // local name
      (CASE_S(QType::AFSDB, "1 afs-server.rec.test.", "\x00\x01\x0a""afs-server\x03rec\x04test\x00"))
+     (CASE_L(QType::AFSDB, "\\# 23 00010a6166732d73657276657203726563047465737400", "1 afs-server.rec.test.", "\x00\x01\x0a""afs-server\x03rec\x04test\x00"))
 // non-local name
      (CASE_S(QType::AFSDB, "1 afs-server.example.com.", "\x00\x01\x0a""afs-server\x07""example\x03""com\x00"))
      (CASE_S(QType::KEY, "0 3 3 V19hwufL6LJARVIxzHDyGdvZ7dbQE0Kyl18yPIWj/sbCcsBbz7zO6Q2qgdzmWI3OvGNne2nxflhorhefKIMsUg==", "\x00\x00\x03\x03\x57\x5f\x61\xc2\xe7\xcb\xe8\xb2\x40\x45\x52\x31\xcc\x70\xf2\x19\xdb\xd9\xed\xd6\xd0\x13\x42\xb2\x97\x5f\x32\x3c\x85\xa3\xfe\xc6\xc2\x72\xc0\x5b\xcf\xbc\xce\xe9\x0d\xaa\x81\xdc\xe6\x58\x8d\xce\xbc\x63\x67\x7b\x69\xf1\x7e\x58\x68\xae\x17\x9f\x28\x83\x2c\x52"))


### PR DESCRIPTION
### Short description
This PR allows records of known type to be provided as raw data, in `\#` format.

In order to achieve this:
- `PacketReader` is modified to add a "standalone" mode, in which no header exists before the payload, and no attempt is made to handle compressed DNS names (as compression only works within an entire packet).
- When attempting to parse a known record type from its zone representation, and said representation starts with '\#', we parse it as `UnknownRecordContent` first, then feed the resulting raw data to a `PacketReader` in standalone mode and then parse the record with the intended type, from the `PacketReader`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
