### PR TITLE
auth: safer error handling in bind parser

### DIFF
--- a/pdns/bindlexer.l
+++ b/pdns/bindlexer.l
@@ -101,6 +101,10 @@ include                 BEGIN(incl);
         yy_switch_to_buffer(yy_create_buffer(yyin,YY_BUF_SIZE));
 
    }
+<incl>.*|\n {
+        bindlexer_cleanup();
+        LEXER_ERROR( "Invalid include directive",yytext+1,-1);
+   }
 
 
 <<EOF>>   {

--- a/pdns/bindlexer.l
+++ b/pdns/bindlexer.l
@@ -49,6 +49,7 @@ static void bindlexer_fatal_error(const char* msg)
 %option nounput
 %option noyy_top_state
 %option noinput
+%option nodefault
 
 %%
 

--- a/pdns/bindlexer.l
+++ b/pdns/bindlexer.l
@@ -19,6 +19,27 @@ char *original_filename;
 int include_stack_ptr = 0;
 extern const char *bind_directory;
 
+/* This is the name mangling of BindParser::lexer_error */
+#define LEXER_ERROR _ZN10BindParser11lexer_errorEPKcPci
+extern void LEXER_ERROR(const char *, char *, int);
+
+static void bindlexer_cleanup()
+{
+  /* be sure not to leave any file open */
+  if (yyin != NULL) {
+    fclose(yyin);
+    yyin = NULL;
+  }
+}
+
+static void bindlexer_fatal_error(const char* msg)
+{
+  bindlexer_cleanup();
+  LEXER_ERROR(msg, NULL, 0);
+}
+
+#define YY_FATAL_ERROR bindlexer_fatal_error
+
 %}
 
 %x comment
@@ -41,16 +62,14 @@ extern const char *bind_directory;
 include                 BEGIN(incl);
 <incl>[ \t;]*            /* eat the whitespace */
 <incl>\"[^ \t\n";]+\";        { /* got the include file name */
-	char filename[1024];
+        char filename[1024];
         if ( include_stack_ptr >= MAX_INCLUDE_DEPTH )
             {
-            fprintf( stderr, "Includes nested too deeply\n" );
-            exit( 1 );
+            YY_FATAL_ERROR( "Includes nested too deeply" );
             }
 
         if (strlen(yytext) <= 2) {
-            fprintf( stderr, "Empty include directive\n" );
-            exit( 1 );
+            YY_FATAL_ERROR( "Empty include directive" );
         }
 
         yytext[strlen(yytext)-2]=0;
@@ -68,14 +87,14 @@ include                 BEGIN(incl);
             ret = snprintf(filename, sizeof(filename), "%s/%s", bind_directory, yytext+1);
         }
         if (ret == -1 || ret >= (int)sizeof(filename)) {
-            fprintf( stderr, "Filename '%s' is too long\n",yytext+1);
-            exit( 1 );
+            bindlexer_cleanup();
+            LEXER_ERROR( "name too long", yytext+1, 0);
         }
 
-	if (!(yyin=fopen(filename,"r"))) {
-	  fprintf( stderr, "Unable to open '%s': %s\n",filename,strerror(errno));
-	  exit( 1 );
-	}
+        if (!(yyin=fopen(filename,"r"))) {
+          bindlexer_cleanup();
+          LEXER_ERROR( "unable to open",filename,errno);
+        }
 
         BEGIN(INITIAL);
         yy_switch_to_buffer(yy_create_buffer(yyin,YY_BUF_SIZE));

--- a/pdns/bindlexer.l
+++ b/pdns/bindlexer.l
@@ -19,9 +19,7 @@ char *original_filename;
 int include_stack_ptr = 0;
 extern const char *bind_directory;
 
-/* This is the name mangling of BindParser::lexer_error */
-#define LEXER_ERROR _ZN10BindParser11lexer_errorEPKcPci
-extern void LEXER_ERROR(const char *, char *, int);
+extern void lexer_error(const char*, const char*, int);
 
 static void bindlexer_cleanup()
 {
@@ -35,7 +33,7 @@ static void bindlexer_cleanup()
 static void bindlexer_fatal_error(const char* msg)
 {
   bindlexer_cleanup();
-  LEXER_ERROR(msg, NULL, 0);
+  lexer_error(msg, NULL, 0);
 }
 
 #define YY_FATAL_ERROR bindlexer_fatal_error
@@ -89,12 +87,12 @@ include                 BEGIN(incl);
         }
         if (ret == -1 || ret >= (int)sizeof(filename)) {
             bindlexer_cleanup();
-            LEXER_ERROR( "name too long", yytext+1, 0);
+            lexer_error( "name too long", yytext+1, 0);
         }
 
         if (!(yyin=fopen(filename,"r"))) {
           bindlexer_cleanup();
-          LEXER_ERROR( "unable to open",filename,errno);
+          lexer_error( "unable to open",filename,errno);
         }
 
         BEGIN(INITIAL);
@@ -103,7 +101,7 @@ include                 BEGIN(incl);
    }
 <incl>.*|\n {
         bindlexer_cleanup();
-        LEXER_ERROR( "Invalid include directive",yytext+1,-1);
+        lexer_error( "Invalid include directive",yytext+1,-1);
    }
 
 

