### PR TITLE
auth: finer TSIG key deletion

### DIFF
--- a/docs/appendices/backend-writers-guide.rst
+++ b/docs/appendices/backend-writers-guide.rst
@@ -863,7 +863,7 @@ In order for a backend to support the storage of TSIG keys, the following operat
       /* ... */
       virtual bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content);
       virtual bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content);
-      virtual bool deleteTSIGKey(const DNSName& name);
+      virtual bool deleteTSIGKey(const DNSName& name, const DNSName& algorithm);
       virtual bool getTSIGKeys(std::vector< struct TSIGKey > &keys);
       /* ... */
     }

--- a/docs/appendices/backend-writers-guide.rst
+++ b/docs/appendices/backend-writers-guide.rst
@@ -864,7 +864,7 @@ In order for a backend to support the storage of TSIG keys, the following operat
       /* ... */
       virtual bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content);
       virtual bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content);
-      virtual bool deleteTSIGKey(const DNSName& name);
+      virtual bool deleteTSIGKey(const DNSName& name, const DNSName& algorithm);
       virtual bool getTSIGKeys(std::vector< struct TSIGKey > &keys);
       /* ... */
     }

--- a/docs/backends/generic-sql.rst
+++ b/docs/backends/generic-sql.rst
@@ -363,6 +363,8 @@ TSIG
 -  ``set-tsig-key-query``: Called to set the algorithm and secret for a
    named TSIG key.
 -  ``delete-tsig-key-query``: Called to delete a named TSIG key.
+-  ``delete-tsig-key-algorithm-query``: Called to delete a named TSIG key with
+   the given algorithm.
 
 Comment queries
 ^^^^^^^^^^^^^^^

--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -844,7 +844,7 @@ Response:
 Retrieves the key needed to sign AXFR.
 
 -  Mandatory: no
--  Parameters: name
+-  Parameters: name, optional algorithm
 -  Reply: algorithm, content
 
 Example JSON/RPC

--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -30,7 +30,7 @@ Important notices
 -----------------
 
 Broken networks with IPv6 suffixes
-==================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In some (broken) network setups, the IP addresses provided in the
 request (when this is an IPv6 address) may be suffixed with a ``%`` and
@@ -38,7 +38,7 @@ the name of the network interface (e.g. ``%eth1``). Keep this in mind
 when checking the IP addresses.
 
 Breaking changes from pre v4.0 to v4.0+
-=======================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Before version 4.0, the DNS names passed in queries were sent without a trailing
 dot, after version 4.0 the DNS names are always sent with trailing dot, e.g.
@@ -165,7 +165,7 @@ Methods required for different features
 :Always required: ``initialize``, ``lookup``
 :Primary operation: ``list``, ``getUpdatedMasters``, ``setNotified``
 :Secondary operation: ``getUnfreshSlaveInfos``, ``startTransaction``, ``commitTransaction``, ``abortTransaction``, ``feedRecord``, ``setFresh``
-:DNSSEC operation (live-signing): ``getDomainKeys``, ``getBeforeAndAfterNamesAbsolute``
+:DNSSEC operation (live-signing): ``getBeforeAndAfterNamesAbsolute``, ``getDomainKeys``, ``removeDomainKey``, ``addDomainKey``, ``activateDomainKey``, ``deactivateDomainKey``, ``publishDomainKey``, ``unpublishDomainKey``, ``getTSIGKey``, ``setTSIGKey``, ``deleteTSIGKey``, ``getTSIGKeys``
 :Filling the Zone Cache: ``getAllDomains``
 :HTTP API specific: ``APILookup``
 
@@ -879,6 +879,96 @@ Response:
     Content-Type: text/javascript; charset=utf-8
 
     {"result":{"algorithm":"hmac-md5","content":"kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys="}}
+
+``setTSIGKey``
+~~~~~~~~~~~~~~
+
+Registers a TSIG key.
+
+-  Mandatory: no
+-  Parameters: name, algorithm, content
+-  Reply: true on success / false on failure
+
+Example JSON/RPC
+''''''''''''''''
+
+Query:
+
+.. code-block:: json
+
+    {"method":"settsigkey","parameters":{"name":"example.com.","algorithm":"hmac-md5","content":"kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys="}}
+
+Response:
+
+.. code-block:: json
+
+    {"result":true}
+
+``deleteTSIGKey``
+~~~~~~~~~~~~~~~~~
+
+Deletes a TSIG key.
+
+-  Mandatory: no
+-  Parameters: name, optional algorithm
+-  Reply: true on success / false on failure
+
+Example JSON/RPC
+''''''''''''''''
+
+Query:
+
+.. code-block:: json
+
+    {"method":"deletetsigkey","parameters":{"name":"example.com.","algorithm":"hmac-md5"}}
+
+Response:
+
+.. code-block:: json
+
+    {"result":true}
+
+``getTSIGKeys``
+~~~~~~~~~~~~~~~
+
+Retrieves the list of all available TSIG keys.
+
+-  Mandatory: no
+-  Parameters: none
+-  Reply: list of keys (name, algorithm, content)
+
+Example JSON/RPC
+''''''''''''''''
+
+Query:
+
+.. code-block:: json
+
+    {"method":"gettsigkeys","parameters":{}}
+
+Response:
+
+.. code-block:: json
+
+    {"result":{"name":"example.com.","algorithm":"hmac-md5","content":"kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys="}}
+
+Example HTTP/RPC
+''''''''''''''''
+
+Query:
+
+.. code-block:: http
+
+    GET /dnsapi/gettsigkeys HTTP/1.1
+
+Response:
+
+.. code-block:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: text/javascript; charset=utf-8
+
+    {"result":{"name":"example.com.","algorithm":"hmac-md5","content":"kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys="}}
 
 ``getDomainInfo``
 ~~~~~~~~~~~~~~~~~

--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: "0.0.19"
+  version: "0.0.20"
   title: PowerDNS Authoritative HTTP API
   license:
     name: MIT
@@ -457,6 +457,46 @@ paths:
     delete:
       summary: "Delete the TSIGKey with tsigkey_id"
       operationId: deleteTSIGKey
+      tags:
+        - tsigkey
+      responses:
+        "204":
+          description: "OK, key was deleted"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/tsigkeys/{tsigkey_id}/{algorithm_id}":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - name: tsigkey_id
+        in: path
+        required: true
+        description: 'The id of the TSIGkey. Should match the "id" field in the TSIGKey object'
+        schema:
+          type: string
+      - name: algorithm_id
+        in: path
+        required: true
+        description: 'The algorithm of the TSIGkey. Should match the "algorithm" field in the TSIGKey object'
+        schema:
+          type: string
+    get:
+      summary: "Get a specific TSIGKeys on the server, including the actual key"
+      operationId: getTSIGKeyWithAlgorithm
+      tags:
+        - tsigkey
+      responses:
+        "200":
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TSIGKey"
+        default:
+          $ref: "#/components/responses/Error"
+    delete:
+      summary: "Delete the TSIGKey with tsigkey_id and algorithm_id"
+      operationId: deleteTSIGKeyWithAlgorithm
       tags:
         - tsigkey
       responses:

