### PR TITLE
rec: reject NSECs whose next names are out of the zone earlier

### DIFF
--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -327,6 +327,11 @@ void AggressiveNSECCache::insertNSEC(const DNSName& zone, const DNSName& owner, 
         return;
       }
 
+      if (!next.isPartOf(zone)) {
+        /* the next name is not part of the zone, something is very wrong */
+        return;
+      }
+
       if (isMinimallyCoveringNSEC(owner, content)) {
         /* not accepting minimally covering answers since they only deny one name */
         return;

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -321,14 +321,16 @@ void AggressiveNSECCache::insertNSEC(const DNSName& zone, const DNSName& owner, 
       }
 
       next = content->d_next;
-      if (next.canonCompare(owner) && next != zone) {
-        /* not accepting a NSEC whose next domain name is before the owner
-           unless the next domain name is the apex, sorry */
+      if (!next.isPartOf(zone)) {
+        /* the next name is not part of the zone, something is very wrong */
         return;
       }
 
-      if (!next.isPartOf(zone)) {
-        /* the next name is not part of the zone, something is very wrong */
+      // we know from the test above that next is part of zone, so
+      // if next.wirelength() == zone.wirelength() then next == zone
+      if (next.canonCompare(owner) && next.wirelength() != zone.wirelength()) {
+        /* not accepting a NSEC whose next domain name is before the owner
+           unless the next domain name is the apex, sorry */
         return;
       }
 

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -4274,12 +4274,13 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
     }
 
     if (rec->d_type == QType::NSEC) {
-      if (auto* nsecRecord = getRR<NSECRecordContent>(*rec); nsecRecord != nullptr) {
+      if (auto nsecRecord = getRR<NSECRecordContent>(*rec); nsecRecord != nullptr) {
         if (!nsecRecord->d_next.isPartOf(auth)) {
           LOG(prefix << qname << ": Removing NSEC record '" << rec->toString() << "' in the " << DNSResourceRecord::placeString(rec->d_place) << " section received from " << auth << " whose next name does belong to a different zone" << endl);
           skipvec[counter] = true;
           ++skipCount;
           continue;
+        }
       }
     }
 

--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -4273,6 +4273,16 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
       continue;
     }
 
+    if (rec->d_type == QType::NSEC) {
+      if (auto* nsecRecord = getRR<NSECRecordContent>(*rec); nsecRecord != nullptr) {
+        if (!nsecRecord->d_next.isPartOf(auth)) {
+          LOG(prefix << qname << ": Removing NSEC record '" << rec->toString() << "' in the " << DNSResourceRecord::placeString(rec->d_place) << " section received from " << auth << " whose next name does belong to a different zone" << endl);
+          skipvec[counter] = true;
+          ++skipCount;
+          continue;
+      }
+    }
+
     // Disallow QType DNAME in non-answer section or containing an answer that is not a parent of or equal to the question name
     // i.e. disallowed bar.example.com. DNAME bar.example.net. when asking foo.example.com
     // But allow it when asking for foo.bar.example.com.

--- a/pdns/recursordist/test-syncres_cc10.cc
+++ b/pdns/recursordist/test-syncres_cc10.cc
@@ -445,7 +445,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_missing_soa)
           setLWResult(res, 0, false, false, true);
           addRecordToLW(res, DNSName("powerdns.com."), QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 3600);
           /* no DS */
-          addNSECRecordToLW(DNSName("powerdns.com."), DNSName("powerdnsz.com."), {QType::NS}, 600, res->d_records);
+          addNSECRecordToLW(DNSName("powerdns.com."), DNSName("a.powerdns.com."), {QType::NS}, 600, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
           return LWResult::Result::Success;
@@ -454,14 +454,14 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_missing_soa)
       else if (address == ComboAddress("192.0.2.2:53")) {
         if (domain == DNSName("nxd.sub.powerdns.com.")) {
           setLWResult(res, RCode::NXDomain, true, false, true);
-          addNSECRecordToLW(DNSName("nxc.sub.powerdns.com."), DNSName("nxe.sub.powerdnsz.com."), {QType::AAAA}, 600, res->d_records);
+          addNSECRecordToLW(DNSName("nxc.sub.powerdns.com."), DNSName("nxe.sub.powerdns.com."), {QType::AAAA}, 600, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("sub.powerdns.com."), 300);
           return LWResult::Result::Success;
         }
         if (domain == DNSName("nodata.sub.powerdns.com.")) {
           setLWResult(res, 0, true, false, true);
           /* NSEC but no SOA */
-          addNSECRecordToLW(DNSName("nodata.sub.powerdns.com."), DNSName("nodata2.sub.powerdnsz.com."), {QType::AAAA}, 600, res->d_records);
+          addNSECRecordToLW(DNSName("nodata.sub.powerdns.com."), DNSName("nodata2.sub.powerdns.com."), {QType::AAAA}, 600, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("sub.powerdns.com."), 300);
           return LWResult::Result::Success;
         }

--- a/pdns/recursordist/test-syncres_cc7.cc
+++ b/pdns/recursordist/test-syncres_cc7.cc
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname_glue)
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
-        addNSECRecordToLW(domain, DNSName("z.power-dns.com."), {QType::NS}, 600, res->d_records);
+        addNSECRecordToLW(domain, DNSName("z.powerdns.com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         return LWResult::Result::Success;
       }

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -1242,7 +1242,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity)
       setLWResult(res, RCode::NoError, true, false, true);
       addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
       addRRSIG(keys, res->d_records, domain, 300);
-      addNSECRecordToLW(domain, DNSName("z."), {QType::NSEC, QType::RRSIG}, 600, res->d_records);
+      addNSECRecordToLW(domain, DNSName("z") + domain, {QType::NSEC, QType::RRSIG}, 600, res->d_records);
       addRRSIG(keys, res->d_records, domain, 1, false, std::nullopt, std::nullopt, fixedNow);
       return LWResult::Result::Success;
     }

--- a/pdns/recursordist/test-syncres_cc9.cc
+++ b/pdns/recursordist/test-syncres_cc9.cc
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure)
       setLWResult(res, RCode::NoError, true, false, true);
       addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
       addRRSIG(keys, res->d_records, domain, 300);
