### PR TITLE
Two coverity fixes

### DIFF
--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -473,7 +473,7 @@ pdns::expected<size_t, int> sendMsgWithOptions(int socketDesc, const void* buffe
     }
   } while (true);
 
-  return 0;
+  // NOTREACHED
 }
 
 template class NetmaskTree<bool, Netmask>;

--- a/pdns/query-local-address.cc
+++ b/pdns/query-local-address.cc
@@ -102,7 +102,7 @@ namespace pdns
         itf = Interface{ parts.at(1), idx };
       }
 
-      AddressAndInterface tmp{ComboAddress{addr}, itf};
+      AddressAndInterface tmp{ComboAddress{addr}, std::move(itf)};
       if (tmp.d_address.isIPv4()) {
         g_localQueryAddresses4.emplace_back(std::move(tmp));
         continue;


### PR DESCRIPTION
I hope compilers are smart enough to see that the bottom of the function cannot be reached (clang is happy with the missing return).

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
