### PR TITLE
auth sqlite: prevent file descriptor leaks in some conditions

### DIFF
--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -297,10 +297,19 @@ SSQLite3::SSQLite3(Logr::log_t log, const std::string& database, const std::stri
   d_slog = log;
   m_dolog = false;
 
-  if (access(database.c_str(), F_OK) == -1) {
-    if (!creat) {
+  if (access(database.c_str(), W_OK) == -1) {
+    if (!creat && errno == ENOENT) {
       throw SSqlException("SQLite database '" + database + "' does not exist yet");
     }
+    if (errno == EACCES) {
+      throw SSqlException("SQLite database '" + database + "' is not writable");
+    }
+    // Other errors will cause sqlite3_open() to fail anyway. We needed to
+    // explicitly check for write access here, for SQLite < 3.46 in some
+    // configuration will leak file descriptors if the database can not be
+    // open read-write; refer to
+    // https://github.com/PowerDNS/pdns/issues/13952#issuecomment-2008254248
+    // for details.
   }
   else {
     if (creat) {


### PR DESCRIPTION
### Short description
This PR implements a simple workaround for #13952, where non-writable SQLite databases can cause file descriptor leaks in some configurations (only with SQLite < 3.46).
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
