### PR TITLE
auth api: allow a primary server address to be passed to the axfr-retrieve endpoint

### DIFF
--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: "0.0.19"
+  version: "0.0.20"
   title: PowerDNS Authoritative HTTP API
   license:
     name: MIT
@@ -711,10 +711,22 @@ paths:
       - $ref: "#/components/parameters/zone_id"
     put:
       summary: Retrieve slave zone from its master.
-      description: "Fails when zone kind is not Slave, or slave is disabled in the configuration. Clients MUST NOT send a body."
+      description: "Fails when zone kind is not Slave, or slave is disabled in the configuration. Clients need not send a body, unless they want to specify a particular primary server address to use."
       operationId: axfrRetrieveZone
       tags:
         - zones
+      requestBody:
+        required: false
+        description: An optional primary server address to request AXFR from.
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                primary:
+                  type: string
+                  description: The address of the primary server to use.
       responses:
         "200":
           description: OK

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2457,6 +2457,25 @@ static void apiServerZoneAxfrRetrieve(HttpRequest* req, HttpResponse* resp)
 {
   ZoneData zoneData{req};
 
+  // Allow a preferred primary to be passed in the body.
+  if (!req->body.empty()) {
+    const auto& document = req->json();
+    if (!document["primary"].is_null()) {
+      if (!document["primary"].is_string()) {
+        throw ApiException("Invalid primary address");
+      }
+      ComboAddress primary_ip;
+      try {
+        primary_ip = ComboAddress(document["primary"].string_value(), 53);
+      }
+      catch (...) {
+        throw ApiException("Invalid primary address");
+      }
+      zoneData.domainInfo.primaries.clear();
+      zoneData.domainInfo.primaries.push_back(primary_ip);
+    }
+  }
+
   if (zoneData.domainInfo.primaries.empty()) {
     throw ApiException("Domain '" + zoneData.zoneName.toString() + "' is not a secondary domain (or has no primary defined)");
   }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1025,14 +1025,26 @@ class AuthZones(ZonesApiTestCase, AuthZonesHelperMixin):
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/" + data["id"]))
         r.raise_for_status()
 
-    def test_retrieve_slave_zone(self):
+    def test_retrieve_secondary_zone(self):
         name, payload, data = self.create_zone(kind="Slave", nameservers=None, masters=["127.0.0.2"])
         print("payload:", payload)
         print("data:", data)
         r = self.session.put(self.url("/api/v1/servers/localhost/zones/" + data["id"] + "/axfr-retrieve"))
         data = r.json()
         print("status for axfr-retrieve:", data)
-        self.assertEqual(data["result"], "Added retrieval request for '" + payload["name"] + "' from primary 127.0.0.2")
+        self.assertEqual(data["result"], "Added retrieval request for '" + name + "' from primary 127.0.0.2")
+
+    def test_retrieve_secondary_zone_from_explicit_primary(self):
+        name, payload, data = self.create_zone(kind="Slave", nameservers=None, masters=["127.0.0.2"])
+        print("payload:", payload)
+        print("data:", data)
+        r = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/" + data["id"] + "/axfr-retrieve"),
+            data=json.dumps({"primary": "127.0.0.53:4242"}),
+        )
+        data = r.json()
+        print("status for axfr-retrieve:", data)
+        self.assertEqual(data["result"], "Added retrieval request for '" + name + "' from primary 127.0.0.53:4242")
 
     def test_notify_master_zone(self):
         name, payload, data = self.create_zone(kind="Master")


### PR DESCRIPTION
### Short description
This adds the ability to the `axfr-retrieve` API endpoint to be passed a primary server address to request from, instead of picking one at random from the primaries of the zone.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
