### PR TITLE
dnsname: Count earlier compression hops in the name length check

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -145,6 +145,8 @@ size_t DNSName::parsePacketUncompressed(const pdns::views::UnsignedCharView& vie
 {
   const size_t initialPos = pos;
   const size_t neededSizeForFinalLabel = /* final empty label length */ (d_storage.empty() ? 1U : 0U);
+  // what a previous compression pointer already gathered, including the final empty label we are about to override
+  const size_t alreadyStoredLength = d_storage.size();
   size_t totalLength = 0;
   unsigned char labellen = 0;
 
@@ -170,7 +172,7 @@ size_t DNSName::parsePacketUncompressed(const pdns::views::UnsignedCharView& vie
     }
     checkLabelLength(labellen);
     // reserve one byte for the label length, plus one byte for the final empty label if we were empty before
-    if (totalLength + labellen > s_maxDNSNameLength - (neededSizeForFinalLabel + 1)) {
+    if (alreadyStoredLength + totalLength + labellen > s_maxDNSNameLength - (neededSizeForFinalLabel + 1)) {
       throw std::range_error("name too long to append");
     }
     if (pos + labellen >= view.size()) {

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -866,6 +866,28 @@ BOOST_AUTO_TEST_CASE(test_name_length_too_long_from_wire) {
   BOOST_CHECK_THROW(DNSName(name.c_str(), name.size(), 0, true), std::range_error);
 }
 
+BOOST_AUTO_TEST_CASE(test_name_length_too_long_from_wire_compressed) { // Length of a compressed name is the sum of every part
+
+  // two chunks of three 63-byte labels, the second one pointing at the first:
+  // each chunk fits on its own, the name they spell out together does not
+  string name;
+  for (size_t label = 0; label < 3; label++) {
+    name.append(1, '\x3f');
+    name.append(63, 'a');
+  }
+  name.append(1, '\x00');
+
+  const size_t second = name.size();
+  for (size_t label = 0; label < 3; label++) {
+    name.append(1, '\x3f');
+    name.append(63, 'b');
+  }
+  name.append(1, '\xc0');
+  name.append(1, '\x00');
+
+  BOOST_CHECK_THROW(DNSName(name.c_str(), name.size(), second, true), std::range_error);
+}
+
 BOOST_AUTO_TEST_CASE(test_compression) { // Compression test
 
   string name("\x03""com\x00""\x07""example\xc0""\x00""\x03""www\xc0""\x05", 21);


### PR DESCRIPTION
### Short description

`parsePacketUncompressed` caps a wire name at 255 bytes using `totalLength`, which is local to one invocation, but `packetParser` calls it once per compression pointer and every hop appends to the same `d_storage`:

- each hop gets its own 253-byte budget, so the limit lands per hop rather than on the finished name
- chunks that are individually legal chain up: a 9905-byte message parses into 9793 bytes of storage, and the 14-bit pointer range is the only thing capping it
- `canonCompare_three_way` keeps label offsets in a `std::array<uint8_t,64>`, so once storage passes 255 those offsets wrap and the `string_view` it builds takes a length byte from the wrong place and runs off the end of the name
- names with fewer than 64 labels miss the `slowCanonCompare_three_way` fallback, so 3-label chunks reach that path

Counting what earlier hops already stored puts the bound back on the whole name. Uncompressed names keep the same budget they have today, and the pointer chains in `test_compression*` still parse.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