--- a/pdns/bindparser.yy
+++ b/pdns/bindparser.yy
@@ -124,9 +124,14 @@ void BindParser::lexer_error(const char *msg, char *filename, int error)
     text = std::string("Lexer error in bind configuration '") + string(current_filename) + "' around line " + std::to_string(linenumber) + ": " + std::string(msg);
   }
   else {
-    text = std::string("File '") + std::string(filename) + "': " + std::string(msg);
-    if (error != 0) {
-      text.append(": ").append(strerror(error));
+    if (error < 0) {
+      text = std::string(msg) + ": '" + std::string(filename) + "'";
+    }
+    else {
+      text = std::string("File '") + std::string(filename) + "': " + std::string(msg);
+      if (error != 0) {
+        text.append(": ").append(strerror(error));
+      }
     }
   }
   throw PDNSException(text);

--- a/pdns/bindparser.yy
+++ b/pdns/bindparser.yy
@@ -105,6 +105,33 @@ void BindParser::commit(BindDomainInfo DI)
   d_zonedomains.push_back(DI);
 }
 
+// Although [filename] below could be const, the lack of const modifier is
+// intentional, so that all parameter types are distinct, preventing mangling
+// of that symbol to use compression due to repeated parameter types.
+// This allows bindlexer.l to use a non-ambiguous mangled name.
+// If that paremeter were to be declared const, the mangling could be either
+// _ZN10BindParser11lexer_errorEPKcS1_i
+//   or
+// _ZN10BindParser11lexer_errorEPKcPKci
+// depending on the compiler being used, with no way to know which flavour
+// would be used, at compile-time.
+void BindParser::lexer_error(const char *msg, char *filename, int error)
+{
+  std::string text;
+
+  if (filename == nullptr) {
+    extern char *current_filename;
+    text = std::string("Lexer error in bind configuration '") + string(current_filename) + "' around line " + std::to_string(linenumber) + ": " + std::string(msg);
+  }
+  else {
+    text = std::string("File '") + std::string(filename) + "': " + std::string(msg);
+    if (error != 0) {
+      text.append(": ").append(strerror(error));
+    }
+  }
+  throw PDNSException(text);
+}
+
 %}
 
 %token AWORD QUOTEDWORD OBRACE EBRACE SEMICOLON ZONETOK FILETOK OPTIONSTOK

--- a/pdns/bindparser.yy
+++ b/pdns/bindparser.yy
@@ -105,17 +105,7 @@ void BindParser::commit(BindDomainInfo DI)
   d_zonedomains.push_back(DI);
 }
 
-// Although [filename] below could be const, the lack of const modifier is
-// intentional, so that all parameter types are distinct, preventing mangling
-// of that symbol to use compression due to repeated parameter types.
-// This allows bindlexer.l to use a non-ambiguous mangled name.
-// If that paremeter were to be declared const, the mangling could be either
-// _ZN10BindParser11lexer_errorEPKcS1_i
-//   or
-// _ZN10BindParser11lexer_errorEPKcPKci
-// depending on the compiler being used, with no way to know which flavour
-// would be used, at compile-time.
-void BindParser::lexer_error(const char *msg, char *filename, int error)
+void BindParser::lexer_error(const char* msg, const char* filename, int error)
 {
   std::string text;
 
@@ -135,6 +125,15 @@ void BindParser::lexer_error(const char *msg, char *filename, int error)
     }
   }
   throw PDNSException(text);
+}
+
+extern "C" {
+
+void lexer_error(const char* msg, const char* filename, int error)
+{
+  BindParser::lexer_error(msg, filename, error);
+}
+
 }
 
 %}

--- a/pdns/bindparserclasses.hh
+++ b/pdns/bindparserclasses.hh
@@ -92,4 +92,6 @@ private:
   set<string> alsoNotify;
   vector<BindDomainInfo> d_zonedomains;
   bool d_verbose{false};
+
+  static void lexer_error(const char *msg, char *filename, int error);
 };

--- a/pdns/bindparserclasses.hh
+++ b/pdns/bindparserclasses.hh
@@ -87,11 +87,18 @@ class BindParser
   void setVerbose(bool verbose);
   void addAlsoNotify(const string &host);
   set<string> & getAlsoNotify() { return this->alsoNotify; } 
+
+  static void lexer_error(const char *msg, const char *filename, int error);
+
 private:
   string d_dir{"."};
   set<string> alsoNotify;
   vector<BindDomainInfo> d_zonedomains;
   bool d_verbose{false};
-
-  static void lexer_error(const char *msg, char *filename, int error);
 };
+
+extern "C" {
+
+void lexer_error(const char *msg, const char *filename, int error);
+
+}


### PR DESCRIPTION
### Short description
While parser errors when reading bind configuration files are reported using regular exceptions, lexer errors are reported on standard error, and the process exits.
This can be a major annoyance, should one want to reload the configuration, after making a bad typo.

This PR replaces the existing lexer error routine with a nicer one which will also raise an exception, so that the damage can be controlled and the program keeps running.

Unfortunately, this will cause a `-Wunused-function` warning, as there does not seem to be a documented way to have `lex` omit the body of `yy_fatal_error` (which is being replaced).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