--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: "0.0.21"
+  version: "0.0.22"
   title: PowerDNS Authoritative HTTP API
   license:
     name: MIT
@@ -430,6 +430,46 @@ paths:
     delete:
       summary: "Delete the TSIGKey with tsigkey_id"
       operationId: deleteTSIGKey
+      tags:
+        - tsigkey
+      responses:
+        "204":
+          description: "OK, key was deleted"
+        default:
+          $ref: "#/components/responses/Error"
+
+  "/servers/{server_id}/tsigkeys/{tsigkey_id}/{algorithm_id}":
+    parameters:
+      - $ref: "#/components/parameters/server_id"
+      - name: tsigkey_id
+        in: path
+        required: true
+        description: 'The id of the TSIGkey. Should match the "id" field in the TSIGKey object'
+        schema:
+          type: string
+      - name: algorithm_id
+        in: path
+        required: true
+        description: 'The algorithm of the TSIGkey. Should match the "algorithm" field in the TSIGKey object'
+        schema:
+          type: string
+    get:
+      summary: "Get a specific TSIGKeys on the server, including the actual key"
+      operationId: getTSIGKeyWithAlgorithm
+      tags:
+        - tsigkey
+      responses:
+        "200":
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TSIGKey"
+        default:
+          $ref: "#/components/responses/Error"
+    delete:
+      summary: "Delete the TSIGKey with tsigkey_id and algorithm_id"
+      operationId: deleteTSIGKeyWithAlgorithm
       tags:
         - tsigkey
       responses:

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -140,9 +140,10 @@ tsigkey deactivate *ZONE* *NAME* {**primary**,\ **secondary**,\ **producer**,\ *
     Disable TSIG authenticated AXFR using the key *NAME* for zone
     *ZONE*.
 
-tsigkey delete *NAME*
+tsigkey delete *NAME* [*ALGORITHM*]
 
-    Delete the TSIG key *NAME*. Warning: this does not deactivate said key.
+    Delete all TSIG keys matching *NAME* (and *ALGORITHM* if specified).
+    Warning: this does not deactivate said keys.
 
 tsigkey generate *NAME* *ALGORITHM*
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -11,6 +11,15 @@ upgrade notes if your version is older than 3.4.2.
 5.1.x to master
 ---------------
 
+New TSIG query for SQL backends
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to support the ability to delete a TSIG key matching a specific algorithm only, a new query, ``delete-tsig-key-algorithm-query``, has been added to the SQL backends.
+
+This query is similar to the existing ``delete-tsig-key-query``, but should match on a key name and algorithm, instead of on a key name alone.
+
+If you have modified the ``delete-tsig-key-query`` in your particular setup, be sure to add a matching ``delete-tsig-key-algorithm-query``.
+
 NAPTR additional answers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -19,6 +19,15 @@ very old OpenSSL (or compatible) libraries, not providing the OpenSSL 1.1.0
 API, has been removed. No operating system aged less than 10 years should be
 affected by this, but we're mentioning it, just in case.
 
+New TSIG query for SQL backends
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to support the ability to delete a TSIG key matching a specific algorithm only, a new query, ``delete-tsig-key-algorithm-query``, has been added to the SQL backends.
+
+This query is similar to the existing ``delete-tsig-key-query``, but should match on a key name and algorithm, instead of on a key name alone.
+
+If you have modified the ``delete-tsig-key-query`` in your particular setup, be sure to add a matching ``delete-tsig-key-algorithm-query``.
+
 NAPTR additional answers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -220,7 +220,7 @@ public:
   bool unpublishDomainKey(const ZoneName& name, unsigned int keyId) override;
   bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content) override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
-  bool deleteTSIGKey(const DNSName& name) override;
+  bool deleteTSIGKey(const DNSName& name, const DNSName& algorithm) override;
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys) override;
   // end of DNSSEC
 
@@ -297,6 +297,7 @@ private:
   unique_ptr<SSqlStatement> d_getTSIGKeyQuery_stmt;
   unique_ptr<SSqlStatement> d_setTSIGKeyQuery_stmt;
   unique_ptr<SSqlStatement> d_deleteTSIGKeyQuery_stmt;
+  unique_ptr<SSqlStatement> d_deleteTSIGKeyWithAlgorithmQuery_stmt;
   unique_ptr<SSqlStatement> d_getTSIGKeysQuery_stmt;
 
   string d_logprefix;

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -115,7 +115,7 @@ bool Bind2Backend::setTSIGKey(const DNSName& /* name */, const DNSName& /* algor
   return false;
 }
 
-bool Bind2Backend::deleteTSIGKey(const DNSName& /* name */)
+bool Bind2Backend::deleteTSIGKey(const DNSName& /* name */, const DNSName& /* algorithm */)
 {
   return false;
 }
@@ -178,6 +178,7 @@ void Bind2Backend::setupStatements()
   d_getTSIGKeyQuery_stmt = d_dnssecdb->prepare("select algorithm, secret from tsigkeys where name=:key_name", 1);
   d_setTSIGKeyQuery_stmt = d_dnssecdb->prepare("replace into tsigkeys (name,algorithm,secret) values(:key_name, :algorithm, :content)", 3);
   d_deleteTSIGKeyQuery_stmt = d_dnssecdb->prepare("delete from tsigkeys where name=:key_name", 1);
+  d_deleteTSIGKeyWithAlgorithmQuery_stmt = d_dnssecdb->prepare("delete from tsigkeys where name=:key_name and algorithm=:algorithm", 2);
   d_getTSIGKeysQuery_stmt = d_dnssecdb->prepare("select name,algorithm,secret from tsigkeys", 0);
 }
 
@@ -198,6 +199,7 @@ void Bind2Backend::freeStatements()
   d_getTSIGKeyQuery_stmt.reset();
   d_setTSIGKeyQuery_stmt.reset();
   d_deleteTSIGKeyQuery_stmt.reset();
+  d_deleteTSIGKeyWithAlgorithmQuery_stmt.reset();
   d_getTSIGKeysQuery_stmt.reset();
 }
 
@@ -495,13 +497,18 @@ bool Bind2Backend::setTSIGKey(const DNSName& name, const DNSName& algorithm, con
   return true;
 }
 
