### PR TITLE
dnsdist: Fix drops in the web dashboard

### DIFF
--- a/pdns/dnsdistdist/html/local.js
+++ b/pdns/dnsdistdist/html/local.js
@@ -126,7 +126,7 @@ $(document).ready(function() {
                          appendCellToRow(row, latency);
                          appendCellToRow(row, tcpLatency);
                          appendCellToRow(row, b["queries"]);
-                         appendCellToRow(row, b["reused"]);
+                         appendCellToRow(row, b["reuseds"]);
                          appendCellToRow(row, b["qps"].toFixed(2));
                          appendCellToRow(row, b["outstanding"]);
                          appendCellToRow(row, b["weight"]);


### PR DESCRIPTION
### Short description
The `Drops` column in the dnsdist web dashboard is empty because the dashboard reads the `reused` field, while the API exposes the value as `reuseds`.

This PR changes the dashboard to use `reuseds` again, so the backend drop count is displayed correctly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

