### PR TITLE
auth: fix embarassing lmdb bug

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2484,7 +2484,8 @@ bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
     info.primaries = primaries;
     info.account = account;
 
-    txn.put(info, 0, d_random_ids, domain.hash());
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+    info.id = static_cast<domainid_t>(txn.put(info, 0, d_random_ids, domain.hash()));
     txn.commit();
     writeTransientDomainInfo(info);
   }


### PR DESCRIPTION
### Short description
When operating in split domain table mode, upon creating a new domain, its "transient" data (notification times) were written using zero as the domain id, regardless of the actual domain id value.

The oneliner fix is trivial.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
