### PR TITLE
auth settings docs: fix "added-in" version numbers

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -491,7 +491,7 @@ Overrides :ref:`setting-default-soa-edit`
 -  String
 -  Default: DEFAULT
 
-.. versionadded:: 5.2.0
+.. versionadded:: 5.1.0
 
 The default :ref:`metadata-soa-edit-api` metadata value for zones created via
 the API when the zone creation request does not include the ``soa_edit_api`` field.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1409,7 +1409,7 @@ compile-time.
 -  Boolean
 -  Default: yes
 
-.. versionadded:: 5.2.0
+.. versionadded:: 5.1.4
 
 Add NAPTR `a` and `s` records to the additional answer section.
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
