### PR TITLE
remove objectionable abort() calls

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -213,7 +213,7 @@ void DNSName::packetParser(const char* qpos, size_t len, size_t offset, bool unc
   pos++;
   if (labellen != 0 && pos < view.size()) {
     if (labellen < 0xc0) {
-      abort();
+      throw std::range_error("Invalid label byte during decompression ("+std::to_string(labellen)+")");
     }
 
     if (!uncompress) {

--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -337,7 +337,7 @@ SSQLite3::~SSQLite3()
       continue;
     }
     cerr << "Unable to close down sqlite connection: " << ret << endl;
-    abort();
+    break;
   }
 }
 


### PR DESCRIPTION
### Short description
It is extremely impolite to have software `abort()`, so try to behave more nicely.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