-bool Bind2Backend::deleteTSIGKey(const DNSName& name)
+bool Bind2Backend::deleteTSIGKey(const DNSName& name, const DNSName& algorithm)
 {
   if (!d_dnssecdb || d_hybrid)
     return false;
 
   try {
-    d_deleteTSIGKeyQuery_stmt->bind("key_name", name)->execute()->reset();
+    if (!algorithm.empty()) {
+      d_deleteTSIGKeyWithAlgorithmQuery_stmt->bind("key_name", name)->bind("algorithm", algorithm)->execute()->reset();
+    }
+    else {
+      d_deleteTSIGKeyQuery_stmt->bind("key_name", name)->execute()->reset();
+    }
   }
   catch (SSqlException& e) {
     throw PDNSException("Error accessing DNSSEC database in BIND backend, deleteTSIGKey(): " + e.txtReason());

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -465,6 +465,8 @@ bool Bind2Backend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& c
     SSqlStatement::row_t row;
     while (d_getTSIGKeyQuery_stmt->hasNextRow()) {
       d_getTSIGKeyQuery_stmt->nextRow(row);
+      // Note that this will return the last key found matching name and
+      // optional algorithm.
       if (row.size() >= 2 && (algorithm.empty() || algorithm == DNSName(row[0]))) {
         algorithm = DNSName(row[0]);
         content = row[1];

--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -167,6 +167,7 @@ public:
     declare(suffix, "get-tsig-key-query", "", "select algorithm, secret from tsigkeys where name=?");
     declare(suffix, "set-tsig-key-query", "", "replace into tsigkeys (name,algorithm,secret) values(?,?,?)");
     declare(suffix, "delete-tsig-key-query", "", "delete from tsigkeys where name=?");
+    declare(suffix, "delete-tsig-key-algorithm-query", "", "delete from tsigkeys where name=? and algorithm=?");
     declare(suffix, "get-tsig-keys-query", "", "select name,algorithm, secret from tsigkeys");
 
     declare(suffix, "get-all-domains-query", "Retrieve all domains", "select domains.id, domains.name, records.content, domains.type, domains.master, domains.notified_serial, domains.last_check, domains.account, domains.catalog from domains LEFT JOIN records ON records.domain_id=domains.id AND records.type='SOA' AND records.name=domains.name WHERE records.disabled=0 OR ?");

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -149,6 +149,7 @@ public:
     // "merge" query: https://msdn.microsoft.com/en-us/library/bb510625.aspx
     declare(suffix, "set-tsig-key-query", "", "insert into tsigkeys (name,algorithm,secret) values(?,?,?)");
     declare(suffix, "delete-tsig-key-query", "", "delete from tsigkeys where name=?");
+    declare(suffix, "delete-tsig-key-algorithm-query", "", "delete from tsigkeys where name=? and algorithm=?");
     declare(suffix, "get-tsig-keys-query", "", "select name,algorithm, secret from tsigkeys");
 
     declare(suffix, "get-all-domains-query", "Retrieve all domains", "select domains.id, domains.name, records.content, domains.type, domains.master, domains.notified_serial, domains.last_check, domains.account, domains.catalog from domains LEFT JOIN records ON records.domain_id=domains.id AND records.type='SOA' AND records.name=domains.name WHERE records.disabled=0 OR records.disabled=?");

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -174,6 +174,7 @@ public:
     declare(suffix, "get-tsig-key-query", "", "select algorithm, secret from tsigkeys where name=$1");
     declare(suffix, "set-tsig-key-query", "", "insert into tsigkeys (name,algorithm,secret) values($1,$2,$3) on conflict(name,algorithm) do update set secret=Excluded.secret");
     declare(suffix, "delete-tsig-key-query", "", "delete from tsigkeys where name=$1");
+    declare(suffix, "delete-tsig-key-algorithm-query", "", "delete from tsigkeys where name=$1 and algorithm=$2");
     declare(suffix, "get-tsig-keys-query", "", "select name,algorithm, secret from tsigkeys");
 
     declare(suffix, "get-all-domains-query", "Retrieve all domains", "select domains.id, domains.name, records.content, domains.type, domains.master, domains.notified_serial, domains.last_check, domains.account, domains.catalog from domains LEFT JOIN records ON records.domain_id=domains.id AND records.type='SOA' AND records.name=domains.name WHERE records.disabled=false OR $1");

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -159,6 +159,7 @@ public:
     declare(suffix, "get-tsig-key-query", "", "select algorithm, secret from tsigkeys where name=:key_name");
     declare(suffix, "set-tsig-key-query", "", "replace into tsigkeys (name,algorithm,secret) values(:key_name,:algorithm,:content)");
     declare(suffix, "delete-tsig-key-query", "", "delete from tsigkeys where name=:key_name");
+    declare(suffix, "delete-tsig-key-algorithm-query", "", "delete from tsigkeys where name=:key_name and algorithm=:algorithm");
     declare(suffix, "get-tsig-keys-query", "", "select name,algorithm, secret from tsigkeys");
 
     declare(suffix, "get-all-domains-query", "Retrieve all domains", "select domains.id, domains.name, records.content, domains.type, domains.master, domains.notified_serial, domains.last_check, domains.account, domains.catalog from domains LEFT JOIN records ON records.domain_id=domains.id AND records.type='SOA' AND records.name=domains.name WHERE records.disabled=0 OR :include_disabled");

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -3448,7 +3448,7 @@ bool LMDBBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, cons
 
   return true;
 }
-bool LMDBBackend::deleteTSIGKey(const DNSName& name)
+bool LMDBBackend::deleteTSIGKey(const DNSName& name, const DNSName& algorithm)
 {
   auto txn = d_ttsig->getRWTransaction();
 
@@ -3459,6 +3459,9 @@ bool LMDBBackend::deleteTSIGKey(const DNSName& name)
 
   for (auto id : ids) {
     if (txn.get(id, key)) {
+      if (!algorithm.empty() && key.algorithm != algorithm) {
+        continue;
+      }
       txn.del(id);
     }
   }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -3409,6 +3409,8 @@ bool LMDBBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& co
   TSIGKey key;
   for (auto id : ids) {
     if (txn.get(id, key)) {
+      // Note that this will return the last key found matching name and
+      // optional algorithm.
       if (algorithm.empty() || algorithm == DNSName(key.algorithm)) {
         algorithm = DNSName(key.algorithm);
         content = key.key;

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -3428,7 +3428,7 @@ bool LMDBBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, cons
 
   return true;
 }
-bool LMDBBackend::deleteTSIGKey(const DNSName& name)
+bool LMDBBackend::deleteTSIGKey(const DNSName& name, const DNSName& algorithm)
 {
   auto txn = d_ttsig->getRWTransaction();
 
@@ -3439,6 +3439,9 @@ bool LMDBBackend::deleteTSIGKey(const DNSName& name)
 
   for (auto id : ids) {
     if (txn.get(id, key)) {
+      if (!algorithm.empty() && key.algorithm != algorithm) {
+        continue;
+      }
       txn.del(id);
     }
   }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -3389,6 +3389,8 @@ bool LMDBBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& co
   TSIGKey key;
   for (auto id : ids) {
     if (txn.get(id, key)) {
+      // Note that this will return the last key found matching name and
+      // optional algorithm.
       if (algorithm.empty() || algorithm == DNSName(key.algorithm)) {
         algorithm = DNSName(key.algorithm);
         content = key.key;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -157,7 +157,7 @@ public:
   // TSIG
   bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content) override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
-  bool deleteTSIGKey(const DNSName& name) override;
+  bool deleteTSIGKey(const DNSName& name, const DNSName& algorithm) override;
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys) override;
 
   // DNSSEC

--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -146,6 +146,9 @@ void HTTPConnector::restful_requestbuilder(const std::string& method, const Json
     verb = "PATCH";
   }
   else if (method == "deleteTSIGKey") {
+    if (!parameters["algorithm"].is_null() && parameters["algorithm"].is_string()) {
+      req.GET()["algorithm"] = parameters["algorithm"].string_value();
+    }
     verb = "DELETE";
   }
   else if (method == "addDomainKey") {

--- a/modules/remotebackend/pdns_unittest.py
+++ b/modules/remotebackend/pdns_unittest.py
@@ -292,10 +292,12 @@ class Handler(pdns.remotebackend.Handler):
         for name, key in TSIG_KEYS.items():
             self.result.append(key)
 
-    def do_deletetsigkey(self, name="", **kwargs):
+    def do_deletetsigkey(self, name="", algorithm="", **kwargs):
+        self.result = False
         if name in TSIG_KEYS:
-            del TSIG_KEYS[name]
-            self.result = True
+            if algorithm == "" or TSIG_KEYS[name]["algorithm"] == algorithm:
+                del TSIG_KEYS[name]
+                self.result = True
 
     def do_starttransaction(self, **kwargs):
         self.result = True

--- a/modules/remotebackend/regression-tests/dnsbackend.py
+++ b/modules/remotebackend/regression-tests/dnsbackend.py
@@ -46,10 +46,15 @@ class DNSBackendHandler(http.server.BaseHTTPRequestHandler):
             "gettsigkey",
             "getdomaininfo",
             "settsigkey",
-            "deletetsigkey",
             "getalldomainmetadata",
         ):
             self.args["name"] = parts.pop(0)
+        elif self.method == "deletetsigkey":
+            self.args["name"] = parts.pop(0)
+            if len(parts) > 0:
+                self.args["algorithm"] = parts.pop(0)
+            else:
+                self.args["algorithm"] = ""
         elif self.method == "setnotified":
             self.args["id"] = int(parts.pop(0))
         elif self.method == "feedents":

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -552,7 +552,7 @@ bool RemoteBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, std::str
 
   Json::object parameters;
   parameters["name"] = name.toString();
-  if (!algorithm.empty()) {
+  if (!algorithm.empty()) { // don't send a single dot in this case!
     parameters["algorithm"] = algorithm.toString();
   }
   Json query = Json::object{
@@ -585,15 +585,20 @@ bool RemoteBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, co
   return connector->send(query) && connector->recv(answer);
 }
 
-bool RemoteBackend::deleteTSIGKey(const DNSName& name)
+bool RemoteBackend::deleteTSIGKey(const DNSName& name, const DNSName& algorithm)
 {
   // no point doing dnssec if it's not supported
   if (!d_dnssec) {
     return false;
   }
+  Json::object parameters;
+  parameters["name"] = name.toString();
+  if (!algorithm.empty()) { // don't send a single dot in this case!
+    parameters["algorithm"] = algorithm.toString();
+  }
   Json query = Json::object{
     {"method", "deleteTSIGKey"},
-    {"parameters", Json::object{{"name", name.toString()}}}};
+    {"parameters", parameters}};
 
   Json answer;
   return connector->send(query) && connector->recv(answer);

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -550,9 +550,14 @@ bool RemoteBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, std::str
     return false;
   }
 
+  Json::object parameters;
+  parameters["name"] = name.toString();
+  if (!algorithm.empty()) {
+    parameters["algorithm"] = algorithm.toString();
+  }
   Json query = Json::object{
     {"method", "getTSIGKey"},
-    {"parameters", Json::object{{"name", name.toString()}}}};
+    {"parameters", parameters}};
 
   Json answer;
   if (!this->send(query) || !this->recv(answer)) {

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -199,7 +199,7 @@ public:
   bool commitTransaction() override;
   bool abortTransaction() override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
-  bool deleteTSIGKey(const DNSName& name) override;
+  bool deleteTSIGKey(const DNSName& name, const DNSName& algorithm) override;
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys) override;
   string directBackendCmd(const string& querystr) override;
   bool searchRecords(const string& pattern, size_t maxResults, vector<DNSResourceRecord>& result) override;

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -226,7 +226,8 @@ BOOST_AUTO_TEST_CASE(test_method_deleteTSIGKey)
   std::string algorithm;
   std::string content;
   BOOST_TEST_MESSAGE("Testing deleteTSIGKey method");
-  BOOST_CHECK_MESSAGE(backendUnderTest->deleteTSIGKey(DNSName("unit.test.")), "did not return true");
+  BOOST_CHECK_MESSAGE(!backendUnderTest->deleteTSIGKey(DNSName("unit.test."), DNSName("my.fantastic.algorithm")), "did not return false");
+  BOOST_CHECK_MESSAGE(backendUnderTest->deleteTSIGKey(DNSName("unit.test."), DNSName()), "did not return true");
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getTSIGKeys)

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -227,7 +227,8 @@ BOOST_AUTO_TEST_CASE(test_method_deleteTSIGKey)
   std::string algorithm;
   std::string content;
   BOOST_TEST_MESSAGE("Testing deleteTSIGKey method");
-  BOOST_CHECK_MESSAGE(backendUnderTest->deleteTSIGKey(DNSName("unit.test.")), "did not return true");
+  BOOST_CHECK_MESSAGE(!backendUnderTest->deleteTSIGKey(DNSName("unit.test."), DNSName("my.fantastic.algorithm")), "did not return false");
+  BOOST_CHECK_MESSAGE(backendUnderTest->deleteTSIGKey(DNSName("unit.test."), DNSName()), "did not return true");
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getTSIGKeys)

--- a/modules/remotebackend/unittest_http.py
+++ b/modules/remotebackend/unittest_http.py
@@ -57,10 +57,15 @@ class DNSBackendHandler(http.server.BaseHTTPRequestHandler):
             "gettsigkey",
             "getdomaininfo",
             "settsigkey",
-            "deletetsigkey",
             "getalldomainmetadata",
         ):
             self.args["name"] = parts.pop(0)
+        elif self.method == "deletetsigkey":
+            self.args["name"] = parts.pop(0)
+            if len(parts) > 0:
+                self.args["algorithm"] = parts.pop(0)
+            else:
+                self.args["algorithm"] = ""
         elif self.method == "setnotified":
             self.args["id"] = int(parts.pop(0))
         elif self.method == "feedents":

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -133,6 +133,7 @@ GSQLBackend::GSQLBackend(const string &mode, const string &suffix)
   d_getTSIGKeyQuery = getArg("get-tsig-key-query");
   d_setTSIGKeyQuery = getArg("set-tsig-key-query");
   d_deleteTSIGKeyQuery = getArg("delete-tsig-key-query");
+  d_deleteTSIGKeyWithAlgorithmQuery = getArg("delete-tsig-key-algorithm-query");
   d_getTSIGKeysQuery = getArg("get-tsig-keys-query");
 
   d_SearchRecordsQuery = getArg("search-records-query");
@@ -198,6 +199,7 @@ GSQLBackend::GSQLBackend(const string &mode, const string &suffix)
   d_getTSIGKeyQuery_stmt = nullptr;
   d_setTSIGKeyQuery_stmt = nullptr;
   d_deleteTSIGKeyQuery_stmt = nullptr;
+  d_deleteTSIGKeyWithAlgorithmQuery_stmt = nullptr;
   d_getTSIGKeysQuery_stmt = nullptr;
   d_getAllDomainsQuery_stmt = nullptr;
   d_ListCommentsQuery_stmt = nullptr;
@@ -271,6 +273,7 @@ void GSQLBackend::allocateStatements()
     d_getTSIGKeyQuery_stmt = d_db->prepare(d_getTSIGKeyQuery, 1);
     d_setTSIGKeyQuery_stmt = d_db->prepare(d_setTSIGKeyQuery, 3);
     d_deleteTSIGKeyQuery_stmt = d_db->prepare(d_deleteTSIGKeyQuery, 1);
+    d_deleteTSIGKeyWithAlgorithmQuery_stmt = d_db->prepare(d_deleteTSIGKeyWithAlgorithmQuery, 2);
     d_getTSIGKeysQuery_stmt = d_db->prepare(d_getTSIGKeysQuery, 0);
     d_getAllDomainsQuery_stmt = d_db->prepare(d_getAllDomainsQuery, 1);
     d_ListCommentsQuery_stmt = d_db->prepare(d_ListCommentsQuery, 1);
@@ -344,6 +347,7 @@ void GSQLBackend::freeStatements()
   d_getTSIGKeyQuery_stmt.reset();
   d_setTSIGKeyQuery_stmt.reset();
   d_deleteTSIGKeyQuery_stmt.reset();
+  d_deleteTSIGKeyWithAlgorithmQuery_stmt.reset();
   d_getTSIGKeysQuery_stmt.reset();
   d_getAllDomainsQuery_stmt.reset();
   d_ListCommentsQuery_stmt.reset();
@@ -1413,17 +1417,28 @@ bool GSQLBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, cons
   return true;
 }
 
-bool GSQLBackend::deleteTSIGKey(const DNSName& name)
+bool GSQLBackend::deleteTSIGKey(const DNSName& name, const DNSName& algorithm)
 {
   try {
     reconnectIfNeeded();
 
-    // clang-format off
-    d_deleteTSIGKeyQuery_stmt->
-      bind("key_name", name)->
-      execute()->
-      reset();
-    // clang-format on
+    if (!algorithm.empty()) {
+      // clang-format off
+      d_deleteTSIGKeyWithAlgorithmQuery_stmt->
+        bind("key_name", name)->
+        bind("algorithm", algorithm)->
+        execute()->
+        reset();
+      // clang-format on
+    }
+    else {
+      // clang-format off
+      d_deleteTSIGKeyQuery_stmt->
+        bind("key_name", name)->
+        execute()->
+        reset();
+      // clang-format on
+    }
   }
   catch (SSqlException &e) {
     throw PDNSException("GSQLBackend unable to delete TSIG key with name '" + name.toLogString() + "': "+e.txtReason());

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1375,6 +1375,8 @@ bool GSQLBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& co
       d_getTSIGKeyQuery_stmt->nextRow(row);
       ASSERT_ROW_COLUMNS("get-tsig-key-query", row, 2);
       try{
+        // Note that this will return the last key found matching name and
+        // optional algorithm.
         if (algorithm.empty() || algorithm == DNSName(row[0])) {
           algorithm = DNSName(row[0]);
           content = row[1];

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1383,6 +1383,8 @@ bool GSQLBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& co
       d_getTSIGKeyQuery_stmt->nextRow(row);
       ASSERT_ROW_COLUMNS("get-tsig-key-query", row, 2);
       try{
+        // Note that this will return the last key found matching name and
+        // optional algorithm.
         if (algorithm.empty() || algorithm == DNSName(row[0])) {
           algorithm = DNSName(row[0]);
           content = row[1];

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -133,6 +133,7 @@ GSQLBackend::GSQLBackend(const string &mode, const string &suffix)
   d_getTSIGKeyQuery = getArg("get-tsig-key-query");
   d_setTSIGKeyQuery = getArg("set-tsig-key-query");
   d_deleteTSIGKeyQuery = getArg("delete-tsig-key-query");
+  d_deleteTSIGKeyWithAlgorithmQuery = getArg("delete-tsig-key-algorithm-query");
   d_getTSIGKeysQuery = getArg("get-tsig-keys-query");
 
   d_SearchRecordsQuery = getArg("search-records-query");
@@ -198,6 +199,7 @@ GSQLBackend::GSQLBackend(const string &mode, const string &suffix)
   d_getTSIGKeyQuery_stmt = nullptr;
   d_setTSIGKeyQuery_stmt = nullptr;
   d_deleteTSIGKeyQuery_stmt = nullptr;
+  d_deleteTSIGKeyWithAlgorithmQuery_stmt = nullptr;
   d_getTSIGKeysQuery_stmt = nullptr;
   d_getAllDomainsQuery_stmt = nullptr;
   d_ListCommentsQuery_stmt = nullptr;
@@ -271,6 +273,7 @@ void GSQLBackend::allocateStatements()
     d_getTSIGKeyQuery_stmt = d_db->prepare(d_getTSIGKeyQuery, 1);
     d_setTSIGKeyQuery_stmt = d_db->prepare(d_setTSIGKeyQuery, 3);
     d_deleteTSIGKeyQuery_stmt = d_db->prepare(d_deleteTSIGKeyQuery, 1);
+    d_deleteTSIGKeyWithAlgorithmQuery_stmt = d_db->prepare(d_deleteTSIGKeyWithAlgorithmQuery, 2);
     d_getTSIGKeysQuery_stmt = d_db->prepare(d_getTSIGKeysQuery, 0);
     d_getAllDomainsQuery_stmt = d_db->prepare(d_getAllDomainsQuery, 1);
     d_ListCommentsQuery_stmt = d_db->prepare(d_ListCommentsQuery, 1);
@@ -344,6 +347,7 @@ void GSQLBackend::freeStatements()
   d_getTSIGKeyQuery_stmt.reset();
   d_setTSIGKeyQuery_stmt.reset();
   d_deleteTSIGKeyQuery_stmt.reset();
+  d_deleteTSIGKeyWithAlgorithmQuery_stmt.reset();
   d_getTSIGKeysQuery_stmt.reset();
   d_getAllDomainsQuery_stmt.reset();
   d_ListCommentsQuery_stmt.reset();
@@ -1421,17 +1425,28 @@ bool GSQLBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, cons
   return true;
 }
 
-bool GSQLBackend::deleteTSIGKey(const DNSName& name)
+bool GSQLBackend::deleteTSIGKey(const DNSName& name, const DNSName& algorithm)
 {
   try {
     reconnectIfNeeded();
 
-    // clang-format off
-    d_deleteTSIGKeyQuery_stmt->
-      bind("key_name", name)->
-      execute()->
-      reset();
-    // clang-format on
+    if (!algorithm.empty()) {
+      // clang-format off
+      d_deleteTSIGKeyWithAlgorithmQuery_stmt->
+        bind("key_name", name)->
+        bind("algorithm", algorithm)->
+        execute()->
+        reset();
+      // clang-format on
+    }
+    else {
+      // clang-format off
+      d_deleteTSIGKeyQuery_stmt->
+        bind("key_name", name)->
+        execute()->
+        reset();
+      // clang-format on
+    }
   }
   catch (SSqlException &e) {
     throw PDNSException("GSQLBackend unable to delete TSIG key with name '" + name.toLogString() + "': "+e.txtReason());

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -109,7 +109,7 @@ public:
 
   bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content) override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
-  bool deleteTSIGKey(const DNSName& name) override;
+  bool deleteTSIGKey(const DNSName& name, const DNSName& algorithm) override;
   bool getTSIGKeys(std::vector< struct TSIGKey > &keys) override;
 
   bool listComments(const domainid_t domain_id) override;
@@ -225,6 +225,7 @@ private:
   string d_getTSIGKeyQuery;
   string d_setTSIGKeyQuery;
   string d_deleteTSIGKeyQuery;
+  string d_deleteTSIGKeyWithAlgorithmQuery;
   string d_getTSIGKeysQuery;
 
   string d_getAllDomainsQuery;
@@ -298,6 +299,7 @@ private:
   unique_ptr<SSqlStatement> d_getTSIGKeyQuery_stmt;
   unique_ptr<SSqlStatement> d_setTSIGKeyQuery_stmt;
   unique_ptr<SSqlStatement> d_deleteTSIGKeyQuery_stmt;
+  unique_ptr<SSqlStatement> d_deleteTSIGKeyWithAlgorithmQuery_stmt;
   unique_ptr<SSqlStatement> d_getTSIGKeysQuery_stmt;
   unique_ptr<SSqlStatement> d_getAllDomainsQuery_stmt;
   unique_ptr<SSqlStatement> d_ListCommentsQuery_stmt;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -251,7 +251,7 @@ public:
   virtual bool setTSIGKey(const DNSName& /* name */, const DNSName& /* algorithm */, const string& /* content */) { return false; }
   virtual bool getTSIGKey(const DNSName& /* name */, DNSName& /* algorithm */, string& /* content */) { return false; }
   virtual bool getTSIGKeys(std::vector<struct TSIGKey>& /* keys */) { return false; }
-  virtual bool deleteTSIGKey(const DNSName& /* name */) { return false; }
+  virtual bool deleteTSIGKey(const DNSName& /* name */, const DNSName& /* algorithm */) { return false; }
 
   virtual bool getBeforeAndAfterNamesAbsolute(domainid_t /* id */, const DNSName& qname, DNSName& /* unhashed */, DNSName& /* before */, DNSName& /* after */)
   {

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -252,7 +252,7 @@ public:
   virtual bool setTSIGKey(const DNSName& /* name */, const DNSName& /* algorithm */, const string& /* content */) { return false; }
   virtual bool getTSIGKey(const DNSName& /* name */, DNSName& /* algorithm */, string& /* content */) { return false; }
   virtual bool getTSIGKeys(std::vector<struct TSIGKey>& /* keys */) { return false; }
-  virtual bool deleteTSIGKey(const DNSName& /* name */) { return false; }
+  virtual bool deleteTSIGKey(const DNSName& /* name */, const DNSName& /* algorithm */) { return false; }
 
   virtual bool getBeforeAndAfterNamesAbsolute(domainid_t /* id */, const DNSName& qname, DNSName& /* unhashed */, DNSName& /* before */, DNSName& /* after */)
   {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -5264,14 +5264,29 @@ static int deleteTSIGKey(vector<string>& cmds, const std::string_view synopsis)
     return usage(synopsis);
   }
   DNSName name(cmds.at(0));
+  DNSName algo;
+  if (cmds.size() >= 2) {
+    algo = DNSName(cmds.at(1));
+  }
 
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
-  if (B.deleteTSIGKey(name)) {
-    cout << "Deleted TSIG key " << name << endl;
+  if (!algo.empty()) {
+    if (B.deleteTSIGKey(name, algo)) {
+      cout << "Deleted TSIG key " << name << endl;
+    }
+    else {
+      cerr << "Failure deleting TSIG key " << name << endl;
+      return 1;
+    }
   }
   else {
-    cerr << "Failure deleting TSIG key " << name << endl;
-    return 1;
+    if (B.deleteTSIGKey(name, algo)) {
+      cout << "Deleted TSIG key " << name << " with algorithm " << algo << endl;
+    }
+    else {
+      cerr << "Failure deleting TSIG key " << name << " with algorithm " << algo << endl;
+      return 1;
+    }
   }
   return 0;
 }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -311,7 +311,7 @@ static const groupCommandDispatcher TSIGKEYCommands{
     "ZONE NAME {primary|secondary|producer|consumer}",
     "\tDisable TSIG authenticated AXFR using the key NAME for ZONE"}},
    {"delete", {true, deleteTSIGKey,
-    "NAME",
+    "NAME [ALGORITHM]",
     "\tDelete TSIG key (warning: will not unmap key!)"}},
    {"generate", {true, generateTSIGKey,
     "NAME ALGORITHM",
@@ -5285,14 +5285,29 @@ static int deleteTSIGKey(vector<string>& cmds, const std::string_view synopsis)
     return usage(synopsis);
   }
   DNSName name(cmds.at(0));
+  DNSName algo;
+  if (cmds.size() >= 2) {
+    algo = DNSName(cmds.at(1));
+  }
 
   UtilBackend B("default"); // NOLINT(readability-identifier-length)
-  if (B.deleteTSIGKey(name)) {
-    cout << "Deleted TSIG key " << name << endl;
+  if (algo.empty()) {
+    if (B.deleteTSIGKey(name, algo)) {
+      cout << "Deleted TSIG key(s) " << name << endl;
+    }
+    else {
+      cerr << "Failure deleting TSIG key(s) " << name << endl;
+      return 1;
+    }
   }
   else {
-    cerr << "Failure deleting TSIG key " << name << endl;
-    return 1;
+    if (B.deleteTSIGKey(name, algo)) {
+      cout << "Deleted TSIG key " << name << " with algorithm " << algo << endl;
+    }
+    else {
+      cerr << "Failure deleting TSIG key " << name << " with algorithm " << algo << endl;
+      return 1;
+    }
   }
   return 0;
 }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -947,7 +947,6 @@ bool UeberBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, con
 
 bool UeberBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& content)
 {
-  algorithm.clear();
   content.clear();
 
   for (auto& backend : backends) {

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -969,10 +969,10 @@ bool UeberBackend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
   return false;
 }
 
-bool UeberBackend::deleteTSIGKey(const DNSName& name)
+bool UeberBackend::deleteTSIGKey(const DNSName& name, const DNSName& algorithm)
 {
   for (auto& backend : backends) {
-    if (backend->deleteTSIGKey(name)) {
+    if (backend->deleteTSIGKey(name, algorithm)) {
       return true;
     }
   }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -972,10 +972,10 @@ bool UeberBackend::getTSIGKeys(std::vector<struct TSIGKey>& keys)
   return false;
 }
 
-bool UeberBackend::deleteTSIGKey(const DNSName& name)
+bool UeberBackend::deleteTSIGKey(const DNSName& name, const DNSName& algorithm)
 {
   for (auto& backend : backends) {
-    if (backend->deleteTSIGKey(name)) {
+    if (backend->deleteTSIGKey(name, algorithm)) {
       return true;
     }
   }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -950,7 +950,6 @@ bool UeberBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, con
 
 bool UeberBackend::getTSIGKey(const DNSName& name, DNSName& algorithm, string& content)
 {
-  algorithm.clear();
   content.clear();
 
   for (auto& backend : backends) {

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -101,7 +101,7 @@ public:
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content);
   bool getTSIGKey(const DNSName& name, DNSName& algorithm, string& content);
   bool getTSIGKeys(std::vector<struct TSIGKey>& keys);
-  bool deleteTSIGKey(const DNSName& name);
+  bool deleteTSIGKey(const DNSName& name, const DNSName& algorithm);
 
   void viewList(vector<string>& result);
   void viewListZones(const string& view, vector<ZoneName>& result);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1805,10 +1805,10 @@ static bool checkNewRecords(HttpResponse* resp, vector<DNSResourceRecord>& recor
 
 static void checkTSIGKey(UeberBackend& backend, const DNSName& keyname, const DNSName& algo, const string& content)
 {
-  DNSName algoFromDB;
+  DNSName algoFromDB{algo};
   string contentFromDB;
   if (backend.getTSIGKey(keyname, algoFromDB, contentFromDB)) {
-    throw HttpConflictException("A TSIG key with the name '" + keyname.toLogString() + "' already exists");
+    throw HttpConflictException("A TSIG key with the name '" + keyname.toLogString() + "' and algorithm '" + algo.toLogString() + "' already exists");
   }
 
   TSIGHashEnum the{};
@@ -1890,7 +1890,14 @@ public:
     keyName(apiZoneIdToName(req->parameters["id"]).operator const DNSName&())
   {
     try {
+      bool algorithm_specified = req->parameters.count("algorithm") != 0;
+      if (algorithm_specified) {
+        algo = DNSName(req->parameters["algorithm"]);
+      }
       if (!backend.getTSIGKey(keyName, algo, content)) {
+        if (algorithm_specified) {
+          throw HttpNotFoundException("TSIG key with name '" + keyName.toLogString() + "' and algorithm '" + req->parameters["algorithm"] + "' not found");
+        }
         throw HttpNotFoundException("TSIG key with name '" + keyName.toLogString() + "' not found");
       }
     }
@@ -1947,8 +1954,8 @@ static void apiServerTSIGKeyDetailPUT(HttpRequest* req, HttpResponse* resp)
   }
   if (tsigKeyData.tsigKey.name != tsigKeyData.keyName) {
     // Remove the old key
-    if (!tsigKeyData.backend.deleteTSIGKey(tsigKeyData.keyName)) {
-      throw HttpInternalServerErrorException("Unable to remove TSIG key '" + tsigKeyData.keyName.toStringNoDot() + "'");
+    if (!tsigKeyData.backend.deleteTSIGKey(tsigKeyData.keyName, tsigKeyData.algo)) {
+      throw HttpInternalServerErrorException("Unable to remove TSIG key '" + tsigKeyData.keyName.toStringNoDot() + "' with algorithm '" + tsigKeyData.algo.toString() + "'");
     }
   }
   resp->setJsonBody(makeJSONTSIGKey(tsigKeyData.tsigKey));
@@ -1957,8 +1964,12 @@ static void apiServerTSIGKeyDetailPUT(HttpRequest* req, HttpResponse* resp)
 static void apiServerTSIGKeyDetailDELETE(HttpRequest* req, HttpResponse* resp)
 {
   TSIGKeyData tsigKeyData{req};
-  if (!tsigKeyData.backend.deleteTSIGKey(tsigKeyData.keyName)) {
-    throw HttpInternalServerErrorException("Unable to remove TSIG key '" + tsigKeyData.keyName.toStringNoDot() + "'");
+  // Delete with name only if no algorithm has been provided
+  if (req->parameters.count("algorithm") == 0) {
+    tsigKeyData.algo.clear();
+  }
+  if (!tsigKeyData.backend.deleteTSIGKey(tsigKeyData.keyName, tsigKeyData.algo)) {
+    throw HttpInternalServerErrorException("Unable to remove TSIG key '" + tsigKeyData.keyName.toStringNoDot() + "' with algorithm '" + tsigKeyData.algo.toString() + "'");
   }
   resp->body = "";
   resp->status = 204;
@@ -3350,6 +3361,8 @@ void AuthWebServer::webThread(Logr::log_t slog)
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>", apiServerTSIGKeyDetailGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>", apiServerTSIGKeyDetailPUT, "PUT");
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>", apiServerTSIGKeyDetailDELETE, "DELETE");
+      d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>/<algorithm>", apiServerTSIGKeyDetailGET, "GET");
+      d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>/<algorithm>", apiServerTSIGKeyDetailDELETE, "DELETE");
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys", apiServerTSIGKeysGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys", apiServerTSIGKeysPOST, "POST");
       d_ws->registerApiHandler("/api/v1/servers/localhost/views", apiServerViewsAllGET, "GET");

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1902,10 +1902,10 @@ static bool checkNewRecords(HttpResponse* resp, vector<DNSResourceRecord>& recor
 
 static void checkTSIGKey(UeberBackend& backend, const DNSName& keyname, const DNSName& algo, const string& content)
 {
-  DNSName algoFromDB;
+  DNSName algoFromDB{algo};
   string contentFromDB;
   if (backend.getTSIGKey(keyname, algoFromDB, contentFromDB)) {
-    throw HttpConflictException("A TSIG key with the name '" + keyname.toLogString() + "' already exists");
+    throw HttpConflictException("A TSIG key with the name '" + keyname.toLogString() + "' and algorithm '" + algo.toLogString() + "' already exists");
   }
 
   TSIGHashEnum the{};
@@ -1987,7 +1987,14 @@ public:
     keyName(apiZoneIdToName(req->parameters["id"]).operator const DNSName&())
   {
     try {
+      bool algorithm_specified = req->parameters.count("algorithm") != 0;
+      if (algorithm_specified) {
+        algo = DNSName(req->parameters["algorithm"]);
+      }
       if (!backend.getTSIGKey(keyName, algo, content)) {
+        if (algorithm_specified) {
+          throw HttpNotFoundException("TSIG key with name '" + keyName.toLogString() + "' and algorithm '" + req->parameters["algorithm"] + "' not found");
+        }
         throw HttpNotFoundException("TSIG key with name '" + keyName.toLogString() + "' not found");
       }
     }
@@ -2044,8 +2051,8 @@ static void apiServerTSIGKeyDetailPUT(HttpRequest* req, HttpResponse* resp)
   }
   if (tsigKeyData.tsigKey.name != tsigKeyData.keyName) {
     // Remove the old key
-    if (!tsigKeyData.backend.deleteTSIGKey(tsigKeyData.keyName)) {
-      throw HttpInternalServerErrorException("Unable to remove TSIG key '" + tsigKeyData.keyName.toStringNoDot() + "'");
+    if (!tsigKeyData.backend.deleteTSIGKey(tsigKeyData.keyName, tsigKeyData.algo)) {
+      throw HttpInternalServerErrorException("Unable to remove TSIG key '" + tsigKeyData.keyName.toStringNoDot() + "' with algorithm '" + tsigKeyData.algo.toString() + "'");
     }
   }
   resp->setJsonBody(makeJSONTSIGKey(tsigKeyData.tsigKey));
@@ -2054,8 +2061,12 @@ static void apiServerTSIGKeyDetailPUT(HttpRequest* req, HttpResponse* resp)
 static void apiServerTSIGKeyDetailDELETE(HttpRequest* req, HttpResponse* resp)
 {
   TSIGKeyData tsigKeyData{req};
-  if (!tsigKeyData.backend.deleteTSIGKey(tsigKeyData.keyName)) {
-    throw HttpInternalServerErrorException("Unable to remove TSIG key '" + tsigKeyData.keyName.toStringNoDot() + "'");
+  // Delete with name only if no algorithm has been provided
+  if (req->parameters.count("algorithm") == 0) {
+    tsigKeyData.algo.clear();
+  }
+  if (!tsigKeyData.backend.deleteTSIGKey(tsigKeyData.keyName, tsigKeyData.algo)) {
+    throw HttpInternalServerErrorException("Unable to remove TSIG key '" + tsigKeyData.keyName.toStringNoDot() + "' with algorithm '" + tsigKeyData.algo.toString() + "'");
   }
   resp->body = "";
   resp->status = 204;
@@ -3466,6 +3477,8 @@ void AuthWebServer::webThread(Logr::log_t slog)
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>", apiServerTSIGKeyDetailGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>", apiServerTSIGKeyDetailPUT, "PUT");
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>", apiServerTSIGKeyDetailDELETE, "DELETE");
+      d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>/<algorithm>", apiServerTSIGKeyDetailGET, "GET");
+      d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys/<id>/<algorithm>", apiServerTSIGKeyDetailDELETE, "DELETE");
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys", apiServerTSIGKeysGET, "GET");
       d_ws->registerApiHandler("/api/v1/servers/localhost/tsigkeys", apiServerTSIGKeysPOST, "POST");
       d_ws->registerApiHandler("/api/v1/servers/localhost/views", apiServerViewsAllGET, "GET");

--- a/regression-tests.api/test_TSIG.py
+++ b/regression-tests.api/test_TSIG.py
@@ -70,10 +70,33 @@ class AuthTSIG(ApiTestCase, AuthTSIGHelperMixin):
 
     def test_remove_key(self):
         """
-        Create a key and attempt to delete it
+        Create two keys with the same name but different algorithm and attempt to delete them in one operation
         """
         name, payload, data = self.create_tsig_key()
+        name2, payload2, data2 = self.create_tsig_key(name=name, algorithm="hmac-sha512")
+        self.assertEqual(name, name2)
         r = self.session.delete(self.url("/api/v1/servers/localhost/tsigkeys/" + data["id"]))
+        self.assertEqual(r.status_code, 204)
+        r = self.session.get(self.url("/api/v1/servers/localhost/tsigkeys"), headers={"accept": "application/json"})
+        self.assertEqual(r.status_code, 200)
+        keys = r.json()
+        self.assertEqual(len([key for key in keys if key["name"] == name]), 0)
+
+    def test_remove_key_with_algorithm(self):
+        """
+        Create two keys with the same name but different algorithm, and attempt to delete them one by one
+        """
+        name, payload, data = self.create_tsig_key()
+        name2, payload2, data2 = self.create_tsig_key(name=name, algorithm="hmac-sha512")
+        self.assertEqual(name, name2)
+        r = self.session.delete(self.url("/api/v1/servers/localhost/tsigkeys/" + data["id"] + "/" + data["algorithm"]))
+        self.assertEqual(r.status_code, 204)
+        r = self.session.get(self.url("/api/v1/servers/localhost/tsigkeys"), headers={"accept": "application/json"})
+        self.assertEqual(r.status_code, 200)
+        keys = r.json()
+        data2["key"] = ""  # key contents won't be returned
+        self.assertEqual([key for key in keys if key["name"] == name], [data2])
+        r = self.session.delete(self.url("/api/v1/servers/localhost/tsigkeys/" + data["id"] + "/" + data2["algorithm"]))
         self.assertEqual(r.status_code, 204)
         r = self.session.get(self.url("/api/v1/servers/localhost/tsigkeys"), headers={"accept": "application/json"})
         self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
### Short description
This PR adds the ability to specifiy an algorithm, in addition to a name, when performing a TSIG key deletion.
For SQL backends, this relies upon an extra query.

Will fix #1466.

Note that, before this PR, the API would not let you have multiple TSIG keys with the same name, but different algorithms, while `pdnsutil` wouldn't mind. This restriction is lifted as part of these changes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
