### PR TITLE
upload-to-pulp action: use add_content_units attribute for all deb release components in Pulp

### DIFF
--- a/upload-to-pulp/upload-packages-to-pulp.py
+++ b/upload-to-pulp/upload-packages-to-pulp.py
@@ -265,10 +265,10 @@ def pulp_upload_deb_packages_by_folder(repo_name, distribution_name, source):
     modify_repository_url = PULP_API_URL + repository_href + "modify/"
 
     repository_modify_payload = {
-        "add_content_units": packages,
-        "add_release_components": release_components,
-        "add_release_architectures": release_architectures,
-        "add_package_release_components": package_release_components
+        "add_content_units": packages
+        + release_components
+        + release_architectures
+        + package_release_components
     }
 
     try:


### PR DESCRIPTION
This PR updates the `upload-to-pulp` action to use only the `add_content_units` attribute for objects instead of custom ones when batch-uploading DEB packages to Pulp.

Test: <https://github.com/romeroalx/pdns/actions/runs/29917342718>

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
