### PR TITLE
Fix warning: anonymous non-C-compatible type given name for linkage purposes by alias declaration

### DIFF
--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -56,7 +56,7 @@ public:
   ~GeoIPBackend() override;
 
   using filevec_t = std::vector<std::unique_ptr<GeoIPInterface>>;
-  using state_t = struct
+  using state_t = struct state_t
   {
     unsigned int instance_count{0};
     std::vector<GeoIPDomain> domains;


### PR DESCRIPTION
clang reports:

In file included from ../pdns/../modules/geoipbackend/geoipinterface.hh:25: ../pdns/../modules/geoipbackend/geoipbackend.hh:59:25: warning: anonymous non-C-compatible type given name for linkage purposes by alias declaration; add a tag name here [-Wnon-c-typedef-for-linkage]
   59 |   using state_t = struct
      |                         ^
      |                          state_t
../pdns/../modules/geoipbackend/geoipbackend.hh:61:5: note: type is not C-compatible due to this default member initializer
   61 |     unsigned int instance_count{0};
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../pdns/../modules/geoipbackend/geoipbackend.hh:59:9: note: type is given name 'state_t' for linkage purposes by this alias declaration
   59 |   using state_t = struct
      |         ^
1 warning generated.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
