### PR TITLE
dnsdist-1.9.x: Backport 14130 - Fix TCP I/O timeout and callback being used for HTTP/2

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -432,7 +432,7 @@ void IncomingTCPConnectionState::queueResponse(std::shared_ptr<IncomingTCPConnec
 
     // for the same reason we need to update the state right away, nobody will do that for us
     if (state->active()) {
-      updateIO(state, iostate, now);
+      state->updateIO(state, iostate, now);
       // if we have not finished reading every available byte, we _need_ to do an actual read
       // attempt before waiting for the socket to become readable again, because if there is
       // buffered data available the socket might never become readable again.
@@ -474,18 +474,22 @@ void IncomingTCPConnectionState::handleAsyncReady([[maybe_unused]] int desc, FDM
   }
 }
 
+void IncomingTCPConnectionState::updateIOForAsync(std::shared_ptr<IncomingTCPConnectionState>& conn)
+{
+  auto fds = conn->d_handler.getAsyncFDs();
+  for (const auto desc : fds) {
+    conn->d_threadData.mplexer->addReadFD(desc, handleAsyncReady, conn);
+  }
+  conn->d_ioState->update(IOState::Done, handleIOCallback, conn);
+}
+
 void IncomingTCPConnectionState::updateIO(std::shared_ptr<IncomingTCPConnectionState>& state, IOState newState, const struct timeval& now)
 {
   if (newState == IOState::Async) {
-    auto fds = state->d_handler.getAsyncFDs();
-    for (const auto desc : fds) {
-      state->d_threadData.mplexer->addReadFD(desc, handleAsyncReady, state);
-    }
-    state->d_ioState->update(IOState::Done, handleIOCallback, state);
+    updateIOForAsync(state);
+    return;
   }
-  else {
-    state->d_ioState->update(newState, handleIOCallback, state, newState == IOState::NeedWrite ? state->getClientWriteTTD(now) : state->getClientReadTTD(now));
-  }
+  state->d_ioState->update(newState, handleIOCallback, state, newState == IOState::NeedWrite ? state->getClientWriteTTD(now) : state->getClientReadTTD(now));
 }
 
 /* called from the backend code when a new response has been received */

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -432,7 +432,7 @@ void IncomingTCPConnectionState::queueResponse(std::shared_ptr<IncomingTCPConnec
 
     // for the same reason we need to update the state right away, nobody will do that for us
     if (state->active()) {
-      state->updateIO(state, iostate, now);
+      state->updateIO(iostate, now);
       // if we have not finished reading every available byte, we _need_ to do an actual read
       // attempt before waiting for the socket to become readable again, because if there is
       // buffered data available the socket might never become readable again.
@@ -483,13 +483,14 @@ void IncomingTCPConnectionState::updateIOForAsync(std::shared_ptr<IncomingTCPCon
   conn->d_ioState->update(IOState::Done, handleIOCallback, conn);
 }
 
-void IncomingTCPConnectionState::updateIO(std::shared_ptr<IncomingTCPConnectionState>& state, IOState newState, const struct timeval& now)
+void IncomingTCPConnectionState::updateIO(IOState newState, const struct timeval& now)
 {
+  auto sharedPtrToConn = shared_from_this();
   if (newState == IOState::Async) {
-    updateIOForAsync(state);
+    updateIOForAsync(sharedPtrToConn);
     return;
   }
-  state->d_ioState->update(newState, handleIOCallback, state, newState == IOState::NeedWrite ? state->getClientWriteTTD(now) : state->getClientReadTTD(now));
+  d_ioState->update(newState, handleIOCallback, sharedPtrToConn, newState == IOState::NeedWrite ? getClientWriteTTD(now) : getClientReadTTD(now));
 }
 
 /* called from the backend code when a new response has been received */
@@ -1217,12 +1218,12 @@ void IncomingTCPConnectionState::handleIO()
       return;
     }
 
-    auto state = shared_from_this();
+    auto sharedPtrToConn = shared_from_this();
     if (iostate == IOState::Done) {
-      d_ioState->update(iostate, handleIOCallback, state);
+      d_ioState->update(iostate, handleIOCallback, sharedPtrToConn);
     }
     else {
-      updateIO(state, iostate, now);
+      updateIO(iostate, now);
     }
     ioGuard.release();
   } while ((iostate == IOState::NeedRead || iostate == IOState::NeedWrite) && !d_lastIOBlocked);
@@ -1237,21 +1238,21 @@ void IncomingTCPConnectionState::notifyIOError(const struct timeval& now, TCPRes
     return;
   }
 
-  std::shared_ptr<IncomingTCPConnectionState> state = shared_from_this();
-  --state->d_currentQueriesCount;
-  state->d_hadErrors = true;
+  auto sharedPtrToConn = shared_from_this();
+  --sharedPtrToConn->d_currentQueriesCount;
+  sharedPtrToConn->d_hadErrors = true;
 
-  if (state->d_state == State::sendingResponse) {
+  if (sharedPtrToConn->d_state == State::sendingResponse) {
     /* if we have responses to send, let's do that first */
   }
-  else if (!state->d_queuedResponses.empty()) {
+  else if (!sharedPtrToConn->d_queuedResponses.empty()) {
     /* stop reading and send what we have */
     try {
-      auto iostate = sendQueuedResponses(state, now);
+      auto iostate = sendQueuedResponses(sharedPtrToConn, now);
 
-      if (state->active() && iostate != IOState::Done) {
+      if (sharedPtrToConn->active() && iostate != IOState::Done) {
         // we need to update the state right away, nobody will do that for us
-        updateIO(state, iostate, now);
+        updateIO(iostate, now);
       }
     }
     catch (const std::exception& e) {
@@ -1260,7 +1261,7 @@ void IncomingTCPConnectionState::notifyIOError(const struct timeval& now, TCPRes
   }
   else {
     // the backend code already tried to reconnect if it was possible
-    state->terminateClientConnection();
+    sharedPtrToConn->terminateClientConnection();
   }
 }
 

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -1250,9 +1250,8 @@ boost::optional<struct timeval> IncomingHTTP2Connection::getIdleClientReadTTD(st
   return now;
 }
 
-void IncomingHTTP2Connection::updateIO(std::shared_ptr<IncomingTCPConnectionState>& conn, IOState newState, const timeval& now)
+void IncomingHTTP2Connection::updateIO(IOState newState, const timeval& now)
 {
-  (void)conn;
   (void)now;
   updateIO(newState, newState == IOState::NeedWrite ? handleWritableIOCallback : handleReadableIOCallback);
 }

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -1250,9 +1250,22 @@ boost::optional<struct timeval> IncomingHTTP2Connection::getIdleClientReadTTD(st
   return now;
 }
 
+void IncomingHTTP2Connection::updateIO(std::shared_ptr<IncomingTCPConnectionState>& conn, IOState newState, const timeval& now)
+{
+  (void)conn;
+  (void)now;
+  updateIO(newState, newState == IOState::NeedWrite ? handleWritableIOCallback : handleReadableIOCallback);
+}
+
 void IncomingHTTP2Connection::updateIO(IOState newState, const FDMultiplexer::callbackfunc_t& callback)
 {
   boost::optional<struct timeval> ttd{boost::none};
+
+  if (newState == IOState::Async) {
+    auto shared = shared_from_this();
+    updateIOForAsync(shared);
+    return;
+  }
 
   auto shared = std::dynamic_pointer_cast<IncomingHTTP2Connection>(shared_from_this());
   if (!shared || !d_ioState) {

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -89,7 +89,7 @@ private:
   void stopIO();
   std::unordered_map<StreamID, PendingQuery>::iterator getStreamContext(StreamID streamID);
   uint32_t getConcurrentStreamsCount() const;
-  void updateIO(std::shared_ptr<IncomingTCPConnectionState>& conn, IOState newState, const timeval& now) override;
+  void updateIO(IOState newState, const timeval& now) override;
   void updateIO(IOState newState, const FDMultiplexer::callbackfunc_t& callback);
   void handleIOError();
   bool sendResponse(StreamID streamID, PendingQuery& context, uint16_t responseCode, const HeadersMap& customResponseHeaders, const std::string& contentType = "", bool addContentType = true);

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -89,6 +89,7 @@ private:
   void stopIO();
   std::unordered_map<StreamID, PendingQuery>::iterator getStreamContext(StreamID streamID);
   uint32_t getConcurrentStreamsCount() const;
+  void updateIO(std::shared_ptr<IncomingTCPConnectionState>& conn, IOState newState, const timeval& now) override;
   void updateIO(IOState newState, const FDMultiplexer::callbackfunc_t& callback);
   void handleIOError();
   bool sendResponse(StreamID streamID, PendingQuery& context, uint16_t responseCode, const HeadersMap& customResponseHeaders, const std::string& contentType = "", bool addContentType = true);

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -127,10 +127,10 @@ public:
 
   static void queueResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response, bool fromBackend);
   static void handleTimeout(std::shared_ptr<IncomingTCPConnectionState>& state, bool write);
+  static void updateIOForAsync(std::shared_ptr<IncomingTCPConnectionState>& conn);
 
   virtual void handleIO();
   virtual void updateIO(std::shared_ptr<IncomingTCPConnectionState>& conn, IOState newState, const timeval& now);
-  void updateIOForAsync(std::shared_ptr<IncomingTCPConnectionState>& conn);
 
   QueryProcessingResult handleQuery(PacketBuffer&& query, const struct timeval& now, std::optional<int32_t> streamID);
   virtual void handleResponse(const struct timeval& now, TCPResponse&& response) override;

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -124,12 +124,13 @@ public:
 
   static void handleIOCallback(int desc, FDMultiplexer::funcparam_t& param);
   static void handleAsyncReady(int desc, FDMultiplexer::funcparam_t& param);
-  static void updateIO(std::shared_ptr<IncomingTCPConnectionState>& state, IOState newState, const struct timeval& now);
 
   static void queueResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response, bool fromBackend);
   static void handleTimeout(std::shared_ptr<IncomingTCPConnectionState>& state, bool write);
 
   virtual void handleIO();
+  virtual void updateIO(std::shared_ptr<IncomingTCPConnectionState>& conn, IOState newState, const timeval& now);
+  void updateIOForAsync(std::shared_ptr<IncomingTCPConnectionState>& conn);
 
   QueryProcessingResult handleQuery(PacketBuffer&& query, const struct timeval& now, std::optional<int32_t> streamID);
   virtual void handleResponse(const struct timeval& now, TCPResponse&& response) override;

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -130,7 +130,7 @@ public:
   static void updateIOForAsync(std::shared_ptr<IncomingTCPConnectionState>& conn);
 
   virtual void handleIO();
-  virtual void updateIO(std::shared_ptr<IncomingTCPConnectionState>& conn, IOState newState, const timeval& now);
+  virtual void updateIO(IOState newState, const timeval& now);
 
   QueryProcessingResult handleQuery(PacketBuffer&& query, const struct timeval& now, std::optional<int32_t> streamID);
   virtual void handleResponse(const struct timeval& now, TCPResponse&& response) override;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #14130 to rel/dnsdist-1.9.x

It turns out that they are NOT "always replaced by the correct HTTP/2 ones", causing incoming DoH connections to be dropped earlier than desired.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
