### PR TITLE
reject duplicate SvcParamKeys in the SVCB/HTTPS text parser

### DIFF
--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -360,6 +360,7 @@ void RecordTextReader::xfrSVCBValueList(vector<string> &val) {
 
 void RecordTextReader::xfrSvcParamKeyVals(set<SvcParam>& val) // NOLINT(readability-function-cognitive-complexity)
 {
+  set<SvcParam::SvcParamKey> seenKeys;
   while (d_pos != d_end) {
     skipSpaces();
     if (d_pos == d_end)
@@ -382,6 +383,10 @@ void RecordTextReader::xfrSvcParamKeyVals(set<SvcParam>& val) // NOLINT(readabil
       key = SvcParam::keyFromString(k, generic);
     } catch (const std::invalid_argument &e) {
       throw RecordTextException(e.what());
+    }
+
+    if (!seenKeys.insert(key).second) {
+      throw RecordTextException("SvcParamKey '" + k + "' appears more than once");
     }
 
     if (d_pos != d_end && d_string.at(d_pos) == '=') {

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -399,6 +399,8 @@ BOOST_AUTO_TEST_CASE(test_record_types_bad_values) {
      (ZONE_CASE(QType::SOA, "ns.rec.test hostmaster.test.rec 20130512010 3600 3600 604800 120")) // too long serial
      (ZONE_CASE(QType::TXT, "\\02unlimited")) // incorrect escape
      (ZONE_CASE(QType::TXT, "\\384excessive")) // incorrect escape
+     (ZONE_CASE(QType::HTTPS, "1 . port=443 port=8080")) // repeated SvcParamKey
+     (ZONE_CASE(QType::SVCB, "1 foo.powerdns.org. alpn=h2 alpn=h3")) // repeated SvcParamKey
 ;
 
   int n=0;


### PR DESCRIPTION
### Short description

`RecordTextReader::xfrSvcParamKeyVals` collects the SvcParams of an SVCB or HTTPS record into a `std::set<SvcParam>` that sorts only on the key, so presentation text that repeats a SvcParamKey (`1 . port=443 port=8080`, or the same key written as its `keyNNN` alias) is accepted with every value after the first silently dropped. The wire parser `PacketReader::xfrSvcParamKeyVals` rejects the same bytes with `Found SVCParamKey X after SVCParamKey Y`, so a record that zone or API text can store cannot be read back off the wire, and RFC 9460 treats a repeated key as malformed on both sides.

Track the keys already seen while walking the text and throw a `RecordTextException` on the first repeat, which lines the text path up with the wire path and the RFC. Out-of-order keys stay valid, since presentation format asks only for uniqueness and not sorting. The check sits next to where each key is decoded so every SvcParam type passes through it without a per-case guard.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