-      addNSECRecordToLW(domain, DNSName("z."), {QType::NSEC, QType::RRSIG}, 600, res->d_records);
+      addNSECRecordToLW(domain, DNSName("z") + domain, {QType::NSEC, QType::RRSIG}, 600, res->d_records);
       addRRSIG(keys, res->d_records, domain, 1, false, std::nullopt, std::nullopt, fixedNow);
       return LWResult::Result::Success;
     }

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -589,6 +589,7 @@ dState getDenial(const cspmap_t& validrrsets, const DNSName& qname, const uint16
         const DNSName owner = getNSECOwnerName(validset.first.first, validset.second.signatures);
         const DNSName signer = getSigner(validset.second.signatures);
         if (!validset.first.first.isPartOf(signer) || !owner.isPartOf(signer) || !nameToDeny.isPartOf(signer) || !nsec->d_next.isPartOf(signer)) {
+          VLOG(log, nameToDeny << ": Initial owner (" << validset.first.first << "), reconstructed owner (" << owner << ") or name to deny (" << nameToDeny << ") are not part of the signer (" << signer << ")!" << endl);
           continue;
         }
 
@@ -741,6 +742,7 @@ dState getDenial(const cspmap_t& validrrsets, const DNSName& qname, const uint16
         numberOfLabelsOfParentZone = std::min(numberOfLabelsOfParentZone, static_cast<uint8_t>(signer.countLabels()));
 
         if (!qname.isPartOf(signer)) {
+          VLOG(log, qname << ": is not part of the signer (" << signer << ")!" << endl);
           continue;
         }
 

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -199,7 +199,7 @@ bool denialProvesNoDelegation(const DNSName& zone, const std::vector<DNSRecord>&
         return !nsec->isSet(QType::NS);
       }
 
-      if (isCoveredByNSEC(zone, record.d_name, nsec->d_next)) {
+      if (isCoveredByNSEC(zone, record.d_name, nsec->d_next) && nsec->d_next.isPartOf(zone)) {
         return true;
       }
     }
@@ -588,7 +588,7 @@ dState getDenial(const cspmap_t& validrrsets, const DNSName& qname, const uint16
         }
         const DNSName owner = getNSECOwnerName(validset.first.first, validset.second.signatures);
         const DNSName signer = getSigner(validset.second.signatures);
-        if (!validset.first.first.isPartOf(signer) || !owner.isPartOf(signer) || !nameToDeny.isPartOf(signer)) {
+        if (!validset.first.first.isPartOf(signer) || !owner.isPartOf(signer) || !nameToDeny.isPartOf(signer) || !nsec->d_next.isPartOf(signer)) {
           continue;
         }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Reject having a next field out-of-zone NSECs at the earliest opportunity. Currently the invalidity is determined correctly both while validating and in the aggressive cache case, but a bit late in the flow.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)

